### PR TITLE
fix(ci): pin iii CLI to v0.12.0 stable in publish-registry workflow

### DIFF
--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -54,11 +54,11 @@ jobs:
 
       - name: Install iii CLI
         env:
-          VERSION: '0.11.6-next.1'
+          VERSION: '0.12.0'
         run: |
           set -euo pipefail
           curl -fsSL https://install.iii.dev/iii/main/install.sh -o /tmp/install-iii.sh
-          sh /tmp/install-iii.sh --next
+          sh /tmp/install-iii.sh
           {
             echo "$HOME/.local/bin"
             echo "$HOME/.iii/bin"


### PR DESCRIPTION
## Summary

`.github/workflows/_publish-registry.yml` hardcoded `VERSION: '0.11.6-next.1'` in the *Install iii CLI* step. The install script honors the `VERSION` env var **before** the `--next` selector, so every release pulled an outdated CLI that no longer matched the positional `iii trigger <FUNCTION_PATH>` syntax used in the same workflow file.

Result: every recent release failed at *Start III engine* with:

\`\`\`
error: unexpected argument 'engine::workers::list' found
##[error]iii engine did not become ready
\`\`\`

Repro: https://github.com/iii-hq/workers/actions/runs/26130293894/job/76949911584

## Fix

- Bump pinned version to \`0.12.0\` (latest stable).
- Drop the `--next` flag — it was being ignored by the env override anyway, and the stable channel ships the CLI surface this workflow relies on.

## Test plan

- [ ] Re-tag any worker (or wait for the next release tag) and confirm the *Start III engine* step now succeeds with \`iii v0.12.0\`.