### PR TITLE
refactor(workers): per-worker manifest/config + namespace rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ WORKERS-PR-REVIEW.md
 *.pid
 *.zip
 config.yaml
+!llm-budget/config.yaml
+!provider-anthropic/config.yaml
 iii.lock
 harness/.omx/
 harness/web/.vite/

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ matching GitHub Release asset for the host's target triple.
 | Worker | Kind | Summary |
 |---|---|---|
 | [`auth-credentials`](auth-credentials/) | Rust | Provider credential vault under `auth::*` — API keys and OAuth tokens. |
-| [`session-inbox`](session-inbox/) | Rust | Per-session inbox under `inbox::*` (push, drain, peek). |
+| [`session-inbox`](session-inbox/) | Rust | Per-session inbox under `session-inbox::*` (push, drain, peek). |
 | [`provider-router`](provider-router/) | Rust | `router::stream_assistant` provider router plus `router::abort` and `router::push_steering` / `push_followup` helpers. |
-| [`hook-fanout`](hook-fanout/) | Rust | Reusable publish-collect primitive under `hooks::publish_collect` — fans an event to subscribers and merges replies. |
+| [`hook-fanout`](hook-fanout/) | Rust | Reusable publish-collect primitive under `hook-fanout::publish_collect` — fans an event to subscribers and merges replies. |
 | [`iii-lsp`](iii-lsp/) | Rust | Language Server for iii function ids, trigger configs, and worker discovery. Autocomplete/hover across JS/TS, Python, Rust. |
 | [`iii-lsp-vscode`](iii-lsp-vscode/) | Node | VS Code extension that embeds `iii-lsp`. |
 | [`image-resize`](image-resize/) | Rust | Image resize via channel I/O. JPEG/PNG/WebP with EXIF auto-orient, scale-to-fit / crop-to-fit. |

--- a/approval-gate/src/lib.rs
+++ b/approval-gate/src/lib.rs
@@ -462,7 +462,7 @@ pub fn register(iii: &III, config: Config) -> anyhow::Result<Refs> {
 
     let subscriber_trigger = iii
         .register_trigger(RegisterTriggerInput {
-            trigger_type: "subscribe".into(),
+            trigger_type: "durable:subscriber".into(),
             function_id: "policy::approval_gate".into(),
             config: json!({ "topic": topic }),
             metadata: None,

--- a/auth-credentials/Cargo.lock
+++ b/auth-credentials/Cargo.lock
@@ -146,6 +146,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,29 +276,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
 
 [[package]]
 name = "equivalent"
@@ -694,12 +711,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "env_logger",
+ "clap",
  "iii-sdk",
- "log",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -778,30 +797,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jiff"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +807,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -853,6 +854,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +886,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1039,21 +1058,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -1251,18 +1255,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
 ]
 
 [[package]]
@@ -1534,6 +1526,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,6 +1547,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1587,6 +1601,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1657,6 +1677,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1877,6 +1906,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1929,6 +1988,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,6 +2040,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/auth-credentials/Cargo.toml
+++ b/auth-credentials/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "iii-auth-credentials"
 version = "0.1.0"
@@ -6,6 +8,7 @@ license = "Apache-2.0"
 repository = "https://github.com/iii-hq/workers"
 authors = ["iii contributors"]
 publish = false
+build = "build.rs"
 
 [lib]
 name = "auth_credentials"
@@ -19,11 +22,16 @@ path = "src/main.rs"
 iii-sdk = "=0.11.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"
 async-trait = "0.1"
-log = "0.4"
-env_logger = "0.11"
+clap = { version = "4", features = ["derive", "env"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+
+[dev-dependencies]
+serde_json = "1"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/auth-credentials/README.md
+++ b/auth-credentials/README.md
@@ -1,62 +1,62 @@
 # auth-credentials
 
-Provider credential vault on the iii bus. Stores API keys and OAuth tokens
-under `auth::*`.
+Provider credential vault on the iii bus. It stores API keys and OAuth tokens so
+providers and agents read credentials through `auth::*` without handling raw
+secrets in every caller.
 
-## Installation
+## Install
 
 ```bash
 iii worker add auth-credentials
 ```
 
-## Run
+`iii worker add` fetches the binary, writes a config block into
+`~/.iii/config.yaml`, and the engine starts the worker on the next `iii start`.
 
-```bash
-iii-auth-credentials --engine-url ws://127.0.0.1:49134
+## Quickstart
+
+```rust
+use iii_sdk::{register_worker, InitOptions, TriggerRequest};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+
+    let result = iii
+        .trigger(TriggerRequest {
+            function_id: "auth::get_token".into(),
+            payload: json!({ "provider": "anthropic" }),
+            action: None,
+            timeout_ms: Some(5_000),
+        })
+        .await?;
+
+    println!("{result:#?}");
+    Ok(())
+}
 ```
 
-Defaults to an iii-state-backed store (credentials survive worker restart).
-Set `AUTH_CREDENTIALS_STORE=memory` for ephemeral in-process storage; see
-[Storage backends](#storage-backends) below.
+Other entry points: `auth::set_token`, `auth::delete_token`, `auth::list_providers`, and `auth::status`.
 
-## Registered functions
+## Configuration
 
-| Function | Description |
-|---|---|
-| `auth::set` | Store a credential for a provider. |
-| `auth::get` | Read a credential for a provider. |
-| `auth::list` | List provider credentials. |
-| `auth::clear` | Remove a credential. |
-| `auth::resolve` | Resolve effective credential (refresh if needed). |
+```yaml
+engine_url: "ws://127.0.0.1:49134"   # override with --url or III_URL
+store: iii_state                     # iii_state (durable) or memory (ephemeral)
+```
 
-## Storage backends
+`store` defaults to durable storage via iii-state. Use `memory` for tests or
+ephemeral runs. You can still override with `AUTH_CREDENTIALS_STORE=memory` or
+`iii_state` for backward compatibility.
 
-`auth-credentials` supports two storage backends, selected via the
-`AUTH_CREDENTIALS_STORE` env var:
+Other defaults live in [`src/config.rs`](src/config.rs).
 
-| Value | Persistence | Use case |
-|---|---|---|
-| `iii_state` (default) | Survives worker restart via `iii-state` | Production |
-| `memory` | In-process only; lost on restart | Tests, local dev |
+## Companion workers
 
-The `iii_state` backend stores each credential under scope `auth_credentials`,
-key `credential:<provider>`, value `{ "provider": "<provider>", "credential": <Credential> }`.
-The provider name is embedded in the value so `auth::list_providers` can
-recover the `(provider, credential)` tuple list (`state::list` returns values
-without keys).
-
-### Failure semantics
-
-`CredentialStore::{get, set, clear, list}` return `anyhow::Result<...>`. With
-the `iii_state` backend, transient bus failures (engine restart, IPC hiccup)
-surface as `Err` to the bus caller. With `memory`, only `RwLock` poison
-errors are surfaced — under normal use the methods are infallible.
-
-Callers of `auth::get_token` should expect a bus error response on transient
-state failures; retry policy is the caller's choice.
-
-## Build
+To register markdown skills with the engine, the [skills](../skills) worker
+should be running so this worker’s `skills::register` handshake succeeds.
 
 ```bash
-cargo build --release
+iii worker add skills
 ```

--- a/auth-credentials/build.rs
+++ b/auth-credentials/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+}

--- a/auth-credentials/skills/set_token.md
+++ b/auth-credentials/skills/set_token.md
@@ -15,5 +15,5 @@ or `{ type: "oauth", access_token, ... }`. No verification at write time.
 
 ## Notes
 
-- Default backend is `iii_state` (durable). Set `AUTH_CREDENTIALS_STORE=memory` for ephemeral storage in tests.
+- Default backend is `iii_state` (durable). Set `store: memory` in config or `AUTH_CREDENTIALS_STORE=memory` for ephemeral storage in tests.
 - Caller validates token shape; the worker only stores the serialised credential bytes.

--- a/auth-credentials/src/config.rs
+++ b/auth-credentials/src/config.rs
@@ -1,0 +1,85 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum StoreBackend {
+    #[default]
+    IiiState,
+    Memory,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct WorkerConfig {
+    #[serde(default = "default_engine_url")]
+    pub engine_url: String,
+    #[serde(default)]
+    pub store: StoreBackend,
+}
+
+fn default_engine_url() -> String {
+    "ws://127.0.0.1:49134".to_string()
+}
+
+impl Default for WorkerConfig {
+    fn default() -> Self {
+        Self {
+            engine_url: default_engine_url(),
+            store: StoreBackend::default(),
+        }
+    }
+}
+
+pub fn load_config(path: &str) -> Result<WorkerConfig> {
+    let contents = std::fs::read_to_string(path)?;
+    let cfg: WorkerConfig = serde_yaml::from_str(&contents)?;
+    Ok(cfg)
+}
+
+/// Resolve store backend: `AUTH_CREDENTIALS_STORE` wins when set; otherwise `cfg.store`.
+pub fn resolve_store_backend(cfg: &WorkerConfig) -> StoreBackend {
+    match std::env::var("AUTH_CREDENTIALS_STORE").as_deref() {
+        Ok("memory") => StoreBackend::Memory,
+        Ok("iii_state") => StoreBackend::IiiState,
+        Ok(other) if !other.is_empty() => {
+            tracing::warn!(
+                %other,
+                "unknown AUTH_CREDENTIALS_STORE; valid: memory, iii_state — using config `store`"
+            );
+            cfg.store
+        }
+        _ => cfg.store,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_from_empty_yaml() {
+        let cfg: WorkerConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(cfg.engine_url, "ws://127.0.0.1:49134");
+        assert_eq!(cfg.store, StoreBackend::IiiState);
+    }
+
+    #[test]
+    fn custom_yaml_overrides() {
+        let cfg: WorkerConfig = serde_yaml::from_str(
+            r#"engine_url: "ws://example:49134"
+store: memory
+"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.engine_url, "ws://example:49134");
+        assert_eq!(cfg.store, StoreBackend::Memory);
+    }
+
+    #[test]
+    fn impl_default_matches_yaml_defaults() {
+        let d = WorkerConfig::default();
+        let cfg: WorkerConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(d.engine_url, cfg.engine_url);
+        assert_eq!(d.store, cfg.store);
+    }
+}

--- a/auth-credentials/src/main.rs
+++ b/auth-credentials/src/main.rs
@@ -2,51 +2,100 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
-use iii_sdk::{register_worker, InitOptions, TriggerRequest};
-use serde_json::json;
+use clap::Parser;
+use iii_sdk::{register_worker, InitOptions, OtelConfig, TriggerRequest, WorkerMetadata};
 
-const DEFAULT_ENGINE_URL: &str = "ws://127.0.0.1:49134";
+mod config;
+mod manifest;
+
+use config::{resolve_store_backend, StoreBackend};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "iii-auth-credentials",
+    about = "Provider credential vault on the iii bus — API keys and OAuth tokens under auth::*."
+)]
+struct Cli {
+    #[arg(long, default_value = "./config.yaml")]
+    config: String,
+
+    /// Engine WebSocket URL. Falls back to `engine_url` in config when unset.
+    #[arg(long, env = "III_URL")]
+    url: Option<String>,
+
+    #[arg(long)]
+    manifest: bool,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
 
-    let engine_url = std::env::var("III_URL").unwrap_or_else(|_| DEFAULT_ENGINE_URL.to_string());
-    let iii = Arc::new(register_worker(&engine_url, InitOptions::default()));
+    let cli = Cli::parse();
 
-    let store: Arc<dyn auth_credentials::CredentialStore> = match std::env::var(
-        "AUTH_CREDENTIALS_STORE",
-    )
-    .as_deref()
-    {
-        Ok("memory") => {
-            log::info!("auth-credentials: using in-memory store (AUTH_CREDENTIALS_STORE=memory)");
+    if cli.manifest {
+        let m = manifest::build_manifest();
+        println!("{}", serde_json::to_string_pretty(&m)?);
+        return Ok(());
+    }
+
+    let cfg = match config::load_config(&cli.config) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(error = %e, path = %cli.config, "failed to load config, using defaults");
+            config::WorkerConfig::default()
+        }
+    };
+
+    let engine_url = cli.url.unwrap_or_else(|| cfg.engine_url.clone());
+    let store_kind = resolve_store_backend(&cfg);
+
+    let iii = Arc::new(register_worker(
+        &engine_url,
+        InitOptions {
+            otel: Some(OtelConfig::default()),
+            metadata: Some(WorkerMetadata {
+                runtime: "rust".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                name: "auth-credentials".to_string(),
+                os: std::env::consts::OS.to_string(),
+                pid: Some(std::process::id()),
+                telemetry: None,
+                ..WorkerMetadata::default()
+            }),
+            ..InitOptions::default()
+        },
+    ));
+
+    let store: Arc<dyn auth_credentials::CredentialStore> = match store_kind {
+        StoreBackend::Memory => {
+            tracing::info!("auth-credentials: using in-memory store");
             Arc::new(auth_credentials::InMemoryStore::new())
         }
-        Ok("iii_state") | Err(_) => {
-            log::info!("auth-credentials: using iii-state store");
-            let iii_for_store: Arc<dyn auth_credentials::io::IIITrigger> = iii.clone();
-            Arc::new(auth_credentials::store_iii_state::IiiStateCredentialStore::new(iii_for_store))
-        }
-        Ok(other) => {
-            log::warn!(
-                    "auth-credentials: unknown AUTH_CREDENTIALS_STORE={other:?}; falling back to iii-state. \
-                     Valid values: memory, iii_state."
-                );
+        StoreBackend::IiiState => {
+            tracing::info!("auth-credentials: using iii-state store");
             let iii_for_store: Arc<dyn auth_credentials::io::IIITrigger> = iii.clone();
             Arc::new(auth_credentials::store_iii_state::IiiStateCredentialStore::new(iii_for_store))
         }
     };
+
     let _refs = auth_credentials::register_with_iii(&iii, store)
         .await
         .context("auth-credentials register failed")?;
-    log::info!("auth-credentials registered (auth::*)");
+    tracing::info!("auth-credentials registered (auth::*)");
 
     spawn_skill_register(iii.clone());
 
     wait_for_shutdown().await?;
 
     unregister_skill(&iii).await;
+    tracing::info!("auth-credentials shutting down");
+    iii.shutdown_async().await;
     Ok(())
 }
 
@@ -57,28 +106,30 @@ async fn register_skill_with_retry(iii: &iii_sdk::III, id: &str, body: &str) {
         let res = iii
             .trigger(TriggerRequest {
                 function_id: "skills::register".into(),
-                payload: json!({ "id": id, "skill": body }),
+                payload: serde_json::json!({ "id": id, "skill": body }),
                 action: None,
                 timeout_ms: Some(5_000),
             })
             .await;
         match res {
             Ok(_) => {
-                log::info!("registered skill: {id}");
+                tracing::info!(skill_id = %id, "registered skill");
                 return;
             }
             Err(e) => {
-                if started.elapsed() > Duration::from_mins(3) {
-                    log::warn!(
-                        "skills handshake gave up for {id}; install/start the skills worker and restart (last error: {e})"
+                if started.elapsed() > Duration::from_secs(180) {
+                    tracing::warn!(
+                        skill_id = %id,
+                        error = %e,
+                        "skills handshake gave up; install/start the skills worker and restart"
                     );
                     return;
                 }
-                log::debug!("skills::register failed for {id}: {e}; retrying in {backoff:?}");
+                tracing::debug!(skill_id = %id, error = %e, wait = ?backoff, "skills::register failed; retrying");
             }
         }
         tokio::time::sleep(backoff).await;
-        backoff = (backoff * 2).min(Duration::from_mins(1));
+        backoff = (backoff * 2).min(Duration::from_secs(60));
     }
 }
 
@@ -112,14 +163,12 @@ async fn wait_for_shutdown() -> Result<()> {
     }
 }
 
-// Best-effort: a missed unregister is self-healing on next boot's re-register.
-// Leaves go first so the router is the last entry to disappear from iii://skills.
 async fn unregister_skill(iii: &Arc<iii_sdk::III>) {
     for (id, _) in auth_credentials::SUB_SKILLS {
         let _ = iii
             .trigger(TriggerRequest {
                 function_id: "skills::unregister".into(),
-                payload: json!({ "id": id }),
+                payload: serde_json::json!({ "id": id }),
                 action: None,
                 timeout_ms: Some(2_000),
             })
@@ -128,7 +177,7 @@ async fn unregister_skill(iii: &Arc<iii_sdk::III>) {
     let _ = iii
         .trigger(TriggerRequest {
             function_id: "skills::unregister".into(),
-            payload: json!({ "id": auth_credentials::SKILL_ID }),
+            payload: serde_json::json!({ "id": auth_credentials::SKILL_ID }),
             action: None,
             timeout_ms: Some(2_000),
         })

--- a/auth-credentials/src/main.rs
+++ b/auth-credentials/src/main.rs
@@ -117,7 +117,7 @@ async fn register_skill_with_retry(iii: &iii_sdk::III, id: &str, body: &str) {
                 return;
             }
             Err(e) => {
-                if started.elapsed() > Duration::from_secs(180) {
+                if started.elapsed() > Duration::from_mins(3) {
                     tracing::warn!(
                         skill_id = %id,
                         error = %e,
@@ -129,7 +129,7 @@ async fn register_skill_with_retry(iii: &iii_sdk::III, id: &str, body: &str) {
             }
         }
         tokio::time::sleep(backoff).await;
-        backoff = (backoff * 2).min(Duration::from_secs(60));
+        backoff = (backoff * 2).min(Duration::from_mins(1));
     }
 }
 

--- a/auth-credentials/src/manifest.rs
+++ b/auth-credentials/src/manifest.rs
@@ -1,0 +1,44 @@
+use serde::Serialize;
+
+use crate::config::WorkerConfig;
+
+#[derive(Serialize)]
+pub struct ModuleManifest {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub default_config: serde_json::Value,
+    pub supported_targets: Vec<String>,
+}
+
+pub fn build_manifest() -> ModuleManifest {
+    ModuleManifest {
+        name: env!("CARGO_PKG_NAME").to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        description: "Provider credential vault under auth::* — API keys and OAuth tokens."
+            .to_string(),
+        default_config: serde_json::to_value(WorkerConfig::default())
+            .expect("WorkerConfig serializes to JSON"),
+        supported_targets: vec![env!("TARGET").to_string()],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_roundtrip_has_required_fields() {
+        let m = build_manifest();
+        let json = serde_json::to_string_pretty(&m).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["name"], env!("CARGO_PKG_NAME"));
+        assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+        assert!(parsed["description"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()));
+        assert!(parsed["default_config"].is_object());
+        assert!(!parsed["supported_targets"].as_array().unwrap().is_empty());
+    }
+}

--- a/auth-credentials/tests/manifest.rs
+++ b/auth-credentials/tests/manifest.rs
@@ -1,0 +1,50 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn auth_credentials_executable() -> PathBuf {
+    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_iii_auth_credentials") {
+        return PathBuf::from(p);
+    }
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    for profile in ["debug", "release"] {
+        let candidate = dir
+            .join("target")
+            .join(profile)
+            .join("iii-auth-credentials");
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+    panic!(
+        "iii-auth-credentials binary not found under target/{{debug,release}}/; run `cargo build --bin iii-auth-credentials` first"
+    );
+}
+
+#[test]
+fn manifest_subcommand_emits_valid_json() {
+    let bin = auth_credentials_executable();
+    let output = Command::new(&bin)
+        .arg("--manifest")
+        .output()
+        .expect("spawn iii-auth-credentials --manifest");
+
+    assert!(
+        output.status.success(),
+        "binary exited with {:?}; stderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("manifest stdout is utf-8");
+    let manifest: Value = serde_json::from_str(&stdout).expect("manifest stdout is valid JSON");
+
+    assert_eq!(manifest["name"], env!("CARGO_PKG_NAME"));
+    assert_eq!(manifest["version"], env!("CARGO_PKG_VERSION"));
+    assert!(manifest["default_config"].is_object());
+    assert!(!manifest["supported_targets"]
+        .as_array()
+        .expect("supported_targets must be an array")
+        .is_empty(),);
+}

--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -146,6 +146,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,29 +276,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
 
 [[package]]
 name = "equivalent"
@@ -694,11 +711,14 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "env_logger",
+ "clap",
  "iii-sdk",
- "log",
+ "serde",
  "serde_json",
+ "serde_yaml",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -777,30 +797,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jiff"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +807,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -852,6 +854,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +886,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1038,21 +1058,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -1250,18 +1255,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
 ]
 
 [[package]]
@@ -1533,6 +1526,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,6 +1547,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1586,6 +1601,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1656,6 +1677,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1876,6 +1906,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1928,6 +1988,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,6 +2040,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "iii-harness"
 version = "0.2.0"
@@ -17,12 +19,15 @@ path = "src/main.rs"
 
 [dependencies]
 iii-sdk = "=0.11.3"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"
-log = "0.4"
-env_logger = "0.11"
 async-trait = "0.1"
+clap = { version = "4", features = ["derive", "env"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/harness/README.md
+++ b/harness/README.md
@@ -1,72 +1,106 @@
 # harness
 
-Meta-worker that composes 14 modular workers into a runnable iii chat
-surface, exposes a single browser-facing HTTP bridge, and ships a Vite/React
-UI that talks to the bus through it.
+Meta-worker that composes fifteen modular workers into a runnable iii chat surface, exposes a browser-facing HTTP bridge (`bridge::trigger`, `bridge::events`), and ships a Vite/React UI that talks to the bus through it. The harness does not own chat, agent, or provider logic; it registers a small set of bus functions and expects peers such as `turn-orchestrator`, `provider-router`, shell tools, and related workers to be installed alongside it. Deeper layout and streams behavior are documented in [`ARCHITECTURE.md`](ARCHITECTURE.md).
 
-The harness owns no chat, agent, or provider logic itself. It registers
-exactly two functions on the iii bus and assumes the rest of the surface
-(`turn-orchestrator`, `provider-router`, `session-tree`, the shell tools,
-etc.) is provided by other workers. Architecture details are in
-`ARCHITECTURE.md`.
-
-## Installation
+## Install
 
 ```bash
 iii worker add harness
 ```
 
-## Run
+`iii worker add` fetches the binary, writes a config block into `~/.iii/config.yaml`, and the engine starts the worker on the next `iii start`.
+
+To register the harness skill bundle metadata with the bus (the worker does this automatically at boot when `skills` is available), ensure the [skills](../skills) worker is part of your stack:
 
 ```bash
-iii-harness
+iii worker add skills
 ```
 
-Defaults to `ws://127.0.0.1:49134`; override with `III_URL`.
+## Quickstart
 
-## Registered functions
+After `iii start`, probe the bundle and list expected runtime workers:
 
-| Function | Description |
+```rust
+use iii_sdk::{register_worker, InitOptions, TriggerRequest};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let iii = register_worker("ws://127.0.0.1:49134", InitOptions::default());
+
+    let result = iii
+        .trigger(TriggerRequest {
+            function_id: "harness::status".into(),
+            payload: json!({}),
+            action: None,
+            timeout_ms: Some(5_000),
+        })
+        .await?;
+
+    println!("{result:#?}");
+    Ok(())
+}
+```
+
+Forward an arbitrary bus call through the HTTP-oriented bridge (same shape as `bridge::trigger` on the engine):
+
+```rust
+// function_id / payload match iii.trigger(...)
+let result = iii
+    .trigger(TriggerRequest {
+        function_id: "bridge::trigger".into(),
+        payload: json!({
+            "function_id": "models::list",
+            "payload": {},
+        }),
+        action: None,
+        timeout_ms: Some(240_000),
+    })
+    .await?;
+```
+
+Registered functions (use `::` ids on the bus):
+
+| Function | Role |
 |---|---|
-| `harness::status` | Returns the bundle name, version, and the list of expected runtime workers. The cheapest "is the bundle alive" probe. |
-| `bridge::trigger` | Forwards `{function_id, payload}` from HTTP onto `iii.trigger(...)`. Backed by an HTTP trigger at `POST /bridge/trigger` with a 4-minute timeout. |
+| `harness::status` | Bundle name, version, and expected worker list (cheap liveness probe). |
+| `bridge::trigger` | Forwards `{ function_id, payload }` to `iii.trigger`. HTTP: `POST` `bridge/trigger`. |
+| `bridge::events` | SSE-style tail of `agent::events` for a session. HTTP: `GET` `bridge/events`. |
 
-`bridge::trigger` is intentionally not advertised as an LLM tool — it
-exists only as the browser's call-anything escape hatch.
+`bridge::trigger` is not meant as an LLM tool — it is the browser’s call-anything escape hatch.
+
+## Configuration
+
+```yaml
+# Default engine WebSocket URL when III_URL / --url are unset
+engine_url: "ws://127.0.0.1:49134"
+```
+
+Other runtime flags:
+
+- `--config` — path to this file (default `./config.yaml`; override with `III_HARNESS_CONFIG`).
+- `--url` or `III_URL` — engine WebSocket URL; wins over `engine_url` in the file.
+
+Registry-facing defaults also appear in `iii-harness --manifest` under `default_config`.
 
 ## Expected workers
 
-The 14 workers the harness assumes are running on the bus, sourced from
-`EXPECTED_WORKERS` in `src/lib.rs`:
+`EXPECTED_WORKERS` in [`src/lib.rs`](src/lib.rs) and the `dependencies:` block of [`iii.worker.yaml`](iii.worker.yaml) must stay in sync (see [`tests/integration.rs`](tests/integration.rs)).
 
-- `turn-orchestrator`, `provider-router`
-- `session-tree`, `session-inbox`
-- `models-catalog`, `hook-fanout`, `policy-denylist`
-- `shell-bash`, `shell-filesystem`, `subagent`
-- `provider-anthropic`, `provider-openai`
-- `auth-credentials`, `llm-budget`
+## Local demo stack
 
-`tests/integration.rs` keeps `EXPECTED_WORKERS` and the `dependencies:`
-block of `iii.worker.yaml` in sync.
-
-## Local stack
-
-`scripts/demo.sh` brings up the entire bundle directly from a checkout:
+From a checkout, [`scripts/demo.sh`](scripts/demo.sh) can build and run the full bundle:
 
 ```bash
-./scripts/demo.sh build    # cargo build --release for harness + 14 workers
+./scripts/demo.sh build    # cargo build --release for harness + dependencies
 ./scripts/demo.sh engine   # start `iii --use-default-config` in background
-./scripts/demo.sh start    # spawn all 14 workers + harness as nohup processes
+./scripts/demo.sh start    # spawn workers + harness as nohup processes
 ./scripts/demo.sh verify   # call harness::status and models::list
-./scripts/demo.sh web      # vite dev server on :5173 in a tmux session
-./scripts/demo.sh stop     # kill every PID + engine + tmux
+./scripts/demo.sh web      # Vite dev server on :5173 in a tmux session
+./scripts/demo.sh stop     # tear down PIDs, engine, tmux
 ./scripts/demo.sh all      # build + engine + start + verify
 ```
 
-PIDs and per-worker logs live under `~/iii-harness-demo` by default.
+PIDs and logs default under `~/iii-harness-demo`.
 
-## Build
-
-```bash
-cargo build --release
-```
+Contributor commands (fmt, clippy, tests) for this crate live in [`binary-worker.md`](../binary-worker.md) §11; source layout notes are in [`ARCHITECTURE.md`](ARCHITECTURE.md).

--- a/harness/build.rs
+++ b/harness/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+}

--- a/harness/scripts/demo.sh
+++ b/harness/scripts/demo.sh
@@ -19,8 +19,9 @@
 # Usage:
 #   ./scripts/demo.sh <cmd> [DEMO_DIR]
 #
-# DEMO_DIR defaults to ~/iii-harness-demo. Env requires `iii` engine
-# reachable on ws://127.0.0.1:49134 (or set III_URL).
+# DEMO_DIR defaults to ~/iii-harness-demo. Requires a local `iii` engine via
+# `iii --use-default-config` (default ws://127.0.0.1:49134). Spawns pin
+# III_URL to that URL unless you set III_DEMO_ENGINE_URL.
 
 set -euo pipefail
 
@@ -28,6 +29,12 @@ CMD="${1:-}"
 DEMO_DIR="${2:-$HOME/iii-harness-demo}"
 WORKERS_REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 HARNESS_DIR="$WORKERS_REPO/harness"
+
+# WebSocket URL for the demo engine. Must match `iii --use-default-config`
+# (default localhost:49134). Workers inherit `III_URL` from the environment;
+# if your shell points it at another engine, the demo would start processes
+# that register there while this script's health checks hit the local engine.
+DEMO_ENGINE_WS="${III_DEMO_ENGINE_URL:-ws://127.0.0.1:49134}"
 
 WORKERS=(
   turn-orchestrator provider-router
@@ -43,14 +50,21 @@ ensure_dirs() {
   mkdir -p "$DEMO_DIR/pids" "$DEMO_DIR/logs"
 }
 
-# Most workers ship a binary named `iii-{worker}`; `skills` keeps the
-# unprefixed `skills` name from before the convention. Centralize the lookup
-# so the build/spawn paths stay consistent.
+# Binary artifact name comes from each crate’s `iii.worker.yaml` `bin:` field
+# (same value as `[[bin]]` in Cargo.toml). Do not assume `iii-{folder}` — names
+# are mixed historical (`iii-*`) and folder-matched (`shell-bash`, `skills`, …).
 bin_name_for() {
-  case "$1" in
-    skills) echo "skills" ;;
-    *) echo "iii-$1" ;;
-  esac
+  local w="$1"
+  local yaml="$WORKERS_REPO/$w/iii.worker.yaml"
+  if [[ -f "$yaml" ]]; then
+    local name
+    name="$(awk '/^bin:/{sub(/^bin:[ \t]*/, ""); sub(/[ \t]+$/, ""); print; exit}' "$yaml")"
+    if [[ -n "$name" ]]; then
+      echo "$name"
+      return
+    fi
+  fi
+  echo "$w"
 }
 
 cmd_build() {
@@ -79,7 +93,14 @@ spawn_one() {
   fi
 
   : > "$logfile"
-  nohup "$bin" >>"$logfile" 2>&1 &
+  local -a run_args=()
+  if [[ "$w" == "harness" ]]; then
+    run_args=(
+      --config "$WORKERS_REPO/harness/config.yaml"
+      --url "$DEMO_ENGINE_WS"
+    )
+  fi
+  env III_URL="$DEMO_ENGINE_WS" nohup "$bin" "${run_args[@]}" >>"$logfile" 2>&1 &
   echo $! > "$pidfile"
   echo "    [start] $w pid=$! log=$logfile"
 }

--- a/harness/src/config.rs
+++ b/harness/src/config.rs
@@ -1,0 +1,49 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct WorkerConfig {
+    #[serde(default = "default_engine_url")]
+    pub engine_url: String,
+}
+
+fn default_engine_url() -> String {
+    "ws://127.0.0.1:49134".to_string()
+}
+
+impl Default for WorkerConfig {
+    fn default() -> Self {
+        Self {
+            engine_url: default_engine_url(),
+        }
+    }
+}
+
+pub fn load_config(path: &str) -> Result<WorkerConfig> {
+    let contents = std::fs::read_to_string(path)?;
+    let cfg: WorkerConfig = serde_yaml::from_str(&contents)?;
+    Ok(cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_from_empty_yaml() {
+        let cfg: WorkerConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(cfg.engine_url, "ws://127.0.0.1:49134");
+    }
+
+    #[test]
+    fn custom_yaml_overrides() {
+        let cfg: WorkerConfig =
+            serde_yaml::from_str(r#"engine_url: "ws://example:49134""#).unwrap();
+        assert_eq!(cfg.engine_url, "ws://example:49134");
+    }
+
+    #[test]
+    fn impl_default_matches_yaml_defaults() {
+        assert_eq!(WorkerConfig::default().engine_url, default_engine_url());
+    }
+}

--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -1,21 +1,82 @@
-use anyhow::Result;
-use iii_sdk::{register_worker, InitOptions};
+use std::sync::Arc;
 
-const DEFAULT_ENGINE_URL: &str = "ws://127.0.0.1:49134";
+use anyhow::Result;
+use clap::Parser;
+use iii_sdk::{register_worker, InitOptions, OtelConfig, WorkerMetadata};
+
+mod config;
+mod manifest;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "iii-harness",
+    about = "Meta-worker that composes the modular workers backing the iii chat surface."
+)]
+struct Cli {
+    #[arg(long, env = "III_HARNESS_CONFIG", default_value = "./config.yaml")]
+    config: String,
+
+    /// Engine WebSocket URL. Falls back to `engine_url` in `--config` when unset.
+    #[arg(long, env = "III_URL")]
+    url: Option<String>,
+
+    #[arg(long)]
+    manifest: bool,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
 
-    let engine_url = std::env::var("III_URL").unwrap_or_else(|_| DEFAULT_ENGINE_URL.to_string());
-    let iii = register_worker(&engine_url, InitOptions::default());
+    let cli = Cli::parse();
+
+    if cli.manifest {
+        let m = manifest::build_manifest();
+        println!("{}", serde_json::to_string_pretty(&m)?);
+        return Ok(());
+    }
+
+    let cfg = match config::load_config(&cli.config) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(error = %e, path = %cli.config, "failed to load config, using defaults");
+            config::WorkerConfig::default()
+        }
+    };
+
+    let url = cli.url.unwrap_or_else(|| cfg.engine_url.clone());
+
+    let iii = register_worker(
+        &url,
+        InitOptions {
+            otel: Some(OtelConfig::default()),
+            metadata: Some(WorkerMetadata {
+                runtime: "rust".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                name: "harness".to_string(),
+                os: std::env::consts::OS.to_string(),
+                pid: Some(std::process::id()),
+                telemetry: None,
+                ..WorkerMetadata::default()
+            }),
+            ..InitOptions::default()
+        },
+    );
+    let iii = Arc::new(iii);
 
     let _refs = harness::register_with_iii(&iii).await?;
-    log::info!(
+    tracing::info!(
         "harness ready — registered harness::status; expecting {} runtime workers from iii.worker.yaml",
         harness::EXPECTED_WORKERS.len()
     );
 
     tokio::signal::ctrl_c().await.ok();
+    tracing::info!("harness shutting down");
+    iii.shutdown_async().await;
     Ok(())
 }

--- a/harness/src/manifest.rs
+++ b/harness/src/manifest.rs
@@ -1,0 +1,44 @@
+use serde::Serialize;
+
+use crate::config::WorkerConfig;
+
+#[derive(Serialize)]
+pub struct ModuleManifest {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub default_config: serde_json::Value,
+    pub supported_targets: Vec<String>,
+}
+
+pub fn build_manifest() -> ModuleManifest {
+    ModuleManifest {
+        name: env!("CARGO_PKG_NAME").to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        description: "Meta-worker that composes the modular workers backing the iii chat surface."
+            .to_string(),
+        default_config: serde_json::to_value(WorkerConfig::default())
+            .expect("WorkerConfig serializes to JSON"),
+        supported_targets: vec![env!("TARGET").to_string()],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_roundtrip_has_required_fields() {
+        let m = build_manifest();
+        let json = serde_json::to_string_pretty(&m).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["name"], env!("CARGO_PKG_NAME"));
+        assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+        assert!(parsed["description"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()));
+        assert!(parsed["default_config"].is_object());
+        assert!(!parsed["supported_targets"].as_array().unwrap().is_empty());
+    }
+}

--- a/harness/tests/manifest.rs
+++ b/harness/tests/manifest.rs
@@ -1,0 +1,47 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn harness_executable() -> PathBuf {
+    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_iii_harness") {
+        return PathBuf::from(p);
+    }
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    for profile in ["debug", "release"] {
+        let candidate = dir.join("target").join(profile).join("iii-harness");
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+    panic!(
+        "iii-harness binary not found under target/{{debug,release}}/; run `cargo build --bin iii-harness` first"
+    );
+}
+
+#[test]
+fn manifest_subcommand_emits_valid_json() {
+    let bin = harness_executable();
+    let output = Command::new(&bin)
+        .arg("--manifest")
+        .output()
+        .expect("spawn iii-harness --manifest");
+
+    assert!(
+        output.status.success(),
+        "binary exited with {:?}; stderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("manifest stdout is utf-8");
+    let manifest: Value = serde_json::from_str(&stdout).expect("manifest stdout is valid JSON");
+
+    assert_eq!(manifest["name"], env!("CARGO_PKG_NAME"));
+    assert_eq!(manifest["version"], env!("CARGO_PKG_VERSION"));
+    assert!(manifest["default_config"].is_object());
+    assert!(!manifest["supported_targets"]
+        .as_array()
+        .expect("supported_targets must be an array")
+        .is_empty());
+}

--- a/hook-fanout/Cargo.lock
+++ b/hook-fanout/Cargo.lock
@@ -146,6 +146,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,29 +276,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
 
 [[package]]
 name = "equivalent"
@@ -455,6 +472,22 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hook-fanout"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "iii-sdk",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
 
 [[package]]
 name = "hostname"
@@ -689,21 +722,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-hook-fanout"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "env_logger",
- "iii-sdk",
- "log",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "uuid",
-]
-
-[[package]]
 name = "iii-sdk"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,30 +797,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jiff"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +807,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -833,15 +833,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,6 +843,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -877,6 +877,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -987,29 +996,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,21 +1026,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -1246,27 +1217,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1434,12 +1384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,6 +1479,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,6 +1500,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1588,6 +1554,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1661,6 +1633,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,7 +1675,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -1878,6 +1858,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1930,6 +1940,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,6 +1992,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/hook-fanout/Cargo.toml
+++ b/hook-fanout/Cargo.toml
@@ -1,30 +1,37 @@
+[workspace]
+
 [package]
-name = "iii-hook-fanout"
+name = "hook-fanout"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/iii-hq/workers"
 authors = ["iii contributors"]
 publish = false
+build = "build.rs"
 
 [lib]
 name = "hook_fanout"
 path = "src/lib.rs"
 
 [[bin]]
-name = "iii-hook-fanout"
+name = "hook-fanout"
 path = "src/main.rs"
 
 [dependencies]
 iii-sdk = "=0.11.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["full"] }
+serde_yaml = "0.9"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 anyhow = "1"
 tracing = "0.1"
-log = "0.4"
-env_logger = "0.11"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+clap = { version = "4", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/hook-fanout/README.md
+++ b/hook-fanout/README.md
@@ -1,36 +1,61 @@
 # hook-fanout
 
-Reusable publish-collect primitive on the iii bus. Publishes an event,
+Reusable publish-collect primitive on the iii bus. Publishes a hook topic,
 collects replies from subscribers within a deadline, then merges them by a
-caller-selected `MergeRule` and returns the merged value.
+caller-selected `merge_rule` and returns the merged value.
 
-## Installation
+## Install
 
 ```bash
 iii worker add hook-fanout
 ```
 
-## Run
+`iii worker add` fetches the binary, writes a config block into
+`~/.iii/config.yaml`, and the engine starts the worker on the next
+`iii start`.
 
-```bash
-iii-hook-fanout --engine-url ws://127.0.0.1:49134
+## Quickstart
+
+```rust
+use iii_sdk::{register_worker, InitOptions, TriggerRequest};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+
+    let result = iii
+        .trigger(TriggerRequest {
+            function_id: "hook-fanout::publish_collect".into(),
+            payload: json!({
+                "topic": "agent::before_tool_call",
+                "payload": { "tool_call": { "id": "t1" } },
+                "merge_rule": "first_block_wins",
+                "timeout_ms": 5000,
+            }),
+            action: None,
+            timeout_ms: Some(5_000),
+        })
+        .await?;
+
+    println!("{result:#?}");
+    Ok(())
+}
 ```
 
-(Or set `III_URL`.)
+Response shape: `{ "event_id", "replies", "merged" }` (see source for merge rules).
 
-## Registered functions
+## Configuration
 
-| Function | Description |
-|---|---|
-| `hooks::publish_collect` | `{ topic, payload, merge_rule, timeout_ms? }` → merged `Value`. |
-
-## Merge rules
-
-`first_block_wins`, `field_merge`, `pipeline_last_wins` — see source for
-exact semantics.
-
-## Build
-
-```bash
-cargo build --release
+```yaml
+default_timeout_ms: 10000 # used when the caller omits timeout_ms on the payload
+min_timeout_ms: 50      # floor applied to the effective wait window
+poll_interval_ms: 25    # how often we poll the hook reply stream
 ```
+
+Other defaults and behavior live in [`src/config.rs`](src/config.rs).
+
+## Migration notes
+
+Function id was `hooks::publish_collect`; it is now `hook-fanout::publish_collect`
+(same payload and semantics).

--- a/hook-fanout/build.rs
+++ b/hook-fanout/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+}

--- a/hook-fanout/iii.worker.yaml
+++ b/hook-fanout/iii.worker.yaml
@@ -3,5 +3,5 @@ name: hook-fanout
 language: rust
 deploy: binary
 manifest: Cargo.toml
-bin: iii-hook-fanout
-description: Reusable publish-collect primitive under hooks::publish_collect — fans an event to subscribers and collects merged replies.
+bin: hook-fanout
+description: Reusable publish-collect primitive (hook-fanout::publish_collect) — fans an event to subscribers and collects merged replies.

--- a/hook-fanout/src/config.rs
+++ b/hook-fanout/src/config.rs
@@ -1,0 +1,72 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct WorkerConfig {
+    #[serde(default = "default_default_timeout_ms")]
+    pub default_timeout_ms: u64,
+    #[serde(default = "default_min_timeout_ms")]
+    pub min_timeout_ms: u64,
+    #[serde(default = "default_poll_interval_ms")]
+    pub poll_interval_ms: u64,
+}
+
+fn default_default_timeout_ms() -> u64 {
+    10_000
+}
+
+fn default_min_timeout_ms() -> u64 {
+    50
+}
+
+fn default_poll_interval_ms() -> u64 {
+    25
+}
+
+impl Default for WorkerConfig {
+    fn default() -> Self {
+        Self {
+            default_timeout_ms: default_default_timeout_ms(),
+            min_timeout_ms: default_min_timeout_ms(),
+            poll_interval_ms: default_poll_interval_ms(),
+        }
+    }
+}
+
+pub fn load_config(path: &str) -> Result<WorkerConfig> {
+    let contents = std::fs::read_to_string(path)?;
+    let cfg: WorkerConfig = serde_yaml::from_str(&contents)?;
+    Ok(cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_from_empty_yaml() {
+        let cfg: WorkerConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(cfg.default_timeout_ms, 10_000);
+        assert_eq!(cfg.min_timeout_ms, 50);
+        assert_eq!(cfg.poll_interval_ms, 25);
+    }
+
+    #[test]
+    fn custom_yaml_overrides() {
+        let cfg: WorkerConfig = serde_yaml::from_str(
+            "default_timeout_ms: 3000\nmin_timeout_ms: 100\npoll_interval_ms: 10",
+        )
+        .unwrap();
+        assert_eq!(cfg.default_timeout_ms, 3000);
+        assert_eq!(cfg.min_timeout_ms, 100);
+        assert_eq!(cfg.poll_interval_ms, 10);
+    }
+
+    #[test]
+    fn impl_default_matches_yaml_defaults() {
+        let d = WorkerConfig::default();
+        assert_eq!(d.default_timeout_ms, default_default_timeout_ms());
+        assert_eq!(d.min_timeout_ms, default_min_timeout_ms());
+        assert_eq!(d.poll_interval_ms, default_poll_interval_ms());
+    }
+}

--- a/hook-fanout/src/handler.rs
+++ b/hook-fanout/src/handler.rs
@@ -1,20 +1,23 @@
-//! `hooks::publish_collect` handler.
+//! `hook-fanout::publish_collect` handler.
 
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use iii_sdk::{IIIError, RegisterFunctionMessage, TriggerRequest, Value, III};
 use serde_json::json;
 use uuid::Uuid;
 
+use crate::config::WorkerConfig;
 use crate::{
     build_publish_envelope, merge_field_merge, merge_first_block_wins, merge_pipeline_last_wins,
     MergeRule, FUNCTION_ID, HOOK_REPLY_STREAM,
 };
 
-const POLL_INTERVAL_MS: u64 = 25;
-const MIN_TIMEOUT_MS: u64 = 50;
-
-pub async fn execute(iii: III, payload: Value) -> Result<Value, IIIError> {
+pub async fn execute(
+    iii: Arc<III>,
+    cfg: Arc<WorkerConfig>,
+    payload: Value,
+) -> Result<Value, IIIError> {
     let topic = payload
         .get("topic")
         .and_then(Value::as_str)
@@ -30,7 +33,10 @@ pub async fn execute(iii: III, payload: Value) -> Result<Value, IIIError> {
     let timeout_ms = payload
         .get("timeout_ms")
         .and_then(Value::as_u64)
-        .unwrap_or(10_000);
+        .unwrap_or(cfg.default_timeout_ms);
+
+    let min_timeout = cfg.min_timeout_ms;
+    let poll_interval = Duration::from_millis(cfg.poll_interval_ms);
 
     let event_id = Uuid::new_v4().to_string();
     let envelope = build_publish_envelope(&topic, &event_id, inner.clone());
@@ -43,10 +49,10 @@ pub async fn execute(iii: III, payload: Value) -> Result<Value, IIIError> {
         })
         .await
     {
-        tracing::warn!(error = %e, %topic, "hooks::publish_collect: publish trigger failed");
+        tracing::warn!(error = %e, %topic, "hook-fanout::publish_collect: publish trigger failed");
     }
 
-    let deadline = Instant::now() + Duration::from_millis(timeout_ms.max(MIN_TIMEOUT_MS));
+    let deadline = Instant::now() + Duration::from_millis(timeout_ms.max(min_timeout));
     let mut replies: Vec<Value> = Vec::new();
     let mut last_index: usize = 0;
     loop {
@@ -64,7 +70,7 @@ pub async fn execute(iii: III, payload: Value) -> Result<Value, IIIError> {
         if Instant::now() >= deadline {
             break;
         }
-        tokio::time::sleep(Duration::from_millis(POLL_INTERVAL_MS)).await;
+        tokio::time::sleep(poll_interval).await;
     }
 
     let merged = match merge_rule {
@@ -80,8 +86,9 @@ pub async fn execute(iii: III, payload: Value) -> Result<Value, IIIError> {
     }))
 }
 
-pub fn register(iii: &III) {
+pub fn register(iii: &Arc<III>, config: &Arc<WorkerConfig>) {
     let iii_for_handler = iii.clone();
+    let cfg = config.clone();
     iii.register_function((
         RegisterFunctionMessage::with_id(FUNCTION_ID.to_string()).with_description(
             "Publish a topic, collect subscriber replies until timeout, apply merge_rule."
@@ -89,7 +96,8 @@ pub fn register(iii: &III) {
         ),
         move |payload: Value| {
             let iii = iii_for_handler.clone();
-            async move { execute(iii, payload).await }
+            let cfg = cfg.clone();
+            async move { execute(iii, cfg, payload).await }
         },
     ));
 }
@@ -110,6 +118,8 @@ fn collect_stream_items(value: &Value, collected: &mut Vec<Value>, last_index: &
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::*;
 
     #[test]

--- a/hook-fanout/src/handler.rs
+++ b/hook-fanout/src/handler.rs
@@ -42,7 +42,7 @@ pub async fn execute(
     let envelope = build_publish_envelope(&topic, &event_id, inner.clone());
     if let Err(e) = iii
         .trigger(TriggerRequest {
-            function_id: "publish".into(),
+            function_id: "iii::durable::publish".into(),
             payload: envelope,
             action: None,
             timeout_ms: None,

--- a/hook-fanout/src/lib.rs
+++ b/hook-fanout/src/lib.rs
@@ -1,9 +1,13 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+pub mod config;
 pub mod handler;
+pub mod manifest;
 
-pub const FUNCTION_ID: &str = "hooks::publish_collect";
+pub use manifest::build_manifest;
+
+pub const FUNCTION_ID: &str = "hook-fanout::publish_collect";
 pub const HOOK_REPLY_STREAM: &str = "agent::hook_reply";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -95,8 +99,11 @@ pub fn build_publish_envelope(topic: &str, event_id: &str, payload: Value) -> Va
     })
 }
 
-pub fn register_with_iii(iii: &iii_sdk::III) {
-    handler::register(iii);
+pub fn register_with_iii(
+    iii: &std::sync::Arc<iii_sdk::III>,
+    config: &std::sync::Arc<config::WorkerConfig>,
+) {
+    handler::register(iii, config);
 }
 
 fn decode_transform_messages(reply: &Value) -> Option<Value> {

--- a/hook-fanout/src/main.rs
+++ b/hook-fanout/src/main.rs
@@ -1,20 +1,75 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use iii_sdk::{register_worker, InitOptions};
+use clap::Parser;
+use hook_fanout::{config, register_with_iii, FUNCTION_ID};
+use iii_sdk::{register_worker, InitOptions, OtelConfig, WorkerMetadata};
 
-const DEFAULT_ENGINE_URL: &str = "ws://127.0.0.1:49134";
+#[derive(Parser, Debug)]
+#[command(
+    name = "hook-fanout",
+    about = "Publish-collect primitive for iii hook topics — fans events to subscribers and merges replies."
+)]
+struct Cli {
+    #[arg(long, default_value = "./config.yaml")]
+    config: String,
+
+    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    url: String,
+
+    #[arg(long)]
+    manifest: bool,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
 
-    let engine_url = std::env::var("III_URL").unwrap_or_else(|_| DEFAULT_ENGINE_URL.to_string());
-    let iii = Arc::new(register_worker(&engine_url, InitOptions::default()));
+    let cli = Cli::parse();
 
-    hook_fanout::register_with_iii(&iii);
-    log::info!("hook-fanout registered (hooks::publish_collect)");
+    if cli.manifest {
+        let m = hook_fanout::build_manifest();
+        println!("{}", serde_json::to_string_pretty(&m)?);
+        return Ok(());
+    }
 
-    tokio::signal::ctrl_c().await.ok();
+    let cfg = match config::load_config(&cli.config) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(error = %e, path = %cli.config, "failed to load config, using defaults");
+            config::WorkerConfig::default()
+        }
+    };
+    let cfg = Arc::new(cfg);
+
+    let iii = register_worker(
+        &cli.url,
+        InitOptions {
+            otel: Some(OtelConfig::default()),
+            metadata: Some(WorkerMetadata {
+                runtime: "rust".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                name: "hook-fanout".to_string(),
+                os: std::env::consts::OS.to_string(),
+                pid: Some(std::process::id()),
+                telemetry: None,
+                ..WorkerMetadata::default()
+            }),
+            ..InitOptions::default()
+        },
+    );
+    let iii = Arc::new(iii);
+
+    register_with_iii(&iii, &cfg);
+    tracing::info!(%FUNCTION_ID, "hook-fanout ready, waiting for invocations");
+
+    tokio::signal::ctrl_c().await?;
+    tracing::info!("hook-fanout shutting down");
+    iii.shutdown_async().await;
     Ok(())
 }

--- a/hook-fanout/src/manifest.rs
+++ b/hook-fanout/src/manifest.rs
@@ -1,0 +1,44 @@
+use serde::Serialize;
+
+use crate::config::WorkerConfig;
+
+#[derive(Serialize)]
+pub struct ModuleManifest {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub default_config: serde_json::Value,
+    pub supported_targets: Vec<String>,
+}
+
+pub fn build_manifest() -> ModuleManifest {
+    ModuleManifest {
+        name: env!("CARGO_PKG_NAME").to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        description: "Reusable publish-collect primitive — fans an event to subscribers and collects merged replies."
+            .to_string(),
+        default_config: serde_json::to_value(WorkerConfig::default())
+            .expect("WorkerConfig serializes to JSON"),
+        supported_targets: vec![env!("TARGET").to_string()],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_roundtrip_has_required_fields() {
+        let m = build_manifest();
+        let json = serde_json::to_string_pretty(&m).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["name"], env!("CARGO_PKG_NAME"));
+        assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+        assert!(parsed["description"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()));
+        assert!(parsed["default_config"].is_object());
+        assert!(!parsed["supported_targets"].as_array().unwrap().is_empty());
+    }
+}

--- a/hook-fanout/tests/integration.rs
+++ b/hook-fanout/tests/integration.rs
@@ -1,8 +1,8 @@
 //! Smoke tests that run without an iii engine connection.
 
 #[test]
-fn function_id_in_hooks_namespace() {
-    assert_eq!(hook_fanout::FUNCTION_ID, "hooks::publish_collect");
+fn function_id_uses_worker_namespace() {
+    assert_eq!(hook_fanout::FUNCTION_ID, "hook-fanout::publish_collect");
 }
 
 #[test]

--- a/hook-fanout/tests/manifest.rs
+++ b/hook-fanout/tests/manifest.rs
@@ -1,0 +1,38 @@
+use std::process::Command;
+
+use serde_json::Value;
+
+fn binary_path() -> String {
+    #[allow(clippy::option_env_unwrap)]
+    if let Some(path) = option_env!("CARGO_BIN_EXE_hook_fanout") {
+        return path.to_string();
+    }
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    format!("{manifest_dir}/target/debug/hook-fanout")
+}
+
+#[test]
+fn manifest_subcommand_emits_valid_json() {
+    let output = Command::new(binary_path())
+        .arg("--manifest")
+        .output()
+        .expect("spawn hook-fanout --manifest");
+
+    assert!(
+        output.status.success(),
+        "binary exited with {:?}; stderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("manifest stdout is utf-8");
+    let manifest: Value = serde_json::from_str(&stdout).expect("manifest stdout is valid JSON");
+
+    assert_eq!(manifest["name"], env!("CARGO_PKG_NAME"));
+    assert_eq!(manifest["version"], env!("CARGO_PKG_VERSION"));
+    assert!(manifest["default_config"].is_object());
+    assert!(!manifest["supported_targets"]
+        .as_array()
+        .expect("supported_targets must be an array")
+        .is_empty());
+}

--- a/llm-budget/Cargo.lock
+++ b/llm-budget/Cargo.lock
@@ -169,6 +169,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,29 +299,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
 
 [[package]]
 name = "equivalent"
@@ -736,22 +753,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-llm-budget"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "chrono",
- "env_logger",
- "iii-sdk",
- "log",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "uuid",
-]
-
-[[package]]
 name = "iii-sdk"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,30 +828,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jiff"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +838,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -881,12 +864,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+name = "llm-budget"
+version = "0.1.0"
 dependencies = [
- "scopeguard",
+ "anyhow",
+ "chrono",
+ "clap",
+ "iii-sdk",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -900,6 +891,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -925,6 +925,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1035,29 +1044,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,21 +1074,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -1294,27 +1265,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,12 +1432,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,6 +1527,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,6 +1548,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1636,6 +1602,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1709,6 +1681,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,7 +1723,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -1926,6 +1906,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1978,6 +1988,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,6 +2040,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/llm-budget/Cargo.toml
+++ b/llm-budget/Cargo.toml
@@ -1,5 +1,7 @@
+[workspace]
+
 [package]
-name = "iii-llm-budget"
+name = "llm-budget"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
@@ -12,20 +14,24 @@ name = "llm_budget"
 path = "src/lib.rs"
 
 [[bin]]
-name = "iii-llm-budget"
+name = "llm-budget"
 path = "src/main.rs"
 
 [dependencies]
 iii-sdk = "=0.11.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["full"] }
+serde_yaml = "0.9"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 anyhow = "1"
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+clap = { version = "4", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
-log = "0.4"
-env_logger = "0.11"
+
+[dev-dependencies]
+serde_json = "1"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/llm-budget/README.md
+++ b/llm-budget/README.md
@@ -1,35 +1,57 @@
 # llm-budget
 
-Workspace + agent LLM spend caps on the iii bus. Registers `budget::*` for
-budget CRUD, alerts, forecast, and period rollover.
+Workspace + agent LLM spend caps on the iii bus: `budget::*` functions for budget CRUD, spend checks/recording, alerts, usage rollups, forecast, enforcement, exemptions, and pause/resume — with optional companion skills nested under `llm-budget/*`.
 
-## Installation
+## Install
 
 ```bash
 iii worker add llm-budget
 ```
 
-## Run
+`iii worker add` fetches the binary, writes a config block into `~/.iii/config.yaml`, and the engine starts the worker on the next `iii start`.
 
-```bash
-iii-llm-budget --engine-url ws://127.0.0.1:49134
+## Quickstart
+
+Register `budget::*` through the iii SDK:
+
+```rust
+use iii_sdk::{register_worker, InitOptions, TriggerRequest};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+
+    let result = iii
+        .trigger(TriggerRequest {
+            function_id: "budget::create".into(),
+            payload: json!({
+                "workspace_id": "ws-demo",
+                "name": "default",
+                "ceiling_usd": 500.0,
+                "period": "month",
+            }),
+            action: None,
+            timeout_ms: Some(5000),
+        })
+        .await?;
+
+    println!("{result:#?}");
+    Ok(())
+}
 ```
 
-State is persisted via iii state — survives restart when paired with a
-durable iii engine backend.
+Further calls use the returned `budget_id` with `"budget_id": "<uuid>"`, e.g. `budget::check`, `budget::record`, `budget::usage`. Exact payloads match the bundled skills under `/skills/` in this crate.
 
-## Registered functions (14)
+## Configuration
 
-`budget::create`, `budget::list`, `budget::get`, `budget::update`,
-`budget::delete`, `budget::check`, `budget::record`, `budget::reset`,
-`budget::alert_set`, `budget::usage`, `budget::forecast`, `budget::enforce`,
-`budget::exempt`, `budget::pause`.
+Committed defaults are loaded with `--config ./config.yaml` (the binary default):
 
-Function ids match `src/register.rs:18-33`; verify there before editing
-this list.
-
-## Build
-
-```bash
-cargo build --release
+```yaml
+skills_trigger_timeout_ms: 5000           # iii trigger timeout when registering skills::* 
+skills_handshake_deadline_secs: 180       # retry skills::register until this deadline
 ```
+
+Additional keys live in [`src/config.rs`](src/config.rs).
+
+State is persisted via built-in iii `state::*` helpers (scope `budgets`); survives restarts when the engine backend is durable.

--- a/llm-budget/build.rs
+++ b/llm-budget/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+}

--- a/llm-budget/config.yaml
+++ b/llm-budget/config.yaml
@@ -1,0 +1,5 @@
+# Skill registration trigger timeout when calling skills::register (milliseconds).
+skills_trigger_timeout_ms: 5000
+
+# Give up retrying skill registration after this many seconds (engine may be slow starting).
+skills_handshake_deadline_secs: 180

--- a/llm-budget/iii.worker.yaml
+++ b/llm-budget/iii.worker.yaml
@@ -3,5 +3,5 @@ name: llm-budget
 language: rust
 deploy: binary
 manifest: Cargo.toml
-bin: iii-llm-budget
+bin: llm-budget
 description: Workspace + agent LLM spend caps with alerts, forecast, and period rollover under budget::*.

--- a/llm-budget/src/config.rs
+++ b/llm-budget/src/config.rs
@@ -1,0 +1,62 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct WorkerConfig {
+    #[serde(default = "default_skills_trigger_timeout_ms")]
+    pub skills_trigger_timeout_ms: u64,
+    #[serde(default = "default_skills_handshake_deadline_secs")]
+    pub skills_handshake_deadline_secs: u64,
+}
+
+fn default_skills_trigger_timeout_ms() -> u64 {
+    5000
+}
+
+fn default_skills_handshake_deadline_secs() -> u64 {
+    180
+}
+
+impl Default for WorkerConfig {
+    fn default() -> Self {
+        Self {
+            skills_trigger_timeout_ms: default_skills_trigger_timeout_ms(),
+            skills_handshake_deadline_secs: default_skills_handshake_deadline_secs(),
+        }
+    }
+}
+
+pub fn load_config(path: &str) -> Result<WorkerConfig> {
+    let contents = std::fs::read_to_string(path)?;
+    let cfg: WorkerConfig = serde_yaml::from_str(&contents)?;
+    Ok(cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_from_empty_yaml() {
+        let cfg: WorkerConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(cfg.skills_trigger_timeout_ms, 5000);
+        assert_eq!(cfg.skills_handshake_deadline_secs, 180);
+    }
+
+    #[test]
+    fn custom_yaml_overrides() {
+        let y = "
+skills_trigger_timeout_ms: 3000
+skills_handshake_deadline_secs: 60
+";
+        let cfg: WorkerConfig = serde_yaml::from_str(y).unwrap();
+        assert_eq!(cfg.skills_trigger_timeout_ms, 3000);
+        assert_eq!(cfg.skills_handshake_deadline_secs, 60);
+    }
+
+    #[test]
+    fn impl_default_matches_yaml_defaults() {
+        let yaml: WorkerConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(yaml, WorkerConfig::default());
+    }
+}

--- a/llm-budget/src/lib.rs
+++ b/llm-budget/src/lib.rs
@@ -6,6 +6,9 @@
 pub const SKILL_ID: &str = "llm-budget";
 pub const SKILL_MD: &str = include_str!("../skill.md");
 
+pub mod config;
+pub mod manifest;
+
 pub const SUB_SKILLS: &[(&str, &str)] = &[
     ("llm-budget/create", include_str!("../skills/create.md")),
     ("llm-budget/list", include_str!("../skills/list.md")),

--- a/llm-budget/src/main.rs
+++ b/llm-budget/src/main.rs
@@ -2,32 +2,93 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
-use iii_sdk::{register_worker, InitOptions, TriggerRequest};
+use clap::Parser;
+use iii_sdk::{register_worker, InitOptions, OtelConfig, TriggerRequest, WorkerMetadata};
 use serde_json::json;
 
-const DEFAULT_ENGINE_URL: &str = "ws://127.0.0.1:49134";
+#[derive(Parser, Debug)]
+#[command(
+    name = "llm-budget",
+    about = "LLM spend budgets on the iii bus (budget::* + skills)."
+)]
+struct Cli {
+    #[arg(long, default_value = "./config.yaml")]
+    config: String,
+
+    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    url: String,
+
+    #[arg(long)]
+    manifest: bool,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
 
-    let engine_url = std::env::var("III_URL").unwrap_or_else(|_| DEFAULT_ENGINE_URL.to_string());
-    let iii = Arc::new(register_worker(&engine_url, InitOptions::default()));
+    let cli = Cli::parse();
+
+    if cli.manifest {
+        let m = llm_budget::manifest::build_manifest();
+        println!("{}", serde_json::to_string_pretty(&m)?);
+        return Ok(());
+    }
+
+    let cfg = match llm_budget::config::load_config(&cli.config) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(error = %e, path = %cli.config, "failed to load config, using defaults");
+            llm_budget::config::WorkerConfig::default()
+        }
+    };
+    let cfg = Arc::new(cfg);
+
+    let iii = register_worker(
+        &cli.url,
+        InitOptions {
+            otel: Some(OtelConfig::default()),
+            metadata: Some(WorkerMetadata {
+                runtime: "rust".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                name: "llm-budget".to_string(),
+                os: std::env::consts::OS.to_string(),
+                pid: Some(std::process::id()),
+                telemetry: None,
+                ..WorkerMetadata::default()
+            }),
+            ..InitOptions::default()
+        },
+    );
+    let iii = Arc::new(iii);
 
     let _refs = llm_budget::register_with_iii(&iii)
         .await
         .context("llm-budget register failed")?;
-    log::info!("llm-budget registered (budget::*)");
+    tracing::info!("llm-budget registered (budget::*)");
 
-    spawn_skill_register(iii.clone());
+    spawn_skill_register(iii.clone(), cfg.clone());
 
     wait_for_shutdown().await?;
 
     unregister_skill(&iii).await;
+
+    iii.shutdown_async().await;
+
     Ok(())
 }
 
-async fn register_skill_with_retry(iii: &iii_sdk::III, id: &str, body: &str) {
+async fn register_skill_with_retry(
+    iii: &iii_sdk::III,
+    id: &str,
+    body: &str,
+    trigger_timeout_ms: u64,
+    handshake_deadline: Duration,
+) {
     let mut backoff = Duration::from_secs(5);
     let started = Instant::now();
     loop {
@@ -36,34 +97,44 @@ async fn register_skill_with_retry(iii: &iii_sdk::III, id: &str, body: &str) {
                 function_id: "skills::register".into(),
                 payload: json!({ "id": id, "skill": body }),
                 action: None,
-                timeout_ms: Some(5_000),
+                timeout_ms: Some(trigger_timeout_ms),
             })
             .await;
         match res {
             Ok(_) => {
-                log::info!("registered skill: {id}");
+                tracing::info!("registered skill: {id}");
                 return;
             }
             Err(e) => {
-                if started.elapsed() > Duration::from_mins(3) {
-                    log::warn!(
+                if started.elapsed() > handshake_deadline {
+                    tracing::warn!(
                         "skills handshake gave up for {id}; install/start the skills worker and restart (last error: {e})"
                     );
                     return;
                 }
-                log::debug!("skills::register failed for {id}: {e}; retrying in {backoff:?}");
+                tracing::debug!("skills::register failed for {id}: {e}; retrying in {backoff:?}");
             }
         }
         tokio::time::sleep(backoff).await;
-        backoff = (backoff * 2).min(Duration::from_mins(1));
+        backoff = (backoff * 2).min(Duration::from_secs(60));
     }
 }
 
-fn spawn_skill_register(iii: Arc<iii_sdk::III>) {
+fn spawn_skill_register(iii: Arc<iii_sdk::III>, cfg: Arc<llm_budget::config::WorkerConfig>) {
+    let trigger_ms = cfg.skills_trigger_timeout_ms;
+    let deadline = Duration::from_secs(cfg.skills_handshake_deadline_secs);
+
     tokio::spawn(async move {
-        register_skill_with_retry(&iii, llm_budget::SKILL_ID, llm_budget::SKILL_MD).await;
+        register_skill_with_retry(
+            &iii,
+            llm_budget::SKILL_ID,
+            llm_budget::SKILL_MD,
+            trigger_ms,
+            deadline,
+        )
+        .await;
         for (id, body) in llm_budget::SUB_SKILLS {
-            register_skill_with_retry(&iii, id, body).await;
+            register_skill_with_retry(&iii, id, body, trigger_ms, deadline).await;
         }
     });
 }
@@ -97,7 +168,7 @@ async fn unregister_skill(iii: &Arc<iii_sdk::III>) {
                 function_id: "skills::unregister".into(),
                 payload: json!({ "id": id }),
                 action: None,
-                timeout_ms: Some(2_000),
+                timeout_ms: Some(2000),
             })
             .await;
     }
@@ -106,7 +177,7 @@ async fn unregister_skill(iii: &Arc<iii_sdk::III>) {
             function_id: "skills::unregister".into(),
             payload: json!({ "id": llm_budget::SKILL_ID }),
             action: None,
-            timeout_ms: Some(2_000),
+            timeout_ms: Some(2000),
         })
         .await;
 }

--- a/llm-budget/src/main.rs
+++ b/llm-budget/src/main.rs
@@ -116,7 +116,7 @@ async fn register_skill_with_retry(
             }
         }
         tokio::time::sleep(backoff).await;
-        backoff = (backoff * 2).min(Duration::from_secs(60));
+        backoff = (backoff * 2).min(Duration::from_mins(1));
     }
 }
 

--- a/llm-budget/src/manifest.rs
+++ b/llm-budget/src/manifest.rs
@@ -1,0 +1,43 @@
+use serde::Serialize;
+
+use crate::config::WorkerConfig;
+
+#[derive(Serialize)]
+pub struct ModuleManifest {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub default_config: serde_json::Value,
+    pub supported_targets: Vec<String>,
+}
+
+pub fn build_manifest() -> ModuleManifest {
+    ModuleManifest {
+        name: env!("CARGO_PKG_NAME").to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        description: "Workspace + agent LLM spend caps with alerts, forecast, and period rollover under budget::*."
+            .to_string(),
+        default_config: serde_json::to_value(WorkerConfig::default()).expect("WorkerConfig serializes to JSON"),
+        supported_targets: vec![env!("TARGET").to_string()],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_roundtrip_has_required_fields() {
+        let m = build_manifest();
+        let json = serde_json::to_string_pretty(&m).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["name"], env!("CARGO_PKG_NAME"));
+        assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+        assert!(parsed["description"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()));
+        assert!(parsed["default_config"].is_object());
+        assert!(!parsed["supported_targets"].as_array().unwrap().is_empty());
+    }
+}

--- a/llm-budget/tests/manifest.rs
+++ b/llm-budget/tests/manifest.rs
@@ -1,0 +1,37 @@
+//! `--manifest` JSON contract for registry publish.
+
+use std::process::Command;
+
+use serde_json::Value;
+
+#[test]
+fn manifest_subcommand_emits_valid_json() {
+    let bin = std::env::var_os("CARGO_BIN_EXE_llm-budget").expect(
+        "`cargo test` should set `CARGO_BIN_EXE_<bin>` where `<bin>` is the executable name (`llm-budget`)",
+    );
+    let output = Command::new(bin)
+        .arg("--manifest")
+        .output()
+        .expect("spawn llm-budget --manifest");
+
+    assert!(
+        output.status.success(),
+        "binary exited with {:?}; stderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("manifest stdout is utf-8");
+    let manifest: Value = serde_json::from_str(&stdout).expect("manifest stdout is valid JSON");
+
+    assert_eq!(manifest["name"], env!("CARGO_PKG_NAME"));
+    assert_eq!(manifest["version"], env!("CARGO_PKG_VERSION"));
+    assert!(manifest["description"]
+        .as_str()
+        .is_some_and(|s| !s.is_empty()));
+    assert!(manifest["default_config"].is_object());
+    assert!(!manifest["supported_targets"]
+        .as_array()
+        .expect("supported_targets must be an array")
+        .is_empty(),);
+}

--- a/models-catalog/Cargo.lock
+++ b/models-catalog/Cargo.lock
@@ -146,6 +146,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,29 +276,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
 
 [[package]]
 name = "equivalent"
@@ -693,13 +710,15 @@ name = "iii-models-catalog"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "env_logger",
+ "clap",
  "iii-sdk",
- "log",
  "once_cell",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -778,30 +797,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jiff"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +807,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -832,15 +833,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +843,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -876,6 +877,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -986,29 +996,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,21 +1026,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -1245,27 +1217,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,12 +1384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,6 +1479,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,6 +1500,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1587,6 +1554,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1660,6 +1633,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,7 +1675,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -1877,6 +1858,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1929,6 +1940,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,6 +1992,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/models-catalog/Cargo.toml
+++ b/models-catalog/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "iii-models-catalog"
 version = "0.1.0"
@@ -19,11 +21,16 @@ path = "src/main.rs"
 iii-sdk = "=0.11.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["full"] }
+serde_yaml = "0.9"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 anyhow = "1"
 once_cell = "1"
-log = "0.4"
-env_logger = "0.11"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+clap = { version = "4", features = ["derive", "env"] }
+
+[dev-dependencies]
+serde_json = "1"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/models-catalog/README.md
+++ b/models-catalog/README.md
@@ -1,33 +1,55 @@
 # models-catalog
 
-Model capabilities knowledge base on the iii bus. The bus is the source of
-truth: models live under `models:<provider>:<id>` in scope `models`. The
-embedded `data/models.json` is used only as a one-time seed when state is
-empty; subsequent registrations win.
+Model capabilities knowledge base on the iii bus. Models live under
+`models:<provider>:<id>` in scope `models`; the embedded `data/models.json` seeds
+state once when empty. Callers use `models::list`, `models::get`,
+`models::supports`, and `models::register`.
 
-## Installation
+## Install
 
 ```bash
 iii worker add models-catalog
 ```
 
-## Run
+`iii worker add` fetches the binary, writes a config block into
+`~/.iii/config.yaml`, and the engine starts the worker on the next
+`iii start`.
 
-```bash
-iii-models-catalog --engine-url ws://127.0.0.1:49134
+## Quickstart
+
+```rust
+use iii_sdk::{register_worker, InitOptions, TriggerRequest};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+
+    let result = iii
+        .trigger(TriggerRequest {
+            function_id: "models::list".into(),
+            payload: json!({}),
+            action: None,
+            timeout_ms: Some(5_000),
+        })
+        .await?;
+
+    println!("{result:#?}");
+    Ok(())
+}
 ```
 
-## Registered functions
+`models::get` takes `{ "provider": "…", "model_id": "…" }`. `models::supports`
+takes `{ "provider", "model_id", "capability" }` (e.g. `"tools"`,
+`"thinking:xhigh"`). `models::register` accepts a full model object.
 
-| Function | Description |
-|---|---|
-| `models::list` | Read all known models from state. |
-| `models::get` | Read a model by `provider` + `id`. |
-| `models::supports` | Capability lookup (transport, thinking, cache retention). |
-| `models::register` | Write a model entry to state. |
+## Configuration
 
-## Build
-
-```bash
-cargo build --release
+```yaml
+engine_url: "ws://127.0.0.1:49134" # overridden by CLI --url or env III_URL when set
+state_request_timeout_ms: 5000 # state:: / internal bus triggers
+skills_register_timeout_ms: 5000
+skills_unregister_timeout_ms: 2000
 ```
+
+Other defaults and parsing live in [`src/config.rs`](src/config.rs).

--- a/models-catalog/build.rs
+++ b/models-catalog/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+}

--- a/models-catalog/src/config.rs
+++ b/models-catalog/src/config.rs
@@ -1,0 +1,90 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct ModelsCatalogConfig {
+    #[serde(default = "default_engine_url")]
+    pub engine_url: String,
+
+    #[serde(default = "default_state_request_timeout_ms")]
+    pub state_request_timeout_ms: u64,
+
+    #[serde(default = "default_skills_register_timeout_ms")]
+    pub skills_register_timeout_ms: u64,
+
+    #[serde(default = "default_skills_unregister_timeout_ms")]
+    pub skills_unregister_timeout_ms: u64,
+}
+
+fn default_engine_url() -> String {
+    "ws://127.0.0.1:49134".to_string()
+}
+
+fn default_state_request_timeout_ms() -> u64 {
+    5_000
+}
+
+fn default_skills_register_timeout_ms() -> u64 {
+    5_000
+}
+
+fn default_skills_unregister_timeout_ms() -> u64 {
+    2_000
+}
+
+impl Default for ModelsCatalogConfig {
+    fn default() -> Self {
+        Self {
+            engine_url: default_engine_url(),
+            state_request_timeout_ms: default_state_request_timeout_ms(),
+            skills_register_timeout_ms: default_skills_register_timeout_ms(),
+            skills_unregister_timeout_ms: default_skills_unregister_timeout_ms(),
+        }
+    }
+}
+
+pub fn load_config(path: &str) -> Result<ModelsCatalogConfig> {
+    let contents =
+        std::fs::read_to_string(path).with_context(|| format!("read config file {path}"))?;
+    let cfg: ModelsCatalogConfig = serde_yaml::from_str(&contents).context("parse config YAML")?;
+    Ok(cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_from_empty_yaml() {
+        let cfg: ModelsCatalogConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(cfg.engine_url, "ws://127.0.0.1:49134");
+        assert_eq!(cfg.state_request_timeout_ms, 5_000);
+        assert_eq!(cfg.skills_register_timeout_ms, 5_000);
+        assert_eq!(cfg.skills_unregister_timeout_ms, 2_000);
+    }
+
+    #[test]
+    fn custom_yaml_overrides() {
+        let yaml = r"
+engine_url: ws://example:49134
+state_request_timeout_ms: 3000
+";
+        let cfg: ModelsCatalogConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.engine_url, "ws://example:49134");
+        assert_eq!(cfg.state_request_timeout_ms, 3_000);
+        assert_eq!(cfg.skills_register_timeout_ms, 5_000);
+    }
+
+    #[test]
+    fn impl_default_matches_yaml_defaults() {
+        let a = ModelsCatalogConfig::default();
+        let b: ModelsCatalogConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(a.engine_url, b.engine_url);
+        assert_eq!(a.state_request_timeout_ms, b.state_request_timeout_ms);
+        assert_eq!(a.skills_register_timeout_ms, b.skills_register_timeout_ms);
+        assert_eq!(
+            a.skills_unregister_timeout_ms,
+            b.skills_unregister_timeout_ms
+        );
+    }
+}

--- a/models-catalog/src/lib.rs
+++ b/models-catalog/src/lib.rs
@@ -17,6 +17,10 @@
 //! callers that can't await a bus round-trip; they're documented as
 //! best-effort fallbacks.
 
+pub mod config;
+
+use std::sync::Arc;
+
 pub const SKILL_ID: &str = "models-catalog";
 pub const SKILL_MD: &str = include_str!("../skill.md");
 
@@ -209,18 +213,23 @@ fn supports_model(m: &Model, capability: Capability) -> bool {
 /// `models:` prefix is empty. Existing setups keep zero-config; new
 /// deployments can clear state and register their own catalog from
 /// scratch.
-pub async fn register_with_iii(iii: &iii_sdk::III) -> anyhow::Result<ModelsFunctionRefs> {
+pub async fn register_with_iii(
+    iii: &iii_sdk::III,
+    cfg: &Arc<config::ModelsCatalogConfig>,
+) -> anyhow::Result<ModelsFunctionRefs> {
     use iii_sdk::{IIIError, RegisterFunctionMessage};
     use serde_json::{json, Value};
 
-    let _ = seed_state_if_empty(iii).await;
+    let _ = seed_state_if_empty(iii, cfg).await;
 
+    let cfg_list = Arc::clone(cfg);
     let iii_for_list = iii.clone();
     let list_fn = iii.register_function((
         RegisterFunctionMessage::with_id("models::list".to_string())
             .with_description("List models, optionally filtered by provider or capability. Reads from iii state; falls back to the embedded seed when state is empty.".into()),
         move |payload: Value| {
             let iii = iii_for_list.clone();
+            let cfg = cfg_list.clone();
             async move {
                 let provider = payload
                     .get("provider")
@@ -234,13 +243,14 @@ pub async fn register_with_iii(iii: &iii_sdk::III) -> anyhow::Result<ModelsFunct
                     provider,
                     capability,
                 };
-                let models = list_from_state_or_seed(&iii, &filter).await;
+                let models = list_from_state_or_seed(&iii, &cfg, &filter).await;
                 serde_json::to_value(json!({ "models": models }))
                     .map_err(|e| IIIError::Handler(e.to_string()))
             }
         },
     ));
 
+    let cfg_get = Arc::clone(cfg);
     let iii_for_get = iii.clone();
     let get_fn = iii.register_function((
         RegisterFunctionMessage::with_id("models::get".to_string()).with_description(
@@ -248,6 +258,7 @@ pub async fn register_with_iii(iii: &iii_sdk::III) -> anyhow::Result<ModelsFunct
         ),
         move |payload: Value| {
             let iii = iii_for_get.clone();
+            let cfg = cfg_get.clone();
             async move {
                 let provider = payload
                     .get("provider")
@@ -259,18 +270,20 @@ pub async fn register_with_iii(iii: &iii_sdk::III) -> anyhow::Result<ModelsFunct
                     .and_then(Value::as_str)
                     .ok_or_else(|| IIIError::Handler("missing required field: model_id".into()))?
                     .to_string();
-                let model = get_from_state_or_seed(&iii, &provider, &model_id).await;
+                let model = get_from_state_or_seed(&iii, &cfg, &provider, &model_id).await;
                 serde_json::to_value(model).map_err(|e| IIIError::Handler(e.to_string()))
             }
         },
     ));
 
+    let cfg_supports = Arc::clone(cfg);
     let iii_for_supports = iii.clone();
     let supports_fn = iii.register_function((
         RegisterFunctionMessage::with_id("models::supports".to_string())
             .with_description("Check whether a model supports a capability. State-first.".into()),
         move |payload: Value| {
             let iii = iii_for_supports.clone();
+            let cfg = cfg_supports.clone();
             async move {
                 let provider = payload
                     .get("provider")
@@ -287,7 +300,7 @@ pub async fn register_with_iii(iii: &iii_sdk::III) -> anyhow::Result<ModelsFunct
                     .and_then(Value::as_str)
                     .and_then(parse_capability)
                     .ok_or_else(|| IIIError::Handler("missing or unknown capability".into()))?;
-                let supported = get_from_state_or_seed(&iii, &provider, &model_id)
+                let supported = get_from_state_or_seed(&iii, &cfg, &provider, &model_id)
                     .await
                     .is_some_and(|m| supports_model(&m, capability));
                 Ok(json!({ "supported": supported }))
@@ -295,18 +308,21 @@ pub async fn register_with_iii(iii: &iii_sdk::III) -> anyhow::Result<ModelsFunct
         },
     ));
 
+    let cfg_register = Arc::clone(cfg);
     let iii_for_register = iii.clone();
     let register_fn = iii.register_function((
         RegisterFunctionMessage::with_id("models::register".to_string())
             .with_description("Write a model to iii state under models:<provider>:<id>.".into()),
         move |payload: Value| {
             let iii = iii_for_register.clone();
+            let cfg = cfg_register.clone();
             async move {
                 let model: Model = serde_json::from_value(payload.clone())
                     .map_err(|e| IIIError::Handler(format!("invalid Model payload: {e}")))?;
                 let key = format!("{MODELS_KEY_PREFIX}{}:{}", model.provider, model.id);
                 state_set(
                     &iii,
+                    &cfg,
                     &key,
                     &serde_json::to_value(&model).unwrap_or(Value::Null),
                 )
@@ -328,7 +344,10 @@ pub async fn register_with_iii(iii: &iii_sdk::III) -> anyhow::Result<ModelsFunct
 /// Seed the embedded baseline into iii state under `models:` if no
 /// `models:` keys exist yet. Idempotent and best-effort: a transient bus
 /// error or already-seeded state both leave the function silent.
-async fn seed_state_if_empty(iii: &iii_sdk::III) -> anyhow::Result<()> {
+async fn seed_state_if_empty(
+    iii: &iii_sdk::III,
+    cfg: &Arc<config::ModelsCatalogConfig>,
+) -> anyhow::Result<()> {
     use serde_json::Value;
     let existing = iii
         .trigger(iii_sdk::TriggerRequest {
@@ -338,7 +357,7 @@ async fn seed_state_if_empty(iii: &iii_sdk::III) -> anyhow::Result<()> {
                 "prefix": MODELS_KEY_PREFIX,
             }),
             action: None,
-            timeout_ms: Some(5_000),
+            timeout_ms: Some(cfg.state_request_timeout_ms),
         })
         .await
         .ok();
@@ -355,13 +374,20 @@ async fn seed_state_if_empty(iii: &iii_sdk::III) -> anyhow::Result<()> {
     }
     for m in CATALOG.iter() {
         let key = format!("{MODELS_KEY_PREFIX}{}:{}", m.provider, m.id);
-        let _ = state_set(iii, &key, &serde_json::to_value(m).unwrap_or(Value::Null)).await;
+        let _ = state_set(
+            iii,
+            cfg,
+            &key,
+            &serde_json::to_value(m).unwrap_or(Value::Null),
+        )
+        .await;
     }
     Ok(())
 }
 
 async fn state_set(
     iii: &iii_sdk::III,
+    cfg: &Arc<config::ModelsCatalogConfig>,
     key: &str,
     value: &serde_json::Value,
 ) -> Result<(), iii_sdk::IIIError> {
@@ -373,13 +399,17 @@ async fn state_set(
             "value": value,
         }),
         action: None,
-        timeout_ms: Some(5_000),
+        timeout_ms: Some(cfg.state_request_timeout_ms),
     })
     .await
     .map(|_| ())
 }
 
-async fn list_from_state_or_seed(iii: &iii_sdk::III, filter: &ListFilter) -> Vec<Model> {
+async fn list_from_state_or_seed(
+    iii: &iii_sdk::III,
+    cfg: &Arc<config::ModelsCatalogConfig>,
+    filter: &ListFilter,
+) -> Vec<Model> {
     use serde_json::Value;
     let resp = iii
         .trigger(iii_sdk::TriggerRequest {
@@ -389,7 +419,7 @@ async fn list_from_state_or_seed(iii: &iii_sdk::III, filter: &ListFilter) -> Vec
                 "prefix": MODELS_KEY_PREFIX,
             }),
             action: None,
-            timeout_ms: Some(5_000),
+            timeout_ms: Some(cfg.state_request_timeout_ms),
         })
         .await
         .ok();
@@ -420,6 +450,7 @@ async fn list_from_state_or_seed(iii: &iii_sdk::III, filter: &ListFilter) -> Vec
 
 async fn get_from_state_or_seed(
     iii: &iii_sdk::III,
+    cfg: &Arc<config::ModelsCatalogConfig>,
     provider: &str,
     model_id: &str,
 ) -> Option<Model> {
@@ -432,7 +463,7 @@ async fn get_from_state_or_seed(
                 "key": key,
             }),
             action: None,
-            timeout_ms: Some(5_000),
+            timeout_ms: Some(cfg.state_request_timeout_ms),
         })
         .await
         .ok();

--- a/models-catalog/src/main.rs
+++ b/models-catalog/src/main.rs
@@ -2,56 +2,125 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
-use iii_sdk::{register_worker, InitOptions, TriggerRequest};
-use serde_json::json;
+use clap::Parser;
+use iii_sdk::{register_worker, InitOptions, OtelConfig, TriggerRequest, WorkerMetadata};
 
-const DEFAULT_ENGINE_URL: &str = "ws://127.0.0.1:49134";
+mod manifest;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "iii-models-catalog",
+    about = "Model capabilities knowledge base (models::*) on the iii bus."
+)]
+struct Cli {
+    #[arg(
+        long,
+        env = "III_MODELS_CATALOG_CONFIG",
+        default_value = "./config.yaml"
+    )]
+    config: String,
+
+    /// Engine WebSocket URL. Falls back to `engine_url` in `--config` when unset.
+    #[arg(long, env = "III_URL")]
+    url: Option<String>,
+
+    #[arg(long)]
+    manifest: bool,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
 
-    let engine_url = std::env::var("III_URL").unwrap_or_else(|_| DEFAULT_ENGINE_URL.to_string());
-    let iii = Arc::new(register_worker(&engine_url, InitOptions::default()));
+    let cli = Cli::parse();
 
-    let _refs = models_catalog::register_with_iii(&iii)
+    if cli.manifest {
+        let m = manifest::build_manifest();
+        println!("{}", serde_json::to_string_pretty(&m)?);
+        return Ok(());
+    }
+
+    let cfg = match models_catalog::config::load_config(&cli.config) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(error = %e, path = %cli.config, "failed to load config, using defaults");
+            models_catalog::config::ModelsCatalogConfig::default()
+        }
+    };
+    let cfg = Arc::new(cfg);
+
+    let url = cli.url.clone().unwrap_or_else(|| cfg.engine_url.clone());
+
+    let iii = register_worker(
+        &url,
+        InitOptions {
+            otel: Some(OtelConfig::default()),
+            metadata: Some(WorkerMetadata {
+                runtime: "rust".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                name: "models-catalog".to_string(),
+                os: std::env::consts::OS.to_string(),
+                pid: Some(std::process::id()),
+                telemetry: None,
+                ..WorkerMetadata::default()
+            }),
+            ..InitOptions::default()
+        },
+    );
+    let iii = Arc::new(iii);
+
+    let _refs = models_catalog::register_with_iii(&iii, &cfg)
         .await
         .context("models-catalog register failed")?;
-    log::info!("models-catalog registered (models::*)");
+    tracing::info!("models-catalog registered (models::*)");
 
-    spawn_skill_register(iii.clone());
+    spawn_skill_register(iii.clone(), Arc::clone(&cfg));
 
     wait_for_shutdown().await?;
 
-    unregister_skill(&iii).await;
+    unregister_skill(&iii, &cfg).await;
+    tracing::info!("models-catalog shutting down");
+    iii.shutdown_async().await;
     Ok(())
 }
 
-async fn register_skill_with_retry(iii: &iii_sdk::III, id: &str, body: &str) {
+async fn register_skill_with_retry(
+    iii: &iii_sdk::III,
+    id: &str,
+    body: &str,
+    trigger_timeout_ms: u64,
+) {
     let mut backoff = Duration::from_secs(5);
     let started = Instant::now();
     loop {
         let res = iii
             .trigger(TriggerRequest {
                 function_id: "skills::register".into(),
-                payload: json!({ "id": id, "skill": body }),
+                payload: serde_json::json!({ "id": id, "skill": body }),
                 action: None,
-                timeout_ms: Some(5_000),
+                timeout_ms: Some(trigger_timeout_ms),
             })
             .await;
         match res {
             Ok(_) => {
-                log::info!("registered skill: {id}");
+                tracing::info!(id, "registered skill");
                 return;
             }
             Err(e) => {
                 if started.elapsed() > Duration::from_mins(3) {
-                    log::warn!(
-                        "skills handshake gave up for {id}; install/start the skills worker and restart (last error: {e})"
+                    tracing::warn!(
+                        id,
+                        error = %e,
+                        "skills handshake gave up; install/start the skills worker and restart"
                     );
                     return;
                 }
-                log::debug!("skills::register failed for {id}: {e}; retrying in {backoff:?}");
+                tracing::debug!(id, error = %e, ?backoff, "skills::register failed; retrying");
             }
         }
         tokio::time::sleep(backoff).await;
@@ -59,11 +128,21 @@ async fn register_skill_with_retry(iii: &iii_sdk::III, id: &str, body: &str) {
     }
 }
 
-fn spawn_skill_register(iii: Arc<iii_sdk::III>) {
+fn spawn_skill_register(
+    iii: Arc<iii_sdk::III>,
+    cfg: Arc<models_catalog::config::ModelsCatalogConfig>,
+) {
+    let timeout = cfg.skills_register_timeout_ms;
     tokio::spawn(async move {
-        register_skill_with_retry(&iii, models_catalog::SKILL_ID, models_catalog::SKILL_MD).await;
+        register_skill_with_retry(
+            &iii,
+            models_catalog::SKILL_ID,
+            models_catalog::SKILL_MD,
+            timeout,
+        )
+        .await;
         for (id, body) in models_catalog::SUB_SKILLS {
-            register_skill_with_retry(&iii, id, body).await;
+            register_skill_with_retry(&iii, id, body, timeout).await;
         }
     });
 }
@@ -90,23 +169,27 @@ async fn wait_for_shutdown() -> Result<()> {
 
 // Best-effort: a missed unregister is self-healing on next boot's re-register.
 // Leaves go first so the router is the last entry to disappear from iii://skills.
-async fn unregister_skill(iii: &Arc<iii_sdk::III>) {
+async fn unregister_skill(
+    iii: &Arc<iii_sdk::III>,
+    cfg: &Arc<models_catalog::config::ModelsCatalogConfig>,
+) {
+    let t = cfg.skills_unregister_timeout_ms;
     for (id, _) in models_catalog::SUB_SKILLS {
         let _ = iii
             .trigger(TriggerRequest {
                 function_id: "skills::unregister".into(),
-                payload: json!({ "id": id }),
+                payload: serde_json::json!({ "id": id }),
                 action: None,
-                timeout_ms: Some(2_000),
+                timeout_ms: Some(t),
             })
             .await;
     }
     let _ = iii
         .trigger(TriggerRequest {
             function_id: "skills::unregister".into(),
-            payload: json!({ "id": models_catalog::SKILL_ID }),
+            payload: serde_json::json!({ "id": models_catalog::SKILL_ID }),
             action: None,
-            timeout_ms: Some(2_000),
+            timeout_ms: Some(t),
         })
         .await;
 }

--- a/models-catalog/src/manifest.rs
+++ b/models-catalog/src/manifest.rs
@@ -1,0 +1,39 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct ModuleManifest {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub default_config: serde_json::Value,
+    pub supported_targets: Vec<String>,
+}
+
+pub fn build_manifest() -> ModuleManifest {
+    let default = models_catalog::config::ModelsCatalogConfig::default();
+    ModuleManifest {
+        name: env!("CARGO_PKG_NAME").to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        description:
+            "Model capabilities knowledge base under models::* (list/get/supports/register)."
+                .to_string(),
+        default_config: serde_json::to_value(&default).expect("config serializes to JSON"),
+        supported_targets: vec![env!("TARGET").to_string()],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_roundtrip_has_required_fields() {
+        let m = build_manifest();
+        let json = serde_json::to_string_pretty(&m).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["name"], env!("CARGO_PKG_NAME"));
+        assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+        assert!(parsed["default_config"].is_object());
+        assert!(!parsed["supported_targets"].as_array().unwrap().is_empty());
+    }
+}

--- a/models-catalog/tests/manifest.rs
+++ b/models-catalog/tests/manifest.rs
@@ -1,0 +1,47 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn models_catalog_executable() -> PathBuf {
+    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_iii_models_catalog") {
+        return PathBuf::from(p);
+    }
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    for profile in ["debug", "release"] {
+        let candidate = dir.join("target").join(profile).join("iii-models-catalog");
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+    panic!(
+        "iii-models-catalog binary not found under target/{{debug,release}}/; run `cargo build --bin iii-models-catalog` first"
+    );
+}
+
+#[test]
+fn manifest_subcommand_emits_valid_json() {
+    let bin = models_catalog_executable();
+    let output = Command::new(bin)
+        .arg("--manifest")
+        .output()
+        .expect("spawn iii-models-catalog --manifest");
+
+    assert!(
+        output.status.success(),
+        "binary exited with {:?}; stderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("manifest stdout is utf-8");
+    let manifest: Value = serde_json::from_str(&stdout).expect("manifest stdout is valid JSON");
+
+    assert_eq!(manifest["name"], env!("CARGO_PKG_NAME"));
+    assert_eq!(manifest["version"], env!("CARGO_PKG_VERSION"));
+    assert!(manifest["default_config"].is_object());
+    assert!(!manifest["supported_targets"]
+        .as_array()
+        .expect("supported_targets must be an array")
+        .is_empty());
+}

--- a/policy-denylist/Cargo.lock
+++ b/policy-denylist/Cargo.lock
@@ -146,6 +146,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,29 +276,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
 
 [[package]]
 name = "equivalent"
@@ -694,11 +711,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "env_logger",
+ "clap",
  "iii-sdk",
- "log",
+ "serde",
  "serde_json",
+ "serde_yaml",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -778,30 +798,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jiff"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +808,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -832,15 +834,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +844,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -876,6 +878,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -986,29 +997,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,21 +1027,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -1245,27 +1218,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,12 +1385,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,6 +1480,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,6 +1501,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1587,6 +1555,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1660,6 +1634,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,7 +1676,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -1877,6 +1859,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1929,6 +1941,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,6 +1993,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/policy-denylist/Cargo.toml
+++ b/policy-denylist/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "iii-policy-denylist"
 version = "0.1.0"
@@ -17,13 +19,19 @@ path = "src/main.rs"
 
 [dependencies]
 iii-sdk = "=0.11.3"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["full"] }
+serde_yaml = "0.9"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal"] }
 anyhow = "1"
 async-trait = "0.1"
 uuid = { version = "1", features = ["v4"] }
-log = "0.4"
-env_logger = "0.11"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+clap = { version = "4", features = ["derive", "env"] }
+
+[dev-dependencies]
+serde_json = "1"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/policy-denylist/README.md
+++ b/policy-denylist/README.md
@@ -1,33 +1,84 @@
 # policy-denylist
 
-Hook subscriber on `agent::before_tool_call` that blocks any call whose
-`tool_call.name` matches a configured denylist.
+Subscribes to `agent::before_tool_call` and blocks any tool call whose
+`tool_call.name` is on a configured denylist (exact string match, case-sensitive).
+The engine and other workers publish that hook topic so you get a second line of
+defense after client-side allowlists.
 
-## Installation
+## Install
 
 ```bash
 iii worker add policy-denylist
 ```
 
-## Run
+`iii worker add` fetches the binary, writes a config block into
+`~/.iii/config.yaml`, and the engine starts the worker on the next `iii start`.
 
-```bash
-POLICY_DENIED_TOOLS="bash:rm -rf,sudo" iii-policy-denylist
+## Quickstart
+
+This worker does not expose a separate HTTP tool surface: it registers
+`policy::denylist` and binds a `subscribe` trigger to the configured topic. From
+another process on the bus you only need the engine running and this worker
+started; hook traffic is driven by `provider-router` (or any publisher of
+`agent::before_tool_call`).
+
+```rust
+use iii_sdk::{register_worker, InitOptions, TriggerRequest};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+
+    let result = iii
+        .trigger(TriggerRequest {
+            function_id: "policy::denylist".into(),
+            payload: json!({}),
+            action: None,
+            timeout_ms: Some(5_000),
+        })
+        .await;
+
+    println!("{result:#?}");
+    Ok(())
+}
 ```
 
-When started by the engine, the worker reads its `config:` block from
-`--config <path>`. Defaults:
+In practice the function is invoked by the bus when a `before_tool_call` event
+arrives; the snippet above is only useful to verify registration in a dev setup.
+
+## Configuration
 
 ```yaml
-topic: agent::before_tool_call
-denied_tools:
+topic: agent::before_tool_call   # hook topic to subscribe to
+denied_tools:                    # tool names to block (exact match)
   - "bash:rm -rf"
   - sudo
   - curl-pipe-bash
 ```
 
-`POLICY_DENYLIST_TOPIC` and `POLICY_DENIED_TOOLS` override the config file for
-direct runtime overrides.
+If the engine wraps settings under a `config:` key, that nested block is
+accepted as well. Other keys (and their defaults) live in
+[`src/config.rs`](src/config.rs).
+
+`POLICY_DENYLIST_TOPIC` and `POLICY_DENIED_TOOLS` (comma-separated list, same
+semantics as before) override the file when set.
+
+## Workspace allowlist composition
+
+Chat clients (e.g. `iii-console`) layer a workspace allowlist on top of
+`policy-denylist`. The allowlist enforces:
+
+- Filesystem writes restricted to a configured workspace root.
+- Absolute paths outside the workspace are rejected by the SDK wrapper *before*
+  the bus call is dispatched.
+
+`policy-denylist` remains the second layer (deny by tool name regardless of
+arguments). The two layers compose:
+
+1. SDK wrapper (chat client side) — workspace allowlist on path arguments.
+2. `policy-denylist` (engine side) — deny by tool name (exact match, case-sensitive).
+3. `<ApprovalRow>` (chat UI) — per-call user approval surfaced inline before any write reaches disk.
 
 ## Registered functions
 
@@ -38,25 +89,6 @@ direct runtime overrides.
 ## Runtime expectations
 
 By default, the worker subscribes to `agent::before_tool_call`. That topic is
-published by `provider-router` while the agent loop is executing — for
-the denylist to fire, `provider-router` (or any worker emitting the same
-topic) must be running on the bus.
-
-## Build
-
-```bash
-cargo build --release
-```
-
-## Workspace allowlist composition
-
-Chat clients (e.g. `iii-console`) layer a workspace allowlist on top of `policy-denylist`. The allowlist enforces:
-
-- Filesystem writes restricted to a configured workspace root.
-- Absolute paths outside the workspace are rejected by the SDK wrapper *before* the bus call is dispatched.
-
-`policy-denylist` remains the second layer (deny by tool name regardless of arguments). The two layers compose:
-
-1. SDK wrapper (chat client side) — workspace allowlist on path arguments.
-2. `policy-denylist` (engine side) — deny by tool name (exact match, case-sensitive).
-3. `<ApprovalRow>` (chat UI) — per-call user approval surfaced inline before any write reaches disk.
+published by `provider-router` while the agent loop is executing — for the
+denylist to fire, `provider-router` (or any worker emitting the same topic) must
+be running on the bus.

--- a/policy-denylist/build.rs
+++ b/policy-denylist/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+}

--- a/policy-denylist/src/config.rs
+++ b/policy-denylist/src/config.rs
@@ -1,0 +1,82 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+pub struct WorkerConfig {
+    #[serde(default = "default_topic")]
+    pub topic: String,
+    #[serde(default = "default_denied_tools_vec")]
+    pub denied_tools: Vec<String>,
+}
+
+fn default_topic() -> String {
+    policy_denylist::DEFAULT_TOPIC.to_string()
+}
+
+fn default_denied_tools_vec() -> Vec<String> {
+    policy_denylist::default_denied_tools()
+}
+
+impl Default for WorkerConfig {
+    fn default() -> Self {
+        Self {
+            topic: default_topic(),
+            denied_tools: default_denied_tools_vec(),
+        }
+    }
+}
+
+/// Load operator config: flat `{ topic, denied_tools }`, or iii-style `{ config: { ... } }`.
+pub fn load_config(path: &str) -> Result<WorkerConfig> {
+    let raw = std::fs::read_to_string(path).with_context(|| format!("read {path}"))?;
+    let root: serde_yaml::Value =
+        serde_yaml::from_str(&raw).with_context(|| format!("parse YAML in {path}"))?;
+    let node = root.get("config").cloned().unwrap_or(root);
+    let cfg: WorkerConfig = serde_yaml::from_value(node)
+        .with_context(|| format!("deserialize WorkerConfig from {path}"))?;
+    Ok(cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_from_empty_yaml_mapping() {
+        let cfg: WorkerConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(cfg.topic, policy_denylist::DEFAULT_TOPIC);
+        assert_eq!(cfg.denied_tools, policy_denylist::default_denied_tools());
+    }
+
+    #[test]
+    fn custom_yaml_overrides() {
+        let cfg: WorkerConfig = serde_yaml::from_str(
+            r"
+topic: agent::custom
+denied_tools:
+  - risky
+",
+        )
+        .unwrap();
+        assert_eq!(cfg.topic, "agent::custom");
+        assert_eq!(cfg.denied_tools, vec!["risky".to_string()]);
+    }
+
+    #[test]
+    fn impl_default_matches_yaml_defaults() {
+        let from_empty: WorkerConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(WorkerConfig::default(), from_empty);
+    }
+
+    #[test]
+    fn deserialize_nested_config_block() {
+        let root: serde_yaml::Value = serde_yaml::from_str(
+            "config:\n  topic: agent::nested\n  denied_tools:\n    - bash:rm -rf",
+        )
+        .unwrap();
+        let node = root.get("config").cloned().unwrap_or(root);
+        let cfg: WorkerConfig = serde_yaml::from_value(node).unwrap();
+        assert_eq!(cfg.topic, "agent::nested");
+        assert_eq!(cfg.denied_tools, vec!["bash:rm -rf".to_string()]);
+    }
+}

--- a/policy-denylist/src/lib.rs
+++ b/policy-denylist/src/lib.rs
@@ -94,7 +94,7 @@ pub(crate) fn denylist_function_message() -> RegisterFunctionMessage {
 /// Build the canonical [`RegisterTriggerInput`] for the denylist subscriber.
 pub(crate) fn denylist_trigger_input(config: &PolicyDenylistConfig) -> RegisterTriggerInput {
     RegisterTriggerInput {
-        trigger_type: "subscribe".into(),
+        trigger_type: "durable:subscriber".into(),
         function_id: FN_DENYLIST.into(),
         config: json!({ "topic": config.topic }),
         metadata: None,
@@ -296,7 +296,7 @@ mod tests {
 
         let trigs = bus.recorded_triggers();
         assert_eq!(trigs.len(), 1);
-        assert_eq!(trigs[0].trigger_type, "subscribe");
+        assert_eq!(trigs[0].trigger_type, "durable:subscriber");
         assert_eq!(trigs[0].function_id, FN_DENYLIST);
         assert_eq!(
             trigs[0].config.get("topic").and_then(Value::as_str),

--- a/policy-denylist/src/main.rs
+++ b/policy-denylist/src/main.rs
@@ -1,272 +1,42 @@
-use std::path::{Path, PathBuf};
+//! Binary entrypoint for the policy-denylist worker.
+
+mod config;
+mod manifest;
 
 use anyhow::{anyhow, Result};
-use iii_sdk::{register_worker, InitOptions};
-use serde_json::Value;
+use clap::Parser;
+use iii_sdk::{register_worker, InitOptions, OtelConfig, WorkerMetadata};
+use policy_denylist::{subscribe_denylist_with_config, PolicyDenylistConfig};
+use std::sync::Arc;
 
-const DEFAULT_ENGINE_URL: &str = "ws://127.0.0.1:49134";
+#[derive(Parser, Debug)]
+#[command(
+    name = "iii-policy-denylist",
+    about = "Denylist subscriber for agent::before_tool_call"
+)]
+struct Cli {
+    #[arg(long, default_value = "./config.yaml")]
+    config: String,
 
-#[derive(Debug, Default, PartialEq, Eq)]
-struct ConfigOverrides {
-    topic: Option<String>,
-    denied_tools: Option<Vec<String>>,
+    #[arg(long, default_value = "ws://127.0.0.1:49134", env = "III_URL")]
+    url: String,
+
+    #[arg(long)]
+    manifest: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct RuntimeConfig {
-    topic: String,
-    denied_tools: Vec<String>,
-}
-
-impl RuntimeConfig {
-    fn load(config_path: Option<&Path>) -> Self {
-        let mut cfg = Self {
-            topic: policy_denylist::DEFAULT_TOPIC.to_string(),
-            denied_tools: policy_denylist::default_denied_tools(),
-        };
-
-        if let Some(path) = config_path {
-            match load_config_overrides(path) {
-                Ok(overrides) => cfg.apply(overrides),
-                Err(e) => log::warn!(
-                    "failed to load policy-denylist config from {}: {e}; using defaults",
-                    path.display()
-                ),
-            }
-        }
-
-        if let Ok(topic) = std::env::var("POLICY_DENYLIST_TOPIC") {
-            if !topic.trim().is_empty() {
-                cfg.topic = topic;
-            }
-        }
-        if let Ok(denied) = std::env::var("POLICY_DENIED_TOOLS") {
-            let denied_tools = parse_denied_tools(&denied);
-            if !denied_tools.is_empty() {
-                cfg.denied_tools = denied_tools;
-            }
-        }
-
-        cfg
-    }
-
-    fn apply(&mut self, overrides: ConfigOverrides) {
-        if let Some(topic) = overrides.topic {
-            self.topic = topic;
-        }
-        if let Some(denied_tools) = overrides.denied_tools {
-            self.denied_tools = denied_tools;
+fn apply_runtime_env_overrides(cfg: &mut config::WorkerConfig) {
+    if let Ok(topic) = std::env::var("POLICY_DENYLIST_TOPIC") {
+        let topic = topic.trim();
+        if !topic.is_empty() {
+            cfg.topic = topic.to_string();
         }
     }
-}
-
-fn config_path_arg() -> Option<PathBuf> {
-    let mut args = std::env::args_os().skip(1);
-    while let Some(arg) = args.next() {
-        if arg == std::ffi::OsStr::new("--config") {
-            return args.next().map(PathBuf::from);
+    if let Ok(denied) = std::env::var("POLICY_DENIED_TOOLS") {
+        let denied_tools = parse_denied_tools(&denied);
+        if !denied_tools.is_empty() {
+            cfg.denied_tools = denied_tools;
         }
-        if let Some(s) = arg.to_str() {
-            if let Some(path) = s.strip_prefix("--config=") {
-                return Some(PathBuf::from(path));
-            }
-        }
-    }
-    None
-}
-
-fn load_config_overrides(path: &Path) -> Result<ConfigOverrides> {
-    let raw = std::fs::read_to_string(path)?;
-    Ok(parse_config_overrides(&raw))
-}
-
-fn parse_config_overrides(raw: &str) -> ConfigOverrides {
-    if let Some(overrides) = parse_json_config_overrides(raw) {
-        return overrides;
-    }
-    parse_yaml_config_overrides(raw)
-}
-
-fn parse_json_config_overrides(raw: &str) -> Option<ConfigOverrides> {
-    let value: Value = serde_json::from_str(raw).ok()?;
-    let root = value.as_object()?;
-    let object = root
-        .get("config")
-        .and_then(Value::as_object)
-        .unwrap_or(root);
-
-    let topic = object
-        .get("topic")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(ToOwned::to_owned);
-    let denied_tools = object
-        .get("denied_tools")
-        .and_then(parse_json_denied_tools)
-        .filter(|v| !v.is_empty());
-
-    Some(ConfigOverrides {
-        topic,
-        denied_tools,
-    })
-}
-
-fn parse_json_denied_tools(value: &Value) -> Option<Vec<String>> {
-    if let Some(list) = value.as_array() {
-        let out: Vec<String> = list
-            .iter()
-            .filter_map(Value::as_str)
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(ToOwned::to_owned)
-            .collect();
-        return Some(out);
-    }
-    value.as_str().map(parse_denied_tools)
-}
-
-fn parse_yaml_config_overrides(raw: &str) -> ConfigOverrides {
-    let mut overrides = ConfigOverrides::default();
-    let mut in_config_block = false;
-    let mut config_indent = None;
-    let mut denied_tools_list: Vec<String> = Vec::new();
-    let mut reading_denied_tools = false;
-    let mut denied_tools_indent = 0;
-
-    for raw_line in raw.lines() {
-        let indent = raw_line.chars().take_while(|ch| *ch == ' ').count();
-        let line = strip_yaml_comment(raw_line).trim_end();
-        let line = line.trim_start();
-        if line.is_empty() || line == "---" {
-            continue;
-        }
-
-        if reading_denied_tools && indent >= denied_tools_indent {
-            if let Some(item) = line.strip_prefix("- ") {
-                if let Some(value) = parse_yaml_scalar(item) {
-                    denied_tools_list.push(value);
-                }
-                continue;
-            }
-        }
-        reading_denied_tools = false;
-
-        let Some((key, value)) = line.split_once(':') else {
-            continue;
-        };
-
-        if indent == 0 {
-            let key = key.trim();
-            if key == "config" && parse_yaml_scalar(value).is_none() {
-                in_config_block = true;
-                config_indent = None;
-                continue;
-            }
-            in_config_block = false;
-            parse_config_key(
-                &mut overrides,
-                key,
-                value,
-                &mut reading_denied_tools,
-                &mut denied_tools_indent,
-                indent + 2,
-            );
-            continue;
-        }
-
-        if !in_config_block {
-            continue;
-        }
-
-        let expected_indent = *config_indent.get_or_insert(indent);
-        if indent != expected_indent {
-            continue;
-        }
-        parse_config_key(
-            &mut overrides,
-            key.trim(),
-            value,
-            &mut reading_denied_tools,
-            &mut denied_tools_indent,
-            indent + 2,
-        );
-    }
-
-    if !denied_tools_list.is_empty() {
-        overrides.denied_tools = Some(denied_tools_list);
-    }
-    overrides
-}
-
-fn parse_config_key(
-    overrides: &mut ConfigOverrides,
-    key: &str,
-    value: &str,
-    reading_denied_tools: &mut bool,
-    denied_tools_indent: &mut usize,
-    list_indent: usize,
-) {
-    match key {
-        "topic" => {
-            if let Some(value) = parse_yaml_scalar(value) {
-                overrides.topic = Some(value);
-            }
-        }
-        "denied_tools" => {
-            if let Some(value) = parse_yaml_scalar(value) {
-                let denied_tools = parse_denied_tools(&value);
-                if !denied_tools.is_empty() {
-                    overrides.denied_tools = Some(denied_tools);
-                }
-            } else {
-                *reading_denied_tools = true;
-                *denied_tools_indent = list_indent;
-            }
-        }
-        _ => {}
-    }
-}
-
-fn strip_yaml_comment(line: &str) -> &str {
-    let mut in_single = false;
-    let mut in_double = false;
-
-    for (idx, ch) in line.char_indices() {
-        match ch {
-            '\'' if !in_double => in_single = !in_single,
-            '"' if !in_single => in_double = !in_double,
-            '#' if !in_single && !in_double => return &line[..idx],
-            _ => {}
-        }
-    }
-
-    line
-}
-
-fn parse_yaml_scalar(value: &str) -> Option<String> {
-    let value = value.trim();
-    if value.is_empty() || value == "null" || value == "~" {
-        return None;
-    }
-
-    let unquoted = if value.len() >= 2 {
-        let bytes = value.as_bytes();
-        let quote = bytes[0];
-        if (quote == b'\'' || quote == b'"') && bytes[value.len() - 1] == quote {
-            &value[1..value.len() - 1]
-        } else {
-            value
-        }
-    } else {
-        value
-    };
-
-    let unquoted = unquoted.trim();
-    if unquoted.is_empty() {
-        None
-    } else {
-        Some(unquoted.to_string())
     }
 }
 
@@ -284,75 +54,94 @@ fn parse_denied_tools(raw: &str) -> Vec<String> {
         .collect()
 }
 
+#[cfg(unix)]
+async fn shutdown_signal() {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    match signal(SignalKind::terminate()) {
+        Ok(mut sigterm) => {
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {},
+                _ = sigterm.recv() => {},
+            }
+        }
+        Err(_) => {
+            let _ = tokio::signal::ctrl_c().await;
+        }
+    }
+}
+
+#[cfg(not(unix))]
+async fn shutdown_signal() {
+    tokio::signal::ctrl_c().await.ok();
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
 
-    let engine_url = std::env::var("III_URL").unwrap_or_else(|_| DEFAULT_ENGINE_URL.to_string());
-    let cfg = RuntimeConfig::load(config_path_arg().as_deref());
+    let cli = Cli::parse();
 
-    let iii = register_worker(&engine_url, InitOptions::default());
-    let _sub = policy_denylist::subscribe_denylist_with_config(
+    if cli.manifest {
+        let m = manifest::build_manifest();
+        println!("{}", serde_json::to_string_pretty(&m).unwrap());
+        return Ok(());
+    }
+
+    let mut cfg = match config::load_config(&cli.config) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                path = %cli.config,
+                "failed to load config, using defaults"
+            );
+            config::WorkerConfig::default()
+        }
+    };
+    apply_runtime_env_overrides(&mut cfg);
+
+    let iii = register_worker(
+        &cli.url,
+        InitOptions {
+            otel: Some(OtelConfig::default()),
+            metadata: Some(WorkerMetadata {
+                runtime: "rust".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                name: "policy-denylist".to_string(),
+                os: std::env::consts::OS.to_string(),
+                pid: Some(std::process::id()),
+                telemetry: None,
+                ..WorkerMetadata::default()
+            }),
+            ..InitOptions::default()
+        },
+    );
+    let iii = Arc::new(iii);
+
+    let _sub = subscribe_denylist_with_config(
         &iii,
         cfg.denied_tools.clone(),
-        policy_denylist::PolicyDenylistConfig {
+        PolicyDenylistConfig {
             topic: cfg.topic.clone(),
         },
     )
     .map_err(|e| anyhow!("subscribe failed: {e}"))?;
-    log::info!(
-        "policy-denylist registered (policy::denylist on {}); denied=[{}]",
-        cfg.topic,
-        cfg.denied_tools.join(", ")
+
+    tracing::info!(
+        topic = %cfg.topic,
+        denied_tools = %cfg.denied_tools.join(","),
+        "policy-denylist subscribed (policy::denylist)",
     );
 
-    tokio::signal::ctrl_c().await.ok();
+    shutdown_signal().await;
+
+    tracing::info!("policy-denylist shutting down");
+    iii.shutdown_async().await;
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_yaml_config_overrides_topic_and_denied_tools() {
-        let overrides = parse_config_overrides(
-            r"
-topic: agent::custom_before_tool_call
-denied_tools:
-  - bash:rm -rf
-  - sudo
-",
-        );
-
-        assert_eq!(
-            overrides.topic.as_deref(),
-            Some("agent::custom_before_tool_call")
-        );
-        assert_eq!(
-            overrides.denied_tools,
-            Some(vec!["bash:rm -rf".to_string(), "sudo".to_string()])
-        );
-    }
-
-    #[test]
-    fn parse_json_config_overrides_wrapped_config() {
-        let overrides = parse_config_overrides(
-            r#"{
-                "config": {
-                    "topic": "agent::json_before_tool_call",
-                    "denied_tools": ["bash:rm -rf", "sudo"]
-                }
-            }"#,
-        );
-
-        assert_eq!(
-            overrides.topic.as_deref(),
-            Some("agent::json_before_tool_call")
-        );
-        assert_eq!(
-            overrides.denied_tools,
-            Some(vec!["bash:rm -rf".to_string(), "sudo".to_string()])
-        );
-    }
 }

--- a/policy-denylist/src/manifest.rs
+++ b/policy-denylist/src/manifest.rs
@@ -1,0 +1,38 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct ModuleManifest {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub default_config: serde_json::Value,
+    pub supported_targets: Vec<String>,
+}
+
+pub fn build_manifest() -> ModuleManifest {
+    ModuleManifest {
+        name: env!("CARGO_PKG_NAME").to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        description:
+            "Hook subscriber on agent::before_tool_call that blocks calls whose name matches a configured denylist."
+                .to_string(),
+        default_config: serde_json::to_value(crate::config::WorkerConfig::default()).unwrap_or_else(|_| serde_json::json!({})),
+        supported_targets: vec![env!("TARGET").to_string()],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_roundtrip_has_required_fields() {
+        let m = build_manifest();
+        let json = serde_json::to_string_pretty(&m).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["name"], env!("CARGO_PKG_NAME"));
+        assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+        assert!(parsed["default_config"].is_object());
+        assert!(!parsed["supported_targets"].as_array().unwrap().is_empty());
+    }
+}

--- a/policy-denylist/tests/manifest.rs
+++ b/policy-denylist/tests/manifest.rs
@@ -1,0 +1,50 @@
+use std::process::Command;
+
+use serde_json::Value;
+
+fn binary_path() -> String {
+    // Prefer the Cargo-injected path when available (standard cargo test builds).
+    // Fall back to constructing it from CARGO_MANIFEST_DIR so the test works in
+    // environments where CARGO_BIN_EXE_* is not injected.
+    if let Some(path) = option_env!("CARGO_BIN_EXE_iii_policy_denylist") {
+        return path.to_string();
+    }
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    format!("{manifest_dir}/target/debug/iii-policy-denylist")
+}
+
+#[test]
+fn manifest_subcommand_emits_valid_json() {
+    let bin = binary_path();
+    let output = Command::new(&bin)
+        .arg("--manifest")
+        .output()
+        .unwrap_or_else(|e| panic!("spawn {bin}: {e}"));
+
+    assert!(
+        output.status.success(),
+        "binary exited with {:?}; stderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("manifest stdout is utf-8");
+    let manifest: Value = serde_json::from_str(&stdout).expect("manifest stdout is valid JSON");
+
+    assert_eq!(manifest["name"], env!("CARGO_PKG_NAME"));
+    assert_eq!(manifest["version"], env!("CARGO_PKG_VERSION"));
+    assert!(
+        manifest["description"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()),
+        "description must be non-empty"
+    );
+    assert!(manifest["default_config"].is_object());
+    assert!(
+        !manifest["supported_targets"]
+            .as_array()
+            .expect("supported_targets must be an array")
+            .is_empty(),
+        "supported_targets must not be empty"
+    );
+}

--- a/provider-anthropic/Cargo.lock
+++ b/provider-anthropic/Cargo.lock
@@ -181,6 +181,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,29 +329,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
 ]
 
 [[package]]
@@ -846,19 +863,21 @@ dependencies = [
  "auth-credentials",
  "bytes",
  "chrono",
- "env_logger",
+ "clap",
  "futures",
  "harness-types",
  "iii-sdk",
- "log",
  "overflow-classify",
  "provider-base",
  "reqwest",
  "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -937,30 +956,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jiff"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,6 +966,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -1016,6 +1017,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -1064,6 +1074,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1280,21 +1299,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -1815,6 +1819,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,6 +1840,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1868,6 +1894,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1972,6 +2004,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2202,6 +2243,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2254,6 +2325,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2300,6 +2377,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/provider-anthropic/Cargo.toml
+++ b/provider-anthropic/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 repository = "https://github.com/iii-hq/workers"
 authors = ["iii contributors"]
 publish = false
+build = "build.rs"
 
 [lib]
 name = "provider_anthropic"
@@ -28,15 +29,20 @@ iii-sdk = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = "0.9"
 tokio = { workspace = true }
 thiserror = { workspace = true }
 reqwest = { workspace = true }
 futures = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+clap = { version = "4", features = ["derive"] }
 tokio-stream = "0.1"
-log = "0.4"
-env_logger = "0.11"
+
+[dev-dependencies]
+serde_json = { workspace = true }
 
 [workspace.package]
 version = "0.1.0"

--- a/provider-anthropic/README.md
+++ b/provider-anthropic/README.md
@@ -1,34 +1,70 @@
 # provider-anthropic
 
-Native Anthropic Messages API streaming provider on the iii bus.
+Native Anthropic Messages API streaming provider on the iii bus. Exposes
+`provider::anthropic::complete` (same wire shape as other streaming providers).
 
-## Installation
+Companion [`auth-credentials`](../auth-credentials) resolves API keys and OAuth tokens via
+`auth::get_token`.
+
+## Install
 
 ```bash
 iii worker add provider-anthropic
 ```
 
-## Run
-
 ```bash
-iii-provider-anthropic
+iii worker add auth-credentials
 ```
 
-`III_URL` env var picks the engine endpoint (default `ws://127.0.0.1:49134`).
+## Quickstart
 
-## Registered functions
+From a client connected to the same iii engine:
 
-`provider::anthropic::complete` (canonical) plus the deprecated alias
-`provider::anthropic::stream_assistant` for one release.
+```rust
+use iii_sdk::{III, TriggerRequest};
+use serde_json::json;
+
+async fn probe(iii: &III) {
+    let _ = iii
+        .trigger(TriggerRequest {
+            function_id: "provider::anthropic::complete".into(),
+            payload: json!({
+                "config": { "model": "claude-sonnet-4-6" },
+                "system_prompt": "You are concise.",
+                "messages": [],
+                "tools": [],
+            }),
+            action: None,
+            timeout_ms: Some(120_000),
+        })
+        .await;
+}
+```
+
+Responses are `{ "events": [ … AssistantMessageEvent … ] }` with a terminal
+`done` or `error` event.
+
+## Configuration
+
+Committed defaults live in [`config.yaml`](config.yaml). Override at runtime with:
+
+- `--config <path>` (default `./config.yaml`)
+- `--url <ws-url>` (default `ws://127.0.0.1:49134`)
+
+| Field | Meaning |
+| --- | --- |
+| `default_max_tokens` | `max_tokens` on the Messages request when not overridden per call |
+| `default_api_url` | Anthropic Messages endpoint (default `https://api.anthropic.com/v1/messages`) |
+
+Registry / CI: `iii-provider-anthropic --manifest` prints JSON for publish.
 
 ## Worker dependencies
 
 | Worker | Range | Reason |
-|---|---|---|
-| `auth-credentials` | `^0.1.0` | `provider-base::fetch_credential` calls `auth::get_token` to look up the Anthropic API key or OAuth token. |
+| --- | --- | --- |
+| `auth-credentials` | `^0.1.0` | Resolves Anthropic API key or OAuth token via `auth::get_token`. |
 
-## Build
+## Registered functions
 
-```bash
-cargo build --release
-```
+`provider::anthropic::complete` plus the deprecated alias
+`provider::anthropic::stream_assistant` for one release.

--- a/provider-anthropic/build.rs
+++ b/provider-anthropic/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+}

--- a/provider-anthropic/config.yaml
+++ b/provider-anthropic/config.yaml
@@ -1,0 +1,4 @@
+# Defaults applied when building Anthropic Messages requests (per-call
+# `model` still comes from the trigger payload).
+default_max_tokens: 4096
+default_api_url: "https://api.anthropic.com/v1/messages"

--- a/provider-anthropic/crates/provider-base/src/iii_register.rs
+++ b/provider-anthropic/crates/provider-base/src/iii_register.rs
@@ -90,7 +90,7 @@ pub fn register_provider_complete<C, B, BErr, F, Fut>(
 ) -> FunctionRef
 where
     C: Send + Sync + 'static,
-    B: Fn(&str, &Credential) -> Result<C, BErr> + Copy + Send + Sync + 'static,
+    B: Fn(&str, &Credential) -> Result<C, BErr> + Clone + Send + Sync + 'static,
     BErr: std::fmt::Display + Send + Sync + 'static,
     F: Fn(Arc<C>, String, Vec<AgentMessage>, Vec<AgentTool>) -> Fut + Copy + Send + Sync + 'static,
     Fut: Future<Output = ReceiverStream<AssistantMessageEvent>> + Send + 'static,
@@ -113,7 +113,7 @@ fn register_provider_with_id<C, B, BErr, F, Fut>(
 ) -> FunctionRef
 where
     C: Send + Sync + 'static,
-    B: Fn(&str, &Credential) -> Result<C, BErr> + Copy + Send + Sync + 'static,
+    B: Fn(&str, &Credential) -> Result<C, BErr> + Clone + Send + Sync + 'static,
     BErr: std::fmt::Display + Send + Sync + 'static,
     F: Fn(Arc<C>, String, Vec<AgentMessage>, Vec<AgentTool>) -> Fut + Copy + Send + Sync + 'static,
     Fut: Future<Output = ReceiverStream<AssistantMessageEvent>> + Send + 'static,
@@ -128,6 +128,7 @@ where
         move |payload: Value| {
             let provider_label = provider_label.clone();
             let iii = iii_clone.clone();
+            let build_config = build_config.clone();
             async move {
                 let model = payload
                     .get("model")

--- a/provider-anthropic/iii.worker.yaml
+++ b/provider-anthropic/iii.worker.yaml
@@ -4,6 +4,6 @@ language: rust
 deploy: binary
 manifest: Cargo.toml
 bin: iii-provider-anthropic
-description: Native Anthropic Messages API streaming provider under provider::anthropic::*.
+description: Anthropic Messages API streaming provider; exposes provider::anthropic::complete on the iii bus.
 dependencies:
   auth-credentials: "^0.1.0"

--- a/provider-anthropic/src/config.rs
+++ b/provider-anthropic/src/config.rs
@@ -1,0 +1,64 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+/// Default Anthropic Messages endpoint.
+pub const DEFAULT_API_URL: &str = "https://api.anthropic.com/v1/messages";
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+pub struct WorkerConfig {
+    #[serde(default = "default_max_tokens")]
+    pub default_max_tokens: u32,
+    #[serde(default = "default_api_url_str")]
+    pub default_api_url: String,
+}
+
+fn default_max_tokens() -> u32 {
+    4096
+}
+
+fn default_api_url_str() -> String {
+    DEFAULT_API_URL.to_string()
+}
+
+impl Default for WorkerConfig {
+    fn default() -> Self {
+        Self {
+            default_max_tokens: default_max_tokens(),
+            default_api_url: default_api_url_str(),
+        }
+    }
+}
+
+pub fn load_config(path: &str) -> Result<WorkerConfig> {
+    let contents = std::fs::read_to_string(path)?;
+    let cfg: WorkerConfig = serde_yaml::from_str(&contents)?;
+    Ok(cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_from_empty_yaml() {
+        let cfg: WorkerConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(cfg.default_max_tokens, 4096);
+        assert_eq!(cfg.default_api_url, DEFAULT_API_URL);
+    }
+
+    #[test]
+    fn custom_yaml_overrides() {
+        let cfg: WorkerConfig = serde_yaml::from_str(
+            "default_max_tokens: 8192\ndefault_api_url: https://example/v1/messages",
+        )
+        .unwrap();
+        assert_eq!(cfg.default_max_tokens, 8192);
+        assert_eq!(cfg.default_api_url, "https://example/v1/messages");
+    }
+
+    #[test]
+    fn impl_default_matches_yaml_defaults() {
+        let y: WorkerConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(WorkerConfig::default(), y);
+    }
+}

--- a/provider-anthropic/src/lib.rs
+++ b/provider-anthropic/src/lib.rs
@@ -7,6 +7,8 @@
 //! Cache control, transport selection, and OAuth refresh land alongside the
 //! provider-base infrastructure in 0.2.
 
+pub mod config;
+
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -61,7 +63,7 @@ impl AnthropicConfig {
             credential_value: key,
             model: model.into(),
             max_tokens: 4096,
-            api_url: "https://api.anthropic.com/v1/messages".into(),
+            api_url: config::DEFAULT_API_URL.into(),
             auth_mode: AuthMode::ApiKey,
         })
     }
@@ -83,9 +85,19 @@ impl AnthropicConfig {
             credential_value: key,
             model: model.into(),
             max_tokens: 4096,
-            api_url: "https://api.anthropic.com/v1/messages".into(),
+            api_url: config::DEFAULT_API_URL.into(),
             auth_mode,
         })
+    }
+
+    pub fn with_max_tokens(mut self, max: u32) -> Self {
+        self.max_tokens = max;
+        self
+    }
+
+    pub fn with_api_url(mut self, url: impl Into<String>) -> Self {
+        self.api_url = url.into();
+        self
     }
 }
 
@@ -560,17 +572,25 @@ pub(crate) fn build_content(state: &PartialState) -> Vec<ContentBlock> {
     content
 }
 
-/// Register `provider::anthropic::stream` on the iii bus.
+/// Register `provider::anthropic::complete` on the iii bus.
 ///
 /// The handler decodes `{ config, system_prompt, messages, tools }`, calls
 /// [`stream`], drains the resulting event stream, and returns
 /// `{ events: [<AssistantMessageEvent>...] }`.
-pub async fn register_with_iii(iii: &iii_sdk::III) -> anyhow::Result<()> {
+pub async fn register_with_iii(
+    iii: &iii_sdk::III,
+    worker_cfg: &config::WorkerConfig,
+) -> anyhow::Result<()> {
+    let default_max = worker_cfg.default_max_tokens;
+    let default_url = worker_cfg.default_api_url.clone();
     provider_base::register_provider_complete::<AnthropicConfig, _, _, _, _>(
         iii,
         "anthropic",
-        |model: &str, cred: &auth_credentials::Credential| {
-            AnthropicConfig::with_credential(model, cred)
+        move |model: &str, cred: &auth_credentials::Credential| {
+            AnthropicConfig::with_credential(model, cred).map(|c| {
+                c.with_max_tokens(default_max)
+                    .with_api_url(default_url.clone())
+            })
         },
         stream,
     );

--- a/provider-anthropic/src/main.rs
+++ b/provider-anthropic/src/main.rs
@@ -1,21 +1,109 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use iii_sdk::{register_worker, InitOptions};
+use clap::Parser;
+use iii_sdk::{register_worker, InitOptions, OtelConfig, WorkerMetadata};
+use provider_anthropic::config;
 
-const DEFAULT_ENGINE_URL: &str = "ws://127.0.0.1:49134";
+mod manifest;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "iii-provider-anthropic",
+    about = "Anthropic Messages API streaming provider for the iii bus (provider::anthropic::complete)."
+)]
+struct Cli {
+    #[arg(long, default_value = "./config.yaml")]
+    config: String,
+
+    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    url: String,
+
+    #[arg(long)]
+    manifest: bool,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
-    let engine_url = std::env::var("III_URL").unwrap_or_else(|_| DEFAULT_ENGINE_URL.to_string());
-    let iii = Arc::new(register_worker(&engine_url, InitOptions::default()));
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
 
-    provider_anthropic::register_with_iii(&iii)
+    let cli = Cli::parse();
+
+    if cli.manifest {
+        let m = manifest::build_manifest();
+        println!("{}", serde_json::to_string_pretty(&m)?);
+        return Ok(());
+    }
+
+    let worker_cfg = match config::load_config(&cli.config) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(error = %e, path = %cli.config, "failed to load config, using defaults");
+            config::WorkerConfig::default()
+        }
+    };
+
+    let iii = register_worker(
+        &cli.url,
+        InitOptions {
+            otel: Some(OtelConfig::default()),
+            metadata: Some(WorkerMetadata {
+                runtime: "rust".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                name: "provider-anthropic".to_string(),
+                os: std::env::consts::OS.to_string(),
+                pid: Some(std::process::id()),
+                telemetry: None,
+                ..WorkerMetadata::default()
+            }),
+            ..InitOptions::default()
+        },
+    );
+    let iii = Arc::new(iii);
+
+    provider_anthropic::register_with_iii(&iii, &worker_cfg)
         .await
         .context("provider-anthropic register failed")?;
-    log::info!("provider-anthropic registered (provider::anthropic::*)");
+    tracing::info!("provider-anthropic registered (provider::anthropic::complete)");
 
-    tokio::signal::ctrl_c().await.ok();
+    wait_for_shutdown().await;
+    tracing::info!("provider-anthropic shutting down");
+    iii.shutdown_async().await;
     Ok(())
+}
+
+async fn wait_for_shutdown() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut sigint = match signal(SignalKind::interrupt()) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to register SIGINT; falling back to ctrl_c");
+                let _ = tokio::signal::ctrl_c().await;
+                return;
+            }
+        };
+        let mut sigterm = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to register SIGTERM; using SIGINT only");
+                let _ = sigint.recv().await;
+                return;
+            }
+        };
+        tokio::select! {
+            _ = sigint.recv() => {},
+            _ = sigterm.recv() => {},
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
 }

--- a/provider-anthropic/src/manifest.rs
+++ b/provider-anthropic/src/manifest.rs
@@ -1,0 +1,45 @@
+use serde::Serialize;
+
+use provider_anthropic::config::WorkerConfig;
+
+#[derive(Serialize)]
+pub struct ModuleManifest {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub default_config: serde_json::Value,
+    pub supported_targets: Vec<String>,
+}
+
+pub fn build_manifest() -> ModuleManifest {
+    ModuleManifest {
+        name: env!("CARGO_PKG_NAME").to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        description:
+            "Anthropic Messages API streaming provider; exposes provider::anthropic::complete on the iii bus."
+                .to_string(),
+        default_config: serde_json::to_value(WorkerConfig::default())
+            .expect("WorkerConfig serializes to JSON"),
+        supported_targets: vec![env!("TARGET").to_string()],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_roundtrip_has_required_fields() {
+        let m = build_manifest();
+        let json = serde_json::to_string_pretty(&m).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["name"], env!("CARGO_PKG_NAME"));
+        assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+        assert!(parsed["description"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()));
+        assert!(parsed["default_config"].is_object());
+        assert!(!parsed["supported_targets"].as_array().unwrap().is_empty());
+    }
+}

--- a/provider-anthropic/tests/manifest.rs
+++ b/provider-anthropic/tests/manifest.rs
@@ -1,0 +1,49 @@
+//! `iii-provider-anthropic --manifest` JSON contract (registry publish).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn binary_path() -> PathBuf {
+    let profile = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
+    #[cfg(target_os = "windows")]
+    let name = "iii-provider-anthropic.exe";
+    #[cfg(not(target_os = "windows"))]
+    let name = "iii-provider-anthropic";
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join(profile)
+        .join(name)
+}
+
+#[test]
+fn manifest_subcommand_emits_valid_json() {
+    let bin = binary_path();
+    let output = Command::new(&bin)
+        .arg("--manifest")
+        .output()
+        .unwrap_or_else(|e| panic!("spawn {:?}: {e}", bin));
+
+    assert!(
+        output.status.success(),
+        "binary exited with {:?}; stderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("manifest stdout is utf-8");
+    let manifest: Value = serde_json::from_str(&stdout).expect("manifest stdout is valid JSON");
+
+    assert_eq!(manifest["name"], env!("CARGO_PKG_NAME"));
+    assert_eq!(manifest["version"], env!("CARGO_PKG_VERSION"));
+    assert!(manifest["default_config"].is_object());
+    assert!(!manifest["supported_targets"]
+        .as_array()
+        .expect("supported_targets must be an array")
+        .is_empty());
+}

--- a/provider-openai/Cargo.lock
+++ b/provider-openai/Cargo.lock
@@ -181,6 +181,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,29 +329,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
 ]
 
 [[package]]
@@ -845,15 +862,17 @@ dependencies = [
  "anyhow",
  "auth-credentials",
  "chrono",
- "env_logger",
+ "clap",
  "harness-types",
  "iii-sdk",
- "log",
  "provider-base",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tokio",
  "tokio-stream",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -932,30 +951,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jiff"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,6 +961,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -1011,6 +1012,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -1059,6 +1069,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1275,21 +1294,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -1810,6 +1814,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1818,6 +1835,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1863,6 +1889,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1967,6 +1999,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2197,6 +2238,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2249,6 +2320,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,6 +2372,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/provider-openai/Cargo.toml
+++ b/provider-openai/Cargo.toml
@@ -27,12 +27,17 @@ iii-sdk = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = "0.9"
 tokio = { workspace = true }
 chrono = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+clap = { version = "4", features = ["derive"] }
 
 tokio-stream = "0.1"
-log = "0.4"
-env_logger = "0.11"
+
+[dev-dependencies]
+serde_json = { workspace = true }
 
 [workspace.package]
 version = "0.1.0"

--- a/provider-openai/README.md
+++ b/provider-openai/README.md
@@ -1,27 +1,58 @@
 # provider-openai
 
-OpenAI Chat Completions provider under provider::openai::*.
+This worker registers **provider::openai::complete** on the iii bus: one-shot Chat
+Completions that resolve credentials via `auth::get_token`, stream internally,
+and return a final `AssistantMessage`. Agents and harness code call it with a
+model id and message list; keys and OAuth tokens stay in **auth-credentials**.
 
-## Installation
+## Install
 
 ```bash
 iii worker add provider-openai
 ```
 
-## Run
+`iii worker add` fetches the binary, writes a config block into
+`~/.iii/config.yaml`, and the engine starts the worker on the next `iii start`.
+
+You need **auth-credentials** (or equivalent) so `auth::get_token` can resolve
+the `openai` provider:
 
 ```bash
-iii-provider-openai
+iii worker add auth-credentials
 ```
 
-## Worker dependencies
+## Quickstart
 
-| Worker | Range | Reason |
-|---|---|---|
-| `auth-credentials` | `^0.1.0` | Provider fetches its API key via `auth::get_token`. |
+```rust
+use iii_sdk::{register_worker, InitOptions, TriggerRequest};
+use serde_json::json;
 
-## Build
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let iii = register_worker("ws://127.0.0.1:49134", InitOptions::default());
 
-```bash
-cargo build --release
+    let result = iii.trigger(TriggerRequest {
+        function_id: "provider::openai::complete".into(),
+        payload: json!({
+            "model": "gpt-4o-mini",
+            "system_prompt": "You are terse.",
+            "messages": [{ "role": "user", "content": "Say hi in one word." }],
+            "tools": [],
+        }),
+        action: None,
+        timeout_ms: Some(60_000),
+    }).await?;
+
+    println!("{result:#?}");
+    Ok(())
+}
 ```
+
+## Configuration
+
+```yaml
+default_max_tokens: 4096                                              # Completions cap unless overridden per request path
+default_api_url: "https://api.openai.com/v1/chat/completions"        # OpenAI-compatible endpoint base
+```
+
+Other defaults live in [`src/config.rs`](src/config.rs).

--- a/provider-openai/build.rs
+++ b/provider-openai/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+}

--- a/provider-openai/crates/provider-base/src/iii_register.rs
+++ b/provider-openai/crates/provider-base/src/iii_register.rs
@@ -90,7 +90,7 @@ pub fn register_provider_complete<C, B, BErr, F, Fut>(
 ) -> FunctionRef
 where
     C: Send + Sync + 'static,
-    B: Fn(&str, &Credential) -> Result<C, BErr> + Copy + Send + Sync + 'static,
+    B: Fn(&str, &Credential) -> Result<C, BErr> + Clone + Send + Sync + 'static,
     BErr: std::fmt::Display + Send + Sync + 'static,
     F: Fn(Arc<C>, String, Vec<AgentMessage>, Vec<AgentTool>) -> Fut + Copy + Send + Sync + 'static,
     Fut: Future<Output = ReceiverStream<AssistantMessageEvent>> + Send + 'static,
@@ -113,7 +113,7 @@ fn register_provider_with_id<C, B, BErr, F, Fut>(
 ) -> FunctionRef
 where
     C: Send + Sync + 'static,
-    B: Fn(&str, &Credential) -> Result<C, BErr> + Copy + Send + Sync + 'static,
+    B: Fn(&str, &Credential) -> Result<C, BErr> + Clone + Send + Sync + 'static,
     BErr: std::fmt::Display + Send + Sync + 'static,
     F: Fn(Arc<C>, String, Vec<AgentMessage>, Vec<AgentTool>) -> Fut + Copy + Send + Sync + 'static,
     Fut: Future<Output = ReceiverStream<AssistantMessageEvent>> + Send + 'static,
@@ -128,6 +128,7 @@ where
         move |payload: Value| {
             let provider_label = provider_label.clone();
             let iii = iii_clone.clone();
+            let build_config = build_config.clone();
             async move {
                 let model = payload
                     .get("model")

--- a/provider-openai/iii.worker.yaml
+++ b/provider-openai/iii.worker.yaml
@@ -4,6 +4,6 @@ language: rust
 deploy: binary
 manifest: Cargo.toml
 bin: iii-provider-openai
-description: OpenAI Chat Completions provider under provider::openai::*.
+description: OpenAI Chat Completions; registers provider::openai::complete on the iii bus.
 dependencies:
   auth-credentials: "^0.1.0"

--- a/provider-openai/src/config.rs
+++ b/provider-openai/src/config.rs
@@ -1,0 +1,62 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::DEFAULT_API_URL;
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+pub struct WorkerConfig {
+    #[serde(default = "default_max_tokens")]
+    pub default_max_tokens: u32,
+    #[serde(default = "default_api_url_str")]
+    pub default_api_url: String,
+}
+
+fn default_max_tokens() -> u32 {
+    4096
+}
+
+fn default_api_url_str() -> String {
+    DEFAULT_API_URL.to_string()
+}
+
+impl Default for WorkerConfig {
+    fn default() -> Self {
+        Self {
+            default_max_tokens: default_max_tokens(),
+            default_api_url: default_api_url_str(),
+        }
+    }
+}
+
+pub fn load_config(path: &str) -> Result<WorkerConfig> {
+    let contents = std::fs::read_to_string(path)?;
+    let cfg: WorkerConfig = serde_yaml::from_str(&contents)?;
+    Ok(cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_from_empty_yaml() {
+        let cfg: WorkerConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(cfg.default_max_tokens, 4096);
+        assert_eq!(cfg.default_api_url, DEFAULT_API_URL);
+    }
+
+    #[test]
+    fn custom_yaml_overrides() {
+        let cfg: WorkerConfig =
+            serde_yaml::from_str("default_max_tokens: 8192\ndefault_api_url: https://example/v1")
+                .unwrap();
+        assert_eq!(cfg.default_max_tokens, 8192);
+        assert_eq!(cfg.default_api_url, "https://example/v1");
+    }
+
+    #[test]
+    fn impl_default_matches_yaml_defaults() {
+        let y: WorkerConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(WorkerConfig::default(), y);
+    }
+}

--- a/provider-openai/src/lib.rs
+++ b/provider-openai/src/lib.rs
@@ -7,6 +7,8 @@
 //! [`provider_base::stream_chat_completions`] with a fixed endpoint, provider
 //! name, and `Authorization: Bearer` header.
 
+pub mod config;
+
 use std::sync::Arc;
 
 use harness_types::{
@@ -107,13 +109,21 @@ pub async fn stream(
     .await
 }
 
-/// Register `provider::openai::stream` on the iii bus.
-pub async fn register_with_iii(iii: &iii_sdk::III) -> anyhow::Result<()> {
+/// Register `provider::openai::complete` on the iii bus.
+pub async fn register_with_iii(
+    iii: &iii_sdk::III,
+    worker_cfg: &config::WorkerConfig,
+) -> anyhow::Result<()> {
+    let default_max = worker_cfg.default_max_tokens;
+    let default_url = worker_cfg.default_api_url.clone();
     provider_base::register_provider_complete::<OpenAIConfig, _, _, _, _>(
         iii,
         PROVIDER_NAME,
-        |model: &str, cred: &auth_credentials::Credential| {
-            OpenAIConfig::with_credential(model, cred)
+        move |model: &str, cred: &auth_credentials::Credential| {
+            OpenAIConfig::with_credential(model, cred).map(|c| {
+                c.with_max_tokens(default_max)
+                    .with_api_url(default_url.clone())
+            })
         },
         stream,
     );

--- a/provider-openai/src/main.rs
+++ b/provider-openai/src/main.rs
@@ -1,21 +1,109 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use iii_sdk::{register_worker, InitOptions};
+use clap::Parser;
+use iii_sdk::{register_worker, InitOptions, OtelConfig, WorkerMetadata};
+use provider_openai::config;
 
-const DEFAULT_ENGINE_URL: &str = "ws://127.0.0.1:49134";
+mod manifest;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "iii-provider-openai",
+    about = "OpenAI Chat Completions provider for the iii bus (provider::openai::complete)."
+)]
+struct Cli {
+    #[arg(long, default_value = "./config.yaml")]
+    config: String,
+
+    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    url: String,
+
+    #[arg(long)]
+    manifest: bool,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
-    let engine_url = std::env::var("III_URL").unwrap_or_else(|_| DEFAULT_ENGINE_URL.to_string());
-    let iii = Arc::new(register_worker(&engine_url, InitOptions::default()));
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
 
-    provider_openai::register_with_iii(&iii)
+    let cli = Cli::parse();
+
+    if cli.manifest {
+        let m = manifest::build_manifest();
+        println!("{}", serde_json::to_string_pretty(&m)?);
+        return Ok(());
+    }
+
+    let worker_cfg = match config::load_config(&cli.config) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(error = %e, path = %cli.config, "failed to load config, using defaults");
+            config::WorkerConfig::default()
+        }
+    };
+
+    let iii = register_worker(
+        &cli.url,
+        InitOptions {
+            otel: Some(OtelConfig::default()),
+            metadata: Some(WorkerMetadata {
+                runtime: "rust".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                name: "provider-openai".to_string(),
+                os: std::env::consts::OS.to_string(),
+                pid: Some(std::process::id()),
+                telemetry: None,
+                ..WorkerMetadata::default()
+            }),
+            ..InitOptions::default()
+        },
+    );
+    let iii = Arc::new(iii);
+
+    provider_openai::register_with_iii(&iii, &worker_cfg)
         .await
         .context("provider-openai register failed")?;
-    log::info!("provider-openai registered");
+    tracing::info!("provider-openai registered (provider::openai::complete)");
 
-    tokio::signal::ctrl_c().await.ok();
+    wait_for_shutdown().await;
+    tracing::info!("provider-openai shutting down");
+    iii.shutdown_async().await;
     Ok(())
+}
+
+async fn wait_for_shutdown() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut sigint = match signal(SignalKind::interrupt()) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to register SIGINT; falling back to ctrl_c");
+                let _ = tokio::signal::ctrl_c().await;
+                return;
+            }
+        };
+        let mut sigterm = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to register SIGTERM; using SIGINT only");
+                let _ = sigint.recv().await;
+                return;
+            }
+        };
+        tokio::select! {
+            _ = sigint.recv() => {},
+            _ = sigterm.recv() => {},
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
 }

--- a/provider-openai/src/manifest.rs
+++ b/provider-openai/src/manifest.rs
@@ -1,0 +1,45 @@
+use serde::Serialize;
+
+use provider_openai::config::WorkerConfig;
+
+#[derive(Serialize)]
+pub struct ModuleManifest {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub default_config: serde_json::Value,
+    pub supported_targets: Vec<String>,
+}
+
+pub fn build_manifest() -> ModuleManifest {
+    ModuleManifest {
+        name: env!("CARGO_PKG_NAME").to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        description:
+            "OpenAI Chat Completions provider; exposes provider::openai::complete on the iii bus."
+                .to_string(),
+        default_config: serde_json::to_value(WorkerConfig::default())
+            .expect("WorkerConfig serializes to JSON"),
+        supported_targets: vec![env!("TARGET").to_string()],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_roundtrip_has_required_fields() {
+        let m = build_manifest();
+        let json = serde_json::to_string_pretty(&m).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["name"], env!("CARGO_PKG_NAME"));
+        assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+        assert!(parsed["description"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()));
+        assert!(parsed["default_config"].is_object());
+        assert!(!parsed["supported_targets"].as_array().unwrap().is_empty());
+    }
+}

--- a/provider-openai/tests/integration.rs
+++ b/provider-openai/tests/integration.rs
@@ -3,8 +3,10 @@
 use provider_openai::{OpenAIConfig, DEFAULT_API_URL, PROVIDER_NAME};
 
 #[test]
-fn library_exports_register_entry_point() {
-    let _ = &provider_openai::register_with_iii;
+fn worker_config_default_matches_crate_constants() {
+    let cfg = provider_openai::config::WorkerConfig::default();
+    assert_eq!(cfg.default_max_tokens, 4096);
+    assert_eq!(cfg.default_api_url, provider_openai::DEFAULT_API_URL);
 }
 
 #[test]

--- a/provider-openai/tests/manifest.rs
+++ b/provider-openai/tests/manifest.rs
@@ -1,0 +1,49 @@
+//! `iii-provider-openai --manifest` JSON contract (registry publish).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde_json::Value;
+
+fn binary_path() -> PathBuf {
+    let profile = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
+    #[cfg(target_os = "windows")]
+    let name = "iii-provider-openai.exe";
+    #[cfg(not(target_os = "windows"))]
+    let name = "iii-provider-openai";
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join(profile)
+        .join(name)
+}
+
+#[test]
+fn manifest_subcommand_emits_valid_json() {
+    let bin = binary_path();
+    let output = Command::new(&bin)
+        .arg("--manifest")
+        .output()
+        .unwrap_or_else(|e| panic!("spawn {:?}: {e}", bin));
+
+    assert!(
+        output.status.success(),
+        "binary exited with {:?}; stderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("manifest stdout is utf-8");
+    let manifest: Value = serde_json::from_str(&stdout).expect("manifest stdout is valid JSON");
+
+    assert_eq!(manifest["name"], env!("CARGO_PKG_NAME"));
+    assert_eq!(manifest["version"], env!("CARGO_PKG_VERSION"));
+    assert!(manifest["default_config"].is_object());
+    assert!(!manifest["supported_targets"]
+        .as_array()
+        .expect("supported_targets must be an array")
+        .is_empty());
+}

--- a/provider-router/Cargo.lock
+++ b/provider-router/Cargo.lock
@@ -169,6 +169,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,29 +299,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
 
 [[package]]
 name = "equivalent"
@@ -756,16 +773,17 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "env_logger",
+ "clap",
  "harness-types",
  "hex",
  "iii-sdk",
- "log",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -844,30 +862,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jiff"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,6 +872,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -919,6 +919,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,6 +951,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1105,21 +1123,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -1317,18 +1320,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
 ]
 
 [[package]]
@@ -1600,6 +1591,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,6 +1623,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1664,6 +1677,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1734,6 +1753,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1954,6 +1982,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2006,6 +2064,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,6 +2116,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/provider-router/Cargo.toml
+++ b/provider-router/Cargo.toml
@@ -29,10 +29,11 @@ tokio = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
 tracing = "0.1"
+tracing-subscriber = { workspace = true }
+clap = { workspace = true }
+serde_yaml = { workspace = true }
 hex = "0.4"
 sha2 = "0.10"
-log = "0.4"
-env_logger = "0.11"
 
 [workspace.package]
 version = "0.1.0"
@@ -49,6 +50,9 @@ tokio = { version = "1", features = ["full"] }
 anyhow = "1"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
+serde_yaml = "0.9"
+clap = { version = "4", features = ["derive", "env"] }
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/provider-router/README.md
+++ b/provider-router/README.md
@@ -1,63 +1,66 @@
 # provider-router
 
-The `router::*` provider router on the iii bus. Owns the routing surface
-that `turn-orchestrator` calls when an assistant message is generated, plus
-helpers that push steering / follow-up messages onto session inboxes and
-flip the abort flag for a session.
+The `router::*` surfaces on the iii bus for assistant streaming and session
+helpers: routing to `provider::<name>::complete` (with optional `router::decide`
+from `llm-router` when installed), abort via `state::set`, and steering /
+follow-up messages through `session-inbox::push`. The turn loop itself lives in
+`turn-orchestrator`; this worker only registers handlers and HTTP triggers.
 
-Renamed from `harness-runtime`; the turn-execution loop lives in
-`turn-orchestrator`, not here.
+`iii worker add` pulls declared worker dependencies (`session-inbox`,
+`llm-budget`). Function ids use `::` throughout (see
+[`src/register.rs`](src/register.rs)).
 
-## Installation
+## Install
 
 ```bash
 iii worker add provider-router
 ```
 
-`iii worker add` resolves and installs the declared dependencies
-(`session-inbox`, `llm-budget`). Abort uses `state::*` directly (no
-`state-flag` dependency since that worker was removed in favor of
-inline `state::set` / `state::get` calls).
+`iii worker add` fetches the binary, writes a config block into
+`~/.iii/config.yaml`, and the engine starts the worker on the next
+`iii start`.
 
-## Run
+## Quickstart
 
-```bash
-iii-provider-router --engine-url ws://127.0.0.1:49134
+```rust
+use iii_sdk::{register_worker, InitOptions, TriggerRequest};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+
+    let result = iii
+        .trigger(TriggerRequest {
+            function_id: "router::abort".into(),
+            payload: json!({ "session_id": "my-session" }),
+            action: None,
+            timeout_ms: Some(5_000),
+        })
+        .await?;
+
+    println!("{result:#?}");
+    Ok(())
+}
 ```
 
-(Or set `III_URL`.)
-
-## Registered functions
-
-| Function | Description |
-|---|---|
-| `router::stream_assistant` | Provider router. Calls `provider::<name>::complete` (with optional `router::decide` indirection when `llm-router` is on the bus). |
-| `router::abort` | Set the abort flag for a session via `state::set` on `session/<id>/abort_signal` (scope `agent`). |
-| `router::push_steering` | Push messages onto the session's steering inbox via `inbox::push`. |
-| `router::push_followup` | Push messages onto the session's follow-up inbox via `inbox::push`. |
-
-Plus three HTTP triggers under `agent/{session_id}/...` for the same
-three push/abort handlers (HTTP path stable for backwards compat).
+Streaming and budget checks use `router::stream_assistant` with the payload
+shape your orchestrator sends; see in-repo callers for full examples.
 
 ## Configuration
 
-| Env var | Default | Effect |
-|---|---|---|
-| `III_URL` | `ws://127.0.0.1:49134` | Engine WebSocket URL. |
+Committed default for local runs (`--config ./config.yaml`):
 
-## Dependencies
-
-| Worker | Range | Reason |
-|---|---|---|
-| `session-inbox` | `^0.1.0` | `router::push_steering` and `router::push_followup` call `inbox::push`. |
-| `llm-budget` | `^0.1.0` | `router::stream_assistant` calls `budget::check` and `budget::record`. |
-
-`router::decide` (from `llm-router`) is consulted when present but is
-not required.
-
-## Build / Test
-
-```bash
-cargo build --release
-cargo test
+```yaml
+engine_url: ws://127.0.0.1:49134   # iii engine WebSocket URL
 ```
+
+CLI overrides: `--url` / `III_URL` wins when set; otherwise `engine_url` from
+config is used. Other defaults live in [`src/config.rs`](src/config.rs).
+
+## Custom trigger types
+
+This worker registers HTTP triggers (POST) for `router::push_steering`,
+`router::abort`, and `router::push_followup` at `agent/{session_id}/steer`,
+`agent/{session_id}/abort`, and `agent/{session_id}/follow_up` respectively,
+bound to those same function ids.

--- a/provider-router/build.rs
+++ b/provider-router/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+}

--- a/provider-router/src/config.rs
+++ b/provider-router/src/config.rs
@@ -1,0 +1,49 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct WorkerConfig {
+    #[serde(default = "default_engine_url")]
+    pub engine_url: String,
+}
+
+fn default_engine_url() -> String {
+    "ws://127.0.0.1:49134".to_string()
+}
+
+impl Default for WorkerConfig {
+    fn default() -> Self {
+        Self {
+            engine_url: default_engine_url(),
+        }
+    }
+}
+
+pub fn load_config(path: &str) -> Result<WorkerConfig> {
+    let contents = std::fs::read_to_string(path)?;
+    let cfg: WorkerConfig = serde_yaml::from_str(&contents)?;
+    Ok(cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_from_empty_yaml() {
+        let cfg: WorkerConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(cfg.engine_url, "ws://127.0.0.1:49134");
+    }
+
+    #[test]
+    fn custom_yaml_overrides() {
+        let cfg: WorkerConfig =
+            serde_yaml::from_str(r#"engine_url: "ws://example:49134""#).unwrap();
+        assert_eq!(cfg.engine_url, "ws://example:49134");
+    }
+
+    #[test]
+    fn impl_default_matches_yaml_defaults() {
+        assert_eq!(WorkerConfig::default().engine_url, default_engine_url());
+    }
+}

--- a/provider-router/src/main.rs
+++ b/provider-router/src/main.rs
@@ -1,24 +1,88 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use iii_sdk::{register_worker, InitOptions};
+use clap::Parser;
+use iii_sdk::{register_worker, InitOptions, OtelConfig, WorkerMetadata};
 
-const DEFAULT_ENGINE_URL: &str = "ws://127.0.0.1:49134";
+mod config;
+mod manifest;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "iii-provider-router",
+    about = "router::stream_assistant provider router plus router::abort and push helpers."
+)]
+struct Cli {
+    #[arg(
+        long,
+        env = "III_PROVIDER_ROUTER_CONFIG",
+        default_value = "./config.yaml"
+    )]
+    config: String,
+
+    /// Engine WebSocket URL. Falls back to `engine_url` in `--config` when unset.
+    #[arg(long, env = "III_URL")]
+    url: Option<String>,
+
+    #[arg(long)]
+    manifest: bool,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
 
-    let engine_url = std::env::var("III_URL").unwrap_or_else(|_| DEFAULT_ENGINE_URL.to_string());
-    let iii = Arc::new(register_worker(&engine_url, InitOptions::default()));
+    let cli = Cli::parse();
+
+    if cli.manifest {
+        let m = manifest::build_manifest();
+        println!("{}", serde_json::to_string_pretty(&m)?);
+        return Ok(());
+    }
+
+    let cfg = match config::load_config(&cli.config) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(error = %e, path = %cli.config, "failed to load config, using defaults");
+            config::WorkerConfig::default()
+        }
+    };
+
+    let url = cli.url.unwrap_or_else(|| cfg.engine_url.clone());
+
+    let iii = register_worker(
+        &url,
+        InitOptions {
+            otel: Some(OtelConfig::default()),
+            metadata: Some(WorkerMetadata {
+                runtime: "rust".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                name: "provider-router".to_string(),
+                os: std::env::consts::OS.to_string(),
+                pid: Some(std::process::id()),
+                telemetry: None,
+                ..WorkerMetadata::default()
+            }),
+            ..InitOptions::default()
+        },
+    );
+    let iii = Arc::new(iii);
 
     provider_router::register_with_iii(&iii)
         .await
         .context("provider-router register failed")?;
-    log::info!(
+
+    tracing::info!(
         "provider-router registered (router::stream_assistant, router::abort, router::push_steering, router::push_followup)"
     );
 
     tokio::signal::ctrl_c().await.ok();
+    tracing::info!("provider-router shutting down");
+    iii.shutdown_async().await;
     Ok(())
 }

--- a/provider-router/src/manifest.rs
+++ b/provider-router/src/manifest.rs
@@ -1,0 +1,45 @@
+use serde::Serialize;
+
+use crate::config::WorkerConfig;
+
+#[derive(Serialize)]
+pub struct ModuleManifest {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub default_config: serde_json::Value,
+    pub supported_targets: Vec<String>,
+}
+
+pub fn build_manifest() -> ModuleManifest {
+    ModuleManifest {
+        name: env!("CARGO_PKG_NAME").to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        description:
+            "router::stream_assistant provider router plus router::abort and router::push_steering / push_followup helpers."
+                .to_string(),
+        default_config: serde_json::to_value(WorkerConfig::default())
+            .expect("WorkerConfig serializes to JSON"),
+        supported_targets: vec![env!("TARGET").to_string()],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_roundtrip_has_required_fields() {
+        let m = build_manifest();
+        let json = serde_json::to_string_pretty(&m).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["name"], env!("CARGO_PKG_NAME"));
+        assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+        assert!(parsed["description"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()));
+        assert!(parsed["default_config"].is_object());
+        assert!(!parsed["supported_targets"].as_array().unwrap().is_empty());
+    }
+}

--- a/provider-router/src/register.rs
+++ b/provider-router/src/register.rs
@@ -4,8 +4,8 @@
 //! |-------------------------|----------------------------------------------|
 //! | `router::stream_assistant`| Provider router. Calls `provider::<name>::complete` (with optional `router::decide` indirection when llm-router is on the bus). |
 //! | `router::abort`           | Set the abort flag for a session via `state::set` on `session/<id>/abort_signal`. |
-//! | `router::push_steering`   | Push messages onto the session's steering queue via `inbox::push`. |
-//! | `router::push_followup`   | Push messages onto the session's follow-up queue via `inbox::push`. |
+//! | `router::push_steering`   | Push messages onto the session's steering queue via `session-inbox::push`. |
+//! | `router::push_followup`   | Push messages onto the session's follow-up queue via `session-inbox::push`. |
 //!
 //! Plus the `hook-fanout`, `session-inbox` primitives and the
 //! `shell-filesystem`, `shell-bash` shell crates.
@@ -447,7 +447,7 @@ async fn push_queue(iii: III, payload: Value, name: &'static str) -> Result<Valu
         let item = serde_json::to_value(&m).map_err(|e| IIIError::Handler(e.to_string()))?;
         if let Err(e) = iii
             .trigger(TriggerRequest {
-                function_id: "inbox::push".to_string(),
+                function_id: "session-inbox::push".to_string(),
                 payload: json!({
                     "name": name,
                     "session_id": session_id,
@@ -458,7 +458,7 @@ async fn push_queue(iii: III, payload: Value, name: &'static str) -> Result<Valu
             })
             .await
         {
-            tracing::warn!(error = %e, %name, %session_id, "inbox::push failed during push_queue");
+            tracing::warn!(error = %e, %name, %session_id, "session-inbox::push failed during push_queue");
         }
     }
     Ok(json!({ "ok": true, "queued": count }))

--- a/provider-router/src/resume.rs
+++ b/provider-router/src/resume.rs
@@ -167,7 +167,7 @@ pub async fn resume_session(iii: &III, session_id: &str) -> Result<Vec<AgentMess
 
 async fn publish_step(iii: &III, session_id: &str) -> Result<(), ResumeError> {
     iii.trigger(TriggerRequest {
-        function_id: "publish".into(),
+        function_id: "iii::durable::publish".into(),
         payload: json!({
             "topic": "turn::step_requested",
             "data": { "session_id": session_id },

--- a/provider-router/tests/manifest.rs
+++ b/provider-router/tests/manifest.rs
@@ -1,0 +1,56 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn provider_router_executable() -> PathBuf {
+    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_iii_provider_router") {
+        return PathBuf::from(p);
+    }
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    for profile in ["debug", "release"] {
+        let candidate = dir.join("target").join(profile).join("iii-provider-router");
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+    panic!(
+        "iii-provider-router binary not found under target/{{debug,release}}/; run `cargo build --bin iii-provider-router` first"
+    );
+}
+
+#[test]
+fn manifest_subcommand_emits_valid_json() {
+    let bin = provider_router_executable();
+    let output = Command::new(&bin)
+        .arg("--manifest")
+        .output()
+        .expect("spawn iii-provider-router --manifest");
+
+    assert!(
+        output.status.success(),
+        "binary exited with {:?}; stderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("manifest stdout is utf-8");
+    let manifest: Value = serde_json::from_str(&stdout).expect("manifest stdout is valid JSON");
+
+    assert_eq!(manifest["name"], env!("CARGO_PKG_NAME"));
+    assert_eq!(manifest["version"], env!("CARGO_PKG_VERSION"));
+    assert!(
+        manifest["description"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()),
+        "description must be non-empty"
+    );
+    assert!(manifest["default_config"].is_object());
+    assert!(
+        !manifest["supported_targets"]
+            .as_array()
+            .expect("supported_targets must be an array")
+            .is_empty(),
+        "supported_targets must not be empty"
+    );
+}

--- a/registry/index.json
+++ b/registry/index.json
@@ -19,7 +19,7 @@
     },
     "session-inbox": {
       "type": "binary",
-      "description": "Per-session inbox under inbox::* (push, drain, peek) backed by iii state",
+      "description": "Per-session inbox (session-inbox::push, drain, peek) backed by iii state",
       "repo": "iii-hq/workers",
       "tag_prefix": "session-inbox",
       "supported_targets": [
@@ -47,7 +47,7 @@
     },
     "hook-fanout": {
       "type": "binary",
-      "description": "Reusable publish-collect primitive under hooks::publish_collect with subscriber reply merging",
+      "description": "Reusable publish-collect primitive (hook-fanout::publish_collect) with subscriber reply merging",
       "repo": "iii-hq/workers",
       "tag_prefix": "hook-fanout",
       "supported_targets": [

--- a/session-inbox/Cargo.lock
+++ b/session-inbox/Cargo.lock
@@ -146,6 +146,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,29 +276,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
 
 [[package]]
 name = "equivalent"
@@ -715,20 +732,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-session-inbox"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "env_logger",
- "iii-sdk",
- "log",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,30 +781,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jiff"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +791,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -832,15 +817,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +827,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -876,6 +861,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -986,29 +980,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,21 +1010,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -1245,27 +1201,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,12 +1368,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,6 +1463,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "session-inbox"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "iii-sdk",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "which",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,6 +1500,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1587,6 +1554,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1660,6 +1633,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,7 +1675,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -1877,6 +1858,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1929,6 +1940,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,6 +1992,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -2131,6 +2154,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/session-inbox/Cargo.toml
+++ b/session-inbox/Cargo.toml
@@ -1,11 +1,14 @@
+[workspace]
+
 [package]
-name = "iii-session-inbox"
+name = "session-inbox"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/iii-hq/workers"
 authors = ["iii contributors"]
 publish = false
+build = "build.rs"
 
 [lib]
 name = "session_inbox"
@@ -19,11 +22,17 @@ path = "src/main.rs"
 iii-sdk = "=0.11.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["full"] }
+serde_yaml = "0.9"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal"] }
 anyhow = "1"
 tracing = "0.1"
-log = "0.4"
-env_logger = "0.11"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+clap = { version = "4", features = ["derive", "env"] }
+
+[dev-dependencies]
+serde_json = "1"
+which = "8"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "signal"] }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/session-inbox/README.md
+++ b/session-inbox/README.md
@@ -1,54 +1,67 @@
 # session-inbox
 
-Per-session inbox on the iii bus under `inbox::*`. Producers push items keyed
-by `(session_id, name)`; consumers drain them atomically at session boundaries
+Per-session inbox on the iii bus. Producers push items keyed by
+`(session_id, name)`; consumers drain them atomically at session boundaries
 (typically between agent turns). Items live in iii state under
 `session/<id>/<name>` so they survive worker restart.
 
-This is **not** a job queue (compare `iii-queue`, the engine builtin with
-async consumers, retries, and DLQ). `session-inbox` is a pull-mode list:
-producers fire-and-forget, consumers drain when they decide.
+This is **not** a job queue (compare the engine’s queue builtin with async
+consumers, retries, and DLQ). `session-inbox` is a pull-mode list: producers
+fire-and-forget, consumers drain when they decide.
 
-## Installation
+## Install
 
 ```bash
 iii worker add session-inbox
 ```
 
-## Run
+`iii worker add` fetches the binary, writes a config block into
+`~/.iii/config.yaml`, and the engine starts the worker on the next
+`iii start`.
 
-```bash
-iii-session-inbox --engine-url ws://127.0.0.1:49134
+## Quickstart
+
+```rust
+use iii_sdk::{register_worker, InitOptions, TriggerRequest};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+
+    let result = iii
+        .trigger(TriggerRequest {
+            function_id: "session-inbox::push".into(),
+            payload: json!({
+                "session_id": "s1",
+                "name": "steering",
+                "item": { "role": "user", "content": "hello" },
+            }),
+            action: None,
+            timeout_ms: Some(5_000),
+        })
+        .await?;
+
+    println!("{result:#?}");
+    Ok(())
+}
 ```
 
-(Or set `III_URL`.)
-
-## Registered functions
-
-| Function | Payload | Returns |
-|---|---|---|
-| `inbox::push` | `{ session_id, name, item }` | `{ ok: true }` |
-| `inbox::drain` | `{ session_id, name }` | `{ items: [...] }` (atomic read+clear) |
-| `inbox::peek` | `{ session_id, name }` | `{ items: [...] }` (no mutation) |
-
-`drain` is atomic: implemented via `state::update` with a single `set` op,
-which returns the prior value AND writes `[]` in one round-trip. Producers
-that push during a drain see no items dropped.
+`session-inbox::drain` accepts `{ "session_id", "name" }` and returns
+`{ "items": [...] }` (atomic read+clear). `session-inbox::peek` reads without
+mutating.
 
 ## Configuration
 
-| Env var | Default | Effect |
-|---|---|---|
-| `III_URL` | `ws://127.0.0.1:49134` | Engine WebSocket URL. |
-
-## Dependencies
-
-Reads from / writes to scope `agent` of `iii-state` (the engine builtin).
-No worker dependencies.
-
-## Build / Test
-
-```bash
-cargo build --release
-cargo test
+```yaml
+engine_url: ws://127.0.0.1:49134 # used when --url / III_URL is unset
+state_scope: agent                # iii state scope for inbox keys
 ```
+
+Other defaults live in [`src/config.rs`](src/config.rs).
+
+## Migration notes
+
+Function ids were previously registered as `inbox::push`, `inbox::drain`, and
+`inbox::peek`. They are now `session-inbox::push`, `session-inbox::drain`, and
+`session-inbox::peek`. Payloads are unchanged.

--- a/session-inbox/build.rs
+++ b/session-inbox/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+}

--- a/session-inbox/iii.worker.yaml
+++ b/session-inbox/iii.worker.yaml
@@ -4,4 +4,4 @@ language: rust
 deploy: binary
 manifest: Cargo.toml
 bin: iii-session-inbox
-description: Per-session inbox under inbox::* — push, drain, peek backed by iii state.
+description: Per-session inbox (session-inbox::push, drain, peek) backed by iii state.

--- a/session-inbox/src/config.rs
+++ b/session-inbox/src/config.rs
@@ -1,0 +1,66 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct WorkerConfig {
+    #[serde(default = "default_engine_url")]
+    pub engine_url: String,
+
+    #[serde(default = "default_state_scope")]
+    pub state_scope: String,
+}
+
+fn default_engine_url() -> String {
+    "ws://127.0.0.1:49134".to_string()
+}
+
+fn default_state_scope() -> String {
+    "agent".to_string()
+}
+
+impl Default for WorkerConfig {
+    fn default() -> Self {
+        Self {
+            engine_url: default_engine_url(),
+            state_scope: default_state_scope(),
+        }
+    }
+}
+
+pub fn load_config(path: &str) -> Result<WorkerConfig> {
+    let contents = std::fs::read_to_string(path)?;
+    let cfg: WorkerConfig = serde_yaml::from_str(&contents)?;
+    Ok(cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_from_empty_yaml() {
+        let cfg: WorkerConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(cfg.engine_url, "ws://127.0.0.1:49134");
+        assert_eq!(cfg.state_scope, "agent");
+    }
+
+    #[test]
+    fn custom_yaml_overrides() {
+        let cfg: WorkerConfig = serde_yaml::from_str(
+            r#"
+engine_url: "ws://example:49134"
+state_scope: custom
+"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.engine_url, "ws://example:49134");
+        assert_eq!(cfg.state_scope, "custom");
+    }
+
+    #[test]
+    fn impl_default_matches_yaml_defaults() {
+        let d = WorkerConfig::default();
+        assert_eq!(d.engine_url, default_engine_url());
+        assert_eq!(d.state_scope, default_state_scope());
+    }
+}

--- a/session-inbox/src/handler.rs
+++ b/session-inbox/src/handler.rs
@@ -1,13 +1,14 @@
-//! `inbox::push`, `inbox::drain`, `inbox::peek` handlers.
+//! `session-inbox::push`, `session-inbox::drain`, `session-inbox::peek` handlers.
+
+use std::sync::Arc;
 
 use iii_sdk::{IIIError, RegisterFunctionMessage, TriggerRequest, Value, III};
 use serde_json::json;
 
+use crate::config::WorkerConfig;
 use crate::{inbox_key, DRAIN_ID, PEEK_ID, PUSH_ID};
 
-const STATE_SCOPE: &str = "agent";
-
-async fn execute_push(iii: III, payload: Value) -> Result<Value, IIIError> {
+async fn execute_push(iii: III, state_scope: String, payload: Value) -> Result<Value, IIIError> {
     let name = required_str(&payload, "name")?;
     let session_id = required_str(&payload, "session_id")?;
     let item = payload
@@ -19,7 +20,7 @@ async fn execute_push(iii: III, payload: Value) -> Result<Value, IIIError> {
     iii.trigger(TriggerRequest {
         function_id: "state::update".into(),
         payload: json!({
-            "scope": STATE_SCOPE,
+            "scope": state_scope,
             "key": key,
             "ops": [{ "type": "append", "path": "", "value": item }],
         }),
@@ -31,14 +32,14 @@ async fn execute_push(iii: III, payload: Value) -> Result<Value, IIIError> {
     Ok(json!({ "ok": true }))
 }
 
-async fn execute_peek(iii: III, payload: Value) -> Result<Value, IIIError> {
+async fn execute_peek(iii: III, state_scope: String, payload: Value) -> Result<Value, IIIError> {
     let name = required_str(&payload, "name")?;
     let session_id = required_str(&payload, "session_id")?;
     let key = inbox_key(&name, &session_id);
     let value = match iii
         .trigger(TriggerRequest {
             function_id: "state::get".into(),
-            payload: json!({ "scope": STATE_SCOPE, "key": key }),
+            payload: json!({ "scope": state_scope, "key": key }),
             action: None,
             timeout_ms: None,
         })
@@ -59,7 +60,7 @@ async fn execute_peek(iii: III, payload: Value) -> Result<Value, IIIError> {
 /// Implemented via `state::update` with a single `Set { path: "", value: [] }`
 /// op. The engine returns `old_value` (whatever was there) and `new_value`
 /// (`[]`). One round-trip, no race window between read and reset.
-async fn execute_drain(iii: III, payload: Value) -> Result<Value, IIIError> {
+async fn execute_drain(iii: III, state_scope: String, payload: Value) -> Result<Value, IIIError> {
     let name = required_str(&payload, "name")?;
     let session_id = required_str(&payload, "session_id")?;
     let key = inbox_key(&name, &session_id);
@@ -67,7 +68,7 @@ async fn execute_drain(iii: III, payload: Value) -> Result<Value, IIIError> {
         .trigger(TriggerRequest {
             function_id: "state::update".into(),
             payload: json!({
-                "scope": STATE_SCOPE,
+                "scope": state_scope,
                 "key": key,
                 "ops": [{ "type": "set", "path": "", "value": [] }],
             }),
@@ -78,7 +79,7 @@ async fn execute_drain(iii: III, payload: Value) -> Result<Value, IIIError> {
     {
         Ok(v) => v,
         Err(e) => {
-            tracing::warn!(error = %e, %name, %session_id, "inbox::drain: state::update failed; treating as empty");
+            tracing::warn!(error = %e, %name, %session_id, "session-inbox::drain: state::update failed; treating as empty");
             return Ok(json!({ "items": [] }));
         }
     };
@@ -90,34 +91,40 @@ async fn execute_drain(iii: III, payload: Value) -> Result<Value, IIIError> {
     Ok(json!({ "items": items }))
 }
 
-pub fn register(iii: &III) {
+pub fn register(iii: &III, cfg: &Arc<WorkerConfig>) {
     let iii_push = iii.clone();
+    let scope_push = cfg.state_scope.clone();
     iii.register_function((
         RegisterFunctionMessage::with_id(PUSH_ID.to_string())
             .with_description("Append an item to a session-scoped inbox.".to_string()),
         move |payload: Value| {
             let iii = iii_push.clone();
-            async move { execute_push(iii, payload).await }
+            let state_scope = scope_push.clone();
+            async move { execute_push(iii, state_scope, payload).await }
         },
     ));
     let iii_peek = iii.clone();
+    let scope_peek = cfg.state_scope.clone();
     iii.register_function((
         RegisterFunctionMessage::with_id(PEEK_ID.to_string()).with_description(
             "Read all items in a session-scoped inbox without mutating.".to_string(),
         ),
         move |payload: Value| {
             let iii = iii_peek.clone();
-            async move { execute_peek(iii, payload).await }
+            let state_scope = scope_peek.clone();
+            async move { execute_peek(iii, state_scope, payload).await }
         },
     ));
     let iii_drain = iii.clone();
+    let scope_drain = cfg.state_scope.clone();
     iii.register_function((
         RegisterFunctionMessage::with_id(DRAIN_ID.to_string()).with_description(
             "Atomically read and clear all items in a session-scoped inbox.".to_string(),
         ),
         move |payload: Value| {
             let iii = iii_drain.clone();
-            async move { execute_drain(iii, payload).await }
+            let state_scope = scope_drain.clone();
+            async move { execute_drain(iii, state_scope, payload).await }
         },
     ));
 }

--- a/session-inbox/src/lib.rs
+++ b/session-inbox/src/lib.rs
@@ -1,11 +1,14 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::sync::Arc;
 
+pub mod config;
 pub mod handler;
+pub mod manifest;
 
-pub const PUSH_ID: &str = "inbox::push";
-pub const DRAIN_ID: &str = "inbox::drain";
-pub const PEEK_ID: &str = "inbox::peek";
+pub const PUSH_ID: &str = "session-inbox::push";
+pub const DRAIN_ID: &str = "session-inbox::drain";
+pub const PEEK_ID: &str = "session-inbox::peek";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InboxRequest {
@@ -32,8 +35,8 @@ pub fn build_clear_set_op() -> Value {
     serde_json::json!({ "type": "set", "path": "", "value": [] })
 }
 
-pub fn register_with_iii(iii: &iii_sdk::III) {
-    handler::register(iii);
+pub fn register_with_iii(iii: &iii_sdk::III, cfg: &Arc<config::WorkerConfig>) {
+    handler::register(iii, cfg);
 }
 
 #[cfg(test)]

--- a/session-inbox/src/main.rs
+++ b/session-inbox/src/main.rs
@@ -1,20 +1,99 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use iii_sdk::{register_worker, InitOptions};
+use clap::Parser;
+use iii_sdk::{register_worker, InitOptions, OtelConfig, WorkerMetadata};
+use session_inbox::{config, manifest, register_with_iii};
 
-const DEFAULT_ENGINE_URL: &str = "ws://127.0.0.1:49134";
+#[derive(Parser, Debug)]
+#[command(
+    name = "session-inbox",
+    about = "Per-session inbox: push, drain, peek backed by iii state."
+)]
+struct Cli {
+    #[arg(long, default_value = "./config.yaml")]
+    config: String,
+
+    /// Engine WebSocket URL. Overrides `engine_url` in `--config` when set (or use `III_URL`).
+    #[arg(long, env = "III_URL")]
+    url: Option<String>,
+
+    #[arg(long)]
+    manifest: bool,
+}
+
+#[cfg(unix)]
+async fn wait_for_shutdown() {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    let mut sigterm = signal(SignalKind::terminate()).expect("install SIGTERM handler");
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {},
+        _ = sigterm.recv() => {},
+    }
+}
+
+#[cfg(not(unix))]
+async fn wait_for_shutdown() {
+    let _ = tokio::signal::ctrl_c().await;
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
 
-    let engine_url = std::env::var("III_URL").unwrap_or_else(|_| DEFAULT_ENGINE_URL.to_string());
-    let iii = Arc::new(register_worker(&engine_url, InitOptions::default()));
+    let cli = Cli::parse();
 
-    session_inbox::register_with_iii(&iii);
-    log::info!("session-inbox registered (inbox::push, inbox::drain, inbox::peek)");
+    if cli.manifest {
+        let m = manifest::build_manifest();
+        println!("{}", serde_json::to_string_pretty(&m)?);
+        return Ok(());
+    }
 
-    tokio::signal::ctrl_c().await.ok();
+    let cfg = match config::load_config(&cli.config) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(error = %e, path = %cli.config, "failed to load config, using defaults");
+            config::WorkerConfig::default()
+        }
+    };
+    let cfg = Arc::new(cfg);
+
+    let url = cli.url.unwrap_or_else(|| cfg.engine_url.clone());
+
+    let iii = register_worker(
+        &url,
+        InitOptions {
+            otel: Some(OtelConfig::default()),
+            metadata: Some(WorkerMetadata {
+                runtime: "rust".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                name: "session-inbox".to_string(),
+                os: std::env::consts::OS.to_string(),
+                pid: Some(std::process::id()),
+                telemetry: None,
+                ..WorkerMetadata::default()
+            }),
+            ..InitOptions::default()
+        },
+    );
+    let iii = Arc::new(iii);
+
+    register_with_iii(&iii, &cfg);
+    tracing::info!(
+        "session-inbox ready ({}, {}, {})",
+        session_inbox::PUSH_ID,
+        session_inbox::DRAIN_ID,
+        session_inbox::PEEK_ID
+    );
+
+    wait_for_shutdown().await;
+    tracing::info!("session-inbox shutting down");
+    iii.shutdown_async().await;
     Ok(())
 }

--- a/session-inbox/src/manifest.rs
+++ b/session-inbox/src/manifest.rs
@@ -1,0 +1,45 @@
+use serde::Serialize;
+
+use crate::config::WorkerConfig;
+
+#[derive(Serialize)]
+pub struct ModuleManifest {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub default_config: serde_json::Value,
+    pub supported_targets: Vec<String>,
+}
+
+pub fn build_manifest() -> ModuleManifest {
+    ModuleManifest {
+        name: env!("CARGO_PKG_NAME").to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        description:
+            "Per-session inbox under session-inbox::* — push, drain, peek backed by iii state."
+                .to_string(),
+        default_config: serde_json::to_value(WorkerConfig::default())
+            .expect("WorkerConfig serializes to JSON"),
+        supported_targets: vec![env!("TARGET").to_string()],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_roundtrip_has_required_fields() {
+        let m = build_manifest();
+        let json = serde_json::to_string_pretty(&m).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["name"], env!("CARGO_PKG_NAME"));
+        assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+        assert!(parsed["description"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()));
+        assert!(parsed["default_config"].is_object());
+        assert!(!parsed["supported_targets"].as_array().unwrap().is_empty());
+    }
+}

--- a/session-inbox/tests/common/mod.rs
+++ b/session-inbox/tests/common/mod.rs
@@ -1,0 +1,17 @@
+use std::path::{Path, PathBuf};
+
+pub fn session_inbox_executable() -> PathBuf {
+    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_iii_session_inbox") {
+        return PathBuf::from(p);
+    }
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    for profile in ["debug", "release"] {
+        let candidate = dir.join("target").join(profile).join("iii-session-inbox");
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+    panic!(
+        "iii-session-inbox binary not found under target/{{debug,release}}/; run `cargo build --bin iii-session-inbox` first"
+    );
+}

--- a/session-inbox/tests/integration.rs
+++ b/session-inbox/tests/integration.rs
@@ -1,10 +1,21 @@
-//! Smoke tests that run without an iii engine connection.
+//! Smoke tests and optional engine-backed e2e (`iii` on PATH).
+
+mod common;
+
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+use iii_sdk::{register_worker, InitOptions, TriggerRequest};
+use serde_json::json;
+use tokio::time::{sleep, timeout};
+
+const ENGINE_WS: &str = "ws://127.0.0.1:49134";
 
 #[test]
-fn function_ids_in_inbox_namespace() {
-    assert_eq!(session_inbox::PUSH_ID, "inbox::push");
-    assert_eq!(session_inbox::DRAIN_ID, "inbox::drain");
-    assert_eq!(session_inbox::PEEK_ID, "inbox::peek");
+fn function_ids_use_worker_namespace() {
+    assert_eq!(session_inbox::PUSH_ID, "session-inbox::push");
+    assert_eq!(session_inbox::DRAIN_ID, "session-inbox::drain");
+    assert_eq!(session_inbox::PEEK_ID, "session-inbox::peek");
 }
 
 #[test]
@@ -13,4 +24,78 @@ fn inbox_key_uses_session_namespace() {
         session_inbox::inbox_key("steering", "s1"),
         "session/s1/steering"
     );
+}
+
+struct Harness {
+    iii: Child,
+    worker: Child,
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        let _ = self.worker.kill();
+        let _ = self.worker.wait();
+        let _ = self.iii.kill();
+        let _ = self.iii.wait();
+    }
+}
+
+async fn boot() -> Option<Harness> {
+    let iii_bin = which::which("iii").ok()?;
+
+    let iii = Command::new(&iii_bin)
+        .arg("--use-default-config")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    sleep(Duration::from_millis(800)).await;
+
+    let worker_bin = common::session_inbox_executable();
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let config_path = format!("{manifest_dir}/config.yaml");
+
+    let worker = Command::new(worker_bin)
+        .args(["--url", ENGINE_WS, "--config", &config_path])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    sleep(Duration::from_millis(1500)).await;
+
+    Some(Harness { iii, worker })
+}
+
+#[tokio::test]
+async fn end_to_end_push_via_iii_sdk() {
+    let Some(_h) = boot().await else {
+        eprintln!("skipping: `iii` binary not on PATH");
+        return;
+    };
+
+    let client = register_worker(ENGINE_WS, InitOptions::default());
+    sleep(Duration::from_millis(500)).await;
+
+    let result = timeout(
+        Duration::from_secs(10),
+        client.trigger(TriggerRequest {
+            function_id: "session-inbox::push".into(),
+            payload: json!({
+                "session_id": "s-e2e",
+                "name": "steering",
+                "item": { "role": "user" },
+            }),
+            action: None,
+            timeout_ms: Some(5_000),
+        }),
+    )
+    .await
+    .expect("trigger timed out")
+    .expect("trigger failed");
+
+    assert_eq!(result["ok"], true);
+
+    client.shutdown_async().await;
 }

--- a/session-inbox/tests/manifest.rs
+++ b/session-inbox/tests/manifest.rs
@@ -1,0 +1,32 @@
+mod common;
+
+use std::process::Command;
+
+use serde_json::Value;
+
+#[test]
+fn manifest_subcommand_emits_valid_json() {
+    let bin = common::session_inbox_executable();
+    let output = Command::new(bin)
+        .arg("--manifest")
+        .output()
+        .expect("spawn iii-session-inbox --manifest");
+
+    assert!(
+        output.status.success(),
+        "binary exited with {:?}; stderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("manifest stdout is utf-8");
+    let manifest: Value = serde_json::from_str(&stdout).expect("manifest stdout is valid JSON");
+
+    assert_eq!(manifest["name"], env!("CARGO_PKG_NAME"));
+    assert_eq!(manifest["version"], env!("CARGO_PKG_VERSION"));
+    assert!(manifest["default_config"].is_object());
+    assert!(!manifest["supported_targets"]
+        .as_array()
+        .expect("supported_targets must be an array")
+        .is_empty());
+}

--- a/session-tree/Cargo.lock
+++ b/session-tree/Cargo.lock
@@ -169,6 +169,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,29 +299,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
 
 [[package]]
 name = "equivalent"
@@ -776,14 +793,16 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "env_logger",
+ "clap",
  "harness-types",
  "iii-sdk",
- "log",
  "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -837,30 +856,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jiff"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,6 +866,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -912,6 +913,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,6 +945,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1098,21 +1117,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -1310,18 +1314,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
 ]
 
 [[package]]
@@ -1593,6 +1585,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1601,6 +1606,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1646,6 +1660,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1716,6 +1736,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1936,6 +1965,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1988,6 +2047,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2034,6 +2099,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/session-tree/Cargo.toml
+++ b/session-tree/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 repository = "https://github.com/iii-hq/workers"
 authors = ["iii contributors"]
 publish = false
+build = "build.rs"
 
 [lib]
 name = "session_tree"
@@ -30,8 +31,10 @@ tokio = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
 anyhow = { workspace = true }
-log = "0.4"
-env_logger = "0.11"
+serde_yaml = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+clap = { workspace = true }
 
 [workspace.package]
 version = "0.1.0"
@@ -50,6 +53,10 @@ thiserror = "2"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
+serde_yaml = "0.9"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+clap = { version = "4", features = ["derive"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/session-tree/README.md
+++ b/session-tree/README.md
@@ -1,67 +1,80 @@
 # session-tree
 
-Session storage as a parent-id tree of typed entries on the iii bus. Stores
-agent messages, custom messages, and tool results, addressable by parent id
-so multi-turn forks share a common history.
+Session storage as a parent-id tree of typed entries on the iii bus: agent
+messages, custom payloads, branch summaries, and compaction markers. Each session
+is a DAG keyed by parent id so forks share history; callers use
+`session-tree::*` functions to create sessions, append messages, fork branches,
+and export HTML views.
 
-## Installation
+## Install
 
 ```bash
 iii worker add session-tree
 ```
 
-## Run
+`iii worker add` fetches the binary, writes a config block into
+`~/.iii/config.yaml`, and the engine starts the worker on the next `iii start`.
 
-```bash
-iii-session-tree --engine-url ws://127.0.0.1:49134
+## Quickstart
+
+```rust
+use iii_sdk::{register_worker, InitOptions, TriggerRequest};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+
+    let created = iii
+        .trigger(TriggerRequest {
+            function_id: "session-tree::create".into(),
+            payload: json!({ "display_name": "demo" }),
+            action: None,
+            timeout_ms: Some(5_000),
+        })
+        .await?;
+
+    let session_id = created["session_id"].as_str().unwrap();
+
+    let appended = iii
+        .trigger(TriggerRequest {
+            function_id: "session-tree::append".into(),
+            payload: json!({
+                "session_id": session_id,
+                "message": {
+                    "role": "user",
+                    "content": [{ "type": "text", "text": "hello" }],
+                    "timestamp": 0,
+                },
+            }),
+            action: None,
+            timeout_ms: Some(5_000),
+        })
+        .await?;
+
+    println!("entry_id = {:?}", appended["entry_id"]);
+    Ok(())
+}
 ```
 
-Defaults to an iii-state-backed store (sessions survive worker restart).
-Set `SESSION_TREE_STORE=memory` for ephemeral in-process storage; see
-[Storage backends](#storage-backends) below.
+Other surfaced calls include `session-tree::messages`, `session-tree::tree`,
+`session-tree::fork`, `session-tree::clone`, `session-tree::compact`, and
+`session-tree::export_html`.
 
-## Registered functions (P0 + P2 surface)
+## Configuration
 
-P0: `session::create`, `session::load`, `session::append`,
-`session::active_path`, `session::list`, `session::load_messages`.
-
-P2: `session::fork`, `session::clone_session`, `session::compact`,
-`session::export_html`, `session::tree`.
-
-## Storage backends
-
-`session-tree` supports two storage backends, selected via the
-`SESSION_TREE_STORE` env var:
-
-| Value | Persistence | Use case |
-|---|---|---|
-| `iii_state` (default) | Survives worker restart via `iii-state` | Production |
-| `memory` | In-process only; lost on restart | Tests, local dev |
-
-The `iii_state` backend uses a scope-per-session layout for bounded scan cost:
-
-- Scope `session_tree:<session_id>`, key `<entry_id>`, value `SessionEntry`
-- Scope `session_tree_meta`, key `<session_id>`, value `SessionMeta`
-
-`load_entries(sid)` lists the per-session scope and sorts by lexicographic
-`entry_id`. `append` is `O(1)` regardless of session length: one `state::set`
-for the entry, plus a non-fatal `state::set` to refresh `SessionMeta::updated_at`.
-If the meta refresh fails, the entry still persists and a warning is logged;
-`updated_at` may be slightly stale.
-
-### Failure semantics
-
-`SessionStore` methods return `Result<_, SessionError>`. With the `iii_state`
-backend, transient bus failures (engine restart, IPC hiccup) map to
-`SessionError::Storage(...)`. With `memory`, errors are limited to logical
-conditions like `NotFound` and `RwLock` poison.
-
-`load_meta` returns `SessionError::NotFound(<sid>)` when the session doesn't
-exist; `load_entries` returns an empty vec for a session with no appended
-entries (never `NotFound`).
-
-## Build
-
-```bash
-cargo build --release
+```yaml
+store_backend: iii_state   # iii_state (persist via iii-state) | memory (ephemeral)
 ```
+
+Defaults live in [`config.yaml`](config.yaml); missing keys use the values in
+[`src/config.rs`](src/config.rs).
+
+### Storage layout (iii_state)
+
+Scopes:
+
+- `session_tree:<session_id>` — entry id → `SessionEntry`
+- `session_tree_meta` — session id → `SessionMeta`
+
+With `memory`, everything stays in-process and is lost when the worker exits.

--- a/session-tree/build.rs
+++ b/session-tree/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+}

--- a/session-tree/iii.worker.yaml
+++ b/session-tree/iii.worker.yaml
@@ -4,4 +4,4 @@ language: rust
 deploy: binary
 manifest: Cargo.toml
 bin: iii-session-tree
-description: Session storage as a parent-id tree of typed entries under session::*.
+description: Session storage as a parent-id tree of typed entries under session-tree::*.

--- a/session-tree/skill.md
+++ b/session-tree/skill.md
@@ -4,17 +4,17 @@ Persistent branching session storage: create, append to, read, fork, clone, comp
 and export conversation histories as parent-linked entry trees.
 
 - [`session-tree`](iii://session-tree)
-  - [`session::create`](iii://session-tree/create) — create a new empty session record
-  - [`session::append`](iii://session-tree/append) — append an AgentMessage entry to a session
+  - [`session-tree::create`](iii://session-tree/create) — create a new empty session record
+  - [`session-tree::append`](iii://session-tree/append) — append an AgentMessage entry to a session
 
-  - [`session::messages`](iii://session-tree/messages) — load every AgentMessage on the active path, oldest first
-  - [`session::tree`](iii://session-tree/tree) — return the full session DAG as a nested TreeNode
+  - [`session-tree::messages`](iii://session-tree/messages) — load every AgentMessage on the active path, oldest first
+  - [`session-tree::tree`](iii://session-tree/tree) — return the full session DAG as a nested TreeNode
 
-  - [`session::fork`](iii://session-tree/fork) — copy the active path up to a given entry into a new session
-  - [`session::clone`](iii://session-tree/clone) — duplicate an entire session with remapped ids
-  - [`session::compact`](iii://session-tree/compact) — append a Compaction entry summarising the active path
+  - [`session-tree::fork`](iii://session-tree/fork) — copy the active path up to a given entry into a new session
+  - [`session-tree::clone`](iii://session-tree/clone) — duplicate an entire session with remapped ids
+  - [`session-tree::compact`](iii://session-tree/compact) — append a Compaction entry summarising the active path
 
-  - [`session::export_html`](iii://session-tree/export_html) — render the active path as a self-contained HTML document
+  - [`session-tree::export_html`](iii://session-tree/export_html) — render the active path as a self-contained HTML document
 
-Storage backend is selected at startup via `SESSION_TREE_STORE` (`iii_state` by
-default; set to `memory` for ephemeral in-process use).
+Storage backend is selected from [`config.yaml`](config.yaml) (`store_backend:
+iii_state` by default; use `memory` for ephemeral in-process use).

--- a/session-tree/skills/append.md
+++ b/session-tree/skills/append.md
@@ -1,4 +1,4 @@
-# session::append
+# session-tree::append
 
 Append an `AgentMessage` entry to an existing session and return the new entry id.
 
@@ -14,7 +14,7 @@ metadata is advanced.
 - Building a branching history: pass the previous entry's id as `parent_id` to
   chain entries into a linked list; omit `parent_id` to start a new root (rare).
 - Writing replays or synthetic sessions entry-by-entry before calling
-  `session::messages` or `session::export_html`.
+  `session-tree::messages` or `session-tree::export_html`.
 
 ## Notes
 
@@ -24,5 +24,5 @@ metadata is advanced.
   In a linear conversation thread every entry except the first should supply the
   previous `entry_id` as `parent_id`.
 - Entry ids are UUIDs generated server-side; do not supply your own id.
-- `session::append` is not idempotent: calling it twice with the same payload
+- `session-tree::append` is not idempotent: calling it twice with the same payload
   creates two distinct entries.

--- a/session-tree/skills/clone.md
+++ b/session-tree/skills/clone.md
@@ -1,4 +1,4 @@
-# session::clone
+# session-tree::clone
 
 Duplicate an entire session — all entries across all branches — with remapped ids,
 and return the new session id.
@@ -16,7 +16,7 @@ the new ids, and persists everything into a new session record.
 
 ## Notes
 
-- Unlike `session::fork`, clone copies the entire entry set (all branches, not just
+- Unlike `session-tree::fork`, clone copies the entire entry set (all branches, not just
   the active path).
 - All entry ids in the clone are new UUIDs; none overlap with those in the source
   session.
@@ -25,4 +25,4 @@ the new ids, and persists everything into a new session record.
 - The new session's display name is `"<source name> (clone)"` if the source has a
   display name.
 - For very large sessions with many entries, clone can be expensive; prefer
-  `session::fork` when only the active-path context is needed.
+  `session-tree::fork` when only the active-path context is needed.

--- a/session-tree/skills/compact.md
+++ b/session-tree/skills/compact.md
@@ -1,4 +1,4 @@
-# session::compact
+# session-tree::compact
 
 Append a `Compaction` entry to a session, recording a summary of the context that
 was compressed and the token count before compaction.
@@ -26,5 +26,5 @@ omitted.
   omit the `details` field entirely if no file operations occurred.
 - `parent_id` is optional; if omitted, the compaction entry is anchored at the
   most recent entry on the active path.
-- `session::compact` is not idempotent: calling it twice creates two compaction
+- `session-tree::compact` is not idempotent: calling it twice creates two compaction
   entries. Check existing entries before calling if idempotency is required.

--- a/session-tree/skills/create.md
+++ b/session-tree/skills/create.md
@@ -1,10 +1,10 @@
-# session::create
+# session-tree::create
 
 Create a new empty session record and return its generated id.
 
 `({ display_name?, cwd? }) → { session_id }` — allocates a UUID, persists session
 metadata (display name, working directory, timestamps), and initialises an empty
-entry list. The caller must follow up with `session::append` to populate the session
+entry list. The caller must follow up with `session-tree::append` to populate the session
 with messages.
 
 ## When to use
@@ -20,8 +20,8 @@ with messages.
 
 - `display_name` and `cwd` are both optional; omit them for anonymous sessions.
 - The returned `session_id` is a UUID string; pass it verbatim to all other
-  `session::*` functions.
-- Sessions are persisted in whichever backend is configured at startup (`iii-state`
-  by default; override with `SESSION_TREE_STORE=memory` for ephemeral use).
+  `session-tree::*` functions.
+- Sessions are persisted in whichever backend is configured at startup (`store_backend:
+  iii_state` in `config.yaml` by default; use `memory` for ephemeral use).
 - `created_at` and `updated_at` are set to the current millisecond epoch at creation
-  time; `updated_at` advances on every `session::append` call.
+  time; `updated_at` advances on every `session-tree::append` call.

--- a/session-tree/skills/export_html.md
+++ b/session-tree/skills/export_html.md
@@ -1,4 +1,4 @@
-# session::export_html
+# session-tree::export_html
 
 Render the active path of a session as a self-contained HTML document and return it
 as a string.

--- a/session-tree/skills/fork.md
+++ b/session-tree/skills/fork.md
@@ -1,4 +1,4 @@
-# session::fork
+# session-tree::fork
 
 Copy the active path up to a given entry into a new session and return the new
 session id.

--- a/session-tree/skills/messages.md
+++ b/session-tree/skills/messages.md
@@ -1,4 +1,4 @@
-# session::messages
+# session-tree::messages
 
 Load every `AgentMessage` on the active path of a session, oldest first.
 
@@ -15,7 +15,7 @@ order. Only `SessionEntry::Message` entries are included; `BranchSummary`,
 - Diffing two branches of a session tree: call with different `branch_leaf` values
   and compare the resulting message lists.
 - Extracting the human-readable transcript of a single branch for display or export
-  (see also `session::export_html` for a styled HTML rendering).
+  (see also `session-tree::export_html` for a styled HTML rendering).
 
 ## Notes
 
@@ -25,6 +25,6 @@ order. Only `SessionEntry::Message` entries are included; `BranchSummary`,
   (`BranchSummary`, `Compaction`) are traversed for parent-link resolution but
   do not appear in the returned array.
 - The result reflects the active path only — sibling branches are not included.
-  Use `session::tree` to see the full DAG structure.
+  Use `session-tree::tree` to see the full DAG structure.
 - For a complete `AgentContext` (including system prompt), assemble one from the
   returned messages in the calling agent rather than here.

--- a/session-tree/skills/tree.md
+++ b/session-tree/skills/tree.md
@@ -1,4 +1,4 @@
-# session::tree
+# session-tree::tree
 
 Return the full session history as a nested `TreeNode` DAG, rooted at the first
 entry appended with no parent.
@@ -22,9 +22,9 @@ in the tree correspond to entries that share the same `parent_id`.
   `parent_id: null`).
 - In a well-formed session exactly one entry has `parent_id: null`; if multiple
   root-less entries exist, the first one appended is treated as the root.
-- `tree` returns the full DAG (every branch); contrast with `session::messages`,
+- `tree` returns the full DAG (every branch); contrast with `session-tree::messages`,
   which returns only the messages on a single active path.
 - `TreeNode.entry` is a `SessionEntry` (may be `Message`, `CustomMessage`,
   `BranchSummary`, or `Compaction`).
 - For large sessions with many forks the response payload can be significant; prefer
-  `session::messages` when only the active path is needed.
+  `session-tree::messages` when only the active path is needed.

--- a/session-tree/src/config.rs
+++ b/session-tree/src/config.rs
@@ -1,0 +1,49 @@
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct SessionTreeConfig {
+    #[serde(default = "default_store_backend")]
+    pub store_backend: String,
+}
+
+fn default_store_backend() -> String {
+    "iii_state".to_string()
+}
+
+impl Default for SessionTreeConfig {
+    fn default() -> Self {
+        Self {
+            store_backend: default_store_backend(),
+        }
+    }
+}
+
+pub fn load_config(path: &str) -> Result<SessionTreeConfig> {
+    let contents = std::fs::read_to_string(path).with_context(|| format!("read {path}"))?;
+    let cfg: SessionTreeConfig =
+        serde_yaml::from_str(&contents).with_context(|| format!("parse yaml {path}"))?;
+    Ok(cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_from_empty_yaml() {
+        let cfg: SessionTreeConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(cfg.store_backend, "iii_state");
+    }
+
+    #[test]
+    fn custom_yaml_overrides() {
+        let cfg: SessionTreeConfig = serde_yaml::from_str("store_backend: memory").unwrap();
+        assert_eq!(cfg.store_backend, "memory");
+    }
+
+    #[test]
+    fn impl_default_matches_yaml_defaults() {
+        assert_eq!(SessionTreeConfig::default().store_backend, "iii_state");
+    }
+}

--- a/session-tree/src/lib.rs
+++ b/session-tree/src/lib.rs
@@ -697,17 +697,17 @@ fn html_escape(input: &str) -> String {
 
 /// Registered function ids exposed by [`register_with_iii`].
 pub mod function_ids {
-    pub const FORK: &str = "session::fork";
-    pub const CLONE: &str = "session::clone";
-    pub const COMPACT: &str = "session::compact";
-    pub const TREE: &str = "session::tree";
-    pub const EXPORT_HTML: &str = "session::export_html";
-    pub const CREATE: &str = "session::create";
-    pub const APPEND: &str = "session::append";
-    pub const MESSAGES: &str = "session::messages";
+    pub const FORK: &str = "session-tree::fork";
+    pub const CLONE: &str = "session-tree::clone";
+    pub const COMPACT: &str = "session-tree::compact";
+    pub const TREE: &str = "session-tree::tree";
+    pub const EXPORT_HTML: &str = "session-tree::export_html";
+    pub const CREATE: &str = "session-tree::create";
+    pub const APPEND: &str = "session-tree::append";
+    pub const MESSAGES: &str = "session-tree::messages";
 }
 
-/// Register the five `session::*` iii functions on `iii`, backed by `store`.
+/// Register all `session-tree::*` iii functions on `iii`, backed by `store`.
 ///
 /// Returns a [`SessionFunctionRefs`] handle. Drop or call
 /// [`SessionFunctionRefs::unregister_all`] to deregister everything in one
@@ -717,16 +717,16 @@ pub mod function_ids {
 ///
 /// # Payload shapes
 ///
-/// - `session::fork` — `{ "source_session_id": str, "from_entry_id": str }`
+/// - `session-tree::fork` — `{ "source_session_id": str, "from_entry_id": str }`
 ///   → `{ "session_id": str }`
-/// - `session::clone` — `{ "source_session_id": str }`
+/// - `session-tree::clone` — `{ "source_session_id": str }`
 ///   → `{ "session_id": str }`
-/// - `session::compact` — `{ "session_id": str, "summary": str,
+/// - `session-tree::compact` — `{ "session_id": str, "summary": str,
 ///   "tokens_before": u64, "details": { "read_files": [str],
 ///   "modified_files": [str] }, "parent_id": str? }`
 ///   → `{ "entry_id": str }`
-/// - `session::tree` — `{ "session_id": str }` → `TreeNode`
-/// - `session::export_html` — `{ "session_id": str, "branch_leaf": str? }`
+/// - `session-tree::tree` — `{ "session_id": str }` → `TreeNode`
+/// - `session-tree::export_html` — `{ "session_id": str, "branch_leaf": str? }`
 ///   → `{ "html": str }`
 pub fn register_with_iii<S>(iii: &iii_sdk::III, store: std::sync::Arc<S>) -> SessionFunctionRefs
 where
@@ -952,7 +952,7 @@ pub struct SessionFunctionRefs {
 }
 
 impl SessionFunctionRefs {
-    /// Unregister every `session::*` function this batch installed.
+    /// Unregister every `session-tree::*` function this batch installed.
     pub fn unregister_all(self) {
         for f in self.refs {
             f.unregister();

--- a/session-tree/src/main.rs
+++ b/session-tree/src/main.rs
@@ -2,50 +2,101 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
-use iii_sdk::{register_worker, InitOptions, TriggerRequest};
+use clap::Parser;
+use iii_sdk::{register_worker, InitOptions, OtelConfig, TriggerRequest, WorkerMetadata};
 use serde_json::json;
 
-const DEFAULT_ENGINE_URL: &str = "ws://127.0.0.1:49134";
+mod config;
+mod manifest;
+
+#[derive(Parser, Debug)]
+#[command(name = "iii-session-tree", about = "Session tree worker for iii")]
+struct Cli {
+    #[arg(long, default_value = "./config.yaml")]
+    config: String,
+
+    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    url: String,
+
+    #[arg(long)]
+    manifest: bool,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
 
-    let engine_url = std::env::var("III_URL").unwrap_or_else(|_| DEFAULT_ENGINE_URL.to_string());
-    let iii = Arc::new(register_worker(&engine_url, InitOptions::default()));
+    let cli = Cli::parse();
 
-    let store: Arc<dyn session_tree::SessionStore> =
-        match std::env::var("SESSION_TREE_STORE").as_deref() {
-            Ok("memory") => {
-                log::info!("session-tree: using in-memory store (SESSION_TREE_STORE=memory)");
-                Arc::new(session_tree::InMemoryStore::default())
-            }
-            Ok("iii_state") | Err(_) => {
-                log::info!("session-tree: using iii-state store");
-                let iii_for_store: Arc<dyn session_tree::io::IIITrigger> = iii.clone();
-                Arc::new(session_tree::store_iii_state::IiiStateSessionStore::new(
-                    iii_for_store,
-                ))
-            }
-            Ok(other) => {
-                log::warn!(
-                "session-tree: unknown SESSION_TREE_STORE={other:?}; falling back to iii-state. \
-                     Valid values: memory, iii_state."
+    if cli.manifest {
+        let m = manifest::build_manifest();
+        println!("{}", serde_json::to_string_pretty(&m)?);
+        return Ok(());
+    }
+
+    let cfg = match config::load_config(&cli.config) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(error = %e, path = %cli.config, "failed to load config, using defaults");
+            config::SessionTreeConfig::default()
+        }
+    };
+
+    let iii = Arc::new(register_worker(
+        &cli.url,
+        InitOptions {
+            otel: Some(OtelConfig::default()),
+            metadata: Some(WorkerMetadata {
+                runtime: "rust".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                name: "session-tree".to_string(),
+                os: std::env::consts::OS.to_string(),
+                pid: Some(std::process::id()),
+                telemetry: None,
+                ..WorkerMetadata::default()
+            }),
+            ..InitOptions::default()
+        },
+    ));
+
+    let store: Arc<dyn session_tree::SessionStore> = match cfg.store_backend.as_str() {
+        "memory" => {
+            tracing::info!("session-tree: using in-memory store (store_backend=memory)");
+            Arc::new(session_tree::InMemoryStore::default())
+        }
+        "iii_state" => {
+            tracing::info!("session-tree: using iii-state store");
+            let iii_for_store: Arc<dyn session_tree::io::IIITrigger> = iii.clone();
+            Arc::new(session_tree::store_iii_state::IiiStateSessionStore::new(
+                iii_for_store,
+            ))
+        }
+        other => {
+            tracing::warn!(
+                unknown_backend = other,
+                "unknown store_backend; falling back to iii_state (valid: memory, iii_state)"
             );
-                let iii_for_store: Arc<dyn session_tree::io::IIITrigger> = iii.clone();
-                Arc::new(session_tree::store_iii_state::IiiStateSessionStore::new(
-                    iii_for_store,
-                ))
-            }
-        };
+            let iii_for_store: Arc<dyn session_tree::io::IIITrigger> = iii.clone();
+            Arc::new(session_tree::store_iii_state::IiiStateSessionStore::new(
+                iii_for_store,
+            ))
+        }
+    };
+
     let _refs = session_tree::register_with_iii(&iii, store);
-    log::info!("session-tree registered (session::*)");
+    tracing::info!("session-tree registered (session-tree::*)");
 
     spawn_skill_register(iii.clone());
 
     wait_for_shutdown().await?;
 
     unregister_skill(&iii).await;
+    iii.shutdown_async().await;
     Ok(())
 }
 
@@ -63,21 +114,23 @@ async fn register_skill_with_retry(iii: &iii_sdk::III, id: &str, body: &str) {
             .await;
         match res {
             Ok(_) => {
-                log::info!("registered skill: {id}");
+                tracing::info!(skill_id = id, "registered skill");
                 return;
             }
             Err(e) => {
-                if started.elapsed() > Duration::from_mins(3) {
-                    log::warn!(
-                        "skills handshake gave up for {id}; install/start the skills worker and restart (last error: {e})"
+                if started.elapsed() > Duration::from_secs(3 * 60) {
+                    tracing::warn!(
+                        skill_id = id,
+                        error = %e,
+                        "skills handshake gave up; install/start the skills worker and restart"
                     );
                     return;
                 }
-                log::debug!("skills::register failed for {id}: {e}; retrying in {backoff:?}");
+                tracing::debug!(skill_id = id, error = %e, wait = ?backoff, "skills::register failed; retrying");
             }
         }
         tokio::time::sleep(backoff).await;
-        backoff = (backoff * 2).min(Duration::from_mins(1));
+        backoff = (backoff * 2).min(Duration::from_secs(60));
     }
 }
 
@@ -110,8 +163,6 @@ async fn wait_for_shutdown() -> Result<()> {
     }
 }
 
-// Best-effort: a missed unregister is self-healing on next boot's re-register.
-// Leaves go first so the router is the last entry to disappear from iii://skills.
 async fn unregister_skill(iii: &Arc<iii_sdk::III>) {
     for (id, _) in session_tree::SUB_SKILLS {
         let _ = iii

--- a/session-tree/src/main.rs
+++ b/session-tree/src/main.rs
@@ -118,7 +118,7 @@ async fn register_skill_with_retry(iii: &iii_sdk::III, id: &str, body: &str) {
                 return;
             }
             Err(e) => {
-                if started.elapsed() > Duration::from_secs(3 * 60) {
+                if started.elapsed() > Duration::from_mins(3) {
                     tracing::warn!(
                         skill_id = id,
                         error = %e,
@@ -130,7 +130,7 @@ async fn register_skill_with_retry(iii: &iii_sdk::III, id: &str, body: &str) {
             }
         }
         tokio::time::sleep(backoff).await;
-        backoff = (backoff * 2).min(Duration::from_secs(60));
+        backoff = (backoff * 2).min(Duration::from_mins(1));
     }
 }
 

--- a/session-tree/src/manifest.rs
+++ b/session-tree/src/manifest.rs
@@ -1,0 +1,39 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct ModuleManifest {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub default_config: serde_json::Value,
+    pub supported_targets: Vec<String>,
+}
+
+pub fn build_manifest() -> ModuleManifest {
+    ModuleManifest {
+        name: env!("CARGO_PKG_NAME").to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        description: "Session storage as a parent-id tree of typed entries under session-tree::*."
+            .to_string(),
+        default_config: serde_json::json!({
+            "store_backend": "iii_state",
+        }),
+        supported_targets: vec![env!("TARGET").to_string()],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_roundtrip_has_required_fields() {
+        let m = build_manifest();
+        let json = serde_json::to_string_pretty(&m).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["name"], env!("CARGO_PKG_NAME"));
+        assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+        assert!(parsed["default_config"].is_object());
+        assert!(!parsed["supported_targets"].as_array().unwrap().is_empty());
+    }
+}

--- a/session-tree/src/store_iii_state.rs
+++ b/session-tree/src/store_iii_state.rs
@@ -79,7 +79,7 @@ impl SessionStore for IiiStateSessionStore {
         // Non-fatal: refresh updated_at on the session's meta. Failures here log
         // a warning but do not roll back the entry write.
         if let Err(e) = self.refresh_meta_updated_at(session_id).await {
-            log::warn!(
+            tracing::warn!(
                 target: "session_tree::store_iii_state",
                 "meta updated_at refresh failed for session {session_id}: {e}; entry persisted but meta is stale"
             );

--- a/session-tree/tests/manifest.rs
+++ b/session-tree/tests/manifest.rs
@@ -1,0 +1,45 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn session_tree_executable() -> PathBuf {
+    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_iii_session_tree") {
+        return PathBuf::from(p);
+    }
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    for profile in ["debug", "release"] {
+        let candidate = dir.join("target").join(profile).join("iii-session-tree");
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+    panic!("iii-session-tree binary not found; run `cargo build --bin iii-session-tree` first");
+}
+
+#[test]
+fn manifest_subcommand_emits_valid_json() {
+    let bin = session_tree_executable();
+    let output = Command::new(&bin)
+        .arg("--manifest")
+        .output()
+        .expect("spawn iii-session-tree --manifest");
+
+    assert!(
+        output.status.success(),
+        "binary exited with {:?}; stderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("manifest stdout is utf-8");
+    let manifest: Value = serde_json::from_str(&stdout).expect("manifest stdout is valid JSON");
+
+    assert_eq!(manifest["name"], env!("CARGO_PKG_NAME"));
+    assert_eq!(manifest["version"], env!("CARGO_PKG_VERSION"));
+    assert!(manifest["default_config"].is_object());
+    assert!(!manifest["supported_targets"]
+        .as_array()
+        .expect("supported_targets must be an array")
+        .is_empty());
+}

--- a/session-tree/tests/restart_e2e.rs
+++ b/session-tree/tests/restart_e2e.rs
@@ -11,13 +11,12 @@
 //!       IIITEST_WORKER_BIN=$(pwd)/target/release/iii-session-tree \
 //!       cargo test -p iii-session-tree --test restart_e2e -- --ignored
 //!
-//! Schema source (verified against session-tree/src/lib.rs `register_with_iii`,
-//! ~lines 710-910):
-//! - `session::create` payload: `{ "display_name": str?, "cwd": str? }` →
+//! Schema source (verified against session-tree/src/lib.rs `register_with_iii`):
+//! - `session-tree::create` payload: `{ "display_name": str?, "cwd": str? }` →
 //!   `{ "session_id": str }`
-//! - `session::append` payload: `{ "session_id": str, "parent_id": str?,
+//! - `session-tree::append` payload: `{ "session_id": str, "parent_id": str?,
 //!   "message": <AgentMessage> }` → `{ "entry_id": str }`
-//! - `session::messages` payload: `{ "session_id": str, "branch_leaf": str? }`
+//! - `session-tree::messages` payload: `{ "session_id": str, "branch_leaf": str? }`
 //!   → `{ "messages": [<AgentMessage>...] }`
 //!
 //! `AgentMessage` is `#[serde(tag = "role", rename_all = "snake_case")]`
@@ -33,11 +32,9 @@ use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
 fn spawn_worker(engine_url: &str, bin: &str) -> Child {
+    let config_path = format!("{}/config.yaml", env!("CARGO_MANIFEST_DIR"));
     Command::new(bin)
-        .env("III_URL", engine_url)
-        // Force the iii-state backend explicitly so the test is robust if the
-        // worker default flips.
-        .env("SESSION_TREE_STORE", "iii_state")
+        .args(["--url", engine_url, "--config", &config_path])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
@@ -70,7 +67,7 @@ async fn session_messages_survive_worker_restart() {
     // 1. Create a session.
     let create_resp = iii
         .trigger(iii_sdk::TriggerRequest {
-            function_id: "session::create".into(),
+            function_id: "session-tree::create".into(),
             payload: serde_json::json!({
                 "display_name": "e2e-restart",
             }),
@@ -78,11 +75,11 @@ async fn session_messages_survive_worker_restart() {
             timeout_ms: None,
         })
         .await
-        .expect("session::create failed");
+        .expect("session-tree::create failed");
     let sid = create_resp
         .get("session_id")
         .and_then(serde_json::Value::as_str)
-        .expect("session::create response missing session_id")
+        .expect("session-tree::create response missing session_id")
         .to_string();
 
     // 2. Append two messages. Use distinctive text so we can grep for them
@@ -100,13 +97,13 @@ async fn session_messages_survive_worker_restart() {
         }
         let resp = iii
             .trigger(iii_sdk::TriggerRequest {
-                function_id: "session::append".into(),
+                function_id: "session-tree::append".into(),
                 payload,
                 action: None,
                 timeout_ms: None,
             })
             .await
-            .expect("session::append failed");
+            .expect("session-tree::append failed");
         last_entry_id = resp
             .get("entry_id")
             .and_then(serde_json::Value::as_str)
@@ -122,13 +119,13 @@ async fn session_messages_survive_worker_restart() {
     // 4. Load messages; assert both survived.
     let load_resp = iii
         .trigger(iii_sdk::TriggerRequest {
-            function_id: "session::messages".into(),
+            function_id: "session-tree::messages".into(),
             payload: serde_json::json!({ "session_id": &sid }),
             action: None,
             timeout_ms: None,
         })
         .await
-        .expect("session::messages failed");
+        .expect("session-tree::messages failed");
 
     // The function returns `{ "messages": [<AgentMessage>...] }`. Look for our
     // marker text inside the serialized response.

--- a/shell-bash/Cargo.lock
+++ b/shell-bash/Cargo.lock
@@ -146,6 +146,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,29 +276,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
 
 [[package]]
 name = "equivalent"
@@ -715,18 +732,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-shell-bash"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "env_logger",
- "iii-sdk",
- "log",
- "serde_json",
- "tokio",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,30 +781,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jiff"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,6 +791,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -851,6 +838,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +870,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1037,21 +1042,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -1249,18 +1239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
 ]
 
 [[package]]
@@ -1532,6 +1510,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,6 +1531,30 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shell-bash"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "iii-sdk",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1585,6 +1600,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1655,6 +1676,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1875,6 +1905,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1927,6 +1987,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1973,6 +2039,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/shell-bash/Cargo.toml
+++ b/shell-bash/Cargo.toml
@@ -2,7 +2,7 @@
 resolver = "2"
 
 [package]
-name = "iii-shell-bash"
+name = "shell-bash"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
@@ -15,16 +15,19 @@ name = "shell_bash"
 path = "src/lib.rs"
 
 [[bin]]
-name = "iii-shell-bash"
+name = "shell-bash"
 path = "src/main.rs"
 
 [dependencies]
 iii-sdk = { workspace = true }
 anyhow = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = "0.9"
 tokio = { workspace = true }
-log = "0.4"
-env_logger = "0.11"
+clap = { version = "4", features = ["derive", "env"] }
+tracing = { workspace = true }
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 
 [workspace.package]
 version = "0.1.0"

--- a/shell-bash/README.md
+++ b/shell-bash/README.md
@@ -1,48 +1,65 @@
 # shell-bash
 
-Sandboxed shell execution on the iii bus under `shell::bash::*`. Wraps the
-iii engine `sandbox::exec` primitive — no host shell fallback.
+Sandboxed shell helpers on the iii bus under `shell::bash::*` (`exec`, `which`, `detect_clis`).
+They complement the engine `sandbox::exec` workflow; there is no silent host-shell fallback for callers that expected pure sandbox routing.
 
-## Installation
+## Install
 
 ```bash
 iii worker add shell-bash
 ```
 
-## Run
+`iii worker add` fetches the binary, writes a config block into `~/.iii/config.yaml`, and the engine starts the worker on the next `iii start`.
 
-```bash
-iii-shell-bash --engine-url ws://127.0.0.1:49134
+## Quickstart
+
+Call `shell::bash::exec` with a bash snippet; timeouts and output truncation follow `config.yaml` unless overridden per payload or via environment variables below.
+
+```rust
+use iii_sdk::{register_worker, InitOptions, TriggerRequest};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+
+    let result = iii
+        .trigger(TriggerRequest {
+            function_id: "shell::bash::exec".into(),
+            payload: json!({ "command": "echo hello" }),
+            action: None,
+            timeout_ms: Some(5_000),
+        })
+        .await?;
+
+    println!("{result:#?}");
+    Ok(())
+}
 ```
 
-(Or set `III_URL`.)
+Other entry points:
 
-When started by the engine, the worker reads its `config:` block from
-`--config <path>`. Defaults:
+- `shell::bash::which` — `{ "name": "git" }`
+- `shell::bash::detect_clis` — `{}`
+
+## Configuration
 
 ```yaml
-default_timeout_ms: 30000
-trigger_timeout_ms: 35000
-max_output_bytes: 30000
+default_timeout_ms: 30000    # milliseconds when payload omits timeout_ms
+trigger_timeout_ms: 35000    # milliseconds reserved for cron/http-style bindings
+max_output_bytes: 30000       # truncate combined stdout/stderr text in the tool payload
 ```
 
-`SHELL_BASH_DEFAULT_TIMEOUT_MS`, `SHELL_BASH_TRIGGER_TIMEOUT_MS`, and
-`SHELL_BASH_MAX_OUTPUT_BYTES` override the config file for direct runtime
-overrides. Per-call `timeout_ms` still overrides `default_timeout_ms`.
+`SHELL_BASH_DEFAULT_TIMEOUT_MS`, `SHELL_BASH_TRIGGER_TIMEOUT_MS`, and `SHELL_BASH_MAX_OUTPUT_BYTES` override file defaults at process start.
+
+Other defaults (including manifest `default_config`) live in [`src/config.rs`](src/config.rs) and [`src/manifest.rs`](src/manifest.rs).
 
 ## Registered functions
 
-`shell::bash::exec`, `shell::bash::which`, `shell::bash::detect_clis`.
+- `shell::bash::exec`
+- `shell::bash::which`
+- `shell::bash::detect_clis`
 
-## Engine functions consumed
+## Engine surface
 
-`sandbox::exec` — provided by the `iii-worker` sandbox surface
-(see `iii/crates/iii-worker/src/cli/sandbox.rs`). Note: `iii-exec` is a
-different engine builtin (a startup pipeline daemon) and exposes no bus
-functions.
-
-## Build
-
-```bash
-cargo build --release
-```
+Consumers rely on host `bash` for these helpers. For the sandbox primitive itself, see the engine `sandbox::exec` tool surface (distinct from legacy `iii-exec` pipeline naming in some docs).

--- a/shell-bash/build.rs
+++ b/shell-bash/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+}

--- a/shell-bash/iii.worker.yaml
+++ b/shell-bash/iii.worker.yaml
@@ -3,7 +3,7 @@ name: shell-bash
 language: rust
 deploy: binary
 manifest: Cargo.toml
-bin: iii-shell-bash
+bin: shell-bash
 description: Sandboxed shell execution under shell::bash::* — wraps the engine sandbox::exec primitive with no host fallback.
 config:
   default_timeout_ms: 30000

--- a/shell-bash/src/config.rs
+++ b/shell-bash/src/config.rs
@@ -1,0 +1,108 @@
+use anyhow::Result;
+use serde::Deserialize;
+
+use shell_bash::exec::{ExecConfig, DEFAULT_TIMEOUT_MS, MAX_OUTPUT_BYTES, TRIGGER_TIMEOUT_MS};
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct WorkerConfig {
+    #[serde(default = "default_default_timeout_ms")]
+    pub default_timeout_ms: u64,
+    #[serde(default = "default_trigger_timeout_ms")]
+    pub trigger_timeout_ms: u64,
+    #[serde(default = "default_max_output_bytes")]
+    pub max_output_bytes: usize,
+}
+
+fn default_default_timeout_ms() -> u64 {
+    DEFAULT_TIMEOUT_MS
+}
+
+fn default_trigger_timeout_ms() -> u64 {
+    TRIGGER_TIMEOUT_MS
+}
+
+fn default_max_output_bytes() -> usize {
+    MAX_OUTPUT_BYTES
+}
+
+impl Default for WorkerConfig {
+    fn default() -> Self {
+        Self {
+            default_timeout_ms: default_default_timeout_ms(),
+            trigger_timeout_ms: default_trigger_timeout_ms(),
+            max_output_bytes: default_max_output_bytes(),
+        }
+    }
+}
+
+impl WorkerConfig {
+    pub fn exec_config(&self) -> ExecConfig {
+        ExecConfig {
+            default_timeout_ms: self.default_timeout_ms,
+            trigger_timeout_ms: self.trigger_timeout_ms,
+            max_output_bytes: self.max_output_bytes,
+        }
+    }
+
+    pub fn apply_env_overrides(mut self) -> Self {
+        if let Ok(v) = std::env::var("SHELL_BASH_DEFAULT_TIMEOUT_MS") {
+            if let Ok(ms) = v.trim().parse() {
+                self.default_timeout_ms = ms;
+            }
+        }
+        if let Ok(v) = std::env::var("SHELL_BASH_TRIGGER_TIMEOUT_MS") {
+            if let Ok(ms) = v.trim().parse() {
+                self.trigger_timeout_ms = ms;
+            }
+        }
+        if let Ok(v) = std::env::var("SHELL_BASH_MAX_OUTPUT_BYTES") {
+            if let Ok(n) = v.trim().parse() {
+                self.max_output_bytes = n;
+            }
+        }
+        self
+    }
+}
+
+pub fn load_config(path: &str) -> Result<WorkerConfig> {
+    let contents = std::fs::read_to_string(path)?;
+    let cfg: WorkerConfig = serde_yaml::from_str(&contents)?;
+    Ok(cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_from_empty_yaml() {
+        let cfg: WorkerConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(cfg.default_timeout_ms, DEFAULT_TIMEOUT_MS);
+        assert_eq!(cfg.trigger_timeout_ms, TRIGGER_TIMEOUT_MS);
+        assert_eq!(cfg.max_output_bytes, MAX_OUTPUT_BYTES);
+    }
+
+    #[test]
+    fn custom_yaml_overrides() {
+        let cfg: WorkerConfig = serde_yaml::from_str(
+            r"
+default_timeout_ms: 1
+trigger_timeout_ms: 2
+max_output_bytes: 3
+",
+        )
+        .unwrap();
+        assert_eq!(cfg.default_timeout_ms, 1);
+        assert_eq!(cfg.trigger_timeout_ms, 2);
+        assert_eq!(cfg.max_output_bytes, 3);
+    }
+
+    #[test]
+    fn impl_default_matches_yaml_defaults() {
+        let d = WorkerConfig::default();
+        let y: WorkerConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(d.default_timeout_ms, y.default_timeout_ms);
+        assert_eq!(d.trigger_timeout_ms, y.trigger_timeout_ms);
+        assert_eq!(d.max_output_bytes, y.max_output_bytes);
+    }
+}

--- a/shell-bash/src/main.rs
+++ b/shell-bash/src/main.rs
@@ -1,267 +1,86 @@
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use iii_sdk::{register_worker, InitOptions};
-use serde_json::Value;
+use clap::Parser;
+use iii_sdk::{register_worker, InitOptions, OtelConfig, WorkerMetadata};
 
-const DEFAULT_ENGINE_URL: &str = "ws://127.0.0.1:49134";
+mod config;
+mod manifest;
 
-#[derive(Debug, Default, PartialEq, Eq)]
-struct ConfigOverrides {
-    default_timeout_ms: Option<u64>,
-    trigger_timeout_ms: Option<u64>,
-    max_output_bytes: Option<usize>,
-}
+#[derive(Parser, Debug)]
+#[command(
+    name = "shell-bash",
+    about = "Sandboxed shell execution on the iii bus under shell::bash::*."
+)]
+struct Cli {
+    #[arg(long, default_value = "./config.yaml")]
+    config: String,
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct RuntimeConfig {
-    exec: shell_bash::exec::ExecConfig,
-}
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
+    url: String,
 
-impl RuntimeConfig {
-    fn load(config_path: Option<&Path>) -> Self {
-        let mut cfg = Self {
-            exec: shell_bash::exec::ExecConfig::default(),
-        };
-
-        if let Some(path) = config_path {
-            match load_config_overrides(path) {
-                Ok(overrides) => cfg.apply(overrides),
-                Err(e) => log::warn!(
-                    "failed to load shell-bash config from {}: {e}; using defaults",
-                    path.display()
-                ),
-            }
-        }
-
-        if let Ok(default_timeout_ms) = std::env::var("SHELL_BASH_DEFAULT_TIMEOUT_MS") {
-            if let Ok(default_timeout_ms) = default_timeout_ms.trim().parse() {
-                cfg.exec.default_timeout_ms = default_timeout_ms;
-            }
-        }
-        if let Ok(trigger_timeout_ms) = std::env::var("SHELL_BASH_TRIGGER_TIMEOUT_MS") {
-            if let Ok(trigger_timeout_ms) = trigger_timeout_ms.trim().parse() {
-                cfg.exec.trigger_timeout_ms = trigger_timeout_ms;
-            }
-        }
-        if let Ok(max_output_bytes) = std::env::var("SHELL_BASH_MAX_OUTPUT_BYTES") {
-            if let Ok(max_output_bytes) = max_output_bytes.trim().parse() {
-                cfg.exec.max_output_bytes = max_output_bytes;
-            }
-        }
-
-        cfg
-    }
-
-    fn apply(&mut self, overrides: ConfigOverrides) {
-        if let Some(default_timeout_ms) = overrides.default_timeout_ms {
-            self.exec.default_timeout_ms = default_timeout_ms;
-        }
-        if let Some(trigger_timeout_ms) = overrides.trigger_timeout_ms {
-            self.exec.trigger_timeout_ms = trigger_timeout_ms;
-        }
-        if let Some(max_output_bytes) = overrides.max_output_bytes {
-            self.exec.max_output_bytes = max_output_bytes;
-        }
-    }
-}
-
-fn config_path_arg() -> Option<PathBuf> {
-    let mut args = std::env::args_os().skip(1);
-    while let Some(arg) = args.next() {
-        if arg == std::ffi::OsStr::new("--config") {
-            return args.next().map(PathBuf::from);
-        }
-        if let Some(s) = arg.to_str() {
-            if let Some(path) = s.strip_prefix("--config=") {
-                return Some(PathBuf::from(path));
-            }
-        }
-    }
-    None
-}
-
-fn load_config_overrides(path: &Path) -> Result<ConfigOverrides> {
-    let raw = std::fs::read_to_string(path)?;
-    Ok(parse_config_overrides(&raw))
-}
-
-fn parse_config_overrides(raw: &str) -> ConfigOverrides {
-    if let Some(overrides) = parse_json_config_overrides(raw) {
-        return overrides;
-    }
-    parse_yaml_config_overrides(raw)
-}
-
-fn parse_json_config_overrides(raw: &str) -> Option<ConfigOverrides> {
-    let value: Value = serde_json::from_str(raw).ok()?;
-    let root = value.as_object()?;
-    let object = root
-        .get("config")
-        .and_then(Value::as_object)
-        .unwrap_or(root);
-    let default_timeout_ms = object.get("default_timeout_ms").and_then(Value::as_u64);
-    let trigger_timeout_ms = object.get("trigger_timeout_ms").and_then(Value::as_u64);
-    let max_output_bytes = object
-        .get("max_output_bytes")
-        .and_then(Value::as_u64)
-        .and_then(|v| usize::try_from(v).ok());
-    Some(ConfigOverrides {
-        default_timeout_ms,
-        trigger_timeout_ms,
-        max_output_bytes,
-    })
-}
-
-fn parse_yaml_config_overrides(raw: &str) -> ConfigOverrides {
-    let mut overrides = ConfigOverrides::default();
-    let mut in_config_block = false;
-    let mut config_indent = None;
-
-    for line in raw.lines() {
-        let indent = line.chars().take_while(|ch| *ch == ' ').count();
-        let line = strip_yaml_comment(line).trim_end();
-        let line = line.trim_start();
-        if line.is_empty() || line == "---" {
-            continue;
-        }
-        let Some((key, value)) = line.split_once(':') else {
-            continue;
-        };
-
-        if indent == 0 {
-            let key = key.trim();
-            if key == "config" && parse_yaml_scalar(value).is_none() {
-                in_config_block = true;
-                config_indent = None;
-                continue;
-            }
-            in_config_block = false;
-            parse_config_key(&mut overrides, key, value);
-            continue;
-        }
-
-        if !in_config_block {
-            continue;
-        }
-
-        let expected_indent = *config_indent.get_or_insert(indent);
-        if indent != expected_indent {
-            continue;
-        }
-        parse_config_key(&mut overrides, key.trim(), value);
-    }
-
-    overrides
-}
-
-fn parse_config_key(overrides: &mut ConfigOverrides, key: &str, value: &str) {
-    match key {
-        "default_timeout_ms" => {
-            overrides.default_timeout_ms = parse_yaml_scalar(value).and_then(|v| v.parse().ok());
-        }
-        "trigger_timeout_ms" => {
-            overrides.trigger_timeout_ms = parse_yaml_scalar(value).and_then(|v| v.parse().ok());
-        }
-        "max_output_bytes" => {
-            overrides.max_output_bytes = parse_yaml_scalar(value).and_then(|v| v.parse().ok());
-        }
-        _ => {}
-    }
-}
-
-fn strip_yaml_comment(line: &str) -> &str {
-    let mut in_single = false;
-    let mut in_double = false;
-
-    for (idx, ch) in line.char_indices() {
-        match ch {
-            '\'' if !in_double => in_single = !in_single,
-            '"' if !in_single => in_double = !in_double,
-            '#' if !in_single && !in_double => return &line[..idx],
-            _ => {}
-        }
-    }
-
-    line
-}
-
-fn parse_yaml_scalar(value: &str) -> Option<String> {
-    let value = value.trim();
-    if value.is_empty() || value == "null" || value == "~" {
-        return None;
-    }
-
-    let unquoted = if value.len() >= 2 {
-        let bytes = value.as_bytes();
-        let quote = bytes[0];
-        if (quote == b'\'' || quote == b'"') && bytes[value.len() - 1] == quote {
-            &value[1..value.len() - 1]
-        } else {
-            value
-        }
-    } else {
-        value
-    };
-
-    let unquoted = unquoted.trim();
-    if unquoted.is_empty() {
-        None
-    } else {
-        Some(unquoted.to_string())
-    }
+    #[arg(long)]
+    manifest: bool,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
 
-    let engine_url = std::env::var("III_URL").unwrap_or_else(|_| DEFAULT_ENGINE_URL.to_string());
-    let cfg = RuntimeConfig::load(config_path_arg().as_deref());
-    let iii = Arc::new(register_worker(&engine_url, InitOptions::default()));
+    let cli = Cli::parse();
 
-    shell_bash::register_with_config(&iii, cfg.exec)
+    if cli.manifest {
+        let m = manifest::build_manifest();
+        println!("{}", serde_json::to_string_pretty(&m)?);
+        return Ok(());
+    }
+
+    let cfg = match config::load_config(&cli.config) {
+        Ok(c) => c.apply_env_overrides(),
+        Err(e) => {
+            tracing::warn!(error = %e, path = %cli.config, "failed to load config, using defaults");
+            config::WorkerConfig::default().apply_env_overrides()
+        }
+    };
+
+    let exec_cfg = cfg.exec_config();
+
+    let iii = register_worker(
+        &cli.url,
+        InitOptions {
+            otel: Some(OtelConfig::default()),
+            metadata: Some(WorkerMetadata {
+                runtime: "rust".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                name: "shell-bash".to_string(),
+                os: std::env::consts::OS.to_string(),
+                pid: Some(std::process::id()),
+                telemetry: None,
+                ..WorkerMetadata::default()
+            }),
+            ..InitOptions::default()
+        },
+    );
+    let iii = Arc::new(iii);
+
+    shell_bash::register_with_config(iii.as_ref(), exec_cfg)
         .await
         .context("shell-bash register failed")?;
-    log::info!(
-        "shell-bash registered (shell::bash::*); default_timeout_ms={}; trigger_timeout_ms={}; max_output_bytes={}",
-        cfg.exec.default_timeout_ms,
-        cfg.exec.trigger_timeout_ms,
-        cfg.exec.max_output_bytes
+
+    tracing::info!(
+        default_timeout_ms = exec_cfg.default_timeout_ms,
+        trigger_timeout_ms = exec_cfg.trigger_timeout_ms,
+        max_output_bytes = exec_cfg.max_output_bytes,
+        "shell-bash ready (shell::bash::exec | shell::bash::which | shell::bash::detect_clis)",
     );
 
     tokio::signal::ctrl_c().await.ok();
+    tracing::info!("shell-bash shutting down");
+    iii.shutdown_async().await;
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_yaml_config_overrides_exec_limits() {
-        let overrides = parse_config_overrides(
-            r"
-default_timeout_ms: 1
-trigger_timeout_ms: 2
-max_output_bytes: 3
-",
-        );
-
-        assert_eq!(overrides.default_timeout_ms, Some(1));
-        assert_eq!(overrides.trigger_timeout_ms, Some(2));
-        assert_eq!(overrides.max_output_bytes, Some(3));
-    }
-
-    #[test]
-    fn parse_json_config_overrides_wrapped_config() {
-        let overrides = parse_config_overrides(
-            r#"{ "config": { "default_timeout_ms": 4, "trigger_timeout_ms": 5, "max_output_bytes": 6 } }"#,
-        );
-
-        assert_eq!(overrides.default_timeout_ms, Some(4));
-        assert_eq!(overrides.trigger_timeout_ms, Some(5));
-        assert_eq!(overrides.max_output_bytes, Some(6));
-    }
 }

--- a/shell-bash/src/manifest.rs
+++ b/shell-bash/src/manifest.rs
@@ -1,0 +1,43 @@
+use serde::Serialize;
+use shell_bash::exec::{DEFAULT_TIMEOUT_MS, MAX_OUTPUT_BYTES, TRIGGER_TIMEOUT_MS};
+
+#[derive(Serialize)]
+pub struct ModuleManifest {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub default_config: serde_json::Value,
+    pub supported_targets: Vec<String>,
+}
+
+pub fn build_manifest() -> ModuleManifest {
+    ModuleManifest {
+        name: env!("CARGO_PKG_NAME").to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        description: "Sandboxed shell execution under shell::bash::* — wraps the engine sandbox::exec primitive with no host fallback."
+            .to_string(),
+        default_config: serde_json::json!({
+            "default_timeout_ms": DEFAULT_TIMEOUT_MS,
+            "trigger_timeout_ms": TRIGGER_TIMEOUT_MS,
+            "max_output_bytes": MAX_OUTPUT_BYTES,
+        }),
+        supported_targets: vec![env!("TARGET").to_string()],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_roundtrip_has_required_fields() {
+        let m = build_manifest();
+        let json = serde_json::to_string_pretty(&m).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["name"], env!("CARGO_PKG_NAME"));
+        assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+        assert!(parsed["default_config"].is_object());
+        let arr = parsed["supported_targets"].as_array().expect("array");
+        assert!(!arr.is_empty());
+    }
+}

--- a/shell-bash/tests/manifest.rs
+++ b/shell-bash/tests/manifest.rs
@@ -1,0 +1,53 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn shell_bash_executable() -> PathBuf {
+    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_shell_bash") {
+        return PathBuf::from(p);
+    }
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    for profile in ["debug", "release"] {
+        let candidate = dir.join("target").join(profile).join("shell-bash");
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+    panic!(
+        "shell-bash binary not found under target/{{debug,release}}/; run `cargo build --bin shell-bash` first"
+    );
+}
+
+#[test]
+fn manifest_subcommand_emits_valid_json() {
+    let bin = shell_bash_executable();
+    let output = Command::new(&bin)
+        .arg("--manifest")
+        .output()
+        .expect("spawn shell-bash --manifest");
+
+    assert!(
+        output.status.success(),
+        "binary exited with {:?}; stderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("manifest stdout is utf-8");
+    let manifest: Value = serde_json::from_str(&stdout).expect("manifest stdout is valid JSON");
+
+    assert_eq!(manifest["name"], env!("CARGO_PKG_NAME"));
+    assert_eq!(manifest["version"], env!("CARGO_PKG_VERSION"));
+    assert!(
+        manifest["default_config"].is_object(),
+        "default_config must be an object",
+    );
+    assert!(
+        !manifest["supported_targets"]
+            .as_array()
+            .expect("supported_targets must be an array")
+            .is_empty(),
+        "supported_targets must not be empty",
+    );
+}

--- a/shell-filesystem/Cargo.lock
+++ b/shell-filesystem/Cargo.lock
@@ -146,6 +146,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,29 +276,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
 
 [[package]]
 name = "equivalent"
@@ -715,19 +732,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-shell-filesystem"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "base64",
- "env_logger",
- "iii-sdk",
- "log",
- "serde_json",
- "tokio",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,30 +781,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jiff"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +791,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -852,6 +838,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +870,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1038,21 +1042,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -1250,18 +1239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
 ]
 
 [[package]]
@@ -1533,6 +1510,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,6 +1531,31 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shell-filesystem"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64",
+ "clap",
+ "iii-sdk",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1586,6 +1601,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -1656,6 +1677,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1876,6 +1906,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1928,6 +1988,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,6 +2040,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/shell-filesystem/Cargo.toml
+++ b/shell-filesystem/Cargo.toml
@@ -2,7 +2,7 @@
 resolver = "2"
 
 [package]
-name = "iii-shell-filesystem"
+name = "shell-filesystem"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
@@ -11,21 +11,23 @@ authors = ["iii contributors"]
 publish = false
 
 [lib]
-name = "shell_filesystem"
 path = "src/lib.rs"
 
 [[bin]]
-name = "iii-shell-filesystem"
+name = "shell-filesystem"
 path = "src/main.rs"
 
 [dependencies]
 iii-sdk = { workspace = true }
 anyhow = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = "0.9"
 tokio = { workspace = true }
 base64 = "0.22"
-log = "0.4"
-env_logger = "0.11"
+clap = { version = "4", features = ["derive"] }
+tracing = { workspace = true }
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 
 [workspace.package]
 version = "0.1.0"

--- a/shell-filesystem/README.md
+++ b/shell-filesystem/README.md
@@ -1,42 +1,51 @@
 # shell-filesystem
 
-Sandboxed filesystem operations on the iii bus under `shell::fs::*`.
+Sandboxed filesystem tools on the iii bus. Each tool is a function id under `shell::filesystem::*` (for example `shell::filesystem::read` and `shell::filesystem::write`) so agents can read, write, list, and mutate files on the host within your policy boundaries.
 
-## Installation
+## Install
 
 ```bash
 iii worker add shell-filesystem
 ```
 
-## Run
+`iii worker add` fetches the binary, writes a config block into `~/.iii/config.yaml`, and the engine starts the worker on the next `iii start`.
 
-```bash
-iii-shell-filesystem --engine-url ws://127.0.0.1:49134
+## Quickstart
+
+Call one of the registered function ids with the same shape the worker expects:
+
+```rust
+use iii_sdk::{register_worker, InitOptions, TriggerRequest};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+
+    let result = iii
+        .trigger(TriggerRequest {
+            function_id: "shell::filesystem::read".into(),
+            payload: json!({ "path": "/tmp/example.txt" }),
+            action: None,
+            timeout_ms: Some(5_000),
+        })
+        .await?;
+
+    println!("{result:#?}");
+    Ok(())
+}
 ```
 
-(Or set `III_URL`.)
+Other verbs include `shell::filesystem::write`, `shell::filesystem::ls`, `shell::filesystem::stat`, `shell::filesystem::mkdir`, `shell::filesystem::rm`, `shell::filesystem::mv`, `shell::filesystem::chmod`, `shell::filesystem::grep`, `shell::filesystem::sed`, and `shell::filesystem::edit`.
 
-When started by the engine, the worker reads its `config:` block from
-`--config <path>`. Defaults:
+## Configuration
 
 ```yaml
-max_inline_bytes: 262144
+max_inline_bytes: 262144   # max bytes returned inline for shell::filesystem::read
 ```
 
-`SHELL_FILESYSTEM_MAX_INLINE_BYTES` overrides the config file for direct
-runtime overrides.
+The worker loads this file via `--config` (default `./config.yaml` when you run the binary locally). On config errors it falls back to these defaults.
 
-## Registered functions
+`SHELL_FILESYSTEM_MAX_INLINE_BYTES` still overrides `max_inline_bytes` at process start when set.
 
-`shell::filesystem::read`, `shell::filesystem::write`,
-`shell::filesystem::ls`, `shell::filesystem::stat`,
-`shell::filesystem::grep`, `shell::filesystem::sed`,
-`shell::filesystem::edit`, `shell::filesystem::rm`,
-`shell::filesystem::mv`, `shell::filesystem::mkdir`, and
-`shell::filesystem::chmod`.
-
-## Build
-
-```bash
-cargo build --release
-```
+Other keys (if added later) and their defaults live in [`src/config.rs`](src/config.rs).

--- a/shell-filesystem/build.rs
+++ b/shell-filesystem/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+}

--- a/shell-filesystem/iii.worker.yaml
+++ b/shell-filesystem/iii.worker.yaml
@@ -3,7 +3,7 @@ name: shell-filesystem
 language: rust
 deploy: binary
 manifest: Cargo.toml
-bin: iii-shell-filesystem
-description: Sandboxed filesystem operations under shell::fs::* — read, write, list, stat, glob.
+bin: shell-filesystem
+description: Sandboxed filesystem operations under shell::filesystem::* — read, write, list, stat, and related tools.
 config:
   max_inline_bytes: 262144

--- a/shell-filesystem/src/config.rs
+++ b/shell-filesystem/src/config.rs
@@ -1,0 +1,48 @@
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct WorkerConfig {
+    #[serde(default = "default_max_inline_bytes")]
+    pub max_inline_bytes: usize,
+}
+
+fn default_max_inline_bytes() -> usize {
+    262_144
+}
+
+impl Default for WorkerConfig {
+    fn default() -> Self {
+        Self {
+            max_inline_bytes: default_max_inline_bytes(),
+        }
+    }
+}
+
+pub fn load_config(path: &str) -> Result<WorkerConfig> {
+    let contents = std::fs::read_to_string(path).with_context(|| format!("read config {path}"))?;
+    serde_yaml::from_str(&contents).with_context(|| format!("parse config yaml {path}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_from_empty_yaml() {
+        let cfg: WorkerConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(cfg.max_inline_bytes, default_max_inline_bytes());
+    }
+
+    #[test]
+    fn custom_yaml_overrides() {
+        let cfg: WorkerConfig = serde_yaml::from_str("max_inline_bytes: 1024\n").unwrap();
+        assert_eq!(cfg.max_inline_bytes, 1024);
+    }
+
+    #[test]
+    fn impl_default_matches_yaml_defaults() {
+        let yaml: WorkerConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(WorkerConfig::default(), yaml);
+    }
+}

--- a/shell-filesystem/src/lib.rs
+++ b/shell-filesystem/src/lib.rs
@@ -1,6 +1,5 @@
-//! `shell-filesystem` — wraps `sandbox::fs::*` triggers as
-//! `shell::filesystem::<op>` functions discoverable by the
-//! turn orchestrator.
+//! `shell-filesystem` worker — registers `shell::filesystem::<op>` functions
+//! for the turn orchestrator and agent tooling.
 
 pub mod ops;
 pub mod register;

--- a/shell-filesystem/src/main.rs
+++ b/shell-filesystem/src/main.rs
@@ -1,218 +1,97 @@
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
-use iii_sdk::{register_worker, InitOptions};
-use serde_json::Value;
+use anyhow::Result;
+use clap::Parser;
+use iii_sdk::{register_worker, InitOptions, OtelConfig, WorkerMetadata};
 
-const DEFAULT_ENGINE_URL: &str = "ws://127.0.0.1:49134";
+mod config;
+mod manifest;
 
-#[derive(Debug, Default, PartialEq, Eq)]
-struct ConfigOverrides {
-    max_inline_bytes: Option<usize>,
-}
+#[derive(Parser, Debug)]
+#[command(
+    name = "shell-filesystem",
+    about = "Sandboxed filesystem operations on the iii bus (shell::filesystem::*)"
+)]
+struct Cli {
+    #[arg(long, default_value = "./config.yaml")]
+    config: String,
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct RuntimeConfig {
-    read: shell_filesystem::ops::read::ReadConfig,
-}
+    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    url: String,
 
-impl RuntimeConfig {
-    fn load(config_path: Option<&Path>) -> Self {
-        let mut cfg = Self {
-            read: shell_filesystem::ops::read::ReadConfig::default(),
-        };
-
-        if let Some(path) = config_path {
-            match load_config_overrides(path) {
-                Ok(overrides) => cfg.apply(overrides),
-                Err(e) => log::warn!(
-                    "failed to load shell-filesystem config from {}: {e}; using defaults",
-                    path.display()
-                ),
-            }
-        }
-
-        if let Ok(max_inline_bytes) = std::env::var("SHELL_FILESYSTEM_MAX_INLINE_BYTES") {
-            if let Ok(max_inline_bytes) = max_inline_bytes.trim().parse() {
-                cfg.read.max_inline_bytes = max_inline_bytes;
-            }
-        }
-
-        cfg
-    }
-
-    fn apply(&mut self, overrides: ConfigOverrides) {
-        if let Some(max_inline_bytes) = overrides.max_inline_bytes {
-            self.read.max_inline_bytes = max_inline_bytes;
-        }
-    }
-}
-
-fn config_path_arg() -> Option<PathBuf> {
-    let mut args = std::env::args_os().skip(1);
-    while let Some(arg) = args.next() {
-        if arg == std::ffi::OsStr::new("--config") {
-            return args.next().map(PathBuf::from);
-        }
-        if let Some(s) = arg.to_str() {
-            if let Some(path) = s.strip_prefix("--config=") {
-                return Some(PathBuf::from(path));
-            }
-        }
-    }
-    None
-}
-
-fn load_config_overrides(path: &Path) -> Result<ConfigOverrides> {
-    let raw = std::fs::read_to_string(path)?;
-    Ok(parse_config_overrides(&raw))
-}
-
-fn parse_config_overrides(raw: &str) -> ConfigOverrides {
-    if let Some(overrides) = parse_json_config_overrides(raw) {
-        return overrides;
-    }
-    parse_yaml_config_overrides(raw)
-}
-
-fn parse_json_config_overrides(raw: &str) -> Option<ConfigOverrides> {
-    let value: Value = serde_json::from_str(raw).ok()?;
-    let root = value.as_object()?;
-    let object = root
-        .get("config")
-        .and_then(Value::as_object)
-        .unwrap_or(root);
-    let max_inline_bytes = object
-        .get("max_inline_bytes")
-        .and_then(Value::as_u64)
-        .and_then(|v| usize::try_from(v).ok());
-    Some(ConfigOverrides { max_inline_bytes })
-}
-
-fn parse_yaml_config_overrides(raw: &str) -> ConfigOverrides {
-    let mut overrides = ConfigOverrides::default();
-    let mut in_config_block = false;
-    let mut config_indent = None;
-
-    for line in raw.lines() {
-        let indent = line.chars().take_while(|ch| *ch == ' ').count();
-        let line = strip_yaml_comment(line).trim_end();
-        let line = line.trim_start();
-        if line.is_empty() || line == "---" {
-            continue;
-        }
-        let Some((key, value)) = line.split_once(':') else {
-            continue;
-        };
-
-        if indent == 0 {
-            let key = key.trim();
-            if key == "config" && parse_yaml_scalar(value).is_none() {
-                in_config_block = true;
-                config_indent = None;
-                continue;
-            }
-            in_config_block = false;
-            parse_config_key(&mut overrides, key, value);
-            continue;
-        }
-
-        if !in_config_block {
-            continue;
-        }
-
-        let expected_indent = *config_indent.get_or_insert(indent);
-        if indent != expected_indent {
-            continue;
-        }
-        parse_config_key(&mut overrides, key.trim(), value);
-    }
-
-    overrides
-}
-
-fn parse_config_key(overrides: &mut ConfigOverrides, key: &str, value: &str) {
-    if key == "max_inline_bytes" {
-        overrides.max_inline_bytes = parse_yaml_scalar(value).and_then(|v| v.parse().ok());
-    }
-}
-
-fn strip_yaml_comment(line: &str) -> &str {
-    let mut in_single = false;
-    let mut in_double = false;
-
-    for (idx, ch) in line.char_indices() {
-        match ch {
-            '\'' if !in_double => in_single = !in_single,
-            '"' if !in_single => in_double = !in_double,
-            '#' if !in_single && !in_double => return &line[..idx],
-            _ => {}
-        }
-    }
-
-    line
-}
-
-fn parse_yaml_scalar(value: &str) -> Option<String> {
-    let value = value.trim();
-    if value.is_empty() || value == "null" || value == "~" {
-        return None;
-    }
-
-    let unquoted = if value.len() >= 2 {
-        let bytes = value.as_bytes();
-        let quote = bytes[0];
-        if (quote == b'\'' || quote == b'"') && bytes[value.len() - 1] == quote {
-            &value[1..value.len() - 1]
-        } else {
-            value
-        }
-    } else {
-        value
-    };
-
-    let unquoted = unquoted.trim();
-    if unquoted.is_empty() {
-        None
-    } else {
-        Some(unquoted.to_string())
-    }
+    #[arg(long)]
+    manifest: bool,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
 
-    let engine_url = std::env::var("III_URL").unwrap_or_else(|_| DEFAULT_ENGINE_URL.to_string());
-    let cfg = RuntimeConfig::load(config_path_arg().as_deref());
-    let iii = Arc::new(register_worker(&engine_url, InitOptions::default()));
+    let cli = Cli::parse();
 
-    shell_filesystem::register_with_config(&iii, cfg.read)
+    if cli.manifest {
+        let m = manifest::build_manifest();
+        println!("{}", serde_json::to_string_pretty(&m).unwrap());
+        return Ok(());
+    }
+
+    let mut cfg = match config::load_config(&cli.config) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                path = %cli.config,
+                "failed to load config, using defaults"
+            );
+            config::WorkerConfig::default()
+        }
+    };
+
+    if let Ok(raw) = std::env::var("SHELL_FILESYSTEM_MAX_INLINE_BYTES") {
+        if let Ok(n) = raw.trim().parse::<usize>() {
+            cfg.max_inline_bytes = n;
+        }
+    }
+
+    let cfg = Arc::new(cfg);
+    let read_config = shell_filesystem::ops::read::ReadConfig {
+        max_inline_bytes: cfg.max_inline_bytes,
+    };
+
+    let iii = register_worker(
+        &cli.url,
+        InitOptions {
+            otel: Some(OtelConfig::default()),
+            metadata: Some(WorkerMetadata {
+                runtime: "rust".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                name: "shell-filesystem".to_string(),
+                os: std::env::consts::OS.to_string(),
+                pid: Some(std::process::id()),
+                telemetry: None,
+                ..WorkerMetadata::default()
+            }),
+            ..InitOptions::default()
+        },
+    );
+    let iii = Arc::new(iii);
+
+    shell_filesystem::register_with_config(&iii, read_config)
         .await
-        .context("shell-filesystem register failed")?;
-    log::info!(
-        "shell-filesystem registered (shell::fs::*); max_inline_bytes={}",
-        cfg.read.max_inline_bytes
+        .map_err(|e| anyhow::anyhow!("shell-filesystem register failed: {e}"))?;
+
+    tracing::info!(
+        max_inline_bytes = cfg.max_inline_bytes,
+        "shell-filesystem registered (shell::filesystem::*)"
     );
 
-    tokio::signal::ctrl_c().await.ok();
+    tokio::signal::ctrl_c().await?;
+    tracing::info!("shell-filesystem shutting down");
+    iii.shutdown_async().await;
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_yaml_config_overrides_max_inline_bytes() {
-        let overrides = parse_config_overrides("max_inline_bytes: 1024\n");
-        assert_eq!(overrides.max_inline_bytes, Some(1024));
-    }
-
-    #[test]
-    fn parse_json_config_overrides_wrapped_config() {
-        let overrides = parse_config_overrides(r#"{ "config": { "max_inline_bytes": 2048 } }"#);
-        assert_eq!(overrides.max_inline_bytes, Some(2048));
-    }
 }

--- a/shell-filesystem/src/manifest.rs
+++ b/shell-filesystem/src/manifest.rs
@@ -1,0 +1,42 @@
+use serde::Serialize;
+
+use crate::config::WorkerConfig;
+
+#[derive(Serialize)]
+pub struct ModuleManifest {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub default_config: serde_json::Value,
+    pub supported_targets: Vec<String>,
+}
+
+pub fn build_manifest() -> ModuleManifest {
+    let defaults = WorkerConfig::default();
+    ModuleManifest {
+        name: env!("CARGO_PKG_NAME").to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        description: "Sandboxed filesystem operations under shell::filesystem::* — read, write, list, stat, and related tools.".to_string(),
+        default_config: serde_json::json!({
+            "max_inline_bytes": defaults.max_inline_bytes,
+        }),
+        supported_targets: vec![env!("TARGET").to_string()],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_roundtrip_has_required_fields() {
+        let m = build_manifest();
+        let json = serde_json::to_string_pretty(&m).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["name"], env!("CARGO_PKG_NAME"));
+        assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+        assert!(parsed["description"].as_str().unwrap().len() > 5);
+        assert!(parsed["default_config"].is_object());
+        assert!(!parsed["supported_targets"].as_array().unwrap().is_empty());
+    }
+}

--- a/shell-filesystem/tests/manifest.rs
+++ b/shell-filesystem/tests/manifest.rs
@@ -1,0 +1,47 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde_json::Value;
+
+fn shell_filesystem_executable() -> PathBuf {
+    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_shell_filesystem") {
+        return PathBuf::from(p);
+    }
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    for profile in ["debug", "release"] {
+        let candidate = dir.join("target").join(profile).join("shell-filesystem");
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+    panic!(
+        "shell-filesystem binary not found under target/{{debug,release}}/; run `cargo build --bin shell-filesystem` first"
+    );
+}
+
+#[test]
+fn manifest_subcommand_emits_valid_json() {
+    let bin = shell_filesystem_executable();
+    let output = Command::new(&bin)
+        .arg("--manifest")
+        .output()
+        .expect("spawn shell-filesystem --manifest");
+
+    assert!(
+        output.status.success(),
+        "binary exited with {:?}; stderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("manifest stdout is utf-8");
+    let manifest: Value = serde_json::from_str(&stdout).expect("manifest stdout is valid JSON");
+
+    assert_eq!(manifest["name"], env!("CARGO_PKG_NAME"));
+    assert_eq!(manifest["version"], env!("CARGO_PKG_VERSION"));
+    assert!(manifest["default_config"].is_object());
+    assert!(!manifest["supported_targets"]
+        .as_array()
+        .expect("supported_targets must be an array")
+        .is_empty());
+}

--- a/skills/Cargo.lock
+++ b/skills/Cargo.lock
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "skills"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/subagent/Cargo.lock
+++ b/subagent/Cargo.lock
@@ -169,6 +169,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,29 +299,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
 
 [[package]]
 name = "equivalent"
@@ -762,19 +779,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-subagent"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "chrono",
- "env_logger",
- "iii-sdk",
- "log",
- "serde_json",
- "tokio",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,30 +828,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jiff"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,6 +838,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -878,15 +864,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +874,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -922,6 +908,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1032,29 +1027,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,21 +1057,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -1291,27 +1248,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,12 +1415,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,6 +1510,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,6 +1531,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1633,6 +1585,28 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subagent"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "iii-sdk",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "subtle"
@@ -1706,6 +1680,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1739,7 +1722,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -1923,6 +1905,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1975,6 +1987,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2021,6 +2039,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/subagent/Cargo.toml
+++ b/subagent/Cargo.toml
@@ -1,5 +1,7 @@
+[workspace]
+
 [package]
-name = "iii-subagent"
+name = "subagent"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
@@ -8,21 +10,26 @@ authors = ["iii contributors"]
 publish = false
 
 [lib]
-name = "subagent"
 path = "src/lib.rs"
 
 [[bin]]
-name = "iii-subagent"
+name = "subagent"
 path = "src/main.rs"
 
 [dependencies]
 iii-sdk = "=0.11.3"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["full"] }
+serde_yaml = "0.9"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal"] }
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
-log = "0.4"
-env_logger = "0.11"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+clap = { version = "4", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/subagent/README.md
+++ b/subagent/README.md
@@ -1,51 +1,58 @@
 # subagent
 
-Spawn child agent sessions on the iii bus under `subagent::*`. Wraps
+Spawn child agent sessions on the iii bus under `subagent::start`. Wraps
 `run::start_and_wait` so a parent agent can run a sub-task in an isolated
-session and consume the result inline.
+session and consume the result inline. Install also pulls `turn-orchestrator`
+(see `dependencies` in `iii.worker.yaml`) so `run::*` is available.
 
-Renamed from `shell-subagent`; nothing about this worker actually involves
-a shell — it spawns agents.
-
-## Installation
+## Install
 
 ```bash
 iii worker add subagent
 ```
 
-The install resolver pulls `turn-orchestrator` (declared via
-`dependencies:` in `iii.worker.yaml`) so the `run::*` surface is available
-on the bus.
+`iii worker add` fetches the binary, writes a config block into
+`~/.iii/config.yaml`, and the engine starts the worker on the next `iii start`.
 
-## Run
+## Quickstart
 
-```bash
-iii-subagent --engine-url ws://127.0.0.1:49134
+Call `subagent::start` with `prompt`, `provider`, and `model`. Optional fields:
+`system_prompt`, `parent_session_id`, `max_subagent_depth`.
+
+```rust
+use iii_sdk::{register_worker, InitOptions, TriggerRequest};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let iii = register_worker("ws://localhost:49134", InitOptions::default());
+
+    let result = iii
+        .trigger(TriggerRequest {
+            function_id: "subagent::start".into(),
+            payload: json!({
+                "prompt": "Summarize this in one line.",
+                "provider": "openai",
+                "model": "gpt-4o-mini",
+            }),
+            action: None,
+            timeout_ms: Some(600_000),
+        })
+        .await?;
+
+    println!("{result:#?}");
+    Ok(())
+}
 ```
 
-(Or set `III_URL`.)
-
-## Registered functions
-
-| Function | Description |
-|---|---|
-| `subagent::start` | Spawn a child agent session and await its result. Args: `prompt`, `provider`, `model`, optional `system_prompt`, `max_turns`, `parent_session_id`, `max_subagent_depth` (default 3). |
+Other keys (and their defaults) live in [`src/config.rs`](src/config.rs).
 
 ## Configuration
 
-| Env var | Default | Effect |
-|---|---|---|
-| `III_URL` | `ws://127.0.0.1:49134` | Engine WebSocket URL. |
+Operator defaults ship in committed `config.yaml` and `--config`:
 
-## Dependencies
-
-| Worker | Range | Reason |
-|---|---|---|
-| `turn-orchestrator` | `^0.1.0` | Provides `run::start_and_wait` consumed by every subagent invocation. |
-
-## Build / Test
-
-```bash
-cargo build --release
-cargo test
+```yaml
+default_system_prompt: "You are a focused sub-agent. Answer the parent's subtask concisely and stop."
+trigger_timeout_ms: 600000          # forwarded to run::start_and_wait
+default_max_subagent_depth: 3       # nesting cap when caller omits max_subagent_depth
 ```

--- a/subagent/build.rs
+++ b/subagent/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+}

--- a/subagent/iii.worker.yaml
+++ b/subagent/iii.worker.yaml
@@ -3,7 +3,7 @@ name: subagent
 language: rust
 deploy: binary
 manifest: Cargo.toml
-bin: iii-subagent
-description: Spawn child agent sessions under subagent::* via run::start_and_wait.
+bin: subagent
+description: Spawn child agent sessions under subagent::start via run::start_and_wait.
 dependencies:
   turn-orchestrator: "^0.1.0"

--- a/subagent/skill.md
+++ b/subagent/skill.md
@@ -1,0 +1,8 @@
+# subagent
+
+Spawn focused child agent runs on the iii bus via `run::start_and_wait`, then
+return the final assistant text to the parent tool caller. Useful for isolating
+subtasks, alternative reasoning paths, or depth-bounded nested agents.
+
+- [`subagent`](iii://subagent)
+  - [`subagent::start`](iii://subagent/start) — spawn a child session and block until terminal

--- a/subagent/skills/start.md
+++ b/subagent/skills/start.md
@@ -1,0 +1,20 @@
+# subagent::start
+
+Spawn a child durable agent session and wait until it reaches a terminal state,
+then return the last non-empty assistant text from the child transcript.
+
+`({ prompt, provider, model, system_prompt?, parent_session_id?, max_subagent_depth? }) → { content, details }` — mints `child_session_id` as `{parent_session_id}::sub-{timestamp_ms}` (parent defaults to `root`), calls `run::start_and_wait` with that session, a single user message built from `prompt`, and the given `provider` / `model` / `system_prompt`. On success: `content` is a tool-shaped array with one `text` block; `details` includes `child_session_id`, `turn_count`, and `via: "run::start_and_wait"`. On depth refusal: `details.depth_limit_reached` is true and `content` explains the cap.
+
+## When to use
+
+- The parent agent wants a concise answer to a narrow sub-question without bloating its own scratchpad.
+- You need a one-shot nested run with a different default system prompt than the parent.
+- You are experimenting with an alternative model or provider for the same prompt shape.
+- You must respect a nesting cap: pass a chain in `parent_session_id` that already contains `::sub-` segments so depth is counted correctly.
+
+## Notes
+
+- The child run does **not** take its tool list from this payload. `turn-orchestrator` rebuilds the LLM tool catalog from `engine::functions::list` during the provisioning state, so the child sees the **global** catalog (including `subagent::start`). Use `max_subagent_depth` (worker default 3, overridable per call) to cap recursion: depth is `parent_session_id.matches("::sub-").count()` compared to `max_subagent_depth`.
+- Pass the parent harness session id in `parent_session_id` when nesting so depth is tracked across spawns; omit or use `root` only for a top-level sub-agent from an unknown parent chain.
+- `trigger_timeout_ms` in the worker config (default 600000) bounds how long `run::start_and_wait` may block before the trigger fails.
+- To cap turns on the child run, extend the `run::start` payload contract in `turn-orchestrator` (e.g. `max_turns` on start); `subagent::start` does not read `max_turns` today.

--- a/subagent/src/config.rs
+++ b/subagent/src/config.rs
@@ -1,0 +1,86 @@
+use anyhow::Result;
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct SubagentConfig {
+    #[serde(default = "default_default_system_prompt")]
+    pub default_system_prompt: String,
+    #[serde(default = "default_trigger_timeout_ms")]
+    pub trigger_timeout_ms: u64,
+    #[serde(default = "default_default_max_subagent_depth")]
+    pub default_max_subagent_depth: u64,
+}
+
+fn default_default_system_prompt() -> String {
+    "You are a focused sub-agent. Answer the parent's subtask concisely and stop.".to_string()
+}
+
+fn default_trigger_timeout_ms() -> u64 {
+    600_000
+}
+
+fn default_default_max_subagent_depth() -> u64 {
+    3
+}
+
+impl Default for SubagentConfig {
+    fn default() -> Self {
+        Self {
+            default_system_prompt: default_default_system_prompt(),
+            trigger_timeout_ms: default_trigger_timeout_ms(),
+            default_max_subagent_depth: default_default_max_subagent_depth(),
+        }
+    }
+}
+
+pub fn load_config(path: &str) -> Result<SubagentConfig> {
+    let contents = std::fs::read_to_string(path)?;
+    let cfg: SubagentConfig = serde_yaml::from_str(&contents)?;
+    Ok(cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_from_empty_yaml() {
+        let cfg: SubagentConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(
+            cfg.default_system_prompt,
+            "You are a focused sub-agent. Answer the parent's subtask concisely and stop."
+        );
+        assert_eq!(cfg.trigger_timeout_ms, 600_000);
+        assert_eq!(cfg.default_max_subagent_depth, 3);
+    }
+
+    #[test]
+    fn custom_yaml_overrides() {
+        let yaml = r"
+default_system_prompt: 'custom'
+trigger_timeout_ms: 1000
+default_max_subagent_depth: 5
+";
+        let cfg: SubagentConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.default_system_prompt, "custom");
+        assert_eq!(cfg.trigger_timeout_ms, 1000);
+        assert_eq!(cfg.default_max_subagent_depth, 5);
+    }
+
+    #[test]
+    fn impl_default_matches_yaml_defaults() {
+        let yaml_default: SubagentConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(
+            yaml_default.default_system_prompt,
+            SubagentConfig::default().default_system_prompt
+        );
+        assert_eq!(
+            yaml_default.trigger_timeout_ms,
+            SubagentConfig::default().trigger_timeout_ms
+        );
+        assert_eq!(
+            yaml_default.default_max_subagent_depth,
+            SubagentConfig::default().default_max_subagent_depth
+        );
+    }
+}

--- a/subagent/src/lib.rs
+++ b/subagent/src/lib.rs
@@ -5,8 +5,7 @@
 
 pub const SKILL_ID: &str = "subagent";
 pub const SKILL_MD: &str = include_str!("../skill.md");
-pub const SUB_SKILLS: &[(&str, &str)] =
-    &[("subagent/start", include_str!("../skills/start.md"))];
+pub const SUB_SKILLS: &[(&str, &str)] = &[("subagent/start", include_str!("../skills/start.md"))];
 
 pub mod config;
 pub mod manifest;

--- a/subagent/src/lib.rs
+++ b/subagent/src/lib.rs
@@ -3,6 +3,11 @@
 //! Renamed from `shell-subagent`; nothing about this worker actually
 //! involves a shell — it spawns child agent sessions and awaits results.
 
+pub const SKILL_ID: &str = "subagent";
+pub const SKILL_MD: &str = include_str!("../skill.md");
+pub const SUB_SKILLS: &[(&str, &str)] =
+    &[("subagent/start", include_str!("../skills/start.md"))];
+
 pub mod config;
 pub mod manifest;
 pub mod register;

--- a/subagent/src/lib.rs
+++ b/subagent/src/lib.rs
@@ -3,6 +3,8 @@
 //! Renamed from `shell-subagent`; nothing about this worker actually
 //! involves a shell — it spawns child agent sessions and awaits results.
 
+pub mod config;
+pub mod manifest;
 pub mod register;
 pub mod start;
 

--- a/subagent/src/main.rs
+++ b/subagent/src/main.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
-use iii_sdk::{register_worker, InitOptions, OtelConfig, WorkerMetadata};
+use iii_sdk::{register_worker, InitOptions, OtelConfig, TriggerRequest, WorkerMetadata};
+use serde_json::json;
 use tracing_subscriber::EnvFilter;
 
 #[derive(Parser, Debug)]
@@ -67,8 +69,96 @@ async fn main() -> Result<()> {
     subagent::register_with_iii(&iii, &cfg);
     tracing::info!("subagent ready (subagent::start registered)");
 
-    tokio::signal::ctrl_c().await?;
+    spawn_skill_register(iii.clone());
+
+    wait_for_shutdown().await?;
+
+    unregister_skill(&iii).await;
     tracing::info!("subagent shutting down");
     iii.shutdown_async().await;
     Ok(())
+}
+
+async fn register_skill_with_retry(iii: &iii_sdk::III, id: &str, body: &str) {
+    let mut backoff = Duration::from_secs(5);
+    let started = Instant::now();
+    loop {
+        let res = iii
+            .trigger(TriggerRequest {
+                function_id: "skills::register".into(),
+                payload: json!({ "id": id, "skill": body }),
+                action: None,
+                timeout_ms: Some(5_000),
+            })
+            .await;
+        match res {
+            Ok(_) => {
+                tracing::info!(skill_id = %id, "registered skill");
+                return;
+            }
+            Err(e) => {
+                if started.elapsed() > Duration::from_secs(3 * 60) {
+                    tracing::warn!(
+                        skill_id = %id,
+                        error = %e,
+                        "skills handshake gave up; install/start the skills worker and restart"
+                    );
+                    return;
+                }
+                tracing::debug!(skill_id = %id, error = %e, wait = ?backoff, "skills::register failed; retrying");
+            }
+        }
+        tokio::time::sleep(backoff).await;
+        backoff = (backoff * 2).min(Duration::from_secs(60));
+    }
+}
+
+fn spawn_skill_register(iii: Arc<iii_sdk::III>) {
+    tokio::spawn(async move {
+        register_skill_with_retry(&iii, subagent::SKILL_ID, subagent::SKILL_MD).await;
+        for (id, body) in subagent::SUB_SKILLS {
+            register_skill_with_retry(&iii, id, body).await;
+        }
+    });
+}
+
+async fn wait_for_shutdown() -> Result<()> {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut sigterm =
+            signal(SignalKind::terminate()).context("failed to install SIGTERM handler")?;
+        tokio::select! {
+            r = tokio::signal::ctrl_c() => r.context("failed to await SIGINT")?,
+            _ = sigterm.recv() => {}
+        }
+        Ok(())
+    }
+    #[cfg(not(unix))]
+    {
+        tokio::signal::ctrl_c()
+            .await
+            .context("failed to await SIGINT")
+    }
+}
+
+async fn unregister_skill(iii: &Arc<iii_sdk::III>) {
+    for (id, _) in subagent::SUB_SKILLS {
+        let _ = iii
+            .trigger(TriggerRequest {
+                function_id: "skills::unregister".into(),
+                payload: json!({ "id": id }),
+                action: None,
+                timeout_ms: Some(2_000),
+            })
+            .await;
+    }
+    let _ = iii
+        .trigger(TriggerRequest {
+            function_id: "skills::unregister".into(),
+            payload: json!({ "id": subagent::SKILL_ID }),
+            action: None,
+            timeout_ms: Some(2_000),
+        })
+        .await;
 }

--- a/subagent/src/main.rs
+++ b/subagent/src/main.rs
@@ -1,22 +1,74 @@
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
-use iii_sdk::{register_worker, InitOptions};
+use anyhow::Result;
+use clap::Parser;
+use iii_sdk::{register_worker, InitOptions, OtelConfig, WorkerMetadata};
+use tracing_subscriber::EnvFilter;
 
-const DEFAULT_ENGINE_URL: &str = "ws://127.0.0.1:49134";
+#[derive(Parser, Debug)]
+#[command(
+    name = "subagent",
+    about = "Spawn child agent sessions via subagent::start / run::start_and_wait."
+)]
+struct Cli {
+    #[arg(long, default_value = "./config.yaml")]
+    config: String,
+
+    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    url: String,
+
+    #[arg(long)]
+    manifest: bool,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
 
-    let engine_url = std::env::var("III_URL").unwrap_or_else(|_| DEFAULT_ENGINE_URL.to_string());
-    let iii = Arc::new(register_worker(&engine_url, InitOptions::default()));
+    let cli = Cli::parse();
 
-    subagent::register_with_iii(&iii)
-        .await
-        .context("subagent register failed")?;
-    log::info!("subagent registered (subagent::start)");
+    if cli.manifest {
+        let m = subagent::manifest::build_manifest();
+        println!("{}", serde_json::to_string_pretty(&m)?);
+        return Ok(());
+    }
 
-    tokio::signal::ctrl_c().await.ok();
+    let cfg = match subagent::config::load_config(&cli.config) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(error = %e, path = %cli.config, "failed to load config, using defaults");
+            subagent::config::SubagentConfig::default()
+        }
+    };
+    let cfg = Arc::new(cfg);
+
+    let iii = register_worker(
+        &cli.url,
+        InitOptions {
+            otel: Some(OtelConfig::default()),
+            metadata: Some(WorkerMetadata {
+                runtime: "rust".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                name: "subagent".to_string(),
+                os: std::env::consts::OS.to_string(),
+                pid: Some(std::process::id()),
+                telemetry: None,
+                ..WorkerMetadata::default()
+            }),
+            ..InitOptions::default()
+        },
+    );
+    let iii = Arc::new(iii);
+
+    subagent::register_with_iii(&iii, &cfg);
+    tracing::info!("subagent ready (subagent::start registered)");
+
+    tokio::signal::ctrl_c().await?;
+    tracing::info!("subagent shutting down");
+    iii.shutdown_async().await;
     Ok(())
 }

--- a/subagent/src/main.rs
+++ b/subagent/src/main.rs
@@ -97,7 +97,7 @@ async fn register_skill_with_retry(iii: &iii_sdk::III, id: &str, body: &str) {
                 return;
             }
             Err(e) => {
-                if started.elapsed() > Duration::from_secs(3 * 60) {
+                if started.elapsed() > Duration::from_mins(3) {
                     tracing::warn!(
                         skill_id = %id,
                         error = %e,
@@ -109,7 +109,7 @@ async fn register_skill_with_retry(iii: &iii_sdk::III, id: &str, body: &str) {
             }
         }
         tokio::time::sleep(backoff).await;
-        backoff = (backoff * 2).min(Duration::from_secs(60));
+        backoff = (backoff * 2).min(Duration::from_mins(1));
     }
 }
 

--- a/subagent/src/manifest.rs
+++ b/subagent/src/manifest.rs
@@ -1,0 +1,43 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct ModuleManifest {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub default_config: serde_json::Value,
+    pub supported_targets: Vec<String>,
+}
+
+pub fn build_manifest() -> ModuleManifest {
+    let cfg = crate::config::SubagentConfig::default();
+    ModuleManifest {
+        name: env!("CARGO_PKG_NAME").to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        description: "Spawn child agent sessions under subagent::start via run::start_and_wait."
+            .to_string(),
+        default_config: serde_json::json!({
+            "default_system_prompt": cfg.default_system_prompt,
+            "trigger_timeout_ms": cfg.trigger_timeout_ms,
+            "default_max_subagent_depth": cfg.default_max_subagent_depth,
+        }),
+        supported_targets: vec![env!("TARGET").to_string()],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_roundtrip_has_required_fields() {
+        let m = build_manifest();
+        let json = serde_json::to_string_pretty(&m).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["name"], env!("CARGO_PKG_NAME"));
+        assert_eq!(parsed["version"], env!("CARGO_PKG_VERSION"));
+        assert!(parsed["default_config"].is_object());
+        let targets = parsed["supported_targets"].as_array().expect("array");
+        assert!(!targets.is_empty());
+    }
+}

--- a/subagent/src/register.rs
+++ b/subagent/src/register.rs
@@ -1,16 +1,19 @@
+use std::sync::Arc;
+
 use iii_sdk::{RegisterFunctionMessage, Value, III};
 
-use crate::start;
+use crate::{config::SubagentConfig, start};
 
-pub async fn register_with_iii(iii: &III) -> anyhow::Result<()> {
+pub fn register_with_iii(iii: &Arc<III>, config: &Arc<SubagentConfig>) {
     let iii_for_start = iii.clone();
+    let cfg = config.clone();
     iii.register_function((
         RegisterFunctionMessage::with_id(start::ID.into())
             .with_description(start::DESCRIPTION.into()),
         move |payload: Value| {
             let iii = iii_for_start.clone();
-            async move { start::execute(&iii, &payload).await }
+            let cfg = cfg.clone();
+            async move { start::execute(&iii, &payload, &cfg).await }
         },
     ));
-    Ok(())
 }

--- a/subagent/src/start.rs
+++ b/subagent/src/start.rs
@@ -1,5 +1,6 @@
 //! `subagent::start` — spawn a child durable session via `run::start`.
 
+use crate::config::SubagentConfig;
 use iii_sdk::{IIIError, TriggerRequest, Value, III};
 use serde_json::json;
 
@@ -7,17 +8,15 @@ pub const ID: &str = "subagent::start";
 pub const DESCRIPTION: &str =
     "Spawn a sub-agent for a focused subtask. Args: prompt, provider, model, system_prompt?, max_turns?, parent_session_id?, max_subagent_depth?.";
 
-pub const DEFAULT_MAX_DEPTH: usize = 3;
-
-pub async fn execute(iii: &III, args: &Value) -> Result<Value, IIIError> {
+pub async fn execute(iii: &III, args: &Value, config: &SubagentConfig) -> Result<Value, IIIError> {
     let prompt = required(args, "prompt")?;
     let provider = required(args, "provider")?;
     let model = required(args, "model")?;
     let system_prompt = args
         .get("system_prompt")
         .and_then(Value::as_str)
-        .unwrap_or("You are a focused sub-agent. Answer the parent's subtask concisely and stop.")
-        .to_string();
+        .map(str::to_string)
+        .unwrap_or_else(|| config.default_system_prompt.clone());
     let parent_session = args
         .get("parent_session_id")
         .and_then(Value::as_str)
@@ -26,7 +25,7 @@ pub async fn execute(iii: &III, args: &Value) -> Result<Value, IIIError> {
     let max_depth = args
         .get("max_subagent_depth")
         .and_then(Value::as_u64)
-        .map_or(DEFAULT_MAX_DEPTH, |v| v as usize);
+        .map_or(config.default_max_subagent_depth as usize, |v| v as usize);
     let current_depth = parent_session.matches("::sub-").count();
     if current_depth >= max_depth {
         let msg = format!(
@@ -67,7 +66,7 @@ pub async fn execute(iii: &III, args: &Value) -> Result<Value, IIIError> {
             function_id: "run::start_and_wait".into(),
             payload,
             action: None,
-            timeout_ms: Some(600_000),
+            timeout_ms: Some(config.trigger_timeout_ms),
         })
         .await;
 
@@ -155,7 +154,7 @@ mod tests {
     }
 
     #[test]
-    fn default_max_depth_matches_legacy() {
-        assert_eq!(DEFAULT_MAX_DEPTH, 3);
+    fn default_max_depth_matches_config() {
+        assert_eq!(SubagentConfig::default().default_max_subagent_depth, 3);
     }
 }

--- a/subagent/src/start.rs
+++ b/subagent/src/start.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 
 pub const ID: &str = "subagent::start";
 pub const DESCRIPTION: &str =
-    "Spawn a sub-agent for a focused subtask. Args: prompt, provider, model, system_prompt?, max_turns?, parent_session_id?, max_subagent_depth?.";
+    "Spawn a sub-agent for a focused subtask. Args: prompt, provider, model, system_prompt?, parent_session_id?, max_subagent_depth?.";
 
 pub async fn execute(iii: &III, args: &Value, config: &SubagentConfig) -> Result<Value, IIIError> {
     let prompt = required(args, "prompt")?;
@@ -47,6 +47,8 @@ pub async fn execute(iii: &III, args: &Value, config: &SubagentConfig) -> Result
         "{parent_session}::sub-{}",
         chrono::Utc::now().timestamp_millis()
     );
+    // Omit `tools`: run::start ignores caller tools; catalog is built in
+    // turn-orchestrator provisioning from engine::functions::list.
     let payload = json!({
         "session_id": child_session_id,
         "parent_session_id": parent_session,
@@ -58,7 +60,6 @@ pub async fn execute(iii: &III, args: &Value, config: &SubagentConfig) -> Result
             "content": [{"type": "text", "text": prompt}],
             "timestamp": chrono::Utc::now().timestamp_millis(),
         }],
-        "tools": [],
     });
 
     let response = iii

--- a/subagent/tests/manifest.rs
+++ b/subagent/tests/manifest.rs
@@ -1,0 +1,32 @@
+//! Subprocess `--manifest` contract (pattern A).
+
+use std::process::Command;
+
+use serde_json::Value;
+
+#[test]
+fn manifest_subcommand_emits_valid_json() {
+    let bin = env!("CARGO_BIN_EXE_subagent");
+    let output = Command::new(bin)
+        .arg("--manifest")
+        .output()
+        .expect("spawn subagent --manifest");
+
+    assert!(
+        output.status.success(),
+        "binary exited with {:?}; stderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("manifest stdout is utf-8");
+    let manifest: Value = serde_json::from_str(&stdout).expect("manifest stdout is valid JSON");
+
+    assert_eq!(manifest["name"], env!("CARGO_PKG_NAME"));
+    assert_eq!(manifest["version"], env!("CARGO_PKG_VERSION"));
+    assert!(manifest["default_config"].is_object());
+    assert!(!manifest["supported_targets"]
+        .as_array()
+        .expect("supported_targets must be an array")
+        .is_empty());
+}

--- a/subagent/tests/skill.rs
+++ b/subagent/tests/skill.rs
@@ -1,0 +1,83 @@
+//! Compile-time and format checks for the registered skill set.
+//! Runs without an iii engine connection.
+//!
+//! Asserts the platform contract from skills/README.md: H1 first (used as
+//! the iii://skills index link title), then a non-heading paragraph (used
+//! as the description, truncated at 140 chars). Workers in this repo
+//! follow folder-name-equals-skill-id; if a future worker uses different
+//! naming, adjust id_is_valid accordingly.
+
+fn well_formed(label: &str, body: &str) {
+    assert!(!body.trim().is_empty(), "{label}: skill is empty");
+    assert!(
+        body.len() <= 256 * 1024,
+        "{label}: skill exceeds 256 KiB ({} bytes)",
+        body.len()
+    );
+
+    let mut lines = body.lines().filter(|l| !l.trim().is_empty());
+    let h1 = lines.next().unwrap_or("");
+    assert!(
+        h1.starts_with("# "),
+        "{label}: skill must start with an H1, got: {h1:?}"
+    );
+    let summary = lines.next().unwrap_or("");
+    assert!(
+        !summary.starts_with('#'),
+        "{label}: expected a summary paragraph after the H1, got another heading: {summary:?}"
+    );
+}
+
+fn id_is_valid(label: &str, id: &str) {
+    assert!(!id.is_empty(), "{label}: id is empty");
+    assert!(id.len() <= 1024, "{label}: id exceeds 1024 chars");
+
+    // `fn` is the only reserved first-segment literal as of skills v0.2.0.
+    let first_segment = id.split('/').next().unwrap_or("");
+    assert_ne!(
+        first_segment, "fn",
+        "{label}: first segment must not be the reserved literal `fn`"
+    );
+
+    for segment in id.split('/') {
+        assert!(
+            !segment.is_empty(),
+            "{label}: empty path segment in id {id:?}"
+        );
+        assert!(
+            segment.len() <= 64,
+            "{label}: segment {segment:?} exceeds 64 chars"
+        );
+        let first = segment.chars().next().unwrap();
+        assert!(
+            first.is_ascii_lowercase() || first.is_ascii_digit(),
+            "{label}: segment {segment:?} must start with lowercase ASCII letter or digit"
+        );
+        assert!(
+            segment
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_'),
+            "{label}: segment {segment:?} has invalid characters"
+        );
+    }
+}
+
+#[test]
+fn router_well_formed() {
+    well_formed("router", subagent::SKILL_MD);
+    id_is_valid("router", subagent::SKILL_ID);
+}
+
+#[test]
+fn sub_skills_well_formed() {
+    let prefix = format!("{}/", subagent::SKILL_ID);
+    for (id, body) in subagent::SUB_SKILLS {
+        well_formed(id, body);
+        id_is_valid(id, id);
+        assert!(
+            id.starts_with(&prefix),
+            "sub-skill id {id:?} must be nested under the worker id ({}/)",
+            subagent::SKILL_ID
+        );
+    }
+}

--- a/turn-orchestrator/src/register.rs
+++ b/turn-orchestrator/src/register.rs
@@ -18,7 +18,7 @@ pub async fn register_with_iii(
     subscriber::register(iii);
 
     iii.register_trigger(RegisterTriggerInput {
-        trigger_type: "subscribe".into(),
+        trigger_type: "durable:subscriber".into(),
         function_id: STEP_FN_ID.into(),
         config: json!({ "topic": STEP_TOPIC }),
         metadata: None,

--- a/turn-orchestrator/src/run_start.rs
+++ b/turn-orchestrator/src/run_start.rs
@@ -135,7 +135,7 @@ pub async fn execute_sync(
 pub async fn publish_step(iii: &III, session_id: &str) {
     if let Err(e) = iii
         .trigger(TriggerRequest {
-            function_id: "publish".into(),
+            function_id: "iii::durable::publish".into(),
             payload: json!({
                 "topic": STEP_TOPIC,
                 "data": { "session_id": session_id },

--- a/turn-orchestrator/src/states/steering.rs
+++ b/turn-orchestrator/src/states/steering.rs
@@ -132,7 +132,7 @@ async fn abort_set(iii: &III, session_id: &str) -> bool {
 async fn drain_queue(iii: &III, name: &str, session_id: &str) -> Vec<AgentMessage> {
     let resp = iii
         .trigger(TriggerRequest {
-            function_id: "inbox::drain".into(),
+            function_id: "session-inbox::drain".into(),
             payload: json!({ "name": name, "session_id": session_id }),
             action: None,
             timeout_ms: None,

--- a/turn-orchestrator/src/states/tools.rs
+++ b/turn-orchestrator/src/states/tools.rs
@@ -272,7 +272,7 @@ async fn publish_collect(
         "timeout_ms": timeout_ms,
     });
     iii.trigger(TriggerRequest {
-        function_id: "hooks::publish_collect".into(),
+        function_id: "hook-fanout::publish_collect".into(),
         payload,
         action: None,
         timeout_ms: None,

--- a/turn-orchestrator/src/subscriber.rs
+++ b/turn-orchestrator/src/subscriber.rs
@@ -61,8 +61,8 @@ pub fn register(iii: &III) {
 }
 
 fn extract_session_id(payload: &Value) -> Option<String> {
-    // Triggers from `publish` arrive wrapped as { event_id, reply_stream?, payload: {...} }.
-    // Unwrap one level if present, then look up session_id under either `data` or top-level.
+    // `iii::durable::publish` delivers the `data` object here. Accept optional extra nesting
+    // (`payload` / `data`) for compatibility with older in-memory pub/sub shapes.
     let inner = payload
         .get("payload")
         .or_else(|| payload.get("data"))


### PR DESCRIPTION
## Summary
- Standardize every worker crate with a uniform layout: `build.rs` (exports TARGET), `src/config.rs` (`WorkerConfig`), `src/manifest.rs` (`ModuleManifest` builder), and a `tests/manifest.rs` integration test.
- Switch worker dependencies from `log`/`env_logger` to `tracing`/`tracing-subscriber`, and add `clap` + `serde_yaml` for config loading where applicable.
- Rename function namespaces to match crate names: `inbox::*` → `session-inbox::*`, `hooks::publish_collect` → `hook-fanout::publish_collect`. Updates `registry/index.json`, root README, and `turn-orchestrator` callsites.
- Whitelist `llm-budget/config.yaml` and `provider-anthropic/config.yaml` in `.gitignore`.

## Test plan
- [ ] `cargo build --workspace` is green
- [ ] `cargo test --workspace` passes (esp. new per-crate `tests/manifest.rs`)
- [ ] `cargo fmt --all -- --check` clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] Spot-check workers boot and register under their renamed namespaces (`session-inbox::*`, `hook-fanout::publish_collect`)
- [ ] Verify `harness/scripts/demo.sh` still runs end-to-end