### PR TITLE
fix(ci): drop engine built-in trigger types from publish via baseline diff

### DIFF
--- a/.github/scripts/build_publish_payload.py
+++ b/.github/scripts/build_publish_payload.py
@@ -127,6 +127,7 @@ def normalize_worker_interface(
     workers_json: dict[str, Any],
     functions_json: dict[str, Any],
     trigger_types_json: dict[str, Any] | None = None,
+    baseline_trigger_types_json: dict[str, Any] | None = None,
 ) -> dict[str, list[dict[str, Any]]]:
     workers = _extract_array(workers_json, "workers")
     worker = _match_worker(workers, worker_name)
@@ -162,11 +163,19 @@ def normalize_worker_interface(
             }
         )
 
+    baseline_ids = {
+        tt["id"]
+        for tt in _extract_array(baseline_trigger_types_json or {}, "trigger_types")
+        if isinstance(tt.get("id"), str)
+    }
+
     triggers = []
     if trigger_types_json:
         for trigger_type in _extract_array(trigger_types_json, "trigger_types"):
             tt_id = trigger_type.get("id")
             if not isinstance(tt_id, str) or tt_id.startswith("engine::"):
+                continue
+            if tt_id in baseline_ids:
                 continue
             triggers.append(_normalize_registry_trigger_type(trigger_type))
 

--- a/.github/scripts/collect_worker_interface.py
+++ b/.github/scripts/collect_worker_interface.py
@@ -70,7 +70,14 @@ def main() -> int:
     parser.add_argument("--worker", required=True)
     parser.add_argument("--out", default="worker-interface.json")
     parser.add_argument("--wait-seconds", type=int, default=0)
+    parser.add_argument("--trigger-types-baseline", default="")
     args = parser.parse_args()
+
+    baseline_json = None
+    if args.trigger_types_baseline:
+        baseline_path = pathlib.Path(args.trigger_types_baseline)
+        if baseline_path.exists():
+            baseline_json = json.loads(baseline_path.read_text(encoding="utf-8"))
 
     workers_json = wait_for_worker(args.worker, args.wait_seconds)
     functions_json = run_iii("engine::functions::list", {"include_internal": True})
@@ -81,6 +88,7 @@ def main() -> int:
         workers_json=workers_json,
         functions_json=functions_json,
         trigger_types_json=trigger_types_json,
+        baseline_trigger_types_json=baseline_json,
     )
     pathlib.Path(args.out).write_text(json.dumps(interface, indent=2) + "\n", encoding="utf-8")
     print(json.dumps(interface, indent=2))

--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -93,6 +93,15 @@ jobs:
           cat iii-engine.log || true
           exit 1
 
+      - name: Snapshot engine trigger types baseline
+        run: |
+          set -euo pipefail
+          iii trigger \
+            --function-id='engine::trigger-types::list' \
+            --payload='{"include_internal": false}' \
+            > trigger-types-baseline.json
+          cat trigger-types-baseline.json
+
       - name: Start local worker for interface collection
         env:
           WORKER: ${{ inputs.worker }}
@@ -190,7 +199,12 @@ jobs:
         env:
           WORKER: ${{ inputs.worker }}
         run: |
-          args=("--worker" "$WORKER" "--out" "worker-interface.json" "--wait-seconds" "120")
+          args=(
+            "--worker" "$WORKER"
+            "--out" "worker-interface.json"
+            "--wait-seconds" "120"
+            "--trigger-types-baseline" "trigger-types-baseline.json"
+          )
           python3 .github/scripts/collect_worker_interface.py "${args[@]}"
 
       - name: Assert worker interface was collected


### PR DESCRIPTION
## Summary

Every worker we've published recently has a `log` trigger type that it doesn't register itself ([example](https://github.com/iii-hq/workers/actions/runs/25373721952) — `image-resize/v0.1.8`). iii-hq/iii's observability module ([`engine/src/workers/observability/mod.rs:1487-1494`](https://github.com/iii-hq/iii/blob/main/engine/src/workers/observability/mod.rs#L1487)) registers `log` as a built-in trigger type with no `engine::` prefix:

```rust
let log_trigger_type = TriggerType::new(
    LOG_TRIGGER_TYPE,           // = "log"  (mod.rs:226)
    "Log event trigger",
    Box::new(self.clone()),
    None,
);
let _ = self.engine.register_trigger_type(log_trigger_type).await;
```

Both filters miss it: the engine's `include_internal: false` only skips `engine::*` ([`engine_fn/mod.rs:587`](https://github.com/iii-hq/iii/blob/main/engine/src/workers/engine_fn/mod.rs#L587)), and so does our normalizer (post-#73). `log` ends up attached to every worker.

## Fix

Take a baseline snapshot of `engine::trigger-types::list` after the engine is ready but **before** the target worker starts. Diff against the post-worker list — what the target added is what we publish.

```
Start III engine                            ← engine + built-in trigger types live (e.g. `log`)
NEW: Snapshot trigger types baseline        ← write trigger-types-baseline.json
Start local worker (cargo / release-binary) ← target worker registers its own types
Collect worker interface                    ← exclude any id present in the baseline
```

## Why this approach

| Scenario | Hardcode `{log}` | Engine renames to `engine::log` | **Diff snapshot** |
|---|:-:|:-:|:-:|
| Engine adds another flat built-in | leaks | only if also renamed | filtered |
| Engine renames `log` → `engine::log` | dead code | filtered | filtered |
| Coordinated change with iii-hq/iii? | no | yes | no |

Self-correcting: any new engine built-in is automatically excluded next publish without changes here.

## Implementation

- New workflow step `Snapshot engine trigger types baseline` between engine ready check and `Start local worker for interface collection`. One `iii trigger` call (~100ms) writing `trigger-types-baseline.json`.
- `collect_worker_interface.py` gains `--trigger-types-baseline <path>` and reads the file if it exists.
- `normalize_worker_interface` accepts `baseline_trigger_types_json` and skips any id already present.

## Test plan

- [ ] After merge, dispatch `create-tag.yml` for `image-resize` (no own trigger types) — published `triggers` is `[]`.
- [ ] Dispatch for `skills` — `triggers` contains `skills::on-change` and `prompts::on-change` only (no `log`).
- [ ] Confirm `Snapshot engine trigger types baseline` step prints a JSON containing at least `{"id": "log"}` so the filter has something to match.