### PR TITLE
feat(iii-directory): skills index and fixes to registry operations

### DIFF
--- a/iii-directory/Cargo.lock
+++ b/iii-directory/Cargo.lock
@@ -1070,9 +1070,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0226f7ce0d9071f9cb75ea7b7ac1241b15282915ccd41d9bbd2ee0db94f90c6"
+checksum = "6feab7af22d4f583024c5515139b3430c8f4ad1b7a7956351fa52079f05b2dab"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/iii-directory/Cargo.toml
+++ b/iii-directory/Cargo.toml
@@ -15,7 +15,7 @@ name = "iii_directory"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.11.3"
+iii-sdk = "=0.11.6"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time", "fs", "process"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/iii-directory/README.md
+++ b/iii-directory/README.md
@@ -7,10 +7,10 @@ split into four sub-namespaces (all MCP-agnostic):
 
 | Surface | What clients see | When to use it |
 |---|---|---|
-| **Skills** (`directory::skills::*`) | Enriched listing via `directory::skills::list` (`{ id, title, description, bytes, modified_at }` per row) and a single-skill reader `directory::skills::get { id }` returning `{ id, title, description, body, modified_at }` | Orientation: "when and why to use my worker's tools" |
+| **Skills** (`directory::skills::*`) | Enriched listing via `directory::skills::list` (`{ id, title, type, description, bytes, modified_at }` per row), a single-skill reader `directory::skills::get { id }` returning `{ id, title, type, description, body, modified_at }`, and `directory::skills::index` which renders a short per-worker overview document (one `## <title>` + first paragraph + `read more` link per `type: index` skill). `title` prefers the YAML frontmatter `title:` over the body H1; `type` is lifted from frontmatter `type:` (e.g. `index`, `how-to`, `reference`) and serialised as `null` when absent. | Orientation: "when and why to use my worker's tools" |
 | **Prompts** (`directory::prompts::*`) | Static prompt templates listed by `directory::prompts::list` and read by `directory::prompts::get` | Parametric command templates the *user* invokes |
 | **Engine** (`directory::engine::*`) | Read-side enrichment over `engine::functions::list`, `engine::workers::list`, `engine::trigger-types::list`, `engine::triggers::list` | "What's connected to the engine right now?" |
-| **Registry** (`directory::registry::*`) | HTTP proxy over `api.workers.iii.dev` with the same `workers::{list,info}` shape as `directory::engine::workers::*` | "What's published in the public registry?" |
+| **Registry** (`directory::registry::*`) | HTTP proxy over `api.workers.iii.dev` with `workers::{list,info}`. Rows share the core `name` / `description` / `version` fields with `directory::engine::workers::*` and add publication metadata (`type`, `config`, `supported_targets`, `total_downloads`, `dependencies`, optional `image`). `workers::list` is cursor-paginated with a server-authored page size. | "What's published in the public registry?" |
 
 Skills and prompts are sourced from a single configured folder on disk
 (`skills_folder`). The only write path is the
@@ -20,8 +20,11 @@ Skills and prompts are sourced from a single configured folder on disk
 downloaded, files belong to the developer — edit them however you want.
 
 `directory::engine::workers::*` and `directory::registry::workers::*`
-share the same envelope shape so callers can switch between the local
-engine view and the published-registry view without re-learning the API.
+share the core `name` / `description` / `version` fields so a parser
+that touches only those keys works against either surface; the
+registry view also surfaces publication metadata (`type`, `config`,
+`supported_targets`, `total_downloads`, `dependencies`, optional
+`image`) and the engine view adds runtime / connection state.
 
 ## Table of contents
 
@@ -126,6 +129,11 @@ A few rules:
 
 - **Skill ids** are the relative path under `skills_folder` with `.md`
   stripped. Each segment must satisfy `[a-z0-9_-]{1,64}`.
+- **Skill frontmatter is optional.** When present, the reader honours
+  two keys: `title:` (used by `directory::skills::list` and
+  `directory::skills::get` in preference to a body `# H1`) and
+  `type:` (free-form classifier surfaced verbatim on both responses).
+  Any other YAML keys are ignored.
 - **Prompts** live under any `*/prompts/*.md` path. They must start with
   a YAML frontmatter block declaring at least `description`; `name`
   is optional and overrides the file-stem default.
@@ -163,7 +171,7 @@ tree-shaped picker iterate `list` rows themselves and indent by
 
 ## Functions
 
-Fifteen functions, all under `directory::*`. All registrations are
+Sixteen functions, all under `directory::*`. All registrations are
 namespace-clean; this worker is intentionally agnostic to MCP and any
 other adapter.
 
@@ -172,8 +180,9 @@ other adapter.
 | Function ID | Description |
 |---|---|
 | `directory::skills::download` | Pull markdown into `skills_folder`. Either `{repo, skill, branch?}` (defaults `branch=main`) or `{worker, version?|tag?}` (defaults `tag=latest`). |
-| `directory::skills::list` | Enriched listing of every fs-backed skill: `{ id, title, description, bytes, modified_at }` per row. Title and description are extracted from each body's H1 + first paragraph so consumers can render a picker without a follow-up `get` per row. |
-| `directory::skills::get` | Fetch one skill by id. Returns `{ id, title, description, body, modified_at }` — same flat shape as `directory::prompts::get`. Accepts a bare id or the same id prefixed with `iii://`. |
+| `directory::skills::list` | Enriched listing of every fs-backed skill: `{ id, title, type, description, bytes, modified_at }` per row. `title` prefers the YAML frontmatter `title:` over the body H1, `type` is lifted from frontmatter `type:` (`null` when absent), and `description` is the first paragraph of the body — so consumers can render a picker without a follow-up `get` per row. |
+| `directory::skills::get` | Fetch one skill by id. Returns `{ id, title, type, description, body, modified_at }` — same shape `directory::skills::list` rows use, plus the raw markdown `body`. Same title-resolution and `type` precedence as `list`. Accepts a bare id or the same id prefixed with `iii://`. |
+| `directory::skills::index` | Render one short markdown entry per installed worker (skills with frontmatter `type: index`). Returns `{ body, workers_count }` where `body` is a ready-to-paste page: `# Skills index`, then one `## <worker title>` heading + the worker's first overview paragraph + a `Read iii://<ns>/index` pointer the agent can follow with `directory::skills::get`. Token-light by design; use `directory::skills::list` for per-skill rows. |
 
 ### `directory::prompts::*` (filesystem reader)
 
@@ -192,15 +201,15 @@ other adapter.
 | `directory::engine::triggers::info` | Single trigger-type detail: configuration schema, return schema, instance count. |
 | `directory::engine::registered-triggers::list` | List registered trigger INSTANCES (subscriber rows). |
 | `directory::engine::registered-triggers::info` | Composite: instance + trigger-type detail + function detail. |
-| `directory::engine::workers::list` | List workers connected to the engine; same row shape as `directory::registry::workers::list`. |
+| `directory::engine::workers::list` | List workers connected to the engine; shares the core `name` / `description` / `version` fields with `directory::registry::workers::list`. |
 | `directory::engine::workers::info` | One worker's `worker` envelope + functions + trigger types + registered triggers. |
 
 ### `directory::registry::*` (workers registry HTTP proxy)
 
 | Function ID | Description |
 |---|---|
-| `directory::registry::workers::list` | Search published workers in `api.workers.iii.dev`. Same row shape as `directory::engine::workers::list`. |
-| `directory::registry::workers::info` | Full registry detail for one worker: `worker` envelope (matching `directory::engine::workers::info.worker`) plus `readme`, `api_reference`, `skills_tree`. |
+| `directory::registry::workers::list` | Browse / search published workers in `api.workers.iii.dev`. Optional free-text `search` (matched fuzzy by `pg_trgm`) and opaque `cursor` for pagination; page size is server-authored. Response is `{ workers: [...], pagination: { next_cursor, has_more, page_size } }`. Shares the core `name` / `description` / `version` fields with `directory::engine::workers::list`. |
+| `directory::registry::workers::info` | Full registry detail for one worker. Fans out two parallel registry calls — `GET /w/{slug}` for the worker envelope (publication metadata + readme + functions + triggers) and `GET /w/{slug}/skills` for the skills/prompts tree — and merges them into `{ worker, readme, api_reference, skills_tree }`. The user-facing input still accepts `version:` (semver) or `tag:` (e.g. `latest`); both go on the wire as `?version=…`. |
 
 Both `directory::registry::*` responses are cached in-process for
 `registry_cache_ttl_ms` (default 60s).

--- a/iii-directory/skills/directory/registry/workers/info.md
+++ b/iii-directory/skills/directory/registry/workers/info.md
@@ -8,17 +8,19 @@ title: Inspect one worker's full registry metadata
 
 Call `directory::registry::workers::info` to pull the FULL published
 metadata for one worker from the public registry: worker envelope
-(name, description, version, repo, author), readme markdown, the API
+(name, description, version, repo, author, plus the publication
+metadata `type` / `config` / `supported_targets` / `total_downloads` /
+`dependencies` / optional `image`), readme markdown, the API
 reference (functions + triggers with schemas), and the list of skill /
 prompt files the bundle ships.
 
 This is the REMOTE counterpart to `directory::engine::workers::info`.
-Both responses wrap the worker payload in a top-level `worker` field,
+Both responses wrap the worker payload in a top-level `worker` field
 and the core fields (`name`, `description`, `version`) are guaranteed
-on both surfaces so a parser that touches only those keys works against
-either; everything else is surface-specific (registry adds `repo` /
-`author` plus the top-level `readme`, `api_reference`, `skills_tree`,
-directory adds runtime/connection state).
+on both surfaces, so a parser that only touches those keys works
+against either; everything else is surface-specific (registry adds
+publication metadata plus the top-level `readme`, `api_reference`,
+`skills_tree`; the engine view adds runtime / connection state).
 
 | Question                                                  | Use this                              |
 |-----------------------------------------------------------|---------------------------------------|
@@ -36,18 +38,25 @@ directory adds runtime/connection state).
 ```
 
 You may pass either `version` or `tag`, not both. With neither, the
-worker info defaults to `tag: "latest"`.
+worker info defaults to `tag: "latest"`. The worker rewrites both
+inputs to `?version=…` on the wire (per the OpenAPI contract — the
+registry's `?version` query param accepts both tags and exact semvers).
 
 # Outputs
 
 ```json
 {
-  "worker": {                                          // same shape as directory::registry::workers::list rows
-    "name":        "agent-memory",                     // shared core field with directory::engine::workers::info.worker
-    "description": "Persistent memory tier for agents.", // shared core field
-    "version":     "1.2.3",                            // shared core field (the resolved version)
-    "repo":        "https://github.com/iii-hq/workers",
-    "author":      { "name": "iii", "is_verified": true }
+  "worker": {
+    "name":              "agent-memory",                       // shared core field
+    "description":       "Persistent memory tier for agents.", // shared core field
+    "type":              "binary",                             // binary | image | engine
+    "version":           "1.2.3",                              // shared core field (resolved)
+    "repo":              "https://github.com/iii-hq/workers",
+    "config":            {},
+    "supported_targets": ["x86_64-unknown-linux-gnu"],
+    "total_downloads":   4242,
+    "dependencies":      [],
+    "author":            { "name": "iii", "pfp": null, "verified": true }
   },
   "readme": "# agent-memory\n\nDocs here.",            // optional; null if registry omits it
   "api_reference": {
@@ -77,13 +86,19 @@ worker info defaults to `tag: "latest"`.
 }
 ```
 
+`worker` / `readme` / `api_reference` come from `GET /w/{slug}?version=…`.
+`skills_tree` comes from a parallel `GET /w/{slug}/skills?version=…`
+call — the worker fans both out concurrently and merges them, dropping
+the markdown `content` and prompt `args_schema` from the skills payload
+(call `directory::skills::download` to materialise bodies on disk).
+
 # Caching
 
 Each unique `(name, version|tag)` pair is cached for
 `registry_cache_ttl_ms` (default 60s). Repeat calls within the TTL
-window don't hit the registry — they return the same response from
-in-process memory. To bust the cache, wait out the TTL or call with a
-different version/tag.
+window don't hit the registry — they return the same merged response
+from in-process memory. To bust the cache, wait out the TTL or call
+with a different version/tag.
 
 # Worked example
 
@@ -102,7 +117,7 @@ Pin to an exact version:
 # Related
 
 - `directory::registry::workers::list` — discover the worker name first.
-- `directory::engine::workers::info` — same `worker` envelope against
-  the connected engine.
+- `directory::engine::workers::info` — same core `worker` fields
+  (`name` / `description` / `version`) against the connected engine.
 - `directory::skills::download` — install the worker's skill bundle
   locally (uses the same registry under the hood).

--- a/iii-directory/skills/directory/registry/workers/list.md
+++ b/iii-directory/skills/directory/registry/workers/list.md
@@ -6,16 +6,17 @@ title: List workers from the public registry
 
 # When to use
 
-Use `directory::registry::workers::list` to search the public workers
-registry (`api.workers.iii.dev`) by free-text term and get back a list
-of PUBLISHED workers — the workers a user could install, regardless of
+Use `directory::registry::workers::list` to browse or search the public
+workers registry (`api.workers.iii.dev`) and get back a page of
+PUBLISHED workers — the workers a user could install, regardless of
 whether any of them are currently connected to this engine.
 
 This is the REMOTE counterpart to `directory::engine::workers::list`.
-Rows on both surfaces share a fixed set of core fields (`name`,
-`description`, `version`) so a parser that touches only those keys
-works against either; everything else is surface-specific (registry
-adds `repo` / `author`, directory adds runtime/connection state).
+Rows on both surfaces share the core fields `name` / `description` /
+`version` (so a parser that only touches those keys works against
+either), but the registry row also surfaces publication metadata
+(`type`, `config`, `supported_targets`, `total_downloads`,
+`dependencies`, optional `image`) that the engine view doesn't have.
 
 | Question                                          | Use this                              |
 |---------------------------------------------------|---------------------------------------|
@@ -26,15 +27,14 @@ adds `repo` / `author`, directory adds runtime/connection state).
 
 ```json
 {
-  "search": "memory",   // required, non-empty; forwarded to GET /search?q=...
-  "limit":  20          // optional, default 20, capped at 100
+  "search": "memory",   // optional free-text query (matched fuzzy by pg_trgm against name + description)
+  "cursor": "..."       // optional opaque cursor returned by a previous call's pagination.next_cursor
 }
 ```
 
-The registry doesn't currently expose an unscoped browse endpoint, so
-`search` MUST be non-empty. (Local `directory::engine::workers::list`
-allows empty `search` since it has access to all connected workers
-locally.)
+Both fields are optional. With no `search`, the registry orders by
+`total_downloads DESC`. With `search`, it ranks by similarity. Page
+size is server-authored — the client cannot override it.
 
 # Outputs
 
@@ -42,26 +42,47 @@ locally.)
 {
   "workers": [
     {
-      "name":        "agent-memory",                            // shared core field
-      "description": "Persistent memory tier for agents.",      // shared core field
-      "version":     "0.4.0",                                   // shared core field (latest published)
-      "repo":        "https://github.com/iii-hq/workers",
-      "author":      { "name": "iii", "profile_picture": null, "is_verified": true }
+      "name":              "agent-memory",                       // shared core field
+      "description":       "Persistent memory tier for agents.", // shared core field
+      "type":              "binary",                             // binary | image | engine
+      "version":           "0.4.0",                              // shared core field (latest published)
+      "repo":              "https://github.com/iii-hq/workers",
+      "config":            {},
+      "supported_targets": ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin"],
+      "total_downloads":   4242,
+      "dependencies":      [],
+      "author":            { "name": "iii", "pfp": null, "verified": true }
     }
-  ]
+  ],
+  "pagination": {
+    "next_cursor": "eyJzIjo0Mi4wLCJpZCI6IjBkNTRhMWZmLTJjMjMtNGY4MC05ZTRkLTRmNmVkM2EwYTgxMiJ9",
+    "has_more":    true,
+    "page_size":   20
+  }
 }
 ```
 
 The first three fields (`name`, `description`, `version`) are shared
-with `directory::engine::workers::list` rows.
+with `directory::engine::workers::list` rows; everything else is
+registry-only metadata.
+
+`pagination.next_cursor` is opaque — pass it back as `cursor:` to fetch
+the next page. `null` on the last page (with `has_more: false`).
+`page_size` is the server's choice; clients can't override it.
 
 # Caching
 
-Each unique `(search, limit)` pair is cached for `registry_cache_ttl_ms`
+Each unique `(search, cursor)` pair is cached for `registry_cache_ttl_ms`
 (default 60s). Repeat calls within the TTL window don't hit the
 registry — they return the same response from in-process memory.
 
 # Worked example
+
+Browse the most-downloaded workers (no search):
+
+```json
+{}
+```
 
 Find every published worker mentioning "memory":
 
@@ -69,17 +90,17 @@ Find every published worker mentioning "memory":
 { "search": "memory" }
 ```
 
-Top 5 results for "router":
+Fetch the next page (using a cursor from a previous call):
 
 ```json
-{ "search": "router", "limit": 5 }
+{ "search": "memory", "cursor": "eyJzIjo0Mi4wLCJpZCI6IjBkNTRhMWZmLTJjMjMtNGY4MC05ZTRkLTRmNmVkM2EwYTgxMiJ9" }
 ```
 
 # Related
 
 - `directory::registry::workers::info` — full registry detail for one
   worker.
-- `directory::engine::workers::list` — same row shape against connected
-  workers.
+- `directory::engine::workers::list` — same shared core fields against
+  connected workers.
 - `directory::skills::download` — install a worker's skill bundle by
   name.

--- a/iii-directory/skills/directory/skills/get.md
+++ b/iii-directory/skills/directory/skills/get.md
@@ -9,9 +9,10 @@ title: Read one skill body by id
 Call `directory::skills::get` whenever you need the **body** of one
 skill — the markdown a worker publishes to teach the agent when and
 why to use its functions. It returns the body alongside the same
-`title`, `description`, and `modified_at` fields each
+`title`, `type`, `description`, and `modified_at` fields each
 `directory::skills::list` row already carries, so the API mirrors
-`directory::prompts::get` exactly.
+`directory::prompts::get` (plus `type` lifted from the file's YAML
+frontmatter).
 
 Reach for it when:
 
@@ -51,6 +52,7 @@ Any other URI scheme (`https://`, `ftp://`, ...) is rejected.
 {
   "id":          "agent-memory/observe",
   "title":       "How to observe",
+  "type":        "how-to",
   "description": "Record an event in agent memory.",
   "body":        "# How to observe\n\n...",
   "modified_at": "2026-05-01T12:34:56+00:00"
@@ -59,17 +61,22 @@ Any other URI scheme (`https://`, `ftp://`, ...) is rejected.
 
 - `id` echoes the resolved id (the same string accepted as input,
   with any `iii://` prefix stripped).
-- `title` is the first `# H1` line in the body, falling back to `id`
-  when the file has no H1.
+- `title` resolves in this order: YAML frontmatter `title:` (when
+  present and non-empty after trim), then the first `# H1` line in
+  the body, with the bare `id` as a final fallback.
+- `type` is the YAML frontmatter `type:` field (free-form classifier;
+  common values are `index`, `how-to`, `reference`). `null` when the
+  file has no frontmatter or omits the key.
 - `description` is the first non-heading paragraph, empty when the
   file has only headings.
 - `body` is the raw markdown post-frontmatter from disk.
 - `modified_at` is the file mtime as RFC 3339 (empty if the FS
   doesn't expose it).
 
-The shape is intentionally identical to
-`directory::prompts::get` (with `id` standing in for that surface's
-`name`) so a single client struct can target either reader.
+The shape is intentionally close to `directory::prompts::get` (with
+`id` standing in for that surface's `name`); the `type` field is
+unique to skills and reflects the frontmatter classifier authors use
+to tag their files.
 
 # Worked example
 
@@ -83,14 +90,14 @@ The agent loaded a worker skill that links to a deeper sub-skill at
 Same response either way:
 
 ```json
-{ "id": "resend/email/send", "title": "...", "description": "...", "body": "...", "modified_at": "..." }
+{ "id": "resend/email/send", "title": "...", "type": "...", "description": "...", "body": "...", "modified_at": "..." }
 ```
 
 # Related
 
 - `directory::skills::list` — discover the ids that resolve via
-  `directory::skills::get` (already carries `title` + `description`,
-  so a picker UI doesn't need a `get` per row).
+  `directory::skills::get` (already carries `title` + `type` +
+  `description`, so a picker UI doesn't need a `get` per row).
 - `directory::skills::download` — populate `skills_folder` so there's
   something to fetch.
 - `directory::engine::functions::info` — for the **structured** view

--- a/iii-directory/skills/directory/skills/index.md
+++ b/iii-directory/skills/directory/skills/index.md
@@ -1,0 +1,146 @@
+---
+type: how-to
+function_id: directory::skills::index
+title: Bootstrap an agent harness with a short per-worker skills index
+---
+
+# When to use
+
+Call `directory::skills::index` when an agent harness needs to know
+**which workers are installed** and how to read each one's full
+reference — without paying the token cost of dumping every individual
+skill. The response is intentionally short: one `## <worker title>`
+heading + that worker's first overview paragraph + a `Read iii://...`
+pointer the agent can follow with `directory::skills::get` when it
+actually needs the details.
+
+Reach for it when:
+
+- You're bootstrapping a fresh agent session and want the system
+  prompt to list the available workers so the model can plan which
+  one to drill into.
+- You want a copy-paste-ready overview of *workers* (not every skill)
+  for a README, changelog, or chat message.
+- You need a stable "what's installed?" snapshot keyed by worker
+  rather than by skill id.
+
+Use [`directory::skills::list`](iii://directory/skills/list) instead
+when you need **per-skill rows** (`id`, `title`, `type`, `bytes`,
+`modified_at`) — e.g. for a picker UI, programmatic filtering, or
+anything that wants every skill, not just the worker overviews.
+Use [`directory::skills::get`](iii://directory/skills/get) to fetch
+the full body of any `iii://<ns>/index` link surfaced in the response.
+
+# Inputs
+
+```json
+{}
+```
+
+No parameters. The worker re-scans `skills_folder` on every call and
+re-reads each `type: index` overview to populate the description, so
+edits to a worker's `index.md` are visible immediately (same policy
+as `directory::skills::list`).
+
+# Outputs
+
+```json
+{
+  "body": "# Skills index\n\n2 worker(s).\n\n## agent-memory\n\nPersistent memory tier for agents.\n\nRead [`iii://agent-memory/index`](iii://agent-memory/index) for the full worker reference.\n\n## iii-directory\n\nEngine introspection, workers registry proxy, and filesystem-backed skill + prompt reader for the iii engine. ...\n\nRead [`iii://iii-directory/index`](iii://iii-directory/index) for the full worker reference.\n",
+  "workers_count": 2
+}
+```
+
+- `body` is the rendered markdown document. The harness usually
+  pastes this verbatim into a system prompt or message.
+- `workers_count` is the number of worker entries rendered (i.e. the
+  count of `type: index` skills surviving the filter). Cheap sanity
+  check that doesn't require re-parsing the body.
+
+# Rendering rules
+
+Only skills with frontmatter `type: index` appear in the body — one
+entry per installed worker. Skills of any other type (`how-to`,
+`reference`, untyped, ...) are filtered out. This is important: a
+how-to skill that happens to live at `<ns>/index.md` (frontmatter
+`type: how-to`) will NOT be mistaken for a worker overview.
+
+The body always starts with:
+
+```markdown
+# Skills index
+
+<N> worker(s).
+```
+
+Then, for every `type: index` skill (sorted lex by id, same order
+`directory::skills::list` returns):
+
+```markdown
+## <resolved title>
+
+<first paragraph from the overview>
+
+Read [`iii://<id>`](iii://<id>) for the full worker reference.
+```
+
+- `<resolved title>` follows the same precedence as every other
+  `directory::skills::*` response: frontmatter `title:` wins, then the
+  first body `# H1`, then the bare `id` as a last resort.
+- The description paragraph is the first non-heading paragraph from
+  the worker's `index.md` body (already extracted by the same helper
+  `directory::skills::list` uses, so the text matches what a row in
+  that listing would carry).
+- When the overview body has no paragraph (heading-only file), the
+  description block — and its surrounding blank line — is skipped so
+  the section stays compact: `\n## <title>\n\nRead ...`.
+
+There is intentionally no `###`, no per-skill bullets, and no nested
+grouping. If you need that level of detail for one specific worker,
+follow its `iii://<ns>/index` link with `directory::skills::get`.
+
+# Worked example
+
+Given a `skills_folder` that contains two workers (`agent-memory`
+with an `index.md` whose frontmatter declares
+`title: agent-memory, type: index` and a one-paragraph overview, plus
+this `iii-directory` worker's own `index.md`), the response body
+looks like:
+
+```markdown
+# Skills index
+
+2 worker(s).
+
+## agent-memory
+
+Persistent memory tier for agents. Records observations and recalls
+them on demand via `agent-memory::observe` and `agent-memory::recall`.
+
+Read [`iii://agent-memory/index`](iii://agent-memory/index) for the full worker reference.
+
+## iii-directory
+
+Engine introspection, workers registry proxy, and filesystem-backed
+skill + prompt reader for the [iii engine](https://github.com/iii-hq/iii).
+Every public function sits under a single `directory::*` namespace,
+split into four sub-namespaces (all MCP-agnostic):
+
+Read [`iii://iii-directory/index`](iii://iii-directory/index) for the full worker reference.
+```
+
+The harness pastes this into the system prompt; when the agent
+decides it needs to call a specific function, it follows the
+matching `iii://...` link with `directory::skills::get` to pull the
+full reference + how-tos.
+
+# Related
+
+- [`directory::skills::list`](iii://directory/skills/list) — same set
+  of skills as structured rows (`{ id, title, type, description,
+  bytes, modified_at }`) when you want every skill, not just the
+  `type: index` overviews.
+- [`directory::skills::get`](iii://directory/skills/get) — fetch the
+  full body of any `iii://<ns>/index` link surfaced in the response.
+- [`directory::skills::download`](iii://directory/skills/download) —
+  populate `skills_folder` so there are workers to index.

--- a/iii-directory/skills/directory/skills/list.md
+++ b/iii-directory/skills/directory/skills/list.md
@@ -9,9 +9,11 @@ title: Enumerate every skill on disk with title and description
 Call `directory::skills::list` when you need an enumeration of every
 markdown skill the iii-directory worker is currently serving from its
 `skills_folder`. One row per file (recursive `**/*.md`, `prompts/`
-segments excluded), sorted lex by `id`. Each row already carries the
-H1 `title` and first-paragraph `description` so a picker / table-of-
-contents UI doesn't need a follow-up `directory::skills::get` per row.
+segments excluded), sorted lex by `id`. Each row already carries
+`title` (frontmatter `title:` when present, else the body H1),
+`type` (frontmatter `type:` — e.g. `index`, `how-to`, `reference`),
+and `description` (first paragraph), so a picker / table-of-contents
+UI doesn't need a follow-up `directory::skills::get` per row.
 
 This is the single "what's on disk?" call. Use it when:
 
@@ -42,6 +44,7 @@ visible immediately, no caching.
     {
       "id":          "agent-memory/observe",
       "title":       "How to observe",
+      "type":        "how-to",
       "description": "Record an event in agent memory.",
       "bytes":       1234,
       "modified_at": "2026-05-01T12:34:56+00:00"
@@ -53,8 +56,12 @@ visible immediately, no caching.
 - `id` is the relative path under `skills_folder` with `.md` stripped
   (e.g. `agent-memory/observe.md` → `agent-memory/observe`). Same
   string `directory::skills::get` accepts.
-- `title` is the first `# H1` line in the body, falling back to `id`
-  when the file has no H1.
+- `title` resolves in this order: YAML frontmatter `title:` (when
+  present and non-empty after trim), then the first `# H1` line in
+  the body, with the bare `id` as a final fallback.
+- `type` is the YAML frontmatter `type:` field (free-form classifier;
+  common values are `index`, `how-to`, `reference`). `null` when the
+  file has no frontmatter or omits the key.
 - `description` is the first non-heading paragraph, empty when the
   file has only headings.
 - `bytes` is the on-disk file size (raw, including frontmatter).
@@ -83,6 +90,6 @@ each child immediately after its parent.
 # Related
 
 - `directory::skills::get` — read one body by id (returns the same
-  `id` / `title` / `description` / `modified_at` plus `body`).
+  `id` / `title` / `type` / `description` / `modified_at` plus `body`).
 - `directory::skills::download` — populate `skills_folder` from the
   registry or a GitHub repo.

--- a/iii-directory/skills/index.md
+++ b/iii-directory/skills/index.md
@@ -27,8 +27,11 @@ split into four sub-namespaces (all MCP-agnostic):
   registry?"
 
 `directory::engine::workers::*` and `directory::registry::workers::*`
-share the same envelope shape, so callers can switch between the local
-engine view and the published-registry view without re-learning the API.
+share the core `name` / `description` / `version` fields, so a parser
+that touches only those keys works against either surface. The registry
+view also surfaces publication metadata (`type`, `config`,
+`supported_targets`, `total_downloads`, `dependencies`, optional
+`image`); the engine view adds runtime / connection state.
 
 Skills and prompts are sourced from a single configured folder on disk
 (`skills_folder`); see [the README](../README.md) for the install,
@@ -38,8 +41,9 @@ configuration, and `directory::skills::download` flow.
 
 ### `directory::skills::*` — filesystem-backed skill reader
 
-- [`directory::skills::list`](iii://directory/skills/list) — enriched listing of every skill on disk (id, title, description, bytes, modified_at).
-- [`directory::skills::get`](iii://directory/skills/get) — read one skill body by id (returns the same id/title/description/modified_at as `list` plus `body`).
+- [`directory::skills::list`](iii://directory/skills/list) — enriched listing of every skill on disk (id, title, type, description, bytes, modified_at). `title` prefers the YAML frontmatter `title:` over the body H1; `type` is lifted from frontmatter `type:` (`null` when absent).
+- [`directory::skills::get`](iii://directory/skills/get) — read one skill body by id (returns the same id/title/type/description/modified_at as `list` plus `body`).
+- [`directory::skills::index`](iii://directory/skills/index) — short markdown index of every installed worker (one `## <title>` + first paragraph + `read more` link per `type: index` skill); designed for token-light agent bootstrap.
 - [`directory::skills::download`](iii://directory/skills/download) — pull markdown into `skills_folder` from the workers registry or a GitHub repo.
 
 ### `directory::prompts::*` — filesystem-backed prompt reader
@@ -54,10 +58,10 @@ configuration, and `directory::skills::download` flow.
 - [`directory::engine::triggers::info`](iii://directory/engine/triggers/info) — inspect one trigger type's schemas + live instance count.
 - [`directory::engine::registered-triggers::list`](iii://directory/engine/registered-triggers/list) — list registered trigger instances (subscriber rows).
 - [`directory::engine::registered-triggers::info`](iii://directory/engine/registered-triggers/info) — inspect one registered trigger (instance + type + function).
-- [`directory::engine::workers::list`](iii://directory/engine/workers/list) — list workers connected to the engine; same row shape as `directory::registry::workers::list`.
+- [`directory::engine::workers::list`](iii://directory/engine/workers/list) — list workers connected to the engine; shares the core `name` / `description` / `version` fields with `directory::registry::workers::list`.
 - [`directory::engine::workers::info`](iii://directory/engine/workers/info) — inspect one connected worker's full surface.
 
 ### `directory::registry::*` — what's published in the public registry
 
-- [`directory::registry::workers::list`](iii://directory/registry/workers/list) — search published workers in `api.workers.iii.dev`; same row shape as `directory::engine::workers::list`.
+- [`directory::registry::workers::list`](iii://directory/registry/workers/list) — browse / search published workers in `api.workers.iii.dev`. Cursor-paginated; rows share the core `name` / `description` / `version` fields with `directory::engine::workers::list` and add publication metadata (`type`, `config`, `supported_targets`, `total_downloads`, `dependencies`, optional `image`).
 - [`directory::registry::workers::info`](iii://directory/registry/workers/info) — full registry detail for one worker (envelope + readme + api_reference + skills_tree).

--- a/iii-directory/src/fs_source.rs
+++ b/iii-directory/src/fs_source.rs
@@ -20,10 +20,13 @@
 //!
 //! Public surface:
 //!
-//! - [`split_frontmatter`]   — minimal `---\n...\n---\n` parser.
-//! - [`scan_skills`]         — id-keyed listing of all `**/*.md` outside `*/prompts/*`.
-//! - [`scan_prompts`]        — name-keyed listing of `*/prompts/*.md`.
-//! - [`read_body`]           — cap-checked body read with frontmatter stripped.
+//! - [`split_frontmatter`]            — minimal `---\n...\n---\n` parser.
+//! - [`scan_skills`]                  — id-keyed listing of all `**/*.md` outside `*/prompts/*`.
+//! - [`scan_prompts`]                 — name-keyed listing of `*/prompts/*.md`.
+//! - [`read_body`]                    — cap-checked body read with frontmatter stripped.
+//! - [`read_skill_with_frontmatter`]  — same caps as `read_body` plus a
+//!   parsed `SkillFrontmatter` (title + type) so the skills reader can
+//!   prefer the frontmatter title over a body H1 in one read.
 
 use std::path::{Path, PathBuf};
 
@@ -70,6 +73,25 @@ struct PromptFrontmatter {
     name: Option<String>,
     #[serde(default)]
     description: Option<String>,
+}
+
+/// Subset of skill frontmatter fields surfaced by
+/// `directory::skills::list` and `directory::skills::get`. Anything else
+/// in the YAML block is preserved verbatim by [`split_frontmatter`] but
+/// ignored here. Both fields are optional so files without frontmatter
+/// (or without these keys) parse as `Default::default()` rather than
+/// erroring — the reader still falls back to the body H1 / id for the
+/// title and serialises a `null` type.
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct SkillFrontmatter {
+    /// Optional human-readable title. When non-empty (after trim) the
+    /// reader returns this verbatim instead of the first body `# H1`.
+    #[serde(default)]
+    pub title: Option<String>,
+    /// Free-form classifier (e.g. `index`, `how-to`, `reference`).
+    /// Renamed from the YAML key `type` to avoid the Rust reserved word.
+    #[serde(default, rename = "type")]
+    pub kind: Option<String>,
 }
 
 // ───────────────────────── pure helpers ──────────────────────────────
@@ -346,6 +368,18 @@ pub fn scan_prompts(skills_folder: &Path) -> (Vec<FsPrompt>, Vec<SkipReason>) {
 /// Empty-after-strip bodies are an error so the resolver returns a
 /// clear "not found" rather than serving an empty resource.
 pub fn read_body(abs_path: &Path) -> Result<String, String> {
+    let (_, body) = read_skill_with_frontmatter(abs_path)?;
+    Ok(body)
+}
+
+/// Like [`read_body`] but also returns the parsed [`SkillFrontmatter`].
+/// Files without a frontmatter block (or with malformed YAML) still
+/// succeed and yield `SkillFrontmatter::default()` so the read path
+/// keeps working for plain markdown — only the size cap and the
+/// empty-body rule are hard errors. Callers use the returned title /
+/// type to fill in the corresponding `directory::skills::*` response
+/// fields without re-reading the file.
+pub fn read_skill_with_frontmatter(abs_path: &Path) -> Result<(SkillFrontmatter, String), String> {
     let raw = std::fs::read_to_string(abs_path)
         .map_err(|e| format!("read {}: {e}", abs_path.display()))?;
     if raw.len() > SKILL_BODY_MAX_BYTES {
@@ -355,12 +389,15 @@ pub fn read_body(abs_path: &Path) -> Result<String, String> {
             raw.len()
         ));
     }
-    let (_, body) = split_frontmatter(&raw);
+    let (fm_text, body) = split_frontmatter(&raw);
     let trimmed = body.trim_matches('\n');
     if trimmed.is_empty() {
         return Err(format!("file {} has empty body", abs_path.display()));
     }
-    Ok(body.to_string())
+    let fm = fm_text
+        .and_then(|t| serde_yaml::from_str::<SkillFrontmatter>(t).ok())
+        .unwrap_or_default();
+    Ok((fm, body.to_string()))
 }
 
 #[cfg(test)]
@@ -635,5 +672,77 @@ mod tests {
         let path = tmp.path().join("nope.md");
         let err = read_body(&path).unwrap_err();
         assert!(err.contains("read"));
+    }
+
+    // ── read_skill_with_frontmatter ──────────────────────────────────
+
+    #[test]
+    fn read_with_frontmatter_extracts_title_and_type() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("foo.md");
+        std::fs::write(
+            &path,
+            "---\ntitle: Real title\ntype: how-to\n---\n# Body H1\n\nThe body.\n",
+        )
+        .unwrap();
+        let (fm, body) = read_skill_with_frontmatter(&path).unwrap();
+        assert_eq!(fm.title.as_deref(), Some("Real title"));
+        assert_eq!(fm.kind.as_deref(), Some("how-to"));
+        assert_eq!(body, "# Body H1\n\nThe body.\n");
+    }
+
+    #[test]
+    fn read_with_frontmatter_defaults_when_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("plain.md");
+        std::fs::write(&path, "# Plain\n\nbody\n").unwrap();
+        let (fm, body) = read_skill_with_frontmatter(&path).unwrap();
+        assert!(fm.title.is_none());
+        assert!(fm.kind.is_none());
+        assert_eq!(body, "# Plain\n\nbody\n");
+    }
+
+    #[test]
+    fn read_with_frontmatter_tolerates_unrelated_yaml_keys() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("rich.md");
+        std::fs::write(
+            &path,
+            "---\ntitle: Hi\ntype: index\nfunctions: [a::b]\nfunction_id: c::d\n---\nbody\n",
+        )
+        .unwrap();
+        let (fm, _) = read_skill_with_frontmatter(&path).unwrap();
+        assert_eq!(fm.title.as_deref(), Some("Hi"));
+        assert_eq!(fm.kind.as_deref(), Some("index"));
+    }
+
+    #[test]
+    fn read_with_frontmatter_falls_back_on_invalid_yaml() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("bad.md");
+        std::fs::write(&path, "---\nnot: [valid yaml\n---\n# heading\nbody\n").unwrap();
+        let (fm, body) = read_skill_with_frontmatter(&path).unwrap();
+        assert!(fm.title.is_none());
+        assert!(fm.kind.is_none());
+        assert!(body.contains("# heading"));
+    }
+
+    #[test]
+    fn read_with_frontmatter_enforces_size_cap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("big.md");
+        let body = "x".repeat(SKILL_BODY_MAX_BYTES + 1);
+        std::fs::write(&path, &body).unwrap();
+        let err = read_skill_with_frontmatter(&path).unwrap_err();
+        assert!(err.contains("too large"), "got: {err}");
+    }
+
+    #[test]
+    fn read_with_frontmatter_rejects_empty_body() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("only-fm.md");
+        std::fs::write(&path, "---\ntitle: x\n---\n").unwrap();
+        let err = read_skill_with_frontmatter(&path).unwrap_err();
+        assert!(err.contains("empty body"), "got: {err}");
     }
 }

--- a/iii-directory/src/functions/directory.rs
+++ b/iii-directory/src/functions/directory.rs
@@ -12,12 +12,13 @@
 //!   * `directory::engine::workers::list`              — list connected workers, filterable
 //!   * `directory::engine::workers::info`              — worker envelope + its functions + trigger types + registered triggers
 //!
-//! All handlers are pure thin wrappers around `iii.list_*` SDK helpers
-//! (which call `engine::functions::list`, `engine::workers::list`,
-//! `engine::trigger-types::list`, `engine::triggers::list`) plus
-//! filesystem-backed how-to skill discovery via [`crate::how_to`].
+//! All handlers are thin wrappers around `III::trigger` calls to the
+//! engine introspection endpoints (`engine::functions::list`,
+//! `engine::workers::list`, `engine::trigger-types::list`,
+//! `engine::triggers::list`) plus filesystem-backed how-to skill discovery
+//! via [`crate::how_to`].
 //!
-//! Worker-name attribution: SDK 0.11.3 returns no `worker` field on
+//! Worker-name attribution: the SDK returns no `worker` field on
 //! `FunctionInfo` / `TriggerTypeInfo` / `TriggerInfo`; we cross-reference
 //! `WorkerInfo.functions[]` (canonical for functions and registered
 //! triggers) and fall back to the first `::` segment of the id (only
@@ -33,7 +34,7 @@ use std::sync::Arc;
 
 use iii_sdk::{
     FunctionInfo as SdkFunctionInfo, IIIError, RegisterFunction, TriggerInfo as SdkTriggerInfo,
-    TriggerTypeInfo, WorkerInfo, III,
+    TriggerRequest, TriggerTypeInfo, WorkerInfo, III,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -508,16 +509,14 @@ pub async fn function_info(
         return Err("function_id must be non-empty".into());
     }
     let (functions, workers) = fetch_functions_and_workers(iii).await?;
-    let triggers = iii
-        .list_triggers(true)
+    let triggers = engine_list_triggers(iii, true)
         .await
         .map_err(|e| format!("engine::triggers::list: {e}"))?;
     function_info_core(&functions, &workers, &triggers, cfg, &function_id)
 }
 
 pub async fn trigger_list(iii: &III, input: TriggerListInput) -> Result<TriggerListOutput, String> {
-    let trigger_types = iii
-        .list_trigger_types(true)
+    let trigger_types = engine_list_trigger_types(iii, true)
         .await
         .map_err(|e| format!("engine::trigger-types::list: {e}"))?;
 
@@ -561,12 +560,10 @@ pub async fn trigger_info(iii: &III, input: TriggerInfoInput) -> Result<TriggerI
     if id.is_empty() {
         return Err("id must be non-empty".into());
     }
-    let trigger_types = iii
-        .list_trigger_types(true)
+    let trigger_types = engine_list_trigger_types(iii, true)
         .await
         .map_err(|e| format!("engine::trigger-types::list: {e}"))?;
-    let triggers = iii
-        .list_triggers(true)
+    let triggers = engine_list_triggers(iii, true)
         .await
         .map_err(|e| format!("engine::triggers::list: {e}"))?;
     trigger_info_core(&trigger_types, &triggers, &id)
@@ -576,12 +573,10 @@ pub async fn registered_trigger_list(
     iii: &III,
     input: RegisteredTriggerListInput,
 ) -> Result<RegisteredTriggerListOutput, String> {
-    let triggers = iii
-        .list_triggers(true)
+    let triggers = engine_list_triggers(iii, true)
         .await
         .map_err(|e| format!("engine::triggers::list: {e}"))?;
-    let workers = iii
-        .list_workers()
+    let workers = engine_list_workers(iii)
         .await
         .map_err(|e| format!("engine::workers::list: {e}"))?;
     let owner_map = build_function_owner_map(&workers);
@@ -644,12 +639,10 @@ pub async fn registered_trigger_info(
     if id.is_empty() {
         return Err("id must be non-empty".into());
     }
-    let triggers = iii
-        .list_triggers(true)
+    let triggers = engine_list_triggers(iii, true)
         .await
         .map_err(|e| format!("engine::triggers::list: {e}"))?;
-    let trigger_types = iii
-        .list_trigger_types(true)
+    let trigger_types = engine_list_trigger_types(iii, true)
         .await
         .map_err(|e| format!("engine::trigger-types::list: {e}"))?;
     let (functions, workers) = fetch_functions_and_workers(iii).await?;
@@ -683,8 +676,7 @@ pub async fn registered_trigger_info(
 }
 
 pub async fn worker_list(iii: &III, input: WorkerListInput) -> Result<WorkerListOutput, String> {
-    let workers = iii
-        .list_workers()
+    let workers = engine_list_workers(iii)
         .await
         .map_err(|e| format!("engine::workers::list: {e}"))?;
 
@@ -725,8 +717,7 @@ pub async fn worker_info(iii: &III, input: WorkerInfoInput) -> Result<WorkerInfo
         return Err("name must be non-empty".into());
     }
 
-    let workers = iii
-        .list_workers()
+    let workers = engine_list_workers(iii)
         .await
         .map_err(|e| format!("engine::workers::list: {e}"))?;
     let worker = workers
@@ -735,16 +726,13 @@ pub async fn worker_info(iii: &III, input: WorkerInfoInput) -> Result<WorkerInfo
         .cloned()
         .ok_or_else(|| format!("worker not found: {name}"))?;
 
-    let functions = iii
-        .list_functions()
+    let functions = engine_list_functions(iii)
         .await
         .map_err(|e| format!("engine::functions::list: {e}"))?;
-    let trigger_types = iii
-        .list_trigger_types(true)
+    let trigger_types = engine_list_trigger_types(iii, true)
         .await
         .map_err(|e| format!("engine::trigger-types::list: {e}"))?;
-    let triggers = iii
-        .list_triggers(true)
+    let triggers = engine_list_triggers(iii, true)
         .await
         .map_err(|e| format!("engine::triggers::list: {e}"))?;
 
@@ -938,15 +926,79 @@ pub fn trigger_info_core(
     })
 }
 
+async fn engine_list_functions(iii: &III) -> Result<Vec<SdkFunctionInfo>, IIIError> {
+    let result = iii
+        .trigger(TriggerRequest {
+            function_id: "engine::functions::list".into(),
+            payload: serde_json::json!({}),
+            action: None,
+            timeout_ms: None,
+        })
+        .await?;
+    Ok(result
+        .get("functions")
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default())
+}
+
+async fn engine_list_workers(iii: &III) -> Result<Vec<WorkerInfo>, IIIError> {
+    let result = iii
+        .trigger(TriggerRequest {
+            function_id: "engine::workers::list".into(),
+            payload: serde_json::json!({}),
+            action: None,
+            timeout_ms: None,
+        })
+        .await?;
+    Ok(result
+        .get("workers")
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default())
+}
+
+async fn engine_list_triggers(
+    iii: &III,
+    include_internal: bool,
+) -> Result<Vec<SdkTriggerInfo>, IIIError> {
+    let result = iii
+        .trigger(TriggerRequest {
+            function_id: "engine::triggers::list".into(),
+            payload: serde_json::json!({ "include_internal": include_internal }),
+            action: None,
+            timeout_ms: None,
+        })
+        .await?;
+    Ok(result
+        .get("triggers")
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default())
+}
+
+async fn engine_list_trigger_types(
+    iii: &III,
+    include_internal: bool,
+) -> Result<Vec<TriggerTypeInfo>, IIIError> {
+    let result = iii
+        .trigger(TriggerRequest {
+            function_id: "engine::trigger-types::list".into(),
+            payload: serde_json::json!({ "include_internal": include_internal }),
+            action: None,
+            timeout_ms: None,
+        })
+        .await?;
+    Ok(result
+        .get("trigger_types")
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default())
+}
+
 async fn fetch_functions_and_workers(
     iii: &III,
 ) -> Result<(Vec<SdkFunctionInfo>, Vec<WorkerInfo>), String> {
-    let functions = iii
-        .list_functions()
+    let functions = engine_list_functions(iii)
         .await
         .map_err(|e| format!("engine::functions::list: {e}"))?;
-    let workers = iii
-        .list_workers()
+    let workers = engine_list_workers(iii)
         .await
         .map_err(|e| format!("engine::workers::list: {e}"))?;
     Ok((functions, workers))

--- a/iii-directory/src/functions/mod.rs
+++ b/iii-directory/src/functions/mod.rs
@@ -55,7 +55,7 @@ pub fn register_all(
     directory::register(iii, cfg);
     registry::register(iii, cfg);
     tracing::info!(
-        "iii-directory registered 2 directory::skills::* (list + get), \
+        "iii-directory registered 3 directory::skills::* (list + get + index), \
          2 directory::prompts::* (list + get), 1 directory::skills::download, \
          8 directory::engine::* and 2 directory::registry::workers::* functions"
     );

--- a/iii-directory/src/functions/registry.rs
+++ b/iii-directory/src/functions/registry.rs
@@ -5,27 +5,31 @@
 //! learn one shape:
 //!
 //!   * `directory::registry::workers::list`  — list workers in the
-//!     public registry, filterable by `search`. Same row envelope
-//!     (`Worker`) as [`crate::functions::directory::Worker`].
+//!     public registry, filterable by `search` and paginated via
+//!     opaque `cursor`. Same row envelope (`Worker`) as
+//!     [`crate::functions::directory::Worker`] for the shared core
+//!     fields (`name`, `description`, `version`).
 //!   * `directory::registry::workers::info`  — full registry metadata
 //!     for one worker. Wraps the registry-side fields in a top-level
 //!     `worker` envelope (same shape as the list rows), with `readme`
 //!     / `api_reference` / `skills_tree` as surface-specific extras.
+//!     `skills_tree` is fetched from a separate `/w/{slug}/skills`
+//!     endpoint in parallel and merged into the response.
 //!
 //! Both responses are cached in-process for `registry_cache_ttl_ms`
 //! (default 60s) so repeat lookups don't hammer the registry — every
 //! call is a separate HTTP request without it.
 //!
-//! HTTP shapes assumed:
+//! Wire contract (mirrors `openapi.yaml`):
 //!
-//!   * `GET {base}/search?q=…&limit=…` → `{ workers: [...] }`
-//!   * `GET {base}/w/{worker}?version=…|tag=…` → flat envelope mirroring
-//!     the publish payload (`name`, `version`, `description`, `repo`,
-//!     `author`, `readme`, `functions`, `triggers`, `skills_tree`).
-//!
-//! If either path turns out to differ on the live registry, only the
-//! `fetch_*` helpers below need adjusting; the public function
-//! input/output contracts stay stable.
+//!   * `GET {base}/w?search=…&cursor=…` →
+//!     `{ workers: [WorkerListItem], pagination: { next_cursor, has_more, page_size } }`.
+//!     Page size is server-authored; the client cannot override it.
+//!   * `GET {base}/w/{slug}?version=…` → `{ worker: WorkerDetail }`.
+//!     `version` accepts either a tag (`latest`) or an exact semver
+//!     (`1.2.3`). The legacy `?tag=` query param is not used.
+//!   * `GET {base}/w/{slug}/skills?version=…` →
+//!     `{ name, version, skills: [{path, content}], prompts: [{name, description?, args_schema?, content}] }`.
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -39,54 +43,107 @@ use tokio::sync::RwLock;
 use crate::config::SkillsConfig;
 use crate::sources::build_http_client;
 
-const SEARCH_LIMIT_DEFAULT: u32 = 20;
-const SEARCH_LIMIT_MAX: u32 = 100;
-
 // ---------- public input/output shapes ----------
 
 /// `directory::registry::workers::list` input. Mirrors
 /// [`crate::functions::directory::WorkerListInput.search`] so callers
 /// can switch between local and registry surfaces without re-learning
-/// the API. Adds `limit` for paging because the registry is paged.
+/// the API. Adds `cursor` for paging because the registry is paged
+/// (server-authored page size — the client cannot override it).
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct WorkerListInput {
-    /// Free-text query forwarded to the registry as `?q=…`. Required —
-    /// the public registry doesn't support an unscoped browse endpoint.
+    /// Optional free-text query. Forwarded to the registry as
+    /// `?search=…`; the registry ranks results by `pg_trgm` similarity
+    /// against `lower(name)` and `lower(description)`. When omitted,
+    /// results are ordered by `total_downloads DESC`.
     #[serde(default)]
     pub search: Option<String>,
-    /// Max results to return. Defaults to 20; capped at 100.
+    /// Opaque cursor returned by a previous call's
+    /// `pagination.next_cursor`. Pass back verbatim to fetch the next
+    /// page; omit (or pass `null`) to fetch the first page.
     #[serde(default)]
-    pub limit: Option<u32>,
+    pub cursor: Option<String>,
 }
 
+/// Author block for a published worker. Field names match the
+/// `WorkerAuthor` schema in `openapi.yaml` (`pfp`, `verified`).
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
-pub struct RegistryAuthor {
+pub struct WorkerAuthor {
     pub name: Option<String>,
-    pub profile_picture: Option<String>,
+    /// Profile picture URL. `null` when the author hasn't uploaded one.
     #[serde(default)]
-    pub is_verified: bool,
+    pub pfp: Option<String>,
+    #[serde(default)]
+    pub verified: bool,
+}
+
+/// Worker dependency entry. Mirrors the `Dependency` schema in
+/// `openapi.yaml`.
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+pub struct Dependency {
+    pub name: String,
+    pub version: String,
 }
 
 /// Shared worker envelope used by both
 /// `directory::registry::workers::list` rows and the `worker` field of
-/// `directory::registry::workers::info`. Same field names as
+/// `directory::registry::workers::info`. Field names match the
+/// OpenAPI `WorkerListItem` schema. The shared core fields (`name`,
+/// `description`, `version`) line up with
 /// [`crate::functions::directory::Worker`] so callers learn one shape
 /// across local + registry surfaces.
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 pub struct Worker {
     pub name: String,
+    #[serde(default)]
     pub description: Option<String>,
+    /// Worker kind — `binary`, `image`, or `engine`.
+    #[serde(default, rename = "type")]
+    pub kind: Option<String>,
     /// Latest published version (worker-list) or the resolved version
     /// (worker-info, when called with `version` / `tag`).
-    pub version: Option<String>,
-    pub repo: Option<String>,
     #[serde(default)]
-    pub author: Option<RegistryAuthor>,
+    pub version: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
+    /// Free-form runtime configuration block from the publish payload.
+    #[serde(default = "default_config_object")]
+    pub config: Value,
+    #[serde(default)]
+    pub supported_targets: Vec<String>,
+    /// Container image tag, populated only for `type=image` workers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+    #[serde(default)]
+    pub total_downloads: u64,
+    #[serde(default)]
+    pub dependencies: Vec<Dependency>,
+    #[serde(default)]
+    pub author: Option<WorkerAuthor>,
+}
+
+fn default_config_object() -> Value {
+    Value::Object(serde_json::Map::new())
+}
+
+/// Pagination envelope returned alongside a worker-list page. Mirrors
+/// the OpenAPI `Pagination` schema.
+#[derive(Debug, Serialize, Deserialize, Clone, Default, JsonSchema)]
+pub struct Pagination {
+    /// Opaque cursor for the next page. `null` on the last page.
+    #[serde(default)]
+    pub next_cursor: Option<String>,
+    #[serde(default)]
+    pub has_more: bool,
+    /// Server-authored page size. The client cannot override this.
+    #[serde(default)]
+    pub page_size: u32,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct WorkerListOutput {
     pub workers: Vec<Worker>,
+    pub pagination: Pagination,
 }
 
 /// `directory::registry::workers::info` input. Pass either `version`
@@ -234,10 +291,14 @@ fn register_worker_list(iii: &Arc<III>, cfg: &Arc<SkillsConfig>, cache: Registry
             },
         )
         .description(
-            "List workers from the public registry (api.workers.iii.dev) \
-             matching the free-text term `search`. Same row shape as \
-             directory::engine::workers::list so callers learn one envelope. \
-             Results are cached for `registry_cache_ttl_ms` (default 60s).",
+            "List workers from the public registry (api.workers.iii.dev). \
+             Optional free-text `search` is matched fuzzily by the registry; \
+             omit it to browse by `total_downloads DESC`. Pagination is \
+             cursor-based with a server-authored page size — pass back \
+             `pagination.next_cursor` as `cursor` to fetch the next page. \
+             Shares the core `name` / `description` / `version` fields with \
+             directory::engine::workers::list. Results are cached for \
+             `registry_cache_ttl_ms` (default 60s).",
         ),
     );
 }
@@ -260,11 +321,14 @@ fn register_worker_info(iii: &Arc<III>, cfg: &Arc<SkillsConfig>, cache: Registry
         )
         .description(
             "Fetch full registry metadata for one worker: worker envelope \
-             (same shape as directory::registry::workers::list rows and \
-             directory::engine::workers::info), readme, full API reference \
-             (functions + triggers schemas), and tree of skill/prompt \
-             file paths. Pass either `version` or `tag` (defaults to \
-             tag=\"latest\"). Results are cached for `registry_cache_ttl_ms`.",
+             (same core fields as directory::engine::workers::info plus \
+             registry-only `type` / `config` / `supported_targets` / \
+             `total_downloads` / `dependencies` / `image`), readme, full \
+             API reference (functions + triggers schemas), and the tree \
+             of skill / prompt file paths fetched from the registry's \
+             /w/{slug}/skills endpoint. Pass either `version` or `tag` \
+             (defaults to tag=\"latest\"). Results are cached for \
+             `registry_cache_ttl_ms`.",
         ),
     );
 }
@@ -272,6 +336,11 @@ fn register_worker_info(iii: &Arc<III>, cfg: &Arc<SkillsConfig>, cache: Registry
 // ---------- input validation (pure) ----------
 
 /// Resolved version specifier produced by [`classify_worker_info_input`].
+/// Both arms serialise as `?version=…` on the wire (the OpenAPI
+/// `/w/{slug}` and `/w/{slug}/skills` endpoints accept either a tag
+/// or an exact semver under the same `version` query param). The enum
+/// distinction is preserved purely so the cache key, error messages,
+/// and unit tests can tell which user-facing input was supplied.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WorkerInfoSpec {
     Version(String),
@@ -279,10 +348,21 @@ pub enum WorkerInfoSpec {
 }
 
 impl WorkerInfoSpec {
-    pub fn as_query_param(&self) -> (&'static str, &str) {
+    /// User-facing label (for cache keys and diagnostics). The wire
+    /// query key is always `version` — see [`Self::query_value`].
+    pub fn label(&self) -> &'static str {
         match self {
-            WorkerInfoSpec::Version(v) => ("version", v.as_str()),
-            WorkerInfoSpec::Tag(t) => ("tag", t.as_str()),
+            WorkerInfoSpec::Version(_) => "version",
+            WorkerInfoSpec::Tag(_) => "tag",
+        }
+    }
+
+    /// The `?version=…` value to send to the registry. Tags and
+    /// semvers go down the same wire path per the OpenAPI contract.
+    pub fn query_value(&self) -> &str {
+        match self {
+            WorkerInfoSpec::Version(v) => v.as_str(),
+            WorkerInfoSpec::Tag(t) => t.as_str(),
         }
     }
 }
@@ -312,11 +392,6 @@ pub fn classify_worker_info_input(
     Ok((name, spec))
 }
 
-pub fn clamp_search_limit(limit: Option<u32>) -> u32 {
-    let raw = limit.unwrap_or(SEARCH_LIMIT_DEFAULT);
-    raw.clamp(1, SEARCH_LIMIT_MAX)
-}
-
 // ---------- core handlers ----------
 
 pub async fn worker_list(
@@ -324,24 +399,45 @@ pub async fn worker_list(
     cache: &RegistryCache,
     input: WorkerListInput,
 ) -> Result<WorkerListOutput, String> {
-    let q = input.search.as_deref().unwrap_or("").trim().to_string();
-    if q.is_empty() {
-        return Err("search must be non-empty".into());
-    }
-    let limit = clamp_search_limit(input.limit);
-    let cache_key = format!("worker-list:{q}:{limit}");
+    let search = input
+        .search
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    let cursor = input
+        .cursor
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    let cache_key = format!(
+        "worker-list:{}:{}",
+        search.as_deref().unwrap_or(""),
+        cursor.as_deref().unwrap_or("")
+    );
     if let Some(cached) = cache.get::<WorkerListOutput>(&cache_key).await {
         return Ok(cached);
     }
 
-    let url = format!("{}/search", cfg.registry_base());
+    let url = format!("{}/w", cfg.registry_base());
     let client = build_http_client(cfg.download_timeout_ms)?;
-    let response = client
-        .get(&url)
-        .query(&[("q", q.as_str()), ("limit", &limit.to_string())])
-        .send()
-        .await
-        .map_err(|e| format!("GET {url} (q={q}, limit={limit}): {e}"))?;
+    let mut request = client.get(&url);
+    let mut query: Vec<(&str, &str)> = Vec::with_capacity(2);
+    if let Some(s) = search.as_deref() {
+        query.push(("search", s));
+    }
+    if let Some(c) = cursor.as_deref() {
+        query.push(("cursor", c));
+    }
+    if !query.is_empty() {
+        request = request.query(&query);
+    }
+
+    let response = request.send().await.map_err(|e| {
+        format!(
+            "GET {url} (search={:?}, cursor={:?}): {e}",
+            search.as_deref().unwrap_or(""),
+            cursor.as_deref().unwrap_or("")
+        )
+    })?;
     let status = response.status();
     if !status.is_success() {
         let body = response.text().await.unwrap_or_default();
@@ -355,8 +451,7 @@ pub async fn worker_list(
         .await
         .map_err(|e| format!("decode registry response: {e}"))?;
 
-    let workers = parse_worker_list_response(&body);
-    let out = WorkerListOutput { workers };
+    let out = parse_worker_list_response(&body);
     cache.put(cache_key, &out).await;
     Ok(out)
 }
@@ -369,22 +464,45 @@ pub async fn worker_info(
     let (name, spec) = classify_worker_info_input(input)?;
     let cache_key = format!(
         "worker-info:{name}:{}={}",
-        spec.as_query_param().0,
-        spec.as_query_param().1
+        spec.label(),
+        spec.query_value()
     );
     if let Some(cached) = cache.get::<WorkerInfoOutput>(&cache_key).await {
         return Ok(cached);
     }
 
-    let url = format!("{}/w/{name}", cfg.registry_base());
-    let (key, value) = spec.as_query_param();
+    let base = cfg.registry_base();
+    let detail_url = format!("{base}/w/{name}");
+    let skills_url = format!("{base}/w/{name}/skills");
+    let version_value = spec.query_value().to_string();
     let client = build_http_client(cfg.download_timeout_ms)?;
+
+    // Fan out the two GETs concurrently. Per OpenAPI both endpoints
+    // accept `?version=` for either tag or exact semver, so both legs
+    // share the same query value.
+    let detail_fut = fetch_json(&client, &detail_url, &version_value);
+    let skills_fut = fetch_json(&client, &skills_url, &version_value);
+    let (detail_body, skills_body) = tokio::try_join!(detail_fut, skills_fut)?;
+
+    let out = parse_worker_info_response(&name, &detail_body, &skills_body);
+    cache.put(cache_key, &out).await;
+    Ok(out)
+}
+
+/// Issue `GET {url}?version={version}` and decode the body as JSON.
+/// Surfaces non-2xx statuses as `Err(String)` so the caller can fail
+/// the whole `worker_info` call.
+async fn fetch_json(
+    client: &reqwest::Client,
+    url: &str,
+    version_value: &str,
+) -> Result<Value, String> {
     let response = client
-        .get(&url)
-        .query(&[(key, value)])
+        .get(url)
+        .query(&[("version", version_value)])
         .send()
         .await
-        .map_err(|e| format!("GET {url} ({key}={value}): {e}"))?;
+        .map_err(|e| format!("GET {url} (version={version_value}): {e}"))?;
     let status = response.status();
     if !status.is_success() {
         let body = response.text().await.unwrap_or_default();
@@ -393,128 +511,90 @@ pub async fn worker_info(
             body.trim()
         ));
     }
-    let body = response
+    response
         .json::<Value>()
         .await
-        .map_err(|e| format!("decode registry response: {e}"))?;
-
-    let out = parse_worker_info_response(&name, &body);
-    cache.put(cache_key, &out).await;
-    Ok(out)
+        .map_err(|e| format!("decode registry response from {url}: {e}"))
 }
 
 // ---------- pure response parsers ----------
 
-/// Tolerant parse of the worker-list response. Accepts either the canonical
-/// `{ "workers": [...] }` envelope OR a bare array, and silently drops
-/// entries that don't include a `name`. Field aliases supported:
-/// `latest_version` → `version` (registry uses the longer name when
-/// listing, the short one when serving worker-info).
-pub fn parse_worker_list_response(value: &Value) -> Vec<Worker> {
-    let arr: &[Value] = value
+/// Parse the `WorkerListResponse` envelope returned by `GET /w`.
+/// Tolerates a missing `pagination` block (defaults to "no more pages")
+/// so a future server hotfix can't break the worker. Entries without
+/// a `name` field are dropped silently.
+pub fn parse_worker_list_response(value: &Value) -> WorkerListOutput {
+    let workers = value
         .get("workers")
         .and_then(|w| w.as_array())
-        .or_else(|| value.as_array())
-        .map(Vec::as_slice)
-        .unwrap_or(&[]);
-    arr.iter().filter_map(parse_worker_envelope).collect()
+        .map(|arr| arr.iter().filter_map(parse_worker_envelope).collect())
+        .unwrap_or_default();
+    let pagination = value
+        .get("pagination")
+        .and_then(|p| serde_json::from_value::<Pagination>(p.clone()).ok())
+        .unwrap_or_default();
+    WorkerListOutput {
+        workers,
+        pagination,
+    }
 }
 
-/// Project a single registry-shaped JSON object into a [`Worker`].
-/// Returns `None` if there's no `name` field.
+/// Project a single registry-shaped `WorkerListItem` JSON object into
+/// a [`Worker`]. Returns `None` if there's no `name` field.
 fn parse_worker_envelope(v: &Value) -> Option<Worker> {
-    let name = v.get("name").and_then(|n| n.as_str())?.to_string();
-    let description = v
-        .get("description")
-        .and_then(|d| d.as_str())
-        .map(String::from);
-    let version = v
-        .get("version")
-        .or_else(|| v.get("latest_version"))
-        .and_then(|x| x.as_str())
-        .map(String::from);
-    let repo = v
-        .get("repo")
-        .or_else(|| v.get("repository"))
-        .and_then(|r| r.as_str())
-        .map(String::from);
-    let author = v
-        .get("author")
-        .and_then(|a| serde_json::from_value::<RegistryAuthor>(a.clone()).ok());
-    Some(Worker {
-        name,
-        description,
-        version,
-        repo,
-        author,
-    })
+    v.get("name").and_then(|n| n.as_str())?;
+    serde_json::from_value::<Worker>(v.clone()).ok()
 }
 
-/// Tolerant parse of the worker-info response. Missing fields default
-/// to `None` / empty so a registry that ships partial metadata for a
-/// new worker still returns something useful.
-pub fn parse_worker_info_response(default_name: &str, value: &Value) -> WorkerInfoOutput {
-    // Build the worker envelope, defaulting `name` to `default_name`
-    // when the payload omits it.
-    let worker = match parse_worker_envelope(value) {
-        Some(mut w) if w.name.is_empty() => {
-            w.name = default_name.to_string();
-            w
-        }
-        Some(w) => w,
-        None => Worker {
-            name: default_name.to_string(),
-            description: value
-                .get("description")
-                .and_then(|d| d.as_str())
-                .map(String::from),
-            version: value
-                .get("version")
-                .or_else(|| value.get("latest_version"))
-                .and_then(|v| v.as_str())
-                .map(String::from),
-            repo: value
-                .get("repo")
-                .or_else(|| value.get("repository"))
-                .and_then(|r| r.as_str())
-                .map(String::from),
-            author: value
-                .get("author")
-                .and_then(|a| serde_json::from_value::<RegistryAuthor>(a.clone()).ok()),
-        },
-    };
+/// Parse the `{ worker: WorkerDetail }` envelope from `GET /w/{slug}`
+/// merged with the `WorkerSkillsDownloadResponse` from
+/// `GET /w/{slug}/skills`. Both inputs are tolerated when partially
+/// populated so a registry that ships partial metadata for a new
+/// worker still returns something useful.
+pub fn parse_worker_info_response(
+    default_name: &str,
+    detail_body: &Value,
+    skills_body: &Value,
+) -> WorkerInfoOutput {
+    // The OpenAPI `/w/{slug}` response is `{ worker: WorkerDetail }`.
+    // Fall back to the top-level object for forward-compatibility with
+    // any older deployment that returned a flat publish payload.
+    let detail = detail_body.get("worker").unwrap_or(detail_body);
 
-    let readme = value
+    let worker = parse_worker_envelope(detail).unwrap_or_else(|| Worker {
+        name: default_name.to_string(),
+        description: None,
+        kind: None,
+        version: None,
+        repo: None,
+        config: default_config_object(),
+        supported_targets: Vec::new(),
+        image: None,
+        total_downloads: 0,
+        dependencies: Vec::new(),
+        author: None,
+    });
+
+    let readme = detail
         .get("readme")
         .and_then(|v| v.as_str())
         .map(String::from);
 
-    // api_reference: accept either a nested object, or a top-level pair
-    // of `functions` / `triggers` arrays alongside the rest of the
-    // payload (the publish payload uses the flat shape).
-    let api_reference = if let Some(api) = value.get("api_reference") {
-        serde_json::from_value::<ApiReference>(api.clone()).unwrap_or_default()
-    } else {
-        let functions = value
-            .get("functions")
-            .cloned()
-            .unwrap_or_else(|| Value::Array(Vec::new()));
-        let triggers = value
-            .get("triggers")
-            .cloned()
-            .unwrap_or_else(|| Value::Array(Vec::new()));
-        let composed = serde_json::json!({
-            "functions": functions,
-            "triggers": triggers,
-        });
-        serde_json::from_value::<ApiReference>(composed).unwrap_or_default()
-    };
+    let functions = detail
+        .get("functions")
+        .cloned()
+        .unwrap_or_else(|| Value::Array(Vec::new()));
+    let triggers = detail
+        .get("triggers")
+        .cloned()
+        .unwrap_or_else(|| Value::Array(Vec::new()));
+    let api_reference = serde_json::from_value::<ApiReference>(serde_json::json!({
+        "functions": functions,
+        "triggers": triggers,
+    }))
+    .unwrap_or_default();
 
-    let skills_tree = value
-        .get("skills_tree")
-        .or_else(|| value.get("skillsTree"))
-        .and_then(|v| serde_json::from_value::<SkillsTree>(v.clone()).ok())
-        .unwrap_or_default();
+    let skills_tree = parse_skills_tree(skills_body);
 
     WorkerInfoOutput {
         worker,
@@ -522,6 +602,44 @@ pub fn parse_worker_info_response(default_name: &str, value: &Value) -> WorkerIn
         api_reference,
         skills_tree,
     }
+}
+
+/// Project a `WorkerSkillsDownloadResponse` body into the metadata-only
+/// `SkillsTree` shape. Drops markdown bodies (`content`) and prompt
+/// `args_schema` / `content` since this view is for picker UIs, not
+/// content rendering. Use `directory::skills::download` to materialise
+/// the bodies on disk.
+fn parse_skills_tree(value: &Value) -> SkillsTree {
+    let skills = value
+        .get("skills")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|s| {
+                    s.get("path")
+                        .and_then(|p| p.as_str())
+                        .map(|p| SkillsTreeSkill { path: p.to_string() })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let prompts = value
+        .get("prompts")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|p| {
+                    let name = p.get("name").and_then(|n| n.as_str())?.to_string();
+                    let description = p
+                        .get("description")
+                        .and_then(|d| d.as_str())
+                        .map(String::from);
+                    Some(SkillsTreePrompt { name, description })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    SkillsTree { skills, prompts }
 }
 
 #[cfg(test)]
@@ -587,115 +705,211 @@ mod tests {
     }
 
     #[test]
-    fn clamp_search_limit_caps_to_max() {
-        assert_eq!(clamp_search_limit(None), SEARCH_LIMIT_DEFAULT);
-        assert_eq!(clamp_search_limit(Some(10)), 10);
-        assert_eq!(clamp_search_limit(Some(500)), SEARCH_LIMIT_MAX);
-        assert_eq!(clamp_search_limit(Some(0)), 1);
+    fn worker_info_spec_label_distinguishes_arms() {
+        assert_eq!(WorkerInfoSpec::Version("1.2.3".into()).label(), "version");
+        assert_eq!(WorkerInfoSpec::Tag("latest".into()).label(), "tag");
     }
 
     #[test]
-    fn parse_worker_list_response_accepts_envelope() {
+    fn worker_info_spec_query_value_uses_inner_string() {
+        assert_eq!(
+            WorkerInfoSpec::Version("1.2.3".into()).query_value(),
+            "1.2.3"
+        );
+        assert_eq!(WorkerInfoSpec::Tag("latest".into()).query_value(), "latest");
+    }
+
+    #[test]
+    fn parse_worker_list_response_accepts_envelope_with_pagination() {
         let v = json!({
             "workers": [
                 {
                     "name": "resend",
-                    "latest_version": "1.2.3",
                     "description": "Email worker",
+                    "type": "binary",
+                    "version": "1.2.3",
                     "repo": "https://github.com/iii/resend",
-                    "author": { "name": "iii", "is_verified": true }
+                    "config": { "runtime": "edge" },
+                    "supported_targets": ["x86_64-unknown-linux-gnu"],
+                    "total_downloads": 42,
+                    "dependencies": [],
+                    "author": { "name": "iii", "pfp": null, "verified": true }
+                }
+            ],
+            "pagination": {
+                "next_cursor": "opaque-cursor",
+                "has_more": true,
+                "page_size": 20
+            }
+        });
+        let out = parse_worker_list_response(&v);
+        assert_eq!(out.workers.len(), 1);
+        assert_eq!(out.workers[0].name, "resend");
+        assert_eq!(out.workers[0].kind.as_deref(), Some("binary"));
+        assert_eq!(out.workers[0].version.as_deref(), Some("1.2.3"));
+        assert_eq!(out.workers[0].total_downloads, 42);
+        assert_eq!(out.workers[0].supported_targets, vec!["x86_64-unknown-linux-gnu".to_string()]);
+        let author = out.workers[0].author.as_ref().unwrap();
+        assert_eq!(author.name.as_deref(), Some("iii"));
+        assert!(author.verified);
+        assert!(author.pfp.is_none());
+        assert_eq!(out.pagination.next_cursor.as_deref(), Some("opaque-cursor"));
+        assert!(out.pagination.has_more);
+        assert_eq!(out.pagination.page_size, 20);
+    }
+
+    #[test]
+    fn parse_worker_list_response_defaults_pagination_when_missing() {
+        let v = json!({ "workers": [ { "name": "alpha" } ] });
+        let out = parse_worker_list_response(&v);
+        assert_eq!(out.workers.len(), 1);
+        assert_eq!(out.workers[0].name, "alpha");
+        assert!(out.pagination.next_cursor.is_none());
+        assert!(!out.pagination.has_more);
+        assert_eq!(out.pagination.page_size, 0);
+    }
+
+    #[test]
+    fn parse_worker_list_response_drops_entries_without_name() {
+        let v = json!({ "workers": [ { "no_name": true }, { "name": "ok" } ] });
+        let out = parse_worker_list_response(&v);
+        assert_eq!(out.workers.len(), 1);
+        assert_eq!(out.workers[0].name, "ok");
+    }
+
+    #[test]
+    fn parse_worker_list_response_handles_empty_envelope() {
+        let v = json!({});
+        let out = parse_worker_list_response(&v);
+        assert!(out.workers.is_empty());
+        assert!(!out.pagination.has_more);
+    }
+
+    #[test]
+    fn parse_worker_info_unwraps_worker_envelope_and_merges_skills() {
+        let detail = json!({
+            "worker": {
+                "name": "resend",
+                "description": "Email worker",
+                "type": "binary",
+                "version": "1.2.3",
+                "repo": "https://github.com/iii/resend",
+                "config": {},
+                "supported_targets": ["x86_64-unknown-linux-gnu"],
+                "total_downloads": 1234,
+                "dependencies": [{ "name": "todo-worker", "version": "0.1.0" }],
+                "author": { "name": "iii", "pfp": null, "verified": true },
+                "readme": "# Resend\n\nDocs here.",
+                "functions": [
+                    {
+                        "name": "send",
+                        "description": "Send an email.",
+                        "request_schema": { "type": "object" },
+                        "response_schema": { "type": "object" }
+                    }
+                ],
+                "triggers": [
+                    {
+                        "name": "on-bounce",
+                        "description": "Fires when a delivery bounces.",
+                        "invocation_schema": { "type": "object" },
+                        "return_schema": { "type": "object" }
+                    }
+                ]
+            }
+        });
+        let skills = json!({
+            "name": "resend",
+            "version": "1.2.3",
+            "skills": [
+                { "path": "index.md", "content": "ignored" },
+                { "path": "emails/send-email.md", "content": "ignored" }
+            ],
+            "prompts": [
+                {
+                    "name": "send-email",
+                    "description": "Compose.",
+                    "args_schema": { "type": "object" },
+                    "content": "ignored"
                 }
             ]
         });
-        let workers = parse_worker_list_response(&v);
-        assert_eq!(workers.len(), 1);
-        assert_eq!(workers[0].name, "resend");
-        assert_eq!(workers[0].version.as_deref(), Some("1.2.3"));
-        assert!(workers[0].author.as_ref().unwrap().is_verified);
-    }
-
-    #[test]
-    fn parse_worker_list_response_accepts_bare_array() {
-        let v = json!([
-            { "name": "alpha" },
-            { "name": "beta", "description": "desc" }
-        ]);
-        let workers = parse_worker_list_response(&v);
-        assert_eq!(workers.len(), 2);
-        assert_eq!(workers[1].description.as_deref(), Some("desc"));
-    }
-
-    #[test]
-    fn parse_worker_list_response_drops_invalid_entries() {
-        let v = json!({ "workers": [ { "no_name": true }, { "name": "ok" } ] });
-        let workers = parse_worker_list_response(&v);
-        assert_eq!(workers.len(), 1);
-        assert_eq!(workers[0].name, "ok");
-    }
-
-    #[test]
-    fn parse_worker_info_handles_flat_publish_payload() {
-        let v = json!({
-            "name": "resend",
-            "version": "1.2.3",
-            "description": "Email worker",
-            "repo": "https://github.com/iii/resend",
-            "readme": "# Resend\n\nDocs here.",
-            "author": { "name": "iii", "is_verified": true },
-            "functions": [
-                {
-                    "name": "send",
-                    "description": "Send an email.",
-                    "request_schema": { "type": "object" },
-                    "response_schema": { "type": "object" }
-                }
-            ],
-            "triggers": [
-                {
-                    "name": "on-bounce",
-                    "description": "Fires when a delivery bounces.",
-                    "invocation_schema": { "type": "object" }
-                }
-            ],
-            "skills_tree": {
-                "skills": [ { "path": "index.md" } ],
-                "prompts": [ { "name": "send-email", "description": "Compose." } ]
-            }
-        });
-        let out = parse_worker_info_response("resend", &v);
+        let out = parse_worker_info_response("resend", &detail, &skills);
         assert_eq!(out.worker.name, "resend");
         assert_eq!(out.worker.version.as_deref(), Some("1.2.3"));
         assert_eq!(out.worker.description.as_deref(), Some("Email worker"));
+        assert_eq!(out.worker.kind.as_deref(), Some("binary"));
+        assert_eq!(out.worker.total_downloads, 1234);
+        assert_eq!(out.worker.dependencies.len(), 1);
+        assert_eq!(out.worker.dependencies[0].name, "todo-worker");
+        assert!(out.worker.author.as_ref().unwrap().verified);
         assert!(out.readme.as_deref().unwrap().contains("# Resend"));
         assert_eq!(out.api_reference.functions.len(), 1);
         assert_eq!(out.api_reference.functions[0].name, "send");
         assert_eq!(out.api_reference.triggers.len(), 1);
-        assert_eq!(out.skills_tree.skills.len(), 1);
+        assert_eq!(out.api_reference.triggers[0].name, "on-bounce");
+        assert_eq!(out.skills_tree.skills.len(), 2);
+        assert_eq!(out.skills_tree.skills[0].path, "index.md");
         assert_eq!(out.skills_tree.prompts.len(), 1);
-        assert!(out.worker.author.as_ref().unwrap().is_verified);
+        assert_eq!(out.skills_tree.prompts[0].name, "send-email");
+        assert_eq!(
+            out.skills_tree.prompts[0].description.as_deref(),
+            Some("Compose.")
+        );
     }
 
     #[test]
-    fn parse_worker_info_handles_nested_api_reference() {
-        let v = json!({
-            "name": "x",
-            "api_reference": {
-                "functions": [{ "name": "f1" }],
-                "triggers": []
-            }
-        });
-        let out = parse_worker_info_response("x", &v);
-        assert_eq!(out.api_reference.functions.len(), 1);
-        assert!(out.api_reference.triggers.is_empty());
-    }
-
-    #[test]
-    fn parse_worker_info_falls_back_to_default_name() {
-        let v = json!({});
-        let out = parse_worker_info_response("fallback", &v);
+    fn parse_worker_info_falls_back_to_default_name_on_empty_bodies() {
+        let detail = json!({});
+        let skills = json!({ "skills": [], "prompts": [] });
+        let out = parse_worker_info_response("fallback", &detail, &skills);
         assert_eq!(out.worker.name, "fallback");
         assert!(out.worker.version.is_none());
         assert!(out.api_reference.functions.is_empty());
+        assert!(out.skills_tree.skills.is_empty());
+        assert!(out.skills_tree.prompts.is_empty());
+    }
+
+    #[test]
+    fn parse_worker_info_tolerates_legacy_flat_payload() {
+        // Forward-compat: an older deployment that returns the flat
+        // publish payload (no `worker` key) is still readable.
+        let detail = json!({
+            "name": "legacy",
+            "version": "0.1.0",
+            "description": "Legacy worker",
+            "type": "binary",
+            "config": {},
+            "supported_targets": [],
+            "total_downloads": 0,
+            "dependencies": [],
+            "author": null,
+            "functions": [{ "name": "f1" }],
+            "triggers": []
+        });
+        let skills = json!({ "skills": [], "prompts": [] });
+        let out = parse_worker_info_response("legacy", &detail, &skills);
+        assert_eq!(out.worker.name, "legacy");
+        assert_eq!(out.api_reference.functions.len(), 1);
+    }
+
+    #[test]
+    fn parse_skills_tree_drops_entries_without_path_or_name() {
+        let v = json!({
+            "skills": [
+                { "path": "ok.md", "content": "x" },
+                { "content": "missing path" }
+            ],
+            "prompts": [
+                { "name": "ok", "description": "fine" },
+                { "description": "missing name" }
+            ]
+        });
+        let tree = parse_skills_tree(&v);
+        assert_eq!(tree.skills.len(), 1);
+        assert_eq!(tree.skills[0].path, "ok.md");
+        assert_eq!(tree.prompts.len(), 1);
+        assert_eq!(tree.prompts[0].name, "ok");
     }
 
     #[tokio::test]

--- a/iii-directory/src/functions/skills.rs
+++ b/iii-directory/src/functions/skills.rs
@@ -4,13 +4,20 @@
 //!
 //!   * `directory::skills::list` — enriched listing of every markdown
 //!     skill under `skills_folder`, sorted by id. Each row carries
-//!     `id`, `title`, `description`, `bytes`, and `modified_at` so a
-//!     consumer can render a picker / index in one round trip without
-//!     follow-up `get` calls per row.
+//!     `id`, `title`, `type`, `description`, `bytes`, and `modified_at`
+//!     so a consumer can render a picker / index in one round trip
+//!     without follow-up `get` calls per row.
 //!   * `directory::skills::get`  — fetch one skill by id. Returns
-//!     `{ id, title, description, body, modified_at }` — the same flat
-//!     shape `directory::prompts::get` returns for prompts so the two
-//!     read APIs stay symmetric.
+//!     `{ id, title, type, description, body, modified_at }` — the
+//!     same flat shape `directory::prompts::get` returns for prompts
+//!     plus `type` from the file's YAML frontmatter.
+//!
+//! Title resolution precedence (shared by `list` and `get`): the YAML
+//! frontmatter `title:` wins when present and non-empty, then the
+//! first `# H1` line in the body, with the bare id as final fallback.
+//! `type` is read straight from the frontmatter `type:` key (e.g.
+//! `index`, `how-to`, `reference`) and serialised as `null` when the
+//! file omits it.
 //!
 //! There are no write paths in this module. Files arrive on disk via
 //! `directory::skills::download` (see [`crate::functions::download`])
@@ -27,7 +34,7 @@ use serde::Serialize;
 use serde_json::json;
 
 use crate::config::SkillsConfig;
-use crate::fs_source::{self, FsSkill};
+use crate::fs_source::{self, FsSkill, SkillFrontmatter};
 
 /// Soft-cap on a single skill body (matches the historic state-backed
 /// limit the registry enforced).
@@ -52,8 +59,10 @@ const URI_PREFIX: &str = "iii://";
 /// Description for the `directory::skills::get` registration.
 const GET_DESCRIPTION: &str =
     "Fetch one filesystem-backed skill by id. Returns the raw markdown body plus id, \
-     title, description, and modified_at — same flat shape as directory::prompts::get. \
-     Accepts a bare id (e.g. \"directory/skills/list\") or the same id prefixed with iii://.";
+     title, type, description, and modified_at — same flat shape as directory::prompts::get \
+     with `type` lifted from the YAML frontmatter and `title` preferring frontmatter \
+     over the body H1. Accepts a bare id (e.g. \"directory/skills/list\") or the same \
+     id prefixed with iii://.";
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 struct ListSkillsInput {}
@@ -61,8 +70,13 @@ struct ListSkillsInput {}
 #[derive(Debug, Serialize, JsonSchema)]
 struct SkillEntry {
     id: String,
-    /// First `# H1` line in the body, falling back to `id` when absent.
+    /// Frontmatter `title:` when present and non-empty, otherwise the
+    /// first `# H1` line in the body, otherwise the bare `id`.
     title: String,
+    /// Frontmatter `type:` (e.g. `index`, `how-to`, `reference`).
+    /// `null` when the file has no frontmatter or omits the key.
+    #[serde(rename = "type")]
+    kind: Option<String>,
     /// First paragraph of the body, empty when the file has only headings.
     description: String,
     bytes: usize,
@@ -73,6 +87,22 @@ struct SkillEntry {
 #[derive(Debug, Serialize, JsonSchema)]
 struct ListSkillsOutput {
     skills: Vec<SkillEntry>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+struct IndexSkillsInput {}
+
+#[derive(Debug, Serialize, JsonSchema)]
+struct IndexSkillsOutput {
+    /// Rendered markdown document — one short `## <title>` block per
+    /// installed worker (skills with frontmatter `type: index`),
+    /// carrying the worker's first-paragraph overview and a read-more
+    /// link pointing at `iii://<ns>/index`. Sorted lex by id.
+    body: String,
+    /// Number of worker entries rendered (i.e. the count of
+    /// `type: index` skills that survived the filter). Cheap sanity
+    /// check that doesn't require re-parsing the body.
+    workers_count: usize,
 }
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
@@ -87,7 +117,13 @@ pub struct SkillGetInput {
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct SkillGetOutput {
     pub id: String,
+    /// Frontmatter `title:` when present and non-empty, otherwise the
+    /// first `# H1` line in the body, otherwise the bare `id`.
     pub title: String,
+    /// Frontmatter `type:` (e.g. `index`, `how-to`, `reference`).
+    /// `null` when the file has no frontmatter or omits the key.
+    #[serde(rename = "type")]
+    pub kind: Option<String>,
     pub description: String,
     /// Raw markdown body (post-frontmatter) from disk.
     pub body: String,
@@ -98,6 +134,7 @@ pub struct SkillGetOutput {
 pub fn register(iii: &Arc<III>, cfg: &Arc<SkillsConfig>) {
     register_list_skills(iii, cfg);
     register_get_skill(iii, cfg);
+    register_index_skills(iii, cfg);
 }
 
 fn register_list_skills(iii: &Arc<III>, cfg: &Arc<SkillsConfig>) {
@@ -112,9 +149,11 @@ fn register_list_skills(iii: &Arc<III>, cfg: &Arc<SkillsConfig>) {
             }
         })
         .description(
-            "List filesystem-backed skills (id, title, description, bytes, modified_at) from \
-             skills_folder. Each row carries the H1 title and first-paragraph description so \
-             consumers can render a picker or indented index without one get per row.",
+            "List filesystem-backed skills (id, title, type, description, bytes, modified_at) \
+             from skills_folder. `title` prefers the YAML frontmatter `title:` over the body H1, \
+             `type` is lifted from frontmatter `type:`, and `description` is the first paragraph \
+             of the body — so consumers can render a picker or indented index without one get \
+             per row.",
         ),
     );
 }
@@ -131,6 +170,39 @@ fn register_get_skill(iii: &Arc<III>, cfg: &Arc<SkillsConfig>) {
     );
 }
 
+fn register_index_skills(iii: &Arc<III>, cfg: &Arc<SkillsConfig>) {
+    let cfg_inner = cfg.clone();
+    iii.register_function(
+        RegisterFunction::new_async(
+            "directory::skills::index",
+            move |_input: IndexSkillsInput| {
+                let cfg = cfg_inner.clone();
+                async move {
+                    let (entries, _skipped) = fs_source::scan_skills(&cfg.resolved_skills_folder());
+                    let rows: Vec<SkillEntry> =
+                        entries.into_iter().map(skill_entry_from_fs).collect();
+                    let body = render_index_markdown(&rows);
+                    let workers_count = rows
+                        .iter()
+                        .filter(|e| e.kind.as_deref() == Some("index"))
+                        .count();
+                    Ok::<_, IIIError>(IndexSkillsOutput {
+                        body,
+                        workers_count,
+                    })
+                }
+            },
+        )
+        .description(
+            "Render one short markdown entry per installed worker (skills with frontmatter \
+             `type: index`). Each entry is a `## <worker title>` heading, the first paragraph \
+             of the worker's overview, and a `Read iii://<ns>/index` line the agent can \
+             follow via `directory::skills::get` for the full reference. Token-light by \
+             design; for per-skill rows use `directory::skills::list`.",
+        ),
+    );
+}
+
 // ---------- core handler ----------
 
 pub async fn get_skill(cfg: &SkillsConfig, req: SkillGetInput) -> Result<SkillGetOutput, String> {
@@ -139,15 +211,15 @@ pub async fn get_skill(cfg: &SkillsConfig, req: SkillGetInput) -> Result<SkillGe
     let Some(fs) = find_fs_skill(cfg, &id) else {
         return Err(format!("Skill not found: {id}"));
     };
-    let body = fs_source::read_body(&fs.abs_path)?;
-    let title = extract_title(&body)
-        .map(str::to_string)
-        .unwrap_or_else(|| fs.id.clone());
+    let (fm, body) = fs_source::read_skill_with_frontmatter(&fs.abs_path)?;
+    let title = resolve_title(&fm, &body, &fs.id);
+    let kind = clean_optional(fm.kind);
     let description = extract_description(&body).unwrap_or_default();
     let (_, modified_at) = fs_metadata(&fs);
     Ok(SkillGetOutput {
         id: fs.id,
         title,
+        kind,
         description,
         body,
         modified_at,
@@ -228,6 +300,31 @@ pub fn extract_title(markdown: &str) -> Option<&str> {
     })
 }
 
+/// Pick the best title for a skill: frontmatter `title:` (when present
+/// and non-empty after trim), then the first body `# H1`, then the
+/// bare `id` so the response field is never empty.
+pub fn resolve_title(fm: &SkillFrontmatter, body: &str, id: &str) -> String {
+    if let Some(t) = fm.title.as_deref() {
+        let trimmed = t.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    if let Some(h1) = extract_title(body) {
+        if !h1.is_empty() {
+            return h1.to_string();
+        }
+    }
+    id.to_string()
+}
+
+/// Trim, then drop the value when the result is empty. Used to keep
+/// the response `type` field as `null` rather than an empty string
+/// when the frontmatter declares `type:` with no value.
+pub fn clean_optional(s: Option<String>) -> Option<String> {
+    s.map(|s| s.trim().to_string()).filter(|s| !s.is_empty())
+}
+
 pub fn extract_description(markdown: &str) -> Option<String> {
     let mut buf = String::new();
     for line in markdown.lines() {
@@ -255,6 +352,54 @@ pub fn extract_description(markdown: &str) -> Option<String> {
     Some(buf)
 }
 
+/// Render a `directory::skills::index` markdown document from already
+/// title/description-resolved rows. Filters down to entries with
+/// frontmatter `type: index` (one per installed worker) and emits a
+/// compact per-worker block:
+///
+/// ```markdown
+/// # Skills index
+///
+/// N worker(s).
+///
+/// ## <resolved title>
+///
+/// <first paragraph from the worker's overview>
+///
+/// Read [`iii://<id>`](iii://<id>) for the full worker reference.
+/// ```
+///
+/// The description block is omitted (no extra blank line) when the
+/// overview body has no paragraph. Entries must already be sorted lex
+/// by `id` (the order `fs_source::scan_skills` returns); this function
+/// does not re-sort.
+fn render_index_markdown(entries: &[SkillEntry]) -> String {
+    let workers: Vec<&SkillEntry> = entries
+        .iter()
+        .filter(|e| e.kind.as_deref() == Some("index"))
+        .collect();
+
+    let mut out = String::new();
+    out.push_str("# Skills index\n\n");
+    out.push_str(&format!("{} worker(s).\n", workers.len()));
+
+    for worker in workers {
+        out.push('\n');
+        out.push_str(&format!("## {}\n", worker.title));
+        if !worker.description.is_empty() {
+            out.push('\n');
+            out.push_str(&format!("{}\n", worker.description));
+        }
+        out.push('\n');
+        out.push_str(&format!(
+            "Read [`iii://{id}`](iii://{id}) for the full worker reference.\n",
+            id = worker.id
+        ));
+    }
+
+    out
+}
+
 // ---------- fs lookup ----------
 
 /// Targeted lookup for the read path. Returns `None` if no file under
@@ -264,25 +409,26 @@ fn find_fs_skill(cfg: &SkillsConfig, id: &str) -> Option<FsSkill> {
     fs.into_iter().find(|s| s.id == id)
 }
 
-/// Build a `SkillEntry` for `list` output. Reads the file body so the
-/// row carries title + description; on read failure the row still
-/// surfaces the id with empty title/description so a single broken
-/// file doesn't hide every other skill from the picker.
+/// Build a `SkillEntry` for `list` output. Reads the file body and
+/// frontmatter so the row carries title + type + description; on read
+/// failure the row still surfaces the id with empty title / null type /
+/// empty description so a single broken file doesn't hide every other
+/// skill from the picker.
 fn skill_entry_from_fs(fs: FsSkill) -> SkillEntry {
     let (bytes, modified_at) = fs_metadata(&fs);
-    let (title, description) = match fs_source::read_body(&fs.abs_path) {
-        Ok(body) => {
-            let title = extract_title(&body)
-                .map(str::to_string)
-                .unwrap_or_else(|| fs.id.clone());
+    let (title, kind, description) = match fs_source::read_skill_with_frontmatter(&fs.abs_path) {
+        Ok((fm, body)) => {
+            let title = resolve_title(&fm, &body, &fs.id);
+            let kind = clean_optional(fm.kind);
             let description = extract_description(&body).unwrap_or_default();
-            (title, description)
+            (title, kind, description)
         }
-        Err(_) => (fs.id.clone(), String::new()),
+        Err(_) => (fs.id.clone(), None, String::new()),
     };
     SkillEntry {
         id: fs.id,
         title,
+        kind,
         description,
         bytes,
         modified_at,
@@ -461,6 +607,61 @@ mod tests {
         );
     }
 
+    // ── resolve_title / clean_optional ──────────────────────────────────
+
+    #[test]
+    fn resolve_title_prefers_frontmatter_over_h1() {
+        let fm = SkillFrontmatter {
+            title: Some("Frontmatter wins".into()),
+            kind: None,
+        };
+        assert_eq!(
+            resolve_title(&fm, "# Body H1\n\nbody", "ns/foo"),
+            "Frontmatter wins"
+        );
+    }
+
+    #[test]
+    fn resolve_title_trims_frontmatter_whitespace() {
+        let fm = SkillFrontmatter {
+            title: Some("   spaced   ".into()),
+            kind: None,
+        };
+        assert_eq!(resolve_title(&fm, "# H1", "id"), "spaced");
+    }
+
+    #[test]
+    fn resolve_title_falls_back_to_h1_when_frontmatter_missing() {
+        let fm = SkillFrontmatter::default();
+        assert_eq!(resolve_title(&fm, "# Body H1\n\nbody", "ns/foo"), "Body H1");
+    }
+
+    #[test]
+    fn resolve_title_falls_back_to_h1_when_frontmatter_blank() {
+        let fm = SkillFrontmatter {
+            title: Some("   ".into()),
+            kind: None,
+        };
+        assert_eq!(resolve_title(&fm, "# Body H1", "ns/foo"), "Body H1");
+    }
+
+    #[test]
+    fn resolve_title_falls_back_to_id_when_no_h1_or_frontmatter() {
+        let fm = SkillFrontmatter::default();
+        assert_eq!(resolve_title(&fm, "no heading here", "ns/foo"), "ns/foo");
+    }
+
+    #[test]
+    fn clean_optional_drops_blank_strings() {
+        assert_eq!(clean_optional(None), None);
+        assert_eq!(clean_optional(Some("".into())), None);
+        assert_eq!(clean_optional(Some("   ".into())), None);
+        assert_eq!(
+            clean_optional(Some(" how-to ".into())),
+            Some("how-to".into())
+        );
+    }
+
     // ── skill_entry_from_fs ─────────────────────────────────────────────
 
     #[test]
@@ -475,9 +676,29 @@ mod tests {
         let entry = skill_entry_from_fs(fs);
         assert_eq!(entry.id, "foo");
         assert_eq!(entry.title, "My title");
+        assert_eq!(entry.kind, None);
         assert_eq!(entry.description, "First paragraph.");
         assert!(entry.bytes > 0);
         assert!(!entry.modified_at.is_empty());
+    }
+
+    #[test]
+    fn list_row_prefers_frontmatter_title_and_carries_type() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("foo.md");
+        std::fs::write(
+            &path,
+            "---\ntitle: Real title\ntype: how-to\n---\n# Body H1\n\nFirst paragraph.\n",
+        )
+        .unwrap();
+        let fs = FsSkill {
+            id: "foo".into(),
+            abs_path: path,
+        };
+        let entry = skill_entry_from_fs(fs);
+        assert_eq!(entry.title, "Real title");
+        assert_eq!(entry.kind.as_deref(), Some("how-to"));
+        assert_eq!(entry.description, "First paragraph.");
     }
 
     #[test]
@@ -491,6 +712,7 @@ mod tests {
         };
         let entry = skill_entry_from_fs(fs);
         assert_eq!(entry.title, "bare");
+        assert_eq!(entry.kind, None);
         assert_eq!(entry.description, "no heading at all");
     }
 
@@ -504,7 +726,260 @@ mod tests {
         };
         let entry = skill_entry_from_fs(fs);
         assert_eq!(entry.title, "missing");
+        assert_eq!(entry.kind, None);
         assert_eq!(entry.description, "");
         assert_eq!(entry.bytes, 0);
+    }
+
+    // ── get_skill (full handler) ────────────────────────────────────────
+
+    fn cfg_with_skills_folder(root: &std::path::Path) -> SkillsConfig {
+        SkillsConfig {
+            skills_folder: root.to_string_lossy().into_owned(),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn get_prefers_frontmatter_title_and_returns_type() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ns = tmp.path().join("ns");
+        std::fs::create_dir_all(&ns).unwrap();
+        std::fs::write(
+            ns.join("doc.md"),
+            "---\ntitle: Real title\ntype: how-to\n---\n# Body H1\n\nThe body.\n",
+        )
+        .unwrap();
+        let cfg = cfg_with_skills_folder(tmp.path());
+        let out = get_skill(
+            &cfg,
+            SkillGetInput {
+                id: "ns/doc".into(),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.id, "ns/doc");
+        assert_eq!(out.title, "Real title");
+        assert_eq!(out.kind.as_deref(), Some("how-to"));
+        assert!(out.body.contains("Body H1"));
+    }
+
+    #[tokio::test]
+    async fn get_falls_back_to_h1_without_frontmatter() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ns = tmp.path().join("ns");
+        std::fs::create_dir_all(&ns).unwrap();
+        std::fs::write(ns.join("plain.md"), "# Just an H1\n\nbody.\n").unwrap();
+        let cfg = cfg_with_skills_folder(tmp.path());
+        let out = get_skill(
+            &cfg,
+            SkillGetInput {
+                id: "ns/plain".into(),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.title, "Just an H1");
+        assert_eq!(out.kind, None);
+    }
+
+    #[tokio::test]
+    async fn get_serialises_type_field_with_correct_json_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ns = tmp.path().join("ns");
+        std::fs::create_dir_all(&ns).unwrap();
+        std::fs::write(
+            ns.join("doc.md"),
+            "---\ntitle: T\ntype: index\n---\n# H\n\nb\n",
+        )
+        .unwrap();
+        let cfg = cfg_with_skills_folder(tmp.path());
+        let out = get_skill(
+            &cfg,
+            SkillGetInput {
+                id: "ns/doc".into(),
+            },
+        )
+        .await
+        .unwrap();
+        let v = serde_json::to_value(&out).unwrap();
+        assert_eq!(v["type"].as_str(), Some("index"));
+        assert!(v.get("kind").is_none(), "kind should be renamed to type");
+        assert!(v["title"].as_str() == Some("T"));
+    }
+
+    // ── render_index_markdown ───────────────────────────────────────────
+
+    /// Build a `SkillEntry` for renderer tests. The `kind` argument
+    /// drives the `type: index` filter — pass `Some("index")` for a
+    /// worker overview, anything else (or `None`) to exercise the
+    /// "should be filtered out" path.
+    fn entry(id: &str, title: &str, kind: Option<&str>, description: &str) -> SkillEntry {
+        SkillEntry {
+            id: id.into(),
+            title: title.into(),
+            kind: kind.map(String::from),
+            description: description.into(),
+            bytes: 0,
+            modified_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn render_index_starts_with_h1_and_worker_count() {
+        let body = render_index_markdown(&[
+            entry(
+                "agent-memory/index",
+                "agent-memory",
+                Some("index"),
+                "Memory tier.",
+            ),
+            entry(
+                "iii-directory/index",
+                "iii-directory",
+                Some("index"),
+                "Directory worker.",
+            ),
+        ]);
+        assert!(
+            body.starts_with("# Skills index\n\n2 worker(s).\n"),
+            "got: {body}"
+        );
+    }
+
+    #[test]
+    fn render_index_empty_input_still_emits_header() {
+        let body = render_index_markdown(&[]);
+        assert_eq!(body, "# Skills index\n\n0 worker(s).\n");
+    }
+
+    #[test]
+    fn render_index_filters_to_type_index() {
+        let body = render_index_markdown(&[
+            entry(
+                "agent-memory/index",
+                "agent-memory",
+                Some("index"),
+                "Worker overview.",
+            ),
+            entry(
+                "agent-memory/observe",
+                "Observe",
+                Some("how-to"),
+                "Record an event.",
+            ),
+            entry("agent-memory/strays", "Stray", None, "Untyped skill."),
+        ]);
+        assert!(body.contains("## agent-memory"), "missing h2; got: {body}");
+        assert!(
+            !body.contains("## Observe"),
+            "how-to should be filtered out; got: {body}"
+        );
+        assert!(
+            !body.contains("## Stray"),
+            "untyped skill should be filtered out; got: {body}"
+        );
+        // Filtered-out skills must not leak into the read-more pointers either.
+        assert!(
+            !body.contains("iii://agent-memory/observe"),
+            "filtered-out how-to leaked a link; got: {body}"
+        );
+        assert!(body.contains("1 worker(s).\n"), "wrong count; got: {body}");
+    }
+
+    #[test]
+    fn render_index_emits_h2_per_worker_using_resolved_title() {
+        let body = render_index_markdown(&[
+            entry(
+                "agent-memory/index",
+                "agent-memory",
+                Some("index"),
+                "Memory tier.",
+            ),
+            entry(
+                "iii-directory/index",
+                "iii-directory",
+                Some("index"),
+                "Directory worker.",
+            ),
+        ]);
+        assert_eq!(
+            body.matches("\n## ").count(),
+            2,
+            "expected exactly two `##` headings; got: {body}"
+        );
+        assert!(body.contains("\n## agent-memory\n"), "got: {body}");
+        assert!(body.contains("\n## iii-directory\n"), "got: {body}");
+    }
+
+    #[test]
+    fn render_index_includes_description_paragraph() {
+        let body = render_index_markdown(&[entry(
+            "iii-directory/index",
+            "iii-directory",
+            Some("index"),
+            "Engine introspection and filesystem-backed skill reader.",
+        )]);
+        // Description sits between the `## title` and the read-more line,
+        // separated by blank lines on either side.
+        assert!(
+            body.contains(
+                "\n## iii-directory\n\nEngine introspection and filesystem-backed skill reader.\n\nRead "
+            ),
+            "description not framed correctly; got: {body}"
+        );
+    }
+
+    #[test]
+    fn render_index_emits_dive_deeper_link() {
+        let body = render_index_markdown(&[entry(
+            "agent-memory/index",
+            "agent-memory",
+            Some("index"),
+            "Memory tier.",
+        )]);
+        assert!(
+            body.contains(
+                "Read [`iii://agent-memory/index`](iii://agent-memory/index) for the full worker reference.\n"
+            ),
+            "missing dive-deeper pointer; got: {body}"
+        );
+    }
+
+    #[test]
+    fn render_index_skips_blank_description() {
+        let body = render_index_markdown(&[entry(
+            "bare/index",
+            "bare",
+            Some("index"),
+            "", // body has no paragraph
+        )]);
+        // Title comes immediately before the read-more line — no extra
+        // blank paragraph in the middle.
+        assert!(
+            body.contains("\n## bare\n\nRead [`iii://bare/index`](iii://bare/index)"),
+            "blank-description block should compress; got: {body}"
+        );
+        // And the rest of the document still has the header.
+        assert!(body.contains("1 worker(s).\n"));
+    }
+
+    #[test]
+    fn render_index_ordering_follows_input_lex_order() {
+        // Input is already lex-sorted by `scan_skills`; the renderer
+        // emits sections in the same order.
+        let body = render_index_markdown(&[
+            entry("agent-memory/index", "agent-memory", Some("index"), "a"),
+            entry("iii-directory/index", "iii-directory", Some("index"), "b"),
+            entry("resend/index", "resend", Some("index"), "c"),
+        ]);
+        let am = body.find("## agent-memory").expect("am missing");
+        let iii = body.find("## iii-directory").expect("iii missing");
+        let resend = body.find("## resend").expect("resend missing");
+        assert!(
+            am < iii && iii < resend,
+            "headings out of order; got: {body}"
+        );
     }
 }

--- a/iii-directory/src/lib.rs
+++ b/iii-directory/src/lib.rs
@@ -9,9 +9,10 @@
 //!   * **Skills** (`directory::skills::*`): a filesystem-backed markdown
 //!     reader keyed by short skill ids
 //!     (slashed-path-relative-to-`skills_folder`).
-//!     `directory::skills::list` enumerates them with title/description
-//!     pre-populated; `directory::skills::get` reads one body + metadata
-//!     (same flat shape as `directory::prompts::get`).
+//!     `directory::skills::list` enumerates them with title/type/description
+//!     pre-populated; `directory::skills::get` reads one body + metadata.
+//!     `title` prefers the YAML frontmatter `title:` over the body H1,
+//!     and `type` is lifted verbatim from frontmatter `type:`.
 //!   * **Prompts** (`directory::prompts::*`): filesystem-backed
 //!     slash-command templates loaded from
 //!     `<skills_folder>/<ns>/prompts/*.md` files with YAML frontmatter.

--- a/iii-directory/src/sources/registry.rs
+++ b/iii-directory/src/sources/registry.rs
@@ -38,6 +38,14 @@ use super::{build_http_client, validate_relative_path, write_file_atomic, Downlo
 use crate::functions::prompts::validate_name as validate_prompt_name;
 
 /// Specifier for which version of a worker's skills to pull.
+///
+/// Both arms serialise as `?version=…` on the wire — per the
+/// OpenAPI contract, `/w/{slug}/skills` accepts either a tag
+/// (`latest`, `beta`) or an exact semver under the same `version`
+/// query param. The enum variants are preserved purely so the
+/// user-facing input on `directory::skills::download` (which still
+/// distinguishes `version:` from `tag:`) round-trips through the
+/// download path unchanged for diagnostics and logging.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VersionSpec {
     Version(String),
@@ -45,10 +53,13 @@ pub enum VersionSpec {
 }
 
 impl VersionSpec {
+    /// The `?version=…` value to send to the registry. Both variants
+    /// share the same wire key; `("version", value)` is returned to
+    /// keep the `(key, value)` tuple shape callers already use.
     pub fn as_query_param(&self) -> (&'static str, &str) {
         match self {
             VersionSpec::Version(v) => ("version", v.as_str()),
-            VersionSpec::Tag(t) => ("tag", t.as_str()),
+            VersionSpec::Tag(t) => ("version", t.as_str()),
         }
     }
 }
@@ -242,11 +253,13 @@ mod tests {
     }
 
     #[test]
-    fn version_spec_query_param_picks_key() {
+    fn version_spec_query_param_always_uses_version_key() {
         let v = VersionSpec::Version("1.2.3".into());
         assert_eq!(v.as_query_param(), ("version", "1.2.3"));
         let t = VersionSpec::Tag("latest".into());
-        assert_eq!(t.as_query_param(), ("tag", "latest"));
+        // Per the OpenAPI contract, both tags and exact semvers go on
+        // the wire as `?version=…`.
+        assert_eq!(t.as_query_param(), ("version", "latest"));
     }
 
     #[test]

--- a/iii-directory/tests/features/download_registry.feature
+++ b/iii-directory/tests/features/download_registry.feature
@@ -1,9 +1,12 @@
 @engine @download @download_registry
 Feature: directory::skills::download worker= source (workers registry HTTP)
   Pulls a worker's skills + prompts bundle from
-  `{registry_url}/w/{worker}/skills?version=… | tag=…` into
+  `{registry_url}/w/{worker}/skills?version=…` into
   `<skills_folder>/<worker>/`. Skills are written verbatim; prompts
   are written under `<worker>/prompts/<name>.md` with YAML frontmatter.
+  The user-facing input accepts either `version:` (exact semver) or
+  `tag:` (e.g. `latest`); both are forwarded as `?version=` per the
+  OpenAPI contract.
 
   Background:
     Given the iii engine is reachable

--- a/iii-directory/tests/features/read.feature
+++ b/iii-directory/tests/features/read.feature
@@ -44,6 +44,23 @@ Feature: filesystem-backed reads (directory::skills::list / directory::skills::g
     When I list skills
     Then the listing entry "ns/labelled" has title "Labelled skill"
     And  the listing entry "ns/labelled" has description "First paragraph summary."
+    And  the listing entry "ns/labelled" has a null type
+
+  Scenario: list rows prefer the frontmatter title and surface the frontmatter type
+    Given a skill file at "ns/branded.md" with body:
+      """
+      ---
+      title: Real title from frontmatter
+      type: how-to
+      ---
+      # Body H1 ignored
+
+      First paragraph summary.
+      """
+    When I list skills
+    Then the listing entry "ns/branded" has title "Real title from frontmatter"
+    And  the listing entry "ns/branded" has type "how-to"
+    And  the listing entry "ns/branded" has description "First paragraph summary."
 
   # ── nested directory hierarchy ───────────────────────────────────────
 
@@ -79,6 +96,23 @@ Feature: filesystem-backed reads (directory::skills::list / directory::skills::g
     And  the get response has description "Body content here."
     And  the get response body contains "Body content here."
     And  the get response has a non-empty modified_at
+    And  the get response has a null type
+
+  Scenario: directory::skills::get prefers the frontmatter title and exposes the frontmatter type
+    Given a skill file at "ns/branded-get.md" with body:
+      """
+      ---
+      title: Real title from frontmatter
+      type: how-to
+      ---
+      # Body H1 ignored
+
+      Body content here.
+      """
+    When I get skill "ns/branded-get"
+    Then the get response has title "Real title from frontmatter"
+    And  the get response has type "how-to"
+    And  the get response body contains "Body H1 ignored"
 
   Scenario: directory::skills::get accepts the legacy iii:// prefix
     Given a skill file at "ns/prefixed.md" with body:
@@ -129,3 +163,47 @@ Feature: filesystem-backed reads (directory::skills::list / directory::skills::g
     When I list skills
     Then no listing entry has id "ns/Bad-Name"
     And  no listing entry has id "ns/bad-name"
+
+  # ── directory::skills::index ─────────────────────────────────────────
+
+  Scenario: directory::skills::index lists workers and filters out non-index skills
+    Given a skill file at "team-a/index.md" with body:
+      """
+      ---
+      title: team-a
+      type: index
+      ---
+      # team-a
+
+      Alpha team's worker. Owns alpha-only tooling.
+      """
+    And   a skill file at "team-b/index.md" with body:
+      """
+      ---
+      title: team-b
+      type: index
+      ---
+      # team-b
+
+      Bravo team's worker. Handles all bravo workflows.
+      """
+    And   a skill file at "team-a/foo.md" with body:
+      """
+      ---
+      type: how-to
+      ---
+      # Foo
+
+      A how-to that must not appear in the worker index.
+      """
+    When I index skills
+    Then the index response has at least 2 workers
+    And  the index response body contains "# Skills index"
+    And  the index response body contains "## team-a"
+    And  the index response body contains "## team-b"
+    And  the index response body contains "Alpha team's worker. Owns alpha-only tooling."
+    And  the index response body contains "Bravo team's worker. Handles all bravo workflows."
+    And  the index response body contains "Read [`iii://team-a/index`](iii://team-a/index) for the full worker reference."
+    And  the index response body contains "Read [`iii://team-b/index`](iii://team-b/index) for the full worker reference."
+    And  the index response body does not contain "team-a/foo"
+    And  the index response body does not contain "## Foo"

--- a/iii-directory/tests/features/registry_worker_info.feature
+++ b/iii-directory/tests/features/registry_worker_info.feature
@@ -1,44 +1,70 @@
 @engine @registry @registry_worker_info
 Feature: directory::registry::workers::info (workers registry HTTP proxy)
-  HTTP `GET {registry_base}/w/{name}?version=…|tag=…` proxied to the
-  workers registry. The flat publish payload is decoded into a
-  `{ worker: { name, description, version, repo, author }, readme,
-  api_reference: { functions, triggers }, skills_tree }` envelope —
-  the `worker` field has the same shape as
-  `directory::engine::workers::info.worker` so callers can switch
-  between local + registry surfaces with one parser.
+  Two parallel registry calls back the response:
+    * `GET {base}/w/{name}?version=…` returns `{ worker: WorkerDetail }`
+      whose `worker` field carries name / description / version / repo /
+      author / type / config / supported_targets / total_downloads /
+      dependencies plus readme / functions / triggers.
+    * `GET {base}/w/{name}/skills?version=…` returns the skills + prompts
+      tree merged into the response as `skills_tree`.
+  The OpenAPI uses `?version=` for both endpoints; tags (`latest`) and
+  exact semvers share that wire param. The user-facing input still
+  accepts `tag:` for ergonomics — the worker rewrites it to `?version=`.
+  The `worker` field shares its core fields (`name`, `description`,
+  `version`) with `directory::engine::workers::info.worker`.
 
   Background:
     Given the iii engine is reachable
 
-  Scenario: workers::info returns the full publish envelope at a tag
+  Scenario: workers::info merges the detail envelope and skills tree at a tag
     Given a wiremock registry serving worker info "resend" at tag "latest" with body:
+      """
+      {
+        "worker": {
+          "name": "resend",
+          "description": "Email worker",
+          "type": "binary",
+          "version": "1.2.3",
+          "repo": "https://github.com/iii-hq/resend",
+          "config": {},
+          "supported_targets": ["x86_64-unknown-linux-gnu"],
+          "total_downloads": 4242,
+          "dependencies": [],
+          "author": { "name": "iii", "pfp": null, "verified": true },
+          "readme": "# resend\n\nDocs body.",
+          "functions": [
+            {
+              "name": "send",
+              "description": "Send an email.",
+              "request_schema": { "type": "object" },
+              "response_schema": { "type": "object" }
+            }
+          ],
+          "triggers": [
+            {
+              "name": "on-bounce",
+              "description": "Fires on a bounce.",
+              "invocation_schema": { "type": "object" },
+              "return_schema": { "type": "object" }
+            }
+          ]
+        }
+      }
+      """
+    And a wiremock registry serving worker skills "resend" at version "latest" with body:
       """
       {
         "name": "resend",
         "version": "1.2.3",
-        "description": "Email worker",
-        "repo": "https://github.com/iii-hq/resend",
-        "readme": "# resend\n\nDocs body.",
-        "author": { "name": "iii", "is_verified": true },
-        "functions": [
+        "skills": [{ "path": "index.md", "content": "# resend" }],
+        "prompts": [
           {
-            "name": "send",
-            "description": "Send an email.",
-            "request_schema": { "type": "object" },
-            "response_schema": { "type": "object" }
+            "name": "send-email",
+            "description": "Compose.",
+            "args_schema": { "type": "object" },
+            "content": "Compose body."
           }
-        ],
-        "triggers": [
-          {
-            "name": "on-bounce",
-            "description": "Fires on a bounce."
-          }
-        ],
-        "skills_tree": {
-          "skills": [{ "path": "index.md" }],
-          "prompts": [{ "name": "send-email", "description": "Compose." }]
-        }
+        ]
       }
       """
     When I trigger directory::registry::workers::info with payload:
@@ -58,12 +84,26 @@ Feature: directory::registry::workers::info (workers registry HTTP proxy)
     Given a wiremock registry serving worker info "resend" at tag "latest" with body:
       """
       {
-        "name": "resend",
-        "version": "1.2.3",
-        "functions": [],
-        "triggers": [],
-        "skills_tree": {"skills": [], "prompts": []}
+        "worker": {
+          "name": "resend",
+          "description": "Email worker",
+          "type": "binary",
+          "version": "1.2.3",
+          "repo": "https://github.com/iii-hq/resend",
+          "config": {},
+          "supported_targets": [],
+          "total_downloads": 0,
+          "dependencies": [],
+          "author": null,
+          "readme": "",
+          "functions": [],
+          "triggers": []
+        }
       }
+      """
+    And a wiremock registry serving worker skills "resend" at version "latest" with body:
+      """
+      { "name": "resend", "version": "1.2.3", "skills": [], "prompts": [] }
       """
     When I trigger directory::registry::workers::info with payload:
       """
@@ -88,6 +128,7 @@ Feature: directory::registry::workers::info (workers registry HTTP proxy)
 
   Scenario: workers::info HTTP 404 surfaces in the failure message
     Given a wiremock registry that returns 404 for worker info "missing"
+    And a wiremock registry that returns 404 for worker skills "missing"
     When I trigger directory::registry::workers::info with payload:
       """
       {"name": "missing", "tag": "latest"}
@@ -98,12 +139,26 @@ Feature: directory::registry::workers::info (workers registry HTTP proxy)
     Given a wiremock registry serving worker info "cached" at tag "latest" with body:
       """
       {
-        "name": "cached",
-        "version": "1.0.0",
-        "functions": [],
-        "triggers": [],
-        "skills_tree": {"skills": [], "prompts": []}
+        "worker": {
+          "name": "cached",
+          "description": null,
+          "type": "binary",
+          "version": "1.0.0",
+          "repo": null,
+          "config": {},
+          "supported_targets": [],
+          "total_downloads": 0,
+          "dependencies": [],
+          "author": null,
+          "readme": "",
+          "functions": [],
+          "triggers": []
+        }
       }
+      """
+    And a wiremock registry serving worker skills "cached" at version "latest" with body:
+      """
+      { "name": "cached", "version": "1.0.0", "skills": [], "prompts": [] }
       """
     When I trigger directory::registry::workers::info with payload:
       """
@@ -116,3 +171,4 @@ Feature: directory::registry::workers::info (workers registry HTTP proxy)
       """
     Then the directory::registry::workers::info call succeeds
     And  the wiremock registry received exactly 1 request to "/w/cached"
+    And  the wiremock registry received exactly 1 request to "/w/cached/skills"

--- a/iii-directory/tests/features/registry_worker_list.feature
+++ b/iii-directory/tests/features/registry_worker_list.feature
@@ -1,32 +1,51 @@
 @engine @registry @registry_worker_list
 Feature: directory::registry::workers::list (workers registry HTTP proxy)
-  HTTP `GET {registry_base}/search?q=…&limit=…` proxied through to the
-  workers registry. Responses are cached briefly per `(search, limit)`
-  so the same lookup within `registry_cache_ttl_ms` doesn't re-hit
-  HTTP. Row shape mirrors `directory::engine::workers::list` so callers
-  learn one envelope.
+  HTTP `GET {registry_base}/w?search=…&cursor=…` proxied through to the
+  workers registry. Page size is server-authored; clients pass back
+  `pagination.next_cursor` to fetch the next page. Responses are cached
+  briefly per `(search, cursor)` so the same lookup within
+  `registry_cache_ttl_ms` doesn't re-hit HTTP. The shared core fields
+  (`name`, `description`, `version`) line up with
+  `directory::engine::workers::list` so callers learn one envelope.
 
   Background:
     Given the iii engine is reachable
 
-  Scenario: workers::list forwards the search term and returns workers from the envelope
+  Scenario: workers::list forwards the search term and returns the paginated envelope
     Given a wiremock registry serving search "email" with body:
       """
       {
         "workers": [
           {
             "name": "resend",
-            "latest_version": "1.2.3",
             "description": "Email worker",
+            "type": "binary",
+            "version": "1.2.3",
             "repo": "https://github.com/iii-hq/resend",
-            "author": { "name": "iii", "is_verified": true }
+            "config": {},
+            "supported_targets": ["x86_64-unknown-linux-gnu"],
+            "total_downloads": 42,
+            "dependencies": [],
+            "author": { "name": "iii", "pfp": null, "verified": true }
           },
           {
             "name": "mailgun",
-            "latest_version": "0.4.0",
-            "description": "Mailgun adapter"
+            "description": "Mailgun adapter",
+            "type": "binary",
+            "version": "0.4.0",
+            "repo": "https://github.com/iii-hq/mailgun",
+            "config": {},
+            "supported_targets": [],
+            "total_downloads": 7,
+            "dependencies": [],
+            "author": null
           }
-        ]
+        ],
+        "pagination": {
+          "next_cursor": "next-page",
+          "has_more": true,
+          "page_size": 20
+        }
       }
       """
     When I trigger directory::registry::workers::list with payload:
@@ -37,18 +56,20 @@ Feature: directory::registry::workers::list (workers registry HTTP proxy)
     And  the registry worker-list response includes worker "resend"
     And  the registry worker-list response includes worker "mailgun"
     And  the registry worker-list response worker "resend" has version "1.2.3"
-
-  Scenario: workers::list rejects an empty search
-    When I trigger directory::registry::workers::list with payload:
-      """
-      {"search": "  "}
-      """
-    Then the directory::registry::workers::list call fails with a message mentioning "non-empty"
+    And  the registry worker-list pagination has_more is true
+    And  the registry worker-list pagination next_cursor is "next-page"
 
   Scenario: workers::list returns an empty list when the registry has no matches
     Given a wiremock registry serving search "nope" with body:
       """
-      { "workers": [] }
+      {
+        "workers": [],
+        "pagination": {
+          "next_cursor": null,
+          "has_more": false,
+          "page_size": 20
+        }
+      }
       """
     When I trigger directory::registry::workers::list with payload:
       """
@@ -56,6 +77,8 @@ Feature: directory::registry::workers::list (workers registry HTTP proxy)
       """
     Then the directory::registry::workers::list call succeeds
     And  the registry worker-list response is empty
+    And  the registry worker-list pagination has_more is false
+    And  the registry worker-list pagination next_cursor is null
 
   Scenario: registry HTTP error surfaces in the failure message
     Given a wiremock registry that returns 502 for search "broken"

--- a/iii-directory/tests/steps/download_registry.rs
+++ b/iii-directory/tests/steps/download_registry.rs
@@ -53,9 +53,11 @@ async fn wiremock_at_tag(
     let Some(shared) = workers::shared() else {
         return;
     };
+    // The user-facing input still says `tag:`, but `VersionSpec::Tag`
+    // serialises as `?version=…` on the wire (per the OpenAPI contract).
     Mock::given(method("GET"))
         .and(path(format!("/w/{worker}/skills")))
-        .and(query_param("tag", &tag))
+        .and(query_param("version", &tag))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_string(body)

--- a/iii-directory/tests/steps/read.rs
+++ b/iii-directory/tests/steps/read.rs
@@ -15,6 +15,7 @@ use crate::common::world::IiiSkillsWorld;
 const LAST_LIST: &str = "read_last_list";
 const LAST_GET: &str = "read_last_get";
 const LAST_GET_ERR: &str = "read_last_get_err";
+const LAST_INDEX: &str = "read_last_index";
 
 #[given("the iii engine is reachable")]
 async fn engine_reachable(_world: &mut IiiSkillsWorld) {}
@@ -29,7 +30,13 @@ fn write_fixture(world: &IiiSkillsWorld, rel: &str, body: &str) {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).expect("create_dir_all");
     }
-    std::fs::write(&path, body).expect("write fixture");
+    // Gherkin docstrings come back with a leading `\n` (the newline right
+    // after the opening `"""`). That trips the YAML frontmatter parser
+    // because it expects the body to start with `---\n` at byte 0, so
+    // strip it before writing — otherwise scenarios that declare
+    // frontmatter never see it round-trip.
+    let normalized = body.strip_prefix('\n').unwrap_or(body);
+    std::fs::write(&path, normalized).expect("write fixture");
 }
 
 #[given(regex = r#"^a skill file at "([^"]+)" with body:$"#)]
@@ -115,6 +122,31 @@ fn listing_entry_description(world: &mut IiiSkillsWorld, id: String, expected: S
     assert_eq!(entry["description"].as_str().unwrap_or(""), expected);
 }
 
+#[then(regex = r#"^the listing entry "([^"]+)" has type "([^"]+)"$"#)]
+fn listing_entry_type(world: &mut IiiSkillsWorld, id: String, expected: String) {
+    if world.iii.is_none() {
+        return;
+    }
+    let entry = list_entry(world, &id).unwrap_or_else(|| panic!("id {id:?} missing from listing"));
+    assert_eq!(
+        entry["type"].as_str().unwrap_or(""),
+        expected,
+        "entry: {entry:?}"
+    );
+}
+
+#[then(regex = r#"^the listing entry "([^"]+)" has a null type$"#)]
+fn listing_entry_null_type(world: &mut IiiSkillsWorld, id: String) {
+    if world.iii.is_none() {
+        return;
+    }
+    let entry = list_entry(world, &id).unwrap_or_else(|| panic!("id {id:?} missing from listing"));
+    assert!(
+        entry["type"].is_null(),
+        "expected null type for {id:?}; got: {entry:?}"
+    );
+}
+
 // ── skills::get ─────────────────────────────────────────────────────
 
 #[when(regex = r#"^I get skill "([^"]*)"$"#)]
@@ -171,6 +203,31 @@ fn get_description(world: &mut IiiSkillsWorld, expected: String) {
     assert_eq!(v["description"].as_str().unwrap_or(""), expected);
 }
 
+#[then(regex = r#"^the get response has type "([^"]+)"$"#)]
+fn get_type(world: &mut IiiSkillsWorld, expected: String) {
+    if world.iii.is_none() {
+        return;
+    }
+    let v = world.stash.get(LAST_GET).expect("no get recorded");
+    assert_eq!(
+        v["type"].as_str().unwrap_or(""),
+        expected,
+        "response: {v:?}"
+    );
+}
+
+#[then("the get response has a null type")]
+fn get_null_type(world: &mut IiiSkillsWorld) {
+    if world.iii.is_none() {
+        return;
+    }
+    let v = world.stash.get(LAST_GET).expect("no get recorded");
+    assert!(
+        v["type"].is_null(),
+        "expected null type; got response: {v:?}"
+    );
+}
+
 #[then(regex = r#"^the get response body contains "([^"]+)"$"#)]
 fn get_body_contains(world: &mut IiiSkillsWorld, needle: String) {
     if world.iii.is_none() {
@@ -213,5 +270,65 @@ fn get_fails_mentioning(world: &mut IiiSkillsWorld, needle: String) {
     assert!(
         err.contains(&needle),
         "expected error to mention {needle:?}; got: {err:?}"
+    );
+}
+
+// ── skills::index ───────────────────────────────────────────────────
+
+#[when("I index skills")]
+async fn index_skills(world: &mut IiiSkillsWorld) {
+    world.stash.remove(LAST_INDEX);
+    let Some(iii) = world.iii.clone() else {
+        return;
+    };
+    if let Ok(v) = iii
+        .trigger(TriggerRequest {
+            function_id: "directory::skills::index".to_string(),
+            payload: json!({}),
+            action: None,
+            timeout_ms: Some(5_000),
+        })
+        .await
+    {
+        world.stash.insert(LAST_INDEX.into(), v);
+    }
+}
+
+#[then(regex = r#"^the index response has at least (\d+) workers$"#)]
+fn index_min_count(world: &mut IiiSkillsWorld, min: usize) {
+    if world.iii.is_none() {
+        return;
+    }
+    let v = world.stash.get(LAST_INDEX).expect("no index recorded");
+    let count = v["workers_count"].as_u64().unwrap_or(0) as usize;
+    assert!(
+        count >= min,
+        "expected workers_count >= {min}; got {count} in {v:?}"
+    );
+}
+
+#[then(regex = r#"^the index response body contains "([^"]+)"$"#)]
+fn index_body_contains(world: &mut IiiSkillsWorld, needle: String) {
+    if world.iii.is_none() {
+        return;
+    }
+    let v = world.stash.get(LAST_INDEX).expect("no index recorded");
+    let body = v["body"].as_str().unwrap_or("");
+    assert!(
+        body.contains(&needle),
+        "expected index body to contain {needle:?}; got:\n{body}"
+    );
+}
+
+#[then(regex = r#"^the index response body does not contain "([^"]+)"$"#)]
+fn index_body_lacks(world: &mut IiiSkillsWorld, needle: String) {
+    if world.iii.is_none() {
+        return;
+    }
+    let v = world.stash.get(LAST_INDEX).expect("no index recorded");
+    let body = v["body"].as_str().unwrap_or("");
+    assert!(
+        !body.contains(&needle),
+        "expected index body NOT to contain {needle:?}; got:\n{body}"
     );
 }

--- a/iii-directory/tests/steps/registry.rs
+++ b/iii-directory/tests/steps/registry.rs
@@ -58,8 +58,8 @@ async fn wiremock_search(_world: &mut IiiSkillsWorld, q: String, step: &cucumber
         return;
     };
     Mock::given(method("GET"))
-        .and(path("/search"))
-        .and(query_param("q", &q))
+        .and(path("/w"))
+        .and(query_param("search", &q))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_string(body)
@@ -75,8 +75,8 @@ async fn wiremock_search_status(_world: &mut IiiSkillsWorld, status: u16, q: Str
         return;
     };
     Mock::given(method("GET"))
-        .and(path("/search"))
-        .and(query_param("q", &q))
+        .and(path("/w"))
+        .and(query_param("search", &q))
         .respond_with(ResponseTemplate::new(status).set_body_string("upstream error"))
         .mount(&shared.mock_server)
         .await;
@@ -95,9 +95,12 @@ async fn wiremock_worker_info_tag(
     let Some(shared) = workers::shared() else {
         return;
     };
+    // The worker still accepts `tag:` in its input, but on the wire it
+    // forwards the value as `?version=…` (per OpenAPI). The mock matches
+    // that wire shape.
     Mock::given(method("GET"))
         .and(path(format!("/w/{worker}")))
-        .and(query_param("tag", &tag))
+        .and(query_param("version", &tag))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_string(body)
@@ -139,6 +142,43 @@ async fn wiremock_worker_info_status(_world: &mut IiiSkillsWorld, status: u16, w
     };
     Mock::given(method("GET"))
         .and(path(format!("/w/{worker}")))
+        .respond_with(ResponseTemplate::new(status).set_body_string("not found"))
+        .mount(&shared.mock_server)
+        .await;
+}
+
+#[given(
+    regex = r#"^a wiremock registry serving worker skills "([^"]+)" at version "([^"]+)" with body:$"#
+)]
+async fn wiremock_worker_skills_version(
+    _world: &mut IiiSkillsWorld,
+    worker: String,
+    version: String,
+    step: &cucumber::gherkin::Step,
+) {
+    let body = step.docstring.as_deref().unwrap_or("").to_string();
+    let Some(shared) = workers::shared() else {
+        return;
+    };
+    Mock::given(method("GET"))
+        .and(path(format!("/w/{worker}/skills")))
+        .and(query_param("version", &version))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(body)
+                .insert_header("content-type", "application/json"),
+        )
+        .mount(&shared.mock_server)
+        .await;
+}
+
+#[given(regex = r#"^a wiremock registry that returns (\d+) for worker skills "([^"]+)"$"#)]
+async fn wiremock_worker_skills_status(_world: &mut IiiSkillsWorld, status: u16, worker: String) {
+    let Some(shared) = workers::shared() else {
+        return;
+    };
+    Mock::given(method("GET"))
+        .and(path(format!("/w/{worker}/skills")))
         .respond_with(ResponseTemplate::new(status).set_body_string("not found"))
         .mount(&shared.mock_server)
         .await;
@@ -245,6 +285,42 @@ fn worker_list_version(world: &mut IiiSkillsWorld, name: String, version: String
         entry["version"].as_str().unwrap_or(""),
         version,
         "version mismatch on entry: {entry:?}"
+    );
+}
+
+#[then(regex = r#"^the registry worker-list pagination has_more is (true|false)$"#)]
+fn worker_list_pagination_has_more(world: &mut IiiSkillsWorld, expected: String) {
+    if world.iii.is_none() {
+        return;
+    }
+    let v = last_ok(world);
+    let actual = v["pagination"]["has_more"]
+        .as_bool()
+        .expect("missing pagination.has_more");
+    let want = expected == "true";
+    assert_eq!(actual, want, "pagination: {:?}", v["pagination"]);
+}
+
+#[then(regex = r#"^the registry worker-list pagination next_cursor is "([^"]*)"$"#)]
+fn worker_list_pagination_next_cursor(world: &mut IiiSkillsWorld, expected: String) {
+    if world.iii.is_none() {
+        return;
+    }
+    let v = last_ok(world);
+    let actual = v["pagination"]["next_cursor"].as_str().unwrap_or("");
+    assert_eq!(actual, expected, "pagination: {:?}", v["pagination"]);
+}
+
+#[then("the registry worker-list pagination next_cursor is null")]
+fn worker_list_pagination_next_cursor_null(world: &mut IiiSkillsWorld) {
+    if world.iii.is_none() {
+        return;
+    }
+    let v = last_ok(world);
+    assert!(
+        v["pagination"]["next_cursor"].is_null(),
+        "expected null next_cursor; got: {:?}",
+        v["pagination"]
     );
 }
 


### PR DESCRIPTION
- Bump iii-sdk dependency version from 0.11.3 to 0.11.6 in Cargo.toml and update the corresponding checksum in Cargo.lock.
- Enhance README and skill documentation to reflect changes in skill metadata, including the addition of the `type` field in skill responses.
- Introduce a new `directory::skills::index` function to provide a concise overview of installed workers, improving agent bootstrapping efficiency.
- Update various skill-related documentation to clarify the structure and usage of skills and prompts, ensuring consistency across the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added `directory::skills::index` function for rendering token-light skill indices
  * Skills now support YAML frontmatter for structured metadata (title, type)
  * Registry workers API now uses cursor-based pagination for improved scalability

* **Improvements**
  * Skills list and get endpoints now return additional metadata fields
  * Registry worker responses include expanded publication metadata (type, config, dependencies, etc.)
  * Clarified distinction between engine and registry worker introspection surfaces

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/workers/pull/133)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->