### PR TITLE
ci(skill-check): bump to v0.4 + scope: pr-diff (follow-up to #129)

### DIFF
--- a/.github/workflows/skill-check.yml
+++ b/.github/workflows/skill-check.yml
@@ -17,7 +17,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.head_ref }}    # check out the PR branch directly
-      - uses: iii-hq/skills-and-validation@v0.3
+      - uses: iii-hq/skills-and-validation@v0.4
         with:
           write: true
+          scope: pr-diff
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
Follow-up to #129. v0.4.0 of \`skills-and-validation\` adds the \`scope: pr-diff\` input which restricts validation to files in the PR diff (rather than walking the entire workers glob on every push). Bumps the action ref to \`@v0.4\` and enables the new input.

## Context
The previous PR (#129) shipped v0.3 with the persistent AI skip-cache. The cache helps on subsequent pushes but every push still walks the whole glob. v0.4 fixes that at the source: in worker mode, only workers with a changed file under their dir get validated; others are skipped entirely.

A diff that touches any \`.skill-check.yaml\` bails to full scan since model/rules edits affect verdicts globally.

Verified end-to-end on iii-hq/skills-test#8.

## Test plan
- [ ] First push (this PR): only files touched by this PR are checked
- [ ] Future PRs that touch one worker validate only that worker; other workers show as skipped in the summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)