### PR TITLE
fix(harness-node): close /compact failure modes end-to-end

### DIFF
--- a/console/Cargo.lock
+++ b/console/Cargo.lock
@@ -257,7 +257,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -46,11 +46,11 @@ function formatCompactResult(result: CompactResult): string {
         result.autoContinued ? ' (continued)' : ''
       }`
     case 'busy':
-      return 'compact: another compaction is in progress'
+      return 'compact: another compaction is in progress — try again in a moment'
     case 'overflow':
       return `compact failed: ${result.message}`
     case 'empty':
-      return 'compact: nothing to summarise yet'
+      return 'compact: session is too small to summarise — try again after a few more turns'
     case 'error':
       return `compact failed: ${result.message}`
   }
@@ -158,6 +158,7 @@ export function ChatView({
             sessionId,
             conversation.model,
             priorHistory,
+            contextWindow,
           )
           if (result.status === 'ok') {
             const marker: SystemMessage = {

--- a/console/web/src/lib/backend/mock.ts
+++ b/console/web/src/lib/backend/mock.ts
@@ -131,7 +131,7 @@ export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 export const mockBackend: ChatBackend = {
   id: 'mock',
   stream: mockStream,
-  async compactSession(_sessionId, _model, _history) {
+  async compactSession(_sessionId, _model, _history, _contextWindow) {
     return { status: 'empty' }
   },
 }

--- a/console/web/src/lib/backend/real.ts
+++ b/console/web/src/lib/backend/real.ts
@@ -188,6 +188,7 @@ async function realCompactSession(
   sessionId: string,
   model: ModelId,
   history?: AgentMessage[],
+  contextWindow?: number,
 ): Promise<CompactResult> {
   const { provider, model: modelId } = resolveRunParams(model)
   const client = await getIiiClient()
@@ -196,6 +197,7 @@ async function realCompactSession(
     // stale tree (only the first turn mirrored) doesn't yield a spurious
     // 'empty' when the UI has plenty to summarise. No-op when the tree
     // already has equal-or-more entries.
+    let reconcileFailed = false
     if (history && history.length > 0) {
       await client
         .call('session-tree::ensure', { session_id: sessionId })
@@ -206,13 +208,32 @@ async function realCompactSession(
           state_snapshot: history,
         })
         .catch((err) => {
+          // A failed reconcile can yield a spurious 'empty' from a stale tree.
+          reconcileFailed = true
           if (import.meta.env.DEV) {
             console.warn(
-              '[compact_session] reconcile failed; compacting as-is',
+              '[compact_session] reconcile failed; compacting against current session-tree',
               err,
             )
           }
         })
+    }
+
+    // Passing limit.context lets the server skip the models::get lookup.
+    // We don't know max_output here; 4096 is the same conservative default
+    // the server falls back to when models::get returns nothing.
+    const DEFAULT_MAX_OUTPUT = 4_096
+    const modelPayload: {
+      id: string
+      providerID: string
+      limit?: { context: number; input: number; output: number }
+    } = { id: modelId, providerID: provider }
+    if (typeof contextWindow === 'number' && contextWindow > 0) {
+      modelPayload.limit = {
+        context: contextWindow,
+        input: contextWindow,
+        output: DEFAULT_MAX_OUTPUT,
+      }
     }
 
     const resp = await client.call<{
@@ -225,13 +246,23 @@ async function realCompactSession(
       reason?: string
     }>('context-compaction::compact_session', {
       session_id: sessionId,
-      model: { id: modelId, providerID: provider },
+      model: modelPayload,
     })
+    // Empty + reconcileFailed → likely stale tree; tell the user to retry.
+    const surfaceEmpty = (): CompactResult =>
+      reconcileFailed
+        ? {
+            status: 'error',
+            message:
+              'compact: could not sync session history to server; retry /compact',
+          }
+        : { status: 'empty' }
+
     if (resp?.status === 'ok') {
       const tokensBefore =
         typeof resp.tokens_before === 'number' ? resp.tokens_before : 0
       // Surface zero-token "ok" as semantic empty.
-      if (tokensBefore === 0) return { status: 'empty' }
+      if (tokensBefore === 0) return surfaceEmpty()
       // Fallback placeholder for engines that predate summary_text on the
       // wire; without it the marker has no <conversation-summary> to ship.
       const summaryText =
@@ -257,7 +288,7 @@ async function realCompactSession(
             : 'unknown summariser error'
       return { status: 'overflow', message }
     }
-    if (resp?.status === 'empty') return { status: 'empty' }
+    if (resp?.status === 'empty') return surfaceEmpty()
     return {
       status: 'error',
       message: `unexpected status: ${String(resp?.status ?? 'null')}`,

--- a/console/web/src/lib/backend/types.ts
+++ b/console/web/src/lib/backend/types.ts
@@ -96,12 +96,14 @@ export interface ChatBackend {
     decision: 'allow' | 'deny',
   ): Promise<void>
   /**
-   * Powers `/compact`. `history` is reconciled into session-tree before
-   * compacting so a stale mirror doesn't yield a spurious 'empty'.
+   * Powers `/compact`. `history` is reconciled into session-tree first so a
+   * stale mirror doesn't yield a spurious 'empty'. `contextWindow` skips
+   * the server's `models::get` lookup when known.
    */
   compactSession?(
     sessionId: string,
     model: ModelId,
     history?: AgentMessage[],
+    contextWindow?: number,
   ): Promise<CompactResult>
 }

--- a/harness-node/docs/workers/context-compaction.md
+++ b/harness-node/docs/workers/context-compaction.md
@@ -115,12 +115,18 @@ Takes only a `session_id`; resolves the model and last user message internally.
   provider/model fields exists in the session, or `models::get` fails.
 
 **Sequence:**
-1. Resolves the model by scanning the most recent assistant message in
-   `session-tree::messages` and looking up limits via `models::get`.
-2. Finds the last user message entry id from the same message list.
-3. Calls `handleSync` with `projected_tokens: 999_999` to force compaction
-   unconditionally (no overflow pre-check).
-4. Returns the same `CompactNowResult` shape as `compact_now`.
+1. Resolves the model: explicit `payload.model.limit` → session-tree scan
+   → orchestrator `run_request` → conservative fallback. Avoids forcing
+   `models::get` when the UI already knows the context window.
+2. Calls `handleSync` with `projected_tokens: 999_999` and
+   `last_user_message_id: ''` to force compaction unconditionally and
+   skip the replay / auto-continue branch. `/compact` runs against a
+   conversation at rest — there is no in-flight user message to re-inject.
+   Without this, single-turn sessions with one user message at index 0
+   collapsed to `truncatedMessages = []` and surfaced as `empty`.
+3. Returns the same `CompactNowResult` shape as `compact_now`, but
+   `auto_continued` is always `false` and no synthetic "Continue…" prompt
+   is appended.
 
 ## Model-adaptive threshold
 
@@ -173,7 +179,11 @@ scratch, so the summary converges rather than growing without bound.
 
 Tools listed in `COMPACT_PRUNE_PROTECTED_TOOLS` are never pruned.
 
-## Replay + auto-continue (sync path only)
+## Replay + auto-continue (`compact_now` only)
+
+Only the turn-orchestrator overflow path uses replay. `compact_session`
+runs against a conversation at rest and passes `last_user_message_id: ''`
+so this branch is skipped — `auto_continued` is always `false` on that path.
 
 When `compact_now` runs:
 
@@ -206,7 +216,7 @@ All knobs are env-driven; no `config.yaml` fields are read.
 | `COMPACT_PRUNE_PROTECT` | `40000` | Tokens of tool output to preserve from the tail before pruning. |
 | `COMPACT_PRUNE_MIN_FREE` | `20000` | Minimum tokens the prune pass must free; skips if below this. |
 | `COMPACT_TOOL_OUTPUT_MAX_CHARS` | `2000` | Per-output character cap applied before sending to the summariser. |
-| `COMPACT_BUSY_TIMEOUT_MS` | `3000` | Max ms `compact_now` waits for the compaction lease before returning `{ status: 'busy' }`. |
+| `COMPACT_BUSY_TIMEOUT_MS` | `30000` | Max ms `compact_now` / `compact_session` waits for the compaction lease before returning `{ status: 'busy' }`. Sized to cover a typical summariser stream (10–30s) so user-initiated `/compact` doesn't race the async TurnEnd path. |
 | `COMPACT_PRUNE_PROTECTED_TOOLS` | _(empty)_ | Comma-separated function IDs whose outputs are never pruned. |
 | `COMPACT_SUMMARIZER_PROVIDER` | `anthropic` | `anthropic` or `openai` — picks the streaming provider. |
 | `COMPACT_SUMMARIZER_MODEL` | _(model in use)_ | Model id passed to the provider stream. Defaults to the same model as the session. |

--- a/harness-node/src/context-compaction/config.ts
+++ b/harness-node/src/context-compaction/config.ts
@@ -5,7 +5,9 @@ const DEFAULT_MAX_PRESERVE_RECENT_TOKENS = 8_000;
 const DEFAULT_PRUNE_PROTECT = 40_000;
 const DEFAULT_PRUNE_MIN_FREE = 20_000;
 const DEFAULT_TOOL_OUTPUT_MAX_CHARS = 2_000;
-const DEFAULT_BUSY_TIMEOUT_MS = 3_000;
+// Sized to cover a summariser stream (10-30s); shorter values surface
+// `busy` to users when async compaction is mid-flight.
+const DEFAULT_BUSY_TIMEOUT_MS = 30_000;
 
 function intEnv(name: string, def: number): number {
   const v = process.env[name];

--- a/harness-node/src/context-compaction/handler-sync.ts
+++ b/harness-node/src/context-compaction/handler-sync.ts
@@ -56,7 +56,7 @@ export async function handleSync(iii: ISdk, input: CompactNowInput): Promise<Com
       >({
         function_id: 'session-tree::messages',
         payload: { session_id: input.session_id },
-        timeoutMs: 10_000,
+        timeoutMs: 30_000,
       });
       const entries: MessageWithEntryId[] = (resp?.messages ?? [])
         .filter(

--- a/harness-node/src/context-compaction/lease.ts
+++ b/harness-node/src/context-compaction/lease.ts
@@ -1,12 +1,10 @@
-/**
- * Single-writer lease via nonce-and-readback. state::* has no CAS, so we
- * write a unique nonce and read it back — exactly one writer sees its own
- * nonce survive (last write wins).
- */
+// Single-writer lease via atomic state::update. The set-and-return-old
+// semantics close the read-modify-write race: a concurrent writer sees
+// our nonce in old_value and restores its predecessor.
 
 import { randomUUID } from 'node:crypto';
 import type { ISdk } from '../runtime/iii.js';
-import { stateGet, stateSet } from '../runtime/state.js';
+import { stateGet, stateSet, stateUpdate } from '../runtime/state.js';
 
 export type LeaseKind = 'compaction' | 'prune';
 
@@ -36,6 +34,11 @@ export function readLeaseTimestampSecs(v: unknown): number {
   return 0;
 }
 
+function isLeaseActive(v: unknown, now_secs: number): boolean {
+  const ts_secs = readLeaseTimestampSecs(v);
+  return ts_secs > 0 && now_secs - ts_secs < LEASE_TTL_SECS;
+}
+
 export async function acquireLease(
   iii: ISdk,
   session_id: string,
@@ -45,25 +48,39 @@ export async function acquireLease(
   const now_ms = Date.now();
   const now_secs = Math.floor(now_ms / 1000);
 
+  // Fast path: skip the atomic set when a valid lease is clearly held.
   const existing = await stateGet(iii, STATE_SCOPE, key);
-  if (existing) {
-    const ts_secs = readLeaseTimestampSecs(existing);
-    if (ts_secs > 0 && now_secs - ts_secs < LEASE_TTL_SECS) return null;
-  }
+  if (existing && isLeaseActive(existing, now_secs)) return null;
 
   const nonce = mintLeaseNonce();
-  await stateSet(iii, STATE_SCOPE, key, { nonce, ts: now_ms });
+  // path: '' targets FieldPath::root in the engine — set the whole value
+  // atomically. Without `path`, the engine fails to deserialize the op and
+  // stateUpdate falls into its catch + returns null.
+  const result = await stateUpdate(iii, STATE_SCOPE, key, [
+    { type: 'set', path: '', value: { nonce, ts: now_ms } },
+  ]);
+  // stateUpdate swallows backend errors and returns null. Treat a null
+  // envelope as "we did NOT acquire the lease" — otherwise a transient
+  // state-store failure would let every concurrent caller declare itself
+  // the winner, defeating the whole point of the lease.
+  if (!result) return null;
+  const oldValue = result.old_value;
 
-  const stored = await stateGet(iii, STATE_SCOPE, key);
-  const storedNonce =
-    stored &&
-    typeof stored === 'object' &&
-    typeof (stored as Record<string, unknown>).nonce === 'string'
-      ? ((stored as Record<string, unknown>).nonce as string)
-      : null;
-  return storedNonce === nonce ? nonce : null;
+  // If we just overwrote a concurrent acquirer's active lease, restore it
+  // and bow out. stateUpdate is atomic, so only one caller can see
+  // old_value == null (or expired) — exactly one winner.
+  if (oldValue && isLeaseActive(oldValue, now_secs)) {
+    await stateSet(iii, STATE_SCOPE, key, oldValue);
+    return null;
+  }
+  return nonce;
 }
 
+// Known race: between the stateGet and the stateSet a new acquirer could
+// claim the lease, and our stateSet(null) would clear it. Closing this
+// needs a CAS-like primitive in iii-database (delete-if-matches). In
+// practice this is bounded by LEASE_TTL_SECS (300s) >> the summariser's
+// own timeout (120s), so a duplicate claim resolves itself via TTL.
 export async function releaseLease(
   iii: ISdk,
   session_id: string,

--- a/harness-node/src/context-compaction/register.ts
+++ b/harness-node/src/context-compaction/register.ts
@@ -1,4 +1,5 @@
 import type { ISdk } from '../runtime/iii.js';
+import { logger } from '../runtime/otel.js';
 import { pruneMinFree, pruneProtect, pruneProtectedTools } from './config.js';
 import { handleAsync } from './handler-async.js';
 import { type CompactNowInput, handleSync } from './handler-sync.js';
@@ -11,6 +12,16 @@ import {
 import { prune } from './prune.js';
 
 const AGENT_EVENTS_STREAM = 'agent::events';
+
+// Sized so preserveRecentBudget clamps to its 2k minimum when the real
+// model is unknown — compaction is best-effort, not fatal.
+const FALLBACK_MODEL_LIMIT = {
+  context: 32_000,
+  input: 32_000,
+  output: 4_000,
+};
+const FALLBACK_MODEL_ID = 'unknown';
+const FALLBACK_PROVIDER_ID = 'unknown';
 
 // payload.model: { id, providerID } with optional limit; null on malformed.
 async function resolveExplicitModel(
@@ -126,38 +137,36 @@ export async function register(iii: ISdk): Promise<void> {
       }
       const session_id = session_id_raw;
 
-      // First-hit chain: explicit payload → session-tree → run_request.
-      // The last fallback covers first-turn sessions with no mirrored assistant.
+      const explicitObj = obj.model as { id?: string; providerID?: string } | undefined;
       let model = await resolveExplicitModel(iii, obj.model);
       if (!model) model = await resolveModelFromSession(iii, session_id);
       if (!model) model = await resolveModelFromRunRequest(iii, session_id);
       if (!model) {
-        throw new Error(
-          `context-compaction::compact_session: could not resolve model for session ${session_id}`,
-        );
+        const providedId =
+          typeof explicitObj?.id === 'string' && explicitObj.id ? explicitObj.id : null;
+        const providedProvider =
+          typeof explicitObj?.providerID === 'string' && explicitObj.providerID
+            ? explicitObj.providerID
+            : null;
+        logger.warn('compact_session: model resolution failed; using fallback limit', {
+          session_id,
+          requestedProvider: providedProvider,
+          requestedModel: providedId,
+        });
+        model = {
+          providerID: providedProvider ?? FALLBACK_PROVIDER_ID,
+          modelID: providedId ?? FALLBACK_MODEL_ID,
+          modelLimit: FALLBACK_MODEL_LIMIT,
+        };
       }
 
-      const resp = await iii.trigger<
-        unknown,
-        { messages?: Array<{ entry_id?: string; message?: { role?: string } }> }
-      >({
-        function_id: 'session-tree::messages',
-        payload: { session_id },
-        timeoutMs: 10_000,
-      });
-      const messages = resp?.messages ?? [];
-      let last_user_message_id = '';
-      for (let i = messages.length - 1; i >= 0; i--) {
-        if (messages[i]?.message?.role === 'user') {
-          last_user_message_id = messages[i]?.entry_id ?? '';
-          break;
-        }
-      }
-
+      // Empty last_user_message_id skips handleSync's replay branch.
+      // Replay belongs to compact_now (orchestrator overflow); /compact
+      // runs against a conversation at rest with nothing to re-inject.
       return handleSync(iii, {
         session_id,
         projected_tokens: 999_999,
-        last_user_message_id,
+        last_user_message_id: '',
         model: {
           id: model.modelID,
           providerID: model.providerID,

--- a/harness-node/src/context-compaction/stream-collect.ts
+++ b/harness-node/src/context-compaction/stream-collect.ts
@@ -44,26 +44,41 @@ export async function streamAndCollect(
     timeoutMs: SUMMARIZER_TIMEOUT_MS,
   });
 
-  while (!terminal) {
-    if (events.length > 0) {
-      const tail = events[events.length - 1];
-      if (tail && (tail.type === 'done' || tail.type === 'error')) {
-        terminal = tail;
-        break;
-      }
-    }
+  // trigger() resolved, but the channel may not have delivered the
+  // terminal event yet. Poll for up to GRACE_MS before giving up so a
+  // slow IPC hop doesn't masquerade as "stream returned without a
+  // terminal event".
+  const GRACE_MS = 1_000;
+  const deadline = Date.now() + GRACE_MS;
+  while (!terminal && Date.now() < deadline) {
     await new Promise<void>((r) => {
       resolveNext = r;
       setTimeout(r, 25);
     });
-    break;
   }
 
   if (!terminal) {
     throw new Error('summariser stream returned without a terminal event');
   }
   if ((terminal as AssistantMessageEvent).type === 'error') {
-    return (terminal as { type: 'error'; error: AssistantMessage }).error;
+    // Surface provider errors as a thrown exception so summarizeAndAppend's
+    // catch treats them as compaction failures. Without this, the error
+    // AssistantMessage's text content got silently written as the summary.
+    const errMsg = (terminal as { type: 'error'; error: AssistantMessage }).error;
+    const detail =
+      typeof errMsg.error_message === 'string' && errMsg.error_message.length > 0
+        ? errMsg.error_message
+        : extractTextFromMessage(errMsg);
+    throw new Error(`summariser stream error: ${detail || 'unknown provider error'}`);
   }
   return (terminal as { type: 'done'; message: AssistantMessage }).message;
+}
+
+function extractTextFromMessage(msg: AssistantMessage): string {
+  for (const block of msg.content ?? []) {
+    if ((block as { type?: string }).type === 'text') {
+      return (block as { type: 'text'; text: string }).text;
+    }
+  }
+  return '';
 }

--- a/harness-node/src/context-compaction/summarize.ts
+++ b/harness-node/src/context-compaction/summarize.ts
@@ -40,6 +40,18 @@ export type SummarizeOk = {
 export type SummarizeFailure = { kind: 'compact'; reason: string };
 export type SummarizeOutcome = SummarizeOk | SummarizeFailure | 'empty';
 
+// Auth / 4xx / malformed requests won't fix on retry. Everything else
+// (5xx, 429, network, timeout, unknown) gets one retry. Conservative
+// default: when in doubt, retry.
+export function isRetryableStreamError(err: unknown): boolean {
+  if (!(err instanceof Error)) return true;
+  const msg = err.message.toLowerCase();
+  if (/\b(40[01345]|auth|unauthorized|forbidden|invalid[_ ]?(api[_ ]?key|key|request)|malformed)\b/.test(msg)) {
+    return false;
+  }
+  return true;
+}
+
 export function renderUserPrompt(older: AgentMessage[]): string {
   let out =
     'Summarise the conversation below following the system-prompt structure exactly. Keep identifiers verbatim.\n\n';
@@ -113,7 +125,7 @@ async function appendCompaction(
       tail_start_id,
       details: { read_files: [], modified_files: [] },
     },
-    timeoutMs: 10_000,
+    timeoutMs: 30_000,
   });
   return resp?.entry_id ?? '';
 }
@@ -151,33 +163,53 @@ export async function summarizeAndAppend(
   const systemPrompt = buildPrompt({ previousSummary, context: [] });
   const userPrompt = renderUserPrompt(stripped);
 
-  const providerName = summarizerProvider() ?? 'anthropic';
+  // Default to the session's provider, NOT a hardcoded 'anthropic'.
+  // Otherwise an OpenAI session ends up calling Anthropic with an OpenAI
+  // model id (e.g. gpt-5-mini) and the provider returns not_found_error.
+  const providerName = summarizerProvider() ?? model.providerID;
   const summariserId =
     providerName === 'openai' ? 'provider::openai::stream' : 'provider::anthropic::stream';
   const modelId = summarizerModel() ?? model.modelID;
 
+  // One 250ms retry for transient failures (429/5xx/network). Permanent
+  // failures (auth, malformed request) skip the retry to release the lease
+  // sooner.
+  const streamInput = {
+    system_prompt: systemPrompt,
+    model: modelId,
+    messages: [
+      {
+        role: 'user' as const,
+        content: [{ type: 'text' as const, text: userPrompt }],
+        timestamp: Date.now(),
+      },
+    ],
+    tools: [],
+  };
   let final: AssistantMessage;
   try {
-    final = await streamAndCollect(
-      iii,
-      {
-        system_prompt: systemPrompt,
-        model: modelId,
-        messages: [
-          {
-            role: 'user',
-            content: [{ type: 'text', text: userPrompt }],
-            timestamp: Date.now(),
-          },
-        ],
-        tools: [],
-      },
-      summariserId,
-    );
-  } catch (err) {
-    const reason = err instanceof Error ? err.message : String(err);
-    logger.warn('summariser stream failed', { session_id, err: reason });
-    return { kind: 'compact', reason };
+    final = await streamAndCollect(iii, streamInput, summariserId);
+  } catch (firstErr) {
+    const firstReason = firstErr instanceof Error ? firstErr.message : String(firstErr);
+    if (!isRetryableStreamError(firstErr)) {
+      logger.warn('summariser stream failed (non-retryable)', { session_id, err: firstReason });
+      return { kind: 'compact', reason: firstReason };
+    }
+    logger.warn('summariser stream failed; retrying once', { session_id, err: firstReason });
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 250);
+    });
+    try {
+      final = await streamAndCollect(iii, streamInput, summariserId);
+    } catch (secondErr) {
+      const reason = secondErr instanceof Error ? secondErr.message : String(secondErr);
+      logger.warn('summariser stream failed after retry', {
+        session_id,
+        err: reason,
+        firstErr: firstReason,
+      });
+      return { kind: 'compact', reason };
+    }
   }
 
   let summary = '';

--- a/harness-node/src/runtime/state.ts
+++ b/harness-node/src/runtime/state.ts
@@ -9,12 +9,17 @@
 import type { ISdk } from 'iii-sdk';
 import { logger } from './otel.js';
 
+// Mirrors engine `UpdateOp` (sdk/packages/rust/iii/src/types.rs). Variants
+// that target a JSON field (`set`, `increment`, `decrement`, `remove`) take
+// a required `path` string — `""` (FieldPath::root) means "the whole value".
+// `merge`/`append` accept an optional MergePath (string or array of strings).
 export type StateUpdateOp =
-  | { type: 'set'; value: unknown }
-  | { type: 'merge'; value: Record<string, unknown> }
-  | { type: 'append'; value: unknown }
-  | { type: 'increment'; value: number }
-  | { type: 'delete' }
+  | { type: 'set'; path: string; value: unknown }
+  | { type: 'merge'; path?: string | string[]; value: Record<string, unknown> }
+  | { type: 'append'; path?: string | string[]; value: unknown }
+  | { type: 'increment'; path: string; by: number }
+  | { type: 'decrement'; path: string; by: number }
+  | { type: 'remove'; path: string }
   | { type: string; [k: string]: unknown };
 
 export async function stateGet(iii: ISdk, scope: string, key: string): Promise<unknown> {

--- a/harness-node/tests/context-compaction/compact-session-registered.test.ts
+++ b/harness-node/tests/context-compaction/compact-session-registered.test.ts
@@ -77,6 +77,18 @@ function buildSdk(opts: {
       else stateStore.set(p.key as string, p.value);
       return { ok: true };
     }
+    if (fn === 'state::update') {
+      const key = p.key as string;
+      const ops = (p.ops ?? []) as Array<{ type: string; value?: unknown }>;
+      const oldValue = stateStore.has(key) ? stateStore.get(key) : null;
+      let newValue: unknown = oldValue;
+      for (const op of ops) {
+        if (op.type === 'set') newValue = op.value;
+      }
+      if (newValue === null || newValue === undefined) stateStore.delete(key);
+      else stateStore.set(key, newValue);
+      return { old_value: oldValue ?? null, new_value: newValue ?? null };
+    }
     if (fn === 'session-tree::messages') {
       return { messages: opts.sessionEntries };
     }
@@ -136,9 +148,11 @@ function buildSdk(opts: {
 }
 
 describe('context-compaction::compact_session via registered handler', () => {
-  it('returns ok with tokens_before > 0 and auto_continued=true for a multi-turn session', async () => {
-    // 2 user + 2 assistant turns. compact_session picks u2 as the
-    // replay target → truncatedMessages = [u1, a1] → summarise.
+  it('returns ok with tokens_before > 0 and auto_continued=false for a multi-turn session', async () => {
+    // 2 user + 2 assistant turns. compact_session does NOT extract a
+    // replay target (the replay mechanism is for compact_now's overflow
+    // pre-flight only), so all 4 entries feed into selection. The summary
+    // covers turn 1, turn 2 stays as tail.
     const entries = [
       userEntry('e1', 'first question'),
       asstEntry('e2', 'first answer'),
@@ -168,8 +182,8 @@ describe('context-compaction::compact_session via registered handler', () => {
     };
 
     expect(result.status).toBe('ok');
-    expect(result.auto_continued).toBe(true);
-    // Bug repro target: this MUST be > 0 for any non-empty head.
+    // /compact is user-initiated; no in-flight turn to auto-continue.
+    expect(result.auto_continued).toBe(false);
     expect(typeof result.tokens_before).toBe('number');
     expect(result.tokens_before).toBeGreaterThan(0);
     // Surface every field so we can spot wire-format weirdness.
@@ -177,20 +191,20 @@ describe('context-compaction::compact_session via registered handler', () => {
       ['auto_continued', 'status', 'summary_text', 'tail_start_id', 'tokens_before'].sort(),
     );
     // summary_text MUST be present and non-empty so the UI marker can ship
-    // it as the next-turn <conversation-summary> block (Option A fix).
+    // it as the next-turn <conversation-summary> block.
     expect(typeof result.summary_text).toBe('string');
     expect((result.summary_text ?? '').length).toBeGreaterThan(0);
   });
 
-  it('returns empty when last user message is the FIRST entry (truncated is empty)', async () => {
-    // Session with ONLY one user message that matches last_user_message_id.
-    // - extractReplayTarget: idx=0 → replay=u1, truncatedMessages=[]
-    // - summarize sees []: returns 'empty'
-    // - handler-sync: returns { status: 'empty' }
-    // This proves the suspected UI scenario actually returns 'empty', NOT 'ok'.
-    // If a real call sees 'ok' with tokens=0, the bug is elsewhere.
+  it('summarises a session with only one user message and nothing else', async () => {
+    // Before the fix this returned 'empty' because compact_session
+    // extracted u1 as the replay target, leaving truncatedMessages = [].
+    // After the fix the single user message is summarised normally.
     const entries = [userEntry('only-user', 'just one message')];
-    const { iii, handlers } = buildSdk({ sessionEntries: entries });
+    const { iii, handlers } = buildSdk({
+      sessionEntries: entries,
+      summaryText: 'summary of the lone user message',
+    });
     await register(iii);
     const handler = handlers.get('context-compaction::compact_session');
 
@@ -199,9 +213,54 @@ describe('context-compaction::compact_session via registered handler', () => {
       model: { id: 'fake-model', providerID: 'anthropic' },
     })) as { status: string; tokens_before?: number; auto_continued?: boolean };
 
-    expect(result.status).toBe('empty');
-    // 'empty' shape: just { status }. No tokens_before, no auto_continued.
-    expect(result.tokens_before).toBeUndefined();
-    expect(result.auto_continued).toBeUndefined();
+    expect(result.status).toBe('ok');
+    expect(result.tokens_before).toBeGreaterThan(0);
+    expect(result.auto_continued).toBe(false);
+  });
+
+  it('summarises a single-user-turn session with many subsequent entries', async () => {
+    // Regression: a long-running task with one user message + lots of
+    // assistant/tool output ends up at ~30k+ tokens. Before the fix,
+    // compact_session always extracted the last user message via
+    // extractReplayTarget; with only one user message at idx=0,
+    // truncatedMessages was [] and summarize returned 'empty'. The user
+    // saw "compact: session is too small to summarise" despite a 30%
+    // full context window.
+    //
+    // After the fix, compact_session does NOT extract a replay target
+    // (that mechanism is for the compact_now overflow path), so the full
+    // entry list is summarised normally.
+    const longText = 'x'.repeat(8_000);
+    const entries = [
+      userEntry('u1', 'the only user question — start a long task'),
+      asstEntry('a1', `${longText} first assistant chunk`),
+      asstEntry('a2', `${longText} second assistant chunk`),
+      asstEntry('a3', `${longText} third assistant chunk`),
+      asstEntry('a4', `${longText} fourth assistant chunk`),
+    ];
+
+    const { iii, handlers } = buildSdk({
+      sessionEntries: entries,
+      summaryText: 'summary of the long task',
+    });
+
+    await register(iii);
+    const handler = handlers.get('context-compaction::compact_session');
+
+    const result = (await handler?.({
+      session_id: 'one-turn-large-session',
+      model: { id: 'fake-model', providerID: 'anthropic' },
+    })) as {
+      status: string;
+      tokens_before?: number;
+      auto_continued?: boolean;
+      summary_text?: string;
+    };
+
+    expect(result.status).toBe('ok');
+    expect(result.tokens_before).toBeGreaterThan(0);
+    // /compact (user-initiated) does NOT auto-continue. Replay is only
+    // appropriate for the orchestrator's overflow pre-flight.
+    expect(result.auto_continued).toBe(false);
   });
 });

--- a/harness-node/tests/context-compaction/compact-session.test.ts
+++ b/harness-node/tests/context-compaction/compact-session.test.ts
@@ -48,6 +48,21 @@ function makeStubIii(
         }
         return { ok: true };
       }
+      if (function_id === 'state::update') {
+        const key = p['key'] as string;
+        const ops = (p['ops'] ?? []) as Array<{ type: string; value?: unknown }>;
+        const oldValue = stateStore.has(key) ? stateStore.get(key) : null;
+        let newValue: unknown = oldValue;
+        for (const op of ops) {
+          if (op.type === 'set') newValue = op.value;
+        }
+        if (newValue === null || newValue === undefined) {
+          stateStore.delete(key);
+        } else {
+          stateStore.set(key, newValue);
+        }
+        return { old_value: oldValue ?? null, new_value: newValue ?? null };
+      }
 
       return null;
     }),
@@ -115,38 +130,27 @@ async function runCompactSession(iii: ISdk, session_id: unknown, payloadModel?: 
     throw new Error('context-compaction::compact_session: session_id is required');
   }
 
-  // Mirrors register.ts fallback chain so the test catches drift.
+  // Mirrors register.ts fallback chain so the test catches drift. When
+  // all three sources fail, register.ts now falls back to a conservative
+  // model limit rather than throwing — compaction is best-effort.
+  const FALLBACK = {
+    providerID: 'unknown',
+    modelID: 'unknown',
+    modelLimit: { context: 32_000, input: 32_000, output: 4_000 },
+  };
   let model = await resolveExplicitModel(iii, payloadModel);
   if (!model) model = await resolveModelFromSession(iii, session_id);
   if (!model) model = await resolveModelFromRunRequest(iii, session_id);
-  if (!model) {
-    throw new Error(
-      `context-compaction::compact_session: could not resolve model for session ${session_id}`,
-    );
-  }
+  if (!model) model = FALLBACK;
 
-  const resp = await iii.trigger<
-    unknown,
-    { messages?: Array<{ entry_id?: string; message?: { role?: string } }> }
-  >({
-    function_id: 'session-tree::messages',
-    payload: { session_id },
-    timeoutMs: 10_000,
-  });
-
-  const messages = resp?.messages ?? [];
-  let last_user_message_id = '';
-  for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i]?.message?.role === 'user') {
-      last_user_message_id = messages[i]?.entry_id ?? '';
-      break;
-    }
-  }
-
+  // Mirrors register.ts: /compact does NOT extract a replay target.
+  // The replay mechanism is for compact_now (turn-orchestrator overflow
+  // pre-flight) only. Passing '' tells extractReplayTarget that no entry
+  // matches, so the full entries list is summarised.
   return handleSync(iii, {
     session_id,
     projected_tokens: 999_999,
-    last_user_message_id,
+    last_user_message_id: '',
     model: {
       id: model.modelID,
       providerID: model.providerID,
@@ -174,16 +178,15 @@ describe('compact_session smoke', () => {
     );
   });
 
-  it('throws when neither session-tree nor run_request can resolve a model', async () => {
-    // No assistant messages AND no run_request — the final fallback also fails.
+  it('uses the fallback model limit when no source can resolve a model', async () => {
+    // No assistant messages AND no run_request. compact_session used to
+    // throw; it now degrades to a conservative fallback so /compact still
+    // runs (with a small preserve-recent budget) rather than failing.
     const iii = makeStubIii({
       'session-tree::messages': { messages: [] },
-      // state::get returns null by default in the stub for any unknown key,
-      // which is what `resolveModelFromRunRequest` sees.
     });
-    await expect(runCompactSession(iii, 'no-messages-session')).rejects.toThrow(
-      'could not resolve model for session no-messages-session',
-    );
+    const result = await runCompactSession(iii, 'no-messages-session');
+    expect(['ok', 'empty', 'overflow', 'busy']).toContain(result.status);
   });
 
   it('falls back to run_request when session-tree has no assistant messages', async () => {
@@ -214,6 +217,18 @@ describe('compact_session smoke', () => {
           else stateStore.set(p['key'] as string, v);
           return { ok: true };
         }
+        if (function_id === 'state::update') {
+          const key = p['key'] as string;
+          const ops = (p['ops'] ?? []) as Array<{ type: string; value?: unknown }>;
+          const oldValue = stateStore.has(key) ? stateStore.get(key) : null;
+          let newValue: unknown = oldValue;
+          for (const op of ops) {
+            if (op.type === 'set') newValue = op.value;
+          }
+          if (newValue === null || newValue === undefined) stateStore.delete(key);
+          else stateStore.set(key, newValue);
+          return { old_value: oldValue ?? null, new_value: newValue ?? null };
+        }
         return null;
       }),
       registerFunction: vi.fn(),
@@ -230,12 +245,34 @@ describe('compact_session smoke', () => {
   it('uses explicit payload.model when provided (skips session scan)', async () => {
     // Even when session-tree returns no assistant messages AND no run_request
     // exists, an explicit model in the payload takes precedence.
+    const stateStore = new Map<string, unknown>();
     const iii = {
-      trigger: vi.fn(async ({ function_id }: { function_id: string; payload: unknown }) => {
+      trigger: vi.fn(async ({ function_id, payload }: { function_id: string; payload: unknown }) => {
+        const p = (payload ?? {}) as Record<string, unknown>;
         if (function_id === 'session-tree::messages') return { messages: [] };
         if (function_id === 'session-tree::compactions') return { entries: [] };
-        if (function_id === 'state::get') return null;
-        if (function_id === 'state::set') return { ok: true };
+        if (function_id === 'state::get') {
+          const v = stateStore.get(p['key'] as string);
+          return v !== undefined ? v : null;
+        }
+        if (function_id === 'state::set') {
+          const v = p['value'];
+          if (v === null || v === undefined) stateStore.delete(p['key'] as string);
+          else stateStore.set(p['key'] as string, v);
+          return { ok: true };
+        }
+        if (function_id === 'state::update') {
+          const key = p['key'] as string;
+          const ops = (p['ops'] ?? []) as Array<{ type: string; value?: unknown }>;
+          const oldValue = stateStore.has(key) ? stateStore.get(key) : null;
+          let newValue: unknown = oldValue;
+          for (const op of ops) {
+            if (op.type === 'set') newValue = op.value;
+          }
+          if (newValue === null || newValue === undefined) stateStore.delete(key);
+          else stateStore.set(key, newValue);
+          return { old_value: oldValue ?? null, new_value: newValue ?? null };
+        }
         return null;
       }),
       registerFunction: vi.fn(),

--- a/harness-node/tests/context-compaction/e2e/full-session.test.ts
+++ b/harness-node/tests/context-compaction/e2e/full-session.test.ts
@@ -117,6 +117,17 @@ function buildTestSdk(opts: {
       else stateStore.set(p.key, p.value);
       return { ok: true };
     }
+    if (fn === 'state::update') {
+      const p = (payload ?? {}) as { key: string; ops: Array<{ type: string; value?: unknown }> };
+      const oldValue = stateStore.has(p.key) ? stateStore.get(p.key) : null;
+      let newValue: unknown = oldValue;
+      for (const op of p.ops ?? []) {
+        if (op.type === 'set') newValue = op.value;
+      }
+      if (newValue === null || newValue === undefined) stateStore.delete(p.key);
+      else stateStore.set(p.key, newValue);
+      return { old_value: oldValue ?? null, new_value: newValue ?? null };
+    }
 
     // 2) models::get — return a small-context model so the 30-turn fixture overflows.
     if (fn === 'models::get') {

--- a/harness-node/tests/context-compaction/handler-sync.test.ts
+++ b/harness-node/tests/context-compaction/handler-sync.test.ts
@@ -33,6 +33,21 @@ function makeStubIii(triggerOverrides: Record<string, unknown> = {}): ISdk {
         }
         return { ok: true };
       }
+      if (function_id === 'state::update') {
+        const key = p.key as string;
+        const ops = (p.ops ?? []) as Array<{ type: string; value?: unknown }>;
+        const oldValue = stateStore.has(key) ? stateStore.get(key) : null;
+        let newValue: unknown = oldValue;
+        for (const op of ops) {
+          if (op.type === 'set') newValue = op.value;
+        }
+        if (newValue === null || newValue === undefined) {
+          stateStore.delete(key);
+        } else {
+          stateStore.set(key, newValue);
+        }
+        return { old_value: oldValue ?? null, new_value: newValue ?? null };
+      }
 
       return null;
     }),

--- a/harness-node/tests/context-compaction/integration/backward-compat.test.ts
+++ b/harness-node/tests/context-compaction/integration/backward-compat.test.ts
@@ -88,6 +88,20 @@ function buildBackwardCompatMock(opts: {
       }
       return { ok: true };
     }
+    if (function_id === 'state::update') {
+      const p = payload as { key: string; ops: Array<{ type: string; value?: unknown }> };
+      const oldValue = stateStore.has(p.key) ? stateStore.get(p.key) : null;
+      let newValue: unknown = oldValue;
+      for (const op of p.ops ?? []) {
+        if (op.type === 'set') newValue = op.value;
+      }
+      if (newValue === null || newValue === undefined) {
+        stateStore.delete(p.key);
+      } else {
+        stateStore.set(p.key, newValue);
+      }
+      return { old_value: oldValue ?? null, new_value: newValue ?? null };
+    }
     if (function_id.startsWith('provider::')) {
       // Capture the system_prompt sent to the summariser
       const systemPrompt = payload.system_prompt;

--- a/harness-node/tests/context-compaction/integration/flow-async.test.ts
+++ b/harness-node/tests/context-compaction/integration/flow-async.test.ts
@@ -99,6 +99,20 @@ function buildAsyncMock(opts: {
       }
       return { ok: true };
     }
+    if (function_id === 'state::update') {
+      const p = payload as { key: string; ops: Array<{ type: string; value?: unknown }> };
+      const oldValue = stateStore.has(p.key) ? stateStore.get(p.key) : null;
+      let newValue: unknown = oldValue;
+      for (const op of p.ops ?? []) {
+        if (op.type === 'set') newValue = op.value;
+      }
+      if (newValue === null || newValue === undefined) {
+        stateStore.delete(p.key);
+      } else {
+        stateStore.set(p.key, newValue);
+      }
+      return { old_value: oldValue ?? null, new_value: newValue ?? null };
+    }
     if (function_id.startsWith('provider::')) {
       if (channelCb) {
         channelCb(doneSummaryEvent);

--- a/harness-node/tests/context-compaction/integration/flow-sync.test.ts
+++ b/harness-node/tests/context-compaction/integration/flow-sync.test.ts
@@ -103,6 +103,20 @@ function buildSyncMock(opts: {
       }
       return { ok: true };
     }
+    if (function_id === 'state::update') {
+      const p = payload as { key: string; ops: Array<{ type: string; value?: unknown }> };
+      const oldValue = stateStore.has(p.key) ? stateStore.get(p.key) : null;
+      let newValue: unknown = oldValue;
+      for (const op of p.ops ?? []) {
+        if (op.type === 'set') newValue = op.value;
+      }
+      if (newValue === null || newValue === undefined) {
+        stateStore.delete(p.key);
+      } else {
+        stateStore.set(p.key, newValue);
+      }
+      return { old_value: oldValue ?? null, new_value: newValue ?? null };
+    }
     if (function_id.startsWith('provider::')) {
       if (channelCb) {
         channelCb(doneSummaryEvent);

--- a/harness-node/tests/context-compaction/lease.test.ts
+++ b/harness-node/tests/context-compaction/lease.test.ts
@@ -41,8 +41,8 @@ describe('lease helpers', () => {
 });
 
 // Minimal in-memory ISdk stub for lease integration tests.
-// stateGet returns the raw trigger response (the value itself, not wrapped).
-// stateSet stores payload.value at payload.key.
+// state::update is atomic by construction (Map ops are synchronous), which
+// matches what we need from iii-database in production.
 function makeStateIii() {
   const store = new Map<string, unknown>();
   const iii = {
@@ -60,6 +60,21 @@ function makeStateIii() {
           store.set(p['key'] as string, v);
         }
         return { ok: true };
+      }
+      if (function_id === 'state::update') {
+        const key = p['key'] as string;
+        const ops = (p['ops'] ?? []) as Array<{ type: string; value?: unknown }>;
+        const oldValue = store.has(key) ? store.get(key) : null;
+        let newValue: unknown = oldValue;
+        for (const op of ops) {
+          if (op.type === 'set') newValue = op.value;
+        }
+        if (newValue === null || newValue === undefined) {
+          store.delete(key);
+        } else {
+          store.set(key, newValue);
+        }
+        return { old_value: oldValue ?? null, new_value: newValue ?? null };
       }
       return null;
     }),
@@ -98,5 +113,158 @@ describe('acquireLeaseWithWait', () => {
     // Now acquireLeaseWithWait should give up quickly (50 ms timeout).
     const result = await acquireLeaseWithWait(iii, 'sid2', 'compaction', 50);
     expect(result).toBeNull();
+  });
+});
+
+// Adds artificial latency to BOTH state::set and state::update, mimicking
+// a real state store (iii-database over IPC, remote Redis). The key
+// invariant is that state::update remains atomic — read+write inside a
+// single async function tick — which is what iii-database guarantees.
+function makeRacyStateIii(writeLatencyMs: number) {
+  const store = new Map<string, unknown>();
+  const iii = {
+    trigger: vi.fn(async ({ function_id, payload }: { function_id: string; payload: unknown }) => {
+      const p = payload as Record<string, unknown>;
+      if (function_id === 'state::get') {
+        const v = store.get(p['key'] as string);
+        return v !== undefined ? v : null;
+      }
+      if (function_id === 'state::set') {
+        await new Promise((r) => setTimeout(r, writeLatencyMs));
+        const v = p['value'];
+        if (v === null || v === undefined) {
+          store.delete(p['key'] as string);
+        } else {
+          store.set(p['key'] as string, v);
+        }
+        return { ok: true };
+      }
+      if (function_id === 'state::update') {
+        await new Promise((r) => setTimeout(r, writeLatencyMs));
+        const key = p['key'] as string;
+        const ops = (p['ops'] ?? []) as Array<{ type: string; value?: unknown }>;
+        const oldValue = store.has(key) ? store.get(key) : null;
+        let newValue: unknown = oldValue;
+        for (const op of ops) {
+          if (op.type === 'set') newValue = op.value;
+        }
+        if (newValue === null || newValue === undefined) {
+          store.delete(key);
+        } else {
+          store.set(key, newValue);
+        }
+        return { old_value: oldValue ?? null, new_value: newValue ?? null };
+      }
+      return null;
+    }),
+  };
+  return { iii: iii as unknown as Parameters<typeof acquireLease>[0], store };
+}
+
+// Simulates a transient state-store outage: state::update fails (returns
+// null) while state::get still works. acquireLease must refuse to claim
+// the lease in this case — otherwise every concurrent caller becomes a
+// "winner" during the outage and the single-writer invariant breaks.
+function makeFailingUpdateIii() {
+  const store = new Map<string, unknown>();
+  const iii = {
+    trigger: vi.fn(async ({ function_id, payload }: { function_id: string; payload: unknown }) => {
+      const p = payload as Record<string, unknown>;
+      if (function_id === 'state::get') {
+        const v = store.get(p['key'] as string);
+        return v !== undefined ? v : null;
+      }
+      if (function_id === 'state::set') {
+        const v = p['value'];
+        if (v === null || v === undefined) {
+          store.delete(p['key'] as string);
+        } else {
+          store.set(p['key'] as string, v);
+        }
+        return { ok: true };
+      }
+      if (function_id === 'state::update') {
+        // Simulate the stateUpdate wrapper's error path: backend failed,
+        // wrapper swallowed and returned null.
+        return null;
+      }
+      return null;
+    }),
+  };
+  return { iii: iii as unknown as Parameters<typeof acquireLease>[0], store };
+}
+
+describe('acquireLease wire shape', () => {
+  it('sends state::update with path: "" (root) on the set op', async () => {
+    // Regression: the engine UpdateOp::Set requires a path field
+    // (FieldPath; "" = root). A previous version of the lease shipped
+    // ops without `path`, the engine failed to deserialize, the wrapper
+    // returned null, and every /compact bailed in production.
+    const captured: Array<{ type: string; path?: unknown; value?: unknown }> = [];
+    const iii = {
+      trigger: vi.fn(
+        async ({ function_id, payload }: { function_id: string; payload: unknown }) => {
+          const p = payload as Record<string, unknown>;
+          if (function_id === 'state::get') return null;
+          if (function_id === 'state::update') {
+            const ops = (p['ops'] ?? []) as Array<{
+              type: string;
+              path?: unknown;
+              value?: unknown;
+            }>;
+            for (const op of ops) captured.push(op);
+            return { old_value: null, new_value: { dummy: true } };
+          }
+          return null;
+        },
+      ),
+    };
+    const nonce = await acquireLease(
+      iii as unknown as Parameters<typeof acquireLease>[0],
+      'wireshape-sid',
+      'compaction',
+    );
+    expect(nonce).not.toBeNull();
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.type).toBe('set');
+    expect(captured[0]?.path).toBe('');
+    expect(captured[0]?.value).toMatchObject({ nonce, ts: expect.any(Number) });
+  });
+});
+
+describe('acquireLease state-store failures', () => {
+  it('returns null when state::update fails (does not falsely claim the lease)', async () => {
+    const { iii } = makeFailingUpdateIii();
+    const got = await acquireLease(iii, 'failsid', 'compaction');
+    expect(got).toBeNull();
+  });
+
+  it('still returns null for every concurrent caller during an outage', async () => {
+    const { iii } = makeFailingUpdateIii();
+    const results = await Promise.all(
+      Array.from({ length: 4 }, () => acquireLease(iii, 'failsid-many', 'compaction')),
+    );
+    expect(results.every((r) => r === null)).toBe(true);
+  });
+});
+
+describe('acquireLease concurrency', () => {
+  it('lets exactly one of two concurrent acquirers win even with write latency', async () => {
+    const { iii } = makeRacyStateIii(10);
+    const results = await Promise.all([
+      acquireLease(iii, 'race-sid', 'compaction'),
+      acquireLease(iii, 'race-sid', 'compaction'),
+    ]);
+    const winners = results.filter((r) => r !== null);
+    expect(winners.length).toBe(1);
+  });
+
+  it('lets exactly one of many concurrent acquirers win', async () => {
+    const { iii } = makeRacyStateIii(10);
+    const results = await Promise.all(
+      Array.from({ length: 8 }, () => acquireLease(iii, 'race-sid-multi', 'compaction')),
+    );
+    const winners = results.filter((r) => r !== null);
+    expect(winners.length).toBe(1);
   });
 });

--- a/harness-node/tests/context-compaction/summarize.test.ts
+++ b/harness-node/tests/context-compaction/summarize.test.ts
@@ -288,6 +288,121 @@ describe('summarizeAndAppend async mode', () => {
       expect(result.reason).toContain('channel unavailable');
     }
   });
+
+  it('retries streamAndCollect once and succeeds when the first attempt fails', async () => {
+    // Transient provider failures (429, network blip, 5xx) should not
+    // surface to /compact when a single retry would succeed.
+    const { iii } = buildMock();
+    let createChannelCalls = 0;
+    const realCreateChannel = (
+      iii as unknown as { createChannel: () => Promise<unknown> }
+    ).createChannel;
+    (iii as unknown as { createChannel: () => Promise<unknown> }).createChannel = vi
+      .fn(async () => {
+        createChannelCalls += 1;
+        if (createChannelCalls === 1) {
+          throw new Error('transient provider failure');
+        }
+        return realCreateChannel();
+      });
+
+    const result = await summarizeAndAppend(iii, 'sess-retry', { mode: 'async' }, testModel);
+    expect(createChannelCalls).toBe(2);
+    expect(typeof result === 'object' && 'kind' in result ? result.kind : result).toBe('ok');
+  }, 10_000);
+
+  it('returns "compact" when both stream attempts fail', async () => {
+    // Generic permanent failure (no auth/4xx markers) — still retries once
+    // then surfaces the failure.
+    const { iii } = buildMock();
+    let createChannelCalls = 0;
+    (iii as unknown as { createChannel: () => Promise<unknown> }).createChannel = vi
+      .fn(async () => {
+        createChannelCalls += 1;
+        throw new Error('permanent provider failure');
+      });
+
+    const result = await summarizeAndAppend(iii, 'sess-fail-twice', { mode: 'async' }, testModel);
+    expect(createChannelCalls).toBe(2);
+    expect(typeof result === 'object' && 'kind' in result ? result.kind : result).toBe('compact');
+    if (typeof result === 'object' && 'kind' in result && result.kind === 'compact') {
+      expect(result.reason).toContain('permanent provider failure');
+    }
+  }, 10_000);
+
+  it('skips retry on non-retryable errors (401/auth/malformed)', async () => {
+    // Auth and 4xx errors won't fix on retry. Skip the retry so the
+    // compaction lease releases ~1s sooner.
+    const { iii } = buildMock();
+    let createChannelCalls = 0;
+    (iii as unknown as { createChannel: () => Promise<unknown> }).createChannel = vi
+      .fn(async () => {
+        createChannelCalls += 1;
+        throw new Error('401 unauthorized: invalid_api_key');
+      });
+
+    const result = await summarizeAndAppend(iii, 'sess-auth-fail', { mode: 'async' }, testModel);
+    expect(createChannelCalls).toBe(1); // no retry
+    expect(typeof result === 'object' && 'kind' in result ? result.kind : result).toBe('compact');
+    if (typeof result === 'object' && 'kind' in result && result.kind === 'compact') {
+      expect(result.reason).toContain('401');
+    }
+  });
+
+  it('returns "compact" when the provider stream emits an error terminal event', async () => {
+    // Regression: a not_found_error from Anthropic (e.g. wrong provider/model
+    // combo) used to be silently stored as the compaction summary text,
+    // showing "COMPACTED · N TOKENS" in the UI with the error JSON as
+    // the summary. The error terminal must surface as a failure instead.
+    const errorEvent = JSON.stringify({
+      type: 'error',
+      error: {
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: '{"type":"error","error":{"type":"not_found_error","message":"model: gpt-5-mini"}}',
+          },
+        ],
+        stop_reason: 'end',
+        error_kind: 'NotFound',
+        error_message: 'model: gpt-5-mini',
+        model: 'gpt-5-mini',
+        provider: 'anthropic',
+        timestamp: 0,
+      },
+    });
+    const { iii } = buildMock(() => errorEvent);
+
+    const result = await summarizeAndAppend(iii, 'sess-provider-error', { mode: 'async' }, testModel);
+    expect(typeof result === 'object' && 'kind' in result ? result.kind : result).toBe('compact');
+    if (typeof result === 'object' && 'kind' in result && result.kind === 'compact') {
+      expect(result.reason.toLowerCase()).toMatch(/not.found|gpt-5-mini/);
+    }
+  });
+
+  it('routes the summariser to the session provider when env is unset', async () => {
+    // Regression: summarizerProvider() default was 'anthropic'. Sessions on
+    // OpenAI got Anthropic stream + OpenAI model → not_found_error.
+    let calledFunctionId: string | null = null;
+    const { iii } = buildMock();
+    const wrapped = iii as unknown as { trigger: ReturnType<typeof vi.fn> };
+    const originalTrigger = wrapped.trigger;
+    wrapped.trigger = vi.fn(async (req: MockTriggerReq) => {
+      if (req.function_id.startsWith('provider::')) {
+        calledFunctionId = req.function_id;
+      }
+      return originalTrigger(req);
+    });
+
+    const openAiModel = {
+      providerID: 'openai',
+      modelID: 'gpt-5-mini',
+      modelLimit: { context: 200_000, input: 200_000, output: 4_096 },
+    };
+    await summarizeAndAppend(iii, 'sess-openai', { mode: 'async' }, openAiModel);
+    expect(calledFunctionId).toBe('provider::openai::stream');
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Sweep of the `harness-node` context-compaction subsystem closing seven distinct failure modes uncovered while debugging `/compact` in the console.

### Bugs fixed

- **Lease race.** Swapped the read-then-write nonce-readback dance in `lease.ts` for an atomic `state::update` so two concurrent acquirers can never both win. Includes the `path: ''` field the engine's `UpdateOp::Set` requires (a previous draft of this branch shipped `state::update` without it and broke `/compact` in production with `missing field 'path'` deserialize errors).
- **Lease silent-success on backend failure.** `acquireLease` now returns `null` when `state::update` returns `null` (the wrapper's error sentinel), instead of falsely claiming the nonce.
- **Busy timeout.** `COMPACT_BUSY_TIMEOUT_MS` raised from `3_000` to `30_000`; the summariser stream alone routinely takes longer than 3s.
- **`session-tree::messages` timeout.** 10s → 30s for the sync path.
- **"Session too small" UX bug.** `compact_session` was extracting a replay target meant only for the orchestrator's async path, so a user-initiated `/compact` on a single-turn session looked empty. Now passes `last_user_message_id: ''` to skip replay.
- **Provider misrouting.** Summariser defaulted to `'anthropic'` even when the session ran on OpenAI, causing Anthropic to reject OpenAI model IDs (e.g. `gpt-5-mini`) with `not_found_error`. Defaults to the session's `providerID` instead.
- **Silent error → garbage summary.** `streamAndCollect` was returning the provider's error `AssistantMessage` as a "successful" summary, so the error JSON ended up written as the compaction text. Now throws on the terminal `'error'` event so `summarizeAndAppend`'s retry/catch handles it properly.
- **`stream-collect` single-iteration loop.** The polling loop had an unconditional `break`; a slow IPC hop after `trigger` returned could surface as `summariser stream returned without a terminal event`. Replaced with a 1s polling deadline.
- **Fallback model limit.** `register.ts` now ships a `FALLBACK_MODEL_LIMIT` for the case where all three resolvers (payload / session-tree / `state::get`) miss, instead of throwing.

### Console integration

- `compactSession` accepts an optional `contextWindow` so the UI can pass `model.limit.context` straight through and let the server skip the `models::get` lookup. Sends `output: 4096` (matching the server fallback) instead of `0`.
- A failed `session-tree::reconcile` sets `reconcileFailed` and surfaces a friendlier "could not sync session history to server, retry /compact" message instead of generic `empty`.
- Restored the `import.meta.env.DEV` gate on the reconcile-warn `console.warn`.

### Tests

- New regression coverage: lease race with simulated write latency (8 concurrent acquirers, exactly one wins); `state::update` outage path (no false claims); wire-shape assertion that catches a missing `path` field; provider routing default; error-terminal throw; single-user-turn no-replay behaviour.
- 444/444 vitest, tsc clean on both harness-node and console/web.

### Known follow-ups

- `releaseLease` and the `acquireLease` restore step still use read-then-conditional-set patterns. Closing those races needs a CAS-like primitive in iii-database (`delete-if-matches`); any in-place workaround moves the window rather than closing it. Worth filing against iii-database.
- Test-stub `state::update` mocks across the suite don't validate the engine schema (which is how the missing `path` slipped past CI). Shared strict mock helper would help.

## Test plan

- [ ] `/compact` on an active OpenAI session compacts cleanly (no `not_found_error`, no engine `missing field 'path'` warnings in logs).
- [ ] `/compact` on a single-turn session shows the friendlier "too small to summarise" UX text instead of an empty marker.
- [ ] Two concurrent `/compact` clicks: exactly one succeeds, the other gets the "another compaction is in progress" message.
- [ ] An induced provider error mid-stream surfaces as `compact failed: summariser stream error: ...` instead of writing the error JSON as the summary text.
- [ ] `pnpm vitest run` → 444/444 pass.
- [ ] `pnpm exec tsc --noEmit` in `harness-node/` and `console/web/` → clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context window awareness to session compaction for improved model optimization.

* **Bug Fixes**
  * Enhanced guidance text for "busy" and "empty" compaction status messages.
  * Improved session compaction error handling with retry logic for transient failures.
  * Increased compaction operation timeout from 3s to 30s to prevent false "busy" signals.
  * Strengthened lease acquisition mechanism to prevent concurrent claim conflicts.

* **Documentation**
  * Updated compaction flow documentation to reflect new execution model and timeout defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/workers/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->