### PR TITLE
revert(database): downgrade iii-database to 0.0.4

### DIFF
--- a/iii-database/Cargo.toml
+++ b/iii-database/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "iii-database"
-version = "1.0.4"
+version = "0.0.4"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary
- Reverts `iii-database` version in `iii-database/Cargo.toml` from `1.0.4` back to `0.0.4`.

## Test plan
- [ ] `cargo check -p iii-database`
- [ ] Confirm downstream consumers resolve against the expected `0.0.x` version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->