### PR TITLE
docs(mcp,a2a): document phase 0/2a feature surfaces in READMEs

### DIFF
--- a/a2a/README.md
+++ b/a2a/README.md
@@ -42,14 +42,24 @@ For the use case the old `engine::*` hard floor hid, use the `introspect` worker
 ### CLI flags
 
 ```text
---engine-url <URL>   WebSocket URL of the iii engine (default ws://localhost:49134)
---base-url <URL>     Public origin advertised in the agent card. The card is served
-                     at <base-url>/a2a. Default: http://localhost:3111
---rbac-tag <TAG>     Forward an `x-iii-rbac-tag` header on the worker WebSocket
-                     upgrade. iii-worker-manager's `auth_function_id` reads
-                     this tag to apply policy.
---debug              Verbose logging
+--engine-url <URL>           WebSocket URL of the iii engine (default ws://localhost:49134)
+--base-url <URL>             Public origin advertised in the agent card. The card is served
+                             at <base-url>/a2a. Default: http://localhost:3111
+--agent-name <NAME>          Agent card `name` (default: iii-engine)
+--agent-description <TEXT>   Agent card `description`
+--provider-org <ORG>         AgentProvider.organization (default: iii)
+--provider-url <URL>         AgentProvider.url (default: https://github.com/iii-hq/iii)
+--docs-url <URL>             AgentCard.documentationUrl
+                             (default: https://github.com/iii-hq/workers/tree/main/a2a)
+--rbac-tag <TAG>             Forward an `x-iii-rbac-tag` header on the worker WebSocket
+                             upgrade. iii-worker-manager's `auth_function_id` reads
+                             this tag to apply policy.
+--debug                      Verbose logging
 ```
+
+Empty `--provider-org` or `--provider-url` omits the `provider` object
+from the card (A2A v0.3 requires both fields when the object is present).
+Empty `--docs-url` omits `documentationUrl`.
 
 ## Local testing
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -225,3 +225,31 @@ your `auth_function_id` can scope policy on it.
 
 Result is wrapped as `{ content: [{ type: "text", text: ... }] }` per MCP
 spec. Errors surface as `isError: true`.
+
+## MCP 2025-06-18 spec coverage
+
+Beyond the core `tools/list` + `tools/call` path, this worker speaks:
+
+- **Pagination** on `tools/list`, `resources/list`, `prompts/list` —
+  opaque `cursor` round-trip per spec.
+- **`completion/complete`** — argument autocomplete for prompt args
+  (e.g. language enum on `register-function`).
+- **`logging/setLevel`** + **`notifications/message`** — per-session
+  level bridged into `tracing`.
+- **`resources/subscribe`** + **`resources/unsubscribe`** +
+  **`notifications/resources/updated`** — change notifications when
+  `iii.list_functions()` / `list_workers()` / `list_triggers()` shift
+  for a subscribed URI.
+- **`resources/templates/list`** — templates for `iii://functions/{id}`,
+  `iii://workers/{id}`, `iii://triggers/{id}`.
+- **Tool annotations + outputSchema + structured content** — tools
+  surface `title`, `annotations` (`readOnlyHint`, `destructiveHint`,
+  `idempotentHint`, `openWorldHint`), and `outputSchema` from
+  `FunctionInfo.metadata.mcp.*`.
+- **Progress + cancellation** — `_meta.progressToken` on `tools/call`
+  emits `notifications/progress`; `notifications/cancelled` flips a
+  per-request cancel channel and short-circuits the in-flight trigger.
+
+Server-to-client requests (`sampling/createMessage`,
+`elicitation/create`) and Streamable HTTP SSE remain on the Phase 2b/2c
+roadmap.


### PR DESCRIPTION
## Summary

- **a2a/README.md** — CLI flags table missed the agent-identity flags shipped in phase 0. Adds \`--agent-name\`, \`--agent-description\`, \`--provider-org\`, \`--provider-url\`, \`--docs-url\` with defaults and the AgentProvider/documentationUrl omit-when-empty semantics.
- **mcp/README.md** — adds an \"MCP 2025-06-18 spec coverage\" section enumerating the methods landed in phase 2a: pagination, completion/complete, logging/setLevel + notifications/message, resources/subscribe + resources/unsubscribe + notifications/resources/updated, resources/templates/list, tool annotations + outputSchema + structured content, progress + cancellation. Calls out 2b/2c (sampling/elicitation, Streamable HTTP SSE) as still outstanding.

Pure docs — no code changes.

## Test plan

- [x] \`git diff\` reviewed; only README markdown touched
- [ ] CI lint passes (READMEs only — no rust/node/python jobs to run)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded CLI flag documentation with new agent card metadata configuration options and conditional field behavior guidance
  * Enhanced MCP specification support documentation covering paginated lists, per-session logging, notifications, resource subscriptions, extended tool metadata, and call progress/cancellation capabilities
  * Clarified Phase 2b/2c roadmap items for future releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->