### PR TITLE
fix(ci): use III_CI_APP_* secrets in create-tag workflow

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -60,8 +60,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.III_CI_APP_ID }}
+          private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- The `Create Tag` workflow's `Generate token` step failed with `[@octokit/auth-app] appId option is required` ([run](https://github.com/iii-hq/workers/actions/runs/24855686838/job/72767798327)).
- Root cause: the workflow referenced `secrets.GH_APP_ID` / `secrets.GH_APP_PRIVATE_KEY`, but this repo only has `III_CI_APP_ID` / `III_CI_APP_PRIVATE_KEY` (the naming already used in `iii-hq/iii`). The empty `app-id` input crashed `actions/create-github-app-token@v2` before any token was minted.
- Rename both references so the `iii-hq-ci` GitHub App token can be generated.

## Test plan
- [ ] Re-run the failed `Create Tag` workflow via `workflow_dispatch` and confirm the `Generate token` step succeeds.
- [ ] Verify the subsequent `Checkout`, `Commit and push`, and `Create and push annotated tag` steps complete using the app token.