### PR TITLE
fix(ci): update publish workflow to new `iii trigger` CLI shape

### DIFF
--- a/.github/scripts/collect_worker_interface.py
+++ b/.github/scripts/collect_worker_interface.py
@@ -21,14 +21,13 @@ def count_worker_matches(workers_json: dict[str, object], worker_name: str) -> i
     )
 
 
-def run_iii(function_id: str, payload: dict[str, object]) -> dict[str, object]:
+def run_iii(function_path: str, payload: dict[str, object]) -> dict[str, object]:
     completed = subprocess.run(
         [
             "iii",
             "trigger",
-            "--function-id",
-            function_id,
-            "--payload",
+            function_path,
+            "--json",
             json.dumps(payload),
         ],
         check=True,

--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -80,7 +80,7 @@ jobs:
               exit 1
             fi
 
-            if iii trigger --function-id='engine::workers::list' --payload='{}' >/tmp/iii-workers.json 2>/tmp/iii-trigger.err; then
+            if iii trigger 'engine::workers::list' --json '{}' >/tmp/iii-workers.json 2>/tmp/iii-trigger.err; then
               cat /tmp/iii-workers.json
               exit 0
             fi
@@ -97,8 +97,8 @@ jobs:
         run: |
           set -euo pipefail
           iii trigger \
-            --function-id='engine::trigger-types::list' \
-            --payload='{"include_internal": false}' \
+            'engine::trigger-types::list' \
+            --json '{"include_internal": false}' \
             > trigger-types-baseline.json
           cat trigger-types-baseline.json
 


### PR DESCRIPTION
## Summary

- `.github/workflows/_publish-registry.yml` and `.github/scripts/collect_worker_interface.py` still invoked `iii trigger --function-id=<id> --payload=<json>`, which iii PR #1615 replaced with positional `<FUNCTION_PATH> --json <json>`.
- Engine readiness probe failed with `error: unexpected argument '--function-id' found`, breaking the publish-registry job.
- Updates both call sites to the new CLI shape; no behavior change beyond restoring CI.

Mirrors [iii-hq/iii#1646](https://github.com/iii-hq/iii/pull/1646).

## Test plan

- [ ] Re-run `Publish registry` job and confirm readiness probe succeeds.
- [ ] Confirm `worker-interface.json` is collected for each worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal command-line interface invocation patterns for improved consistency and argument handling across automation tools and workflows.

* **Chores**
  * Updated automation workflow configurations to align with revised CLI calling conventions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/workers/pull/139)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->