### PR TITLE
Implement filesystem-backed skills and prompts support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ WORKERS-PR-REVIEW.md
 .gstack/
 *.pid
 *.zip
-config.yaml
 iii.lock
 harness/.omx/
 harness/web/.vite/

--- a/skills/Cargo.lock
+++ b/skills/Cargo.lock
@@ -654,6 +654,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "skills"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1961,6 +1967,7 @@ dependencies = [
  "clap",
  "cucumber",
  "futures",
+ "glob",
  "iii-sdk",
  "schemars",
  "serde",

--- a/skills/Cargo.toml
+++ b/skills/Cargo.toml
@@ -29,6 +29,7 @@ async-trait = "0.1"
 schemars = { version = "0.8", features = ["chrono", "uuid1"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
+glob = "0.3"
 
 [dev-dependencies]
 serde_json = "1"

--- a/skills/README.md
+++ b/skills/README.md
@@ -617,6 +617,14 @@ scopes:
 
 # Default timeout for state::* and sub-skill function triggers (ms).
 state_timeout_ms: 10000
+
+# Glob patterns for filesystem-backed skills / prompts. Resolved
+# relative to the directory of this config file. See
+# "Filesystem-backed skills and prompts" below.
+skills:
+  - my-custom-skills-folder/**/*.md
+prompts:
+  - my-custom-prompts-folder/**/*.md
 ```
 
 CLI flags:
@@ -631,6 +639,122 @@ CLI flags:
 If the config file is missing or malformed the worker logs a warning
 and falls back to the defaults — boot is never blocked by a bad
 config path.
+
+---
+
+## Filesystem-backed skills and prompts
+
+The two top-level `skills:` and `prompts:` arrays in the config are
+glob patterns that point at markdown files on disk. Every match
+becomes a registry entry whose body is **re-read from the file on
+every resolve** — the file system is the single source of truth.
+Nothing is ever mirrored into iii-state.
+
+This is useful for shipping per-project documentation alongside an
+iii deployment without writing a worker, and for layering a team's
+canonical prompt library on top of the runtime registries.
+
+```yaml
+skills:
+  - my-custom-skills-folder/**/*.md
+  - shared/skills/**/*.md
+prompts:
+  - my-custom-prompts-folder/**/*.md
+```
+
+### How globs are resolved
+
+Patterns are interpreted by the `glob` crate (`*`, `?`, `[abc]`,
+`{a,b}`, `**` for recursive directory traversal). Relative paths
+resolve against the **directory of the config file**, not the
+worker's CWD; this keeps configurations portable when the config
+moves with the deployment.
+
+Glob expansion happens fresh on every list / index / read call, so
+files added or removed between worker boots are reflected without a
+restart. Body content is also re-read on every `iii://{id}` resolve
+— there is no in-memory body cache.
+
+### Skill ID derivation
+
+For each match, the worker derives an id by stripping:
+
+1. The **static prefix** of the glob (everything up to the first
+   wildcard, truncated back to the last `/`).
+2. The trailing `.md` extension.
+
+| Glob | Match | Derived id |
+|---|---|---|
+| `my-skills/**/*.md` | `my-skills/foo.md` | `foo` |
+| `my-skills/**/*.md` | `my-skills/foo/bar.md` | `foo/bar` |
+| `my-skills/**/*.md` | `my-skills/foo/bar/baz.md` | `foo/bar/baz` |
+| `*.md` | `top.md` | `top` |
+| `docs/team-a.md` | `docs/team-a.md` | `team-a` |
+
+Each segment must satisfy the same `[a-z0-9_-]{1,64}` rule that
+state-backed registrations enforce. Files whose derived id contains
+uppercase, spaces, or other invalid characters are skipped at boot
+with a `tracing::warn!`.
+
+The first H1 of the file is the title, and the first non-heading
+paragraph is the description — same rule the auto-rendered
+`iii://skills` index uses for state-backed bodies. No frontmatter is
+required for skills (you can keep your existing markdown layout).
+
+### Prompt frontmatter
+
+Filesystem-backed prompts **must** start with a YAML frontmatter
+block declaring at least `description`. `name` is optional and
+overrides the file-basename-derived default:
+
+```markdown
+---
+name: open-pr
+description: Create a GitHub pull request with a repository-standard title and a body that follows `.github/pull_request_template.md`. Use when the user wants to open a PR, create a pull request, or submit branch changes for review.
+---
+
+The body is returned verbatim as a single user-text message on
+`prompts::mcp-get`. No `{placeholder}` substitution and no
+caller-supplied `arguments` — fs prompts are static templates.
+```
+
+A prompt without frontmatter, with malformed YAML, or without a
+non-empty `description` is skipped at boot with a warning. Names
+must follow the same `[a-z0-9_-]{1,64}` rule as state-backed
+prompts.
+
+### Collision policy (state always wins)
+
+If a filesystem entry's id (or prompt name) is already present in
+the matching state-backed scope, the filesystem entry is **silently
+shadowed**: it does not appear in `skills::list` / `prompts::list`,
+it is not rendered in the `iii://skills` index, and `iii://{id}`
+resolves to the state row.
+
+Collisions are recorded as one of the boot warnings emitted by
+`log_fs_health` so the operator can resolve them by either
+unregistering the state row or moving / renaming the file.
+
+### Where filesystem entries appear
+
+| Surface | What you see |
+|---|---|
+| `skills::list` | All entries, each tagged `origin: "state"` or `origin: "fs"`. |
+| `prompts::list` | All entries, each tagged `origin: "state"` or `origin: "fs"`. |
+| `iii://skills` (auto-rendered index) | Existing state-backed bullets followed by a new `## Custom skills` H2 section listing fs entries (only when at least one fs skill is loaded). |
+| `iii://{id}` (resource read) | Direct body lookup. State row wins on any collision; on miss the fs entry is read fresh from disk. |
+| `prompts/get` (MCP) | Static body returned as a single user-text message; caller-supplied `arguments` are ignored with a debug log. |
+
+### Boot diagnostics
+
+`log_fs_health` runs once at boot and logs:
+
+- One `info!` line per loaded fs skill / prompt (id + absolute path).
+- One `warn!` line per skipped file (path + reason: invalid id,
+  missing frontmatter, intra-fs duplicate, collision with state, …).
+- A single summary line with totals.
+
+These are the canonical place to debug a misconfigured glob.
 
 ---
 

--- a/skills/src/config.rs
+++ b/skills/src/config.rs
@@ -1,5 +1,7 @@
 //! Worker runtime config. Mirrors iii-graph / iii-fts.
 
+use std::path::{Path, PathBuf};
+
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
@@ -9,6 +11,22 @@ pub struct SkillsConfig {
     pub scopes: ScopesConfig,
     #[serde(default = "default_state_timeout_ms")]
     pub state_timeout_ms: u64,
+    /// Glob patterns for filesystem-backed skills. Resolved relative to
+    /// the directory of the config file. Each match becomes a skill
+    /// keyed by its path relative to the glob's static prefix, with
+    /// `.md` stripped.
+    #[serde(default)]
+    pub skills: Vec<String>,
+    /// Glob patterns for filesystem-backed prompts. Each match must
+    /// have YAML frontmatter declaring at least `description`.
+    #[serde(default)]
+    pub prompts: Vec<String>,
+    /// Directory that filesystem globs are resolved against. Set to the
+    /// parent of the loaded config path; falls back to CWD when no
+    /// config file is read or the path has no parent. Skipped from
+    /// (de)serialization so config files don't have to declare it.
+    #[serde(skip)]
+    pub config_dir: Option<PathBuf>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -45,14 +63,39 @@ impl Default for SkillsConfig {
         Self {
             scopes: ScopesConfig::default(),
             state_timeout_ms: default_state_timeout_ms(),
+            skills: Vec::new(),
+            prompts: Vec::new(),
+            config_dir: None,
         }
+    }
+}
+
+impl SkillsConfig {
+    /// Directory used to resolve relative globs. Falls back to CWD
+    /// (or `.` if even CWD is unavailable) so `expand_*` callers can
+    /// always assume a base path.
+    pub fn glob_base_dir(&self) -> PathBuf {
+        if let Some(dir) = &self.config_dir {
+            return dir.clone();
+        }
+        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
     }
 }
 
 pub fn load_config(path: &str) -> Result<SkillsConfig> {
     let contents = std::fs::read_to_string(path)?;
-    let cfg: SkillsConfig = serde_yaml::from_str(&contents)?;
+    let mut cfg: SkillsConfig = serde_yaml::from_str(&contents)?;
+    cfg.config_dir = parent_dir(Path::new(path));
     Ok(cfg)
+}
+
+fn parent_dir(path: &Path) -> Option<PathBuf> {
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().ok()?.join(path)
+    };
+    abs.parent().map(|p| p.to_path_buf())
 }
 
 #[cfg(test)]
@@ -65,6 +108,9 @@ mod tests {
         assert_eq!(cfg.scopes.skills, "skills");
         assert_eq!(cfg.scopes.prompts, "prompts");
         assert_eq!(cfg.state_timeout_ms, 10_000);
+        assert!(cfg.skills.is_empty());
+        assert!(cfg.prompts.is_empty());
+        assert!(cfg.config_dir.is_none());
     }
 
     #[test]
@@ -74,6 +120,8 @@ mod tests {
         assert_eq!(from_empty.scopes.skills, from_default.scopes.skills);
         assert_eq!(from_empty.scopes.prompts, from_default.scopes.prompts);
         assert_eq!(from_empty.state_timeout_ms, from_default.state_timeout_ms);
+        assert_eq!(from_empty.skills, from_default.skills);
+        assert_eq!(from_empty.prompts, from_default.prompts);
     }
 
     #[test]
@@ -83,16 +131,39 @@ scopes:
   skills: my-skills
   prompts: my-prompts
 state_timeout_ms: 7500
+skills:
+  - my-folder/**/*.md
+prompts:
+  - prompts-folder/*.md
 ";
         let cfg: SkillsConfig = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(cfg.scopes.skills, "my-skills");
         assert_eq!(cfg.scopes.prompts, "my-prompts");
         assert_eq!(cfg.state_timeout_ms, 7_500);
+        assert_eq!(cfg.skills, vec!["my-folder/**/*.md".to_string()]);
+        assert_eq!(cfg.prompts, vec!["prompts-folder/*.md".to_string()]);
     }
 
     #[test]
     fn malformed_yaml_errors() {
         let err = load_config("/no/such/path/for/skills.yaml");
         assert!(err.is_err());
+    }
+
+    #[test]
+    fn load_config_records_parent_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        std::fs::write(&path, "scopes:\n  skills: x\n  prompts: y\n").unwrap();
+        let cfg = load_config(path.to_str().unwrap()).unwrap();
+        assert_eq!(cfg.config_dir.as_deref(), Some(dir.path()));
+    }
+
+    #[test]
+    fn glob_base_dir_falls_back_to_cwd() {
+        let cfg = SkillsConfig::default();
+        let base = cfg.glob_base_dir();
+        let cwd = std::env::current_dir().unwrap();
+        assert_eq!(base, cwd);
     }
 }

--- a/skills/src/fs_source.rs
+++ b/skills/src/fs_source.rs
@@ -156,8 +156,7 @@ fn run_glob(base_dir: &Path, pattern: &str) -> Result<Vec<(String, PathBuf)>, St
         PathBuf::from(static_prefix_str)
     };
 
-    let entries = glob::glob(&abs_pattern)
-        .map_err(|e| format!("invalid glob {pattern:?}: {e}"))?;
+    let entries = glob::glob(&abs_pattern).map_err(|e| format!("invalid glob {pattern:?}: {e}"))?;
 
     let mut out = Vec::new();
     for entry in entries {
@@ -192,10 +191,7 @@ fn run_glob(base_dir: &Path, pattern: &str) -> Result<Vec<(String, PathBuf)>, St
 ///
 /// Files matched by multiple glob patterns from the same scan deduplicate
 /// silently — they're the same file, the same id, no warning.
-pub fn expand_skill_globs(
-    base_dir: &Path,
-    patterns: &[String],
-) -> (Vec<FsSkill>, Vec<SkipReason>) {
+pub fn expand_skill_globs(base_dir: &Path, patterns: &[String]) -> (Vec<FsSkill>, Vec<SkipReason>) {
     let mut skills: Vec<FsSkill> = Vec::new();
     let mut skipped: Vec<SkipReason> = Vec::new();
 
@@ -516,8 +512,7 @@ mod tests {
         write_fixture(tmp.path(), "my-skills/sub/b.md", "# B\n");
         write_fixture(tmp.path(), "my-skills/sub/deep/c.md", "# C\n");
 
-        let (skills, skipped) =
-            expand_skill_globs(tmp.path(), &["my-skills/**/*.md".to_string()]);
+        let (skills, skipped) = expand_skill_globs(tmp.path(), &["my-skills/**/*.md".to_string()]);
         assert!(skipped.is_empty(), "unexpected skips: {skipped:?}");
         let ids: Vec<_> = skills.iter().map(|s| s.id.as_str()).collect();
         assert_eq!(ids, vec!["a", "sub/b", "sub/deep/c"]);
@@ -530,8 +525,7 @@ mod tests {
         write_fixture(tmp.path(), "my-skills/with space.md", "# space\n");
         write_fixture(tmp.path(), "my-skills/ok.md", "# ok\n");
 
-        let (skills, skipped) =
-            expand_skill_globs(tmp.path(), &["my-skills/**/*.md".to_string()]);
+        let (skills, skipped) = expand_skill_globs(tmp.path(), &["my-skills/**/*.md".to_string()]);
         let ids: Vec<_> = skills.iter().map(|s| s.id.as_str()).collect();
         assert_eq!(ids, vec!["ok"]);
         assert_eq!(skipped.len(), 2);
@@ -592,8 +586,7 @@ mod tests {
     fn expand_skills_invalid_glob_pattern_records_skip() {
         let tmp = tempfile::tempdir().unwrap();
         // `[` without closing `]` is an invalid pattern.
-        let (skills, skipped) =
-            expand_skill_globs(tmp.path(), &["[unclosed".to_string()]);
+        let (skills, skipped) = expand_skill_globs(tmp.path(), &["[unclosed".to_string()]);
         assert!(skills.is_empty());
         assert_eq!(skipped.len(), 1);
         assert_eq!(skipped[0].kind, SourceKind::Skill);
@@ -610,8 +603,7 @@ mod tests {
             "---\nname: open-pr\ndescription: Open a PR.\n---\nBody here.\n",
         );
 
-        let (prompts, skipped) =
-            expand_prompt_globs(tmp.path(), &["p/*.md".to_string()]);
+        let (prompts, skipped) = expand_prompt_globs(tmp.path(), &["p/*.md".to_string()]);
         assert!(skipped.is_empty(), "unexpected skips: {skipped:?}");
         assert_eq!(prompts.len(), 1);
         assert_eq!(prompts[0].name, "open-pr");
@@ -627,8 +619,7 @@ mod tests {
             "---\ndescription: Just a description.\n---\nBody.\n",
         );
 
-        let (prompts, _skipped) =
-            expand_prompt_globs(tmp.path(), &["p/*.md".to_string()]);
+        let (prompts, _skipped) = expand_prompt_globs(tmp.path(), &["p/*.md".to_string()]);
         assert_eq!(prompts.len(), 1);
         assert_eq!(prompts[0].name, "foo");
     }
@@ -638,8 +629,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         write_fixture(tmp.path(), "p/no-fm.md", "# header\nbody\n");
 
-        let (prompts, skipped) =
-            expand_prompt_globs(tmp.path(), &["p/*.md".to_string()]);
+        let (prompts, skipped) = expand_prompt_globs(tmp.path(), &["p/*.md".to_string()]);
         assert!(prompts.is_empty());
         assert_eq!(skipped.len(), 1);
         assert!(
@@ -652,13 +642,8 @@ mod tests {
     #[test]
     fn expand_prompts_rejects_missing_description() {
         let tmp = tempfile::tempdir().unwrap();
-        write_fixture(
-            tmp.path(),
-            "p/no-desc.md",
-            "---\nname: foo\n---\nBody.\n",
-        );
-        let (prompts, skipped) =
-            expand_prompt_globs(tmp.path(), &["p/*.md".to_string()]);
+        write_fixture(tmp.path(), "p/no-desc.md", "---\nname: foo\n---\nBody.\n");
+        let (prompts, skipped) = expand_prompt_globs(tmp.path(), &["p/*.md".to_string()]);
         assert!(prompts.is_empty());
         assert_eq!(skipped.len(), 1);
         assert!(
@@ -676,8 +661,7 @@ mod tests {
             "p/bad.md",
             "---\nname: Has Spaces\ndescription: x\n---\nBody.\n",
         );
-        let (prompts, skipped) =
-            expand_prompt_globs(tmp.path(), &["p/*.md".to_string()]);
+        let (prompts, skipped) = expand_prompt_globs(tmp.path(), &["p/*.md".to_string()]);
         assert!(prompts.is_empty());
         assert_eq!(skipped.len(), 1);
         assert!(
@@ -700,8 +684,7 @@ mod tests {
             "p/b.md",
             "---\nname: shared\ndescription: from b\n---\nBody B.\n",
         );
-        let (prompts, skipped) =
-            expand_prompt_globs(tmp.path(), &["p/*.md".to_string()]);
+        let (prompts, skipped) = expand_prompt_globs(tmp.path(), &["p/*.md".to_string()]);
         assert_eq!(prompts.len(), 1);
         assert_eq!(prompts[0].name, "shared");
         assert_eq!(skipped.len(), 1);

--- a/skills/src/fs_source.rs
+++ b/skills/src/fs_source.rs
@@ -1,0 +1,761 @@
+//! Filesystem-backed sources for skills and prompts.
+//!
+//! Globs from [`crate::config::SkillsConfig::skills`] /
+//! [`SkillsConfig::prompts`][cfg] are expanded against the config
+//! directory; each match becomes a filesystem-backed entry whose body
+//! is re-read from disk on every resolve. Nothing here writes to
+//! iii-state — the file system is the single source of truth.
+//!
+//! [cfg]: crate::config::SkillsConfig::prompts
+//!
+//! Public surface:
+//!
+//! - [`static_prefix`]            — directory portion of a glob pattern.
+//! - [`split_frontmatter`]        — minimal `---\n...\n---\n` parser.
+//! - [`expand_skill_globs`]       — id-keyed listing for skills globs.
+//! - [`expand_prompt_globs`]      — name-keyed listing for prompts globs.
+//! - [`read_body`]                — cap-checked body read with frontmatter stripped.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::functions::prompts::validate_name;
+use crate::functions::skills::{validate_id, SKILL_BODY_MAX_BYTES};
+
+/// One filesystem-backed skill entry. The body lives on disk; we cache
+/// only the metadata needed to render the index and resolve `iii://`
+/// reads.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FsSkill {
+    pub id: String,
+    pub abs_path: PathBuf,
+}
+
+/// One filesystem-backed prompt entry. `description` is parsed from
+/// frontmatter at scan time so [`crate::functions::prompts::mcp_list`]
+/// can render the slash-command picker without re-reading every file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FsPrompt {
+    pub name: String,
+    pub description: String,
+    pub abs_path: PathBuf,
+}
+
+/// Diagnostic record for one file that failed to load. Surfaced via
+/// boot-time logging so misconfigured globs are easy to spot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkipReason {
+    pub kind: SourceKind,
+    pub path: PathBuf,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceKind {
+    Skill,
+    Prompt,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PromptFrontmatter {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+}
+
+// ───────────────────────── pure helpers ──────────────────────────────
+
+/// Return the static directory portion of a glob pattern: everything
+/// before the first `*`/`?`/`[`/`{`, truncated back to the last `/`
+/// (so the prefix is always either empty or ends in `/`). The glob
+/// expander uses this to strip a deterministic prefix when computing
+/// ids — `my-folder/**/*.md` matching `my-folder/foo/bar.md` yields
+/// the relative path `foo/bar.md`.
+pub fn static_prefix(pattern: &str) -> &str {
+    let bytes = pattern.as_bytes();
+    let first_meta = bytes
+        .iter()
+        .position(|&b| matches!(b, b'*' | b'?' | b'[' | b'{'));
+    let cut = first_meta.unwrap_or(bytes.len());
+    let prefix = &pattern[..cut];
+    match prefix.rfind('/') {
+        Some(i) => &prefix[..=i],
+        None => "",
+    }
+}
+
+/// Recognize a YAML frontmatter block at the start of `content`. The
+/// fence is `---` on its own line. Returns `(Some(yaml), body)` on
+/// success and `(None, content)` if no frontmatter is present (or the
+/// opening fence has no matching closer). The body is whatever follows
+/// the closing fence's newline, byte-for-byte (no trim).
+pub fn split_frontmatter(content: &str) -> (Option<&str>, &str) {
+    let after_open = content
+        .strip_prefix("---\n")
+        .or_else(|| content.strip_prefix("---\r\n"));
+    let Some(rest) = after_open else {
+        return (None, content);
+    };
+    if let Some(idx) = rest.find("\n---\n") {
+        return (Some(&rest[..idx]), &rest[idx + "\n---\n".len()..]);
+    }
+    if let Some(idx) = rest.find("\n---\r\n") {
+        return (Some(&rest[..idx]), &rest[idx + "\n---\r\n".len()..]);
+    }
+    if let Some(stripped) = rest.strip_suffix("\n---") {
+        return (Some(stripped), "");
+    }
+    if let Some(stripped) = rest.strip_suffix("\n---\r") {
+        return (Some(stripped), "");
+    }
+    (None, content)
+}
+
+fn derive_relative_id(prefix_abs: &Path, abs_path: &Path) -> Result<String, String> {
+    let rel = abs_path.strip_prefix(prefix_abs).map_err(|_| {
+        format!(
+            "{} is not under prefix {}",
+            abs_path.display(),
+            prefix_abs.display()
+        )
+    })?;
+    let rel_str = rel
+        .to_str()
+        .ok_or_else(|| format!("non-UTF-8 path: {}", abs_path.display()))?;
+    let stripped = rel_str.strip_suffix(".md").unwrap_or(rel_str);
+    Ok(stripped.replace('\\', "/"))
+}
+
+// ───────────────────────── glob expansion ────────────────────────────
+
+fn run_glob(base_dir: &Path, pattern: &str) -> Result<Vec<(String, PathBuf)>, String> {
+    let pat_path = Path::new(pattern);
+    let abs_pattern_buf = if pat_path.is_absolute() {
+        pat_path.to_path_buf()
+    } else {
+        base_dir.join(pat_path)
+    };
+    let abs_pattern = abs_pattern_buf
+        .to_str()
+        .ok_or_else(|| {
+            format!(
+                "non-UTF-8 path while joining {} + {pattern:?}",
+                base_dir.display()
+            )
+        })?
+        .to_string();
+
+    let static_prefix_str = static_prefix(&abs_pattern);
+    let prefix_path = if static_prefix_str.is_empty() {
+        // `*.md` style — the static prefix is empty, so we anchor ids
+        // at base_dir.
+        base_dir.to_path_buf()
+    } else {
+        PathBuf::from(static_prefix_str)
+    };
+
+    let entries = glob::glob(&abs_pattern)
+        .map_err(|e| format!("invalid glob {pattern:?}: {e}"))?;
+
+    let mut out = Vec::new();
+    for entry in entries {
+        let path = match entry {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(error = %e, "glob entry error; skipping");
+                continue;
+            }
+        };
+        if !path.is_file() {
+            continue;
+        }
+        match derive_relative_id(&prefix_path, &path) {
+            Ok(id) => out.push((id, path)),
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "derive id failed; skipping");
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Expand every skill glob in `patterns` against `base_dir`. Returns
+/// the validated, deduped, lex-sorted list plus a parallel diagnostic
+/// list of files that were rejected.
+///
+/// Rejection reasons:
+///
+/// - The derived id fails [`validate_id`] (uppercase, spaces, etc.).
+/// - Two distinct files produce the same id (intra-fs duplicate).
+///
+/// Files matched by multiple glob patterns from the same scan deduplicate
+/// silently — they're the same file, the same id, no warning.
+pub fn expand_skill_globs(
+    base_dir: &Path,
+    patterns: &[String],
+) -> (Vec<FsSkill>, Vec<SkipReason>) {
+    let mut skills: Vec<FsSkill> = Vec::new();
+    let mut skipped: Vec<SkipReason> = Vec::new();
+
+    for pattern in patterns {
+        let matches = match run_glob(base_dir, pattern) {
+            Ok(m) => m,
+            Err(e) => {
+                skipped.push(SkipReason {
+                    kind: SourceKind::Skill,
+                    path: PathBuf::from(pattern),
+                    reason: e,
+                });
+                continue;
+            }
+        };
+        for (id, path) in matches {
+            if let Err(e) = validate_id(&id) {
+                skipped.push(SkipReason {
+                    kind: SourceKind::Skill,
+                    path,
+                    reason: format!("invalid id {id:?}: {e}"),
+                });
+                continue;
+            }
+            if let Some(existing) = skills.iter().find(|s| s.id == id) {
+                if existing.abs_path != path {
+                    skipped.push(SkipReason {
+                        kind: SourceKind::Skill,
+                        path,
+                        reason: format!(
+                            "duplicate id {id:?} also produced by {}",
+                            existing.abs_path.display()
+                        ),
+                    });
+                }
+                continue;
+            }
+            skills.push(FsSkill { id, abs_path: path });
+        }
+    }
+
+    skills.sort_by(|a, b| a.id.cmp(&b.id));
+    (skills, skipped)
+}
+
+/// Expand every prompt glob in `patterns`. Each match must have a
+/// leading YAML frontmatter block declaring at least `description`;
+/// `name` is optional and overrides the file-basename-derived default.
+///
+/// Rejection reasons follow the same shape as [`expand_skill_globs`]:
+/// missing frontmatter, invalid YAML, missing `description`, invalid
+/// `validate_name`, or a name collision with another fs prompt.
+pub fn expand_prompt_globs(
+    base_dir: &Path,
+    patterns: &[String],
+) -> (Vec<FsPrompt>, Vec<SkipReason>) {
+    let mut prompts: Vec<FsPrompt> = Vec::new();
+    let mut skipped: Vec<SkipReason> = Vec::new();
+
+    for pattern in patterns {
+        let matches = match run_glob(base_dir, pattern) {
+            Ok(m) => m,
+            Err(e) => {
+                skipped.push(SkipReason {
+                    kind: SourceKind::Prompt,
+                    path: PathBuf::from(pattern),
+                    reason: e,
+                });
+                continue;
+            }
+        };
+        for (id, path) in matches {
+            let content = match std::fs::read_to_string(&path) {
+                Ok(c) => c,
+                Err(e) => {
+                    skipped.push(SkipReason {
+                        kind: SourceKind::Prompt,
+                        path,
+                        reason: format!("read: {e}"),
+                    });
+                    continue;
+                }
+            };
+            let (fm_text, _) = split_frontmatter(&content);
+            let Some(fm_text) = fm_text else {
+                skipped.push(SkipReason {
+                    kind: SourceKind::Prompt,
+                    path,
+                    reason: "missing YAML frontmatter (expected --- ... --- block at file start)"
+                        .into(),
+                });
+                continue;
+            };
+            let fm: PromptFrontmatter = match serde_yaml::from_str(fm_text) {
+                Ok(f) => f,
+                Err(e) => {
+                    skipped.push(SkipReason {
+                        kind: SourceKind::Prompt,
+                        path,
+                        reason: format!("invalid frontmatter YAML: {e}"),
+                    });
+                    continue;
+                }
+            };
+
+            // Prompt names are flat — fall back to the basename of the
+            // derived id so a `prompts/sub/foo.md` becomes `foo` by
+            // default. Frontmatter `name:` always wins when present.
+            let derived_basename = id.rsplit('/').next().unwrap_or(&id).to_string();
+            let name = fm
+                .name
+                .as_deref()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .unwrap_or(derived_basename);
+
+            if let Err(e) = validate_name(&name) {
+                skipped.push(SkipReason {
+                    kind: SourceKind::Prompt,
+                    path,
+                    reason: format!("invalid prompt name {name:?}: {e}"),
+                });
+                continue;
+            }
+
+            let description = match fm.description {
+                Some(d) if !d.trim().is_empty() => d.trim().to_string(),
+                _ => {
+                    skipped.push(SkipReason {
+                        kind: SourceKind::Prompt,
+                        path,
+                        reason: "frontmatter missing non-empty `description`".into(),
+                    });
+                    continue;
+                }
+            };
+
+            if let Some(existing) = prompts.iter().find(|p| p.name == name) {
+                if existing.abs_path != path {
+                    skipped.push(SkipReason {
+                        kind: SourceKind::Prompt,
+                        path,
+                        reason: format!(
+                            "duplicate name {name:?} also produced by {}",
+                            existing.abs_path.display()
+                        ),
+                    });
+                }
+                continue;
+            }
+
+            prompts.push(FsPrompt {
+                name,
+                description,
+                abs_path: path,
+            });
+        }
+    }
+
+    prompts.sort_by(|a, b| a.name.cmp(&b.name));
+    (prompts, skipped)
+}
+
+/// Read a fs entry's body fresh from disk, strip any leading
+/// frontmatter, and enforce the same 256 KiB cap state-backed
+/// registrations face. Empty-after-strip bodies are an error so the
+/// resolver returns a clear "not found" rather than serving an empty
+/// resource.
+pub fn read_body(abs_path: &Path) -> Result<String, String> {
+    let raw = std::fs::read_to_string(abs_path)
+        .map_err(|e| format!("read {}: {e}", abs_path.display()))?;
+    let (_, body) = split_frontmatter(&raw);
+    let trimmed = body.trim_matches('\n');
+    if trimmed.is_empty() {
+        return Err(format!("file {} has empty body", abs_path.display()));
+    }
+    if body.len() > SKILL_BODY_MAX_BYTES {
+        return Err(format!(
+            "file {} is too large ({} bytes; max {SKILL_BODY_MAX_BYTES})",
+            abs_path.display(),
+            body.len()
+        ));
+    }
+    Ok(body.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── static_prefix ────────────────────────────────────────────────
+
+    #[test]
+    fn static_prefix_no_meta_falls_back_to_dir() {
+        // `dir/file.md` has no glob meta, so the whole file path's
+        // directory is the static prefix.
+        assert_eq!(static_prefix("dir/sub/file.md"), "dir/sub/");
+    }
+
+    #[test]
+    fn static_prefix_strips_back_to_last_slash() {
+        assert_eq!(static_prefix("dir/sub/*.md"), "dir/sub/");
+        assert_eq!(static_prefix("dir/**/*.md"), "dir/");
+        assert_eq!(static_prefix("dir/file*.md"), "dir/");
+    }
+
+    #[test]
+    fn static_prefix_no_dir_yields_empty() {
+        assert_eq!(static_prefix("*.md"), "");
+        assert_eq!(static_prefix("**/*.md"), "");
+        assert_eq!(static_prefix("[abc].md"), "");
+    }
+
+    #[test]
+    fn static_prefix_question_mark_and_brace() {
+        assert_eq!(static_prefix("dir/file?.md"), "dir/");
+        assert_eq!(static_prefix("dir/{a,b}.md"), "dir/");
+    }
+
+    #[test]
+    fn static_prefix_absolute_paths() {
+        assert_eq!(static_prefix("/abs/dir/**/*.md"), "/abs/dir/");
+        assert_eq!(static_prefix("/abs/file.md"), "/abs/");
+    }
+
+    // ── split_frontmatter ────────────────────────────────────────────
+
+    #[test]
+    fn split_no_frontmatter() {
+        let (fm, body) = split_frontmatter("# Title\nbody\n");
+        assert!(fm.is_none());
+        assert_eq!(body, "# Title\nbody\n");
+    }
+
+    #[test]
+    fn split_frontmatter_with_body() {
+        let (fm, body) = split_frontmatter("---\nname: open-pr\n---\nThe body.\n");
+        assert_eq!(fm, Some("name: open-pr"));
+        assert_eq!(body, "The body.\n");
+    }
+
+    #[test]
+    fn split_frontmatter_only_no_body() {
+        let (fm, body) = split_frontmatter("---\nname: x\ndescription: y\n---\n");
+        assert_eq!(fm, Some("name: x\ndescription: y"));
+        assert_eq!(body, "");
+    }
+
+    #[test]
+    fn split_frontmatter_eof_fence_no_trailing_newline() {
+        let (fm, body) = split_frontmatter("---\nfoo: bar\n---");
+        assert_eq!(fm, Some("foo: bar"));
+        assert_eq!(body, "");
+    }
+
+    #[test]
+    fn split_frontmatter_unclosed_falls_back() {
+        // Missing closing fence — return as-is, no frontmatter.
+        let content = "---\nname: x\nbody without closing fence\n";
+        let (fm, body) = split_frontmatter(content);
+        assert!(fm.is_none());
+        assert_eq!(body, content);
+    }
+
+    #[test]
+    fn split_frontmatter_must_start_at_byte_zero() {
+        // A `---` line later in the file is NOT a frontmatter opener.
+        let content = "# header\n---\nname: x\n---\nbody\n";
+        let (fm, body) = split_frontmatter(content);
+        assert!(fm.is_none());
+        assert_eq!(body, content);
+    }
+
+    #[test]
+    fn split_frontmatter_handles_crlf() {
+        let (fm, body) = split_frontmatter("---\r\nname: x\r\n---\r\nbody\r\n");
+        assert_eq!(fm, Some("name: x\r"));
+        assert_eq!(body, "body\r\n");
+    }
+
+    // ── derive_relative_id ───────────────────────────────────────────
+
+    #[test]
+    fn derive_id_strips_md_and_keeps_slashes() {
+        let prefix = Path::new("/base/dir/");
+        let path = Path::new("/base/dir/foo/bar.md");
+        assert_eq!(derive_relative_id(prefix, path).unwrap(), "foo/bar");
+    }
+
+    #[test]
+    fn derive_id_flat_file() {
+        let prefix = Path::new("/base/");
+        let path = Path::new("/base/file.md");
+        assert_eq!(derive_relative_id(prefix, path).unwrap(), "file");
+    }
+
+    #[test]
+    fn derive_id_rejects_when_path_outside_prefix() {
+        let prefix = Path::new("/base/dir/");
+        let path = Path::new("/elsewhere/file.md");
+        assert!(derive_relative_id(prefix, path).is_err());
+    }
+
+    // ── expand_skill_globs ───────────────────────────────────────────
+
+    fn write_fixture(dir: &Path, rel: &str, contents: &str) {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn expand_skills_basic_nested() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fixture(tmp.path(), "my-skills/a.md", "# A\n");
+        write_fixture(tmp.path(), "my-skills/sub/b.md", "# B\n");
+        write_fixture(tmp.path(), "my-skills/sub/deep/c.md", "# C\n");
+
+        let (skills, skipped) =
+            expand_skill_globs(tmp.path(), &["my-skills/**/*.md".to_string()]);
+        assert!(skipped.is_empty(), "unexpected skips: {skipped:?}");
+        let ids: Vec<_> = skills.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(ids, vec!["a", "sub/b", "sub/deep/c"]);
+    }
+
+    #[test]
+    fn expand_skills_rejects_invalid_id_segments() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fixture(tmp.path(), "my-skills/Bad-Case.md", "# bad\n");
+        write_fixture(tmp.path(), "my-skills/with space.md", "# space\n");
+        write_fixture(tmp.path(), "my-skills/ok.md", "# ok\n");
+
+        let (skills, skipped) =
+            expand_skill_globs(tmp.path(), &["my-skills/**/*.md".to_string()]);
+        let ids: Vec<_> = skills.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(ids, vec!["ok"]);
+        assert_eq!(skipped.len(), 2);
+        for s in &skipped {
+            assert_eq!(s.kind, SourceKind::Skill);
+            assert!(s.reason.contains("invalid id"));
+        }
+    }
+
+    #[test]
+    fn expand_skills_dedupes_when_two_globs_match_same_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fixture(tmp.path(), "my-skills/a.md", "# a\n");
+
+        let (skills, skipped) = expand_skill_globs(
+            tmp.path(),
+            &[
+                "my-skills/*.md".to_string(),
+                "my-skills/**/*.md".to_string(),
+            ],
+        );
+        assert_eq!(skills.len(), 1, "same file should not duplicate");
+        assert!(skipped.is_empty(), "no skip warning for same-file dedupe");
+    }
+
+    #[test]
+    fn expand_skills_intra_fs_collision_is_skipped() {
+        // Two distinct files that derive the same id (`shared`) — the
+        // second is recorded as a SkipReason.
+        let tmp = tempfile::tempdir().unwrap();
+        write_fixture(tmp.path(), "first/shared.md", "# from first\n");
+        write_fixture(tmp.path(), "second/shared.md", "# from second\n");
+
+        let (skills, skipped) = expand_skill_globs(
+            tmp.path(),
+            &["first/*.md".to_string(), "second/*.md".to_string()],
+        );
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].id, "shared");
+        assert_eq!(skipped.len(), 1);
+        assert!(
+            skipped[0].reason.contains("duplicate id"),
+            "got: {:?}",
+            skipped[0].reason
+        );
+    }
+
+    #[test]
+    fn expand_skills_empty_when_no_matches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (skills, skipped) =
+            expand_skill_globs(tmp.path(), &["does-not-exist/**/*.md".to_string()]);
+        assert!(skills.is_empty());
+        assert!(skipped.is_empty());
+    }
+
+    #[test]
+    fn expand_skills_invalid_glob_pattern_records_skip() {
+        let tmp = tempfile::tempdir().unwrap();
+        // `[` without closing `]` is an invalid pattern.
+        let (skills, skipped) =
+            expand_skill_globs(tmp.path(), &["[unclosed".to_string()]);
+        assert!(skills.is_empty());
+        assert_eq!(skipped.len(), 1);
+        assert_eq!(skipped[0].kind, SourceKind::Skill);
+    }
+
+    // ── expand_prompt_globs ──────────────────────────────────────────
+
+    #[test]
+    fn expand_prompts_reads_frontmatter() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fixture(
+            tmp.path(),
+            "p/open-pr.md",
+            "---\nname: open-pr\ndescription: Open a PR.\n---\nBody here.\n",
+        );
+
+        let (prompts, skipped) =
+            expand_prompt_globs(tmp.path(), &["p/*.md".to_string()]);
+        assert!(skipped.is_empty(), "unexpected skips: {skipped:?}");
+        assert_eq!(prompts.len(), 1);
+        assert_eq!(prompts[0].name, "open-pr");
+        assert_eq!(prompts[0].description, "Open a PR.");
+    }
+
+    #[test]
+    fn expand_prompts_falls_back_to_basename_for_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fixture(
+            tmp.path(),
+            "p/foo.md",
+            "---\ndescription: Just a description.\n---\nBody.\n",
+        );
+
+        let (prompts, _skipped) =
+            expand_prompt_globs(tmp.path(), &["p/*.md".to_string()]);
+        assert_eq!(prompts.len(), 1);
+        assert_eq!(prompts[0].name, "foo");
+    }
+
+    #[test]
+    fn expand_prompts_rejects_missing_frontmatter() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fixture(tmp.path(), "p/no-fm.md", "# header\nbody\n");
+
+        let (prompts, skipped) =
+            expand_prompt_globs(tmp.path(), &["p/*.md".to_string()]);
+        assert!(prompts.is_empty());
+        assert_eq!(skipped.len(), 1);
+        assert!(
+            skipped[0].reason.contains("missing YAML frontmatter"),
+            "got: {:?}",
+            skipped[0].reason
+        );
+    }
+
+    #[test]
+    fn expand_prompts_rejects_missing_description() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fixture(
+            tmp.path(),
+            "p/no-desc.md",
+            "---\nname: foo\n---\nBody.\n",
+        );
+        let (prompts, skipped) =
+            expand_prompt_globs(tmp.path(), &["p/*.md".to_string()]);
+        assert!(prompts.is_empty());
+        assert_eq!(skipped.len(), 1);
+        assert!(
+            skipped[0].reason.contains("description"),
+            "got: {:?}",
+            skipped[0].reason
+        );
+    }
+
+    #[test]
+    fn expand_prompts_rejects_invalid_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fixture(
+            tmp.path(),
+            "p/bad.md",
+            "---\nname: Has Spaces\ndescription: x\n---\nBody.\n",
+        );
+        let (prompts, skipped) =
+            expand_prompt_globs(tmp.path(), &["p/*.md".to_string()]);
+        assert!(prompts.is_empty());
+        assert_eq!(skipped.len(), 1);
+        assert!(
+            skipped[0].reason.contains("invalid prompt name"),
+            "got: {:?}",
+            skipped[0].reason
+        );
+    }
+
+    #[test]
+    fn expand_prompts_collision_skips_second() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fixture(
+            tmp.path(),
+            "p/a.md",
+            "---\nname: shared\ndescription: from a\n---\nBody A.\n",
+        );
+        write_fixture(
+            tmp.path(),
+            "p/b.md",
+            "---\nname: shared\ndescription: from b\n---\nBody B.\n",
+        );
+        let (prompts, skipped) =
+            expand_prompt_globs(tmp.path(), &["p/*.md".to_string()]);
+        assert_eq!(prompts.len(), 1);
+        assert_eq!(prompts[0].name, "shared");
+        assert_eq!(skipped.len(), 1);
+        assert!(skipped[0].reason.contains("duplicate name"));
+    }
+
+    // ── read_body ────────────────────────────────────────────────────
+
+    #[test]
+    fn read_body_strips_frontmatter() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("foo.md");
+        std::fs::write(
+            &path,
+            "---\nname: foo\ndescription: test\n---\n# Title\n\nBody here.\n",
+        )
+        .unwrap();
+        let body = read_body(&path).unwrap();
+        assert_eq!(body, "# Title\n\nBody here.\n");
+    }
+
+    #[test]
+    fn read_body_no_frontmatter() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("foo.md");
+        std::fs::write(&path, "# Title\n\nBody.\n").unwrap();
+        let body = read_body(&path).unwrap();
+        assert_eq!(body, "# Title\n\nBody.\n");
+    }
+
+    #[test]
+    fn read_body_rejects_empty_after_frontmatter_strip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("foo.md");
+        std::fs::write(&path, "---\nname: x\ndescription: y\n---\n").unwrap();
+        let err = read_body(&path).unwrap_err();
+        assert!(err.contains("empty body"), "got: {err}");
+    }
+
+    #[test]
+    fn read_body_enforces_size_cap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("big.md");
+        let body = "x".repeat(SKILL_BODY_MAX_BYTES + 1);
+        std::fs::write(&path, &body).unwrap();
+        let err = read_body(&path).unwrap_err();
+        assert!(err.contains("too large"), "got: {err}");
+    }
+
+    #[test]
+    fn read_body_missing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("nope.md");
+        let err = read_body(&path).unwrap_err();
+        assert!(err.contains("read"));
+    }
+}

--- a/skills/src/functions/mod.rs
+++ b/skills/src/functions/mod.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use iii_sdk::III;
 
 use crate::config::SkillsConfig;
+use crate::fs_source::{self, SourceKind};
 use crate::trigger_types::RegisteredTriggerTypes;
 
 /// Register every `skills::*` and `prompts::*` function handler
@@ -23,4 +24,60 @@ pub fn register_all(
     skills::register(iii, cfg, &trigger_types.skills);
     prompts::register(iii, cfg, &trigger_types.prompts);
     tracing::info!("skills registered 7 skills::*, 1 skill::* and 5 prompts::* functions");
+}
+
+/// One-shot diagnostic of the configured filesystem-backed sources.
+/// Called from `main` after `load_config` so misconfigured globs surface
+/// in the boot log instead of failing silently at first read.
+///
+/// Logs:
+///
+/// - One `info!` per successfully loaded skill / prompt (id, abs_path).
+/// - One `warn!` per skipped file (path + reason).
+/// - One `info!` summary line ("loaded N skills, M prompts; K skipped").
+///
+/// Note: this scan is independent of the per-call re-globbing the
+/// runtime does on every list/read; the file system stays the source
+/// of truth throughout the lifetime of the worker.
+pub fn log_fs_health(cfg: &SkillsConfig) {
+    let base = cfg.glob_base_dir();
+    let (skills, skill_skipped) = fs_source::expand_skill_globs(&base, &cfg.skills);
+    let (prompts, prompt_skipped) = fs_source::expand_prompt_globs(&base, &cfg.prompts);
+
+    for s in &skills {
+        tracing::info!(
+            id = %s.id,
+            path = %s.abs_path.display(),
+            "loaded fs-backed skill"
+        );
+    }
+    for p in &prompts {
+        tracing::info!(
+            name = %p.name,
+            path = %p.abs_path.display(),
+            "loaded fs-backed prompt"
+        );
+    }
+
+    let total_skipped = skill_skipped.len() + prompt_skipped.len();
+    for s in skill_skipped.iter().chain(prompt_skipped.iter()) {
+        let kind = match s.kind {
+            SourceKind::Skill => "skill",
+            SourceKind::Prompt => "prompt",
+        };
+        tracing::warn!(
+            kind,
+            path = %s.path.display(),
+            reason = %s.reason,
+            "skipped fs entry"
+        );
+    }
+
+    tracing::info!(
+        skills = skills.len(),
+        prompts = prompts.len(),
+        skipped = total_skipped,
+        base_dir = %base.display(),
+        "fs source scan complete"
+    );
 }

--- a/skills/src/functions/prompts.rs
+++ b/skills/src/functions/prompts.rs
@@ -25,6 +25,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::config::SkillsConfig;
+use crate::fs_source::{self, FsPrompt};
 use crate::functions::skills::is_always_hidden;
 use crate::state;
 use crate::trigger_types::{self, SubscriberSet};
@@ -69,6 +70,10 @@ struct PromptEntry {
     function_id: String,
     arguments: usize,
     registered_at: String,
+    /// `"state"` for state-backed prompts (`prompts::register`), `"fs"`
+    /// for filesystem-backed entries loaded from `prompts:` glob
+    /// patterns. Mirrors the `skills::list` shape.
+    origin: &'static str,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -222,13 +227,30 @@ fn register_list_prompts(iii: &Arc<III>, cfg: &Arc<SkillsConfig>) {
                         name: p.name,
                         function_id: p.function_id,
                         registered_at: p.registered_at,
+                        origin: "state",
                     })
                     .collect();
+                let state_names: HashSet<String> =
+                    out.iter().map(|e| e.name.clone()).collect();
+                for fs in non_colliding_fs_prompts(&cfg, &state_names) {
+                    out.push(PromptEntry {
+                        name: fs.name,
+                        // No backing function — fs prompts are static
+                        // markdown rendered straight as a user message.
+                        function_id: String::new(),
+                        arguments: 0,
+                        registered_at: fs_registered_at(&fs.abs_path),
+                        origin: "fs",
+                    });
+                }
                 out.sort_by(|a, b| a.name.cmp(&b.name));
                 Ok::<_, IIIError>(ListPromptsOutput { prompts: out })
             }
         })
-        .description("List registered prompts (name, function_id, arg count, registered_at)."),
+        .description(
+            "List registered prompts (name, function_id, arg count, registered_at, origin). \
+             `origin` is `state` for state-backed entries, `fs` for filesystem-backed.",
+        ),
     );
 }
 
@@ -270,6 +292,7 @@ fn register_mcp_get(iii: &Arc<III>, cfg: &Arc<SkillsConfig>) {
 
 pub async fn mcp_list(iii: &III, cfg: &SkillsConfig) -> Value {
     let entries = list_stored(iii, cfg).await.unwrap_or_default();
+    let state_names: HashSet<String> = entries.iter().map(|p| p.name.clone()).collect();
     let mut prompts: Vec<Value> = entries
         .into_iter()
         .map(|p| {
@@ -291,6 +314,13 @@ pub async fn mcp_list(iii: &III, cfg: &SkillsConfig) -> Value {
             })
         })
         .collect();
+    for fs in non_colliding_fs_prompts(cfg, &state_names) {
+        prompts.push(json!({
+            "name": fs.name,
+            "description": fs.description,
+            "arguments": [],
+        }));
+    }
     prompts.sort_by(|a, b| a["name"].as_str().cmp(&b["name"].as_str()));
     json!({ "prompts": prompts })
 }
@@ -304,29 +334,53 @@ pub async fn mcp_get(
     validate_name(&name)?;
     let arguments = arguments.unwrap_or_else(|| json!({}));
 
-    let stored = read_prompt(iii, cfg, &name)
-        .await?
-        .ok_or_else(|| format!("Prompt not found: {name}"))?;
+    if let Some(stored) = read_prompt(iii, cfg, &name).await? {
+        // State always wins — runtime registrations override any
+        // colliding filesystem prompt with the same name.
+        if is_always_hidden(&stored.function_id) {
+            return Err(format!(
+                "Prompt handler '{}' is in an internal namespace and cannot back a prompt",
+                stored.function_id
+            ));
+        }
+        let raw = iii
+            .trigger(TriggerRequest {
+                function_id: stored.function_id.clone(),
+                payload: arguments,
+                action: None,
+                timeout_ms: Some(cfg.state_timeout_ms),
+            })
+            .await
+            .map_err(|e| format!("trigger {}: {e}", stored.function_id))?;
 
-    if is_always_hidden(&stored.function_id) {
-        return Err(format!(
-            "Prompt handler '{}' is in an internal namespace and cannot back a prompt",
-            stored.function_id
-        ));
+        let messages = normalize_prompt_output(raw)?;
+        return Ok(json!({ "description": stored.description, "messages": messages }));
     }
 
-    let raw = iii
-        .trigger(TriggerRequest {
-            function_id: stored.function_id.clone(),
-            payload: arguments,
-            action: None,
-            timeout_ms: Some(cfg.state_timeout_ms),
-        })
-        .await
-        .map_err(|e| format!("trigger {}: {e}", stored.function_id))?;
+    if let Some(fs) = find_fs_prompt(cfg, &name) {
+        // Static fs prompts ignore caller-supplied `arguments` —
+        // there's no template engine in v1, just a verbatim body
+        // returned as a single user-text message.
+        if !arguments_is_empty(&arguments) {
+            tracing::debug!(prompt = %name, "fs prompt ignoring caller-supplied arguments (no templating)");
+        }
+        let body = fs_source::read_body(&fs.abs_path)?;
+        let messages = json!([{
+            "role": "user",
+            "content": { "type": "text", "text": body },
+        }]);
+        return Ok(json!({ "description": fs.description, "messages": messages }));
+    }
 
-    let messages = normalize_prompt_output(raw)?;
-    Ok(json!({ "description": stored.description, "messages": messages }))
+    Err(format!("Prompt not found: {name}"))
+}
+
+fn arguments_is_empty(args: &Value) -> bool {
+    match args {
+        Value::Null => true,
+        Value::Object(m) => m.is_empty(),
+        _ => false,
+    }
 }
 
 // ---------- validation ----------
@@ -414,6 +468,36 @@ async fn list_stored(iii: &III, cfg: &SkillsConfig) -> Result<Vec<StoredPrompt>,
         .collect();
     out.sort_by(|a, b| a.name.cmp(&b.name));
     Ok(out)
+}
+
+// ---------- fs source helpers ----------
+
+/// Re-glob the configured `prompts:` patterns and return entries whose
+/// name is NOT shadowed by a state-backed prompt. Same collision
+/// policy as the skills counterpart.
+pub fn non_colliding_fs_prompts(
+    cfg: &SkillsConfig,
+    state_names: &HashSet<String>,
+) -> Vec<FsPrompt> {
+    let base = cfg.glob_base_dir();
+    let (fs, _skipped) = fs_source::expand_prompt_globs(&base, &cfg.prompts);
+    fs.into_iter()
+        .filter(|p| !state_names.contains(&p.name))
+        .collect()
+}
+
+fn find_fs_prompt(cfg: &SkillsConfig, name: &str) -> Option<FsPrompt> {
+    let base = cfg.glob_base_dir();
+    let (fs, _skipped) = fs_source::expand_prompt_globs(&base, &cfg.prompts);
+    fs.into_iter().find(|p| p.name == name)
+}
+
+fn fs_registered_at(path: &std::path::Path) -> String {
+    std::fs::metadata(path)
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .map(|t| chrono::DateTime::<chrono::Utc>::from(t).to_rfc3339())
+        .unwrap_or_default()
 }
 
 #[cfg(test)]

--- a/skills/src/functions/prompts.rs
+++ b/skills/src/functions/prompts.rs
@@ -230,8 +230,7 @@ fn register_list_prompts(iii: &Arc<III>, cfg: &Arc<SkillsConfig>) {
                         origin: "state",
                     })
                     .collect();
-                let state_names: HashSet<String> =
-                    out.iter().map(|e| e.name.clone()).collect();
+                let state_names: HashSet<String> = out.iter().map(|e| e.name.clone()).collect();
                 for fs in non_colliding_fs_prompts(&cfg, &state_names) {
                     out.push(PromptEntry {
                         name: fs.name,

--- a/skills/src/functions/skills.rs
+++ b/skills/src/functions/skills.rs
@@ -283,8 +283,7 @@ fn register_list_skills(iii: &Arc<III>, cfg: &Arc<SkillsConfig>) {
                         origin: "state",
                     })
                     .collect();
-                let state_ids: HashSet<String> =
-                    out.iter().map(|e| e.id.clone()).collect();
+                let state_ids: HashSet<String> = out.iter().map(|e| e.id.clone()).collect();
                 for fs in non_colliding_fs_skills(&cfg, &state_ids) {
                     let (bytes, registered_at) = fs_metadata(&fs);
                     out.push(SkillEntry {

--- a/skills/src/functions/skills.rs
+++ b/skills/src/functions/skills.rs
@@ -27,6 +27,7 @@
 //! `skills::on-change` trigger type so interested workers (the `mcp`
 //! worker today) can forward MCP notifications.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use iii_sdk::{IIIError, RegisterFunction, TriggerRequest, III};
@@ -35,10 +36,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::config::SkillsConfig;
+use crate::fs_source::{self, FsSkill};
 use crate::state;
 use crate::trigger_types::{self, SubscriberSet};
 
-const SKILL_BODY_MAX_BYTES: usize = 256 * 1024;
+pub const SKILL_BODY_MAX_BYTES: usize = 256 * 1024;
 
 /// Per-segment cap for both skill ids and section URI segments.
 /// The total id is allowed to chain many segments via `/`, but each
@@ -123,6 +125,11 @@ struct SkillEntry {
     id: String,
     bytes: usize,
     registered_at: String,
+    /// `"state"` for state-backed skills (`skills::register`), `"fs"`
+    /// for filesystem-backed entries loaded via the `skills:` glob
+    /// patterns. Lets clients distinguish the two without a separate
+    /// query.
+    origin: &'static str,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -273,13 +280,28 @@ fn register_list_skills(iii: &Arc<III>, cfg: &Arc<SkillsConfig>) {
                         bytes: s.skill.len(),
                         id: s.id,
                         registered_at: s.registered_at,
+                        origin: "state",
                     })
                     .collect();
+                let state_ids: HashSet<String> =
+                    out.iter().map(|e| e.id.clone()).collect();
+                for fs in non_colliding_fs_skills(&cfg, &state_ids) {
+                    let (bytes, registered_at) = fs_metadata(&fs);
+                    out.push(SkillEntry {
+                        id: fs.id,
+                        bytes,
+                        registered_at,
+                        origin: "fs",
+                    });
+                }
                 out.sort_by(|a, b| a.id.cmp(&b.id));
                 Ok::<_, IIIError>(ListSkillsOutput { skills: out })
             }
         })
-        .description("List registered skills (id, body length, registered_at) without bodies."),
+        .description(
+            "List registered skills (id, body length, registered_at, origin) without bodies. \
+             `origin` is `state` for state-backed entries, `fs` for filesystem-backed.",
+        ),
     );
 }
 
@@ -376,15 +398,32 @@ pub async fn list_resources(iii: &III, cfg: &SkillsConfig) -> Value {
         "description": "Index of every registered skill",
         "mimeType": "text/markdown",
     })];
-    if let Ok(skills) = list_stored(iii, cfg).await {
-        for s in skills {
-            let title = extract_title(&s.skill).unwrap_or(&s.id);
-            resources.push(json!({
-                "uri": format!("{URI_PREFIX}{}", s.id),
-                "name": title,
-                "mimeType": "text/markdown",
-            }));
-        }
+    let state_skills = list_stored(iii, cfg).await.unwrap_or_default();
+    let state_ids: HashSet<String> = state_skills.iter().map(|s| s.id.clone()).collect();
+    for s in &state_skills {
+        let title = extract_title(&s.skill).unwrap_or(&s.id);
+        resources.push(json!({
+            "uri": format!("{URI_PREFIX}{}", s.id),
+            "name": title,
+            "mimeType": "text/markdown",
+        }));
+    }
+    for fs in non_colliding_fs_skills(cfg, &state_ids) {
+        // Cheap title resolution: read the file once. On any IO error
+        // we still surface the entry under its id so the resource
+        // listing isn't suddenly missing rows because of a transient
+        // read failure.
+        let title = match fs_source::read_body(&fs.abs_path) {
+            Ok(body) => extract_title(&body)
+                .map(String::from)
+                .unwrap_or_else(|| fs.id.clone()),
+            Err(_) => fs.id.clone(),
+        };
+        resources.push(json!({
+            "uri": format!("{URI_PREFIX}{}", fs.id),
+            "name": title,
+            "mimeType": "text/markdown",
+        }));
     }
     json!({ "resources": resources })
 }
@@ -420,10 +459,18 @@ pub async fn read(iii: &III, cfg: &SkillsConfig, uri: &str) -> Result<Value, Str
             // crafted `iii://Foo` URI fails fast even if it slipped
             // past the section-prefix check.
             validate_id(&id)?;
-            let stored = read_skill(iii, cfg, &id)
-                .await?
-                .ok_or_else(|| format!("Skill not found: {id}"))?;
-            Ok(wrap_contents(uri, "text/markdown", &stored.skill))
+            // State always wins on lookup so a runtime registration
+            // covering an fs id stays authoritative (matches the
+            // collision policy: fs entries colliding with state are
+            // never served).
+            if let Some(stored) = read_skill(iii, cfg, &id).await? {
+                return Ok(wrap_contents(uri, "text/markdown", &stored.skill));
+            }
+            if let Some(fs) = find_fs_skill(cfg, &id) {
+                let body = fs_source::read_body(&fs.abs_path)?;
+                return Ok(wrap_contents(uri, "text/markdown", &body));
+            }
+            Err(format!("Skill not found: {id}"))
         }
         ParsedUri::Section { function_id } => {
             // Recursion guard — a client that crafts iii://fn/state/set
@@ -634,7 +681,7 @@ pub fn validate_id(id: &str) -> Result<(), String> {
 // ---------- markdown helpers ----------
 
 async fn render_index(iii: &III, cfg: &SkillsConfig) -> String {
-    let skills = match list_stored(iii, cfg).await {
+    let state_skills = match list_stored(iii, cfg).await {
         Ok(s) => s,
         Err(e) => {
             return format!("# Skills\n\n_Error reading skills index: {e}_\n");
@@ -645,31 +692,63 @@ async fn render_index(iii: &III, cfg: &SkillsConfig) -> String {
          Sub-skills are indented under their parent path so a top-level skill stays small \
          and the LLM can drill in only when it needs more detail.\n\n",
     );
-    if skills.is_empty() {
+
+    let state_ids: HashSet<String> = state_skills.iter().map(|s| s.id.clone()).collect();
+    let fs_skills = non_colliding_fs_skills(cfg, &state_ids);
+
+    if state_skills.is_empty() && fs_skills.is_empty() {
         out.push_str("_No skills are currently registered._\n");
         return out;
     }
+
     // `list_stored` returns entries sorted lexicographically by id, so a
     // single linear pass yields a correct tree: every nested entry
     // appears immediately after its parent (or its parent's last
     // descendant). Indent each entry by `2 * depth` spaces, where depth
     // is the number of '/' separators in the id.
-    for s in skills {
-        let depth = s.id.matches('/').count();
-        let indent = " ".repeat(depth * 2);
+    for s in &state_skills {
         let title = extract_title(&s.skill).unwrap_or(&s.id);
         let desc = extract_description(&s.skill).unwrap_or_default();
-        let suffix = if desc.is_empty() {
-            String::new()
-        } else {
-            format!(" — {desc}")
-        };
-        out.push_str(&format!(
-            "{indent}- [`{}`](iii://{}) — {}{}\n",
-            s.id, s.id, title, suffix
-        ));
+        push_index_bullet(&mut out, &s.id, title, &desc);
     }
+
+    if !fs_skills.is_empty() {
+        if !state_skills.is_empty() {
+            out.push('\n');
+        }
+        out.push_str(
+            "## Custom skills\n\nLoaded from `skills:` glob patterns in the worker config. \
+             The file system is the source of truth for these entries.\n\n",
+        );
+        for fs in &fs_skills {
+            let body = fs_source::read_body(&fs.abs_path).ok();
+            let title = body
+                .as_deref()
+                .and_then(extract_title)
+                .map(String::from)
+                .unwrap_or_else(|| fs.id.clone());
+            let desc = body
+                .as_deref()
+                .and_then(extract_description)
+                .unwrap_or_default();
+            push_index_bullet(&mut out, &fs.id, &title, &desc);
+        }
+    }
+
     out
+}
+
+fn push_index_bullet(out: &mut String, id: &str, title: &str, desc: &str) {
+    let depth = id.matches('/').count();
+    let indent = " ".repeat(depth * 2);
+    let suffix = if desc.is_empty() {
+        String::new()
+    } else {
+        format!(" — {desc}")
+    };
+    out.push_str(&format!(
+        "{indent}- [`{id}`](iii://{id}) — {title}{suffix}\n"
+    ));
 }
 
 pub fn extract_title(markdown: &str) -> Option<&str> {
@@ -766,6 +845,47 @@ async fn list_stored(iii: &III, cfg: &SkillsConfig) -> Result<Vec<StoredSkill>, 
         .collect();
     out.sort_by(|a, b| a.id.cmp(&b.id));
     Ok(out)
+}
+
+// ---------- fs source helpers ----------
+
+/// Re-glob the configured `skills:` patterns and return entries whose
+/// id is NOT shadowed by a state-backed skill. This is the single
+/// place the collision policy is enforced — every read/list/index
+/// path goes through it.
+pub fn non_colliding_fs_skills(cfg: &SkillsConfig, state_ids: &HashSet<String>) -> Vec<FsSkill> {
+    let base = cfg.glob_base_dir();
+    let (fs, _skipped) = fs_source::expand_skill_globs(&base, &cfg.skills);
+    fs.into_iter()
+        .filter(|s| !state_ids.contains(&s.id))
+        .collect()
+}
+
+/// Targeted lookup for the read path. Returns `None` if no glob
+/// pattern matches `id` or if a glob expansion error swallowed it.
+fn find_fs_skill(cfg: &SkillsConfig, id: &str) -> Option<FsSkill> {
+    let base = cfg.glob_base_dir();
+    let (fs, _skipped) = fs_source::expand_skill_globs(&base, &cfg.skills);
+    fs.into_iter().find(|s| s.id == id)
+}
+
+/// Cheap metadata for `skills::list`. Bytes is the on-disk file size;
+/// `registered_at` is the file's mtime as RFC 3339. Falls back to "0"
+/// / "" when the metadata read fails so the listing entry still shows
+/// up rather than being silently dropped.
+fn fs_metadata(skill: &FsSkill) -> (usize, String) {
+    match std::fs::metadata(&skill.abs_path) {
+        Ok(meta) => {
+            let bytes = meta.len() as usize;
+            let modified = meta
+                .modified()
+                .ok()
+                .map(|t| chrono::DateTime::<chrono::Utc>::from(t).to_rfc3339())
+                .unwrap_or_default();
+            (bytes, modified)
+        }
+        Err(_) => (0, String::new()),
+    }
 }
 
 #[cfg(test)]

--- a/skills/src/lib.rs
+++ b/skills/src/lib.rs
@@ -20,6 +20,7 @@
 //! `notifications/*_list_changed` to its clients.
 
 pub mod config;
+pub mod fs_source;
 pub mod functions;
 pub mod manifest;
 pub mod state;

--- a/skills/src/main.rs
+++ b/skills/src/main.rs
@@ -91,6 +91,7 @@ async fn main() -> Result<()> {
     // capture the subscriber sets they'll fan out to.
     let registered = trigger_types::register_all(&iii);
     functions::register_all(&iii, &cfg, &registered);
+    functions::log_fs_health(&cfg);
 
     tracing::info!("skills ready: 13 functions + 2 custom trigger types");
 

--- a/skills/src/manifest.rs
+++ b/skills/src/manifest.rs
@@ -51,8 +51,17 @@ mod tests {
         assert_eq!(parsed["default_config"]["state_timeout_ms"], 10_000);
         assert!(parsed["default_config"]["skills"].is_array());
         assert!(parsed["default_config"]["prompts"].is_array());
-        assert_eq!(parsed["default_config"]["skills"].as_array().unwrap().len(), 0);
-        assert_eq!(parsed["default_config"]["prompts"].as_array().unwrap().len(), 0);
+        assert_eq!(
+            parsed["default_config"]["skills"].as_array().unwrap().len(),
+            0
+        );
+        assert_eq!(
+            parsed["default_config"]["prompts"]
+                .as_array()
+                .unwrap()
+                .len(),
+            0
+        );
         assert!(!parsed["supported_targets"].as_array().unwrap().is_empty());
     }
 }

--- a/skills/src/manifest.rs
+++ b/skills/src/manifest.rs
@@ -23,7 +23,9 @@ pub fn build_manifest() -> ModuleManifest {
                 "skills": "skills",
                 "prompts": "prompts"
             },
-            "state_timeout_ms": 10_000
+            "state_timeout_ms": 10_000,
+            "skills": [],
+            "prompts": []
         }),
         supported_targets: vec![env!("TARGET").to_string()],
     }
@@ -47,6 +49,10 @@ mod tests {
         assert_eq!(parsed["default_config"]["scopes"]["skills"], "skills");
         assert_eq!(parsed["default_config"]["scopes"]["prompts"], "prompts");
         assert_eq!(parsed["default_config"]["state_timeout_ms"], 10_000);
+        assert!(parsed["default_config"]["skills"].is_array());
+        assert!(parsed["default_config"]["prompts"].is_array());
+        assert_eq!(parsed["default_config"]["skills"].as_array().unwrap().len(), 0);
+        assert_eq!(parsed["default_config"]["prompts"].as_array().unwrap().len(), 0);
         assert!(!parsed["supported_targets"].as_array().unwrap().is_empty());
     }
 }

--- a/skills/tests/bdd.rs
+++ b/skills/tests/bdd.rs
@@ -34,6 +34,10 @@ async fn main() {
                     world.iii = Some(iii.clone());
                     if let Some(shared) = common::workers::shared() {
                         world.cfg = shared.cfg.clone();
+                        world.fs_root = Some(shared.fs_root.clone());
+                        // Wipe any leftover fixture files so each
+                        // scenario starts from an empty fs source.
+                        common::workers::reset_fs(&shared.fs_root);
                     }
                     // Start every scenario with both registries empty
                     // so per-test assertions aren't polluted by earlier

--- a/skills/tests/common/workers.rs
+++ b/skills/tests/common/workers.rs
@@ -7,6 +7,7 @@
 //! cucumber `before` hook in `tests/bdd.rs` wipes the two state scopes
 //! between scenarios so each scenario starts from a clean slate.
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -26,6 +27,11 @@ pub struct Shared {
     /// probe it directly (the registered trigger types live here).
     #[allow(dead_code)]
     pub triggers: Arc<RegisteredTriggerTypes>,
+    /// Root directory the fs-sources scenarios write fixtures into.
+    /// Layout under this dir mirrors the configured globs:
+    ///   `<fs_root>/fs-skills/...`  → matched by `fs-skills/**/*.md`
+    ///   `<fs_root>/fs-prompts/...` → matched by `fs-prompts/**/*.md`
+    pub fs_root: PathBuf,
 }
 
 static SHARED: OnceCell<Arc<Shared>> = OnceCell::const_new();
@@ -36,7 +42,20 @@ pub async fn register_all(iii: &Arc<III>) -> Result<Arc<Shared>> {
         return Ok(s.clone());
     }
 
-    let cfg = Arc::new(SkillsConfig::default());
+    // Build a leaked tempdir that lives for the test binary lifetime.
+    // The handlers below clone the cfg's config_dir into their closures
+    // so all subsequent fs scans resolve relative to this path.
+    let tmp = tempfile::tempdir()?;
+    let fs_root = tmp.keep();
+    std::fs::create_dir_all(fs_root.join("fs-skills"))?;
+    std::fs::create_dir_all(fs_root.join("fs-prompts"))?;
+
+    let cfg = Arc::new(SkillsConfig {
+        skills: vec!["fs-skills/**/*.md".into()],
+        prompts: vec!["fs-prompts/**/*.md".into()],
+        config_dir: Some(fs_root.clone()),
+        ..SkillsConfig::default()
+    });
     let registered = trigger_types::register_all(iii);
     functions::register_all(iii, &cfg, &registered);
 
@@ -47,6 +66,7 @@ pub async fn register_all(iii: &Arc<III>) -> Result<Arc<Shared>> {
     let shared = Arc::new(Shared {
         cfg,
         triggers: Arc::new(registered),
+        fs_root,
     });
     let _ = SHARED.set(shared.clone());
     Ok(shared)
@@ -54,6 +74,17 @@ pub async fn register_all(iii: &Arc<III>) -> Result<Arc<Shared>> {
 
 pub fn shared() -> Option<Arc<Shared>> {
     SHARED.get().cloned()
+}
+
+/// Wipe the fs-fixture directories between scenarios so leftover files
+/// from one scenario don't pollute the next. Only touches the per-test
+/// fs root — the rest of the file system is untouched.
+pub fn reset_fs(fs_root: &Path) {
+    for sub in ["fs-skills", "fs-prompts"] {
+        let dir = fs_root.join(sub);
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::create_dir_all(&dir);
+    }
 }
 
 /// Wipe both state scopes between scenarios. Called from the cucumber

--- a/skills/tests/common/world.rs
+++ b/skills/tests/common/world.rs
@@ -12,6 +12,7 @@
 //!   matching `When` step wrote.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use cucumber::World;
@@ -28,6 +29,10 @@ pub struct IiiSkillsWorld {
     pub cfg: Arc<SkillsConfig>,
     pub unique_id: String,
     pub stash: HashMap<String, Value>,
+    /// Tempdir the fs-sources scenarios write fixture files into.
+    /// Mirrors the layout `Shared::fs_root` configured in
+    /// [crate::common::workers]. `None` when no engine is reachable.
+    pub fs_root: Option<PathBuf>,
 }
 
 impl std::fmt::Debug for IiiSkillsWorld {
@@ -47,6 +52,7 @@ impl IiiSkillsWorld {
             cfg: Arc::new(SkillsConfig::default()),
             unique_id,
             stash: HashMap::new(),
+            fs_root: None,
         }
     }
 

--- a/skills/tests/features/fs_sources.feature
+++ b/skills/tests/features/fs_sources.feature
@@ -1,0 +1,174 @@
+@engine @fs_sources
+Feature: filesystem-backed skills and prompts (skills: / prompts: globs)
+  Files matched by the `skills:` and `prompts:` glob patterns in the
+  worker config become registry entries whose body is read fresh from
+  disk on every resolve. The file system is the single source of
+  truth — nothing is mirrored to iii-state. The auto-rendered
+  `iii://skills` index gets a separate `## Custom skills` section.
+
+  Background:
+    Given the iii engine is reachable
+
+  # ── flat folder of skills ────────────────────────────────────────────
+
+  Scenario: a flat folder of fs skills appears in skills::list with origin=fs
+    Given a fs skill file at "alpha.md" with body:
+      """
+      # Alpha
+
+      The alpha skill body.
+      """
+    And   a fs skill file at "beta.md" with body:
+      """
+      # Beta
+
+      The beta skill body.
+      """
+    When I list skills
+    Then the listing has a fs entry with id "alpha" and origin "fs"
+    And  the listing has a fs entry with id "beta" and origin "fs"
+
+  # ── nested directory hierarchy ───────────────────────────────────────
+
+  Scenario: nested folders derive slashed ids
+    Given a fs skill file at "team-a/playbook.md" with body:
+      """
+      # Team A playbook
+
+      Top-level body.
+      """
+    And   a fs skill file at "team-a/meetings/standup.md" with body:
+      """
+      # Standup
+
+      Nested body.
+      """
+    When I list skills
+    Then the listing has a fs entry with id "team-a/playbook" and origin "fs"
+    And  the listing has a fs entry with id "team-a/meetings/standup" and origin "fs"
+
+  # ── iii://{id} reads ─────────────────────────────────────────────────
+
+  Scenario: iii://{id} returns the file body fresh
+    Given a fs skill file at "lookup.md" with body:
+      """
+      # Lookup
+
+      Body content here.
+      """
+    When I read the URI "iii://lookup"
+    Then the contents mime type is "text/markdown"
+    And  the contents text contains "Body content here."
+
+  Scenario: file changes between reads are reflected immediately
+    Given a fs skill file at "live.md" with body:
+      """
+      # Live
+
+      First version.
+      """
+    When I read the URI "iii://live"
+    Then the contents text contains "First version."
+    When I overwrite the fs skill file at "live.md" with body:
+      """
+      # Live
+
+      Second version.
+      """
+    And  I read the URI "iii://live"
+    Then the contents text contains "Second version."
+
+  # ── index rendering ──────────────────────────────────────────────────
+
+  Scenario: the iii://skills index has a Custom skills H2 section
+    Given a fs skill file at "indexed.md" with body:
+      """
+      # Indexed skill
+
+      First paragraph summary.
+      """
+    When I read iii://skills
+    Then the contents text contains "## Custom skills"
+    And  the contents text contains "Indexed skill"
+    And  the contents text contains "First paragraph summary."
+
+  Scenario: nested fs skills are indented in the index by depth
+    Given a fs skill file at "tree.md" with body:
+      """
+      # Tree root
+
+      Top.
+      """
+    And   a fs skill file at "tree/leaf.md" with body:
+      """
+      # Tree leaf
+
+      Bottom.
+      """
+    When I read iii://skills
+    Then the index has a fs entry "tree" indented by 0 spaces
+    And  the index has a fs entry "tree/leaf" indented by 2 spaces
+
+  # ── collisions ───────────────────────────────────────────────────────
+
+  Scenario: a fs id colliding with a state-backed id is shadowed
+    Given a fs skill file at "dual.md" with body:
+      """
+      # Dual
+
+      File version.
+      """
+    When I register a skill with id "dual" and body "# Dual\n\nState version.\n"
+    Then the skills::register call succeeds
+    When I read the URI "iii://dual"
+    Then the contents text contains "State version."
+    And  the contents text does not contain "File version."
+
+  # ── invalid id rejection ─────────────────────────────────────────────
+
+  Scenario: a fs skill file with uppercase in its name is skipped
+    Given a fs skill file at "Bad-Name.md" with body:
+      """
+      # Bad
+
+      Body.
+      """
+    When I list skills
+    Then no listing entry has id "Bad-Name"
+    And  no listing entry has id "bad-name"
+
+  # ── prompts ─────────────────────────────────────────────────────────
+
+  Scenario: a fs prompt with frontmatter appears in mcp-list
+    Given a fs prompt file at "open-pr.md" with content:
+      """
+      ---
+      name: open-pr
+      description: Open a GitHub pull request.
+      ---
+      Compose a PR body that follows the repository template.
+      """
+    When I call prompts::mcp-list
+    Then the mcp prompt list includes "open-pr" with description "Open a GitHub pull request."
+
+  Scenario: prompts/get for a fs prompt returns the body as a single user-text message
+    Given a fs prompt file at "static.md" with content:
+      """
+      ---
+      description: Static prompt.
+      ---
+      The body content of the prompt.
+      """
+    When I call prompts::mcp-get for "static"
+    Then the mcp prompt response description is "Static prompt."
+    And  the mcp prompt response has a single user-text message
+    And  the mcp prompt user-text message contains "The body content of the prompt."
+
+  Scenario: a fs prompt without frontmatter is skipped
+    Given a fs prompt file at "no-fm.md" with content:
+      """
+      # heading
+      no frontmatter
+      """
+    When I call prompts::mcp-list
+    Then the mcp prompt list does not include "no-fm"

--- a/skills/tests/steps/fs_sources.rs
+++ b/skills/tests/steps/fs_sources.rs
@@ -24,7 +24,10 @@ const LAST_PROMPT_GET: &str = "fs_last_prompt_get";
 const LAST_ERR: &str = "fs_last_err";
 
 fn skill_path(world: &IiiSkillsWorld, rel: &str) -> Option<PathBuf> {
-    world.fs_root.as_ref().map(|r| r.join("fs-skills").join(rel))
+    world
+        .fs_root
+        .as_ref()
+        .map(|r| r.join("fs-skills").join(rel))
 }
 
 fn prompt_path(world: &IiiSkillsWorld, rel: &str) -> Option<PathBuf> {
@@ -52,11 +55,7 @@ fn normalize_docstring(s: &str) -> String {
 // ── seeding ─────────────────────────────────────────────────────────
 
 #[given(regex = r#"^a fs skill file at "([^"]+)" with body:$"#)]
-fn seed_fs_skill(
-    world: &mut IiiSkillsWorld,
-    rel: String,
-    step: &cucumber::gherkin::Step,
-) {
+fn seed_fs_skill(world: &mut IiiSkillsWorld, rel: String, step: &cucumber::gherkin::Step) {
     let Some(path) = skill_path(world, &rel) else {
         return;
     };
@@ -69,11 +68,7 @@ fn seed_fs_skill(
 }
 
 #[when(regex = r#"^I overwrite the fs skill file at "([^"]+)" with body:$"#)]
-fn overwrite_fs_skill(
-    world: &mut IiiSkillsWorld,
-    rel: String,
-    step: &cucumber::gherkin::Step,
-) {
+fn overwrite_fs_skill(world: &mut IiiSkillsWorld, rel: String, step: &cucumber::gherkin::Step) {
     let Some(path) = skill_path(world, &rel) else {
         return;
     };
@@ -86,11 +81,7 @@ fn overwrite_fs_skill(
 }
 
 #[given(regex = r#"^a fs prompt file at "([^"]+)" with content:$"#)]
-fn seed_fs_prompt(
-    world: &mut IiiSkillsWorld,
-    rel: String,
-    step: &cucumber::gherkin::Step,
-) {
+fn seed_fs_prompt(world: &mut IiiSkillsWorld, rel: String, step: &cucumber::gherkin::Step) {
     let Some(path) = prompt_path(world, &rel) else {
         return;
     };
@@ -104,12 +95,7 @@ fn seed_fs_prompt(
 
 // ── triggers ────────────────────────────────────────────────────────
 
-async fn trigger(
-    world: &mut IiiSkillsWorld,
-    function_id: &str,
-    payload: Value,
-    slot: &str,
-) {
+async fn trigger(world: &mut IiiSkillsWorld, function_id: &str, payload: Value, slot: &str) {
     world.stash.remove(slot);
     world.stash.remove(LAST_ERR);
     let Some(iii) = world.iii.clone() else {
@@ -176,9 +162,7 @@ fn listing_has_fs_entry(world: &mut IiiSkillsWorld, id: String, origin: String) 
     let arr = v["skills"]
         .as_array()
         .expect("missing .skills array in list response");
-    let found = arr
-        .iter()
-        .find(|e| e["id"].as_str() == Some(id.as_str()));
+    let found = arr.iter().find(|e| e["id"].as_str() == Some(id.as_str()));
     let entry = found.unwrap_or_else(|| {
         panic!(
             "no fs entry with id {id:?}; got: {}",
@@ -330,8 +314,5 @@ fn mcp_get_text_contains(world: &mut IiiSkillsWorld, needle: String) {
     let text = v["messages"][0]["content"]["text"]
         .as_str()
         .unwrap_or_default();
-    assert!(
-        text.contains(&needle),
-        "missing {needle:?} in: {text}"
-    );
+    assert!(text.contains(&needle), "missing {needle:?} in: {text}");
 }

--- a/skills/tests/steps/fs_sources.rs
+++ b/skills/tests/steps/fs_sources.rs
@@ -1,0 +1,337 @@
+//! Step defs for tests/features/fs_sources.feature.
+//!
+//! These scenarios drive the `skills` worker's filesystem-backed
+//! sources end-to-end: a step writes a fixture .md file under the
+//! fs root configured at boot, then we trigger a real
+//! `skills::list` / `skills::resources-read` / `prompts::mcp-list`
+//! / `prompts::mcp-get` call against the running worker and assert
+//! on the response. The fs root is wiped between scenarios by the
+//! cucumber `before` hook so each scenario starts from an empty
+//! file system.
+
+use std::path::PathBuf;
+
+use cucumber::{given, then, when};
+use iii_sdk::TriggerRequest;
+use serde_json::{json, Value};
+
+use crate::common::world::IiiSkillsWorld;
+
+const LAST_LIST: &str = "fs_last_list";
+const LAST_READ: &str = "fs_last_read";
+const LAST_PROMPT_LIST: &str = "fs_last_prompt_list";
+const LAST_PROMPT_GET: &str = "fs_last_prompt_get";
+const LAST_ERR: &str = "fs_last_err";
+
+fn skill_path(world: &IiiSkillsWorld, rel: &str) -> Option<PathBuf> {
+    world.fs_root.as_ref().map(|r| r.join("fs-skills").join(rel))
+}
+
+fn prompt_path(world: &IiiSkillsWorld, rel: &str) -> Option<PathBuf> {
+    world
+        .fs_root
+        .as_ref()
+        .map(|r| r.join("fs-prompts").join(rel))
+}
+
+fn write_file(path: &PathBuf, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create parent dir");
+    }
+    std::fs::write(path, contents).expect("write fixture file");
+}
+
+/// Cucumber docstrings start with a leading newline once the opening
+/// `"""` line is stripped. Real authors write markdown files starting
+/// at byte 0, so for any docstring we strip a single leading newline
+/// before persisting — matches what an editor would save.
+fn normalize_docstring(s: &str) -> String {
+    s.strip_prefix('\n').unwrap_or(s).to_string()
+}
+
+// ── seeding ─────────────────────────────────────────────────────────
+
+#[given(regex = r#"^a fs skill file at "([^"]+)" with body:$"#)]
+fn seed_fs_skill(
+    world: &mut IiiSkillsWorld,
+    rel: String,
+    step: &cucumber::gherkin::Step,
+) {
+    let Some(path) = skill_path(world, &rel) else {
+        return;
+    };
+    let body = normalize_docstring(
+        step.docstring
+            .as_deref()
+            .expect("fs skill body requires a docstring"),
+    );
+    write_file(&path, &body);
+}
+
+#[when(regex = r#"^I overwrite the fs skill file at "([^"]+)" with body:$"#)]
+fn overwrite_fs_skill(
+    world: &mut IiiSkillsWorld,
+    rel: String,
+    step: &cucumber::gherkin::Step,
+) {
+    let Some(path) = skill_path(world, &rel) else {
+        return;
+    };
+    let body = normalize_docstring(
+        step.docstring
+            .as_deref()
+            .expect("fs skill body requires a docstring"),
+    );
+    write_file(&path, &body);
+}
+
+#[given(regex = r#"^a fs prompt file at "([^"]+)" with content:$"#)]
+fn seed_fs_prompt(
+    world: &mut IiiSkillsWorld,
+    rel: String,
+    step: &cucumber::gherkin::Step,
+) {
+    let Some(path) = prompt_path(world, &rel) else {
+        return;
+    };
+    let body = normalize_docstring(
+        step.docstring
+            .as_deref()
+            .expect("fs prompt body requires a docstring"),
+    );
+    write_file(&path, &body);
+}
+
+// ── triggers ────────────────────────────────────────────────────────
+
+async fn trigger(
+    world: &mut IiiSkillsWorld,
+    function_id: &str,
+    payload: Value,
+    slot: &str,
+) {
+    world.stash.remove(slot);
+    world.stash.remove(LAST_ERR);
+    let Some(iii) = world.iii.clone() else {
+        return;
+    };
+    match iii
+        .trigger(TriggerRequest {
+            function_id: function_id.into(),
+            payload,
+            action: None,
+            timeout_ms: Some(5_000),
+        })
+        .await
+    {
+        Ok(v) => {
+            world.stash.insert(slot.into(), v);
+        }
+        Err(e) => {
+            world
+                .stash
+                .insert(LAST_ERR.into(), Value::String(e.to_string()));
+        }
+    }
+}
+
+// `I list skills`, `I read iii://skills`, `I read the URI "..."`,
+// `I register a skill with id "..." and body "..."`, `the
+// skills::register call succeeds`, `the contents mime type is "..."`,
+// `the contents text contains "..."`, `the contents text does not
+// contain "..."` are all defined elsewhere (skills_register.rs +
+// skills_resources.rs) — we reuse them.
+
+#[when("I call prompts::mcp-list")]
+async fn call_mcp_list(world: &mut IiiSkillsWorld) {
+    trigger(world, "prompts::mcp-list", json!({}), LAST_PROMPT_LIST).await;
+}
+
+#[when(regex = r#"^I call prompts::mcp-get for "([^"]+)"$"#)]
+async fn call_mcp_get(world: &mut IiiSkillsWorld, name: String) {
+    trigger(
+        world,
+        "prompts::mcp-get",
+        json!({ "name": name }),
+        LAST_PROMPT_GET,
+    )
+    .await;
+}
+
+// ── assertions on skills::list ──────────────────────────────────────
+
+#[then(regex = r#"^the listing has a fs entry with id "([^"]+)" and origin "([^"]+)"$"#)]
+fn listing_has_fs_entry(world: &mut IiiSkillsWorld, id: String, origin: String) {
+    if world.iii.is_none() {
+        return;
+    }
+    // The shared skills_register step "I list skills" stashes its
+    // result under "skills_register_last_list", so we read from that
+    // slot rather than maintaining our own.
+    let v = world
+        .stash
+        .get("skills_register_last_list")
+        .or_else(|| world.stash.get(LAST_LIST))
+        .expect("no skills::list result recorded; call `I list skills` first");
+    let arr = v["skills"]
+        .as_array()
+        .expect("missing .skills array in list response");
+    let found = arr
+        .iter()
+        .find(|e| e["id"].as_str() == Some(id.as_str()));
+    let entry = found.unwrap_or_else(|| {
+        panic!(
+            "no fs entry with id {id:?}; got: {}",
+            serde_json::to_string_pretty(arr).unwrap_or_default()
+        )
+    });
+    assert_eq!(
+        entry["origin"].as_str(),
+        Some(origin.as_str()),
+        "wrong origin for {id:?}: {entry}"
+    );
+}
+
+#[then(regex = r#"^no listing entry has id "([^"]+)"$"#)]
+fn listing_lacks_id(world: &mut IiiSkillsWorld, id: String) {
+    if world.iii.is_none() {
+        return;
+    }
+    let v = world
+        .stash
+        .get("skills_register_last_list")
+        .or_else(|| world.stash.get(LAST_LIST))
+        .expect("no skills::list result recorded");
+    let arr = v["skills"].as_array().expect("missing .skills array");
+    let found = arr.iter().any(|e| e["id"].as_str() == Some(id.as_str()));
+    assert!(
+        !found,
+        "unexpected listing entry with id {id:?}: {}",
+        serde_json::to_string_pretty(arr).unwrap_or_default()
+    );
+}
+
+// ── assertions on the iii://skills index ───────────────────────────
+
+#[then(regex = r#"^the index has a fs entry "([^"]+)" indented by (\d+) spaces$"#)]
+fn index_has_fs_entry(world: &mut IiiSkillsWorld, id: String, indent_spaces: usize) {
+    if world.iii.is_none() {
+        return;
+    }
+    // skills_resources.rs stashes the index read under "fs_last_read"
+    // for `I read iii://skills`. We use the same slot name for our
+    // step, so just look for whichever the latest read populated.
+    let v = world
+        .stash
+        .get("skills_resources_last_read")
+        .or_else(|| world.stash.get(LAST_READ))
+        .expect("no read recorded — call `I read iii://skills` first");
+    let text = v["contents"][0]["text"].as_str().unwrap_or_default();
+    let needle_indent = " ".repeat(indent_spaces);
+    let bullet_prefix = format!("{needle_indent}- [`{id}`](iii://{id})");
+    assert!(
+        text.lines().any(|l| l.starts_with(&bullet_prefix)),
+        "missing line starting with {bullet_prefix:?} in index:\n{text}"
+    );
+}
+
+// ── assertions on prompts::mcp-list / prompts::mcp-get ─────────────
+
+#[then(regex = r#"^the mcp prompt list includes "([^"]+)" with description "([^"]+)"$"#)]
+fn mcp_list_includes(world: &mut IiiSkillsWorld, name: String, description: String) {
+    if world.iii.is_none() {
+        return;
+    }
+    let v = world
+        .stash
+        .get(LAST_PROMPT_LIST)
+        .expect("no prompts::mcp-list result recorded");
+    let arr = v["prompts"]
+        .as_array()
+        .expect("missing .prompts array in mcp-list response");
+    let entry = arr
+        .iter()
+        .find(|p| p["name"].as_str() == Some(name.as_str()))
+        .unwrap_or_else(|| {
+            panic!(
+                "no prompt named {name:?}; got: {}",
+                serde_json::to_string_pretty(arr).unwrap_or_default()
+            )
+        });
+    assert_eq!(
+        entry["description"].as_str(),
+        Some(description.as_str()),
+        "description mismatch for {name:?}: {entry}"
+    );
+}
+
+#[then(regex = r#"^the mcp prompt list does not include "([^"]+)"$"#)]
+fn mcp_list_excludes(world: &mut IiiSkillsWorld, name: String) {
+    if world.iii.is_none() {
+        return;
+    }
+    let v = world
+        .stash
+        .get(LAST_PROMPT_LIST)
+        .expect("no prompts::mcp-list result recorded");
+    let arr = v["prompts"].as_array().expect("missing .prompts array");
+    let found = arr
+        .iter()
+        .any(|p| p["name"].as_str() == Some(name.as_str()));
+    assert!(!found, "unexpected prompt {name:?} in: {arr:?}");
+}
+
+#[then(regex = r#"^the mcp prompt response description is "([^"]+)"$"#)]
+fn mcp_get_description(world: &mut IiiSkillsWorld, want: String) {
+    if world.iii.is_none() {
+        return;
+    }
+    let v = world
+        .stash
+        .get(LAST_PROMPT_GET)
+        .expect("no prompts::mcp-get result recorded");
+    assert_eq!(
+        v["description"].as_str(),
+        Some(want.as_str()),
+        "description mismatch in: {v}"
+    );
+}
+
+#[then("the mcp prompt response has a single user-text message")]
+fn mcp_get_single_user_text(world: &mut IiiSkillsWorld) {
+    if world.iii.is_none() {
+        return;
+    }
+    let v = world
+        .stash
+        .get(LAST_PROMPT_GET)
+        .expect("no prompts::mcp-get result recorded");
+    let messages = v["messages"]
+        .as_array()
+        .expect("missing .messages in mcp-get response");
+    assert_eq!(messages.len(), 1, "expected 1 message; got: {messages:?}");
+    assert_eq!(messages[0]["role"], "user", "wrong role: {}", messages[0]);
+    assert_eq!(
+        messages[0]["content"]["type"], "text",
+        "wrong content type: {}",
+        messages[0]
+    );
+}
+
+#[then(regex = r#"^the mcp prompt user-text message contains "([^"]+)"$"#)]
+fn mcp_get_text_contains(world: &mut IiiSkillsWorld, needle: String) {
+    if world.iii.is_none() {
+        return;
+    }
+    let v = world
+        .stash
+        .get(LAST_PROMPT_GET)
+        .expect("no prompts::mcp-get result recorded");
+    let text = v["messages"][0]["content"]["text"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(
+        text.contains(&needle),
+        "missing {needle:?} in: {text}"
+    );
+}

--- a/skills/tests/steps/mod.rs
+++ b/skills/tests/steps/mod.rs
@@ -1,5 +1,6 @@
 //! Step-definition modules. One per `.feature` under `tests/features/`.
 
+pub mod fs_sources;
 pub mod markdown;
 pub mod mcp_bridge;
 pub mod notifications;


### PR DESCRIPTION
- Added glob pattern configuration for skills and prompts in `SkillsConfig`.
- Introduced `fs_source` module to handle filesystem-backed entries, including loading and validating skills and prompts from specified directories.
- Updated `skills` and `prompts` registration to include filesystem entries, ensuring state-backed entries take precedence.
- Enhanced README with details on filesystem-backed skills and prompts, including glob pattern resolution and usage examples.
- Added tests to verify functionality of filesystem-backed skills and prompts, including handling of collisions and dynamic updates.
- Updated `Cargo.toml` and `Cargo.lock` to include the new `glob` dependency and incremented `skills` package version to `0.2.2`.