### PR TITLE
fix(ci): collect trigger types instead of trigger instances

### DIFF
--- a/.github/scripts/build_publish_payload.py
+++ b/.github/scripts/build_publish_payload.py
@@ -2,7 +2,6 @@
 import argparse
 import json
 import pathlib
-import re
 import sys
 from typing import Any
 
@@ -67,12 +66,6 @@ def _string_or_empty(value: Any) -> str:
     return value if isinstance(value, str) else ""
 
 
-def _slug(value: Any, fallback: str) -> str:
-    raw = value if isinstance(value, str) else fallback
-    slug = re.sub(r"[^a-z0-9]+", "-", raw.lower()).strip("-")
-    return slug or fallback
-
-
 def _normalize_registry_function(function: dict[str, Any]) -> dict[str, Any]:
     return {
         "name": function.get("name"),
@@ -83,44 +76,13 @@ def _normalize_registry_function(function: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _derive_trigger_name(trigger: dict[str, Any]) -> str:
-    metadata = _metadata_or_empty(trigger.get("metadata"))
-    for key in ("registry_name", "name"):
-        value = metadata.get(key)
-        if isinstance(value, str) and value.strip():
-            return _slug(value, "trigger")
-
-    config = trigger.get("config") if isinstance(trigger.get("config"), dict) else {}
-    api_path = config.get("api_path")
-    if isinstance(api_path, str) and api_path.strip():
-        return _slug(api_path, "trigger")
-
-    function_id = trigger.get("function_id")
-    if isinstance(function_id, str) and function_id.strip():
-        return _slug(function_id.rsplit("::", 1)[-1], "trigger")
-
-    return _slug(trigger.get("trigger_type") or trigger.get("name"), "trigger")
-
-
 def _normalize_registry_trigger(trigger: dict[str, Any]) -> dict[str, Any]:
-    config = trigger.get("config") if isinstance(trigger.get("config"), dict) else {}
-    metadata = _metadata_or_empty(trigger.get("metadata")).copy()
-    for source_key, metadata_key in (
-        ("id", "engine_id"),
-        ("trigger_type", "trigger_type"),
-        ("function_id", "function_id"),
-    ):
-        if trigger.get(source_key) is not None:
-            metadata.setdefault(metadata_key, trigger.get(source_key))
-    if config:
-        metadata.setdefault("config", config)
-
     return {
-        "name": _derive_trigger_name(trigger),
+        "name": trigger.get("name"),
         "description": _string_or_empty(trigger.get("description")),
         "invocation_schema": _schema_or_empty(trigger.get("invocation_schema")),
         "return_schema": _schema_or_empty(trigger.get("return_schema")),
-        "metadata": metadata,
+        "metadata": _metadata_or_empty(trigger.get("metadata")),
     }
 
 
@@ -149,12 +111,22 @@ def _match_worker(workers: list[dict[str, Any]], worker_name: str) -> dict[str, 
     )
 
 
+def _normalize_registry_trigger_type(trigger_type: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": _string_or_empty(trigger_type.get("id")),
+        "description": _string_or_empty(trigger_type.get("description")),
+        "invocation_schema": _schema_or_empty(trigger_type.get("trigger_request_format")),
+        "return_schema": _schema_or_empty(trigger_type.get("call_request_format")),
+        "metadata": {},
+    }
+
+
 def normalize_worker_interface(
     *,
     worker_name: str,
     workers_json: dict[str, Any],
     functions_json: dict[str, Any],
-    triggers_json: dict[str, Any] | None = None,
+    trigger_types_json: dict[str, Any] | None = None,
 ) -> dict[str, list[dict[str, Any]]]:
     workers = _extract_array(workers_json, "workers")
     worker = _match_worker(workers, worker_name)
@@ -190,13 +162,13 @@ def normalize_worker_interface(
             }
         )
 
-    worker_ids = set(worker_function_ids)
     triggers = []
-    if triggers_json:
-        for trigger in _extract_array(triggers_json, "triggers"):
-            if trigger.get("function_id") not in worker_ids:
+    if trigger_types_json:
+        for trigger_type in _extract_array(trigger_types_json, "trigger_types"):
+            tt_id = trigger_type.get("id")
+            if not isinstance(tt_id, str) or tt_id.startswith("engine::"):
                 continue
-            triggers.append(_normalize_registry_trigger(trigger))
+            triggers.append(_normalize_registry_trigger_type(trigger_type))
 
     return {"functions": functions, "triggers": triggers}
 

--- a/.github/scripts/collect_worker_interface.py
+++ b/.github/scripts/collect_worker_interface.py
@@ -50,16 +50,16 @@ def wait_for_worker(worker_name: str, wait_seconds: int) -> dict[str, object]:
     return workers_json
 
 
-def collect_triggers() -> dict[str, object] | None:
+def collect_trigger_types() -> dict[str, object] | None:
     try:
-        return run_iii("engine::triggers::list", {"include_internal": True})
+        return run_iii("engine::trigger-types::list", {"include_internal": False})
     except (
         subprocess.CalledProcessError,
         subprocess.TimeoutExpired,
         json.JSONDecodeError,
     ) as exc:
         print(
-            f"::warning::could not collect triggers; publishing triggers=[]: {exc}",
+            f"::warning::could not collect trigger types; publishing triggers=[]: {exc}",
             file=sys.stderr,
         )
         return None
@@ -74,13 +74,13 @@ def main() -> int:
 
     workers_json = wait_for_worker(args.worker, args.wait_seconds)
     functions_json = run_iii("engine::functions::list", {"include_internal": True})
-    triggers_json = collect_triggers()
+    trigger_types_json = collect_trigger_types()
 
     interface = normalize_worker_interface(
         worker_name=args.worker,
         workers_json=workers_json,
         functions_json=functions_json,
-        triggers_json=triggers_json,
+        trigger_types_json=trigger_types_json,
     )
     pathlib.Path(args.out).write_text(json.dumps(interface, indent=2) + "\n", encoding="utf-8")
     print(json.dumps(interface, indent=2))


### PR DESCRIPTION
## Summary

`skills` v0.1.3 published successfully ([run](https://github.com/iii-hq/workers/actions/runs/25340455295)) but with `triggers=[]`, even though the worker exposes two trigger types:

```rust
// skills/src/trigger_types.rs:115-128
iii.register_trigger_type(RegisterTriggerType::new("skills::on-change", ...));
iii.register_trigger_type(RegisterTriggerType::new("prompts::on-change", ...));
```

`collect_worker_interface.py` was calling `engine::triggers::list`, which returns trigger **instances** (subscriptions some other worker has registered), not the trigger **types** the worker itself defines. Inside the publish job only the target worker is connected, so the instances list is empty by construction — and trigger types we actually want to publish never show up.

## Fix

- `collect_worker_interface.py`: query `engine::trigger-types::list` with `include_internal: false` (engine drops its own `engine::*` types).
- `build_publish_payload.py`: map `TriggerTypeInfo` (defined in [iii-hq/iii engine_fn/mod.rs:121-128](https://github.com/iii-hq/iii/blob/main/engine/src/workers/engine_fn/mod.rs#L121)) to the registry trigger schema:
  - `id` → `name` (e.g. `skills::on-change`)
  - `description` → `description`
  - `trigger_request_format` → `invocation_schema`
  - `call_request_format` → `return_schema`
- Drop `_derive_trigger_name` / `_slug` and the instance-shape fields in `_normalize_registry_trigger`. The collect path emits registry-shape entries directly, so `build_payload`'s passthrough now just enforces the schema.

## Test plan

- [ ] After merge, dispatch `create-tag.yml` for `skills` with `tag=next`.
- [ ] `Collect worker interface` step prints `triggers` containing two entries with names `skills::on-change` and `prompts::on-change`.
- [ ] `POST /publish` returns 200, registry shows both trigger types on the skills entry.
- [ ] Publish image-resize (or any other worker that doesn't register trigger types) — `triggers` stays empty, no regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal build and worker collection scripts to improve trigger data processing architecture. Worker interface normalization now leverages trigger type metadata instead of individual trigger instances, enabling more efficient and streamlined data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->