### PR TITLE
ci: trim whitespace from tag input in release workflows

### DIFF
--- a/.github/workflows/release-lsp-binary.yml
+++ b/.github/workflows/release-lsp-binary.yml
@@ -34,8 +34,10 @@ jobs:
     steps:
       - name: Resolve tag
         id: resolve
+        env:
+          RAW_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
+          TAG=$(echo "$RAW_TAG" | xargs)
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Extract metadata from tag

--- a/.github/workflows/release-lsp.yml
+++ b/.github/workflows/release-lsp.yml
@@ -30,8 +30,10 @@ jobs:
     steps:
       - name: Resolve tag
         id: resolve
+        env:
+          RAW_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
+          TAG=$(echo "$RAW_TAG" | xargs)
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Extract metadata from tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,10 @@ jobs:
     steps:
       - name: Resolve tag
         id: resolve
+        env:
+          RAW_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
+          TAG=$(echo "$RAW_TAG" | xargs)
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Extract metadata from tag


### PR DESCRIPTION
## Summary
- The `iii-lsp/v1.0.0` release binary upload [failed](https://github.com/iii-hq/workers/actions/runs/24205983744) because the `workflow_dispatch` tag input had a leading space (` iii-lsp/v1.0.0`)
- `softprops/action-gh-release` trimmed the space when creating the release, but `taiki-e/upload-rust-binary-action` used the raw value — so `gh release upload " iii-lsp/v1.0.0"` couldn't find the release tagged `iii-lsp/v1.0.0`
- Fix: pipe the tag input through `xargs` to trim whitespace, and use `env:` instead of inline `${{ }}` to avoid shell injection

## Test plan
- [ ] Re-run the `iii-lsp/v1.0.0` release via `workflow_dispatch` after merging
- [ ] Verify binary assets appear on the release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved tag resolution in release workflows with whitespace normalization to ensure consistent and reliable handling across all release pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->