### PR TITLE
chore: align worker bin name with worker name

### DIFF
--- a/approval-gate/Cargo.lock
+++ b/approval-gate/Cargo.lock
@@ -68,6 +68,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approval-gate"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap",
+ "iii-sdk",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,22 +719,6 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "iii-approval-gate"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "clap",
- "iii-sdk",
- "serde",
- "serde_json",
- "serde_yaml",
- "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/approval-gate/Cargo.toml
+++ b/approval-gate/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 
 [package]
-name = "iii-approval-gate"
+name = "approval-gate"
 version = "0.1.0"
 description = "Hook subscriber on agent::before_function_call that pauses function calls listed in approval_required until the UI resolves them via approval::resolve."
 edition = "2021"
@@ -15,7 +15,7 @@ name = "approval_gate"
 path = "src/lib.rs"
 
 [[bin]]
-name = "iii-approval-gate"
+name = "approval-gate"
 path = "src/main.rs"
 
 [dependencies]

--- a/approval-gate/iii.worker.yaml
+++ b/approval-gate/iii.worker.yaml
@@ -3,7 +3,7 @@ name: approval-gate
 language: rust
 deploy: binary
 manifest: Cargo.toml
-bin: iii-approval-gate
+bin: approval-gate
 description: Hook subscriber on agent::before_function_call that pauses function calls listed in approval_required until the UI resolves them via approval::resolve.
 
 runtime:

--- a/approval-gate/src/main.rs
+++ b/approval-gate/src/main.rs
@@ -14,7 +14,7 @@ use serde_json::json;
 
 #[derive(Parser, Debug)]
 #[command(
-    name = "iii-approval-gate",
+    name = "approval-gate",
     about = "Approval gate subscriber for agent::before_function_call"
 )]
 struct Cli {

--- a/approval-gate/tests/manifest.rs
+++ b/approval-gate/tests/manifest.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 use serde_json::Value;
 
 fn binary_path() -> String {
-    if let Some(path) = option_env!("CARGO_BIN_EXE_iii_approval_gate") {
+    if let Some(path) = option_env!("CARGO_BIN_EXE_approval_gate") {
         return path.to_string();
     }
     let manifest_dir = env!("CARGO_MANIFEST_DIR");

--- a/approval-gate/tests/manifest.rs
+++ b/approval-gate/tests/manifest.rs
@@ -7,7 +7,7 @@ fn binary_path() -> String {
         return path.to_string();
     }
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    format!("{manifest_dir}/target/debug/iii-approval-gate")
+    format!("{manifest_dir}/target/debug/approval-gate")
 }
 
 #[test]

--- a/auth-credentials/Cargo.lock
+++ b/auth-credentials/Cargo.lock
@@ -85,6 +85,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auth-credentials"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap",
+ "iii-sdk",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,22 +719,6 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "iii-auth-credentials"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "clap",
- "iii-sdk",
- "serde",
- "serde_json",
- "serde_yaml",
- "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/auth-credentials/Cargo.toml
+++ b/auth-credentials/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 
 [package]
-name = "iii-auth-credentials"
+name = "auth-credentials"
 version = "0.1.0"
 description = "Provider credential vault under auth::* — API keys and OAuth tokens."
 edition = "2021"
@@ -16,7 +16,7 @@ name = "auth_credentials"
 path = "src/lib.rs"
 
 [[bin]]
-name = "iii-auth-credentials"
+name = "auth-credentials"
 path = "src/main.rs"
 
 [dependencies]

--- a/auth-credentials/iii.worker.yaml
+++ b/auth-credentials/iii.worker.yaml
@@ -3,7 +3,7 @@ name: auth-credentials
 language: rust
 deploy: binary
 manifest: Cargo.toml
-bin: iii-auth-credentials
+bin: auth-credentials
 description: Provider credential vault under auth::* — API keys and OAuth tokens.
 
 runtime:

--- a/auth-credentials/src/main.rs
+++ b/auth-credentials/src/main.rs
@@ -12,7 +12,7 @@ use config::{resolve_store_backend, StoreBackend};
 
 #[derive(Parser, Debug)]
 #[command(
-    name = "iii-auth-credentials",
+    name = "auth-credentials",
     about = "Provider credential vault on the iii bus — API keys and OAuth tokens under auth::*."
 )]
 struct Cli {

--- a/auth-credentials/tests/manifest.rs
+++ b/auth-credentials/tests/manifest.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use serde_json::Value;
 
 fn auth_credentials_executable() -> PathBuf {
-    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_iii_auth_credentials") {
+    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_auth_credentials") {
         return PathBuf::from(p);
     }
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -12,7 +12,7 @@ fn auth_credentials_executable() -> PathBuf {
         let candidate = dir
             .join("target")
             .join(profile)
-            .join("iii-auth-credentials");
+            .join("auth-credentials");
         if candidate.is_file() {
             return candidate;
         }
@@ -28,7 +28,7 @@ fn manifest_subcommand_emits_valid_json() {
     let output = Command::new(&bin)
         .arg("--manifest")
         .output()
-        .expect("spawn iii-auth-credentials --manifest");
+        .expect("spawn auth-credentials --manifest");
 
     assert!(
         output.status.success(),

--- a/auth-credentials/tests/manifest.rs
+++ b/auth-credentials/tests/manifest.rs
@@ -9,16 +9,13 @@ fn auth_credentials_executable() -> PathBuf {
     }
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     for profile in ["debug", "release"] {
-        let candidate = dir
-            .join("target")
-            .join(profile)
-            .join("auth-credentials");
+        let candidate = dir.join("target").join(profile).join("auth-credentials");
         if candidate.is_file() {
             return candidate;
         }
     }
     panic!(
-        "iii-auth-credentials binary not found under target/{{debug,release}}/; run `cargo build --bin iii-auth-credentials` first"
+        "auth-credentials binary not found under target/{{debug,release}}/; run `cargo build --bin auth-credentials` first"
     );
 }
 

--- a/auth-credentials/tests/restart_e2e.rs
+++ b/auth-credentials/tests/restart_e2e.rs
@@ -2,13 +2,13 @@
 //!
 //! Requires:
 //! - `IIITEST_ENGINE_URL`: WebSocket URL of a running iii engine
-//! - `IIITEST_WORKER_BIN`: absolute path to the iii-auth-credentials binary
+//! - `IIITEST_WORKER_BIN`: absolute path to the auth-credentials binary
 //!
 //! Marked `#[ignore]` so cargo test default runs skip it. To execute:
-//!     cargo build --release -p iii-auth-credentials
+//!     cargo build --release -p auth-credentials
 //!     IIITEST_ENGINE_URL=ws://127.0.0.1:49134 \
-//!       IIITEST_WORKER_BIN=$(pwd)/target/release/iii-auth-credentials \
-//!       cargo test -p iii-auth-credentials --test restart_e2e -- --ignored
+//!       IIITEST_WORKER_BIN=$(pwd)/target/release/auth-credentials \
+//!       cargo test -p auth-credentials --test restart_e2e -- --ignored
 
 use std::process::{Child, Command, Stdio};
 use std::time::Duration;
@@ -23,7 +23,7 @@ fn spawn_worker(engine_url: &str, bin: &str) -> Child {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
-        .expect("spawn iii-auth-credentials")
+        .expect("spawn auth-credentials")
 }
 
 async fn wait_for_ready() {

--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -453,6 +453,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "harness"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap",
+ "harness-types",
+ "iii-sdk",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "serial_test",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "which",
+]
+
+[[package]]
 name = "harness-types"
 version = "0.1.0"
 dependencies = [
@@ -711,25 +730,6 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "iii-harness"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "clap",
- "harness-types",
- "iii-sdk",
- "serde",
- "serde_json",
- "serde_yaml",
- "serial_test",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "which",
 ]
 
 [[package]]

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["crates/harness-types"]
 
 [package]
-name = "iii-harness"
+name = "harness"
 version = "0.1.0"
 description = "Meta-worker that composes the modular workers backing the iii chat surface."
 edition = "2021"
@@ -16,7 +16,7 @@ name = "harness"
 path = "src/lib.rs"
 
 [[bin]]
-name = "iii-harness"
+name = "harness"
 path = "src/main.rs"
 
 [dependencies]

--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -3,7 +3,7 @@ name: harness
 language: rust
 deploy: binary
 manifest: Cargo.toml
-bin: iii-harness
+bin: harness
 description: Meta-worker that composes the modular workers backing the iii chat surface.
 
 runtime:

--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -9,7 +9,7 @@ mod manifest;
 
 #[derive(Parser, Debug)]
 #[command(
-    name = "iii-harness",
+    name = "harness",
     about = "Meta-worker that composes the modular workers backing the iii chat surface."
 )]
 struct Cli {

--- a/harness/tests/common/mod.rs
+++ b/harness/tests/common/mod.rs
@@ -103,7 +103,7 @@ fn find_session_tree_binary() -> Option<PathBuf> {
         let candidate = session_tree_dir
             .join("target")
             .join(profile)
-            .join("iii-session-tree");
+            .join("session-tree");
         if candidate.is_file() {
             return Some(candidate);
         }

--- a/harness/tests/manifest.rs
+++ b/harness/tests/manifest.rs
@@ -15,7 +15,7 @@ fn harness_executable() -> PathBuf {
         }
     }
     panic!(
-        "iii-harness binary not found under target/{{debug,release}}/; run `cargo build --bin iii-harness` first"
+        "harness binary not found under target/{{debug,release}}/; run `cargo build --bin harness` first"
     );
 }
 

--- a/harness/tests/manifest.rs
+++ b/harness/tests/manifest.rs
@@ -4,12 +4,12 @@ use std::process::Command;
 use serde_json::Value;
 
 fn harness_executable() -> PathBuf {
-    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_iii_harness") {
+    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_harness") {
         return PathBuf::from(p);
     }
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     for profile in ["debug", "release"] {
-        let candidate = dir.join("target").join(profile).join("iii-harness");
+        let candidate = dir.join("target").join(profile).join("harness");
         if candidate.is_file() {
             return candidate;
         }
@@ -25,7 +25,7 @@ fn manifest_subcommand_emits_valid_json() {
     let output = Command::new(&bin)
         .arg("--manifest")
         .output()
-        .expect("spawn iii-harness --manifest");
+        .expect("spawn harness --manifest");
 
     assert!(
         output.status.success(),

--- a/harness/tests/sse_bridge.rs
+++ b/harness/tests/sse_bridge.rs
@@ -1,7 +1,7 @@
 //! Engine-backed smoke test for /bridge/events.
 //!
 //! Skipped when no engine is reachable. To run locally:
-//!   harness/scripts/demo.sh engine && cargo test -p iii-harness --test sse_bridge
+//!   harness/scripts/demo.sh engine && cargo test -p harness --test sse_bridge
 
 use harness::register_with_iii;
 use iii_sdk::{register_worker, InitOptions, TriggerRequest};

--- a/models-catalog/Cargo.lock
+++ b/models-catalog/Cargo.lock
@@ -706,22 +706,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-models-catalog"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "clap",
- "iii-sdk",
- "once_cell",
- "serde",
- "serde_json",
- "serde_yaml",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "iii-sdk"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +852,22 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "models-catalog"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "iii-sdk",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/models-catalog/Cargo.toml
+++ b/models-catalog/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 
 [package]
-name = "iii-models-catalog"
+name = "models-catalog"
 version = "0.1.0"
 description = "Model capabilities knowledge base under models::* (list/get/supports/register)."
 edition = "2021"
@@ -15,7 +15,7 @@ name = "models_catalog"
 path = "src/lib.rs"
 
 [[bin]]
-name = "iii-models-catalog"
+name = "models-catalog"
 path = "src/main.rs"
 
 [dependencies]

--- a/models-catalog/iii.worker.yaml
+++ b/models-catalog/iii.worker.yaml
@@ -3,7 +3,7 @@ name: models-catalog
 language: rust
 deploy: binary
 manifest: Cargo.toml
-bin: iii-models-catalog
+bin: models-catalog
 description: Model capabilities knowledge base under models::* (list/get/supports/register).
 
 runtime:

--- a/models-catalog/src/main.rs
+++ b/models-catalog/src/main.rs
@@ -9,7 +9,7 @@ mod manifest;
 
 #[derive(Parser, Debug)]
 #[command(
-    name = "iii-models-catalog",
+    name = "models-catalog",
     about = "Model capabilities knowledge base (models::*) on the iii bus."
 )]
 struct Cli {

--- a/models-catalog/tests/manifest.rs
+++ b/models-catalog/tests/manifest.rs
@@ -4,12 +4,12 @@ use std::process::Command;
 use serde_json::Value;
 
 fn models_catalog_executable() -> PathBuf {
-    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_iii_models_catalog") {
+    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_models_catalog") {
         return PathBuf::from(p);
     }
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     for profile in ["debug", "release"] {
-        let candidate = dir.join("target").join(profile).join("iii-models-catalog");
+        let candidate = dir.join("target").join(profile).join("models-catalog");
         if candidate.is_file() {
             return candidate;
         }
@@ -25,7 +25,7 @@ fn manifest_subcommand_emits_valid_json() {
     let output = Command::new(bin)
         .arg("--manifest")
         .output()
-        .expect("spawn iii-models-catalog --manifest");
+        .expect("spawn models-catalog --manifest");
 
     assert!(
         output.status.success(),

--- a/models-catalog/tests/manifest.rs
+++ b/models-catalog/tests/manifest.rs
@@ -15,7 +15,7 @@ fn models_catalog_executable() -> PathBuf {
         }
     }
     panic!(
-        "iii-models-catalog binary not found under target/{{debug,release}}/; run `cargo build --bin iii-models-catalog` first"
+        "models-catalog binary not found under target/{{debug,release}}/; run `cargo build --bin models-catalog` first"
     );
 }
 

--- a/oauth-anthropic/Cargo.lock
+++ b/oauth-anthropic/Cargo.lock
@@ -814,27 +814,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-oauth-anthropic"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "auth-credentials",
- "base64",
- "chrono",
- "env_logger",
- "iii-sdk",
- "log",
- "rand 0.8.6",
- "reqwest",
- "serde",
- "serde_json",
- "sha2",
- "thiserror",
- "tokio",
- "url",
-]
-
-[[package]]
 name = "iii-sdk"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,6 +1025,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "oauth-anthropic"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "auth-credentials",
+ "base64",
+ "chrono",
+ "env_logger",
+ "iii-sdk",
+ "log",
+ "rand 0.8.6",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/oauth-anthropic/Cargo.toml
+++ b/oauth-anthropic/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/auth-credentials"]
 
 [package]
-name = "iii-oauth-anthropic"
+name = "oauth-anthropic"
 version = "0.1.0"
 description = "Anthropic Claude Pro/Max OAuth (PKCE localhost flow) under oauth::anthropic::*."
 edition = "2021"
@@ -17,7 +17,7 @@ name = "oauth_anthropic"
 path = "src/lib.rs"
 
 [[bin]]
-name = "iii-oauth-anthropic"
+name = "oauth-anthropic"
 path = "src/main.rs"
 
 [dependencies]

--- a/oauth-anthropic/iii.worker.yaml
+++ b/oauth-anthropic/iii.worker.yaml
@@ -3,7 +3,7 @@ name: oauth-anthropic
 language: rust
 deploy: binary
 manifest: Cargo.toml
-bin: iii-oauth-anthropic
+bin: oauth-anthropic
 description: Anthropic Claude Pro/Max OAuth (PKCE localhost flow) under oauth::anthropic::*.
 
 runtime:

--- a/oauth-openai-codex/Cargo.lock
+++ b/oauth-openai-codex/Cargo.lock
@@ -814,27 +814,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-oauth-openai-codex"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "auth-credentials",
- "base64",
- "chrono",
- "env_logger",
- "iii-sdk",
- "log",
- "rand 0.8.6",
- "reqwest",
- "serde",
- "serde_json",
- "sha2",
- "thiserror",
- "tokio",
- "url",
-]
-
-[[package]]
 name = "iii-sdk"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,6 +1025,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "oauth-openai-codex"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "auth-credentials",
+ "base64",
+ "chrono",
+ "env_logger",
+ "iii-sdk",
+ "log",
+ "rand 0.8.6",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/oauth-openai-codex/Cargo.toml
+++ b/oauth-openai-codex/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/auth-credentials"]
 
 [package]
-name = "iii-oauth-openai-codex"
+name = "oauth-openai-codex"
 version = "0.1.0"
 description = "OpenAI Codex OAuth (PKCE localhost flow) under oauth::openai_codex::*."
 edition = "2021"
@@ -17,7 +17,7 @@ name = "oauth_openai_codex"
 path = "src/lib.rs"
 
 [[bin]]
-name = "iii-oauth-openai-codex"
+name = "oauth-openai-codex"
 path = "src/main.rs"
 
 [dependencies]

--- a/oauth-openai-codex/iii.worker.yaml
+++ b/oauth-openai-codex/iii.worker.yaml
@@ -3,7 +3,7 @@ name: oauth-openai-codex
 language: rust
 deploy: binary
 manifest: Cargo.toml
-bin: iii-oauth-openai-codex
+bin: oauth-openai-codex
 description: OpenAI Codex OAuth (PKCE localhost flow) under oauth::openai_codex::*.
 
 runtime:

--- a/policy-denylist/Cargo.lock
+++ b/policy-denylist/Cargo.lock
@@ -706,23 +706,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-policy-denylist"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "clap",
- "iii-sdk",
- "serde",
- "serde_json",
- "serde_yaml",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "uuid",
-]
-
-[[package]]
 name = "iii-sdk"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,6 +1010,23 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "policy-denylist"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap",
+ "iii-sdk",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
 
 [[package]]
 name = "potential_utf"

--- a/policy-denylist/Cargo.toml
+++ b/policy-denylist/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 
 [package]
-name = "iii-policy-denylist"
+name = "policy-denylist"
 version = "0.1.0"
 description = "Hook subscriber on agent::before_function_call that blocks calls whose function id matches a configured denylist."
 edition = "2021"
@@ -15,7 +15,7 @@ name = "policy_denylist"
 path = "src/lib.rs"
 
 [[bin]]
-name = "iii-policy-denylist"
+name = "policy-denylist"
 path = "src/main.rs"
 
 [dependencies]

--- a/policy-denylist/iii.worker.yaml
+++ b/policy-denylist/iii.worker.yaml
@@ -3,7 +3,7 @@ name: policy-denylist
 language: rust
 deploy: binary
 manifest: Cargo.toml
-bin: iii-policy-denylist
+bin: policy-denylist
 description: Hook subscriber on agent::before_function_call that blocks calls whose function id matches a configured denylist.
 
 runtime:

--- a/policy-denylist/src/main.rs
+++ b/policy-denylist/src/main.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 #[derive(Parser, Debug)]
 #[command(
-    name = "iii-policy-denylist",
+    name = "policy-denylist",
     about = "Denylist subscriber for agent::before_function_call"
 )]
 struct Cli {

--- a/policy-denylist/tests/manifest.rs
+++ b/policy-denylist/tests/manifest.rs
@@ -10,7 +10,7 @@ fn binary_path() -> String {
         return path.to_string();
     }
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    format!("{manifest_dir}/target/debug/iii-policy-denylist")
+    format!("{manifest_dir}/target/debug/policy-denylist")
 }
 
 #[test]

--- a/policy-denylist/tests/manifest.rs
+++ b/policy-denylist/tests/manifest.rs
@@ -6,7 +6,7 @@ fn binary_path() -> String {
     // Prefer the Cargo-injected path when available (standard cargo test builds).
     // Fall back to constructing it from CARGO_MANIFEST_DIR so the test works in
     // environments where CARGO_BIN_EXE_* is not injected.
-    if let Some(path) = option_env!("CARGO_BIN_EXE_iii_policy_denylist") {
+    if let Some(path) = option_env!("CARGO_BIN_EXE_policy_denylist") {
         return path.to_string();
     }
     let manifest_dir = env!("CARGO_MANIFEST_DIR");

--- a/provider-anthropic/Cargo.lock
+++ b/provider-anthropic/Cargo.lock
@@ -803,31 +803,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-provider-anthropic"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "auth-credentials",
- "bytes",
- "chrono",
- "clap",
- "futures",
- "harness-types",
- "iii-sdk",
- "overflow-classify",
- "provider-base",
- "reqwest",
- "serde",
- "serde_json",
- "serde_yaml",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "iii-sdk"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,6 +1228,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "provider-anthropic"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "auth-credentials",
+ "bytes",
+ "chrono",
+ "clap",
+ "futures",
+ "harness-types",
+ "iii-sdk",
+ "overflow-classify",
+ "provider-base",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/provider-anthropic/Cargo.toml
+++ b/provider-anthropic/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/harness-types", "crates/overflow-classify", "crates/auth-credentials", "crates/provider-base"]
 
 [package]
-name = "iii-provider-anthropic"
+name = "provider-anthropic"
 version = "0.1.0"
 description = "Anthropic Messages API streaming provider; exposes provider::anthropic::complete on the iii bus."
 edition = "2021"
@@ -18,7 +18,7 @@ name = "provider_anthropic"
 path = "src/lib.rs"
 
 [[bin]]
-name = "iii-provider-anthropic"
+name = "provider-anthropic"
 path = "src/main.rs"
 
 [dependencies]

--- a/provider-anthropic/iii.worker.yaml
+++ b/provider-anthropic/iii.worker.yaml
@@ -3,7 +3,7 @@ name: provider-anthropic
 language: rust
 deploy: binary
 manifest: Cargo.toml
-bin: iii-provider-anthropic
+bin: provider-anthropic
 description: Anthropic Messages API streaming provider; exposes provider::anthropic::complete on the iii bus.
 
 runtime:

--- a/provider-anthropic/src/main.rs
+++ b/provider-anthropic/src/main.rs
@@ -9,7 +9,7 @@ mod manifest;
 
 #[derive(Parser, Debug)]
 #[command(
-    name = "iii-provider-anthropic",
+    name = "provider-anthropic",
     about = "Anthropic Messages API streaming provider for the iii bus (provider::anthropic::complete)."
 )]
 struct Cli {

--- a/provider-anthropic/tests/manifest.rs
+++ b/provider-anthropic/tests/manifest.rs
@@ -1,4 +1,4 @@
-//! `iii-provider-anthropic --manifest` JSON contract (registry publish).
+//! `provider-anthropic --manifest` JSON contract (registry publish).
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -12,9 +12,9 @@ fn binary_path() -> PathBuf {
         "release"
     };
     #[cfg(target_os = "windows")]
-    let name = "iii-provider-anthropic.exe";
+    let name = "provider-anthropic.exe";
     #[cfg(not(target_os = "windows"))]
-    let name = "iii-provider-anthropic";
+    let name = "provider-anthropic";
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("target")
         .join(profile)

--- a/provider-openai/Cargo.lock
+++ b/provider-openai/Cargo.lock
@@ -803,26 +803,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-provider-openai"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "auth-credentials",
- "chrono",
- "clap",
- "harness-types",
- "iii-sdk",
- "provider-base",
- "serde",
- "serde_json",
- "serde_yaml",
- "tokio",
- "tokio-stream",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "iii-sdk"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,6 +1246,26 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "provider-openai"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "auth-credentials",
+ "chrono",
+ "clap",
+ "harness-types",
+ "iii-sdk",
+ "provider-base",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/provider-openai/Cargo.toml
+++ b/provider-openai/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/harness-types", "crates/overflow-classify", "crates/auth-credentials", "crates/provider-base"]
 
 [package]
-name = "iii-provider-openai"
+name = "provider-openai"
 version = "0.1.0"
 description = "OpenAI Chat Completions; registers provider::openai::complete on the iii bus."
 edition = "2021"
@@ -17,7 +17,7 @@ name = "provider_openai"
 path = "src/lib.rs"
 
 [[bin]]
-name = "iii-provider-openai"
+name = "provider-openai"
 path = "src/main.rs"
 
 [dependencies]

--- a/provider-openai/iii.worker.yaml
+++ b/provider-openai/iii.worker.yaml
@@ -3,7 +3,7 @@ name: provider-openai
 language: rust
 deploy: binary
 manifest: Cargo.toml
-bin: iii-provider-openai
+bin: provider-openai
 description: OpenAI Chat Completions; registers provider::openai::complete on the iii bus.
 
 runtime:

--- a/provider-openai/src/main.rs
+++ b/provider-openai/src/main.rs
@@ -9,7 +9,7 @@ mod manifest;
 
 #[derive(Parser, Debug)]
 #[command(
-    name = "iii-provider-openai",
+    name = "provider-openai",
     about = "OpenAI Chat Completions provider for the iii bus (provider::openai::complete)."
 )]
 struct Cli {

--- a/provider-openai/tests/manifest.rs
+++ b/provider-openai/tests/manifest.rs
@@ -1,4 +1,4 @@
-//! `iii-provider-openai --manifest` JSON contract (registry publish).
+//! `provider-openai --manifest` JSON contract (registry publish).
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -12,9 +12,9 @@ fn binary_path() -> PathBuf {
         "release"
     };
     #[cfg(target_os = "windows")]
-    let name = "iii-provider-openai.exe";
+    let name = "provider-openai.exe";
     #[cfg(not(target_os = "windows"))]
-    let name = "iii-provider-openai";
+    let name = "provider-openai";
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("target")
         .join(profile)

--- a/provider-router/Cargo.lock
+++ b/provider-router/Cargo.lock
@@ -767,26 +767,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-provider-router"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "clap",
- "harness-types",
- "hex",
- "iii-sdk",
- "serde",
- "serde_json",
- "serde_yaml",
- "sha2",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "iii-sdk"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,6 +1177,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "provider-router"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "clap",
+ "harness-types",
+ "hex",
+ "iii-sdk",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha2",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/provider-router/Cargo.toml
+++ b/provider-router/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/harness-types"]
 
 [package]
-name = "iii-provider-router"
+name = "provider-router"
 version = "0.1.0"
 description = "router::stream_assistant provider router plus router::abort and router::push_steering / push_followup helpers."
 edition = "2021"
@@ -17,7 +17,7 @@ name = "provider_router"
 path = "src/lib.rs"
 
 [[bin]]
-name = "iii-provider-router"
+name = "provider-router"
 path = "src/main.rs"
 
 [dependencies]

--- a/provider-router/iii.worker.yaml
+++ b/provider-router/iii.worker.yaml
@@ -3,7 +3,7 @@ name: provider-router
 language: rust
 deploy: binary
 manifest: Cargo.toml
-bin: iii-provider-router
+bin: provider-router
 description: router::stream_assistant provider router plus router::abort and router::push_steering / push_followup helpers.
 
 runtime:

--- a/provider-router/src/main.rs
+++ b/provider-router/src/main.rs
@@ -9,7 +9,7 @@ mod manifest;
 
 #[derive(Parser, Debug)]
 #[command(
-    name = "iii-provider-router",
+    name = "provider-router",
     about = "router::stream_assistant provider router plus router::abort and push helpers."
 )]
 struct Cli {

--- a/provider-router/tests/manifest.rs
+++ b/provider-router/tests/manifest.rs
@@ -4,12 +4,12 @@ use std::process::Command;
 use serde_json::Value;
 
 fn provider_router_executable() -> PathBuf {
-    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_iii_provider_router") {
+    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_provider_router") {
         return PathBuf::from(p);
     }
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     for profile in ["debug", "release"] {
-        let candidate = dir.join("target").join(profile).join("iii-provider-router");
+        let candidate = dir.join("target").join(profile).join("provider-router");
         if candidate.is_file() {
             return candidate;
         }
@@ -25,7 +25,7 @@ fn manifest_subcommand_emits_valid_json() {
     let output = Command::new(&bin)
         .arg("--manifest")
         .output()
-        .expect("spawn iii-provider-router --manifest");
+        .expect("spawn provider-router --manifest");
 
     assert!(
         output.status.success(),

--- a/provider-router/tests/manifest.rs
+++ b/provider-router/tests/manifest.rs
@@ -15,7 +15,7 @@ fn provider_router_executable() -> PathBuf {
         }
     }
     panic!(
-        "iii-provider-router binary not found under target/{{debug,release}}/; run `cargo build --bin iii-provider-router` first"
+        "provider-router binary not found under target/{{debug,release}}/; run `cargo build --bin provider-router` first"
     );
 }
 

--- a/session-inbox/Cargo.toml
+++ b/session-inbox/Cargo.toml
@@ -16,7 +16,7 @@ name = "session_inbox"
 path = "src/lib.rs"
 
 [[bin]]
-name = "iii-session-inbox"
+name = "session-inbox"
 path = "src/main.rs"
 
 [dependencies]

--- a/session-inbox/iii.worker.yaml
+++ b/session-inbox/iii.worker.yaml
@@ -3,7 +3,7 @@ name: session-inbox
 language: rust
 deploy: binary
 manifest: Cargo.toml
-bin: iii-session-inbox
+bin: session-inbox
 description: Per-session inbox (session-inbox::push, drain, peek) backed by iii state.
 
 runtime:

--- a/session-inbox/tests/common/mod.rs
+++ b/session-inbox/tests/common/mod.rs
@@ -6,12 +6,12 @@ pub fn session_inbox_executable() -> PathBuf {
     }
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     for profile in ["debug", "release"] {
-        let candidate = dir.join("target").join(profile).join("iii-session-inbox");
+        let candidate = dir.join("target").join(profile).join("session-inbox");
         if candidate.is_file() {
             return candidate;
         }
     }
     panic!(
-        "iii-session-inbox binary not found under target/{{debug,release}}/; run `cargo build --bin iii-session-inbox` first"
+        "session-inbox binary not found under target/{{debug,release}}/; run `cargo build --bin session-inbox` first"
     );
 }

--- a/session-inbox/tests/common/mod.rs
+++ b/session-inbox/tests/common/mod.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 pub fn session_inbox_executable() -> PathBuf {
-    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_iii_session_inbox") {
+    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_session_inbox") {
         return PathBuf::from(p);
     }
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));

--- a/session-inbox/tests/manifest.rs
+++ b/session-inbox/tests/manifest.rs
@@ -10,7 +10,7 @@ fn manifest_subcommand_emits_valid_json() {
     let output = Command::new(bin)
         .arg("--manifest")
         .output()
-        .expect("spawn iii-session-inbox --manifest");
+        .expect("spawn session-inbox --manifest");
 
     assert!(
         output.status.success(),

--- a/session-tree/Cargo.lock
+++ b/session-tree/Cargo.lock
@@ -787,28 +787,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-session-tree"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "clap",
- "harness-types",
- "iii-sdk",
- "serde",
- "serde_json",
- "serde_yaml",
- "serial_test",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "uuid",
- "which",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,6 +1616,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "session-tree"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "clap",
+ "harness-types",
+ "iii-sdk",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "serial_test",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+ "which",
 ]
 
 [[package]]

--- a/session-tree/Cargo.toml
+++ b/session-tree/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/harness-types"]
 
 [package]
-name = "iii-session-tree"
+name = "session-tree"
 version = "0.1.0"
 description = "Session storage as a parent-id tree of typed entries under session-tree::*."
 edition = "2021"
@@ -18,7 +18,7 @@ name = "session_tree"
 path = "src/lib.rs"
 
 [[bin]]
-name = "iii-session-tree"
+name = "session-tree"
 path = "src/main.rs"
 
 [dependencies]

--- a/session-tree/iii.worker.yaml
+++ b/session-tree/iii.worker.yaml
@@ -3,7 +3,7 @@ name: session-tree
 language: rust
 deploy: binary
 manifest: Cargo.toml
-bin: iii-session-tree
+bin: session-tree
 description: Session storage as a parent-id tree of typed entries under session-tree::*.
 
 runtime:

--- a/session-tree/src/main.rs
+++ b/session-tree/src/main.rs
@@ -10,7 +10,7 @@ mod config;
 mod manifest;
 
 #[derive(Parser, Debug)]
-#[command(name = "iii-session-tree", about = "Session tree worker for iii")]
+#[command(name = "session-tree", about = "Session tree worker for iii")]
 struct Cli {
     #[arg(long, default_value = "./config.yaml")]
     config: String,

--- a/session-tree/tests/common/mod.rs
+++ b/session-tree/tests/common/mod.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 pub fn session_tree_executable() -> PathBuf {
-    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_iii-session-tree") {
+    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_session-tree") {
         return PathBuf::from(p);
     }
     if let Some(p) = std::env::var_os("CARGO_BIN_EXE_session_tree") {
@@ -9,12 +9,12 @@ pub fn session_tree_executable() -> PathBuf {
     }
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     for profile in ["debug", "release"] {
-        let candidate = dir.join("target").join(profile).join("iii-session-tree");
+        let candidate = dir.join("target").join(profile).join("session-tree");
         if candidate.is_file() {
             return candidate;
         }
     }
     panic!(
-        "iii-session-tree binary not found under target/{{debug,release}}/; run `cargo build --bin iii-session-tree` first"
+        "session-tree binary not found under target/{{debug,release}}/; run `cargo build --bin session-tree` first"
     );
 }

--- a/session-tree/tests/common/mod.rs
+++ b/session-tree/tests/common/mod.rs
@@ -4,7 +4,7 @@ pub fn session_tree_executable() -> PathBuf {
     if let Some(p) = std::env::var_os("CARGO_BIN_EXE_iii-session-tree") {
         return PathBuf::from(p);
     }
-    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_iii_session_tree") {
+    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_session_tree") {
         return PathBuf::from(p);
     }
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));

--- a/session-tree/tests/integration.rs
+++ b/session-tree/tests/integration.rs
@@ -1,13 +1,13 @@
 //! Smoke + bus-level integration tests for `session-tree::list` and
 //! `session-tree::messages`.
 //!
-//! The bus tests boot a real `iii` engine and the `iii-session-tree` worker
+//! The bus tests boot a real `iii` engine and the `session-tree` worker
 //! against a transient in-memory store, then drive each function through
 //! `iii.trigger`. They skip silently when the `iii` CLI is not on PATH so
 //! `cargo test` stays green in plain dev environments.
 //!
 //! To run them locally:
-//!   cargo build --bin iii-session-tree
+//!   cargo build --bin session-tree
 //!   cargo test --test integration
 
 mod common;

--- a/session-tree/tests/manifest.rs
+++ b/session-tree/tests/manifest.rs
@@ -4,12 +4,12 @@ use std::process::Command;
 use serde_json::Value;
 
 fn session_tree_executable() -> PathBuf {
-    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_iii_session_tree") {
+    if let Some(p) = std::env::var_os("CARGO_BIN_EXE_session_tree") {
         return PathBuf::from(p);
     }
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     for profile in ["debug", "release"] {
-        let candidate = dir.join("target").join(profile).join("iii-session-tree");
+        let candidate = dir.join("target").join(profile).join("session-tree");
         if candidate.is_file() {
             return candidate;
         }
@@ -23,7 +23,7 @@ fn manifest_subcommand_emits_valid_json() {
     let output = Command::new(&bin)
         .arg("--manifest")
         .output()
-        .expect("spawn iii-session-tree --manifest");
+        .expect("spawn session-tree --manifest");
 
     assert!(
         output.status.success(),

--- a/session-tree/tests/manifest.rs
+++ b/session-tree/tests/manifest.rs
@@ -14,7 +14,7 @@ fn session_tree_executable() -> PathBuf {
             return candidate;
         }
     }
-    panic!("iii-session-tree binary not found; run `cargo build --bin iii-session-tree` first");
+    panic!("session-tree binary not found; run `cargo build --bin session-tree` first");
 }
 
 #[test]

--- a/session-tree/tests/restart_e2e.rs
+++ b/session-tree/tests/restart_e2e.rs
@@ -3,13 +3,13 @@
 //!
 //! Requires:
 //! - `IIITEST_ENGINE_URL`: WebSocket URL of a running iii engine
-//! - `IIITEST_WORKER_BIN`: absolute path to the iii-session-tree binary
+//! - `IIITEST_WORKER_BIN`: absolute path to the session-tree binary
 //!
 //! Marked `#[ignore]` so cargo test default runs skip it. To execute:
-//!     cargo build --release -p iii-session-tree
+//!     cargo build --release -p session-tree
 //!     IIITEST_ENGINE_URL=ws://127.0.0.1:49134 \
-//!       IIITEST_WORKER_BIN=$(pwd)/target/release/iii-session-tree \
-//!       cargo test -p iii-session-tree --test restart_e2e -- --ignored
+//!       IIITEST_WORKER_BIN=$(pwd)/target/release/session-tree \
+//!       cargo test -p session-tree --test restart_e2e -- --ignored
 //!
 //! Schema source (verified against session-tree/src/lib.rs `register_with_iii`):
 //! - `session-tree::create` payload: `{ "display_name": str?, "cwd": str? }` →
@@ -38,7 +38,7 @@ fn spawn_worker(engine_url: &str, bin: &str) -> Child {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
-        .expect("spawn iii-session-tree")
+        .expect("spawn session-tree")
 }
 
 async fn wait_for_ready() {

--- a/shell/Cargo.lock
+++ b/shell/Cargo.lock
@@ -732,31 +732,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-shell"
-version = "0.3.1"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64",
- "clap",
- "iii-sdk",
- "libc",
- "once_cell",
- "regex",
- "schemars",
- "serde",
- "serde_json",
- "serde_yaml",
- "shell-words",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "uuid",
- "walkdir",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,6 +1515,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shell"
+version = "0.3.2"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64",
+ "clap",
+ "iii-sdk",
+ "libc",
+ "once_cell",
+ "regex",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "shell-words",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+ "walkdir",
 ]
 
 [[package]]

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -1,13 +1,13 @@
 [workspace]
 
 [package]
-name = "iii-shell"
+name = "shell"
 version = "0.3.2"
 edition = "2021"
 publish = false
 
 [[bin]]
-name = "iii-shell"
+name = "shell"
 path = "src/main.rs"
 
 [dependencies]

--- a/shell/iii.worker.yaml
+++ b/shell/iii.worker.yaml
@@ -3,7 +3,7 @@ name: shell
 language: rust
 deploy: binary
 manifest: Cargo.toml
-bin: iii-shell
+bin: shell
 description: Unix shell + filesystem worker — exec with allowlist/denylist/timeout/output caps and background jobs; fs::ls|stat|mkdir|rm|chmod|mv|grep|sed|read|write with host jail, denylist, size caps, and sandbox-target forwarding
 
 # POSIX-only: src/fs/host.rs uses std::os::unix::fs::PermissionsExt / chown /

--- a/shell/src/config.rs
+++ b/shell/src/config.rs
@@ -323,7 +323,7 @@ mod tests {
         let yaml = r#"
 allowlist: []
 fs:
-  host_root: /tmp/iii-shell
+  host_root: /tmp/shell
   max_read_bytes: 1024
   denylist_paths:
     - /etc
@@ -333,7 +333,7 @@ sandbox:
         let c: ShellConfig = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(
             c.fs.host_root.as_deref(),
-            Some(std::path::Path::new("/tmp/iii-shell"))
+            Some(std::path::Path::new("/tmp/shell"))
         );
         assert_eq!(c.fs.max_read_bytes, 1024);
         assert!(!c.sandbox.enabled);

--- a/shell/src/exec/mod.rs
+++ b/shell/src/exec/mod.rs
@@ -8,7 +8,7 @@ pub mod sandbox;
 
 pub use backend::{ExecBackend, ExecCallResult, ExecOutcome};
 // These two re-exports are the public-API surface for downstream
-// consumers of `iii_shell::exec::*` and the back-compat surface for
+// consumers of `shell::exec::*` and the back-compat surface for
 // internal `crate::exec::{parse_argv, build_command, run_to_completion,
 // HostExecBackend, ExecError}` import paths. Rustc flags them as
 // unused inside the binary target (the binary uses fully-qualified

--- a/shell/src/fs/host.rs
+++ b/shell/src/fs/host.rs
@@ -1127,7 +1127,7 @@ mod tests {
     use std::fs;
 
     fn tmp() -> PathBuf {
-        let d = std::env::temp_dir().join(format!("iii-shell-fs-{}", uuid::Uuid::new_v4()));
+        let d = std::env::temp_dir().join(format!("shell-fs-{}", uuid::Uuid::new_v4()));
         fs::create_dir_all(&d).unwrap();
         d
     }
@@ -1706,7 +1706,7 @@ mod tests {
         let b = stub_backend(HostFsConfig::default());
         let err = b
             .write(crate::fs::WriteArgs {
-                path: "/tmp/iii-shell-write-bad-mode".into(),
+                path: "/tmp/shell-write-bad-mode".into(),
                 mode: "not-octal".into(),
                 parents: false,
                 content: stub_ref(),
@@ -1726,7 +1726,7 @@ mod tests {
         let b = stub_backend(cfg);
         let err = b
             .write(crate::fs::WriteArgs {
-                path: "/etc/iii-shell-escape".into(),
+                path: "/etc/shell-escape".into(),
                 mode: "0644".into(),
                 parents: false,
                 content: stub_ref(),
@@ -1817,7 +1817,7 @@ mod tests {
         let b = stub_backend(cfg);
         let err = b
             .read(crate::fs::ReadArgs {
-                path: "/etc/iii-shell-escape".into(),
+                path: "/etc/shell-escape".into(),
             })
             .await
             .unwrap_err();

--- a/shell/src/fs/sandbox.rs
+++ b/shell/src/fs/sandbox.rs
@@ -19,7 +19,7 @@ use crate::fs::{
 // TriggerFwd + IiiTriggerFwd live in `crate::triggers`; re-exported
 // here so existing `use crate::fs::sandbox::{TriggerFwd, IiiTriggerFwd}`
 // call sites inside the crate, plus the public
-// `iii_shell::fs::sandbox::TriggerFwd` surface consumed by
+// `shell::fs::sandbox::TriggerFwd` surface consumed by
 // `tests/sandbox_dispatch.rs`, keep compiling without mechanical churn.
 pub use crate::triggers::{IiiTriggerFwd, TriggerFwd};
 

--- a/shell/src/fs/wire.rs
+++ b/shell/src/fs/wire.rs
@@ -1,5 +1,5 @@
 //! Serde mirrors of the engine daemon's `sandbox::fs::*` JSON shapes.
-//! Authoritative reference: `crates/iii-shell-proto/src/lib.rs:69-100`
+//! Authoritative reference: `crates/shell-proto/src/lib.rs:69-100`
 //! (FsEntry, FsMatch, FsSedFileResult) in the motia repo.
 
 use schemars::JsonSchema;

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -18,10 +18,7 @@ mod triggers;
 use functions::types::{KillRequest, StatusRequest};
 
 #[derive(Parser, Debug)]
-#[command(
-    name = "shell",
-    about = "Unix shell execution worker for iii agents"
-)]
+#[command(name = "shell", about = "Unix shell execution worker for iii agents")]
 struct Cli {
     #[arg(long, default_value = "./config.yaml")]
     config: String,
@@ -311,12 +308,12 @@ async fn main() -> Result<()> {
         );
     }
 
-    tracing::info!("iii-shell registered 15 functions, ready");
+    tracing::info!("shell registered 15 functions, ready");
 
     spawn_skill_register(iii.clone());
 
     tokio::signal::ctrl_c().await?;
-    tracing::info!("iii-shell shutting down");
+    tracing::info!("shell shutting down");
     unregister_skill(&iii).await;
     iii.shutdown_async().await;
     Ok(())

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -19,7 +19,7 @@ use functions::types::{KillRequest, StatusRequest};
 
 #[derive(Parser, Debug)]
 #[command(
-    name = "iii-shell",
+    name = "shell",
     about = "Unix shell execution worker for iii agents"
 )]
 struct Cli {
@@ -368,8 +368,8 @@ async fn register_skill_with_retry(iii: &III, id: &str, body: &str) {
 /// so a missing `skills` worker never delays shell's readiness.
 fn spawn_skill_register(iii: III) {
     tokio::spawn(async move {
-        register_skill_with_retry(&iii, iii_shell::SKILL_ID, iii_shell::SKILL_MD).await;
-        for (id, body) in iii_shell::SUB_SKILLS {
+        register_skill_with_retry(&iii, shell::SKILL_ID, shell::SKILL_MD).await;
+        for (id, body) in shell::SUB_SKILLS {
             register_skill_with_retry(&iii, id, body).await;
         }
     });
@@ -380,7 +380,7 @@ fn spawn_skill_register(iii: III) {
 /// inevitably skip this path; an operator can clean up via
 /// `skills::list` + `skills::unregister` manually.
 async fn unregister_skill(iii: &III) {
-    for (id, _) in iii_shell::SUB_SKILLS {
+    for (id, _) in shell::SUB_SKILLS {
         let _ = iii
             .trigger(TriggerRequest {
                 function_id: "skills::unregister".into(),
@@ -393,7 +393,7 @@ async fn unregister_skill(iii: &III) {
     let _ = iii
         .trigger(TriggerRequest {
             function_id: "skills::unregister".into(),
-            payload: json!({ "id": iii_shell::SKILL_ID }),
+            payload: json!({ "id": shell::SKILL_ID }),
             action: None,
             timeout_ms: Some(2_000),
         })

--- a/shell/src/manifest.rs
+++ b/shell/src/manifest.rs
@@ -2,7 +2,7 @@ use serde_json::{json, Value};
 
 pub fn build_manifest() -> Value {
     json!({
-        "name": "iii-shell",
+        "name": "shell",
         "version": env!("CARGO_PKG_VERSION"),
         "description": "Unix shell execution worker for iii agents",
         "functions": [

--- a/shell/tests/e2e/run-tests-jailed.sh
+++ b/shell/tests/e2e/run-tests-jailed.sh
@@ -11,7 +11,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 WORKER_SRC="${WORKER_SRC:-$(cd "$ROOT_DIR/../.." && pwd)}"
 III_BIN="${III_BIN:-$(command -v iii 2>/dev/null || echo "$HOME/.local/bin/iii")}"
-WORKER_BIN_TARGET="${WORKER_BIN_TARGET:-$WORKER_SRC/target/release/iii-shell}"
+WORKER_BIN_TARGET="${WORKER_BIN_TARGET:-$WORKER_SRC/target/release/shell}"
 WORKER_BIN_LINK="${WORKER_BIN_LINK:-$HOME/.iii/workers/shell}"
 JAIL_ROOT="${JAIL_ROOT:-/private/tmp/iii-shell-jailed-root}"
 
@@ -36,7 +36,7 @@ Runs the jailed vuln-repro suite (config-jailed.yaml) — currently just
 S-C1 (symlink-parent jail escape).
 
   --keep     Leave the engine running after the run.
-  --no-build Skip cargo build of the iii-shell worker.
+  --no-build Skip cargo build of the shell worker.
 EOF
       exit 0
       ;;
@@ -63,8 +63,8 @@ trap cleanup EXIT INT TERM
 mkdir -p "$ROOT_DIR/reports" "$ROOT_DIR/data" "$(dirname "$WORKER_BIN_LINK")" "$JAIL_ROOT"
 
 if [[ "$NO_BUILD" -eq 0 ]]; then
-  echo "[run-tests-jailed] cargo build --release (iii-shell worker)"
-  (cd "$WORKER_SRC" && cargo build --release --bin iii-shell)
+  echo "[run-tests-jailed] cargo build --release (shell worker)"
+  (cd "$WORKER_SRC" && cargo build --release --bin shell)
 fi
 if [[ ! -x "$WORKER_BIN_TARGET" ]]; then
   echo "[run-tests-jailed] FATAL: worker binary missing at $WORKER_BIN_TARGET" >&2

--- a/shell/tests/e2e/run-tests.sh
+++ b/shell/tests/e2e/run-tests.sh
@@ -9,10 +9,10 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # `curl -fsSL https://install.iii.dev/iii/main/install.sh | sh` puts it).
 WORKER_SRC="${WORKER_SRC:-$(cd "$ROOT_DIR/../.." && pwd)}"
 III_BIN="${III_BIN:-$(command -v iii 2>/dev/null || echo "$HOME/.local/bin/iii")}"
-WORKER_BIN_TARGET="${WORKER_BIN_TARGET:-$WORKER_SRC/target/release/iii-shell}"
+WORKER_BIN_TARGET="${WORKER_BIN_TARGET:-$WORKER_SRC/target/release/shell}"
 # The engine resolves binaries by registered worker name (`shell` per
 # iii.worker.yaml), not by cargo bin name. If the engine actually looks up
-# by binary name, override with WORKER_BIN_LINK=$HOME/.iii/workers/iii-shell.
+# by binary name, override with WORKER_BIN_LINK=$HOME/.iii/workers/shell.
 WORKER_BIN_LINK="${WORKER_BIN_LINK:-$HOME/.iii/workers/shell}"
 
 REPORT_PATH="$ROOT_DIR/reports/report.json"
@@ -33,7 +33,7 @@ for arg in "$@"; do
 Usage: $0 [--keep] [--no-build]
 
   --keep     Leave the engine running after the run (for debugging).
-  --no-build Skip cargo build of the iii-shell worker.
+  --no-build Skip cargo build of the shell worker.
 
 Env overrides:
   WORKER_SRC          Path to the shell worker crate (default: ../..).
@@ -83,10 +83,10 @@ reap_orphans() {
     kill -9 $port_pid 2>/dev/null || true
   fi
   # Stale shell + iii-worker sandbox-daemon survivors from previous
-  # iii-shell test runs. Match narrowly on the test-config path
+  # shell test runs. Match narrowly on the test-config path
   # signature so we don't touch unrelated iii processes the user has
   # going. -f matches against the full command line.
-  pkill -f "iii-shell --config /var/folders" 2>/dev/null || true
+  pkill -f "shell --config /var/folders" 2>/dev/null || true
   pkill -f "iii-worker sandbox-daemon --config /var/folders" 2>/dev/null || true
   sleep 0.5
 }
@@ -96,8 +96,8 @@ mkdir -p "$ROOT_DIR/reports" "$ROOT_DIR/data" "$(dirname "$WORKER_BIN_LINK")"
 
 # 1. Build the worker (unless --no-build)
 if [[ "$NO_BUILD" -eq 0 ]]; then
-  echo "[run-tests] cargo build --release (iii-shell worker)"
-  (cd "$WORKER_SRC" && cargo build --release --bin iii-shell)
+  echo "[run-tests] cargo build --release (shell worker)"
+  (cd "$WORKER_SRC" && cargo build --release --bin shell)
 fi
 if [[ ! -x "$WORKER_BIN_TARGET" ]]; then
   echo "[run-tests] FATAL: worker binary missing at $WORKER_BIN_TARGET — run without --no-build" >&2

--- a/shell/tests/function_handlers.rs
+++ b/shell/tests/function_handlers.rs
@@ -5,10 +5,10 @@ use std::sync::Arc;
 use iii_sdk::III;
 use serde_json::{json, Value};
 
-use iii_shell::config::ShellConfig;
-use iii_shell::functions;
-use iii_shell::functions::types::{ExecBgRequest, ExecRequest, KillRequest, StatusRequest};
-use iii_shell::jobs::{self, now_ms, JobHandle, JobRecord, JobStatus};
+use shell::config::ShellConfig;
+use shell::functions;
+use shell::functions::types::{ExecBgRequest, ExecRequest, KillRequest, StatusRequest};
+use shell::jobs::{self, now_ms, JobHandle, JobRecord, JobStatus};
 
 async fn seed(handle: JobHandle) -> String {
     match jobs::try_reserve_and_insert(handle, usize::MAX).await {
@@ -310,13 +310,13 @@ async fn list_handler_returns_jobs_array_and_count() {
     assert!(r["count"].is_number());
 }
 
-fn fs_host_backend() -> Arc<dyn iii_shell::fs::FsBackend> {
+fn fs_host_backend() -> Arc<dyn shell::fs::FsBackend> {
     use std::fmt;
 
     #[derive(Debug)]
     struct StubChan;
     #[async_trait::async_trait]
-    impl iii_shell::fs::host::ChannelMaker for StubChan {
+    impl shell::fs::host::ChannelMaker for StubChan {
         async fn create_channel(&self, _: usize) -> Result<iii_sdk::Channel, iii_sdk::IIIError> {
             Err(iii_sdk::IIIError::Handler("stub channel".into()))
         }
@@ -330,8 +330,8 @@ fn fs_host_backend() -> Arc<dyn iii_shell::fs::FsBackend> {
         }
     }
 
-    Arc::new(iii_shell::fs::host::HostFsBackend::new(
-        Arc::new(iii_shell::fs::host::HostFsConfig::default()),
+    Arc::new(shell::fs::host::HostFsBackend::new(
+        Arc::new(shell::fs::host::HostFsConfig::default()),
         Arc::new(StubChan),
     ))
 }

--- a/shell/tests/function_handlers.rs
+++ b/shell/tests/function_handlers.rs
@@ -34,7 +34,7 @@ fn fresh_iii() -> III {
 }
 
 fn tmpdir(prefix: &str) -> std::path::PathBuf {
-    let d = std::env::temp_dir().join(format!("iii-shell-fn-{}-{}", prefix, uuid::Uuid::new_v4()));
+    let d = std::env::temp_dir().join(format!("shell-fn-{}-{}", prefix, uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&d).unwrap();
     d
 }

--- a/shell/tests/host_fs_branches.rs
+++ b/shell/tests/host_fs_branches.rs
@@ -28,11 +28,7 @@ fn backend() -> HostFsBackend {
 }
 
 fn tmpdir(prefix: &str) -> std::path::PathBuf {
-    let d = std::env::temp_dir().join(format!(
-        "iii-shell-host-{}-{}",
-        prefix,
-        uuid::Uuid::new_v4()
-    ));
+    let d = std::env::temp_dir().join(format!("shell-host-{}-{}", prefix, uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&d).unwrap();
     d
 }

--- a/shell/tests/host_fs_branches.rs
+++ b/shell/tests/host_fs_branches.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use iii_sdk::{Channel, IIIError};
 
-use iii_shell::fs::host::{ChannelMaker, HostFsBackend, HostFsConfig};
-use iii_shell::fs::{ChmodArgs, FsBackend, GrepArgs, MkdirArgs, MvArgs, RmArgs, SedArgs, StatArgs};
+use shell::fs::host::{ChannelMaker, HostFsBackend, HostFsConfig};
+use shell::fs::{ChmodArgs, FsBackend, GrepArgs, MkdirArgs, MvArgs, RmArgs, SedArgs, StatArgs};
 
 #[derive(Debug)]
 struct StubChan;

--- a/shell/tests/jobs_lifecycle.rs
+++ b/shell/tests/jobs_lifecycle.rs
@@ -2,7 +2,7 @@
 //! `remove_old`). Each test uses a unique ID prefix to avoid collisions in
 //! the global `JOBS` map shared across the integration-test binary.
 
-use iii_shell::jobs::{self, now_ms, JobHandle, JobRecord, JobStatus};
+use shell::jobs::{self, now_ms, JobHandle, JobRecord, JobStatus};
 
 async fn seed(handle: JobHandle) -> String {
     match jobs::try_reserve_and_insert(handle, usize::MAX).await {

--- a/shell/tests/sandbox_dispatch.rs
+++ b/shell/tests/sandbox_dispatch.rs
@@ -7,8 +7,8 @@ use iii_sdk::IIIError;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use iii_shell::fs::sandbox::{SandboxFsBackend, TriggerFwd};
-use iii_shell::fs::{
+use shell::fs::sandbox::{SandboxFsBackend, TriggerFwd};
+use shell::fs::{
     ChmodArgs, FsBackend, GrepArgs, LsArgs, MkdirArgs, MvArgs, ReadArgs, RmArgs, SedArgs, StatArgs,
     WriteArgs,
 };

--- a/shell/tests/sandbox_exec_dispatch.rs
+++ b/shell/tests/sandbox_exec_dispatch.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the public sandbox-exec surface. The handler-
 //! level dispatch via `target` field is exercised by the existing e2e
 //! shell scripts and the unit tests in `src/functions/exec.rs::tests`;
-//! this file cements the public-API surface (consumed via `iii_shell::*`)
+//! this file cements the public-API surface (consumed via `shell::*`)
 //! so downstream consumers pinning these paths catch drift.
 
 use std::sync::{Arc, Mutex};
@@ -11,9 +11,9 @@ use iii_sdk::IIIError;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use iii_shell::exec::sandbox::SandboxExecBackend;
-use iii_shell::exec::ExecBackend;
-use iii_shell::triggers::TriggerFwd;
+use shell::exec::sandbox::SandboxExecBackend;
+use shell::exec::ExecBackend;
+use shell::triggers::TriggerFwd;
 
 struct StubFwd {
     captured: Mutex<Vec<(String, Value)>>,

--- a/shell/tests/skill.rs
+++ b/shell/tests/skill.rs
@@ -71,14 +71,14 @@ fn id_is_valid(label: &str, id: &str) {
 
 #[test]
 fn router_well_formed() {
-    well_formed("router", iii_shell::SKILL_MD, true);
-    id_is_valid("router", iii_shell::SKILL_ID);
+    well_formed("router", shell::SKILL_MD, true);
+    id_is_valid("router", shell::SKILL_ID);
 }
 
 #[test]
 fn sub_skills_well_formed() {
-    let prefix = format!("{}/", iii_shell::SKILL_ID);
-    for (id, body) in iii_shell::SUB_SKILLS {
+    let prefix = format!("{}/", shell::SKILL_ID);
+    for (id, body) in shell::SUB_SKILLS {
         // Canonical leaves go directly from the topical H1 to ## When to use,
         // so the summary-paragraph assertion only applies to the router skill.
         well_formed(id, body, false);
@@ -86,7 +86,7 @@ fn sub_skills_well_formed() {
         assert!(
             id.starts_with(&prefix),
             "sub-skill id {id:?} must be nested under the worker id ({}/)",
-            iii_shell::SKILL_ID
+            shell::SKILL_ID
         );
     }
 }

--- a/turn-orchestrator/Cargo.lock
+++ b/turn-orchestrator/Cargo.lock
@@ -787,26 +787,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-turn-orchestrator"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "chrono",
- "clap",
- "harness-types",
- "iii-sdk",
- "schemars",
- "serde",
- "serde_json",
- "serde_yaml",
- "serial_test",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "which",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2061,6 +2041,26 @@ dependencies = [
  "sha1",
  "thiserror",
  "utf-8",
+]
+
+[[package]]
+name = "turn-orchestrator"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "harness-types",
+ "iii-sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "serial_test",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "which",
 ]
 
 [[package]]

--- a/turn-orchestrator/Cargo.toml
+++ b/turn-orchestrator/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/harness-types"]
 
 [package]
-name = "iii-turn-orchestrator"
+name = "turn-orchestrator"
 version = "0.1.0"
 description = "Durable run::start state machine driving each agent turn through provisioning, assistant, tools, steering, and tearing-down."
 edition = "2021"
@@ -17,7 +17,7 @@ name = "turn_orchestrator"
 path = "src/lib.rs"
 
 [[bin]]
-name = "iii-turn-orchestrator"
+name = "turn-orchestrator"
 path = "src/main.rs"
 
 [dependencies]

--- a/turn-orchestrator/iii.worker.yaml
+++ b/turn-orchestrator/iii.worker.yaml
@@ -3,7 +3,7 @@ name: turn-orchestrator
 language: rust
 deploy: binary
 manifest: Cargo.toml
-bin: iii-turn-orchestrator
+bin: turn-orchestrator
 description: Durable run::start state machine driving each agent turn through provisioning, assistant, tools, steering, and tearing-down.
 
 runtime:

--- a/turn-orchestrator/src/main.rs
+++ b/turn-orchestrator/src/main.rs
@@ -10,7 +10,7 @@ use turn_orchestrator::{config, manifest};
 
 #[derive(Parser, Debug)]
 #[command(
-    name = "iii-turn-orchestrator",
+    name = "turn-orchestrator",
     about = "Durable run::start state machine driving each agent turn through provisioning, assistant, tools, steering, and tearing-down."
 )]
 struct Cli {

--- a/turn-orchestrator/tests/common/mod.rs
+++ b/turn-orchestrator/tests/common/mod.rs
@@ -109,7 +109,7 @@ fn find_session_tree_binary() -> Option<PathBuf> {
         let candidate = session_tree_dir
             .join("target")
             .join(profile)
-            .join("iii-session-tree");
+            .join("session-tree");
         if candidate.is_file() {
             return Some(candidate);
         }

--- a/turn-orchestrator/tests/manifest.rs
+++ b/turn-orchestrator/tests/manifest.rs
@@ -11,7 +11,7 @@ fn binary_path() -> String {
         return path.to_string();
     }
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    format!("{manifest_dir}/target/debug/iii-turn-orchestrator")
+    format!("{manifest_dir}/target/debug/turn-orchestrator")
 }
 
 #[test]

--- a/turn-orchestrator/tests/manifest.rs
+++ b/turn-orchestrator/tests/manifest.rs
@@ -7,7 +7,7 @@ fn binary_path() -> String {
     // Fall back to constructing it from CARGO_MANIFEST_DIR so the test works in
     // environments where CARGO_BIN_EXE_* is not injected.
     #[allow(clippy::option_env_unwrap)]
-    if let Some(path) = option_env!("CARGO_BIN_EXE_iii_turn_orchestrator") {
+    if let Some(path) = option_env!("CARGO_BIN_EXE_turn_orchestrator") {
         return path.to_string();
     }
     let manifest_dir = env!("CARGO_MANIFEST_DIR");


### PR DESCRIPTION
## Summary

- Rename `bin:` in `iii.worker.yaml` and `[package].name` + `[[bin]].name` in `Cargo.toml` to drop the `iii-` prefix on 14 binary workers, so the worker name (registry key) matches the binary inside the published tar.gz.
- Update touch-points that move with the package name: `CARGO_BIN_EXE_iii_<worker>` env-var lookups in manifest tests, shell's implicit-lib `iii_shell::*` module paths, clap `name = "..."` in `src/main.rs`, and hardcoded binary paths in `tests/manifest.rs`.
- Excludes `acp` (handled separately).

## Why

`iii worker add ./harness` fails resolving `provider-anthropic` (and 14 other deps) with `Binary 'provider-anthropic' not found in archive`. The install code (`iii/crates/iii-worker/src/cli/binary_download.rs`) extracts the binary from the tar.gz by *worker name*, but the publish workflow uses the worker's `bin:` field (`iii-provider-anthropic`) as the binary file name. Aligning the two unblocks installs without touching the install side.

Workers covered: approval-gate, auth-credentials, harness, models-catalog, oauth-anthropic, oauth-openai-codex, policy-denylist, provider-anthropic, provider-openai, provider-router, session-inbox, session-tree, shell, turn-orchestrator.

## Followup

Each renamed worker needs a version bump + republish so the registry serves new archives whose binary file matches the worker name. Existing v0.1.0 archives are still broken.

## Test plan

- [x] `cargo check --bin <name> --tests` passes for all 14 workers
- [x] `cargo test --test manifest` passes for provider-anthropic and harness
- [x] `cargo test` (full suite) passes for shell — 347 tests
- [ ] Confirm publish workflow's `bin_name` resolution still picks up the renamed `[[bin]]` on next tagged release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized package naming across all components by removing prefix identifiers from binary names, package identifiers, and CLI command names for consistency and clarity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/workers/pull/118)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->