### PR TITLE
chore(shell): restrict release matrix to unix targets

### DIFF
--- a/shell/iii.worker.yaml
+++ b/shell/iii.worker.yaml
@@ -6,6 +6,16 @@ manifest: Cargo.toml
 bin: iii-shell
 description: Unix shell + filesystem worker — exec with allowlist/denylist/timeout/output caps and background jobs; fs::ls|stat|mkdir|rm|chmod|mv|grep|sed|read|write with host jail, denylist, size caps, and sandbox-target forwarding
 
+# POSIX-only: src/fs/host.rs uses std::os::unix::fs::PermissionsExt / chown /
+# OpenOptionsExt directly, so the Windows triples cannot compile.
+targets:
+  - x86_64-apple-darwin
+  - aarch64-apple-darwin
+  - x86_64-unknown-linux-gnu
+  - x86_64-unknown-linux-musl
+  - aarch64-unknown-linux-gnu
+  - armv7-unknown-linux-gnueabihf
+
 runtime:
   kind: rust
 


### PR DESCRIPTION
## Summary
Mark shell as POSIX-only via the `targets:` field in `shell/iii.worker.yaml` so its `release.yml` dispatch (and any future call into `_rust-binary.yml`) skips the three Windows triples that can't compile.

## Why
`shell/src/fs/host.rs` uses `std::os::unix::fs::PermissionsExt`, `chown`, and `OpenOptionsExt::mode` directly. Without this restriction the Windows builds fail, the `binary-build` reusable workflow's overall conclusion is failure, and the `publish` job (gated by `if: !failure() && !cancelled()`) never reaches the registry.

This unblocks publishing `shell/v0.3.2` to the workers registry.

## Test plan
- [ ] After merge: `gh workflow run release.yml --ref main -f tag=shell/v0.3.2` builds 6 unix triples, uploads to the existing `shell/v0.3.2` release, and `POST /publish` lands the row at `api.workers.iii.dev/w/shell`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to explicitly restrict and document supported platforms for Rust compilation. Added platform-specific target matrix covering macOS and various Linux distributions. Windows targets are no longer supported due to system-level API dependencies fundamentally incompatible with Windows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/workers/pull/116)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->