### PR TITLE
ci: replace GitHub App token with GITHUB_TOKEN in release workflows

### DIFF
--- a/.github/workflows/_rust-binary.yml
+++ b/.github/workflows/_rust-binary.yml
@@ -30,11 +30,6 @@ on:
         required: false
         type: boolean
         default: false
-    secrets:
-      GH_APP_ID:
-        required: true
-      GH_APP_PRIVATE_KEY:
-        required: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -48,24 +43,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Generate token
-        if: inputs.skip_create_release != true && inputs.dry_run != true
-        id: generate_token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
         if: inputs.skip_create_release != true && inputs.dry_run != true
-        with:
-          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Create GitHub Release
         if: inputs.skip_create_release != true && inputs.dry_run != true
         uses: softprops/action-gh-release@v2
         with:
-          token: ${{ steps.generate_token.outputs.token }}
           tag_name: ${{ inputs.tag_name }}
           name: ${{ inputs.bin_name }} ${{ inputs.tag_name }}
           draft: false
@@ -102,16 +86,7 @@ jobs:
             os: ubuntu-22.04
 
     steps:
-      - name: Generate token
-        id: generate_token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
-        with:
-          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Rewrite SSH to HTTPS for public deps
         run: git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
@@ -154,5 +129,5 @@ jobs:
           zip: windows
           checksum: sha256
           manifest-path: ${{ inputs.manifest_path }}
-          token: ${{ steps.generate_token.outputs.token }}
+          token: ${{ github.token }}
           dry-run: ${{ inputs.dry_run }}

--- a/.github/workflows/release-lsp-binary.yml
+++ b/.github/workflows/release-lsp-binary.yml
@@ -71,21 +71,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Generate token
-        id: generate_token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
-        with:
-          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          token: ${{ steps.generate_token.outputs.token }}
           tag_name: ${{ needs.setup.outputs.tag }}
           name: iii-lsp ${{ needs.setup.outputs.version }}
           draft: false
@@ -108,6 +98,4 @@ jobs:
       is_prerelease: ${{ needs.setup.outputs.is_prerelease == 'true' }}
       skip_create_release: true
       dry_run: ${{ needs.setup.outputs.dry_run == 'true' }}
-    secrets:
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,21 +71,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Generate token
-        id: generate_token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
-        with:
-          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          token: ${{ steps.generate_token.outputs.token }}
           tag_name: ${{ needs.setup.outputs.tag }}
           name: image-resize ${{ needs.setup.outputs.version }}
           draft: false
@@ -108,6 +98,4 @@ jobs:
       is_prerelease: ${{ needs.setup.outputs.is_prerelease == 'true' }}
       skip_create_release: true
       dry_run: ${{ needs.setup.outputs.dry_run == 'true' }}
-    secrets:
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Remove GitHub App token (`GH_APP_ID`/`GH_APP_PRIVATE_KEY`) from `_rust-binary.yml` and `release.yml`, using `GITHUB_TOKEN` instead
- Aligns with the change already done for the VSCode extension release in cc579c8
- Fixes the `release-lsp-binary` workflow failure caused by missing `GH_APP_ID` secret

## Test plan
- [ ] Run `release-lsp-binary` workflow via `workflow_dispatch` with a dry-run tag (e.g., `iii-lsp/v0.1.0-dry-run.1`)
- [ ] Verify `image-resize` release still works after token removal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined CI/CD authentication in release workflows by removing custom GitHub App token generation and transitioning to standard GitHub token authentication. Simplified secret handling across release pipelines to improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->