### PR TITLE
ci: register conductor in create-tag + release workflows

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -12,6 +12,7 @@ on:
           - a2a-client
           - agent
           - coding
+          - conductor
           - eval
           - experiment
           - guardrails

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
       - 'a2a-client/v*'
       - 'agent/v*'
       - 'coding/v*'
+      - 'conductor/v*'
       - 'eval/v*'
       - 'experiment/v*'
       - 'guardrails/v*'


### PR DESCRIPTION
## Summary

Follow-up to #59 (conductor worker merged). Register conductor with the two workflows that hardcode the worker list:

- \`.github/workflows/create-tag.yml\` — adds \`conductor\` to the \`worker\` input choice list so \`gh workflow run create-tag.yml -f worker=conductor -f bump=patch -f tag=latest\` is dispatchable from the Actions UI.
- \`.github/workflows/release.yml\` — adds \`conductor/v*\` to the tag-push trigger so a tag pushed by Create Tag fires the release dispatcher (multi-arch binaries + GH Release + \`POST /publish\`).

Both lists kept alphabetical between \`coding\` and \`eval\`.

## After merge

1. Actions → Create Tag → \`worker: conductor, bump: patch, tag: latest\` → run.
2. Workflow tags \`conductor/v0.1.1\` and pushes — release dispatcher runs.
3. Multi-arch \`iii-conductor\` binaries land in the GitHub Release for that tag.
4. \`POST https://api.workers.iii.dev/publish\` registers conductor for \`iii worker add conductor\`.

(The version bumps from 0.1.0 → 0.1.1 because Create Tag always increments. Initial register is fine at 0.1.1.)

## Test plan

- [ ] CI passes (no worker changes in this PR; only workflow YAML)
- [ ] After merge, dispatch Create Tag and confirm tag appears
- [ ] Confirm release.yml runs to completion against \`conductor/v0.1.1\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated release process for the conductor module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->