### PR TITLE
fix: lowercase iii in lsp extension copy

### DIFF
--- a/iii-lsp-vscode/README.md
+++ b/iii-lsp-vscode/README.md
@@ -1,8 +1,8 @@
-# III Language Server - VS Code Extension
+# iii Language Server - VS Code Extension
 
-Autocompletion, hover documentation, and diagnostics for [III engine](https://github.com/iii-hq/iii) functions and triggers.
+Autocompletion, hover documentation, and diagnostics for [iii engine](https://github.com/iii-hq/iii) functions and triggers.
 
-![III LSP demo](https://raw.githubusercontent.com/iii-hq/workers/main/iii-lsp-vscode/lsp.gif)
+![iii LSP demo](https://raw.githubusercontent.com/iii-hq/workers/main/iii-lsp-vscode/lsp.gif)
 
 ## Supported Languages
 
@@ -18,7 +18,7 @@ Autocompletion, hover documentation, and diagnostics for [III engine](https://gi
 
    To use a custom binary instead, set `iii-lsp.serverPath` to an existing executable path before activation.
 
-2. **III engine** running locally (default: `ws://127.0.0.1:49134`)
+2. **iii engine** running locally (default: `ws://127.0.0.1:49134`)
 
 ## Installation
 
@@ -86,9 +86,9 @@ After activation, `iii-lsp.serverPath` should point to the downloaded binary in 
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `iii-lsp.serverPath` | `""` (auto-filled after first activation) | Path to the installed or custom `iii-lsp` binary |
-| `iii-lsp.engineUrl` | `ws://127.0.0.1:49134` | WebSocket URL of the III engine |
+| `iii-lsp.engineUrl` | `ws://127.0.0.1:49134` | WebSocket URL of the iii engine |
 
-Configure via **Settings** > search "III LSP", or in `settings.json`:
+Configure via **Settings** > search "iii LSP", or in `settings.json`:
 
 ```json
 {

--- a/iii-lsp-vscode/extension.js
+++ b/iii-lsp-vscode/extension.js
@@ -44,7 +44,7 @@ async function activate(context) {
 
   client = new LanguageClient(
     "iii-lsp",
-    "III Language Server",
+    "iii Language Server",
     serverOptions,
     clientOptions
   );

--- a/iii-lsp-vscode/package.json
+++ b/iii-lsp-vscode/package.json
@@ -14,6 +14,9 @@
     "onLanguage:rust"
   ],
   "main": "./extension.js",
+  "categories": [
+    "Programming Languages"
+  ],
   "contributes": {
     "configuration": {
       "title": "iii LSP",
@@ -35,7 +38,18 @@
     "test": "node --test",
     "package:check": "vsce package --out tmp.vsix && rm -f tmp.vsix"
   },
-  "keywords": [],
+  "keywords": [
+    "iii",
+    "III",
+    "iii-lsp",
+    "III-lsp",
+    "iii language server",
+    "language server",
+    "lsp",
+    "autocomplete",
+    "hover",
+    "diagnostics"
+  ],
   "author": "",
   "repository": {
     "type": "git",

--- a/iii-lsp-vscode/package.json
+++ b/iii-lsp-vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iii-lsp",
-  "displayName": "III Language Server",
-  "description": "Autocompletion and hover for III engine functions and triggers",
+  "displayName": "iii Language Server",
+  "description": "Autocompletion and hover for iii engine functions and triggers",
   "version": "0.1.0",
   "publisher": "iii-hq",
   "engines": {
@@ -16,7 +16,7 @@
   "main": "./extension.js",
   "contributes": {
     "configuration": {
-      "title": "III LSP",
+      "title": "iii LSP",
       "properties": {
         "iii-lsp.serverPath": {
           "type": "string",
@@ -26,7 +26,7 @@
         "iii-lsp.engineUrl": {
           "type": "string",
           "default": "ws://127.0.0.1:49134",
-          "description": "WebSocket URL of the III engine."
+          "description": "WebSocket URL of the iii engine."
         }
       }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated product branding to lowercase "iii" across the extension display name, settings configuration, and documentation for consistent brand identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->