### PR TITLE
chore: bump session-inbox to v0.1.3

### DIFF
--- a/session-inbox/Cargo.lock
+++ b/session-inbox/Cargo.lock
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "session-inbox"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/session-inbox/Cargo.toml
+++ b/session-inbox/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "session-inbox"
-version = "0.1.1"
+version = "0.1.3"
 description = "Per-session inbox (session-inbox::push, drain, peek) backed by iii state."
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Bump `session-inbox/Cargo.toml` 0.1.1 → 0.1.3 so we can tag `session-inbox/v0.1.3` and force a fresh registry row, working around a stuck DB entry.

## Why

The harness bundle release tried to publish `session-inbox v0.1.2` three times. Every attempt returned HTTP 200 with a phantom version UUID, but the resolver still reports only `0.1.1, 0.1.0` available. Worse, the `0.1.1` row's `sha256` is corrupted (registry says `5016005b…`, actual archive sha is `dc68c21e…`), which breaks `iii worker add harness` with a SHA256 mismatch.

Symptoms match the bug fixed in `registry/api/src/services/publish.service.ts:86-91` ("transaction-wrapped insert"), so production likely runs an older deployment.

Skipping 0.1.2 (poisoned by the failed publishes) and going straight to 0.1.3 forces a brand-new insert path, hopefully bypassing whatever's wedged. If that fails, we'll need to fix the registry DB directly.

## Release plan after merge

1. `git tag session-inbox/v0.1.3` at the merge commit
2. Push tag → triggers `release.yml` for `session-inbox/v*`
3. Confirm `curl https://api.workers.iii.dev/download/session-inbox` shows `version: 0.1.3` with a sha matching the actual v0.1.3 archive
4. Bump `harness/iii.worker.yaml` dep range to `session-inbox: "^0.1.3"` if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.3

---

**Note:** This release contains minimal user-facing changes. Please refer to previous release notes for details on features and improvements included in this version.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/workers/pull/122)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->