### PR TITLE
feat(llm-router): expose provider in RoutingDecision

### DIFF
--- a/llm-router/src/functions/decide.rs
+++ b/llm-router/src/functions/decide.rs
@@ -70,7 +70,19 @@ async fn handle(iii: III, cfg: Arc<RouterConfig>, payload: Value) -> Result<Valu
         classifier: classifier.as_ref(),
         models: &models,
     };
-    let decision = decide(&req, ctx, &cfg, &mut rng);
+    let mut decision = decide(&req, ctx, &cfg, &mut rng);
+
+    // Enrich the decision with the provider attached to the chosen model's
+    // registration, when one exists. This saves consumers from a separate
+    // lookup against `router::model_list` or a parallel models-catalog call
+    // when they need to dispatch by provider (e.g. agent harnesses calling
+    // `provider::<name>::stream_assistant`).
+    if !decision.model.is_empty() && decision.provider.is_none() {
+        decision.provider = models
+            .iter()
+            .find(|mr| mr.model == decision.model)
+            .and_then(|mr| mr.provider.clone());
+    }
 
     let request_id = format!("req-{}", Uuid::new_v4());
     let log = RoutingLogEntry {

--- a/llm-router/src/router.rs
+++ b/llm-router/src/router.rs
@@ -174,6 +174,7 @@ pub fn decide(
                         ab_test_id: None,
                         fallback: None,
                         confidence: 0.3,
+                        provider: None,
                     };
                 }
             }
@@ -198,6 +199,7 @@ pub fn decide(
                         ab_test_id: None,
                         fallback: None,
                         confidence: confidence * 0.8,
+                        provider: None,
                     };
                 }
             }
@@ -225,6 +227,7 @@ pub fn decide(
                             ab_test_id: None,
                             fallback: policy.action.fallback.clone(),
                             confidence: dconf,
+                            provider: None,
                         };
                     }
                     reason = format!(
@@ -242,6 +245,7 @@ pub fn decide(
             ab_test_id: None,
             fallback: policy.action.fallback.clone(),
             confidence,
+            provider: None,
         };
     }
 
@@ -262,6 +266,7 @@ pub fn decide(
                 ab_test_id: None,
                 fallback: None,
                 confidence,
+                provider: None,
             };
         }
     }
@@ -283,6 +288,7 @@ pub fn decide(
                 ab_test_id: Some(ab.id.clone()),
                 fallback: None,
                 confidence,
+                provider: None,
             };
         }
     }
@@ -294,6 +300,7 @@ pub fn decide(
         ab_test_id: None,
         fallback: None,
         confidence: 0.0,
+        provider: None,
     }
 }
 
@@ -616,5 +623,41 @@ mod tests {
         }];
         assert!(skip_unavailable("m", &h, 0.3));
         assert!(!skip_unavailable("m", &h, 0.8));
+    }
+
+    #[test]
+    fn test_routing_decision_serializes_provider_when_set() {
+        let d = RoutingDecision {
+            model: "claude-sonnet-4".into(),
+            reason: "test".into(),
+            policy_id: None,
+            ab_test_id: None,
+            fallback: None,
+            confidence: 1.0,
+            provider: Some("anthropic".into()),
+        };
+        let v = serde_json::to_value(&d).expect("serialize");
+        assert_eq!(
+            v.get("provider").and_then(|x| x.as_str()),
+            Some("anthropic")
+        );
+    }
+
+    #[test]
+    fn test_routing_decision_omits_provider_when_unset() {
+        let d = RoutingDecision {
+            model: "x".into(),
+            reason: "test".into(),
+            policy_id: None,
+            ab_test_id: None,
+            fallback: None,
+            confidence: 1.0,
+            provider: None,
+        };
+        let v = serde_json::to_value(&d).expect("serialize");
+        assert!(
+            v.get("provider").is_none(),
+            "provider field must be skipped when None"
+        );
     }
 }

--- a/llm-router/src/types.rs
+++ b/llm-router/src/types.rs
@@ -79,6 +79,15 @@ pub struct RoutingDecision {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fallback: Option<String>,
     pub confidence: f64,
+    /// Provider for the chosen `model`, derived from `ModelRegistration`.
+    /// Populated by `router::decide` after the routing decision is made.
+    /// Optional because models can be referenced before they're registered
+    /// (e.g. policy `model: "auto"` resolved by classifier to an
+    /// unregistered model). Consumers who care about provider routing can
+    /// rely on this when set; when absent they may parse a namespaced model
+    /// id (e.g. `anthropic/claude-...`) themselves.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Add `provider: Option<String>` to `RoutingDecision` and populate it from the chosen model's `ModelRegistration.provider` after the routing decision is made.

## Why

Agent harnesses that dispatch by `provider::<name>::stream_assistant` need the provider name to route the call. Today they either:

- Do a second `state.list("models:")` after `router::decide` returns
- Or parse a namespaced model id (`anthropic/claude-...`) themselves

The router already loads the full models list inside `decide`, so wiring the provider through is a free two-line enrichment instead of N+1 round-trips on every routed call.

Concrete consumer: `iii-experimental/harness::agent::stream_assistant` calls `router::decide` once on the bus and then dispatches to `provider::<name>::stream_assistant` — without this field, every routed turn pays a second state lookup.

## Changes

- **types.rs** — new field on `RoutingDecision`:
  ```rust
  #[serde(default, skip_serializing_if = "Option::is_none")]
  pub provider: Option<String>,
  ```
  Optional + skipped-when-none keeps the wire shape backward compatible for existing consumers.

- **functions/decide.rs** — enrichment after `router::decide`:
  ```rust
  if !decision.model.is_empty() && decision.provider.is_none() {
      decision.provider = models
          .iter()
          .find(|mr| mr.model == decision.model)
          .and_then(|mr| mr.provider.clone());
  }
  ```
  Only fills when a registration exists. Models referenced before registration (e.g. policy `model: "auto"` resolved by classifier to an unregistered model) get `None`, which consumers can fall back on by parsing namespaced model ids.

- **router.rs** — 7 `RoutingDecision` construction sites updated with `provider: None`. Two new tests cover serde:
  - `test_routing_decision_serializes_provider_when_set`
  - `test_routing_decision_omits_provider_when_unset`

## Backward compatibility

- Field is `Option<String>` with `#[serde(default)]` — old clients deserializing the new shape see `None`
- `skip_serializing_if = "Option::is_none"` — old shape on the wire when no provider is set
- No changes to `RoutingRequest`, function ids, or state schema

## Test plan

- [x] `cargo test` — 32/32 pass (30 existing + 2 new)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Reviewer sanity check on whether `provider` should also be set by the AB-test variant path (current diff only relies on the `models:` lookup, which covers all paths)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Routing decisions now include optional provider information. When a model is selected and available in the system, the decision output includes the associated provider identifier. The provider field only appears when available, maintaining backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->