### PR TITLE
ci: register mcp-client and a2a-client in release workflows

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -9,6 +9,7 @@ on:
         type: choice
         options:
           - a2a
+          - a2a-client
           - agent
           - coding
           - eval
@@ -20,6 +21,7 @@ on:
           - introspect
           - llm-router
           - mcp
+          - mcp-client
           - proof
           - shell
           - todo-worker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'a2a/v*'
+      - 'a2a-client/v*'
       - 'agent/v*'
       - 'coding/v*'
       - 'eval/v*'
@@ -14,6 +15,7 @@ on:
       - 'introspect/v*'
       - 'llm-router/v*'
       - 'mcp/v*'
+      - 'mcp-client/v*'
       - 'proof/v*'
       - 'shell/v*'
       - 'todo-worker/v*'


### PR DESCRIPTION
## Summary

Phase 4a (mcp-client) and Phase 4b (a2a-client) landed without entries in:

- \`.github/workflows/release.yml\` \`on.push.tags\` — without this, an \`mcp-client/v*\` or \`a2a-client/v*\` push would not fire the Release workflow.
- \`.github/workflows/create-tag.yml\` \`workflow_dispatch.inputs.worker.options\` — the dropdown for cutting tags via the GitHub UI doesn't show them.

This PR adds both. Net result: cutting an \`mcp-client/v0.1.0\` (or \`a2a-client/v0.1.0\`) tag will now trigger the binary build + registry POST, and the maintainer UI will offer them in the dropdown.

\`sensor/\` was deliberately not added — it has no \`iii.worker.yaml\` manifest yet, so the release setup step would fail. \`autoharness/\` is excluded per maintainer.

## Test plan

- [x] \`yamllint\` clean (no syntax change)
- [ ] After merge: \`gh workflow run create-tag.yml -f worker=mcp-client -f bump=patch -f tag=latest -R iii-hq/workers\` → expect Release run + registry entry
- [ ] Same for a2a-client