### PR TITLE
fix(turn-orchestrator): open reader WS so provider stream messages reach the FSM

### DIFF
--- a/harness-node/src/turn-orchestrator/states/assistant.ts
+++ b/harness-node/src/turn-orchestrator/states/assistant.ts
@@ -144,6 +144,10 @@ export async function handleStreaming(iii: ISdk, rec: TurnStateRecord): Promise<
       fn();
     }
   });
+  // iii-sdk@0.12.0's ChannelReader.onMessage doesn't open the read-side
+  // WebSocket — only stream.read / readAll do. Without this resume(), the
+  // provider's writes are dropped engine-side and the queue stays empty.
+  channel.reader.stream.resume();
 
   const input: ProviderStreamInput = buildInput(
     decision,


### PR DESCRIPTION
## Summary
- One-line fix in `harness-node/src/turn-orchestrator/states/assistant.ts`: `channel.reader.stream.resume()` after registering the `onMessage` callback.
- Without this, the read-side WebSocket is never opened, the engine drops every provider write, and the FSM hangs on its empty message queue — manifesting as `run::start_and_wait` timeouts and a UI stuck on "agent streaming".

## Root cause
`iii-sdk@0.12.0` `index.mjs:174-176`:
```js
onMessage(callback) {
  this.messageCallbacks.push(callback);   // does NOT call ensureConnected()
}
```
`ChannelReader.onMessage` only registers the callback. The reader WS is opened lazily by `stream.read()` / `readAll()`. `handleStreaming` consumes solely via `onMessage`, so the WS never opens.

Engine logs confirm: every `dir: write` upgrade was logged for every chat attempt; **zero `dir: read` upgrades** were logged. Each provider write closed cleanly with `total_bytes: 0, msg_count: N` because there was no reader on the other end.

## Fix
Calling `channel.reader.stream.resume()` puts the Readable into flowing mode, which invokes the `_read` callback in `iii-sdk`'s `ChannelReader` constructor:
```js
read() {
  self.ensureConnected();
  if (self.ws) self.ws.resume();
}
```
That opens the read-side WS before the provider starts writing.

## Test plan
- [x] CLI: `iii trigger run::start_and_wait` with `claude-sonnet-4-6` returns `{role: assistant, content: [{type:text,text:"PONG"}]}` in ~3s
- [x] Browser: console at `http://localhost:5173`, agent mode, claude sonnet 4.6 → "PONG" rendered, no console errors, no warn/error logs in the worker tmux
- [x] `pnpm typecheck` clean

## Upstream follow-up worth filing
`iii-sdk`'s `ChannelReader.onMessage` should call `ensureConnected()` so registering a message callback is sufficient to receive messages — that's the API the type signature implies. This PR is the consumer-side workaround until then.
