### PR TITLE
fix(llm-router): RoutingRequest must tolerate iii-sdk caller metadata

### DIFF
--- a/llm-router/src/router.rs
+++ b/llm-router/src/router.rs
@@ -660,4 +660,22 @@ mod tests {
             "provider field must be skipped when None"
         );
     }
+
+    #[test]
+    fn test_routing_request_tolerates_iii_sdk_caller_metadata() {
+        // iii-sdk injects `_caller_worker_id` into every trigger payload.
+        // RoutingRequest must accept (and ignore) that field; otherwise
+        // every `iii.trigger("router::decide", ...)` call gets rejected
+        // before any router logic runs. Regression test for the prior
+        // `deny_unknown_fields` posture.
+        let raw = serde_json::json!({
+            "_caller_worker_id": "worker-uuid-123",
+            "prompt": "hello",
+            "tenant": "acme",
+        });
+        let parsed: RoutingRequest =
+            serde_json::from_value(raw).expect("RoutingRequest must accept caller metadata");
+        assert_eq!(parsed.prompt, "hello");
+        assert_eq!(parsed.tenant.as_deref(), Some("acme"));
+    }
 }

--- a/llm-router/src/types.rs
+++ b/llm-router/src/types.rs
@@ -46,8 +46,19 @@ fn default_enabled() -> bool {
     true
 }
 
+/// Request payload to `router::decide`.
+///
+/// We intentionally **do not** carry `#[serde(deny_unknown_fields)]` here:
+/// when callers reach this function via `iii.trigger(...)`, iii-sdk injects
+/// caller-metadata fields (today: `_caller_worker_id`) into the payload
+/// alongside the user-controlled body. A strict deserializer rejects every
+/// such call with `unknown field _caller_worker_id`, which silently breaks
+/// every consumer (harness, agent runtimes, custom clients) that doesn't
+/// pre-strip metadata. State-stored objects (`Policy`, `AbTest`, etc.) keep
+/// `deny_unknown_fields` because they're hand-written by operators and
+/// schema drift there is a real bug. Function-input shapes are different:
+/// they MUST tolerate engine-injected metadata.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct RoutingRequest {
     #[serde(default)]
     pub tenant: Option<String>,


### PR DESCRIPTION
## Summary

iii-sdk injects `_caller_worker_id` (and potentially other metadata fields) into every `iii.trigger(...)` payload. `RoutingRequest` carried `#[serde(deny_unknown_fields)]`, which silently broke every consumer reaching the router via `iii.trigger`.

## Reproducer

```bash
$ iii --use-default-config &
$ iii-llm-router --config config.yaml &
$ iii trigger --function-id router::decide --payload '{"prompt":"hi"}'
Error: handler error: parse request: unknown field \`_caller_worker_id\`,
  expected one of \`tenant\`, \`feature\`, \`user\`, \`prompt\`, \`tags\`,
  \`budget_remaining_usd\`, \`latency_slo_ms\`, \`min_quality\`,
  \`classifier_id\`
```

Same failure mode bit `iii-experimental/harness`'s `agent::stream_assistant`: with `llm-router` on the bus, probe sees `router::decide`, harness calls it, call returns `invocation_failed`, harness falls back to direct dispatch — so the router was effectively never used in any production-shape tier-3 deployment that went through `iii.trigger`.

## Why

`#[serde(deny_unknown_fields)]` is the right posture for state-stored schemas (`Policy`, `AbTest`, `ClassifierConfig`, `ModelRegistration`, `PolicyAction`, `PolicyMatch`) because operators hand-write them and schema drift is a real bug. Function-input shapes are categorically different: they MUST tolerate engine-injected metadata, because the SDK owns the wire boundary and adds fields any consumer is required to ignore.

## Changes

- **`types.rs`** — drop `#[serde(deny_unknown_fields)]` on `RoutingRequest`. Adds a doc comment explaining the contract distinction so future contributors don't reflexively add it back.
- **`router.rs`** — new test `test_routing_request_tolerates_iii_sdk_caller_metadata` exercises `serde_json::from_value` against a payload carrying `_caller_worker_id` alongside the standard fields. Asserts the field is silently ignored and the rest deserialises cleanly.

## Backward compatibility

- No wire-shape change for callers that already only sent the documented fields.
- Existing `Policy` / `AbTest` / etc. validation is unaffected — those still reject unknown fields.

## Test plan

- [x] `cargo test` — 33/33 (32 prior + 1 new regression)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Reviewer sanity check on whether other `iii.trigger`-reachable function inputs in this crate carry the same hazard (skim of `functions/` shows only `RoutingRequest` and the four state-write payloads, which already use `#[serde(default)]` rather than `deny_unknown_fields`).

## Follow-up

Discovered while running the iii-experimental/harness composability ladder Tier 3 (`iii worker add llm-router` → drive harness → expect provider routing). Without this fix, Tier 3 is silently inert.