### PR TITLE
fix(iii-database): add config.yaml so the worker boots in the publish job

### DIFF
--- a/iii-database/Cargo.toml
+++ b/iii-database/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "iii-database"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 publish = false
 

--- a/iii-database/config.yaml
+++ b/iii-database/config.yaml
@@ -1,6 +1,6 @@
 databases:
   primary:
-    url: sqlite:./data/iii.db
+    url: sqlite:./iii.db
     pool:
       max: 10
       idle_timeout_ms: 30000

--- a/iii-database/config.yaml
+++ b/iii-database/config.yaml
@@ -1,0 +1,7 @@
+databases:
+  primary:
+    url: sqlite:./data/iii.db
+    pool:
+      max: 10
+      idle_timeout_ms: 30000
+      acquire_timeout_ms: 5000


### PR DESCRIPTION
## Summary

`iii-database/v1.0.1` publish failed ([job](https://github.com/iii-hq/workers/actions/runs/25379870200/job/74426834309)) at `Start local worker for interface collection`:

```
INFO iii_database: starting name="iii-database" config=./config.yaml url=ws://127.0.0.1:49134/
Error: loading config from ./config.yaml
Caused by: read ./config.yaml: No such file or directory (os error 2)
```

The repo ships `iii-database/config.yaml.example` but no `config.yaml`, and `iii-database/src/main.rs:51-53` hard-requires the file (`WorkerConfig::from_file` errors on missing path; `from_yaml` rejects empty `databases:`). Other rust workers either ship a real `config.yaml` (image-resize, skills, mcp) or fall back to defaults (image-resize warns and keeps going).

Renaming `.example` wouldn't have worked: the example uses the engine-config shape (`workers: [{name, config: {databases: ...}}]`) but the worker's `WorkerConfig` expects `databases:` at the top level.

## Fix

Add a real `config.yaml` with the inner shape and a sqlite default:

```yaml
databases:
  primary:
    url: sqlite:./data/iii.db
    pool:
      max: 10
      idle_timeout_ms: 30000
      acquire_timeout_ms: 5000
```

- Sqlite is local-file, no credentials → boots cleanly in CI.
- `build_publish_payload.py:233-235` reads `config.yaml` into the registry payload, so users installing iii-database get a working sqlite default they can override (postgres/mysql users supply their own `url` at deploy time).
- `config.yaml.example` is kept untouched as a reference for the engine-config wrapper.

## Test plan

- [ ] After merge, dispatch `create-tag.yml` with `worker=iii-database, bump=patch, tag=next`.
- [ ] `Start local worker for interface collection` step shows `loaded config from ./config.yaml` (or no error) instead of the missing-file traceback.
- [ ] `Collect worker interface` finds the worker and its functions/trigger types.
- [ ] `POST /publish` returns 200 with the iii-database payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 1.0.2.
  * Added primary database configuration pointing to a local SQLite database and configured connection pool settings (max connections, idle timeout, acquire timeout) for more reliable resource management and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->