### PR TITLE
chore: update development scripts for todo-worker and todo-worker-python

### DIFF
--- a/todo-worker-python/iii.worker.yaml
+++ b/todo-worker-python/iii.worker.yaml
@@ -15,4 +15,4 @@ resources:
 
 scripts:
   install: "pip install ."
-  start: "python -m src.main"
+  start: "watchfiles 'python -m src.main'"

--- a/todo-worker-python/pyproject.toml
+++ b/todo-worker-python/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "iii-sdk",
     "opentelemetry-api",
     "opentelemetry-sdk",
+    "watchfiles",
 ]
 
 [project.scripts]

--- a/todo-worker/package.json
+++ b/todo-worker/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "node --import tsx src/index.ts",
+    "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js"
   },


### PR DESCRIPTION
## Summary

Improves the local development experience for the sample **todo-worker** (Node) and **todo-worker-python** examples by reloading the process when source files change.

- **todo-worker**: `dev` script now uses `tsx watch` instead of a one-shot `node --import tsx` run.
- **todo-worker-python**: adds the `watchfiles` dependency and runs the worker under `watchfiles 'python -m src.main'` in `iii.worker.yaml` so edits trigger a restart.

## Type of change

- [ ] Bug fix
- [x] New feature (developer experience)
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Changes are limited to example worker dev workflows
- [x] Python sample declares the new runtime dependency in `pyproject.toml`

## Additional context

The **workers** repository uses `main` as the default branch (there is no `develop` branch here), so this PR targets `main`.

Uncommitted local edits (for example under `image-resize/` or `todo-worker/package-lock.json`) were not included; the PR reflects commit `21b8a38` only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented auto-reload functionality for local development environments. The Python worker and TypeScript worker now monitor file changes and automatically restart during development, improving the development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->