### PR TITLE
chore: bump renamed workers to v0.1.1 (shell v0.3.3)

### DIFF
--- a/approval-gate/Cargo.lock
+++ b/approval-gate/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "approval-gate"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/approval-gate/Cargo.toml
+++ b/approval-gate/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "approval-gate"
-version = "0.1.0"
+version = "0.1.1"
 description = "Hook subscriber on agent::before_function_call that pauses function calls listed in approval_required until the UI resolves them via approval::resolve."
 edition = "2021"
 license = "Apache-2.0"

--- a/auth-credentials/Cargo.lock
+++ b/auth-credentials/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auth-credentials"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/auth-credentials/Cargo.toml
+++ b/auth-credentials/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "auth-credentials"
-version = "0.1.0"
+version = "0.1.1"
 description = "Provider credential vault under auth::* — API keys and OAuth tokens."
 edition = "2021"
 license = "Apache-2.0"

--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/harness-types"]
 
 [package]
 name = "harness"
-version = "0.1.0"
+version = "0.1.1"
 description = "Meta-worker that composes the modular workers backing the iii chat surface."
 edition = "2021"
 license = "Apache-2.0"

--- a/models-catalog/Cargo.lock
+++ b/models-catalog/Cargo.lock
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "models-catalog"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/models-catalog/Cargo.toml
+++ b/models-catalog/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "models-catalog"
-version = "0.1.0"
+version = "0.1.1"
 description = "Model capabilities knowledge base under models::* (list/get/supports/register)."
 edition = "2021"
 license = "Apache-2.0"

--- a/oauth-anthropic/Cargo.lock
+++ b/oauth-anthropic/Cargo.lock
@@ -95,7 +95,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auth-credentials"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "oauth-anthropic"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "auth-credentials",

--- a/oauth-anthropic/Cargo.toml
+++ b/oauth-anthropic/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/auth-credentials"]
 
 [package]
 name = "oauth-anthropic"
-version = "0.1.0"
+version = "0.1.1"
 description = "Anthropic Claude Pro/Max OAuth (PKCE localhost flow) under oauth::anthropic::*."
 edition = "2021"
 license = "Apache-2.0"
@@ -38,7 +38,7 @@ log = "0.4"
 env_logger = "0.11"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/iii-hq/workers"

--- a/oauth-openai-codex/Cargo.lock
+++ b/oauth-openai-codex/Cargo.lock
@@ -95,7 +95,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auth-credentials"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "oauth-openai-codex"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "auth-credentials",

--- a/oauth-openai-codex/Cargo.toml
+++ b/oauth-openai-codex/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/auth-credentials"]
 
 [package]
 name = "oauth-openai-codex"
-version = "0.1.0"
+version = "0.1.1"
 description = "OpenAI Codex OAuth (PKCE localhost flow) under oauth::openai_codex::*."
 edition = "2021"
 license = "Apache-2.0"
@@ -38,7 +38,7 @@ log = "0.4"
 env_logger = "0.11"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/iii-hq/workers"

--- a/policy-denylist/Cargo.lock
+++ b/policy-denylist/Cargo.lock
@@ -1013,7 +1013,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "policy-denylist"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/policy-denylist/Cargo.toml
+++ b/policy-denylist/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "policy-denylist"
-version = "0.1.0"
+version = "0.1.1"
 description = "Hook subscriber on agent::before_function_call that blocks calls whose function id matches a configured denylist."
 edition = "2021"
 license = "Apache-2.0"

--- a/provider-anthropic/Cargo.lock
+++ b/provider-anthropic/Cargo.lock
@@ -95,7 +95,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auth-credentials"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "harness-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "overflow-classify"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "harness-types",
  "once_cell",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "provider-anthropic"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "auth-credentials",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "provider-base"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "auth-credentials",

--- a/provider-anthropic/Cargo.toml
+++ b/provider-anthropic/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/harness-types", "crates/overflow-classify", "crates/auth-cred
 
 [package]
 name = "provider-anthropic"
-version = "0.1.0"
+version = "0.1.1"
 description = "Anthropic Messages API streaming provider; exposes provider::anthropic::complete on the iii bus."
 edition = "2021"
 license = "Apache-2.0"
@@ -46,7 +46,7 @@ tokio-stream = "0.1"
 serde_json = { workspace = true }
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/iii-hq/workers"

--- a/provider-openai/Cargo.lock
+++ b/provider-openai/Cargo.lock
@@ -95,7 +95,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auth-credentials"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "harness-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "overflow-classify"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "harness-types",
  "once_cell",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "provider-base"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "auth-credentials",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "provider-openai"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "auth-credentials",

--- a/provider-openai/Cargo.toml
+++ b/provider-openai/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/harness-types", "crates/overflow-classify", "crates/auth-cred
 
 [package]
 name = "provider-openai"
-version = "0.1.0"
+version = "0.1.1"
 description = "OpenAI Chat Completions; registers provider::openai::complete on the iii bus."
 edition = "2021"
 license = "Apache-2.0"
@@ -41,7 +41,7 @@ tokio-stream = "0.1"
 serde_json = { workspace = true }
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/iii-hq/workers"

--- a/provider-router/Cargo.lock
+++ b/provider-router/Cargo.lock
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "harness-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "provider-router"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/provider-router/Cargo.toml
+++ b/provider-router/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/harness-types"]
 
 [package]
 name = "provider-router"
-version = "0.1.0"
+version = "0.1.1"
 description = "router::stream_assistant provider router plus router::abort and router::push_steering / push_followup helpers."
 edition = "2021"
 license = "Apache-2.0"
@@ -37,7 +37,7 @@ hex = "0.4"
 sha2 = "0.10"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/iii-hq/workers"

--- a/session-inbox/Cargo.lock
+++ b/session-inbox/Cargo.lock
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "session-inbox"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/session-inbox/Cargo.toml
+++ b/session-inbox/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "session-inbox"
-version = "0.1.0"
+version = "0.1.1"
 description = "Per-session inbox (session-inbox::push, drain, peek) backed by iii state."
 edition = "2021"
 license = "Apache-2.0"

--- a/session-tree/Cargo.lock
+++ b/session-tree/Cargo.lock
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "harness-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1620,7 +1620,7 @@ dependencies = [
 
 [[package]]
 name = "session-tree"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/session-tree/Cargo.toml
+++ b/session-tree/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/harness-types"]
 
 [package]
 name = "session-tree"
-version = "0.1.0"
+version = "0.1.1"
 description = "Session storage as a parent-id tree of typed entries under session-tree::*."
 edition = "2021"
 license = "Apache-2.0"
@@ -42,7 +42,7 @@ which = "8"
 serial_test = "3"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/iii-hq/workers"

--- a/shell/Cargo.lock
+++ b/shell/Cargo.lock
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "shell"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "shell"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 publish = false
 

--- a/turn-orchestrator/Cargo.lock
+++ b/turn-orchestrator/Cargo.lock
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "harness-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2045,7 +2045,7 @@ dependencies = [
 
 [[package]]
 name = "turn-orchestrator"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/turn-orchestrator/Cargo.toml
+++ b/turn-orchestrator/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/harness-types"]
 
 [package]
 name = "turn-orchestrator"
-version = "0.1.0"
+version = "0.1.1"
 description = "Durable run::start state machine driving each agent turn through provisioning, assistant, tools, steering, and tearing-down."
 edition = "2021"
 license = "Apache-2.0"
@@ -41,7 +41,7 @@ which = "8"
 serial_test = "3"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/iii-hq/workers"


### PR DESCRIPTION
## Summary

- Bump Cargo.toml version 0.1.0 → 0.1.1 for the 14 workers renamed in #118 (shell: 0.3.2 → 0.3.3).
- Required so the harness-bundle release picks them up — the workflow only publishes deps whose local version > registered version.

## Why

#118 fixed the registry install path (`iii worker add ./harness` failing with `Binary 'provider-anthropic' not found in archive`) by aligning each worker's `bin:` with its `name:`. But the registry still serves v0.1.0 archives that contain the old `iii-<worker>` binaries. Bumping to 0.1.1 lets the release pipeline publish corrected archives.

Bundle deps (12): approval-gate, auth-credentials, models-catalog, oauth-anthropic, oauth-openai-codex, policy-denylist, provider-anthropic, provider-openai, provider-router, session-inbox, session-tree, turn-orchestrator.

Plus harness (0.1.1) — drives the bundle workflow.
Plus shell (0.3.3) — released separately via `shell/v*` tag (excluded from harness bundle).

## Release plan after merge

1. `git tag harness/v0.1.1` → triggers `release-harness-bundle.yml`, fan-out builds + publishes harness + 12 deps.
2. `git tag shell/v0.3.3` → triggers `release.yml` for shell.

## Test plan

- [x] Each worker's Cargo.lock refreshed via `cargo check`
- [x] `cargo check --bin <worker> --tests` passes for every bumped worker