### PR TITLE
fix(ci): use full function_id as registry name to avoid collisions

### DIFF
--- a/.github/scripts/build_publish_payload.py
+++ b/.github/scripts/build_publish_payload.py
@@ -33,8 +33,6 @@ def derive_registry_function_name(function_id: str, metadata: dict[str, Any] | N
         value = metadata.get(key)
         if isinstance(value, str) and value.strip():
             return value.strip()
-    if "::" in function_id:
-        return function_id.rsplit("::", 1)[1]
     return function_id
 
 


### PR DESCRIPTION
## Summary

The `skills` v0.1.2 publish ([failing job](https://github.com/iii-hq/workers/actions/runs/25338691958/job/74291413642)) was rejected by the registry with:

```
HTTP 422
{"error":"functions[4].name: duplicate of functions[0]"}
```

`skills` registers functions in two namespaces (`skills::*` and `prompts::*`) and `derive_registry_function_name` was stripping the namespace via `rsplit("::", 1)[1]`, collapsing distinct function ids onto the same names:

| function_id              | derived name (before) |
|--------------------------|-----------------------|
| `skills::list`           | `list`                |
| `prompts::list`          | `list`                |
| `skills::register`       | `register`            |
| `prompts::register`      | `register`            |
| `skills::unregister`     | `unregister`          |
| `prompts::unregister`    | `unregister`          |

Default to the full `function_id`, so the registry sees `skills::list` and `prompts::list` as distinct. The `metadata.registry_name` / `metadata.name` overrides stay first in priority — workers that want a friendly short name can still opt in.

## Test plan

- [ ] Re-dispatch `create-tag.yml` with `worker=skills, bump=patch, tag=next` after this lands.
- [ ] `Build payload` step shows function entries with names like `skills::list`, `prompts::register`, etc. (no duplicates).
- [ ] `POST /publish` returns HTTP 200.