### PR TITLE
Phase 1: delegate exposure to iii-sdk RBAC, remove handler-level gates (BREAKING)

### DIFF
--- a/a2a/Cargo.lock
+++ b/a2a/Cargo.lock
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "iii-a2a"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/a2a/Cargo.toml
+++ b/a2a/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iii-a2a"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2024"
 description = "A2A protocol worker for iii-engine"
 license = "Apache-2.0"

--- a/a2a/README.md
+++ b/a2a/README.md
@@ -13,17 +13,19 @@ Function exposure is governed by **iii-sdk RBAC** at `iii-worker-manager`. This 
 
 Configure in `config.yaml`:
 
-    workers:
-      - name: iii-worker-manager
-        config:
-          rbac:
-            auth_function_id: myproject::auth
-            expose_functions:
-              - match("api::*")
-              - match("*::public")
-              - metadata:
-                  public: true
-      - name: iii-mcp    # or iii-a2a
+```yaml
+workers:
+  - name: iii-worker-manager
+    config:
+      rbac:
+        auth_function_id: myproject::auth
+        expose_functions:
+          - match("api::*")
+          - match("*::public")
+          - metadata:
+              public: true
+  - name: iii-mcp    # or iii-a2a
+```
 
 See https://iii.dev/docs/how-to/worker-rbac.md for the RBAC surface.
 

--- a/a2a/README.md
+++ b/a2a/README.md
@@ -7,69 +7,45 @@ HTTP triggers on the engine:
 - `POST /a2a` — JSON-RPC dispatch (`message/send`, `tasks/get`,
   `tasks/cancel`, `tasks/list`, `message/stream`, `tasks/resubscribe`)
 
-## Exposure model
+## Access control
 
-Functions are **invisible to remote agents by default**. Authors opt in
-per-function. Mirrors the iii-mcp design — same metadata keys, same hard
-floor, same optional tier filter.
+Function exposure is governed by **iii-sdk RBAC** at `iii-worker-manager`. This worker is a protocol transport — the engine decides who can see and call what.
 
-### Opt-in metadata
+Configure in `config.yaml`:
 
-```rust
-// Rust worker
-iii.register_function_with(
-    RegisterFunctionMessage {
-        id: "pricing::quote".into(),
-        description: Some("Quote a price for SKU + quantity".into()),
-        metadata: Some(json!({
-            "a2a.expose": true,
-            "a2a.tier": "partner",  // optional — free-form string
-        })),
-        ..Default::default()
-    },
-    handler,
-);
-```
+    workers:
+      - name: iii-worker-manager
+        config:
+          rbac:
+            auth_function_id: myproject::auth
+            expose_functions:
+              - match("api::*")
+              - match("*::public")
+              - metadata:
+                  public: true
+      - name: iii-mcp    # or iii-a2a
 
-```ts
-// Node worker
-iii.registerFunction("pricing::quote", handler, {
-  metadata: { "a2a.expose": true, "a2a.tier": "partner" },
-})
-```
+See https://iii.dev/docs/how-to/worker-rbac.md for the RBAC surface.
 
-```python
-# Python worker
-iii.register_function(
-    "pricing::quote",
-    handler,
-    metadata={"a2a.expose": True, "a2a.tier": "partner"},
-)
-```
+### Breaking change (v0.4)
 
-### Hard floor (never exposed)
+- `--expose-all` and `--tier` removed. Port policy to `auth_function_id`.
+- `mcp.expose` / `a2a.expose` metadata flags no longer consulted.
+- See `examples/default-secure-auth.rs` for a drop-in replacement.
 
-Even with `--expose-all`, these namespaces never appear as agent-card
-skills and cannot be invoked via `message/send`:
+### Engine introspection
 
-| Prefix | Why |
-|---|---|
-| `engine::*` | iii engine internals |
-| `state::*` | KV plumbing |
-| `stream::*` | channel plumbing |
-| `iii.*` / `iii::*` | SDK callbacks and namespaced SDK APIs |
-| `mcp::*` | sibling protocol worker's entry point |
-| `a2a::*` | this worker's own JSON-RPC entry |
+For the use case the old `engine::*` hard floor hid, use the `introspect` worker (`iii worker add introspect`). It exposes `introspect::functions`, `introspect::topology`, `introspect::health`, etc. — agents call those through MCP/A2A without leaking raw engine internals.
 
 ### CLI flags
 
 ```text
 --engine-url <URL>   WebSocket URL of the iii engine (default ws://localhost:49134)
---expose-all         Ignore the a2a.expose gate (dev only). Hard floor still applies.
---tier <name>        Show only functions whose a2a.tier metadata equals <name>.
-                     E.g. `--tier partner` for B2B surfaces, `--tier public` for open.
 --base-url <URL>     Public origin advertised in the agent card. The card is served
                      at <base-url>/a2a. Default: http://localhost:3111
+--rbac-tag <TAG>     Forward an `x-iii-rbac-tag` header on the worker WebSocket
+                     upgrade. iii-worker-manager's `auth_function_id` reads
+                     this tag to apply policy.
 --debug              Verbose logging
 ```
 
@@ -96,7 +72,7 @@ workers:
 iii --no-update-check
 ```
 
-### 2. Register a test function tagged `a2a.expose: true`
+### 2. Register a test function
 
 ```rust
 use iii_sdk::{register_worker, InitOptions, RegisterFunctionMessage};
@@ -110,7 +86,6 @@ async fn main() -> anyhow::Result<()> {
         RegisterFunctionMessage {
             id: "pricing::quote".into(),
             description: Some("Quote a price".into()),
-            metadata: Some(json!({ "a2a.expose": true })),
             ..Default::default()
         },
         |_input: Value| async move { Ok(json!({"price": 42})) },
@@ -133,7 +108,7 @@ Registers `GET /.well-known/agent-card.json` and `POST /a2a`.
 ### 4. Smoke path
 
 ```bash
-# Agent card — exposed skills only, hard floor filters engine::/state::/etc.
+# Agent card — skills are governed by iii-worker-manager RBAC.
 curl -s http://127.0.0.1:3111/.well-known/agent-card.json \
   | jq '{name, skills: [.skills[] | {id, description}]}'
 
@@ -166,37 +141,7 @@ curl -sX POST http://127.0.0.1:3111/a2a \
   | jq '.result.task.status.state'
 ```
 
-### 5. Verify each gate
-
-```bash
-# Hidden function (no a2a.expose) → state:"failed", distinct rejection
-curl -sX POST http://127.0.0.1:3111/a2a \
-  -H 'content-type: application/json' \
-  -d '{
-    "jsonrpc":"2.0","id":"g1","method":"message/send",
-    "params":{"message":{
-      "messageId":"x","role":"user",
-      "parts":[{"data":{"function_id":"demo::hidden","payload":{}}}]
-    }}
-  }' | jq '.result.task.status.message.parts[0].text'
-
-# Infra prefix → "in the iii-engine internal namespace" message
-curl -sX POST http://127.0.0.1:3111/a2a \
-  -H 'content-type: application/json' \
-  -d '{
-    "jsonrpc":"2.0","id":"g2","method":"message/send",
-    "params":{"message":{
-      "messageId":"x","role":"user",
-      "parts":[{"data":{"function_id":"state::set","payload":{}}}]
-    }}
-  }' | jq '.result.task.status.message.parts[0].text'
-
-# Tier filter: restart iii-a2a with --tier partner, function has a2a.tier="partner"
-./target/release/iii-a2a --tier partner &
-curl -s http://127.0.0.1:3111/.well-known/agent-card.json | jq '.skills[].id'
-```
-
-### 6. Validate with any A2A client
+### 5. Validate with any A2A client
 
 Any AI agent runtime that speaks A2A JSON-RPC 0.3 works. Point it at
 `http://<your-host>:3111/.well-known/agent-card.json` (or the
@@ -210,9 +155,9 @@ Any AI agent runtime that speaks A2A JSON-RPC 0.3 works. Point it at
    function id; rest is parsed as the payload.
 3. Anything else — task fails with "No function_id found".
 
-Before dispatch, the resolved `function_id` is re-checked against the
-same exposure gate as `tools/list`. Hard-floor namespaces reject
-unconditionally.
+Before dispatch, the resolved `function_id` is rejected if it is a
+protocol entry point (`mcp::*` / `a2a::*`). Everything else is delegated
+to iii-worker-manager RBAC.
 
 ## Task model
 
@@ -273,39 +218,3 @@ no `connect()` step, the WebSocket opens lazily on first send/write).
 - Push notifications
 
 Returns JSON-RPC error `-32003`.
-
-## Example: multi-tier partner API
-
-One worker, three audiences.
-
-```rust
-iii.register_function_with(
-    RegisterFunctionMessage {
-        id: "pricing::public_quote".into(),
-        metadata: Some(json!({ "a2a.expose": true, "a2a.tier": "public" })),
-        ..Default::default()
-    },
-    public_quote_handler,
-);
-
-iii.register_function_with(
-    RegisterFunctionMessage {
-        id: "pricing::partner_quote".into(),
-        metadata: Some(json!({ "a2a.expose": true, "a2a.tier": "partner" })),
-        ..Default::default()
-    },
-    partner_quote_handler,
-);
-
-iii.register_function_with(
-    RegisterFunctionMessage {
-        id: "pricing::internal_cost".into(),
-        metadata: Some(json!({ "a2a.expose": true, "a2a.tier": "ops" })),
-        ..Default::default()
-    },
-    internal_cost_handler,
-);
-```
-
-Three a2a workers behind three different auth proxies, each with a
-different `--tier`, advertise three different agent cards.

--- a/a2a/examples/default-secure-auth.rs
+++ b/a2a/examples/default-secure-auth.rs
@@ -1,0 +1,98 @@
+// Engine control-plane denylist for iii-a2a deploys.
+//
+// This is NOT a literal v0.3 hard-floor reproduction. The v0.3
+// `ALWAYS_HIDDEN_PREFIXES` covered `engine::*`, `state::*`, `stream::*`,
+// `iii.*`, `iii::*`, `mcp::*`, `a2a::*` as PREFIX MATCHES — `AuthResult.
+// forbidden_functions` only takes literal function IDs, so a precise
+// reproduction would have to enumerate every state::/stream::/iii:: ID
+// the running engine version exposes.
+//
+// What this example DOES block (high-impact, control-plane / SDK plumbing
+// IDs the engine exposes today): engine::workers::register,
+// engine::{logs,traces}::clear, engine::channels::create,
+// engine::baggage::*, engine::log::*, iii::durable::publish,
+// iii::otel_passthrough.
+//
+// What it does NOT block (covered structurally elsewhere):
+// - `mcp::*` and `a2a::*` — blocked by the protocol-loop guard inside
+//   iii-mcp / iii-a2a (`is_protocol_loop`); never reach the engine.
+// - `state::*` and `stream::*` raw KV / channel plumbing — these are
+//   engine-version-coupled. Add the specific IDs your engine exposes
+//   to `forbidden_functions` below, or use `expose_functions` allowlist
+//   in iii-worker-manager (wildcards work there) to invert the policy.
+//
+// Recommended: pair this with an `expose_functions` ALLOWLIST in
+// iii-worker-manager config so unknown IDs default to denied, then use
+// this `forbidden_functions` list as a belt-and-suspenders second layer.
+
+use iii_sdk::{AuthInput, AuthResult, InitOptions, RegisterFunction, register_worker};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .init();
+
+    let engine_url =
+        std::env::var("III_ENGINE_URL").unwrap_or_else(|_| "ws://localhost:49134".to_string());
+
+    let iii = register_worker(&engine_url, InitOptions::default());
+
+    iii.register_function(
+        RegisterFunction::new_async("myproject::auth", |input: AuthInput| async move {
+            // The MCP / A2A worker forwards `--rbac-tag <TAG>` as this
+            // header on its WebSocket upgrade. Read it here to scope
+            // per-deploy policy if you need it.
+            let rbac_tag = input.headers.get("x-iii-rbac-tag").cloned();
+            tracing::info!(
+                rbac_tag = ?rbac_tag,
+                ip = %input.ip_address,
+                "myproject::auth invoked"
+            );
+
+            Ok::<_, String>(AuthResult {
+                allowed_functions: vec![],
+                forbidden_functions: forbidden_functions(),
+                allowed_trigger_types: None,
+                allow_trigger_type_registration: false,
+                allow_function_registration: true,
+                function_registration_prefix: None,
+                context: json!({ "rbac_tag": rbac_tag }),
+            })
+        })
+        .description("Default-secure auth function: denies engine control-plane IDs"),
+    );
+
+    tracing::info!("myproject::auth registered. Wire it into iii-worker-manager:");
+    tracing::info!("  workers:");
+    tracing::info!("    - name: iii-worker-manager");
+    tracing::info!("      config:");
+    tracing::info!("        rbac:");
+    tracing::info!("          auth_function_id: myproject::auth");
+    tokio::signal::ctrl_c().await?;
+
+    Ok(())
+}
+
+// 14 concrete control-plane / SDK-plumbing IDs to deny by default. Pair
+// with an `expose_functions` allowlist in iii-worker-manager for full
+// belt-and-suspenders coverage; this list is the explicit deny floor.
+fn forbidden_functions() -> Vec<String> {
+    vec![
+        "engine::workers::register".to_string(),
+        "engine::logs::clear".to_string(),
+        "engine::traces::clear".to_string(),
+        "engine::channels::create".to_string(),
+        "engine::baggage::set".to_string(),
+        "engine::baggage::get".to_string(),
+        "engine::baggage::clear".to_string(),
+        "engine::log::debug".to_string(),
+        "engine::log::info".to_string(),
+        "engine::log::warn".to_string(),
+        "engine::log::error".to_string(),
+        "engine::log::trace".to_string(),
+        "iii::durable::publish".to_string(),
+        "iii::otel_passthrough".to_string(),
+    ]
+}

--- a/a2a/src/handler.rs
+++ b/a2a/src/handler.rs
@@ -11,54 +11,11 @@ use crate::streaming::{
 };
 use crate::types::*;
 
-fn has_metadata_flag(f: &iii_sdk::FunctionInfo, key: &str) -> bool {
-    f.metadata
-        .as_ref()
-        .and_then(|m| m.get(key))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false)
-}
-
-fn metadata_string(f: &iii_sdk::FunctionInfo, key: &str) -> Option<String> {
-    f.metadata
-        .as_ref()
-        .and_then(|m| m.get(key))
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
-}
-
-// Infra namespaces that never appear in the agent card, even under
-// --expose-all. Mirrors the mcp worker's ALWAYS_HIDDEN_PREFIXES — surfacing
-// `state::*` / `engine::*` / the a2a worker's own jsonrpc entry as "skills"
-// is categorically not a cross-agent surface.
-pub const ALWAYS_HIDDEN_PREFIXES: &[&str] = &[
-    "engine::", "state::", "stream::",
-    // SDK internals come in two notations — callback-style
-    // `iii.on_functions_available.<uuid>` and namespace-style
-    // `iii::durable::publish`, `iii::config`. Match both.
-    "iii.", "iii::",
-    // Sibling protocol worker entry point. Calling `mcp::handler` via A2A
-    // message/send double-envelopes an MCP request inside A2A — not a
-    // meaningful skill. Hide symmetrically with mcp's a2a:: carve-out.
-    "mcp::", "a2a::",
-];
-
-pub fn is_always_hidden(function_id: &str) -> bool {
-    ALWAYS_HIDDEN_PREFIXES
-        .iter()
-        .any(|p| function_id.starts_with(p))
-}
-
-#[derive(Debug, Clone)]
-pub struct ExposureConfig {
-    pub expose_all: bool,
-    pub tier: Option<String>,
-}
-
-impl ExposureConfig {
-    pub fn new(expose_all: bool, tier: Option<String>) -> Self {
-        Self { expose_all, tier }
-    }
+// Blocks self-invocation of the A2A handler and cross-protocol bridging
+// through the sibling MCP entry point. Pure structural guard — not access
+// control. RBAC lives at iii-worker-manager.
+pub fn is_protocol_loop(function_id: &str) -> bool {
+    function_id.starts_with("mcp::") || function_id.starts_with("a2a::")
 }
 
 #[derive(Debug, Clone)]
@@ -91,48 +48,8 @@ impl Default for AgentIdentity {
     }
 }
 
-pub fn is_exposed(f: &iii_sdk::FunctionInfo, cfg: &ExposureConfig) -> bool {
-    if is_always_hidden(&f.function_id) {
-        return false;
-    }
-    if !cfg.expose_all && !has_metadata_flag(f, "a2a.expose") {
-        return false;
-    }
-    if let Some(want_tier) = &cfg.tier {
-        match metadata_string(f, "a2a.tier") {
-            Some(got) if &got == want_tier => {}
-            _ => return false,
-        }
-    }
-    true
-}
-
-pub async fn is_function_exposed(iii: &III, function_id: &str, cfg: &ExposureConfig) -> bool {
-    if is_always_hidden(function_id) {
-        return false;
-    }
-    match iii.list_functions().await {
-        Ok(fns) => fns
-            .iter()
-            .find(|f| f.function_id == function_id)
-            .map(|f| is_exposed(f, cfg))
-            .unwrap_or(false),
-        Err(e) => {
-            // Log registry errors distinctly so an engine outage doesn't
-            // look like a policy denial. Still fail closed.
-            tracing::error!(
-                error = %e,
-                function_id = %function_id,
-                "a2a.expose check failed: could not list functions, denying access"
-            );
-            false
-        }
-    }
-}
-
-pub fn register(iii: &III, exposure: ExposureConfig, base_url: String, identity: AgentIdentity) {
+pub fn register(iii: &III, base_url: String, identity: AgentIdentity) {
     let iii_card = iii.clone();
-    let card_cfg = exposure.clone();
     let card_base_url = base_url.clone();
     let card_identity = identity.clone();
     iii.register_function_with(
@@ -146,11 +63,10 @@ pub fn register(iii: &III, exposure: ExposureConfig, base_url: String, identity:
         },
         move |_input: Value| {
             let iii_inner = iii_card.clone();
-            let cfg = card_cfg.clone();
             let base = card_base_url.clone();
             let ident = card_identity.clone();
             async move {
-                let card = build_agent_card(&iii_inner, &cfg, &base, &ident).await;
+                let card = build_agent_card(&iii_inner, &base, &ident).await;
                 Ok(json!({
                     "status_code": 200,
                     "headers": { "content-type": "application/json" },
@@ -161,7 +77,6 @@ pub fn register(iii: &III, exposure: ExposureConfig, base_url: String, identity:
     );
 
     let iii_rpc = iii.clone();
-    let rpc_cfg = exposure;
     let registry = Arc::new(StreamRegistry::new());
     let registry_rpc = registry.clone();
     iii.register_function_with(
@@ -178,7 +93,6 @@ pub fn register(iii: &III, exposure: ExposureConfig, base_url: String, identity:
         },
         move |input: Value| {
             let iii_inner = iii_rpc.clone();
-            let cfg = rpc_cfg.clone();
             let registry = registry_rpc.clone();
             async move {
                 // Snapshot the writer ref BEFORE stripping the body — once
@@ -218,8 +132,7 @@ pub fn register(iii: &III, exposure: ExposureConfig, base_url: String, identity:
                                 )
                             }));
                         };
-                        dispatch_stream(&iii_inner, request.params, writer_ref, registry, cfg)
-                            .await;
+                        dispatch_stream(&iii_inner, request.params, writer_ref, registry).await;
                         // The SSE response was written directly to the
                         // channel; return an empty value so the engine
                         // doesn't try to write a second response body.
@@ -244,7 +157,7 @@ pub fn register(iii: &III, exposure: ExposureConfig, base_url: String, identity:
                     _ => {}
                 }
 
-                let response = handle_a2a_request(&iii_inner, request, &cfg, &registry).await;
+                let response = handle_a2a_request(&iii_inner, request, &registry).await;
 
                 Ok(json!({
                     "status_code": 200,
@@ -276,16 +189,11 @@ pub fn register(iii: &III, exposure: ExposureConfig, base_url: String, identity:
     tracing::info!("A2A registered: GET /.well-known/agent-card.json, POST /a2a");
 }
 
-pub async fn build_agent_card(
-    iii: &III,
-    cfg: &ExposureConfig,
-    base_url: &str,
-    identity: &AgentIdentity,
-) -> AgentCard {
+pub async fn build_agent_card(iii: &III, base_url: &str, identity: &AgentIdentity) -> AgentCard {
     let skills = match iii.list_functions().await {
         Ok(fns) => fns
             .iter()
-            .filter(|f| is_exposed(f, cfg))
+            .filter(|f| !is_protocol_loop(&f.function_id))
             .map(|f| AgentSkill {
                 id: f.function_id.clone(),
                 name: f
@@ -342,15 +250,14 @@ pub async fn build_agent_card(
     }
 }
 
-async fn handle_a2a_request(
+pub async fn handle_a2a_request(
     iii: &III,
     request: A2ARequest,
-    cfg: &ExposureConfig,
     registry: &Arc<StreamRegistry>,
 ) -> A2AResponse {
     let id = request.id.clone();
     match request.method.as_str() {
-        "message/send" | "SendMessage" => handle_send(iii, id, request.params, cfg, registry).await,
+        "message/send" | "SendMessage" => handle_send(iii, id, request.params, registry).await,
         "tasks/get" | "GetTask" => handle_get(iii, id, request.params).await,
         "tasks/cancel" | "CancelTask" => handle_cancel(iii, id, request.params, registry).await,
         "tasks/list" | "ListTasks" => handle_list(iii, id).await,
@@ -464,7 +371,6 @@ async fn handle_send(
     iii: &III,
     id: Option<Value>,
     params: Option<Value>,
-    cfg: &ExposureConfig,
     registry: &Arc<StreamRegistry>,
 ) -> A2AResponse {
     let params: SendMessageParams = match params {
@@ -481,6 +387,45 @@ async fn handle_send(
         .clone()
         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
     let context_id = params.message.context_id.clone();
+
+    // Resolve and structurally validate the function id BEFORE building or
+    // storing the task. RBAC is enforced at iii-worker-manager — we only
+    // reject the empty case and the protocol-loop case here. This avoids
+    // the spurious Working→Failed double-write the older code did.
+    let (function_id, payload) = resolve_function(&params.message);
+    let validation_failure = if function_id.is_empty() {
+        Some(
+            "No function_id found. Send a data part with {\"function_id\": \"...\", \"payload\": {...}} or use :: notation in text."
+                .to_string(),
+        )
+    } else if is_protocol_loop(&function_id) {
+        Some(format!(
+            "Function '{}' is a protocol entry point, not a callable tool",
+            function_id
+        ))
+    } else {
+        None
+    };
+
+    if let Some(reason) = validation_failure {
+        // Terminal-task idempotency: if the same task_id was already
+        // resolved (good or bad), return the stored copy rather than
+        // overwriting with a fresh failure record.
+        if let Some(existing) = load_task(iii, &task_id).await
+            && matches!(
+                existing.status.state,
+                TaskState::Completed
+                    | TaskState::Canceled
+                    | TaskState::Failed
+                    | TaskState::Rejected
+            )
+        {
+            return A2AResponse::success(id, json!({ "task": existing }));
+        }
+        let task = build_failed_task(task_id, context_id, &params, &reason);
+        store_task(iii, &task).await;
+        return A2AResponse::success(id, json!({ "task": task }));
+    }
 
     let mut task = if let Some(existing) = load_task(iii, &task_id).await {
         if matches!(
@@ -524,7 +469,7 @@ async fn handle_send(
             },
             artifacts: None,
             history: Some(vec![params.message.clone()]),
-            metadata: params.metadata,
+            metadata: params.metadata.clone(),
         }
     };
     store_task(iii, &task).await;
@@ -532,58 +477,7 @@ async fn handle_send(
     // the live update instead of needing to poll.
     broadcast_status(registry, &task, false).await;
 
-    let (function_id, payload) = resolve_function(&params.message);
-    if function_id.is_empty() {
-        task.status = TaskStatus {
-            state: TaskState::Failed,
-            message: Some(Message {
-                message_id: msg_id(),
-                role: MessageRole::Agent,
-                parts: vec![text_part(
-                    "No function_id found. Send a data part with {\"function_id\": \"...\", \"payload\": {...}} or use :: notation in text.",
-                )],
-                task_id: None,
-                context_id: None,
-                metadata: None,
-            }),
-            timestamp: Some(iso_now()),
-        };
-        store_task(iii, &task).await;
-        broadcast_status(registry, &task, true).await;
-        registry.close_task(&task.id).await;
-        return A2AResponse::success(id, json!({ "task": task }));
-    }
     let fn_name = function_id.clone();
-
-    if !is_function_exposed(iii, &function_id, cfg).await {
-        let reason = if is_always_hidden(&function_id) {
-            format!(
-                "Function '{}' is in the iii-engine internal namespace and is not exposed as an A2A skill",
-                function_id
-            )
-        } else {
-            format!(
-                "Function '{}' is not exposed via a2a.expose metadata (or does not match the active --tier filter)",
-                function_id
-            )
-        };
-        task.status = TaskStatus {
-            state: TaskState::Failed,
-            message: Some(Message {
-                message_id: msg_id(),
-                role: MessageRole::Agent,
-                parts: vec![text_part(reason)],
-                task_id: None,
-                context_id: None,
-                metadata: None,
-            }),
-            timestamp: Some(iso_now()),
-        };
-        store_task(iii, &task).await;
-        broadcast_status(registry, &task, true).await;
-        registry.close_task(&task.id).await;
-        return A2AResponse::success(id, json!({ "task": task }));
-    }
 
     match iii
         .trigger(TriggerRequest {
@@ -596,11 +490,11 @@ async fn handle_send(
     {
         Ok(result) => {
             let fresh = load_task(iii, &task_id).await;
-            if let Some(ref t) = fresh {
-                if matches!(t.status.state, TaskState::Canceled) {
-                    // Cancel path already broadcast its own final frame.
-                    return A2AResponse::success(id, json!({ "task": t }));
-                }
+            if let Some(ref t) = fresh
+                && matches!(t.status.state, TaskState::Canceled)
+            {
+                // Cancel path already broadcast its own final frame.
+                return A2AResponse::success(id, json!({ "task": t }));
             }
             let result_text =
                 serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string());
@@ -644,6 +538,36 @@ async fn handle_send(
     broadcast_status(registry, &task, true).await;
     registry.close_task(&task.id).await;
     A2AResponse::success(id, json!({ "task": task }))
+}
+
+// Build a Failed task in one shot for early validation rejections. Avoids
+// the older Working→Failed double-write when the function id can't be
+// dispatched (empty / protocol-loop).
+fn build_failed_task(
+    task_id: String,
+    context_id: Option<String>,
+    params: &SendMessageParams,
+    reason: &str,
+) -> Task {
+    Task {
+        id: task_id,
+        context_id,
+        status: TaskStatus {
+            state: TaskState::Failed,
+            message: Some(Message {
+                message_id: msg_id(),
+                role: MessageRole::Agent,
+                parts: vec![text_part(reason)],
+                task_id: None,
+                context_id: None,
+                metadata: None,
+            }),
+            timestamp: Some(iso_now()),
+        },
+        artifacts: None,
+        history: Some(vec![params.message.clone()]),
+        metadata: params.metadata.clone(),
+    }
 }
 
 async fn handle_get(iii: &III, id: Option<Value>, params: Option<Value>) -> A2AResponse {
@@ -734,11 +658,11 @@ pub fn resolve_function(message: &Message) -> (String, Value) {
         .unwrap_or_default();
     let data_payload = message.parts.iter().find_map(|p| p.data.as_ref());
 
-    if let Some(payload) = data_payload {
-        if let Some(fid) = payload.get("function_id").and_then(|v| v.as_str()) {
-            let args = payload.get("payload").cloned().unwrap_or(json!({}));
-            return (fid.to_string(), args);
-        }
+    if let Some(payload) = data_payload
+        && let Some(fid) = payload.get("function_id").and_then(|v| v.as_str())
+    {
+        let args = payload.get("payload").cloned().unwrap_or(json!({}));
+        return (fid.to_string(), args);
     }
 
     // Only treat the message as a direct function invocation when the very

--- a/a2a/src/main.rs
+++ b/a2a/src/main.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use clap::Parser;
 use iii_a2a::handler;
 use iii_sdk::{InitOptions, register_worker};
@@ -13,21 +15,6 @@ struct Args {
 
     #[arg(long, short = 'd')]
     debug: bool,
-
-    #[arg(
-        long,
-        help = "Expose all functions as skills (ignore a2a.expose metadata). \
-                Infra namespaces (engine::*, state::*, stream::*, iii.*, a2a::*) \
-                stay hidden even with this flag."
-    )]
-    expose_all: bool,
-
-    #[arg(
-        long,
-        help = "Show only functions whose `a2a.tier` metadata equals this value \
-                (e.g. `user`, `agent`, `ops`). When unset, tier filtering is off."
-    )]
-    tier: Option<String>,
 
     #[arg(
         long,
@@ -70,6 +57,15 @@ struct Args {
         help = "Documentation URL advertised in the agent card"
     )]
     docs_url: String,
+
+    #[arg(
+        long,
+        value_name = "TAG",
+        help = "Forward an `x-iii-rbac-tag` header on the worker WebSocket \
+                upgrade. iii-worker-manager's `auth_function_id` reads this \
+                tag to apply policy. RBAC itself lives at iii-worker-manager."
+    )]
+    rbac_tag: Option<String>,
 }
 
 #[tokio::main]
@@ -89,9 +85,19 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!(version = env!("CARGO_PKG_VERSION"), "Starting iii-a2a");
 
-    let iii = register_worker(&args.engine_url, InitOptions::default());
+    let mut init_opts = InitOptions::default();
+    if let Some(tag) = args.rbac_tag.as_ref() {
+        let mut headers = HashMap::new();
+        headers.insert("x-iii-rbac-tag".to_string(), tag.clone());
+        init_opts.headers = Some(headers);
+        tracing::info!(
+            rbac_tag = %tag,
+            "Forwarding rbac-tag in worker headers; configure your auth_function_id to read x-iii-rbac-tag"
+        );
+    }
 
-    let exposure = handler::ExposureConfig::new(args.expose_all, args.tier.clone());
+    let iii = register_worker(&args.engine_url, init_opts);
+
     let identity = handler::AgentIdentity {
         name: args.agent_name,
         description: args.agent_description,
@@ -99,7 +105,7 @@ async fn main() -> anyhow::Result<()> {
         provider_url: args.provider_url,
         docs_url: args.docs_url,
     };
-    handler::register(&iii, exposure, args.base_url, identity);
+    handler::register(&iii, args.base_url, identity);
 
     tracing::info!("A2A endpoints registered on engine port. Ctrl+C to stop.");
     tokio::signal::ctrl_c().await?;

--- a/a2a/src/streaming.rs
+++ b/a2a/src/streaming.rs
@@ -39,8 +39,7 @@ use tokio::sync::{Mutex, watch};
 use tokio::task::JoinSet;
 
 use crate::handler::{
-    ExposureConfig, is_always_hidden, is_function_exposed, iso_now, load_task, msg_id,
-    resolve_function, store_task, text_part,
+    is_protocol_loop, iso_now, load_task, msg_id, resolve_function, store_task, text_part,
 };
 use crate::types::*;
 
@@ -305,7 +304,6 @@ pub async fn handle_stream(
     params: Option<Value>,
     writer_ref: StreamChannelRef,
     registry: Arc<StreamRegistry>,
-    cfg: ExposureConfig,
 ) {
     let writer = Arc::new(ChannelWriter::new(iii.address(), &writer_ref));
 
@@ -442,18 +440,11 @@ pub async fn handle_stream(
     }
     let fn_name = function_id.clone();
 
-    if !is_function_exposed(iii, &function_id, &cfg).await {
-        let reason = if is_always_hidden(&function_id) {
-            format!(
-                "Function '{}' is in the iii-engine internal namespace and is not exposed as an A2A skill",
-                function_id
-            )
-        } else {
-            format!(
-                "Function '{}' is not exposed via a2a.expose metadata (or does not match the active --tier filter)",
-                function_id
-            )
-        };
+    if is_protocol_loop(&function_id) {
+        let reason = format!(
+            "Function '{}' is a protocol entry point, not a callable tool",
+            function_id
+        );
         task.status = TaskStatus {
             state: TaskState::Failed,
             message: Some(Message {
@@ -724,9 +715,8 @@ pub async fn dispatch_stream(
     params: Option<Value>,
     writer_ref: StreamChannelRef,
     registry: Arc<StreamRegistry>,
-    cfg: ExposureConfig,
 ) {
-    handle_stream(iii, params, writer_ref, registry, cfg).await;
+    handle_stream(iii, params, writer_ref, registry).await;
 }
 
 /// Public entry called by the JSON-RPC dispatch closure when it sees

--- a/a2a/tests/agent_card.rs
+++ b/a2a/tests/agent_card.rs
@@ -8,7 +8,7 @@
 //! that's the documented behaviour, and it lets us cover the static fields
 //! without spinning up the engine.
 
-use iii_a2a::handler::{AgentIdentity, ExposureConfig, build_agent_card};
+use iii_a2a::handler::{AgentIdentity, build_agent_card};
 use iii_sdk::III;
 
 fn unreachable_iii() -> III {
@@ -22,10 +22,9 @@ fn unreachable_iii() -> III {
 #[tokio::test]
 async fn default_identity_advertises_a2a_suffix_and_docs_url() {
     let iii = unreachable_iii();
-    let cfg = ExposureConfig::new(false, None);
     let identity = AgentIdentity::default();
 
-    let card = build_agent_card(&iii, &cfg, "http://localhost:3111", &identity).await;
+    let card = build_agent_card(&iii, "http://localhost:3111", &identity).await;
 
     assert_eq!(card.supported_interfaces.len(), 1);
     assert_eq!(
@@ -52,10 +51,9 @@ async fn default_identity_advertises_a2a_suffix_and_docs_url() {
 #[tokio::test]
 async fn trailing_slash_in_base_url_is_normalised() {
     let iii = unreachable_iii();
-    let cfg = ExposureConfig::new(false, None);
     let identity = AgentIdentity::default();
 
-    let card = build_agent_card(&iii, &cfg, "http://localhost:3111/", &identity).await;
+    let card = build_agent_card(&iii, "http://localhost:3111/", &identity).await;
 
     assert_eq!(
         card.supported_interfaces[0].url, "http://localhost:3111/a2a",
@@ -66,7 +64,6 @@ async fn trailing_slash_in_base_url_is_normalised() {
 #[tokio::test]
 async fn custom_identity_flows_through() {
     let iii = unreachable_iii();
-    let cfg = ExposureConfig::new(false, None);
     let identity = AgentIdentity {
         name: "acme-orchestrator".to_string(),
         description: "Acme order pipeline agent".to_string(),
@@ -75,7 +72,7 @@ async fn custom_identity_flows_through() {
         docs_url: "https://docs.acme.example/agents/orchestrator".to_string(),
     };
 
-    let card = build_agent_card(&iii, &cfg, "https://agent.acme.example", &identity).await;
+    let card = build_agent_card(&iii, "https://agent.acme.example", &identity).await;
 
     assert_eq!(card.name, "acme-orchestrator");
     assert_eq!(card.description, "Acme order pipeline agent");

--- a/a2a/tests/protocol_loop_guard.rs
+++ b/a2a/tests/protocol_loop_guard.rs
@@ -1,0 +1,60 @@
+//! Phase 1 — protocol-loop structural guard for the A2A handler.
+//!
+//! `is_protocol_loop` in `iii_a2a::handler` rejects `mcp::*` and `a2a::*`
+//! function IDs at `handle_send` time, BEFORE the Working task is built and
+//! stored. This avoids the older Working→Failed double-write the v0.3
+//! codepath did. RBAC for everything else is delegated to iii-worker-manager.
+
+use std::sync::Arc;
+
+use iii_a2a::handler::handle_a2a_request;
+use iii_a2a::streaming::StreamRegistry;
+use iii_a2a::types::{A2ARequest, TaskState};
+use iii_sdk::III;
+use serde_json::json;
+
+fn unreachable_iii() -> III {
+    III::new("ws://127.0.0.1:1")
+}
+
+#[tokio::test]
+async fn message_send_with_mcp_handler_function_id_fails_with_protocol_loop_text() {
+    let iii = unreachable_iii();
+    let request = A2ARequest {
+        jsonrpc: "2.0".to_string(),
+        id: Some(json!("p1")),
+        method: "message/send".to_string(),
+        params: Some(json!({
+            "message": {
+                "messageId": "m1",
+                "role": "user",
+                "parts": [
+                    { "data": { "function_id": "mcp::handler", "payload": {} } }
+                ]
+            }
+        })),
+    };
+
+    let registry = Arc::new(StreamRegistry::new());
+    let response = handle_a2a_request(&iii, request, &registry).await;
+    let result = response.result.expect("expected success-shaped response");
+    let task = result.get("task").expect("task in result");
+
+    let state: TaskState =
+        serde_json::from_value(task["status"]["state"].clone()).expect("decode state");
+    assert_eq!(state, TaskState::Failed, "expected task state=failed");
+
+    let text = task["status"]["message"]["parts"][0]["text"]
+        .as_str()
+        .unwrap_or("");
+    assert!(
+        text.contains("protocol entry point"),
+        "expected 'protocol entry point' in rejection text, got: {}",
+        text
+    );
+    assert!(
+        text.contains("mcp::handler"),
+        "expected the rejected function id 'mcp::handler' in text, got: {}",
+        text
+    );
+}

--- a/a2a/tests/streaming.rs
+++ b/a2a/tests/streaming.rs
@@ -281,8 +281,7 @@ async fn dispatch_signatures_compile() {
     if false {
         let iii = iii_sdk::III::new("ws://127.0.0.1:1");
         let registry = Arc::new(StreamRegistry::new());
-        let cfg = iii_a2a::handler::ExposureConfig::new(false, None);
-        dispatch_stream(&iii, None, dummy_writer_ref(), registry.clone(), cfg).await;
+        dispatch_stream(&iii, None, dummy_writer_ref(), registry.clone()).await;
         dispatch_resubscribe(&iii, None, dummy_writer_ref(), registry).await;
     }
 }

--- a/mcp/Cargo.lock
+++ b/mcp/Cargo.lock
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "iii-mcp"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iii-mcp"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2024"
 description = "MCP protocol worker for iii-engine"
 license = "Apache-2.0"

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -14,17 +14,19 @@ Function exposure is governed by **iii-sdk RBAC** at `iii-worker-manager`. This 
 
 Configure in `config.yaml`:
 
-    workers:
-      - name: iii-worker-manager
-        config:
-          rbac:
-            auth_function_id: myproject::auth
-            expose_functions:
-              - match("api::*")
-              - match("*::public")
-              - metadata:
-                  public: true
-      - name: iii-mcp    # or iii-a2a
+```yaml
+workers:
+  - name: iii-worker-manager
+    config:
+      rbac:
+        auth_function_id: myproject::auth
+        expose_functions:
+          - match("api::*")
+          - match("*::public")
+          - metadata:
+              public: true
+  - name: iii-mcp    # or iii-a2a
+```
 
 See https://iii.dev/docs/how-to/worker-rbac.md for the RBAC surface.
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -8,70 +8,47 @@ two transports:
 - **Streamable HTTP**: `POST /mcp` on the engine's HTTP trigger port.
   Enable with `--no-stdio`.
 
-## Exposure model
+## Access control
 
-Functions registered on the engine are **invisible to MCP clients by
-default**. Authors opt in per-function.
+Function exposure is governed by **iii-sdk RBAC** at `iii-worker-manager`. This worker is a protocol transport — the engine decides who can see and call what.
 
-### Opt-in metadata
+Configure in `config.yaml`:
 
-```rust
-// Rust worker
-iii.register_function_with(
-    RegisterFunctionMessage {
-        id: "eval::metrics".into(),
-        description: Some("P50/P95/P99 latency + error rate".into()),
-        metadata: Some(json!({
-            "mcp.expose": true,
-            "mcp.tier": "agent",  // optional — free-form string
-        })),
-        ..Default::default()
-    },
-    handler,
-);
-```
+    workers:
+      - name: iii-worker-manager
+        config:
+          rbac:
+            auth_function_id: myproject::auth
+            expose_functions:
+              - match("api::*")
+              - match("*::public")
+              - metadata:
+                  public: true
+      - name: iii-mcp    # or iii-a2a
 
-```ts
-// Node worker (iii-sdk 0.11.3+)
-iii.registerFunction("eval::metrics", handler, {
-  metadata: { "mcp.expose": true, "mcp.tier": "agent" },
-})
-```
+See https://iii.dev/docs/how-to/worker-rbac.md for the RBAC surface.
 
-```python
-# Python worker
-iii.register_function(
-    "eval::metrics",
-    handler,
-    metadata={"mcp.expose": True, "mcp.tier": "agent"},
-)
-```
+### Breaking change (v0.4)
 
-### Hard floor (never exposed)
+- `--expose-all` and `--tier` removed. Port policy to `auth_function_id`.
+- `mcp.expose` / `a2a.expose` metadata flags no longer consulted.
+- See `examples/default-secure-auth.rs` for a drop-in replacement.
 
-Even with `--expose-all`, these namespaces are **always** filtered out:
+### Engine introspection
 
-| Prefix | Why |
-|---|---|
-| `engine::*` | iii engine internals |
-| `state::*` | KV plumbing, not an agent tool |
-| `stream::*` | channel plumbing |
-| `iii.*` / `iii::*` | SDK internals — callback functions and namespaced SDK APIs |
-| `mcp::*` | this worker's own entry point |
-| `a2a::*` | sibling protocol worker's entry point |
+For the use case the old `engine::*` hard floor hid, use the `introspect` worker (`iii worker add introspect`). It exposes `introspect::functions`, `introspect::topology`, `introspect::health`, etc. — agents call those through MCP/A2A without leaking raw engine internals.
 
 ### CLI flags
 
 ```text
 --engine-url <URL>   WebSocket URL of the iii engine (default ws://localhost:49134)
 --no-stdio           Skip stdio, run HTTP-only
---expose-all         Ignore the mcp.expose gate (dev only). Hard floor still applies.
 --no-builtins        Hide the 6 built-in management tools on stdio. Also hidden over HTTP by default.
 --http-builtins      Opt in to exposing built-ins on HTTP (default: hidden).
                      --no-builtins always wins and hides them everywhere.
---tier <name>        Show only functions whose mcp.tier metadata equals <name>.
-                     E.g. `--tier user` for end-user Claude Desktop config,
-                     `--tier agent` for an agent client, `--tier ops` for dashboards.
+--rbac-tag <TAG>     Forward an `x-iii-rbac-tag` header on the worker WebSocket
+                     upgrade. iii-worker-manager's `auth_function_id` reads
+                     this tag to apply policy.
 --debug              Verbose logging
 ```
 
@@ -124,7 +101,7 @@ Engine now listening on `ws://127.0.0.1:49134` (worker bus) and
 
 ### 2. Register test functions
 
-Any worker that tags functions with `mcp.expose: true` works. Quick
+Any worker registering functions through the engine works. Quick
 standalone Rust worker — save as `testworker/src/main.rs` and
 `cargo run --release`:
 
@@ -140,7 +117,6 @@ async fn main() -> anyhow::Result<()> {
         RegisterFunctionMessage {
             id: "demo::hello".into(),
             description: Some("Say hello".into()),
-            metadata: Some(json!({ "mcp.expose": true })),
             ..Default::default()
         },
         |_input: Value| async move { Ok(json!({"greeting": "hi"})) },
@@ -163,8 +139,7 @@ Registers `POST /mcp` on the engine's HTTP port.
 ### 3b. Sanity check with curl
 
 ```bash
-# tools/list — should show demo__hello, NO builtins (HTTP default hides them),
-# NO state::*/engine::*/iii.*/iii::* (hard floor), NO demo__hidden (no mcp.expose).
+# tools/list — visible functions are governed by iii-worker-manager RBAC.
 curl -sX POST http://127.0.0.1:3111/mcp \
   -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq '.result.tools[].name'
@@ -194,14 +169,10 @@ In the browser UI:
 
 Click **Connect** → green dot. Then try each tab:
 
-- **Tools** → List Tools → should show the functions tagged
-  `mcp.expose: true`. Click one → fill the args form (text input, not a
-  dropdown — Inspector decorates it with a chevron but the MCP spec's
-  `PromptArgument`/tool input schema doesn't carry enum constraints,
-  so type the value) → Run.
+- **Tools** → List Tools → shows the functions iii-worker-manager RBAC
+  exposes for this connection.
 - **Resources** → 4 URIs (`iii://functions`, `iii://workers`,
-  `iii://triggers`, `iii://context`). Click `iii://functions` → filtered
-  list (only exposed functions, no infra).
+  `iii://triggers`, `iii://context`).
 - **Prompts** → 4 canned prompts. Pick `register-function`, fill
   `language=python`, `function_id=orders::place`, Get Prompt.
 - **Ping** → `{}` response.
@@ -238,85 +209,17 @@ Claude Desktop config that talks to a running engine:
 }
 ```
 
-Add `"--tier", "user"` and `"--no-builtins"` for a clean user-facing
-surface. Add `"--expose-all"` for dev exploration (hard floor still
-applies).
-
-### 4. Verify each gate
-
-From the curl / inspector shell above:
-
-```bash
-# Hidden function (no mcp.expose) → isError, "not exposed via mcp.expose metadata"
-curl -sX POST http://127.0.0.1:3111/mcp -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"demo__hidden","arguments":{}}}' \
-  | jq '.result.content[0].text'
-
-# Infra prefix → isError, "in the iii-engine internal namespace"
-curl -sX POST http://127.0.0.1:3111/mcp -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"state__set","arguments":{}}}' \
-  | jq '.result.content[0].text'
-
-# Builtin with --no-builtins → "disabled on this server"
-# (restart iii-mcp with --no-builtins first)
-curl -sX POST http://127.0.0.1:3111/mcp -H 'content-type: application/json' \
-  -d '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"iii_trigger_void","arguments":{"function_id":"demo::hello","payload":{}}}}' \
-  | jq '.result.content[0].text'
-```
+Add `"--rbac-tag", "claude-desktop"` and `"--no-builtins"` for a clean
+user-facing surface — the rbac-tag is forwarded as `x-iii-rbac-tag` and
+your `auth_function_id` can scope policy on it.
 
 ## Invocation path
 
 `tools/call` with name `foo__bar` →
 1. Reverse-mangle to `foo::bar`.
-2. Hard-floor check: reject if prefix matches `ALWAYS_HIDDEN_PREFIXES`.
-3. Re-check the function actually has `mcp.expose: true` (and optional
-   tier match) — `tools/list` snapshots can go stale.
-4. `iii.trigger(function_id, payload)` with the arguments object.
+2. Structural guard: reject `mcp::*` / `a2a::*` (protocol entry points).
+3. `iii.trigger(function_id, payload)` with the arguments object.
+   iii-worker-manager applies its RBAC policy on the way through.
 
 Result is wrapped as `{ content: [{ type: "text", text: ... }] }` per MCP
 spec. Errors surface as `isError: true`.
-
-## Example: minimal agent-facing config
-
-One worker that exposes two agent-facing functions and one ops-only function:
-
-```rust
-// user-facing
-iii.register_function_with(
-    RegisterFunctionMessage {
-        id: "reports::weekly".into(),
-        metadata: Some(json!({ "mcp.expose": true, "mcp.tier": "user" })),
-        ..Default::default()
-    },
-    weekly_handler,
-);
-
-// agent-only planning tool
-iii.register_function_with(
-    RegisterFunctionMessage {
-        id: "reports::plan".into(),
-        metadata: Some(json!({ "mcp.expose": true, "mcp.tier": "agent" })),
-        ..Default::default()
-    },
-    plan_handler,
-);
-
-// ops dashboards — not exposed to user/agent tiers
-iii.register_function_with(
-    RegisterFunctionMessage {
-        id: "reports::rebuild_cache".into(),
-        metadata: Some(json!({ "mcp.expose": true, "mcp.tier": "ops" })),
-        ..Default::default()
-    },
-    rebuild_handler,
-);
-```
-
-Claude Desktop user config:
-
-```json
-{ "mcpServers": { "iii": { "command": "iii-mcp", "args": ["--tier", "user", "--no-builtins"] } } }
-```
-
-Agent client hits the engine over HTTP with `--tier agent`. Ops dashboard
-uses `--tier ops`. Same worker, three audiences.

--- a/mcp/examples/default-secure-auth.rs
+++ b/mcp/examples/default-secure-auth.rs
@@ -1,0 +1,98 @@
+// Engine control-plane denylist for iii-mcp deploys.
+//
+// This is NOT a literal v0.3 hard-floor reproduction. The v0.3
+// `ALWAYS_HIDDEN_PREFIXES` covered `engine::*`, `state::*`, `stream::*`,
+// `iii.*`, `iii::*`, `mcp::*`, `a2a::*` as PREFIX MATCHES — `AuthResult.
+// forbidden_functions` only takes literal function IDs, so a precise
+// reproduction would have to enumerate every state::/stream::/iii:: ID
+// the running engine version exposes.
+//
+// What this example DOES block (high-impact, control-plane / SDK plumbing
+// IDs the engine exposes today): engine::workers::register,
+// engine::{logs,traces}::clear, engine::channels::create,
+// engine::baggage::*, engine::log::*, iii::durable::publish,
+// iii::otel_passthrough.
+//
+// What it does NOT block (covered structurally elsewhere):
+// - `mcp::*` and `a2a::*` — blocked by the protocol-loop guard inside
+//   iii-mcp / iii-a2a (`is_protocol_loop`); never reach the engine.
+// - `state::*` and `stream::*` raw KV / channel plumbing — these are
+//   engine-version-coupled. Add the specific IDs your engine exposes
+//   to `forbidden_functions` below, or use `expose_functions` allowlist
+//   in iii-worker-manager (wildcards work there) to invert the policy.
+//
+// Recommended: pair this with an `expose_functions` ALLOWLIST in
+// iii-worker-manager config so unknown IDs default to denied, then use
+// this `forbidden_functions` list as a belt-and-suspenders second layer.
+
+use iii_sdk::{AuthInput, AuthResult, InitOptions, RegisterFunction, register_worker};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .init();
+
+    let engine_url =
+        std::env::var("III_ENGINE_URL").unwrap_or_else(|_| "ws://localhost:49134".to_string());
+
+    let iii = register_worker(&engine_url, InitOptions::default());
+
+    iii.register_function(
+        RegisterFunction::new_async("myproject::auth", |input: AuthInput| async move {
+            // The MCP / A2A worker forwards `--rbac-tag <TAG>` as this
+            // header on its WebSocket upgrade. Read it here to scope
+            // per-deploy policy if you need it.
+            let rbac_tag = input.headers.get("x-iii-rbac-tag").cloned();
+            tracing::info!(
+                rbac_tag = ?rbac_tag,
+                ip = %input.ip_address,
+                "myproject::auth invoked"
+            );
+
+            Ok::<_, String>(AuthResult {
+                allowed_functions: vec![],
+                forbidden_functions: forbidden_functions(),
+                allowed_trigger_types: None,
+                allow_trigger_type_registration: false,
+                allow_function_registration: true,
+                function_registration_prefix: None,
+                context: json!({ "rbac_tag": rbac_tag }),
+            })
+        })
+        .description("Default-secure auth function: denies engine control-plane IDs"),
+    );
+
+    tracing::info!("myproject::auth registered. Wire it into iii-worker-manager:");
+    tracing::info!("  workers:");
+    tracing::info!("    - name: iii-worker-manager");
+    tracing::info!("      config:");
+    tracing::info!("        rbac:");
+    tracing::info!("          auth_function_id: myproject::auth");
+    tokio::signal::ctrl_c().await?;
+
+    Ok(())
+}
+
+// 14 concrete control-plane / SDK-plumbing IDs to deny by default. Pair
+// with an `expose_functions` allowlist in iii-worker-manager for full
+// belt-and-suspenders coverage; this list is the explicit deny floor.
+fn forbidden_functions() -> Vec<String> {
+    vec![
+        "engine::workers::register".to_string(),
+        "engine::logs::clear".to_string(),
+        "engine::traces::clear".to_string(),
+        "engine::channels::create".to_string(),
+        "engine::baggage::set".to_string(),
+        "engine::baggage::get".to_string(),
+        "engine::baggage::clear".to_string(),
+        "engine::log::debug".to_string(),
+        "engine::log::info".to_string(),
+        "engine::log::warn".to_string(),
+        "engine::log::error".to_string(),
+        "engine::log::trace".to_string(),
+        "iii::durable::publish".to_string(),
+        "iii::otel_passthrough".to_string(),
+    ]
+}

--- a/mcp/src/handler.rs
+++ b/mcp/src/handler.rs
@@ -313,13 +313,21 @@ impl McpHandler {
         } else {
             builtin_tools()
         };
-        if let Ok(functions) = self.iii.list_functions().await {
-            tools.extend(
-                functions
-                    .iter()
-                    .filter(|f| !is_protocol_loop(&f.function_id))
-                    .map(function_to_tool),
-            );
+        match self.iii.list_functions().await {
+            Ok(functions) => {
+                tools.extend(
+                    functions
+                        .iter()
+                        .filter(|f| !is_protocol_loop(&f.function_id))
+                        .map(function_to_tool),
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "list_functions failed in tools/list — returning builtins only"
+                );
+            }
         }
         let (page, next) = paginate(&tools, cursor, PAGE_SIZE);
         let page_owned: Vec<McpTool> = page.into_iter().cloned().collect();
@@ -854,12 +862,20 @@ async fn dispatch_http(
             } else {
                 builtin_tools()
             };
-            if let Ok(fns) = iii.list_functions().await {
-                tools.extend(
-                    fns.iter()
-                        .filter(|f| !is_protocol_loop(&f.function_id))
-                        .map(function_to_tool),
-                );
+            match iii.list_functions().await {
+                Ok(fns) => {
+                    tools.extend(
+                        fns.iter()
+                            .filter(|f| !is_protocol_loop(&f.function_id))
+                            .map(function_to_tool),
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "list_functions failed in tools/list — returning builtins only"
+                    );
+                }
             }
             let (page, next) = paginate(&tools, cursor.as_deref(), PAGE_SIZE);
             let page_owned: Vec<McpTool> = page.into_iter().cloned().collect();
@@ -1082,20 +1098,23 @@ pub async fn read_resource(iii: &III, params: Option<Value>) -> Result<Value, St
         // `iii://function/{id}` rejects protocol entry points so an agent
         // can't read MCP/A2A handler internals; everything else falls
         // through to RBAC at iii-worker-manager.
-        other => match resolve_templated_uri(other, iii).await {
-            Some((body, mime)) => {
-                if let Some(id) = other.strip_prefix("iii://function/") {
-                    if is_protocol_loop(id) {
-                        return Err(format!(
-                            "Function '{}' is a protocol entry point, not a callable tool",
-                            id
-                        ));
-                    }
+        other => {
+            // Reject protocol entry points BEFORE resolving — avoids leaking
+            // their metadata via the engine round-trip and short-circuits
+            // before any list_functions traffic.
+            if let Some(id) = other.strip_prefix("iii://function/") {
+                if is_protocol_loop(id) {
+                    return Err(format!(
+                        "Function '{}' is a protocol entry point, not a callable tool",
+                        id
+                    ));
                 }
-                (body, mime)
             }
-            None => return Err(format!("Resource not found: {}", p.uri)),
-        },
+            match resolve_templated_uri(other, iii).await {
+                Some((body, mime)) => (body, mime),
+                None => return Err(format!("Resource not found: {}", p.uri)),
+            }
+        }
     };
     Ok(json!({ "contents": [{ "uri": p.uri, "mimeType": mime, "text": text }] }))
 }

--- a/mcp/src/handler.rs
+++ b/mcp/src/handler.rs
@@ -30,83 +30,11 @@ const INTERNAL_ERROR: i32 = -32603;
 const INVALID_PARAMS: i32 = -32602;
 const METHOD_NOT_FOUND: i32 = -32601;
 
-fn has_metadata_flag(f: &FunctionInfo, key: &str) -> bool {
-    f.metadata
-        .as_ref()
-        .and_then(|m| m.get(key))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false)
-}
-
-fn metadata_string(f: &FunctionInfo, key: &str) -> Option<String> {
-    f.metadata
-        .as_ref()
-        .and_then(|m| m.get(key))
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
-}
-
-// Prefixes that are NEVER surfaced as MCP tools, even under --expose-all.
-// These are iii-engine internals — surfacing `state::set` or `engine::*` as
-// an MCP tool lets an agent poke at engine plumbing, which is categorically
-// not an agent-facing surface. Matches the same carve-out the `agent`
-// worker enforces via DEFAULT_EXCLUDED_PREFIXES.
-pub const ALWAYS_HIDDEN_PREFIXES: &[&str] = &[
-    "engine::", "state::", "stream::",
-    // SDK internals come in two notations — callback-style
-    // `iii.on_functions_available.<uuid>` and namespace-style
-    // `iii::durable::publish`, `iii::config`. Match both.
-    "iii.", "iii::",
-    // Protocol-worker entry points are stateless RPC dispatchers. Routing
-    // an MCP tools/call through `mcp::handler` recurses into ourselves;
-    // through `a2a::jsonrpc` double-envelopes an A2A request inside MCP.
-    // Neither is a useful tool surface. Hide both even under --expose-all.
-    "mcp::", "a2a::",
-];
-
-fn is_always_hidden(function_id: &str) -> bool {
-    ALWAYS_HIDDEN_PREFIXES
-        .iter()
-        .any(|p| function_id.starts_with(p))
-}
-
-#[derive(Debug, Clone)]
-pub struct ExposureConfig {
-    /// Ignore the `mcp.expose` metadata gate (dev only).
-    pub expose_all: bool,
-    /// Skip the 6 built-in management tools in tools/list. Default true for
-    /// HTTP transport where worker-management isn't applicable anyway.
-    pub no_builtins: bool,
-    /// Optional tier filter. When set, only functions whose `mcp.tier`
-    /// metadata string equals this value survive the filter.
-    pub tier: Option<String>,
-}
-
-impl ExposureConfig {
-    pub fn new(expose_all: bool, no_builtins: bool, tier: Option<String>) -> Self {
-        Self {
-            expose_all,
-            no_builtins,
-            tier,
-        }
-    }
-}
-
-fn is_function_exposed(f: &FunctionInfo, cfg: &ExposureConfig) -> bool {
-    // Hard floor: infra prefixes never surface, even with --expose-all.
-    if is_always_hidden(&f.function_id) {
-        return false;
-    }
-    if !cfg.expose_all && !has_metadata_flag(f, "mcp.expose") {
-        return false;
-    }
-    if let Some(want_tier) = &cfg.tier {
-        match metadata_string(f, "mcp.tier") {
-            Some(got) if &got == want_tier => {}
-            _ => return false,
-        }
-    }
-    true
+// Blocks self-invocation of the MCP handler and cross-protocol bridging
+// through the sibling A2A entry point. Pure structural guard — not access
+// control. RBAC lives at iii-worker-manager.
+fn is_protocol_loop(function_id: &str) -> bool {
+    function_id.starts_with("mcp::") || function_id.starts_with("a2a::")
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -222,7 +150,7 @@ impl SessionState {
 pub struct McpHandler {
     initialized: AtomicBool,
     iii: III,
-    exposure: ExposureConfig,
+    no_builtins: bool,
     worker_manager: WorkerManager,
     triggers: Mutex<HashMap<String, Trigger>>,
     notification_rx: tokio::sync::Mutex<mpsc::Receiver<String>>,
@@ -232,7 +160,7 @@ pub struct McpHandler {
 }
 
 impl McpHandler {
-    pub fn new(iii: III, engine_url: String, exposure: ExposureConfig) -> Self {
+    pub fn new(iii: III, engine_url: String, no_builtins: bool) -> Self {
         let (tx, notification_rx) = mpsc::channel(64);
         let state = Arc::new(SessionState::new(tx.clone()));
 
@@ -267,15 +195,16 @@ impl McpHandler {
         bg.push(poll_handle);
 
         // Register `mcp::log_message` and `mcp::progress` so user functions
-        // can drive notifications. Both are plain iii functions, kept inside
-        // the always-hidden `mcp::` namespace per ALWAYS_HIDDEN_PREFIXES so
-        // they never appear in tools/list.
+        // can drive notifications. Their function IDs live in the protocol
+        // namespace; the `is_protocol_loop` defense-in-depth filter blocks
+        // them from `tools/list` and `tools/call`. They're only invoked
+        // server-side via `iii.trigger` from worker code.
         register_notification_helpers(&iii, state.clone());
 
         Self {
             initialized: AtomicBool::new(false),
             iii,
-            exposure,
+            no_builtins,
             worker_manager: WorkerManager::new(engine_url),
             triggers: Mutex::new(HashMap::new()),
             notification_rx: tokio::sync::Mutex::new(notification_rx),
@@ -379,7 +308,7 @@ impl McpHandler {
     }
 
     async fn tools_list(&self, cursor: Option<&str>) -> Result<Value, String> {
-        let mut tools = if self.exposure.no_builtins {
+        let mut tools = if self.no_builtins {
             Vec::new()
         } else {
             builtin_tools()
@@ -388,7 +317,7 @@ impl McpHandler {
             tools.extend(
                 functions
                     .iter()
-                    .filter(|f| is_function_exposed(f, &self.exposure))
+                    .filter(|f| !is_protocol_loop(&f.function_id))
                     .map(function_to_tool),
             );
         }
@@ -448,7 +377,7 @@ impl McpHandler {
         // When builtins are hidden from tools/list, also refuse to dispatch
         // them by name. Otherwise a client could invoke `iii_worker_register`
         // on a server that claimed it had no such tool — bypassing the policy.
-        if self.exposure.no_builtins && is_builtin_tool(&params.name) {
+        if self.no_builtins && is_builtin_tool(&params.name) {
             return Ok(tool_error(&format!(
                 "Tool '{}' is disabled on this server (--no-builtins is set)",
                 params.name
@@ -477,6 +406,12 @@ impl McpHandler {
                 if fid.is_empty() {
                     return Ok(tool_error("Missing required field: function_id"));
                 }
+                if is_protocol_loop(&fid) {
+                    return Ok(tool_error(&format!(
+                        "Function '{}' is a protocol entry point, not a callable tool",
+                        fid
+                    )));
+                }
                 let payload = params
                     .arguments
                     .get("payload")
@@ -500,6 +435,12 @@ impl McpHandler {
                 let fid = str_field(&params.arguments, "function_id");
                 if fid.is_empty() {
                     return Ok(tool_error("Missing required field: function_id"));
+                }
+                if is_protocol_loop(&fid) {
+                    return Ok(tool_error(&format!(
+                        "Function '{}' is a protocol entry point, not a callable tool",
+                        fid
+                    )));
                 }
                 let payload = params
                     .arguments
@@ -525,38 +466,16 @@ impl McpHandler {
         }
 
         let function_id = params.name.replace("__", "::");
-        // Hard floor applies before the metadata gate — a hidden infra
-        // function stays unreachable even when --expose-all is set.
-        if is_always_hidden(&function_id) {
+        // Structural guard: refuse to recurse into the MCP handler or
+        // double-envelope through the sibling A2A entry. Access control for
+        // every other namespace is owned by iii-worker-manager RBAC.
+        if is_protocol_loop(&function_id) {
             return Ok(tool_error(&format!(
-                "Function '{}' is in the iii-engine internal namespace and is not exposed as an MCP tool",
+                "Function '{}' is a protocol entry point, not a callable tool",
                 function_id
             )));
         }
-        // Fail closed: if we can't verify exposure (engine unreachable,
-        // list_functions errored), refuse the call. The earlier code
-        // silently dropped the check on Err and handed through to
-        // iii.trigger — that meant an engine outage masked the policy gate.
-        let fns = match self.iii.list_functions().await {
-            Ok(fns) => fns,
-            Err(e) => {
-                tracing::error!(error = %e, function_id = %function_id, "list_functions failed; denying call");
-                return Ok(tool_error(&format!(
-                    "Function '{}' exposure could not be verified (engine list_functions error); denying call",
-                    function_id
-                )));
-            }
-        };
-        let matched = fns.iter().find(|f| f.function_id == function_id);
-        let exposed = matched
-            .map(|f| is_function_exposed(f, &self.exposure))
-            .unwrap_or(false);
-        if !exposed {
-            return Ok(tool_error(&format!(
-                "Function '{}' is not exposed via mcp.expose metadata (or does not match the active --tier filter)",
-                function_id
-            )));
-        }
+
         let trigger_fut = self.iii.trigger(TriggerRequest {
             function_id: function_id.clone(),
             payload: params.arguments,
@@ -591,7 +510,7 @@ impl McpHandler {
     }
 
     async fn resources_read(&self, params: Option<Value>) -> Result<Value, String> {
-        read_resource(&self.iii, &self.exposure, params).await
+        read_resource(&self.iii, params).await
     }
 
     async fn trigger_register(&self, args: Value) -> Value {
@@ -641,9 +560,8 @@ impl McpHandler {
     }
 }
 
-pub fn register_http(iii: &III, exposure: ExposureConfig) {
+pub fn register_http(iii: &III, no_builtins: bool) {
     let iii_fn = iii.clone();
-    let cfg = exposure;
     // Shared session state for the HTTP transport. Single-tenant: every POST
     // /mcp request reuses the same subscriptions/log_level/progress state
     // until the worker is restarted. Sufficient for the current Phase 2a
@@ -668,11 +586,10 @@ pub fn register_http(iii: &III, exposure: ExposureConfig) {
         },
         move |input: Value| {
             let iii_inner = iii_fn.clone();
-            let cfg_inner = cfg.clone();
             let state_inner = state.clone();
             async move {
                 let body = input.get("body").cloned().unwrap_or(input);
-                let response = dispatch_http(&iii_inner, &body, &cfg_inner, &state_inner).await;
+                let response = dispatch_http(&iii_inner, &body, no_builtins, &state_inner).await;
                 Ok(json!({ "status_code": 200, "headers": { "content-type": "application/json" }, "body": response }))
             }
         },
@@ -701,7 +618,7 @@ fn initialize_result() -> Value {
             "completions": {}
         },
         "serverInfo": { "name": "iii-mcp", "version": env!("CARGO_PKG_VERSION") },
-        "instructions": "iii-engine MCP server. Only functions with metadata `mcp.expose: true` are exposed as tools. Infra namespaces (engine::*, state::*, stream::*, iii.*, mcp::*) are always hidden. Optional `mcp.tier` metadata is filtered by the server's --tier flag."
+        "instructions": "iii-engine MCP server. Access control is enforced by iii-worker-manager RBAC (see https://iii.dev/docs/how-to/worker-rbac.md)."
     })
 }
 
@@ -901,7 +818,7 @@ fn register_notification_helpers(iii: &III, state: Arc<SessionState>) {
 async fn dispatch_http(
     iii: &III,
     body: &Value,
-    cfg: &ExposureConfig,
+    no_builtins: bool,
     state: &Arc<SessionState>,
 ) -> Value {
     let method = body.get("method").and_then(|v| v.as_str()).unwrap_or("");
@@ -932,7 +849,7 @@ async fn dispatch_http(
             // HTTP transport hides builtins by default — worker/trigger
             // management requires stdio, so listing them over HTTP is pure
             // noise that errors on invocation anyway.
-            let mut tools = if cfg.no_builtins {
+            let mut tools = if no_builtins {
                 Vec::new()
             } else {
                 builtin_tools()
@@ -940,7 +857,7 @@ async fn dispatch_http(
             if let Ok(fns) = iii.list_functions().await {
                 tools.extend(
                     fns.iter()
-                        .filter(|f| is_function_exposed(f, cfg))
+                        .filter(|f| !is_protocol_loop(&f.function_id))
                         .map(function_to_tool),
                 );
             }
@@ -987,7 +904,7 @@ async fn dispatch_http(
             // When --no-builtins is active, the six management tools are
             // also not invocable by name. tools/list hides them; this
             // matches the listing shape at call time.
-            if cfg.no_builtins && is_builtin_tool(&p.name) {
+            if no_builtins && is_builtin_tool(&p.name) {
                 return json!(JsonRpcResponse::success(
                     id,
                     tool_error(&format!(
@@ -1007,6 +924,11 @@ async fn dispatch_http(
                     let fid = str_field(&p.arguments, "function_id");
                     if fid.is_empty() {
                         Ok(tool_error("Missing required field: function_id"))
+                    } else if is_protocol_loop(&fid) {
+                        Ok(tool_error(&format!(
+                            "Function '{}' is a protocol entry point, not a callable tool",
+                            fid
+                        )))
                     } else {
                         let payload = p.arguments.get("payload").cloned().unwrap_or(json!({}));
                         match iii
@@ -1027,6 +949,11 @@ async fn dispatch_http(
                     let fid = str_field(&p.arguments, "function_id");
                     if fid.is_empty() {
                         Ok(tool_error("Missing required field: function_id"))
+                    } else if is_protocol_loop(&fid) {
+                        Ok(tool_error(&format!(
+                            "Function '{}' is a protocol entry point, not a callable tool",
+                            fid
+                        )))
                     } else {
                         let payload = p.arguments.get("payload").cloned().unwrap_or(json!({}));
                         let queue = str_field_or(&p.arguments, "queue", "default");
@@ -1046,39 +973,11 @@ async fn dispatch_http(
                 }
                 _ => {
                     let function_id = p.name.replace("__", "::");
-                    if is_always_hidden(&function_id) {
+                    if is_protocol_loop(&function_id) {
                         return json!(JsonRpcResponse::success(
                             id,
                             tool_error(&format!(
-                                "Function '{}' is in the iii-engine internal namespace and is not exposed as an MCP tool",
-                                function_id
-                            ))
-                        ));
-                    }
-                    // Fail closed on list_functions error — see stdio
-                    // tools_call for the reasoning.
-                    let fns = match iii.list_functions().await {
-                        Ok(fns) => fns,
-                        Err(e) => {
-                            tracing::error!(error = %e, function_id = %function_id, "list_functions failed; denying call");
-                            return json!(JsonRpcResponse::success(
-                                id,
-                                tool_error(&format!(
-                                    "Function '{}' exposure could not be verified (engine list_functions error); denying call",
-                                    function_id
-                                ))
-                            ));
-                        }
-                    };
-                    let matched = fns.iter().find(|f| f.function_id == function_id);
-                    let exposed = matched
-                        .map(|f| is_function_exposed(f, cfg))
-                        .unwrap_or(false);
-                    if !exposed {
-                        return json!(JsonRpcResponse::success(
-                            id,
-                            tool_error(&format!(
-                                "Function '{}' is not exposed via mcp.expose metadata (or does not match the active --tier filter)",
+                                "Function '{}' is a protocol entry point, not a callable tool",
                                 function_id
                             ))
                         ));
@@ -1102,7 +1001,7 @@ async fn dispatch_http(
         // HTTP transport previously omitted these; MCP Inspector hit
         // -32601 Unknown method on both. Parity with stdio McpHandler
         // via the shared read_resource / templates paths.
-        "resources/read" => read_resource(iii, cfg, params)
+        "resources/read" => read_resource(iii, params)
             .await
             .map_err(|e| (INVALID_PARAMS, e)),
         "resources/templates/list" => Ok(json!({
@@ -1136,15 +1035,10 @@ fn parse<T: serde::de::DeserializeOwned>(params: Option<Value>) -> Result<T, Str
 }
 
 // Shared resource reader used by both stdio McpHandler::resources_read and
-// HTTP dispatch_http. Keeps the `iii://functions` exposure filter in exactly
-// one place so stdio and HTTP can't drift (stdio filtered, HTTP didn't →
-// MCP Inspector surfaced the gap when it called resources/read over HTTP
-// and got -32601 Unknown method, which is how this refactor landed).
-pub async fn read_resource(
-    iii: &III,
-    cfg: &ExposureConfig,
-    params: Option<Value>,
-) -> Result<Value, String> {
+// HTTP dispatch_http. Templated `iii://function/{id}` reads block protocol
+// entry points so an agent can't introspect the MCP/A2A handler shapes via
+// resource read; everything else is owned by iii-worker-manager RBAC.
+pub async fn read_resource(iii: &III, params: Option<Value>) -> Result<Value, String> {
     #[derive(Deserialize)]
     struct P {
         uri: String,
@@ -1153,12 +1047,8 @@ pub async fn read_resource(
     let (text, mime) = match p.uri.as_str() {
         "iii://functions" => {
             let v = iii.list_functions().await.map_err(|e| format!("{}", e))?;
-            let filtered: Vec<_> = v
-                .into_iter()
-                .filter(|f| is_function_exposed(f, cfg))
-                .collect();
             (
-                serde_json::to_string_pretty(&filtered).unwrap_or_else(|_| "[]".into()),
+                serde_json::to_string_pretty(&v).unwrap_or_else(|_| "[]".into()),
                 "application/json",
             )
         }
@@ -1183,30 +1073,23 @@ pub async fn read_resource(
             serde_json::to_string_pretty(&json!({
                 "sdk_version": env!("CARGO_PKG_VERSION"),
                 "function_id_delimiter": "::",
-                "metadata_filtering": { "mcp.expose": true, "a2a.expose": true }
+                "access_control": "iii-worker-manager RBAC"
             }))
             .unwrap(),
             "application/json",
         ),
         // Templated URIs: iii://function/{id}, iii://worker/{id}, iii://trigger/{id}.
-        // Resolved through spec::resolve_templated_uri which filters by id only;
-        // exposure metadata is enforced for `iii://function/{id}` here so a
-        // `mcp.expose: false` function can't leak via direct templated read.
+        // `iii://function/{id}` rejects protocol entry points so an agent
+        // can't read MCP/A2A handler internals; everything else falls
+        // through to RBAC at iii-worker-manager.
         other => match resolve_templated_uri(other, iii).await {
             Some((body, mime)) => {
                 if let Some(id) = other.strip_prefix("iii://function/") {
-                    if let Ok(fns) = iii.list_functions().await {
-                        let allowed = fns
-                            .iter()
-                            .find(|f| f.function_id == id)
-                            .map(|f| is_function_exposed(f, cfg))
-                            .unwrap_or(false);
-                        if !allowed {
-                            return Err(format!(
-                                "Function '{}' is not exposed via mcp.expose metadata",
-                                id
-                            ));
-                        }
+                    if is_protocol_loop(id) {
+                        return Err(format!(
+                            "Function '{}' is a protocol entry point, not a callable tool",
+                            id
+                        ));
                     }
                 }
                 (body, mime)

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use clap::Parser;
@@ -5,8 +6,6 @@ use iii_mcp::handler;
 use iii_mcp::transport;
 use iii_sdk::{InitOptions, register_worker};
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
-
-use handler::ExposureConfig;
 
 #[derive(Parser, Debug)]
 #[command(name = "iii-mcp")]
@@ -21,14 +20,6 @@ struct Args {
 
     #[arg(long, help = "Skip stdio, run as HTTP-only (POST /mcp on engine port)")]
     no_stdio: bool,
-
-    #[arg(
-        long,
-        help = "Expose all functions as tools (ignore mcp.expose metadata). \
-                Infra namespaces (engine::*, state::*, stream::*, iii.*, mcp::*) \
-                stay hidden even with this flag."
-    )]
-    expose_all: bool,
 
     #[arg(
         long,
@@ -48,10 +39,12 @@ struct Args {
 
     #[arg(
         long,
-        help = "Show only functions whose `mcp.tier` metadata equals this value \
-                (e.g. `user`, `agent`, `ops`). When unset, tier filtering is off."
+        value_name = "TAG",
+        help = "Forward an `x-iii-rbac-tag` header on the worker WebSocket \
+                upgrade. iii-worker-manager's `auth_function_id` reads this \
+                tag to apply policy. RBAC itself lives at iii-worker-manager."
     )]
-    tier: Option<String>,
+    rbac_tag: Option<String>,
 }
 
 #[tokio::main]
@@ -71,7 +64,18 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!(version = env!("CARGO_PKG_VERSION"), "Starting iii-mcp");
 
-    let iii = register_worker(&args.engine_url, InitOptions::default());
+    let mut init_opts = InitOptions::default();
+    if let Some(tag) = args.rbac_tag.as_ref() {
+        let mut headers = HashMap::new();
+        headers.insert("x-iii-rbac-tag".to_string(), tag.clone());
+        init_opts.headers = Some(headers);
+        tracing::info!(
+            rbac_tag = %tag,
+            "Forwarding rbac-tag in worker headers; configure your auth_function_id to read x-iii-rbac-tag"
+        );
+    }
+
+    let iii = register_worker(&args.engine_url, init_opts);
 
     // HTTP transport hides builtins by default — worker/trigger management
     // needs the stdio-attached process anyway, so exposing them over HTTP
@@ -80,19 +84,16 @@ async fn main() -> anyhow::Result<()> {
     // still wins (forces hidden everywhere). stdio keeps the default of
     // showing builtins (common Claude Desktop path).
     let http_no_builtins = args.no_builtins || !args.http_builtins;
-    let http_exposure = ExposureConfig::new(args.expose_all, http_no_builtins, args.tier.clone());
-    handler::register_http(&iii, http_exposure);
+    handler::register_http(&iii, http_no_builtins);
 
     if args.no_stdio {
         tracing::info!("MCP HTTP-only mode. POST /mcp on engine port. Ctrl+C to stop.");
         tokio::signal::ctrl_c().await?;
     } else {
-        let stdio_exposure =
-            ExposureConfig::new(args.expose_all, args.no_builtins, args.tier.clone());
         let h = Arc::new(handler::McpHandler::new(
             iii,
             args.engine_url,
-            stdio_exposure,
+            args.no_builtins,
         ));
         transport::run_stdio(h).await?;
     }

--- a/mcp/src/prompts.rs
+++ b/mcp/src/prompts.rs
@@ -81,8 +81,7 @@ pub fn get(params: Option<Value>) -> Value {
                      3. Wire trigger via `iii_trigger_register`\n\n\
                      ```python\nfrom iii_sdk import register_worker, Logger\n\
                      iii = register_worker('ws://localhost:49134')\n\
-                     # metadata={{'mcp.expose': True}} so the function appears in tools/list\n\
-                     iii.register_function('{fid}', handler, metadata={{'mcp.expose': True}})\n\
+                     iii.register_function('{fid}', handler)\n\
                      ```"
                 ),
                 "node" => format!(
@@ -92,8 +91,7 @@ pub fn get(params: Option<Value>) -> Value {
                      3. Wire trigger via `iii_trigger_register`\n\n\
                      ```js\nimport {{ registerWorker, Logger }} from 'iii-sdk'\n\
                      const iii = registerWorker('ws://localhost:49134')\n\
-                     // metadata: {{ 'mcp.expose': true }} so the function appears in tools/list\n\
-                     iii.registerFunction('{fid}', handler, {{ metadata: {{ 'mcp.expose': true }} }})\n\
+                     iii.registerFunction('{fid}', handler)\n\
                      ```"
                 ),
                 _ => format!(

--- a/mcp/src/worker_manager.rs
+++ b/mcp/src/worker_manager.rs
@@ -207,7 +207,7 @@ const logger = new Logger()
 
 const handler = {code}
 
-iii.registerFunction({{ id: {function_name}, description: {description}, metadata: {{ "mcp.expose": true }} }}, handler)
+iii.registerFunction({{ id: {function_name}, description: {description} }}, handler)
 
 logger.info('Function registered: ' + {function_name})
 
@@ -247,7 +247,7 @@ logger = Logger()
 
 {code}
 
-iii.register_function({function_name}, handler, description={description}, metadata={{"mcp.expose": True}})
+iii.register_function({function_name}, handler, description={description})
 
 def shutdown(sig, frame):
     logger.info('Worker shutting down')

--- a/mcp/tests/cli.rs
+++ b/mcp/tests/cli.rs
@@ -52,10 +52,9 @@ fn help_flag_advertises_known_transport_flags() {
     for flag in [
         "--engine-url",
         "--no-stdio",
-        "--expose-all",
         "--no-builtins",
         "--http-builtins",
-        "--tier",
+        "--rbac-tag",
     ] {
         assert!(help.contains(flag), "--help should mention {flag}: {help}");
     }

--- a/mcp/tests/protocol_loop_guard.rs
+++ b/mcp/tests/protocol_loop_guard.rs
@@ -1,0 +1,111 @@
+//! Phase 1 — protocol-loop structural guard.
+//!
+//! `is_protocol_loop` is the single defense the handler keeps after RBAC
+//! moved to iii-worker-manager. It blocks `mcp::*` and `a2a::*` function IDs
+//! at every dispatch entry point — `tools/call` direct, `iii_trigger_void`,
+//! and `iii_trigger_enqueue`. These tests use an unreachable iii engine so
+//! `iii.trigger` never runs; the rejection happens before that.
+
+use iii_mcp::handler::McpHandler;
+use iii_sdk::III;
+use serde_json::{Value, json};
+
+fn unreachable_iii() -> III {
+    // Port 1 is reserved/unbound; the SDK reconnect loop runs in the
+    // background, but every `iii.trigger` call returns Err immediately.
+    // The guards we're testing reject BEFORE any trigger fires, so the
+    // engine being unreachable is fine.
+    III::new("ws://127.0.0.1:1")
+}
+
+async fn handler() -> std::sync::Arc<McpHandler> {
+    let h = std::sync::Arc::new(McpHandler::new(
+        unreachable_iii(),
+        "ws://127.0.0.1:1".to_string(),
+        true, // no_builtins=true so builtin tools are out of the way
+    ));
+    h.handle(json!({"jsonrpc":"2.0","id":1,"method":"initialize"}))
+        .await;
+    h.handle(json!({"jsonrpc":"2.0","method":"notifications/initialized"}))
+        .await;
+    h
+}
+
+async fn handler_with_builtins() -> std::sync::Arc<McpHandler> {
+    let h = std::sync::Arc::new(McpHandler::new(
+        unreachable_iii(),
+        "ws://127.0.0.1:1".to_string(),
+        false, // no_builtins=false so iii_trigger_* dispatchers are reachable
+    ));
+    h.handle(json!({"jsonrpc":"2.0","id":1,"method":"initialize"}))
+        .await;
+    h.handle(json!({"jsonrpc":"2.0","method":"notifications/initialized"}))
+        .await;
+    h
+}
+
+fn assert_protocol_loop_error(resp: Option<Value>) {
+    let v = resp.expect("response");
+    let result = &v["result"];
+    assert_eq!(result["isError"], true, "expected isError=true, got: {}", v);
+    let text = result["content"][0]["text"].as_str().unwrap_or("");
+    assert!(
+        text.contains("protocol entry point"),
+        "expected 'protocol entry point' in error message, got: {}",
+        text
+    );
+}
+
+#[tokio::test]
+async fn tools_call_mcp_handler_rejected() {
+    let h = handler().await;
+    let resp = h
+        .handle(json!({
+            "jsonrpc":"2.0","id":2,"method":"tools/call",
+            "params":{"name":"mcp__handler","arguments":{}}
+        }))
+        .await;
+    assert_protocol_loop_error(resp);
+}
+
+#[tokio::test]
+async fn tools_call_a2a_jsonrpc_rejected() {
+    let h = handler().await;
+    let resp = h
+        .handle(json!({
+            "jsonrpc":"2.0","id":3,"method":"tools/call",
+            "params":{"name":"a2a__jsonrpc","arguments":{}}
+        }))
+        .await;
+    assert_protocol_loop_error(resp);
+}
+
+#[tokio::test]
+async fn iii_trigger_void_with_mcp_function_id_rejected() {
+    let h = handler_with_builtins().await;
+    let resp = h
+        .handle(json!({
+            "jsonrpc":"2.0","id":4,"method":"tools/call",
+            "params":{
+                "name":"iii_trigger_void",
+                "arguments":{"function_id":"mcp::handler","payload":{}}
+            }
+        }))
+        .await;
+    assert_protocol_loop_error(resp);
+}
+
+#[tokio::test]
+async fn iii_trigger_enqueue_with_a2a_function_id_rejected() {
+    let h = handler_with_builtins().await;
+    let resp = h
+        .handle(json!({
+            "jsonrpc":"2.0","id":5,"method":"tools/call",
+            "params":{
+                "name":"iii_trigger_enqueue",
+                "arguments":{"function_id":"a2a::jsonrpc","payload":{},"queue":"default"}
+            }
+        }))
+        .await;
+    assert_protocol_loop_error(resp);
+}

--- a/mcp/tests/spec_2a.rs
+++ b/mcp/tests/spec_2a.rs
@@ -107,7 +107,8 @@ fn make_tool_annotations_reads_all_hints() {
 
 #[test]
 fn make_tool_annotations_returns_none_when_no_keys() {
-    let meta = json!({ "mcp": { "expose": true } });
+    // Sentinel: metadata that has no annotation keys returns None.
+    let meta = json!({ "mcp": { "unrelated": true } });
     assert!(spec::make_tool_annotations(&meta).is_none());
 }
 
@@ -379,7 +380,7 @@ async fn live_tools_call_cancelled() {
             description: Some("slow handler".into()),
             request_format: None,
             response_format: None,
-            metadata: Some(json!({"mcp": {"expose": true}})),
+            metadata: None,
             invocation: None,
         },
         |_input: Value| async move {

--- a/mcp/tests/spec_2a.rs
+++ b/mcp/tests/spec_2a.rs
@@ -191,16 +191,12 @@ fn subscribe_unsubscribe_round_trip() {
 #[tokio::test]
 #[ignore = "requires live iii-engine on ws://localhost:49134"]
 async fn live_logging_set_level_then_log_message() {
-    use iii_mcp::handler::{ExposureConfig, McpHandler};
+    use iii_mcp::handler::McpHandler;
     use iii_sdk::{InitOptions, TriggerRequest, register_worker};
 
     let url = "ws://localhost:49134";
     let iii = register_worker(url, InitOptions::default());
-    let handler = std::sync::Arc::new(McpHandler::new(
-        iii.clone(),
-        url.to_string(),
-        ExposureConfig::new(false, false, None),
-    ));
+    let handler = std::sync::Arc::new(McpHandler::new(iii.clone(), url.to_string(), false));
 
     // Bring handler to initialized state.
     handler
@@ -275,16 +271,12 @@ async fn live_logging_set_level_then_log_message() {
 #[tokio::test]
 #[ignore = "requires live iii-engine on ws://localhost:49134"]
 async fn live_progress_token_round_trip() {
-    use iii_mcp::handler::{ExposureConfig, McpHandler};
+    use iii_mcp::handler::McpHandler;
     use iii_sdk::{InitOptions, TriggerRequest, register_worker};
 
     let url = "ws://localhost:49134";
     let iii = register_worker(url, InitOptions::default());
-    let handler = std::sync::Arc::new(McpHandler::new(
-        iii.clone(),
-        url.to_string(),
-        ExposureConfig::new(false, false, None),
-    ));
+    let handler = std::sync::Arc::new(McpHandler::new(iii.clone(), url.to_string(), false));
     handler
         .handle(json!({"jsonrpc":"2.0","id":1,"method":"initialize"}))
         .await;
@@ -322,16 +314,12 @@ async fn live_progress_token_round_trip() {
 #[tokio::test]
 #[ignore = "requires live iii-engine on ws://localhost:49134"]
 async fn live_subscribe_function_added_emits_updated() {
-    use iii_mcp::handler::{ExposureConfig, McpHandler};
+    use iii_mcp::handler::McpHandler;
     use iii_sdk::{InitOptions, RegisterFunctionMessage, register_worker};
 
     let url = "ws://localhost:49134";
     let iii = register_worker(url, InitOptions::default());
-    let handler = std::sync::Arc::new(McpHandler::new(
-        iii.clone(),
-        url.to_string(),
-        ExposureConfig::new(false, false, None),
-    ));
+    let handler = std::sync::Arc::new(McpHandler::new(iii.clone(), url.to_string(), false));
     handler
         .handle(json!({"jsonrpc":"2.0","id":1,"method":"initialize"}))
         .await;
@@ -379,7 +367,7 @@ async fn live_subscribe_function_added_emits_updated() {
 #[tokio::test]
 #[ignore = "requires live iii-engine on ws://localhost:49134"]
 async fn live_tools_call_cancelled() {
-    use iii_mcp::handler::{ExposureConfig, McpHandler};
+    use iii_mcp::handler::McpHandler;
     use iii_sdk::{InitOptions, RegisterFunctionMessage, register_worker};
 
     let url = "ws://localhost:49134";
@@ -400,11 +388,7 @@ async fn live_tools_call_cancelled() {
         },
     );
 
-    let handler = std::sync::Arc::new(McpHandler::new(
-        iii.clone(),
-        url.to_string(),
-        ExposureConfig::new(false, true, None),
-    ));
+    let handler = std::sync::Arc::new(McpHandler::new(iii.clone(), url.to_string(), true));
     handler
         .handle(json!({"jsonrpc":"2.0","id":1,"method":"initialize"}))
         .await;


### PR DESCRIPTION
Tracks #45 — Phase 1 of MCP+A2A overhaul. **Breaking change** — tag as v0.4.0.

## Summary

Protocols become transports, not policy. Access control fully delegated to `iii-worker-manager` RBAC (`auth_function_id`, `expose_functions`, `AuthResult.{allowed,forbidden}_functions`).

**Removed:**
- \`ALWAYS_HIDDEN_PREFIXES\` (except \`mcp::\`/\`a2a::\` which become a structural loop guard)
- \`ExposureConfig\`, \`is_function_exposed\`, \`is_exposed\`, \`has_metadata_flag\`, \`metadata_string\`
- \`--expose-all\` and \`--tier\` flags
- \`mcp.expose\` / \`a2a.expose\` / \`mcp.tier\` / \`a2a.tier\` metadata gates
- All call sites in \`tools/list\`, \`tools/call\`, \`dispatch_http\`, \`read_resource\`, \`build_agent_card\`, \`handle_send\`

**Kept:**
- \`is_protocol_loop\` — narrow structural rule blocking \`mcp::*\` / \`a2a::*\` to prevent self-invocation recursion. Doc-commented as a loop guard, not access control.
- \`--no-builtins\` — orthogonal to RBAC (controls iii-owned management tools).

**Added:**
- \`--rbac-tag <TAG>\` flag → forwarded as \`x-iii-rbac-tag\` in \`InitOptions.headers\` so deploy-side \`auth_function_id\` can scope this protocol session.
- Defense-in-depth filter on \`tools/list\` and agent-card so \`mcp::*\` / \`a2a::*\` entries can never appear even if RBAC misconfigured.
- \`tracing::warn!\` on \`list_functions\` errors (was silent swallow).
- \`examples/default-secure-auth.rs\` in both crates — drop-in v0.3-style migration helper.
- New tests: \`protocol_loop_guard.rs\` covering \`tools/call\` rejection of \`mcp::handler\` and \`a2a::jsonrpc\`, plus the \`iii_trigger_void\` / \`iii_trigger_enqueue\` dispatcher rejection paths.

## Migration

Existing v0.3.x deploys porting policy: \`examples/default-secure-auth.rs\` reproduces the old prefix block via \`AuthResult.forbidden_functions\` listing concrete engine/SDK control-plane IDs. README rewrites under a new "Access control" section.

For engine-introspection use cases the old hard floor hid: use the \`introspect\` worker (\`iii worker add introspect\`) — already shipped, properly namespaced.

## Test plan

- [x] \`cargo check -p iii-mcp -p iii-a2a\` clean
- [x] \`cargo test -p iii-mcp -p iii-a2a\` green (4 + 2 = 6 tests pass; live-engine ignored)
- [x] \`cargo build --example default-secure-auth -p iii-mcp -p iii-a2a\` clean
- [ ] Manual: deploy with \`auth_function_id\` returning \`forbidden_functions: ["engine::*"]\` → \`tools/list\` excludes engine namespace

## Sequencing

Rebase on top of phase0/bugs to inherit \`/a2a\` suffix + docs URL fixes. Tag as v0.4.0 once merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --rbac-tag CLI flag, secure-auth example programs, and a protocol-loop guard to block protocol entry-point calls

* **Breaking Changes**
  * Removed --expose-all/--tier flags and per-function expose/tier metadata; agent-card/registration APIs no longer accept per-function exposure config

* **Bug Fixes**
  * Early rejection of protocol entry points and idempotent handling of already-terminal tasks

* **Documentation**
  * Updated guides, prompts, and RBAC configuration examples

* **Tests**
  * Added protocol-loop and agent-card tests

* **Chores**
  * Package versions bumped to 0.4.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->