### PR TITLE
fix(ci): cargo command for rust workers + fetch annotated tag content

### DIFF
--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -142,8 +142,8 @@ jobs:
                 cargo_args+=(--no-stdio)
               fi
 
-              echo "Starting local worker with: (cd $WORKER && ${cargo_args[*]})"
-              "${cargo_args[@]}" > "../$worker_log" 2>&1 &
+              echo "Starting local worker with: (cd $WORKER && cargo ${cargo_args[*]})"
+              cargo "${cargo_args[@]}" > "../$worker_log" 2>&1 &
               echo "$!" > ../worker.pid
               popd >/dev/null
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Install pyyaml
         run: pip install --quiet pyyaml


### PR DESCRIPTION
## Summary

Two follow-up fixes uncovered by the first publish attempt after #67 merged ([failing run](https://github.com/iii-hq/workers/actions/runs/25318860579)):

- **`_publish-registry.yml`** — the rust worker startup expanded `cargo_args=(run ...)` directly as the command, so the runner tried to exec `run` and died with `run: command not found`. Prefix the expansion with `cargo` so it actually launches `cargo run`.
- **`release.yml`** — `fetch-depth: 0` does not bring annotated tag content. The `git tag -l --format=%(contents)` lookup returned empty, falling back to `registry-tag=latest` even when the create-tag dispatch wrote `registry-tag: next` into the annotation. Add `fetch-tags: true` to the setup checkout.

## Test plan

- [ ] Re-dispatch `create-tag.yml` with `worker=image-resize, bump=patch, tag=next`
- [ ] Verify `Setup` notice prints `registry-tag=next`
- [ ] Verify `Start local worker for interface collection` runs `cargo run --bin image-resize --` and the worker stays alive
- [ ] Verify POST /publish returns 200 with `tag: "next"` in the payload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this release. This update includes internal workflow improvements to the CI/CD pipeline for better build and release automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->