### PR TITLE
fix(ci): layered worker matching with non-internal fallback

### DIFF
--- a/.github/scripts/build_publish_payload.py
+++ b/.github/scripts/build_publish_payload.py
@@ -91,23 +91,30 @@ def _match_worker(workers: list[dict[str, Any]], worker_name: str) -> dict[str, 
     if len(by_name) == 1:
         return by_name[0]
 
-    namespace = worker_name.replace("-", "_")
+    namespaces = {worker_name, worker_name.replace("-", "_"), worker_name.replace("_", "-")}
     by_namespace = [
         w
         for w in workers
         if any(
-            isinstance(fid, str) and fid.startswith(f"{namespace}::")
+            isinstance(fid, str) and any(fid.startswith(f"{ns}::") for ns in namespaces)
             for fid in (w.get("functions") or [])
         )
     ]
     if len(by_namespace) == 1:
         return by_namespace[0]
 
-    summary = [{"id": w.get("id"), "name": w.get("name")} for w in workers]
+    external = [w for w in workers if w.get("internal") is not True]
+    if len(external) == 1:
+        return external[0]
+
+    summary = [
+        {"id": w.get("id"), "name": w.get("name"), "internal": w.get("internal")}
+        for w in workers
+    ]
     raise ValueError(
         f"could not match worker {worker_name!r}: "
-        f"{len(by_name)} by name/id, {len(by_namespace)} by namespace {namespace!r}, "
-        f"workers={summary}"
+        f"{len(by_name)} by name/id, {len(by_namespace)} by namespaces {sorted(namespaces)!r}, "
+        f"{len(external)} non-internal workers, workers={summary}"
     )
 
 


### PR DESCRIPTION
## Summary

`iii-database/v1.0.3` publish ([job](https://github.com/iii-hq/workers/actions/runs/25390411766)) failed:

```
ValueError: could not match worker 'iii-database':
  0 by name/id,
  0 by namespace 'iii_database',
  workers=[
    {id: 'iii-engine-functions',  name: 'iii-engine-functions'},
    {id: 'iii-observability',     name: 'iii-observability'},
    {id: 'iii-telemetry',         name: 'iii-telemetry'},
    {id: 'iii-worker-manager',    name: 'iii-worker-manager'},
    {id: '93be988a-878a-4b6e-...',name: 'runnervmeorf1:2462'},  ← the worker, just unmatched
  ]
```

The worker connected fine. Two reasons matching missed it:

1. The Rust SDK's `register_worker(url, opts)` doesn't pass a name, so the engine assigns a UUID `id` and a hostname-style `name` (`runnervmeorf1:2462`).
2. iii-database registers functions as `iii-database::query` etc. — kebab-case — while every other rust worker (image-resize, skills, mcp) uses snake_case (`image_resize::resize`). Our namespace fallback only normalized hyphens to underscores, so it looked for `iii_database::*` and missed the kebab ids.

## Fix

Layered matching in `_match_worker` (`build_publish_payload.py:89`):

1. **By name/id** — unchanged, preserves the iii-add path (Node/Python workers register with explicit names).
2. **By namespace, both conventions** — try `{worker_name, kebab→snake, snake→kebab}`. Catches kebab and snake worker codebases regardless of the directory's naming style.
3. **NEW: Single non-internal worker** — engine internals (`iii-engine-functions`, `iii-observability`, `iii-telemetry`, `iii-worker-manager`) carry `internal: true`. Within a publish job only the target worker connects, so when exactly one entry has `internal != True` it must be the target.
4. **Raise** — error now includes the non-internal count and per-worker `internal` flag for easier post-mortem.

## Why this is safe

The publish workflow starts the engine with `workers: []` and adds exactly one worker before collecting. There's no realistic path where a second non-internal worker shows up in the list. If `register_worker` ever started passing names, the name match wins early and the new fallback is never consulted. None of the existing rust workers' matching paths regress (snake-case namespaces still hit tier 2 first).

## Test plan

- [ ] Dispatch `create-tag.yml` with `worker=iii-database, bump=patch, tag=next` after this lands. Setup picks up the new bump (1.0.3 → 1.0.4); publish should clear the matcher via the non-internal fallback.
- [ ] Re-publish image-resize/skills/mcp afterward to confirm tier 2 still resolves them (no regression on snake-case workers).