### PR TITLE
feat(console): drive model picker from harness-node models-catalog

### DIFF
--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -11,6 +11,7 @@ import type {
   MessagePatch,
   Mode,
   ModelId,
+  ModelOption,
   ThoughtMessage,
   UserMessage,
 } from '@/types/chat'
@@ -27,6 +28,8 @@ function isAbortError(err: unknown): boolean {
 interface ChatViewProps {
   conversation: Conversation
   backend: ChatBackend
+  modelOptions: ModelOption[]
+  catalogLoading?: boolean
   onUpdateModel: (id: string, model: ModelId) => void
   onUpdateMode: (id: string, mode: Mode) => void
   onAppendMessage: (id: string, message: Message) => void
@@ -36,6 +39,8 @@ interface ChatViewProps {
 export function ChatView({
   conversation,
   backend,
+  modelOptions,
+  catalogLoading,
   onUpdateModel,
   onUpdateMode,
   onAppendMessage,
@@ -225,6 +230,8 @@ export function ChatView({
           <Composer
             mode={conversation.mode}
             model={conversation.model}
+            modelOptions={modelOptions}
+            catalogLoading={catalogLoading}
             onModeChange={(next) => onUpdateMode(conversation.id, next)}
             onModelChange={(next) => onUpdateModel(conversation.id, next)}
             onSubmit={handleSubmit}

--- a/console/web/src/components/chat/Composer.tsx
+++ b/console/web/src/components/chat/Composer.tsx
@@ -1,7 +1,7 @@
 import type { LexicalEditor } from 'lexical'
 import { useCallback, useRef, useState } from 'react'
 import { Button } from '@/components/ui/Button'
-import type { Attachment, Mode, ModelId } from '@/types/chat'
+import type { Attachment, Mode, ModelId, ModelOption } from '@/types/chat'
 import { AttachmentButton } from './AttachmentButton'
 import { AttachmentChip } from './AttachmentChip'
 import { LexicalShell } from './LexicalShell'
@@ -16,6 +16,8 @@ export interface ComposerSubmitPayload {
 interface ComposerProps {
   mode: Mode
   model: ModelId
+  modelOptions: ModelOption[]
+  catalogLoading?: boolean
   onModeChange: (next: Mode) => void
   onModelChange: (next: ModelId) => void
   onSubmit: (payload: ComposerSubmitPayload) => void
@@ -30,6 +32,8 @@ interface ComposerProps {
 export function Composer({
   mode,
   model,
+  modelOptions,
+  catalogLoading,
   onModeChange,
   onModelChange,
   onSubmit,
@@ -95,8 +99,10 @@ export function Composer({
         <div className="flex-1" />
         <ModelPicker
           value={model}
+          options={modelOptions}
           onChange={onModelChange}
           disabled={isStreaming}
+          loading={catalogLoading}
         />
         {isStreaming ? (
           <Button

--- a/console/web/src/components/chat/ModelPicker.tsx
+++ b/console/web/src/components/chat/ModelPicker.tsx
@@ -1,26 +1,37 @@
 import { Select } from '@/components/ui/Select'
-import { MODELS, type ModelId } from '@/types/chat'
+import type { ModelId, ModelOption } from '@/types/chat'
 
 interface ModelPickerProps {
   value: ModelId
+  options: ModelOption[]
   onChange: (next: ModelId) => void
   disabled?: boolean
+  loading?: boolean
   className?: string
 }
 
 export function ModelPicker({
   value,
+  options,
   onChange,
   disabled,
+  loading,
   className,
 }: ModelPickerProps) {
+  const pickerOptions =
+    options.length > 0 ? options : [{ id: value, label: value }]
+  const safeValue = pickerOptions.some((o) => o.id === value)
+    ? value
+    : pickerOptions[0].id
+
   return (
     <Select<ModelId>
-      value={value}
-      options={MODELS.map((m) => ({ value: m.id, label: m.label }))}
+      value={safeValue}
+      options={pickerOptions.map((m) => ({ value: m.id, label: m.label }))}
       onChange={onChange}
-      disabled={disabled}
-      aria-label="model"
+      disabled={disabled || loading}
+      aria-label={loading ? 'model (loading catalog)' : 'model'}
+      aria-busy={loading || undefined}
       className={className}
     />
   )

--- a/console/web/src/hooks/use-conversations.ts
+++ b/console/web/src/hooks/use-conversations.ts
@@ -52,7 +52,15 @@ export interface ConversationsApi {
   updateMessage: (id: string, messageId: string, patch: MessagePatch) => void
 }
 
-export function useConversations(): ConversationsApi {
+/** When set, non-matching `conversation.model` values are rewritten to the first key (catalog load / migration). */
+export function useConversations(
+  catalogKeysForValidation?: readonly string[],
+): ConversationsApi {
+  const catalogSig =
+    catalogKeysForValidation && catalogKeysForValidation.length > 0
+      ? [...catalogKeysForValidation].sort().join('\u0001')
+      : ''
+
   const [conversations, setConversations] = useState<Conversation[]>(() => {
     const loaded = loadConversations()
     /* Always boot with at least one empty conversation so the chat surface
@@ -76,6 +84,23 @@ export function useConversations(): ConversationsApi {
       if (persistRef.current) cancelAnimationFrame(persistRef.current)
     }
   }, [conversations])
+
+  /* Migrate persisted model ids once catalog-backed keys are known. */
+  useEffect(() => {
+    if (!catalogSig) return
+    const keys = catalogSig.split('\u0001')
+    const valid = new Set(keys)
+    const fallback = keys[0]
+    setConversations((prev) => {
+      let changed = false
+      const next = prev.map((c) => {
+        if (valid.has(c.model)) return c
+        changed = true
+        return { ...c, model: fallback, updatedAt: Date.now() }
+      })
+      return changed ? next : prev
+    })
+  }, [catalogSig])
 
   useEffect(() => {
     saveActiveId(activeId)

--- a/console/web/src/hooks/use-model-picker-source.ts
+++ b/console/web/src/hooks/use-model-picker-source.ts
@@ -1,0 +1,59 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  catalogRowsToModelOptions,
+  fetchModelsCatalog,
+} from '@/lib/models-catalog'
+import type { ModelOption } from '@/types/chat'
+import { STATIC_MODEL_OPTIONS } from '@/types/chat'
+
+/**
+ * Populate model picker options from `models::list` when the real backend is
+ * active; mock / playground uses `STATIC_MODEL_OPTIONS` only.
+ */
+export function useModelPickerSource(backendId: string): {
+  modelOptions: ModelOption[]
+  catalogKeys: string[]
+  catalogLoading: boolean
+} {
+  const [modelOptions, setModelOptions] =
+    useState<ModelOption[]>(STATIC_MODEL_OPTIONS)
+  const [catalogLoading, setCatalogLoading] = useState(backendId === 'real')
+
+  useEffect(() => {
+    if (backendId !== 'real') {
+      setModelOptions(STATIC_MODEL_OPTIONS)
+      setCatalogLoading(false)
+      return
+    }
+
+    let cancelled = false
+    setCatalogLoading(true)
+
+    fetchModelsCatalog()
+      .then((rows) => {
+        if (cancelled) return
+        if (rows.length > 0) {
+          setModelOptions(catalogRowsToModelOptions(rows))
+        } else {
+          setModelOptions(STATIC_MODEL_OPTIONS)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setModelOptions(STATIC_MODEL_OPTIONS)
+      })
+      .finally(() => {
+        if (!cancelled) setCatalogLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [backendId])
+
+  const catalogKeys = useMemo(
+    () => modelOptions.map((o) => o.id),
+    [modelOptions],
+  )
+
+  return { modelOptions, catalogKeys, catalogLoading }
+}

--- a/console/web/src/lib/backend/real.ts
+++ b/console/web/src/lib/backend/real.ts
@@ -98,29 +98,6 @@ async function* realStream(
 
   const off = client.on<SessionEventEnvelope>('ui::session::event', (env) => {
     if (!env || env.session_id !== sessionId || !env.event) return
-    // #region debug-instrumentation
-    fetch(
-      'http://127.0.0.1:7806/ingest/e8ef8147-0d15-474f-9b85-6d1770aaadc3',
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Debug-Session-Id': '54c0cd',
-        },
-        body: JSON.stringify({
-          sessionId: '54c0cd',
-          hypothesisId: 'H5',
-          location: 'console/web/src/lib/backend/real.ts:on(ui::session::event)',
-          message: 'frontend received session event',
-          data: {
-            session_id: env.session_id,
-            event_type: (env.event as { type?: string })?.type,
-          },
-          timestamp: Date.now(),
-        }),
-      },
-    ).catch(() => {})
-    // #endregion
     queue.push(env.event)
     wake()
   })

--- a/console/web/src/lib/backend/real.ts
+++ b/console/web/src/lib/backend/real.ts
@@ -28,11 +28,12 @@
  *   - Approvals surface as `pendingApproval: true` but the UI can't yet
  *     resolve them (Phase 3 adds approve/deny buttons calling
  *     `approval::resolve`).
- *   - Provider/system_prompt selection is a coarse mapping (see
- *     `resolveRunParams`); a proper picker integration is Phase 4.
+ *   - Provider/model selection uses the models-catalog via the picker; legacy
+ *     ids without `::` still get a coarse provider guess in `resolveRunParams`.
  */
 
 import { getIiiClient } from '@/lib/iii-client'
+import { parseCatalogModelKey } from '@/lib/catalog-model-key'
 import type { Mode, ModelId } from '@/types/chat'
 import type { AgentEvent, SessionEventEnvelope } from '@/types/iii-agent-event'
 import { translateAgentEvent } from './translate'
@@ -45,17 +46,27 @@ interface RunParams {
 }
 
 /**
- * Map console/web's `Mode` + `ModelId` onto turn-orchestrator's
- * `provider` / `model` / `system_prompt` fields. Phase 4 wires the model
- * picker to a proper config. Permissions are no longer driven from
- * here — see Phase 2.B (§D); the harness owns `iii-permissions.yaml`.
+ * Map console `Mode` + model selection onto turn-orchestrator's
+ * `provider` / `model` / `system_prompt` fields.
+ *
+ * Model ids from the catalog picker are `provider::<catalog_id>`. Legacy
+ * heuristic ids (no `::`) still map `claude*` / `gemini*` / default openai.
  */
 function resolveRunParams(mode: Mode, model: ModelId): RunParams {
-  const provider = model.startsWith('claude')
-    ? 'anthropic'
-    : model.startsWith('gemini')
-      ? 'google'
-      : 'openai'
+  const parsed = parseCatalogModelKey(model)
+  let provider: string
+  let modelId: string
+  if (parsed) {
+    provider = parsed.provider
+    modelId = parsed.id
+  } else {
+    modelId = model
+    provider = model.startsWith('claude')
+      ? 'anthropic'
+      : model.startsWith('gemini')
+        ? 'google'
+        : 'openai'
+  }
 
   const systemPrompt =
     mode === 'plan'
@@ -64,7 +75,7 @@ function resolveRunParams(mode: Mode, model: ModelId): RunParams {
         ? 'You answer the user directly without invoking tools. Be concise; prefer one or two paragraphs.'
         : 'You are an autonomous agent. Use the available functions to satisfy the request. Stop when you have a final answer or hit an irrecoverable error.'
 
-  return { provider, model, systemPrompt }
+  return { provider, model: modelId, systemPrompt }
 }
 
 async function* realStream(

--- a/console/web/src/lib/catalog-model-key.ts
+++ b/console/web/src/lib/catalog-model-key.ts
@@ -1,0 +1,18 @@
+import { CATALOG_MODEL_KEY_SEP } from '@/types/chat'
+
+export function makeCatalogModelKey(provider: string, modelId: string): string {
+  return `${provider}${CATALOG_MODEL_KEY_SEP}${modelId}`
+}
+
+/** Parse `provider::id` returned from models-catalog into run::start fields. */
+export function parseCatalogModelKey(
+  model: string,
+): { provider: string; id: string } | null {
+  const sep = CATALOG_MODEL_KEY_SEP
+  const i = model.indexOf(sep)
+  if (i <= 0) return null
+  const provider = model.slice(0, i)
+  const id = model.slice(i + sep.length)
+  if (!provider || !id) return null
+  return { provider, id }
+}

--- a/console/web/src/lib/models-catalog.ts
+++ b/console/web/src/lib/models-catalog.ts
@@ -1,0 +1,42 @@
+import { getIiiClient } from '@/lib/iii-client'
+import { makeCatalogModelKey } from '@/lib/catalog-model-key'
+import type { ModelOption } from '@/types/chat'
+
+/** Wire shape returned by `models::list` over the iii bus. */
+export interface CatalogModelRow {
+  id: string
+  provider: string
+  display_name: string
+}
+
+export async function fetchModelsCatalog(): Promise<CatalogModelRow[]> {
+  const client = await getIiiClient()
+  const res = await client.call<{ models?: unknown }>('models::list', {})
+  const rows = res?.models
+  if (!Array.isArray(rows)) return []
+  const out: CatalogModelRow[] = []
+  for (const raw of rows) {
+    if (!raw || typeof raw !== 'object') continue
+    const o = raw as Record<string, unknown>
+    const id = typeof o.id === 'string' ? o.id : ''
+    const provider = typeof o.provider === 'string' ? o.provider : ''
+    const display_name =
+      typeof o.display_name === 'string' ? o.display_name : id
+    if (!id || !provider) continue
+    out.push({ id, provider, display_name })
+  }
+  return out
+}
+
+/** Sorted picker options derived from catalog rows. */
+export function catalogRowsToModelOptions(
+  rows: CatalogModelRow[],
+): ModelOption[] {
+  const sorted = [...rows].sort((a, b) =>
+    a.display_name.localeCompare(b.display_name),
+  )
+  return sorted.map((m) => ({
+    id: makeCatalogModelKey(m.provider, m.id),
+    label: m.display_name.toLowerCase(),
+  }))
+}

--- a/console/web/src/pages/Chat.tsx
+++ b/console/web/src/pages/Chat.tsx
@@ -2,11 +2,16 @@ import { ChatView } from '@/components/chat/ChatView'
 import { ConversationSidebar } from '@/components/sidebar/ConversationSidebar'
 import { Prompt } from '@/components/ui/Prompt'
 import { useConversations } from '@/hooks/use-conversations'
+import { useModelPickerSource } from '@/hooks/use-model-picker-source'
 import { getDefaultBackend } from '@/lib/backend'
 
 const backend = getDefaultBackend()
 
 export function Chat() {
+  const { modelOptions, catalogKeys, catalogLoading } = useModelPickerSource(
+    backend.id,
+  )
+
   const {
     conversations,
     activeId,
@@ -19,7 +24,7 @@ export function Chat() {
     setMode,
     appendMessage,
     updateMessage,
-  } = useConversations()
+  } = useConversations(catalogKeys)
 
   return (
     <div className="flex-1 flex min-h-0">
@@ -37,6 +42,8 @@ export function Chat() {
           key={active.id}
           conversation={active}
           backend={backend}
+          modelOptions={modelOptions}
+          catalogLoading={catalogLoading}
           onUpdateModel={setModel}
           onUpdateMode={setMode}
           onAppendMessage={appendMessage}

--- a/console/web/src/pages/Examples/sections/composer-variants.tsx
+++ b/console/web/src/pages/Examples/sections/composer-variants.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { Composer } from '@/components/chat/Composer'
 import { $createFunctionMentionNode } from '@/components/chat/lexical/FunctionMentionNode'
 import type { Attachment, Mode, ModelId } from '@/types/chat'
+import { STATIC_MODEL_OPTIONS } from '@/types/chat'
 import { Section, VariantCard } from '../Section'
 
 const noop = () => {}
@@ -34,7 +35,7 @@ function seedWithText() {
 
 export function ComposerVariantsSection() {
   const [mode, setMode] = useState<Mode>('agent')
-  const [model, setModel] = useState<ModelId>('gpt-5.5-medium')
+  const [model, setModel] = useState<ModelId>(STATIC_MODEL_OPTIONS[0].id)
 
   return (
     <Section
@@ -48,6 +49,7 @@ export function ComposerVariantsSection() {
           <Composer
             mode={mode}
             model={model}
+            modelOptions={STATIC_MODEL_OPTIONS}
             onModeChange={setMode}
             onModelChange={setModel}
             onSubmit={noop}
@@ -57,7 +59,8 @@ export function ComposerVariantsSection() {
         <VariantCard label="pre-seeded with plain text">
           <Composer
             mode="ask"
-            model="claude-opus-4.7-thinking"
+            model="anthropic::claude-opus-4-7"
+            modelOptions={STATIC_MODEL_OPTIONS}
             onModeChange={noop}
             onModelChange={noop}
             onSubmit={noop}
@@ -71,7 +74,8 @@ export function ComposerVariantsSection() {
         >
           <Composer
             mode="agent"
-            model="gpt-5.5-medium"
+            model="openai::gpt-5"
+            modelOptions={STATIC_MODEL_OPTIONS}
             onModeChange={noop}
             onModelChange={noop}
             onSubmit={noop}
@@ -82,7 +86,8 @@ export function ComposerVariantsSection() {
         <VariantCard label="with attachments">
           <Composer
             mode="agent"
-            model="gpt-5.5-medium"
+            model="openai::gpt-5"
+            modelOptions={STATIC_MODEL_OPTIONS}
             onModeChange={noop}
             onModelChange={noop}
             onSubmit={noop}
@@ -93,7 +98,8 @@ export function ComposerVariantsSection() {
         <VariantCard label="disabled (streaming)">
           <Composer
             mode="plan"
-            model="composer-2-fast"
+            model="openai::gpt-5-mini"
+            modelOptions={STATIC_MODEL_OPTIONS}
             onModeChange={noop}
             onModelChange={noop}
             onSubmit={noop}

--- a/console/web/src/pages/Examples/sections/message-variants.tsx
+++ b/console/web/src/pages/Examples/sections/message-variants.tsx
@@ -43,7 +43,7 @@ const userWithAttachments: UserMessage = {
 const assistantComplete: AssistantMessage = {
   id: 'a1',
   role: 'assistant',
-  model: 'claude-opus-4.7-thinking',
+  model: 'anthropic::claude-opus-4-7',
   mode: 'plan',
   content: `## the plan
 
@@ -64,7 +64,7 @@ engine.on('echo', (input) => ({ text: input.text }))
 const assistantStreaming: AssistantMessage = {
   id: 'a2',
   role: 'assistant',
-  model: 'gpt-5.5-medium',
+  model: 'openai::gpt-5',
   mode: 'ask',
   content:
     'sure — a btree-backed index gives you both `O(log n)` lookups and cheap range',
@@ -75,7 +75,7 @@ const assistantStreaming: AssistantMessage = {
 const assistantThinking: AssistantMessage = {
   id: 'a3',
   role: 'assistant',
-  model: 'claude-opus-4.7-thinking',
+  model: 'anthropic::claude-opus-4-7',
   mode: 'agent',
   content: '',
   streaming: true,

--- a/console/web/src/pages/Playground/index.tsx
+++ b/console/web/src/pages/Playground/index.tsx
@@ -5,6 +5,7 @@ import type { ChatBackend, StreamEvent } from '@/lib/backend'
 import {
   type Conversation,
   DEFAULT_MODEL,
+  STATIC_MODEL_OPTIONS,
   type Message,
   type MessagePatch,
   type Mode,
@@ -127,6 +128,7 @@ export function Playground() {
           key={convo.id}
           conversation={convo}
           backend={tappedBackend}
+          modelOptions={STATIC_MODEL_OPTIONS}
           onUpdateModel={setModel}
           onUpdateMode={setMode}
           onAppendMessage={appendMessage}

--- a/console/web/src/types/chat.ts
+++ b/console/web/src/types/chat.ts
@@ -1,22 +1,33 @@
 export type Mode = 'plan' | 'ask' | 'agent'
 
-export type ModelId =
-  | 'gpt-5.5-medium'
-  | 'claude-opus-4.7-thinking'
-  | 'gemini-2.5-pro'
-  | 'composer-2-fast'
+/** Composite `provider::<catalog_model_id>` (matches harness-node models-catalog). */
+export const CATALOG_MODEL_KEY_SEP = '::' as const
+
+export type ModelId = string
 
 export interface ModelOption {
   id: ModelId
   label: string
 }
 
-export const MODELS: ModelOption[] = [
-  { id: 'gpt-5.5-medium', label: 'gpt-5.5 medium' },
-  { id: 'claude-opus-4.7-thinking', label: 'claude opus 4.7 thinking' },
-  { id: 'gemini-2.5-pro', label: 'gemini 2.5 pro' },
-  { id: 'composer-2-fast', label: 'composer 2 fast' },
+/**
+ * When the engine is down or mock backend runs, picker still needs options.
+ * Ids mirror the seeded catalog (`harness-node/.../models.json`).
+ */
+export const STATIC_MODEL_OPTIONS: ModelOption[] = [
+  { id: `openai${CATALOG_MODEL_KEY_SEP}gpt-5`, label: 'gpt-5' },
+  {
+    id: `anthropic${CATALOG_MODEL_KEY_SEP}claude-opus-4-7`,
+    label: 'claude opus 4.7',
+  },
+  {
+    id: `google${CATALOG_MODEL_KEY_SEP}gemini-2-5-pro`,
+    label: 'gemini 2.5 pro',
+  },
+  { id: `openai${CATALOG_MODEL_KEY_SEP}gpt-5-mini`, label: 'gpt-5 mini' },
 ]
+
+export const DEFAULT_MODEL: ModelId = STATIC_MODEL_OPTIONS[0].id
 
 export const MODES: { id: Mode; label: string }[] = [
   { id: 'plan', label: 'plan' },
@@ -24,7 +35,6 @@ export const MODES: { id: Mode; label: string }[] = [
   { id: 'agent', label: 'agent' },
 ]
 
-export const DEFAULT_MODEL: ModelId = 'gpt-5.5-medium'
 export const DEFAULT_MODE: Mode = 'agent'
 
 export type Role = 'user' | 'assistant' | 'thought' | 'function-call'


### PR DESCRIPTION
## Summary
Drive the console model picker from the harness-node `models::list` catalog instead of the hardcoded four-entry `MODELS` enum. Composite `provider::<catalog_model_id>` keys flow from the picker through `resolveRunParams` and into `run::start`.

## Changes
**New files**
- `console/web/src/lib/catalog-model-key.ts` — parse/format the `provider::id` composite key (separator exposed as `CATALOG_MODEL_KEY_SEP`).
- `console/web/src/lib/models-catalog.ts` — thin client wrapper around `models::list` / `models::get`.
- `console/web/src/hooks/use-model-picker-source.ts` — live-updating picker source with a static fallback for when the engine is down or the mock backend is in use.

**Modified**
- `console/web/src/types/chat.ts` — `ModelId` widened to `string`; `STATIC_MODEL_OPTIONS` + `DEFAULT_MODEL` replace the enum-shaped `MODELS`.
- `console/web/src/components/chat/ModelPicker.tsx` — accepts `options` + `loading`; falls back to `{id,label:value}` if catalog is empty so the picker is never blank.
- `console/web/src/components/chat/Composer.tsx`, `components/chat/ChatView.tsx`, `pages/Chat.tsx`, `hooks/use-conversations.ts`, `pages/Examples/sections/*`, `pages/Playground/index.tsx` — thread catalog-shaped ids through.
- `console/web/src/lib/backend/real.ts` — `resolveRunParams` parses `provider::id`; legacy heuristic ids (no `::`) still fall back to the old `claude*` / `gemini*` provider guess.

## Compatibility
Legacy ids without `::` continue to work via the heuristic fallback in `resolveRunParams`, so any persisted session referencing the old hardcoded ids keeps mapping to a provider.

## Test plan
- [ ] Picker populates from `models::list` when harness-node is up; falls back to `STATIC_MODEL_OPTIONS` when the engine is unreachable.
- [ ] Selecting `anthropic::claude-sonnet-4-6` routes a chat request to `provider::anthropic::stream` (verify via run::start payload).
- [ ] Legacy id like `claude-sonnet-4-6` (no `::`) still routes to anthropic via the heuristic branch.
- [ ] `pnpm typecheck` and `pnpm lint` clean.

## Out of scope (held for separate PRs)
- The `:7806` debug-instrumentation block deletion in `real.ts` — staying as a working-tree change for a separate chore PR.
- The Rust `turn-orchestrator/` resume-requested state additions — unrelated feature.
- `.gitignore` `playground*/` entry — housekeeping.
