### PR TITLE
fix(ci): bump iii to v0.11.6-next.1 and refetch annotated release tag

### DIFF
--- a/.github/scripts/build_publish_payload.py
+++ b/.github/scripts/build_publish_payload.py
@@ -126,6 +126,31 @@ def _normalize_registry_trigger(trigger: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _match_worker(workers: list[dict[str, Any]], worker_name: str) -> dict[str, Any]:
+    by_name = [w for w in workers if w.get("name") == worker_name or w.get("id") == worker_name]
+    if len(by_name) == 1:
+        return by_name[0]
+
+    namespace = worker_name.replace("-", "_")
+    by_namespace = [
+        w
+        for w in workers
+        if any(
+            isinstance(fid, str) and fid.startswith(f"{namespace}::")
+            for fid in (w.get("functions") or [])
+        )
+    ]
+    if len(by_namespace) == 1:
+        return by_namespace[0]
+
+    summary = [{"id": w.get("id"), "name": w.get("name")} for w in workers]
+    raise ValueError(
+        f"could not match worker {worker_name!r}: "
+        f"{len(by_name)} by name/id, {len(by_namespace)} by namespace {namespace!r}, "
+        f"workers={summary}"
+    )
+
+
 def normalize_worker_interface(
     *,
     worker_name: str,
@@ -134,11 +159,9 @@ def normalize_worker_interface(
     triggers_json: dict[str, Any] | None = None,
 ) -> dict[str, list[dict[str, Any]]]:
     workers = _extract_array(workers_json, "workers")
-    matches = [w for w in workers if w.get("name") == worker_name or w.get("id") == worker_name]
-    if len(matches) != 1:
-        raise ValueError(f"expected exactly one worker matching {worker_name!r}, found {len(matches)}")
+    worker = _match_worker(workers, worker_name)
 
-    worker_function_ids = matches[0].get("functions") or []
+    worker_function_ids = worker.get("functions") or []
     if not isinstance(worker_function_ids, list):
         raise ValueError("worker `functions` must be an array")
 

--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -54,11 +54,11 @@ jobs:
 
       - name: Install iii CLI
         env:
-          VERSION: '0.11.5'
+          VERSION: '0.11.6-next.1'
         run: |
           set -euo pipefail
           curl -fsSL https://install.iii.dev/iii/main/install.sh -o /tmp/install-iii.sh
-          sh /tmp/install-iii.sh
+          sh /tmp/install-iii.sh --next
           {
             echo "$HOME/.local/bin"
             echo "$HOME/.iii/bin"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,15 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Refetch annotated tag
+        env:
+          RAW_TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$RAW_TAG" ]]; then
+            git fetch origin "+refs/tags/${RAW_TAG}:refs/tags/${RAW_TAG}"
+          fi
+
       - name: Install pyyaml
         run: pip install --quiet pyyaml
 


### PR DESCRIPTION
## Summary

Three follow-ups from the second publish attempt ([failing run](https://github.com/iii-hq/workers/actions/runs/25322596104) on `image-resize` v0.1.6):

- **`_publish-registry.yml` — bump iii install to `v0.11.6-next.1` + `--next`**. The v0.11.5 pin (added in the CodeRabbit review fixes for #67) didn't surface engine builtin workers in `engine::workers::list`. iii-hq/iii#1598 traces the same symptom, with the underlying engine fix landing in iii-hq/iii#1585 (v0.11.6+). External SDK workers were already returned in v0.11.5, but the bump is required for any worker matching pattern that needs the engine list to be authoritative.
- **`release.yml` — explicit annotated tag re-fetch**. `actions/checkout@v4` first fetches `+refs/tags/*:refs/tags/*`, then re-fetches the target SHA with `--no-tags +<SHA>:refs/tags/<tag>`, which silently overwrites the annotated tag with a lightweight one and drops the message. After that, `git tag -l --format=%(contents)` returns empty and `Setup` falls back to `registry-tag=latest` even when the create-tag dispatch wrote `registry-tag: next` into the annotation. Add an explicit `git fetch origin +refs/tags/<tag>:refs/tags/<tag>` so the annotation survives.
- **`build_publish_payload.py` — namespace fallback for worker matching**. `image-resize/src/main.rs:54` (and every other Rust worker on the cargo-run path) calls `register_worker(url, opts)` with no name, so the engine stores them with `id=<UUID>` and `name=null`. Matching `name == worker_name` always failed on those, raising `ValueError: expected exactly one worker matching 'image-resize', found 0`. Fall back to matching workers by registered function namespace (`image-resize` → `image_resize::*`); the iii-add path (Node/Python workers with explicit names) still hits the direct match first.

## Test plan

- [ ] Re-dispatch `create-tag.yml` with `worker=image-resize, bump=patch, tag=next`
- [ ] `Setup` notice prints `registry-tag=next`
- [ ] `Install iii CLI` step logs `installed iii v0.11.6-next.1`
- [ ] `Collect worker interface` matches `image-resize` via namespace fallback (no `found 0`)
- [ ] `POST /publish` returns 200 with `tag: "next"` in the payload