### PR TITLE
feat(harness): cooperative stop button for active runs

### DIFF
--- a/harness/web/src/App.tsx
+++ b/harness/web/src/App.tsx
@@ -380,6 +380,20 @@ export default function App() {
     [active, refreshSessions],
   );
 
+  // Cooperatively stop the active session's run via the backend
+  // `run::stop` function (thin wrapper over `router::abort` +
+  // `approval::sweep_session` + step-publish). The UI button morph and
+  // the "stopping…" intermediate state are owned by `Composer`; this
+  // callback just bridges the bus call.
+  const handleStop = useCallback(async () => {
+    if (!active) return;
+    try {
+      await bridge("run::stop", { session_id: active });
+    } catch (e) {
+      setError(e instanceof BridgeError ? e.message : String(e));
+    }
+  }, [active]);
+
   // /repair — read state::* snapshot, hand it to session-tree::reconcile
   // so any drifted rows get re-keyed with entry_ids. Reload after so the
   // UI's entry_ids reflect the new tree state.
@@ -550,6 +564,8 @@ export default function App() {
               <Composer
                 disabled={composerDisabled}
                 onSend={send}
+                running={isRunning}
+                onStop={handleStop}
                 cwd={cwd.trim()}
                 skillRows={null}
                 sessionMessages={messages}

--- a/harness/web/src/components/Composer.test.tsx
+++ b/harness/web/src/components/Composer.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { fireEvent, render, screen, cleanup } from "@testing-library/react";
+import { Composer } from "./Composer";
+
+afterEach(() => {
+  cleanup();
+});
+
+function setup(overrides: Partial<Parameters<typeof Composer>[0]> = {}) {
+  const onSend = vi.fn().mockResolvedValue(undefined);
+  const onStop = vi.fn().mockResolvedValue(undefined);
+  const utils = render(
+    <Composer
+      disabled={false}
+      onSend={onSend}
+      cwd=""
+      skillRows={null}
+      sessionMessages={[]}
+      running={false}
+      onStop={onStop}
+      {...overrides}
+    />,
+  );
+  return { ...utils, onSend, onStop };
+}
+
+describe("Composer stop button", () => {
+  it("renders the send variant when not running", () => {
+    setup();
+    expect(screen.getByText("send")).toBeTruthy();
+    expect(screen.queryByText("stop")).toBeNull();
+  });
+
+  it("morphs to a stop button when running is true", () => {
+    setup({ running: true });
+    const stopBtn = screen.getByRole("button", {
+      name: /stop current run after current step/i,
+    });
+    expect(stopBtn.getAttribute("data-mode")).toBe("stop");
+    expect(stopBtn.getAttribute("title")).toBe("stop after current step");
+    expect(screen.queryByText("send")).toBeNull();
+  });
+
+  it("clicking the stop button calls onStop, not onSend", () => {
+    const { onSend, onStop } = setup({ running: true });
+    fireEvent.click(
+      screen.getByRole("button", { name: /stop current run/i }),
+    );
+    expect(onStop).toHaveBeenCalledTimes(1);
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("shows 'stopping…' and disables itself after a stop click", async () => {
+    setup({ running: true });
+    const stopBtn = screen.getByRole("button", { name: /stop current run/i });
+    fireEvent.click(stopBtn);
+    // Re-query because the label changed.
+    const stopping = screen.getByRole("button", { name: /stop current run/i });
+    expect(stopping.textContent).toContain("stopping");
+    expect((stopping as HTMLButtonElement).disabled).toBe(true);
+    expect(stopping.getAttribute("aria-busy")).toBe("true");
+  });
+
+  it("form submit is a no-op while running", () => {
+    const { onSend } = setup({ running: true });
+    // The textarea is `readOnly` while running but still focusable. Type
+    // something programmatically (we set value via fireEvent for the test)
+    // and try to submit via Enter.
+    const textarea = screen.getByPlaceholderText(
+      /run in flight/i,
+    ) as HTMLTextAreaElement;
+    fireEvent.keyDown(textarea, {
+      key: "Enter",
+      code: "Enter",
+      shiftKey: false,
+    });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("returns to send variant when running flips back to false", () => {
+    const { rerender, onSend, onStop } = setup({ running: true });
+    fireEvent.click(
+      screen.getByRole("button", { name: /stop current run/i }),
+    );
+    expect(onStop).toHaveBeenCalled();
+    rerender(
+      <Composer
+        disabled={false}
+        onSend={onSend}
+        cwd=""
+        skillRows={null}
+        sessionMessages={[]}
+        running={false}
+        onStop={onStop}
+      />,
+    );
+    expect(screen.getByText("send")).toBeTruthy();
+    expect(screen.queryByText("stop")).toBeNull();
+    expect(screen.queryByText("stopping…")).toBeNull();
+  });
+
+  it("send button has a min-width pinned so the morph does not shift layout", () => {
+    setup();
+    const sendBtn = screen.getByRole("button", { name: /send/i });
+    expect(sendBtn.className).toContain("composer-send");
+    // The min-width is set in CSS, not inline — we can only assert the
+    // class is the same one we styled (sanity check against accidental
+    // class renames).
+  });
+});

--- a/harness/web/src/components/Composer.tsx
+++ b/harness/web/src/components/Composer.tsx
@@ -52,6 +52,14 @@ interface Props {
   sessionMessages: AgentMessage[];
   /** Per-builtin handlers. */
   callbacks?: ComposerCallbacks;
+  /**
+   * External signal that the active session has a run in flight. When true,
+   * the send button morphs into a stop button and the textarea blocks new
+   * submissions. Sourced from `useAgentStream`'s `status === "running"`.
+   */
+  running?: boolean;
+  /** Fires when the user clicks the stop button. */
+  onStop?: () => void | Promise<void>;
 }
 
 const AT_PAGE_SIZE = 25;
@@ -125,9 +133,18 @@ export function Composer({
   skillRows,
   sessionMessages,
   callbacks,
+  running = false,
+  onStop,
 }: Props) {
   const [text, setText] = useState("");
   const [busy, setBusy] = useState(false);
+  // `stopRequested` is a transient local flag: the user clicked stop, the
+  // backend has acked, but the run hasn't finished tearing down yet. It
+  // resets whenever `running` flips false (turn ends naturally or via abort).
+  const [stopRequested, setStopRequested] = useState(false);
+  useEffect(() => {
+    if (!running) setStopRequested(false);
+  }, [running]);
   const [menu, dispatch] = useCommandMenu();
   const [atBrowse, setAtBrowse] = useState<AtBrowseState>(AT_BROWSE_INITIAL);
   const [atPage, setAtPage] = useState(1);
@@ -256,6 +273,10 @@ export function Composer({
   const submit = useCallback(
     async (e?: FormEvent) => {
       e?.preventDefault();
+      // Hard gate on `running`: this catches both the form `onSubmit` path and
+      // the `onKeyDown` history-mode path (Enter in the textarea while a run
+      // is in flight must be a no-op, not a double-fire).
+      if (running) return;
       const trimmed = text.trim();
       if (!trimmed || busy) return;
 
@@ -321,8 +342,14 @@ export function Composer({
         setBusy(false);
       }
     },
-    [text, busy, onSend, callbacks],
+    [text, busy, running, onSend, callbacks],
   );
+
+  const handleStopClick = useCallback(() => {
+    if (stopRequested) return;
+    setStopRequested(true);
+    void onStop?.();
+  }, [stopRequested, onStop]);
 
   const acceptItem = useCallback(
     (item: MenuItem) => {
@@ -543,26 +570,55 @@ export function Composer({
           placeholder={
             disabled
               ? "set a credential to begin"
-              : "address the agent. / for commands, @ for files, ↑ for history."
+              : running
+                ? "run in flight — click stop to interrupt"
+                : "address the agent. / for commands, @ for files, ↑ for history."
           }
           value={text}
           onChange={onChange}
           onKeyDown={onKeyDown}
+          // While a run is in flight use readOnly (not disabled) to keep
+          // focus on the textarea so screen readers don't lose context.
+          // `disabled` still applies for the unauthenticated / mid-submit
+          // states where focus loss is acceptable.
           disabled={disabled || busy}
+          readOnly={running}
           rows={3}
           spellCheck={false}
         />
       </div>
-      <button
-        type="submit"
-        className="composer-send"
-        disabled={disabled || busy || !text.trim()}
-      >
-        <span className="composer-send-mark" aria-hidden>
-          ⏎
-        </span>
-        <span className="composer-send-label">{busy ? "running" : "send"}</span>
-      </button>
+      {running ? (
+        <button
+          type="button"
+          className="composer-send"
+          data-mode="stop"
+          onClick={handleStopClick}
+          disabled={stopRequested}
+          aria-busy={stopRequested || undefined}
+          aria-label="stop current run after current step"
+          title="stop after current step"
+        >
+          <span className="composer-send-mark" aria-hidden>
+            ■
+          </span>
+          <span className="composer-send-label">
+            {stopRequested ? "stopping…" : "stop"}
+          </span>
+        </button>
+      ) : (
+        <button
+          type="submit"
+          className="composer-send"
+          disabled={disabled || busy || !text.trim()}
+        >
+          <span className="composer-send-mark" aria-hidden>
+            ⏎
+          </span>
+          <span className="composer-send-label">
+            {busy ? "running" : "send"}
+          </span>
+        </button>
+      )}
     </form>
   );
 }

--- a/harness/web/src/styles.css
+++ b/harness/web/src/styles.css
@@ -1296,8 +1296,12 @@ p.msg-text {
 
 .composer-send {
   justify-self: end;
+  /* Pin width so the send→stop→stopping morph doesn't shift layout. The
+     three labels (send / stop / stopping…) fit inside this min-width. */
+  min-width: 7.5rem;
   display: inline-flex;
   align-items: baseline;
+  justify-content: center;
   gap: 8px;
   font-family: var(--mono);
   font-size: 12px;
@@ -1311,6 +1315,21 @@ p.msg-text {
   transition:
     background 120ms ease,
     transform 80ms ease;
+}
+
+.composer-send[data-mode="stop"] {
+  background: #b94a3c; /* warm red accent */
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.16);
+}
+
+.composer-send[data-mode="stop"]:hover:not(:disabled) {
+  background: #8f3327;
+}
+
+.composer-send[aria-busy="true"] {
+  background: var(--ink-faint);
+  color: var(--paper);
+  cursor: progress;
 }
 
 .composer-send-mark {

--- a/turn-orchestrator/src/abort.rs
+++ b/turn-orchestrator/src/abort.rs
@@ -1,0 +1,63 @@
+//! Per-session abort flag shared across the state machine.
+//!
+//! The flag is `session/<id>/abort_signal` under scope `agent`. It is the
+//! single coordination primitive between `run::stop` (and the legacy
+//! `router::abort`) and the durable handlers in `states/*`.
+//!
+//! Handlers call [`is_set`] at every state transition that precedes a
+//! costly operation; [`clear`] is called once per turn at the top of
+//! `handle_provisioning`, which is the only safe re-entry point that
+//! cannot race with a still-running `run::stop`.
+
+use iii_sdk::{TriggerRequest, III};
+use serde_json::{json, Value};
+
+const STATE_SCOPE: &str = "agent";
+
+pub fn abort_signal_key(session_id: &str) -> String {
+    format!("session/{session_id}/abort_signal")
+}
+
+pub async fn is_set(iii: &III, session_id: &str) -> bool {
+    iii.trigger(TriggerRequest {
+        function_id: "state::get".into(),
+        payload: json!({
+            "scope": STATE_SCOPE,
+            "key": abort_signal_key(session_id),
+        }),
+        action: None,
+        timeout_ms: None,
+    })
+    .await
+    .ok()
+    .and_then(|v| v.as_bool())
+    .unwrap_or(false)
+}
+
+pub async fn clear(iii: &III, session_id: &str) {
+    if let Err(e) = iii
+        .trigger(TriggerRequest {
+            function_id: "state::set".into(),
+            payload: json!({
+                "scope": STATE_SCOPE,
+                "key": abort_signal_key(session_id),
+                "value": Value::Bool(false),
+            }),
+            action: None,
+            timeout_ms: None,
+        })
+        .await
+    {
+        tracing::warn!(error = %e, %session_id, "abort::clear: state::set failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_uses_session_namespace() {
+        assert_eq!(abort_signal_key("abc"), "session/abc/abort_signal");
+    }
+}

--- a/turn-orchestrator/src/lib.rs
+++ b/turn-orchestrator/src/lib.rs
@@ -1,5 +1,6 @@
 //! Durable session state machine. See plan doc for details.
 
+pub mod abort;
 pub mod agent_call;
 pub mod bootstrap;
 pub mod config;
@@ -8,6 +9,7 @@ pub mod manifest;
 pub mod persistence;
 pub mod register;
 pub mod run_start;
+pub mod run_stop;
 pub mod state;
 pub mod states;
 pub mod subscriber;

--- a/turn-orchestrator/src/register.rs
+++ b/turn-orchestrator/src/register.rs
@@ -9,6 +9,7 @@ use serde_json::json;
 use crate::agent_call;
 use crate::config::TurnOrchestratorConfig;
 use crate::run_start::{self, STEP_TOPIC};
+use crate::run_stop;
 use crate::subscriber::{self, FUNCTION_ID as STEP_FN_ID};
 
 pub async fn register_with_iii(
@@ -16,6 +17,7 @@ pub async fn register_with_iii(
     cfg: &Arc<TurnOrchestratorConfig>,
 ) -> anyhow::Result<()> {
     run_start::register(iii, cfg);
+    run_stop::register(iii);
     agent_call::register(iii);
     subscriber::register(iii, cfg);
 

--- a/turn-orchestrator/src/run_stop.rs
+++ b/turn-orchestrator/src/run_stop.rs
@@ -1,0 +1,136 @@
+//! `run::stop` — cooperative stop entrypoint.
+//!
+//! Thin wrapper that composes three existing primitives:
+//!
+//! 1. `router::abort` writes `session/<id>/abort_signal = true`. The
+//!    durable state handlers (`states/steering`, `states/assistant`,
+//!    `states/functions`) read this flag at every transition and route
+//!    the run to `TearingDown`.
+//! 2. `approval::sweep_session` marks every pending approval row for the
+//!    session as `timed_out` with reason `run_stopped`, so a previously
+//!    queued approval can no longer dispatch the inner function after the
+//!    user clicked stop.
+//! 3. `iii::durable::publish turn::step_requested` wakes the subscriber so
+//!    it can pick the new state up immediately instead of waiting for the
+//!    next natural tick.
+//!
+//! The flag write itself is delegated rather than reimplemented so the
+//! durable state machine and `router::abort` (called from the legacy
+//! HTTP `agent/{session_id}/abort` endpoint) cannot drift.
+
+use iii_sdk::{IIIError, RegisterFunctionMessage, TriggerRequest, Value, III};
+use serde_json::json;
+
+use crate::persistence;
+use crate::run_start;
+use crate::state::TurnState;
+
+pub const FUNCTION_ID: &str = "run::stop";
+
+pub async fn execute(iii: III, payload: Value) -> Result<Value, IIIError> {
+    let session_id = required_str(&payload, "session_id")?;
+
+    let prior = persistence::load_record(&iii, &session_id).await;
+    let prior_state = prior.as_ref().map(|r| r.state);
+
+    // Idempotency: no record → nothing to stop.
+    if prior.is_none() {
+        tracing::info!(%session_id, "run::stop: no record");
+        return Ok(json!({
+            "session_id": session_id,
+            "accepted": false,
+            "reason": "no_record",
+        }));
+    }
+    if prior_state == Some(TurnState::Stopped) {
+        tracing::info!(%session_id, "run::stop: already stopped");
+        return Ok(json!({
+            "session_id": session_id,
+            "accepted": false,
+            "reason": "already_stopped",
+            "prior_state": "stopped",
+        }));
+    }
+
+    // 1) Flag write via existing primitive.
+    if let Err(e) = iii
+        .trigger(TriggerRequest {
+            function_id: "router::abort".into(),
+            payload: json!({ "session_id": session_id }),
+            action: None,
+            timeout_ms: None,
+        })
+        .await
+    {
+        tracing::warn!(error = %e, %session_id, "run::stop: router::abort failed");
+    }
+
+    // 2) Sweep pending approvals so no queued approval can still dispatch
+    //    its inner function after the user clicked stop.
+    if let Err(e) = iii
+        .trigger(TriggerRequest {
+            function_id: "approval::sweep_session".into(),
+            payload: json!({
+                "session_id": session_id,
+                "reason": "run_stopped",
+            }),
+            action: None,
+            timeout_ms: None,
+        })
+        .await
+    {
+        tracing::warn!(error = %e, %session_id, "run::stop: approval::sweep_session failed");
+    }
+
+    // 3) Nudge the durable subscriber so the abort branch fires immediately.
+    run_start::publish_step(&iii, &session_id).await;
+
+    tracing::info!(
+        %session_id,
+        prior_state = ?prior_state,
+        "run::stop accepted",
+    );
+
+    Ok(json!({
+        "session_id": session_id,
+        "accepted": true,
+        "prior_state": prior_state.map(|s| s.as_str()),
+    }))
+}
+
+pub fn register(iii: &III) {
+    let iii_async = iii.clone();
+    iii.register_function((
+        RegisterFunctionMessage::with_id(FUNCTION_ID.to_string()).with_description(
+            "Cooperatively stop an in-flight run: raise the abort flag, sweep \
+             pending approvals, and nudge the durable subscriber. Idempotent; \
+             returns {accepted: false, reason} when the session is unknown or \
+             already stopped."
+                .to_string(),
+        ),
+        move |payload: Value| {
+            let iii = iii_async.clone();
+            async move { execute(iii, payload).await }
+        },
+    ));
+}
+
+fn required_str(payload: &Value, field: &str) -> Result<String, IIIError> {
+    payload
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| IIIError::Handler(format!("missing required field: {field}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn required_str_extracts_or_errors() {
+        let p = json!({ "session_id": "abc" });
+        assert_eq!(required_str(&p, "session_id").unwrap(), "abc");
+        assert!(required_str(&p, "missing").is_err());
+    }
+}

--- a/turn-orchestrator/src/states/assistant.rs
+++ b/turn-orchestrator/src/states/assistant.rs
@@ -11,6 +11,14 @@ use crate::persistence;
 use crate::state::{TurnState, TurnStateRecord};
 
 pub async fn handle_awaiting(iii: &III, record: &mut TurnStateRecord) -> anyhow::Result<()> {
+    // Early abort check: route to SteeringCheck without burning a turn count.
+    // The Abort branch there synthesizes the aborted assistant message and
+    // tears down.
+    if crate::abort::is_set(iii, &record.session_id).await {
+        record.transition_to(TurnState::SteeringCheck);
+        return Ok(());
+    }
+
     if record
         .max_turns
         .map_or(false, |cap| record.turn_count >= cap)

--- a/turn-orchestrator/src/states/functions.rs
+++ b/turn-orchestrator/src/states/functions.rs
@@ -41,6 +41,15 @@ fn unwrap_agent_call(fc: FunctionCall) -> FunctionCall {
     }
 }
 pub async fn handle_prepare(iii: &III, record: &mut TurnStateRecord) -> anyhow::Result<()> {
+    // Abort short-circuit before any policy hook / state writes. Pending
+    // calls are dropped — the SteeringCheck branch will synthesize the
+    // aborted assistant message.
+    if crate::abort::is_set(iii, &record.session_id).await {
+        record.pending_function_calls.clear();
+        record.transition_to(TurnState::SteeringCheck);
+        return Ok(());
+    }
+
     record.function_results.clear();
     let raw = std::mem::take(&mut record.pending_function_calls);
     record.pending_function_calls = raw.into_iter().map(unwrap_agent_call).collect();
@@ -108,6 +117,15 @@ pub async fn handle_execute(iii: &III, record: &mut TurnStateRecord) -> anyhow::
     let prepared = persistence::load_prepared_calls(iii, &record.session_id).await;
     let mut results = persistence::load_executed_calls(iii, &record.session_id).await;
     for (fc, prefilled) in prepared {
+        // Per-call abort check: lets stop interrupt a long batch of pending
+        // function calls without dispatching the rest. Results already
+        // persisted earlier in this loop survive — the SteeringCheck route
+        // will use whatever made it.
+        if crate::abort::is_set(iii, &record.session_id).await {
+            record.pending_function_calls.clear();
+            record.transition_to(TurnState::SteeringCheck);
+            return Ok(());
+        }
         events::emit(
             iii,
             &record.session_id,

--- a/turn-orchestrator/src/states/provisioning.rs
+++ b/turn-orchestrator/src/states/provisioning.rs
@@ -25,6 +25,12 @@ pub async fn handle(
     cfg: &Arc<TurnOrchestratorConfig>,
     record: &mut TurnStateRecord,
 ) -> anyhow::Result<()> {
+    // Single source of truth for "fresh turn entry": clear any sticky abort
+    // flag carried over from a previous stopped run. Doing this here (not in
+    // `run_start::execute`) avoids a race where `run_start` clears the flag
+    // while a previous turn's subscriber tick is still in-flight.
+    crate::abort::clear(iii, &record.session_id).await;
+
     let request = persistence::load_run_request(iii, &record.session_id).await;
 
     let tools = json!([agent_call::agent_call_tool()]);

--- a/turn-orchestrator/src/states/steering.rs
+++ b/turn-orchestrator/src/states/steering.rs
@@ -51,7 +51,7 @@ pub(crate) fn route(
 }
 
 pub async fn handle(iii: &III, record: &mut TurnStateRecord) -> anyhow::Result<()> {
-    let abort = abort_set(iii, &record.session_id).await;
+    let abort = crate::abort::is_set(iii, &record.session_id).await;
     let steering = if abort {
         Vec::new()
     } else {
@@ -177,25 +177,6 @@ fn aborted_message() -> AssistantMessage {
         provider: "harness".into(),
         timestamp: chrono::Utc::now().timestamp_millis(),
     }
-}
-
-async fn abort_set(iii: &III, session_id: &str) -> bool {
-    // Direct state::get (was flag::is_set via the deleted state-flag worker).
-    // Convention: name "abort" maps to key session/<id>/abort_signal under
-    // scope "agent". Mirrors provider-router's state::set on abort.
-    iii.trigger(TriggerRequest {
-        function_id: "state::get".into(),
-        payload: json!({
-            "scope": "agent",
-            "key": format!("session/{session_id}/abort_signal"),
-        }),
-        action: None,
-        timeout_ms: None,
-    })
-    .await
-    .ok()
-    .and_then(|v| v.as_bool())
-    .unwrap_or(false)
 }
 
 async fn drain_queue(iii: &III, name: &str, session_id: &str) -> Vec<AgentMessage> {

--- a/turn-orchestrator/tests/run_stop.rs
+++ b/turn-orchestrator/tests/run_stop.rs
@@ -278,3 +278,336 @@ async fn run_stop_is_idempotent_when_repeated() {
     assert_eq!(sink.abort().len(), 1);
     assert_eq!(sink.sweep().len(), 1);
 }
+
+// ─── abort helper round-trip ───────────────────────────────────────────────
+
+#[tokio::test]
+#[serial]
+async fn abort_helper_set_and_clear_round_trip() {
+    let Some(h) = Harness::boot().await else {
+        return;
+    };
+    let session_id = format!("abort-rt-{}", common::nonce());
+
+    // Unwritten key reads as false (default).
+    assert!(
+        !turn_orchestrator::abort::is_set(&h.iii, &session_id).await,
+        "fresh session should have abort = false"
+    );
+
+    // Manually set via state::set (simulating router::abort).
+    let _ = h
+        .iii
+        .trigger(TriggerRequest {
+            function_id: "state::set".into(),
+            payload: json!({
+                "scope": STATE_SCOPE,
+                "key": turn_orchestrator::abort::abort_signal_key(&session_id),
+                "value": true,
+            }),
+            action: None,
+            timeout_ms: Some(2_000),
+        })
+        .await;
+    assert!(
+        turn_orchestrator::abort::is_set(&h.iii, &session_id).await,
+        "abort flag should be true after state::set"
+    );
+
+    // Clear, verify.
+    turn_orchestrator::abort::clear(&h.iii, &session_id).await;
+    assert!(
+        !turn_orchestrator::abort::is_set(&h.iii, &session_id).await,
+        "abort flag should be false after clear"
+    );
+
+    // Clear is idempotent.
+    turn_orchestrator::abort::clear(&h.iii, &session_id).await;
+    assert!(!turn_orchestrator::abort::is_set(&h.iii, &session_id).await);
+}
+
+// ─── state-machine checkpoint tests (drive transitions::step directly) ────
+//
+// These exercise the abort-flag check at the top of each handler without
+// involving the durable subscriber. We seed a record into the desired
+// state, set the flag manually, and step the machine forward exactly once.
+
+async fn set_abort(iii: &iii_sdk::III, session_id: &str) {
+    let _ = iii
+        .trigger(TriggerRequest {
+            function_id: "state::set".into(),
+            payload: json!({
+                "scope": STATE_SCOPE,
+                "key": turn_orchestrator::abort::abort_signal_key(session_id),
+                "value": true,
+            }),
+            action: None,
+            timeout_ms: Some(2_000),
+        })
+        .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn abort_in_awaiting_routes_to_steering_without_burning_turn_count() {
+    let Some(h) = Harness::boot().await else {
+        return;
+    };
+    let cfg = std::sync::Arc::new(turn_orchestrator::TurnOrchestratorConfig::default());
+    let session_id = format!("abort-awaiting-{}", common::nonce());
+
+    let mut record = TurnStateRecord::new(&session_id, None);
+    record.transition_to(TurnState::AwaitingAssistant);
+    assert_eq!(record.turn_count, 0);
+
+    set_abort(&h.iii, &session_id).await;
+
+    turn_orchestrator::transitions::step(&h.iii, &cfg, &mut record)
+        .await
+        .expect("step succeeded");
+
+    assert_eq!(
+        record.state,
+        TurnState::SteeringCheck,
+        "abort in awaiting should route to SteeringCheck"
+    );
+    assert_eq!(
+        record.turn_count, 0,
+        "abort short-circuit must not burn a turn count"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn abort_in_prepare_drops_pending_calls_and_routes_to_steering() {
+    let Some(h) = Harness::boot().await else {
+        return;
+    };
+    let cfg = std::sync::Arc::new(turn_orchestrator::TurnOrchestratorConfig::default());
+    let session_id = format!("abort-prepare-{}", common::nonce());
+
+    let mut record = TurnStateRecord::new(&session_id, None);
+    record.transition_to(TurnState::FunctionPrepare);
+    record.pending_function_calls = vec![
+        harness_types::FunctionCall {
+            id: "fc-1".into(),
+            function_id: "test::fn".into(),
+            arguments: json!({}),
+        },
+        harness_types::FunctionCall {
+            id: "fc-2".into(),
+            function_id: "test::fn".into(),
+            arguments: json!({}),
+        },
+    ];
+
+    set_abort(&h.iii, &session_id).await;
+
+    turn_orchestrator::transitions::step(&h.iii, &cfg, &mut record)
+        .await
+        .expect("step succeeded");
+
+    assert_eq!(
+        record.state,
+        TurnState::SteeringCheck,
+        "abort in prepare should route to SteeringCheck"
+    );
+    assert!(
+        record.pending_function_calls.is_empty(),
+        "abort in prepare must clear pending_function_calls; still had {:?}",
+        record.pending_function_calls
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn abort_in_execute_interrupts_call_loop() {
+    let Some(h) = Harness::boot().await else {
+        return;
+    };
+    let cfg = std::sync::Arc::new(turn_orchestrator::TurnOrchestratorConfig::default());
+    let session_id = format!("abort-execute-{}", common::nonce());
+
+    // Register a noisy test function so we can detect *any* unintended dispatch.
+    let dispatch_log: std::sync::Arc<std::sync::Mutex<Vec<Value>>> =
+        std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let dispatch_log_h = dispatch_log.clone();
+    let _ref = h.iii.register_function((
+        RegisterFunctionMessage::with_id("test::stop_should_skip".into())
+            .with_description("sink: should never be invoked once abort is set".into()),
+        move |payload: Value| {
+            let log = dispatch_log_h.clone();
+            async move {
+                log.lock().unwrap().push(payload);
+                Ok::<_, IIIError>(json!({ "ok": true }))
+            }
+        },
+    ));
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Seed prepared_calls under the persistence key so handle_execute loads them.
+    let prepared = vec![
+        (
+            harness_types::FunctionCall {
+                id: "fc-skip-1".into(),
+                function_id: "test::stop_should_skip".into(),
+                arguments: json!({}),
+            },
+            None::<harness_types::FunctionResult>,
+        ),
+        (
+            harness_types::FunctionCall {
+                id: "fc-skip-2".into(),
+                function_id: "test::stop_should_skip".into(),
+                arguments: json!({}),
+            },
+            None,
+        ),
+    ];
+    turn_orchestrator::persistence::save_prepared_calls(&h.iii, &session_id, &prepared).await;
+    turn_orchestrator::persistence::save_executed_calls(&h.iii, &session_id, &Vec::new()).await;
+
+    let mut record = TurnStateRecord::new(&session_id, None);
+    record.transition_to(TurnState::FunctionExecute);
+
+    set_abort(&h.iii, &session_id).await;
+
+    turn_orchestrator::transitions::step(&h.iii, &cfg, &mut record)
+        .await
+        .expect("step succeeded");
+
+    assert_eq!(
+        record.state,
+        TurnState::SteeringCheck,
+        "abort in execute should route to SteeringCheck"
+    );
+    assert_eq!(
+        dispatch_log.lock().unwrap().len(),
+        0,
+        "no test function should have been dispatched after abort"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn provisioning_clears_sticky_abort_flag() {
+    let Some(h) = Harness::boot().await else {
+        return;
+    };
+    // Empty default-skills list so provisioning doesn't try directory::skills::get
+    // (it would just soft-fail, but skipping keeps the test focused).
+    let cfg = std::sync::Arc::new(turn_orchestrator::TurnOrchestratorConfig {
+        system_default_skills: Vec::new(),
+        ..turn_orchestrator::TurnOrchestratorConfig::default()
+    });
+    let session_id = format!("clear-on-prov-{}", common::nonce());
+
+    // Seed a run_request so provisioning doesn't choke loading defaults.
+    let _ = h
+        .iii
+        .trigger(TriggerRequest {
+            function_id: "state::set".into(),
+            payload: json!({
+                "scope": STATE_SCOPE,
+                "key": turn_orchestrator::run_request_key(&session_id),
+                "value": json!({
+                    "provider": "test",
+                    "model": "test",
+                    "system_prompt": "",
+                    "approval_required": [],
+                }),
+            }),
+            action: None,
+            timeout_ms: Some(2_000),
+        })
+        .await;
+
+    set_abort(&h.iii, &session_id).await;
+    assert!(turn_orchestrator::abort::is_set(&h.iii, &session_id).await);
+
+    let mut record = TurnStateRecord::new(&session_id, None);
+    // record::new() already starts in Provisioning, but make it explicit.
+    record.transition_to(TurnState::Provisioning);
+
+    turn_orchestrator::transitions::step(&h.iii, &cfg, &mut record)
+        .await
+        .expect("step succeeded");
+
+    assert!(
+        !turn_orchestrator::abort::is_set(&h.iii, &session_id).await,
+        "provisioning must clear the sticky abort flag at the top of every fresh turn"
+    );
+    assert_eq!(
+        record.state,
+        TurnState::AwaitingAssistant,
+        "provisioning should still advance normally after clearing the flag"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn user_can_continue_same_session_after_stop() {
+    // End-to-end sanity: stop the session, then start a fresh turn on the
+    // same session_id. The flag set by `run::stop` must not leak into the
+    // new turn — provisioning clears it. Mirrors the behavior we promise
+    // users in the chat UI.
+    let Some(h) = Harness::boot().await else {
+        return;
+    };
+    let cfg = std::sync::Arc::new(turn_orchestrator::TurnOrchestratorConfig {
+        system_default_skills: Vec::new(),
+        ..turn_orchestrator::TurnOrchestratorConfig::default()
+    });
+    let sink = Sink::new();
+    register_primitives(&h.iii, &sink).await;
+    run_stop::register(&h.iii);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let session_id = format!("continue-{}", common::nonce());
+
+    // --- First turn: seed a record mid-flight, then stop it. ---
+    seed_record(&h.iii, &session_id, TurnState::AwaitingAssistant).await;
+
+    let stop_resp = call_run_stop(&h.iii, &session_id).await.unwrap();
+    assert_eq!(stop_resp["accepted"], json!(true));
+    // run::stop wires through `router::abort` which (in production) writes the
+    // flag. Our test sink for `router::abort` is a no-op, so simulate that
+    // side-effect here: the contract is "router::abort sets the flag".
+    set_abort(&h.iii, &session_id).await;
+    assert!(turn_orchestrator::abort::is_set(&h.iii, &session_id).await);
+
+    // --- Second turn: start fresh on the same session_id. ---
+    let _ = h
+        .iii
+        .trigger(TriggerRequest {
+            function_id: "state::set".into(),
+            payload: json!({
+                "scope": STATE_SCOPE,
+                "key": turn_orchestrator::run_request_key(&session_id),
+                "value": json!({
+                    "provider": "test",
+                    "model": "test",
+                    "system_prompt": "",
+                    "approval_required": [],
+                }),
+            }),
+            action: None,
+            timeout_ms: Some(2_000),
+        })
+        .await;
+
+    let mut record = TurnStateRecord::new(&session_id, None);
+    turn_orchestrator::transitions::step(&h.iii, &cfg, &mut record)
+        .await
+        .expect("provisioning step succeeded");
+
+    assert!(
+        !turn_orchestrator::abort::is_set(&h.iii, &session_id).await,
+        "second-turn provisioning must scrub the abort flag left by the prior stop"
+    );
+    assert_eq!(
+        record.state,
+        TurnState::AwaitingAssistant,
+        "fresh turn proceeds normally"
+    );
+}

--- a/turn-orchestrator/tests/run_stop.rs
+++ b/turn-orchestrator/tests/run_stop.rs
@@ -1,0 +1,280 @@
+//! `run::stop` lifecycle: idempotency, primitives invoked, payload validation.
+//!
+//! Boots a minimal iii engine + session worker. The state-machine-driven
+//! cases (stop-during-streaming, stop-during-execute) require a fully
+//! orchestrated turn loop with provider/sandbox mocks and are exercised
+//! end-to-end during manual QA per the plan's Verification section.
+//! Here we cover the contract `run::stop` directly exposes.
+
+mod common;
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use iii_sdk::{IIIError, RegisterFunctionMessage, TriggerRequest};
+use serde_json::{json, Value};
+use serial_test::serial;
+use tokio::time::timeout;
+
+use common::Harness;
+use turn_orchestrator::{run_stop, TurnState, TurnStateRecord};
+
+const STATE_SCOPE: &str = "agent";
+
+/// Sink for `router::abort` and `approval::sweep_session` invocations.
+#[derive(Default, Clone)]
+struct Sink {
+    abort_calls: Arc<Mutex<Vec<Value>>>,
+    sweep_calls: Arc<Mutex<Vec<Value>>>,
+    step_publishes: Arc<Mutex<Vec<Value>>>,
+}
+
+impl Sink {
+    fn new() -> Self {
+        Self::default()
+    }
+    fn abort(&self) -> Vec<Value> {
+        self.abort_calls.lock().unwrap().clone()
+    }
+    fn sweep(&self) -> Vec<Value> {
+        self.sweep_calls.lock().unwrap().clone()
+    }
+}
+
+async fn register_primitives(iii: &iii_sdk::III, sink: &Sink) {
+    let abort_log = sink.abort_calls.clone();
+    iii.register_function((
+        RegisterFunctionMessage::with_id("router::abort".to_string())
+            .with_description("test sink: capture run::stop's abort flag write".into()),
+        move |payload: Value| {
+            let log = abort_log.clone();
+            async move {
+                log.lock().unwrap().push(payload);
+                Ok::<_, IIIError>(json!({ "ok": true }))
+            }
+        },
+    ));
+
+    let sweep_log = sink.sweep_calls.clone();
+    iii.register_function((
+        RegisterFunctionMessage::with_id("approval::sweep_session".to_string())
+            .with_description("test sink: capture approval sweep".into()),
+        move |payload: Value| {
+            let log = sweep_log.clone();
+            async move {
+                log.lock().unwrap().push(payload);
+                Ok::<_, IIIError>(json!({ "ok": true, "swept": 0 }))
+            }
+        },
+    ));
+
+    let step_log = sink.step_publishes.clone();
+    iii.register_function((
+        RegisterFunctionMessage::with_id("iii::durable::publish".to_string())
+            .with_description("test sink: capture turn::step publishes".into()),
+        move |payload: Value| {
+            let log = step_log.clone();
+            async move {
+                log.lock().unwrap().push(payload);
+                Ok::<_, IIIError>(json!({ "ok": true }))
+            }
+        },
+    ));
+
+    // Allow registrations to settle on the engine. 200ms is not always enough
+    // when the engine is busy; 800ms matches what `Harness::boot` already
+    // waits for the session worker.
+    tokio::time::sleep(Duration::from_millis(800)).await;
+
+    // Sanity-probe each registration so a slow engine doesn't leave us
+    // chasing a phantom failure later. If any probe errors, fail loudly.
+    for fn_id in ["router::abort", "approval::sweep_session"] {
+        iii.trigger(TriggerRequest {
+            function_id: fn_id.into(),
+            payload: json!({ "session_id": "__probe__" }),
+            action: None,
+            timeout_ms: Some(2_000),
+        })
+        .await
+        .unwrap_or_else(|e| panic!("test sink {fn_id} not reachable: {e}"));
+    }
+
+    // Probes count as calls — wipe the sink before tests assert behavior.
+    sink.abort_calls.lock().unwrap().clear();
+    sink.sweep_calls.lock().unwrap().clear();
+    sink.step_publishes.lock().unwrap().clear();
+}
+
+async fn seed_record(iii: &iii_sdk::III, session_id: &str, state: TurnState) {
+    let mut rec = TurnStateRecord::new(session_id, None);
+    rec.transition_to(state);
+    let value = serde_json::to_value(&rec).expect("serialize record");
+    let _ = iii
+        .trigger(TriggerRequest {
+            function_id: "state::set".into(),
+            payload: json!({
+                "scope": STATE_SCOPE,
+                "key": turn_orchestrator::turn_state_key(session_id),
+                "value": value,
+            }),
+            action: None,
+            timeout_ms: Some(2_000),
+        })
+        .await;
+}
+
+async fn call_run_stop(iii: &iii_sdk::III, session_id: &str) -> Result<Value, IIIError> {
+    iii.trigger(TriggerRequest {
+        function_id: run_stop::FUNCTION_ID.into(),
+        payload: json!({ "session_id": session_id }),
+        action: None,
+        timeout_ms: Some(5_000),
+    })
+    .await
+}
+
+#[tokio::test]
+#[serial]
+async fn run_stop_requires_session_id() {
+    let Some(h) = Harness::boot().await else {
+        return;
+    };
+    run_stop::register(&h.iii);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let r = h
+        .iii
+        .trigger(TriggerRequest {
+            function_id: run_stop::FUNCTION_ID.into(),
+            payload: json!({}),
+            action: None,
+            timeout_ms: Some(2_000),
+        })
+        .await;
+    assert!(
+        r.is_err(),
+        "expected handler error for missing session_id, got {:?}",
+        r
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn run_stop_returns_no_record_for_unknown_session() {
+    let Some(h) = Harness::boot().await else {
+        return;
+    };
+    let sink = Sink::new();
+    register_primitives(&h.iii, &sink).await;
+    run_stop::register(&h.iii);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let session_id = format!("nonexistent-{}", common::nonce());
+    let resp = timeout(Duration::from_secs(3), call_run_stop(&h.iii, &session_id))
+        .await
+        .expect("run::stop responded in time")
+        .expect("run::stop succeeded");
+
+    assert_eq!(resp["accepted"], json!(false));
+    assert_eq!(resp["reason"], json!("no_record"));
+    assert!(
+        sink.abort().is_empty(),
+        "router::abort should not be invoked for unknown session"
+    );
+    assert!(
+        sink.sweep().is_empty(),
+        "approval::sweep_session should not be invoked for unknown session"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn run_stop_short_circuits_when_already_stopped() {
+    let Some(h) = Harness::boot().await else {
+        return;
+    };
+    let sink = Sink::new();
+    register_primitives(&h.iii, &sink).await;
+    run_stop::register(&h.iii);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let session_id = format!("already-stopped-{}", common::nonce());
+    seed_record(&h.iii, &session_id, TurnState::Stopped).await;
+
+    let resp = timeout(Duration::from_secs(3), call_run_stop(&h.iii, &session_id))
+        .await
+        .expect("run::stop responded in time")
+        .expect("run::stop succeeded");
+
+    assert_eq!(resp["accepted"], json!(false));
+    assert_eq!(resp["reason"], json!("already_stopped"));
+    assert!(
+        sink.abort().is_empty(),
+        "router::abort should not be invoked when already stopped"
+    );
+    assert!(
+        sink.sweep().is_empty(),
+        "approval::sweep_session should not be invoked when already stopped"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn run_stop_invokes_all_primitives_on_happy_path() {
+    let Some(h) = Harness::boot().await else {
+        return;
+    };
+    let sink = Sink::new();
+    register_primitives(&h.iii, &sink).await;
+    run_stop::register(&h.iii);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let session_id = format!("happy-{}", common::nonce());
+    seed_record(&h.iii, &session_id, TurnState::AwaitingAssistant).await;
+
+    let resp = timeout(Duration::from_secs(3), call_run_stop(&h.iii, &session_id))
+        .await
+        .expect("run::stop responded in time")
+        .expect("run::stop succeeded");
+
+    assert_eq!(resp["accepted"], json!(true));
+    assert_eq!(resp["prior_state"], json!("awaiting_assistant"));
+
+    let abort_calls = sink.abort();
+    assert_eq!(abort_calls.len(), 1, "router::abort invoked once");
+    assert_eq!(abort_calls[0]["session_id"], json!(session_id));
+
+    let sweep_calls = sink.sweep();
+    assert_eq!(sweep_calls.len(), 1, "approval::sweep_session invoked once");
+    assert_eq!(sweep_calls[0]["session_id"], json!(session_id));
+    assert_eq!(sweep_calls[0]["reason"], json!("run_stopped"));
+}
+
+#[tokio::test]
+#[serial]
+async fn run_stop_is_idempotent_when_repeated() {
+    let Some(h) = Harness::boot().await else {
+        return;
+    };
+    let sink = Sink::new();
+    register_primitives(&h.iii, &sink).await;
+    run_stop::register(&h.iii);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let session_id = format!("double-{}", common::nonce());
+    seed_record(&h.iii, &session_id, TurnState::AwaitingAssistant).await;
+
+    let r1 = call_run_stop(&h.iii, &session_id).await.unwrap();
+    assert_eq!(r1["accepted"], json!(true));
+
+    // Simulate the orchestrator's teardown by manually transitioning to Stopped.
+    seed_record(&h.iii, &session_id, TurnState::Stopped).await;
+
+    let r2 = call_run_stop(&h.iii, &session_id).await.unwrap();
+    assert_eq!(r2["accepted"], json!(false));
+    assert_eq!(r2["reason"], json!("already_stopped"));
+
+    // Only the first call should have invoked the primitives.
+    assert_eq!(sink.abort().len(), 1);
+    assert_eq!(sink.sweep().len(), 1);
+}


### PR DESCRIPTION
## Summary

Adds a stop button to the harness chat composer so users can interrupt an in-flight agent turn without waiting for the orchestrator to reach `TearingDown` on its own.

- **Backend:** new `run::stop` bus function — a thin wrapper over the existing `router::abort` flag write plus `approval::sweep_session` and a `turn::step_requested` publish. Returns a typed `{accepted, reason, prior_state}` envelope; idempotent for unknown sessions and already-stopped records.
- **Orchestrator hooks:** the abort flag is now checked at every transition that precedes a costly operation — `provisioning` (clears the flag at entry), `awaiting`, `prepare`, and per-call inside `execute`. `steering::handle` switches to the shared `crate::abort::is_set` helper.
- **Frontend:** the Composer send button morphs to a red stop button while `useAgentStream` reports `status === "running"`. Clicking it shows an honest "stopping…" intermediate state until the run actually tears down, so the user gets feedback even though cooperative stop can't preempt the in-flight provider call.

Built on top of existing primitives — no duplicated flag write, no duplicated approval cleanup. See ``docs/superpowers/specs/2026-05-15-stop-button-design.md`` once that lands (currently local in the planning skill).

### Out of scope / followups (intentional)

- **Mid-stream provider cancellation.** `router::stream_assistant` blocks for up to 300s; cooperative stop cannot preempt that. Worst-case user wait is ~300s (typically <30s for healthy responses). A real fix requires threading a cancellation token through `provider-router` and the provider crates.
- **Subscriber CAS / lease.** A duplicate `turn::step_requested` published by `run::stop` could in principle overlap with the natural step tick. Outside this PR's blast radius.

## Test plan

- [x] `cargo test -p iii-turn-orchestrator` — 118 passed including 5 new integration tests in `tests/run_stop.rs` covering payload validation, unknown-session, already-stopped, primitives invoked on the happy path, and double-stop idempotency.
- [x] `npm --prefix harness/web test` — 139 passed including 7 new Vitest cases in `Composer.test.tsx` covering the send→stop→stopping morph, click routing, no-op Enter while running, and reset on `running` flip.
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual end-to-end: `harness/scripts/demo.sh build engine start web`, send a prompt that triggers a long tool chain, click stop, expect the button to switch to "stopping…" immediately and the transcript to land an aborted assistant message at the next state boundary.
- [ ] Manual approval case: stop while a pending approval row is up, expect the approval to disappear (sweep) and no function execution to happen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to stop in-flight runs; when active, the send button converts to a stop button with updated UI. Clicking stops the session and displays stopping status.

* **Tests**
  * Added comprehensive test coverage for stop functionality, verifying button behavior, state transitions, and full stop operation flow across frontend and backend.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/workers/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->