### PR TITLE
fix(ci): drop stale --no-stdio flag from mcp publish startup

### DIFF
--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -138,9 +138,6 @@ jobs:
                 cargo_args+=(--bin "$BIN")
               fi
               cargo_args+=(--)
-              if [[ "$WORKER" == "mcp" ]]; then
-                cargo_args+=(--no-stdio)
-              fi
 
               echo "Starting local worker with: (cd $WORKER && cargo ${cargo_args[*]})"
               cargo "${cargo_args[@]}" > "../$worker_log" 2>&1 &


### PR DESCRIPTION
## Summary

`mcp/v0.5.1` publish failed ([job](https://github.com/iii-hq/workers/actions/runs/25349334305/job/74325889532)) with the worker dying immediately on startup:

```
Running `target/debug/mcp --no-stdio`
error: unexpected argument '--no-stdio' found

Usage: mcp [OPTIONS]
```

`_publish-registry.yml:141-143` had a worker-specific special case from #67:

```yaml
if [[ "$WORKER" == "mcp" ]]; then
  cargo_args+=(--no-stdio)
fi
```

mcp's CLI no longer accepts `--no-stdio` — `mcp/src/main.rs:25-34` only declares `--config`, `--url`, `--manifest`. cargo exited before the worker could connect, the 2s `kill -0` check after spawn still passed (cargo itself was technically still alive), and `collect_worker_interface` then waited the full 120s before raising `ValueError: could not match worker 'mcp'`.

## Fix

Drop the special case. mcp's default startup is fine for interface collection — the original concern that motivated `--no-stdio` doesn't apply in CI.

Side benefit: removes the worker-name-in-shared-CI anti-pattern flagged in the original review of #67. If a worker ever needs CI-specific startup args again, declare them in `iii.worker.yaml` instead.

## Test plan

- [ ] After merge, dispatch `create-tag.yml` with `worker=mcp, bump=patch, tag=next`.
- [ ] `Start local worker for interface collection` step shows `cargo run --bin mcp --` (no `--no-stdio` appended).
- [ ] mcp registers with the engine, `collect_worker_interface` finds it, publish completes with HTTP 200.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build workflow configuration to streamline worker startup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->