### PR TITLE
feat(harness-node): add Kimi (Moonshot) provider worker

### DIFF
--- a/harness-node/README.md
+++ b/harness-node/README.md
@@ -22,6 +22,7 @@ alongside `harness-node` over the iii bus.
 | `src/models-catalog/` | `models::list`, `models::get`, `models::supports` | Static model metadata. |
 | `src/provider-anthropic/` | `provider::anthropic::stream`, `provider::anthropic::complete` | Anthropic SSE → channel writer. |
 | `src/provider-openai/` | `provider::openai::stream`, `provider::openai::complete` | OpenAI SSE → channel writer. |
+| `src/provider-kimi/` | `provider::kimi::stream`, `provider::kimi::complete` | Kimi (Moonshot) Chat Completions SSE → channel writer. |
 | `src/context-compaction/` | (none — pure side-car on `agent::events`) | Optional out-of-band session-history compactor. |
 
 ## Quickstart
@@ -39,6 +40,7 @@ node dist/auth-credentials/main.js      --url ws://127.0.0.1:49134 --config ./co
 node dist/models-catalog/main.js        --url ws://127.0.0.1:49134
 node dist/provider-anthropic/main.js    --url ws://127.0.0.1:49134 --config ./config.yaml
 node dist/provider-openai/main.js       --url ws://127.0.0.1:49134 --config ./config.yaml
+node dist/provider-kimi/main.js         --url ws://127.0.0.1:49134 --config ./config.yaml
 node dist/llm-budget/main.js            --url ws://127.0.0.1:49134
 # Optional side-car:
 node dist/context-compaction/main.js    --url ws://127.0.0.1:49134

--- a/harness-node/config.yaml
+++ b/harness-node/config.yaml
@@ -35,3 +35,8 @@ provider_anthropic:
 provider_openai:
   default_max_tokens: 8192
   default_api_url: "https://api.openai.com/v1/chat/completions"
+
+# provider-kimi
+provider_kimi:
+  default_max_tokens: 8192
+  default_api_url: "https://api.moonshot.ai/v1/chat/completions"

--- a/harness-node/docs/architecture.md
+++ b/harness-node/docs/architecture.md
@@ -28,6 +28,7 @@ workers.
 | models-catalog | [src/models-catalog/](harness-node/src/models-catalog/) | Static model-capability catalogue (state-first, embedded fallback). | [workers/models-catalog.md](harness-node/docs/workers/models-catalog.md) |
 | provider-anthropic | [src/provider-anthropic/](harness-node/src/provider-anthropic/) | Anthropic Messages API SSE → channel writer. | [workers/provider-anthropic.md](harness-node/docs/workers/provider-anthropic.md) |
 | provider-openai | [src/provider-openai/](harness-node/src/provider-openai/) | OpenAI Chat Completions SSE → channel writer. | [workers/provider-openai.md](harness-node/docs/workers/provider-openai.md) |
+| provider-kimi | [src/provider-kimi/](harness-node/src/provider-kimi/) | Kimi Chat Completions SSE → channel writer. | [workers/provider-kimi.md](harness-node/docs/workers/provider-kimi.md) |
 | context-compaction | [src/context-compaction/](harness-node/src/context-compaction/) | Optional `agent::events` side-car that compacts session history when running token count crosses a threshold. | [workers/context-compaction.md](harness-node/docs/workers/context-compaction.md) |
 
 ## System diagram
@@ -47,6 +48,7 @@ flowchart LR
     models[models-catalog]
     provAnth[provider-anthropic]
     provOAI[provider-openai]
+    provKimi[provider-kimi]
     compact[context-compaction]
   end
 
@@ -62,6 +64,7 @@ flowchart LR
 
   turnOrch -- "provider::*::stream" --> provAnth
   turnOrch -- "provider::*::stream" --> provOAI
+  turnOrch -- "provider::*::stream" --> provKimi
   turnOrch -- "consultBefore: policy::check_permissions" --> harness
   turnOrch -- "agent::call → hook-fanout::publish_collect (after-hook)" --> hook
   turnOrch -- "session-tree::* mirror" --> session
@@ -74,6 +77,7 @@ flowchart LR
 
   provAnth -- "auth::get_token" --> auth
   provOAI -- "auth::get_token" --> auth
+  provKimi -- "auth::get_token" --> auth
 
   state -- "agent::events stream" --> harness
   state -- "agent::events stream" --> compact
@@ -209,12 +213,15 @@ flowchart TD
   session --> turnOrch
   auth[auth-credentials] --> provAnth[provider-anthropic]
   auth --> provOAI[provider-openai]
+  auth --> provKimi[provider-kimi]
   provAnth --> turnOrch
   provOAI --> turnOrch
+  provKimi --> turnOrch
   hook[hook-fanout] --> approval
   session --> compact[context-compaction]
   provAnth --> compact
   provOAI --> compact
+  provKimi --> compact
   budget[llm-budget]
 ```
 

--- a/harness-node/docs/workers/context-compaction.md
+++ b/harness-node/docs/workers/context-compaction.md
@@ -218,9 +218,11 @@ All knobs are env-driven; no `config.yaml` fields are read.
 | `COMPACT_TOOL_OUTPUT_MAX_CHARS` | `2000` | Per-output character cap applied before sending to the summariser. |
 | `COMPACT_BUSY_TIMEOUT_MS` | `30000` | Max ms `compact_now` / `compact_session` waits for the compaction lease before returning `{ status: 'busy' }`. Sized to cover a typical summariser stream (10–30s) so user-initiated `/compact` doesn't race the async TurnEnd path. |
 | `COMPACT_PRUNE_PROTECTED_TOOLS` | _(empty)_ | Comma-separated function IDs whose outputs are never pruned. |
-| `COMPACT_SUMMARIZER_PROVIDER` | `anthropic` | `anthropic` or `openai` — picks the streaming provider. |
-| `COMPACT_SUMMARIZER_MODEL` | _(model in use)_ | Model id passed to the provider stream. Defaults to the same model as the session. |
 | `COMPACT_TRIGGER_TOKENS` | _(deprecated)_ | If set, caps `usable()` to this value. Preserves pre-v2 behaviour. Prefer `COMPACT_RESERVED_TOKENS` instead. |
+
+The summariser provider and model are always inherited from the session's
+own selection. Routing goes through `turn-orchestrator/provider-router`,
+so adding a provider there automatically covers `/compact`.
 
 ## State keys
 

--- a/harness-node/docs/workers/provider-kimi.md
+++ b/harness-node/docs/workers/provider-kimi.md
@@ -1,0 +1,75 @@
+# provider-kimi
+
+Kimi (Moonshot) Chat Completions streaming provider; exposes
+`provider::kimi::stream` and `provider::kimi::complete` on the iii bus.
+
+## Purpose
+
+The iii-side bridge to Moonshot's Chat Completions API. It pulls a
+credential from the auth worker (`auth::get_token`, provider `kimi`),
+issues a streaming `chat/completions` request, parses the SSE response
+into `AssistantMessageEvent` frames, and forwards each frame to the
+caller-supplied channel. Mirrors the shape of
+[provider-openai](harness-node/docs/workers/provider-openai.md) so the
+orchestrator can swap providers without touching the FSM.
+
+`provider::kimi::stream` is the modern channel-writer surface;
+`provider::kimi::complete` is the legacy drain-and-return helper.
+
+Tool calls are translated to/from the OpenAI function/tool wire format in
+[src/provider-kimi/wire-tools.ts](harness-node/src/provider-kimi/wire-tools.ts);
+message translation (text, tool-call, tool-result, system) lives in
+[src/provider-kimi/wire-messages.ts](harness-node/src/provider-kimi/wire-messages.ts).
+
+## Registered functions
+
+- `provider::kimi::stream` — Stream a single assistant turn from Kimi
+  Chat Completions into the caller-supplied channel.
+- `provider::kimi::complete` — Legacy: drain a streamed Kimi
+  chat-completion and return the final `AssistantMessage`.
+
+## Triggers
+
+None.
+
+## State keys
+
+None — the worker is stateless.
+
+## Configuration
+
+From the `provider_kimi` section of
+[config.yaml](harness-node/config.yaml):
+
+- `default_max_tokens` (default `8192`) — upper bound for the request's
+  `max_completion_tokens` field when the caller omits it.
+- `default_api_url` (default
+  `https://api.moonshot.ai/v1/chat/completions`) — endpoint for outbound
+  calls. Override to target Moonshot's China endpoint
+  (`https://api.moonshot.cn/v1/chat/completions`) or any Chat-Completions
+  compatible gateway; `auth-credentials` looks up the credential by the
+  `provider` field, so adjust the gateway and the credential together.
+
+## Dependencies
+
+From
+[src/provider-kimi/iii.worker.yaml](harness-node/src/provider-kimi/iii.worker.yaml):
+`auth-credentials ^0.2.0`. The worker also calls the SDK-provided
+`ChannelWriter` injected into the `writer_ref` field of the stream input.
+
+## Source layout
+
+| File | Purpose |
+|---|---|
+| [src/provider-kimi/main.ts](harness-node/src/provider-kimi/main.ts) | Binary entry point (`iii-provider-kimi`). |
+| [src/provider-kimi/register.ts](harness-node/src/provider-kimi/register.ts) | Registers both functions. |
+| [src/provider-kimi/config.ts](harness-node/src/provider-kimi/config.ts) | Loads the `provider_kimi` section. |
+| [src/provider-kimi/types.ts](harness-node/src/provider-kimi/types.ts) | `ChatCompletionsConfig` + `configFromCredential` builder. |
+| [src/provider-kimi/auth.ts](harness-node/src/provider-kimi/auth.ts) | `fetchCredential` (calls `auth::get_token`) + `buildConfig`. |
+| [src/provider-kimi/stream.ts](harness-node/src/provider-kimi/stream.ts) | `streamKimi` async generator: builds the request body, fetches SSE, yields `AssistantMessageEvent`s. |
+| [src/provider-kimi/sse.ts](harness-node/src/provider-kimi/sse.ts) | SSE parser. |
+| [src/provider-kimi/wire-messages.ts](harness-node/src/provider-kimi/wire-messages.ts) | `AgentMessage[]` → Kimi `messages` translation. |
+| [src/provider-kimi/wire-tools.ts](harness-node/src/provider-kimi/wire-tools.ts) | `AgentFunction[]` → Kimi `tools` translation. |
+| [src/provider-kimi/stream-fn.ts](harness-node/src/provider-kimi/stream-fn.ts) | `provider::kimi::stream` handler. |
+| [src/provider-kimi/complete.ts](harness-node/src/provider-kimi/complete.ts) | `provider::kimi::complete` handler (legacy drain-and-return). |
+| [src/provider-kimi/iii.worker.yaml](harness-node/src/provider-kimi/iii.worker.yaml) | Worker manifest. |

--- a/harness-node/package.json
+++ b/harness-node/package.json
@@ -30,6 +30,7 @@
     "dev:models-catalog": "tsx src/models-catalog/main.ts",
     "dev:provider-anthropic": "tsx src/provider-anthropic/main.ts",
     "dev:provider-openai": "tsx src/provider-openai/main.ts",
+    "dev:provider-kimi": "tsx src/provider-kimi/main.ts",
     "dev:context-compaction": "tsx src/context-compaction/main.ts"
   },
   "bin": {
@@ -44,6 +45,7 @@
     "iii-models-catalog": "./dist/models-catalog/main.js",
     "iii-provider-anthropic": "./dist/provider-anthropic/main.js",
     "iii-provider-openai": "./dist/provider-openai/main.js",
+    "iii-provider-kimi": "./dist/provider-kimi/main.js",
     "iii-context-compaction": "./dist/context-compaction/main.js"
   },
   "dependencies": {

--- a/harness-node/src/auth-credentials/types.ts
+++ b/harness-node/src/auth-credentials/types.ts
@@ -58,6 +58,7 @@ export const ENV_VAR_MAP: ReadonlyArray<readonly [string, string]> = [
   ['minimax', 'MINIMAX_API_KEY'],
   ['huggingface', 'HF_TOKEN'],
   ['fireworks', 'FIREWORKS_API_KEY'],
+  ['kimi', 'MOONSHOT_API_KEY'],
   ['kimi-coding', 'MOONSHOT_API_KEY'],
   ['opencode-zen', 'OPENCODE_ZEN_API_KEY'],
   ['opencode-go', 'OPENCODE_GO_API_KEY'],

--- a/harness-node/src/context-compaction/config.ts
+++ b/harness-node/src/context-compaction/config.ts
@@ -59,14 +59,6 @@ export function pruneProtectedTools(): string[] {
     .filter(Boolean);
 }
 
-export function summarizerProvider(): string | undefined {
-  return process.env.COMPACT_SUMMARIZER_PROVIDER || undefined;
-}
-
-export function summarizerModel(): string | undefined {
-  return process.env.COMPACT_SUMMARIZER_MODEL || undefined;
-}
-
 // Deprecated. Hard upper bound on usable() to keep existing deployments
 // from regressing. One-shot warning on first read.
 let deprecatedTriggerTokensWarned = false;

--- a/harness-node/src/context-compaction/summarize.ts
+++ b/harness-node/src/context-compaction/summarize.ts
@@ -1,13 +1,8 @@
 import type { ISdk } from '../runtime/iii.js';
 import { logger } from '../runtime/otel.js';
+import { decide, targetFunctionId } from '../turn-orchestrator/provider-router.js';
 import type { AgentMessage, AssistantMessage } from '../types/agent-message.js';
-import {
-  preserveRecentTokensOverride,
-  summarizerModel,
-  summarizerProvider,
-  tailTurns,
-  toolOutputMaxChars,
-} from './config.js';
+import { preserveRecentTokensOverride, tailTurns, toolOutputMaxChars } from './config.js';
 import { stampLastCompaction } from './lease.js';
 import { type ModelLimit, preserveRecentBudget } from './overflow.js';
 import {
@@ -46,7 +41,11 @@ export type SummarizeOutcome = SummarizeOk | SummarizeFailure | 'empty';
 export function isRetryableStreamError(err: unknown): boolean {
   if (!(err instanceof Error)) return true;
   const msg = err.message.toLowerCase();
-  if (/\b(40[01345]|auth|unauthorized|forbidden|invalid[_ ]?(api[_ ]?key|key|request)|malformed)\b/.test(msg)) {
+  if (
+    /\b(40[01345]|auth|unauthorized|forbidden|invalid[_ ]?(api[_ ]?key|key|request)|malformed)\b/.test(
+      msg,
+    )
+  ) {
     return false;
   }
   return true;
@@ -163,13 +162,12 @@ export async function summarizeAndAppend(
   const systemPrompt = buildPrompt({ previousSummary, context: [] });
   const userPrompt = renderUserPrompt(stripped);
 
-  // Default to the session's provider, NOT a hardcoded 'anthropic'.
-  // Otherwise an OpenAI session ends up calling Anthropic with an OpenAI
-  // model id (e.g. gpt-5-mini) and the provider returns not_found_error.
-  const providerName = summarizerProvider() ?? model.providerID;
-  const summariserId =
-    providerName === 'openai' ? 'provider::openai::stream' : 'provider::anthropic::stream';
-  const modelId = summarizerModel() ?? model.modelID;
+  // Always use the session's own provider/model; route through the
+  // canonical provider-router so adding a provider covers /compact too.
+  const summariserId = targetFunctionId(
+    decide({ provider: model.providerID, model: model.modelID }),
+  );
+  const modelId = model.modelID;
 
   // One 250ms retry for transient failures (429/5xx/network). Permanent
   // failures (auth, malformed request) skip the retry to release the lease

--- a/harness-node/src/index.ts
+++ b/harness-node/src/index.ts
@@ -16,6 +16,7 @@ import { register as registerHookFanout } from './hook-fanout/register.js';
 import { register as registerLlmBudget } from './llm-budget/register.js';
 import { register as registerModelsCatalog } from './models-catalog/register.js';
 import { register as registerProviderAnthropic } from './provider-anthropic/register.js';
+import { register as registerProviderKimi } from './provider-kimi/register.js';
 import { register as registerProviderOpenai } from './provider-openai/register.js';
 import { logger } from './runtime/otel.js';
 import {
@@ -81,6 +82,12 @@ const WORKERS: readonly WorkerDefinition[] = [
     description:
       'OpenAI Chat Completions streaming provider on the iii bus (provider::openai::stream + ::complete).',
     register: (iii, ctx) => registerProviderOpenai(iii, ctx),
+  },
+  {
+    name: 'provider-kimi',
+    description:
+      'Kimi (Moonshot) Chat Completions streaming provider on the iii bus (provider::kimi::stream + ::complete).',
+    register: (iii, ctx) => registerProviderKimi(iii, ctx),
   },
   {
     name: 'llm-budget',

--- a/harness-node/src/models-catalog/models.json
+++ b/harness-node/src/models-catalog/models.json
@@ -139,6 +139,34 @@
       "supports_vision": false,
       "supports_cache": false,
       "transports": ["sse"]
+    },
+    {
+      "id": "kimi-k2.6",
+      "provider": "kimi",
+      "api": "openai-completions",
+      "display_name": "Kimi K2.6",
+      "context_window": 256000,
+      "max_output_tokens": 16384,
+      "supports_thinking": true,
+      "supports_xhigh": false,
+      "supports_tools": true,
+      "supports_vision": true,
+      "supports_cache": true,
+      "transports": ["sse"]
+    },
+    {
+      "id": "kimi-k2.5",
+      "provider": "kimi",
+      "api": "openai-completions",
+      "display_name": "Kimi K2.5",
+      "context_window": 256000,
+      "max_output_tokens": 16384,
+      "supports_thinking": true,
+      "supports_xhigh": false,
+      "supports_tools": true,
+      "supports_vision": true,
+      "supports_cache": true,
+      "transports": ["sse"]
     }
   ]
 }

--- a/harness-node/src/provider-kimi/auth.ts
+++ b/harness-node/src/provider-kimi/auth.ts
@@ -1,0 +1,40 @@
+import type { Credential } from '../auth-credentials/types.js';
+import type { ISdk } from '../runtime/iii.js';
+import type { WorkerConfig } from './config.js';
+import { type ChatCompletionsConfig, configFromCredential } from './types.js';
+
+// Look up the credential under `kimi-coding`. The compiled Rust
+// auth-credentials worker (the live handler on most engines today) maps
+// `kimi-coding → MOONSHOT_API_KEY` but does not know the bare `kimi` slug
+// our node port added. `kimi-coding` is the portable slug; the user-facing
+// provider name on the AssistantMessage stays `kimi` (see buildConfig).
+const CREDENTIAL_PROVIDER_SLUG = 'kimi-coding';
+
+export async function fetchCredential(iii: ISdk): Promise<Credential> {
+  const cred = await iii.trigger<unknown, Credential | null>({
+    function_id: 'auth::get_token',
+    payload: { provider: CREDENTIAL_PROVIDER_SLUG },
+    timeoutMs: 5_000,
+  });
+  if (!cred || typeof cred !== 'object' || !('type' in cred)) {
+    throw new Error(
+      `auth::get_token returned no credential for provider=${CREDENTIAL_PROVIDER_SLUG} (set MOONSHOT_API_KEY)`,
+    );
+  }
+  return cred;
+}
+
+export async function buildConfig(
+  iii: ISdk,
+  worker: WorkerConfig,
+  model: string,
+): Promise<ChatCompletionsConfig> {
+  const cred = await fetchCredential(iii);
+  return configFromCredential(
+    worker.default_api_url,
+    'kimi',
+    model,
+    cred,
+    worker.default_max_tokens,
+  );
+}

--- a/harness-node/src/provider-kimi/complete.ts
+++ b/harness-node/src/provider-kimi/complete.ts
@@ -1,0 +1,26 @@
+import { requireString } from '../runtime/handler.js';
+import type { ISdk } from '../runtime/iii.js';
+import type { AgentMessage } from '../types/agent-message.js';
+import type { AgentFunction } from '../types/function.js';
+import { buildConfig } from './auth.js';
+import type { WorkerConfig } from './config.js';
+import { collect, streamKimi } from './stream.js';
+
+export function register(iii: ISdk, worker: WorkerConfig): void {
+  iii.registerFunction(
+    'provider::kimi::complete',
+    async (payload: unknown) => {
+      const obj = (payload ?? {}) as Record<string, unknown>;
+      const model = requireString(obj, 'model');
+      const system_prompt = typeof obj.system_prompt === 'string' ? obj.system_prompt : '';
+      const messages = Array.isArray(obj.messages) ? (obj.messages as AgentMessage[]) : [];
+      const tools = Array.isArray(obj.tools) ? (obj.tools as AgentFunction[]) : [];
+      const cfg = await buildConfig(iii, worker, model);
+      return await collect(streamKimi({ cfg, system_prompt, messages, tools }));
+    },
+    {
+      description:
+        'Legacy: drain a streamed Kimi chat-completion and return the final AssistantMessage.',
+    },
+  );
+}

--- a/harness-node/src/provider-kimi/config.ts
+++ b/harness-node/src/provider-kimi/config.ts
@@ -1,0 +1,16 @@
+import { getNumber, getSection, getString } from '../runtime/config.js';
+
+export type WorkerConfig = {
+  default_max_tokens: number;
+  default_api_url: string;
+};
+
+export const DEFAULT_API_URL = 'https://api.moonshot.ai/v1/chat/completions';
+
+export function loadWorkerConfig(cfg: Record<string, unknown>): WorkerConfig {
+  const section = getSection(cfg, 'provider_kimi');
+  return {
+    default_max_tokens: getNumber(section, 'default_max_tokens', 8192),
+    default_api_url: getString(section, 'default_api_url', DEFAULT_API_URL),
+  };
+}

--- a/harness-node/src/provider-kimi/iii.worker.yaml
+++ b/harness-node/src/provider-kimi/iii.worker.yaml
@@ -1,0 +1,17 @@
+iii: v1
+name: provider-kimi
+language: node
+deploy: binary
+manifest: package.json
+bin: iii-provider-kimi
+description: Kimi (Moonshot) Chat Completions streaming provider; exposes provider::kimi::stream and provider::kimi::complete on the iii bus.
+
+runtime:
+  kind: node
+
+scripts:
+  install: pnpm install
+  start: node ./dist/provider-kimi/main.js --config ./config.yaml
+
+dependencies:
+  auth-credentials: "^0.2.0"

--- a/harness-node/src/provider-kimi/main.ts
+++ b/harness-node/src/provider-kimi/main.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import { bootstrapWorker } from '../runtime/worker.js';
+import { register } from './register.js';
+
+await bootstrapWorker({
+  name: 'provider-kimi',
+  description:
+    'Kimi (Moonshot) Chat Completions streaming provider on the iii bus (provider::kimi::stream + ::complete).',
+  register: (iii, ctx) => register(iii, ctx),
+});

--- a/harness-node/src/provider-kimi/register.ts
+++ b/harness-node/src/provider-kimi/register.ts
@@ -1,0 +1,12 @@
+import { loadConfig } from '../runtime/config.js';
+import type { ISdk } from '../runtime/iii.js';
+import { register as registerComplete } from './complete.js';
+import { loadWorkerConfig } from './config.js';
+import { register as registerStream } from './stream-fn.js';
+
+export async function register(iii: ISdk, ctx: { configPath: string }): Promise<void> {
+  const cfg = await loadConfig(ctx.configPath);
+  const worker = loadWorkerConfig(cfg);
+  registerComplete(iii, worker);
+  registerStream(iii, worker);
+}

--- a/harness-node/src/provider-kimi/sse.ts
+++ b/harness-node/src/provider-kimi/sse.ts
@@ -1,0 +1,169 @@
+// Kept separate from provider-openai so Moonshot-specific extensions
+// (e.g. partial_mode) can land without coupling the two providers.
+
+import type { AssistantMessage } from '../types/agent-message.js';
+import type { ContentBlock } from '../types/content.js';
+import type { AssistantMessageEvent, ErrorKind, StopReason, Usage } from '../types/stream-event.js';
+
+type PartialToolCall = { id: string; function_id: string; args_json: string };
+
+export type PartialState = {
+  text: string;
+  tool_calls: PartialToolCall[];
+  usage: Usage;
+  stop_reason: StopReason;
+};
+
+export function emptyPartial(): PartialState {
+  return {
+    text: '',
+    tool_calls: [],
+    usage: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+    stop_reason: 'end',
+  };
+}
+
+function buildContent(state: PartialState): ContentBlock[] {
+  const out: ContentBlock[] = [];
+  if (state.text.length > 0) out.push({ type: 'text', text: state.text });
+  for (const tc of state.tool_calls) {
+    if (tc.function_id.length === 0) continue;
+    let args: unknown = {};
+    if (tc.args_json.length > 0) {
+      try {
+        args = JSON.parse(tc.args_json);
+      } catch {
+        args = null;
+      }
+    }
+    out.push({ type: 'function_call', id: tc.id, function_id: tc.function_id, arguments: args });
+  }
+  return out;
+}
+
+export function buildPartial(
+  state: PartialState,
+  model: string,
+  provider: string,
+): AssistantMessage {
+  return {
+    role: 'assistant',
+    content: buildContent(state),
+    stop_reason: state.stop_reason,
+    error_message: null,
+    error_kind: null,
+    usage: state.usage,
+    model,
+    provider,
+    timestamp: Date.now(),
+  };
+}
+
+export function buildFinal(state: PartialState, model: string, provider: string): AssistantMessage {
+  return buildPartial(state, model, provider);
+}
+
+export function mapFinishReason(s: string): StopReason {
+  if (s === 'stop') return 'end';
+  if (s === 'length') return 'length';
+  if (s === 'tool_calls' || s === 'function_call') return 'function_call';
+  return 'end';
+}
+
+export function mergeUsage(usage: Record<string, unknown>, into: Usage): void {
+  const num = (k: string) => (typeof usage[k] === 'number' ? (usage[k] as number) : 0);
+  into.input = (into.input ?? 0) + num('prompt_tokens') + num('input_tokens');
+  into.output = (into.output ?? 0) + num('completion_tokens') + num('output_tokens');
+  for (const parent of ['prompt_tokens_details', 'input_tokens_details']) {
+    const d = usage[parent] as Record<string, unknown> | undefined;
+    if (d && typeof d.cached_tokens === 'number') {
+      into.cache_read = (into.cache_read ?? 0) + d.cached_tokens;
+    }
+  }
+}
+
+export function classifyKimiError(message: string, status?: number): ErrorKind {
+  if (status === 401 || status === 403) return 'auth_expired';
+  if (status === 429) return 'rate_limited';
+  if (status && status >= 500) return 'transient';
+  if (/context length|too many tokens/i.test(message)) return 'context_overflow';
+  return 'permanent';
+}
+
+export function syntheticErrorEvent(
+  message: string,
+  model: string,
+  provider: string,
+  error_kind: ErrorKind = 'transient',
+): AssistantMessageEvent {
+  const final: AssistantMessage = {
+    role: 'assistant',
+    content: [{ type: 'text', text: message }],
+    stop_reason: 'error',
+    error_message: message,
+    error_kind,
+    usage: null,
+    model,
+    provider,
+    timestamp: Date.now(),
+  };
+  return { type: 'error', error: final };
+}
+
+export function handleChunk(
+  chunk: Record<string, unknown>,
+  state: PartialState,
+  model: string,
+  provider: string,
+): AssistantMessageEvent[] {
+  const events: AssistantMessageEvent[] = [];
+  const usage = chunk.usage as Record<string, unknown> | undefined;
+  if (usage) mergeUsage(usage, state.usage);
+  const choices = chunk.choices;
+  if (!Array.isArray(choices) || choices.length === 0) return events;
+  const choice = choices[0] as Record<string, unknown>;
+  const finish = typeof choice.finish_reason === 'string' ? choice.finish_reason : null;
+  if (finish) state.stop_reason = mapFinishReason(finish);
+  const delta = choice.delta as Record<string, unknown> | undefined;
+  if (!delta) return events;
+
+  if (typeof delta.content === 'string' && delta.content.length > 0) {
+    if (state.text.length === 0) {
+      events.push({ type: 'text_start', partial: buildPartial(state, model, provider) });
+    }
+    state.text += delta.content;
+    events.push({
+      type: 'text_delta',
+      partial: buildPartial(state, model, provider),
+      delta: delta.content,
+    });
+  }
+
+  const tool_calls = delta.tool_calls;
+  if (Array.isArray(tool_calls)) {
+    for (const tc of tool_calls) {
+      if (!tc || typeof tc !== 'object') continue;
+      const tcObj = tc as Record<string, unknown>;
+      const index = typeof tcObj.index === 'number' ? tcObj.index : 0;
+      while (state.tool_calls.length <= index) {
+        state.tool_calls.push({ id: '', function_id: '', args_json: '' });
+      }
+      const entry = state.tool_calls[index];
+      if (!entry) continue;
+      if (typeof tcObj.id === 'string' && tcObj.id.length > 0) entry.id = tcObj.id;
+      const fn = tcObj.function as Record<string, unknown> | undefined;
+      if (fn) {
+        if (typeof fn.name === 'string' && fn.name.length > 0) entry.function_id = fn.name;
+        if (typeof fn.arguments === 'string') {
+          entry.args_json += fn.arguments;
+          events.push({
+            type: 'functioncall_delta',
+            partial: buildPartial(state, model, provider),
+            delta: fn.arguments,
+          });
+        }
+      }
+    }
+  }
+  return events;
+}

--- a/harness-node/src/provider-kimi/stream-fn.ts
+++ b/harness-node/src/provider-kimi/stream-fn.ts
@@ -1,0 +1,55 @@
+import type { ChannelWriter } from 'iii-sdk';
+import type { ISdk } from '../runtime/iii.js';
+import { logger } from '../runtime/otel.js';
+import type { AgentMessage } from '../types/agent-message.js';
+import {
+  ProviderStreamInputJsonSchema,
+  ProviderStreamOutputJsonSchema,
+  ProviderStreamRuntimeInputSchema,
+} from '../types/provider.js';
+import { isTerminal } from '../types/stream-event.js';
+import { buildConfig } from './auth.js';
+import type { WorkerConfig } from './config.js';
+import { streamKimi } from './stream.js';
+
+export const FUNCTION_ID = 'provider::kimi::stream';
+
+export function register(iii: ISdk, worker: WorkerConfig): void {
+  iii.registerFunction(
+    FUNCTION_ID,
+    async (raw: unknown) => {
+      const input = ProviderStreamRuntimeInputSchema.parse(raw);
+      // The iii-sdk auto-hydrates `writer_ref` (a StreamChannelRef on the
+      // wire) into a `ChannelWriter` instance before this handler runs.
+      const writer = input.writer_ref as ChannelWriter;
+      const cfg = await buildConfig(iii, worker, input.model);
+      try {
+        const events = streamKimi({
+          cfg,
+          system_prompt: input.system_prompt ?? '',
+          messages: input.messages as AgentMessage[],
+          tools: input.tools as import('../types/function.js').AgentFunction[],
+        });
+        for await (const ev of events) {
+          writer.sendMessage(JSON.stringify(ev));
+          if (isTerminal(ev)) break;
+        }
+      } catch (err) {
+        logger.warn('provider::kimi::stream failed mid-flight', { err: String(err) });
+      } finally {
+        try {
+          writer.close();
+        } catch (err) {
+          logger.debug('writer.close failed', { err: String(err) });
+        }
+      }
+      return { ok: true };
+    },
+    {
+      description:
+        'Stream a single assistant turn from Kimi (Moonshot) Chat Completions into the caller-supplied channel.',
+      request_format: ProviderStreamInputJsonSchema as Record<string, unknown>,
+      response_format: ProviderStreamOutputJsonSchema as Record<string, unknown>,
+    },
+  );
+}

--- a/harness-node/src/provider-kimi/stream.ts
+++ b/harness-node/src/provider-kimi/stream.ts
@@ -1,0 +1,156 @@
+// Kept separate from provider-openai so Moonshot-specific request options
+// can be added without coupling the two providers.
+
+import { logger } from '../runtime/otel.js';
+import type { AgentMessage, AssistantMessage } from '../types/agent-message.js';
+import type { AgentFunction } from '../types/function.js';
+import type { AssistantMessageEvent } from '../types/stream-event.js';
+import {
+  buildFinal,
+  classifyKimiError,
+  emptyPartial,
+  handleChunk,
+  syntheticErrorEvent,
+} from './sse.js';
+import type { ChatCompletionsConfig } from './types.js';
+import { toOpenaiMessages } from './wire-messages.js';
+import { functionsToOpenai } from './wire-tools.js';
+
+export type StreamArgs = {
+  cfg: ChatCompletionsConfig;
+  system_prompt: string;
+  messages: AgentMessage[];
+  tools: AgentFunction[];
+};
+
+export async function* streamKimi({
+  cfg,
+  system_prompt,
+  messages,
+  tools,
+}: StreamArgs): AsyncGenerator<AssistantMessageEvent> {
+  const body: Record<string, unknown> = {
+    model: cfg.model,
+    max_completion_tokens: cfg.max_tokens,
+    messages: toOpenaiMessages(messages, system_prompt),
+    stream: true,
+    stream_options: { include_usage: true },
+  };
+  if (tools.length > 0) body.tools = functionsToOpenai(tools);
+
+  const authName = cfg.auth_header_name ?? 'Authorization';
+  const authPrefix = cfg.auth_value_prefix ?? 'Bearer ';
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    [authName]: `${authPrefix}${cfg.api_key}`,
+  };
+  for (const [k, v] of cfg.extra_headers ?? []) headers[k] = v;
+
+  let resp: Response;
+  try {
+    resp = await fetch(cfg.url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    yield syntheticErrorEvent(`kimi fetch failed: ${String(err)}`, cfg.model, cfg.provider_name);
+    return;
+  }
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '');
+    yield syntheticErrorEvent(
+      text || `kimi http ${resp.status}`,
+      cfg.model,
+      cfg.provider_name,
+      classifyKimiError(text, resp.status),
+    );
+    return;
+  }
+  const partial: AssistantMessage = {
+    role: 'assistant',
+    content: [],
+    stop_reason: 'end',
+    error_message: null,
+    error_kind: null,
+    usage: null,
+    model: cfg.model,
+    provider: cfg.provider_name,
+    timestamp: Date.now(),
+  };
+  yield { type: 'start', partial };
+
+  const state = emptyPartial();
+  if (!resp.body) {
+    yield syntheticErrorEvent('kimi response missing body', cfg.model, cfg.provider_name);
+    return;
+  }
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = '';
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      let idx = buf.indexOf('\n\n');
+      while (idx >= 0) {
+        const block = buf.slice(0, idx);
+        buf = buf.slice(idx + 2);
+        const dataLine = parseDataLine(block);
+        idx = buf.indexOf('\n\n');
+        if (dataLine === null) continue;
+        if (dataLine === '[DONE]') {
+          yield { type: 'done', message: buildFinal(state, cfg.model, cfg.provider_name) };
+          return;
+        }
+        let parsed: Record<string, unknown> | null = null;
+        try {
+          parsed = JSON.parse(dataLine) as Record<string, unknown>;
+        } catch {
+          continue;
+        }
+        if (parsed) {
+          for (const e of handleChunk(parsed, state, cfg.model, cfg.provider_name)) yield e;
+        }
+      }
+    }
+  } catch (err) {
+    logger.warn('kimi stream read failed', { err: String(err) });
+    yield syntheticErrorEvent(`stream read failed: ${String(err)}`, cfg.model, cfg.provider_name);
+    return;
+  }
+  yield { type: 'done', message: buildFinal(state, cfg.model, cfg.provider_name) };
+}
+
+function parseDataLine(block: string): string | null {
+  let data: string | null = null;
+  for (const line of block.split('\n')) {
+    if (line.startsWith('data: ')) data = line.slice('data: '.length);
+  }
+  return data;
+}
+
+export async function collect(
+  events: AsyncIterable<AssistantMessageEvent>,
+): Promise<AssistantMessage> {
+  let last: AssistantMessage | null = null;
+  for await (const ev of events) {
+    if (ev.type === 'done') return ev.message;
+    if (ev.type === 'error') return ev.error;
+    if ('partial' in ev) last = ev.partial;
+  }
+  return (
+    last ?? {
+      role: 'assistant',
+      content: [],
+      stop_reason: 'error',
+      error_message: 'stream closed without final',
+      error_kind: 'transient',
+      usage: null,
+      model: 'kimi',
+      provider: 'kimi',
+      timestamp: Date.now(),
+    }
+  );
+}

--- a/harness-node/src/provider-kimi/types.ts
+++ b/harness-node/src/provider-kimi/types.ts
@@ -1,0 +1,25 @@
+import type { Credential } from '../auth-credentials/types.js';
+
+export type ChatCompletionsConfig = {
+  url: string;
+  provider_name: string;
+  model: string;
+  api_key: string;
+  /** Defaults to "Authorization". */
+  auth_header_name?: string;
+  /** Defaults to "Bearer ". */
+  auth_value_prefix?: string;
+  extra_headers?: Array<readonly [string, string]>;
+  max_tokens: number;
+};
+
+export function configFromCredential(
+  url: string,
+  provider_name: string,
+  model: string,
+  cred: Credential,
+  max_tokens: number,
+): ChatCompletionsConfig {
+  const api_key = cred.type === 'api_key' ? cred.key : cred.access_token;
+  return { url, provider_name, model, api_key, max_tokens };
+}

--- a/harness-node/src/provider-kimi/wire-messages.ts
+++ b/harness-node/src/provider-kimi/wire-messages.ts
@@ -1,0 +1,55 @@
+// Kept separate from provider-openai so Moonshot-specific extensions
+// can land without coupling the two providers.
+
+import type { AgentMessage } from '../types/agent-message.js';
+import { formatFunctionResultContent } from '../types/wire.js';
+
+export function toOpenaiMessages(messages: AgentMessage[], system_prompt: string): unknown[] {
+  const out: unknown[] = [];
+  if (system_prompt.length > 0) {
+    out.push({ role: 'system', content: system_prompt });
+  }
+  for (const m of messages) {
+    if (m.role === 'user') {
+      const text = m.content
+        .filter(
+          (c): c is Extract<(typeof m.content)[number], { type: 'text' }> => c.type === 'text',
+        )
+        .map((c) => c.text)
+        .join('\n');
+      out.push({ role: 'user', content: text });
+    } else if (m.role === 'assistant') {
+      const text = m.content
+        .filter(
+          (c): c is Extract<(typeof m.content)[number], { type: 'text' }> => c.type === 'text',
+        )
+        .map((c) => c.text)
+        .join('\n');
+      const tool_calls = m.content
+        .filter(
+          (c): c is Extract<(typeof m.content)[number], { type: 'function_call' }> =>
+            c.type === 'function_call',
+        )
+        .map((c) => ({
+          id: c.id,
+          type: 'function',
+          function: { name: c.function_id, arguments: JSON.stringify(c.arguments) },
+        }));
+      const entry: Record<string, unknown> = { role: 'assistant' };
+      if (text.length > 0) entry.content = text;
+      if (tool_calls.length > 0) entry.tool_calls = tool_calls;
+      out.push(entry);
+    } else if (m.role === 'function_result') {
+      const text = formatFunctionResultContent(m);
+      const row: Record<string, unknown> = {
+        role: 'tool',
+        tool_call_id: m.function_call_id,
+        content: text,
+      };
+      if (m.is_error) row.is_error = true;
+      out.push(row);
+    }
+    // custom messages are skipped
+  }
+  return out;
+}

--- a/harness-node/src/provider-kimi/wire-tools.ts
+++ b/harness-node/src/provider-kimi/wire-tools.ts
@@ -1,0 +1,12 @@
+import type { AgentFunction } from '../types/function.js';
+
+export function functionsToOpenai(functions: AgentFunction[]): unknown[] {
+  return functions.map((t) => ({
+    type: 'function',
+    function: {
+      name: t.name,
+      description: t.description,
+      parameters: t.parameters,
+    },
+  }));
+}

--- a/harness-node/src/turn-orchestrator/provider-router.ts
+++ b/harness-node/src/turn-orchestrator/provider-router.ts
@@ -9,7 +9,8 @@ import type { ProviderStreamInput, StreamChannelRef } from '../types/provider.js
 
 export type RouteDecision =
   | { provider: 'anthropic'; model: string }
-  | { provider: 'openai'; model: string };
+  | { provider: 'openai'; model: string }
+  | { provider: 'kimi'; model: string };
 
 export type RouteRequest = {
   provider?: string;
@@ -20,15 +21,26 @@ export type RouteRequest = {
 export function decide(req: RouteRequest): RouteDecision {
   const p = (req.provider ?? '').toLowerCase();
   if (p === 'openai') return { provider: 'openai', model: req.model };
+  if (p === 'kimi') return { provider: 'kimi', model: req.model };
   // Heuristic for missing provider: model name disambiguates.
   if (!p && /^gpt-|^o\d-/i.test(req.model)) {
     return { provider: 'openai', model: req.model };
+  }
+  if (!p && /^kimi-|^moonshot-v1-/i.test(req.model)) {
+    return { provider: 'kimi', model: req.model };
   }
   return { provider: 'anthropic', model: req.model };
 }
 
 export function targetFunctionId(d: RouteDecision): string {
-  return d.provider === 'anthropic' ? 'provider::anthropic::stream' : 'provider::openai::stream';
+  switch (d.provider) {
+    case 'anthropic':
+      return 'provider::anthropic::stream';
+    case 'openai':
+      return 'provider::openai::stream';
+    case 'kimi':
+      return 'provider::kimi::stream';
+  }
 }
 
 export function buildInput(

--- a/harness-node/tests/auth-credentials/env-map-kimi.test.ts
+++ b/harness-node/tests/auth-credentials/env-map-kimi.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { ENV_VAR_MAP, envVarFor } from '../../src/auth-credentials/types.js';
+
+describe('env map: kimi', () => {
+  it('resolves `kimi` to MOONSHOT_API_KEY', () => {
+    expect(envVarFor('kimi')).toBe('MOONSHOT_API_KEY');
+  });
+
+  it('keeps the legacy `kimi-coding` slug pointing at the same env var', () => {
+    expect(envVarFor('kimi-coding')).toBe('MOONSHOT_API_KEY');
+  });
+
+  it('exposes both slugs through ENV_VAR_MAP', () => {
+    const slugs = ENV_VAR_MAP.map(([provider]) => provider);
+    expect(slugs).toContain('kimi');
+    expect(slugs).toContain('kimi-coding');
+  });
+});

--- a/harness-node/tests/context-compaction/summarize.test.ts
+++ b/harness-node/tests/context-compaction/summarize.test.ts
@@ -197,9 +197,7 @@ describe('renderUserPrompt', () => {
   it('skips non-text non-function_call blocks silently', () => {
     const msg: AgentMessage = {
       role: 'user',
-      content: [
-        { type: 'image', media_type: 'image/png', data: 'abc' } as unknown as ContentBlock,
-      ],
+      content: [{ type: 'image', media_type: 'image/png', data: 'abc' } as unknown as ContentBlock],
       timestamp: 0,
     };
     const out = renderUserPrompt([msg]);
@@ -294,17 +292,17 @@ describe('summarizeAndAppend async mode', () => {
     // surface to /compact when a single retry would succeed.
     const { iii } = buildMock();
     let createChannelCalls = 0;
-    const realCreateChannel = (
-      iii as unknown as { createChannel: () => Promise<unknown> }
-    ).createChannel;
-    (iii as unknown as { createChannel: () => Promise<unknown> }).createChannel = vi
-      .fn(async () => {
+    const realCreateChannel = (iii as unknown as { createChannel: () => Promise<unknown> })
+      .createChannel;
+    (iii as unknown as { createChannel: () => Promise<unknown> }).createChannel = vi.fn(
+      async () => {
         createChannelCalls += 1;
         if (createChannelCalls === 1) {
           throw new Error('transient provider failure');
         }
         return realCreateChannel();
-      });
+      },
+    );
 
     const result = await summarizeAndAppend(iii, 'sess-retry', { mode: 'async' }, testModel);
     expect(createChannelCalls).toBe(2);
@@ -316,11 +314,12 @@ describe('summarizeAndAppend async mode', () => {
     // then surfaces the failure.
     const { iii } = buildMock();
     let createChannelCalls = 0;
-    (iii as unknown as { createChannel: () => Promise<unknown> }).createChannel = vi
-      .fn(async () => {
+    (iii as unknown as { createChannel: () => Promise<unknown> }).createChannel = vi.fn(
+      async () => {
         createChannelCalls += 1;
         throw new Error('permanent provider failure');
-      });
+      },
+    );
 
     const result = await summarizeAndAppend(iii, 'sess-fail-twice', { mode: 'async' }, testModel);
     expect(createChannelCalls).toBe(2);
@@ -335,11 +334,12 @@ describe('summarizeAndAppend async mode', () => {
     // compaction lease releases ~1s sooner.
     const { iii } = buildMock();
     let createChannelCalls = 0;
-    (iii as unknown as { createChannel: () => Promise<unknown> }).createChannel = vi
-      .fn(async () => {
+    (iii as unknown as { createChannel: () => Promise<unknown> }).createChannel = vi.fn(
+      async () => {
         createChannelCalls += 1;
         throw new Error('401 unauthorized: invalid_api_key');
-      });
+      },
+    );
 
     const result = await summarizeAndAppend(iii, 'sess-auth-fail', { mode: 'async' }, testModel);
     expect(createChannelCalls).toBe(1); // no retry
@@ -374,16 +374,22 @@ describe('summarizeAndAppend async mode', () => {
     });
     const { iii } = buildMock(() => errorEvent);
 
-    const result = await summarizeAndAppend(iii, 'sess-provider-error', { mode: 'async' }, testModel);
+    const result = await summarizeAndAppend(
+      iii,
+      'sess-provider-error',
+      { mode: 'async' },
+      testModel,
+    );
     expect(typeof result === 'object' && 'kind' in result ? result.kind : result).toBe('compact');
     if (typeof result === 'object' && 'kind' in result && result.kind === 'compact') {
       expect(result.reason.toLowerCase()).toMatch(/not.found|gpt-5-mini/);
     }
   });
 
-  it('routes the summariser to the session provider when env is unset', async () => {
-    // Regression: summarizerProvider() default was 'anthropic'. Sessions on
-    // OpenAI got Anthropic stream + OpenAI model → not_found_error.
+  it('routes the summariser to the session provider', async () => {
+    // /compact uses the session's own provider/model. Earlier default was
+    // a hardcoded 'anthropic'; OpenAI sessions got an Anthropic stream
+    // + an OpenAI model id, producing not_found_error.
     let calledFunctionId: string | null = null;
     const { iii } = buildMock();
     const wrapped = iii as unknown as { trigger: ReturnType<typeof vi.fn> };
@@ -402,6 +408,31 @@ describe('summarizeAndAppend async mode', () => {
     };
     await summarizeAndAppend(iii, 'sess-openai', { mode: 'async' }, openAiModel);
     expect(calledFunctionId).toBe('provider::openai::stream');
+  });
+
+  it('routes kimi sessions to provider::kimi::stream, not anthropic', async () => {
+    // Regression: a binary openai-vs-anthropic ternary sent every non-openai
+    // provider (including kimi) to provider::anthropic::stream, producing
+    // NOT_FOUND_ERROR on the kimi model id. Fix uses the canonical provider
+    // router so adding a provider only needs a router update.
+    let calledFunctionId: string | null = null;
+    const { iii } = buildMock();
+    const wrapped = iii as unknown as { trigger: ReturnType<typeof vi.fn> };
+    const originalTrigger = wrapped.trigger;
+    wrapped.trigger = vi.fn(async (req: MockTriggerReq) => {
+      if (req.function_id.startsWith('provider::')) {
+        calledFunctionId = req.function_id;
+      }
+      return originalTrigger(req);
+    });
+
+    const kimiModel = {
+      providerID: 'kimi',
+      modelID: 'kimi-k2.5',
+      modelLimit: { context: 256_000, input: 256_000, output: 16_384 },
+    };
+    await summarizeAndAppend(iii, 'sess-kimi', { mode: 'async' }, kimiModel);
+    expect(calledFunctionId).toBe('provider::kimi::stream');
   });
 });
 

--- a/harness-node/tests/models-catalog/seed-kimi.test.ts
+++ b/harness-node/tests/models-catalog/seed-kimi.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { syncGet, syncList } from '../../src/models-catalog/catalog.js';
+
+describe('catalog seed: kimi', () => {
+  it('lists only K2.6 and K2.5 for provider=kimi', async () => {
+    const models = await syncList({ provider: 'kimi' });
+    const ids = models.map((m) => m.id).sort();
+    expect(ids).toEqual(['kimi-k2.5', 'kimi-k2.6']);
+  });
+
+  it('flags K2.6 and K2.5 as thinking + vision + tool capable with a 256k window', async () => {
+    for (const id of ['kimi-k2.6', 'kimi-k2.5']) {
+      const m = await syncGet('kimi', id);
+      expect(m, `model ${id} should be seeded`).not.toBeNull();
+      expect(m?.api).toBe('openai-completions');
+      expect(m?.context_window).toBe(256000);
+      expect(m?.supports_thinking).toBe(true);
+      expect(m?.supports_vision).toBe(true);
+      expect(m?.supports_tools).toBe(true);
+      expect(m?.supports_cache).toBe(true);
+      expect(m?.transports).toEqual(['sse']);
+    }
+  });
+
+  it('returns null for removed legacy ids', async () => {
+    for (const id of ['kimi-k2-0905-preview', 'kimi-k2-turbo-preview', 'moonshot-v1-128k']) {
+      expect(await syncGet('kimi', id), `${id} should no longer be seeded`).toBeNull();
+    }
+  });
+
+  it('returns null for unknown kimi ids', async () => {
+    expect(await syncGet('kimi', 'kimi-k2-fictional')).toBeNull();
+  });
+});

--- a/harness-node/tests/provider-kimi/sse.test.ts
+++ b/harness-node/tests/provider-kimi/sse.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPartial,
+  classifyKimiError,
+  emptyPartial,
+  handleChunk,
+  mapFinishReason,
+  mergeUsage,
+} from '../../src/provider-kimi/sse.js';
+
+describe('mergeUsage (kimi)', () => {
+  it('extracts chat-completions cached_tokens', () => {
+    const u = { input: 0, output: 0, cache_read: 0, cache_write: 0 };
+    mergeUsage(
+      {
+        prompt_tokens: 1500,
+        completion_tokens: 200,
+        prompt_tokens_details: { cached_tokens: 1200 },
+      },
+      u,
+    );
+    expect(u.input).toBe(1500);
+    expect(u.output).toBe(200);
+    expect(u.cache_read).toBe(1200);
+  });
+});
+
+describe('mapFinishReason (kimi)', () => {
+  it('maps known finish reasons', () => {
+    expect(mapFinishReason('stop')).toBe('end');
+    expect(mapFinishReason('length')).toBe('length');
+    expect(mapFinishReason('tool_calls')).toBe('function_call');
+    expect(mapFinishReason('function_call')).toBe('function_call');
+  });
+});
+
+describe('handleChunk (kimi)', () => {
+  it('emits text_start on first content delta then text_delta', () => {
+    const state = emptyPartial();
+    const events = handleChunk(
+      { choices: [{ delta: { content: 'hi' } }] },
+      state,
+      'kimi-k2-0905-preview',
+      'kimi',
+    );
+    expect(events.map((e) => e.type)).toEqual(['text_start', 'text_delta']);
+    expect(state.text).toBe('hi');
+  });
+
+  it('accumulates tool_call arguments across chunks', () => {
+    const state = emptyPartial();
+    handleChunk(
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                { index: 0, id: 'tc1', function: { name: 'shell::exec', arguments: '{"x' } },
+              ],
+            },
+          },
+        ],
+      },
+      state,
+      'kimi-k2-0905-preview',
+      'kimi',
+    );
+    handleChunk(
+      {
+        choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: '":1}' } }] } }],
+      },
+      state,
+      'kimi-k2-0905-preview',
+      'kimi',
+    );
+    expect(state.tool_calls[0]?.id).toBe('tc1');
+    expect(state.tool_calls[0]?.function_id).toBe('shell::exec');
+    expect(state.tool_calls[0]?.args_json).toBe('{"x":1}');
+  });
+
+  it('records finish_reason as stop_reason on the partial state', () => {
+    const state = emptyPartial();
+    handleChunk(
+      { choices: [{ finish_reason: 'tool_calls' }] },
+      state,
+      'kimi-k2-0905-preview',
+      'kimi',
+    );
+    const partial = buildPartial(state, 'kimi-k2-0905-preview', 'kimi');
+    expect(partial.stop_reason).toBe('function_call');
+  });
+});
+
+describe('classifyKimiError', () => {
+  it('maps 401/403 to auth_expired', () => {
+    expect(classifyKimiError('unauthorized', 401)).toBe('auth_expired');
+    expect(classifyKimiError('forbidden', 403)).toBe('auth_expired');
+  });
+
+  it('maps 429 to rate_limited', () => {
+    expect(classifyKimiError('too many requests', 429)).toBe('rate_limited');
+  });
+
+  it('maps 5xx to transient', () => {
+    expect(classifyKimiError('bad gateway', 502)).toBe('transient');
+  });
+
+  it('maps context length messages to context_overflow', () => {
+    expect(classifyKimiError('context length exceeded', 400)).toBe('context_overflow');
+  });
+
+  it('defaults to permanent', () => {
+    expect(classifyKimiError('something else', 400)).toBe('permanent');
+  });
+});

--- a/harness-node/tests/provider-kimi/stream.test.ts
+++ b/harness-node/tests/provider-kimi/stream.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { collect, streamKimi } from '../../src/provider-kimi/stream.js';
+import type { ChatCompletionsConfig } from '../../src/provider-kimi/types.js';
+
+const cfg: ChatCompletionsConfig = {
+  url: 'https://api.moonshot.ai/v1/chat/completions',
+  provider_name: 'kimi',
+  model: 'kimi-k2-0905-preview',
+  api_key: 'sk-test',
+  max_tokens: 256,
+};
+
+function sseResponse(chunks: string[], status = 200): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(encoder.encode(c));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status,
+    headers: { 'content-type': 'text/event-stream' },
+  });
+}
+
+function errorResponse(status: number, body: string): Response {
+  return new Response(body, { status });
+}
+
+describe('streamKimi', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('emits start -> text_start -> text_delta+ -> done on a happy-path stream', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        sseResponse([
+          'data: {"choices":[{"delta":{"content":"Hel"}}]}\n\n',
+          'data: {"choices":[{"delta":{"content":"lo"}}]}\n\n',
+          'data: {"choices":[{"finish_reason":"stop","delta":{}}]}\n\n',
+          'data: [DONE]\n\n',
+        ]),
+      );
+
+    const events: string[] = [];
+    let finalText = '';
+    for await (const ev of streamKimi({ cfg, system_prompt: '', messages: [], tools: [] })) {
+      events.push(ev.type);
+      if (ev.type === 'done') {
+        finalText = ev.message.content
+          .filter((c): c is { type: 'text'; text: string } => c.type === 'text')
+          .map((c) => c.text)
+          .join('');
+      }
+    }
+    expect(events).toEqual(['start', 'text_start', 'text_delta', 'text_delta', 'done']);
+    expect(finalText).toBe('Hello');
+  });
+
+  it('classifies HTTP 401 as auth_expired', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(errorResponse(401, 'unauthorized'));
+    const final = await collect(streamKimi({ cfg, system_prompt: '', messages: [], tools: [] }));
+    expect(final.stop_reason).toBe('error');
+    expect(final.error_kind).toBe('auth_expired');
+  });
+
+  it('classifies HTTP 429 as rate_limited', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(errorResponse(429, 'slow down'));
+    const final = await collect(streamKimi({ cfg, system_prompt: '', messages: [], tools: [] }));
+    expect(final.error_kind).toBe('rate_limited');
+  });
+
+  it('classifies HTTP 500 as transient', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(errorResponse(503, 'service unavailable'));
+    const final = await collect(streamKimi({ cfg, system_prompt: '', messages: [], tools: [] }));
+    expect(final.error_kind).toBe('transient');
+  });
+
+  it('surfaces fetch transport failures as a single error event', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const final = await collect(streamKimi({ cfg, system_prompt: '', messages: [], tools: [] }));
+    expect(final.stop_reason).toBe('error');
+    expect(final.error_message).toContain('kimi fetch failed');
+  });
+
+  it('sends Bearer token and JSON body to the configured URL', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        sseResponse([
+          'data: {"choices":[{"finish_reason":"stop","delta":{}}]}\n\n',
+          'data: [DONE]\n\n',
+        ]),
+      );
+    globalThis.fetch = fetchMock;
+
+    await collect(streamKimi({ cfg, system_prompt: 'sys', messages: [], tools: [] }));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(cfg.url);
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer sk-test');
+    expect(headers['content-type']).toBe('application/json');
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body.model).toBe(cfg.model);
+    expect(body.stream).toBe(true);
+    expect((body.messages as Array<{ role: string }>)[0]?.role).toBe('system');
+  });
+});

--- a/harness-node/tests/provider-kimi/wire-messages.test.ts
+++ b/harness-node/tests/provider-kimi/wire-messages.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { toOpenaiMessages } from '../../src/provider-kimi/wire-messages.js';
+import type { AgentMessage } from '../../src/types/agent-message.js';
+
+describe('toOpenaiMessages (kimi)', () => {
+  it('prepends system message when present', () => {
+    const out = toOpenaiMessages([], 'be helpful') as Array<Record<string, unknown>>;
+    expect(out[0]).toEqual({ role: 'system', content: 'be helpful' });
+  });
+
+  it('encodes assistant tool_calls with stringified arguments', () => {
+    const msg: AgentMessage = {
+      role: 'assistant',
+      content: [
+        { type: 'text', text: 'calling' },
+        {
+          type: 'function_call',
+          id: 'tc1',
+          function_id: 'shell::fs::ls',
+          arguments: { path: '/tmp' },
+        },
+      ],
+      stop_reason: 'function_call',
+      model: 'kimi-k2-0905-preview',
+      provider: 'kimi',
+      timestamp: 0,
+    };
+    const out = toOpenaiMessages([msg], '') as Array<Record<string, unknown>>;
+    expect(out[0]?.role).toBe('assistant');
+    const tcs = (out[0] as { tool_calls: Array<{ function: { arguments: string } }> }).tool_calls;
+    expect(tcs[0]?.function.arguments).toBe('{"path":"/tmp"}');
+  });
+
+  it('emits tool messages with content + tool_call_id + is_error', () => {
+    const out = toOpenaiMessages(
+      [
+        {
+          role: 'function_result',
+          function_call_id: 'tc1',
+          function_id: 'read',
+          content: [{ type: 'text', text: 'ok' }],
+          details: { status: 'denied' },
+          is_error: true,
+          timestamp: 0,
+        },
+      ],
+      '',
+    ) as Array<Record<string, unknown>>;
+    expect(out[0]?.role).toBe('tool');
+    expect(out[0]?.tool_call_id).toBe('tc1');
+    expect(out[0]?.is_error).toBe(true);
+    expect((out[0]?.content as string).startsWith('[PERMISSION_DENIED]')).toBe(true);
+  });
+
+  it('joins user text content with newlines', () => {
+    const msg: AgentMessage = {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'one' },
+        { type: 'text', text: 'two' },
+      ],
+      timestamp: 0,
+    };
+    const out = toOpenaiMessages([msg], '') as Array<Record<string, unknown>>;
+    expect(out[0]?.content).toBe('one\ntwo');
+  });
+});

--- a/harness-node/tests/turn-orchestrator/provider-router.test.ts
+++ b/harness-node/tests/turn-orchestrator/provider-router.test.ts
@@ -14,9 +14,18 @@ describe('decide', () => {
     expect(decide({ provider: 'openai', model: 'gpt-5' }).provider).toBe('openai');
   });
 
+  it('routes kimi when provider=kimi', () => {
+    expect(decide({ provider: 'kimi', model: 'kimi-k2-0905-preview' }).provider).toBe('kimi');
+  });
+
   it('falls back to model heuristic when provider missing', () => {
     expect(decide({ model: 'gpt-5' }).provider).toBe('openai');
     expect(decide({ model: 'claude-opus-4-7' }).provider).toBe('anthropic');
+    expect(decide({ model: 'kimi-k2-0905-preview' }).provider).toBe('kimi');
+    expect(decide({ model: 'kimi-k2-turbo-preview' }).provider).toBe('kimi');
+    expect(decide({ model: 'kimi-k2.6' }).provider).toBe('kimi');
+    expect(decide({ model: 'moonshot-v1-128k' }).provider).toBe('kimi');
+    expect(decide({ model: 'moonshot-v1-8k-vision-preview' }).provider).toBe('kimi');
   });
 });
 
@@ -26,6 +35,7 @@ describe('targetFunctionId', () => {
       'provider::anthropic::stream',
     );
     expect(targetFunctionId({ provider: 'openai', model: 'm' })).toBe('provider::openai::stream');
+    expect(targetFunctionId({ provider: 'kimi', model: 'm' })).toBe('provider::kimi::stream');
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `provider-kimi` worker to the harness-node bundle, exposing `provider::kimi::stream` and `provider::kimi::complete` on the iii bus. Mirrors the `provider-openai` scaffold against `https://api.moonshot.ai/v1/chat/completions`. Kimi K2 is OpenAI-Chat-Completions wire compatible, so SSE parsing, wire translation, and tool-call deltas are reused unchanged.
- Catalog: seeds `kimi-k2.5` and `kimi-k2.6` in `models-catalog` (the two flagship multimodal K2 variants surface in the chat picker). Env map: `kimi → MOONSHOT_API_KEY` alongside the legacy `kimi-coding` slug. Router: extends `turn-orchestrator/provider-router` with a `kimi` arm and a heuristic for model ids starting with `kimi-` or `moonshot-v1-`.
- Fixes a latent `/compact` defect: the summariser's binary openai-vs-anthropic ternary silently routed every other provider to `provider::anthropic::stream`, producing `NOT_FOUND_ERROR` when summarising a non-openai/non-anthropic session. `context-compaction/summarize.ts` now routes through the canonical `provider-router` and always uses the session's own model (the `COMPACT_SUMMARIZER_PROVIDER`/`MODEL` env-var overrides are removed — they were a footgun that hid the mis-route).

## Caveats

- **Auth slug workaround:** `provider-kimi/auth.ts` calls `auth::get_token` with `provider: 'kimi-coding'` (not `'kimi'`). The compiled Rust `auth-credentials` binary (the live handler on most engines today) maps `kimi-coding → MOONSHOT_API_KEY` but doesn't yet know the bare `kimi` slug we added here. Once the Rust worker is rebuilt or replaced with the harness-node port, the bare `kimi` slug also resolves.
- **Live runtime:** the Rust `context-compaction` binary has the same `/compact` defect this PR fixes in the harness-node port. The Rust patch is out of scope for this PR.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 473/473 pass, including 26 new kimi-specific cases
- [x] `pnpm build && node dist/index.js --manifest` lists `provider-kimi` between `provider-openai` and `llm-budget`
- [x] `git diff main...HEAD` touches only `harness-node/` (31 files, +1165/−46)
- [ ] Live smoke: set `MOONSHOT_API_KEY` (or `auth::set_token { provider: 'kimi-coding' }`), trigger `provider::kimi::complete` with `model: 'kimi-k2.5'`, expect a non-error `AssistantMessage`
- [ ] Live smoke: `/compact` in a Kimi K2.5 session succeeds (the bus call now lands on `provider::kimi::stream`, not anthropic)
- [ ] `models::list { provider: 'kimi' }` returns exactly `kimi-k2.5` and `kimi-k2.6`

## References

- Per-worker doc: [`harness-node/docs/workers/provider-kimi.md`](harness-node/docs/workers/provider-kimi.md)