### PR TITLE
Phase 2a: MCP 2025-06-18 non-streaming spec methods

### DIFF
--- a/mcp/Cargo.lock
+++ b/mcp/Cargo.lock
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "iii-mcp"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/mcp/Cargo.lock
+++ b/mcp/Cargo.lock
@@ -229,6 +229,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,6 +242,20 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -451,6 +471,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -706,10 +732,12 @@ dependencies = [
 
 [[package]]
 name = "iii-mcp"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
+ "base64",
  "clap",
+ "dashmap",
  "iii-sdk",
  "serde",
  "serde_json",
@@ -829,6 +857,15 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -991,6 +1028,19 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -1215,6 +1265,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,6 +1439,12 @@ dependencies = [
  "serde_derive_internals",
  "syn",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -25,3 +25,5 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 anyhow = "1"
 uuid = { version = "1", features = ["v4"] }
+dashmap = "6"
+base64 = "0.22"

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iii-mcp"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 description = "MCP protocol worker for iii-engine"
 license = "Apache-2.0"

--- a/mcp/src/handler.rs
+++ b/mcp/src/handler.rs
@@ -1,15 +1,22 @@
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
+use dashmap::DashMap;
 use iii_sdk::{
     FunctionInfo, FunctionsAvailableGuard, III, RegisterFunctionMessage, RegisterTriggerInput,
     Trigger, TriggerAction, TriggerRequest, Value,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::{Mutex, mpsc, oneshot};
 
 use crate::prompts;
+use crate::spec::{
+    self, LOG_INFO, PAGE_SIZE, ToolAnnotations, level_from_str, log_message_notification,
+    make_tool_annotations, paginate, progress_notification, resource_updated_notification,
+    resolve_templated_uri,
+};
 use crate::worker_manager::{WorkerCreateParams, WorkerManager, WorkerStopParams};
 
 // Current published MCP spec revision. Bump when moving to a newer one.
@@ -142,6 +149,58 @@ impl JsonRpcResponse {
     }
 }
 
+// Per-session MCP spec state (subscriptions, log level, progress tokens,
+// in-flight cancellation senders). Lives in an Arc so the HTTP `dispatch_http`
+// path can share an instance keyed by session and the stdio handler can hold
+// a single instance for its single attached client.
+pub struct SessionState {
+    pub subscriptions: std::sync::Mutex<HashSet<String>>,
+    pub log_level: AtomicU8,
+    // request_id (from tools/call) → progress token. Unused for routing today
+    // (we simply emit notifications/progress with the token the user provided
+    // via `mcp::progress`), but tracked so cancellation/progress can correlate
+    // when richer routing is needed.
+    pub progress_tokens: DashMap<Value, Value>,
+    // request_id → cancel sender. When `notifications/cancelled` arrives,
+    // we fire the matching sender to abort an in-flight tools/call.
+    pub cancellation_tokens: DashMap<String, oneshot::Sender<()>>,
+    pub notifier: mpsc::Sender<String>,
+}
+
+impl SessionState {
+    pub fn new(notifier: mpsc::Sender<String>) -> Self {
+        Self {
+            subscriptions: std::sync::Mutex::new(HashSet::new()),
+            log_level: AtomicU8::new(LOG_INFO),
+            progress_tokens: DashMap::new(),
+            cancellation_tokens: DashMap::new(),
+            notifier,
+        }
+    }
+
+    pub fn try_send(&self, msg: String) {
+        if self.notifier.try_send(msg).is_err() {
+            tracing::warn!("Notification channel full; dropping message");
+        }
+    }
+
+    pub fn is_subscribed(&self, uri: &str) -> bool {
+        self.subscriptions
+            .lock()
+            .map(|g| g.contains(uri))
+            .unwrap_or(false)
+    }
+
+    fn request_id_key(id: &Value) -> String {
+        // request ids in JSON-RPC can be string or number. Normalize to a
+        // single string key so DashMap keys are uniform.
+        match id {
+            Value::String(s) => s.clone(),
+            other => other.to_string(),
+        }
+    }
+}
+
 pub struct McpHandler {
     initialized: AtomicBool,
     iii: III,
@@ -149,21 +208,52 @@ pub struct McpHandler {
     worker_manager: WorkerManager,
     triggers: Mutex<HashMap<String, Trigger>>,
     notification_rx: tokio::sync::Mutex<mpsc::Receiver<String>>,
+    state: Arc<SessionState>,
     _functions_guard: FunctionsAvailableGuard,
+    _bg_tasks: Vec<tokio::task::JoinHandle<()>>,
 }
 
 impl McpHandler {
     pub fn new(iii: III, engine_url: String, exposure: ExposureConfig) -> Self {
-        let (tx, notification_rx) = mpsc::channel(16);
+        let (tx, notification_rx) = mpsc::channel(64);
+        let state = Arc::new(SessionState::new(tx.clone()));
 
+        // tools/list_changed: piggyback on the SDK's on_functions_available
+        // callback. resources/list_changed shares the same trigger because
+        // listing functions is what `iii://functions` resolves to.
+        let state_for_fn_cb = state.clone();
         let guard = iii.on_functions_available(move |_| {
-            let n = json!({ "jsonrpc": "2.0", "method": "notifications/tools/list_changed" });
-            if let Ok(json) = serde_json::to_string(&n) {
-                if tx.try_send(json).is_err() {
-                    tracing::warn!("Notification channel full, tools/list_changed dropped");
+            let n =
+                json!({ "jsonrpc": "2.0", "method": "notifications/tools/list_changed" });
+            if let Ok(s) = serde_json::to_string(&n) {
+                state_for_fn_cb.try_send(s);
+            }
+            // Also fire resources/updated for iii://functions if subscribed.
+            if state_for_fn_cb.is_subscribed("iii://functions") {
+                if let Ok(s) =
+                    serde_json::to_string(&resource_updated_notification("iii://functions"))
+                {
+                    state_for_fn_cb.try_send(s);
                 }
             }
         });
+
+        // Background poll: workers + triggers don't have an SDK callback, so
+        // poll every 5s and emit resources/updated on diff. Cheap (two engine
+        // round-trips) and only runs while the handler is alive.
+        let mut bg = Vec::new();
+        let iii_poll = iii.clone();
+        let state_poll = state.clone();
+        let poll_handle = tokio::spawn(async move {
+            poll_resource_updates(iii_poll, state_poll).await;
+        });
+        bg.push(poll_handle);
+
+        // Register `mcp::log_message` and `mcp::progress` so user functions
+        // can drive notifications. Both are plain iii functions, kept inside
+        // the always-hidden `mcp::` namespace per ALWAYS_HIDDEN_PREFIXES so
+        // they never appear in tools/list.
+        register_notification_helpers(&iii, state.clone());
 
         Self {
             initialized: AtomicBool::new(false),
@@ -172,8 +262,14 @@ impl McpHandler {
             worker_manager: WorkerManager::new(engine_url),
             triggers: Mutex::new(HashMap::new()),
             notification_rx: tokio::sync::Mutex::new(notification_rx),
+            state,
             _functions_guard: guard,
+            _bg_tasks: bg,
         }
+    }
+
+    pub fn state(&self) -> &Arc<SessionState> {
+        &self.state
     }
 
     pub async fn take_notification(&self) -> Option<String> {
@@ -187,6 +283,18 @@ impl McpHandler {
         if method.starts_with("notifications/") {
             if method == "notifications/initialized" {
                 self.initialized.store(true, Ordering::SeqCst);
+            }
+            if method == "notifications/cancelled" {
+                if let Some(req_id) = body
+                    .get("params")
+                    .and_then(|p| p.get("requestId"))
+                    .cloned()
+                {
+                    let key = SessionState::request_id_key(&req_id);
+                    if let Some((_, sender)) = self.state.cancellation_tokens.remove(&key) {
+                        let _ = sender.send(());
+                    }
+                }
             }
             return None;
         }
@@ -208,23 +316,48 @@ impl McpHandler {
         let method = body.get("method").and_then(|v| v.as_str()).unwrap_or("");
         let id = body.get("id").cloned();
         let params = body.get("params").cloned();
+        let cursor = params
+            .as_ref()
+            .and_then(|p| p.get("cursor"))
+            .and_then(|c| c.as_str())
+            .map(String::from);
 
         let result = match method {
             "initialize" => Ok(initialize_result()),
             "ping" => Ok(json!({})),
-            "tools/list" => self.tools_list().await.map_err(|e| (INTERNAL_ERROR, e)),
+            "tools/list" => self
+                .tools_list(cursor.as_deref())
+                .await
+                .map_err(|e| (INTERNAL_ERROR, e)),
             "tools/call" => self
-                .tools_call(params)
+                .tools_call(id.clone(), body)
                 .await
                 .map_err(|e| (INVALID_PARAMS, e)),
-            "resources/list" => Ok(self.resources_list()),
+            "resources/list" => Ok(self.resources_list(cursor.as_deref())),
             "resources/read" => self
                 .resources_read(params)
                 .await
                 .map_err(|e| (INVALID_PARAMS, e)),
-            "resources/templates/list" => Ok(json!({ "resourceTemplates": [] })),
-            "prompts/list" => Ok(prompts::list()),
+            "resources/templates/list" => Ok(json!({
+                "resourceTemplates": spec::make_resource_templates()
+            })),
+            "resources/subscribe" => spec::handle_resources_subscribe(
+                &self.state.subscriptions,
+                params,
+            )
+            .map_err(|e| (INVALID_PARAMS, e)),
+            "resources/unsubscribe" => spec::handle_resources_unsubscribe(
+                &self.state.subscriptions,
+                params,
+            )
+            .map_err(|e| (INVALID_PARAMS, e)),
+            "prompts/list" => Ok(prompts_list_paginated(cursor.as_deref())),
             "prompts/get" => Ok(prompts::get(params)),
+            "completion/complete" => spec::handle_completion_complete(&self.iii, params)
+                .await
+                .map_err(|e| (INVALID_PARAMS, e)),
+            "logging/setLevel" => spec::handle_logging_set_level(&self.state.log_level, params)
+                .map_err(|e| (INVALID_PARAMS, e)),
             _ => Err((METHOD_NOT_FOUND, format!("Unknown method: {}", method))),
         };
 
@@ -234,7 +367,7 @@ impl McpHandler {
         })
     }
 
-    async fn tools_list(&self) -> Result<Value, String> {
+    async fn tools_list(&self, cursor: Option<&str>) -> Result<Value, String> {
         let mut tools = if self.exposure.no_builtins {
             Vec::new()
         } else {
@@ -248,11 +381,59 @@ impl McpHandler {
                     .map(function_to_tool),
             );
         }
-        Ok(json!({ "tools": tools }))
+        let (page, next) = paginate(&tools, cursor, PAGE_SIZE);
+        let page_owned: Vec<McpTool> = page.into_iter().cloned().collect();
+        let mut out = json!({ "tools": page_owned });
+        if let Some(c) = next {
+            out["nextCursor"] = json!(c);
+        }
+        Ok(out)
     }
 
-    async fn tools_call(&self, params: Option<Value>) -> Result<Value, String> {
-        let params: CallParams = parse(params)?;
+    async fn tools_call(&self, id: Option<Value>, body: &Value) -> Result<Value, String> {
+        let raw_params = body.get("params").cloned();
+        let params: CallParams = parse(raw_params.clone())?;
+
+        // _meta.progressToken: bind it to the request id so a tool implementation
+        // calling `mcp::progress` with this token gets routed through.
+        let progress_token = raw_params
+            .as_ref()
+            .and_then(|p| p.get("_meta"))
+            .and_then(|m| m.get("progressToken"))
+            .cloned();
+        if let (Some(req_id), Some(token)) = (id.clone(), progress_token.clone()) {
+            self.state.progress_tokens.insert(req_id, token);
+        }
+
+        // Register cancellation receiver. Even if tools_call short-circuits
+        // before reaching iii.trigger, the slot is removed at end via the
+        // RAII-ish scope guard pattern below.
+        let req_key = id.as_ref().map(SessionState::request_id_key);
+        let cancel_rx = if let Some(ref key) = req_key {
+            let (tx, rx) = oneshot::channel();
+            self.state.cancellation_tokens.insert(key.clone(), tx);
+            Some(rx)
+        } else {
+            None
+        };
+
+        let result = self.tools_call_inner(params, cancel_rx).await;
+
+        // Cleanup keyed state regardless of outcome.
+        if let Some(key) = req_key {
+            self.state.cancellation_tokens.remove(&key);
+        }
+        if let Some(req_id) = id {
+            self.state.progress_tokens.remove(&req_id);
+        }
+        result
+    }
+
+    async fn tools_call_inner(
+        &self,
+        params: CallParams,
+        cancel_rx: Option<oneshot::Receiver<()>>,
+    ) -> Result<Value, String> {
 
         // When builtins are hidden from tools/list, also refuse to dispatch
         // them by name. Otherwise a client could invoke `iii_worker_register`
@@ -366,16 +547,27 @@ impl McpHandler {
                 function_id
             )));
         }
-        match self
-            .iii
-            .trigger(TriggerRequest {
-                function_id: function_id.clone(),
-                payload: params.arguments,
-                action: None,
-                timeout_ms: None,
-            })
-            .await
-        {
+        let trigger_fut = self.iii.trigger(TriggerRequest {
+            function_id: function_id.clone(),
+            payload: params.arguments,
+            action: None,
+            timeout_ms: None,
+        });
+
+        // notifications/cancelled tracking. If the receiver fires before the
+        // trigger resolves, return a cancelled tool_error rather than an
+        // ordinary failure — clients distinguish via the message text.
+        let outcome = if let Some(rx) = cancel_rx {
+            tokio::select! {
+                biased;
+                _ = rx => return Ok(tool_error("Request cancelled")),
+                r = trigger_fut => r,
+            }
+        } else {
+            trigger_fut.await
+        };
+
+        match outcome {
             Ok(result) => Ok(tool_json(&result)),
             Err(err) => {
                 tracing::error!(function_id = %function_id, error = %err, "Trigger failed");
@@ -384,13 +576,8 @@ impl McpHandler {
         }
     }
 
-    fn resources_list(&self) -> Value {
-        json!({ "resources": [
-            { "uri": "iii://functions", "name": "Functions", "mimeType": "application/json" },
-            { "uri": "iii://workers", "name": "Workers", "mimeType": "application/json" },
-            { "uri": "iii://triggers", "name": "Triggers", "mimeType": "application/json" },
-            { "uri": "iii://context", "name": "Context", "mimeType": "application/json" },
-        ]})
+    fn resources_list(&self, cursor: Option<&str>) -> Value {
+        resources_list_paginated(cursor)
     }
 
     async fn resources_read(&self, params: Option<Value>) -> Result<Value, String> {
@@ -447,6 +634,17 @@ impl McpHandler {
 pub fn register_http(iii: &III, exposure: ExposureConfig) {
     let iii_fn = iii.clone();
     let cfg = exposure;
+    // Shared session state for the HTTP transport. Single-tenant: every POST
+    // /mcp request reuses the same subscriptions/log_level/progress state
+    // until the worker is restarted. Sufficient for the current Phase 2a
+    // surface; per-session multiplexing (Streamable HTTP SSE) is explicitly
+    // out of scope. The notifier mpsc receiver is dropped on the spot — HTTP
+    // has no return channel for notifications, so emitting them is a no-op.
+    let (notifier_tx, notifier_rx) = mpsc::channel(64);
+    drop(notifier_rx);
+    let state = Arc::new(SessionState::new(notifier_tx));
+    register_notification_helpers(iii, state.clone());
+
     iii.register_function_with(
         RegisterFunctionMessage {
             id: "mcp::handler".to_string(),
@@ -457,9 +655,10 @@ pub fn register_http(iii: &III, exposure: ExposureConfig) {
         move |input: Value| {
             let iii_inner = iii_fn.clone();
             let cfg_inner = cfg.clone();
+            let state_inner = state.clone();
             async move {
                 let body = input.get("body").cloned().unwrap_or(input);
-                let response = dispatch_http(&iii_inner, &body, &cfg_inner).await;
+                let response = dispatch_http(&iii_inner, &body, &cfg_inner, &state_inner).await;
                 Ok(json!({ "status_code": 200, "headers": { "content-type": "application/json" }, "body": response }))
             }
         },
@@ -480,18 +679,223 @@ pub fn register_http(iii: &III, exposure: ExposureConfig) {
 fn initialize_result() -> Value {
     json!({
         "protocolVersion": MCP_PROTOCOL_VERSION,
-        "capabilities": { "tools": { "listChanged": true }, "resources": { "subscribe": false, "listChanged": true }, "prompts": { "listChanged": false } },
+        "capabilities": {
+            "tools": { "listChanged": true },
+            "resources": { "subscribe": true, "listChanged": true },
+            "prompts": { "listChanged": false },
+            "logging": {},
+            "completions": {}
+        },
         "serverInfo": { "name": "iii-mcp", "version": env!("CARGO_PKG_VERSION") },
         "instructions": "iii-engine MCP server. Only functions with metadata `mcp.expose: true` are exposed as tools. Infra namespaces (engine::*, state::*, stream::*, iii.*, mcp::*) are always hidden. Optional `mcp.tier` metadata is filtered by the server's --tier flag."
     })
 }
 
-async fn dispatch_http(iii: &III, body: &Value, cfg: &ExposureConfig) -> Value {
+// Static resource list shared by stdio + HTTP. Pagination on this short list
+// is mostly future-proofing — the four built-in URIs always fit in one page.
+fn static_resources() -> Vec<Value> {
+    vec![
+        json!({ "uri": "iii://functions", "name": "Functions", "mimeType": "application/json" }),
+        json!({ "uri": "iii://workers", "name": "Workers", "mimeType": "application/json" }),
+        json!({ "uri": "iii://triggers", "name": "Triggers", "mimeType": "application/json" }),
+        json!({ "uri": "iii://context", "name": "Context", "mimeType": "application/json" }),
+    ]
+}
+
+fn resources_list_paginated(cursor: Option<&str>) -> Value {
+    let items = static_resources();
+    let (page, next) = paginate(&items, cursor, PAGE_SIZE);
+    let page_owned: Vec<Value> = page.into_iter().cloned().collect();
+    let mut out = json!({ "resources": page_owned });
+    if let Some(c) = next {
+        out["nextCursor"] = json!(c);
+    }
+    out
+}
+
+fn prompts_list_paginated(cursor: Option<&str>) -> Value {
+    // prompts::list() returns `{prompts: [...]}`. Pull the array, paginate,
+    // re-wrap. Keeping the wire shape stable — clients call prompts/list
+    // identically with or without cursor support.
+    let full = prompts::list();
+    let arr = full
+        .get("prompts")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let (page, next) = paginate(&arr, cursor, PAGE_SIZE);
+    let page_owned: Vec<Value> = page.into_iter().cloned().collect();
+    let mut out = json!({ "prompts": page_owned });
+    if let Some(c) = next {
+        out["nextCursor"] = json!(c);
+    }
+    out
+}
+
+// Drives `notifications/resources/updated` for `iii://workers` and
+// `iii://triggers` — neither has an SDK callback. 5s poll, content-hash
+// diff so we don't fire on every tick. Stops when the channel closes
+// (handler dropped).
+async fn poll_resource_updates(iii: III, state: Arc<SessionState>) {
+    let mut last_workers: Option<String> = None;
+    let mut last_triggers: Option<String> = None;
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    // Skip the immediate first tick; we want diffs against a known baseline.
+    interval.tick().await;
+    loop {
+        if state.notifier.is_closed() {
+            return;
+        }
+        interval.tick().await;
+        if let Ok(ws) = iii.list_workers().await {
+            let h = serde_json::to_string(&ws).unwrap_or_default();
+            if last_workers.as_ref() != Some(&h) {
+                last_workers = Some(h);
+                if state.is_subscribed("iii://workers") {
+                    if let Ok(s) = serde_json::to_string(&resource_updated_notification(
+                        "iii://workers",
+                    )) {
+                        state.try_send(s);
+                    }
+                }
+            }
+        }
+        if let Ok(ts) = iii.list_triggers(true).await {
+            let h = serde_json::to_string(&ts).unwrap_or_default();
+            if last_triggers.as_ref() != Some(&h) {
+                last_triggers = Some(h);
+                if state.is_subscribed("iii://triggers") {
+                    if let Ok(s) = serde_json::to_string(&resource_updated_notification(
+                        "iii://triggers",
+                    )) {
+                        state.try_send(s);
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Register `mcp::log_message` and `mcp::progress` as iii functions. User
+// code triggers them to emit MCP notifications. Both gated by the current
+// session state — the log level filter is enforced here so no notification
+// leaks past the threshold.
+fn register_notification_helpers(iii: &III, state: Arc<SessionState>) {
+    let state_log = state.clone();
+    iii.register_function_with(
+        RegisterFunctionMessage {
+            id: "mcp::log_message".to_string(),
+            description: Some("Emit an MCP notifications/message".to_string()),
+            request_format: Some(json!({
+                "type": "object",
+                "properties": {
+                    "level": { "type": "string" },
+                    "data": {},
+                    "logger": { "type": "string" }
+                },
+                "required": ["level", "data"]
+            })),
+            response_format: None,
+            metadata: None,
+            invocation: None,
+        },
+        move |input: Value| {
+            let state_inner = state_log.clone();
+            async move {
+                let level_str = input
+                    .get("level")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("info");
+                let data = input.get("data").cloned().unwrap_or(Value::Null);
+                let logger = input.get("logger").and_then(|v| v.as_str());
+                let msg_lvl = match level_from_str(level_str) {
+                    Some(l) => l,
+                    None => return Ok(json!({ "ok": false, "error": "unknown level" })),
+                };
+                let cur = state_inner.log_level.load(Ordering::SeqCst);
+                if msg_lvl < cur {
+                    return Ok(json!({ "ok": true, "filtered": true }));
+                }
+                let n = log_message_notification(level_str, &data, logger);
+                if let Ok(s) = serde_json::to_string(&n) {
+                    state_inner.try_send(s);
+                }
+                Ok(json!({ "ok": true }))
+            }
+        },
+    );
+
+    let state_prog = state.clone();
+    iii.register_function_with(
+        RegisterFunctionMessage {
+            id: "mcp::progress".to_string(),
+            description: Some("Emit an MCP notifications/progress".to_string()),
+            request_format: Some(json!({
+                "type": "object",
+                "properties": {
+                    "token": {},
+                    "progress": { "type": "number" },
+                    "total": { "type": "number" },
+                    "message": { "type": "string" }
+                },
+                "required": ["token", "progress"]
+            })),
+            response_format: None,
+            metadata: None,
+            invocation: None,
+        },
+        move |input: Value| {
+            let state_inner = state_prog.clone();
+            async move {
+                let token = match input.get("token").cloned() {
+                    Some(t) => t,
+                    None => return Ok(json!({ "ok": false, "error": "missing token" })),
+                };
+                let progress = input
+                    .get("progress")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(0.0);
+                let total = input.get("total").and_then(|v| v.as_f64());
+                let message = input.get("message").and_then(|v| v.as_str());
+                let n = progress_notification(&token, progress, total, message);
+                if let Ok(s) = serde_json::to_string(&n) {
+                    state_inner.try_send(s);
+                }
+                Ok(json!({ "ok": true }))
+            }
+        },
+    );
+}
+
+async fn dispatch_http(
+    iii: &III,
+    body: &Value,
+    cfg: &ExposureConfig,
+    state: &Arc<SessionState>,
+) -> Value {
     let method = body.get("method").and_then(|v| v.as_str()).unwrap_or("");
     let id = body.get("id").cloned();
     let params = body.get("params").cloned();
+    let cursor = params
+        .as_ref()
+        .and_then(|p| p.get("cursor"))
+        .and_then(|c| c.as_str())
+        .map(String::from);
 
     if method.starts_with("notifications/") {
+        if method == "notifications/cancelled" {
+            if let Some(req_id) = body
+                .get("params")
+                .and_then(|p| p.get("requestId"))
+                .cloned()
+            {
+                let key = SessionState::request_id_key(&req_id);
+                if let Some((_, sender)) = state.cancellation_tokens.remove(&key) {
+                    let _ = sender.send(());
+                }
+            }
+        }
         return json!(null);
     }
 
@@ -514,7 +918,13 @@ async fn dispatch_http(iii: &III, body: &Value, cfg: &ExposureConfig) -> Value {
                         .map(function_to_tool),
                 );
             }
-            Ok(json!({ "tools": tools }))
+            let (page, next) = paginate(&tools, cursor.as_deref(), PAGE_SIZE);
+            let page_owned: Vec<McpTool> = page.into_iter().cloned().collect();
+            let mut out = json!({ "tools": page_owned });
+            if let Some(c) = next {
+                out["nextCursor"] = json!(c);
+            }
+            Ok(out)
         }
         "tools/call" => {
             let p: CallParams = match params {
@@ -640,21 +1050,31 @@ async fn dispatch_http(iii: &III, body: &Value, cfg: &ExposureConfig) -> Value {
                 }
             }
         }
-        "resources/list" => Ok(json!({ "resources": [
-            { "uri": "iii://functions", "name": "Functions", "mimeType": "application/json" },
-            { "uri": "iii://workers", "name": "Workers", "mimeType": "application/json" },
-            { "uri": "iii://triggers", "name": "Triggers", "mimeType": "application/json" },
-            { "uri": "iii://context", "name": "Context", "mimeType": "application/json" },
-        ]})),
+        "resources/list" => Ok(resources_list_paginated(cursor.as_deref())),
         // HTTP transport previously omitted these; MCP Inspector hit
         // -32601 Unknown method on both. Parity with stdio McpHandler
         // via the shared read_resource / templates paths.
         "resources/read" => read_resource(iii, cfg, params)
             .await
             .map_err(|e| (INVALID_PARAMS, e)),
-        "resources/templates/list" => Ok(json!({ "resourceTemplates": [] })),
-        "prompts/list" => Ok(prompts::list()),
+        "resources/templates/list" => Ok(json!({
+            "resourceTemplates": spec::make_resource_templates()
+        })),
+        "resources/subscribe" => {
+            spec::handle_resources_subscribe(&state.subscriptions, params)
+                .map_err(|e| (INVALID_PARAMS, e))
+        }
+        "resources/unsubscribe" => {
+            spec::handle_resources_unsubscribe(&state.subscriptions, params)
+                .map_err(|e| (INVALID_PARAMS, e))
+        }
+        "prompts/list" => Ok(prompts_list_paginated(cursor.as_deref())),
         "prompts/get" => Ok(prompts::get(params)),
+        "completion/complete" => spec::handle_completion_complete(iii, params)
+            .await
+            .map_err(|e| (INVALID_PARAMS, e)),
+        "logging/setLevel" => spec::handle_logging_set_level(&state.log_level, params)
+            .map_err(|e| (INVALID_PARAMS, e)),
         _ => Err((METHOD_NOT_FOUND, format!("Unknown method: {}", method))),
     };
 
@@ -724,19 +1144,57 @@ pub async fn read_resource(
             .unwrap(),
             "application/json",
         ),
-        _ => return Err(format!("Resource not found: {}", p.uri)),
+        // Templated URIs: iii://function/{id}, iii://worker/{id}, iii://trigger/{id}.
+        // Resolved through spec::resolve_templated_uri which filters by id only;
+        // exposure metadata is enforced for `iii://function/{id}` here so a
+        // `mcp.expose: false` function can't leak via direct templated read.
+        other => match resolve_templated_uri(other, iii).await {
+            Some((body, mime)) => {
+                if let Some(id) = other.strip_prefix("iii://function/") {
+                    if let Ok(fns) = iii.list_functions().await {
+                        let allowed = fns
+                            .iter()
+                            .find(|f| f.function_id == id)
+                            .map(|f| is_function_exposed(f, cfg))
+                            .unwrap_or(false);
+                        if !allowed {
+                            return Err(format!(
+                                "Function '{}' is not exposed via mcp.expose metadata",
+                                id
+                            ));
+                        }
+                    }
+                }
+                (body, mime)
+            }
+            None => return Err(format!("Resource not found: {}", p.uri)),
+        },
     };
     Ok(json!({ "contents": [{ "uri": p.uri, "mimeType": mime, "text": text }] }))
 }
 
 fn function_to_tool(f: &FunctionInfo) -> McpTool {
+    let (title, annotations) = match f.metadata.as_ref() {
+        Some(meta) => {
+            let ann = make_tool_annotations(meta);
+            // Title goes both at top level (per 2025-06-18 spec) and inside
+            // `annotations` if the metadata supplied it; the spec is permissive
+            // about either location, but tools/list clients prefer top-level.
+            let t = ann.as_ref().and_then(|a| a.title.clone());
+            (t, ann)
+        }
+        None => (None, None),
+    };
     McpTool {
         name: f.function_id.replace("::", "__"),
+        title,
         description: f.description.clone(),
         input_schema: f
             .request_format
             .clone()
             .unwrap_or_else(|| json!({ "type": "object", "properties": {} })),
+        output_schema: f.response_format.clone(),
+        annotations,
     }
 }
 
@@ -758,36 +1216,36 @@ fn is_builtin_tool(name: &str) -> bool {
 
 fn builtin_tools() -> Vec<McpTool> {
     vec![
-        McpTool {
-            name: "iii_worker_register".into(),
-            description: Some("Register a new worker (Node.js or Python)".into()),
-            input_schema: json!({ "type": "object", "properties": { "language": { "type": "string", "enum": ["node", "python"] }, "code": { "type": "string" }, "function_name": { "type": "string" }, "description": { "type": "string" } }, "required": ["language", "code", "function_name"] }),
-        },
-        McpTool {
-            name: "iii_worker_stop".into(),
-            description: Some("Stop a worker".into()),
-            input_schema: json!({ "type": "object", "properties": { "id": { "type": "string" } }, "required": ["id"] }),
-        },
-        McpTool {
-            name: "iii_trigger_register".into(),
-            description: Some("Attach an http/cron/queue trigger to a function".into()),
-            input_schema: json!({ "type": "object", "properties": { "trigger_type": { "type": "string" }, "function_id": { "type": "string" }, "config": { "type": "object" } }, "required": ["trigger_type", "function_id", "config"] }),
-        },
-        McpTool {
-            name: "iii_trigger_unregister".into(),
-            description: Some("Unregister a trigger".into()),
-            input_schema: json!({ "type": "object", "properties": { "id": { "type": "string" } }, "required": ["id"] }),
-        },
-        McpTool {
-            name: "iii_trigger_void".into(),
-            description: Some("Fire-and-forget function invocation".into()),
-            input_schema: json!({ "type": "object", "properties": { "function_id": { "type": "string" }, "payload": { "type": "object" } }, "required": ["function_id", "payload"] }),
-        },
-        McpTool {
-            name: "iii_trigger_enqueue".into(),
-            description: Some("Enqueue to named queue".into()),
-            input_schema: json!({ "type": "object", "properties": { "function_id": { "type": "string" }, "payload": { "type": "object" }, "queue": { "type": "string" } }, "required": ["function_id", "payload"] }),
-        },
+        McpTool::new(
+            "iii_worker_register",
+            Some("Register a new worker (Node.js or Python)".into()),
+            json!({ "type": "object", "properties": { "language": { "type": "string", "enum": ["node", "python"] }, "code": { "type": "string" }, "function_name": { "type": "string" }, "description": { "type": "string" } }, "required": ["language", "code", "function_name"] }),
+        ),
+        McpTool::new(
+            "iii_worker_stop",
+            Some("Stop a worker".into()),
+            json!({ "type": "object", "properties": { "id": { "type": "string" } }, "required": ["id"] }),
+        ),
+        McpTool::new(
+            "iii_trigger_register",
+            Some("Attach an http/cron/queue trigger to a function".into()),
+            json!({ "type": "object", "properties": { "trigger_type": { "type": "string" }, "function_id": { "type": "string" }, "config": { "type": "object" } }, "required": ["trigger_type", "function_id", "config"] }),
+        ),
+        McpTool::new(
+            "iii_trigger_unregister",
+            Some("Unregister a trigger".into()),
+            json!({ "type": "object", "properties": { "id": { "type": "string" } }, "required": ["id"] }),
+        ),
+        McpTool::new(
+            "iii_trigger_void",
+            Some("Fire-and-forget function invocation".into()),
+            json!({ "type": "object", "properties": { "function_id": { "type": "string" }, "payload": { "type": "object" } }, "required": ["function_id", "payload"] }),
+        ),
+        McpTool::new(
+            "iii_trigger_enqueue",
+            Some("Enqueue to named queue".into()),
+            json!({ "type": "object", "properties": { "function_id": { "type": "string" }, "payload": { "type": "object" }, "queue": { "type": "string" } }, "required": ["function_id", "payload"] }),
+        ),
     ]
 }
 
@@ -796,8 +1254,27 @@ fn builtin_tools() -> Vec<McpTool> {
 struct McpTool {
     name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
     input_schema: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_schema: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    annotations: Option<ToolAnnotations>,
+}
+
+impl McpTool {
+    fn new(name: &str, description: Option<String>, input_schema: Value) -> Self {
+        Self {
+            name: name.to_string(),
+            title: None,
+            description,
+            input_schema,
+            output_schema: None,
+            annotations: None,
+        }
+    }
 }
 
 #[derive(Deserialize)]

--- a/mcp/src/handler.rs
+++ b/mcp/src/handler.rs
@@ -737,8 +737,20 @@ fn prompts_list_paginated(cursor: Option<&str>) -> Value {
 // diff so we don't fire on every tick. Stops when the channel closes
 // (handler dropped).
 async fn poll_resource_updates(iii: III, state: Arc<SessionState>) {
-    let mut last_workers: Option<String> = None;
-    let mut last_triggers: Option<String> = None;
+    // Prime baselines from one initial fetch BEFORE the loop so the first
+    // diff has something to compare against. Without this, the first
+    // successful list_workers() always produced Some(_) != None and emitted
+    // a phantom resources/updated to every fresh subscriber.
+    let mut last_workers: Option<String> = iii
+        .list_workers()
+        .await
+        .ok()
+        .and_then(|ws| serde_json::to_string(&ws).ok());
+    let mut last_triggers: Option<String> = iii
+        .list_triggers(true)
+        .await
+        .ok()
+        .and_then(|ts| serde_json::to_string(&ts).ok());
     let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     // Skip the immediate first tick; we want diffs against a known baseline.
@@ -782,6 +794,15 @@ async fn poll_resource_updates(iii: III, state: Arc<SessionState>) {
 // session state — the log level filter is enforced here so no notification
 // leaks past the threshold.
 fn register_notification_helpers(iii: &III, state: Arc<SessionState>) {
+    // Idempotent: the same process may construct an HTTP register_http() AND
+    // a stdio McpHandler::new(); both call this. Engine register_function_with
+    // on a duplicate id silently overwrites the prior closure, so the second
+    // call would orphan the first SessionState. Skip after the first call.
+    static REGISTERED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    if REGISTERED.set(()).is_err() {
+        tracing::debug!("mcp::log_message and mcp::progress already registered; skipping");
+        return;
+    }
     let state_log = state.clone();
     iii.register_function_with(
         RegisterFunctionMessage {
@@ -927,19 +948,45 @@ async fn dispatch_http(
             Ok(out)
         }
         "tools/call" => {
+            // _meta.progressToken parity with stdio: bind it to the request
+            // id so a future Streamable HTTP SSE transport (Phase 2c) can
+            // route notifications/progress correlated to the right request.
+            // Today the HTTP `register_http` drops its notifier_rx, so the
+            // notification itself is a no-op — the binding is bookkeeping.
+            let progress_token = params
+                .as_ref()
+                .and_then(|p| p.get("_meta"))
+                .and_then(|m| m.get("progressToken"))
+                .cloned();
+            if let (Some(req_id), Some(token)) = (id.clone(), progress_token) {
+                state.progress_tokens.insert(req_id, token);
+            }
             let p: CallParams = match params {
                 Some(p) => match serde_json::from_value(p) {
                     Ok(p) => p,
                     Err(e) => {
+                        if let Some(req_id) = id.clone() {
+                            state.progress_tokens.remove(&req_id);
+                        }
                         return json!(JsonRpcResponse::error(id, INVALID_PARAMS, format!("{}", e)));
                     }
                 },
-                None => return json!(JsonRpcResponse::error(id, INVALID_PARAMS, "Missing params")),
+                None => {
+                    if let Some(req_id) = id.clone() {
+                        state.progress_tokens.remove(&req_id);
+                    }
+                    return json!(JsonRpcResponse::error(id, INVALID_PARAMS, "Missing params"));
+                }
             };
+            // HTTP path: each POST is single-shot, no notifications/cancelled
+            // correlation. Streamable HTTP SSE (Phase 2c) will add it.
             // When --no-builtins is active, the six management tools are
             // also not invocable by name. tools/list hides them; this
             // matches the listing shape at call time.
             if cfg.no_builtins && is_builtin_tool(&p.name) {
+                if let Some(req_id) = id.clone() {
+                    state.progress_tokens.remove(&req_id);
+                }
                 return json!(JsonRpcResponse::success(
                     id,
                     tool_error(&format!(

--- a/mcp/src/handler.rs
+++ b/mcp/src/handler.rs
@@ -152,6 +152,24 @@ impl JsonRpcResponse {
 // Per-session MCP spec state (subscriptions, log level, progress tokens,
 // in-flight cancellation senders). Lives in an Arc so the HTTP `dispatch_http`
 // path can share an instance keyed by session and the stdio handler can hold
+// RAII guard ensuring the HTTP tools/call path removes its progress_tokens
+// entry on every return path — including early errors before the trigger
+// runs. Stdio's tools_call has its own remove() at function exit; HTTP has
+// many early-return arms inside one big match, so a Drop guard is cheaper
+// than threading cleanup through each branch.
+pub struct ProgressTokenGuard {
+    pub state: Arc<SessionState>,
+    pub req_id: Option<Value>,
+}
+
+impl Drop for ProgressTokenGuard {
+    fn drop(&mut self) {
+        if let Some(rid) = &self.req_id {
+            self.state.progress_tokens.remove(rid);
+        }
+    }
+}
+
 // a single instance for its single attached client.
 pub struct SessionState {
     pub subscriptions: std::sync::Mutex<HashSet<String>>,
@@ -635,7 +653,11 @@ pub fn register_http(iii: &III, exposure: ExposureConfig) {
     let (notifier_tx, notifier_rx) = mpsc::channel(64);
     drop(notifier_rx);
     let state = Arc::new(SessionState::new(notifier_tx));
-    register_notification_helpers(iii, state.clone());
+    // Skip register_notification_helpers on the HTTP path: HTTP has no return
+    // channel for notifications (notifier_rx is dropped above), so the helper
+    // closures captured here would silently swallow every emit. The stdio
+    // McpHandler::new owns the registration; if no stdio session exists, the
+    // helpers simply aren't registered — better than orphaning notifications.
 
     iii.register_function_with(
         RegisterFunctionMessage {
@@ -786,15 +808,10 @@ async fn poll_resource_updates(iii: III, state: Arc<SessionState>) {
 // session state — the log level filter is enforced here so no notification
 // leaks past the threshold.
 fn register_notification_helpers(iii: &III, state: Arc<SessionState>) {
-    // Idempotent: the same process may construct an HTTP register_http() AND
-    // a stdio McpHandler::new(); both call this. Engine register_function_with
-    // on a duplicate id silently overwrites the prior closure, so the second
-    // call would orphan the first SessionState. Skip after the first call.
-    static REGISTERED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
-    if REGISTERED.set(()).is_err() {
-        tracing::debug!("mcp::log_message and mcp::progress already registered; skipping");
-        return;
-    }
+    // Called from McpHandler::new (stdio) only. register_http intentionally
+    // does NOT call this — HTTP drops its notifier_rx and has no return
+    // channel for notifications. Stdio owns the helpers so notifications
+    // route to a live session.
     let state_log = state.clone();
     iii.register_function_with(
         RegisterFunctionMessage {
@@ -949,20 +966,19 @@ async fn dispatch_http(
             if let (Some(req_id), Some(token)) = (id.clone(), progress_token) {
                 state.progress_tokens.insert(req_id, token);
             }
+            // Drop guard cleans up progress_tokens on every return path below.
+            let _progress_guard = ProgressTokenGuard {
+                state: state.clone(),
+                req_id: id.clone(),
+            };
             let p: CallParams = match params {
                 Some(p) => match serde_json::from_value(p) {
                     Ok(p) => p,
                     Err(e) => {
-                        if let Some(req_id) = id.clone() {
-                            state.progress_tokens.remove(&req_id);
-                        }
                         return json!(JsonRpcResponse::error(id, INVALID_PARAMS, format!("{}", e)));
                     }
                 },
                 None => {
-                    if let Some(req_id) = id.clone() {
-                        state.progress_tokens.remove(&req_id);
-                    }
                     return json!(JsonRpcResponse::error(id, INVALID_PARAMS, "Missing params"));
                 }
             };
@@ -972,9 +988,6 @@ async fn dispatch_http(
             // also not invocable by name. tools/list hides them; this
             // matches the listing shape at call time.
             if cfg.no_builtins && is_builtin_tool(&p.name) {
-                if let Some(req_id) = id.clone() {
-                    state.progress_tokens.remove(&req_id);
-                }
                 return json!(JsonRpcResponse::success(
                     id,
                     tool_error(&format!(

--- a/mcp/src/handler.rs
+++ b/mcp/src/handler.rs
@@ -14,8 +14,8 @@ use tokio::sync::{Mutex, mpsc, oneshot};
 use crate::prompts;
 use crate::spec::{
     self, LOG_INFO, PAGE_SIZE, ToolAnnotations, level_from_str, log_message_notification,
-    make_tool_annotations, paginate, progress_notification, resource_updated_notification,
-    resolve_templated_uri,
+    make_tool_annotations, paginate, progress_notification, resolve_templated_uri,
+    resource_updated_notification,
 };
 use crate::worker_manager::{WorkerCreateParams, WorkerManager, WorkerStopParams};
 
@@ -223,8 +223,7 @@ impl McpHandler {
         // listing functions is what `iii://functions` resolves to.
         let state_for_fn_cb = state.clone();
         let guard = iii.on_functions_available(move |_| {
-            let n =
-                json!({ "jsonrpc": "2.0", "method": "notifications/tools/list_changed" });
+            let n = json!({ "jsonrpc": "2.0", "method": "notifications/tools/list_changed" });
             if let Ok(s) = serde_json::to_string(&n) {
                 state_for_fn_cb.try_send(s);
             }
@@ -285,11 +284,7 @@ impl McpHandler {
                 self.initialized.store(true, Ordering::SeqCst);
             }
             if method == "notifications/cancelled" {
-                if let Some(req_id) = body
-                    .get("params")
-                    .and_then(|p| p.get("requestId"))
-                    .cloned()
-                {
+                if let Some(req_id) = body.get("params").and_then(|p| p.get("requestId")).cloned() {
                     let key = SessionState::request_id_key(&req_id);
                     if let Some((_, sender)) = self.state.cancellation_tokens.remove(&key) {
                         let _ = sender.send(());
@@ -341,16 +336,14 @@ impl McpHandler {
             "resources/templates/list" => Ok(json!({
                 "resourceTemplates": spec::make_resource_templates()
             })),
-            "resources/subscribe" => spec::handle_resources_subscribe(
-                &self.state.subscriptions,
-                params,
-            )
-            .map_err(|e| (INVALID_PARAMS, e)),
-            "resources/unsubscribe" => spec::handle_resources_unsubscribe(
-                &self.state.subscriptions,
-                params,
-            )
-            .map_err(|e| (INVALID_PARAMS, e)),
+            "resources/subscribe" => {
+                spec::handle_resources_subscribe(&self.state.subscriptions, params)
+                    .map_err(|e| (INVALID_PARAMS, e))
+            }
+            "resources/unsubscribe" => {
+                spec::handle_resources_unsubscribe(&self.state.subscriptions, params)
+                    .map_err(|e| (INVALID_PARAMS, e))
+            }
             "prompts/list" => Ok(prompts_list_paginated(cursor.as_deref())),
             "prompts/get" => Ok(prompts::get(params)),
             "completion/complete" => spec::handle_completion_complete(&self.iii, params)
@@ -434,7 +427,6 @@ impl McpHandler {
         params: CallParams,
         cancel_rx: Option<oneshot::Receiver<()>>,
     ) -> Result<Value, String> {
-
         // When builtins are hidden from tools/list, also refuse to dispatch
         // them by name. Otherwise a client could invoke `iii_worker_register`
         // on a server that claimed it had no such tool — bypassing the policy.
@@ -765,9 +757,9 @@ async fn poll_resource_updates(iii: III, state: Arc<SessionState>) {
             if last_workers.as_ref() != Some(&h) {
                 last_workers = Some(h);
                 if state.is_subscribed("iii://workers") {
-                    if let Ok(s) = serde_json::to_string(&resource_updated_notification(
-                        "iii://workers",
-                    )) {
+                    if let Ok(s) =
+                        serde_json::to_string(&resource_updated_notification("iii://workers"))
+                    {
                         state.try_send(s);
                     }
                 }
@@ -778,9 +770,9 @@ async fn poll_resource_updates(iii: III, state: Arc<SessionState>) {
             if last_triggers.as_ref() != Some(&h) {
                 last_triggers = Some(h);
                 if state.is_subscribed("iii://triggers") {
-                    if let Ok(s) = serde_json::to_string(&resource_updated_notification(
-                        "iii://triggers",
-                    )) {
+                    if let Ok(s) =
+                        serde_json::to_string(&resource_updated_notification("iii://triggers"))
+                    {
                         state.try_send(s);
                     }
                 }
@@ -906,11 +898,7 @@ async fn dispatch_http(
 
     if method.starts_with("notifications/") {
         if method == "notifications/cancelled" {
-            if let Some(req_id) = body
-                .get("params")
-                .and_then(|p| p.get("requestId"))
-                .cloned()
-            {
+            if let Some(req_id) = body.get("params").and_then(|p| p.get("requestId")).cloned() {
                 let key = SessionState::request_id_key(&req_id);
                 if let Some((_, sender)) = state.cancellation_tokens.remove(&key) {
                     let _ = sender.send(());
@@ -1107,14 +1095,10 @@ async fn dispatch_http(
         "resources/templates/list" => Ok(json!({
             "resourceTemplates": spec::make_resource_templates()
         })),
-        "resources/subscribe" => {
-            spec::handle_resources_subscribe(&state.subscriptions, params)
-                .map_err(|e| (INVALID_PARAMS, e))
-        }
-        "resources/unsubscribe" => {
-            spec::handle_resources_unsubscribe(&state.subscriptions, params)
-                .map_err(|e| (INVALID_PARAMS, e))
-        }
+        "resources/subscribe" => spec::handle_resources_subscribe(&state.subscriptions, params)
+            .map_err(|e| (INVALID_PARAMS, e)),
+        "resources/unsubscribe" => spec::handle_resources_unsubscribe(&state.subscriptions, params)
+            .map_err(|e| (INVALID_PARAMS, e)),
         "prompts/list" => Ok(prompts_list_paginated(cursor.as_deref())),
         "prompts/get" => Ok(prompts::get(params)),
         "completion/complete" => spec::handle_completion_complete(iii, params)

--- a/mcp/src/lib.rs
+++ b/mcp/src/lib.rs
@@ -1,0 +1,9 @@
+// Library crate exposes module surface for integration tests.
+// The binary at `src/main.rs` consumes these via `iii_mcp::*` so the tests
+// can hit the same code paths a deployed binary uses.
+
+pub mod handler;
+pub mod prompts;
+pub mod spec;
+pub mod transport;
+pub mod worker_manager;

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -1,11 +1,8 @@
-mod handler;
-mod prompts;
-mod transport;
-mod worker_manager;
-
 use std::sync::Arc;
 
 use clap::Parser;
+use iii_mcp::handler;
+use iii_mcp::transport;
 use iii_sdk::{InitOptions, register_worker};
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 

--- a/mcp/src/prompts.rs
+++ b/mcp/src/prompts.rs
@@ -1,5 +1,25 @@
 use serde_json::{Value, json};
 
+// Candidate values for completion/complete on prompt arguments.
+// Returns the full unfiltered candidate set; the completion handler does the
+// prefix match. Empty vec for arguments with no enumerable values (e.g. free
+// text like `function_id`, `path`, `schedule`).
+pub fn list_prompt_candidates(name: &str, arg: &str) -> Vec<String> {
+    match (name, arg) {
+        ("register-function", "language") => {
+            vec!["node".to_string(), "python".to_string()]
+        }
+        ("build-api", "method") => vec![
+            "GET".to_string(),
+            "POST".to_string(),
+            "PUT".to_string(),
+            "DELETE".to_string(),
+            "PATCH".to_string(),
+        ],
+        _ => Vec::new(),
+    }
+}
+
 pub fn list() -> Value {
     json!({
         "prompts": [

--- a/mcp/src/spec.rs
+++ b/mcp/src/spec.rs
@@ -1,0 +1,328 @@
+// MCP 2025-06-18 spec helpers shared by stdio and HTTP dispatch paths.
+//
+// Lives in its own module so handler.rs stays focused on transport plumbing.
+// Pagination, tool annotations, completion, logging level, subscription
+// tracking, and templated-URI resolution are all routed through here.
+
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use iii_sdk::III;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+pub const PAGE_SIZE: usize = 50;
+
+// MCP logging levels follow RFC 5424 ordering (debug=lowest, emergency=highest).
+// Stored as a u8 in AtomicU8. A `notifications/message` is emitted only when
+// the message level is >= the configured level. Default is `info`.
+pub const LOG_DEBUG: u8 = 0;
+pub const LOG_INFO: u8 = 1;
+pub const LOG_NOTICE: u8 = 2;
+pub const LOG_WARNING: u8 = 3;
+pub const LOG_ERROR: u8 = 4;
+pub const LOG_CRITICAL: u8 = 5;
+pub const LOG_ALERT: u8 = 6;
+pub const LOG_EMERGENCY: u8 = 7;
+
+pub fn level_from_str(s: &str) -> Option<u8> {
+    match s {
+        "debug" => Some(LOG_DEBUG),
+        "info" => Some(LOG_INFO),
+        "notice" => Some(LOG_NOTICE),
+        "warning" => Some(LOG_WARNING),
+        "error" => Some(LOG_ERROR),
+        "critical" => Some(LOG_CRITICAL),
+        "alert" => Some(LOG_ALERT),
+        "emergency" => Some(LOG_EMERGENCY),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolAnnotations {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub read_only_hint: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub destructive_hint: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idempotent_hint: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub open_world_hint: Option<bool>,
+}
+
+// Pull the four MCP behavior hints + optional title from a function's
+// `metadata.mcp.{title,read_only_hint,destructive_hint,idempotent_hint,open_world_hint}`.
+// Returns None if metadata is missing or carries none of those keys, so the
+// resulting tool object stays compact.
+pub fn make_tool_annotations(metadata: &Value) -> Option<ToolAnnotations> {
+    let mcp = metadata.get("mcp")?;
+    let title = mcp.get("title").and_then(|v| v.as_str()).map(String::from);
+    let read_only = mcp.get("read_only_hint").and_then(|v| v.as_bool());
+    let destructive = mcp.get("destructive_hint").and_then(|v| v.as_bool());
+    let idempotent = mcp.get("idempotent_hint").and_then(|v| v.as_bool());
+    let open_world = mcp.get("open_world_hint").and_then(|v| v.as_bool());
+
+    if title.is_none()
+        && read_only.is_none()
+        && destructive.is_none()
+        && idempotent.is_none()
+        && open_world.is_none()
+    {
+        return None;
+    }
+    Some(ToolAnnotations {
+        title,
+        read_only_hint: read_only,
+        destructive_hint: destructive,
+        idempotent_hint: idempotent,
+        open_world_hint: open_world,
+    })
+}
+
+// Opaque cursor format: `base64url(JSON({"offset": N}))`. Clients treat it as
+// opaque per spec. Encoding choice keeps it ASCII and URL-safe even though
+// MCP transports it as a JSON string.
+fn encode_cursor(offset: usize) -> String {
+    let payload = json!({ "offset": offset }).to_string();
+    URL_SAFE_NO_PAD.encode(payload.as_bytes())
+}
+
+fn decode_cursor(cursor: &str) -> Option<usize> {
+    let bytes = URL_SAFE_NO_PAD.decode(cursor.as_bytes()).ok()?;
+    let v: Value = serde_json::from_slice(&bytes).ok()?;
+    v.get("offset").and_then(|o| o.as_u64()).map(|o| o as usize)
+}
+
+// Slice `items` starting at the offset decoded from `cursor` (or 0 if absent).
+// Returns the page slice and a `nextCursor` only when there are more items.
+// A bad/garbage cursor decodes to offset 0 — never error out, since cursors
+// are spec-opaque and clients sometimes round-trip them across reconnects.
+pub fn paginate<'a, T>(
+    items: &'a [T],
+    cursor: Option<&str>,
+    page: usize,
+) -> (Vec<&'a T>, Option<String>) {
+    let offset = cursor.and_then(decode_cursor).unwrap_or(0);
+    if offset >= items.len() {
+        return (Vec::new(), None);
+    }
+    let end = (offset + page).min(items.len());
+    let slice: Vec<&T> = items[offset..end].iter().collect();
+    let next = if end < items.len() {
+        Some(encode_cursor(end))
+    } else {
+        None
+    };
+    (slice, next)
+}
+
+// completion/complete handler. Two ref types:
+//   - "ref/prompt": completes named prompt arguments. Today the only argument
+//     with a finite value set is `register-function.language` (node|python).
+//   - "ref/tool": prefix-matches against currently exposed function ids.
+//
+// The spec permits `total` larger than `values.len()`, but we always return
+// the full match list (capped at 100), so total == values.len() and
+// hasMore == false. Keeping it simple matches what MCP Inspector expects.
+pub async fn handle_completion_complete(
+    iii: &III,
+    params: Option<Value>,
+) -> Result<Value, String> {
+    #[derive(Deserialize)]
+    struct Argument {
+        name: String,
+        #[serde(default)]
+        value: String,
+    }
+    #[derive(Deserialize)]
+    struct Ref {
+        #[serde(rename = "type")]
+        ref_type: String,
+        #[serde(default)]
+        name: String,
+    }
+    #[derive(Deserialize)]
+    struct P {
+        #[serde(rename = "ref")]
+        reference: Ref,
+        argument: Argument,
+    }
+
+    let p: P = match params {
+        Some(p) => serde_json::from_value(p).map_err(|e| format!("Invalid params: {}", e))?,
+        None => return Err("Missing params".into()),
+    };
+
+    let values: Vec<String> = match p.reference.ref_type.as_str() {
+        "ref/prompt" => crate::prompts::list_prompt_candidates(&p.reference.name, &p.argument.name)
+            .into_iter()
+            .filter(|c| c.starts_with(&p.argument.value))
+            .collect(),
+        "ref/tool" => {
+            let prefix = p.argument.value.clone();
+            match iii.list_functions().await {
+                Ok(fns) => fns
+                    .into_iter()
+                    .map(|f| f.function_id.replace("::", "__"))
+                    .filter(|name| name.starts_with(&prefix))
+                    .take(100)
+                    .collect(),
+                Err(_) => Vec::new(),
+            }
+        }
+        _ => Vec::new(),
+    };
+
+    let total = values.len();
+    Ok(json!({
+        "completion": {
+            "values": values,
+            "total": total,
+            "hasMore": false
+        }
+    }))
+}
+
+pub fn handle_logging_set_level(level_atom: &AtomicU8, params: Option<Value>) -> Result<Value, String> {
+    #[derive(Deserialize)]
+    struct P {
+        level: String,
+    }
+    let p: P = match params {
+        Some(p) => serde_json::from_value(p).map_err(|e| format!("Invalid params: {}", e))?,
+        None => return Err("Missing params".into()),
+    };
+    let lvl = level_from_str(&p.level)
+        .ok_or_else(|| format!("Unknown log level: {}", p.level))?;
+    level_atom.store(lvl, Ordering::SeqCst);
+    Ok(json!({}))
+}
+
+pub fn handle_resources_subscribe(
+    subs: &std::sync::Mutex<HashSet<String>>,
+    params: Option<Value>,
+) -> Result<Value, String> {
+    #[derive(Deserialize)]
+    struct P {
+        uri: String,
+    }
+    let p: P = match params {
+        Some(p) => serde_json::from_value(p).map_err(|e| format!("Invalid params: {}", e))?,
+        None => return Err("Missing params".into()),
+    };
+    if let Ok(mut g) = subs.lock() {
+        g.insert(p.uri);
+    }
+    Ok(json!({}))
+}
+
+pub fn handle_resources_unsubscribe(
+    subs: &std::sync::Mutex<HashSet<String>>,
+    params: Option<Value>,
+) -> Result<Value, String> {
+    #[derive(Deserialize)]
+    struct P {
+        uri: String,
+    }
+    let p: P = match params {
+        Some(p) => serde_json::from_value(p).map_err(|e| format!("Invalid params: {}", e))?,
+        None => return Err("Missing params".into()),
+    };
+    if let Ok(mut g) = subs.lock() {
+        g.remove(&p.uri);
+    }
+    Ok(json!({}))
+}
+
+pub fn make_resource_templates() -> Vec<Value> {
+    vec![
+        json!({
+            "uriTemplate": "iii://function/{id}",
+            "name": "Function",
+            "description": "A specific iii function by ID",
+            "mimeType": "application/json"
+        }),
+        json!({
+            "uriTemplate": "iii://worker/{id}",
+            "name": "Worker",
+            "description": "A specific iii worker by ID",
+            "mimeType": "application/json"
+        }),
+        json!({
+            "uriTemplate": "iii://trigger/{id}",
+            "name": "Trigger",
+            "description": "A specific iii trigger by ID",
+            "mimeType": "application/json"
+        }),
+    ]
+}
+
+// Resolve a templated URI by listing the relevant collection and matching
+// the trailing id segment. Returns the JSON body to embed in the
+// resources/read `contents[0].text`. Caller wraps it in the standard
+// `{contents:[...]}` envelope.
+pub async fn resolve_templated_uri(uri: &str, iii: &III) -> Option<(String, &'static str)> {
+    if let Some(id) = uri.strip_prefix("iii://function/") {
+        let fns = iii.list_functions().await.ok()?;
+        let f = fns.into_iter().find(|f| f.function_id == id)?;
+        let body = serde_json::to_string_pretty(&f).unwrap_or_else(|_| "{}".into());
+        return Some((body, "application/json"));
+    }
+    if let Some(id) = uri.strip_prefix("iii://worker/") {
+        let ws = iii.list_workers().await.ok()?;
+        let w = ws.into_iter().find(|w| w.id == id)?;
+        let body = serde_json::to_string_pretty(&w).unwrap_or_else(|_| "{}".into());
+        return Some((body, "application/json"));
+    }
+    if let Some(id) = uri.strip_prefix("iii://trigger/") {
+        let ts = iii.list_triggers(true).await.ok()?;
+        let t = ts.into_iter().find(|t| t.id == id)?;
+        let body = serde_json::to_string_pretty(&t).unwrap_or_else(|_| "{}".into());
+        return Some((body, "application/json"));
+    }
+    None
+}
+
+// Helper for `notifications/resources/updated` payloads.
+pub fn resource_updated_notification(uri: &str) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/resources/updated",
+        "params": { "uri": uri }
+    })
+}
+
+// Helper for `notifications/message` payloads.
+pub fn log_message_notification(level: &str, data: &Value, logger: Option<&str>) -> Value {
+    let mut params = json!({ "level": level, "data": data });
+    if let Some(name) = logger {
+        params["logger"] = json!(name);
+    }
+    json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/message",
+        "params": params
+    })
+}
+
+pub fn progress_notification(token: &Value, progress: f64, total: Option<f64>, message: Option<&str>) -> Value {
+    let mut params = json!({ "progressToken": token, "progress": progress });
+    if let Some(t) = total {
+        params["total"] = json!(t);
+    }
+    if let Some(m) = message {
+        params["message"] = json!(m);
+    }
+    json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/progress",
+        "params": params
+    })
+}
+

--- a/mcp/src/spec.rs
+++ b/mcp/src/spec.rs
@@ -130,10 +130,7 @@ pub fn paginate<'a, T>(
 // The spec permits `total` larger than `values.len()`, but we always return
 // the full match list (capped at 100), so total == values.len() and
 // hasMore == false. Keeping it simple matches what MCP Inspector expects.
-pub async fn handle_completion_complete(
-    iii: &III,
-    params: Option<Value>,
-) -> Result<Value, String> {
+pub async fn handle_completion_complete(iii: &III, params: Option<Value>) -> Result<Value, String> {
     #[derive(Deserialize)]
     struct Argument {
         name: String,
@@ -189,7 +186,10 @@ pub async fn handle_completion_complete(
     }))
 }
 
-pub fn handle_logging_set_level(level_atom: &AtomicU8, params: Option<Value>) -> Result<Value, String> {
+pub fn handle_logging_set_level(
+    level_atom: &AtomicU8,
+    params: Option<Value>,
+) -> Result<Value, String> {
     #[derive(Deserialize)]
     struct P {
         level: String,
@@ -198,8 +198,7 @@ pub fn handle_logging_set_level(level_atom: &AtomicU8, params: Option<Value>) ->
         Some(p) => serde_json::from_value(p).map_err(|e| format!("Invalid params: {}", e))?,
         None => return Err("Missing params".into()),
     };
-    let lvl = level_from_str(&p.level)
-        .ok_or_else(|| format!("Unknown log level: {}", p.level))?;
+    let lvl = level_from_str(&p.level).ok_or_else(|| format!("Unknown log level: {}", p.level))?;
     level_atom.store(lvl, Ordering::SeqCst);
     Ok(json!({}))
 }
@@ -311,7 +310,12 @@ pub fn log_message_notification(level: &str, data: &Value, logger: Option<&str>)
     })
 }
 
-pub fn progress_notification(token: &Value, progress: f64, total: Option<f64>, message: Option<&str>) -> Value {
+pub fn progress_notification(
+    token: &Value,
+    progress: f64,
+    total: Option<f64>,
+    message: Option<&str>,
+) -> Value {
     let mut params = json!({ "progressToken": token, "progress": progress });
     if let Some(t) = total {
         params["total"] = json!(t);
@@ -325,4 +329,3 @@ pub fn progress_notification(token: &Value, progress: f64, total: Option<f64>, m
         "params": params
     })
 }
-

--- a/mcp/tests/spec_2a.rs
+++ b/mcp/tests/spec_2a.rs
@@ -1,0 +1,434 @@
+// Phase 2a — MCP 2025-06-18 spec method tests.
+//
+// In-process tests cover pure helpers (pagination, completion candidates,
+// tool annotations, templated URI shape). Tests requiring a live engine
+// session — log_message → notifications/message round-trip, subscribe →
+// resources/updated, tools/call cancellation — are gated `#[ignore]` so
+// `cargo test` stays green without an engine running. Run them explicitly
+// with `cargo test -- --ignored` against a local engine.
+
+use iii_mcp::prompts;
+use iii_mcp::spec;
+use serde_json::{Value, json};
+
+// 120 dummy items, page=50 → page0, page1, page2 (50/50/20). Matches the
+// task's pagination spec exactly. Cursor is round-tripped (server-opaque
+// to clients but we decode internally).
+#[test]
+fn pagination_round_trip_120_items() {
+    let items: Vec<i32> = (0..120).collect();
+    let (page0, c0) = spec::paginate(&items, None, spec::PAGE_SIZE);
+    assert_eq!(page0.len(), 50);
+    assert_eq!(*page0[0], 0);
+    assert_eq!(*page0[49], 49);
+    let c0 = c0.expect("cursor after page 0");
+
+    let (page1, c1) = spec::paginate(&items, Some(&c0), spec::PAGE_SIZE);
+    assert_eq!(page1.len(), 50);
+    assert_eq!(*page1[0], 50);
+    assert_eq!(*page1[49], 99);
+    let c1 = c1.expect("cursor after page 1");
+
+    let (page2, c2) = spec::paginate(&items, Some(&c1), spec::PAGE_SIZE);
+    assert_eq!(page2.len(), 20);
+    assert_eq!(*page2[0], 100);
+    assert_eq!(*page2[19], 119);
+    assert!(c2.is_none(), "no cursor after final page");
+}
+
+#[test]
+fn pagination_garbage_cursor_decodes_to_zero() {
+    let items: Vec<i32> = (0..10).collect();
+    let (page, _) = spec::paginate(&items, Some("not-a-real-cursor"), 50);
+    assert_eq!(page.len(), 10);
+}
+
+#[test]
+fn prompt_candidates_for_register_function_language() {
+    let v = prompts::list_prompt_candidates("register-function", "language");
+    assert_eq!(v, vec!["node".to_string(), "python".to_string()]);
+}
+
+#[test]
+fn prompt_candidates_unknown_returns_empty() {
+    let v = prompts::list_prompt_candidates("unknown", "language");
+    assert!(v.is_empty());
+}
+
+// Mimics what the completion handler does for `ref/prompt` of
+// `register-function.language` with value "p" (should match only "python").
+// We exercise the filter directly because the engine path requires a session.
+#[test]
+fn completion_language_prefix_p_matches_python_only() {
+    let candidates = prompts::list_prompt_candidates("register-function", "language");
+    let filtered: Vec<&String> = candidates.iter().filter(|c| c.starts_with("p")).collect();
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0], "python");
+}
+
+#[test]
+fn completion_language_no_prefix_returns_both() {
+    let candidates = prompts::list_prompt_candidates("register-function", "language");
+    let filtered: Vec<&String> = candidates.iter().filter(|c| c.starts_with("")).collect();
+    assert_eq!(filtered.len(), 2);
+}
+
+#[test]
+fn resource_templates_list_returns_three() {
+    let templates = spec::make_resource_templates();
+    assert_eq!(templates.len(), 3);
+    let uris: Vec<&str> = templates
+        .iter()
+        .map(|t| t.get("uriTemplate").and_then(|u| u.as_str()).unwrap())
+        .collect();
+    assert!(uris.contains(&"iii://function/{id}"));
+    assert!(uris.contains(&"iii://worker/{id}"));
+    assert!(uris.contains(&"iii://trigger/{id}"));
+}
+
+#[test]
+fn make_tool_annotations_reads_all_hints() {
+    let meta = json!({
+        "mcp": {
+            "title": "Pretty Title",
+            "read_only_hint": true,
+            "destructive_hint": false,
+            "idempotent_hint": true,
+            "open_world_hint": false
+        }
+    });
+    let ann = spec::make_tool_annotations(&meta).expect("annotations present");
+    assert_eq!(ann.title.as_deref(), Some("Pretty Title"));
+    assert_eq!(ann.read_only_hint, Some(true));
+    assert_eq!(ann.destructive_hint, Some(false));
+    assert_eq!(ann.idempotent_hint, Some(true));
+    assert_eq!(ann.open_world_hint, Some(false));
+}
+
+#[test]
+fn make_tool_annotations_returns_none_when_no_keys() {
+    let meta = json!({ "mcp": { "expose": true } });
+    assert!(spec::make_tool_annotations(&meta).is_none());
+}
+
+#[test]
+fn make_tool_annotations_returns_none_when_no_mcp_block() {
+    let meta = json!({ "other": { "stuff": 1 } });
+    assert!(spec::make_tool_annotations(&meta).is_none());
+}
+
+#[test]
+fn log_level_string_round_trip() {
+    assert_eq!(spec::level_from_str("debug"), Some(spec::LOG_DEBUG));
+    assert_eq!(spec::level_from_str("info"), Some(spec::LOG_INFO));
+    assert_eq!(spec::level_from_str("warning"), Some(spec::LOG_WARNING));
+    assert_eq!(spec::level_from_str("emergency"), Some(spec::LOG_EMERGENCY));
+    assert_eq!(spec::level_from_str("nonsense"), None);
+}
+
+#[test]
+fn log_message_notification_includes_logger_when_set() {
+    let n =
+        spec::log_message_notification("warning", &json!({"msg": "x"}), Some("svc"));
+    assert_eq!(n["method"], "notifications/message");
+    assert_eq!(n["params"]["level"], "warning");
+    assert_eq!(n["params"]["logger"], "svc");
+}
+
+#[test]
+fn log_message_notification_omits_logger_when_unset() {
+    let n = spec::log_message_notification("info", &json!({"msg": "x"}), None);
+    assert!(n["params"].get("logger").is_none());
+}
+
+#[test]
+fn progress_notification_shape() {
+    let n = spec::progress_notification(&json!("t1"), 50.0, Some(100.0), Some("halfway"));
+    assert_eq!(n["method"], "notifications/progress");
+    assert_eq!(n["params"]["progressToken"], json!("t1"));
+    assert_eq!(n["params"]["progress"], 50.0);
+    assert_eq!(n["params"]["total"], 100.0);
+    assert_eq!(n["params"]["message"], "halfway");
+}
+
+#[test]
+fn resource_updated_notification_shape() {
+    let n = spec::resource_updated_notification("iii://functions");
+    assert_eq!(n["method"], "notifications/resources/updated");
+    assert_eq!(n["params"]["uri"], "iii://functions");
+}
+
+#[test]
+fn logging_set_level_updates_atomic() {
+    use std::sync::atomic::{AtomicU8, Ordering};
+    let level = AtomicU8::new(spec::LOG_INFO);
+    spec::handle_logging_set_level(&level, Some(json!({"level": "warning"})))
+        .expect("set warning");
+    assert_eq!(level.load(Ordering::SeqCst), spec::LOG_WARNING);
+
+    let err = spec::handle_logging_set_level(&level, Some(json!({"level": "garbage"})));
+    assert!(err.is_err());
+    assert_eq!(level.load(Ordering::SeqCst), spec::LOG_WARNING);
+}
+
+#[test]
+fn subscribe_unsubscribe_round_trip() {
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+    let subs: Mutex<HashSet<String>> = Mutex::new(HashSet::new());
+    spec::handle_resources_subscribe(&subs, Some(json!({"uri": "iii://functions"})))
+        .expect("subscribe");
+    assert!(subs.lock().unwrap().contains("iii://functions"));
+    spec::handle_resources_unsubscribe(&subs, Some(json!({"uri": "iii://functions"})))
+        .expect("unsubscribe");
+    assert!(!subs.lock().unwrap().contains("iii://functions"));
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests below this line require a live iii-engine. They are
+// gated `#[ignore]` so plain `cargo test` stays green; run with
+// `cargo test -- --ignored` after `iii-engine` is up on ws://localhost:49134.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires live iii-engine on ws://localhost:49134"]
+async fn live_logging_set_level_then_log_message() {
+    use iii_mcp::handler::{ExposureConfig, McpHandler};
+    use iii_sdk::{InitOptions, TriggerRequest, register_worker};
+
+    let url = "ws://localhost:49134";
+    let iii = register_worker(url, InitOptions::default());
+    let handler = std::sync::Arc::new(McpHandler::new(
+        iii.clone(),
+        url.to_string(),
+        ExposureConfig::new(false, false, None),
+    ));
+
+    // Bring handler to initialized state.
+    handler
+        .handle(json!({"jsonrpc":"2.0","id":1,"method":"initialize"}))
+        .await;
+    handler
+        .handle(json!({"jsonrpc":"2.0","method":"notifications/initialized"}))
+        .await;
+
+    // setLevel info, then a `warning` log_message — should fire.
+    handler
+        .handle(json!({"jsonrpc":"2.0","id":2,"method":"logging/setLevel","params":{"level":"info"}}))
+        .await;
+    let _ = iii
+        .trigger(TriggerRequest {
+            function_id: "mcp::log_message".into(),
+            payload: json!({"level": "warning", "data": {"hello": "world"}}),
+            action: None,
+            timeout_ms: None,
+        })
+        .await
+        .expect("log_message trigger");
+
+    // Drain the notification — should be a notifications/message at warning.
+    let mut got_warning = false;
+    for _ in 0..20 {
+        if let Some(n) = handler.take_notification().await {
+            let v: Value = serde_json::from_str(&n).unwrap();
+            if v["method"] == "notifications/message" && v["params"]["level"] == "warning" {
+                got_warning = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    assert!(got_warning, "expected notifications/message at warning level");
+
+    // Bump level to error, fire warning → should be filtered.
+    handler
+        .handle(json!({"jsonrpc":"2.0","id":3,"method":"logging/setLevel","params":{"level":"error"}}))
+        .await;
+    let _ = iii
+        .trigger(TriggerRequest {
+            function_id: "mcp::log_message".into(),
+            payload: json!({"level": "debug", "data": {}}),
+            action: None,
+            timeout_ms: None,
+        })
+        .await;
+
+    let mut filtered = true;
+    for _ in 0..6 {
+        if let Some(n) = handler.take_notification().await {
+            let v: Value = serde_json::from_str(&n).unwrap();
+            if v["method"] == "notifications/message" {
+                filtered = false;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    assert!(filtered, "debug message should not fire when level=error");
+}
+
+#[tokio::test]
+#[ignore = "requires live iii-engine on ws://localhost:49134"]
+async fn live_progress_token_round_trip() {
+    use iii_mcp::handler::{ExposureConfig, McpHandler};
+    use iii_sdk::{InitOptions, TriggerRequest, register_worker};
+
+    let url = "ws://localhost:49134";
+    let iii = register_worker(url, InitOptions::default());
+    let handler = std::sync::Arc::new(McpHandler::new(
+        iii.clone(),
+        url.to_string(),
+        ExposureConfig::new(false, false, None),
+    ));
+    handler
+        .handle(json!({"jsonrpc":"2.0","id":1,"method":"initialize"}))
+        .await;
+    handler
+        .handle(json!({"jsonrpc":"2.0","method":"notifications/initialized"}))
+        .await;
+
+    let _ = iii
+        .trigger(TriggerRequest {
+            function_id: "mcp::progress".into(),
+            payload: json!({"token": "t1", "progress": 50.0}),
+            action: None,
+            timeout_ms: None,
+        })
+        .await
+        .expect("progress trigger");
+
+    let mut got = false;
+    for _ in 0..20 {
+        if let Some(n) = handler.take_notification().await {
+            let v: Value = serde_json::from_str(&n).unwrap();
+            if v["method"] == "notifications/progress"
+                && v["params"]["progressToken"] == "t1"
+                && v["params"]["progress"] == 50.0
+            {
+                got = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    assert!(got, "expected notifications/progress for token t1");
+}
+
+#[tokio::test]
+#[ignore = "requires live iii-engine on ws://localhost:49134"]
+async fn live_subscribe_function_added_emits_updated() {
+    use iii_mcp::handler::{ExposureConfig, McpHandler};
+    use iii_sdk::{InitOptions, RegisterFunctionMessage, register_worker};
+
+    let url = "ws://localhost:49134";
+    let iii = register_worker(url, InitOptions::default());
+    let handler = std::sync::Arc::new(McpHandler::new(
+        iii.clone(),
+        url.to_string(),
+        ExposureConfig::new(false, false, None),
+    ));
+    handler
+        .handle(json!({"jsonrpc":"2.0","id":1,"method":"initialize"}))
+        .await;
+    handler
+        .handle(json!({"jsonrpc":"2.0","method":"notifications/initialized"}))
+        .await;
+    handler
+        .handle(json!({
+            "jsonrpc":"2.0","id":2,"method":"resources/subscribe",
+            "params":{"uri":"iii://functions"}
+        }))
+        .await;
+
+    iii.register_function_with(
+        RegisterFunctionMessage {
+            id: "demo::ping".into(),
+            description: Some("test".into()),
+            request_format: None,
+            response_format: None,
+            metadata: None,
+            invocation: None,
+        },
+        |_input: Value| async move { Ok(json!({"ok": true})) },
+    );
+
+    let mut got = false;
+    for _ in 0..40 {
+        if let Some(n) = handler.take_notification().await {
+            let v: Value = serde_json::from_str(&n).unwrap();
+            if v["method"] == "notifications/resources/updated"
+                && v["params"]["uri"] == "iii://functions"
+            {
+                got = true;
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    assert!(got, "expected notifications/resources/updated for iii://functions");
+}
+
+#[tokio::test]
+#[ignore = "requires live iii-engine on ws://localhost:49134"]
+async fn live_tools_call_cancelled() {
+    use iii_mcp::handler::{ExposureConfig, McpHandler};
+    use iii_sdk::{InitOptions, RegisterFunctionMessage, register_worker};
+
+    let url = "ws://localhost:49134";
+    let iii = register_worker(url, InitOptions::default());
+
+    iii.register_function_with(
+        RegisterFunctionMessage {
+            id: "demo::slow".into(),
+            description: Some("slow handler".into()),
+            request_format: None,
+            response_format: None,
+            metadata: Some(json!({"mcp": {"expose": true}})),
+            invocation: None,
+        },
+        |_input: Value| async move {
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            Ok(json!({"ok": true}))
+        },
+    );
+
+    let handler = std::sync::Arc::new(McpHandler::new(
+        iii.clone(),
+        url.to_string(),
+        ExposureConfig::new(false, true, None),
+    ));
+    handler
+        .handle(json!({"jsonrpc":"2.0","id":1,"method":"initialize"}))
+        .await;
+    handler
+        .handle(json!({"jsonrpc":"2.0","method":"notifications/initialized"}))
+        .await;
+
+    let h2 = handler.clone();
+    let call = tokio::spawn(async move {
+        h2.handle(json!({
+            "jsonrpc":"2.0","id":42,"method":"tools/call",
+            "params":{"name":"demo__slow","arguments":{}}
+        }))
+        .await
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    handler
+        .handle(json!({
+            "jsonrpc":"2.0","method":"notifications/cancelled",
+            "params":{"requestId": 42}
+        }))
+        .await;
+
+    let resp = call.await.expect("join").expect("response");
+    let v: Value = resp;
+    let result = &v["result"];
+    assert_eq!(result["isError"], true);
+    let text = result["content"][0]["text"].as_str().unwrap_or("");
+    assert!(
+        text.to_lowercase().contains("cancel"),
+        "expected cancel message, got {}",
+        text
+    );
+}

--- a/mcp/tests/spec_2a.rs
+++ b/mcp/tests/spec_2a.rs
@@ -128,8 +128,7 @@ fn log_level_string_round_trip() {
 
 #[test]
 fn log_message_notification_includes_logger_when_set() {
-    let n =
-        spec::log_message_notification("warning", &json!({"msg": "x"}), Some("svc"));
+    let n = spec::log_message_notification("warning", &json!({"msg": "x"}), Some("svc"));
     assert_eq!(n["method"], "notifications/message");
     assert_eq!(n["params"]["level"], "warning");
     assert_eq!(n["params"]["logger"], "svc");
@@ -162,8 +161,7 @@ fn resource_updated_notification_shape() {
 fn logging_set_level_updates_atomic() {
     use std::sync::atomic::{AtomicU8, Ordering};
     let level = AtomicU8::new(spec::LOG_INFO);
-    spec::handle_logging_set_level(&level, Some(json!({"level": "warning"})))
-        .expect("set warning");
+    spec::handle_logging_set_level(&level, Some(json!({"level": "warning"}))).expect("set warning");
     assert_eq!(level.load(Ordering::SeqCst), spec::LOG_WARNING);
 
     let err = spec::handle_logging_set_level(&level, Some(json!({"level": "garbage"})));
@@ -214,7 +212,9 @@ async fn live_logging_set_level_then_log_message() {
 
     // setLevel info, then a `warning` log_message — should fire.
     handler
-        .handle(json!({"jsonrpc":"2.0","id":2,"method":"logging/setLevel","params":{"level":"info"}}))
+        .handle(
+            json!({"jsonrpc":"2.0","id":2,"method":"logging/setLevel","params":{"level":"info"}}),
+        )
         .await;
     let _ = iii
         .trigger(TriggerRequest {
@@ -238,11 +238,16 @@ async fn live_logging_set_level_then_log_message() {
         }
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     }
-    assert!(got_warning, "expected notifications/message at warning level");
+    assert!(
+        got_warning,
+        "expected notifications/message at warning level"
+    );
 
     // Bump level to error, fire warning → should be filtered.
     handler
-        .handle(json!({"jsonrpc":"2.0","id":3,"method":"logging/setLevel","params":{"level":"error"}}))
+        .handle(
+            json!({"jsonrpc":"2.0","id":3,"method":"logging/setLevel","params":{"level":"error"}}),
+        )
         .await;
     let _ = iii
         .trigger(TriggerRequest {
@@ -365,7 +370,10 @@ async fn live_subscribe_function_added_emits_updated() {
         }
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
-    assert!(got, "expected notifications/resources/updated for iii://functions");
+    assert!(
+        got,
+        "expected notifications/resources/updated for iii://functions"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Tracks #45 — Phase 2a of MCP+A2A overhaul.

> ⚠️ **Do not merge yet.** Two open blockers from final review (see "Open issues" below). PR is up for visibility / review iteration.

## Summary

Closes the MCP 2025-06-18 spec gap on the non-streaming surface:

- \`completion/complete\` — argument autocomplete (prompts + tools).
- \`logging/setLevel\` + \`notifications/message\` — per-session log level filter; user code emits via \`mcp::log_message\` iii function.
- \`resources/subscribe\` + \`resources/unsubscribe\` + \`notifications/resources/updated\` — hooked into \`iii.on_functions_available\` and a 5s baseline-primed poll loop for workers/triggers.
- \`resources/templates/list\` — three real templates (\`iii://function/{id}\`, \`iii://worker/{id}\`, \`iii://trigger/{id}\`).
- Pagination cursors on \`tools/list\`, \`resources/list\`, \`prompts/list\` (opaque base64-url JSON, page size 50).
- Tool annotations: \`title\`, \`readOnlyHint\`, \`destructiveHint\`, \`idempotentHint\`, \`openWorldHint\`, plus \`outputSchema\` from \`response_format\`.
- \`_meta.progressToken\` — bound per request, emitted by user code via \`mcp::progress\` iii function as \`notifications/progress\`.
- \`notifications/cancelled\` — \`tokio::select!\` against an \`oneshot\` cancel channel; in-flight \`tools/call\` returns \`isError: true\` with "Request cancelled".

Stdio + Streamable-HTTP parity throughout. Idempotent \`register_notification_helpers\` via \`OnceLock\` to avoid duplicate registrations across both transports. Polled baselines primed before the first tick to skip the phantom first-iteration update.

Out of scope (deferred): sampling, elicitation, Streamable HTTP SSE — Phase 2b/2c.

## Test plan

- [x] \`cargo check -p iii-mcp\` clean
- [x] \`cargo test -p iii-mcp\` green (17 pass + 4 ignored)
- [x] \`cargo clippy -p iii-mcp --all-targets\` clean
- [ ] MCP Inspector against the binary

## Open issues (must fix before merge)

- **P0** \`OnceLock\` on \`register_notification_helpers\` is order-dependent: \`main.rs\` calls \`register_http\` first (which drops its \`notifier_rx\`), so the first-caller-wins semantics orphan the stdio session's notifier. \`notifications/message\` and \`notifications/progress\` over stdio silently drop. Fix: maintain a per-transport state map keyed inside the closure, or scope registration to one transport only.
- **P1** \`progress_tokens\` DashMap leaks one entry per HTTP \`tools/call\` — only early-error paths remove it. Wrap the body in defer-style cleanup, or cleanup at function exit.

## Sequencing

Needs rebase onto phase1 once it lands — this branch still carries the pre-RBAC \`ExposureConfig\` flow, which Phase 1 deletes.