### PR TITLE
feat(acp): session/resume, set_mode, set_config_option

### DIFF
--- a/acp/README.md
+++ b/acp/README.md
@@ -205,14 +205,30 @@ at `iii-acp` directly.
 | `initialize` | client → agent | implemented |
 | `authenticate` | client → agent | no-op success |
 | `session/new` | client → agent | implemented |
-| `session/load` | client → agent | implemented (replays history as `session/update`) |
-| `session/list` | client → agent | implemented |
+| `session/load` | client → agent | implemented; replays history as `session/update` notifications |
+| `session/resume` | client → agent | implemented; refreshes cwd + mcpServers, no history replay |
+| `session/list` | client → agent | implemented; dedupes index on read |
 | `session/prompt` | client → agent | implemented; routes to brain fn or echo |
 | `session/cancel` | client → agent | implemented; flips in-process abort + publishes cancel topic |
-| `session/close` | client → agent | implemented |
+| `session/close` | client → agent | implemented; full cleanup of record + history + index |
+| `session/set_mode` | client → agent | implemented; persists `modeId` on session record for the brain |
+| `session/set_config_option` | client → agent | implemented; persists `configId`/`value` pairs on session record |
 | `session/update` | agent → client | streamed during prompt turn |
-| `session/request_permission` | agent → client | deferred (v0.2) |
-| `fs/*`, `terminal/*` | agent → client | deferred — agents use iii primitives directly |
+| `session/request_permission` | agent → client | deferred — needs reverse-RPC framer |
+| `fs/read_text_file`, `fs/write_text_file` | agent → client | deferred — internal iii brains use iii fs primitives directly |
+| `terminal/create`, `terminal/kill`, `terminal/output`, `terminal/release`, `terminal/wait_for_exit` | agent → client | deferred — internal iii brains use iii terminal primitives directly |
+
+`agentCapabilities.sessionCapabilities` advertises `list`, `close`, and
+`resume` on `initialize`. The `loadSession` capability (top-level for now,
+unifying with sessionCapabilities is on the ACP roadmap) is also advertised.
+
+`session/set_mode` and `session/set_config_option` ship without an explicit
+capability flag because the version of the ACP schema in this repo doesn't
+include those slots in `SessionCapabilities` yet — clients that try them
+get a successful response; clients that don't try are unaffected. Both
+methods persist their values on the session record (`mode: Option<String>`
+and `config_options: Map<String, Value>`). Brains opt in to honoring them
+on the next `session/prompt` turn; iii-acp just stores.
 
 ## Brain contract
 

--- a/acp/src/handler.rs
+++ b/acp/src/handler.rs
@@ -14,7 +14,8 @@ use crate::session::{
 use crate::transport::Outbound;
 use crate::types::{
     ACP_PROTOCOL_VERSION, INTERNAL_ERROR, INVALID_PARAMS, JsonRpcResponse, METHOD_NOT_FOUND,
-    SessionCancelParams, SessionLoadParams, SessionNewParams, SessionPromptParams, parse,
+    SessionCancelParams, SessionLoadParams, SessionNewParams, SessionPromptParams,
+    SessionResumeParams, SessionSetConfigOptionParams, SessionSetModeParams, parse,
 };
 
 // Canonical iii brain function. Any worker exposing this id with the
@@ -169,10 +170,13 @@ impl AcpHandler {
             "authenticate" => Ok(json!({})),
             "session/new" => self.session_new(params).await,
             "session/load" => self.session_load(params).await,
+            "session/resume" => self.session_resume(params).await,
             "session/list" => self.session_list().await,
             "session/prompt" => self.session_prompt(params).await,
             "session/cancel" => self.session_cancel(params).await.map(|_| Value::Null),
             "session/close" => self.session_close(params).await.map(|_| Value::Null),
+            "session/set_mode" => self.session_set_mode(params).await,
+            "session/set_config_option" => self.session_set_config_option(params).await,
             _ => Err((METHOD_NOT_FOUND, format!("Unknown method: {}", method))),
         };
 
@@ -204,7 +208,11 @@ impl AcpHandler {
                     "http": true,
                     "sse": false
                 },
-                "sessionCapabilities": {}
+                "sessionCapabilities": {
+                    "list": {},
+                    "close": {},
+                    "resume": {}
+                }
             },
             "agentInfo": {
                 "name": "iii-acp",
@@ -226,6 +234,8 @@ impl AcpHandler {
             mcp_servers: p.mcp_servers,
             created_at_ms: now,
             last_activity_ms: now,
+            mode: None,
+            config_options: serde_json::Map::new(),
         };
         let key = session_key(&session_id);
         let value = serde_json::to_value(&record).map_err(|e| (INTERNAL_ERROR, e.to_string()))?;
@@ -399,6 +409,102 @@ impl AcpHandler {
                 format!("session_close partial failure: {}", errs.join("; ")),
             ))
         }
+    }
+
+    // session/resume — like session/load but skips history replay. Per
+    // ACP spec: "useful for agents that can resume sessions but don't
+    // implement full session loading." We keep history but emit nothing.
+    // The new cwd / mcpServers fields are persisted on the session record
+    // so subsequent session/prompt calls see the refreshed environment.
+    async fn session_resume(&self, params: Option<Value>) -> Result<Value, (i32, String)> {
+        self.require_initialized()?;
+        let p: SessionResumeParams = parse(params).map_err(|e| (INVALID_PARAMS, e))?;
+        let key = session_key(&p.session_id);
+        let scope = scope();
+        let rec_value = state_get(&self.iii, &scope, &key)
+            .await
+            .map_err(|e| (INTERNAL_ERROR, e.to_string()))?
+            .ok_or_else(|| {
+                (
+                    INVALID_PARAMS,
+                    format!("session not found: {}", p.session_id),
+                )
+            })?;
+        let mut record: SessionRecord = serde_json::from_value(rec_value)
+            .map_err(|e| (INTERNAL_ERROR, format!("session decode: {}", e)))?;
+        record.cwd = p.cwd;
+        record.mcp_servers = p.mcp_servers;
+        record.last_activity_ms = now_ms();
+        let new_value =
+            serde_json::to_value(&record).map_err(|e| (INTERNAL_ERROR, e.to_string()))?;
+        state_set(&self.iii, &scope, &key, new_value)
+            .await
+            .map_err(|e| (INTERNAL_ERROR, e.to_string()))?;
+        self.owned_sessions.insert(p.session_id.clone());
+        Ok(json!({}))
+    }
+
+    // session/set_mode — store the mode id on the session record so the
+    // brain can read it on the next prompt turn (e.g. via a system prompt
+    // suffix or per-mode tool gating). Validation of the mode id against
+    // any agent-specific catalog is left to the brain worker.
+    async fn session_set_mode(&self, params: Option<Value>) -> Result<Value, (i32, String)> {
+        self.require_initialized()?;
+        let p: SessionSetModeParams = parse(params).map_err(|e| (INVALID_PARAMS, e))?;
+        self.update_session_record(&p.session_id, |rec| {
+            rec.mode = Some(p.mode_id.clone());
+        })
+        .await?;
+        Ok(json!({}))
+    }
+
+    // session/set_config_option — store an arbitrary configId/value pair
+    // on the session record. Same rationale as set_mode: persistence lives
+    // here, semantics live in the brain.
+    async fn session_set_config_option(
+        &self,
+        params: Option<Value>,
+    ) -> Result<Value, (i32, String)> {
+        self.require_initialized()?;
+        let p: SessionSetConfigOptionParams = parse(params).map_err(|e| (INVALID_PARAMS, e))?;
+        self.update_session_record(&p.session_id, |rec| {
+            rec.config_options
+                .insert(p.config_id.clone(), p.value.clone());
+        })
+        .await?;
+        Ok(json!({}))
+    }
+
+    // Read-modify-write of one session record under the per-session
+    // history mutex (we reuse it to avoid adding a parallel lock map for
+    // the same session). Returns INVALID_PARAMS if the session is
+    // missing, INTERNAL_ERROR on backend failure.
+    async fn update_session_record<F>(
+        &self,
+        session_id: &str,
+        mutate: F,
+    ) -> Result<(), (i32, String)>
+    where
+        F: FnOnce(&mut SessionRecord),
+    {
+        let scope = scope();
+        let key = session_key(session_id);
+        let lock = self.history_lock(session_id);
+        let _g = lock.lock().await;
+        let rec_value = state_get(&self.iii, &scope, &key)
+            .await
+            .map_err(|e| (INTERNAL_ERROR, e.to_string()))?
+            .ok_or_else(|| (INVALID_PARAMS, format!("session not found: {}", session_id)))?;
+        let mut record: SessionRecord = serde_json::from_value(rec_value)
+            .map_err(|e| (INTERNAL_ERROR, format!("session decode: {}", e)))?;
+        mutate(&mut record);
+        record.last_activity_ms = now_ms();
+        let new_value =
+            serde_json::to_value(&record).map_err(|e| (INTERNAL_ERROR, e.to_string()))?;
+        state_set(&self.iii, &scope, &key, new_value)
+            .await
+            .map_err(|e| (INTERNAL_ERROR, e.to_string()))?;
+        Ok(())
     }
 
     async fn run_brain(&self, session_id: &str, prompt: &[Value], cancel: &CancelHandle) -> String {

--- a/acp/src/session.rs
+++ b/acp/src/session.rs
@@ -44,6 +44,13 @@ pub struct SessionRecord {
     pub mcp_servers: Vec<Value>,
     pub created_at_ms: i64,
     pub last_activity_ms: i64,
+    // Optional ACP mode set via session/set_mode. None until first set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    // Per-session config options set via session/set_config_option. Keys are
+    // configId strings, values are arbitrary JSON.
+    #[serde(default)]
+    pub config_options: serde_json::Map<String, Value>,
 }
 
 pub async fn state_get(iii: &III, scope: &str, key: &str) -> Result<Option<Value>, IIIError> {

--- a/acp/src/types.rs
+++ b/acp/src/types.rs
@@ -90,6 +90,32 @@ pub struct SessionCancelParams {
     pub session_id: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionResumeParams {
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    pub cwd: String,
+    #[serde(rename = "mcpServers", default)]
+    pub mcp_servers: Vec<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionSetModeParams {
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    #[serde(rename = "modeId")]
+    pub mode_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionSetConfigOptionParams {
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    #[serde(rename = "configId")]
+    pub config_id: String,
+    pub value: Value,
+}
+
 pub fn parse<T: for<'de> Deserialize<'de>>(params: Option<Value>) -> Result<T, String> {
     let v = params.ok_or_else(|| "params required".to_string())?;
     serde_json::from_value(v).map_err(|e| format!("invalid params: {}", e))

--- a/acp/tests/protocol.rs
+++ b/acp/tests/protocol.rs
@@ -78,3 +78,37 @@ fn parse_returns_error_on_missing_params() {
     let r: Result<iii_acp::types::SessionPromptParams, _> = iii_acp::types::parse(None);
     assert!(r.is_err());
 }
+
+#[test]
+fn session_resume_params_round_trips() {
+    let raw = json!({
+        "sessionId": "sess_abc",
+        "cwd": "/home/user/project",
+        "mcpServers": []
+    });
+    let p: iii_acp::types::SessionResumeParams = serde_json::from_value(raw).unwrap();
+    assert_eq!(p.session_id, "sess_abc");
+    assert_eq!(p.cwd, "/home/user/project");
+    assert!(p.mcp_servers.is_empty());
+}
+
+#[test]
+fn session_set_mode_params_round_trips() {
+    let raw = json!({ "sessionId": "sess_x", "modeId": "code" });
+    let p: iii_acp::types::SessionSetModeParams = serde_json::from_value(raw).unwrap();
+    assert_eq!(p.session_id, "sess_x");
+    assert_eq!(p.mode_id, "code");
+}
+
+#[test]
+fn session_set_config_option_params_round_trips() {
+    let raw = json!({
+        "sessionId": "sess_x",
+        "configId": "thinking_level",
+        "value": "high"
+    });
+    let p: iii_acp::types::SessionSetConfigOptionParams = serde_json::from_value(raw).unwrap();
+    assert_eq!(p.session_id, "sess_x");
+    assert_eq!(p.config_id, "thinking_level");
+    assert_eq!(p.value, json!("high"));
+}


### PR DESCRIPTION
## Summary

PR #63 shipped 8 client→agent methods. ACP defines three more that fell to `METHOD_NOT_FOUND` until now. This PR implements all of them and updates the method table to be exhaustive so the deferred surface is fully visible.

## Methods added

| Method | Behaviour |
|---|---|
| `session/resume` | Like `session/load` but skips history replay. Refreshes `cwd` + `mcpServers` on the session record, claims ownership so subsequent `agent::events` route here. Per ACP: "useful for agents that can resume sessions but don't implement full session loading." |
| `session/set_mode` | Persists `modeId` on the session record. Brain workers can read it on the next prompt turn (system-prompt suffix, per-mode tool gating, etc.). Catalog validation is the brain's concern. |
| `session/set_config_option` | Persists `configId` / `value` pairs in `config_options` on the session record. Same split: persistence here, semantics in the brain. |

## Implementation notes

- `SessionRecord` gains:
  - `mode: Option<String>` (`skip_serializing_if = "Option::is_none"` — backward-compatible with pre-existing records)
  - `config_options: serde_json::Map<String, Value>` (default empty)
- New `update_session_record` helper does a read-modify-write of one record under the **per-session history mutex** that already serializes `append_history`. No parallel lock map.
- `agentCapabilities.sessionCapabilities` now advertises `{ list: {}, close: {}, resume: {} }` — matches the ACP schema slots in this version. `set_mode` / `set_config_option` ship without an explicit capability flag because the in-repo schema doesn't include those slots yet; clients that try them succeed, clients that don't try are unaffected.

## README

Method table is now exhaustive. The misleading "deferred to v0.2" line is replaced with explicit rows for every method:

- Implemented: `initialize`, `authenticate`, `session/{new,load,resume,list,prompt,cancel,close,set_mode,set_config_option}`, `session/update`
- Deferred (reverse-RPC, agents use iii primitives directly): `session/request_permission`, `fs/{read,write}_text_file`, `terminal/{create,kill,output,release,wait_for_exit}`

## Validation

- 17 lib + 10 protocol envelope tests pass (3 new round-trip tests for the new param shapes)
- `cargo clippy --all-targets -- -D warnings` clean
- Live smoke against the 7-worker brain stack:
  - `sessionCapabilities` advertises `{close, list, resume}` on `initialize`
  - `session/set_mode` persists `modeId="code"` (verified via `state::get`)
  - `session/set_config_option` persists `configId="thinking"` value `"high"`
  - `session/resume` refreshes cwd to `"/new"`
  - All three return `{}` on success, `INVALID_PARAMS (-32602)` on missing `sessionId`
  - Full canonical brain flow (real Claude streaming through `agent::events`) still passes

## Test plan

- [x] `cargo test` — 17 lib + 10 protocol envelope tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Live smoke covering all 3 new methods + missing-session error path
- [x] Canonical brain flow regression smoke (session/prompt streaming)
- [ ] Post-merge: trigger acp release if version bumped in a follow-up

## Follow-ups

Reverse-RPC paths remain deferred — they need a JSON-RPC framer that can originate requests from the agent side. Internal iii brains today use iii primitives directly for filesystem and terminal access. Lands as a separate PR when an external ACP agent (consumed via future `acp-client`) needs the editor to act on its behalf.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session resumption capability with environment state preservation and history handling
  * Introduced per-session configuration management and mode settings
  * Extended ACP session lifecycle operations and capabilities

* **Documentation**
  * Expanded ACP session management documentation with new operation details and capability information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->