### PR TITLE
perf(ci): use the prebuilt release binary for interface collection

### DIFF
--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -97,6 +97,9 @@ jobs:
         env:
           WORKER: ${{ inputs.worker }}
           BIN: ${{ inputs.bin }}
+          DEPLOY: ${{ inputs.deploy }}
+          TAG: ${{ inputs.tag }}
+          REPO_URL: ${{ format('https://github.com/{0}', github.repository) }}
         run: |
           set -euo pipefail
           mode=$(python3 - <<'PY'
@@ -104,6 +107,7 @@ jobs:
           import yaml
 
           worker = os.environ["WORKER"]
+          deploy = os.environ.get("DEPLOY", "")
           manifest_path = f"{worker}/iii.worker.yaml"
           manifest = yaml.safe_load(open(manifest_path, encoding="utf-8").read()) or {}
           scripts = manifest.get("scripts") or {}
@@ -112,7 +116,9 @@ jobs:
           has_runtime = bool(runtime.get("kind") or runtime.get("language"))
           language = str(manifest.get("language") or "").strip().lower()
 
-          if has_scripts_start or has_runtime:
+          if deploy == "binary":
+              print("release-binary")
+          elif has_scripts_start or has_runtime:
               print("iii-add")
           elif language == "rust":
               print("cargo-run")
@@ -124,6 +130,29 @@ jobs:
           case "$mode" in
             iii-add)
               iii worker add "./$WORKER" --force --reset-config --wait
+              ;;
+            release-binary)
+              bin_name="${BIN:-$WORKER}"
+              asset_url="$REPO_URL/releases/download/$TAG/${bin_name}-x86_64-unknown-linux-gnu.tar.gz"
+              echo "Fetching prebuilt worker: $asset_url"
+              curl -fsSL "$asset_url" -o /tmp/worker-bin.tar.gz
+              tar -xzf /tmp/worker-bin.tar.gz -C /tmp/
+              bin_path="/tmp/${bin_name}"
+              chmod +x "$bin_path"
+
+              worker_log="worker-$WORKER.log"
+              pushd "$WORKER" >/dev/null
+              echo "Starting local worker with: (cd $WORKER && $bin_path)"
+              "$bin_path" > "../$worker_log" 2>&1 &
+              echo "$!" > ../worker.pid
+              popd >/dev/null
+
+              sleep 2
+              if ! kill -0 "$(cat worker.pid)" 2>/dev/null; then
+                echo "::error::$WORKER exited before interface collection"
+                cat "$worker_log" || true
+                exit 1
+              fi
               ;;
             cargo-run)
               if [[ ! -f "$WORKER/Cargo.toml" ]]; then


### PR DESCRIPTION
## Summary

`Collect worker interface` was paying a full cold `cargo run` (~50-90s for skills/mcp because of 200+ deps) every publish, even though the `binary-build` job upstream already produced a working `x86_64-unknown-linux-gnu` artifact on the GitHub Release that publish depends on. The compile is the dominant cost of the publish step today — see `skills/v0.1.4` ([run](https://github.com/iii-hq/workers/actions/runs/25341543076)) where `Starting local worker` → `HTTP 200` was ~2 minutes wall-clock.

## Fix

Add a `release-binary` mode to `Start local worker for interface collection` for any `deploy: binary` worker:

1. Download `$BIN-x86_64-unknown-linux-gnu.tar.gz` from `$REPO_URL/releases/download/$TAG/` (same URL pattern that `resolve_binary_artifacts.py:37-49` uses).
2. Extract to `/tmp/`, `chmod +x`.
3. Run from the worker directory (so `./config.yaml` resolves the way `cargo run` did).

Mode-detection priority becomes: `binary` deploy → `release-binary` → `iii-add` (Node/Python with `scripts.start`) → `cargo-run` (Rust without binary deploy, if anyone ever adds one) → `unsupported`.

## Why it's safe

- `_rust-binary.yml` is a `needs:` of `publish` in `release.yml`, so when publish runs the asset is guaranteed to be on the release.
- Dry runs skip publish entirely (`release.yml:190`), so we never hit `release-binary` without a release.
- `cargo-run` stays as a defensive fallback; nothing in main currently exercises it but it costs nothing.

## Expected impact

| step | before | after |
|------|-------:|------:|
| `Start local worker` | ~5s setup | ~5s setup |
| Worker boots | 50-90s (cargo compile) | ~5s (curl + extract) |
| `Collect worker interface` | poll until compile finishes | poll until binary registers |

Net: ~50-80s saved per Rust worker publish.

## Test plan

- [ ] After merge, dispatch `create-tag.yml` for one fast worker (`image-resize`) and one heavy worker (`skills` or `mcp`); both should publish in well under a minute end-to-end.
- [ ] `Start local worker` step logs show `Fetching prebuilt worker: ...releases/download/...` rather than `cargo run`.
- [ ] Worker connects to engine, `Collect worker interface` finishes within ~10s of the worker download.
- [ ] `POST /publish` returns 200 with the same payload shape (functions, triggers, etc.) as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release workflow now includes binary deployment mode, enabling deployment using prebuilt worker packages downloaded from release assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->