### PR TITLE
feat: add sandbox worker support with multi-arch Docker builds

### DIFF
--- a/image-resize/.dockerignore
+++ b/image-resize/.dockerignore
@@ -1,0 +1,6 @@
+target/
+.git/
+*.md
+docs/
+iii-launcher/
+.github/

--- a/image-resize/Cargo.lock
+++ b/image-resize/Cargo.lock
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "image-resize"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/image-resize/Dockerfile
+++ b/image-resize/Dockerfile
@@ -1,0 +1,51 @@
+FROM --platform=$BUILDPLATFORM rust:1.88-slim AS builder
+
+ARG TARGETARCH
+ARG TARGETOS
+
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    gcc-x86-64-linux-gnu \
+    gcc-aarch64-linux-gnu \
+    libc6-dev-amd64-cross \
+    libc6-dev-arm64-cross \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN rustup target add x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu
+
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+COPY src/ src/
+COPY build.rs ./
+
+RUN cargo run --release -- --manifest > /build/worker.yaml
+
+RUN case "${TARGETARCH}" in \
+      amd64) \
+        TARGET_TRIPLE="x86_64-unknown-linux-gnu"; \
+        export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc; \
+        ;; \
+      arm64) \
+        TARGET_TRIPLE="aarch64-unknown-linux-gnu"; \
+        export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc; \
+        ;; \
+      *) \
+        echo "Unsupported TARGETARCH=${TARGETARCH}" >&2; \
+        exit 1; \
+        ;; \
+    esac && \
+    cargo build --release --target "${TARGET_TRIPLE}" && \
+    cp "target/${TARGET_TRIPLE}/release/image-resize" /worker
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /worker /worker
+COPY --from=builder /build/worker.yaml /iii/worker.yaml
+
+ENV III_ENGINE_URL=ws://host.containers.internal:49134
+
+ENTRYPOINT ["/worker"]
+CMD ["--url", "ws://host.containers.internal:49134"]

--- a/image-resize/example/config.yaml
+++ b/image-resize/example/config.yaml
@@ -1,10 +1,3 @@
-# workers:
-  # - name: image-resize
-  # - image: docker.io/andersonofl/image-resize:latest
-    # config: 
-      # III_ENGINE_URL: "ws://localhost:49134"
-      # III_API_URL: "http://localhost:3111"
-
 modules:
   - class: modules::api::RestApiModule
     config:

--- a/image-resize/example/config.yaml
+++ b/image-resize/example/config.yaml
@@ -1,22 +1,32 @@
-modules:
-  - class: modules::api::RestApiModule
+workers:
+  - name: iii-stream
+    config:
+      port: ${STREAM_PORT:3112}
+      host: 127.0.0.1
+      adapter:
+        name: kv
+        config:
+          store_method: file_based # Options: in_memory, file_based
+          file_path: ./data/stream_store
+
+  - name: iii-http
     config:
       port: 3111
       host: 127.0.0.1
       default_timeout: 30000
+      concurrency_request_limit: 1024
       cors:
         allowed_origins:
-          - "*"
+          # To allow all origins, use '*':
+           - '*'
         allowed_methods:
           - GET
           - POST
+          - PUT
+          - DELETE
+          - OPTIONS
 
-  - class: modules::stream::StreamModule
-    config:
-      port: 3112
-      host: 0.0.0.0
-
-  - class: modules::observability::OtelModule
+  - name: iii-observability
     config:
       # === Core Configuration (Required) ===
       enabled: ${OTEL_ENABLED:true}

--- a/image-resize/example/config.yaml
+++ b/image-resize/example/config.yaml
@@ -1,14 +1,9 @@
-port: 49134
-
-workers:
-  - class: workers::image_resize::ImageResizeWorker
-    config:
-      width: 200
-      height: 200
-      strategy: scale-to-fit
-      quality:
-        jpeg: 85
-        webp: 80
+# workers:
+  # - name: image-resize
+  # - image: docker.io/andersonofl/image-resize:latest
+    # config: 
+      # III_ENGINE_URL: "ws://localhost:49134"
+      # III_API_URL: "http://localhost:3111"
 
 modules:
   - class: modules::api::RestApiModule

--- a/image-resize/example/iii.toml
+++ b/image-resize/example/iii.toml
@@ -1,2 +1,0 @@
-[workers]
-image-resize = "0.1.0"

--- a/image-resize/example/iii.worker.yaml
+++ b/image-resize/example/iii.worker.yaml
@@ -1,0 +1,19 @@
+iii: v1
+
+name: image-resize-demo
+version: 1.0.0
+
+env:
+  MY_CUSTOM_VAR: "hello222"
+
+runtime:
+  language: typescript
+  entry: src/index.ts
+
+resources:
+  memory: 512
+  cpus: 1
+
+scripts:
+  install: "npm install"
+  start: "npm run dev"

--- a/image-resize/example/iii.workers.yaml
+++ b/image-resize/example/iii.workers.yaml
@@ -1,0 +1,10 @@
+workers:
+  image-resize:
+    image: docker.io/andersonofl/image-resize:latest
+    env:
+      III_ENGINE_URL: "ws://localhost:49134"
+      III_API_URL: "http://localhost:3111"
+    resources:
+      cpus: '0.5'
+      memory: 256Mi
+      

--- a/image-resize/example/package.json
+++ b/image-resize/example/package.json
@@ -1,14 +1,15 @@
 {
-  "name": "@iii-hq/image-resize-demo",
+  "name": "@iii/image-resize-demo",
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "bun src/index.ts"
+    "dev": "node --import tsx src/index.ts"
   },
   "dependencies": {
     "iii-sdk": "0.9.0"
   },
   "devDependencies": {
+    "tsx": "^4.21.0",
     "@types/node": "^24.10.1",
     "typescript": "^5.9.3"
   }

--- a/image-resize/example/src/iii.ts
+++ b/image-resize/example/src/iii.ts
@@ -8,3 +8,5 @@ export const iii = registerWorker(engineWsUrl, {
     serviceName: 'image-resize-demo',
   },
 })
+
+console.info('III worker started', { myCustomVar: process.env.MY_CUSTOM_VAR })

--- a/image-resize/src/manifest.rs
+++ b/image-resize/src/manifest.rs
@@ -41,7 +41,7 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert!(parsed.is_object(), "Manifest must be valid JSON object");
         assert_eq!(parsed["name"], "image-resize");
-        assert_eq!(parsed["version"], "0.1.0");
+        assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Multi-architecture Dockerfile** for the `image-resize` worker — supports both `amd64` and `arm64` via cross-compilation with platform-specific linkers
- **New worker configuration format** — adds `iii.worker.yaml` (defines the worker sandbox runtime: language, entry, resources, scripts) and `iii.workers.yaml` (declares external worker images with env/resource constraints), replacing the previous `iii.toml` approach
- **Example project updates** — switches runtime from `bun` to `node --import tsx`, adds `tsx` dev dependency, updates package scope to `@iii`, and comments out the old inline worker config in `config.yaml`

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Configuration change

## Checklist

- [x] Code follows existing style guidelines
- [x] Changes have been self-reviewed
- [x] Dockerfile supports multi-arch builds (amd64/arm64)
- [x] Worker manifest is auto-generated at build time via `cargo run --release -- --manifest`

## Additional Context

This PR introduces the foundational configuration for running workers as sandboxed containers. The `iii.worker.yaml` defines how the engine should provision a worker sandbox (language runtime, entry point, resource limits, install/start scripts), while `iii.workers.yaml` declares pre-built worker images that can be pulled and launched by the engine. The Dockerfile uses a two-stage build with cross-compilation to produce minimal Debian-based images for both x86_64 and ARM64 targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multi-stage cross-platform container build and packaged runtime image.
  * Added runnable example manifests and a demo worker setup with env defaults and startup scripts.

* **Chores**
  * Updated example project tooling and package name; switched dev startup tooling.
  * Added Docker ignore rules to exclude repo/docs artifacts.
  * Example worker now logs a startup message on launch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->