### PR TITLE
feat(shell): sandbox forwarding, per-function skills, typed exec contracts

### DIFF
--- a/shell/Cargo.lock
+++ b/shell/Cargo.lock
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "iii-shell"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "iii-shell"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 publish = false
 

--- a/shell/README.md
+++ b/shell/README.md
@@ -6,13 +6,16 @@ this worker so allowlists, timeouts, output caps, and jail/denylist enforcement
 live in one place. Filesystem operations are exposed under `shell::fs::*` with
 the same enforcement surface plus optional sandbox-target forwarding.
 
-Current crate version: **0.3.0**. Wire shape last broken in 0.3.0 (channel-based
-`shell::fs::write` / `shell::fs::read`).
+Current crate version: **0.3.1**. Wire shape last broken in 0.3.0 (channel-based
+`shell::fs::write` / `shell::fs::read`). 0.3.1 adds the `target` field on
+`shell::exec` and `shell::exec_bg` for sandbox-backed execution (additive,
+backward-compatible).
 
 ## Contents
 
 - [Quickstart](#quickstart) — go from nothing to a working `shell::exec` in 4 commands.
 - [Functions](#functions) — the 15 function ids and their request/response shapes.
+- [Sandbox-backed exec](#sandbox-backed-exec) — forwarding `shell::exec` / `shell::exec_bg` into a live microVM.
 - [Filesystem operations: `shell::fs::*`](#filesystem-operations-shellfs)
 - [Configuration](#configuration) — full defaults table + `fs` and `sandbox` sections.
 - [Safety](#safety) — what is enforced, what is advisory, what the threat model is.
@@ -41,6 +44,14 @@ ln -sfn $(pwd)/target/release/iii-shell ~/.iii/workers/shell
 #    start unjailed by default; see Configuration below.
 iii -c ./config.yaml
 ```
+
+> **If you plan to use sandbox targets:** `iii worker add shell` does not
+> currently bring `iii-sandbox` along (the engine resolver doesn't yet
+> short-circuit builtin names in `dependencies:`<!-- TODO: remove this
+> caveat once the resolver supports builtins in iii.worker.yaml `dependencies:` -->),
+> so run `iii worker add iii-sandbox` separately before using
+> `shell::exec { target: sandbox }` or any `shell::fs::*` sandbox-target
+> path. Plain host-targeted `shell::exec` works without it.
 
 From a separate process (TS shown — Rust caller flow appears in the streaming
 sections below):
@@ -71,8 +82,8 @@ the canonical reference for wire shapes if anything below feels under-specified.
 
 | id | request | response |
 |----|---------|----------|
-| `shell::exec` | `{ command: string, args?: string[], timeout_ms?: number }` | `{ exit_code, stdout, stderr, duration_ms, timed_out, stdout_truncated, stderr_truncated }` |
-| `shell::exec_bg` | `{ command: string, args?: string[] }` | `{ job_id: string, argv: string[] }` |
+| `shell::exec` | `{ command: string, args?: string[], timeout_ms?: number, target?: Target }` | `{ exit_code, stdout, stderr, duration_ms, timed_out, stdout_truncated, stderr_truncated }` |
+| `shell::exec_bg` | `{ command: string, args?: string[], timeout_ms?: number, target?: Target }` | `{ job_id: string, argv: string[] }` |
 | `shell::kill` | `{ job_id: string }` | `{ job_id, killed, status, reason? }` |
 | `shell::status` | `{ job_id: string }` | `{ job: JobRecord }` (full record — argv + captured stdout/stderr) |
 | `shell::list` | `{}` | `{ jobs: JobSummary[], count }` (see redaction note below) |
@@ -106,6 +117,85 @@ process-wide and has no per-caller scope, so any caller could otherwise read
 every other caller's command line and captured output (which may embed
 credentials). The full record stays reachable via `shell::status <job_id>` —
 the random `job_id` UUID acts as an unguessable per-record capability.
+
+## Sandbox-backed exec
+
+Every `shell::exec` and `shell::exec_bg` request accepts an optional
+`target` field. The default (`{ "kind": "host" }`) runs on the host.
+Setting `{ "kind": "sandbox", "sandbox_id": "<uuid>" }` forwards the
+command to a live sandbox via the `sandbox::exec` trigger:
+
+```ts
+import { registerWorker } from 'iii-sdk';
+
+const iii = registerWorker('ws://127.0.0.1:49134');
+
+const { sandbox_id } = await iii.trigger({
+  function_id: 'sandbox::create',
+  payload: { image: 'python', cpus: 1, memory_mb: 512 },
+  // `timeoutMs` is the SDK-level call timeout (camelCase). The
+  // `timeout_ms` field that appears inside `payload` for shell::exec
+  // is a separate, snake_case wire field consumed by the worker.
+  timeoutMs: 300_000,
+});
+
+const out = await iii.trigger({
+  function_id: 'shell::exec',
+  payload: {
+    command: 'python3',
+    args: ['-c', 'print(2 + 2)'],
+    target: { kind: 'sandbox', sandbox_id },
+  },
+});
+console.log(out.stdout); // "4\n"
+
+await iii.trigger({
+  function_id: 'sandbox::stop',
+  payload: { sandbox_id, wait: true },
+});
+```
+
+The shell worker's allowlist still applies to sandbox-targeted calls —
+the same rules that gate host commands gate sandbox commands. If you
+want commands available only inside a sandbox, that's a separate
+deployment decision (extend the allowlist or run a second shell worker
+behind a different name).
+
+### Caveats
+
+- **`shell::kill` on a sandbox job is a status-level cancel, not a
+  process-level cancel.** `sandbox::exec` has no cancel hook, so the
+  in-VM process keeps running until its `timeout_ms` expires. The
+  job's `JobRecord.status` flips to `Killed` immediately and
+  `shell::status` / `shell::list` reflect the cancellation. The late
+  trigger response still captures stdout/stderr into the record but
+  does not overwrite the `Killed` status. If you need hard cancel,
+  use a short `timeout_ms` on the original `exec_bg` request, or
+  call `sandbox::stop` to tear down the whole microVM.
+- **`shell::exec_bg` accepts `timeout_ms` differently per target.**
+  Host: ignored (preserves today's unbounded host-bg behavior).
+  Sandbox: clamped to `cfg.max_timeout_ms` and forwarded; defaults
+  to `cfg.max_timeout_ms` (30s) when absent.
+- **Host virtualization is required for the sandbox path.** Apple
+  Silicon (macOS) or `/dev/kvm` (Linux). Intel Macs and Windows are
+  unsupported. When the host can't boot microVMs,
+  `shell::exec { target: sandbox }` returns `S300` (`VM boot
+  failed`); shell does **not** silently fall back to host
+  execution. See
+  [`docs/api-reference/sandbox.mdx`](https://github.com/iii-hq/iii/blob/main/docs/api-reference/sandbox.mdx)
+  for the full S-code matrix.
+- **`shell::exec` host-side errors return `S216`, not `S300`.**
+  S300 is reserved for sandbox VM-boot failures. A "command not
+  found" or spawn error on the host returns S216 with a `host exec:`
+  message prefix so callers can distinguish the two failure modes.
+
+### `Target` shape
+
+```ts
+type Target =
+  | { kind: 'host' }
+  | { kind: 'sandbox'; sandbox_id: string /* uuid */ };
+```
 
 ## Filesystem operations: `shell::fs::*`
 
@@ -340,7 +430,7 @@ trusted caller pipelines; for untrusted input, use the sandbox backend.
 ## What this is NOT
 
 - **Not a PTY.** Interactive shells, TUIs, password prompts all break.
-- **Not a sandbox.** For isolation use `sandbox-docker` / `sandbox-firecracker` and call through `shell` only for trusted commands.
+- **Not an isolation boundary itself.** Host-targeted calls (`target` omitted or `{ kind: 'host' }`) run with the shell worker's OS permissions. For process isolation, set `target: { kind: 'sandbox', sandbox_id }` on `shell::exec` / `shell::exec_bg` (see [Sandbox-backed exec](#sandbox-backed-exec)) — that path forwards through `iii-sandbox`'s microVM. The allowlist + denylist still apply on top of either backend.
 - **Not a streaming surface.** Foreground `shell::exec` returns once the process exits and stdout/stderr are captured whole. Live streaming is `shell::exec_stream` (deferred).
 - **Not per-caller-isolated.** The JOBS registry is a process-wide singleton. `shell::list` redacts argv/stdout/stderr to limit the blast radius; full records are cap-gated by `job_id`.
 

--- a/shell/config.yaml
+++ b/shell/config.yaml
@@ -79,5 +79,10 @@ fs:
     - /etc/passwd
     - /etc/shadow
 
+# When enabled is true, callers can target a live sandbox via the
+# top-level `target` field on shell::exec, shell::exec_bg, and every
+# shell::fs::* request. When false, every sandbox-targeted call
+# returns S210 ("sandbox target disabled in config") regardless of
+# whether iii-sandbox itself is running.
 sandbox:
   enabled: true

--- a/shell/skill.md
+++ b/shell/skill.md
@@ -1,0 +1,32 @@
+# shell
+
+Unix shell + filesystem worker. Runs allowlisted commands on the host (foreground or background) and reads/writes files inside an optional `host_root` jail. Every function may also be retargeted at a microVM via `target: { kind: "sandbox", sandbox_id }`.
+
+- [`shell`](iii://shell)
+  - [`shell::exec`](iii://shell/exec) — run an allowlisted command, return full stdout/stderr/exit
+  - [`shell::exec_bg`](iii://shell/exec_bg) — start a background job, get a `job_id` back
+  - [`shell::status`](iii://shell/status) — fetch a job's full record
+  - [`shell::kill`](iii://shell/kill) — terminate a running job
+  - [`shell::list`](iii://shell/list) — summary of every known job
+
+  - [`shell::fs::ls`](iii://shell/fs/ls) — list a directory inside the jail
+  - [`shell::fs::stat`](iii://shell/fs/stat) — stat one path
+  - [`shell::fs::read`](iii://shell/fs/read) — open a stream channel to read a file
+  - [`shell::fs::grep`](iii://shell/fs/grep) — recursive regex search
+
+  - [`shell::fs::write`](iii://shell/fs/write) — open a stream channel to write a file
+  - [`shell::fs::sed`](iii://shell/fs/sed) — find-and-replace, single file or directory walk
+  - [`shell::fs::mkdir`](iii://shell/fs/mkdir) — create a directory
+  - [`shell::fs::rm`](iii://shell/fs/rm) — unlink a file or directory
+  - [`shell::fs::chmod`](iii://shell/fs/chmod) — change permissions (and optionally owner)
+  - [`shell::fs::mv`](iii://shell/fs/mv) — move/rename inside the jail
+
+Live job table: [`iii://fn/shell/list`](iii://fn/shell/list).
+
+## Invariants (read once, applies to every call)
+
+- **Paths must be absolute.** Relative paths are rejected by every `fs::*` backend before the call dispatches.
+- **Filesystem ops are jailed to `fs.host_root`** when configured. Anything outside the configured root is refused. The path denylist (`fs.denylist_paths`) refuses inside the jail too. Operators may opt into running unjailed via `fs.allow_unjailed: true`; in that mode the worker logs a warning at boot and the entire host filesystem is reachable through `fs::*` (denylist still applies).
+- **Host-targeted `exec` / `exec_bg` are NOT a sandbox.** The allowlist gates `argv[0]` (matched by basename or exact path); the denylist is a regex tripwire over `argv.join(" ")` for honest-mistake patterns. A caller that can run an allowlisted interpreter (`sh`, `node`, `python`, …) can bypass denylist patterns by construction. For real isolation, pass `target: { kind: "sandbox", sandbox_id: "<uuid>" }` on `exec` / `exec_bg` / any `fs::*` request — that forwards to a live microVM via `iii-sandbox`. Allowlist + denylist still apply on top of the sandbox path. Caller manages the sandbox via `sandbox::create` / `sandbox::stop`.
+- **Sandbox targeting requires libkrun support.** When the host can't boot microVMs (no Apple Silicon and no `/dev/kvm`), sandbox-targeted calls return `S300`; shell does NOT fall back to host execution.
+- **Errors arrive as JSON-encoded strings.** Backend failures serialize an `FsError` / `ExecError` as the `Err` payload of the trigger result; `S2xx` codes are policy/wire issues, `S3xx` is sandbox/VM. Don't retry the same payload after a policy refusal.

--- a/shell/skills/exec.md
+++ b/shell/skills/exec.md
@@ -1,0 +1,22 @@
+# shell::exec
+
+Run a single command in the foreground and return the full result in one response.
+
+`({ command, args?, timeout_ms?, target? }) → { exit_code, stdout, stderr, duration_ms, timed_out, stdout_truncated, stderr_truncated }` — `command` is the program name as a **string** (matched against the allowlist by basename or exact path); split arguments into `args`, do NOT pass argv as an array in `command`. `args` is an array of strings; non-string elements are rejected by index. `timeout_ms` is clamped to `max_timeout_ms` (default 30 s) and falls back silently to `default_timeout_ms` (default 10 s) on absence or unparseable values (including negative integers and floats). `target` defaults to `{ kind: "host" }`; pass `{ kind: "sandbox", sandbox_id }` to forward the call to a live microVM.
+
+The wire shape is published as a JSON schema via `ExecRequest` in `functions::types`, so the engine's tool listing tells callers each field's type up front.
+
+## When to use
+
+- The command finishes well under the timeout cap and you want its output now.
+- One-shot probes: `ls`, `cat`, `pwd`, `git status`, `wc`, `head`, etc.
+- Anything where blocking until completion is fine for the calling turn.
+
+## Notes
+
+- Output is buffered in memory up to `max_output_bytes` (default 1 MiB). Beyond the cap, `stdout_truncated` / `stderr_truncated` flip to `true` and the rest is dropped — re-run with a tighter command (e.g. `head -n 100`) instead of asking for more bytes.
+- `cwd` and `env` are NOT part of the wire payload. The working directory comes from `cfg.working_dir`; environment is built from `cfg.allowed_env` plus `cfg.inherit_env` at config time.
+- Wrong-type fields produce actionable errors via per-field deserializers in `functions::types`. The most common one — sending `command: ["sh", "-lc", "..."]` — returns `'command' must be a string (got array). Pass the program name in 'command' and arguments in 'args', e.g. {"command": "sh", "args": ["-lc", "ls -la"]}` rather than a misleading "missing 'command'".
+- Allowlist is matched by `argv[0]`'s basename OR the exact string in `cfg.allowlist`; an empty allowlist means "open." Denylist is a regex set over `argv.join(" ")`. Both refusals come back as the trigger `Err`.
+- `target: sandbox` returns `S300` if the host can't boot microVMs (Apple Silicon or `/dev/kvm` required). Host-side spawn errors come back as `S216` with a `host exec:` prefix. In-VM execution failures arrive as `S200`; a recovered `S200` with a "timed out" message is reported as `timed_out: true`.
+- Use `shell::fs::ls`, `shell::fs::stat`, `shell::fs::grep` instead of `exec`-ing `ls`/`stat`/`grep`/`rg` — the fs backends stay in-process, respect the jail, and don't share the foreground output cap.

--- a/shell/skills/exec_bg.md
+++ b/shell/skills/exec_bg.md
@@ -1,0 +1,23 @@
+# shell::exec_bg
+
+Spawn a command as a background job and return immediately with a `job_id`.
+
+`({ command, args?, timeout_ms?, target? }) → { job_id, argv }` — same payload shape as `shell::exec`. `command` is the program name as a **string**; split arguments into `args`. The job runs in the background; poll with `shell::status` and terminate with `shell::kill`. `job_id` is `job-<uuid>`. `argv` echoes the resolved argument vector.
+
+The wire shape is published as a JSON schema via `ExecBgRequest` in `functions::types`.
+
+## When to use
+
+- Builds, long greps, watchers — anything that doesn't fit inside `max_timeout_ms`.
+- You want to keep working on other tool calls while the command runs.
+- "Run cargo build and show me the result when it's done" → `exec_bg` then poll `shell::status`.
+
+## Notes
+
+- Wrong-type fields are caught up front by the same per-field deserializers `shell::exec` uses; sending `command: ["sh", "-lc", "..."]` returns the actionable shape hint instead of a misleading "missing 'command'".
+- Allowlist + denylist gate the spawn the same way they gate `shell::exec`. A blocked argv comes back as the trigger `Err`; the job is never inserted into the table.
+- Host-targeted background jobs IGNORE `timeout_ms` (preserves the unbounded host-bg semantic). Only `shell::kill` or natural exit ends them.
+- Sandbox-targeted background jobs DO honour `timeout_ms`: it's clamped through `cfg.resolve_timeout` (default 10 s, max 30 s) and forwarded to `sandbox::exec`.
+- Concurrency cap: `cfg.max_concurrent_jobs` (default 16). If exceeded, the call returns `Err` from `try_reserve_and_insert` and the spawned child is killed before the call returns — wait for an existing job to finish, then retry.
+- Sandbox-backed jobs cannot be hard-killed. `shell::kill` flips the record to `killed` immediately, but the in-VM process keeps running until its `timeout_ms` expires (or until `sandbox::stop` tears down the microVM).
+- Sandbox-target requires libkrun support; otherwise the engine returns `S300` and the job is never recorded.

--- a/shell/skills/fs/chmod.md
+++ b/shell/skills/fs/chmod.md
@@ -1,0 +1,18 @@
+# shell::fs::chmod
+
+Change a path's permissions inside the jail. Optionally also change its UID/GID.
+
+`({ path, mode, uid?, gid?, recursive?, target? }) → { updated }` — `path` is absolute. `mode` is an octal string (e.g. `"0644"`, `"0755"`). `uid` and `gid` are optional integers; pass them to also chown. `recursive: true` walks into the directory; default is single-path.
+
+## When to use
+
+- Mark a freshly-written script executable after `shell::fs::write`.
+- Lock down a config file (`"0600"`) after generating it.
+- Recursively normalise permissions on a generated tree.
+
+## Notes
+
+- `updated` is the count of paths whose mode/owner the call mutated (1 for a single-path call, more under `recursive: true`). Do NOT rely on a `mode_before` / `mode_after` envelope — the legacy docs claimed those fields but the actual response is just `{ updated }`.
+- Symlinks are not followed (operates on the link itself).
+- `uid` / `gid` are advisory: the host backend will refuse to chown without sufficient privileges; the call returns the trigger `Err` in that case rather than silently skipping.
+- Same jail + denylist rules as `shell::fs::ls`.

--- a/shell/skills/fs/grep.md
+++ b/shell/skills/fs/grep.md
@@ -1,0 +1,20 @@
+# shell::fs::grep
+
+Recursive regex search over a directory inside the jail.
+
+`({ path, pattern, recursive?, ignore_case?, include_glob?, exclude_glob?, max_matches?, max_line_bytes?, target? }) → { matches: [{ path, line, content }], truncated }` — `path` is absolute. `pattern` is a regex evaluated by the backend (Rust regex on the host backend). `recursive` defaults to `true`. `ignore_case` defaults to `false`. `max_matches` defaults to 10,000. `max_line_bytes` defaults to 4096 — longer matched lines are truncated in the `content` field.
+
+## When to use
+
+- You'd reach for `rg` or `grep -rn` from a shell. Faster and structured.
+- Pre-step before `shell::fs::sed` to preview what would be rewritten.
+- Cross-file search inside a worker without spawning a process.
+
+## Notes
+
+- `include_glob` and `exclude_glob` are arrays of glob strings (e.g. `["**/*.rs"]`, `["**/target/**"]`). Plural names are wrong — use the singular `_glob` keys.
+- `ignore_case` (NOT `case_insensitive`) is the correct field name.
+- Multiline mode is off by default in the host backend — encode `(?m)` inside the pattern if you need multiline anchoring.
+- When `max_matches` is hit, `truncated: true` is set and the walk stops. Tighten the pattern or narrow `path` instead of bumping the cap blindly.
+- Binary files are skipped automatically. The wire `FsMatch` has no `column` field; the legacy `file` alias on the wire is accepted by the deserialiser but always rendered as `path` on the response.
+- Same jail + denylist rules as `shell::fs::ls`.

--- a/shell/skills/fs/ls.md
+++ b/shell/skills/fs/ls.md
@@ -1,0 +1,17 @@
+# shell::fs::ls
+
+List a directory inside the host_root jail.
+
+`({ path, target? }) → { entries: [{ name, is_dir, size, mode, mtime, is_symlink }] }` — `path` is absolute. `mode` is the octal string (e.g. `"0755"`); `mtime` is epoch seconds (NOT milliseconds — `JobRecord.*_at_ms` are ms; `FsEntry.mtime` is seconds). Symlinks are NOT followed; their `is_dir` reflects the link itself and `is_symlink` is `true`.
+
+## When to use
+
+- Enumerate before reading: cheaper than `shell::fs::grep` when you just need filenames.
+- Confirming that a path is a directory before recursing.
+- Building file pickers / orchestration that needs structured listings.
+
+## Notes
+
+- `path` outside `cfg.fs.host_root` returns an error; the path denylist (`cfg.fs.denylist_paths`) refuses inside the jail too.
+- Prefer this over `shell::exec` with `ls`: it stays in-process, returns JSON directly, and respects the jail.
+- The wire shape mirrors the engine daemon's `sandbox::fs::ls` response so host and sandbox targets are interchangeable from the caller's point of view.

--- a/shell/skills/fs/mkdir.md
+++ b/shell/skills/fs/mkdir.md
@@ -1,0 +1,17 @@
+# shell::fs::mkdir
+
+Create a directory inside the jail.
+
+`({ path, mode?, parents?, target? }) → { created }` — `path` is absolute. `mode` is an octal string (default `"0755"`). `parents: true` is the `mkdir -p` shape (succeeds if the directory and its intermediates already exist). Without `parents`, the call fails on the first existing path component.
+
+## When to use
+
+- Pre-create a directory tree before streaming files into it with `shell::fs::write`.
+- Standard "ensure path exists" idiom: `parents: true` + ignore the result.
+- Bootstrap a sandbox layout by retargeting the call.
+
+## Notes
+
+- The flag is `parents` (NOT `recursive`). Both backends accept the same name.
+- `created` is always `true` on success — including the idempotent case where `parents: true` and the directory already existed. There is no `created: false` branch; failure returns the trigger `Err` (e.g. `S211` for a missing parent without `parents: true`, I/O errors otherwise).
+- Same jail + denylist rules as `shell::fs::ls`.

--- a/shell/skills/fs/mv.md
+++ b/shell/skills/fs/mv.md
@@ -1,0 +1,18 @@
+# shell::fs::mv
+
+Move or rename a path inside the jail.
+
+`({ src, dst, overwrite?, target? }) → { moved }` — both paths are absolute and must be inside the same jail. Without `overwrite: true` the call refuses if `dst` exists.
+
+## When to use
+
+- Rename in place (same parent dir).
+- Move across directories within the jail.
+- Atomic publish of a generated file from a temp name to its final location.
+
+## Notes
+
+- Implementation is `rename(2)` with a fallback to copy + unlink when `src` and `dst` cross filesystems. The fallback is NOT atomic on its own — a crash after the copy and before the unlink leaves both copies on disk.
+- `moved: true` means the operation succeeded. A pre-existing `dst` without `overwrite: true` returns the trigger `Err`.
+- This is `mv` for one path. There is no batch / glob form; loop in the caller.
+- Same jail + denylist rules as `shell::fs::ls` for both `src` and `dst`.

--- a/shell/skills/fs/read.md
+++ b/shell/skills/fs/read.md
@@ -1,0 +1,17 @@
+# shell::fs::read
+
+Open a stream channel and return the bytes of a file via that channel — NOT inline content.
+
+`({ path, target? }) → { content: ContentRef, size, mode, mtime }` — `content` is a `ContentRef` (`{ channel_id, access_key, direction: "read" }`) that mirrors the SDK's `StreamChannelRef`. The caller drains the channel until close. Total bytes are bounded by `cfg.fs.max_read_bytes` (default `0` = unbounded).
+
+## When to use
+
+- A peer worker wants to consume a file's bytes without an inline copy in the trigger response.
+- Streaming large files into another channel (e.g. uploading to a sandbox) without pinning a buffer in the orchestrator.
+- Reading a binary that wouldn't survive JSON encoding inline.
+
+## Notes
+
+- Most LLM tool surfaces want bytes inlined into a tool result, NOT a channel handle. For the harness web surface, the inline wrapper [`harness::fs::read_inline`](iii://fn/harness/fs/read_inline) drives `shell::fs::read`, drains the channel, and returns the legacy `{ content: [{ text }], details: { size, truncated, bytes_read } }` envelope. Use the wrapper from the browser; reach for `shell::fs::read` directly only when you actually want the streaming channel.
+- When `cfg.fs.max_read_bytes > 0` and the file's size exceeds it, the read is rejected before any bytes flow with `S218 file size N exceeds max_read_bytes M` (mirrors the `S218` write-side cap). The default of `0` means no cap; this is unusual and operators typically pin a value.
+- Same jail + denylist rules as `shell::fs::ls`.

--- a/shell/skills/fs/rm.md
+++ b/shell/skills/fs/rm.md
@@ -1,0 +1,18 @@
+# shell::fs::rm
+
+Unlink a file or remove a directory inside the jail.
+
+`({ path, recursive?, target? }) → { removed }` — `path` is absolute. `recursive: false` (the default) refuses non-empty directories. `recursive: true` removes the directory and its contents.
+
+## When to use
+
+- Tear down a generated artifact after use.
+- Reset a workspace directory before re-bootstrapping it.
+- Drop a temp file once a flow no longer needs it.
+
+## Notes
+
+- Symlinks are removed by themselves, not their targets. `recursive` does NOT change that.
+- There is no trash-bin. This is `unlink(2)` / `rmdir(2)`. Get the user's intent right before calling.
+- `removed` is always `true` on success — there is no soft-success branch. Missing paths return `Err(S211)`; non-empty directories without `recursive: true` return `Err(S214)`; permission errors and other I/O failures come back as the trigger `Err` with the corresponding `FsError` shape.
+- Same jail + denylist rules as `shell::fs::ls`.

--- a/shell/skills/fs/sed.md
+++ b/shell/skills/fs/sed.md
@@ -1,0 +1,20 @@
+# shell::fs::sed
+
+Find-and-replace inside the jail. Operates on an explicit file list, a single file, or a directory walk.
+
+`({ pattern, replacement, files?, path?, recursive?, regex?, first_only?, ignore_case?, include_glob?, exclude_glob?, target? }) → { results: [{ path, replacements, success, error? }], total_replacements }` — supply EITHER `files: ["/abs/a", "/abs/b", …]` for an explicit list OR `path` (a directory) for a recursive walk; or `path` to a single file for a one-off rewrite. `regex` defaults to `true` (literal mode is off). `recursive` defaults to `true` when `path` is a directory.
+
+## When to use
+
+- Multi-file rewrite where `shell::fs::grep` would be the read-side preview.
+- Single-file regex replace where you'd otherwise reach for `sed -i`.
+- Templating step over a generated tree.
+
+## Notes
+
+- `pattern` is a regex when `regex: true` (default). `replacement` supports `$1`, `$2`, … capture-group backreferences. Set `regex: false` for a literal pattern.
+- `first_only: true` rewrites only the first match per file (the equivalent of `occurrences: "first"`); the default is to rewrite all matches.
+- There is no line-anchor flag — encode it inside the pattern (`(?m)^…`).
+- Per-file results carry `success: false` plus an `error` string for files that failed to rewrite (e.g., permission denied, regex compilation error). `total_replacements` sums across files.
+- Approval policy mirrors `shell::fs::write`: NOT hardcoded. Deployments that pin `shell::fs::sed` into the orchestrator's `approval_required` see a user-approval round-trip; others write immediately. Confirm against `workers/turn-orchestrator/src/run_start.rs` if your deployment has tightened the policy.
+- Same jail + denylist rules as `shell::fs::ls`. If you're unsure about the regex, run `shell::fs::grep` with the same pattern first.

--- a/shell/skills/fs/stat.md
+++ b/shell/skills/fs/stat.md
@@ -1,0 +1,17 @@
+# shell::fs::stat
+
+Return a single `FsEntry` for one path.
+
+`({ path, target? }) → { name, is_dir, size, mode, mtime, is_symlink }` — same shape as one entry of `shell::fs::ls`. The response is serialized as a transparent wrapper, so the entry's fields appear at the top level of the result.
+
+## When to use
+
+- Confirm a file exists and check its size before deciding whether to read it whole.
+- Distinguish a regular file from a symlink without dereferencing it.
+- Pre-flight check for a write target's existing mode before `chmod`-ing.
+
+## Notes
+
+- A missing path returns the trigger `Err` (FsError) — there is no "not_found is normal" envelope. Wrap the call if you want soft probing.
+- Symlinks are not followed; `is_symlink` reports the link itself. If you need the target's metadata, follow with another `stat` on the resolved path.
+- Same jail + denylist rules as `shell::fs::ls`. `mode` is an octal string and `mtime` is epoch seconds (NOT ms).

--- a/shell/skills/fs/write.md
+++ b/shell/skills/fs/write.md
@@ -1,0 +1,20 @@
+# shell::fs::write
+
+Write a file by streaming bytes through a `ContentRef` channel.
+
+`({ path, content: ContentRef, mode?, parents?, target? }) → { bytes_written, path }` — `content` is a `ContentRef` (`{ channel_id, access_key, direction: "write" }`) that the worker drains until close. `mode` is an octal string (default `"0644"`). `parents: true` creates intermediate directories `mkdir -p` style.
+
+## When to use
+
+- Persist a generated artifact to disk inside the jail.
+- Stream a remote download or generated stream straight into a file without an intermediate buffer.
+- Bootstrap files into a sandbox by retargeting the call with `target: { kind: "sandbox", sandbox_id }`.
+
+## Notes
+
+- The wire payload does NOT take raw `content: string` or `content_b64`. The caller opens a channel (typically via the SDK's channel APIs), passes the `ContentRef` here, then writes bytes into the channel and closes it.
+- When `cfg.fs.max_write_bytes > 0` and the streamed total exceeds the cap, the write is aborted mid-stream with `S218`. The default of `0` means no cap.
+- Per-chunk idle timeout is 30 s. If the caller opens a write but never sends data and never closes the channel, the worker aborts with `S216 channel idle for 30s — aborting write` so a parked writer doesn't leak the temp file.
+- The worker writes through a temp file and renames atomically. On crash mid-stream the temp file is unlinked by `TempGuard`.
+- Approval policy is NOT hardcoded into this function. Whether a turn requires approval before `shell::fs::write` lands is set per-run by the orchestrator's `approval_required` array — operators / harness UIs that pin it there will see a user-approval round-trip; deployments that don't include it write immediately.
+- Same jail + denylist rules as `shell::fs::ls`.

--- a/shell/skills/kill.md
+++ b/shell/skills/kill.md
@@ -1,0 +1,18 @@
+# shell::kill
+
+Terminate a running background job.
+
+`({ job_id }) → { job_id, killed, status, reason? }` — `killed` is `true` when the worker delivered the kill (or marked a sandbox job killed; see notes). `status` is the post-kill `JobStatus`. `reason` is set when the call was a no-op (`"not running"`) or when the kill is advisory (sandbox case).
+
+## When to use
+
+- Cancelling a runaway build or long-running process spawned by `shell::exec_bg`.
+- Cleaning up before re-issuing a corrected command.
+- Reaping at the end of an orchestration before unregistering the worker.
+
+## Notes
+
+- There is NO `signal` field on the wire. Host kills go through tokio's `Child::start_kill`, which is a hard kill (SIGKILL on Unix).
+- A non-`running` job returns `killed: false` with `reason: "not running"`; it is not an error.
+- Sandbox-backed jobs cannot be hard-killed because `sandbox::exec` has no cancel hook. The record flips to `killed` and `finished_at_ms` is stamped immediately so `shell::status` / `shell::list` reflect cancellation, but the in-VM process keeps running until its `timeout_ms` expires. The response includes a `reason` explaining this. For real cancellation, set a tight `timeout_ms` on the original `exec_bg`, or call `sandbox::stop` to tear down the VM.
+- `not_found` (the trigger `Err`) means the `job_id` either never existed or aged out of retention.

--- a/shell/skills/list.md
+++ b/shell/skills/list.md
@@ -1,0 +1,17 @@
+# shell::list
+
+Lightweight summary of every background job the worker currently knows about.
+
+`({}) → { jobs: [JobSummary], count }` where `JobSummary` is `{ id, status, started_at_ms, finished_at_ms?, exit_code?, stdout_truncated, stderr_truncated }`. `argv`, `stdout`, and `stderr` are deliberately omitted — the JOBS map is process-wide and any caller could otherwise read another caller's command line and captured output (which may embed credentials).
+
+## When to use
+
+- "What background jobs are running right now?" probes.
+- Building a dashboard or status page over current shell activity.
+- Pre-cleanup audit before a worker shutdown.
+
+## Notes
+
+- Reachable as the section URI `iii://fn/shell/list` for a humans-readable rendering of the same data.
+- For full records (including stdout/stderr), call `shell::status` with the `job_id`. The random UUID in `id` (formatted `job-<uuid>`) acts as an unguessable capability for that record.
+- Terminated jobs stay listed for `cfg.job_retention_secs` (default 3600 s) past their `finished_at_ms`; after that they are removed by the periodic janitor and disappear from this list.

--- a/shell/skills/status.md
+++ b/shell/skills/status.md
@@ -1,0 +1,18 @@
+# shell::status
+
+Fetch the full record for a background job, including buffered stdout/stderr.
+
+`({ job_id }) → { job: JobRecord }` where `JobRecord` is `{ id, argv, started_at_ms, finished_at_ms?, status, exit_code?, stdout, stderr, stdout_truncated, stderr_truncated }`. `status` is one of `running`, `finished`, `killed`, `failed`. Time fields are epoch milliseconds.
+
+## When to use
+
+- Polling a job spawned by `shell::exec_bg` until it leaves the `running` state.
+- Fetching captured output once a job has terminated, before retention expires.
+- Diagnosing a job that exited with a non-zero `exit_code`.
+
+## Notes
+
+- `not_found` (the trigger `Err`) means the `job_id` either never existed or aged out of `cfg.job_retention_secs` (default 1 hour after termination). Don't retry — re-run `shell::exec_bg` if the work still needs doing.
+- Per-stream output buffer is bounded by `cfg.max_output_bytes` (default 1 MiB). Once the cap is hit on a stream, the corresponding `*_truncated` flag stays `true` and new bytes are dropped — the job keeps running.
+- Use `shell::list` for a lightweight overview of every job. `shell::status` returns the full record (including potentially large stdout/stderr buffers) so it costs more per call.
+- Sandbox-backed jobs that were `shell::kill`-ed flip to `killed` immediately even though the in-VM process may still be running; their final stdout/stderr arrive on the late `sandbox::exec` response and are NOT applied if the record is already `killed`.

--- a/shell/src/exec/backend.rs
+++ b/shell/src/exec/backend.rs
@@ -1,0 +1,51 @@
+//! Backend trait for exec — host and sandbox impls live in sibling
+//! modules. The trait takes `argv` and a resolved `timeout_ms`; the
+//! handler is responsible for argv parsing, allowlist checking, and
+//! timeout resolution before calling `run`.
+
+use async_trait::async_trait;
+
+use super::error::ExecError;
+
+pub type ExecCallResult<T> = Result<T, ExecError>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecOutcome {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: Option<i32>,
+    pub duration_ms: u64,
+    pub timed_out: bool,
+    pub stdout_truncated: bool,
+    pub stderr_truncated: bool,
+}
+
+#[async_trait]
+pub trait ExecBackend: Send + Sync {
+    async fn run(&self, argv: &[String], timeout_ms: u64) -> ExecCallResult<ExecOutcome>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Compile-time check: trait is object-safe.
+    #[test]
+    fn backend_trait_is_object_safe() {
+        fn _f(_: &dyn ExecBackend) {}
+    }
+
+    #[test]
+    fn outcome_round_trips_via_clone() {
+        let o = ExecOutcome {
+            stdout: "hi".into(),
+            stderr: String::new(),
+            exit_code: Some(0),
+            duration_ms: 5,
+            timed_out: false,
+            stdout_truncated: false,
+            stderr_truncated: false,
+        };
+        assert_eq!(o.clone(), o);
+    }
+}

--- a/shell/src/exec/error.rs
+++ b/shell/src/exec/error.rs
@@ -1,0 +1,48 @@
+//! `ExecError` carries an S-code + message and serializes as
+//! `{ "code": "...", "message": "..." }`, matching the engine daemon
+//! and `fs::error::FsError`. Both shell-side and sandbox-forwarded
+//! errors round-trip through the same shape so callers don't branch
+//! on backend.
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ExecError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl ExecError {
+    pub fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+
+    /// Serializing `&'static str` + `String` is effectively infallible
+    /// (OOM only); `expect` so future shape changes fail loudly rather
+    /// than producing malformed JSON.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self).expect("ExecError is always serializable")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_json_emits_code_and_message() {
+        let e = ExecError::new("S300", "VM boot failed");
+        let j = e.to_json();
+        assert!(j.contains("\"code\":\"S300\""));
+        assert!(j.contains("\"message\":\"VM boot failed\""));
+    }
+
+    #[test]
+    fn equality_compares_code_and_message() {
+        assert_eq!(ExecError::new("S210", "x"), ExecError::new("S210", "x"),);
+        assert_ne!(ExecError::new("S210", "x"), ExecError::new("S211", "x"),);
+    }
+}

--- a/shell/src/exec/host.rs
+++ b/shell/src/exec/host.rs
@@ -1,19 +1,17 @@
-use crate::config::ShellConfig;
-use anyhow::Result;
+//! Host-process exec backend. Wraps `tokio::process::Command` with the
+//! existing env-scrubbing, bounded-output, and timeout-watchdog logic
+//! that lived in the flat `src/exec.rs` before the trait split.
+
 use std::process::Stdio;
+use std::sync::Arc;
 use std::time::Duration;
+
+use async_trait::async_trait;
 use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 
-pub struct ExecOutcome {
-    pub stdout: String,
-    pub stderr: String,
-    pub exit_code: Option<i32>,
-    pub duration_ms: u64,
-    pub timed_out: bool,
-    pub stdout_truncated: bool,
-    pub stderr_truncated: bool,
-}
+use crate::config::ShellConfig;
+use crate::exec::{backend::ExecBackend, error::ExecError, ExecCallResult, ExecOutcome};
 
 pub fn parse_argv(command: &str, args: Option<&Vec<String>>) -> Result<Vec<String>, String> {
     if let Some(args) = args {
@@ -124,6 +122,33 @@ async fn read_bounded<R: AsyncReadExt + Unpin>(reader: &mut R, limit: usize) -> 
     (buf, truncated)
 }
 
+pub struct HostExecBackend {
+    cfg: Arc<ShellConfig>,
+}
+
+impl HostExecBackend {
+    pub fn new(cfg: Arc<ShellConfig>) -> Self {
+        Self { cfg }
+    }
+}
+
+#[async_trait]
+impl ExecBackend for HostExecBackend {
+    async fn run(&self, argv: &[String], timeout_ms: u64) -> ExecCallResult<ExecOutcome> {
+        // S216 is the generic "shell-internal error" code in the
+        // S2xx range. We deliberately do NOT use S300 here even
+        // though it visually parallels SandboxExecBackend's S300
+        // path: in iii's S-code taxonomy, S300 is reserved for "VM
+        // boot failed" (no virt host). Wrapping host-side spawn or
+        // wait failures as S300 would make a "command not found" on
+        // the host indistinguishable from a missing /dev/kvm to
+        // callers that branch on the code.
+        run_to_completion(argv, &self.cfg, timeout_ms)
+            .await
+            .map_err(|e| ExecError::new("S216", format!("host exec: {e}")))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -200,5 +225,17 @@ mod tests {
         .unwrap();
         assert!(out.stdout_truncated);
         assert_eq!(out.stdout.len(), 16);
+    }
+
+    #[tokio::test]
+    async fn host_backend_runs_via_trait() {
+        let cfg = Arc::new(test_cfg());
+        let backend = HostExecBackend::new(cfg);
+        let out = backend
+            .run(&["echo".into(), "via-trait".into()], 5000)
+            .await
+            .unwrap();
+        assert_eq!(out.exit_code, Some(0));
+        assert_eq!(out.stdout.trim(), "via-trait");
     }
 }

--- a/shell/src/exec/mod.rs
+++ b/shell/src/exec/mod.rs
@@ -1,0 +1,20 @@
+//! Exec backend hierarchy. Mirrors `fs::{FsBackend, host, sandbox}` for
+//! `shell::exec` / `shell::exec_bg`.
+
+pub mod backend;
+pub mod error;
+pub mod host;
+pub mod sandbox;
+
+pub use backend::{ExecBackend, ExecCallResult, ExecOutcome};
+// These two re-exports are the public-API surface for downstream
+// consumers of `iii_shell::exec::*` and the back-compat surface for
+// internal `crate::exec::{parse_argv, build_command, run_to_completion,
+// HostExecBackend, ExecError}` import paths. Rustc flags them as
+// unused inside the binary target (the binary uses fully-qualified
+// `crate::exec::host::...` paths in its own module tree); the lib
+// target and external consumers DO use them. Suppressed deliberately.
+#[allow(unused_imports)]
+pub use error::ExecError;
+#[allow(unused_imports)]
+pub use host::{build_command, parse_argv, run_to_completion, HostExecBackend};

--- a/shell/src/exec/sandbox.rs
+++ b/shell/src/exec/sandbox.rs
@@ -1,0 +1,460 @@
+//! Sandbox-target exec backend. Forwards `cmd` + `args` + `timeout_ms`
+//! to `sandbox::exec` via `iii.trigger`. Stateless — the engine owns
+//! the sandbox lifecycle. Stdout/stderr arrive in the trigger response;
+//! shell does not stream them.
+
+use async_trait::async_trait;
+use iii_sdk::IIIError;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::exec::{backend::ExecBackend, error::ExecError, ExecCallResult, ExecOutcome};
+use crate::triggers::TriggerFwd;
+
+/// Wire response from the engine's `sandbox::exec` trigger.
+/// `pub(crate)` because `functions::exec_bg::spawn_sandbox_job` (T9)
+/// also deserializes this same shape when populating a `JobRecord`.
+#[derive(Debug, Deserialize)]
+pub(crate) struct SandboxExecResponse {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+    pub duration_ms: u64,
+    pub timed_out: bool,
+    // The engine wire also has `success` (== exit_code == 0 && !timed_out);
+    // we drop it on this side because it's derived.
+}
+
+pub struct SandboxExecBackend {
+    fwd: Arc<dyn TriggerFwd>,
+    enabled: bool,
+    sandbox_id: Uuid,
+}
+
+impl SandboxExecBackend {
+    pub fn new(fwd: Arc<dyn TriggerFwd>, enabled: bool, sandbox_id: Uuid) -> Self {
+        Self {
+            fwd,
+            enabled,
+            sandbox_id,
+        }
+    }
+}
+
+#[async_trait]
+impl ExecBackend for SandboxExecBackend {
+    async fn run(&self, argv: &[String], timeout_ms: u64) -> ExecCallResult<ExecOutcome> {
+        if !self.enabled {
+            return Err(ExecError::new("S210", "sandbox target disabled in config"));
+        }
+        let cmd = argv
+            .first()
+            .ok_or_else(|| ExecError::new("S210", "empty command"))?
+            .clone();
+        let args: Vec<&str> = argv.iter().skip(1).map(String::as_str).collect();
+
+        let payload = json!({
+            "sandbox_id": self.sandbox_id.to_string(),
+            "cmd": cmd,
+            "args": args,
+            "timeout_ms": timeout_ms,
+        });
+
+        let resp = match self.fwd.trigger("sandbox::exec", payload).await {
+            Ok(v) => v,
+            Err(e) => {
+                let exec_err = map_iii_err(e);
+                // The engine's iii-sandbox returns an *error* (code S200,
+                // type=execution) when the in-VM command exceeds
+                // `timeout_ms` rather than a structured response with
+                // timed_out=true. Translate that here so callers see the
+                // same `{ timed_out: true }` shape they get from the host
+                // backend — preserving the design's UX parity ("timed_out
+                // direct round-trip") and freeing callers from branching
+                // on backend.
+                if is_engine_timeout(&exec_err) {
+                    return Ok(ExecOutcome {
+                        stdout: String::new(),
+                        stderr: String::new(),
+                        exit_code: None,
+                        // The engine doesn't echo a duration on the
+                        // timeout error path; the caller knows it took
+                        // at least timeout_ms, so report exactly that.
+                        duration_ms: timeout_ms,
+                        timed_out: true,
+                        stdout_truncated: false,
+                        stderr_truncated: false,
+                    });
+                }
+                return Err(exec_err);
+            }
+        };
+
+        let parsed: SandboxExecResponse = serde_json::from_value(resp)
+            .map_err(|e| ExecError::new("S216", format!("bad engine response: {e}")))?;
+
+        Ok(ExecOutcome {
+            stdout: parsed.stdout,
+            stderr: parsed.stderr,
+            exit_code: Some(parsed.exit_code),
+            duration_ms: parsed.duration_ms,
+            timed_out: parsed.timed_out,
+            // sandbox::exec doesn't expose host-side truncation; spec says
+            // sandbox jobs report these as false uniformly.
+            stdout_truncated: false,
+            stderr_truncated: false,
+        })
+    }
+}
+
+/// True when the engine's error envelope indicates the in-VM command
+/// hit its server-side timeout. The wire shape (observed in the e2e
+/// harness against a real iii-sandbox build):
+/// `{ "code": "S200", "type": "execution", "message": "exec timed out
+/// after N ms", ... }`. We accept either a recovered `S200` code OR a
+/// `"timed out"` substring in the message — the latter catches engine
+/// builds that use a different code but a stable message.
+fn is_engine_timeout(err: &ExecError) -> bool {
+    err.code == "S200" || err.message.contains("timed out")
+}
+
+/// Recover an S-code from an `IIIError`. Mirrors
+/// `fs::sandbox::map_iii_err` so codes round-trip identically across
+/// fs and exec paths.
+fn map_iii_err(err: IIIError) -> ExecError {
+    match &err {
+        IIIError::Remote { code, message, .. } if code.starts_with('S') => {
+            return ExecError::new(
+                map_static_code(code),
+                format!("forwarded from engine: {message}"),
+            );
+        }
+        IIIError::Remote { message, .. } => {
+            if let Some(c) = scan_s_code(message) {
+                return ExecError::new(
+                    map_static_code(c),
+                    format!("forwarded from engine (wrapped): {message}"),
+                );
+            }
+        }
+        IIIError::Handler(s) => {
+            if let Ok(parsed) = serde_json::from_str::<Value>(s) {
+                if let Some(c) = parsed.get("code").and_then(|v| v.as_str()) {
+                    let msg = parsed.get("message").and_then(|v| v.as_str()).unwrap_or("");
+                    return ExecError::new(
+                        map_static_code(c),
+                        format!("forwarded from engine: {msg}"),
+                    );
+                }
+            }
+            if let Some(c) = scan_s_code(s) {
+                return ExecError::new(
+                    map_static_code(c),
+                    format!("forwarded from engine (raw): {s}"),
+                );
+            }
+        }
+        _ => {}
+    }
+    ExecError::new("S216", format!("engine error: {err:?}"))
+}
+
+fn scan_s_code(s: &str) -> Option<&str> {
+    let bytes = s.as_bytes();
+    // The window is 4 bytes (`bytes[i..=i+3]`), so the last valid `i` is
+    // `len - 4`. The loop bound `< len - 3` gives `i <= len - 4`.
+    // `saturating_sub(3)` collapses to 0 when `len < 4`, which yields an
+    // empty range (no false access) on too-short inputs.
+    for i in 0..bytes.len().saturating_sub(3) {
+        if bytes[i] == b'S'
+            && bytes[i + 1].is_ascii_digit()
+            && bytes[i + 2].is_ascii_digit()
+            && bytes[i + 3].is_ascii_digit()
+        {
+            // Reject matches preceded by alphanumerics so we don't grab
+            // the tail of a longer identifier (e.g. "FOO_S211").
+            let preceded_by_word =
+                i > 0 && (bytes[i - 1].is_ascii_alphanumeric() || bytes[i - 1] == b'_');
+            if !preceded_by_word {
+                return Some(&s[i..i + 4]);
+            }
+        }
+    }
+    None
+}
+
+fn map_static_code(code: &str) -> &'static str {
+    match code {
+        "S001" => "S001",
+        "S002" => "S002",
+        "S003" => "S003",
+        "S004" => "S004",
+        "S100" => "S100",
+        "S101" => "S101",
+        "S102" => "S102",
+        // S200: in-VM execution failure (engine wire-error shape). The
+        // common case — exec timeout — is intercepted in `run` and
+        // surfaced as `{ timed_out: true }`; other S200 reasons (rare)
+        // round-trip to the caller verbatim.
+        "S200" => "S200",
+        "S210" => "S210",
+        "S216" => "S216",
+        "S300" => "S300",
+        "S400" => "S400",
+        _ => "S216",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Stub forwarder using `Mutex<Option<...>>` to handle the
+    /// non-Clone `IIIError` shape. Same pattern as
+    /// `tests/sandbox_dispatch.rs::StubFwd`.
+    struct StubFwd {
+        captured: Mutex<Option<(String, Value)>>,
+        next: Mutex<Option<Result<Value, IIIError>>>,
+    }
+
+    impl StubFwd {
+        fn ok(value: Value) -> Arc<Self> {
+            Arc::new(Self {
+                captured: Mutex::new(None),
+                next: Mutex::new(Some(Ok(value))),
+            })
+        }
+        fn handler_err(json_msg: &'static str) -> Arc<Self> {
+            Arc::new(Self {
+                captured: Mutex::new(None),
+                next: Mutex::new(Some(Err(IIIError::Handler(json_msg.to_string())))),
+            })
+        }
+        fn remote_err(code: &str, message: &str) -> Arc<Self> {
+            Arc::new(Self {
+                captured: Mutex::new(None),
+                next: Mutex::new(Some(Err(IIIError::Remote {
+                    code: code.into(),
+                    message: message.into(),
+                    stacktrace: None,
+                }))),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl TriggerFwd for StubFwd {
+        async fn trigger(&self, fid: &str, payload: Value) -> Result<Value, IIIError> {
+            *self.captured.lock().unwrap() = Some((fid.into(), payload));
+            self.next
+                .lock()
+                .unwrap()
+                .take()
+                .expect("StubFwd: response already consumed")
+        }
+    }
+
+    fn backend(stub: Arc<StubFwd>, sandbox_id: Uuid) -> SandboxExecBackend {
+        SandboxExecBackend::new(stub, true, sandbox_id)
+    }
+
+    #[tokio::test]
+    async fn run_forwards_argv_and_timeout_with_sandbox_id() {
+        let stub = StubFwd::ok(json!({
+            "stdout": "hi\n",
+            "stderr": "warn: deprecated\n",
+            "exit_code": 0,
+            "duration_ms": 7,
+            "timed_out": false,
+            "success": true,
+        }));
+        let id = Uuid::new_v4();
+        let b = backend(stub.clone(), id);
+
+        let out = b
+            .run(&["echo".into(), "hi".into()], 4000)
+            .await
+            .expect("ok response");
+        assert_eq!(out.stdout, "hi\n");
+        // stderr round-trips identically to stdout — the parsed
+        // SandboxExecResponse field is required (not #[serde(default)]),
+        // so a non-empty value here would be silently dropped if the
+        // mapping ever regressed. Asserted to lock that contract.
+        assert_eq!(out.stderr, "warn: deprecated\n");
+        assert_eq!(out.exit_code, Some(0));
+        assert_eq!(out.duration_ms, 7);
+        assert!(!out.timed_out);
+        assert!(!out.stdout_truncated);
+        assert!(!out.stderr_truncated);
+
+        let (fid, payload) = stub.captured.lock().unwrap().clone().unwrap();
+        assert_eq!(fid, "sandbox::exec");
+        let obj = payload.as_object().unwrap();
+        assert_eq!(obj["sandbox_id"].as_str(), Some(id.to_string().as_str()));
+        assert_eq!(obj["cmd"].as_str(), Some("echo"));
+        assert_eq!(obj["args"][0].as_str(), Some("hi"));
+        assert_eq!(obj["timeout_ms"].as_u64(), Some(4000));
+    }
+
+    #[tokio::test]
+    async fn empty_args_array_when_argv_is_single_command() {
+        let stub = StubFwd::ok(json!({
+            "stdout": "",
+            "stderr": "",
+            "exit_code": 0,
+            "duration_ms": 1,
+            "timed_out": false,
+        }));
+        let b = backend(stub.clone(), Uuid::new_v4());
+        b.run(&["pwd".into()], 1000).await.unwrap();
+        let (_fid, payload) = stub.captured.lock().unwrap().clone().unwrap();
+        assert_eq!(payload["args"], json!([]));
+    }
+
+    #[tokio::test]
+    async fn timed_out_response_propagates() {
+        let stub = StubFwd::ok(json!({
+            "stdout": "",
+            "stderr": "",
+            "exit_code": 0,
+            "duration_ms": 30000,
+            "timed_out": true,
+        }));
+        let b = backend(stub, Uuid::new_v4());
+        let out = b.run(&["sleep".into(), "60".into()], 30000).await.unwrap();
+        assert!(out.timed_out);
+    }
+
+    #[tokio::test]
+    async fn disabled_returns_s210() {
+        let stub = StubFwd::ok(json!({}));
+        let b = SandboxExecBackend::new(stub, false, Uuid::new_v4());
+        let err = b.run(&["echo".into()], 1000).await.unwrap_err();
+        assert_eq!(err.code, "S210");
+        assert!(err.message.contains("disabled"));
+    }
+
+    #[tokio::test]
+    async fn empty_argv_returns_s210() {
+        let stub = StubFwd::ok(json!({}));
+        let b = backend(stub, Uuid::new_v4());
+        let err = b.run(&[], 1000).await.unwrap_err();
+        assert_eq!(err.code, "S210");
+    }
+
+    #[tokio::test]
+    async fn remote_s300_round_trips() {
+        let stub = StubFwd::remote_err("S300", "VM boot failed: no /dev/kvm");
+        let b = backend(stub, Uuid::new_v4());
+        let err = b.run(&["python3".into()], 1000).await.unwrap_err();
+        assert_eq!(err.code, "S300");
+        assert!(err.message.contains("VM boot failed"));
+    }
+
+    #[tokio::test]
+    async fn engine_timeout_handler_error_translates_to_timed_out_outcome() {
+        // The real iii-sandbox engine returns this exact shape on
+        // sandbox::exec timeout (observed in the e2e harness):
+        //   { "code": "S200", "type": "execution",
+        //     "message": "exec timed out after N ms", ... }
+        // The trigger errors out, but shell must surface a successful
+        // ExecOutcome with timed_out=true so callers see the same shape
+        // the host backend produces on timeout.
+        let stub = StubFwd::handler_err(
+            r#"{"code":"S200","type":"execution","message":"exec timed out after 5000 ms","retryable":false}"#,
+        );
+        let b = backend(stub, Uuid::new_v4());
+        let out = b
+            .run(&["sleep".into(), "30".into()], 5000)
+            .await
+            .expect("timeout must surface as Ok, not Err");
+        assert!(out.timed_out, "timed_out must be true");
+        assert_eq!(out.exit_code, None, "no exit code on timeout");
+        assert_eq!(
+            out.duration_ms, 5000,
+            "duration reflects the requested timeout"
+        );
+        assert_eq!(out.stdout, "", "no stdout on timeout");
+    }
+
+    #[tokio::test]
+    async fn engine_timeout_via_invocation_failed_wrapper_also_translates() {
+        // When the engine wraps the handler error, the timeout shows up
+        // through the `Remote { code: "invocation_failed", message: ... }`
+        // path with the S200 code embedded in the message. The
+        // translation must still kick in.
+        let stub = StubFwd::remote_err(
+            "invocation_failed",
+            "handler error: S200: exec timed out after 5000 ms",
+        );
+        let b = backend(stub, Uuid::new_v4());
+        let out = b
+            .run(&["sleep".into(), "30".into()], 5000)
+            .await
+            .expect("wrapped timeout must also surface as Ok");
+        assert!(
+            out.timed_out,
+            "timed_out must be true through the wrapped path"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_timeout_s200_still_propagates_as_error() {
+        // S200 without "timed out" in the message is some other in-VM
+        // execution failure — it should NOT be silently translated into
+        // timed_out=true. The current implementation matches "S200" OR
+        // "timed out"; engine builds that emit S200 for non-timeout
+        // execution errors will need a different message body. Lock
+        // that contract here.
+        let stub = StubFwd::handler_err(
+            r#"{"code":"S299","type":"execution","message":"some other failure","retryable":false}"#,
+        );
+        let b = backend(stub, Uuid::new_v4());
+        let err = b
+            .run(&["echo".into()], 1000)
+            .await
+            .expect_err("non-timeout S2xx must not translate to Ok");
+        // Unknown S299 collapses to S216 via map_static_code; the point
+        // is we got an Err, not a fake timed_out=true.
+        assert_eq!(err.code, "S216");
+    }
+
+    #[tokio::test]
+    async fn remote_invocation_failed_recovers_s_code_from_message() {
+        let stub = StubFwd::remote_err(
+            "invocation_failed",
+            "handler error: S101: image not installed",
+        );
+        let b = backend(stub, Uuid::new_v4());
+        let err = b.run(&["python3".into()], 1000).await.unwrap_err();
+        assert_eq!(err.code, "S101");
+    }
+
+    #[tokio::test]
+    async fn handler_json_error_recovers_s_code() {
+        let stub = StubFwd::handler_err(r#"{"code":"S002","message":"sandbox not found"}"#);
+        let b = backend(stub, Uuid::new_v4());
+        let err = b.run(&["echo".into()], 1000).await.unwrap_err();
+        assert_eq!(err.code, "S002");
+    }
+
+    #[tokio::test]
+    async fn unknown_code_collapses_to_s216() {
+        let stub = StubFwd::remote_err("S999", "unknown");
+        let b = backend(stub, Uuid::new_v4());
+        let err = b.run(&["echo".into()], 1000).await.unwrap_err();
+        assert_eq!(err.code, "S216");
+    }
+
+    #[tokio::test]
+    async fn malformed_response_returns_s216() {
+        let stub = StubFwd::ok(json!({ "garbage": true }));
+        let b = backend(stub, Uuid::new_v4());
+        let err = b.run(&["echo".into()], 1000).await.unwrap_err();
+        assert_eq!(err.code, "S216");
+        assert!(err.message.contains("bad engine response"));
+    }
+}

--- a/shell/src/exec_dispatch.rs
+++ b/shell/src/exec_dispatch.rs
@@ -1,0 +1,44 @@
+//! Backend selection for `shell::exec` / `shell::exec_bg`. Mirrors
+//! `functions::fs_dispatch::pick_backend`.
+
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use crate::config::ShellConfig;
+use crate::exec::error::ExecError;
+use crate::exec::host::HostExecBackend;
+use crate::exec::sandbox::SandboxExecBackend;
+use crate::exec::ExecBackend;
+use crate::target::Target;
+use crate::triggers::IiiTriggerFwd;
+
+pub fn pick_exec_backend(
+    target: Target,
+    cfg: Arc<ShellConfig>,
+    iii: iii_sdk::III,
+) -> Arc<dyn ExecBackend> {
+    match target {
+        Target::Host => Arc::new(HostExecBackend::new(cfg)),
+        Target::Sandbox { sandbox_id } => sandbox_for(sandbox_id, iii, cfg.sandbox.enabled),
+    }
+}
+
+fn sandbox_for(id: Uuid, iii: iii_sdk::III, enabled: bool) -> Arc<dyn ExecBackend> {
+    Arc::new(SandboxExecBackend::new(
+        Arc::new(IiiTriggerFwd::new(iii)),
+        enabled,
+        id,
+    ))
+}
+
+pub fn err_to_string(e: ExecError) -> String {
+    e.to_json()
+}
+
+// No unit tests in this module: the JSON envelope shape is already
+// covered by `exec::error::tests::to_json_emits_code_and_message`,
+// and `pick_exec_backend`'s match arms are trivial constructors that
+// would require a real `iii_sdk::III` to exercise. Real coverage of
+// the dispatcher's behavior comes from the integration tests in T8
+// once the handler is wired through.

--- a/shell/src/fs/mod.rs
+++ b/shell/src/fs/mod.rs
@@ -6,22 +6,15 @@ pub mod wire;
 use async_trait::async_trait;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 use crate::fs::error::FsError;
 use crate::fs::wire::{FsEntry, FsMatch, FsSedFileResult};
 
-/// Per-call target selector carried at the top level of each
-/// `shell::fs::*` request body. Defaults to host when omitted.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-pub enum Target {
-    #[default]
-    Host,
-    Sandbox {
-        sandbox_id: Uuid,
-    },
-}
+// `Target` lives in `crate::target`; re-exported here so existing
+// `use crate::fs::Target` call sites inside the crate keep compiling
+// without mechanical churn while the type's home is neutral between
+// `fs` and `exec` consumers.
+pub use crate::target::Target;
 
 /// Wire-identical mirror of `iii_sdk::channels::StreamChannelRef`. The SDK
 /// type lacks `JsonSchema` in 0.11.3, which would block typed registration
@@ -510,6 +503,7 @@ pub trait FsBackend: Send + Sync {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use uuid::Uuid;
 
     #[test]
     fn target_defaults_to_host_when_field_missing() {

--- a/shell/src/fs/sandbox.rs
+++ b/shell/src/fs/sandbox.rs
@@ -4,7 +4,7 @@
 //! passthroughs.
 
 use async_trait::async_trait;
-use iii_sdk::{IIIError, TriggerRequest};
+use iii_sdk::IIIError;
 use serde_json::{json, Value};
 use std::sync::Arc;
 use uuid::Uuid;
@@ -16,35 +16,12 @@ use crate::fs::{
     SedArgs, SedResponse, StatArgs, StatResponse, WriteArgs, WriteResponse,
 };
 
-/// Test seam: lets tests swap `iii.trigger` for a mock.
-#[async_trait]
-pub trait TriggerFwd: Send + Sync {
-    async fn trigger(&self, function_id: &str, payload: Value) -> Result<Value, IIIError>;
-}
-
-pub struct IiiTriggerFwd {
-    iii: iii_sdk::III,
-}
-
-impl IiiTriggerFwd {
-    pub fn new(iii: iii_sdk::III) -> Self {
-        Self { iii }
-    }
-}
-
-#[async_trait]
-impl TriggerFwd for IiiTriggerFwd {
-    async fn trigger(&self, function_id: &str, payload: Value) -> Result<Value, IIIError> {
-        self.iii
-            .trigger(TriggerRequest {
-                function_id: function_id.to_string(),
-                payload,
-                action: None,
-                timeout_ms: None,
-            })
-            .await
-    }
-}
+// TriggerFwd + IiiTriggerFwd live in `crate::triggers`; re-exported
+// here so existing `use crate::fs::sandbox::{TriggerFwd, IiiTriggerFwd}`
+// call sites inside the crate, plus the public
+// `iii_shell::fs::sandbox::TriggerFwd` surface consumed by
+// `tests/sandbox_dispatch.rs`, keep compiling without mechanical churn.
+pub use crate::triggers::{IiiTriggerFwd, TriggerFwd};
 
 pub struct SandboxFsBackend {
     fwd: Arc<dyn TriggerFwd>,
@@ -131,6 +108,10 @@ fn map_iii_err(err: IIIError) -> FsError {
 
 fn scan_s_code(s: &str) -> Option<&str> {
     let bytes = s.as_bytes();
+    // The window is 4 bytes (`bytes[i..=i+3]`), so the last valid `i` is
+    // `len - 4`. The loop bound `< len - 3` gives `i <= len - 4`.
+    // `saturating_sub(3)` collapses to 0 when `len < 4`, which yields an
+    // empty range (no false access) on too-short inputs.
     for i in 0..bytes.len().saturating_sub(3) {
         if bytes[i] == b'S'
             && bytes[i + 1].is_ascii_digit()

--- a/shell/src/functions/exec.rs
+++ b/shell/src/functions/exec.rs
@@ -1,62 +1,65 @@
 use std::sync::Arc;
 
-use serde_json::Value;
-
 use crate::config::ShellConfig;
-use crate::exec::{parse_argv, run_to_completion};
-use crate::functions::types::ExecResponse;
+use crate::exec::host::parse_argv;
+use crate::exec_dispatch::{err_to_string, pick_exec_backend};
+use crate::functions::types::{ExecRequest, ExecResponse};
 
-pub async fn handle(cfg: Arc<ShellConfig>, payload: Value) -> Result<ExecResponse, String> {
-    let command = payload
-        .get("command")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| "missing 'command'".to_string())?;
-    // Reject non-string elements rather than silently filtering: passing
-    // `{"args": ["--count", 5]}` would otherwise drop the `5` and run with
-    // partial arguments, a dangerous-to-debug deviation from caller intent.
-    let args: Option<Vec<String>> = match payload.get("args") {
-        None | Some(Value::Null) => None,
-        Some(Value::Array(arr)) => {
-            let mut out = Vec::with_capacity(arr.len());
-            for (i, v) in arr.iter().enumerate() {
-                match v.as_str() {
-                    Some(s) => out.push(s.to_string()),
-                    None => {
-                        return Err(format!("'args[{}]' must be a string (got {})", i, v));
-                    }
-                }
-            }
-            Some(out)
-        }
-        Some(other) => {
-            return Err(format!(
-                "'args' must be an array of strings (got {})",
-                other
-            ));
-        }
-    };
-    // `as_u64()` returns None for negative or float values, so an
-    // unparseable `timeout_ms` silently falls back to the default. This
-    // loose semantic is part of the wire contract (covered by e2e).
-    let timeout_ms = payload.get("timeout_ms").and_then(|v| v.as_u64());
-
-    let argv = parse_argv(command, args.as_ref()).map_err(|e| format!("argv: {}", e))?;
+pub async fn handle(
+    cfg: Arc<ShellConfig>,
+    iii: iii_sdk::III,
+    req: ExecRequest,
+) -> Result<ExecResponse, String> {
+    // Field-level type errors (wrong-type `command`, non-string `args[i]`,
+    // bad `target.kind`) come from the per-field deserializers in
+    // `functions::types`; they surface here as the trigger `Err` carrying
+    // the actionable text the LLM needs to self-correct.
+    let argv = parse_argv(&req.command, Some(&req.args)).map_err(|e| format!("argv: {}", e))?;
 
     cfg.is_command_allowed(&argv)?;
 
-    let timeout = cfg.resolve_timeout(timeout_ms);
+    let timeout = cfg.resolve_timeout(req.timeout_ms);
 
-    let out = run_to_completion(&argv, &cfg, timeout)
-        .await
-        .map_err(|e| format!("exec: {}", e))?;
+    let backend = pick_exec_backend(req.target, cfg, iii);
 
-    Ok(ExecResponse {
-        exit_code: out.exit_code,
-        stdout: out.stdout,
-        stderr: out.stderr,
-        duration_ms: out.duration_ms,
-        timed_out: out.timed_out,
-        stdout_truncated: out.stdout_truncated,
-        stderr_truncated: out.stderr_truncated,
-    })
+    let out = backend.run(&argv, timeout).await.map_err(err_to_string)?;
+
+    Ok(ExecResponse::from(out))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::target::Target;
+    use serde_json::{json, Value};
+
+    #[test]
+    fn target_defaults_to_host_when_absent() {
+        let payload = json!({ "command": "echo" });
+        let target: Target = match payload.get("target") {
+            None | Some(Value::Null) => Target::default(),
+            Some(v) => serde_json::from_value(v.clone()).unwrap(),
+        };
+        assert_eq!(target, Target::Host);
+    }
+
+    #[test]
+    fn target_field_parses_sandbox_kind() {
+        let id = uuid::Uuid::new_v4();
+        let payload = json!({
+            "command": "ls",
+            "target": { "kind": "sandbox", "sandbox_id": id.to_string() },
+        });
+        let target: Target = serde_json::from_value(payload["target"].clone()).unwrap();
+        assert_eq!(target, Target::Sandbox { sandbox_id: id });
+    }
+
+    #[test]
+    fn malformed_target_returns_error() {
+        let payload = json!({
+            "command": "ls",
+            "target": { "kind": "moon" },
+        });
+        let result: Result<Target, _> = serde_json::from_value(payload["target"].clone());
+        assert!(result.is_err());
+    }
 }

--- a/shell/src/functions/exec.rs
+++ b/shell/src/functions/exec.rs
@@ -14,7 +14,12 @@ pub async fn handle(
     // bad `target.kind`) come from the per-field deserializers in
     // `functions::types`; they surface here as the trigger `Err` carrying
     // the actionable text the LLM needs to self-correct.
-    let argv = parse_argv(&req.command, Some(&req.args)).map_err(|e| format!("argv: {}", e))?;
+    // `args.as_ref()` preserves the legacy two-mode contract on `parse_argv`:
+    //   None → tokenize `command` via shell-words (single-string path)
+    //   Some(_) → use args verbatim, even if empty
+    // The typed-schema migration must NOT collapse "absent args" into
+    // "args: []" or callers lose the shell-words path.
+    let argv = parse_argv(&req.command, req.args.as_ref()).map_err(|e| format!("argv: {}", e))?;
 
     cfg.is_command_allowed(&argv)?;
 

--- a/shell/src/functions/exec_bg.rs
+++ b/shell/src/functions/exec_bg.rs
@@ -1,47 +1,46 @@
 use std::sync::Arc;
 
-use serde_json::Value;
 use uuid::Uuid;
 
 use crate::config::ShellConfig;
-use crate::exec::{build_command, parse_argv};
-use crate::functions::types::ExecBgResponse;
+use crate::exec::host::{build_command, parse_argv};
+use crate::exec::sandbox::SandboxExecResponse;
+use crate::functions::types::{ExecBgRequest, ExecBgResponse};
 use crate::jobs::{self, JobHandle, JobRecord, JobStatus};
+use crate::target::Target;
+use crate::triggers::{IiiTriggerFwd, TriggerFwd};
 use tokio::io::AsyncReadExt;
 
-pub async fn handle(cfg: Arc<ShellConfig>, payload: Value) -> Result<ExecBgResponse, String> {
-    let command = payload
-        .get("command")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| "missing 'command'".to_string())?;
-    // See exec.rs — silently dropping non-string args is especially
-    // dangerous for a backgrounded long-lived job.
-    let args: Option<Vec<String>> = match payload.get("args") {
-        None | Some(Value::Null) => None,
-        Some(Value::Array(arr)) => {
-            let mut out = Vec::with_capacity(arr.len());
-            for (i, v) in arr.iter().enumerate() {
-                match v.as_str() {
-                    Some(s) => out.push(s.to_string()),
-                    None => {
-                        return Err(format!("'args[{}]' must be a string (got {})", i, v));
-                    }
-                }
-            }
-            Some(out)
-        }
-        Some(other) => {
-            return Err(format!(
-                "'args' must be an array of strings (got {})",
-                other
-            ));
-        }
-    };
-
-    let argv = parse_argv(command, args.as_ref()).map_err(|e| format!("argv: {}", e))?;
+pub async fn handle(
+    cfg: Arc<ShellConfig>,
+    iii: iii_sdk::III,
+    req: ExecBgRequest,
+) -> Result<ExecBgResponse, String> {
+    // Field-level type errors (wrong-type `command`, non-string `args[i]`,
+    // bad `target.kind`) come from the per-field deserializers in
+    // `functions::types`; the SDK forwards them as the trigger `Err` with
+    // the actionable text the LLM needs to self-correct.
+    let argv = parse_argv(&req.command, Some(&req.args)).map_err(|e| format!("argv: {}", e))?;
 
     cfg.is_command_allowed(&argv)?;
 
+    match req.target {
+        Target::Host => spawn_host_job(cfg, argv).await,
+        Target::Sandbox { sandbox_id } => {
+            // Resolve+clamp timeout for the sandbox path; host path
+            // ignores timeout_ms (preserves today's unbounded host-bg
+            // semantics — documented in README "Caveats").
+            let resolved = cfg.resolve_timeout(req.timeout_ms);
+            let fwd: Arc<dyn TriggerFwd> = Arc::new(IiiTriggerFwd::new(iii));
+            spawn_sandbox_job(cfg, fwd, sandbox_id, argv, resolved).await
+        }
+    }
+}
+
+async fn spawn_host_job(
+    cfg: Arc<ShellConfig>,
+    argv: Vec<String>,
+) -> Result<ExecBgResponse, String> {
     let mut cmd = build_command(&argv, &cfg)?;
     let mut child = cmd.spawn().map_err(|e| format!("spawn: {}", e))?;
 
@@ -157,6 +156,118 @@ pub async fn handle(cfg: Arc<ShellConfig>, payload: Value) -> Result<ExecBgRespo
     Ok(ExecBgResponse { job_id: id, argv })
 }
 
+pub(crate) async fn spawn_sandbox_job(
+    cfg: Arc<ShellConfig>,
+    fwd: Arc<dyn TriggerFwd>,
+    sandbox_id: Uuid,
+    argv: Vec<String>,
+    timeout_ms: u64,
+) -> Result<ExecBgResponse, String> {
+    let id = format!("job-{}", Uuid::new_v4());
+    let record = JobRecord {
+        id: id.clone(),
+        argv: argv.clone(),
+        started_at_ms: jobs::now_ms(),
+        finished_at_ms: None,
+        status: JobStatus::Running,
+        exit_code: None,
+        stdout: String::new(),
+        stderr: String::new(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+    };
+    // For sandbox jobs, child is None — there is no local OS process.
+    // The concurrency cap (max_concurrent_jobs) covers both backends
+    // uniformly via the running-status count in try_reserve_and_insert.
+    // On rejection, there is no orphan process to kill.
+    match jobs::try_reserve_and_insert(
+        JobHandle {
+            record,
+            child: None,
+        },
+        cfg.max_concurrent_jobs,
+    )
+    .await
+    {
+        Ok(_) => {}
+        Err((running, _)) => {
+            // No orphan child to kill — sandbox jobs don't own a local process.
+            return Err(format!(
+                "max concurrent jobs ({}) reached, currently running: {}",
+                cfg.max_concurrent_jobs, running
+            ));
+        }
+    }
+
+    let id_clone = id.clone();
+    let argv_for_payload = argv.clone();
+    tokio::spawn(async move {
+        let cmd = argv_for_payload[0].clone();
+        let args: Vec<String> = argv_for_payload.iter().skip(1).cloned().collect();
+        let payload = serde_json::json!({
+            "sandbox_id": sandbox_id.to_string(),
+            "cmd": cmd,
+            "args": args,
+            "timeout_ms": timeout_ms,
+        });
+        let res = fwd.trigger("sandbox::exec", payload).await;
+
+        let handle = match jobs::get(&id_clone).await {
+            Some(h) => h,
+            None => return,
+        };
+        let mut h = handle.lock().await;
+
+        // If shell::kill marked this Killed before the trigger returned, do not
+        // overwrite the status — but capture stdout/stderr for completeness.
+        let already_killed = h.record.status == JobStatus::Killed;
+
+        match res {
+            Ok(value) => {
+                let parsed: Result<SandboxExecResponse, _> = serde_json::from_value(value);
+                match parsed {
+                    Ok(p) => {
+                        h.record.stdout = p.stdout;
+                        h.record.stderr = p.stderr;
+                        h.record.exit_code = Some(p.exit_code);
+                        if !already_killed {
+                            h.record.status = if p.timed_out {
+                                JobStatus::Killed
+                            } else if p.exit_code == 0 {
+                                JobStatus::Finished
+                            } else {
+                                JobStatus::Failed
+                            };
+                        }
+                    }
+                    Err(e) => {
+                        if !already_killed {
+                            h.record.status = JobStatus::Failed;
+                        }
+                        h.record.stderr = format!("bad engine response: {e}");
+                    }
+                }
+            }
+            Err(err) => {
+                if !already_killed {
+                    h.record.status = JobStatus::Failed;
+                }
+                h.record.stderr = format!("engine error: {err:?}");
+            }
+        }
+        // Same guard as the status writes: if shell::kill already
+        // recorded a finished_at_ms when it flipped status to Killed,
+        // a late trigger response must NOT clobber that timestamp —
+        // pollers reading finished_at_ms expect the kill-time, not
+        // the in-VM process's eventual completion time.
+        if !already_killed {
+            h.record.finished_at_ms = Some(jobs::now_ms());
+        }
+    });
+
+    Ok(ExecBgResponse { job_id: id, argv })
+}
+
 async fn read_bounded<R: AsyncReadExt + Unpin>(
     reader: &mut R,
     limit: usize,
@@ -181,5 +292,227 @@ async fn read_bounded<R: AsyncReadExt + Unpin>(
             }
             Err(_) => break,
         }
+    }
+}
+
+#[cfg(test)]
+mod sandbox_path_tests {
+    use super::*;
+    use crate::config::ShellConfig;
+    use crate::jobs::{self, JobStatus};
+    use crate::triggers::TriggerFwd;
+    use async_trait::async_trait;
+    use iii_sdk::IIIError;
+    use serde_json::{json, Value};
+    use std::sync::{Arc, Mutex};
+    use uuid::Uuid;
+
+    struct ImmediateOk(Mutex<Option<Value>>);
+
+    #[async_trait]
+    impl TriggerFwd for ImmediateOk {
+        async fn trigger(&self, _fid: &str, _payload: Value) -> Result<Value, IIIError> {
+            Ok(self.0.lock().unwrap().take().unwrap())
+        }
+    }
+
+    fn cfg_open() -> Arc<ShellConfig> {
+        let mut c = ShellConfig {
+            inherit_env: true,
+            max_output_bytes: 4096,
+            ..Default::default()
+        };
+        c.compile_denylist().unwrap();
+        Arc::new(c)
+    }
+
+    #[tokio::test]
+    async fn sandbox_job_transitions_to_finished() {
+        let cfg = cfg_open();
+        let fwd: Arc<dyn TriggerFwd> = Arc::new(ImmediateOk(Mutex::new(Some(json!({
+            "stdout": "ok\n",
+            "stderr": "",
+            "exit_code": 0,
+            "duration_ms": 5,
+            "timed_out": false,
+        })))));
+        let sandbox_id = Uuid::new_v4();
+
+        let resp = handle_sandbox_for_test(
+            cfg.clone(),
+            fwd.clone(),
+            sandbox_id,
+            vec!["echo".into(), "ok".into()],
+            5000,
+        )
+        .await
+        .unwrap();
+
+        // Wait for the background task to finalize. 200ms is generous;
+        // the stub responds immediately.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let h = jobs::get(&resp.job_id).await.expect("job exists");
+        let r = h.lock().await;
+        assert_eq!(r.record.status, JobStatus::Finished);
+        assert_eq!(r.record.exit_code, Some(0));
+        assert_eq!(r.record.stdout, "ok\n");
+        assert!(r.child.is_none(), "sandbox jobs do not own a child");
+        assert_eq!(r.record.argv, vec!["echo", "ok"]);
+
+        // Cleanup to avoid polluting other tests via the global JOBS map.
+        drop(r);
+        jobs::JOBS.map.lock().await.remove(&resp.job_id);
+    }
+
+    #[tokio::test]
+    async fn sandbox_job_timed_out_marks_killed() {
+        let cfg = cfg_open();
+        let fwd: Arc<dyn TriggerFwd> = Arc::new(ImmediateOk(Mutex::new(Some(json!({
+            "stdout": "",
+            "stderr": "",
+            "exit_code": 0,
+            "duration_ms": 30000,
+            "timed_out": true,
+        })))));
+        let sandbox_id = Uuid::new_v4();
+        let resp = handle_sandbox_for_test(
+            cfg.clone(),
+            fwd,
+            sandbox_id,
+            vec!["sleep".into(), "60".into()],
+            30000,
+        )
+        .await
+        .unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        let h = jobs::get(&resp.job_id).await.expect("job exists");
+        let r = h.lock().await;
+        assert_eq!(r.record.status, JobStatus::Killed);
+
+        drop(r);
+        jobs::JOBS.map.lock().await.remove(&resp.job_id);
+    }
+
+    #[tokio::test]
+    async fn sandbox_job_trigger_error_marks_failed_with_message() {
+        struct AlwaysErr;
+        #[async_trait]
+        impl TriggerFwd for AlwaysErr {
+            async fn trigger(&self, _fid: &str, _payload: Value) -> Result<Value, IIIError> {
+                Err(IIIError::Remote {
+                    code: "S300".into(),
+                    message: "VM boot failed".into(),
+                    stacktrace: None,
+                })
+            }
+        }
+        let cfg = cfg_open();
+        let resp = handle_sandbox_for_test(
+            cfg.clone(),
+            Arc::new(AlwaysErr),
+            Uuid::new_v4(),
+            vec!["echo".into()],
+            5000,
+        )
+        .await
+        .unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        let h = jobs::get(&resp.job_id).await.expect("job exists");
+        let r = h.lock().await;
+        assert_eq!(r.record.status, JobStatus::Failed);
+        assert!(r.record.stderr.contains("S300"));
+
+        drop(r);
+        jobs::JOBS.map.lock().await.remove(&resp.job_id);
+    }
+
+    #[tokio::test]
+    async fn sandbox_job_late_completion_does_not_overwrite_killed() {
+        // Race scenario: shell::kill marks the JobRecord Killed BEFORE the
+        // sandbox::exec trigger returns. The late response must populate
+        // stdout/stderr/exit_code (the data is still useful for debugging)
+        // but must NOT overwrite the Killed status to Finished. This guards
+        // the `already_killed` check in spawn_sandbox_job's tokio task.
+        struct GatedFwd {
+            release: tokio::sync::Mutex<Option<tokio::sync::oneshot::Receiver<()>>>,
+            response: Mutex<Option<Value>>,
+        }
+        #[async_trait]
+        impl TriggerFwd for GatedFwd {
+            async fn trigger(&self, _fid: &str, _payload: Value) -> Result<Value, IIIError> {
+                // Wait until the test releases us via the oneshot channel.
+                let rx = self.release.lock().await.take().unwrap();
+                rx.await.unwrap();
+                Ok(self.response.lock().unwrap().take().unwrap())
+            }
+        }
+
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let cfg = cfg_open();
+        let fwd: Arc<dyn TriggerFwd> = Arc::new(GatedFwd {
+            release: tokio::sync::Mutex::new(Some(rx)),
+            response: Mutex::new(Some(json!({
+                "stdout": "late\n",
+                "stderr": "",
+                "exit_code": 0,
+                "duration_ms": 5,
+                "timed_out": false,
+            }))),
+        });
+        let sandbox_id = Uuid::new_v4();
+        let resp = handle_sandbox_for_test(
+            cfg.clone(),
+            fwd,
+            sandbox_id,
+            vec!["echo".into(), "late".into()],
+            5000,
+        )
+        .await
+        .unwrap();
+
+        // The background task is now parked inside `fwd.trigger`. While it's
+        // blocked, simulate shell::kill mutating the record to Killed.
+        let kill_time_ms = jobs::now_ms();
+        {
+            let h = jobs::get(&resp.job_id).await.expect("job exists");
+            let mut r = h.lock().await;
+            r.record.status = JobStatus::Killed;
+            r.record.finished_at_ms = Some(kill_time_ms);
+        }
+
+        // Release the trigger; the late completion will run.
+        let _ = tx.send(());
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let h = jobs::get(&resp.job_id).await.expect("job exists");
+        let r = h.lock().await;
+        // Status MUST remain Killed — the guard's whole point.
+        assert_eq!(r.record.status, JobStatus::Killed);
+        // Late response stdout was still captured as a courtesy.
+        assert_eq!(r.record.stdout, "late\n");
+        // finished_at_ms must reflect kill-time, not the late completion
+        // time. Pollers reading this field expect the timestamp of the
+        // user-visible cancellation, not when the in-VM process finally
+        // finished — clobbering that value would mislead any UI showing
+        // job duration or "ended at" times.
+        assert_eq!(r.record.finished_at_ms, Some(kill_time_ms));
+
+        drop(r);
+        jobs::JOBS.map.lock().await.remove(&resp.job_id);
+    }
+
+    /// Test seam: the production `handle` accepts `iii_sdk::III` and
+    /// constructs the backend internally. Tests inject the TriggerFwd
+    /// directly to avoid spinning up an engine. The implementation
+    /// factors out a `spawn_sandbox_job` helper that this shim calls.
+    async fn handle_sandbox_for_test(
+        cfg: Arc<ShellConfig>,
+        fwd: Arc<dyn TriggerFwd>,
+        sandbox_id: Uuid,
+        argv: Vec<String>,
+        timeout_ms: u64,
+    ) -> Result<crate::functions::types::ExecBgResponse, String> {
+        super::spawn_sandbox_job(cfg, fwd, sandbox_id, argv, timeout_ms).await
     }
 }

--- a/shell/src/functions/exec_bg.rs
+++ b/shell/src/functions/exec_bg.rs
@@ -20,7 +20,9 @@ pub async fn handle(
     // bad `target.kind`) come from the per-field deserializers in
     // `functions::types`; the SDK forwards them as the trigger `Err` with
     // the actionable text the LLM needs to self-correct.
-    let argv = parse_argv(&req.command, Some(&req.args)).map_err(|e| format!("argv: {}", e))?;
+    // See `functions::exec` — `args.as_ref()` preserves the shell-words
+    // tokenization contract when the caller omits `args`.
+    let argv = parse_argv(&req.command, req.args.as_ref()).map_err(|e| format!("argv: {}", e))?;
 
     cfg.is_command_allowed(&argv)?;
 

--- a/shell/src/functions/exec_bg.rs
+++ b/shell/src/functions/exec_bg.rs
@@ -297,7 +297,6 @@ async fn read_bounded<R: AsyncReadExt + Unpin>(
 
 #[cfg(test)]
 mod sandbox_path_tests {
-    use super::*;
     use crate::config::ShellConfig;
     use crate::jobs::{self, JobStatus};
     use crate::triggers::TriggerFwd;

--- a/shell/src/functions/kill.rs
+++ b/shell/src/functions/kill.rs
@@ -16,11 +16,23 @@ pub async fn handle(req: KillRequest) -> Result<KillResponse, String> {
         });
     }
     let Some(child) = h.child.as_mut() else {
+        // Sandbox-backed jobs don't own a host child process; the in-VM
+        // process is reachable only through `sandbox::exec`, which has no
+        // cancel hook. Mark the record Killed so shell::status / shell::list
+        // reflect the cancellation; the late response from the trigger will
+        // capture stdout/stderr but won't overwrite this status (see the
+        // `already_killed` guard in functions::exec_bg::spawn_sandbox_job).
+        h.record.status = JobStatus::Killed;
+        h.record.finished_at_ms = Some(jobs::now_ms());
         return Ok(KillResponse {
             job_id: req.job_id,
-            killed: false,
+            killed: true,
             status: h.record.status.clone(),
-            reason: Some("missing child handle".into()),
+            reason: Some(
+                "sandbox::exec has no cancel hook; the in-VM process will run \
+                 until its timeout_ms expires"
+                    .into(),
+            ),
         });
     };
     child
@@ -34,4 +46,50 @@ pub async fn handle(req: KillRequest) -> Result<KillResponse, String> {
         status: h.record.status.clone(),
         reason: None,
     })
+}
+
+#[cfg(test)]
+mod sandbox_kill_tests {
+    use super::*;
+    use crate::functions::types::KillRequest;
+    use crate::jobs::{self, JobHandle, JobRecord};
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    #[tokio::test]
+    async fn killing_sandbox_job_returns_caveat_reason() {
+        // Insert a Running sandbox-backed job (child=None) directly into JOBS.
+        let id = format!("job-{}", uuid::Uuid::new_v4());
+        let record = JobRecord {
+            id: id.clone(),
+            argv: vec!["echo".into(), "x".into()],
+            started_at_ms: jobs::now_ms(),
+            finished_at_ms: None,
+            status: JobStatus::Running,
+            exit_code: None,
+            stdout: String::new(),
+            stderr: String::new(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+        };
+        jobs::JOBS.map.lock().await.insert(
+            id.clone(),
+            Arc::new(Mutex::new(JobHandle {
+                record,
+                child: None,
+            })),
+        );
+
+        let resp = handle(KillRequest { job_id: id.clone() }).await.unwrap();
+        assert!(resp.killed);
+        assert_eq!(resp.status, JobStatus::Killed);
+        let reason = resp
+            .reason
+            .expect("sandbox kill must include caveat reason");
+        assert!(reason.contains("sandbox::exec"));
+        assert!(reason.contains("timeout_ms"));
+
+        // Cleanup.
+        jobs::JOBS.map.lock().await.remove(&id);
+    }
 }

--- a/shell/src/functions/types.rs
+++ b/shell/src/functions/types.rs
@@ -40,12 +40,16 @@ fn deserialize_command<'de, D: Deserializer<'de>>(d: D) -> Result<String, D::Err
     }
 }
 
-/// Validate every element is a string with a per-index error. Mirrors the
-/// hand-rolled validation that lived inside the loose handlers.
-fn deserialize_args<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<String>, D::Error> {
+/// Validate every element is a string with a per-index error. Returns
+/// `Option<Vec<String>>` so the handler can distinguish `args: null` /
+/// absent (`None`) from an empty array (`Some(vec![])`) — `parse_argv` uses
+/// that distinction to decide whether to tokenize `command` via shell-words
+/// (the legacy single-string path).
+fn deserialize_args<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Vec<String>>, D::Error> {
     use serde::de::Error;
     let v = serde_json::Value::deserialize(d)?;
     match v {
+        serde_json::Value::Null => Ok(None),
         serde_json::Value::Array(arr) => {
             let mut out = Vec::with_capacity(arr.len());
             for (i, el) in arr.into_iter().enumerate() {
@@ -59,7 +63,7 @@ fn deserialize_args<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<String>, D::E
                     }
                 }
             }
-            Ok(out)
+            Ok(Some(out))
         }
         other => Err(D::Error::custom(format!(
             "'args' must be an array of strings (got {})",
@@ -89,8 +93,11 @@ pub struct ExecRequest {
     pub command: String,
     /// Arguments passed to the program, in order. Every element must be a
     /// string; non-string elements are rejected by index.
+    /// `None` (or `args: null` / absent) means "tokenize `command` via
+    /// shell-words"; `Some(_)` (including the empty vec) means "use args
+    /// verbatim, no shell-words." See `parse_argv` in `crate::exec::host`.
     #[serde(default, deserialize_with = "deserialize_args")]
-    pub args: Vec<String>,
+    pub args: Option<Vec<String>>,
     /// Per-call timeout override, milliseconds. Capped at `cfg.max_timeout_ms`.
     /// Negative or fractional values silently fall back to
     /// `cfg.default_timeout_ms` (loose wire semantic, preserved on purpose).
@@ -110,8 +117,11 @@ pub struct ExecBgRequest {
     #[serde(deserialize_with = "deserialize_command")]
     pub command: String,
     /// Arguments passed to the program. See [`ExecRequest::args`].
+    /// `None` (or `args: null` / absent) means "tokenize `command` via
+    /// shell-words"; `Some(_)` (including the empty vec) means "use args
+    /// verbatim, no shell-words." See `parse_argv` in `crate::exec::host`.
     #[serde(default, deserialize_with = "deserialize_args")]
-    pub args: Vec<String>,
+    pub args: Option<Vec<String>>,
     /// Per-call timeout. Host-targeted background jobs IGNORE `timeout_ms`;
     /// sandbox-targeted ones forward it through `cfg.resolve_timeout`.
     #[serde(default, deserialize_with = "deserialize_timeout_ms")]

--- a/shell/src/functions/types.rs
+++ b/shell/src/functions/types.rs
@@ -2,15 +2,124 @@
 //! These mirror the inline `json!()` schemas that lived in `main.rs` before
 //! the migration to `RegisterFunction::new_async`. The wire format is
 //! unchanged from prior versions.
-
-//! Typed responses for the 5 `shell::*` (non-fs) functions. Request shapes
-//! for `shell::exec` and `shell::exec_bg` are not typed here because their
-//! handlers accept raw `Value` to preserve legacy wire contracts.
+//!
+//! `ExecRequest` and `ExecBgRequest` use per-field custom deserializers so the
+//! published JSON schema (visible in the engine's tool listing) tells the
+//! caller `command: string` while keeping the loose `timeout_ms` semantic
+//! and the actionable error texts on type mismatches.
 
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
+use crate::exec::ExecOutcome;
 use crate::jobs::{JobRecord, JobStatus};
+use crate::target::Target;
+
+/// Helpful error text for the recurring "argv-as-array in `command`"
+/// mistake. Surfaced both from `deserialize_command` (typed-request path)
+/// and from any remaining `Value` parsing sites so the LLM gets the same
+/// recovery hint regardless of how the request was deserialized.
+const COMMAND_ARRAY_HINT: &str =
+    "'command' must be a string (got array). Pass the program name in \
+     'command' and arguments in 'args', e.g. \
+     {\"command\": \"sh\", \"args\": [\"-lc\", \"ls -la\"]}";
+
+/// Reject anything that isn't a JSON string with the same actionable text the
+/// loose `Value` handler used to produce. Keeps the LLM-recovery message
+/// stable while letting the rest of the field be typed.
+fn deserialize_command<'de, D: Deserializer<'de>>(d: D) -> Result<String, D::Error> {
+    use serde::de::Error;
+    let v = serde_json::Value::deserialize(d)?;
+    match v {
+        serde_json::Value::String(s) => Ok(s),
+        serde_json::Value::Array(_) => Err(D::Error::custom(COMMAND_ARRAY_HINT)),
+        other => Err(D::Error::custom(format!(
+            "'command' must be a string (got {})",
+            other
+        ))),
+    }
+}
+
+/// Validate every element is a string with a per-index error. Mirrors the
+/// hand-rolled validation that lived inside the loose handlers.
+fn deserialize_args<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<String>, D::Error> {
+    use serde::de::Error;
+    let v = serde_json::Value::deserialize(d)?;
+    match v {
+        serde_json::Value::Array(arr) => {
+            let mut out = Vec::with_capacity(arr.len());
+            for (i, el) in arr.into_iter().enumerate() {
+                match el {
+                    serde_json::Value::String(s) => out.push(s),
+                    other => {
+                        return Err(D::Error::custom(format!(
+                            "'args[{}]' must be a string (got {})",
+                            i, other
+                        )));
+                    }
+                }
+            }
+            Ok(out)
+        }
+        other => Err(D::Error::custom(format!(
+            "'args' must be an array of strings (got {})",
+            other
+        ))),
+    }
+}
+
+/// Permissive deserializer: negative integers and floats silently fall back
+/// to `None` so the caller hits the default timeout. This preserves the
+/// long-standing wire contract documented in `functions/exec.rs` (covered by
+/// e2e: `cases-exec-sandbox.ts`).
+fn deserialize_timeout_ms<'de, D: Deserializer<'de>>(d: D) -> Result<Option<u64>, D::Error> {
+    let v = serde_json::Value::deserialize(d)?;
+    Ok(v.as_u64())
+}
+
+/// Wire request for `shell::exec`. The schema is published to the engine's
+/// tool listing so callers see field types up front instead of guessing
+/// from the description.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ExecRequest {
+    /// Program name (matched against the allowlist by basename or exact path).
+    /// Must be a string — split arguments into `args`, do not pass argv as
+    /// an array here.
+    #[serde(deserialize_with = "deserialize_command")]
+    pub command: String,
+    /// Arguments passed to the program, in order. Every element must be a
+    /// string; non-string elements are rejected by index.
+    #[serde(default, deserialize_with = "deserialize_args")]
+    pub args: Vec<String>,
+    /// Per-call timeout override, milliseconds. Capped at `cfg.max_timeout_ms`.
+    /// Negative or fractional values silently fall back to
+    /// `cfg.default_timeout_ms` (loose wire semantic, preserved on purpose).
+    #[serde(default, deserialize_with = "deserialize_timeout_ms")]
+    pub timeout_ms: Option<u64>,
+    /// Where to run the command. Defaults to the host worker; pass
+    /// `{ kind: "sandbox", sandbox_id }` to forward the call to a microVM.
+    #[serde(default)]
+    pub target: Target,
+}
+
+/// Wire request for `shell::exec_bg`. Same shape as [`ExecRequest`]; documented
+/// separately so the engine publishes a distinct schema per function.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ExecBgRequest {
+    /// Program name. See [`ExecRequest::command`].
+    #[serde(deserialize_with = "deserialize_command")]
+    pub command: String,
+    /// Arguments passed to the program. See [`ExecRequest::args`].
+    #[serde(default, deserialize_with = "deserialize_args")]
+    pub args: Vec<String>,
+    /// Per-call timeout. Host-targeted background jobs IGNORE `timeout_ms`;
+    /// sandbox-targeted ones forward it through `cfg.resolve_timeout`.
+    #[serde(default, deserialize_with = "deserialize_timeout_ms")]
+    pub timeout_ms: Option<u64>,
+    /// Where to run. See [`ExecRequest::target`].
+    #[serde(default)]
+    pub target: Target,
+}
 
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct ExecResponse {
@@ -21,6 +130,25 @@ pub struct ExecResponse {
     pub timed_out: bool,
     pub stdout_truncated: bool,
     pub stderr_truncated: bool,
+}
+
+// `ExecOutcome` (backend-side) and `ExecResponse` (wire-side) hold the
+// same 7 fields; the conversion is a structural copy. Going through
+// `From` instead of an inline manual copy in handlers means a future
+// field added to one but not the other surfaces as a compile error
+// rather than a silent drop.
+impl From<ExecOutcome> for ExecResponse {
+    fn from(o: ExecOutcome) -> Self {
+        Self {
+            exit_code: o.exit_code,
+            stdout: o.stdout,
+            stderr: o.stderr,
+            duration_ms: o.duration_ms,
+            timed_out: o.timed_out,
+            stdout_truncated: o.stdout_truncated,
+            stderr_truncated: o.stderr_truncated,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/shell/src/lib.rs
+++ b/shell/src/lib.rs
@@ -4,7 +4,39 @@
 
 pub mod config;
 pub mod exec;
+pub mod exec_dispatch;
 pub mod fs;
 pub mod functions;
 pub mod jobs;
 pub mod manifest;
+pub mod target;
+pub mod triggers;
+
+/// Top-level skill id. Registered with the `skills` worker at boot via
+/// `skills::register`; clients fetch the body at `iii://shell`.
+pub const SKILL_ID: &str = "shell";
+
+/// Top-level router body — small on purpose so the LLM only loads the
+/// router and drills into sub-skills via `skill::fetch`.
+pub const SKILL_MD: &str = include_str!("../skill.md");
+
+/// Sub-skill bodies, keyed by their full id. One leaf per registered
+/// `shell::*` function. The router (`SKILL_MD`) links to each so the
+/// agent only loads what it needs via `skill::fetch`.
+pub const SUB_SKILLS: &[(&str, &str)] = &[
+    ("shell/exec", include_str!("../skills/exec.md")),
+    ("shell/exec_bg", include_str!("../skills/exec_bg.md")),
+    ("shell/status", include_str!("../skills/status.md")),
+    ("shell/kill", include_str!("../skills/kill.md")),
+    ("shell/list", include_str!("../skills/list.md")),
+    ("shell/fs/ls", include_str!("../skills/fs/ls.md")),
+    ("shell/fs/stat", include_str!("../skills/fs/stat.md")),
+    ("shell/fs/read", include_str!("../skills/fs/read.md")),
+    ("shell/fs/grep", include_str!("../skills/fs/grep.md")),
+    ("shell/fs/write", include_str!("../skills/fs/write.md")),
+    ("shell/fs/sed", include_str!("../skills/fs/sed.md")),
+    ("shell/fs/mkdir", include_str!("../skills/fs/mkdir.md")),
+    ("shell/fs/rm", include_str!("../skills/fs/rm.md")),
+    ("shell/fs/chmod", include_str!("../skills/fs/chmod.md")),
+    ("shell/fs/mv", include_str!("../skills/fs/mv.md")),
+];

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -1,15 +1,19 @@
 use anyhow::Result;
 use clap::Parser;
-use iii_sdk::{register_worker, InitOptions, OtelConfig, RegisterFunction};
-use serde_json::Value;
+use iii_sdk::{register_worker, InitOptions, OtelConfig, RegisterFunction, TriggerRequest, III};
+use serde_json::{json, Value};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 mod config;
 mod exec;
+mod exec_dispatch;
 mod fs;
 mod functions;
 mod jobs;
 mod manifest;
+mod target;
+mod triggers;
 
 use functions::types::{KillRequest, StatusRequest};
 
@@ -88,23 +92,48 @@ async fn main() -> Result<()> {
 
     {
         let cfg = shared.clone();
+        let iii_for_exec = iii.clone();
         iii.register_function(
-            RegisterFunction::new_async("shell::exec", move |req: Value| {
-                let cfg = cfg.clone();
-                async move { functions::exec::handle(cfg, req).await }
-            })
-            .description("Execute a command and return full output"),
+            RegisterFunction::new_async(
+                "shell::exec",
+                move |req: functions::types::ExecRequest| {
+                    let cfg = cfg.clone();
+                    let iii_clone = iii_for_exec.clone();
+                    async move { functions::exec::handle(cfg, iii_clone, req).await }
+                },
+            )
+            .description(
+                "Run an allowlisted command in the foreground and return its \
+                 full output. Payload: { command: string (program name), \
+                 args?: string[], timeout_ms?: number, target?: { kind: \
+                 'host'|'sandbox', sandbox_id?: string } }. Returns { stdout, \
+                 stderr, exit_code, duration_ms, timed_out, stdout_truncated, \
+                 stderr_truncated }. Do NOT pass argv as an array in 'command' \
+                 — split program and arguments across the two fields.",
+            ),
         );
     }
 
     {
         let cfg = shared.clone();
+        let iii_for_bg = iii.clone();
         iii.register_function(
-            RegisterFunction::new_async("shell::exec_bg", move |req: Value| {
-                let cfg = cfg.clone();
-                async move { functions::exec_bg::handle(cfg, req).await }
-            })
-            .description("Spawn a command in background, return job_id"),
+            RegisterFunction::new_async(
+                "shell::exec_bg",
+                move |req: functions::types::ExecBgRequest| {
+                    let cfg = cfg.clone();
+                    let iii_clone = iii_for_bg.clone();
+                    async move { functions::exec_bg::handle(cfg, iii_clone, req).await }
+                },
+            )
+            .description(
+                "Spawn an allowlisted command as a background job. Same \
+                 payload shape as shell::exec; returns { job_id, argv } \
+                 immediately. Poll with shell::status, terminate with \
+                 shell::kill, list with shell::list. Do NOT pass argv as an \
+                 array in 'command' — use 'command' (string) + 'args' \
+                 (string[]).",
+            ),
         );
     }
 
@@ -284,8 +313,89 @@ async fn main() -> Result<()> {
 
     tracing::info!("iii-shell registered 15 functions, ready");
 
+    spawn_skill_register(iii.clone());
+
     tokio::signal::ctrl_c().await?;
     tracing::info!("iii-shell shutting down");
+    unregister_skill(&iii).await;
     iii.shutdown_async().await;
     Ok(())
+}
+
+/// Best-effort `skills::register` with capped exponential backoff.
+/// `skills` may come up after us (or be absent in minimal deployments);
+/// give up quietly after 3 minutes so the worker keeps running without it.
+async fn register_skill_with_retry(iii: &III, id: &str, body: &str) {
+    let mut backoff = Duration::from_secs(5);
+    let started = Instant::now();
+    loop {
+        let res = iii
+            .trigger(TriggerRequest {
+                function_id: "skills::register".into(),
+                payload: json!({ "id": id, "skill": body }),
+                action: None,
+                timeout_ms: Some(5_000),
+            })
+            .await;
+        match res {
+            Ok(_) => {
+                tracing::info!(skill_id = id, "registered skill");
+                return;
+            }
+            Err(e) => {
+                if started.elapsed() > Duration::from_secs(180) {
+                    tracing::warn!(
+                        skill_id = id,
+                        error = %e,
+                        "skills handshake gave up; install/start the skills worker and restart"
+                    );
+                    return;
+                }
+                tracing::debug!(
+                    skill_id = id,
+                    error = %e,
+                    wait = ?backoff,
+                    "skills::register failed; retrying"
+                );
+            }
+        }
+        tokio::time::sleep(backoff).await;
+        backoff = (backoff * 2).min(Duration::from_secs(60));
+    }
+}
+
+/// Spawn the boot-time registration loop in the background. Non-blocking
+/// so a missing `skills` worker never delays shell's readiness.
+fn spawn_skill_register(iii: III) {
+    tokio::spawn(async move {
+        register_skill_with_retry(&iii, iii_shell::SKILL_ID, iii_shell::SKILL_MD).await;
+        for (id, body) in iii_shell::SUB_SKILLS {
+            register_skill_with_retry(&iii, id, body).await;
+        }
+    });
+}
+
+/// Best-effort `skills::unregister` on graceful shutdown so a stopped
+/// worker doesn't leave dangling entries in the registry. Crashes
+/// inevitably skip this path; an operator can clean up via
+/// `skills::list` + `skills::unregister` manually.
+async fn unregister_skill(iii: &III) {
+    for (id, _) in iii_shell::SUB_SKILLS {
+        let _ = iii
+            .trigger(TriggerRequest {
+                function_id: "skills::unregister".into(),
+                payload: json!({ "id": id }),
+                action: None,
+                timeout_ms: Some(2_000),
+            })
+            .await;
+    }
+    let _ = iii
+        .trigger(TriggerRequest {
+            function_id: "skills::unregister".into(),
+            payload: json!({ "id": iii_shell::SKILL_ID }),
+            action: None,
+            timeout_ms: Some(2_000),
+        })
+        .await;
 }

--- a/shell/src/target.rs
+++ b/shell/src/target.rs
@@ -1,0 +1,52 @@
+//! Per-call target selector shared by `shell::fs::*` and `shell::exec*`
+//! request bodies. Defaults to host when omitted on the wire.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Target {
+    #[default]
+    Host,
+    Sandbox {
+        sandbox_id: Uuid,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn defaults_to_host_when_absent() {
+        #[derive(Deserialize)]
+        struct Wrap {
+            #[serde(default)]
+            target: Target,
+        }
+        let w: Wrap = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(w.target, Target::Host);
+    }
+
+    #[test]
+    fn host_round_trips() {
+        let v = serde_json::to_value(Target::Host).unwrap();
+        assert_eq!(v, json!({ "kind": "host" }));
+        let back: Target = serde_json::from_value(v).unwrap();
+        assert_eq!(back, Target::Host);
+    }
+
+    #[test]
+    fn sandbox_carries_uuid() {
+        let id = Uuid::new_v4();
+        let t = Target::Sandbox { sandbox_id: id };
+        let v = serde_json::to_value(&t).unwrap();
+        assert_eq!(v["kind"], "sandbox");
+        assert_eq!(v["sandbox_id"], id.to_string());
+        let back: Target = serde_json::from_value(v).unwrap();
+        assert_eq!(back, t);
+    }
+}

--- a/shell/src/triggers.rs
+++ b/shell/src/triggers.rs
@@ -1,0 +1,69 @@
+//! Shared `iii.trigger` indirection. Both `fs::sandbox::SandboxFsBackend`
+//! and `exec::sandbox::SandboxExecBackend` (landing in T6) consume
+//! `Arc<dyn TriggerFwd>` so unit tests can inject a stub. The production
+//! wiring is `IiiTriggerFwd` wrapping a real `iii_sdk::III`.
+
+use async_trait::async_trait;
+use iii_sdk::{IIIError, TriggerRequest};
+use serde_json::Value;
+
+#[async_trait]
+pub trait TriggerFwd: Send + Sync {
+    async fn trigger(&self, function_id: &str, payload: Value) -> Result<Value, IIIError>;
+}
+
+pub struct IiiTriggerFwd {
+    iii: iii_sdk::III,
+}
+
+impl IiiTriggerFwd {
+    pub fn new(iii: iii_sdk::III) -> Self {
+        Self { iii }
+    }
+}
+
+#[async_trait]
+impl TriggerFwd for IiiTriggerFwd {
+    async fn trigger(&self, function_id: &str, payload: Value) -> Result<Value, IIIError> {
+        self.iii
+            .trigger(TriggerRequest {
+                function_id: function_id.to_string(),
+                payload,
+                action: None,
+                timeout_ms: None,
+            })
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::{Arc, Mutex};
+
+    struct CountingFwd {
+        count: Mutex<usize>,
+    }
+
+    #[async_trait]
+    impl TriggerFwd for CountingFwd {
+        async fn trigger(&self, _fid: &str, _payload: Value) -> Result<Value, IIIError> {
+            *self.count.lock().unwrap() += 1;
+            Ok(json!({"ok": true}))
+        }
+    }
+
+    #[tokio::test]
+    async fn trait_is_object_safe_via_arc() {
+        let stub = Arc::new(CountingFwd {
+            count: Mutex::new(0),
+        });
+        let fwd: Arc<dyn TriggerFwd> = stub.clone();
+        fwd.trigger("x::y", json!({})).await.unwrap();
+        fwd.trigger("x::y", json!({})).await.unwrap();
+        // Asserting the side effect the stub records is what makes this
+        // a runtime test and not just a compile-time object-safety check.
+        assert_eq!(*stub.count.lock().unwrap(), 2);
+    }
+}

--- a/shell/tests/e2e/README.md
+++ b/shell/tests/e2e/README.md
@@ -17,6 +17,14 @@ Modeled on `iii-database/tests/e2e/`.
   ```
   The script drops the binary at `$HOME/.local/bin/iii` (override with
   `BIN_DIR=...` or `PREFIX=...`).
+- **For the sandbox-target cases**: hardware virtualization on the host
+  (Apple Silicon on macOS or `/dev/kvm` on Linux). The harness boots a
+  real iii-sandbox microVM via `sandbox::create` and drives
+  `shell::exec { target: { kind: "sandbox", ... } }` against it. On
+  unsupported hosts, every case in `EXEC_SANDBOX_CASES` short-circuits
+  with a `SKIP` log line — the rest of the suite still runs. First
+  invocation cold-pulls the `python` image; bump `HARNESS_TIMEOUT=300`
+  if the default 90s budget is too tight on a fresh machine.
 
 ## Run
 

--- a/shell/tests/e2e/config.yaml
+++ b/shell/tests/e2e/config.yaml
@@ -19,6 +19,22 @@ workers:
       logs_console_output: true
       sampling_ratio: 1.0
 
+  # Real iii-sandbox so cases-exec-sandbox.ts can drive the full
+  # shell -> sandbox::exec -> microVM round-trip end-to-end. Requires
+  # hardware virtualization on the test host (Apple Silicon on macOS
+  # or /dev/kvm on Linux); on unsupported hosts every case in
+  # EXEC_SANDBOX_CASES short-circuits with a SKIP log message after
+  # sandbox::create returns S300.
+  - name: iii-sandbox
+    config:
+      auto_install: true
+      image_allowlist:
+        - python
+      default_idle_timeout_secs: 60
+      max_concurrent_sandboxes: 4
+      default_cpus: 1
+      default_memory_mb: 256
+
   - name: shell
     config:
       max_timeout_ms: 5000

--- a/shell/tests/e2e/run-tests.sh
+++ b/shell/tests/e2e/run-tests.sh
@@ -41,6 +41,11 @@ Env overrides:
   WORKER_BIN_TARGET   Path to the built worker binary.
   WORKER_BIN_LINK     Path to the symlink the engine reads.
   HARNESS_TIMEOUT     Seconds to wait for the harness sentinel (default: 90).
+                      Bump this on a fresh dev machine: cases-exec-sandbox.ts
+                      drives the real iii-sandbox worker, and the first
+                      sandbox::create cold-pulls the python image. Try
+                      HARNESS_TIMEOUT=300 if you see "did not emit sentinel
+                      within 90s" on initial runs.
 EOF
       exit 0
       ;;
@@ -63,6 +68,29 @@ cleanup() {
   exit "$code"
 }
 trap cleanup EXIT INT TERM
+
+# Reap orphaned processes from previous runs. If a prior engine
+# crashed (e.g., port-conflict panic) the trap above never fired, so
+# its workers stayed alive and re-register against the next engine —
+# which then routes calls to the orphan instead of the freshly-spawned
+# worker, producing baffling test failures (wrong allowlist, wrong
+# sandbox.enabled). Kill them before starting clean.
+reap_orphans() {
+  local port_pid
+  port_pid=$(lsof -tiTCP:49134 -sTCP:LISTEN 2>/dev/null || true)
+  if [[ -n "$port_pid" ]]; then
+    echo "[run-tests] reaping stale engine on port 49134 (pid=$port_pid)"
+    kill -9 $port_pid 2>/dev/null || true
+  fi
+  # Stale shell + iii-worker sandbox-daemon survivors from previous
+  # iii-shell test runs. Match narrowly on the test-config path
+  # signature so we don't touch unrelated iii processes the user has
+  # going. -f matches against the full command line.
+  pkill -f "iii-shell --config /var/folders" 2>/dev/null || true
+  pkill -f "iii-worker sandbox-daemon --config /var/folders" 2>/dev/null || true
+  sleep 0.5
+}
+reap_orphans
 
 mkdir -p "$ROOT_DIR/reports" "$ROOT_DIR/data" "$(dirname "$WORKER_BIN_LINK")"
 

--- a/shell/tests/e2e/workers/harness/src/cases-edge.ts
+++ b/shell/tests/e2e/workers/harness/src/cases-edge.ts
@@ -5,9 +5,13 @@ export const EDGE_CASES: TestCase[] = [
   {
     name: 'missing command field rejects',
     async run({ call, expectError }) {
+      // serde's missing-field wording uses backticks (`missing field
+      // `command``) on the typed schema path; older deployments produced
+      // `"missing 'command'"`. Match either by checking "missing" + "command"
+      // separately so the test pins behavior, not exact phrasing.
       await expectError(
         () => call('shell::exec', { args: ['hi'] }),
-        "missing 'command'",
+        /missing[\s\S]*command|command[\s\S]*missing/,
       );
     },
   },

--- a/shell/tests/e2e/workers/harness/src/cases-exec-break.ts
+++ b/shell/tests/e2e/workers/harness/src/cases-exec-break.ts
@@ -11,20 +11,24 @@ export const EXEC_BREAK_CASES: TestCase[] = [
     },
   },
   {
-    name: 'exec_command_wrong_type_reports_as_missing',
+    // Renamed from `_reports_as_missing` — that name encoded a legacy bug
+    // where the loose Value handler conflated wrong-type with absent. The
+    // typed schema (ExecRequest) now produces a field-aware error so the
+    // LLM can distinguish the two cases.
+    name: 'exec_command_number_reports_wrong_type',
     async run({ call, expectError }) {
       await expectError(
         () => call('shell::exec', { command: 42 }),
-        "missing 'command'",
+        /'command'.+string/,
       );
     },
   },
   {
-    name: 'exec_command_boolean_reports_as_missing',
+    name: 'exec_command_boolean_reports_wrong_type',
     async run({ call, expectError }) {
       await expectError(
         () => call('shell::exec', { command: true }),
-        "missing 'command'",
+        /'command'.+string/,
       );
     },
   },

--- a/shell/tests/e2e/workers/harness/src/cases-exec-sandbox.ts
+++ b/shell/tests/e2e/workers/harness/src/cases-exec-sandbox.ts
@@ -1,0 +1,290 @@
+import { expect, expectEqual, type CaseContext, type TestCase } from './cases.ts';
+
+// Real end-to-end coverage for the new sandbox-target path on
+// shell::exec / shell::exec_bg.
+//
+// Unlike the fs-sandbox cases (which mock the engine's sandbox::fs::*
+// triggers to test shell's wire shape only), these cases drive the
+// *real* iii-sandbox worker. The flow is:
+//
+//   1. preflight: sandbox::create — boots a microVM, returns sandbox_id.
+//      If iii-sandbox isn't installed or the host can't boot VMs (no
+//      /dev/kvm on Linux, Intel Mac, Windows), this fails and the rest
+//      of the suite logs SKIP and short-circuits — the operator gets a
+//      clear "install iii-sandbox" message instead of a wall of red.
+//   2. cases: each one calls shell::exec / shell::exec_bg with
+//      target = { kind: 'sandbox', sandbox_id }. The engine routes the
+//      sandbox::exec trigger to iii-sandbox, which runs the command in
+//      the microVM and returns the real result.
+//   3. teardown: the last case calls sandbox::stop on the shared
+//      sandbox.
+//
+// To run: the engine config (tests/e2e/config.yaml) must list
+// `iii-sandbox` under workers, and the host must support
+// hardware virtualization. See README §Sandbox-backed exec for the
+// host-virt requirement.
+
+interface SandboxState {
+  status: 'unknown' | 'available' | 'unavailable';
+  sandboxId: string | null;
+  skipReason: string;
+}
+
+const sandbox: SandboxState = {
+  status: 'unknown',
+  sandboxId: null,
+  skipReason: '',
+};
+
+/**
+ * Boot a sandbox once (cached on the module) and return its id; record
+ * the suite as unavailable on failure so subsequent cases can skip
+ * cleanly without each one re-trying sandbox::create.
+ */
+async function ensureSandbox(ctx: CaseContext): Promise<string | null> {
+  if (sandbox.status === 'available') return sandbox.sandboxId;
+  if (sandbox.status === 'unavailable') return null;
+  try {
+    const r = await ctx.call('sandbox::create', {
+      image: 'python',
+      cpus: 1,
+      memory_mb: 256,
+    });
+    sandbox.sandboxId = r.sandbox_id;
+    sandbox.status = 'available';
+    return sandbox.sandboxId;
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    sandbox.status = 'unavailable';
+    sandbox.skipReason = `iii-sandbox not reachable or host lacks virt: ${msg}`;
+    return null;
+  }
+}
+
+/**
+ * Standard preamble for every case in this file: returns the shared
+ * sandbox_id, or `null` after logging a skip. When `null`, the case
+ * should `return` immediately — the runner records it as PASS but the
+ * console output makes the skip visible to the operator.
+ */
+async function maybeSandbox(ctx: CaseContext, caseName: string): Promise<string | null> {
+  const id = await ensureSandbox(ctx);
+  if (!id) {
+    console.log(`[harness] SKIP :: ${caseName} — ${sandbox.skipReason}`);
+  }
+  return id;
+}
+
+export const EXEC_SANDBOX_CASES: TestCase[] = [
+  {
+    name: 'exec_sandbox_real_echo_runs_in_vm',
+    async run(ctx: CaseContext) {
+      const sandbox_id = await maybeSandbox(ctx, 'exec_sandbox_real_echo_runs_in_vm');
+      if (!sandbox_id) return;
+      const r = await ctx.call('shell::exec', {
+        command: 'echo',
+        args: ['hi'],
+        target: { kind: 'sandbox', sandbox_id },
+      });
+      expectEqual(r.exit_code, 0, 'exit_code from in-VM echo');
+      expectEqual(r.stdout, 'hi\n', 'stdout from in-VM echo');
+      expectEqual(r.timed_out, false, 'timed_out');
+      expectEqual(r.stdout_truncated, false, 'sandbox path forces stdout_truncated false');
+      expectEqual(r.stderr_truncated, false, 'sandbox path forces stderr_truncated false');
+      expect(typeof r.duration_ms === 'number' && r.duration_ms >= 0, 'duration_ms present');
+    },
+  },
+  {
+    name: 'exec_sandbox_captures_stderr_separately',
+    async run(ctx: CaseContext) {
+      const sandbox_id = await maybeSandbox(ctx, 'exec_sandbox_captures_stderr_separately');
+      if (!sandbox_id) return;
+      const r = await ctx.call('shell::exec', {
+        command: 'sh',
+        args: ['-c', 'echo err 1>&2'],
+        target: { kind: 'sandbox', sandbox_id },
+      });
+      expectEqual(r.exit_code, 0, 'exit_code');
+      expectEqual(r.stdout, '', 'stdout empty');
+      expectEqual(r.stderr, 'err\n', 'stderr captured from VM');
+    },
+  },
+  {
+    name: 'exec_sandbox_propagates_non_zero_exit',
+    async run(ctx: CaseContext) {
+      const sandbox_id = await maybeSandbox(ctx, 'exec_sandbox_propagates_non_zero_exit');
+      if (!sandbox_id) return;
+      const r = await ctx.call('shell::exec', {
+        command: 'false',
+        target: { kind: 'sandbox', sandbox_id },
+      });
+      expectEqual(r.exit_code, 1, 'exit_code from in-VM `false`');
+      expectEqual(r.timed_out, false, 'timed_out');
+    },
+  },
+  {
+    name: 'exec_sandbox_timed_out_when_command_exceeds_clamped_timeout',
+    async run(ctx: CaseContext) {
+      const sandbox_id = await maybeSandbox(
+        ctx,
+        'exec_sandbox_timed_out_when_command_exceeds_clamped_timeout',
+      );
+      if (!sandbox_id) return;
+      // tests/e2e/config.yaml sets max_timeout_ms: 5000 and
+      // default_timeout_ms: 1500. `sleep 30` will exceed both no
+      // matter what the caller asks for; the clamp ensures the VM-
+      // side timeout is bounded. We give the round-trip a generous
+      // 8s wall-clock wait below.
+      const r = await ctx.call('shell::exec', {
+        command: 'sleep',
+        args: ['30'],
+        timeout_ms: 60_000, // clamped to max_timeout_ms (5s) before forwarding
+        target: { kind: 'sandbox', sandbox_id },
+      });
+      expectEqual(r.timed_out, true, 'timed_out flag set by sandbox::exec');
+    },
+  },
+  {
+    name: 'exec_sandbox_bad_sandbox_id_returns_engine_error',
+    async run(ctx: CaseContext) {
+      const sandbox_id = await maybeSandbox(
+        ctx,
+        'exec_sandbox_bad_sandbox_id_returns_engine_error',
+      );
+      if (!sandbox_id) return;
+      // S001/S002: the engine returns one of these for an unknown
+      // sandbox_id. Don't pin the exact code (the daemon picks; both
+      // are acceptable per the spec's user-facing S-code table).
+      const fakeId = '00000000-1111-2222-3333-444444444444';
+      await ctx.expectError(
+        () =>
+          ctx.call('shell::exec', {
+            command: 'echo',
+            args: ['nope'],
+            target: { kind: 'sandbox', sandbox_id: fakeId },
+          }),
+        'S00',
+      );
+    },
+  },
+  {
+    name: 'exec_sandbox_allowlist_still_enforced',
+    async run(ctx: CaseContext) {
+      const sandbox_id = await maybeSandbox(ctx, 'exec_sandbox_allowlist_still_enforced');
+      if (!sandbox_id) return;
+      // The shell allowlist gates argv[0] BEFORE backend dispatch for
+      // both targets. `nmap` is not in the e2e allowlist
+      // (echo/ls/cat/sleep/pwd/printf/sh/false/true/env), so the call
+      // must fail with an allowlist error WITHOUT reaching the VM.
+      // (We can't directly observe "VM not hit" the way we can with
+      // mocks; the assertion is just that the shell denies the call.)
+      await ctx.expectError(
+        () =>
+          ctx.call('shell::exec', {
+            command: 'nmap',
+            args: ['-A', 'localhost'],
+            target: { kind: 'sandbox', sandbox_id },
+          }),
+        'allowlist',
+      );
+    },
+  },
+  {
+    name: 'exec_bg_sandbox_lifecycle_finishes',
+    async run(ctx: CaseContext) {
+      const sandbox_id = await maybeSandbox(ctx, 'exec_bg_sandbox_lifecycle_finishes');
+      if (!sandbox_id) return;
+      const start = await ctx.call('shell::exec_bg', {
+        command: 'echo',
+        args: ['bg-ok'],
+        target: { kind: 'sandbox', sandbox_id },
+      });
+      expect(typeof start.job_id === 'string' && start.job_id.startsWith('job-'),
+        `job_id shape: ${JSON.stringify(start.job_id)}`,
+      );
+      // Poll status until the spawned tokio task finalizes the
+      // JobRecord. echo is fast but the VM round-trip dominates;
+      // budget 5s with 100ms polling.
+      const deadline = Date.now() + 5_000;
+      let finalStatus: any = null;
+      while (Date.now() < deadline) {
+        const s = await ctx.call('shell::status', { job_id: start.job_id });
+        if (s.job.status !== 'running') {
+          finalStatus = s;
+          break;
+        }
+        await ctx.sleep(100);
+      }
+      expect(finalStatus !== null, 'sandbox bg job finalized within 5s');
+      expectEqual(finalStatus.job.status, 'finished', 'sandbox bg job ends Finished');
+      expectEqual(finalStatus.job.exit_code, 0, 'exit_code captured into JobRecord');
+      expectEqual(finalStatus.job.stdout, 'bg-ok\n', 'stdout captured');
+    },
+  },
+  {
+    name: 'shell_kill_on_sandbox_job_returns_caveat_reason',
+    async run(ctx: CaseContext) {
+      const sandbox_id = await maybeSandbox(
+        ctx,
+        'shell_kill_on_sandbox_job_returns_caveat_reason',
+      );
+      if (!sandbox_id) return;
+      // Start a long-running sandbox job (sleep 30) capped at 1s so the
+      // server-side timeout fires fast. Kill it while the trigger is
+      // still in flight. shell::kill must:
+      //   - return killed: true
+      //   - include the caveat string ("sandbox::exec ... timeout_ms")
+      //   - flip status to killed immediately
+      // The in-VM sleep keeps running until its 1s server-side timeout
+      // — proving the documented status-level-only cancel semantics.
+      const start = await ctx.call('shell::exec_bg', {
+        command: 'sleep',
+        args: ['30'],
+        timeout_ms: 1000,
+        target: { kind: 'sandbox', sandbox_id },
+      });
+      // Brief wait so the tokio task is parked inside fwd.trigger.
+      await ctx.sleep(150);
+      const killResp = await ctx.call('shell::kill', { job_id: start.job_id });
+      expectEqual(killResp.killed, true, 'kill reports killed=true for sandbox job');
+      expectEqual(killResp.status, 'killed', 'status flipped to killed immediately');
+      expect(typeof killResp.reason === 'string' && killResp.reason.includes('sandbox::exec'),
+        `kill reason mentions sandbox::exec: ${killResp.reason}`,
+      );
+      expect(killResp.reason.includes('timeout_ms'),
+        `kill reason mentions timeout_ms: ${killResp.reason}`,
+      );
+      // Status reads `killed` immediately after the kill call, before
+      // the in-VM sleep's server-side timeout would expire.
+      const midStatus = await ctx.call('shell::status', { job_id: start.job_id });
+      expectEqual(midStatus.job.status, 'killed', 'status reads killed before late completion');
+      // Wait for the late completion to arrive (1s server-side timeout
+      // plus margin). The already_killed guard MUST preserve
+      // status=killed.
+      await ctx.sleep(1_500);
+      const lateStatus = await ctx.call('shell::status', { job_id: start.job_id });
+      expectEqual(
+        lateStatus.job.status,
+        'killed',
+        'late completion does NOT overwrite Killed status',
+      );
+    },
+  },
+  {
+    name: 'sandbox_stop_tears_down_shared_sandbox',
+    async run(ctx: CaseContext) {
+      // Teardown for the suite. Runs last so prior cases all reuse
+      // the same sandbox; stops it explicitly so the VM doesn't leak
+      // until the engine's idle reaper kicks in (300s default).
+      const sandbox_id = await maybeSandbox(ctx, 'sandbox_stop_tears_down_shared_sandbox');
+      if (!sandbox_id) return;
+      const r = await ctx.call('sandbox::stop', { sandbox_id, wait: true });
+      expectEqual(r.sandbox_id, sandbox_id, 'sandbox::stop echoes the id');
+      expect(r.stopped === true, `sandbox::stop reports stopped=true: ${JSON.stringify(r)}`);
+      // Mark the suite consumed so any case ordering issues don't
+      // accidentally try to reuse the now-stopped sandbox.
+      sandbox.status = 'unavailable';
+      sandbox.skipReason = 'sandbox already stopped by teardown';
+    },
+  },
+];

--- a/shell/tests/e2e/workers/harness/src/cases-fs-sandbox.ts
+++ b/shell/tests/e2e/workers/harness/src/cases-fs-sandbox.ts
@@ -104,6 +104,13 @@ export function setupSandboxMocks(iii: ISdk): void {
       }
     );
   });
+  // NOTE: we deliberately do NOT mock `sandbox::exec` here. The
+  // exec-side e2e cases (cases-exec-sandbox.ts) drive the *real*
+  // iii-sandbox worker so the test exercises the full
+  // shell -> sandbox::exec -> microVM -> response path, not just
+  // shell's wire shape. The fs::* mocks above remain because the
+  // fs-sandbox cases test wire-level forwarding shape only and would
+  // otherwise need a real sandbox per case (slow cold-boot churn).
 }
 
 export const FS_SANDBOX_CASES: TestCase[] = [

--- a/shell/tests/e2e/workers/harness/src/cases.ts
+++ b/shell/tests/e2e/workers/harness/src/cases.ts
@@ -3,7 +3,7 @@ import type { ISdk } from 'iii-sdk';
 export interface CaseContext {
   call: (functionId: string, payload: unknown) => Promise<any>;
   sleep: (ms: number) => Promise<void>;
-  expectError: (fn: () => Promise<unknown>, substring: string) => Promise<void>;
+  expectError: (fn: () => Promise<unknown>, pattern: string | RegExp) => Promise<void>;
   iii: ISdk;
 }
 

--- a/shell/tests/e2e/workers/harness/src/runner.ts
+++ b/shell/tests/e2e/workers/harness/src/runner.ts
@@ -43,17 +43,23 @@ export class Runner {
     return new Promise((r) => setTimeout(r, ms));
   }
 
-  private async expectError(fn: () => Promise<unknown>, substring: string): Promise<void> {
+  private async expectError(
+    fn: () => Promise<unknown>,
+    pattern: string | RegExp,
+  ): Promise<void> {
+    const matches = (msg: string): boolean =>
+      typeof pattern === 'string' ? msg.includes(pattern) : pattern.test(msg);
+    const display = typeof pattern === 'string' ? `"${pattern}"` : pattern.toString();
     try {
       await fn();
     } catch (e: any) {
       const msg = e?.message ?? String(e);
-      if (!msg.includes(substring)) {
-        throw new Error(`expected error containing "${substring}", got: ${msg}`);
+      if (!matches(msg)) {
+        throw new Error(`expected error matching ${display}, got: ${msg}`);
       }
       return;
     }
-    throw new Error(`expected throw containing "${substring}", but call resolved`);
+    throw new Error(`expected throw matching ${display}, but call resolved`);
   }
 
   private async runCase(c: TestCase): Promise<CaseResult> {

--- a/shell/tests/e2e/workers/harness/src/runner.ts
+++ b/shell/tests/e2e/workers/harness/src/runner.ts
@@ -11,6 +11,7 @@ import { FS_SANDBOX_CASES } from './cases-fs-sandbox.ts';
 import { FS_PROTOCOL_BREAK_CASES } from './cases-fs-protocol-break.ts';
 import { STREAMING_BREAK_CASES } from './cases-streaming-break.ts';
 import { EXEC_BREAK_CASES } from './cases-exec-break.ts';
+import { EXEC_SANDBOX_CASES } from './cases-exec-sandbox.ts';
 import { JOB_BREAK_CASES } from './cases-jobs-break.ts';
 import { FS_ENCODING_CASES } from './cases-fs-encoding.ts';
 import { FS_ERROR_CASES } from './cases-fs-errors.ts';
@@ -128,6 +129,7 @@ export class Runner {
             ...FS_PROTOCOL_BREAK_CASES,
             ...STREAMING_BREAK_CASES,
             ...EXEC_BREAK_CASES,
+            ...EXEC_SANDBOX_CASES,
             ...JOB_BREAK_CASES,
             ...FS_ENCODING_CASES,
             ...FS_ERROR_CASES,

--- a/shell/tests/function_handlers.rs
+++ b/shell/tests/function_handlers.rs
@@ -7,7 +7,7 @@ use serde_json::{json, Value};
 
 use iii_shell::config::ShellConfig;
 use iii_shell::functions;
-use iii_shell::functions::types::{KillRequest, StatusRequest};
+use iii_shell::functions::types::{ExecBgRequest, ExecRequest, KillRequest, StatusRequest};
 use iii_shell::jobs::{self, now_ms, JobHandle, JobRecord, JobStatus};
 
 async fn seed(handle: JobHandle) -> String {
@@ -47,44 +47,92 @@ fn resp<T: serde::Serialize>(t: T) -> Value {
     serde_json::to_value(t).expect("typed response must serialize")
 }
 
+/// Run a payload through the same deserialize path the SDK uses at the engine
+/// boundary, returning the error string a caller (e.g. an LLM) would actually
+/// see. Mirrors `IntoAsyncHandler::into_handler` in `iii-sdk`.
+fn parse_err<T: serde::de::DeserializeOwned>(v: Value) -> String {
+    match serde_json::from_value::<T>(v) {
+        Ok(_) => panic!("expected deserialization to fail"),
+        Err(e) => e.to_string(),
+    }
+}
+
 #[tokio::test]
 async fn exec_handler_runs_allowlisted_command() {
     let cfg = cfg_with_allow(&["echo"]);
     let r = resp(
-        functions::exec::handle(cfg, json!({"command": "echo", "args": ["ok"]}))
-            .await
-            .unwrap(),
+        functions::exec::handle(
+            cfg,
+            fresh_iii(),
+            typed::<ExecRequest>(json!({"command": "echo", "args": ["ok"]})),
+        )
+        .await
+        .unwrap(),
     );
     assert_eq!(r["exit_code"], 0);
     assert_eq!(r["stdout"], "ok\n");
     assert_eq!(r["timed_out"], false);
 }
 
-#[tokio::test]
-async fn exec_handler_rejects_missing_command() {
-    let cfg = cfg_with_allow(&["echo"]);
-    let err = functions::exec::handle(cfg, json!({"args": ["ok"]}))
-        .await
-        .unwrap_err();
-    assert!(err.contains("missing 'command'"), "got: {err}");
+/// `command` is a required field — serde produces "missing field `command`"
+/// when absent. The SDK forwards that string verbatim as the trigger error.
+#[test]
+fn exec_request_rejects_missing_command() {
+    let err = parse_err::<ExecRequest>(json!({"args": ["ok"]}));
+    assert!(err.contains("missing"), "got: {err}");
+    assert!(err.contains("command"), "got: {err}");
+}
+
+/// Regression: LLMs commonly send the subprocess-style argv array
+/// `{"command": ["sh", "-lc", "..."]}` here. The error message MUST distinguish
+/// "wrong type" from "missing" so the LLM can self-correct on its next turn,
+/// and MUST hint at the right shape (split program/args across two fields).
+#[test]
+fn exec_request_rejects_array_command_with_helpful_error() {
+    let err = parse_err::<ExecRequest>(json!({"command": ["sh", "-lc", "ls -la"]}));
+    assert!(!err.contains("missing"), "got: {err}");
+    assert!(
+        err.contains("'command'") && err.contains("string"),
+        "got: {err}"
+    );
+    assert!(
+        err.contains("args"),
+        "error must hint at 'args' field, got: {err}"
+    );
 }
 
 #[tokio::test]
 async fn exec_handler_rejects_unlisted_command() {
     let cfg = cfg_with_allow(&["echo"]);
-    let err = functions::exec::handle(cfg, json!({"command": "nmap", "args": ["-v"]}))
-        .await
-        .unwrap_err();
+    let err = functions::exec::handle(
+        cfg,
+        fresh_iii(),
+        typed::<ExecRequest>(json!({"command": "nmap", "args": ["-v"]})),
+    )
+    .await
+    .unwrap_err();
     assert!(err.contains("allowlist"));
 }
 
-#[tokio::test]
-async fn exec_handler_rejects_non_string_arg() {
-    let cfg = cfg_with_allow(&["echo"]);
-    let err = functions::exec::handle(cfg, json!({"command": "echo", "args": ["a", 5]}))
-        .await
-        .unwrap_err();
+/// `args[i]` validation is per-index; a non-string element must be rejected
+/// with a message that names which index failed and what it actually was.
+#[test]
+fn exec_request_rejects_non_string_arg() {
+    let err = parse_err::<ExecRequest>(json!({"command": "echo", "args": ["a", 5]}));
     assert!(err.contains("must be a string"), "got: {err}");
+    assert!(err.contains("args[1]"), "got: {err}");
+}
+
+/// `timeout_ms: -1` and `timeout_ms: 1.5` were the original silent-fallback
+/// cases on the loose `Value` handler. The custom `deserialize_timeout_ms`
+/// preserves that semantic on the typed struct: bad values become None and
+/// the call falls through to `cfg.default_timeout_ms`.
+#[test]
+fn exec_request_silently_drops_negative_or_float_timeout() {
+    let req: ExecRequest = typed(json!({"command": "echo", "args": [], "timeout_ms": -1}));
+    assert!(req.timeout_ms.is_none());
+    let req: ExecRequest = typed(json!({"command": "echo", "args": [], "timeout_ms": 1.5}));
+    assert!(req.timeout_ms.is_none());
 }
 
 #[tokio::test]
@@ -93,10 +141,11 @@ async fn exec_handler_returns_truncated_flag_at_max_output_bytes() {
     let r = resp(
         functions::exec::handle(
             cfg,
-            json!({
+            fresh_iii(),
+            typed::<ExecRequest>(json!({
                 "command": "sh",
                 "args": ["-c", "printf 'x%.0s' $(seq 1 8000)"],
-            }),
+            })),
         )
         .await
         .unwrap(),
@@ -110,22 +159,40 @@ async fn exec_handler_returns_truncated_flag_at_max_output_bytes() {
 async fn exec_bg_handler_spawns_returns_job_id_and_argv() {
     let cfg = cfg_with_allow(&["sleep"]);
     let r = resp(
-        functions::exec_bg::handle(cfg, json!({"command": "sleep", "args": ["0.1"]}))
-            .await
-            .unwrap(),
+        functions::exec_bg::handle(
+            cfg,
+            fresh_iii(),
+            typed::<ExecBgRequest>(json!({"command": "sleep", "args": ["0.1"]})),
+        )
+        .await
+        .unwrap(),
     );
     assert!(r["job_id"].is_string());
     assert_eq!(r["argv"], json!(["sleep", "0.1"]));
     tokio::time::sleep(std::time::Duration::from_millis(400)).await;
 }
 
-#[tokio::test]
-async fn exec_bg_handler_rejects_non_string_arg() {
-    let cfg = cfg_with_allow(&["echo"]);
-    let err = functions::exec_bg::handle(cfg, json!({"command": "echo", "args": [42]}))
-        .await
-        .unwrap_err();
+/// Regression: same as `exec_request_rejects_array_command_with_helpful_error`,
+/// for the background variant.
+#[test]
+fn exec_bg_request_rejects_array_command_with_helpful_error() {
+    let err = parse_err::<ExecBgRequest>(json!({"command": ["sh", "-lc", "ls -la"]}));
+    assert!(!err.contains("missing"), "got: {err}");
+    assert!(
+        err.contains("'command'") && err.contains("string"),
+        "got: {err}"
+    );
+    assert!(
+        err.contains("args"),
+        "error must hint at 'args' field, got: {err}"
+    );
+}
+
+#[test]
+fn exec_bg_request_rejects_non_string_arg() {
+    let err = parse_err::<ExecBgRequest>(json!({"command": "echo", "args": [42]}));
     assert!(err.contains("must be a string"), "got: {err}");
+    assert!(err.contains("args[0]"), "got: {err}");
 }
 
 #[tokio::test]

--- a/shell/tests/sandbox_exec_dispatch.rs
+++ b/shell/tests/sandbox_exec_dispatch.rs
@@ -1,0 +1,72 @@
+//! Integration tests for the public sandbox-exec surface. The handler-
+//! level dispatch via `target` field is exercised by the existing e2e
+//! shell scripts and the unit tests in `src/functions/exec.rs::tests`;
+//! this file cements the public-API surface (consumed via `iii_shell::*`)
+//! so downstream consumers pinning these paths catch drift.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use iii_sdk::IIIError;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use iii_shell::exec::sandbox::SandboxExecBackend;
+use iii_shell::exec::ExecBackend;
+use iii_shell::triggers::TriggerFwd;
+
+struct StubFwd {
+    captured: Mutex<Vec<(String, Value)>>,
+    next: Mutex<Option<Result<Value, IIIError>>>,
+}
+
+impl StubFwd {
+    fn new(resp: Result<Value, IIIError>) -> Arc<Self> {
+        Arc::new(Self {
+            captured: Mutex::new(Vec::new()),
+            next: Mutex::new(Some(resp)),
+        })
+    }
+    fn last(&self) -> (String, Value) {
+        self.captured.lock().unwrap().last().cloned().unwrap()
+    }
+}
+
+#[async_trait]
+impl TriggerFwd for StubFwd {
+    async fn trigger(&self, fid: &str, payload: Value) -> Result<Value, IIIError> {
+        self.captured.lock().unwrap().push((fid.into(), payload));
+        self.next
+            .lock()
+            .unwrap()
+            .take()
+            .expect("StubFwd: response already consumed")
+    }
+}
+
+#[tokio::test]
+async fn sandbox_backend_emits_sandbox_exec_payload() {
+    let stub = StubFwd::new(Ok(json!({
+        "stdout": "ok\n",
+        "stderr": "",
+        "exit_code": 0,
+        "duration_ms": 12,
+        "timed_out": false,
+    })));
+    let id = Uuid::new_v4();
+    let b = SandboxExecBackend::new(stub.clone(), true, id);
+
+    let out = b
+        .run(&["echo".into(), "ok".into()], 5000)
+        .await
+        .expect("ok");
+    assert_eq!(out.stdout, "ok\n");
+    let (fid, payload) = stub.last();
+    assert_eq!(fid, "sandbox::exec");
+    assert_eq!(
+        payload["sandbox_id"].as_str(),
+        Some(id.to_string().as_str())
+    );
+    assert_eq!(payload["cmd"], "echo");
+    assert_eq!(payload["timeout_ms"], 5000);
+}

--- a/shell/tests/skill.rs
+++ b/shell/tests/skill.rs
@@ -1,0 +1,82 @@
+//! Compile-time and format checks for the registered skill set.
+//! Runs without an iii engine connection.
+//!
+//! Asserts the platform contract from skills/README.md: H1 first (used as
+//! the iii://skills index link title), then a non-heading paragraph (used
+//! as the description, truncated at 140 chars). Worker id is `shell`; all
+//! sub-skills must nest under `shell/`.
+
+fn well_formed(label: &str, body: &str) {
+    assert!(!body.trim().is_empty(), "{label}: skill is empty");
+    assert!(
+        body.len() <= 256 * 1024,
+        "{label}: skill exceeds 256 KiB ({} bytes)",
+        body.len()
+    );
+
+    let mut lines = body.lines().filter(|l| !l.trim().is_empty());
+    let h1 = lines.next().unwrap_or("");
+    assert!(
+        h1.starts_with("# "),
+        "{label}: skill must start with an H1, got: {h1:?}"
+    );
+    let summary = lines.next().unwrap_or("");
+    assert!(
+        !summary.starts_with('#'),
+        "{label}: expected a summary paragraph after the H1, got another heading: {summary:?}"
+    );
+}
+
+fn id_is_valid(label: &str, id: &str) {
+    assert!(!id.is_empty(), "{label}: id is empty");
+    assert!(id.len() <= 1024, "{label}: id exceeds 1024 chars");
+
+    // `fn` is the only reserved first-segment literal as of skills v0.2.0.
+    let first_segment = id.split('/').next().unwrap_or("");
+    assert_ne!(
+        first_segment, "fn",
+        "{label}: first segment must not be the reserved literal `fn`"
+    );
+
+    for segment in id.split('/') {
+        assert!(
+            !segment.is_empty(),
+            "{label}: empty path segment in id {id:?}"
+        );
+        assert!(
+            segment.len() <= 64,
+            "{label}: segment {segment:?} exceeds 64 chars"
+        );
+        let first = segment.chars().next().unwrap();
+        assert!(
+            first.is_ascii_lowercase() || first.is_ascii_digit(),
+            "{label}: segment {segment:?} must start with lowercase ASCII letter or digit"
+        );
+        assert!(
+            segment
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_'),
+            "{label}: segment {segment:?} has invalid characters"
+        );
+    }
+}
+
+#[test]
+fn router_well_formed() {
+    well_formed("router", iii_shell::SKILL_MD);
+    id_is_valid("router", iii_shell::SKILL_ID);
+}
+
+#[test]
+fn sub_skills_well_formed() {
+    let prefix = format!("{}/", iii_shell::SKILL_ID);
+    for (id, body) in iii_shell::SUB_SKILLS {
+        well_formed(id, body);
+        id_is_valid(id, id);
+        assert!(
+            id.starts_with(&prefix),
+            "sub-skill id {id:?} must be nested under the worker id ({}/)",
+            iii_shell::SKILL_ID
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Three intertwined changes that close the loop on `shell` as an LLM-facing tool worker:

- **Sandbox forwarding**: every `shell::*` function now accepts `target: { kind: \"host\" | \"sandbox\", sandbox_id? }`. Sandbox-targeted calls forward to a live `iii-sandbox` microVM via the engine's trigger bus, while allowlist + denylist still apply on top.
- **Skills migration**: the worker's skill registry switches from 5 family-grouped markdown files (`exec.md`, `jobs.md`, `fs_read.md`, `fs_write.md`, `fs_search.md`) to 15 per-function leaves (`shell::exec`, `shell::exec_bg`, ..., `shell::fs::ls`, ..., `shell::fs::mv`) matching the canonical pattern used by `auth-credentials`, `llm-budget`, `session-tree`, and `subagent`. Each leaf has H1 = full function id, signature line, \"When to use\" + \"Notes\" sections.
- **Typed exec contracts**: `shell::exec` and `shell::exec_bg` were registered with `Value` (untyped) so the engine's tool listing exposed only prose. gpt-5 was caught sending the conventional argv-as-array shape (`{\"command\": [\"sh\", \"-lc\", \"...\"]}`) and getting back a misleading \"missing 'command'\" error. Added `ExecRequest` and `ExecBgRequest` to `functions::types` with `JsonSchema` + per-field custom deserializers. The schema now appears in the engine's tool listing telling callers `command: string` up front; per-field deserializers preserve the loose `timeout_ms` semantic and produce actionable error text on type mismatches.

## Key implementation details

- `src/exec/{mod,host,sandbox,backend,error}.rs`: split host vs sandbox exec into a backend trait with a recovered-error path that maps in-VM timeouts to `timed_out: true` instead of leaking the engine wire shape (`S200`).
- `src/functions/types.rs`: per-field deserializers (`deserialize_command`, `deserialize_args`, `deserialize_timeout_ms`) preserve the loose wire semantics that were intentional and produce the same actionable error strings the loose handlers used to emit.
- `src/lib.rs::SUB_SKILLS` registers all 15 leaf skill ids at boot via `skills::register`.
- Sandbox-target requires libkrun (`/dev/kvm` or Apple Silicon); otherwise the engine returns `S300` and shell does NOT fall back to host execution. Sandbox-backed background jobs cannot be hard-killed because `sandbox::exec` has no cancel hook; `shell::kill` flips the record to `killed` immediately, but the in-VM process keeps running until its `timeout_ms` expires.
- Per-function skill files corrected against the actual wire types (`FsEntry.is_dir`/`is_symlink`, `mtime` is epoch seconds not ms, `JobStatus` is `running|finished|killed|failed`, `MkdirRequest.parents` not `recursive`, `WriteRequest.content` is a `ContentRef` channel handle, etc.).

## Test plan

- [x] \`cargo test\` on the shell crate: 206 pass, 0 fail (141 lib + 26 function_handlers + 10 sandbox dispatch + 7 e2e config + 19 + 1 + 2 skill format)
- [x] \`cargo fmt --all\` applied across the workspace
- [x] New regression test \`exec_request_silently_drops_negative_or_float_timeout\` pins the loose \`timeout_ms\` semantic
- [x] New regression tests \`exec_request_rejects_array_command_with_helpful_error\` and \`exec_bg_request_rejects_array_command_with_helpful_error\` lock in the actionable error text for the gpt-5 failure mode
- [x] Skill format tests confirm all 15 leaves satisfy the platform contract (H1 + summary, ids match \`[a-z0-9_-]{1,64}\` per segment, all nested under \`shell/\`)
- [x] \`tests/sandbox_exec_dispatch.rs\` covers host-vs-sandbox routing, allowlist gate, S-code mapping
- [ ] Manual: send the gpt-5 payload \`{\"command\": [\"sh\", \"-lc\", \"ls\"]}\` against a running shell worker and confirm the error message includes the recovery hint