### PR TITLE
chore(ci): bump skills-and-validation to v0.3 + switch AI judge to Sonnet

### DIFF
--- a/.github/workflows/skill-check.yml
+++ b/.github/workflows/skill-check.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write          # for auto-fix mode (commits the rendered diff back)
   pull-requests: write     # for the sticky PR comment
+  actions: write           # for the persistent AI skip-cache (v0.3+)
 
 jobs:
   skill-check:
@@ -16,7 +17,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}    # check out the PR branch directly
-      - uses: iii-hq/skills-and-validation@v0.2
+      - uses: iii-hq/skills-and-validation@v0.3
         with:
           write: true
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.skill-check.yaml
+++ b/.skill-check.yaml
@@ -1,6 +1,6 @@
 version: 1
 ai_check:
   provider: anthropic
-  model: claude-opus-4-7
+  model: claude-sonnet-4-6
   api_key_env_var: ANTHROPIC_API_KEY
   max_tokens: 6000


### PR DESCRIPTION
## Summary
- Bump \`iii-hq/skills-and-validation@v0.2\` → \`@v0.3\` in \`.github/workflows/skill-check.yml\`
- Add \`actions: write\` so the new persistent AI skip-cache (v0.3.0+) can save across runs
- Switch \`ai_check.model\` from \`claude-opus-4-7\` to \`claude-sonnet-4-6\` — Opus is overkill for the per-file judge

## Context
v0.3.0 adds a SHA-256-keyed pass-cache for the AI layer backed by \`actions/cache\`. Hash inputs cover artifact text, project rules, system prompt, model, and doc type — so a rule edit (or this model swap) busts the cache automatically. Only PASS verdicts are recorded; FAILs always re-run.

v0.3.1 adds explicit \`[ai-cache] hit: <path>\` logging so a cache hit is visible in the workflow log (the floating \`@v0.3\` tag picks this up automatically).

Verified end-to-end on iii-hq/skills-test#7 — three successive PR pushes show cache restore → save → restore → hit lines for previously-PASSing artifacts.

## Test plan
- [ ] First push: cache miss (model swap invalidated every prior entry); full AI validation under Sonnet; save step records new hashes
- [ ] Second push: cache restore hits; previously-passing artifacts log \`[ai-cache] hit: ...\` and skip the API call
- [ ] No regression for the workers currently passing under Opus — if Sonnet flags new violations or stops flagging known ones, that's a finding to discuss

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated skill validation workflow to the latest version
  * Enhanced AI model configuration for automated skill checks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/workers/pull/129)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->