### PR TITLE
fix(ci): accept map-form dependencies in iii.worker.yaml

### DIFF
--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -79,6 +79,25 @@ jobs:
           root = pathlib.Path(worker)
           meta = yaml.safe_load((root / "iii.worker.yaml").read_text()) or {}
 
+          # Normalize `dependencies` into the array-of-objects wire shape the
+          # registry's /publish endpoint expects. Authors may write either:
+          #   dependencies:
+          #     math-worker: "^0.1.0"       # map form (recommended)
+          # or:
+          #   dependencies:
+          #     - name: math-worker
+          #       version: "^0.1.0"         # explicit wire form
+          raw_deps = meta.get("dependencies") or []
+          if isinstance(raw_deps, dict):
+              deps = [{"name": k, "version": v} for k, v in raw_deps.items()]
+          elif isinstance(raw_deps, list):
+              deps = raw_deps
+          else:
+              print(
+                  f"::error::`dependencies` must be a map or list, got {type(raw_deps).__name__}"
+              )
+              sys.exit(1)
+
           readme_path = root / "README.md"
           readme = readme_path.read_text() if readme_path.exists() else ""
 
@@ -95,7 +114,7 @@ jobs:
               "readme": readme,
               "repo": repo_url,
               "description": meta.get("description", ""),
-              "dependencies": meta.get("dependencies", []),
+              "dependencies": deps,
               "config": config,
           }
 


### PR DESCRIPTION
## Summary

`_publish-registry.yml` previously forwarded `meta.get("dependencies", [])` verbatim, assuming the yaml was already in the array-of-objects shape the registry's `/publish` endpoint expects. The in-flight iii CLI (`iii-hq/iii`) plan parses `dependencies:` as a **map** in `iii.worker.yaml` — the natural, npm/cargo-style shape for authors:

```yaml
dependencies:
  math-worker: "^0.1.0"
  iii-http: "~1.0.0"
```

Without this patch, any worker written in the map form publishes a JSON object where the registry expects a JSON array and fails with 422. This blocks the end-to-end "author declares deps in yaml" feature.

## Change

Normalize before building the payload:

- **Map** → translated to `[{name, version}, ...]`.
- **List** → passed through (backward-compat with any existing fixture using the explicit shape).
- **Null / absent** → `[]`.
- **Anything else** (string, number, etc.) → fail the workflow step with a clear `::error::` pointing at the bad shape.

## Compatibility

No worker in this repo currently declares `dependencies` in its `iii.worker.yaml`, so this patch changes nothing for the 20 existing publish paths. It unblocks the new ones.

## Test Plan

- [x] Local dry-run of the Python transform against map, list, empty, null, and bogus-string inputs. Map and list both produce the expected array-of-objects shape; bogus input fails fast with a workflow error.
- [ ] Next publish of any worker in this repo goes through the updated payload builder. No existing workers declare deps, so behavior is unchanged.
- [ ] Once a worker here adds a map-form `dependencies:` block and publishes, the registry row should contain the translated array. Verify via `GET /w/<name>` or directly in `workerVersion.dependencies`.

## Paired with

- [`iii-hq/registry#8`](https://github.com/iii-hq/registry/pull/8) — registry-side Zod hardening that rejects invalid dep names/ranges at `/publish`. The two PRs are independent but both need to land for the yaml → registry feature to work end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the publishing workflow to properly normalize and validate dependency formats before registry submission. The system now consistently handles dependencies in both map and list formats, with enhanced error reporting for invalid specifications, ensuring more reliable deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->