### PR TITLE
ci: add release workflows for iii-lsp and vscode extension

### DIFF
--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -63,16 +63,7 @@ jobs:
       run:
         working-directory: iii-lsp-vscode
     steps:
-      - name: Generate token
-        id: generate_token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
-        with:
-          token: ${{ steps.generate_token.outputs.token }}
 
       - uses: actions/setup-node@v4
         with:
@@ -100,7 +91,6 @@ jobs:
         if: needs.setup.outputs.dry_run != 'true'
         uses: softprops/action-gh-release@v2
         with:
-          token: ${{ steps.generate_token.outputs.token }}
           tag_name: ${{ needs.setup.outputs.tag }}
           name: iii-lsp-vscode ${{ needs.setup.outputs.version }}
           draft: false


### PR DESCRIPTION
## Summary
- Add release workflows for `iii-lsp` binary and `iii-lsp-vscode` extension (Marketplace + OpenVSX)
- Add `iii-lsp` and `iii-lsp-vscode` to the create-tag workflow
- Add CI lint job for `iii-lsp-vscode` (vsce package dry run)
- Add `iii-lsp` to the worker registry
- Use existing `GH_APP_ID` / `GH_APP_PRIVATE_KEY` secrets instead of creating new ones
- Use `GITHUB_TOKEN` for vscode release workflow (no GitHub App needed)

## Test plan
- [x] CI passes on this branch (vsce package dry run)
- [ ] Trigger `iii-lsp-vscode` release with a dry-run tag
- [ ] Trigger `iii-lsp` release with a dry-run tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the release workflow by simplifying authentication configuration for CI/CD processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->