### PR TITLE
chore: harness rename

### DIFF
--- a/.github/scripts/resolve_bundle_artifact.py
+++ b/.github/scripts/resolve_bundle_artifact.py
@@ -8,7 +8,7 @@
 This CLI mirrors `resolve_binary_artifacts.py` but for the single-artefact
 shape used by `PublishRequestBundle`. It writes a JSON file like:
 
-    { "archive_url": "https://.../harness-node.tar.gz",
+    { "archive_url": "https://.../harness.tar.gz",
       "sha256":      "9f86d08..." }
 
 …which `build_publish_payload.py` reads to populate the `bundle`

--- a/.github/workflows/_bundle.yml
+++ b/.github/workflows/_bundle.yml
@@ -14,7 +14,7 @@ on:
   workflow_call:
     inputs:
       worker:
-        description: 'Worker name (folder), e.g. harness-node'
+        description: 'Worker name (folder), e.g. harness'
         required: true
         type: string
       version:
@@ -22,7 +22,7 @@ on:
         required: true
         type: string
       tag_name:
-        description: 'Git tag for the GitHub Release (e.g., harness-node/v0.1.0)'
+        description: 'Git tag for the GitHub Release (e.g., harness/v0.1.0)'
         required: true
         type: string
       language:

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -11,7 +11,7 @@ on:
           - acp
           - console
           - database
-          - harness-node
+          - harness
           - iii-directory
           - iii-lsp
           - iii-lsp-vscode

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'acp/v*'
       - 'console/v*'
       - 'database/v*'
-      - 'harness-node/v*'
+      - 'harness/v*'
       - 'iii-directory/v*'
       - 'iii-lsp/v*'
       - 'image-resize/v*'

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ asset for the host from the workers registry API.
 | Worker | Kind | Summary |
 |---|---|---|
 | [`acp`](acp/) | Rust | Agent Client Protocol surface — stdio JSON-RPC, exposes iii agents as ACP sessions. |
-| [`harness-node`](harness-node/) | Node | TS port of the iii harness stack — bundles `harness`, `turn-orchestrator`, `approval-gate`, `session`, `hook-fanout`, `auth-credentials`, `models-catalog`, `provider-anthropic`, `provider-openai`, `llm-budget`, and `context-compaction` as one pnpm monorepo. See [`harness-node/README.md`](harness-node/README.md). |
+| [`harness`](harness/) | Node | TS port of the iii harness stack — bundles `harness`, `turn-orchestrator`, `approval-gate`, `session`, `hook-fanout`, `auth-credentials`, `models-catalog`, `provider-anthropic`, `provider-openai`, `llm-budget`, and `context-compaction` as one pnpm monorepo. See [`harness/README.md`](harness/README.md). |
 | [`database`](database/) | Rust | PostgreSQL, MySQL, and SQLite client — query, execute, transactions, prepared statements, and change feeds. |
 | [`iii-directory`](iii-directory/) | Rust | Engine introspection (functions / triggers / workers), workers-registry proxy, and filesystem-backed skill + prompt reader. |
 | [`iii-lsp`](iii-lsp/) | Rust | Language Server for iii function ids, trigger configs, and worker discovery. Autocomplete / hover across JS/TS, Python, Rust. |
@@ -47,7 +47,7 @@ cargo build --release
 ```
 
 Node/Python workers follow the standard `npm install` / `pip install -e .`
-flow — see each module's README for specifics. `harness-node` is a pnpm
+flow — see each module's README for specifics. `harness` is a pnpm
 monorepo (`pnpm install && pnpm build`).
 
 ## Binary releases

--- a/console/web/src/lib/backend/history.ts
+++ b/console/web/src/lib/backend/history.ts
@@ -5,15 +5,9 @@
  */
 
 import type { Message } from '@/types/chat'
-import type {
-  AgentMessage,
-  AssistantMessage,
-  UserMessage,
-} from '@/types/iii-agent-event'
+import type { AgentMessage, AssistantMessage, UserMessage } from '@/types/iii-agent-event'
 
-export function translateUiHistoryForBackend(
-  messages: readonly Message[],
-): AgentMessage[] {
+export function translateUiHistoryForBackend(messages: readonly Message[]): AgentMessage[] {
   // Stacked compactions: only the most recent summary needs to ship since
   // the anchored prompt in summarize.ts already folds the prior one in.
   let lastCompactIdx = -1
@@ -29,13 +23,10 @@ export function translateUiHistoryForBackend(
   const start = lastCompactIdx >= 0 ? lastCompactIdx : 0
 
   if (lastCompactIdx >= 0) {
-    const marker = messages[lastCompactIdx] as Extract<
-      Message,
-      { role: 'system' }
-    >
+    const marker = messages[lastCompactIdx] as Extract<Message, { role: 'system' }>
     const summary = marker.summaryText ?? ''
     if (summary.length > 0) {
-      // Wire-identical to harness-node's buildSummaryMessage.
+      // Wire-identical to harness's buildSummaryMessage.
       out.push({
         role: 'assistant',
         content: [
@@ -52,11 +43,7 @@ export function translateUiHistoryForBackend(
     }
   }
 
-  for (
-    let i = start + (lastCompactIdx >= 0 ? 1 : 0);
-    i < messages.length;
-    i++
-  ) {
+  for (let i = start + (lastCompactIdx >= 0 ? 1 : 0); i < messages.length; i++) {
     const m = messages[i]
     if (m.role === 'user') out.push(toUserMessage(m))
     else if (m.role === 'assistant') {
@@ -75,9 +62,7 @@ function toUserMessage(m: Extract<Message, { role: 'user' }>): UserMessage {
   }
 }
 
-function toAssistantMessage(
-  m: Extract<Message, { role: 'assistant' }>,
-): AssistantMessage | null {
+function toAssistantMessage(m: Extract<Message, { role: 'assistant' }>): AssistantMessage | null {
   // Empty-content assistant messages confuse providers; the wire shape
   // requires at least one text block.
   if (!m.content || m.content.length === 0) return null

--- a/console/web/src/types/chat.ts
+++ b/console/web/src/types/chat.ts
@@ -1,6 +1,6 @@
 export type Mode = 'plan' | 'ask' | 'agent'
 
-/** Composite `provider::<catalog_model_id>` (matches harness-node models-catalog). */
+/** Composite `provider::<catalog_model_id>` (matches harness models-catalog). */
 export const CATALOG_MODEL_KEY_SEP = '::' as const
 
 export type ModelId = string
@@ -13,7 +13,7 @@ export interface ModelOption {
 
 /**
  * When the engine is down or mock backend runs, picker still needs options.
- * Ids mirror the seeded catalog (`harness-node/.../models.json`).
+ * Ids mirror the seeded catalog (`harness/.../models.json`).
  */
 export const STATIC_MODEL_OPTIONS: ModelOption[] = [
   {
@@ -114,12 +114,7 @@ export interface SystemMessage extends BaseMessage {
   tokensBefore?: number
 }
 
-export type Message =
-  | UserMessage
-  | AssistantMessage
-  | ThoughtMessage
-  | FunctionCallMessage
-  | SystemMessage
+export type Message = UserMessage | AssistantMessage | ThoughtMessage | FunctionCallMessage | SystemMessage
 
 /**
  * Loose patch shape passed to updateMessage(). Lists every patchable field
@@ -158,12 +153,7 @@ export interface Conversation {
   updatedAt: number
 }
 
-const KNOWN_ROLES: ReadonlySet<Role> = new Set<Role>([
-  'user',
-  'assistant',
-  'thought',
-  'function-call',
-])
+const KNOWN_ROLES: ReadonlySet<Role> = new Set<Role>(['user', 'assistant', 'thought', 'function-call'])
 
 export function isKnownRole(role: unknown): role is Role {
   return typeof role === 'string' && KNOWN_ROLES.has(role as Role)

--- a/harness/README.md
+++ b/harness/README.md
@@ -1,4 +1,4 @@
-# harness-node
+# harness
 
 Node/TypeScript port of the iii harness stack. One package, one folder per
 worker, one feature per file. Each worker is independently runnable as
@@ -6,7 +6,7 @@ worker, one feature per file. Each worker is independently runnable as
 
 The Rust workers `shell`, `iii-directory`, and the engine's `state::*`/
 `stream::*`/`iii::durable::*` primitives are NOT ported — they run
-alongside `harness-node` over the iii bus.
+alongside `harness` over the iii bus.
 
 ## Workers
 

--- a/harness/docs/architecture.md
+++ b/harness/docs/architecture.md
@@ -1,16 +1,16 @@
-# harness-node architecture
+# harness architecture
 
-`harness-node` is the Node/TypeScript port of the iii harness stack. It ships
+`harness` is the Node/TypeScript port of the iii harness stack. It ships
 as one pnpm package containing 11 workers (one folder per worker, one feature
 per file) plus a shared `runtime/` SDK helper layer and a `types/` wire-type
 mirror of `harness/crates/harness-types`. Each worker is independently runnable
 as `pnpm dev:<worker>` (development) or `iii-<worker>` (production binary);
-[src/index.ts](harness-node/src/index.ts) is the composite entry-point that
+[src/index.ts](harness/src/index.ts) is the composite entry-point that
 spins every worker up in a single process by reusing each worker's
 `register()` callback unchanged.
 
 The Rust workers `shell`, `iii-directory`, and the engine's `state::*` /
-`stream::*` / `iii::durable::*` primitives are NOT ported. `harness-node`
+`stream::*` / `iii::durable::*` primitives are NOT ported. `harness`
 talks to them over the iii bus exactly the same way it talks to its own
 workers.
 
@@ -18,18 +18,18 @@ workers.
 
 | Worker | Folder | Role | Doc |
 |---|---|---|---|
-| harness | [src/harness/](harness-node/src/harness/) | Meta-worker; loads `iii-permissions.yaml`, exposes `harness::trigger` (WS ingestion bridge — see [Telemetry & trace correlation](#telemetry--trace-correlation)) / `policy::check_permissions` / `ui::*`, spins up `agent::events` fan-out. | [workers/harness.md](harness-node/docs/workers/harness.md) |
-| turn-orchestrator | [src/turn-orchestrator/](harness-node/src/turn-orchestrator/) | Durable FSM driving each agent turn; chokepoint dispatcher for `agent::trigger`. | [workers/turn-orchestrator.md](harness-node/docs/workers/turn-orchestrator.md) |
-| approval-gate | [src/approval-gate/](harness-node/src/approval-gate/) | Registers `approval::resolve` and shared approval wire schemas; routes decisions to per-call `turn::approval_resume` fns owned by the turn-orchestrator. | [workers/approval-gate.md](harness-node/docs/workers/approval-gate.md) |
-| session | [src/session/](harness-node/src/session/) | Branching session storage (`session-tree::*`) plus per-session inbox queues (`session-inbox::*`). | [workers/session.md](harness-node/docs/workers/session.md) |
-| llm-budget | [src/llm-budget/](harness-node/src/llm-budget/) | Workspace + agent LLM spend caps with alerts, forecast, period rollover. | [workers/llm-budget.md](harness-node/docs/workers/llm-budget.md) |
-| hook-fanout | [src/hook-fanout/](harness-node/src/hook-fanout/) | Generic publish-and-collect primitive over a stream topic. | [workers/hook-fanout.md](harness-node/docs/workers/hook-fanout.md) |
-| auth-credentials | [src/auth-credentials/](harness-node/src/auth-credentials/) | File-backed multi-provider credential store. | [workers/auth-credentials.md](harness-node/docs/workers/auth-credentials.md) |
-| models-catalog | [src/models-catalog/](harness-node/src/models-catalog/) | Static model-capability catalogue (state-first, embedded fallback). | [workers/models-catalog.md](harness-node/docs/workers/models-catalog.md) |
-| provider-anthropic | [src/provider-anthropic/](harness-node/src/provider-anthropic/) | Anthropic Messages API SSE → channel writer. | [workers/provider-anthropic.md](harness-node/docs/workers/provider-anthropic.md) |
-| provider-openai | [src/provider-openai/](harness-node/src/provider-openai/) | OpenAI Chat Completions SSE → channel writer. | [workers/provider-openai.md](harness-node/docs/workers/provider-openai.md) |
-| provider-kimi | [src/provider-kimi/](harness-node/src/provider-kimi/) | Kimi Chat Completions SSE → channel writer. | [workers/provider-kimi.md](harness-node/docs/workers/provider-kimi.md) |
-| context-compaction | [src/context-compaction/](harness-node/src/context-compaction/) | Optional `agent::events` side-car that compacts session history when running token count crosses a threshold. | [workers/context-compaction.md](harness-node/docs/workers/context-compaction.md) |
+| harness | [src/harness/](harness/src/harness/) | Meta-worker; loads `iii-permissions.yaml`, exposes `harness::trigger` (WS ingestion bridge — see [Telemetry & trace correlation](#telemetry--trace-correlation)) / `policy::check_permissions` / `ui::*`, spins up `agent::events` fan-out. | [workers/harness.md](harness/docs/workers/harness.md) |
+| turn-orchestrator | [src/turn-orchestrator/](harness/src/turn-orchestrator/) | Durable FSM driving each agent turn; chokepoint dispatcher for `agent::trigger`. | [workers/turn-orchestrator.md](harness/docs/workers/turn-orchestrator.md) |
+| approval-gate | [src/approval-gate/](harness/src/approval-gate/) | Registers `approval::resolve` and shared approval wire schemas; routes decisions to per-call `turn::approval_resume` fns owned by the turn-orchestrator. | [workers/approval-gate.md](harness/docs/workers/approval-gate.md) |
+| session | [src/session/](harness/src/session/) | Branching session storage (`session-tree::*`) plus per-session inbox queues (`session-inbox::*`). | [workers/session.md](harness/docs/workers/session.md) |
+| llm-budget | [src/llm-budget/](harness/src/llm-budget/) | Workspace + agent LLM spend caps with alerts, forecast, period rollover. | [workers/llm-budget.md](harness/docs/workers/llm-budget.md) |
+| hook-fanout | [src/hook-fanout/](harness/src/hook-fanout/) | Generic publish-and-collect primitive over a stream topic. | [workers/hook-fanout.md](harness/docs/workers/hook-fanout.md) |
+| auth-credentials | [src/auth-credentials/](harness/src/auth-credentials/) | File-backed multi-provider credential store. | [workers/auth-credentials.md](harness/docs/workers/auth-credentials.md) |
+| models-catalog | [src/models-catalog/](harness/src/models-catalog/) | Static model-capability catalogue (state-first, embedded fallback). | [workers/models-catalog.md](harness/docs/workers/models-catalog.md) |
+| provider-anthropic | [src/provider-anthropic/](harness/src/provider-anthropic/) | Anthropic Messages API SSE → channel writer. | [workers/provider-anthropic.md](harness/docs/workers/provider-anthropic.md) |
+| provider-openai | [src/provider-openai/](harness/src/provider-openai/) | OpenAI Chat Completions SSE → channel writer. | [workers/provider-openai.md](harness/docs/workers/provider-openai.md) |
+| provider-kimi | [src/provider-kimi/](harness/src/provider-kimi/) | Kimi Chat Completions SSE → channel writer. | [workers/provider-kimi.md](harness/docs/workers/provider-kimi.md) |
+| context-compaction | [src/context-compaction/](harness/src/context-compaction/) | Optional `agent::events` side-car that compacts session history when running token count crosses a threshold. | [workers/context-compaction.md](harness/docs/workers/context-compaction.md) |
 
 ## System diagram
 
@@ -37,7 +37,7 @@ workers.
 flowchart LR
   client[Browser or CLI client]
 
-  subgraph harnessNode [harness-node workers]
+  subgraph harnessNode [harness workers]
     harness[harness]
     turnOrch[turn-orchestrator]
     approval[approval-gate]
@@ -89,7 +89,7 @@ flowchart LR
 
 ## Turn FSM
 
-[src/turn-orchestrator/state.ts](harness-node/src/turn-orchestrator/state.ts)
+[src/turn-orchestrator/state.ts](harness/src/turn-orchestrator/state.ts)
 defines an 11-state durable FSM. Every transition is driven by the
 `turn::step` durable subscriber, which is woken by a publish to the
 `turn::step_requested` topic — either by the orchestrator itself
@@ -184,12 +184,12 @@ lookups.
 
 | Folder | Purpose |
 |---|---|
-| [src/runtime/](harness-node/src/runtime/) | Cross-worker SDK helpers. `worker.ts` parses CLI flags, bootstraps an SDK connection, and wraps it in a `Proxy` so every `registerFunction` is auto-instrumented (see [Telemetry & trace correlation](#telemetry--trace-correlation)); `config.ts` loads `config.yaml`; `state.ts` / `stream.ts` wrap the iii engine's state/stream surface; `ids.ts` mints UUID-like ids; `otel.ts` wires `iii-sdk` OTel via `initHarnessOtel`, exposes `instrumentHandler` (per-call span + baggage propagation), and bridges every pino log to an OTel log auto-correlated to the active span; `handler.ts` exposes `unwrapBody` / `requireString`. |
-| [src/types/](harness-node/src/types/) | Wire types that mirror `harness/crates/harness-types/src/*.rs`. `agent-event.ts`, `agent-message.ts`, `content.ts`, `function.ts`, `stream-event.ts`, `thinking.ts`, `provider.ts`, plus `wire.ts` for envelope helpers. |
+| [src/runtime/](harness/src/runtime/) | Cross-worker SDK helpers. `worker.ts` parses CLI flags, bootstraps an SDK connection, and wraps it in a `Proxy` so every `registerFunction` is auto-instrumented (see [Telemetry & trace correlation](#telemetry--trace-correlation)); `config.ts` loads `config.yaml`; `state.ts` / `stream.ts` wrap the iii engine's state/stream surface; `ids.ts` mints UUID-like ids; `otel.ts` wires `iii-sdk` OTel via `initHarnessOtel`, exposes `instrumentHandler` (per-call span + baggage propagation), and bridges every pino log to an OTel log auto-correlated to the active span; `handler.ts` exposes `unwrapBody` / `requireString`. |
+| [src/types/](harness/src/types/) | Wire types that mirror `harness/crates/harness-types/src/*.rs`. `agent-event.ts`, `agent-message.ts`, `content.ts`, `function.ts`, `stream-event.ts`, `thinking.ts`, `provider.ts`, plus `wire.ts` for envelope helpers. |
 
 ## Boot ordering & dependencies
 
-The composite entry-point [src/index.ts](harness-node/src/index.ts) spins
+The composite entry-point [src/index.ts](harness/src/index.ts) spins
 workers up in this order so each dependency is already on the bus before its
 dependants register:
 
@@ -218,13 +218,13 @@ block.
 
 ## Telemetry & trace correlation
 
-Every harness-node function is automatically instrumented with an OTel span
+Every harness function is automatically instrumented with an OTel span
 tagged with `iii.session.id` / `iii.message.id` / `iii.function.id`. This is
 what the engine's `engine::traces::group_by` reads to populate "Group by
 Session" / "Group by Message" / "Group by Function" in the traces UI; without
 the IDs on every span, those groupings return empty.
 
-**The single chokepoint.** [src/runtime/worker.ts](harness-node/src/runtime/worker.ts)
+**The single chokepoint.** [src/runtime/worker.ts](harness/src/runtime/worker.ts)
 calls `initHarnessOtel(serviceName, engineWsUrl)` before opening the SDK,
 then wraps the `ISdk` in a `Proxy` that intercepts `registerFunction(id,
 handler, opts)`. The local function handler is replaced with
@@ -235,7 +235,7 @@ unchanged because there is no local handler to wrap. No per-worker
 worker can accidentally skip the wrap.
 
 **What `instrumentHandler` does per call.** See
-[src/runtime/otel.ts](harness-node/src/runtime/otel.ts). On every
+[src/runtime/otel.ts](harness/src/runtime/otel.ts). On every
 invocation it opens a `harness.<function_id>` SERVER span, extracts
 `session_id` / `message_id` from the input body (with baggage fallback
 for nested calls so a downstream `iii.trigger` inherits the IDs of its
@@ -267,13 +267,13 @@ terminal during `pnpm dev:<worker>`). On top of that, every
 `logger.info/warn/error` also emits an OTel log via `iii-sdk/telemetry`'s
 `getLogger()`, which auto-correlates the log to the currently active
 span. This is what populates the LOGS tab in the traces UI for every
-harness-node span. When `initHarnessOtel` failed to boot (e.g.
+harness span. When `initHarnessOtel` failed to boot (e.g.
 `OTEL_ENABLED=false`), the OTel side is a quiet no-op and pino continues
 to write to stderr unchanged.
 
 **`harness::trigger` as the WS ingestion bridge.** Browser-originated
 requests hit `harness::trigger` (see
-[src/harness/trigger.ts](harness-node/src/harness/trigger.ts)), NOT
+[src/harness/trigger.ts](harness/src/harness/trigger.ts)), NOT
 `run::start` directly. The wrapping `instrumentHandler` reads
 `session_id`/`message_id` from the outer body and seeds baggage; the
 handler then forwards to `iii.trigger` with the inner `function_id` /
@@ -303,7 +303,7 @@ sequenceDiagram
 
 All workers honour `--url` / `III_URL` (engine WebSocket) and `--config`
 (YAML config file; defaults to `./config.yaml`). The shipped
-[config.yaml](harness-node/config.yaml) contains the per-worker sub-sections;
+[config.yaml](harness/config.yaml) contains the per-worker sub-sections;
 each worker reads only the fields it cares about and ignores the rest. The
 harness worker additionally watches the path in `permissions_path` (default
 `./iii-permissions.yaml`, symlinked to the workspace-root file) and reloads

--- a/harness/docs/workers/approval-gate.md
+++ b/harness/docs/workers/approval-gate.md
@@ -21,7 +21,7 @@ and route it to the correct per-call resume function.
 ## Resolution flow
 
 1. While parked, the orchestrator calls `registerApprovalResume` for each
-   pending call (see [approval-resume.ts](harness-node/src/turn-orchestrator/approval-resume.ts)).
+   pending call (see [approval-resume.ts](harness/src/turn-orchestrator/approval-resume.ts)).
 2. The console calls `approval::resolve` with `{ session_id, function_call_id, decision, reason? }`.
 3. `approval::resolve` triggers `turn::approval_resume::<sid>/<cid>` with the decision payload.
 4. The resume handler writes `approvals/<sid>/<cid>` (if not already set), invokes `turn::step`, and unregisters the resume fn.
@@ -42,7 +42,7 @@ Per-call resume functions are registered by the turn-orchestrator, not this work
 ## State keys
 
 All decision records use scope `approvals` (constant `STATE_SCOPE` in
-[src/approval-gate/schemas.ts](harness-node/src/approval-gate/schemas.ts)):
+[src/approval-gate/schemas.ts](harness/src/approval-gate/schemas.ts)):
 
 | Key shape | Value | Purpose |
 |---|---|---|
@@ -53,10 +53,10 @@ separate rows under `approvals` until a decision lands.
 
 ## Denial envelopes
 
-[src/approval-gate/denial.ts](harness-node/src/approval-gate/denial.ts) builds
+[src/approval-gate/denial.ts](harness/src/approval-gate/denial.ts) builds
 `DenialEnvelope` values for policy denies (`permissionsDenyEnvelope` via
-`consultBefore` in [hook.ts](harness-node/src/turn-orchestrator/hook.ts)).
-[src/approval-gate/redact.ts](harness-node/src/approval-gate/redact.ts)
+`consultBefore` in [hook.ts](harness/src/turn-orchestrator/hook.ts)).
+[src/approval-gate/redact.ts](harness/src/approval-gate/redact.ts)
 sanitizes tool args for `args_excerpt` on those envelopes.
 
 ## Pending-approval signalling
@@ -68,7 +68,7 @@ record. On reload it uses `turn::get_state` (not direct iii state reads).
 
 ## Configuration
 
-There is no `approval_gate` section in [config.yaml](harness-node/config.yaml).
+There is no `approval_gate` section in [config.yaml](harness/config.yaml).
 Scope `approvals` is fixed in code (`STATE_SCOPE`).
 
 Policy consultation is a direct `iii.trigger` to `policy::check_permissions`
@@ -78,20 +78,20 @@ from turn-orchestrator `consultBefore`. See
 ## Dependencies
 
 From
-[src/approval-gate/iii.worker.yaml](harness-node/src/approval-gate/iii.worker.yaml):
+[src/approval-gate/iii.worker.yaml](harness/src/approval-gate/iii.worker.yaml):
 no explicit dependency block.
 
 ## Source layout
 
 | File | Purpose |
 |---|---|
-| [src/approval-gate/main.ts](harness-node/src/approval-gate/main.ts) | Binary entry point (`iii-approval-gate`). |
-| [src/approval-gate/resolve.ts](harness-node/src/approval-gate/resolve.ts) | Registers `approval::resolve`; triggers per-call resume fns. |
-| [src/approval-gate/schemas.ts](harness-node/src/approval-gate/schemas.ts) | `STATE_SCOPE`, wire schemas, `parsePolicyReply`, `pendingKey`, `approvalResumeFnId`, `ResolvePayloadSchema`. |
-| [src/approval-gate/denial.ts](harness-node/src/approval-gate/denial.ts) | `permissionsDenyEnvelope` and related helpers. |
-| [src/approval-gate/redact.ts](harness-node/src/approval-gate/redact.ts) | `redact` / `clip` for safe `args_excerpt` on denials. |
-| [src/approval-gate/iii.worker.yaml](harness-node/src/approval-gate/iii.worker.yaml) | Worker manifest. |
+| [src/approval-gate/main.ts](harness/src/approval-gate/main.ts) | Binary entry point (`iii-approval-gate`). |
+| [src/approval-gate/resolve.ts](harness/src/approval-gate/resolve.ts) | Registers `approval::resolve`; triggers per-call resume fns. |
+| [src/approval-gate/schemas.ts](harness/src/approval-gate/schemas.ts) | `STATE_SCOPE`, wire schemas, `parsePolicyReply`, `pendingKey`, `approvalResumeFnId`, `ResolvePayloadSchema`. |
+| [src/approval-gate/denial.ts](harness/src/approval-gate/denial.ts) | `permissionsDenyEnvelope` and related helpers. |
+| [src/approval-gate/redact.ts](harness/src/approval-gate/redact.ts) | `redact` / `clip` for safe `args_excerpt` on denials. |
+| [src/approval-gate/iii.worker.yaml](harness/src/approval-gate/iii.worker.yaml) | Worker manifest. |
 
 Related orchestrator code:
-[approval-resume.ts](harness-node/src/turn-orchestrator/approval-resume.ts),
-[hook.ts](harness-node/src/turn-orchestrator/hook.ts).
+[approval-resume.ts](harness/src/turn-orchestrator/approval-resume.ts),
+[hook.ts](harness/src/turn-orchestrator/hook.ts).

--- a/harness/docs/workers/auth-credentials.md
+++ b/harness/docs/workers/auth-credentials.md
@@ -14,7 +14,7 @@ serialize through an in-process write queue and use atomic `tmp` +
 `auth::get_token` is the resolver every consumer calls. It first looks up
 a stored credential; if none, it falls back to the per-provider
 environment variable defined in
-[src/auth-credentials/types.ts](harness-node/src/auth-credentials/types.ts)
+[src/auth-credentials/types.ts](harness/src/auth-credentials/types.ts)
 (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `AWS_ACCESS_KEY_ID`,
 `HF_TOKEN`, etc.) and synthesises an `ApiKey` credential. `auth::status`
 reports `{ configured, source: "stored" | "environment", label }` without
@@ -46,7 +46,7 @@ None.
 ## Configuration
 
 From the `auth_credentials` section of
-[config.yaml](harness-node/config.yaml):
+[config.yaml](harness/config.yaml):
 
 - `store_path` (default `~/.iii/auth-credentials.json`) — leading `~/` is
   expanded against the OS home directory.
@@ -54,7 +54,7 @@ From the `auth_credentials` section of
 ## Dependencies
 
 From
-[src/auth-credentials/iii.worker.yaml](harness-node/src/auth-credentials/iii.worker.yaml):
+[src/auth-credentials/iii.worker.yaml](harness/src/auth-credentials/iii.worker.yaml):
 no explicit dependency block; the worker only touches the local
 filesystem and the process environment.
 
@@ -62,15 +62,15 @@ filesystem and the process environment.
 
 | File | Purpose |
 |---|---|
-| [src/auth-credentials/main.ts](harness-node/src/auth-credentials/main.ts) | Binary entry point (`iii-auth-credentials`). |
-| [src/auth-credentials/register.ts](harness-node/src/auth-credentials/register.ts) | Composes the five handlers around a single `FileStore`. |
-| [src/auth-credentials/config.ts](harness-node/src/auth-credentials/config.ts) | Loads the `auth_credentials` section. |
-| [src/auth-credentials/types.ts](harness-node/src/auth-credentials/types.ts) | `Credential`, `AuthStatus`, `AuthSource`, `EnvKeyMatch`, and the `ENV_VAR_MAP` per-provider env table. |
-| [src/auth-credentials/store.ts](harness-node/src/auth-credentials/store.ts) | `CredentialStore` interface + `InMemoryStore` + `FileStore` (atomic tmp+rename, in-process queue). |
-| [src/auth-credentials/resolve.ts](harness-node/src/auth-credentials/resolve.ts) | Pure `resolveCredential` / `statusFor` / `findEnvKeys` helpers. |
-| [src/auth-credentials/handlers/get-token.ts](harness-node/src/auth-credentials/handlers/get-token.ts) | `auth::get_token` handler. |
-| [src/auth-credentials/handlers/set-token.ts](harness-node/src/auth-credentials/handlers/set-token.ts) | `auth::set_token` handler. |
-| [src/auth-credentials/handlers/delete-token.ts](harness-node/src/auth-credentials/handlers/delete-token.ts) | `auth::delete_token` handler. |
-| [src/auth-credentials/handlers/list-providers.ts](harness-node/src/auth-credentials/handlers/list-providers.ts) | `auth::list_providers` handler. |
-| [src/auth-credentials/handlers/status.ts](harness-node/src/auth-credentials/handlers/status.ts) | `auth::status` handler. |
-| [src/auth-credentials/iii.worker.yaml](harness-node/src/auth-credentials/iii.worker.yaml) | Worker manifest. |
+| [src/auth-credentials/main.ts](harness/src/auth-credentials/main.ts) | Binary entry point (`iii-auth-credentials`). |
+| [src/auth-credentials/register.ts](harness/src/auth-credentials/register.ts) | Composes the five handlers around a single `FileStore`. |
+| [src/auth-credentials/config.ts](harness/src/auth-credentials/config.ts) | Loads the `auth_credentials` section. |
+| [src/auth-credentials/types.ts](harness/src/auth-credentials/types.ts) | `Credential`, `AuthStatus`, `AuthSource`, `EnvKeyMatch`, and the `ENV_VAR_MAP` per-provider env table. |
+| [src/auth-credentials/store.ts](harness/src/auth-credentials/store.ts) | `CredentialStore` interface + `InMemoryStore` + `FileStore` (atomic tmp+rename, in-process queue). |
+| [src/auth-credentials/resolve.ts](harness/src/auth-credentials/resolve.ts) | Pure `resolveCredential` / `statusFor` / `findEnvKeys` helpers. |
+| [src/auth-credentials/handlers/get-token.ts](harness/src/auth-credentials/handlers/get-token.ts) | `auth::get_token` handler. |
+| [src/auth-credentials/handlers/set-token.ts](harness/src/auth-credentials/handlers/set-token.ts) | `auth::set_token` handler. |
+| [src/auth-credentials/handlers/delete-token.ts](harness/src/auth-credentials/handlers/delete-token.ts) | `auth::delete_token` handler. |
+| [src/auth-credentials/handlers/list-providers.ts](harness/src/auth-credentials/handlers/list-providers.ts) | `auth::list_providers` handler. |
+| [src/auth-credentials/handlers/status.ts](harness/src/auth-credentials/handlers/status.ts) | `auth::status` handler. |
+| [src/auth-credentials/iii.worker.yaml](harness/src/auth-credentials/iii.worker.yaml) | Worker manifest. |

--- a/harness/docs/workers/harness.md
+++ b/harness/docs/workers/harness.md
@@ -8,7 +8,7 @@ surface.
 The harness worker is the glue layer of the bundle. It exposes the policy
 surface every other worker relies on, terminates the
 operator-facing `ui::*` plane, and pumps `agent::events` out to subscribed
-browsers. On boot it reads [config.yaml](harness-node/config.yaml) for the
+browsers. On boot it reads [config.yaml](harness/config.yaml) for the
 engine URL and the permissions file path, loads
 [iii-permissions.yaml](iii-permissions.yaml), and starts watching it with
 `chokidar` so policy changes apply without a restart.
@@ -18,7 +18,7 @@ that drive transitions; its fan-out trigger is a passive stream subscriber.
 
 ## Registered functions
 
-- `harness::trigger` — Forward `{function_id, session_id?, message_id?, payload}` to `iii.trigger` and return the result wrapped in an HTTP-style `{status_code, headers, body}` envelope. Used by console/web so the harness span wrapper can seed `iii.session.id` / `iii.message.id` baggage from the outer body (see [architecture.md § Telemetry & trace correlation](harness-node/docs/architecture.md#telemetry--trace-correlation)). Port of `workers/harness/src/lib.rs:103-159`.
+- `harness::trigger` — Forward `{function_id, session_id?, message_id?, payload}` to `iii.trigger` and return the result wrapped in an HTTP-style `{status_code, headers, body}` envelope. Used by console/web so the harness span wrapper can seed `iii.session.id` / `iii.message.id` baggage from the outer body (see [architecture.md § Telemetry & trace correlation](harness/docs/architecture.md#telemetry--trace-correlation)). Port of `workers/harness/src/lib.rs:103-159`.
 - `ui::subscribe` — Register a browser's interest in a session (or all sessions if session_id is null).
 - `ui::unsubscribe` — Remove a browser's subscription to a session (or its all-sessions sub if session_id is null).
 - `harness::fs::read_inline` — Read a host file via shell::fs::read, drain its channel, and return a `{content:[{text}], details:{size, truncated, bytes_read}}` envelope (max 256 KiB inline by default).
@@ -29,8 +29,8 @@ that drive transitions; its fan-out trigger is a passive stream subscriber.
 
 ## Triggers
 
-- **Stream subscriber** on `agent::events` → `harness::fanout::agent_event_handler`. Registered by [src/harness/fanout/agent-events.ts](harness-node/src/harness/fanout/agent-events.ts).
-- **State trigger** on `scope: agent` gated by `condition_function_id: harness::session::is_create_event` → `harness::fanout::session_created`. Lives in [src/harness/fanout/sessions-poll.ts](harness-node/src/harness/fanout/sessions-poll.ts). This replaced the previous 1 Hz `state::list` diff loop: new sessions now reach all-sessions subscribers reactively, on the same `turn_state` write that creates them.
+- **Stream subscriber** on `agent::events` → `harness::fanout::agent_event_handler`. Registered by [src/harness/fanout/agent-events.ts](harness/src/harness/fanout/agent-events.ts).
+- **State trigger** on `scope: agent` gated by `condition_function_id: harness::session::is_create_event` → `harness::fanout::session_created`. Lives in [src/harness/fanout/sessions-poll.ts](harness/src/harness/fanout/sessions-poll.ts). This replaced the previous 1 Hz `state::list` diff loop: new sessions now reach all-sessions subscribers reactively, on the same `turn_state` write that creates them.
 
 The fanout handler forwards every `agent::events` frame to the per-browser
 endpoint `ui::session::event::<browser_id>` for each browser whose
@@ -43,11 +43,11 @@ evicted from the in-process subscription set.
 The harness reads state but doesn't own any keys. The sessions state
 trigger observes `session/<id>/turn_state` writes — those entries are
 owned by the orchestrator (see
-[workers/turn-orchestrator.md](harness-node/docs/workers/turn-orchestrator.md)).
+[workers/turn-orchestrator.md](harness/docs/workers/turn-orchestrator.md)).
 
 ## Configuration
 
-From the top-level [config.yaml](harness-node/config.yaml):
+From the top-level [config.yaml](harness/config.yaml):
 
 - `engine_url` (default `ws://127.0.0.1:49134`) — used to construct
   `ChannelReader` URIs in `harness::fs::read_inline`.
@@ -57,12 +57,12 @@ From the top-level [config.yaml](harness-node/config.yaml):
 
 ## Dependencies
 
-From [src/harness/iii.worker.yaml](harness-node/src/harness/iii.worker.yaml):
+From [src/harness/iii.worker.yaml](harness/src/harness/iii.worker.yaml):
 
 - iii engine surfaces: `iii-state ^0.11.0`, `iii-queue ^0.11.0`,
   `iii-stream ^0.11.0`, `iii-bridge ^0.11.0`, `iii-http ^0.11.0`,
   `iii-sandbox ^0.11.0`, `iii-directory ^0.5.1`.
-- harness-node siblings: `turn-orchestrator`, `models-catalog`,
+- harness siblings: `turn-orchestrator`, `models-catalog`,
   `provider-anthropic`, `provider-openai`, `approval-gate`, `session`,
   `hook-fanout`, `auth-credentials`, `llm-budget` (all `^0.2.0`).
 - Rust workers: `shell ^0.3.0` (for `harness::fs::read_inline`).
@@ -71,18 +71,18 @@ From [src/harness/iii.worker.yaml](harness-node/src/harness/iii.worker.yaml):
 
 | File | Purpose |
 |---|---|
-| [src/harness/main.ts](harness-node/src/harness/main.ts) | Binary entry point (`iii-harness`). |
-| [src/harness/register.ts](harness-node/src/harness/register.ts) | Composes the worker's bus surface; called by both `main.ts` and the composite [src/index.ts](harness-node/src/index.ts). |
-| [src/harness/config.ts](harness-node/src/harness/config.ts) | Loads `engine_url` + `permissions_path` from `config.yaml`. |
-| [src/harness/trigger.ts](harness-node/src/harness/trigger.ts) | `harness::trigger` handler — WS ingestion bridge for browser-originated requests. Forwards `{function_id, payload}` to `iii.trigger`; the wrapping `instrumentHandler` (see `runtime/otel.ts`) reads `session_id`/`message_id` from the outer body and seeds baggage. Port of `workers/harness/src/lib.rs:103-159`. |
-| [src/harness/ui-subscribe.ts](harness-node/src/harness/ui-subscribe.ts) | In-memory `FanoutState` plus `ui::subscribe` / `ui::unsubscribe`. |
-| [src/harness/fs.ts](harness-node/src/harness/fs.ts) | `harness::fs::read_inline` — wraps `shell::fs::read` and inlines the channel into the legacy `{content, details}` envelope. |
-| [src/harness/policy/check-permissions.ts](harness-node/src/harness/policy/check-permissions.ts) | `registerPolicy` — registers `policy::check_permissions` and maps a `Decision` to the wire reply (`allow` / `deny` / `needs_approval`). |
-| [src/harness/policy/handle.ts](harness-node/src/harness/policy/handle.ts) | `PermissionsHandle` + `loadAndWatch` — loads `iii-permissions.yaml`, holds the current `Permissions`, and hot-reloads it via a debounced `chokidar` watcher. |
-| [src/harness/policy/permissions.ts](harness-node/src/harness/policy/permissions.ts) | `Permissions` — parses the YAML into compiled rules and evaluates a call via `check(function_id, args)` (first match wins → `Decision`). |
-| [src/harness/policy/compile.ts](harness-node/src/harness/policy/compile.ts) | `compileRule` / `matchConstraints` — compiles a `RuleSpec` into a `CompiledRule` and evaluates `equals` / `matches` (regex) arg constraints. |
-| [src/harness/policy/types.ts](harness-node/src/harness/policy/types.ts) | `RuleSpec`, `ConstraintSpec`, `Decision`, `MatchedConstraint` types for `iii-permissions.yaml` rules and evaluation results. |
-| [src/harness/fanout/index.ts](harness-node/src/harness/fanout/index.ts) | Spawns the two fan-out pumps. |
-| [src/harness/fanout/agent-events.ts](harness-node/src/harness/fanout/agent-events.ts) | `agent::events` stream subscriber → per-browser fan-out. |
-| [src/harness/fanout/sessions-poll.ts](harness-node/src/harness/fanout/sessions-poll.ts) | State-trigger handler that detects `session/<id>/turn_state` creates and fans the new session id out to every all-sessions subscriber via `ui::sessions::changed::<browser_id>`. (Filename kept for history; the implementation is no longer a poll loop.) |
-| [src/harness/iii.worker.yaml](harness-node/src/harness/iii.worker.yaml) | iii worker manifest (dependencies, install/start scripts). |
+| [src/harness/main.ts](harness/src/harness/main.ts) | Binary entry point (`iii-harness`). |
+| [src/harness/register.ts](harness/src/harness/register.ts) | Composes the worker's bus surface; called by both `main.ts` and the composite [src/index.ts](harness/src/index.ts). |
+| [src/harness/config.ts](harness/src/harness/config.ts) | Loads `engine_url` + `permissions_path` from `config.yaml`. |
+| [src/harness/trigger.ts](harness/src/harness/trigger.ts) | `harness::trigger` handler — WS ingestion bridge for browser-originated requests. Forwards `{function_id, payload}` to `iii.trigger`; the wrapping `instrumentHandler` (see `runtime/otel.ts`) reads `session_id`/`message_id` from the outer body and seeds baggage. Port of `workers/harness/src/lib.rs:103-159`. |
+| [src/harness/ui-subscribe.ts](harness/src/harness/ui-subscribe.ts) | In-memory `FanoutState` plus `ui::subscribe` / `ui::unsubscribe`. |
+| [src/harness/fs.ts](harness/src/harness/fs.ts) | `harness::fs::read_inline` — wraps `shell::fs::read` and inlines the channel into the legacy `{content, details}` envelope. |
+| [src/harness/policy/check-permissions.ts](harness/src/harness/policy/check-permissions.ts) | `registerPolicy` — registers `policy::check_permissions` and maps a `Decision` to the wire reply (`allow` / `deny` / `needs_approval`). |
+| [src/harness/policy/handle.ts](harness/src/harness/policy/handle.ts) | `PermissionsHandle` + `loadAndWatch` — loads `iii-permissions.yaml`, holds the current `Permissions`, and hot-reloads it via a debounced `chokidar` watcher. |
+| [src/harness/policy/permissions.ts](harness/src/harness/policy/permissions.ts) | `Permissions` — parses the YAML into compiled rules and evaluates a call via `check(function_id, args)` (first match wins → `Decision`). |
+| [src/harness/policy/compile.ts](harness/src/harness/policy/compile.ts) | `compileRule` / `matchConstraints` — compiles a `RuleSpec` into a `CompiledRule` and evaluates `equals` / `matches` (regex) arg constraints. |
+| [src/harness/policy/types.ts](harness/src/harness/policy/types.ts) | `RuleSpec`, `ConstraintSpec`, `Decision`, `MatchedConstraint` types for `iii-permissions.yaml` rules and evaluation results. |
+| [src/harness/fanout/index.ts](harness/src/harness/fanout/index.ts) | Spawns the two fan-out pumps. |
+| [src/harness/fanout/agent-events.ts](harness/src/harness/fanout/agent-events.ts) | `agent::events` stream subscriber → per-browser fan-out. |
+| [src/harness/fanout/sessions-poll.ts](harness/src/harness/fanout/sessions-poll.ts) | State-trigger handler that detects `session/<id>/turn_state` creates and fans the new session id out to every all-sessions subscriber via `ui::sessions::changed::<browser_id>`. (Filename kept for history; the implementation is no longer a poll loop.) |
+| [src/harness/iii.worker.yaml](harness/src/harness/iii.worker.yaml) | iii worker manifest (dependencies, install/start scripts). |

--- a/harness/docs/workers/hook-fanout.md
+++ b/harness/docs/workers/hook-fanout.md
@@ -31,7 +31,7 @@ true }`. The orchestrator's `consultBefore` treats `publish_failed` as a
 `gate_unavailable` denial.
 
 Three merge rules are implemented in
-[src/hook-fanout/merge.ts](harness-node/src/hook-fanout/merge.ts):
+[src/hook-fanout/merge.ts](harness/src/hook-fanout/merge.ts):
 
 | Merge rule | Behaviour |
 |---|---|
@@ -58,8 +58,8 @@ held in the process-local pending map until the call resolves.
 ## Configuration
 
 From the optional `hook_fanout` section of
-[config.yaml](harness-node/config.yaml) (defaults from
-[src/hook-fanout/publish-collect.ts](harness-node/src/hook-fanout/publish-collect.ts)):
+[config.yaml](harness/config.yaml) (defaults from
+[src/hook-fanout/publish-collect.ts](harness/src/hook-fanout/publish-collect.ts)):
 
 - `default_timeout_ms` (default `10000`) — fallback for callers that omit
   `timeout_ms`.
@@ -71,7 +71,7 @@ From the optional `hook_fanout` section of
 ## Dependencies
 
 From
-[src/hook-fanout/iii.worker.yaml](harness-node/src/hook-fanout/iii.worker.yaml):
+[src/hook-fanout/iii.worker.yaml](harness/src/hook-fanout/iii.worker.yaml):
 `iii-stream ^0.11.0`. The worker calls `iii::durable::publish` over the
 bus and consumes `agent::hook_reply` via the stream trigger.
 
@@ -79,11 +79,11 @@ bus and consumes `agent::hook_reply` via the stream trigger.
 
 | File | Purpose |
 |---|---|
-| [src/hook-fanout/main.ts](harness-node/src/hook-fanout/main.ts) | Binary entry point (`iii-hook-fanout`). |
-| [src/hook-fanout/register.ts](harness-node/src/hook-fanout/register.ts) | Wires the public function and the internal stream-trigger handler. |
-| [src/hook-fanout/config.ts](harness-node/src/hook-fanout/config.ts) | Loads the `hook_fanout` config section. |
-| [src/hook-fanout/types.ts](harness-node/src/hook-fanout/types.ts) | `FUNCTION_ID`, `REPLY_HANDLER_FN_ID`, `HOOK_REPLY_STREAM`, `MergeRule`, request/response wire types. |
-| [src/hook-fanout/publish-collect.ts](harness-node/src/hook-fanout/publish-collect.ts) | `execute` (installs the collector, publishes, awaits the exit reason, applies merge_rule, builds the response) + `handleStreamReply` (stream-trigger callback that dispatches replies into pending collectors). |
-| [src/hook-fanout/exit.ts](harness-node/src/hook-fanout/exit.ts) | `ExitReason` enum shared with the publish-collect waiter. |
-| [src/hook-fanout/merge.ts](harness-node/src/hook-fanout/merge.ts) | Pure implementations of the three merge rules. |
-| [src/hook-fanout/iii.worker.yaml](harness-node/src/hook-fanout/iii.worker.yaml) | Worker manifest. |
+| [src/hook-fanout/main.ts](harness/src/hook-fanout/main.ts) | Binary entry point (`iii-hook-fanout`). |
+| [src/hook-fanout/register.ts](harness/src/hook-fanout/register.ts) | Wires the public function and the internal stream-trigger handler. |
+| [src/hook-fanout/config.ts](harness/src/hook-fanout/config.ts) | Loads the `hook_fanout` config section. |
+| [src/hook-fanout/types.ts](harness/src/hook-fanout/types.ts) | `FUNCTION_ID`, `REPLY_HANDLER_FN_ID`, `HOOK_REPLY_STREAM`, `MergeRule`, request/response wire types. |
+| [src/hook-fanout/publish-collect.ts](harness/src/hook-fanout/publish-collect.ts) | `execute` (installs the collector, publishes, awaits the exit reason, applies merge_rule, builds the response) + `handleStreamReply` (stream-trigger callback that dispatches replies into pending collectors). |
+| [src/hook-fanout/exit.ts](harness/src/hook-fanout/exit.ts) | `ExitReason` enum shared with the publish-collect waiter. |
+| [src/hook-fanout/merge.ts](harness/src/hook-fanout/merge.ts) | Pure implementations of the three merge rules. |
+| [src/hook-fanout/iii.worker.yaml](harness/src/hook-fanout/iii.worker.yaml) | Worker manifest. |

--- a/harness/docs/workers/llm-budget.md
+++ b/harness/docs/workers/llm-budget.md
@@ -40,7 +40,7 @@ None.
 ## State keys
 
 All keys live under iii state scope `budgets`. From
-[src/llm-budget/types.ts](harness-node/src/llm-budget/types.ts):
+[src/llm-budget/types.ts](harness/src/llm-budget/types.ts):
 
 | Key shape | Value |
 |---|---|
@@ -52,24 +52,24 @@ All keys live under iii state scope `budgets`. From
 
 The worker reads no top-level config keys; period defaults and rollover
 math live in
-[src/llm-budget/periods.ts](harness-node/src/llm-budget/periods.ts).
+[src/llm-budget/periods.ts](harness/src/llm-budget/periods.ts).
 
 ## Dependencies
 
 From
-[src/llm-budget/iii.worker.yaml](harness-node/src/llm-budget/iii.worker.yaml):
+[src/llm-budget/iii.worker.yaml](harness/src/llm-budget/iii.worker.yaml):
 `iii-state ^0.11.0`.
 
 ## Source layout
 
 | File | Purpose |
 |---|---|
-| [src/llm-budget/main.ts](harness-node/src/llm-budget/main.ts) | Binary entry point (`iii-llm-budget`). |
-| [src/llm-budget/register.ts](harness-node/src/llm-budget/register.ts) | Registers all 14 `budget::*` handlers. |
-| [src/llm-budget/types.ts](harness-node/src/llm-budget/types.ts) | `Budget`, `Alert`, `Exemption`, `SpendLogEntry`, plus the `budgetKey` / `spendLogKey` / `resetLogKey` helpers. |
-| [src/llm-budget/store.ts](harness-node/src/llm-budget/store.ts) | State CRUD: `loadBudget`, `saveBudget`, `deleteBudgetRecord`, `listAllBudgets`, `saveSpendLog`, `listSpendLogs`. |
-| [src/llm-budget/periods.ts](harness-node/src/llm-budget/periods.ts) | `periodStart` / `nextPeriodStart` for `day` / `week` / `month`. |
-| [src/llm-budget/ops.ts](harness-node/src/llm-budget/ops.ts) | Higher-level ops shared across handlers (rollover, alert firing, exemption checks). |
-| [src/llm-budget/handlers/*.ts](harness-node/src/llm-budget/handlers/) | One handler per registered function (`create.ts`, `list.ts`, `get.ts`, `update.ts`, `delete.ts`, `check.ts`, `record.ts`, `reset.ts`, `alert-set.ts`, `usage.ts`, `forecast.ts`, `enforce.ts`, `exempt.ts`, `pause.ts`). |
-| [src/llm-budget/handlers/index.ts](harness-node/src/llm-budget/handlers/index.ts) | Re-exports the per-handler `register*` functions. |
-| [src/llm-budget/iii.worker.yaml](harness-node/src/llm-budget/iii.worker.yaml) | Worker manifest. |
+| [src/llm-budget/main.ts](harness/src/llm-budget/main.ts) | Binary entry point (`iii-llm-budget`). |
+| [src/llm-budget/register.ts](harness/src/llm-budget/register.ts) | Registers all 14 `budget::*` handlers. |
+| [src/llm-budget/types.ts](harness/src/llm-budget/types.ts) | `Budget`, `Alert`, `Exemption`, `SpendLogEntry`, plus the `budgetKey` / `spendLogKey` / `resetLogKey` helpers. |
+| [src/llm-budget/store.ts](harness/src/llm-budget/store.ts) | State CRUD: `loadBudget`, `saveBudget`, `deleteBudgetRecord`, `listAllBudgets`, `saveSpendLog`, `listSpendLogs`. |
+| [src/llm-budget/periods.ts](harness/src/llm-budget/periods.ts) | `periodStart` / `nextPeriodStart` for `day` / `week` / `month`. |
+| [src/llm-budget/ops.ts](harness/src/llm-budget/ops.ts) | Higher-level ops shared across handlers (rollover, alert firing, exemption checks). |
+| [src/llm-budget/handlers/*.ts](harness/src/llm-budget/handlers/) | One handler per registered function (`create.ts`, `list.ts`, `get.ts`, `update.ts`, `delete.ts`, `check.ts`, `record.ts`, `reset.ts`, `alert-set.ts`, `usage.ts`, `forecast.ts`, `enforce.ts`, `exempt.ts`, `pause.ts`). |
+| [src/llm-budget/handlers/index.ts](harness/src/llm-budget/handlers/index.ts) | Re-exports the per-handler `register*` functions. |
+| [src/llm-budget/iii.worker.yaml](harness/src/llm-budget/iii.worker.yaml) | Worker manifest. |

--- a/harness/docs/workers/models-catalog.md
+++ b/harness/docs/workers/models-catalog.md
@@ -13,7 +13,7 @@ and optional `thinking_budgets` / `transports` / `pricing` fields. The
 catalogue is state-first: reads go to iii state under scope `models`,
 prefix `models:`; if state is empty the worker falls back to (and seeds
 state from) the JSON file embedded at
-[src/models-catalog/models.json](harness-node/src/models-catalog/models.json).
+[src/models-catalog/models.json](harness/src/models-catalog/models.json).
 
 The seed happens lazily at `register()` time and never blocks boot.
 Operators can layer their own entries on top with `models::register`.
@@ -57,27 +57,27 @@ match no models from `models::list`.
 
 The worker reads no top-level config keys. The state-request timeout is
 hard-coded to 5 s in
-[src/models-catalog/state.ts](harness-node/src/models-catalog/state.ts)
+[src/models-catalog/state.ts](harness/src/models-catalog/state.ts)
 (`DEFAULT_STATE_CONFIG.state_request_timeout_ms`).
 
 ## Dependencies
 
 From
-[src/models-catalog/iii.worker.yaml](harness-node/src/models-catalog/iii.worker.yaml):
+[src/models-catalog/iii.worker.yaml](harness/src/models-catalog/iii.worker.yaml):
 `iii-state ^0.11.0`.
 
 ## Source layout
 
 | File | Purpose |
 |---|---|
-| [src/models-catalog/main.ts](harness-node/src/models-catalog/main.ts) | Binary entry point (`iii-models-catalog`). |
-| [src/models-catalog/register.ts](harness-node/src/models-catalog/register.ts) | Kicks off `seedStateIfEmpty` and registers the four handlers. |
-| [src/models-catalog/types.ts](harness-node/src/models-catalog/types.ts) | `Model`, `Pricing`, `ThinkingBudgets`, `Capability`, `parseCapability`, `supportsModel`. |
-| [src/models-catalog/catalog.ts](harness-node/src/models-catalog/catalog.ts) | `loadEmbeddedCatalog` reads `models.json` and caches the parsed list. |
-| [src/models-catalog/state.ts](harness-node/src/models-catalog/state.ts) | `seedStateIfEmpty` + state-first `listFromStateOrSeed` / `getFromStateOrSeed`. |
-| [src/models-catalog/models.json](harness-node/src/models-catalog/models.json) | Baked-in baseline catalogue. |
-| [src/models-catalog/handlers/list.ts](harness-node/src/models-catalog/handlers/list.ts) | `models::list` handler. |
-| [src/models-catalog/handlers/get.ts](harness-node/src/models-catalog/handlers/get.ts) | `models::get` handler. |
-| [src/models-catalog/handlers/supports.ts](harness-node/src/models-catalog/handlers/supports.ts) | `models::supports` handler. |
-| [src/models-catalog/handlers/register.ts](harness-node/src/models-catalog/handlers/register.ts) | `models::register` handler. |
-| [src/models-catalog/iii.worker.yaml](harness-node/src/models-catalog/iii.worker.yaml) | Worker manifest. |
+| [src/models-catalog/main.ts](harness/src/models-catalog/main.ts) | Binary entry point (`iii-models-catalog`). |
+| [src/models-catalog/register.ts](harness/src/models-catalog/register.ts) | Kicks off `seedStateIfEmpty` and registers the four handlers. |
+| [src/models-catalog/types.ts](harness/src/models-catalog/types.ts) | `Model`, `Pricing`, `ThinkingBudgets`, `Capability`, `parseCapability`, `supportsModel`. |
+| [src/models-catalog/catalog.ts](harness/src/models-catalog/catalog.ts) | `loadEmbeddedCatalog` reads `models.json` and caches the parsed list. |
+| [src/models-catalog/state.ts](harness/src/models-catalog/state.ts) | `seedStateIfEmpty` + state-first `listFromStateOrSeed` / `getFromStateOrSeed`. |
+| [src/models-catalog/models.json](harness/src/models-catalog/models.json) | Baked-in baseline catalogue. |
+| [src/models-catalog/handlers/list.ts](harness/src/models-catalog/handlers/list.ts) | `models::list` handler. |
+| [src/models-catalog/handlers/get.ts](harness/src/models-catalog/handlers/get.ts) | `models::get` handler. |
+| [src/models-catalog/handlers/supports.ts](harness/src/models-catalog/handlers/supports.ts) | `models::supports` handler. |
+| [src/models-catalog/handlers/register.ts](harness/src/models-catalog/handlers/register.ts) | `models::register` handler. |
+| [src/models-catalog/iii.worker.yaml](harness/src/models-catalog/iii.worker.yaml) | Worker manifest. |

--- a/harness/docs/workers/provider-anthropic.md
+++ b/harness/docs/workers/provider-anthropic.md
@@ -20,9 +20,9 @@ final `AssistantMessage`.
 
 Prompt-cache control blocks, tool definitions, and thinking-budget knobs
 are translated by
-[src/provider-anthropic/wire-messages.ts](harness-node/src/provider-anthropic/wire-messages.ts)
+[src/provider-anthropic/wire-messages.ts](harness/src/provider-anthropic/wire-messages.ts)
 and
-[src/provider-anthropic/wire-tools.ts](harness-node/src/provider-anthropic/wire-tools.ts)
+[src/provider-anthropic/wire-tools.ts](harness/src/provider-anthropic/wire-tools.ts)
 to match the API contract.
 
 ## Registered functions
@@ -37,12 +37,12 @@ None.
 ## State keys
 
 None. The worker is stateless beyond the in-process credential cache used
-by [src/provider-anthropic/cache.ts](harness-node/src/provider-anthropic/cache.ts).
+by [src/provider-anthropic/cache.ts](harness/src/provider-anthropic/cache.ts).
 
 ## Configuration
 
 From the `provider_anthropic` section of
-[config.yaml](harness-node/config.yaml):
+[config.yaml](harness/config.yaml):
 
 - `default_max_tokens` (default `8192`) — upper bound for the request's
   `max_tokens` field when the caller omits it.
@@ -52,7 +52,7 @@ From the `provider_anthropic` section of
 ## Dependencies
 
 From
-[src/provider-anthropic/iii.worker.yaml](harness-node/src/provider-anthropic/iii.worker.yaml):
+[src/provider-anthropic/iii.worker.yaml](harness/src/provider-anthropic/iii.worker.yaml):
 `auth-credentials ^0.2.0`. The worker also calls the SDK-provided
 `ChannelWriter` injected into the `writer_ref` field of the stream input.
 
@@ -60,16 +60,16 @@ From
 
 | File | Purpose |
 |---|---|
-| [src/provider-anthropic/main.ts](harness-node/src/provider-anthropic/main.ts) | Binary entry point (`iii-provider-anthropic`). |
-| [src/provider-anthropic/register.ts](harness-node/src/provider-anthropic/register.ts) | Registers both functions. |
-| [src/provider-anthropic/config.ts](harness-node/src/provider-anthropic/config.ts) | Loads the `provider_anthropic` section. |
-| [src/provider-anthropic/types.ts](harness-node/src/provider-anthropic/types.ts) | `AnthropicConfig` + `configWithCredential` builder. |
-| [src/provider-anthropic/auth.ts](harness-node/src/provider-anthropic/auth.ts) | `fetchCredential` (calls `auth::get_token`) + `buildConfig`. |
-| [src/provider-anthropic/cache.ts](harness-node/src/provider-anthropic/cache.ts) | In-process credential / config cache. |
-| [src/provider-anthropic/stream.ts](harness-node/src/provider-anthropic/stream.ts) | `streamAnthropic` async generator: builds request body, fetches SSE, yields `AssistantMessageEvent`s. |
-| [src/provider-anthropic/sse.ts](harness-node/src/provider-anthropic/sse.ts) | SSE parser. |
-| [src/provider-anthropic/wire-messages.ts](harness-node/src/provider-anthropic/wire-messages.ts) | `AgentMessage[]` → Anthropic `messages` translation (text, tool calls, tool results, thinking blocks, cache markers). |
-| [src/provider-anthropic/wire-tools.ts](harness-node/src/provider-anthropic/wire-tools.ts) | `AgentFunction[]` → Anthropic `tools` translation. |
-| [src/provider-anthropic/stream-fn.ts](harness-node/src/provider-anthropic/stream-fn.ts) | `provider::anthropic::stream` handler. |
-| [src/provider-anthropic/complete.ts](harness-node/src/provider-anthropic/complete.ts) | `provider::anthropic::complete` handler (legacy drain-and-return). |
-| [src/provider-anthropic/iii.worker.yaml](harness-node/src/provider-anthropic/iii.worker.yaml) | Worker manifest. |
+| [src/provider-anthropic/main.ts](harness/src/provider-anthropic/main.ts) | Binary entry point (`iii-provider-anthropic`). |
+| [src/provider-anthropic/register.ts](harness/src/provider-anthropic/register.ts) | Registers both functions. |
+| [src/provider-anthropic/config.ts](harness/src/provider-anthropic/config.ts) | Loads the `provider_anthropic` section. |
+| [src/provider-anthropic/types.ts](harness/src/provider-anthropic/types.ts) | `AnthropicConfig` + `configWithCredential` builder. |
+| [src/provider-anthropic/auth.ts](harness/src/provider-anthropic/auth.ts) | `fetchCredential` (calls `auth::get_token`) + `buildConfig`. |
+| [src/provider-anthropic/cache.ts](harness/src/provider-anthropic/cache.ts) | In-process credential / config cache. |
+| [src/provider-anthropic/stream.ts](harness/src/provider-anthropic/stream.ts) | `streamAnthropic` async generator: builds request body, fetches SSE, yields `AssistantMessageEvent`s. |
+| [src/provider-anthropic/sse.ts](harness/src/provider-anthropic/sse.ts) | SSE parser. |
+| [src/provider-anthropic/wire-messages.ts](harness/src/provider-anthropic/wire-messages.ts) | `AgentMessage[]` → Anthropic `messages` translation (text, tool calls, tool results, thinking blocks, cache markers). |
+| [src/provider-anthropic/wire-tools.ts](harness/src/provider-anthropic/wire-tools.ts) | `AgentFunction[]` → Anthropic `tools` translation. |
+| [src/provider-anthropic/stream-fn.ts](harness/src/provider-anthropic/stream-fn.ts) | `provider::anthropic::stream` handler. |
+| [src/provider-anthropic/complete.ts](harness/src/provider-anthropic/complete.ts) | `provider::anthropic::complete` handler (legacy drain-and-return). |
+| [src/provider-anthropic/iii.worker.yaml](harness/src/provider-anthropic/iii.worker.yaml) | Worker manifest. |

--- a/harness/docs/workers/provider-kimi.md
+++ b/harness/docs/workers/provider-kimi.md
@@ -10,16 +10,16 @@ credential from the auth worker (`auth::get_token`, provider `kimi`),
 issues a streaming `chat/completions` request, parses the SSE response
 into `AssistantMessageEvent` frames, and forwards each frame to the
 caller-supplied channel. Mirrors the shape of
-[provider-openai](harness-node/docs/workers/provider-openai.md) so the
+[provider-openai](harness/docs/workers/provider-openai.md) so the
 orchestrator can swap providers without touching the FSM.
 
 `provider::kimi::stream` is the modern channel-writer surface;
 `provider::kimi::complete` is the legacy drain-and-return helper.
 
 Tool calls are translated to/from the OpenAI function/tool wire format in
-[src/provider-kimi/wire-tools.ts](harness-node/src/provider-kimi/wire-tools.ts);
+[src/provider-kimi/wire-tools.ts](harness/src/provider-kimi/wire-tools.ts);
 message translation (text, tool-call, tool-result, system) lives in
-[src/provider-kimi/wire-messages.ts](harness-node/src/provider-kimi/wire-messages.ts).
+[src/provider-kimi/wire-messages.ts](harness/src/provider-kimi/wire-messages.ts).
 
 ## Registered functions
 
@@ -39,7 +39,7 @@ None — the worker is stateless.
 ## Configuration
 
 From the `provider_kimi` section of
-[config.yaml](harness-node/config.yaml):
+[config.yaml](harness/config.yaml):
 
 - `default_max_tokens` (default `8192`) — upper bound for the request's
   `max_completion_tokens` field when the caller omits it.
@@ -53,7 +53,7 @@ From the `provider_kimi` section of
 ## Dependencies
 
 From
-[src/provider-kimi/iii.worker.yaml](harness-node/src/provider-kimi/iii.worker.yaml):
+[src/provider-kimi/iii.worker.yaml](harness/src/provider-kimi/iii.worker.yaml):
 `auth-credentials ^0.2.0`. The worker also calls the SDK-provided
 `ChannelWriter` injected into the `writer_ref` field of the stream input.
 
@@ -61,15 +61,15 @@ From
 
 | File | Purpose |
 |---|---|
-| [src/provider-kimi/main.ts](harness-node/src/provider-kimi/main.ts) | Binary entry point (`iii-provider-kimi`). |
-| [src/provider-kimi/register.ts](harness-node/src/provider-kimi/register.ts) | Registers both functions. |
-| [src/provider-kimi/config.ts](harness-node/src/provider-kimi/config.ts) | Loads the `provider_kimi` section. |
-| [src/provider-kimi/types.ts](harness-node/src/provider-kimi/types.ts) | `ChatCompletionsConfig` + `configFromCredential` builder. |
-| [src/provider-kimi/auth.ts](harness-node/src/provider-kimi/auth.ts) | `fetchCredential` (calls `auth::get_token`) + `buildConfig`. |
-| [src/provider-kimi/stream.ts](harness-node/src/provider-kimi/stream.ts) | `streamKimi` async generator: builds the request body, fetches SSE, yields `AssistantMessageEvent`s. |
-| [src/provider-kimi/sse.ts](harness-node/src/provider-kimi/sse.ts) | SSE parser. |
-| [src/provider-kimi/wire-messages.ts](harness-node/src/provider-kimi/wire-messages.ts) | `AgentMessage[]` → Kimi `messages` translation. |
-| [src/provider-kimi/wire-tools.ts](harness-node/src/provider-kimi/wire-tools.ts) | `AgentFunction[]` → Kimi `tools` translation. |
-| [src/provider-kimi/stream-fn.ts](harness-node/src/provider-kimi/stream-fn.ts) | `provider::kimi::stream` handler. |
-| [src/provider-kimi/complete.ts](harness-node/src/provider-kimi/complete.ts) | `provider::kimi::complete` handler (legacy drain-and-return). |
-| [src/provider-kimi/iii.worker.yaml](harness-node/src/provider-kimi/iii.worker.yaml) | Worker manifest. |
+| [src/provider-kimi/main.ts](harness/src/provider-kimi/main.ts) | Binary entry point (`iii-provider-kimi`). |
+| [src/provider-kimi/register.ts](harness/src/provider-kimi/register.ts) | Registers both functions. |
+| [src/provider-kimi/config.ts](harness/src/provider-kimi/config.ts) | Loads the `provider_kimi` section. |
+| [src/provider-kimi/types.ts](harness/src/provider-kimi/types.ts) | `ChatCompletionsConfig` + `configFromCredential` builder. |
+| [src/provider-kimi/auth.ts](harness/src/provider-kimi/auth.ts) | `fetchCredential` (calls `auth::get_token`) + `buildConfig`. |
+| [src/provider-kimi/stream.ts](harness/src/provider-kimi/stream.ts) | `streamKimi` async generator: builds the request body, fetches SSE, yields `AssistantMessageEvent`s. |
+| [src/provider-kimi/sse.ts](harness/src/provider-kimi/sse.ts) | SSE parser. |
+| [src/provider-kimi/wire-messages.ts](harness/src/provider-kimi/wire-messages.ts) | `AgentMessage[]` → Kimi `messages` translation. |
+| [src/provider-kimi/wire-tools.ts](harness/src/provider-kimi/wire-tools.ts) | `AgentFunction[]` → Kimi `tools` translation. |
+| [src/provider-kimi/stream-fn.ts](harness/src/provider-kimi/stream-fn.ts) | `provider::kimi::stream` handler. |
+| [src/provider-kimi/complete.ts](harness/src/provider-kimi/complete.ts) | `provider::kimi::complete` handler (legacy drain-and-return). |
+| [src/provider-kimi/iii.worker.yaml](harness/src/provider-kimi/iii.worker.yaml) | Worker manifest. |

--- a/harness/docs/workers/provider-openai.md
+++ b/harness/docs/workers/provider-openai.md
@@ -11,16 +11,16 @@ credential from the auth worker (`auth::get_token`, provider `openai`),
 issues a streaming `chat/completions` request, parses the SSE response
 into `AssistantMessageEvent` frames, and forwards each frame to the
 caller-supplied channel. Mirrors the shape of
-[provider-anthropic](harness-node/docs/workers/provider-anthropic.md) so
+[provider-anthropic](harness/docs/workers/provider-anthropic.md) so
 the orchestrator can swap providers without touching the FSM.
 
 `provider::openai::stream` is the modern channel-writer surface;
 `provider::openai::complete` is the legacy drain-and-return helper.
 
 Tool calls are translated to/from the OpenAI function/tool wire format in
-[src/provider-openai/wire-tools.ts](harness-node/src/provider-openai/wire-tools.ts);
+[src/provider-openai/wire-tools.ts](harness/src/provider-openai/wire-tools.ts);
 message translation (text, tool-call, tool-result, system) lives in
-[src/provider-openai/wire-messages.ts](harness-node/src/provider-openai/wire-messages.ts).
+[src/provider-openai/wire-messages.ts](harness/src/provider-openai/wire-messages.ts).
 
 ## Registered functions
 
@@ -38,7 +38,7 @@ None — the worker is stateless.
 ## Configuration
 
 From the `provider_openai` section of
-[config.yaml](harness-node/config.yaml):
+[config.yaml](harness/config.yaml):
 
 - `default_max_tokens` (default `8192`) — upper bound for the request's
   `max_tokens` field when the caller omits it.
@@ -51,7 +51,7 @@ From the `provider_openai` section of
 ## Dependencies
 
 From
-[src/provider-openai/iii.worker.yaml](harness-node/src/provider-openai/iii.worker.yaml):
+[src/provider-openai/iii.worker.yaml](harness/src/provider-openai/iii.worker.yaml):
 `auth-credentials ^0.2.0`. The worker also calls the SDK-provided
 `ChannelWriter` injected into the `writer_ref` field of the stream input.
 
@@ -59,15 +59,15 @@ From
 
 | File | Purpose |
 |---|---|
-| [src/provider-openai/main.ts](harness-node/src/provider-openai/main.ts) | Binary entry point (`iii-provider-openai`). |
-| [src/provider-openai/register.ts](harness-node/src/provider-openai/register.ts) | Registers both functions. |
-| [src/provider-openai/config.ts](harness-node/src/provider-openai/config.ts) | Loads the `provider_openai` section. |
-| [src/provider-openai/types.ts](harness-node/src/provider-openai/types.ts) | `ChatCompletionsConfig` + `configFromCredential` builder. |
-| [src/provider-openai/auth.ts](harness-node/src/provider-openai/auth.ts) | `fetchCredential` (calls `auth::get_token`) + `buildConfig`. |
-| [src/provider-openai/stream.ts](harness-node/src/provider-openai/stream.ts) | `streamOpenai` async generator: builds the request body, fetches SSE, yields `AssistantMessageEvent`s. |
-| [src/provider-openai/sse.ts](harness-node/src/provider-openai/sse.ts) | SSE parser. |
-| [src/provider-openai/wire-messages.ts](harness-node/src/provider-openai/wire-messages.ts) | `AgentMessage[]` → OpenAI `messages` translation. |
-| [src/provider-openai/wire-tools.ts](harness-node/src/provider-openai/wire-tools.ts) | `AgentFunction[]` → OpenAI `tools` translation. |
-| [src/provider-openai/stream-fn.ts](harness-node/src/provider-openai/stream-fn.ts) | `provider::openai::stream` handler. |
-| [src/provider-openai/complete.ts](harness-node/src/provider-openai/complete.ts) | `provider::openai::complete` handler (legacy drain-and-return). |
-| [src/provider-openai/iii.worker.yaml](harness-node/src/provider-openai/iii.worker.yaml) | Worker manifest. |
+| [src/provider-openai/main.ts](harness/src/provider-openai/main.ts) | Binary entry point (`iii-provider-openai`). |
+| [src/provider-openai/register.ts](harness/src/provider-openai/register.ts) | Registers both functions. |
+| [src/provider-openai/config.ts](harness/src/provider-openai/config.ts) | Loads the `provider_openai` section. |
+| [src/provider-openai/types.ts](harness/src/provider-openai/types.ts) | `ChatCompletionsConfig` + `configFromCredential` builder. |
+| [src/provider-openai/auth.ts](harness/src/provider-openai/auth.ts) | `fetchCredential` (calls `auth::get_token`) + `buildConfig`. |
+| [src/provider-openai/stream.ts](harness/src/provider-openai/stream.ts) | `streamOpenai` async generator: builds the request body, fetches SSE, yields `AssistantMessageEvent`s. |
+| [src/provider-openai/sse.ts](harness/src/provider-openai/sse.ts) | SSE parser. |
+| [src/provider-openai/wire-messages.ts](harness/src/provider-openai/wire-messages.ts) | `AgentMessage[]` → OpenAI `messages` translation. |
+| [src/provider-openai/wire-tools.ts](harness/src/provider-openai/wire-tools.ts) | `AgentFunction[]` → OpenAI `tools` translation. |
+| [src/provider-openai/stream-fn.ts](harness/src/provider-openai/stream-fn.ts) | `provider::openai::stream` handler. |
+| [src/provider-openai/complete.ts](harness/src/provider-openai/complete.ts) | `provider::openai::complete` handler (legacy drain-and-return). |
+| [src/provider-openai/iii.worker.yaml](harness/src/provider-openai/iii.worker.yaml) | Worker manifest. |

--- a/harness/docs/workers/session.md
+++ b/harness/docs/workers/session.md
@@ -70,7 +70,7 @@ ids are non-monotonic relative to wall-clock order.
 
 ## Configuration
 
-From the `session` section of [config.yaml](harness-node/config.yaml):
+From the `session` section of [config.yaml](harness/config.yaml):
 
 - `store_backend` (default `iii_state`; alternative `memory`) — which
   `SessionStore` implementation `register()` instantiates.
@@ -81,20 +81,20 @@ From the `session` section of [config.yaml](harness-node/config.yaml):
 
 ## Dependencies
 
-From [src/session/iii.worker.yaml](harness-node/src/session/iii.worker.yaml):
+From [src/session/iii.worker.yaml](harness/src/session/iii.worker.yaml):
 `iii-state ^0.11.0`.
 
 ## Source layout
 
 | File | Purpose |
 |---|---|
-| [src/session/main.ts](harness-node/src/session/main.ts) | Binary entry point (`iii-session`). |
-| [src/session/register.ts](harness-node/src/session/register.ts) | Picks the backend and wires both sub-surfaces. |
-| [src/session/config.ts](harness-node/src/session/config.ts) | Loads the `session` config section. |
-| [src/session/tree/register.ts](harness-node/src/session/tree/register.ts) | Registers all 11 `session-tree::*` functions; exports `FUNCTION_IDS`. |
-| [src/session/tree/operations.ts](harness-node/src/session/tree/operations.ts) | Pure tree algorithms: create, fork, clone, compact, active path, messages, reconcile, tree, export_html, list. |
-| [src/session/tree/store.ts](harness-node/src/session/tree/store.ts) | `SessionStore` interface + `InMemoryStore` + `IiiStateSessionStore`. |
-| [src/session/tree/types.ts](harness-node/src/session/tree/types.ts) | `SessionEntry` (`message` / `custom_message` / `branch_summary` / `compaction`, each with an explicit `timestamp`), `SessionMeta`, `TreeNode`, `ReconcileResult`, `SessionError`, plus the `entryTimestamp` helper used by the `(timestamp, id)` sort. |
-| [src/session/inbox/handlers.ts](harness-node/src/session/inbox/handlers.ts) | Registers the three `session-inbox::*` functions. |
-| [src/session/inbox/key.ts](harness-node/src/session/inbox/key.ts) | `inboxKey(name, session_id) → "session/<sid>/<name>"`. |
-| [src/session/iii.worker.yaml](harness-node/src/session/iii.worker.yaml) | Worker manifest. |
+| [src/session/main.ts](harness/src/session/main.ts) | Binary entry point (`iii-session`). |
+| [src/session/register.ts](harness/src/session/register.ts) | Picks the backend and wires both sub-surfaces. |
+| [src/session/config.ts](harness/src/session/config.ts) | Loads the `session` config section. |
+| [src/session/tree/register.ts](harness/src/session/tree/register.ts) | Registers all 11 `session-tree::*` functions; exports `FUNCTION_IDS`. |
+| [src/session/tree/operations.ts](harness/src/session/tree/operations.ts) | Pure tree algorithms: create, fork, clone, compact, active path, messages, reconcile, tree, export_html, list. |
+| [src/session/tree/store.ts](harness/src/session/tree/store.ts) | `SessionStore` interface + `InMemoryStore` + `IiiStateSessionStore`. |
+| [src/session/tree/types.ts](harness/src/session/tree/types.ts) | `SessionEntry` (`message` / `custom_message` / `branch_summary` / `compaction`, each with an explicit `timestamp`), `SessionMeta`, `TreeNode`, `ReconcileResult`, `SessionError`, plus the `entryTimestamp` helper used by the `(timestamp, id)` sort. |
+| [src/session/inbox/handlers.ts](harness/src/session/inbox/handlers.ts) | Registers the three `session-inbox::*` functions. |
+| [src/session/inbox/key.ts](harness/src/session/inbox/key.ts) | `inboxKey(name, session_id) → "session/<sid>/<name>"`. |
+| [src/session/iii.worker.yaml](harness/src/session/iii.worker.yaml) | Worker manifest. |

--- a/harness/docs/workers/turn-orchestrator.md
+++ b/harness/docs/workers/turn-orchestrator.md
@@ -38,34 +38,34 @@ unreachable → deny with a `gate_unavailable` `DenialEnvelope`.
 
 ## Triggers
 
-- **Durable subscriber** on `turn::step_requested` → `turn::step`. Registered in [src/turn-orchestrator/subscriber.ts](harness-node/src/turn-orchestrator/subscriber.ts). Each `step` loads the `TurnStateRecord`, runs one transition, saves it back, and re-publishes `turn::step_requested` unless the run is terminal **or** paused on approvals (`function_awaiting_approval`). Paused turns are woken when `approval::resolve` or abort triggers a per-call `turn::approval_resume` function (see [workers/approval-gate.md](workers/approval-gate.md)).
-- **State trigger** on `scope: agent` gated by `condition_function_id: turn::is_abort_signal_set` → `turn::on_abort_signal`. Registered in [src/turn-orchestrator/on-abort-signal.ts](harness-node/src/turn-orchestrator/on-abort-signal.ts). Publishes `turn::step_requested` the moment `session/<id>/abort_signal` is set to `true`, so the FSM advances to `steering_check` (and observes the abort) on the next safe boundary without waiting for the current step to time out.
-- **State trigger** on `scope: agent` gated by `condition_function_id: turn::is_terminal_state_write` → `turn::on_terminal_state`. Registered in [src/turn-orchestrator/on-terminal.ts](harness-node/src/turn-orchestrator/on-terminal.ts). Fires on the `session/<id>/turn_state` write that lands `stopped`; the handler resolves the per-session waiter installed by `run::start_and_wait` so the sync wrapper returns without polling.
-- **State trigger** on `scope: agent` gated by `condition_function_id: turn::is_stepable_record_write` → `turn::on_record_written`. Registered in [src/turn-orchestrator/on-record-written.ts](harness-node/src/turn-orchestrator/on-record-written.ts). Directly triggers `turn::step` for the affected session on every non-terminal, non-parking `session/<sid>/turn_state` write. Replaces the imperative `publishStep` self-publish — saving the record is now the wake.
-- **State trigger** on `scope: agent` gated by `condition_function_id: turn::is_turn_state_write` → `turn::on_turn_state_changed`. Registered in [src/turn-orchestrator/on-turn-state-changed.ts](harness-node/src/turn-orchestrator/on-turn-state-changed.ts). Fires on every `session/<sid>/turn_state` write (created or updated) and emits a `turn_state_changed` event to `agent::events` carrying the full new (and prior) record so the UI can derive pending approvals from state rather than from a signal event.
+- **Durable subscriber** on `turn::step_requested` → `turn::step`. Registered in [src/turn-orchestrator/subscriber.ts](harness/src/turn-orchestrator/subscriber.ts). Each `step` loads the `TurnStateRecord`, runs one transition, saves it back, and re-publishes `turn::step_requested` unless the run is terminal **or** paused on approvals (`function_awaiting_approval`). Paused turns are woken when `approval::resolve` or abort triggers a per-call `turn::approval_resume` function (see [workers/approval-gate.md](workers/approval-gate.md)).
+- **State trigger** on `scope: agent` gated by `condition_function_id: turn::is_abort_signal_set` → `turn::on_abort_signal`. Registered in [src/turn-orchestrator/on-abort-signal.ts](harness/src/turn-orchestrator/on-abort-signal.ts). Publishes `turn::step_requested` the moment `session/<id>/abort_signal` is set to `true`, so the FSM advances to `steering_check` (and observes the abort) on the next safe boundary without waiting for the current step to time out.
+- **State trigger** on `scope: agent` gated by `condition_function_id: turn::is_terminal_state_write` → `turn::on_terminal_state`. Registered in [src/turn-orchestrator/on-terminal.ts](harness/src/turn-orchestrator/on-terminal.ts). Fires on the `session/<id>/turn_state` write that lands `stopped`; the handler resolves the per-session waiter installed by `run::start_and_wait` so the sync wrapper returns without polling.
+- **State trigger** on `scope: agent` gated by `condition_function_id: turn::is_stepable_record_write` → `turn::on_record_written`. Registered in [src/turn-orchestrator/on-record-written.ts](harness/src/turn-orchestrator/on-record-written.ts). Directly triggers `turn::step` for the affected session on every non-terminal, non-parking `session/<sid>/turn_state` write. Replaces the imperative `publishStep` self-publish — saving the record is now the wake.
+- **State trigger** on `scope: agent` gated by `condition_function_id: turn::is_turn_state_write` → `turn::on_turn_state_changed`. Registered in [src/turn-orchestrator/on-turn-state-changed.ts](harness/src/turn-orchestrator/on-turn-state-changed.ts). Fires on every `session/<sid>/turn_state` write (created or updated) and emits a `turn_state_changed` event to `agent::events` carrying the full new (and prior) record so the UI can derive pending approvals from state rather than from a signal event.
 
 ## Turn FSM
 
 The full FSM, transitions, and dispatch table lives in
-[src/turn-orchestrator/transitions.ts](harness-node/src/turn-orchestrator/transitions.ts).
+[src/turn-orchestrator/transitions.ts](harness/src/turn-orchestrator/transitions.ts).
 The 11 states from
-[src/turn-orchestrator/state.ts](harness-node/src/turn-orchestrator/state.ts):
+[src/turn-orchestrator/state.ts](harness/src/turn-orchestrator/state.ts):
 
 | State | Handler | Role |
 |---|---|---|
-| `provisioning` | [states/provisioning.ts](harness-node/src/turn-orchestrator/states/provisioning.ts) | Boot the sandbox, prime the system prompt, fetch function schemas. |
-| `awaiting_assistant` | [states/assistant.ts](harness-node/src/turn-orchestrator/states/assistant.ts) | Request an assistant turn via `provider::<name>::stream`. |
+| `provisioning` | [states/provisioning.ts](harness/src/turn-orchestrator/states/provisioning.ts) | Boot the sandbox, prime the system prompt, fetch function schemas. |
+| `awaiting_assistant` | [states/assistant.ts](harness/src/turn-orchestrator/states/assistant.ts) | Request an assistant turn via `provider::<name>::stream`. |
 | `assistant_streaming` | same | Drain the channel; relay events. |
 | `assistant_finished` | same | Persist the final `AssistantMessage`; pick next state. |
-| `function_prepare` | [states/functions.ts](harness-node/src/turn-orchestrator/states/functions.ts) | Snapshot the pending function calls. |
+| `function_prepare` | [states/functions.ts](harness/src/turn-orchestrator/states/functions.ts) | Snapshot the pending function calls. |
 | `function_execute` | same | Run each call via `dispatchWithHook` → `agent::trigger`. If the gate returns `pending`, append the call to `awaiting_approval` and transition to `function_awaiting_approval` (the rest of the batch is left for the resumed step). Each call is bracketed by a `function_execution_start` / `function_execution_end` pair; the `end` event carries `duration_ms` (wall-clock between the matching start and end), persisted on `ExecutedEntry` so resumed runs replay the original timing instead of the ~0ms it takes to re-emit. Approval wait time is naturally excluded — pending calls return without an end emit, and the resumed step re-emits a fresh start that resets the timer. |
 | `function_awaiting_approval` | same (`handleAwaitingApproval`) | Read `approvals/<sid>/<cid>` for every entry in `awaiting_approval`. While any decision is still missing, return without stepping (the next `turn::approval_resume` invoke will wake `turn::step`). When all decisions are present, fold them into the prepared snapshot — `allow` → `pre_approved: true`, `deny`/`aborted` → `blocked` with a denial result — clear `awaiting_approval`, and transition back to `function_execute`. |
 | `function_finalize` | same | Persist results; emit `function_call_end` + `turn_end` events. |
-| `steering_check` | [states/steering.ts](harness-node/src/turn-orchestrator/states/steering.ts) | Decide whether to continue, stop, or hit `max_turns`. |
-| `tearing_down` | [states/tearing-down.ts](harness-node/src/turn-orchestrator/states/tearing-down.ts) | Emit `agent_end` once, free the sandbox if any. |
+| `steering_check` | [states/steering.ts](harness/src/turn-orchestrator/states/steering.ts) | Decide whether to continue, stop, or hit `max_turns`. |
+| `tearing_down` | [states/tearing-down.ts](harness/src/turn-orchestrator/states/tearing-down.ts) | Emit `agent_end` once, free the sandbox if any. |
 | `stopped` | (no-op) | Terminal. Idempotent. |
 
-`dispatchWithHook` in [agent-trigger.ts](harness-node/src/turn-orchestrator/agent-trigger.ts)
+`dispatchWithHook` in [agent-trigger.ts](harness/src/turn-orchestrator/agent-trigger.ts)
 now returns one of three shapes: `{ kind: 'result' }`, `{ kind: 'deny' }`,
 or `{ kind: 'pending' }`. Pending is what triggers the
 `function_awaiting_approval` park.
@@ -73,7 +73,7 @@ or `{ kind: 'pending' }`. Pending is what triggers the
 ## State keys
 
 All keys live under iii state scope `agent`. From
-[src/turn-orchestrator/state.ts](harness-node/src/turn-orchestrator/state.ts):
+[src/turn-orchestrator/state.ts](harness/src/turn-orchestrator/state.ts):
 
 | Key shape | Purpose |
 |---|---|
@@ -102,7 +102,7 @@ decisions back into the prepared snapshot.
 ## Configuration
 
 From the top-level `turn-orchestrator` section of
-[config.yaml](harness-node/config.yaml):
+[config.yaml](harness/config.yaml):
 
 - `sync_default_timeout_ms` (default `120000`) — wall-clock cap on a
   `run::start_and_wait` call; if the terminal state trigger doesn't
@@ -114,7 +114,7 @@ From the top-level `turn-orchestrator` section of
 ## Dependencies
 
 From
-[src/turn-orchestrator/iii.worker.yaml](harness-node/src/turn-orchestrator/iii.worker.yaml):
+[src/turn-orchestrator/iii.worker.yaml](harness/src/turn-orchestrator/iii.worker.yaml):
 `session ^0.2.0`, `hook-fanout ^0.2.0`, `provider-anthropic ^0.2.0`,
 `provider-openai ^0.2.0`.
 
@@ -122,26 +122,26 @@ From
 
 | File | Purpose |
 |---|---|
-| [src/turn-orchestrator/main.ts](harness-node/src/turn-orchestrator/main.ts) | Binary entry point. |
-| [src/turn-orchestrator/register.ts](harness-node/src/turn-orchestrator/register.ts) | Composes `run::start*`, `agent::trigger`, `turn::step`, the abort-signal and terminal-state state triggers, and kicks off the bootstrap. |
-| [src/turn-orchestrator/run-start.ts](harness-node/src/turn-orchestrator/run-start.ts) | `run::start` + `run::start_and_wait` handlers and the `publishStep` helper. `executeSync` installs a terminal-state waiter, kicks the run, then races the waiter against `sync_default_timeout_ms` — no polling. |
-| [src/turn-orchestrator/get-state.ts](harness-node/src/turn-orchestrator/get-state.ts) | `turn::get_state` — one-shot reader that returns the current `TurnStateRecord` for a session. UI clients call this on reload to recover in-progress modals; the orchestrator owns the state schema/key layout so clients never read iii state directly. |
-| [src/turn-orchestrator/on-terminal.ts](harness-node/src/turn-orchestrator/on-terminal.ts) | State trigger adapter — `turn::is_terminal_state_write` (condition) + `turn::on_terminal_state` (handler) — plus the in-process `installTerminalWaiter` / `clearTerminalWaiter` API used by `executeSync` to await a terminal `turn_state` write reactively. |
-| [src/turn-orchestrator/agent-trigger.ts](harness-node/src/turn-orchestrator/agent-trigger.ts) | The dispatcher chokepoint; `dispatchWithHook` runs `consultBefore` before triggering the function and returns `result` / `deny` / `pending`. |
-| [src/turn-orchestrator/hook.ts](harness-node/src/turn-orchestrator/hook.ts) | `consultBefore` — calls `policy::check_permissions` directly (5 s timeout) and maps the reply via `parsePolicyReply` (`approval-gate/schemas.ts`) to `allow` / `pending` / `deny`; fails closed with a `gate_unavailable` envelope. `publishAfter` still routes through `hook-fanout::publish_collect` for the after-hook fanout path. |
-| [src/turn-orchestrator/approval-resume.ts](harness-node/src/turn-orchestrator/approval-resume.ts) | Per-call `turn::approval_resume` registration, handler (persist + `turn::step`), and startup recovery for parked sessions. |
-| [src/turn-orchestrator/abort.ts](harness-node/src/turn-orchestrator/abort.ts) | `performAbortSideEffects` — writes `session/<sid>/abort_signal = true` and, for turns paused on approvals, triggers each `turn::approval_resume` fn with `{decision: 'aborted'}`. |
-| [src/turn-orchestrator/on-abort-signal.ts](harness-node/src/turn-orchestrator/on-abort-signal.ts) | State trigger adapter — `turn::is_abort_signal_set` (condition) + `turn::on_abort_signal` (handler) — publishes `turn::step_requested` whenever `session/<id>/abort_signal` is set to `true`. |
-| [src/turn-orchestrator/subscriber.ts](harness-node/src/turn-orchestrator/subscriber.ts) | `turn::step` durable subscriber. Skips the auto re-publish of `turn::step_requested` while the record is in `function_awaiting_approval` (per-call resume fns own that wake). |
-| [src/turn-orchestrator/transitions.ts](harness-node/src/turn-orchestrator/transitions.ts) | State → handler dispatch table. |
-| [src/turn-orchestrator/states/*.ts](harness-node/src/turn-orchestrator/states/) | One file per FSM state; `states/functions.ts` owns `function_prepare`, `function_execute`, `function_awaiting_approval`, and `function_finalize`. |
-| [src/turn-orchestrator/state.ts](harness-node/src/turn-orchestrator/state.ts) | `TurnState`, `TurnStateRecord` (now with `awaiting_approval?: AwaitingApprovalEntry[]`), state-key helpers. |
-| [src/turn-orchestrator/persistence.ts](harness-node/src/turn-orchestrator/persistence.ts) | Load/save helpers + the `session-tree::*` messages mirror. `PreparedEntry` now carries `pre_approved` so resumed turns can dispatch the call without re-asking the gate. |
-| [src/turn-orchestrator/events.ts](harness-node/src/turn-orchestrator/events.ts) | `emit(iii, sid, event)` — appends a sequenced `AgentEvent` to the `agent::events` stream. |
-| [src/turn-orchestrator/on-record-written.ts](harness-node/src/turn-orchestrator/on-record-written.ts) | State-trigger adapter — `turn::is_stepable_record_write` (condition) + `turn::on_record_written` (handler) — directly triggers `turn::step` on every non-terminal, non-parking `turn_state` write. Replaces the imperative `publishStep` self-publish so saving the record is itself the wake. |
-| [src/turn-orchestrator/on-turn-state-changed.ts](harness-node/src/turn-orchestrator/on-turn-state-changed.ts) | State-trigger adapter — `turn::is_turn_state_write` (condition) + `turn::on_turn_state_changed` (handler) — emits `turn_state_changed` to `agent::events` on every `turn_state` write (created or updated). Carries the full new (and prior) `TurnStateRecord` so the console can derive pending approvals from state rather than from a signal event. |
-| [src/turn-orchestrator/provider-router.ts](harness-node/src/turn-orchestrator/provider-router.ts) | Picks `provider::<name>::stream` for the run's `provider` field. |
-| [src/turn-orchestrator/system-prompt.ts](harness-node/src/turn-orchestrator/system-prompt.ts) | Builds the system prompt from `run_request.system_prompt` + bootstrap skills. |
-| [src/turn-orchestrator/bootstrap.ts](harness-node/src/turn-orchestrator/bootstrap.ts) | Best-effort skill download via `directory::skills::download`. |
-| [src/turn-orchestrator/config.ts](harness-node/src/turn-orchestrator/config.ts) | Loads the worker's config slice. |
-| [src/turn-orchestrator/iii.worker.yaml](harness-node/src/turn-orchestrator/iii.worker.yaml) | Worker manifest. |
+| [src/turn-orchestrator/main.ts](harness/src/turn-orchestrator/main.ts) | Binary entry point. |
+| [src/turn-orchestrator/register.ts](harness/src/turn-orchestrator/register.ts) | Composes `run::start*`, `agent::trigger`, `turn::step`, the abort-signal and terminal-state state triggers, and kicks off the bootstrap. |
+| [src/turn-orchestrator/run-start.ts](harness/src/turn-orchestrator/run-start.ts) | `run::start` + `run::start_and_wait` handlers and the `publishStep` helper. `executeSync` installs a terminal-state waiter, kicks the run, then races the waiter against `sync_default_timeout_ms` — no polling. |
+| [src/turn-orchestrator/get-state.ts](harness/src/turn-orchestrator/get-state.ts) | `turn::get_state` — one-shot reader that returns the current `TurnStateRecord` for a session. UI clients call this on reload to recover in-progress modals; the orchestrator owns the state schema/key layout so clients never read iii state directly. |
+| [src/turn-orchestrator/on-terminal.ts](harness/src/turn-orchestrator/on-terminal.ts) | State trigger adapter — `turn::is_terminal_state_write` (condition) + `turn::on_terminal_state` (handler) — plus the in-process `installTerminalWaiter` / `clearTerminalWaiter` API used by `executeSync` to await a terminal `turn_state` write reactively. |
+| [src/turn-orchestrator/agent-trigger.ts](harness/src/turn-orchestrator/agent-trigger.ts) | The dispatcher chokepoint; `dispatchWithHook` runs `consultBefore` before triggering the function and returns `result` / `deny` / `pending`. |
+| [src/turn-orchestrator/hook.ts](harness/src/turn-orchestrator/hook.ts) | `consultBefore` — calls `policy::check_permissions` directly (5 s timeout) and maps the reply via `parsePolicyReply` (`approval-gate/schemas.ts`) to `allow` / `pending` / `deny`; fails closed with a `gate_unavailable` envelope. `publishAfter` still routes through `hook-fanout::publish_collect` for the after-hook fanout path. |
+| [src/turn-orchestrator/approval-resume.ts](harness/src/turn-orchestrator/approval-resume.ts) | Per-call `turn::approval_resume` registration, handler (persist + `turn::step`), and startup recovery for parked sessions. |
+| [src/turn-orchestrator/abort.ts](harness/src/turn-orchestrator/abort.ts) | `performAbortSideEffects` — writes `session/<sid>/abort_signal = true` and, for turns paused on approvals, triggers each `turn::approval_resume` fn with `{decision: 'aborted'}`. |
+| [src/turn-orchestrator/on-abort-signal.ts](harness/src/turn-orchestrator/on-abort-signal.ts) | State trigger adapter — `turn::is_abort_signal_set` (condition) + `turn::on_abort_signal` (handler) — publishes `turn::step_requested` whenever `session/<id>/abort_signal` is set to `true`. |
+| [src/turn-orchestrator/subscriber.ts](harness/src/turn-orchestrator/subscriber.ts) | `turn::step` durable subscriber. Skips the auto re-publish of `turn::step_requested` while the record is in `function_awaiting_approval` (per-call resume fns own that wake). |
+| [src/turn-orchestrator/transitions.ts](harness/src/turn-orchestrator/transitions.ts) | State → handler dispatch table. |
+| [src/turn-orchestrator/states/*.ts](harness/src/turn-orchestrator/states/) | One file per FSM state; `states/functions.ts` owns `function_prepare`, `function_execute`, `function_awaiting_approval`, and `function_finalize`. |
+| [src/turn-orchestrator/state.ts](harness/src/turn-orchestrator/state.ts) | `TurnState`, `TurnStateRecord` (now with `awaiting_approval?: AwaitingApprovalEntry[]`), state-key helpers. |
+| [src/turn-orchestrator/persistence.ts](harness/src/turn-orchestrator/persistence.ts) | Load/save helpers + the `session-tree::*` messages mirror. `PreparedEntry` now carries `pre_approved` so resumed turns can dispatch the call without re-asking the gate. |
+| [src/turn-orchestrator/events.ts](harness/src/turn-orchestrator/events.ts) | `emit(iii, sid, event)` — appends a sequenced `AgentEvent` to the `agent::events` stream. |
+| [src/turn-orchestrator/on-record-written.ts](harness/src/turn-orchestrator/on-record-written.ts) | State-trigger adapter — `turn::is_stepable_record_write` (condition) + `turn::on_record_written` (handler) — directly triggers `turn::step` on every non-terminal, non-parking `turn_state` write. Replaces the imperative `publishStep` self-publish so saving the record is itself the wake. |
+| [src/turn-orchestrator/on-turn-state-changed.ts](harness/src/turn-orchestrator/on-turn-state-changed.ts) | State-trigger adapter — `turn::is_turn_state_write` (condition) + `turn::on_turn_state_changed` (handler) — emits `turn_state_changed` to `agent::events` on every `turn_state` write (created or updated). Carries the full new (and prior) `TurnStateRecord` so the console can derive pending approvals from state rather than from a signal event. |
+| [src/turn-orchestrator/provider-router.ts](harness/src/turn-orchestrator/provider-router.ts) | Picks `provider::<name>::stream` for the run's `provider` field. |
+| [src/turn-orchestrator/system-prompt.ts](harness/src/turn-orchestrator/system-prompt.ts) | Builds the system prompt from `run_request.system_prompt` + bootstrap skills. |
+| [src/turn-orchestrator/bootstrap.ts](harness/src/turn-orchestrator/bootstrap.ts) | Best-effort skill download via `directory::skills::download`. |
+| [src/turn-orchestrator/config.ts](harness/src/turn-orchestrator/config.ts) | Loads the worker's config slice. |
+| [src/turn-orchestrator/iii.worker.yaml](harness/src/turn-orchestrator/iii.worker.yaml) | Worker manifest. |

--- a/harness/package.json
+++ b/harness/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "harness-node",
+  "name": "harness",
   "version": "0.1.0",
   "private": true,
   "description": "Node port of the iii harness stack: harness, approval-gate, turn-orchestrator, session, llm-budget, providers, and side-cars.",
@@ -35,7 +35,7 @@
     "dev:context-compaction": "tsx src/context-compaction/main.ts"
   },
   "bin": {
-    "harness-node": "./dist/index.js",
+    "harness": "./dist/index.js",
     "iii-harness": "./dist/harness/main.js",
     "iii-approval-gate": "./dist/approval-gate/main.js",
     "iii-turn-orchestrator": "./dist/turn-orchestrator/main.js",

--- a/harness/scripts/build-bundle.mjs
+++ b/harness/scripts/build-bundle.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Single-file ESM bundle for harness-node (`dist/bundle/index.mjs`).
+ * Single-file ESM bundle for harness (`dist/bundle/index.mjs`).
  *
  * Two real-world bundling quirks the CLI form of esbuild can't handle:
  *

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Composite entry-point: spins up every harness-node worker in one
+ * Composite entry-point: spins up every harness worker in one
  * process. CLI parsing happens once here so the per-worker
  * `bootstrapWorker` calls don't fight over `process.argv`. Each worker's
  * register callback is reused as-is from its own folder, so the bus
@@ -104,8 +104,8 @@ const WORKERS: readonly WorkerDefinition[] = [
 
 async function main(): Promise<void> {
   const program = new Command()
-    .name('harness-node')
-    .description('Run every harness-node worker in one process.')
+    .name('harness')
+    .description('Run every harness worker in one process.')
     .option('--config <path>', 'config file path', DEFAULT_CONFIG_PATH)
     .option('--url <url>', 'iii engine WebSocket URL', process.env.III_URL ?? DEFAULT_URL)
     .option('--manifest', 'print combined manifest JSON and exit')
@@ -119,7 +119,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  logger.info('harness-node starting', {
+  logger.info('harness starting', {
     url: cli.url,
     config: cli.config,
     workers: WORKERS.length,
@@ -138,15 +138,15 @@ async function main(): Promise<void> {
       handles.push(handle);
     }
   } catch (err) {
-    logger.error('harness-node startup failed; tearing down workers', { err: String(err) });
+    logger.error('harness startup failed; tearing down workers', { err: String(err) });
     await shutdownAll(handles);
     throw err;
   }
 
-  logger.info('harness-node ready', { workers: handles.map((h) => h.name) });
+  logger.info('harness ready', { workers: handles.map((h) => h.name) });
 
   await waitForShutdown();
-  logger.info('harness-node shutting down');
+  logger.info('harness shutting down');
   await shutdownAll(handles);
 }
 

--- a/harness/src/runtime/otel.ts
+++ b/harness/src/runtime/otel.ts
@@ -54,7 +54,7 @@ export type Logger = {
 // `warn!` / `error!` becomes both a span event and an OTel log,
 // correlated to the active trace via context propagation). The Node
 // port uses `pino`, which writes to stderr only. Without this bridge,
-// the `LOGS` tab in the traces UI is silent on every harness-node
+// the `LOGS` tab in the traces UI is silent on every harness
 // span — even though the same workers in Rust populate it.
 //
 // We keep `pino` for stderr (devs still see logs in their terminal)
@@ -255,7 +255,7 @@ export type Handler<TIn = unknown, TOut = unknown> = (input: TIn) => Promise<TOu
  *   - `exception`             — only on throw, with type/message/stack
  *
  * This is what populates the "EVENTS" tab in the traces UI for
- * harness-node-emitted spans. Without it, harness-node spans look
+ * harness-emitted spans. Without it, harness spans look
  * "empty" compared to Rust harness spans, because the Rust harness
  * gets the same events for free via `iii-sdk-rust` (and via the
  * `tracing-opentelemetry::OpenTelemetryLayer` bridge, which doesn't

--- a/harness/src/runtime/worker.ts
+++ b/harness/src/runtime/worker.ts
@@ -99,7 +99,7 @@ export async function runWorker(opts: RunWorkerOptions): Promise<WorkerHandle> {
  * pass through unchanged — there's no local handler to wrap.
  *
  * This is the single point of correctness for trace correlation: every
- * harness-node `register.ts` calls `iii.registerFunction(...)` on an SDK
+ * harness `register.ts` calls `iii.registerFunction(...)` on an SDK
  * instance that flowed out of this function, so no per-callsite changes
  * are needed and no new register.ts can accidentally skip the wrap.
  */

--- a/harness/src/turn-orchestrator/on-abort-signal.ts
+++ b/harness/src/turn-orchestrator/on-abort-signal.ts
@@ -13,7 +13,7 @@
  * can safely react.
  *
  * Mirror of the canonical pattern in
- * `harness-node/src/harness/fanout/sessions-poll.ts`.
+ * `harness/src/harness/fanout/sessions-poll.ts`.
  */
 
 import type { ISdk } from '../runtime/iii.js';

--- a/harness/tests/context-compaction/template.test.ts
+++ b/harness/tests/context-compaction/template.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { SUMMARY_TEMPLATE, buildPrompt } from '../../src/context-compaction/template.js';
 
 describe('SUMMARY_TEMPLATE', () => {
-  it('contains the harness-node-specific Tool Calls Made section', () => {
+  it('contains the harness-specific Tool Calls Made section', () => {
     expect(SUMMARY_TEMPLATE).toContain('## Tool Calls Made');
   });
   it('contains all required sections', () => {

--- a/harness/tests/fixtures/sessions/medium-with-tools.json
+++ b/harness/tests/fixtures/sessions/medium-with-tools.json
@@ -136,7 +136,7 @@
         "content": [
           {
             "type": "text",
-            "text": "The README describes the harness-node project — a Node.js runtime for motia workers with context compaction support."
+            "text": "The README describes the harness project — a Node.js runtime for motia workers with context compaction support."
           }
         ],
         "stop_reason": "end",

--- a/harness/tests/runtime/log-bridge.test.ts
+++ b/harness/tests/runtime/log-bridge.test.ts
@@ -104,10 +104,10 @@ describe('logger -> OTel bridge', () => {
   });
 
   it('child(bindings) merges bindings into every emitted log', () => {
-    const child = logger.child({ worker: 'harness-node', request_id: 'r-1' });
+    const child = logger.child({ worker: 'harness', request_id: 'r-1' });
     child.info('handled');
     expect(captured[0].attributes).toMatchObject({
-      worker: 'harness-node',
+      worker: 'harness',
       request_id: 'r-1',
     });
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated documentation paths and references across the project

* **Chores**
  * Renamed package from `harness-node` to `harness`
  * CLI executable command changed to `harness` (previously `harness-node`)
  * Updated workflow configurations and internal references

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/workers/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->