### PR TITLE
docs(acp): drop stale 'deferred to v0.2' from README header

### DIFF
--- a/acp/README.md
+++ b/acp/README.md
@@ -9,9 +9,13 @@ and drive it through their native agent UI. No editor plugin, no fork, no
 bespoke per-client integration.
 
 > Status: 0.1.0. Server-side only (`acp-client` for consuming external ACP
-> agents ships separately). Reverse-RPC paths (`session/request_permission`,
-> `fs/*`, `terminal/*`) are deferred to v0.2 — internal iii brains use iii
-> primitives directly for filesystem and terminal access.
+> agents ships separately). All eleven client→agent methods are implemented
+> (`initialize`, `authenticate`, `session/{new,load,resume,list,prompt,cancel,close,set_mode,set_config_option}`)
+> plus the `session/update` agent→client notification. Reverse-RPC paths
+> (`session/request_permission`, `fs/{read,write}_text_file`,
+> `terminal/{create,kill,output,release,wait_for_exit}`) remain deferred —
+> internal iii brains use iii primitives directly for filesystem and
+> terminal access. Full per-method status in the [Methods](#methods) table.
 
 ## Why this exists (vs MCP, skills, agent workers)
 


### PR DESCRIPTION
## Summary

PR #86 shipped `session/resume`, `session/set_mode`, and `session/set_config_option`, but the acp README header still said reverse-RPC paths are "deferred to v0.2". That line conflated:

- Three client→agent methods (now done in #86)
- The reverse-RPC surface (`session/request_permission`, `fs/*`, `terminal/*` — still deferred, but "v0.2" isn't accurate framing for them either since they only land when external ACP agents need them via `acp-client`)

## Change

Replaces the misleading status line with explicit per-method enumeration:
- All eleven client→agent methods listed as implemented
- Reverse-RPC paths spelled out fully (`fs/{read,write}_text_file`, `terminal/{create,kill,output,release,wait_for_exit}`)
- Points readers at the existing Methods table for full status

No code changes.

## Test plan

- [x] Header text matches the actual code surface in `acp/src/handler.rs`
- [x] Method list aligns with the Methods table later in the README