### PR TITLE
ci(harness-bundle): publish every bundled dep at the harness version

### DIFF
--- a/.github/workflows/_rust-binary.yml
+++ b/.github/workflows/_rust-binary.yml
@@ -35,6 +35,11 @@ on:
         required: false
         type: string
         default: ''
+      version_override:
+        description: 'When set, rewrite [package].version in manifest_path to this value before building. Used by the harness bundle to force coordinated versions across deps.'
+        required: false
+        type: string
+        default: ''
 
 env:
   CARGO_TERM_COLOR: always
@@ -149,6 +154,42 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: ${{ inputs.bin_name }}-${{ matrix.target }}
+
+      - name: Rewrite [package].version (bundle coordinated release)
+        if: inputs.version_override != ''
+        shell: bash
+        env:
+          MANIFEST: ${{ inputs.manifest_path }}
+          VERSION: ${{ inputs.version_override }}
+        run: |
+          python3 - <<'PY'
+          import os, pathlib, re, sys
+          path = pathlib.Path(os.environ["MANIFEST"])
+          version = os.environ["VERSION"]
+          if not path.is_file():
+              print(f"::error::manifest not found: {path}")
+              sys.exit(1)
+          lines = path.read_text().splitlines(keepends=True)
+          out, in_package, rewrote = [], False, False
+          for line in lines:
+              stripped = line.strip()
+              if stripped.startswith("["):
+                  in_package = stripped == "[package]"
+                  out.append(line)
+                  continue
+              if in_package and not rewrote:
+                  m = re.match(r'(\s*version\s*=\s*)"[^"]*"(.*)', line)
+                  if m:
+                      out.append(f'{m.group(1)}"{version}"{m.group(2)}\n')
+                      rewrote = True
+                      continue
+              out.append(line)
+          if not rewrote:
+              print(f"::error::[package].version not found in {path}")
+              sys.exit(1)
+          path.write_text("".join(out))
+          print(f"::notice::set [package].version to {version} in {path}")
+          PY
 
       - name: Build and upload binary
         uses: taiki-e/upload-rust-binary-action@v1

--- a/.github/workflows/release-harness-bundle.yml
+++ b/.github/workflows/release-harness-bundle.yml
@@ -2,16 +2,18 @@ name: Release harness bundle
 
 # Single-dispatch fan-out for the harness meta-worker. A `harness/v*` tag
 # triggers one CI run that builds + publishes harness plus every in-repo
-# dependency listed in harness/iii.worker.yaml whose local manifest version
-# is greater than the version currently registered on https://workers.iii.dev/.
+# dependency listed in harness/iii.worker.yaml, all at the harness version.
+# The workflow rewrites each dep's [package].version to the harness version
+# before building, so the published binary embeds the coordinated version
+# regardless of what's checked into Cargo.toml.
 #
 # Skips:
 #   - dependencies not present as folders in this repo (e.g. iii-sandbox)
-#   - dependencies whose local version <= registered version
+#   - dependencies already registered at >= the harness version
 #   - the `skills` worker (held by maintainers; bump + tag separately)
+#   - the `shell` worker (releases on its own tag via release.yml)
 #
-# Reuses _rust-binary.yml and _publish-registry.yml exactly as the
-# per-worker release.yml does.
+# Reuses _rust-binary.yml (with version_override) and _publish-registry.yml.
 
 on:
   push:
@@ -99,9 +101,14 @@ jobs:
               return tuple(parts)
 
           def registered_version(worker: str) -> str | None:
-              url = f"{api}/workers/{urllib.parse.quote(worker)}"
+              # /download/<name> is the public lookup endpoint; it returns
+              # {"version": "...", "binaries": {...}, ...} for binary workers.
+              url = f"{api}/download/{urllib.parse.quote(worker)}"
               try:
                   with urllib.request.urlopen(url, timeout=15) as resp:
+                      if resp.status == 204:
+                          # Engine-baked worker: no artefact, no version info.
+                          return None
                       data = json.loads(resp.read())
                   return data.get("version") or data.get("latest")
               except Exception as exc:  # noqa: BLE001
@@ -135,6 +142,10 @@ jobs:
               "targets": normalize_targets(harness_meta),
           })
 
+          # Every bundled dep ships at the harness version. The workflow
+          # rewrites each dep's [package].version at build time so the binary
+          # embeds the same version we publish, regardless of what's in the
+          # checked-out Cargo.toml.
           for dep_name in sorted(deps):
               if dep_name in excluded:
                   print(f"::notice::{dep_name}: excluded from bundle")
@@ -156,18 +167,18 @@ jobs:
                   print(f"::warning::{dep_name}: cannot read version from {manifest}; skipping")
                   continue
               reg_ver = registered_version(dep_name)
-              if reg_ver and parse_semver(local_ver) <= parse_semver(reg_ver):
-                  print(f"::notice::{dep_name}: local v{local_ver} <= registered v{reg_ver}; skipping")
+              if reg_ver and parse_semver(harness_version) <= parse_semver(reg_ver):
+                  print(f"::notice::{dep_name}: harness v{harness_version} <= registered v{reg_ver}; skipping")
                   continue
               bin_name = meta.get("bin") or meta.get("name") or dep_name
               publish_set.append({
                   "worker": dep_name,
-                  "version": local_ver,
+                  "version": harness_version,
                   "manifest": manifest,
                   "bin": bin_name,
                   "targets": normalize_targets(meta),
               })
-              print(f"::notice::{dep_name}: queued v{local_ver} (registry v{reg_ver or 'none'})")
+              print(f"::notice::{dep_name}: queued v{harness_version} (local v{local_ver}, registry v{reg_ver or 'none'})")
 
           # Pull registry-tag (latest|next) from the annotated harness tag message.
           registry_tag = "latest"
@@ -206,6 +217,7 @@ jobs:
       manifest_path: ${{ matrix.entry.worker }}/${{ matrix.entry.manifest }}
       tag_name: ${{ matrix.entry.worker }}/v${{ matrix.entry.version }}
       targets: ${{ matrix.entry.targets }}
+      version_override: ${{ matrix.entry.version }}
     secrets: inherit
 
   publish:


### PR DESCRIPTION
## Summary

- `release-harness-bundle.yml`: every in-repo dep in `harness/iii.worker.yaml` ships at the harness tag's version instead of its local `Cargo.toml` version.
- `_rust-binary.yml`: new optional `version_override` input rewrites `[package].version` in the manifest before `cargo build`, so the published binary embeds the coordinated version.
- Fix the registry-lookup endpoint (`/workers/<name>` → `/download/<name>`) so the "skip if already registered" check actually works instead of always falling through.

## Why

Today, tagging `harness/v0.1.2` publishes harness@0.1.2 but every dep stays at whatever's in its own `Cargo.toml` — typically 0.1.1 from the last bump. The registry rejects re-publishing 0.1.1 with HTTP 409 (`Version 0.1.0 already exists for hook-fanout`, same for llm-budget last run), and the version landscape becomes confusing: harness 0.1.2 ships with deps that say 0.1.1.

After this PR, tagging `harness/v0.1.3` produces a coherent bundle: harness 0.1.3 + every bundled dep 0.1.3. No manual per-dep bumps required, no spurious 409s.

## Cargo.toml in repo can lag

Per the design choice — the workflow rewrites `[package].version` on the fly in the build job. The repo's `Cargo.toml` files don't need pre-release bumps. The tradeoff: `cargo build` locally still reports the dev version (e.g., 0.1.1), only the published artifact reports the harness version.

## Excluded from the bundle

- `shell` — releases on its own `shell/v*` tag via `release.yml`
- `skills` — held by maintainers, separate tag
- `iii-sandbox` — external engine worker

## Test plan

- [ ] Tag `harness/v0.1.3` post-merge → confirm harness + 11 deps publish at 0.1.3, no HTTP 409s
- [ ] Confirm each dep's archive at `releases/download/<dep>/v0.1.3/<dep>-<target>.tar.gz` contains a binary whose `--manifest` JSON reports `version: 0.1.3`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflows to support version coordination for bundled releases. Bundled dependencies now align with the harness version, ensuring consistent versioning across release packages. Added version override capability to the build process for coordinated release management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/workers/pull/121)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->