### PR TITLE
refactor(database): update README and tests to use registerWorker and…

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -93,22 +93,33 @@ SQLite ignores the `tls` block (local-file driver).
 ## Quick start (SQLite)
 
 ```ts
-import { call } from 'iii-sdk'
+import { registerWorker } from 'iii-sdk'
 
-await call('database::execute', {
-  db: 'primary',
-  sql: 'CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, email TEXT)'
+const iii = registerWorker(process.env.III_URL ?? 'ws://127.0.0.1:49134')
+
+await iii.trigger({
+  function_id: 'database::execute',
+  payload: {
+    db: 'primary',
+    sql: 'CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, email TEXT)',
+  },
 })
 
-await call('database::execute', {
-  db: 'primary',
-  sql: 'INSERT INTO users (email) VALUES (?), (?)',
-  params: ['a@x', 'b@x']
+await iii.trigger({
+  function_id: 'database::execute',
+  payload: {
+    db: 'primary',
+    sql: 'INSERT INTO users (email) VALUES (?), (?)',
+    params: ['a@x', 'b@x'],
+  },
 })
 
-const { rows } = await call('database::query', {
-  db: 'primary',
-  sql: 'SELECT id, email FROM users ORDER BY id'
+const { rows } = await iii.trigger({
+  function_id: 'database::query',
+  payload: {
+    db: 'primary',
+    sql: 'SELECT id, email FROM users ORDER BY id',
+  },
 })
 ```
 

--- a/database/tests/e2e/workers/harness/package-lock.json
+++ b/database/tests/e2e/workers/harness/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "iii-database-tests-harness",
+  "name": "database-tests-harness",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "iii-database-tests-harness",
+      "name": "database-tests-harness",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -464,7 +464,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -785,7 +784,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },

--- a/database/tests/e2e/workers/harness/src/test.ts
+++ b/database/tests/e2e/workers/harness/src/test.ts
@@ -1,17 +1,28 @@
-import { call } from 'iii-sdk'
+import { registerWorker } from 'iii-sdk'
 
-await call('database::execute', {
-  db: 'primary',
-  sql: 'CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, email TEXT)',
+const iii = registerWorker(process.env.III_URL ?? 'ws://127.0.0.1:49134')
+
+await iii.trigger({
+  function_id: 'database::execute',
+  payload: {
+    db: 'primary',
+    sql: 'CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, email TEXT)',
+  },
 })
 
-await call('database::execute', {
-  db: 'primary',
-  sql: 'INSERT INTO users (email) VALUES (?), (?)',
-  params: ['a@x', 'b@x'],
+await iii.trigger({
+  function_id: 'database::execute',
+  payload: {
+    db: 'primary',
+    sql: 'INSERT INTO users (email) VALUES (?), (?)',
+    params: ['a@x', 'b@x'],
+  },
 })
 
-const { rows } = await call('database::query', {
-  db: 'primary',
-  sql: 'SELECT id, email FROM users ORDER BY id',
+const { rows } = await iii.trigger({
+  function_id: 'database::query',
+  payload: {
+    db: 'primary',
+    sql: 'SELECT id, email FROM users ORDER BY id',
+  },
 })

--- a/storage/README.md
+++ b/storage/README.md
@@ -21,31 +21,45 @@ Upload a profile photo, hand the browser a presigned URL for the next
 upload, then read it back.
 
 ```ts
-import { call } from 'iii-sdk'
+import { registerWorker } from 'iii-sdk'
 
-await call('storage::putObject', {
-  bucket: 'uploads',
-  key: 'u/1/profile.jpg',
-  body_base64: fileBase64,         // ≤ 10 MiB inline; use presignUrl above that
-  content_type: 'image/jpeg',
+const iii = registerWorker(process.env.III_URL ?? 'ws://127.0.0.1:49134')
+
+await iii.trigger({
+  function_id: 'storage::putObject',
+  payload: {
+    bucket: 'uploads',
+    key: 'u/1/profile.jpg',
+    body_base64: fileBase64,         // ≤ 10 MiB inline; use presignUrl above that
+    content_type: 'image/jpeg',
+  },
 })
 
-const { url, expires_at } = await call('storage::presignUrl', {
-  bucket: 'uploads',
-  key: 'u/1/next.jpg',
-  method: 'PUT',
-  expires_in_seconds: 600,
-  content_type: 'image/jpeg',      // pinned into the signature
+const { url, expires_at } = await iii.trigger({
+  function_id: 'storage::presignUrl',
+  payload: {
+    bucket: 'uploads',
+    key: 'u/1/next.jpg',
+    method: 'PUT',
+    expires_in_seconds: 600,
+    content_type: 'image/jpeg',      // pinned into the signature
+  },
 })
 
-const { body_base64, content_type } = await call('storage::getObject', {
-  bucket: 'uploads',
-  key: 'u/1/profile.jpg',
+const { body_base64, content_type } = await iii.trigger({
+  function_id: 'storage::getObject',
+  payload: {
+    bucket: 'uploads',
+    key: 'u/1/profile.jpg',
+  },
 })
 
-await call('storage::deleteObject', {
-  bucket: 'uploads',
-  key: 'u/1/profile.jpg',
+await iii.trigger({
+  function_id: 'storage::deleteObject',
+  payload: {
+    bucket: 'uploads',
+    key: 'u/1/profile.jpg',
+  },
 })                                  // idempotent: returns { deleted: false } if absent
 ```
 


### PR DESCRIPTION
… trigger

Replaced instances of `call` with `registerWorker` and `trigger` in the database README and test files to align with the new function naming conventions. This change enhances clarity and consistency across the codebase. Additionally, updated the package-lock.json to reflect the new package name for the tests harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Database quickstart guide updated with new code examples showing current SDK usage
  * Storage quickstart guide updated with new code examples showing current SDK usage
  * Test harness reference implementation updated with current patterns
  * Examples now reflect the latest recommended approaches for database and storage operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/workers/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->