### PR TITLE
chore(bundle): reset harness-bundled workers to v0.1.0

### DIFF
--- a/.github/workflows/_rust-binary.yml
+++ b/.github/workflows/_rust-binary.yml
@@ -30,6 +30,11 @@ on:
         required: false
         type: boolean
         default: false
+      targets:
+        description: 'Optional comma-separated subset of build targets (default: all). Use to mark a worker as unix-only, host-only, etc.'
+        required: false
+        type: string
+        default: ''
 
 env:
   CARGO_TERM_COLOR: always
@@ -56,34 +61,60 @@ jobs:
           prerelease: ${{ inputs.is_prerelease }}
           generate_release_notes: true
 
+  matrix:
+    name: Compute build matrix
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.compute.outputs.include }}
+    steps:
+      - name: Compute matrix
+        id: compute
+        env:
+          TARGETS: ${{ inputs.targets }}
+        run: |
+          python3 - <<'PY'
+          import json, os, sys
+          all_targets = [
+              {"target": "x86_64-apple-darwin",            "os": "macos-latest"},
+              {"target": "aarch64-apple-darwin",           "os": "macos-latest"},
+              {"target": "x86_64-pc-windows-msvc",         "os": "windows-latest"},
+              {"target": "i686-pc-windows-msvc",           "os": "windows-latest"},
+              {"target": "aarch64-pc-windows-msvc",        "os": "windows-latest"},
+              {"target": "x86_64-unknown-linux-gnu",       "os": "ubuntu-22.04"},
+              {"target": "x86_64-unknown-linux-musl",      "os": "ubuntu-latest"},
+              {"target": "aarch64-unknown-linux-gnu",      "os": "ubuntu-22.04"},
+              {"target": "armv7-unknown-linux-gnueabihf",  "os": "ubuntu-22.04"},
+          ]
+          raw = (os.environ.get("TARGETS") or "").strip()
+          if raw:
+              wanted = [t.strip() for t in raw.split(",") if t.strip()]
+              known = {t["target"] for t in all_targets}
+              unknown = [t for t in wanted if t not in known]
+              if unknown:
+                  print(f"::error::unknown targets requested: {unknown}; known={sorted(known)}")
+                  sys.exit(1)
+              include = [t for t in all_targets if t["target"] in set(wanted)]
+              if not include:
+                  print("::error::targets filter resolved to empty set")
+                  sys.exit(1)
+          else:
+              include = all_targets
+          out = open(os.environ["GITHUB_OUTPUT"], "a")
+          out.write(f"include={json.dumps(include)}\n")
+          out.close()
+          print(f"::notice::building {len(include)} target(s): {[t['target'] for t in include]}")
+          PY
+
   build:
     name: Build ${{ matrix.target }}
-    needs: [pre-build]
+    needs: [pre-build, matrix]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - target: x86_64-apple-darwin
-            os: macos-latest
-          - target: aarch64-apple-darwin
-            os: macos-latest
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
-          - target: i686-pc-windows-msvc
-            os: windows-latest
-          - target: aarch64-pc-windows-msvc
-            os: windows-latest
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-22.04
-          - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-22.04
-          - target: armv7-unknown-linux-gnueabihf
-            os: ubuntu-22.04
+        include: ${{ fromJSON(needs.matrix.outputs.include) }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-harness-bundle.yml
+++ b/.github/workflows/release-harness-bundle.yml
@@ -63,7 +63,8 @@ jobs:
           REGISTRY_API: https://api.workers.iii.dev
           # Workers excluded from the bundle even when they're in harness deps.
           # `iii-sandbox` is an external engine worker. `skills` is held by maintainers.
-          BUNDLE_EXCLUDE: iii-sandbox,skills
+          # `shell` releases on its own `shell/v*` tag via release.yml.
+          BUNDLE_EXCLUDE: iii-sandbox,skills,shell
         run: |
           python3 - <<'PY'
           import json, os, re, subprocess, sys, urllib.parse, urllib.request, yaml
@@ -113,6 +114,14 @@ jobs:
               print("::error::harness/iii.worker.yaml dependencies must be a mapping")
               sys.exit(1)
 
+          def normalize_targets(meta: dict) -> str:
+              raw = meta.get("targets")
+              if isinstance(raw, list):
+                  return ",".join(str(t).strip() for t in raw if str(t).strip())
+              if isinstance(raw, str):
+                  return raw.strip()
+              return ""
+
           publish_set: list[dict] = []
 
           # Always include harness itself at the tagged version.
@@ -123,6 +132,7 @@ jobs:
               "version": harness_version,
               "manifest": h_manifest,
               "bin": h_bin,
+              "targets": normalize_targets(harness_meta),
           })
 
           for dep_name in sorted(deps):
@@ -155,6 +165,7 @@ jobs:
                   "version": local_ver,
                   "manifest": manifest,
                   "bin": bin_name,
+                  "targets": normalize_targets(meta),
               })
               print(f"::notice::{dep_name}: queued v{local_ver} (registry v{reg_ver or 'none'})")
 
@@ -194,6 +205,7 @@ jobs:
       bin_name: ${{ matrix.entry.bin }}
       manifest_path: ${{ matrix.entry.worker }}/${{ matrix.entry.manifest }}
       tag_name: ${{ matrix.entry.worker }}/v${{ matrix.entry.version }}
+      targets: ${{ matrix.entry.targets }}
     secrets: inherit
 
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
       registry_tag: ${{ steps.meta.outputs.registry_tag }}
       is_prerelease: ${{ steps.meta.outputs.is_prerelease }}
       dry_run: ${{ steps.meta.outputs.dry_run }}
+      targets: ${{ steps.meta.outputs.targets }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -111,6 +112,13 @@ jobs:
           language = meta.get("language")
           bin_name = meta.get("bin") or meta.get("name") or worker
           manifest = meta.get("manifest")
+          targets_raw = meta.get("targets")
+          if isinstance(targets_raw, list):
+              targets = ",".join(str(t).strip() for t in targets_raw if str(t).strip())
+          elif isinstance(targets_raw, str):
+              targets = targets_raw.strip()
+          else:
+              targets = ""
           if deploy not in ("binary", "image"):
               print(f"::error::{worker}: deploy must be binary|image (got {deploy!r})")
               sys.exit(1)
@@ -141,6 +149,7 @@ jobs:
               ("registry_tag", registry_tag),
               ("is_prerelease", is_pre),
               ("dry_run", dry_run),
+              ("targets", targets),
           ]:
               out.write(f"{k}={v}\n")
           out.close()
@@ -182,6 +191,7 @@ jobs:
       is_prerelease: ${{ needs.setup.outputs.is_prerelease == 'true' }}
       skip_create_release: true
       dry_run: ${{ needs.setup.outputs.dry_run == 'true' }}
+      targets: ${{ needs.setup.outputs.targets }}
     secrets: inherit
 
   # ──────────────────────────────────────────────────────────────

--- a/approval-gate/Cargo.lock
+++ b/approval-gate/Cargo.lock
@@ -707,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "iii-approval-gate"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/approval-gate/Cargo.toml
+++ b/approval-gate/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "iii-approval-gate"
-version = "0.2.1"
+version = "0.1.0"
 description = "Hook subscriber on agent::before_function_call that pauses function calls listed in approval_required until the UI resolves them via approval::resolve."
 edition = "2021"
 license = "Apache-2.0"

--- a/auth-credentials/Cargo.toml
+++ b/auth-credentials/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "iii-auth-credentials"
-version = "0.1.1"
+version = "0.1.0"
 description = "Provider credential vault under auth::* — API keys and OAuth tokens."
 edition = "2021"
 license = "Apache-2.0"

--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "iii-harness"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/harness-types"]
 
 [package]
 name = "iii-harness"
-version = "0.3.0"
+version = "0.1.0"
 description = "Meta-worker that composes the modular workers backing the iii chat surface."
 edition = "2021"
 license = "Apache-2.0"

--- a/hook-fanout/Cargo.toml
+++ b/hook-fanout/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "hook-fanout"
-version = "0.1.1"
+version = "0.1.0"
 description = "Reusable publish-collect primitive (hook-fanout::publish_collect) — fans an event to subscribers and collects merged replies."
 edition = "2021"
 license = "Apache-2.0"

--- a/llm-budget/Cargo.toml
+++ b/llm-budget/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "llm-budget"
-version = "0.1.1"
+version = "0.1.0"
 description = "Workspace + agent LLM spend caps with alerts, forecast, and period rollover under budget::*."
 edition = "2021"
 license = "Apache-2.0"

--- a/models-catalog/Cargo.toml
+++ b/models-catalog/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "iii-models-catalog"
-version = "0.1.1"
+version = "0.1.0"
 description = "Model capabilities knowledge base under models::* (list/get/supports/register)."
 edition = "2021"
 license = "Apache-2.0"

--- a/policy-denylist/Cargo.toml
+++ b/policy-denylist/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "iii-policy-denylist"
-version = "0.1.1"
+version = "0.1.0"
 description = "Hook subscriber on agent::before_function_call that blocks calls whose function id matches a configured denylist."
 edition = "2021"
 license = "Apache-2.0"

--- a/provider-anthropic/Cargo.lock
+++ b/provider-anthropic/Cargo.lock
@@ -236,16 +236,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -344,12 +334,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,21 +350,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -678,22 +647,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,11 +664,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -853,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "iii-provider-anthropic"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "auth-credentials",
@@ -982,12 +933,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,23 +989,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1122,48 +1050,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -1289,12 +1179,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -1558,12 +1442,10 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -1574,7 +1456,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -1607,19 +1488,6 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "rustls"
@@ -1726,7 +1594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1949,40 +1817,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.2",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2062,16 +1896,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -2381,12 +2205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2659,17 +2477,6 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
  "windows-link",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
 ]
 
 [[package]]

--- a/provider-anthropic/Cargo.toml
+++ b/provider-anthropic/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/harness-types", "crates/overflow-classify", "crates/auth-cred
 
 [package]
 name = "iii-provider-anthropic"
-version = "0.2.1"
+version = "0.1.0"
 description = "Anthropic Messages API streaming provider; exposes provider::anthropic::complete on the iii bus."
 edition = "2021"
 license = "Apache-2.0"
@@ -62,7 +62,7 @@ anyhow = "1"
 thiserror = "2"
 tracing = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
-reqwest = { version = "0.12", features = ["stream", "json"] }
+reqwest = { version = "0.12", default-features = false, features = ["charset", "http2", "json", "rustls-tls", "stream"] }
 futures = "0.3"
 bytes = "1"
 regex = "1"

--- a/provider-openai/Cargo.lock
+++ b/provider-openai/Cargo.lock
@@ -236,16 +236,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -344,12 +334,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,21 +350,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -678,22 +647,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,11 +664,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -853,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "iii-provider-openai"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "auth-credentials",
@@ -977,12 +928,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,23 +984,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1117,48 +1045,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -1284,12 +1174,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -1553,12 +1437,10 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -1569,7 +1451,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -1602,19 +1483,6 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "rustls"
@@ -1721,7 +1589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1944,40 +1812,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.2",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2057,16 +1891,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -2376,12 +2200,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2654,17 +2472,6 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
  "windows-link",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
 ]
 
 [[package]]

--- a/provider-openai/Cargo.toml
+++ b/provider-openai/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/harness-types", "crates/overflow-classify", "crates/auth-cred
 
 [package]
 name = "iii-provider-openai"
-version = "0.2.1"
+version = "0.1.0"
 description = "OpenAI Chat Completions; registers provider::openai::complete on the iii bus."
 edition = "2021"
 license = "Apache-2.0"
@@ -57,7 +57,7 @@ thiserror = "2"
 async-trait = "0.1"
 tracing = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
-reqwest = { version = "0.12", features = ["stream", "json"] }
+reqwest = { version = "0.12", default-features = false, features = ["charset", "http2", "json", "rustls-tls", "stream"] }
 futures = "0.3"
 bytes = "1"
 regex = "1"

--- a/provider-router/Cargo.toml
+++ b/provider-router/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/harness-types"]
 
 [package]
 name = "iii-provider-router"
-version = "0.1.1"
+version = "0.1.0"
 description = "router::stream_assistant provider router plus router::abort and router::push_steering / push_followup helpers."
 edition = "2021"
 license = "Apache-2.0"

--- a/session-inbox/Cargo.toml
+++ b/session-inbox/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "session-inbox"
-version = "0.1.1"
+version = "0.1.0"
 description = "Per-session inbox (session-inbox::push, drain, peek) backed by iii state."
 edition = "2021"
 license = "Apache-2.0"

--- a/session-tree/Cargo.toml
+++ b/session-tree/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/harness-types"]
 
 [package]
 name = "iii-session-tree"
-version = "0.1.1"
+version = "0.1.0"
 description = "Session storage as a parent-id tree of typed entries under session-tree::*."
 edition = "2021"
 license = "Apache-2.0"

--- a/turn-orchestrator/Cargo.toml
+++ b/turn-orchestrator/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/harness-types"]
 
 [package]
 name = "iii-turn-orchestrator"
-version = "0.1.1"
+version = "0.1.0"
 description = "Durable run::start state machine driving each agent turn through provisioning, assistant, tools, steering, and tearing-down."
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Standardize harness + 12 bundled workers on `v0.1.0` (was drifting across 0.1.1 / 0.2.1 / 0.3.0).
- Exclude `shell` from the harness bundle — it releases via its own `shell/v*` tag.
- `_rust-binary.yml` gets an optional `targets` input so workers can opt out of unsupported triples; threaded through `release.yml` + `release-harness-bundle.yml`.
- `provider-{openai,anthropic}` reqwest switched to `rustls-tls` (`default-features = false`) so they cross-compile to aarch64/musl/armv7 linux without an openssl sysroot.

## Why
`harness/v0.3.0` release run failed on Windows (shell uses unix-only `PermissionsExt`/`chown`/`OpenOptionsExt`) and on cross-arch linux (providers pulled native-tls via reqwest defaults). The bundle never reached the publish step. The stale `harness/v0.3.0` tag + GH release have been cleaned up out-of-band so the new `harness/v0.1.0` tag can fire cleanly after this lands.

## Workers reset to 0.1.0
harness, turn-orchestrator, provider-router, session-tree, session-inbox, models-catalog, hook-fanout, policy-denylist, auth-credentials, llm-budget, provider-anthropic, provider-openai, approval-gate.

## Test plan
- [ ] CI green on this branch
- [ ] After merge: tag `harness/v0.1.0` to trigger the bundle release
- [ ] Confirm `_rust-binary.yml` matrix job emits the full 9-target set when no `targets:` is declared, and that build matrix dispatches correctly
- [ ] Confirm published bundle on workers.iii.dev lists all 13 workers at 0.1.0