### PR TITLE
fix(workflows): prevent cascading skips in matrix builds due to skipp…

### DIFF
--- a/.github/workflows/_rust-binary.yml
+++ b/.github/workflows/_rust-binary.yml
@@ -184,6 +184,12 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     needs: [pre-build, matrix, web-build]
+    # `web-build` is gated on `inputs.web_bundle`, so it is skipped for any
+    # worker without a `web/package.json` (database, shell, mcp, …). GitHub
+    # Actions' default `success()` gate treats a skipped need as "not
+    # succeeded", which would cascade-skip every matrix shard and leak
+    # downstream as an empty GitHub Release — see #66 (database/v0.1.0).
+    if: ${{ !failure() && !cancelled() }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write


### PR DESCRIPTION
…ed web-build job

Updated the build job condition in the Rust binary workflow to ensure that skipped jobs do not lead to cascading failures in matrix builds. This change addresses an issue where skipped jobs could result in empty GitHub Releases, as noted in issue #66.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where GitHub releases could be skipped or remain incomplete when certain build dependencies were disabled, ensuring releases are generated reliably in all scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/workers/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->