### PR TITLE
feat(iii-aura): add on-device multimodal voice + vision worker

### DIFF
--- a/iii-aura/.gitignore
+++ b/iii-aura/.gitignore
@@ -1,0 +1,31 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+dist/
+*.profraw
+
+# Node
+node_modules/
+dist/
+
+# Environment / secrets
+.env
+.env.*
+
+# Lock files
+uv.lock
+pnpm-lock.yaml
+package-lock.json
+
+# IDE
+.idea/
+.vscode/
+*.swp
+
+# OS
+.DS_Store
+
+# iii engine data
+data/

--- a/iii-aura/README.md
+++ b/iii-aura/README.md
@@ -1,0 +1,159 @@
+# Aura — iii On-Device Multimodal AI
+
+Real-time voice and vision conversations powered by local models, wired entirely through iii primitives. No standalone WebSocket server, no REST polling — the **iii-browser-sdk** handles everything: function registration, triggers, channels, and state.
+
+## Architecture
+
+```text
+Browser (iii-browser-sdk)          iii Engine               Python Worker (iii-sdk)
+─────────────────────────     ─────────────────────     ─────────────────────────
+registerWorker(ws://RBAC)  ◄──► iii-worker-manager  ◄──► registerWorker(ws://internal)
+
+ui::aura::transcript       ◄─── trigger(Void)       ◄─── aura::ingest::turn
+ui::aura::playback         ◄─── trigger(Void)       ◄─── (TTS chunks via channel)
+
+createChannel() ───────────────► /ws/channels/...   ──► ChannelReader (audio+image)
+
+trigger(aura::session::open) ──► invoke             ──► state::set (session metadata)
+trigger(aura::interrupt)    ──► invoke(Void)        ──► asyncio.Event
+```
+
+### How it works
+
+1. The **browser** connects as a full iii worker via `iii-browser-sdk` and registers two functions (`ui::aura::transcript`, `ui::aura::playback`) that the backend can invoke.
+2. When the user speaks, the browser creates an iii **channel**, sends audio + camera frame as binary data, then triggers `aura::ingest::turn` on the Python worker.
+3. The Python worker reads the channel, runs Gemma 4 E2B inference, and pushes results back: transcript text via a **void trigger** and TTS audio via a new **channel**.
+4. The browser receives both, updates the UI, and plays audio — all through iii primitives.
+
+### Primitives used
+
+| Primitive | Role |
+|-----------|------|
+| **iii-browser-sdk** | Browser acts as a full worker — registers functions, triggers, creates channels |
+| **iii-worker-manager** (2 ports) | Internal for Python worker, RBAC-filtered for browser |
+| **Channels** | Binary audio upload (browser → worker) and TTS playback (worker → browser) |
+| **State** (`state::set` / `state::get`) | Session metadata persistence |
+| **Triggers** (sync + `TriggerAction.Void()`) | Function invocation and fire-and-forget push |
+
+## Requirements
+
+- Python 3.12+
+- macOS with Apple Silicon, or Linux with a supported GPU
+- ~3 GB free RAM for Gemma 4 E2B
+- Node.js 18+ (for the browser dev server)
+- A running iii engine
+
+## Quick Start
+
+### 1. Start the engine
+
+```bash
+# From an iii-engine checkout or binary:
+iii --config iii-aura/iii-config.example.yaml
+```
+
+### 2. Start the Python worker
+
+```bash
+cd iii-aura/python-worker
+uv sync                   # install dependencies (add --extra mac or --extra linux for TTS)
+uv run iii-aura
+```
+
+Models download automatically on first run (~2.6 GB for Gemma 4 E2B + TTS models).
+
+### 3. Start the browser app
+
+```bash
+cd iii-aura/browser
+npm install               # or pnpm install
+npm run dev               # or pnpm dev
+```
+
+Open http://localhost:5180, grant camera and microphone access, and start talking.
+
+## Configuration
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `III_URL` | `ws://127.0.0.1:49134` | Internal worker-manager URL (Python worker) |
+| `III_INTERNAL_PORT` | `49134` | Engine internal WS port |
+| `III_BROWSER_PORT` | `49135` | Engine RBAC WS port (browser SDK) |
+| `MODEL_PATH` | auto-download | Local path to `gemma-4-E2B-it.litertlm` |
+| `KOKORO_ONNX` | unset | Set to force ONNX TTS backend on macOS |
+
+### Browser SDK URL
+
+The browser app connects to `ws://localhost:49135` by default. To override, set `window.__III_URL__` before the module loads, or edit `src/aura.ts`.
+
+### Context management
+
+Each voice turn runs in a fresh Gemma conversation to prevent GPU context overflow from accumulated audio + image tokens. This trades multi-turn memory for reliability — every response is independent.
+
+### Queue-based inference (optional)
+
+If sync trigger timeouts are an issue with slow hardware, uncomment the `iii-queue` block in `iii-config.example.yaml` and switch the browser's `aura::ingest::turn` trigger to use `TriggerAction.Enqueue({ queue: 'aura' })`. The Python worker already pushes results back via `Void` triggers, so the completion path is unchanged.
+
+## Function IDs
+
+| Function | Direction | Description |
+|----------|-----------|-------------|
+| `aura::session::open` | browser → worker | Create a session, returns `session_id` |
+| `aura::ingest::turn` | browser → worker | Send audio+image via channel, receive inference result |
+| `aura::interrupt` | browser → worker | Cancel in-flight generation |
+| `aura::session::close` | browser → worker | Close session and free resources |
+| `ui::aura::transcript` | worker → browser | Push transcript text + LLM timing |
+| `ui::aura::playback` | worker → browser | Push TTS audio via channel reader ref |
+
+## Extending Aura
+
+Aura is designed as a **default inference worker**, not a monolith. Additional workers can plug into the same engine and extend capabilities without modifying Aura's code.
+
+### Add a new worker
+
+Register new functions under `aura::*` or a sibling namespace (e.g. `aura-tools::*`) from any Python, TypeScript, or Rust worker connected to the same engine port:
+
+```python
+from iii import register_worker
+
+iii = register_worker("ws://127.0.0.1:49134")
+
+iii.register_function("aura-tools::summarize", summarize_handler,
+    description="Summarize the last N conversation turns")
+```
+
+The browser (or Python worker) can then call `aura-tools::summarize` via `trigger()`.
+
+### Share state
+
+Use the `state` module with scoped keys:
+
+- **`aura`** scope: session metadata (managed by the default worker)
+- **`aura-settings`** scope: user preferences (e.g. voice, language, system prompt)
+- **`aura-history`** scope: conversation transcripts
+
+Any worker that can reach `state::set` / `state::get` on the engine can read or write these scopes.
+
+### Cron / queue triggers
+
+Add periodic tasks (e.g. session cleanup, model health checks) using cron triggers:
+
+```python
+iii.register_trigger({
+    "type": "cron",
+    "function_id": "aura::cleanup::expired-sessions",
+    "config": {"expression": "0 0 * * * * *"},  # every hour
+})
+```
+
+Or queue-based pipelines for heavy background processing:
+
+```python
+await iii.trigger_async({
+    "function_id": "aura-tools::long-analysis",
+    "payload": {"session_id": session_id, "data": large_payload},
+    "action": TriggerAction.Enqueue(queue="aura"),
+})
+```

--- a/iii-aura/browser/index.html
+++ b/iii-aura/browser/index.html
@@ -345,8 +345,6 @@
 
 <div class="iii-badge">Powered by iii</div>
 
-<script src="https://cdn.jsdelivr.net/npm/onnxruntime-web@1.22.0/dist/ort.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@ricky0123/vad-web@0.0.29/dist/bundle.min.js"></script>
 <script type="module">
   import { init } from './src/aura.ts'
   init()

--- a/iii-aura/browser/index.html
+++ b/iii-aura/browser/index.html
@@ -1,0 +1,355 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Aura — iii On-Device AI</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600&family=Syne:wght@700;800&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --c-bg: #050509;
+    --c-surface: rgba(255,255,255,0.04);
+    --c-surface-hover: rgba(255,255,255,0.07);
+    --c-text: #c8cad0;
+    --c-text-dim: #5a5d66;
+    --c-text-bright: #eef0f4;
+    --c-listen: #4ade80;
+    --c-listen-dim: rgba(74,222,128,0.12);
+    --c-process: #f59e0b;
+    --c-process-dim: rgba(245,158,11,0.12);
+    --c-speak: #818cf8;
+    --c-speak-dim: rgba(129,140,248,0.12);
+    --c-loading: #3a3d46;
+    --c-loading-dim: rgba(58,61,70,0.12);
+    --glow: var(--c-loading);
+    --glow-dim: var(--c-loading-dim);
+    --font-body: 'Instrument Sans', system-ui, sans-serif;
+    --font-display: 'Syne', system-ui, sans-serif;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    font-family: var(--font-body);
+    background: var(--c-bg);
+    color: var(--c-text);
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    overflow: hidden;
+    position: relative;
+  }
+
+  body::before {
+    content: '';
+    position: fixed;
+    top: 20%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 800px;
+    height: 600px;
+    background: radial-gradient(ellipse, var(--glow-dim) 0%, transparent 70%);
+    pointer-events: none;
+    transition: background 0.6s ease;
+    z-index: 0;
+  }
+
+  header {
+    width: 100%;
+    max-width: 720px;
+    padding: 20px 8px 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    z-index: 2;
+    flex-shrink: 0;
+  }
+
+  .logo { display: flex; align-items: center; gap: 10px; }
+
+  .logo-mark {
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+    background: linear-gradient(135deg, var(--glow) 0%, transparent 100%);
+    opacity: 0.7;
+    transition: background 0.4s ease, opacity 0.4s ease;
+  }
+
+  .logo h1 {
+    font-family: var(--font-body);
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--c-text-bright);
+    letter-spacing: 0.01em;
+  }
+
+  .status-pill {
+    font-size: 11px;
+    font-weight: 600;
+    padding: 5px 12px;
+    border-radius: 100px;
+    background: var(--c-surface);
+    color: var(--c-text-dim);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    transition: color 0.3s, background 0.3s;
+  }
+
+  .status-pill::before {
+    content: '';
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--c-text-dim);
+    transition: background 0.3s;
+  }
+  .status-pill.connected { color: var(--c-listen); background: var(--c-listen-dim); }
+  .status-pill.connected::before { background: var(--c-listen); }
+  .status-pill.disconnected { color: #f87171; background: rgba(248,113,113,0.1); }
+  .status-pill.disconnected::before { background: #f87171; }
+  .status-pill.processing { color: var(--c-process); background: var(--c-process-dim); }
+  .status-pill.processing::before { background: var(--c-process); }
+
+  .portal-stack {
+    flex: 1;
+    width: 100%;
+    max-width: 720px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 20px 8px 16px;
+    gap: 0;
+    z-index: 2;
+    min-height: 0;
+  }
+
+  .viewport-wrap {
+    position: relative;
+    width: 100%;
+    max-width: 640px;
+    aspect-ratio: 16/9;
+    border-radius: 18px;
+    flex-shrink: 0;
+    overflow: hidden;
+  }
+
+  .viewport-wrap::before,
+  .viewport-wrap::after,
+  .viewport-glow {
+    content: '';
+    position: absolute;
+    inset: -3px;
+    border-radius: 20px;
+    pointer-events: none;
+    transition: box-shadow 0.4s ease, opacity 0.4s ease;
+  }
+
+  .viewport-wrap::before { box-shadow: inset 0 0 30px var(--glow-dim), 0 0 15px var(--glow-dim); z-index: 3; }
+  .viewport-wrap::after { box-shadow: 0 0 40px 8px var(--glow-dim); z-index: 2; }
+  .viewport-glow { z-index: 1; }
+
+  #video {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 18px;
+    background: #111;
+    transition: opacity 0.3s;
+  }
+
+  .waveform-wrap {
+    width: 100%;
+    max-width: 400px;
+    height: 48px;
+    margin: 12px auto 8px;
+    flex-shrink: 0;
+  }
+
+  #waveform { width: 100%; height: 100%; }
+
+  .transcript {
+    flex: 1;
+    width: 100%;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 8px 0;
+    min-height: 0;
+    scrollbar-width: thin;
+    scrollbar-color: var(--c-surface-hover) transparent;
+  }
+
+  .msg {
+    padding: 12px 16px;
+    border-radius: 14px;
+    max-width: 85%;
+    font-size: 14px;
+    line-height: 1.5;
+    word-break: break-word;
+  }
+
+  .msg.user {
+    align-self: flex-end;
+    background: var(--c-surface-hover);
+    color: var(--c-text-bright);
+    border-bottom-right-radius: 4px;
+  }
+
+  .msg.assistant {
+    align-self: flex-start;
+    background: var(--c-surface);
+    color: var(--c-text);
+    border-bottom-left-radius: 4px;
+  }
+
+  .msg .meta {
+    font-size: 10px;
+    color: var(--c-text-dim);
+    margin-top: 6px;
+    letter-spacing: 0.03em;
+  }
+
+  .controls {
+    width: 100%;
+    max-width: 720px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    padding: 8px 0 16px;
+    flex-shrink: 0;
+  }
+
+  .ctrl-btn {
+    font-family: var(--font-body);
+    font-size: 12px;
+    font-weight: 500;
+    padding: 8px 16px;
+    border-radius: 100px;
+    border: 1px solid rgba(255,255,255,0.08);
+    background: var(--c-surface);
+    color: var(--c-text-dim);
+    cursor: pointer;
+    transition: all 0.2s;
+    letter-spacing: 0.02em;
+  }
+
+  .ctrl-btn:hover { background: var(--c-surface-hover); color: var(--c-text); }
+  .ctrl-btn.active { color: var(--c-listen); border-color: rgba(74,222,128,0.25); }
+
+  .state-indicator {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--c-text-dim);
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+  }
+
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--c-loading);
+    transition: background 0.3s;
+  }
+  .dot.listening { background: var(--c-listen); }
+  .dot.processing { background: var(--c-process); }
+  .dot.speaking { background: var(--c-speak); }
+
+  .on-device-pill {
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--c-text-dim);
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .on-device-pill svg { width: 10px; height: 10px; }
+
+  .loading-dots { display: inline-flex; gap: 4px; }
+  .loading-dots span {
+    width: 6px; height: 6px; border-radius: 50%;
+    background: var(--c-text-dim);
+    animation: blink 1.4s infinite both;
+  }
+  .loading-dots span:nth-child(2) { animation-delay: 0.2s; }
+  .loading-dots span:nth-child(3) { animation-delay: 0.4s; }
+
+  @keyframes blink {
+    0%, 80%, 100% { opacity: 0.2; }
+    40% { opacity: 1; }
+  }
+
+  .iii-badge {
+    position: fixed;
+    bottom: 12px;
+    right: 16px;
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--c-text-dim);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    z-index: 10;
+    opacity: 0.5;
+  }
+</style>
+</head>
+<body>
+
+<header>
+  <div class="logo">
+    <div class="logo-mark"></div>
+    <h1>Aura</h1>
+  </div>
+  <span id="status" class="status-pill">Connecting</span>
+</header>
+
+<div class="portal-stack">
+  <div id="viewportWrap" class="viewport-wrap loading">
+    <div class="viewport-glow"></div>
+    <video id="video" autoplay muted playsinline></video>
+  </div>
+
+  <div class="waveform-wrap">
+    <canvas id="waveform"></canvas>
+  </div>
+
+  <div id="messages" class="transcript"></div>
+
+  <div class="controls">
+    <button id="cameraToggle" class="ctrl-btn active">Camera On</button>
+    <div class="state-indicator">
+      <div id="stateDot" class="dot loading"></div>
+      <span id="stateText">Loading...</span>
+    </div>
+    <span class="on-device-pill">
+      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="2" y="4" width="12" height="9" rx="2"/><path d="M5 4V3a3 3 0 0 1 6 0v1"/></svg>
+      On-device
+    </span>
+  </div>
+</div>
+
+<div class="iii-badge">Powered by iii</div>
+
+<script src="https://cdn.jsdelivr.net/npm/onnxruntime-web@1.22.0/dist/ort.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@ricky0123/vad-web@0.0.29/dist/bundle.min.js"></script>
+<script type="module">
+  import { init } from './src/aura.ts'
+  init()
+</script>
+</body>
+</html>

--- a/iii-aura/browser/package.json
+++ b/iii-aura/browser/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "iii-browser-sdk": "^0.11.0-next.9"
+    "iii-browser-sdk": "0.11.3"
   },
   "devDependencies": {
     "vite": "^6.0.0",

--- a/iii-aura/browser/package.json
+++ b/iii-aura/browser/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "iii-browser-sdk": "^0.10.0-beta.4"
+    "iii-browser-sdk": "^0.11.0-next.9"
   },
   "devDependencies": {
     "vite": "^6.0.0",

--- a/iii-aura/browser/package.json
+++ b/iii-aura/browser/package.json
@@ -9,7 +9,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "iii-browser-sdk": "0.11.3"
+    "iii-browser-sdk": "0.11.3",
+    "onnxruntime-web": "^1.22.0",
+    "@ricky0123/vad-web": "^0.0.29"
   },
   "devDependencies": {
     "vite": "^6.0.0",

--- a/iii-aura/browser/package.json
+++ b/iii-aura/browser/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "iii-aura-browser",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "iii-browser-sdk": "^0.10.0-beta.4"
+  },
+  "devDependencies": {
+    "vite": "^6.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/iii-aura/browser/src/aura.ts
+++ b/iii-aura/browser/src/aura.ts
@@ -1,0 +1,515 @@
+/**
+ * iii Aura — browser-side worker.
+ *
+ * Connects to the iii engine via iii-browser-sdk and registers UI handler
+ * functions that the Python inference worker can invoke. All communication
+ * flows through iii primitives: trigger, createChannel, and state.
+ */
+
+import { registerWorker, TriggerAction } from 'iii-browser-sdk'
+import type { ChannelReader, ISdk } from 'iii-browser-sdk'
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const III_URL = (window as any).__III_URL__ ?? 'ws://localhost:49135'
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+let iii: ISdk
+let sessionId: string | null = null
+let appState: 'loading' | 'listening' | 'processing' | 'speaking' = 'loading'
+let mediaStream: MediaStream | null = null
+let audioCtx: AudioContext | null = null
+let analyser: AnalyserNode | null = null
+let micSource: MediaStreamAudioSourceNode | null = null
+let cameraEnabled = true
+let ignoreIncomingAudio = false
+let speakingStartedAt = 0
+
+// Streaming playback state
+let streamSampleRate = 24000
+let streamNextTime = 0
+let streamSources: AudioBufferSourceNode[] = []
+
+// VAD reference
+let myvad: any = null
+
+// DOM refs (populated by init)
+let videoEl: HTMLVideoElement
+let messagesEl: HTMLDivElement
+let statusEl: HTMLSpanElement
+let stateDotEl: HTMLDivElement
+let stateTextEl: HTMLSpanElement
+let cameraToggleEl: HTMLButtonElement
+let viewportWrapEl: HTMLDivElement
+let waveformCanvas: HTMLCanvasElement
+let waveformCtx: CanvasRenderingContext2D
+
+const BAR_COUNT = 40
+const BAR_GAP = 3
+let ambientPhase = 0
+const BARGE_IN_GRACE_MS = 800
+
+// ---------------------------------------------------------------------------
+// iii connection + function registration
+// ---------------------------------------------------------------------------
+
+async function connectIII() {
+  iii = registerWorker(III_URL)
+
+  // Register browser-side functions the backend can invoke
+  iii.registerFunction(
+    'ui::aura::transcript',
+    async (data: { text: string; transcription?: string; llm_time: number }) => {
+      // Update the latest user bubble with the real transcription
+      if (data.transcription) {
+        const userMsgs = messagesEl.querySelectorAll('.msg.user')
+        const lastUserMsg = userMsgs[userMsgs.length - 1]
+        if (lastUserMsg) {
+          const meta = lastUserMsg.querySelector('.meta')
+          const metaClone = meta ? meta.cloneNode(true) : null
+          lastUserMsg.textContent = data.transcription
+          if (metaClone) lastUserMsg.appendChild(metaClone)
+        }
+      }
+      addMessage('assistant', data.text, `LLM ${data.llm_time}s`)
+      return null
+    },
+  )
+
+  iii.registerFunction(
+    'ui::aura::playback',
+    async (data: { reader: ChannelReader; sample_rate: number; sentence_count: number }) => {
+      if (ignoreIncomingAudio) return null
+
+      streamSampleRate = data.sample_rate || 24000
+      startStreamPlayback()
+
+      const reader = data.reader
+
+      reader.onBinary((pcmBytes: Uint8Array) => {
+        if (ignoreIncomingAudio) return
+        const int16 = new Int16Array(pcmBytes.buffer, pcmBytes.byteOffset, pcmBytes.byteLength / 2)
+        const float32 = new Float32Array(int16.length)
+        for (let i = 0; i < int16.length; i++) float32[i] = int16[i] / 32768
+        queueAudioChunk(float32)
+      })
+
+      reader.onMessage((msg: string) => {
+        try {
+          const parsed = JSON.parse(msg)
+          if (parsed.type === 'audio_end') {
+            if (ignoreIncomingAudio) {
+              ignoreIncomingAudio = false
+              stopPlayback()
+              setState('listening')
+              return
+            }
+            const meta = messagesEl.querySelector('.msg.assistant:last-child .meta')
+            if (meta) meta.textContent += ` · TTS ${parsed.tts_time}s`
+          }
+        } catch { /* ignore */ }
+      })
+
+      return null
+    },
+  )
+
+  iii.onFunctionsAvailable((fns: Array<{ function_id: string }>) => {
+    console.log(`iii connected — ${fns.length} functions available`)
+    setStatus('connected', 'Connected')
+    if (appState === 'loading') openSession()
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Session management
+// ---------------------------------------------------------------------------
+
+async function openSession() {
+  try {
+    const result = await iii.trigger<Record<string, never>, { session_id: string }>({
+      function_id: 'aura::session::open',
+      payload: {},
+    })
+    sessionId = result.session_id
+    console.log('Session opened', sessionId)
+    setState('listening')
+  } catch (err) {
+    console.error('Failed to open session', err)
+    setStatus('disconnected', 'Error')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Speech turn: capture audio + optional camera frame → channel → trigger
+// ---------------------------------------------------------------------------
+
+async function sendTurn(audioSamples: Float32Array) {
+  if (!sessionId) return
+
+  setState('processing')
+  setStatus('processing', 'Processing')
+  const hasImage = cameraEnabled
+  addMessage('user', '<span class="loading-dots"><span></span><span></span><span></span></span>', hasImage ? 'with camera' : '', true)
+
+  // Convert float32@16kHz to WAV bytes
+  const wavBytes = float32ToWav(audioSamples)
+
+  // Capture camera frame
+  let imageB64: string | null = null
+  if (hasImage) imageB64 = captureFrame()
+
+  // Create a channel for sending audio+metadata to the backend
+  const channel = await iii.createChannel()
+
+  // Send metadata (including optional image) as a text message first
+  channel.writer.sendMessage(JSON.stringify({ has_image: hasImage, image: imageB64 }))
+
+  // Send audio binary
+  channel.writer.sendBinary(new Uint8Array(wavBytes))
+  channel.writer.close()
+
+  // Trigger the ingest function (sync — will return when inference is done)
+  try {
+    await iii.trigger({
+      function_id: 'aura::ingest::turn',
+      payload: {
+        session_id: sessionId,
+        reader: channel.readerRef,
+        has_image: hasImage,
+      },
+    })
+  } catch (err) {
+    console.error('Ingest failed', err)
+    setState('listening')
+    setStatus('connected', 'Connected')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Barge-in / interrupt
+// ---------------------------------------------------------------------------
+
+function sendInterrupt() {
+  if (!sessionId) return
+  iii.trigger({
+    function_id: 'aura::interrupt',
+    payload: { session_id: sessionId },
+    action: TriggerAction.Void(),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Audio helpers
+// ---------------------------------------------------------------------------
+
+function float32ToWav(samples: Float32Array): ArrayBuffer {
+  const buf = new ArrayBuffer(44 + samples.length * 2)
+  const v = new DataView(buf)
+  const w = (o: number, s: string) => { for (let i = 0; i < s.length; i++) v.setUint8(o + i, s.charCodeAt(i)) }
+  w(0, 'RIFF'); v.setUint32(4, 36 + samples.length * 2, true); w(8, 'WAVE'); w(12, 'fmt ')
+  v.setUint32(16, 16, true); v.setUint16(20, 1, true); v.setUint16(22, 1, true)
+  v.setUint32(24, 16000, true); v.setUint32(28, 32000, true); v.setUint16(32, 2, true)
+  v.setUint16(34, 16, true); w(36, 'data'); v.setUint32(40, samples.length * 2, true)
+  for (let i = 0; i < samples.length; i++) {
+    const s = Math.max(-1, Math.min(1, samples[i]))
+    v.setInt16(44 + i * 2, s < 0 ? s * 0x8000 : s * 0x7fff, true)
+  }
+  return buf
+}
+
+function captureFrame(): string | null {
+  if (!cameraEnabled || !videoEl.videoWidth) return null
+  const canvas = document.createElement('canvas')
+  const scale = 320 / videoEl.videoWidth
+  canvas.width = 320
+  canvas.height = videoEl.videoHeight * scale
+  canvas.getContext('2d')!.drawImage(videoEl, 0, 0, canvas.width, canvas.height)
+  return canvas.toDataURL('image/jpeg', 0.7).split(',')[1]
+}
+
+function ensureAudioCtx() {
+  if (!audioCtx) {
+    audioCtx = new AudioContext()
+    analyser = audioCtx.createAnalyser()
+    analyser.fftSize = 256
+    analyser.smoothingTimeConstant = 0.75
+  }
+}
+
+function startStreamPlayback() {
+  stopPlayback()
+  ensureAudioCtx()
+  if (audioCtx!.state === 'suspended') audioCtx!.resume()
+  streamNextTime = audioCtx!.currentTime + 0.05
+  speakingStartedAt = Date.now()
+  setState('speaking')
+}
+
+function queueAudioChunk(float32: Float32Array) {
+  ensureAudioCtx()
+  const audioBuffer = audioCtx!.createBuffer(1, float32.length, streamSampleRate)
+  audioBuffer.getChannelData(0).set(float32)
+
+  const source = audioCtx!.createBufferSource()
+  source.buffer = audioBuffer
+  source.connect(audioCtx!.destination)
+  source.connect(analyser!)
+
+  const startAt = Math.max(streamNextTime, audioCtx!.currentTime)
+  source.start(startAt)
+  streamNextTime = startAt + audioBuffer.duration
+
+  streamSources.push(source)
+  source.onended = () => {
+    const idx = streamSources.indexOf(source)
+    if (idx !== -1) streamSources.splice(idx, 1)
+    if (streamSources.length === 0 && appState === 'speaking') {
+      setState('listening')
+      setStatus('connected', 'Connected')
+    }
+  }
+}
+
+function stopPlayback() {
+  for (const src of streamSources) { try { src.stop() } catch { /* ignore */ } }
+  streamSources = []
+  streamNextTime = 0
+}
+
+// ---------------------------------------------------------------------------
+// Camera
+// ---------------------------------------------------------------------------
+
+async function startCamera() {
+  try {
+    mediaStream = await navigator.mediaDevices.getUserMedia({
+      video: { width: 640, height: 480, facingMode: 'user' },
+      audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+    })
+    videoEl.srcObject = mediaStream
+    return
+  } catch { /* fallback below */ }
+
+  const results = await Promise.allSettled([
+    navigator.mediaDevices.getUserMedia({ video: { width: 640, height: 480, facingMode: 'user' } }),
+    navigator.mediaDevices.getUserMedia({ audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true } }),
+  ])
+  mediaStream = new MediaStream()
+  for (const r of results) {
+    if (r.status === 'fulfilled') r.value.getTracks().forEach(t => mediaStream!.addTrack(t))
+  }
+  if (mediaStream.getVideoTracks().length) videoEl.srcObject = mediaStream
+}
+
+// ---------------------------------------------------------------------------
+// VAD handlers
+// ---------------------------------------------------------------------------
+
+function handleSpeechStart() {
+  if (appState === 'speaking') {
+    if (Date.now() - speakingStartedAt < BARGE_IN_GRACE_MS) return
+    stopPlayback()
+    ignoreIncomingAudio = true
+    sendInterrupt()
+    setState('listening')
+    console.log('Barge-in: interrupted playback')
+  }
+}
+
+function handleSpeechEnd(audio: Float32Array) {
+  if (appState !== 'listening') return
+  sendTurn(audio)
+}
+
+// ---------------------------------------------------------------------------
+// UI helpers
+// ---------------------------------------------------------------------------
+
+function setState(s: typeof appState) {
+  appState = s
+  stateDotEl.className = `dot ${s}`
+  const labels: Record<string, string> = { loading: 'Loading...', listening: 'Listening', processing: 'Thinking...', speaking: 'Speaking' }
+  stateTextEl.textContent = labels[s] || s
+
+  viewportWrapEl.className = `viewport-wrap ${s}`
+  if (s !== 'speaking') {
+    viewportWrapEl.style.boxShadow = ''
+    const glow = viewportWrapEl.querySelector('.viewport-glow') as HTMLElement | null
+    if (glow) glow.style.boxShadow = ''
+  }
+
+  const stateVars: Record<string, [string, string]> = {
+    listening: ['#4ade80', 'rgba(74,222,128,0.12)'],
+    processing: ['#f59e0b', 'rgba(245,158,11,0.12)'],
+    speaking: ['#818cf8', 'rgba(129,140,248,0.12)'],
+    loading: ['#3a3d46', 'rgba(58,61,70,0.12)'],
+  }
+  const [glow, glowDim] = stateVars[s] || stateVars.loading
+  document.documentElement.style.setProperty('--glow', glow)
+  document.documentElement.style.setProperty('--glow-dim', glowDim)
+
+  if (s === 'speaking') requestAnimationFrame(updateSpeakingGlow)
+  if (myvad) myvad.setOptions({ positiveSpeechThreshold: s === 'speaking' ? 0.92 : 0.5 })
+
+  if (s === 'listening' && mediaStream && audioCtx && analyser) {
+    if (!micSource) micSource = audioCtx.createMediaStreamSource(mediaStream)
+    try { micSource.connect(analyser) } catch { /* ignore */ }
+  } else if (micSource && s !== 'listening') {
+    try { micSource.disconnect(analyser!) } catch { /* ignore */ }
+  }
+}
+
+function setStatus(cls: string, text: string) {
+  statusEl.className = `status-pill ${cls}`
+  statusEl.textContent = text
+}
+
+function addMessage(role: string, text: string, meta?: string, html = false) {
+  const div = document.createElement('div')
+  div.className = `msg ${role}`
+  if (html) {
+    div.innerHTML = text
+  } else {
+    div.textContent = text
+  }
+  if (meta) {
+    const metaEl = document.createElement('div')
+    metaEl.className = 'meta'
+    metaEl.textContent = meta
+    div.appendChild(metaEl)
+  }
+  messagesEl.appendChild(div)
+  messagesEl.scrollTop = messagesEl.scrollHeight
+}
+
+// ---------------------------------------------------------------------------
+// Waveform + speaking glow
+// ---------------------------------------------------------------------------
+
+function initWaveformCanvas() {
+  const dpr = window.devicePixelRatio || 1
+  const rect = waveformCanvas.getBoundingClientRect()
+  waveformCanvas.width = rect.width * dpr
+  waveformCanvas.height = rect.height * dpr
+  waveformCtx.scale(dpr, dpr)
+}
+
+function drawWaveform() {
+  const w = waveformCanvas.getBoundingClientRect().width
+  const h = waveformCanvas.getBoundingClientRect().height
+  waveformCtx.clearRect(0, 0, w, h)
+
+  const barWidth = (w - (BAR_COUNT - 1) * BAR_GAP) / BAR_COUNT
+  const color = { listening: '#4ade80', processing: '#f59e0b', speaking: '#818cf8', loading: '#3a3d46' }[appState] || '#3a3d46'
+  waveformCtx.fillStyle = color
+
+  let dataArray: Uint8Array<ArrayBuffer> | null = null
+  if (analyser) {
+    dataArray = new Uint8Array(analyser.frequencyBinCount)
+    analyser.getByteFrequencyData(dataArray)
+  }
+
+  for (let i = 0; i < BAR_COUNT; i++) {
+    let amplitude = 0
+    if (dataArray) {
+      const binIndex = Math.floor((i / BAR_COUNT) * dataArray.length * 0.6)
+      amplitude = dataArray[binIndex] / 255
+    }
+    if (!dataArray || amplitude < 0.02) {
+      ambientPhase += 0.0001
+      const drift = Math.sin(ambientPhase * 3 + i * 0.4) * 0.5 + 0.5
+      amplitude = 0.03 + drift * 0.04
+    }
+
+    const barH = Math.max(2, amplitude * (h - 4))
+    const x = i * (barWidth + BAR_GAP)
+    const y = (h - barH) / 2
+    waveformCtx.globalAlpha = 0.3 + amplitude * 0.7
+    waveformCtx.beginPath()
+    ;(waveformCtx as any).roundRect(x, y, barWidth, barH, Math.min(barWidth / 2, barH / 2, 3))
+    waveformCtx.fill()
+  }
+  waveformCtx.globalAlpha = 1
+  requestAnimationFrame(drawWaveform)
+}
+
+function updateSpeakingGlow() {
+  if (appState !== 'speaking' || !analyser) return
+  const data = new Uint8Array(analyser.frequencyBinCount)
+  analyser.getByteFrequencyData(data)
+  let sum = 0
+  for (let i = 0; i < data.length; i++) sum += data[i]
+  const avg = sum / data.length / 255
+  const intensity = 0.3 + avg * 0.7
+  const spread = 20 + avg * 60
+  const inner = 15 + avg * 25
+  const glow = viewportWrapEl.querySelector('.viewport-glow') as HTMLElement | null
+  if (glow) glow.style.boxShadow = `0 0 ${spread}px ${spread * 0.4}px rgba(129,140,248,${intensity * 0.25})`
+  viewportWrapEl.style.boxShadow = `inset 0 0 ${inner}px rgba(129,140,248,${intensity * 0.15}), 0 0 ${inner}px rgba(129,140,248,${intensity * 0.2})`
+  requestAnimationFrame(updateSpeakingGlow)
+}
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+export async function init() {
+  videoEl = document.getElementById('video') as HTMLVideoElement
+  messagesEl = document.getElementById('messages') as HTMLDivElement
+  statusEl = document.getElementById('status') as HTMLSpanElement
+  stateDotEl = document.getElementById('stateDot') as HTMLDivElement
+  stateTextEl = document.getElementById('stateText') as HTMLSpanElement
+  cameraToggleEl = document.getElementById('cameraToggle') as HTMLButtonElement
+  viewportWrapEl = document.getElementById('viewportWrap') as HTMLDivElement
+  waveformCanvas = document.getElementById('waveform') as HTMLCanvasElement
+  waveformCtx = waveformCanvas.getContext('2d')!
+
+  initWaveformCanvas()
+  window.addEventListener('resize', initWaveformCanvas)
+
+  await startCamera()
+  await connectIII()
+
+  // Initialize Silero VAD from CDN
+  const vad = (window as any).vad as any
+  myvad = await vad.MicVAD.new({
+    getStream: async () => new MediaStream(mediaStream!.getAudioTracks()),
+    positiveSpeechThreshold: 0.5,
+    negativeSpeechThreshold: 0.25,
+    redemptionMs: 600,
+    minSpeechMs: 300,
+    preSpeechPadMs: 300,
+    onSpeechStart: handleSpeechStart,
+    onSpeechEnd: handleSpeechEnd,
+    onVADMisfire: () => console.log('VAD misfire (too short)'),
+    onnxWASMBasePath: 'https://cdn.jsdelivr.net/npm/onnxruntime-web@1.22.0/dist/',
+    baseAssetPath: 'https://cdn.jsdelivr.net/npm/@ricky0123/vad-web@0.0.29/dist/',
+  })
+  myvad.start()
+
+  const initAudio = () => {
+    ensureAudioCtx()
+    if (audioCtx!.state === 'suspended') audioCtx!.resume()
+    document.removeEventListener('click', initAudio)
+    document.removeEventListener('keydown', initAudio)
+  }
+  document.addEventListener('click', initAudio)
+  document.addEventListener('keydown', initAudio)
+  ensureAudioCtx()
+
+  cameraToggleEl.addEventListener('click', () => {
+    cameraEnabled = !cameraEnabled
+    cameraToggleEl.classList.toggle('active', cameraEnabled)
+    cameraToggleEl.textContent = cameraEnabled ? 'Camera On' : 'Camera Off'
+    videoEl.style.opacity = cameraEnabled ? '1' : '0.3'
+  })
+
+  drawWaveform()
+  console.log('Aura initialized')
+}

--- a/iii-aura/browser/src/aura.ts
+++ b/iii-aura/browser/src/aura.ts
@@ -8,6 +8,7 @@
 
 import { registerWorker, TriggerAction } from 'iii-browser-sdk'
 import type { ChannelReader, ISdk } from 'iii-browser-sdk'
+import * as vad from '@ricky0123/vad-web'
 
 // ---------------------------------------------------------------------------
 // Config
@@ -91,6 +92,23 @@ async function connectIII() {
 
       const reader = data.reader
 
+      // Fallback in case the `audio_end` control message is dropped on the
+      // channel — without it the UI would be stuck in 'speaking'. Timeout
+      // forces the same cleanup path that audio_end would have taken.
+      const PLAYBACK_TIMEOUT_MS = 60_000
+      let playbackTimeout: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+        console.warn('ui::aura::playback: no audio_end within timeout, resetting')
+        stopPlayback()
+        setState('listening')
+        playbackTimeout = null
+      }, PLAYBACK_TIMEOUT_MS)
+      const clearPlaybackTimeout = () => {
+        if (playbackTimeout) {
+          clearTimeout(playbackTimeout)
+          playbackTimeout = null
+        }
+      }
+
       reader.onBinary((pcmBytes: Uint8Array) => {
         if (ignoreIncomingAudio) return
         const int16 = new Int16Array(pcmBytes.buffer, pcmBytes.byteOffset, pcmBytes.byteLength / 2)
@@ -103,6 +121,7 @@ async function connectIII() {
         try {
           const parsed = JSON.parse(msg)
           if (parsed.type === 'audio_end') {
+            clearPlaybackTimeout()
             if (ignoreIncomingAudio) {
               ignoreIncomingAudio = false
               stopPlayback()
@@ -155,7 +174,7 @@ async function sendTurn(audioSamples: Float32Array) {
   setState('processing')
   setStatus('processing', 'Processing')
   const hasImage = cameraEnabled
-  addMessage('user', '<span class="loading-dots"><span></span><span></span><span></span></span>', hasImage ? 'with camera' : '', true)
+  addLoadingMessage(hasImage ? 'with camera' : '')
 
   // Convert float32@16kHz to WAV bytes
   const wavBytes = float32ToWav(audioSamples)
@@ -370,14 +389,31 @@ function setStatus(cls: string, text: string) {
   statusEl.textContent = text
 }
 
-function addMessage(role: string, text: string, meta?: string, html = false) {
+// Role-tagged message renderer. Always uses textContent for `text` and `meta`
+// to keep LLM-generated content out of the DOM parser — untrusted HTML can't
+// ship here. Callers that need the loading-dots affordance use
+// `addLoadingMessage()` below, which constructs the DOM directly.
+function addMessage(role: string, text: string, meta?: string) {
   const div = document.createElement('div')
   div.className = `msg ${role}`
-  if (html) {
-    div.innerHTML = text
-  } else {
-    div.textContent = text
+  div.textContent = text
+  if (meta) {
+    const metaEl = document.createElement('div')
+    metaEl.className = 'meta'
+    metaEl.textContent = meta
+    div.appendChild(metaEl)
   }
+  messagesEl.appendChild(div)
+  messagesEl.scrollTop = messagesEl.scrollHeight
+}
+
+function addLoadingMessage(meta: string) {
+  const div = document.createElement('div')
+  div.className = 'msg user'
+  const dots = document.createElement('span')
+  dots.className = 'loading-dots'
+  for (let i = 0; i < 3; i++) dots.appendChild(document.createElement('span'))
+  div.appendChild(dots)
   if (meta) {
     const metaEl = document.createElement('div')
     metaEl.className = 'meta'
@@ -476,8 +512,7 @@ export async function init() {
   await startCamera()
   await connectIII()
 
-  // Initialize Silero VAD from CDN
-  const vad = (window as any).vad as any
+  // Initialize Silero VAD (bundled via npm)
   myvad = await vad.MicVAD.new({
     getStream: async () => new MediaStream(mediaStream!.getAudioTracks()),
     positiveSpeechThreshold: 0.5,
@@ -488,9 +523,7 @@ export async function init() {
     onSpeechStart: handleSpeechStart,
     onSpeechEnd: handleSpeechEnd,
     onVADMisfire: () => console.log('VAD misfire (too short)'),
-    onnxWASMBasePath: 'https://cdn.jsdelivr.net/npm/onnxruntime-web@1.22.0/dist/',
-    baseAssetPath: 'https://cdn.jsdelivr.net/npm/@ricky0123/vad-web@0.0.29/dist/',
-  })
+  } as any)
   myvad.start()
 
   const initAudio = () => {

--- a/iii-aura/browser/tsconfig.json
+++ b/iii-aura/browser/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/iii-aura/browser/vite.config.ts
+++ b/iii-aura/browser/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  server: {
+    port: 5180,
+    open: true,
+  },
+})

--- a/iii-aura/iii-config.example.yaml
+++ b/iii-aura/iii-config.example.yaml
@@ -1,0 +1,69 @@
+# iii engine configuration for the Aura on-device multimodal worker.
+#
+# Start the engine with:
+#   cargo run --release -- --config examples/iii-aura/iii-config.example.yaml
+#
+# Then start the Python worker and the browser app — see README.md.
+
+workers:
+  # Internal worker-manager (Python worker connects here)
+  - name: iii-worker-manager
+    config:
+      port: ${III_INTERNAL_PORT:49134}
+
+  # RBAC worker-manager (browser SDK connects here)
+  - name: iii-worker-manager
+    config:
+      host: 0.0.0.0
+      port: ${III_BROWSER_PORT:49135}
+      rbac:
+        expose_functions:
+          - match("aura::*")
+          - match("engine::channels::create")
+          - match("engine::functions::list")
+          - match("state::*")
+
+  - name: iii-state
+    config:
+      adapter:
+        name: kv
+        config:
+          store_method: file_based
+          file_path: ./data/aura_state.db
+
+  - name: iii-http
+    config:
+      host: 0.0.0.0
+      port: ${AURA_HTTP_PORT:3111}
+      cors:
+        allowed_origins:
+          - "http://localhost:5180"
+          - "http://127.0.0.1:5180"
+        allowed_methods:
+          - GET
+          - POST
+          - OPTIONS
+
+  # Uncomment if you need queue-based inference to avoid sync timeouts:
+  # - name: iii-queue
+  #   config:
+  #     queue_configs:
+  #       aura:
+  #         max_retries: 1
+  #         concurrency: 1
+  #         type: standard
+  #     adapter:
+  #       name: builtin
+
+  - name: iii-observability
+    config:
+      enabled: true
+      service_name: iii-aura
+      exporter: memory
+      sampling_ratio: 1.0
+      memory_max_spans: 5000
+      metrics_enabled: true
+      metrics_exporter: memory
+      logs_enabled: true
+      logs_exporter: memory
+      logs_console_output: true

--- a/iii-aura/python-worker/pyproject.toml
+++ b/iii-aura/python-worker/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "On-device multimodal voice + vision worker for the iii engine"
 requires-python = ">=3.12"
 dependencies = [
-    "iii-sdk",
+    "iii-sdk>=0.11.0.dev9",
     "litert-lm>=0.10.1",
     "numpy>=2.0",
     "huggingface-hub>=0.16.0",

--- a/iii-aura/python-worker/pyproject.toml
+++ b/iii-aura/python-worker/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "On-device multimodal voice + vision worker for the iii engine"
 requires-python = ">=3.12"
 dependencies = [
-    "iii-sdk>=0.11.0.dev9",
+    "iii-sdk==0.11.3",
     "litert-lm>=0.10.1",
     "numpy>=2.0",
     "huggingface-hub>=0.16.0",

--- a/iii-aura/python-worker/pyproject.toml
+++ b/iii-aura/python-worker/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "iii-aura"
+version = "0.1.0"
+description = "On-device multimodal voice + vision worker for the iii engine"
+requires-python = ">=3.12"
+dependencies = [
+    "iii-sdk",
+    "litert-lm>=0.10.1",
+    "numpy>=2.0",
+    "huggingface-hub>=0.16.0",
+]
+
+[project.optional-dependencies]
+mac = [
+    "mlx-audio>=0.4.2",
+    "misaki[en]>=0.9.4",
+    "num2words>=0.5.14",
+]
+linux = [
+    "kokoro-onnx>=0.5.0",
+]
+dev = [
+    "ruff",
+]
+
+[project.scripts]
+iii-aura = "iii_aura.worker:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/iii_aura"]
+
+[tool.ruff]
+line-length = 120
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W"]

--- a/iii-aura/python-worker/src/iii_aura/__init__.py
+++ b/iii-aura/python-worker/src/iii_aura/__init__.py
@@ -1,0 +1,1 @@
+"""iii Aura — on-device multimodal voice + vision worker."""

--- a/iii-aura/python-worker/src/iii_aura/inference.py
+++ b/iii-aura/python-worker/src/iii_aura/inference.py
@@ -1,0 +1,69 @@
+"""Gemma 4 E2B model loading and tool definition."""
+
+import atexit
+import os
+
+import litert_lm
+
+HF_REPO = "litert-community/gemma-4-E2B-it-litert-lm"
+HF_FILENAME = "gemma-4-E2B-it.litertlm"
+
+SYSTEM_PROMPT = (
+    "You are a friendly, conversational AI assistant. The user is talking to you "
+    "through a microphone and showing you their camera. "
+    "You MUST always use the respond_to_user tool to reply. "
+    "First transcribe exactly what the user said, then write your response."
+)
+
+
+def resolve_model_path() -> str:
+    path = os.environ.get("MODEL_PATH", "")
+    if path:
+        return path
+    from huggingface_hub import hf_hub_download
+
+    print(f"Downloading {HF_REPO}/{HF_FILENAME} (first run only)...")
+    return hf_hub_download(repo_id=HF_REPO, filename=HF_FILENAME)
+
+
+engine = None
+tool_result: dict[str, str] = {}
+
+
+def respond_to_user(transcription: str, response: str) -> str:
+    """Respond to the user's voice message.
+
+    Args:
+        transcription: Exact transcription of what the user said in the audio.
+        response: Your conversational response to the user. Keep it to 1-4 short sentences.
+    """
+    tool_result["transcription"] = transcription
+    tool_result["response"] = response
+    return "OK"
+
+
+def load():
+    """Load the Gemma engine (call once at startup)."""
+    global engine
+    model_path = resolve_model_path()
+    print(f"Loading Gemma 4 E2B from {model_path}...")
+    engine = litert_lm.Engine(
+        model_path,
+        backend=litert_lm.Backend.GPU,
+        vision_backend=litert_lm.Backend.GPU,
+        audio_backend=litert_lm.Backend.CPU,
+    )
+    engine.__enter__()
+    atexit.register(unload)
+    print("Gemma engine loaded.")
+
+
+def unload():
+    """Release the Gemma engine (called automatically at exit)."""
+    global engine
+    if engine is not None:
+        try:
+            engine.__exit__(None, None, None)
+        except Exception:
+            pass
+        engine = None

--- a/iii-aura/python-worker/src/iii_aura/tts.py
+++ b/iii-aura/python-worker/src/iii_aura/tts.py
@@ -1,0 +1,62 @@
+"""Platform-aware Kokoro TTS: MLX on Apple Silicon, ONNX elsewhere."""
+
+import os
+import platform
+import sys
+
+import numpy as np
+
+
+def _is_apple_silicon() -> bool:
+    return sys.platform == "darwin" and platform.machine() == "arm64"
+
+
+class TTSBackend:
+    sample_rate: int = 24000
+
+    def generate(self, text: str, voice: str = "af_heart", speed: float = 1.1) -> np.ndarray:
+        raise NotImplementedError
+
+
+class MLXBackend(TTSBackend):
+    def __init__(self):
+        from mlx_audio.tts.generate import load_model  # type: ignore[import-not-found]
+
+        self._model = load_model("mlx-community/Kokoro-82M-bf16")
+        self.sample_rate = self._model.sample_rate
+        list(self._model.generate(text="Hello", voice="af_heart", speed=1.0))
+
+    def generate(self, text: str, voice: str = "af_heart", speed: float = 1.1) -> np.ndarray:
+        results = list(self._model.generate(text=text, voice=voice, speed=speed))
+        return np.concatenate([np.array(r.audio) for r in results])
+
+
+class ONNXBackend(TTSBackend):
+    def __init__(self):
+        import kokoro_onnx  # type: ignore[import-not-found]
+        from huggingface_hub import hf_hub_download
+
+        model_path = hf_hub_download("fastrtc/kokoro-onnx", "kokoro-v1.0.onnx")
+        voices_path = hf_hub_download("fastrtc/kokoro-onnx", "voices-v1.0.bin")
+
+        self._model = kokoro_onnx.Kokoro(model_path, voices_path)
+        self.sample_rate = 24000
+
+    def generate(self, text: str, voice: str = "af_heart", speed: float = 1.1) -> np.ndarray:
+        pcm, _sr = self._model.create(text, voice=voice, speed=speed)
+        return pcm
+
+
+def load() -> TTSBackend:
+    """Load the best available TTS backend for this platform."""
+    if _is_apple_silicon() and not os.environ.get("KOKORO_ONNX"):
+        try:
+            backend = MLXBackend()
+            print(f"TTS: mlx-audio (Apple GPU, sample_rate={backend.sample_rate})")
+            return backend
+        except ImportError:
+            print("TTS: mlx-audio not installed, falling back to kokoro-onnx")
+
+    backend = ONNXBackend()
+    print(f"TTS: kokoro-onnx (CPU, sample_rate={backend.sample_rate})")
+    return backend

--- a/iii-aura/python-worker/src/iii_aura/worker.py
+++ b/iii-aura/python-worker/src/iii_aura/worker.py
@@ -1,0 +1,290 @@
+"""iii Aura worker — on-device multimodal voice + vision, wired through iii primitives.
+
+Functions:
+    aura::session::open    — create a session, returns session_id
+    aura::ingest::turn     — receive audio+image via channel, run inference, stream TTS back
+    aura::interrupt        — cancel in-flight generation for a session
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import concurrent.futures
+import concurrent.futures.thread as _cft
+import json
+import os
+import re
+import time
+import uuid
+from typing import Any
+
+import numpy as np
+
+from iii import ChannelReader, InitOptions, Logger, TriggerAction, register_worker  # type: ignore[import-not-found]
+
+from . import tts as tts_module
+from . import inference
+
+SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+
+logger = Logger(service_name="iii-aura")
+
+_interrupts: dict[str, asyncio.Event] = {}
+_tts: tts_module.TTSBackend | None = None
+
+
+def _patch_localhost(obj: Any, attr: str = "_url") -> None:
+    """Replace localhost with 127.0.0.1 to bypass DNS when litert_lm poisons the executor."""
+    if hasattr(obj, attr):
+        setattr(obj, attr, getattr(obj, attr).replace("://localhost", "://127.0.0.1"))
+
+
+def _clean_model_tokens(s: str) -> str:
+    return s.replace('<|"|>', "").strip()
+
+
+class _SafeExecutor(concurrent.futures.ThreadPoolExecutor):
+    """ThreadPoolExecutor that resets the global _shutdown flag before each submit.
+
+    litert_lm's C++ init sets concurrent.futures.thread._shutdown = True,
+    which poisons ALL executors. This subclass ensures it's always cleared.
+    """
+
+    def submit(self, fn, /, *args, **kwargs):
+        _cft._shutdown = False
+        return super().submit(fn, *args, **kwargs)
+
+
+_executor: _SafeExecutor | None = None
+
+iii = None
+
+
+def _split_sentences(text: str) -> list[str]:
+    parts = SENTENCE_SPLIT_RE.split(text.strip())
+    return [s.strip() for s in parts if s.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Functions registered with the iii engine
+# ---------------------------------------------------------------------------
+
+async def _session_open(data: dict[str, Any]) -> dict[str, Any]:
+    session_id = str(uuid.uuid4())
+    _interrupts[session_id] = asyncio.Event()
+
+    await iii.trigger_async({
+        "function_id": "state::set",
+        "payload": {
+            "scope": "aura",
+            "key": session_id,
+            "value": {"session_id": session_id, "created_at": time.time()},
+        },
+    })
+
+    logger.info("Session opened", {"session_id": session_id})
+    return {"session_id": session_id}
+
+
+async def _ingest_turn(data: dict[str, Any]) -> dict[str, Any]:
+    session_id = data["session_id"]
+    reader: ChannelReader = data["reader"]
+
+    interrupted = _interrupts.get(session_id)
+    if interrupted is None:
+        interrupted = asyncio.Event()
+        _interrupts[session_id] = interrupted
+    interrupted.clear()
+
+    _patch_localhost(reader)
+
+    # Read audio + metadata from channel
+    messages: list[str] = []
+    reader.on_message(lambda msg: messages.append(msg))
+    raw = await reader.read_all()
+
+    image_b64: str | None = None
+    if messages:
+        try:
+            image_b64 = json.loads(messages[0]).get("image")
+        except json.JSONDecodeError:
+            pass
+
+    audio_b64 = base64.b64encode(raw).decode() if raw else None
+
+    # Build multimodal content for Gemma 4 E2B
+    content: list[dict[str, str]] = []
+    if audio_b64:
+        content.append({"type": "audio", "blob": audio_b64})
+    if image_b64:
+        content.append({"type": "image", "blob": image_b64})
+
+    if audio_b64 and image_b64:
+        content.append({"type": "text", "text": (
+            "The user just spoke to you (audio) while showing their camera (image). "
+            "Respond to what they said, referencing what you see if relevant."
+        )})
+    elif audio_b64:
+        content.append({"type": "text", "text": "The user just spoke to you. Respond to what they said."})
+    elif image_b64:
+        content.append({"type": "text", "text": "The user is showing you their camera. Describe what you see."})
+    else:
+        return {"error": "no_input"}
+
+    # LLM inference on the GPU executor thread
+    loop = asyncio.get_running_loop()
+    t0 = time.time()
+    inference.tool_result.clear()
+
+    def _infer():
+        # Fresh conversation per turn — avoids context overflow from multimodal tokens
+        conv = inference.engine.create_conversation(
+            messages=[{"role": "system", "content": inference.SYSTEM_PROMPT}],
+            tools=[inference.respond_to_user],
+        )
+        conv.__enter__()
+        try:
+            return conv.send_message({"role": "user", "content": content})
+        finally:
+            conv.__exit__(None, None, None)
+
+    response = await loop.run_in_executor(_executor, _infer)
+    llm_time = time.time() - t0
+
+    if inference.tool_result:
+        transcription = _clean_model_tokens(inference.tool_result.get("transcription", ""))
+        text_response = _clean_model_tokens(inference.tool_result.get("response", ""))
+    else:
+        transcription = None
+        text_response = response["content"][0]["text"]
+
+    logger.info("LLM complete", {"llm_time": round(llm_time, 2), "text": text_response[:80]})
+
+    if interrupted.is_set():
+        return {"interrupted": True}
+
+    # Send transcript to browser
+    await iii.trigger_async({
+        "function_id": "ui::aura::transcript",
+        "payload": {
+            "text": text_response,
+            "transcription": transcription,
+            "llm_time": round(llm_time, 2),
+        },
+        "action": TriggerAction.Void(),
+    })
+
+    if interrupted.is_set():
+        return {"interrupted": True}
+
+    # Stream TTS audio back via channel
+    sentences = _split_sentences(text_response) or [text_response]
+    playback_channel = await iii.create_channel_async()
+
+    if hasattr(playback_channel, 'writer'):
+        _patch_localhost(playback_channel.writer)
+
+    await iii.trigger_async({
+        "function_id": "ui::aura::playback",
+        "payload": {
+            "reader": playback_channel.reader_ref.model_dump(),
+            "sample_rate": _tts.sample_rate,
+            "sentence_count": len(sentences),
+        },
+        "action": TriggerAction.Void(),
+    })
+
+    tts_start = time.time()
+    for i, sentence in enumerate(sentences):
+        if interrupted.is_set():
+            logger.info(f"Interrupted during TTS (sentence {i + 1}/{len(sentences)})")
+            break
+
+        pcm = await loop.run_in_executor(_executor, lambda s=sentence: _tts.generate(s))
+        if interrupted.is_set():
+            break
+
+        pcm_int16 = (pcm * 32767).clip(-32768, 32767).astype(np.int16)
+        await playback_channel.writer.write(pcm_int16.tobytes())
+        await playback_channel.writer.send_message_async(json.dumps({
+            "type": "audio_chunk", "index": i,
+        }))
+
+    tts_time = time.time() - tts_start
+    logger.info("TTS complete", {"tts_time": round(tts_time, 2), "sentences": len(sentences)})
+
+    await playback_channel.writer.send_message_async(json.dumps({
+        "type": "audio_end", "tts_time": round(tts_time, 2),
+    }))
+    await playback_channel.writer.close_async()
+
+    return {"llm_time": round(llm_time, 2), "tts_time": round(tts_time, 2)}
+
+
+async def _interrupt(data: dict[str, Any]) -> None:
+    session_id = data.get("session_id", "")
+    ev = _interrupts.get(session_id)
+    if ev:
+        ev.set()
+        logger.info("Interrupt signalled", {"session_id": session_id})
+
+
+async def _session_close(data: dict[str, Any]) -> dict[str, Any]:
+    session_id = data.get("session_id", "")
+    ev = _interrupts.pop(session_id, None)
+    if ev:
+        ev.set()
+    logger.info("Session closed", {"session_id": session_id})
+    return {"closed": True}
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    global iii, _tts, _executor
+
+    # Load LLM + TTS models
+    print("[aura] Loading models...")
+    inference.load()
+    _tts = tts_module.load()
+    print("[aura] Models loaded.")
+
+    # Single-worker executor for GPU calls — resets the global _shutdown flag
+    # that litert_lm's C++ init sets on concurrent.futures
+    _cft._shutdown = False
+    _executor = _SafeExecutor(max_workers=1)
+
+    engine_ws_url = os.environ.get("III_URL", "ws://127.0.0.1:49134")
+    print(f"[aura] Connecting to {engine_ws_url}")
+    iii = register_worker(
+        address=engine_ws_url,
+        options=InitOptions(
+            worker_name="iii-aura",
+            otel={"enabled": True, "service_name": "iii-aura"},
+        ),
+    )
+    print("[aura] Connected to engine!")
+
+    iii.register_function("aura::session::open", _session_open, description="Open an Aura session")
+    iii.register_function("aura::ingest::turn", _ingest_turn, description="Ingest a voice+vision turn")
+    iii.register_function("aura::interrupt", _interrupt, description="Interrupt in-flight generation")
+    iii.register_function("aura::session::close", _session_close, description="Close a session and free resources")
+
+    iii.register_trigger({
+        "type": "http",
+        "function_id": "aura::session::open",
+        "config": {"api_path": "/aura/session", "http_method": "POST"},
+    })
+
+    iii.on_functions_available(
+        lambda fns: logger.info(f"Aura worker ready — {len(fns)} functions available")
+    )
+
+    logger.info("iii-aura worker started")
+
+
+if __name__ == "__main__":
+    main()

--- a/iii-aura/python-worker/src/iii_aura/worker.py
+++ b/iii-aura/python-worker/src/iii_aura/worker.py
@@ -15,6 +15,8 @@ import concurrent.futures.thread as _cft
 import json
 import os
 import re
+import signal
+import threading
 import time
 import uuid
 from typing import Any
@@ -157,7 +159,21 @@ async def _ingest_turn(data: dict[str, Any]) -> dict[str, Any]:
         text_response = _clean_model_tokens(inference.tool_result.get("response", ""))
     else:
         transcription = None
-        text_response = response["content"][0]["text"]
+        # Defensive read — if the tool call didn't fire and the response
+        # shape is unexpected, fall back to an empty string so the turn
+        # completes instead of raising and aborting the whole session.
+        text_response = ""
+        try:
+            content_items = response.get("content") if isinstance(response, dict) else None
+            if isinstance(content_items, list) and content_items:
+                first = content_items[0]
+                if isinstance(first, dict) and isinstance(first.get("text"), str):
+                    text_response = first["text"]
+        except (KeyError, IndexError, TypeError) as exc:
+            logger.warn(
+                "unexpected LLM response shape, returning empty text",
+                {"error": str(exc)},
+            )
 
     logger.info("LLM complete", {"llm_time": round(llm_time, 2), "text": text_response[:80]})
 
@@ -284,6 +300,19 @@ def main():
     )
 
     logger.info("iii-aura worker started")
+
+    # Block main thread until a signal arrives — without this the process
+    # would exit right after registration and the async handlers above
+    # would never get to run.
+    stop = threading.Event()
+    signal.signal(signal.SIGTERM, lambda *_: stop.set())
+    signal.signal(signal.SIGINT, lambda *_: stop.set())
+    stop.wait()
+    logger.info("iii-aura shutting down")
+    try:
+        iii.shutdown()
+    except Exception:
+        pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds **iii-aura**, a real-time on-device multimodal AI assistant (voice + vision) wired entirely through iii primitives
- Python worker runs Gemma 4 E2B for speech/vision understanding and Kokoro TTS for voice output, orchestrated through channels, state, and triggers
- Browser connects as a full iii worker via `iii-browser-sdk` — registers functions, creates channels, handles playback

## What's included

| Component | Description |
|-----------|-------------|
| `python-worker/` | Gemma 4 E2B inference + Kokoro TTS, registers `aura::session::open`, `aura::ingest::turn`, `aura::interrupt` |
| `browser/` | Vite app with VAD, camera capture, audio playback — registers `ui::aura::transcript`, `ui::aura::playback` |
| `iii-config.example.yaml` | Engine config with dual worker-managers (internal + RBAC), state, HTTP, observability |
| `README.md` | Architecture diagram, quick start, env vars, extending guide |

## iii primitives used

- **iii-browser-sdk** — browser acts as a full worker
- **Channels** — binary audio streaming (browser ↔ worker)
- **State** — session metadata persistence
- **Triggers** (`Void`) — fire-and-forget push from worker → browser
- **iii-worker-manager** (2 ports) — internal for Python, RBAC-filtered for browser

## Test plan

- [ ] `uv sync && uv run iii-aura` starts and connects to the engine
- [ ] Browser at `localhost:5180` connects, opens session, captures voice + camera
- [ ] LLM inference returns transcription + response via `ui::aura::transcript`
- [ ] TTS audio streams back via channel and plays in browser
- [ ] Barge-in (speaking during playback) interrupts and restarts listening

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced iii-aura: on-device multimodal voice+vision app with browser UI, camera + waveform visualization, VAD-based capture, barge-in support, real-time transcription, AI responses, and sentence-by-sentence streamed TTS playback.

* **Documentation**
  * Added a comprehensive README with architecture, quick-start commands, env config, session/queue guidance, and extension tips.

* **Chores**
  * Added packaging, example runtime config, browser build tooling, Python worker packaging, and a .gitignore to exclude local/generated artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->