### PR TITLE
docs+ci: LICENSE (Apache 2.0), refreshed README, binary releases for all Rust workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,30 +16,86 @@ jobs:
     name: Detect changes
     runs-on: ubuntu-latest
     outputs:
+      a2a: ${{ steps.filter.outputs.a2a }}
+      agent: ${{ steps.filter.outputs.agent }}
+      coding: ${{ steps.filter.outputs.coding }}
+      eval: ${{ steps.filter.outputs.eval }}
+      experiment: ${{ steps.filter.outputs.experiment }}
+      guardrails: ${{ steps.filter.outputs.guardrails }}
       image-resize: ${{ steps.filter.outputs.image-resize }}
       iii-lsp: ${{ steps.filter.outputs.iii-lsp }}
       iii-lsp-vscode: ${{ steps.filter.outputs.iii-lsp-vscode }}
+      introspect: ${{ steps.filter.outputs.introspect }}
+      llm-router: ${{ steps.filter.outputs.llm-router }}
+      mcp: ${{ steps.filter.outputs.mcp }}
+      shell: ${{ steps.filter.outputs.shell }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
+            a2a:
+              - 'a2a/**'
+            agent:
+              - 'agent/**'
+            coding:
+              - 'coding/**'
+            eval:
+              - 'eval/**'
+            experiment:
+              - 'experiment/**'
+            guardrails:
+              - 'guardrails/**'
             image-resize:
               - 'image-resize/**'
             iii-lsp:
               - 'iii-lsp/**'
             iii-lsp-vscode:
               - 'iii-lsp-vscode/**'
+            introspect:
+              - 'introspect/**'
+            llm-router:
+              - 'llm-router/**'
+            mcp:
+              - 'mcp/**'
+            shell:
+              - 'shell/**'
 
-  image-resize:
-    name: "image-resize: Test, Format, Lint"
+  rust-worker:
+    name: "${{ matrix.worker }}: Test, Format, Lint"
     needs: changes
-    if: needs.changes.outputs.image-resize == 'true'
+    if: |
+      (matrix.worker == 'a2a' && needs.changes.outputs.a2a == 'true') ||
+      (matrix.worker == 'agent' && needs.changes.outputs.agent == 'true') ||
+      (matrix.worker == 'coding' && needs.changes.outputs.coding == 'true') ||
+      (matrix.worker == 'eval' && needs.changes.outputs.eval == 'true') ||
+      (matrix.worker == 'experiment' && needs.changes.outputs.experiment == 'true') ||
+      (matrix.worker == 'guardrails' && needs.changes.outputs.guardrails == 'true') ||
+      (matrix.worker == 'image-resize' && needs.changes.outputs.image-resize == 'true') ||
+      (matrix.worker == 'introspect' && needs.changes.outputs.introspect == 'true') ||
+      (matrix.worker == 'llm-router' && needs.changes.outputs.llm-router == 'true') ||
+      (matrix.worker == 'mcp' && needs.changes.outputs.mcp == 'true') ||
+      (matrix.worker == 'shell' && needs.changes.outputs.shell == 'true')
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        worker:
+          - a2a
+          - agent
+          - coding
+          - eval
+          - experiment
+          - guardrails
+          - image-resize
+          - introspect
+          - llm-router
+          - mcp
+          - shell
     defaults:
       run:
-        working-directory: image-resize
+        working-directory: ${{ matrix.worker }}
     steps:
       - uses: actions/checkout@v4
 
@@ -49,7 +105,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: image-resize -> target
+          workspaces: ${{ matrix.worker }} -> target
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -8,9 +8,19 @@ on:
         required: true
         type: choice
         options:
+          - a2a
+          - agent
+          - coding
+          - eval
+          - experiment
+          - guardrails
           - image-resize
           - iii-lsp
           - iii-lsp-vscode
+          - introspect
+          - llm-router
+          - mcp
+          - shell
       bump:
         description: 'Version bump type'
         required: true

--- a/.github/workflows/release-rust-worker.yml
+++ b/.github/workflows/release-rust-worker.yml
@@ -1,0 +1,132 @@
+name: Release Rust Worker
+
+on:
+  push:
+    tags:
+      - 'a2a/v*'
+      - 'agent/v*'
+      - 'coding/v*'
+      - 'eval/v*'
+      - 'experiment/v*'
+      - 'guardrails/v*'
+      - 'introspect/v*'
+      - 'llm-router/v*'
+      - 'mcp/v*'
+      - 'shell/v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g., shell/v0.1.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-rust-worker-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # ──────────────────────────────────────────────────────────────
+  # Setup: derive worker name, binary name, manifest path, version
+  # ──────────────────────────────────────────────────────────────
+
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      worker: ${{ steps.meta.outputs.worker }}
+      bin_name: ${{ steps.meta.outputs.bin_name }}
+      manifest_path: ${{ steps.meta.outputs.manifest_path }}
+      version: ${{ steps.meta.outputs.version }}
+      is_prerelease: ${{ steps.meta.outputs.is_prerelease }}
+      dry_run: ${{ steps.meta.outputs.dry_run }}
+    steps:
+      - name: Resolve tag
+        id: resolve
+        env:
+          RAW_TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          TAG=$(echo "$RAW_TAG" | xargs)
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Extract metadata from tag
+        id: meta
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          # Tag shape: <worker>/v<version>
+          WORKER="${TAG%%/*}"
+          REST="${TAG#*/}"
+          VERSION="${REST#v}"
+
+          case "$WORKER" in
+            a2a|agent|coding|eval|experiment|guardrails|introspect|llm-router|mcp|shell)
+              BIN="iii-${WORKER}"
+              ;;
+            *)
+              echo "::error::Unsupported worker in tag: $WORKER (tag=$TAG)"
+              exit 1
+              ;;
+          esac
+
+          if [[ "$VERSION" =~ -dry-run\.[0-9]+$ ]]; then
+            DRY=true; PRE=true
+          elif [[ "$VERSION" =~ -([a-z]+)\.[0-9]+$ ]]; then
+            DRY=false; PRE=true
+          else
+            DRY=false; PRE=false
+          fi
+
+          {
+            echo "worker=$WORKER"
+            echo "bin_name=$BIN"
+            echo "manifest_path=$WORKER/Cargo.toml"
+            echo "version=$VERSION"
+            echo "is_prerelease=$PRE"
+            echo "dry_run=$DRY"
+          } >> "$GITHUB_OUTPUT"
+          echo "::notice::$WORKER release -- tag=$TAG version=$VERSION bin=$BIN"
+
+  # ──────────────────────────────────────────────────────────────
+  # GitHub Release (skipped on dry runs)
+  # ──────────────────────────────────────────────────────────────
+
+  create-release:
+    name: Create GitHub Release
+    needs: [setup]
+    if: needs.setup.outputs.dry_run != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.setup.outputs.tag }}
+          name: ${{ needs.setup.outputs.bin_name }} ${{ needs.setup.outputs.version }}
+          draft: false
+          prerelease: ${{ needs.setup.outputs.is_prerelease == 'true' }}
+          generate_release_notes: true
+
+  # ──────────────────────────────────────────────────────────────
+  # Binary build + upload
+  # ──────────────────────────────────────────────────────────────
+
+  binary-build:
+    name: Binary Release
+    needs: [setup, create-release]
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/_rust-binary.yml
+    with:
+      bin_name: ${{ needs.setup.outputs.bin_name }}
+      manifest_path: ${{ needs.setup.outputs.manifest_path }}
+      tag_name: ${{ needs.setup.outputs.tag }}
+      is_prerelease: ${{ needs.setup.outputs.is_prerelease == 'true' }}
+      skip_create_release: true
+      dry_run: ${{ needs.setup.outputs.dry_run == 'true' }}
+    secrets: inherit

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,122 +1,92 @@
-# Motia Workers
+# iii workers
 
-Worker modules for the [III engine](https://github.com/iii-hq/iii).
+Workers for the [iii engine](https://github.com/iii-hq/iii). Each directory is a
+self-contained worker module: a process that connects to the engine over
+WebSocket, registers functions + triggers, and does something useful.
+
+Workers are discoverable through the [registry](registry/index.json) and — for
+binary-shipped workers — installed via `iii worker add <name>`, which pulls the
+matching GitHub Release asset for the host's target triple.
 
 ## Modules
 
-### todo-worker-python
-
-A Python-based todo CRUD worker that connects to the III engine via WebSocket and exposes a REST API for managing todos.
-
-**Routes:**
-
-| Method | Path | Description |
+| Worker | Kind | Summary |
 |---|---|---|
-| `POST` | `/todos` | Create a new todo |
-| `GET` | `/todos` | List all todos |
-| `GET` | `/todos/:id` | Get a todo by ID |
-| `PUT` | `/todos/:id` | Update a todo |
-| `DELETE` | `/todos/:id` | Delete a todo |
+| [`a2a`](a2a/) | Rust | A2A (Agent-to-Agent) JSON-RPC protocol worker. Publishes an agent card, routes `message/send` to exposed functions gated by `a2a.expose` metadata. |
+| [`agent`](agent/) | Rust | Chat + planning agent that discovers other workers' functions at runtime and drives them via `iii.trigger()`. |
+| [`coding`](coding/) | Rust | Code-generation / refactor assistant. |
+| [`eval`](eval/) | Rust | OTel span ingestion, latency percentiles, baseline + drift detection, system health score. |
+| [`experiment`](experiment/) | Rust | A/B experiment tracking with weighted variant sampling and outcome aggregation. |
+| [`guardrails`](guardrails/) | Rust | Input/output guardrails — PII detection, prompt-injection filters, length enforcement. |
+| [`iii-lsp`](iii-lsp/) | Rust | Language Server for iii function ids, trigger configs, and worker discovery. Autocomplete/hover across JS/TS, Python, Rust. |
+| [`iii-lsp-vscode`](iii-lsp-vscode/) | Node | VS Code extension that embeds `iii-lsp`. |
+| [`image-resize`](image-resize/) | Rust | Image resize via channel I/O. JPEG/PNG/WebP with EXIF auto-orient, scale-to-fit / crop-to-fit. |
+| [`introspect`](introspect/) | Rust | Live topology, trace walks, Mermaid diagrams, and per-function explain output. |
+| [`llm-router`](llm-router/) | Rust | Unopinionated LLM routing brain — policies, classifiers, A/B tests, health + budget aware. Sits in front of any gateway. |
+| [`mcp`](mcp/) | Rust | Model Context Protocol surface — stdio + HTTP JSON-RPC, exposes iii functions tagged `mcp.expose` as MCP tools. |
+| [`proof`](proof/) | Node | AI-driven browser testing — diffs changes, generates test plans, drives Playwright. |
+| [`shell`](shell/) | Rust | Sandboxed-ish Unix shell execution. Allowlist + denylist, timeout + output caps, background jobs. |
+| [`todo-worker`](todo-worker/) | Node | Quickstart CRUD todo worker using the Node iii SDK. |
+| [`todo-worker-python`](todo-worker-python/) | Python | Quickstart CRUD todo worker using the Python iii SDK. |
 
-**Features:**
-- In-memory todo storage
-- Full CRUD operations with validation
-- OpenTelemetry observability support
+## SDK
 
-#### Prerequisites
+All workers target [`iii-sdk`](https://crates.io/crates/iii-sdk) v0.11.3
+(Rust), `iii-sdk@0.11.3` on npm, or `iii-sdk==0.11.3` on PyPI.
 
-- Python 3.10+
-- A running III engine instance
+## Build
 
-#### Install
-
-```bash
-cd todo-worker-python
-pip install .
-```
-
-#### Usage
-
-```bash
-# Run with defaults (connects to ws://localhost:49134)
-todo-worker
-
-# Custom engine URL
-III_URL=ws://host:port todo-worker
-```
-
-#### Docker
+Rust workers:
 
 ```bash
-cd todo-worker-python
-docker build -t todo-worker-python .
-docker run --rm -e III_URL=ws://host:port todo-worker-python
-```
-
----
-
-### image-resize
-
-A Rust-based image resize worker that connects to the III engine via WebSocket and processes images through stream channels.
-
-**Supported formats:** JPEG, PNG, WebP (including cross-format conversion)
-
-**Resize strategies:**
-
-| Strategy | Behavior |
-|---|---|
-| `scale-to-fit` | Scales the image to fit within the target dimensions, preserving aspect ratio (default) |
-| `crop-to-fit` | Scales and center-crops to fill the exact target dimensions |
-
-**Features:**
-- EXIF orientation auto-correction
-- Configurable quality per format (JPEG, WebP)
-- Per-request parameter overrides (dimensions, quality, strategy, output format)
-- Module manifest output (`--manifest`)
-
-#### Prerequisites
-
-- Rust 1.70+
-- A running III engine instance
-
-#### Build
-
-```bash
-cd image-resize
+cd <worker>
 cargo build --release
 ```
 
-#### Usage
+Node/Python workers follow the standard `npm install` / `pip install -e .`
+flow — see each module's README for specifics.
 
-```bash
-# Run with defaults (connects to ws://127.0.0.1:49134)
-./target/release/image-resize
+## Binary releases
 
-# Custom config and engine URL
-./target/release/image-resize --config ./config.yaml --url ws://host:port
+Rust workers that ship as standalone binaries (`a2a`, `agent`, `coding`,
+`eval`, `experiment`, `guardrails`, `iii-lsp`, `image-resize`, `introspect`,
+`llm-router`, `mcp`, `shell`) are released via GitHub Actions:
 
-# Print module manifest
-./target/release/image-resize --manifest
+1. Trigger the **Create Tag** workflow (Actions tab) — pick a worker, bump
+   type (`patch`/`minor`/`major`), and optional prerelease label.
+2. A tag of the form `<worker>/v<X.Y.Z>` is pushed to `main`.
+3. The matching **Release** workflow fires on the tag, builds cross-compiled
+   binaries for 9 targets (Linux gnu/musl, macOS x86_64 + aarch64, Windows
+   x86_64/i686/aarch64, armv7), and uploads them to a GitHub Release with
+   SHA-256 checksums.
+
+Targets per build:
+
+```text
+aarch64-apple-darwin
+x86_64-apple-darwin
+x86_64-pc-windows-msvc
+i686-pc-windows-msvc
+aarch64-pc-windows-msvc
+x86_64-unknown-linux-gnu
+x86_64-unknown-linux-musl
+aarch64-unknown-linux-gnu
+armv7-unknown-linux-gnueabihf
 ```
 
-#### Configuration
+## Registry
 
-Create a `config.yaml` file:
+[`registry/index.json`](registry/index.json) is the discovery manifest. Each
+entry declares the worker kind (`binary` / container image), the release tag
+prefix, supported targets, and a default config. `iii worker add <name>`
+reads this file to locate the right asset for the host.
 
-```yaml
-width: 200        # default target width
-height: 200       # default target height
-strategy: scale-to-fit  # or crop-to-fit
-quality:
-  jpeg: 85
-  webp: 80
-```
+## CI
 
-All fields are optional and fall back to the defaults shown above.
+Pull requests trigger per-worker `cargo fmt --check`, `cargo clippy
+--all-targets --all-features -- -D warnings`, and `cargo test --all-features`
+for Rust modules that changed (see [`.github/workflows/ci.yml`](.github/workflows/ci.yml)).
 
-#### Tests
+## License
 
-```bash
-cd image-resize
-cargo test
-```
+Apache 2.0 — see [`LICENSE`](LICENSE).

--- a/registry/index.json
+++ b/registry/index.json
@@ -1,6 +1,79 @@
 {
     "version": 1,
     "workers": {
+        "a2a": {
+            "type": "binary",
+            "description": "A2A (Agent-to-Agent) JSON-RPC protocol worker",
+            "repo": "iii-hq/workers",
+            "tag_prefix": "a2a",
+            "supported_targets": ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"],
+            "has_checksum": true,
+            "default_config": {
+                "expose_all": false,
+                "base_url": "http://localhost:3111"
+            },
+            "version": "0.3.0"
+        },
+        "agent": {
+            "type": "binary",
+            "description": "Chat + planning agent that discovers and drives other iii workers",
+            "repo": "iii-hq/workers",
+            "tag_prefix": "agent",
+            "supported_targets": ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"],
+            "has_checksum": true,
+            "default_config": {
+                "anthropic_model": "claude-haiku-4-5-20251001",
+                "max_tokens": 4096,
+                "max_iterations": 10,
+                "session_ttl_hours": 24
+            },
+            "version": "0.1.0"
+        },
+        "coding": {
+            "type": "binary",
+            "description": "Code-generation / refactor assistant",
+            "repo": "iii-hq/workers",
+            "tag_prefix": "coding",
+            "supported_targets": ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"],
+            "has_checksum": true,
+            "default_config": {},
+            "version": "0.1.0"
+        },
+        "eval": {
+            "type": "binary",
+            "description": "OTel span ingestion, percentiles, baseline + drift detection, health score",
+            "repo": "iii-hq/workers",
+            "tag_prefix": "eval",
+            "supported_targets": ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"],
+            "has_checksum": true,
+            "default_config": {
+                "retention_hours": 24,
+                "drift_threshold": 0.15,
+                "cron_drift_check": "0 */10 * * * *",
+                "max_spans_per_function": 1000
+            },
+            "version": "0.1.0"
+        },
+        "experiment": {
+            "type": "binary",
+            "description": "A/B experiment tracking with weighted variants and outcome aggregation",
+            "repo": "iii-hq/workers",
+            "tag_prefix": "experiment",
+            "supported_targets": ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"],
+            "has_checksum": true,
+            "default_config": {},
+            "version": "0.1.0"
+        },
+        "guardrails": {
+            "type": "binary",
+            "description": "PII, prompt-injection, and length guardrails for input/output",
+            "repo": "iii-hq/workers",
+            "tag_prefix": "guardrails",
+            "supported_targets": ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"],
+            "has_checksum": true,
+            "default_config": {},
+            "version": "0.1.0"
+        },
         "image-resize": {
             "type": "binary",
             "description": "III engine image resize worker",
@@ -24,12 +97,65 @@
         },
         "iii-lsp": {
             "type": "binary",
-            "description": "III Language Server — autocompletion and hover for III engine functions and triggers",
+            "description": "III Language Server \u2014 autocompletion and hover for III engine functions and triggers",
             "repo": "iii-hq/workers",
             "tag_prefix": "iii-lsp",
             "supported_targets": ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"],
             "has_checksum": true,
             "default_config": {},
+            "version": "0.1.0"
+        },
+        "introspect": {
+            "type": "binary",
+            "description": "Live topology, trace walks, Mermaid diagrams, per-function explain",
+            "repo": "iii-hq/workers",
+            "tag_prefix": "introspect",
+            "supported_targets": ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"],
+            "has_checksum": true,
+            "default_config": {},
+            "version": "0.1.0"
+        },
+        "llm-router": {
+            "type": "binary",
+            "description": "Unopinionated LLM routing brain \u2014 policies, classifiers, A/B tests, health + budget aware",
+            "repo": "iii-hq/workers",
+            "tag_prefix": "llm-router",
+            "supported_targets": ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"],
+            "has_checksum": true,
+            "default_config": {
+                "state_scope": "llm-router",
+                "classifier_default_id": "default",
+                "stats_default_days": 7,
+                "health_skip_threshold_error_rate": 0.3
+            },
+            "version": "0.1.0"
+        },
+        "mcp": {
+            "type": "binary",
+            "description": "Model Context Protocol surface \u2014 stdio + HTTP JSON-RPC, exposes iii functions as MCP tools",
+            "repo": "iii-hq/workers",
+            "tag_prefix": "mcp",
+            "supported_targets": ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"],
+            "has_checksum": true,
+            "default_config": {
+                "expose_all": false
+            },
+            "version": "0.3.0"
+        },
+        "shell": {
+            "type": "binary",
+            "description": "Unix shell execution worker \u2014 allowlist + denylist, timeout + output caps, background jobs",
+            "repo": "iii-hq/workers",
+            "tag_prefix": "shell",
+            "supported_targets": ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"],
+            "has_checksum": true,
+            "default_config": {
+                "max_timeout_ms": 30000,
+                "default_timeout_ms": 10000,
+                "max_output_bytes": 1048576,
+                "max_concurrent_jobs": 16,
+                "job_retention_secs": 3600
+            },
             "version": "0.1.0"
         },
         "todo-worker": {


### PR DESCRIPTION
## Summary
- Adds **Apache 2.0 `LICENSE`** at the repo root — closes the licensing gap.
- Rewrites **`README.md`** as a full module table covering the 17 merged workers plus build/release/registry/CI guidance.
- **`release-rust-worker.yml`** — new generic release workflow for `a2a`, `agent`, `coding`, `eval`, `experiment`, `guardrails`, `introspect`, `llm-router`, `mcp`, `shell`. Tag `<worker>/v<X.Y.Z>` ships 9-target cross-compiled binaries with SHA-256 checksums through the existing `_rust-binary.yml`.
- **`create-tag.yml`** choice list expanded to every newly releasable worker.
- **`ci.yml`** runs `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` + `cargo test --all-features` per-worker via `paths-filter` + matrix.
- **`registry/index.json`** now carries binary entries for all 10 new Rust workers so `iii worker add <name>` can resolve release assets.

## Per-worker bin names
| Tag prefix | Binary name |
|---|---|
| a2a | iii-a2a |
| agent | iii-agent |
| coding | iii-coding |
| eval | iii-eval |
| experiment | iii-experiment |
| guardrails | iii-guardrails |
| introspect | iii-introspect |
| llm-router | iii-llm-router |
| mcp | iii-mcp |
| shell | iii-shell |

image-resize and iii-lsp keep their existing dedicated release files.

## Test plan
- [ ] CI green
- [ ] (post-merge) Trigger `Create Tag` against a single worker (dry-run) to verify the generic release path
- [ ] Verify `registry/index.json` is accepted by downstream `iii worker add`