### PR TITLE
Chat dock collapse toggle + provider config + DB-backed storage

### DIFF
--- a/console/DESIGN.md
+++ b/console/DESIGN.md
@@ -1,0 +1,1864 @@
+---
+version: alpha
+name: iii Schematic
+description: A minimal, blueprint-style design system for the iii engine. Engineering-document aesthetic in warm cream and ink, with a single vivid orange accent and an all-monospace voice.
+colors:
+  bg: "#f2f0ed"
+  panel: "#e9e6e2"
+  paper: "#f2f0ed"
+  paper-2: "#ebe8e3"
+  ink: "#0a0a0a"
+  ink-2: "#1a1a1a"
+  ink-soft: "#1a1a1a"
+  ink-faint: "#6b6865"
+  ink-ghost: "#a3a09c"
+  mute: "#6b6865"
+  mute-2: "#a3a09c"
+  rule: "#d8d5d0"
+  rule-2: "#e6e3df"
+  accent: "#ff5a1f"
+  accent-dark: "#3ea8ff"
+  bg-dark: "#111110"
+  panel-dark: "#1a1916"
+  ink-dark: "#f2f0ed"
+  ink-faint-dark: "#9c9893"
+  ink-ghost-dark: "#5d5a55"
+  rule-dark: "#2a2926"
+  rule-2-dark: "#1f1e1c"
+  alert: "#c43e1c"
+  warn: "#a87a00"
+typography:
+  logo:
+    fontFamily: Chivo Mono
+    fontSize: 18px
+    fontWeight: 600
+    lineHeight: 1
+    letterSpacing: -0.02em
+  display-hero:
+    fontFamily: Chivo Mono
+    fontSize: 72px
+    fontWeight: 600
+    lineHeight: 1.02
+    letterSpacing: -0.02em
+  display-foot:
+    fontFamily: Chivo Mono
+    fontSize: 48px
+    fontWeight: 600
+    lineHeight: 1.05
+    letterSpacing: -0.03em
+  headline-section:
+    fontFamily: Chivo Mono
+    fontSize: 28px
+    fontWeight: 500
+    lineHeight: 1.25
+    letterSpacing: -0.01em
+  headline-card:
+    fontFamily: Chivo Mono
+    fontSize: 20px
+    fontWeight: 500
+    lineHeight: 1.1
+    letterSpacing: -0.02em
+  title-cell:
+    fontFamily: Chivo Mono
+    fontSize: 16px
+    fontWeight: 600
+    lineHeight: 1.3
+    letterSpacing: -0.01em
+  body-md:
+    fontFamily: Chivo Mono
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 1.7
+  body-sm:
+    fontFamily: Chivo Mono
+    fontSize: 13px
+    fontWeight: 400
+    lineHeight: 1.7
+  code-md:
+    fontFamily: Chivo Mono
+    fontSize: 13px
+    fontWeight: 400
+    lineHeight: 1.65
+  code-sm:
+    fontFamily: Chivo Mono
+    fontSize: 12.5px
+    fontWeight: 400
+    lineHeight: 1.55
+  label-caps-lg:
+    fontFamily: Chivo Mono
+    fontSize: 12px
+    fontWeight: 500
+    lineHeight: 1
+    letterSpacing: 0.18em
+  label-caps-md:
+    fontFamily: Chivo Mono
+    fontSize: 12px
+    fontWeight: 500
+    lineHeight: 1
+    letterSpacing: 0.14em
+  label-caps-sm:
+    fontFamily: Chivo Mono
+    fontSize: 11px
+    fontWeight: 500
+    lineHeight: 1
+    letterSpacing: 0.06em
+  micro:
+    fontFamily: Chivo Mono
+    fontSize: 9px
+    fontWeight: 400
+    lineHeight: 1
+    letterSpacing: 0.04em
+rounded:
+  none: 0px
+  sm: 0px
+  md: 0px
+  lg: 0px
+  full: 9999px
+spacing:
+  base: 16px
+  hairline: 1px
+  micro: 2px
+  4: 4px
+  6: 6px
+  8: 8px
+  10: 10px
+  12: 12px
+  14: 14px
+  16: 16px
+  18: 18px
+  20: 20px
+  24: 24px
+  28: 28px
+  32: 32px
+  36: 36px
+  44: 44px
+  56: 56px
+  64: 64px
+  80: 80px
+  96: 96px
+  gutter: 24px
+  section-x: 36px
+  section-y: 80px
+  sheet-max: 1200px
+  content-max: 1216px
+  border-width: 1px
+components:
+  button-primary:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.bg}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.none}"
+    padding: 12px 20px
+  button-primary-hover:
+    backgroundColor: "{colors.bg}"
+    textColor: "{colors.ink}"
+  button-ghost:
+    backgroundColor: "{colors.bg}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.none}"
+    padding: 12px 20px
+  button-ghost-hover:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.bg}"
+  button-pill:
+    backgroundColor: "{colors.bg}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.none}"
+    padding: 6px 12px
+  button-pill-hover:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.bg}"
+  button-icon:
+    backgroundColor: "{colors.bg}"
+    textColor: "{colors.ink-faint}"
+    rounded: "{rounded.none}"
+    size: 30px
+  button-icon-hover:
+    textColor: "{colors.ink}"
+  nav-link:
+    typography: "{typography.body-sm}"
+    textColor: "{colors.mute}"
+    padding: 6px 0
+  nav-link-hover:
+    textColor: "{colors.ink}"
+  card:
+    backgroundColor: "{colors.bg}"
+    rounded: "{rounded.none}"
+    padding: 28px
+  card-focus:
+    backgroundColor: "{colors.panel}"
+  card-head:
+    backgroundColor: "{colors.panel}"
+    typography: "{typography.label-caps-lg}"
+    textColor: "{colors.ink-faint}"
+    padding: 10px 14px
+  input:
+    backgroundColor: "{colors.bg}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.none}"
+    padding: 10px 2px
+  input-placeholder:
+    textColor: "{colors.ink-ghost}"
+  input-focus:
+    backgroundColor: "{colors.bg}"
+    textColor: "{colors.ink}"
+  badge-numeric:
+    backgroundColor: "{colors.accent}"
+    textColor: "{colors.bg}"
+    typography: "{typography.label-caps-sm}"
+    rounded: "{rounded.none}"
+    padding: 0 4px
+    height: 16px
+  status-dot:
+    backgroundColor: "{colors.accent}"
+    rounded: "{rounded.full}"
+    size: 6px
+  rule-line:
+    backgroundColor: "{colors.rule}"
+    height: 1px
+  code-block:
+    backgroundColor: "{colors.bg}"
+    typography: "{typography.code-sm}"
+    textColor: "{colors.ink}"
+    padding: 18px 20px
+  terminal-button:
+    backgroundColor: "{colors.bg}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.none}"
+    padding: 10px 14px
+  terminal-prompt:
+    textColor: "{colors.accent}"
+  toggle-active:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.bg}"
+  toggle-inactive:
+    backgroundColor: "{colors.bg}"
+    textColor: "{colors.mute}"
+---
+
+# iii Schematic — design system
+
+This document is a self-contained, portable spec for the iii Schematic UI: a
+warm-cream, ink-on-paper, monospace web UI built like an engineering drafting
+sheet. Everything needed to reproduce the system in another project lives
+inside this file — there are no links to repository sources.
+
+The YAML frontmatter above is the machine-readable token spec. The sections
+below translate it into implementation-ready CSS and React. They assume:
+
+- **Tailwind CSS v4** (uses the `@theme` and `@utility` directives).
+- **React + TypeScript**.
+- A `cn` helper built on `clsx` + `tailwind-merge`.
+- Optional: `class-variance-authority` (`cva`) and `@radix-ui/react-slot` for
+  the `Button` component below.
+
+To adopt the system: copy §0 (Setup) into a new project, then bring over the
+canonical components in §10 as-is.
+
+---
+
+## 0. Setup
+
+### Font
+
+Load Chivo Mono in `index.html`. Weights 400/500/600 cover the entire scale
+(body, label-caps, headlines, display).
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  rel="stylesheet"
+  href="https://fonts.googleapis.com/css2?family=Chivo+Mono:wght@400;500;600&display=swap"
+/>
+```
+
+### HTML shell
+
+Light is the canonical theme. Dark is opt-in via a `data-theme="dark"`
+attribute on `<html>` (you can also wire `prefers-color-scheme` to set it on
+load — see §3).
+
+```html
+<html lang="en" class="antialiased">
+  <body class="bg-bg text-ink font-sans">
+    <div id="root"></div>
+  </body>
+</html>
+```
+
+### Theme stylesheet
+
+The full design-token stylesheet — drop this in as your global CSS entrypoint:
+
+```css
+@import "tailwindcss";
+
+@theme {
+  --font-sans: "Chivo Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, "Liberation Mono", "Courier New", monospace;
+  --font-mono: "Chivo Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, "Liberation Mono", "Courier New", monospace;
+
+  /* paper / surface ramp (3-step) */
+  --color-bg: #f2f0ed;
+  --color-panel: #e9e6e2;
+  --color-paper-2: #ebe8e3;
+
+  /* ink ramp (3-step) */
+  --color-ink: #0a0a0a;
+  --color-ink-faint: #6b6865;
+  --color-ink-ghost: #a3a09c;
+
+  /* structural lines */
+  --color-rule: #d8d5d0;
+  --color-rule-2: #e6e3df;
+
+  /* accent (single hero — hot orange) */
+  --color-accent: #ff5a1f;
+  --color-accent-fg: #f2f0ed;
+
+  /* status */
+  --color-alert: #c43e1c;
+  --color-warn: #a87a00;
+
+  /* radii — only two are allowed */
+  --radius-none: 0px;
+  --radius-full: 9999px;
+
+  /* spacing scale (carried from the YAML) */
+  --spacing-gutter: 24px;
+  --spacing-section-x: 36px;
+  --spacing-section-y: 80px;
+  --spacing-sheet-max: 1200px;
+  --spacing-content-max: 1216px;
+}
+
+/* dark theme: invert paper/ink and swap accent to electric blue */
+[data-theme="dark"] {
+  --color-bg: #111110;
+  --color-panel: #1a1916;
+  --color-paper-2: #1f1e1c;
+  --color-ink: #f2f0ed;
+  --color-ink-faint: #9c9893;
+  --color-ink-ghost: #5d5a55;
+  --color-rule: #2a2926;
+  --color-rule-2: #1f1e1c;
+  --color-accent: #3ea8ff;
+  --color-accent-fg: #111110;
+}
+
+@layer base {
+  html,
+  body,
+  #root {
+    height: 100%;
+  }
+
+  html,
+  body {
+    scrollbar-gutter: stable;
+  }
+
+  html {
+    overflow-y: scroll;
+  }
+
+  body {
+    background-color: var(--color-bg);
+    color: var(--color-ink);
+    /* explicitly disable decorative ligatures — the schematic feel relies on
+       monospace columns, not typographic flourishes */
+    font-feature-settings: "liga" 0, "clig" 0, "calt" 0, "dlig" 0;
+  }
+
+  ::selection {
+    background-color: var(--color-accent);
+    color: var(--color-accent-fg);
+  }
+
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: var(--color-rule);
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background: var(--color-ink-ghost);
+  }
+}
+
+@keyframes pulse-dot {
+  0% {
+    box-shadow: 0 0 0 0 var(--color-accent);
+  }
+  100% {
+    box-shadow: 0 0 0 8px transparent;
+  }
+}
+
+@utility pulse-dot {
+  animation: pulse-dot 1.6s ease-out infinite;
+}
+
+@keyframes blink {
+  0%, 49% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+@utility blink {
+  animation: blink 1s steps(1) infinite;
+}
+
+@keyframes wiggle {
+  0%, 90%, 100% { transform: rotate(0deg); }
+  93% { transform: rotate(-3deg); }
+  96% { transform: rotate(3deg); }
+}
+
+@utility wiggle {
+  animation: wiggle 3s ease-in-out infinite;
+}
+
+/* the one sanctioned shadow stack — used only for the "deal" stack
+   animation on language cards */
+@utility deal-shadow {
+  box-shadow: -2px 0 0 var(--color-rule),
+    -16px 4px 36px -10px rgba(0, 0, 0, 0.22);
+}
+```
+
+### `cn` helper
+
+Every component below uses this helper. Install `clsx` and `tailwind-merge`,
+then expose it from `lib/utils.ts`:
+
+```ts
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+```
+
+---
+
+## 1. Philosophy — "iii Schematic"
+
+The app should feel like an **engineering document**, not a SaaS dashboard.
+
+- The page is a **drafting sheet**: cream paper, hairline ink rules,
+  monospace voice, an unflinching commitment to lowercase. Nothing is
+  rounded; everything sits on a 1px grid.
+- Color is rationed: the palette is essentially **black-on-cream**, broken
+  only by a single hot orange used for state, focus, and emphasis.
+- The personality is **technical but unintimidating** — the same energy as a
+  well-kept lab notebook or a hand-drawn architecture diagram. It must feel
+  built by engineers, for engineers, and for the agents working alongside
+  them.
+- Density is deliberate: spec sheets, code, traces, and console panels
+  coexist on the same surface without a hierarchy contest.
+
+### Voice
+
+- All UI copy is **lowercase**, including headlines, buttons, and nav items.
+- Headlines treat sentence fragments as visual blocks (e.g. *"any task. one
+  experience."*).
+- Numbers and metadata always use **tabular monospace**, never proportional
+  figures.
+- The wordmark is pronounced *"three eye"* — every "i" stays lowercase.
+
+> If you removed all the type, the page should still read as a structured
+> document. Lines establish hierarchy before color does.
+
+---
+
+## 2. Typography — single typeface (Chivo Mono)
+
+Chivo Mono is wired to **both** `--font-sans` and `--font-mono` in the theme
+(see §0), so every default text node is monospaced. There is no secondary
+face in this design language.
+
+**Rule:** every UI surface uses Chivo Mono (the default). Don't reach for a
+sans-serif or a second monospace stack — variety comes from weight, scale,
+case, and letter-spacing, not family.
+
+Decorative ligatures are explicitly disabled in `@layer base`
+(`liga 0, clig 0, calt 0, dlig 0`) to preserve the schematic feel.
+
+### Size scale
+
+| Use                      | Token              | Size / weight / extras                         |
+| ------------------------ | ------------------ | ---------------------------------------------- |
+| Hero headline            | `display-hero`     | 72px / 600 / `tracking-[-0.02em]`              |
+| Footer CTA               | `display-foot`     | 48px / 600 / `tracking-[-0.03em]`              |
+| Section headline         | `headline-section` | 28px / 500 / `tracking-[-0.01em]`              |
+| Card headline            | `headline-card`    | 20px / 500 / `tracking-[-0.02em]`              |
+| Cell title               | `title-cell`       | 16px / 600 / `tracking-[-0.01em]`              |
+| Body                     | `body-md`          | 14px / 400 / line-height 1.7                   |
+| Compact body             | `body-sm`          | 13px / 400 / line-height 1.7                   |
+| Code block               | `code-md`          | 13px / 400 / line-height 1.65                  |
+| Compact code / terminal  | `code-sm`          | 12.5px / 400 / line-height 1.55                |
+| Label (caps, large)      | `label-caps-lg`    | 12px / 500 / UPPER, `tracking-[0.18em]`        |
+| Label (caps, medium)     | `label-caps-md`    | 12px / 500 / UPPER, `tracking-[0.14em]`        |
+| Label (caps, small)      | `label-caps-sm`    | 11px / 500 / UPPER, `tracking-[0.06em]`        |
+| Diagram micro            | `micro`            | 9px / 400 / `tracking-[0.04em]`                |
+
+### Number & label rendering
+
+- Any numeric or timestamp cell uses `tabular-nums` so columns align. See the
+  duration column in `Trace` and the version row in `WorkerCard` (§10).
+- The **only** uppercase text in the system is the `label-caps-*` set
+  (uppercase + tracking). Used for: tab strips, status pills, table headers,
+  code-block chrome, section eyebrows. Never capitalize a sentence to "fix" a
+  heading — rewrite it instead.
+
+---
+
+## 3. Color tokens
+
+All tokens live in the `@theme` block in §0. Use the Tailwind utility
+(`bg-bg`, `text-ink-faint`, `text-accent`, `border-rule`, …) — **never** the
+raw CSS variable.
+
+### Paper / surface (3-step neutral scale)
+
+| Token     | Use                                                  |
+| --------- | ---------------------------------------------------- |
+| `bg`      | Page (warm cream paper) — every default surface      |
+| `panel`   | Header strips, focused cards, code-block chrome      |
+| `paper-2` | Nested separation when `panel` would be too heavy    |
+
+### Ink (3-step contrast)
+
+| Token       | Use                                                |
+| ----------- | -------------------------------------------------- |
+| `ink`       | Primary type, wordmark, primary buttons, hairlines |
+| `ink-faint` | Body in muted contexts, captions, inactive nav     |
+| `ink-ghost` | Line numbers, placeholders, timestamps             |
+
+### Rules (the structural lines)
+
+| Token    | Use                                                          |
+| -------- | ------------------------------------------------------------ |
+| `rule`   | Default 1px borders — defines every container                |
+| `rule-2` | Nested separators (e.g. card head → body) when `rule` is too loud |
+
+### Accent — hot orange (single hero)
+
+`accent`, `accent-fg`. Reserved for: the active state, the live pulse, the
+keyword/return value in a code block, the `iii` highlight in a sentence, the
+focus underline on the email row, the orange `$` prompt. **Never** for body
+text or large fills.
+
+### Status
+
+`alert`, `warn` — desaturated on purpose. Status is expressed through **text
+color + a small icon/stripe**, not full-color backgrounds.
+
+| Token    | Use                                       |
+| -------- | ----------------------------------------- |
+| `accent` | live / running / success                  |
+| `alert`  | error states (traces, status panels)      |
+| `warn`   | warning states                            |
+
+### Dark theme
+
+Override the same tokens inside a `[data-theme="dark"]` block (see §0). The
+ramp inverts (`#111110 → #1a1916 → #1f1e1c` for paper; `#f2f0ed → #9c9893 →
+#5d5a55` for ink) and the accent swaps to electric blue (`#3ea8ff`). Same
+structural logic — never collapses into pure black.
+
+To follow the OS, set the attribute on load:
+
+```ts
+const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+document.documentElement.dataset.theme = isDark ? 'dark' : 'light'
+```
+
+---
+
+## 4. The "lines define structure" rule (key composition pattern)
+
+> **Borders define every container. Add a border before reaching for a
+> background fill.**
+
+This is the inverse of a surface-stacking system: the schematic is held
+together by 1px ink rules. A new line means a new container. Cards, cells,
+panels, code blocks, and inputs are all defined by `border border-rule` — not
+by background steps.
+
+### Pattern
+
+```tsx
+<div className="border border-rule bg-bg">
+  <div className="px-3.5 py-2.5 border-b border-rule bg-panel font-mono text-[12px] uppercase tracking-[0.18em] text-ink-faint">
+    title
+  </div>
+  <div className="p-7">{/* body */}</div>
+</div>
+```
+
+The single tonal step (`bg → panel`) on the header strip is the only "lift"
+allowed in default states (see §5).
+
+### Allowed accents on top of borders
+
+These are not extra borders, they are accents on the existing 1px grid:
+
+- `border-l-2 border-accent` rail on a focused `WorkerCard` (see §10).
+- `divide-x divide-rule` for inline grids (e.g. a metrics strip).
+- The "feature grid" trick: draw 1px rules on the **top + left** of the grid
+  and the **right + bottom** of each cell. This produces a single,
+  perfectly-aligned grid of borders with no doubled lines.
+
+### The single-shadow exception
+
+The system carries no default shadows. The **one** allowed transient shadow
+is `.deal-shadow` (defined in §0), used only on the language-card stack
+when a card slides on top of another — a deliberate tactile cue, not a
+default elevation.
+
+**When in doubt:** add a 1px `border-rule`. Don't reach for a background fill
+or a shadow.
+
+---
+
+## 5. Surfaces & elevation
+
+The 3-step ramp is the only tonal tool. Think of it as a depth axis with one
+step of contrast — borders do the rest.
+
+```
+bg            page (cream paper)
+ └─ panel        header strips, focused cards, code-block chrome
+     └─ paper-2     nested separation when needed
+```
+
+Most cards/panels should accept a `focused` (or `variant`) prop that lifts
+the body from `bg` to `panel`. That single tonal step is the only "lift"
+allowed in default states.
+
+### Where elevation actually shows up
+
+1. **Tonal layering** — the 3-step ramp above.
+2. **Hairline rules** — 1px lines in `rule` and `rule-2` do the work that
+   shadows would do in other systems.
+3. **Reserved transient shadow** — the `.deal-shadow` utility, used only on
+   the language-card stack (`HelloCard` flow mode in §10).
+4. **Pulse + glow** — the live state uses `.pulse-dot` (1.6s expanding
+   `box-shadow` ring) on a 6px accent dot. This is the only "glow" the
+   system allows.
+
+Dark mode keeps the same rule-driven hierarchy — the ramp flips but never
+collapses into pure black.
+
+---
+
+## 6. Radii & shape
+
+Rectilinear sharpness, period. The system is built from squares and 1px
+strokes; the only curves are functional ones (status dots, glyph circles).
+
+| Token          | Value   | Used for                                        |
+| -------------- | ------- | ----------------------------------------------- |
+| `rounded-none` | 0px     | **Default for everything** (containers, buttons, cards, inputs, code blocks, badges, panels) |
+| `rounded-full` | 9999px  | Status dots and glyph circles **only**          |
+
+Never reach for `rounded-sm`, `rounded-md`, `rounded-lg`, or anything in
+between. There is no "soft" variant — the YAML aliases `sm/md/lg` to `0px`
+on purpose.
+
+### Stroke weight
+
+- 1px is the default for all UI borders.
+- SVG diagrams use 1–1.25px strokes; thicker strokes (1.25px `accent`) are
+  reserved for emphasized worker connections.
+- The wordmark is six rectangles (three "i"s, each a stem + a tittle), all
+  sharing the same square unit. The mark is the design system in miniature:
+  identical units, no curves, deliberate negative space.
+
+---
+
+## 7. Spacing & layout
+
+The page is a vertical sheet, max 1200px, sitting on cream paper with a 1px
+ink-rule outer border. There is no hero card, no rounded container — the
+entire site reads as one continuous spec sheet.
+
+- **Sheet:** `min(1200px, 100%)` centered, 1px outer rule (see `Sheet` in
+  §10).
+- **Sticky nav:** `py-4.5` vertical padding, collapses to `py-2.5` on
+  scroll. Bordered bottom only.
+- **Section padding:** `px-9` on desktop (36px), `px-4.5` on tablet (18px),
+  `px-3.5` on small mobile (14px). Vertical: `py-20` to `py-24` (80–96px)
+  between major sections.
+- **Hero grid:** Two equal columns (`1fr 1fr`) with a 64px gap on desktop;
+  collapses to a single column under 880px.
+- **Feature grids:** Always **3-up** on desktop (`grid-cols-3`), divided by
+  1px rules drawn on the **top + left** of the grid and the **right +
+  bottom** of each cell.
+- **Card padding:** 18–28px internal. Cards never carry shadows in their
+  default state.
+- **Density rhythm:** 4/8 micro-scale for inline gaps (icon-to-text,
+  dot-to-label), 12/14/16 for component padding, 24/28 for card padding, 36
+  for section gutters, 64–96 for section breathing room.
+- **Scroll anchors:** Anchored sections reserve a 90px scroll-margin to
+  clear the sticky nav.
+- **Responsiveness uses container queries**, not viewport breakpoints. Pages
+  set `@container` and grids use `@3xl:` / `@4xl:` to split. This keeps
+  panels responsive when embedded in different layouts.
+
+---
+
+## 8. Schematic motifs (utilities)
+
+Reach for these to keep the engineering-document feel consistent:
+
+- `Prompt` (§10) — orange `$` (or `>`) used on terminal/install rows and as
+  a page eyebrow above titles.
+- `Caret` (§10) — blinking 6×13 ink caret with the `.blink` utility.
+- `StatusDot` (§10) — 6px circle, `accent` fill, optional `.pulse-dot` for
+  "live" emphasis.
+- `.deal-shadow` (§0) — the one allowed transient shadow on stacked cards.
+- `.wiggle` (§0) — 1s wiggle every 3s on the wiggle CTA, to draw the eye in
+  long flows.
+- Lowercase copy is the default; UPPERCASE only via the `label-caps-*`
+  styles.
+
+---
+
+## 9. Status & semantics
+
+`StatusPanel` (§10) is the canonical status display — bordered, monospaced,
+icon + headline + detail. The body fill stays `bg` in every variant; only
+the chrome (border + icon + headline) changes.
+
+| Variant     | Border + icon token | Body fill |
+| ----------- | ------------------- | --------- |
+| `v-info`    | `rule` (ink icon)   | `bg`      |
+| `v-success` | `accent`            | `bg`      |
+| `v-warn`    | `warn`              | `bg`      |
+| `v-alert`   | `alert`             | `bg`      |
+
+**In tables and traces:** express row severity with a left-edge `border-l-2`
+stripe plus a faint tinted background (e.g. `bg-alert/5`). Never with a
+full ring or a solid status background. See `Trace` (§10).
+
+For inline "live" emphasis, pair a `StatusDot` with the `pulse-dot`
+utility — the only sanctioned glow.
+
+---
+
+## 10. Canonical components
+
+Each component below is the reference implementation for that role. Copy
+them verbatim into a new project — they all depend only on `cn` (§0), React,
+and (for `Button`) `cva` and `@radix-ui/react-slot`.
+
+### `Prompt`
+
+The orange `$` (or `>`) eyebrow used on terminal/install rows and above page
+titles. Renders the prompt symbol in `accent`, with optional inline content
+in `ink`.
+
+```tsx
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+interface PromptProps {
+  symbol?: string
+  className?: string
+  children?: React.ReactNode
+}
+
+export function Prompt({ symbol = '$', className, children }: PromptProps) {
+  return (
+    <span className={cn('font-mono text-accent', className)}>
+      {symbol}
+      {children !== undefined ? (
+        <span className="text-ink ml-2">{children}</span>
+      ) : null}
+    </span>
+  )
+}
+```
+
+### `Caret`
+
+A blinking 6×13 ink caret. Uses the `.blink` utility from §0. Drop next to a
+command to read as a typed query mid-stroke.
+
+```tsx
+import { cn } from '@/lib/utils'
+
+interface CaretProps {
+  className?: string
+}
+
+export function Caret({ className }: CaretProps) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        'blink inline-block w-[6px] h-[13px] bg-ink align-middle',
+        className,
+      )}
+    />
+  )
+}
+```
+
+### `StatusDot`
+
+6px circle. The only place `rounded-full` is allowed besides glyphs.
+Optional `.pulse-dot` glow for "live" emphasis.
+
+```tsx
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+type DotTone = 'accent' | 'alert' | 'warn' | 'ink'
+
+const dotTone: Record<DotTone, string> = {
+  accent: 'bg-accent',
+  alert: 'bg-alert',
+  warn: 'bg-warn',
+  ink: 'bg-ink',
+}
+
+interface StatusDotProps extends React.HTMLAttributes<HTMLSpanElement> {
+  tone?: DotTone
+  pulse?: boolean
+}
+
+export function StatusDot({
+  tone = 'accent',
+  pulse,
+  className,
+  ...props
+}: StatusDotProps) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        'inline-block size-1.5 rounded-full shrink-0',
+        dotTone[tone],
+        pulse && 'pulse-dot',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+```
+
+### `Button`
+
+Variants: `primary` (ink fill, hover inverts to outlined `bg`), `ghost`
+(transparent → solid ink on hover), `pill` (compact nav button), `icon`
+(30×30 rule-bordered), `terminal` (full-width row with `$` prompt + command
++ optional copy), `wiggle` (primary + corner badge slot + `.wiggle`). Sizes:
+`sm` `md` `lg` `icon`. Depends on `class-variance-authority` and
+`@radix-ui/react-slot`.
+
+```tsx
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-x-2 whitespace-nowrap font-mono lowercase rounded-none transition-[background-color,color,border-color] duration-150 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent disabled:pointer-events-none disabled:opacity-40 select-none',
+  {
+    variants: {
+      variant: {
+        primary:
+          'bg-ink text-bg border border-ink hover:bg-bg hover:text-ink',
+        ghost:
+          'bg-transparent text-ink border border-transparent hover:bg-ink hover:text-bg',
+        pill:
+          'bg-bg text-ink border border-ink hover:bg-ink hover:text-bg',
+        icon:
+          'bg-bg text-ink-faint border border-rule hover:text-ink',
+        terminal:
+          'bg-bg text-ink border border-rule justify-start',
+        wiggle:
+          'wiggle bg-ink text-bg border border-ink hover:bg-bg hover:text-ink relative',
+      },
+      size: {
+        sm: 'h-8 px-3 text-[13px]',
+        md: 'h-9 px-5 text-[13px]',
+        lg: 'h-11 px-5 text-[14px]',
+        icon: 'size-[30px] p-0',
+      },
+    },
+    defaultVariants: {
+      variant: 'primary',
+      size: 'md',
+    },
+  },
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild, children, ...props }, ref) => {
+    const Comp: React.ElementType = asChild ? Slot : 'button'
+    return (
+      <Comp
+        ref={ref}
+        className={cn(buttonVariants({ variant, size }), className)}
+        {...props}
+      >
+        {children}
+      </Comp>
+    )
+  },
+)
+Button.displayName = 'Button'
+
+export { buttonVariants }
+```
+
+### `StatusPanel`
+
+A row component for system messages: 18px icon slot, 13px Semi-Bold
+headline, 12px ink-faint detail. Variants tint the **border + icon +
+headline only** — body fill stays `bg`.
+
+```tsx
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export type StatusVariant = 'info' | 'success' | 'warn' | 'alert'
+
+const variantTone: Record<
+  StatusVariant,
+  { border: string; icon: string; headline: string }
+> = {
+  info: {
+    border: 'border-rule',
+    icon: 'text-ink',
+    headline: 'text-ink',
+  },
+  success: {
+    border: 'border-accent',
+    icon: 'text-accent',
+    headline: 'text-accent',
+  },
+  warn: {
+    border: 'border-warn',
+    icon: 'text-warn',
+    headline: 'text-warn',
+  },
+  alert: {
+    border: 'border-alert',
+    icon: 'text-alert',
+    headline: 'text-alert',
+  },
+}
+
+interface StatusPanelProps {
+  variant?: StatusVariant
+  icon?: React.ReactNode
+  headline: React.ReactNode
+  detail?: React.ReactNode
+  className?: string
+}
+
+export function StatusPanel({
+  variant = 'info',
+  icon,
+  headline,
+  detail,
+  className,
+}: StatusPanelProps) {
+  const tone = variantTone[variant]
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-x-3 border bg-bg px-3.5 py-3',
+        tone.border,
+        className,
+      )}
+    >
+      {icon ? (
+        <span
+          aria-hidden
+          className={cn('size-[18px] shrink-0', tone.icon)}
+        >
+          {icon}
+        </span>
+      ) : null}
+      <div className="min-w-0 flex flex-col gap-y-0.5">
+        <div
+          className={cn(
+            'font-mono text-[13px] font-semibold lowercase',
+            tone.headline,
+          )}
+        >
+          {headline}
+        </div>
+        {detail ? (
+          <div className="font-mono text-[12px] text-ink-faint lowercase">
+            {detail}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+```
+
+### `CodeBlock`
+
+`bg` fill, 1px `rule` border, monospace at 12.5px / line-height 1.55. Light
+syntax tinting: comments italic-ghost, strings in `accent`, keywords
+bold-ink, numbers in `alert`. The accent orange is reserved for **string
+literals and the active call return**, not arbitrary keywords.
+
+```tsx
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+interface CodeBlockProps extends React.HTMLAttributes<HTMLPreElement> {
+  children: React.ReactNode
+}
+
+export function CodeBlock({ className, children, ...props }: CodeBlockProps) {
+  return (
+    <pre
+      className={cn(
+        'border border-rule bg-bg overflow-x-auto px-5 py-4 font-mono text-[12.5px] leading-[1.55] text-ink',
+        className,
+      )}
+      {...props}
+    >
+      <code>{children}</code>
+    </pre>
+  )
+}
+```
+
+### `Terminal` & `TerminalRow`
+
+Header strip in `panel` with a label-caps title; body in `bg` with an orange
+`$` prompt, ink command, and an animated 6×13 ink caret.
+
+```tsx
+import * as React from 'react'
+import { Prompt } from './Prompt'
+import { Caret } from './Caret'
+import { cn } from '@/lib/utils'
+
+interface TerminalProps {
+  title?: React.ReactNode
+  children: React.ReactNode
+  className?: string
+}
+
+export function Terminal({ title, children, className }: TerminalProps) {
+  return (
+    <div className={cn('border border-rule bg-bg', className)}>
+      {title ? (
+        <div className="bg-panel px-3.5 py-2 border-b border-rule font-mono text-[11px] font-medium uppercase tracking-[0.06em] text-ink-faint">
+          {title}
+        </div>
+      ) : null}
+      <div className="p-4 font-mono text-[13px] text-ink">{children}</div>
+    </div>
+  )
+}
+
+interface TerminalRowProps {
+  command: React.ReactNode
+  showCaret?: boolean
+  className?: string
+}
+
+export function TerminalRow({
+  command,
+  showCaret,
+  className,
+}: TerminalRowProps) {
+  return (
+    <div className={cn('flex items-center gap-x-2', className)}>
+      <Prompt symbol="$" />
+      <span className="text-ink">{command}</span>
+      {showCaret ? <Caret /> : null}
+    </div>
+  )
+}
+```
+
+### `Trace`
+
+Header strip + a list of trace rows with a `StatusDot`, op label, duration,
+and a label-caps status. A waterfall of horizontal bars follows: `rule-2`
+background, `ink` fill, `alert` fill for error spans.
+
+> `TraceStatus` is the consumer's own domain type. The shape assumed here is
+> `{ id, op, durationMs, status, startMs?, spanMs? }`. Replace with whatever
+> your project uses.
+
+```tsx
+import * as React from 'react'
+import { StatusDot } from './StatusDot'
+import { cn } from '@/lib/utils'
+
+export type TraceStatus = 'ok' | 'warn' | 'err'
+
+interface TraceRow {
+  id: string
+  op: string
+  durationMs: number
+  status: TraceStatus
+  startMs?: number
+  spanMs?: number
+}
+
+interface TraceProps {
+  title: React.ReactNode
+  rows: TraceRow[]
+  totalMs?: number
+  className?: string
+}
+
+const statusTone: Record<
+  TraceStatus,
+  { dot: 'accent' | 'warn' | 'alert'; label: string; bar: string }
+> = {
+  ok: { dot: 'accent', label: 'text-accent', bar: 'bg-ink' },
+  warn: { dot: 'warn', label: 'text-warn', bar: 'bg-warn' },
+  err: { dot: 'alert', label: 'text-alert', bar: 'bg-alert' },
+}
+
+export function Trace({ title, rows, totalMs, className }: TraceProps) {
+  const span =
+    totalMs ??
+    Math.max(
+      ...rows.map((r) => (r.startMs ?? 0) + (r.spanMs ?? r.durationMs)),
+    )
+  return (
+    <div className={cn('border border-rule bg-bg', className)}>
+      <div className="bg-panel px-3.5 py-2 border-b border-rule font-mono text-[11px] font-medium uppercase tracking-[0.06em] text-ink-faint">
+        {title}
+      </div>
+      <ul className="divide-y divide-rule-2">
+        {rows.map((row) => {
+          const tone = statusTone[row.status]
+          const start = ((row.startMs ?? 0) / span) * 100
+          const width = ((row.spanMs ?? row.durationMs) / span) * 100
+          return (
+            <li
+              key={row.id}
+              className="grid grid-cols-[auto_1fr_auto_auto] items-center gap-x-3 px-3.5 py-2 font-mono text-[12px]"
+            >
+              <StatusDot tone={tone.dot} />
+              <span className="text-ink truncate lowercase">{row.op}</span>
+              <span className="text-ink-faint tabular-nums">
+                {row.durationMs}ms
+              </span>
+              <span
+                className={cn(
+                  'text-[11px] uppercase tracking-[0.06em] font-medium',
+                  tone.label,
+                )}
+              >
+                {row.status}
+              </span>
+              <div className="col-span-4 mt-1 h-1 bg-rule-2 relative">
+                <div
+                  className={cn('absolute top-0 h-full', tone.bar)}
+                  style={{ left: `${start}%`, width: `${width}%` }}
+                />
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+```
+
+### `Cell`
+
+A grid-bordered cell — the universal container for short prose blocks
+(features, hellos, pull-quotes). 28px padding, `bg` fill, optional 16px
+Semi-Bold ink title, 13px ink-faint body capped at ~34ch.
+
+```tsx
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+interface CellProps {
+  title?: React.ReactNode
+  children: React.ReactNode
+  className?: string
+}
+
+export function Cell({ title, children, className }: CellProps) {
+  return (
+    <div className={cn('border border-rule bg-bg p-7', className)}>
+      {title ? (
+        <div className="font-mono text-[16px] font-semibold tracking-[-0.01em] text-ink mb-3 lowercase">
+          {title}
+        </div>
+      ) : null}
+      <div className="font-mono text-[13px] leading-[1.7] text-ink-faint max-w-[34ch]">
+        {children}
+      </div>
+    </div>
+  )
+}
+```
+
+### `WorkerCard`
+
+400px-wide ticker card with a name + version row, description, a
+`panel`-tinted command block, and a footer with a kind tag and check icon.
+Focused state switches body fill from `bg` to `panel` and grows a
+`border-l-2 border-l-accent` rail on the left edge.
+
+```tsx
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+interface WorkerCardProps {
+  name: string
+  version: string
+  description: React.ReactNode
+  command: React.ReactNode
+  kind: string
+  focused?: boolean
+  className?: string
+}
+
+export function WorkerCard({
+  name,
+  version,
+  description,
+  command,
+  kind,
+  focused,
+  className,
+}: WorkerCardProps) {
+  return (
+    <article
+      className={cn(
+        'w-[400px] border border-rule transition-colors',
+        focused ? 'bg-panel border-l-2 border-l-accent' : 'bg-bg',
+        className,
+      )}
+    >
+      <header className="flex items-center justify-between px-4 py-3 border-b border-rule-2">
+        <div className="font-mono text-[16px] font-semibold lowercase text-ink">
+          {name}
+        </div>
+        <div className="font-mono text-[11px] uppercase tracking-[0.06em] text-ink-ghost tabular-nums">
+          v{version}
+        </div>
+      </header>
+      <div className="px-4 py-3 font-mono text-[13px] leading-[1.7] text-ink-faint">
+        {description}
+      </div>
+      <div className="bg-panel font-mono text-[12.5px] text-ink px-4 py-2 border-t border-rule-2">
+        {command}
+      </div>
+      <footer className="flex items-center justify-between px-4 py-2 border-t border-rule-2">
+        <span className="font-mono text-[11px] uppercase tracking-[0.06em] text-ink-faint">
+          {kind}
+        </span>
+        <span aria-hidden className="text-accent">
+          ✓
+        </span>
+      </footer>
+    </article>
+  )
+}
+```
+
+### `HelloCard`
+
+Code card with a head row (icon + meta + step number) and a code body. In
+`flow` mode, two language cards stack with a 120px peek and use the
+`.deal-shadow` utility (the one allowed transient shadow) when sliding on
+top of one another.
+
+```tsx
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+interface HelloCardItem {
+  id: string
+  language: string
+  step: number
+  body: React.ReactNode
+}
+
+interface HelloCardProps {
+  items: HelloCardItem[]
+  flow?: boolean
+  className?: string
+}
+
+export function HelloCard({ items, flow, className }: HelloCardProps) {
+  return (
+    <div className={cn('relative', className)}>
+      {items.map((item, idx) => {
+        const isUnder = flow && idx > 0
+        return (
+          <div
+            key={item.id}
+            className={cn(
+              'border border-rule bg-bg',
+              isUnder && 'absolute inset-x-0 -z-10 deal-shadow',
+            )}
+            style={isUnder ? { top: `${idx * 120}px` } : undefined}
+          >
+            <header className="flex items-center justify-between px-4 py-2 border-b border-rule-2 bg-panel font-mono text-[11px] uppercase tracking-[0.06em] text-ink-faint">
+              <span>{item.language}</span>
+              <span className="text-ink-ghost tabular-nums">
+                step {item.step}
+              </span>
+            </header>
+            <pre className="bg-bg px-5 py-4 font-mono text-[12.5px] leading-[1.55] text-ink overflow-x-auto">
+              <code>{item.body}</code>
+            </pre>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+```
+
+### `EmailRow`
+
+No border, no fill — just a 1px ink underline that switches to `accent` on
+focus. The submit arrow lives inside the row, right-aligned. Helper text
+below is label-caps in `ink-ghost`.
+
+```tsx
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+interface EmailRowProps
+  extends Omit<React.FormHTMLAttributes<HTMLFormElement>, 'children'> {
+  helper?: React.ReactNode
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>
+}
+
+export function EmailRow({
+  helper,
+  inputProps,
+  className,
+  ...formProps
+}: EmailRowProps) {
+  return (
+    <form className={cn('flex flex-col gap-y-2', className)} {...formProps}>
+      <div className="flex items-center gap-x-2 border-b border-ink focus-within:border-accent transition-colors">
+        <input
+          type="email"
+          {...inputProps}
+          className={cn(
+            'flex-1 bg-transparent font-mono text-[13px] text-ink placeholder:text-ink-ghost py-2 outline-none lowercase',
+            inputProps?.className,
+          )}
+        />
+        <button
+          type="submit"
+          aria-label="submit"
+          className="text-ink hover:text-accent transition-colors"
+        >
+          →
+        </button>
+      </div>
+      {helper ? (
+        <div className="font-mono text-[11px] uppercase tracking-[0.06em] text-ink-ghost">
+          {helper}
+        </div>
+      ) : null}
+    </form>
+  )
+}
+```
+
+### `SearchField`
+
+Large 24px display-style text with a blinking 2px `accent` caret. Reads as a
+typed query mid-stroke.
+
+```tsx
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+interface SearchFieldProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  showCaret?: boolean
+}
+
+export function SearchField({
+  showCaret = true,
+  className,
+  ...props
+}: SearchFieldProps) {
+  return (
+    <label
+      className={cn(
+        'flex items-center gap-x-2 font-mono text-[24px] text-ink',
+        className,
+      )}
+    >
+      <input
+        type="search"
+        {...props}
+        className="flex-1 bg-transparent outline-none placeholder:text-ink-ghost lowercase"
+      />
+      {showCaret ? (
+        <span
+          aria-hidden
+          className="blink inline-block w-[2px] h-[24px] bg-accent align-middle"
+        />
+      ) : null}
+    </label>
+  )
+}
+```
+
+### `ModeToggle`
+
+Two-up segmented control with a 1px `rule` border and 2px internal padding.
+Active button: solid `ink` fill, `bg` text. Inactive: transparent,
+`ink-faint` text. Joined left-to-right with internal 1px dividers when more
+than two options are passed.
+
+```tsx
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+interface ModeToggleOption<T extends string> {
+  value: T
+  label: React.ReactNode
+}
+
+interface ModeToggleProps<T extends string> {
+  value: T
+  onChange: (next: T) => void
+  options: ModeToggleOption<T>[]
+  className?: string
+}
+
+export function ModeToggle<T extends string>({
+  value,
+  onChange,
+  options,
+  className,
+}: ModeToggleProps<T>) {
+  return (
+    <div
+      role="tablist"
+      className={cn('inline-flex border border-rule p-[2px]', className)}
+    >
+      {options.map((opt) => {
+        const active = opt.value === value
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="tab"
+            aria-pressed={active}
+            onClick={() => onChange(opt.value)}
+            className={cn(
+              'font-mono text-[13px] px-3 py-1 transition-colors lowercase',
+              active
+                ? 'bg-ink text-bg'
+                : 'bg-transparent text-ink-faint hover:text-ink',
+            )}
+          >
+            {opt.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+```
+
+### `NumericBadge`
+
+16px tall, 4px horizontal padding, `accent` fill on a `bg` border. Sits on
+the top-right corner of a CTA to indicate count or unread.
+
+```tsx
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+interface NumericBadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  count: number | string
+}
+
+export function NumericBadge({
+  count,
+  className,
+  ...props
+}: NumericBadgeProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center justify-center bg-accent text-bg font-mono text-[11px] font-medium uppercase tracking-[0.06em] px-1 h-4 tabular-nums border border-bg',
+        className,
+      )}
+      {...props}
+    >
+      {count}
+    </span>
+  )
+}
+```
+
+### `Sheet` & `PageHeader`
+
+`Sheet` is the standard page-level wrapper — `min(1200px, 100%)`, centered,
+1px outer rule. `PageHeader` carries an `eyebrow` (rendered through
+`Prompt`), a `title` (display-hero or headline-section), an optional
+description in `ink-faint`, and an `actions` slot on the right.
+
+```tsx
+import * as React from 'react'
+import { Prompt } from '@/components/terminal/Prompt'
+import { cn } from '@/lib/utils'
+
+interface SheetProps {
+  children: React.ReactNode
+  className?: string
+}
+
+export function Sheet({ children, className }: SheetProps) {
+  return (
+    <div
+      className={cn(
+        'mx-auto w-full max-w-[1200px] border-x border-rule min-h-screen bg-bg',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+
+interface PageHeaderProps {
+  eyebrow?: React.ReactNode
+  title: React.ReactNode
+  description?: React.ReactNode
+  actions?: React.ReactNode
+  className?: string
+}
+
+export function PageHeader({
+  eyebrow,
+  title,
+  description,
+  actions,
+  className,
+}: PageHeaderProps) {
+  return (
+    <div
+      className={cn(
+        'flex items-end justify-between flex-wrap gap-6 px-9 py-12',
+        className,
+      )}
+    >
+      <div className="min-w-0">
+        {eyebrow ? (
+          <div className="font-mono text-[11px] uppercase tracking-[0.06em] text-ink-faint mb-3">
+            <Prompt symbol="$">{eyebrow}</Prompt>
+          </div>
+        ) : null}
+        <h1 className="font-mono text-[28px] font-medium tracking-[-0.01em] text-ink lowercase">
+          {title}
+        </h1>
+        {description ? (
+          <p className="mt-3 font-mono text-[14px] leading-[1.7] text-ink-faint max-w-[60ch] lowercase">
+            {description}
+          </p>
+        ) : null}
+      </div>
+      {actions ? (
+        <div className="flex items-center gap-x-3">{actions}</div>
+      ) : null}
+    </div>
+  )
+}
+```
+
+---
+
+## 11. Do / don't
+
+**Do**
+
+- Keep every text element **lowercase**, including headlines and buttons.
+  The only uppercase text is the `label-caps-*` styles with explicit
+  tracking.
+- Lean on **1px hairline rules** to define structure. Add a border before
+  reaching for a background fill.
+- **Ration the orange accent.** One accent moment per visible region — the
+  rest is ink, faint, and ghost.
+- Use the **`panel` tone** for headers and focused states. It is the only
+  "elevation" the system permits.
+- Keep the `iii` wordmark in lowercase, with all six rectangles in `ink`
+  (never colored).
+- Use **Chivo Mono for everything**, including body copy. Switching faces
+  breaks the schematic.
+- Use the **Tailwind utility** (`bg-bg`, `text-ink-faint`, `border-rule`,
+  `text-accent`) — never the raw CSS variable.
+- Use **container queries** (`@container`, `@3xl:`, `@4xl:`) for panel-level
+  responsiveness. Pages set `@container` and grids split with `@3xl:`.
+- Use **`tabular-nums`** on every number, timestamp, and KPI.
+
+**Don't**
+
+- Don't introduce **rounded corners** on containers, buttons, inputs, or
+  cards. Reserve `rounded-full` for true symbols (dots, glyphs).
+- Don't add **drop shadows** for default elevation. The `.deal-shadow`
+  stack-card animation is the only sanctioned shadow.
+- Don't use the orange accent for **body text, large fills, or decorative
+  blocks.** It loses meaning the moment it stops being rare.
+- Don't mix proportional and tabular figures. Numbers are always tabular
+  monospace.
+- Don't use **gradients** or color stops anywhere. The system is flat by
+  design.
+- Don't capitalize a sentence to "fix" a heading — rewrite it instead.
+- Don't stack two headings of the same scale. Headlines are always paired
+  with an ink-faint continuation, never another headline.
+- Don't add a **second typeface**, even for code or numbers. The
+  single-face constraint is load-bearing.
+- Don't paint **full-color status backgrounds** — use text color plus a
+  small icon, dot, or left stripe.
+- Don't introduce **viewport breakpoints** for panel layouts — use
+  container queries.
+
+---
+
+## 12. App-level patterns
+
+These patterns are not part of the canonical primitive set in §10 but
+are app-level compositions that the iii worker registry relies on. They are
+documented here so that any other surface adopting the iii Schematic can
+pick them up consistently.
+
+### Theme toggle
+
+Light is canonical. To let users switch themes (without losing the
+schematic feel), expose a two-segment `ModeToggle` in the sticky nav strip
+labelled `light` / `dark`. Selection persists to `localStorage` under the
+key `iii-theme` and is applied by setting `data-theme="dark"` (or
+`"light"`) on `<html>`. To avoid a flash of the wrong theme, run a tiny
+inline script in `<head>` before paint:
+
+```html
+<script>
+  try {
+    var t = localStorage.getItem('iii-theme');
+    document.documentElement.dataset.theme =
+      t === 'dark' || t === 'light' ? t : 'light';
+  } catch (_) {
+    document.documentElement.dataset.theme = 'light';
+  }
+</script>
+```
+
+The toggle component itself is the standard `ModeToggle` from §10, with
+`light` and `dark` as its two options. It is the **only** decoration in the
+nav strip's right slot, so the structure stays a clean `[wordmark] —
+[toggle]` row. There is no auto OS-follow: the user picks once and that
+choice sticks.
+
+### Hybrid registry layout
+
+For listing pages that have both a small set of "highlighted" items and a
+much longer browseable index (the worker registry being the canonical
+example), use a **hybrid layout** inside a single `Sheet`:
+
+1. **Featured row** — a 3-up grid of `WorkerCard` (the spec component from
+   §10), shown only when no search filter is active. The grid uses
+   container queries (`grid-cols-1 @3xl:grid-cols-2 @5xl:grid-cols-3`) so
+   it stays responsive within the `Sheet`. Eyebrow above the grid is a
+   `label-caps-lg` heading sitting on a `border-t border-rule` separator.
+2. **Search + index** — the spec's `SearchField` (24px display caret)
+   immediately above a `border border-rule bg-bg` container with rows
+   separated by `divide-y divide-rule-2`. Each row is a compact
+   row-shaped variant of `WorkerCard` (no command block; just name +
+   version + description + meta). Hover states use the same
+   `bg-panel border-l-2 border-l-accent` rail that focused `WorkerCard`s
+   use in §10.
+3. **Search behaviour** — when the search field has a non-empty query, the
+   featured row collapses entirely; only the filtered index is shown so
+   that "featured" content never competes with results.
+4. **Empty state** — the `Cell` from §10, with a `title` that names the
+   missing thing and a one-line ink-faint body. Never a centered
+   illustration; never an oversize fill.
+
+This pattern keeps the **same surface tone** for both the showcase and the
+index — the `Sheet` is unbroken from top to bottom — and uses the existing
+primitives without inventing a new "hero card" shape.
+
+### API reference panel
+
+For documenting a worker's registered functions and triggers (the "api
+reference" tab on the worker detail page), use a stacked, expanded-by-default
+"datasheet" composition rather than a sidebar+console pattern. The whole
+surface should read top-to-bottom like a printed engineering spec, with no
+accordions or modals at the row level.
+
+The composition has three nesting levels and uses one tonal step per level:
+
+```
+section eyebrow (label-caps)            <- bg page
+  card        bg-panel head + bg body   <- per function/trigger
+    pane      bg-paper-2 head + bg body <- per schema (request/response)
+      tree    flat type-table           <- per field
+```
+
+1. **Sections** — two `Section`s (functions, triggers), each with a
+   `label-caps-lg` eyebrow on the left and a small ink-ghost count on the
+   right. Same chrome already used by other tabs on the worker page; do not
+   wrap the section bodies in an additional border.
+2. **Card** — a bordered `article` per function/trigger. The `bg-panel` head
+   strip carries the name (`title-cell`) on the left, any `metadata.tags`
+   rendered as `rule-2`-bordered label-caps-sm pills next to it, and the
+   kind label (`FUNCTION` / `TRIGGER`) in label-caps on the right. Function
+   and trigger cards share the exact same head; the only difference is
+   what the name represents. **Triggers do not carry a separate "type"
+   chip** — a trigger card *is* the definition of a trigger type, so the
+   trigger's name (e.g. `http-endpoint`, `cron`, `queue`) is the type. Each
+   card carries a stable `id` (`fn-<name>` / `trigger-<name>`) plus
+   `scroll-mt-20` so that anchor navigation lands cleanly below the sticky
+   site header.
+3. **Pane** — the two schemas inside a card sit in a `@2xl:grid-cols-2`
+   grid, separated by a 1px `bg-rule-2` gutter. Each pane is a
+   `border-rule` block with a `bg-paper-2` head strip carrying a
+   label-caps-sm eyebrow (`request` / `response` for functions,
+   `invocation` / `return` for triggers). The `bg-paper-2` step makes the
+   pane read as one tonal level "down" from the card's `bg-panel` head.
+4. **Tree** — fields render as a flat type-table inside the pane body, one
+   row per field. Each row is `name  type  required-marker  enum  constraints`
+   on one line, with the description on a second line in
+   `text-ink-faint text-[12px]`. Nested objects, arrays-of-objects, and
+   union variants indent under the parent with a `border-l border-rule-2`
+   guide. Nesting deeper than three levels collapses behind a native
+   `<details>` row labelled "… expand N nested" so the surface stays
+   client-JS-free.
+
+**Rendering rule.** Schemas in this surface render as type tables — never
+as raw JSON dumps. If a schema construct can't be expressed in the table
+(e.g. JSON Schema `$ref` or vendor extensions), surface it as an inline
+`label-caps` chip rather than dropping in a `<pre>` block.
+
+**Accent rationing (§3).** The required-field marker (`*`) is the only
+accent inside a schema tree. There is no accent on the card head — every
+trigger row stays ink-on-paper, just like a function row.
+
+**Empty states.** Use `Cell` for "no functions registered" / "no triggers
+registered" within a present section, and a `StatusPanel variant="info"`
+when the worker registers neither — same convention as the rest of the
+worker page.
+
+**Sidebar summary.** Pair the panel with an `api` card in the worker
+page's right-hand `aside` (placed between `details` and `author`) listing
+every function and trigger the worker exposes. The card uses the same
+chrome as the other sidebar cards (`border-rule` block + `bg-panel` head
++ `label-caps-lg` title) and contains two sub-sections — `functions` and
+`triggers` — each headed by a `label-caps-sm` eyebrow with a tabular
+count on the right. Each row is a Next.js `Link` whose `href` always
+includes `?tab=api#<anchor>`, where the anchor is the same id stamped on
+the corresponding card. This makes the same link work from any tab:
+clicking from `readme` switches to `api` and scrolls to the target,
+clicking from `api` just scrolls. **Always show the card** when the
+worker has any API surface — it doubles as a table of contents on the
+api tab and as a discovery hint on the other tabs. Names render in their
+original casing (e.g. `transcodeVideo`) — the lowercase rule does not
+apply to identifiers.
+
+**Sticky aside.** The sidebar `aside` is sticky inside the page's main
+scroll container at `@4xl` and above:
+`@4xl:sticky @4xl:top-4 @4xl:self-start @4xl:max-h-[calc(100dvh-2rem)] @4xl:overflow-y-auto`.
+`self-start` is required so the grid cell sizes to its content (sticky
+needs the element to be smaller than its containing block). The
+`max-h` + internal `overflow-y-auto` is defensive — for very long
+sidebars (e.g. a worker with 50 functions) the `api` card scrolls
+internally instead of overflowing the viewport. At narrower widths the
+aside stacks below the main column and is not sticky.
+
+**Selection echo.** When a sidebar link is clicked, the corresponding
+function/trigger card lights up with the canonical `border-l-2
+border-l-accent` rail (the same recipe used by `WorkerCard` focused
+state in §10 and the `versions` Row's `aria-current` style) and the
+clicked sidebar link itself switches to `text-accent`. This gives the
+user a clear "you are here" signal that survives any subsequent
+scrolling. The 1px → 2px border shift on the left edge is the
+sanctioned accent on the existing rule grid (§4 "Allowed accents on top
+of borders").
+
+**Why CSS `:target` is not enough.** Next.js `Link` performs same-page
+hash navigation through `history.pushState`, which does **not** fire
+`hashchange` and which most browsers do **not** treat as a `:target`
+re-evaluation trigger. As a result, plain
+`target:border-l-2 target:border-l-accent` only highlights on full page
+load and back/forward — *not* on a soft sidebar click. The api panel
+must drive the highlight from JS instead.
+
+**Shared hash hub.** Both the sidebar links and the cards subscribe to
+a single client-side hash hub
+([`use-active-hash.ts`](app/src/components/api-reference/use-active-hash.ts)) — a module-level
+`Set<Subscriber>` plus one global pair of `hashchange` + `popstate`
+listeners that broadcast the latest `window.location.hash` to every
+mounted subscriber. The hub also exports `setActiveHash(hash)` so click
+handlers can dispatch optimistically the moment the user clicks, before
+the URL has changed. There is exactly one source of truth for "what is
+selected", and it is shared across the sidebar (which lives in the
+`aside`) and the card grid (which lives in the main content column),
+without any context provider crossing that distance.
+
+Wiring:
+
+- **Cards** wrap their `<article>` in a tiny client component
+  ([`hash-card.tsx`](app/src/components/api-reference/hash-card.tsx))
+  that calls `useActiveHash()` and conditionally adds
+  `border-l-2 border-l-accent` when the hash matches its `id`. The card
+  body (header, description, schema panes) is still a server-rendered
+  React tree passed in as `children`, so the only JS that runs in the
+  browser is the wrapper.
+- **Sidebar links** ([`summary-list.tsx`](app/src/components/api-reference/summary-list.tsx))
+  call `useActiveHash()` for their visual state and
+  `setActiveHash(target)` from `onClick`, which broadcasts to the
+  card subscribers immediately so the rail and the link light up in
+  the same frame as the click — even though Next.js will not have
+  fired `hashchange` yet.
+
+This is also why the sidebar uses a single `SummaryList` client
+component for *both* `functions` and `triggers` sub-sections rather
+than one client component per section: with the hub providing a single
+source of truth, splitting state would only cause stale highlights when
+the user crossed sub-sections.
+
+**Accent rationing.** Per §3, the selection still costs only one accent
+moment per visible region: in the sidebar it is the active link; on the
+panel it is the rail on the targeted card. The required-marker accent
+inside the schema tree continues to coexist because it lives at a
+different scale (a single character per row).

--- a/console/PRODUCT.md
+++ b/console/PRODUCT.md
@@ -1,0 +1,55 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Two audiences share the console equally:
+
+- **Engine developers** building and testing iii workers, agent flows, and function registrations on a local or staging engine. They need to invoke `@` functions, switch models, approve tool calls, and confirm behavior before shipping.
+- **Operators and SREs** debugging live or near-live sessions: tracing spans, following critical paths, filtering by service or session, and correlating chat activity with OpenTelemetry output.
+
+Both use the same binary on one port. Context is usually a desk with a large monitor, long sessions, and the engine running on localhost or a reachable cluster. The UI is a work surface, not a marketing moment.
+
+## Product Purpose
+
+Console is the local control panel for the [iii](https://github.com/iii-hq) engine: agentic chat, trace exploration, and provider configuration in a single embedded SPA served by one Rust binary.
+
+Success looks like an operator who can steer an agent, watch function calls resolve, jump from a conversation session into the trace explorer, and configure AI providers without leaving the browser or fighting CORS. The product exists to make the engine legible: what ran, why it failed, and what to do next.
+
+## Brand Personality
+
+**Instrument panel.** Calm, precise, nothing decorative. Like reading a schematic or an engineering document, not a consumer chat app.
+
+Voice is monospace, lowercase labels, explicit state (running / pending / error), and warm cream-and-ink warmth without softness. Confidence comes from clarity and density, not from gradients, mascots, or empty hero space. The iii Schematic design system (see DESIGN.md) encodes this: blueprint aesthetic, single vivid accent, zero border-radius by default.
+
+Three words: **precise**, **legible**, **warm**.
+
+## Anti-references
+
+Do not drift toward:
+
+- **Generic AI SaaS** — purple gradients, glass cards, hero metrics, Inter everywhere, rounded pill UI
+- **Observability cliché** — dark navy + teal defaults, colored side-stripe alerts, Datadog-style chrome overload
+- **ChatGPT clone** — centered bubble chat, soft shadows, consumer messaging patterns
+- **Category reflex** — "AI tool" or "traces dashboard" should not predict the palette or layout; the schematic identity should be recognizable on its own
+
+Avoid modals when inline or progressive disclosure works. Avoid decorative motion. Avoid nested card grids that repeat icon + heading + blurb.
+
+## Design Principles
+
+1. **Instrument over interface** — Every element on the schematic earns its place. Prefer density, labels, and state badges over decoration and empty padding.
+2. **Dev and ops parity** — Building a worker and debugging a failed trace are equally first-class journeys; neither audience is secondary.
+3. **Live truth** — Catalogs, traces, and chat stream from the engine. Static fallbacks exist only when the engine is unreachable, and they read as degraded, not default.
+4. **Show the mechanism** — Sessions, spans, function calls, approvals, and context usage stay visible. Hide complexity in collapsible detail, not in opaque summaries.
+5. **Keyboard-native power** — Numbered shortcuts, arrow navigation, focus rings, and live regions for streaming. Long-session operators should not reach for the mouse for routine actions.
+
+## Accessibility & Inclusion
+
+- Target **WCAG 2.1 AA** contrast for text and interactive controls in both light and dark themes.
+- Full **keyboard operability** for configuration, provider dialogs, and list navigation; suppress shortcuts only inside text inputs and the chat composer.
+- **Live regions** for streaming chat and status changes where appropriate.
+- Respect **`prefers-reduced-motion`** for non-essential animation (thinking shimmer, transitions).
+- Theme persisted with **pre-paint init** to avoid flash of wrong theme on load.

--- a/console/web/package.json
+++ b/console/web/package.json
@@ -16,6 +16,8 @@
   },
   "dependencies": {
     "@lexical/react": "^0.44.0",
+    "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/console/web/pnpm-lock.yaml
+++ b/console/web/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@lexical/react':
         specifier: ^0.44.0
         version: 0.44.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(yjs@13.6.30)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-select':
+        specifier: ^2.2.6
+        version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.14)(react@19.2.6)
@@ -318,6 +324,9 @@ packages:
   '@preact/signals-core@1.14.2':
     resolution: {integrity: sha512-RZHdBj9ZF4n40Rp4jS052EHHjBWf96P9oNdXPfhQTovCuWY9iQn3Gq+gOTJSgBO9A/JBuPfMOWsSX/lIU9Pc/A==}
 
+  '@radix-ui/number@1.1.1':
+    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
+
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
@@ -365,6 +374,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-direction@1.1.1':
     resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
     peerDependencies:
@@ -376,6 +398,28 @@ packages:
 
   '@radix-ui/react-dismissable-layer@1.1.11':
     resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -450,6 +494,19 @@ packages:
 
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-select@2.2.6':
+    resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -543,6 +600,15 @@ packages:
 
   '@radix-ui/react-use-layout-effect@1.1.1':
     resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.1':
+    resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -920,6 +986,10 @@ packages:
   '@xyflow/system@0.0.76':
     resolution: {integrity: sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1029,6 +1099,9 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
@@ -1069,6 +1142,10 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1419,6 +1496,36 @@ packages:
       '@types/react': '>=18'
       react: '>=18'
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react@19.2.6:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
     engines: {node: '>=0.10.0'}
@@ -1539,6 +1646,26 @@ packages:
 
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -1943,6 +2070,8 @@ snapshots:
 
   '@preact/signals-core@1.14.2': {}
 
+  '@radix-ui/number@1.1.1': {}
+
   '@radix-ui/primitive@1.1.3': {}
 
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
@@ -1978,6 +2107,28 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
+      aria-hidden: 1.2.6
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-direction@1.1.1(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       react: 19.2.6
@@ -1991,6 +2142,23 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
@@ -2064,6 +2232,35 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-select@2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      aria-hidden: 1.2.6
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -2147,6 +2344,12 @@ snapshots:
       '@types/react': 19.2.14
 
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       react: 19.2.6
     optionalDependencies:
@@ -2473,6 +2676,10 @@ snapshots:
       d3-selection: 3.0.0
       d3-zoom: 3.0.0
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   assertion-error@2.0.1: {}
 
   ast-v8-to-istanbul@1.0.0:
@@ -2562,6 +2769,8 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  detect-node-es@1.1.0: {}
+
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
@@ -2591,6 +2800,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  get-nonce@1.0.1: {}
 
   graceful-fs@4.2.11: {}
 
@@ -3150,6 +3361,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.6)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.6)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.6)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.6)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.6):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.6
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   react@19.2.6: {}
 
   remark-gfm@4.0.1:
@@ -3261,8 +3499,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   typescript@6.0.3: {}
 
@@ -3300,6 +3537,21 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.6):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.6
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   use-sync-external-store@1.6.0(react@19.2.6):
     dependencies:

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -1,14 +1,28 @@
-import { lazy, Suspense } from 'react'
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import { ChatDock } from '@/components/chat/ChatDock'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/components/ui/Dialog'
 import { ModeToggle } from '@/components/ui/ModeToggle'
 import { Sheet } from '@/components/ui/Sheet'
 import { Wordmark } from '@/components/ui/Wordmark'
 import { useChatDock } from '@/hooks/use-chat-dock'
 import { useHashRoute, type View } from '@/hooks/use-hash-route'
-import { type Theme, useTheme } from '@/hooks/use-theme'
-import { ConversationsProvider } from '@/lib/conversations-context'
+import { useTheme } from '@/hooks/use-theme'
+import { type DockSignal, getDockSignal } from '@/lib/chat-activity'
+import { ConversationsProvider, useConversationsCtx } from '@/lib/conversations-context'
 import { cn } from '@/lib/utils'
-import { Chat } from '@/pages/Chat'
+import { Configuration } from '@/pages/Configuration'
 import { Traces } from '@/pages/Traces'
 
 const PLAYGROUND_ENABLED = !!import.meta.env.VITE_PLAYGROUND
@@ -30,23 +44,56 @@ const Playground = PLAYGROUND_ENABLED
 
 const VIEW_OPTIONS: { value: View; label: string }[] = PLAYGROUND_ENABLED
   ? [
-      { value: 'chat', label: 'chat' },
       { value: 'traces', label: 'traces' },
       { value: 'playground', label: 'playground' },
       { value: 'examples', label: 'examples' },
     ]
-  : [
-      { value: 'chat', label: 'chat' },
-      { value: 'traces', label: 'traces' },
-    ]
+  : [{ value: 'traces', label: 'traces' }]
 
 export function App() {
   const [theme, setTheme] = useTheme()
   const [view, setView] = useHashRoute()
   const dock = useChatDock()
+  const [shortcutsOpen, setShortcutsOpen] = useState(false)
 
-  const dockEligible = view !== 'chat'
-  const dockVisible = dockEligible && dock.open
+  /* When the dock transitions from collapsed → expanded, focus the
+     composer so the user can start typing immediately. requestAnimationFrame
+     waits for the mount/paint cycle; if the editor isn't there (no active
+     conversation, etc.) the focus is a no-op. */
+  const wasCollapsedRef = useRef(dock.collapsed)
+  useEffect(() => {
+    const wasCollapsed = wasCollapsedRef.current
+    wasCollapsedRef.current = dock.collapsed
+    if (!wasCollapsed || dock.collapsed) return
+    if (typeof window === 'undefined') return
+    const frame = window.requestAnimationFrame(() => {
+      const editor = document.querySelector<HTMLElement>('.composer-editor')
+      editor?.focus()
+    })
+    return () => window.cancelAnimationFrame(frame)
+  }, [dock.collapsed])
+
+  /* `?` opens the shortcuts overlay. Ignored when the user is typing into
+     editable elements so we don't fight the composer. */
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== '?') return
+      if (e.metaKey || e.ctrlKey || e.altKey) return
+      const target = e.target as HTMLElement | null
+      if (target?.isContentEditable) return
+      const tag = target?.tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
+      e.preventDefault()
+      setShortcutsOpen(true)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
+
+  const collapseDock = useCallback(() => {
+    dock.setCollapsed(true)
+  }, [dock])
 
   return (
     <ConversationsProvider>
@@ -54,34 +101,35 @@ export function App() {
         <Header
           view={view}
           onViewChange={setView}
-          theme={theme}
-          onThemeChange={setTheme}
-          dockEligible={dockEligible}
-          dockOpen={dock.open}
-          onToggleDock={dock.toggle}
+          dockCollapsed={dock.collapsed}
+          onToggleDock={dock.toggleCollapsed}
+          onOpenShortcuts={() => setShortcutsOpen(true)}
         />
         <div className="flex-1 flex min-h-0">
-          {dockVisible ? (
-            <ChatDock
-              width={dock.width}
-              onWidthChange={dock.setWidth}
-              onClose={() => dock.setOpen(false)}
-            />
-          ) : null}
+          <ChatDock
+            width={dock.width}
+            onWidthChange={dock.setWidth}
+            collapsed={dock.collapsed}
+            onCollapse={collapseDock}
+          />
           <div className="flex-1 flex flex-col min-w-0 min-h-0">
             <Suspense fallback={<RouteFallback />}>
-              {view === 'traces' ? (
-                <Traces />
+              {view === 'configuration' ? (
+                <Configuration theme={theme} onThemeChange={setTheme} />
               ) : view === 'examples' && Examples ? (
                 <Examples />
               ) : view === 'playground' && Playground ? (
                 <Playground />
               ) : (
-                <Chat />
+                <Traces />
               )}
             </Suspense>
           </div>
         </div>
+        <ShortcutsDialog
+          open={shortcutsOpen}
+          onOpenChange={setShortcutsOpen}
+        />
       </Sheet>
     </ConversationsProvider>
   )
@@ -90,65 +138,204 @@ export function App() {
 interface HeaderProps {
   view: View
   onViewChange: (next: View) => void
-  theme: Theme
-  onThemeChange: (next: Theme) => void
-  dockEligible: boolean
-  dockOpen: boolean
+  dockCollapsed: boolean
   onToggleDock: () => void
+  onOpenShortcuts: () => void
 }
 
 function Header({
   view,
   onViewChange,
-  theme,
-  onThemeChange,
-  dockEligible,
-  dockOpen,
+  dockCollapsed,
   onToggleDock,
+  onOpenShortcuts,
 }: HeaderProps) {
+  const onConfiguration = view === 'configuration'
   return (
-    <header className="flex items-center justify-between px-6 h-12 border-b border-rule shrink-0">
+    <header className="flex items-center justify-between pl-3 pr-6 h-12 border-b border-rule shrink-0">
       <div className="flex items-center gap-3">
+        <DockToggle collapsed={dockCollapsed} onToggle={onToggleDock} />
         <Wordmark />
         <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-faint">
           {view}
         </span>
       </div>
       <div className="flex items-center gap-3">
-        {dockEligible ? (
-          <button
-            type="button"
-            onClick={onToggleDock}
-            aria-pressed={dockOpen}
-            aria-label={dockOpen ? 'close chat dock' : 'open chat dock'}
-            className={cn(
-              'font-mono text-[13px] px-3 py-1 border transition-colors lowercase',
-              dockOpen
-                ? 'bg-ink text-bg border-ink'
-                : 'bg-transparent text-ink-faint border-rule hover:text-ink hover:border-ink',
-            )}
-          >
-            <span aria-hidden className="mr-1">
-              {dockOpen ? '×' : '+'}
-            </span>
-            chat
-          </button>
-        ) : null}
         <ModeToggle<View>
           value={view}
           onChange={onViewChange}
           options={VIEW_OPTIONS}
         />
-        <ModeToggle<Theme>
-          value={theme}
-          onChange={onThemeChange}
-          options={[
-            { value: 'light', label: 'light' },
-            { value: 'dark', label: 'dark' },
-          ]}
-        />
+        <button
+          type="button"
+          onClick={onOpenShortcuts}
+          aria-label="keyboard shortcuts (?)"
+          title="keyboard shortcuts (?)"
+          className="font-mono text-[14px] leading-none w-7 h-7 flex items-center justify-center border bg-transparent text-ink-faint border-rule hover:text-ink hover:border-ink transition-colors focus-visible:border-accent focus-visible:outline-none"
+        >
+          <span aria-hidden>?</span>
+        </button>
+        <button
+          type="button"
+          onClick={() => onViewChange('configuration')}
+          aria-pressed={onConfiguration}
+          aria-label="configuration"
+          title="configuration"
+          className={cn(
+            'font-mono text-[14px] leading-none w-7 h-7 flex items-center justify-center border transition-colors',
+            onConfiguration
+              ? 'bg-ink text-bg border-ink'
+              : 'bg-transparent text-ink-faint border-rule hover:text-ink hover:border-ink',
+          )}
+        >
+          <span aria-hidden>⚙</span>
+        </button>
       </div>
     </header>
+  )
+}
+
+interface DockToggleProps {
+  collapsed: boolean
+  onToggle: () => void
+}
+
+/**
+ * Global chat-dock toggle, pinned to the leftmost slot of the app header.
+ * One typographic glyph (`>_`), one place: the button state communicates
+ * open/closed via the same pressed-vs-outlined vocabulary the configuration
+ * gear uses on the opposite end of the header. The `?` button between them
+ * documents this binding (and every other) — no inline kbd hint needed.
+ *
+ * The `_` of the `>_` glyph blinks at terminal cadence so the toggle reads
+ * as an AI prompt waiting for input. Suppressed during `active` so the
+ * button never carries two concurrent motion sources (the square accent
+ * ring is the focal motion; a flickering cursor underneath would be noise).
+ *
+ * Collapsed state is dimensional, not binary: `getDockSignal()` resolves
+ * the active conversation into one of four states. `active` (streaming,
+ * pending approval, running tool call) pulses accent so blocking events
+ * don't get buried. `attention` and `error` (system message tones) tint
+ * the border statically — motion is the wrong gesture for "the engine
+ * reported a problem." Clicking the toggle in any signal state expands
+ * the dock, which auto-scrolls to the latest message; the user lands on
+ * the warn / error content without hunting.
+ */
+function DockToggle({ collapsed, onToggle }: DockToggleProps) {
+  const { active } = useConversationsCtx()
+  const signal = getDockSignal(active)
+  const expanded = !collapsed
+  const baseLabel = collapsed ? 'open chat dock' : 'collapse chat dock'
+  const signalPreview = useDockSignalPreview(signal, active)
+  /* When the toggle border carries a warn/error tint, surface the actual
+     system-message text in `title` + `aria-label` so the user can triage
+     without expanding the dock and hunting. Idle/active states get the
+     plain label. */
+  const fullLabel = signalPreview
+    ? `${baseLabel} (⌘\\) — ${signalPreview}`
+    : `${baseLabel} (⌘\\)`
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-label={fullLabel}
+      aria-expanded={expanded}
+      aria-controls="chat-dock"
+      title={fullLabel}
+      className={cn(
+        'font-mono text-[14px] leading-none w-7 h-7 flex items-center justify-center border transition-colors focus-visible:border-accent focus-visible:outline-none',
+        expanded ? 'bg-ink text-bg border-ink' : dockToggleSignalClass(signal),
+      )}
+    >
+      {/* Single optical mark: `>` plus a `_` cursor pulled snug underneath
+          via negative letter-spacing so the cluster sits in roughly the
+          same visual footprint as `⚙` and `?` next to it in the header. */}
+      <span
+        aria-hidden
+        className="inline-flex items-baseline"
+        style={{ letterSpacing: '-0.18em' }}
+      >
+        {'>'}
+        <span className={signal === 'active' ? undefined : 'blink'}>_</span>
+      </span>
+    </button>
+  )
+}
+
+const PREVIEW_MAX_LENGTH = 80
+
+/**
+ * Returns a truncated preview of the latest warn/error system message in
+ * the active conversation, or `null` when the dock signal doesn't warrant
+ * one. Surfaced through the toggle's `title` and `aria-label` so the user
+ * gets inline triage from the chrome itself.
+ */
+function useDockSignalPreview(
+  signal: DockSignal,
+  active: ReturnType<typeof useConversationsCtx>['active'],
+): string | null {
+  if (signal !== 'error' && signal !== 'attention') return null
+  if (!active) return null
+  for (let i = active.messages.length - 1; i >= 0; i--) {
+    const m = active.messages[i]
+    if (m && m.role === 'system' && (m.tone === 'error' || m.tone === 'warn')) {
+      const flat = m.content.replace(/\s+/g, ' ').trim()
+      return flat.length > PREVIEW_MAX_LENGTH
+        ? `${flat.slice(0, PREVIEW_MAX_LENGTH - 1)}…`
+        : flat
+    }
+  }
+  return null
+}
+
+function dockToggleSignalClass(signal: DockSignal): string {
+  switch (signal) {
+    case 'active':
+      return 'bg-transparent text-accent border-accent pulse-square'
+    case 'attention':
+      return 'bg-transparent text-warn border-warn'
+    case 'error':
+      return 'bg-transparent text-alert border-alert'
+    default:
+      return 'bg-transparent text-ink-faint border-rule hover:text-ink hover:border-ink'
+  }
+}
+
+interface ShortcutsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const SHORTCUTS: { combo: string; description: string }[] = [
+  { combo: '⌘\\', description: 'toggle chat dock' },
+  { combo: 'Esc', description: 'collapse chat dock when focused inside' },
+  { combo: '?', description: 'open this shortcut overlay' },
+]
+
+function ShortcutsDialog({ open, onOpenChange }: ShortcutsDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogTitle className="text-[11px] uppercase tracking-[0.18em] text-ink-faint">
+          keyboard shortcuts
+        </DialogTitle>
+        <DialogDescription className="mt-1">
+          press <kbd className="font-mono text-ink">?</kbd> any time to reopen
+          this list.
+        </DialogDescription>
+        <ul className="mt-4 divide-y divide-rule-2 border-t border-b border-rule-2">
+          {SHORTCUTS.map(({ combo, description }) => (
+            <li
+              key={combo}
+              className="flex items-center justify-between gap-6 py-2 font-mono text-[12px] text-ink"
+            >
+              <span className="text-ink-faint">{description}</span>
+              <kbd className="text-ink tracking-[0.06em]">{combo}</kbd>
+            </li>
+          ))}
+        </ul>
+      </DialogContent>
+    </Dialog>
   )
 }
 

--- a/console/web/src/components/chat/ChatDock.tsx
+++ b/console/web/src/components/chat/ChatDock.tsx
@@ -10,23 +10,40 @@ import { ChatPanel } from './ChatPanel'
 interface ChatDockProps {
   width: number
   onWidthChange: (next: number) => void
-  onClose: () => void
+  collapsed: boolean
+  /**
+   * Bound to `Escape` while focus is on the dock chrome (not the
+   * composer or any other text input). Lets keyboard users dismiss the
+   * dock symmetrically with the `⌘\` open shortcut.
+   */
+  onCollapse: () => void
 }
 
 const clamp = (w: number, max: number) =>
   Math.max(DOCK_MIN_WIDTH, Math.min(max, w))
 
 /**
- * Left-sticky chat panel that sits beside the active route (traces /
- * playground / examples). Sized via a drag handle on the right edge — the
- * dock is anchored to the left, so dragging the handle to the right
- * increases the dock width, mirroring the trace/span resize pattern.
+ * Collapsible, resizable left-sticky chat panel that sits beside the active
+ * route (traces / configuration / playground / examples). When expanded, the
+ * width is set via a drag handle on the right edge — the dock is anchored to
+ * the left, so dragging right increases the dock width, mirroring the
+ * trace/span resize pattern. The dock has no fixed upper width: the drag is
+ * capped by the live viewport so the route content next to the dock always
+ * keeps at least `DOCK_NEIGHBOR_MIN_WIDTH` pixels visible.
  *
- * The dock has no fixed upper width: the drag is capped by the live
- * viewport so the route content next to the dock always keeps at least
- * `DOCK_NEIGHBOR_MIN_WIDTH` pixels visible.
+ * When collapsed, the dock renders nothing (no thin strip): the toggle
+ * affordance lives in the global app header at the leftmost slot, matching
+ * Cursor's chat-panel pattern. The previous width is preserved across
+ * collapse/expand. Toggle via the header button or `⌘/Ctrl + \` (the
+ * shortcut is wired inside `useChatDock` so it works even while the dock
+ * is unmounted).
  */
-export function ChatDock({ width, onWidthChange, onClose }: ChatDockProps) {
+export function ChatDock({
+  width,
+  onWidthChange,
+  collapsed,
+  onCollapse,
+}: ChatDockProps) {
   const [isResizing, setIsResizing] = useState(false)
   /* Tracked in state so aria-valuemax stays accurate as the window resizes,
      even when the user isn't actively dragging. */
@@ -81,16 +98,29 @@ export function ChatDock({ width, onWidthChange, onClose }: ChatDockProps) {
     onWidthChange(DOCK_DEFAULT_WIDTH)
   }, [onWidthChange])
 
+  if (collapsed) return null
+
   return (
     <>
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: focus-only Esc shortcut for keyboard users; chrome remains operable by mouse */}
       <aside
+        id="chat-dock"
         style={{ width }}
+        onKeyDown={(e) => {
+          if (e.key !== 'Escape') return
+          const target = e.target as HTMLElement | null
+          if (target?.isContentEditable) return
+          const tag = target?.tagName
+          if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
+          e.preventDefault()
+          onCollapse()
+        }}
         className={cn(
           'flex flex-col flex-shrink-0 h-full overflow-hidden bg-bg border-r border-rule',
           isResizing && 'select-none',
         )}
       >
-        <ChatPanel density="dock" onClose={onClose} />
+        <ChatPanel density="dock" />
       </aside>
       {/* biome-ignore lint/a11y/useSemanticElements: drag handle is not a standard input; semantic separator + tabIndex is enough */}
       <div

--- a/console/web/src/components/chat/ChatPanel.tsx
+++ b/console/web/src/components/chat/ChatPanel.tsx
@@ -8,8 +8,6 @@ export type ChatPanelDensity = 'route' | 'dock'
 
 interface ChatPanelProps {
   density?: ChatPanelDensity
-  /** When provided, the dock header renders a close affordance. */
-  onClose?: () => void
 }
 
 const SIDEBAR_COLLAPSED_KEY = 'iii-chat-sidebar-collapsed'
@@ -32,7 +30,7 @@ function persistSidebarCollapsed(value: boolean): void {
   }
 }
 
-export function ChatPanel({ density = 'route', onClose }: ChatPanelProps) {
+export function ChatPanel({ density = 'route' }: ChatPanelProps) {
   const {
     conversations,
     activeId,
@@ -85,7 +83,6 @@ export function ChatPanel({ density = 'route', onClose }: ChatPanelProps) {
           modelOptions={modelOptions}
           catalogLoading={catalogLoading}
           density={density}
-          onClose={onClose}
           onUpdateModel={setModel}
           onUpdateMode={setMode}
           onUpdateAutoAccept={setAutoAccept}

--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -1,4 +1,4 @@
-import { Copy, X } from 'lucide-react'
+import { Copy } from 'lucide-react'
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { LiveRegion } from '@/components/ui/LiveRegion'
 import { StatusDot } from '@/components/ui/StatusDot'
@@ -72,8 +72,6 @@ interface ChatViewProps {
   modelOptions: ModelOption[]
   catalogLoading?: boolean
   density?: 'route' | 'dock'
-  /** When provided, renders a close affordance in the header (dock mode). */
-  onClose?: () => void
   onUpdateModel: (id: string, model: ModelId) => void
   onUpdateMode: (id: string, mode: Mode) => void
   onUpdateAutoAccept: (id: string, autoAccept: boolean) => void
@@ -88,7 +86,6 @@ export function ChatView({
   modelOptions,
   catalogLoading,
   density = 'route',
-  onClose,
   onUpdateModel,
   onUpdateMode,
   onUpdateAutoAccept,
@@ -552,16 +549,6 @@ export function ChatView({
               {isStreaming ? 'streaming' : 'ready'}
             </span>
           </div>
-          {onClose ? (
-            <button
-              type="button"
-              onClick={onClose}
-              aria-label="close chat dock"
-              className="flex items-center justify-center size-6 -mr-1 text-ink-faint hover:text-ink transition-colors"
-            >
-              <X className="size-3.5" />
-            </button>
-          ) : null}
         </div>
       </header>
 

--- a/console/web/src/components/chat/ModelPicker.tsx
+++ b/console/web/src/components/chat/ModelPicker.tsx
@@ -1,9 +1,25 @@
+import * as SelectPrimitive from '@radix-ui/react-select'
+import { Settings } from 'lucide-react'
+import { useState } from 'react'
+import { ProviderSettingsDialog } from '@/components/providers/ProviderSettingsDialog'
+import {
+  ACTIVE_PROVIDERS,
+  type ActiveProvider,
+  ENV_VAR_MAP,
+} from '@/components/providers/provider-registry'
 import { Select, type SelectGroup } from '@/components/ui/Select'
 import {
   CATALOG_MODEL_KEY_SEP,
   type ModelId,
   type ModelOption,
 } from '@/types/chat'
+
+const ENV_VAR_BY_ID = new Map(ENV_VAR_MAP)
+const ACTIVE_PROVIDER_SET: ReadonlySet<string> = new Set(ACTIVE_PROVIDERS)
+
+function isActiveProvider(id: string): id is ActiveProvider {
+  return ACTIVE_PROVIDER_SET.has(id)
+}
 
 interface ModelPickerProps {
   value: ModelId
@@ -35,6 +51,10 @@ export function ModelPicker({
   loading,
   className,
 }: ModelPickerProps) {
+  const [settingsProvider, setSettingsProvider] = useState<ActiveProvider | null>(
+    null,
+  )
+
   const pickerOptions =
     options.length > 0 ? options : [{ id: value, label: value }]
   const safeValue = pickerOptions.some((o) => o.id === value)
@@ -42,14 +62,54 @@ export function ModelPicker({
     : pickerOptions[0].id
 
   return (
-    <Select<ModelId>
-      value={safeValue}
-      groups={groupByProvider(pickerOptions)}
-      onChange={onChange}
-      disabled={disabled || loading}
-      aria-label={loading ? 'model (loading catalog)' : 'model'}
-      aria-busy={loading || undefined}
-      className={className}
-    />
+    <>
+      <Select<ModelId>
+        value={safeValue}
+        groups={groupByProvider(pickerOptions)}
+        onChange={onChange}
+        disabled={disabled || loading}
+        aria-label={loading ? 'model (loading catalog)' : 'model'}
+        aria-busy={loading || undefined}
+        className={className}
+        renderGroupHeader={(g) => (
+          <div className="flex items-center justify-between gap-2 pr-2 pt-2 pb-1">
+            <SelectPrimitive.Label className="px-3 text-[11px] uppercase tracking-[0.12em] text-ink-faint">
+              {g.label}
+            </SelectPrimitive.Label>
+            {isActiveProvider(g.label) ? (
+              <button
+                type="button"
+                aria-label={`configure ${g.label}`}
+                title={`configure ${g.label}`}
+                // Stop Radix Select from interpreting the click as an
+                // option-pick / outside-click; the gear opens the provider
+                // settings dialog, which steals focus and closes the
+                // dropdown naturally.
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  setSettingsProvider(g.label as ActiveProvider)
+                }}
+                className="text-ink-faint hover:text-ink transition-colors p-0.5 -mr-0.5"
+              >
+                <Settings size={12} />
+              </button>
+            ) : null}
+          </div>
+        )}
+      />
+
+      {settingsProvider ? (
+        <ProviderSettingsDialog
+          provider={settingsProvider}
+          envVar={ENV_VAR_BY_ID.get(settingsProvider) ?? ''}
+          open
+          onOpenChange={(open) => {
+            if (!open) setSettingsProvider(null)
+          }}
+        />
+      ) : null}
+    </>
   )
 }

--- a/console/web/src/components/providers/ProviderRow.tsx
+++ b/console/web/src/components/providers/ProviderRow.tsx
@@ -1,0 +1,174 @@
+import { Settings } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import {
+  type ActiveProvider,
+  isLocalProvider,
+  PROVIDER_DISPLAY,
+} from '@/components/providers/provider-registry'
+import { ProviderSettingsDialog } from '@/components/providers/ProviderSettingsDialog'
+import { StatusBadge } from '@/components/providers/StatusBadge'
+import { useAuthStatus, useProviderConfig } from '@/hooks/use-providers'
+import { cn } from '@/lib/utils'
+
+interface ProviderRowProps {
+  id: ActiveProvider
+  envVar: string
+  /**
+   * Position in the active providers list (0-based). Displayed as a
+   * 1-based shortcut number prefix on the row so the keyboard binding
+   * (press N to open provider N) is self-documenting — no hidden
+   * footnote needed.
+   */
+  index?: number
+}
+
+/**
+ * One row per active provider. The entire row is the affordance: a single
+ * `<button>` opens `ProviderSettingsDialog`, which owns every mutation
+ * (set / clear key, set / clear runtime overrides, remove credential).
+ *
+ * The gear icon at the trailing edge is decorative and reinforces the
+ * "click to configure" semantic; making the whole row clickable resolved
+ * the discoverability issue where a 14px ghost gear was the only entry
+ * point operators could reach.
+ *
+ * For local providers (lmstudio, llamacpp) the env-var column is replaced
+ * with `[local]` — the env var is meaningless for providers that don't
+ * require a key, and the full env var name is still visible inside the
+ * dialog for operators who need it.
+ *
+ * The `savedFlash` cue is preserved: when the dialog reports a successful
+ * mutation we briefly tint the row so the change is noticeable even with
+ * the dialog still mounted.
+ */
+export function ProviderRow({ id, envVar, index }: ProviderRowProps) {
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [savedFlash, setSavedFlash] = useState(false)
+  const statusQuery = useAuthStatus(id)
+  const configQuery = useProviderConfig(id)
+  const local = isLocalProvider(id)
+  const displayName = PROVIDER_DISPLAY[id] ?? id
+  // Row-level signal that runtime overrides (api url / max tokens) are
+  // active for this provider. Without this, operators with a custom base
+  // URL set weeks ago had no surface indicator that requests were routing
+  // somewhere non-default — they had to open the dialog AND expand
+  // advanced to discover it. The dialog already uses the same query;
+  // React Query dedupes by key so this adds no extra fetches.
+  const hasOverride = !!(
+    configQuery.data?.default_api_url || configQuery.data?.default_max_tokens
+  )
+
+  useEffect(() => {
+    if (!savedFlash) return
+    const t = setTimeout(() => setSavedFlash(false), 650)
+    return () => clearTimeout(t)
+  }, [savedFlash])
+
+  // H7: number-key shortcuts on the Configuration page dispatch a window
+  // event with the target provider id. Each row listens for its own id.
+  // Lightweight cross-component wiring without lifting dialog state.
+  useEffect(() => {
+    function onOpenRequest(event: Event) {
+      const detail = (event as CustomEvent<string>).detail
+      if (detail === id) setDialogOpen(true)
+    }
+    window.addEventListener('iii:open-provider', onOpenRequest)
+    return () => window.removeEventListener('iii:open-provider', onOpenRequest)
+  }, [id])
+
+  return (
+    <div
+      className={cn(
+        'border-b border-rule last:border-b-0',
+        savedFlash && 'trace-flash',
+      )}
+    >
+      <button
+        type="button"
+        data-provider-row
+        onClick={() => setDialogOpen(true)}
+        aria-label={`configure ${id}${index != null ? ` (shortcut ${index + 1})` : ''}`}
+        className="group w-full text-left flex items-center gap-4 py-3 -mx-3 px-3 hover:bg-rule/40 transition-colors focus:outline-none focus-visible:bg-rule/40"
+      >
+        <span className="font-mono text-[13px] text-ink w-36 shrink-0 truncate flex items-center gap-2">
+          {index != null ? (
+            <kbd
+              className="font-mono text-[10px] text-ink bg-panel border border-rule px-1.5 leading-none py-0.5 shrink-0 rounded-sm shadow-[0_1px_0_0_rgb(0_0_0_/_0.04)]"
+              title={`press ${index + 1} to open`}
+            >
+              {index + 1}
+            </kbd>
+          ) : null}
+          {displayName}
+        </span>
+        {local && !statusQuery.data?.configured ? (
+          // Local-and-unconfigured: show `[local]` to telegraph "this
+          // provider doesn't need a key here." Once a key is set (via
+          // env or stored), the env-var column reverts to showing the
+          // actual var name — at that point the status badge ([env] or
+          // [stored]) carries the "configured" signal, and the env var
+          // name is the meaningful identifier in this column.
+          <span
+            className="font-mono text-[11px] text-ink-ghost w-44 shrink-0"
+            title="local server; no api key needed (base url is configurable in advanced)"
+          >
+            [local]
+          </span>
+        ) : (
+          <span
+            className="font-mono text-[11px] text-ink-faint w-44 shrink-0 truncate"
+            title={envVar}
+          >
+            {envVar}
+          </span>
+        )}
+        <span className="flex-1 min-w-0 flex items-center gap-2">
+          <StatusBadge
+            status={statusQuery.data}
+            isLoading={statusQuery.isLoading}
+            isError={statusQuery.isError}
+            envVar={envVar}
+          />
+          {hasOverride ? (
+            // Single-word badge matching `[stored]` / `[env]` / `[local]`
+            // disclosure shape. Axes + values both live in the title
+            // tooltip; the visible badge is purely a signal that an
+            // override exists. Dialog is the place to inspect details
+            // — same as how `[stored]` doesn't render the masked key
+            // value inline.
+            <span
+              className="font-mono text-[11px] text-ink shrink-0"
+              title={
+                [
+                  configQuery.data?.default_api_url
+                    ? `endpoint = ${configQuery.data.default_api_url}`
+                    : null,
+                  configQuery.data?.default_max_tokens != null
+                    ? `max tokens = ${configQuery.data.default_max_tokens}`
+                    : null,
+                ]
+                  .filter(Boolean)
+                  .join(' · ') || 'runtime overrides active'
+              }
+            >
+              [overridden]
+            </span>
+          ) : null}
+        </span>
+        <Settings
+          size={14}
+          aria-hidden
+          className="shrink-0 text-ink-ghost group-hover:text-ink-faint transition-colors"
+        />
+      </button>
+
+      <ProviderSettingsDialog
+        provider={id}
+        envVar={envVar}
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        onMutated={() => setSavedFlash(true)}
+      />
+    </div>
+  )
+}

--- a/console/web/src/components/providers/ProviderSettingsDialog.tsx
+++ b/console/web/src/components/providers/ProviderSettingsDialog.tsx
@@ -1,0 +1,978 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { ChevronDown, ChevronUp, Eye, EyeOff, X } from 'lucide-react'
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import {
+  type ActiveProvider,
+  isLocalProvider,
+  localBaseUrlEnv,
+  PROVIDER_DEFAULTS,
+  PROVIDER_DISPLAY,
+  PROVIDER_DOCS,
+  PROVIDER_DOCS_LABEL,
+  PROVIDER_KEY_PLACEHOLDER,
+} from '@/components/providers/provider-registry'
+import { StatusBadge } from '@/components/providers/StatusBadge'
+import { Button } from '@/components/ui/Button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/components/ui/Dialog'
+import { Input } from '@/components/ui/Input'
+import {
+  useAuthStatus,
+  useClearProviderConfig,
+  useDeleteToken,
+  useProviderConfig,
+  useSetProviderConfig,
+  useSetToken,
+} from '@/hooks/use-providers'
+import {
+  normalizeErrorMessage,
+  validateApiUrl,
+  validateMaxTokens,
+} from '@/lib/providers'
+import { cn } from '@/lib/utils'
+
+interface ProviderSettingsDialogProps {
+  provider: ActiveProvider
+  envVar: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Fires after any successful mutation so the row can flash. */
+  onMutated?: () => void
+}
+
+/**
+ * Errors surfaced inside the dialog always carry a recovery hint. The
+ * raw message names what failed; the hint tells the operator what to try
+ * next. Different mutations get different hints because the recovery
+ * path differs (key format vs URL reachability vs harness liveness).
+ */
+interface SurfaceError {
+  message: string
+  hint: string
+}
+
+/**
+ * Post-destructive-action receipt. Holds the previous state so a `reset
+ * overrides` can be undone within the receipt window; `remove key` has
+ * no true undo (the credential isn't available client-side) so we only
+ * show a receipt — the operator can re-type the key in the field above.
+ *
+ * `expiresAt` (reset only) drives a visible countdown so operators
+ * know how long they have to act. Without it the affordance would be
+ * silently ephemeral — operators relying on it would discover its
+ * expiry by accident.
+ */
+type UndoState =
+  | {
+      kind: 'reset'
+      prev: { default_api_url?: string; default_max_tokens?: number }
+      expiresAt: number
+    }
+  | { kind: 'remove' }
+  | null
+
+const UNDO_WINDOW_MS = 8000
+
+/**
+ * Single dialog with a single primary `save`. Reads the current credential
+ * status and stored overrides, lets the user touch any of them in a flat
+ * layout, then commits everything that's actually dirty in parallel on
+ * save. Advanced fields (base url + max tokens) live behind a "show
+ * advanced" disclosure but auto-expand whenever a non-default override is
+ * already stored, so the user always sees what's already in effect.
+ *
+ * Destructive surfaces (`reset overrides`, `remove key`) use an
+ * armed-confirm pattern -- one click reveals a confirmation chip, second
+ * click commits. Mirrors the `remove credential` pattern from earlier so
+ * nothing in this dialog is a one-tap footgun.
+ */
+export function ProviderSettingsDialog({
+  provider,
+  envVar,
+  open,
+  onOpenChange,
+  onMutated,
+}: ProviderSettingsDialogProps) {
+  const qc = useQueryClient()
+  const statusQuery = useAuthStatus(provider)
+  const status = statusQuery.data
+  const isStored = status?.source === 'stored'
+  const isConfigured = status?.configured ?? false
+  const defaults = PROVIDER_DEFAULTS[provider]
+  const docsUrl = PROVIDER_DOCS[provider]
+
+  const configQuery = useProviderConfig(provider)
+  const setTokenMut = useSetToken()
+  const setConfigMut = useSetProviderConfig()
+  const clearConfigMut = useClearProviderConfig()
+  const deleteTokenMut = useDeleteToken()
+
+  // Waits for the post-mutation refetch to settle before resolving so the
+  // dialog only closes once the row badge will render the new state. Without
+  // this, the dialog closes -> row flashes -> badge revalidation lags by one
+  // poll cycle, leaving the success moment desynchronized.
+  async function waitForFreshStatus() {
+    await Promise.all([
+      qc.refetchQueries({ queryKey: ['provider', 'status', provider] }),
+      qc.refetchQueries({ queryKey: ['provider', 'config', provider] }),
+    ])
+  }
+
+  // --- form state ---------------------------------------------------------
+
+  const [key, setKey] = useState('')
+  const [revealed, setRevealed] = useState(false)
+  const [apiUrl, setApiUrl] = useState('')
+  const [maxTokens, setMaxTokens] = useState('')
+  const [urlError, setUrlError] = useState<string | null>(null)
+  const [maxTokensError, setMaxTokensError] = useState<string | null>(null)
+
+  const storedUrl = configQuery.data?.default_api_url ?? ''
+  const storedMaxTokens =
+    configQuery.data?.default_max_tokens != null
+      ? String(configQuery.data.default_max_tokens)
+      : ''
+  const hasOverride = !!storedUrl || !!storedMaxTokens
+
+  // Populate from server overrides + reset key field every time the dialog
+  // re-opens or the provider changes.
+  useEffect(() => {
+    if (!open) return
+    if (configQuery.isLoading) return
+    setKey('')
+    setRevealed(false)
+    setApiUrl(storedUrl)
+    setMaxTokens(storedMaxTokens)
+    setUrlError(null)
+    setMaxTokensError(null)
+    setShowAdvanced(hasOverride)
+    setArmed(null)
+    setUndo(null)
+    setTokenMut.reset()
+    setConfigMut.reset()
+    clearConfigMut.reset()
+    deleteTokenMut.reset()
+    // We only re-run on (open, provider, configQuery.data) because the
+    // mutation hooks change identity on every render. Including them would
+    // wipe form state mid-save.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, provider, configQuery.data, configQuery.isLoading])
+
+  // --- collapsible advanced + armed confirm states -----------------------
+
+  const [showAdvanced, setShowAdvanced] = useState(hasOverride)
+  type Armed = 'reset' | 'remove' | null
+  const [armed, setArmed] = useState<Armed>(null)
+  const [undo, setUndo] = useState<UndoState>(null)
+  const [nowTick, setNowTick] = useState(() => Date.now())
+  const dialogBodyRef = useRef<HTMLDivElement>(null)
+
+  // Tick every 500ms while a reset undo is active so the countdown
+  // label can re-render. Stops the moment the undo is consumed or
+  // expires (so we don't burn CPU on a dialog with no undo state).
+  useEffect(() => {
+    if (undo?.kind !== 'reset') return
+    const id = setInterval(() => setNowTick(Date.now()), 500)
+    return () => clearInterval(id)
+  }, [undo?.kind])
+
+  // Auto-clear the RESET receipt after the undo window closes — only
+  // for resets, because that's the action where undo actually does
+  // something (re-saves the snapshotted config). For REMOVE there's no
+  // true undo (credential isn't kept client-side), so a countdown
+  // would be a false-affordance: the operator watches a timer for an
+  // action they can't take. Instead the remove receipt persists until
+  // the user closes the dialog, framed as actionable guidance ("type
+  // the key above to re-add") rather than a recovery window.
+  useEffect(() => {
+    if (undo?.kind !== 'reset') return
+    const t = setTimeout(() => setUndo(null), UNDO_WINDOW_MS)
+    return () => clearTimeout(t)
+  }, [undo])
+
+  // Stable input ids for proper <label htmlFor> association in Field.
+  const keyInputId = useId()
+  const urlInputId = useId()
+  const tokensInputId = useId()
+  // Stable error ids for aria-describedby on the inputs they describe.
+  const keyErrorId = useId()
+  // ARIA disclosure pattern: button.aria-controls = region.id, so
+  // assistive tech can navigate from the toggle to the content directly.
+  const advancedRegionId = useId()
+
+  // --- dirty tracking ----------------------------------------------------
+
+  const keyDirty = key.trim().length > 0
+  const urlDirty = apiUrl.trim() !== storedUrl
+  const tokensDirty = maxTokens.trim() !== storedMaxTokens
+  const isDirty = keyDirty || urlDirty || tokensDirty
+
+  const pending =
+    setTokenMut.isPending ||
+    setConfigMut.isPending ||
+    clearConfigMut.isPending ||
+    deleteTokenMut.isPending
+
+  // One error memo per mutation so the hint matches the action that
+  // actually failed. The previous "first non-null wins" pattern misled
+  // operators when `Promise.all` had two ops and only one failed (the
+  // hint always pointed to the first-checked mutation, not the real
+  // culprit). Now each error renders proximate to the input that
+  // produced it (key error under key field, overrides error inside
+  // advanced, destructive errors inside the destructive zone).
+  const keyError = useMemo<SurfaceError | null>(() => {
+    if (!setTokenMut.error) return null
+    return {
+      message: normalizeErrorMessage(setTokenMut.error),
+      hint: 'check the key format. the harness must be running to store credentials.',
+    }
+  }, [setTokenMut.error])
+
+  const overridesError = useMemo<SurfaceError | null>(() => {
+    if (!setConfigMut.error) return null
+    return {
+      message: normalizeErrorMessage(setConfigMut.error),
+      hint: 'verify the url is reachable and the max tokens value is within range.',
+    }
+  }, [setConfigMut.error])
+
+  const resetError = useMemo<SurfaceError | null>(() => {
+    if (!clearConfigMut.error) return null
+    return {
+      message: normalizeErrorMessage(clearConfigMut.error),
+      hint: 'the harness may be unreachable. retry, or refresh to see current state.',
+    }
+  }, [clearConfigMut.error])
+
+  const removeError = useMemo<SurfaceError | null>(() => {
+    if (!deleteTokenMut.error) return null
+    return {
+      message: normalizeErrorMessage(deleteTokenMut.error),
+      hint: 'the credential may still exist. close the dialog and refresh to verify.',
+    }
+  }, [deleteTokenMut.error])
+
+  // Partial-success detection: when `save()` ran parallel mutations and
+  // one succeeded while the other failed, the dialog stays open with
+  // an error visible. Without an explicit success signal, the operator
+  // sees the badge update to [stored] AND an error in the same dialog
+  // and can't tell what actually happened. The success indicators (✓)
+  // render only in this partial state so a fully-successful save (which
+  // closes the dialog) doesn't flash them.
+  const isPartialSuccess =
+    (setTokenMut.isSuccess && !!setConfigMut.error) ||
+    (!!setTokenMut.error && setConfigMut.isSuccess)
+
+  // If an error came from the advanced section (overrides / reset),
+  // auto-expand advanced so the error is actually visible to be
+  // scrolled to. Without this, an operator who saved an invalid URL
+  // with advanced collapsed would see scroll-to nothing (the error
+  // is rendered inside a hidden disclosure).
+  useEffect(() => {
+    if (overridesError || resetError) {
+      setShowAdvanced(true)
+    }
+  }, [overridesError, resetError])
+
+  // Scroll the first surface error into view when any appears so the
+  // operator never has a failure surface below the fold. Errors render
+  // proximate to the action that produced them (per-mutation), and this
+  // hook makes sure the proximate location is also visible.
+  useEffect(() => {
+    if (!keyError && !overridesError && !resetError && !removeError) return
+    // Defer one tick so the auto-expand effect above has rendered the
+    // advanced section before we try to scroll into it.
+    const t = setTimeout(() => {
+      const el = dialogBodyRef.current?.querySelector('[data-dialog-error]')
+      if (el) {
+        ;(el as HTMLElement).scrollIntoView({
+          behavior: 'smooth',
+          block: 'nearest',
+        })
+      }
+    }, 0)
+    return () => clearTimeout(t)
+  }, [keyError, overridesError, resetError, removeError])
+
+  // --- save (combined) ---------------------------------------------------
+
+  async function save() {
+    if (!isDirty) return
+
+    // Validate first so we don't fire any mutation if anything is bad.
+    let validatedUrl: string | undefined
+    let validatedTokens: number | undefined
+    if (urlDirty) {
+      const trimmed = apiUrl.trim()
+      if (trimmed.length > 0) {
+        const v = validateApiUrl(trimmed)
+        if (!v.ok) {
+          setUrlError(v.error)
+          return
+        }
+        validatedUrl = v.value
+      }
+    }
+    if (tokensDirty) {
+      const trimmed = maxTokens.trim()
+      if (trimmed.length > 0) {
+        const v = validateMaxTokens(trimmed)
+        if (!v.ok) {
+          setMaxTokensError(v.error)
+          return
+        }
+        validatedTokens = v.value
+      }
+    }
+
+    // Use Promise.allSettled so a single-op failure doesn't suppress
+    // the other op's outcome. With Promise.all, if setToken rejects
+    // first, setConfig's rejection becomes an unhandled promise even
+    // though we want both errors to surface in their per-mutation
+    // memos. allSettled lets each mutation hook record its own
+    // success/failure state independently.
+    const ops: Promise<unknown>[] = []
+    if (keyDirty) {
+      ops.push(
+        setTokenMut.mutateAsync({
+          provider,
+          credential: { type: 'api_key', key: key.trim() },
+        }),
+      )
+    }
+    if (validatedUrl !== undefined || validatedTokens !== undefined) {
+      ops.push(
+        setConfigMut.mutateAsync({
+          provider,
+          ...(validatedUrl !== undefined && { default_api_url: validatedUrl }),
+          ...(validatedTokens !== undefined && {
+            default_max_tokens: validatedTokens,
+          }),
+        }),
+      )
+    }
+
+    const results = await Promise.allSettled(ops)
+    if (results.some((r) => r.status === 'rejected')) {
+      // Errors surface via per-mutation memos (keyError, overridesError),
+      // each scrolled into view. Leave the dialog open for correction.
+      // The operator sees what landed AND what didn't.
+      return
+    }
+    // All attempted ops succeeded. Clear any stale "key removed" or
+    // "overrides reset" receipt — the operator just re-added the key
+    // (or saved new overrides), so the receipt's instruction is done.
+    // Without this, after `removeKey → re-type → save` the receipt
+    // would still read "key removed. type a new key above..." while
+    // the badge above shows [stored], leaving the operator with two
+    // contradictory signals.
+    setUndo(null)
+    // Wait for status refetch BEFORE firing the flash: out-of-order
+    // makes the row flash tint a stale badge. With this order the
+    // badge already shows the new state when the flash starts, and
+    // they land together.
+    await waitForFreshStatus()
+    onMutated?.()
+    onOpenChange(false)
+  }
+
+  // --- destructive actions (armed-confirm) -------------------------------
+
+  async function resetOverrides() {
+    // Snapshot the previous overrides BEFORE clearing so we can offer
+    // true undo (re-saving the snapshotted values).
+    const prev = {
+      default_api_url: configQuery.data?.default_api_url,
+      default_max_tokens: configQuery.data?.default_max_tokens,
+    }
+    try {
+      await clearConfigMut.mutateAsync(provider)
+      setArmed(null)
+      await waitForFreshStatus()
+      onMutated?.()
+      // Reset the field inputs to defaults so the dialog matches the
+      // newly-cleared server state.
+      setApiUrl('')
+      setMaxTokens('')
+      setUndo({
+        kind: 'reset',
+        prev,
+        expiresAt: Date.now() + UNDO_WINDOW_MS,
+      })
+    } catch {
+      // Error surfaces via the form error memo; keep armed for retry.
+    }
+  }
+
+  async function undoReset() {
+    if (undo?.kind !== 'reset') return
+    const { prev } = undo
+    setUndo(null)
+    try {
+      await setConfigMut.mutateAsync({
+        provider,
+        ...(prev.default_api_url !== undefined && {
+          default_api_url: prev.default_api_url,
+        }),
+        ...(prev.default_max_tokens !== undefined && {
+          default_max_tokens: prev.default_max_tokens,
+        }),
+      })
+      await waitForFreshStatus()
+      onMutated?.()
+      // Repopulate field inputs from the restored values.
+      setApiUrl(prev.default_api_url ?? '')
+      setMaxTokens(
+        prev.default_max_tokens != null ? String(prev.default_max_tokens) : '',
+      )
+    } catch {
+      // Error surfaces via the form error memo.
+    }
+  }
+
+  async function removeKey() {
+    try {
+      await deleteTokenMut.mutateAsync(provider)
+      setArmed(null)
+      await waitForFreshStatus()
+      onMutated?.()
+      // Don't auto-close. Show a receipt instead so the operator has
+      // a recovery window — the key field is empty above and they can
+      // re-type if the remove was a mistake. True undo isn't possible:
+      // we don't keep the credential client-side.
+      setUndo({ kind: 'remove' })
+      // Scroll the dialog content to the top so the key field (the
+      // re-add target the receipt points at) is back in view. Without
+      // this, after a remove from an expanded-advanced dialog the
+      // receipt appears below the destructive zone with the key field
+      // potentially off-screen — operator reads "type a new key above"
+      // with nothing above to type into.
+      const scrollContainer = dialogBodyRef.current?.closest(
+        '[role="dialog"]',
+      )
+      if (scrollContainer) scrollContainer.scrollTop = 0
+    } catch {
+      // Error surfaces via the remove error memo; keep armed for retry.
+    }
+  }
+
+  // --- render ------------------------------------------------------------
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-w-md"
+        onEscapeKeyDown={(e) => {
+          // When an armed-confirm is showing, Escape should disarm it
+          // rather than close the entire dialog. Operators reflexively
+          // press Escape to cancel the confirm step; without this, they'd
+          // also lose any unsaved edits to the form fields above.
+          if (armed !== null) {
+            e.preventDefault()
+            setArmed(null)
+          }
+        }}
+      >
+        <div className="flex items-baseline justify-between gap-4">
+          <DialogTitle className="font-mono text-[16px] text-ink lowercase tracking-[-0.01em]">
+            {PROVIDER_DISPLAY[provider] ?? provider}
+          </DialogTitle>
+          <span
+            className="font-mono text-[11px] text-ink-faint truncate"
+            title={envVar}
+          >
+            {envVar}
+          </span>
+        </div>
+        {/* `DialogDescription` maps to `aria-describedby` on the dialog
+            root; using the live status badge here meant screen readers
+            announced the loading "dot dot dot" as the dialog's accessible
+            description. Keep the description stable + static, and render
+            the visual badge in a sibling element. */}
+        <DialogDescription className="sr-only">
+          credential settings for {provider}
+        </DialogDescription>
+        <div className="mt-1 flex items-center gap-2">
+          <StatusBadge
+            status={status}
+            isLoading={statusQuery.isLoading}
+            isError={statusQuery.isError}
+            envVar={envVar}
+          />
+        </div>
+
+        <div ref={dialogBodyRef} className="mt-5 flex flex-col gap-3">
+          <Field label="api key" error={null} htmlFor={keyInputId}>
+            <div className="flex items-center gap-2">
+              <div className="flex-1">
+                <Input
+                  id={keyInputId}
+                  type={revealed ? 'text' : 'password'}
+                  value={key}
+                  onChange={setKey}
+                  placeholder={
+                    isConfigured
+                      ? 'leave blank to keep current'
+                      : PROVIDER_KEY_PLACEHOLDER[provider]
+                  }
+                  preserveCase
+                  aria-invalid={!!keyError}
+                  aria-describedby={keyError ? keyErrorId : undefined}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') save()
+                  }}
+                />
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                type="button"
+                onClick={() => setRevealed((r) => !r)}
+                aria-label={revealed ? 'hide key' : 'reveal key'}
+              >
+                {revealed ? <EyeOff size={14} /> : <Eye size={14} />}
+              </Button>
+            </div>
+            {/* Error rendered FIRST when present — operators correcting
+                a failed save shouldn't have to scroll past contextual
+                notes (env-precedence, docs link, security footnote) to
+                find the recovery message. The success indicator follows
+                the same priority. */}
+            {keyError ? (
+              <div
+                id={keyErrorId}
+                data-dialog-error
+                className="mt-2"
+                role="alert"
+              >
+                <p className="font-mono text-[11px] text-alert">
+                  error: {keyError.message}
+                </p>
+                <p className="font-mono text-[11px] text-ink-faint mt-0.5">
+                  {keyError.hint}
+                </p>
+              </div>
+            ) : null}
+            {isPartialSuccess && setTokenMut.isSuccess ? (
+              <p className="font-mono text-[11px] text-ink-faint mt-2">
+                <span className="text-accent mr-1">✓</span> key saved
+              </p>
+            ) : null}
+            {status?.source === 'environment' ? (
+              keyDirty ? (
+                <p className="mt-1.5 font-mono text-[11px] text-ink-faint">
+                  note: {envVar} is set in the environment and takes
+                  precedence at runtime. saving stores this key as a
+                  fallback — it will take effect once the env var is
+                  unset.
+                </p>
+              ) : (
+                <p className="mt-1.5 font-mono text-[11px] text-ink-faint">
+                  this provider's key currently comes from {envVar}.
+                </p>
+              )
+            ) : null}
+            {/* Local-provider context lives in two places by design:
+                (1) the per-provider key placeholder above ("any string
+                (local server usually accepts anything)") covers the
+                no-key-needed case at the input itself; (2) the
+                env-var-precedence note inside the advanced section
+                covers the LMSTUDIO_BASE_URL / LLAMACPP_BASE_URL
+                override. An extra paragraph here would just rephrase
+                what the placeholder already says. */}
+            <p className="mt-1.5 font-mono text-[11px] text-ink-faint">
+              {/* Local providers link to setup docs (not a credentials
+                  dashboard) regardless of configured state — "dashboard:"
+                  would falsely imply key management for a local server. */}
+              {isLocalProvider(provider)
+                ? 'docs: '
+                : isConfigured
+                  ? 'dashboard: '
+                  : 'get a key: '}
+              <a
+                href={`https://${docsUrl}`}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="text-ink hover:text-accent transition-colors"
+              >
+                {PROVIDER_DOCS_LABEL[provider]}
+              </a>
+            </p>
+            <p className="mt-1 font-mono text-[10px] text-ink-ghost">
+              stored on this machine, never sent to the browser after save.
+            </p>
+          </Field>
+
+          <button
+            type="button"
+            onClick={() => setShowAdvanced((v) => !v)}
+            className="mt-1 flex items-center gap-1 font-mono text-[11px] text-ink-faint hover:text-ink transition-colors w-fit"
+            aria-expanded={showAdvanced}
+            aria-controls={advancedRegionId}
+            disabled={configQuery.isLoading}
+            title={
+              configQuery.isLoading ? 'loading stored overrides...' : undefined
+            }
+          >
+            {showAdvanced ? (
+              <ChevronUp size={12} />
+            ) : (
+              <ChevronDown size={12} />
+            )}
+            {configQuery.isLoading
+              ? 'loading overrides...'
+              : showAdvanced
+                ? 'hide advanced'
+                : 'show advanced'}
+          </button>
+
+          {showAdvanced ? (
+            <div id={advancedRegionId} className="flex flex-col gap-3 pt-1">
+              <p className="font-mono text-[11px] text-ink-faint -mt-1">
+                route requests through a proxy or self-hosted endpoint.
+                {hasOverride || isStored
+                  ? ' destructive actions live below.'
+                  : ''}
+              </p>
+              <Field label="base url" error={urlError} htmlFor={urlInputId}>
+                <Input
+                  id={urlInputId}
+                  // Use type="text" instead of type="url": the latter
+                  // triggers browser-native validation that fires before
+                  // our `validateApiUrl` and surfaces an inconsistent
+                  // error popover (instead of our copy-controlled
+                  // `urlError`). Validation logic is the same; the input
+                  // type just controls whether the browser intervenes.
+                  type="text"
+                  value={apiUrl}
+                  onChange={(v) => {
+                    setApiUrl(v)
+                    if (urlError) setUrlError(null)
+                  }}
+                  placeholder={defaults.default_api_url}
+                  preserveCase
+                />
+                {/* Always-visible default hint so the format / example
+                    is reachable even when the field is filled (and the
+                    placeholder is therefore suppressed). */}
+                <p className="mt-1 font-mono text-[11px] text-ink-faint break-all">
+                  default: {defaults.default_api_url}
+                </p>
+              </Field>
+              <Field
+                label="max tokens"
+                error={maxTokensError}
+                htmlFor={tokensInputId}
+              >
+                <p className="mb-1 font-mono text-[11px] text-ink-faint">
+                  ceiling enforced by the harness on tokens the model may
+                  generate per request. if the model's own max is lower,
+                  the model wins.
+                </p>
+                <Input
+                  id={tokensInputId}
+                  type="number"
+                  value={maxTokens}
+                  onChange={(v) => {
+                    setMaxTokens(v)
+                    if (maxTokensError) setMaxTokensError(null)
+                  }}
+                  placeholder={`${defaults.default_max_tokens} (default)`}
+                  min={1}
+                  max={1_048_576}
+                />
+              </Field>
+              {isLocalProvider(provider) ? (
+                <p className="font-mono text-[11px] text-ink-faint -mt-1">
+                  local provider · the {localBaseUrlEnv(provider)} env var, if set,
+                  overrides this on startup.
+                </p>
+              ) : null}
+              {overridesError ? (
+                <div data-dialog-error role="alert">
+                  <p className="font-mono text-[11px] text-alert">
+                    error: {overridesError.message}
+                  </p>
+                  <p className="font-mono text-[11px] text-ink-faint mt-0.5">
+                    {overridesError.hint}
+                  </p>
+                </div>
+              ) : null}
+              {isPartialSuccess && setConfigMut.isSuccess ? (
+                <p className="font-mono text-[11px] text-ink-faint">
+                  <span className="text-accent mr-1">✓</span> overrides saved
+                </p>
+              ) : null}
+
+              {/* Destructive zone: both destructive surfaces live behind the
+                  advanced disclosure so the dialog footer stays focused on
+                  the primary save / cancel actions. Operators who want to
+                  reset overrides or remove a key signal that intent by
+                  expanding advanced first. */}
+              {hasOverride || isStored ? (
+                <div className="mt-2 pt-3 border-t border-rule flex flex-col gap-3">
+                  {hasOverride ? (
+                    armed === 'reset' ? (
+                      <ArmedConfirm
+                        label="reset overrides to defaults?"
+                        confirmLabel="yes, reset"
+                        pending={clearConfigMut.isPending}
+                        onCancel={() => setArmed(null)}
+                        onConfirm={resetOverrides}
+                      />
+                    ) : (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setArmed('reset')}
+                        // Disable while remove is armed so an operator
+                        // can't silently replace the armed state by
+                        // clicking the other destructive button. They
+                        // must explicitly cancel the active confirm
+                        // first — no surprise re-arming.
+                        disabled={pending || armed === 'remove'}
+                        className="self-start text-ink-faint"
+                      >
+                        reset overrides
+                      </Button>
+                    )
+                  ) : null}
+                  {isStored ? (
+                    armed === 'remove' ? (
+                      <ArmedConfirm
+                        label="remove stored key?"
+                        confirmLabel="yes, remove"
+                        pending={deleteTokenMut.isPending}
+                        onCancel={() => setArmed(null)}
+                        onConfirm={removeKey}
+                        danger
+                      />
+                    ) : (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setArmed('remove')}
+                        // Disabled while reset is armed (see comment on
+                        // the reset button above).
+                        disabled={pending || armed === 'reset'}
+                        className="self-start text-alert hover:text-alert"
+                      >
+                        remove key
+                      </Button>
+                    )
+                  ) : null}
+                  {isStored ? (
+                    <p className="font-mono text-[11px] text-ink-faint -mt-1">
+                      env-var fallback (if any) still applies after remove.
+                    </p>
+                  ) : null}
+                  {resetError ? (
+                    <div data-dialog-error role="alert">
+                      <p className="font-mono text-[11px] text-alert">
+                        error: {resetError.message}
+                      </p>
+                      <p className="font-mono text-[11px] text-ink-faint mt-0.5">
+                        {resetError.hint}
+                      </p>
+                    </div>
+                  ) : null}
+                  {removeError ? (
+                    <div data-dialog-error role="alert">
+                      <p className="font-mono text-[11px] text-alert">
+                        error: {removeError.message}
+                      </p>
+                      <p className="font-mono text-[11px] text-ink-faint mt-0.5">
+                        {removeError.hint}
+                      </p>
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+
+        </div>
+
+        {/* Pinned region: undo receipts and surface errors live directly
+            above the footer so they're always proximate to the actions
+            that triggered them. `sticky bottom-0` keeps the entire band
+            visible even when the dialog body overflows — operator never
+            has to scroll to find Save or to read why a save failed.
+            Dark-mode bg must match `DialogContent` or the sticky band
+            paints the wrong color over scrolled content. */}
+        <div className="sticky bottom-0 bg-bg dark:bg-bg-dark mt-6 pt-4 border-t border-rule">
+          {undo ? (
+            <div
+              role="status"
+              aria-live="polite"
+              className="mb-3 flex items-start justify-between gap-2 px-2 py-1.5 border border-rule"
+            >
+              <div className="min-w-0">
+                <p className="font-mono text-[11px] text-ink">
+                  {/* Use a neutral glyph for destructive-action receipts
+                      (· before "key removed" / "overrides reset"). The
+                      ✓ glyph stays reserved for affirmative successes
+                      (`✓ key saved`) so the two signal vocabularies
+                      don't collide. */}
+                  <span className="text-ink-faint mr-1">·</span>
+                  {undo.kind === 'reset'
+                    ? 'overrides reset to defaults'
+                    : 'key removed'}
+                </p>
+                {undo.kind === 'remove' ? (
+                  <p className="font-mono text-[11px] text-ink-faint mt-0.5">
+                    type a new key above to re-add.
+                  </p>
+                ) : null}
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                {undo.kind === 'reset' ? (
+                  <button
+                    type="button"
+                    onClick={undoReset}
+                    className="font-mono text-[11px] text-accent hover:text-ink transition-colors"
+                  >
+                    undo · {Math.max(
+                      0,
+                      Math.ceil((undo.expiresAt - nowTick) / 1000),
+                    )}
+                    s left
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  onClick={() => setUndo(null)}
+                  aria-label="dismiss receipt"
+                  title="dismiss"
+                  className="text-ink-ghost hover:text-ink transition-colors p-0.5"
+                >
+                  <X size={14} aria-hidden />
+                </button>
+              </div>
+            </div>
+          ) : null}
+          {/* Errors render at the action that produced them (per-mutation
+              proximity); see field-adjacent SurfaceError blocks above.
+              Auto-scroll-into-view handles below-the-fold visibility. */}
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onOpenChange(false)}
+              disabled={pending}
+            >
+              cancel
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={save}
+              disabled={!isDirty || pending}
+            >
+              {pending ? 'saving...' : 'save'}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+/* ---------------------------------------------------------------------- */
+/*  Helpers                                                                */
+/* ---------------------------------------------------------------------- */
+
+interface FieldProps {
+  label: string
+  error: string | null
+  children: React.ReactNode
+  /**
+   * When provided, the label becomes a real `<label htmlFor={...}>`
+   * binding the visible text to the input. Without it, click-to-focus
+   * fails and the visible label is not the accessible name. Pass the
+   * matching `id` to the input element rendered as children.
+   */
+  htmlFor?: string
+}
+
+function Field({ label, error, children, htmlFor }: FieldProps) {
+  return (
+    <div className={cn('flex items-start gap-3')}>
+      <label
+        htmlFor={htmlFor}
+        className="font-mono text-[12px] text-ink w-24 shrink-0 pt-2"
+      >
+        {label}
+      </label>
+      <div className="flex-1 min-w-0">
+        {children}
+        {error ? (
+          <p className="mt-1 font-mono text-[11px] text-alert">{error}</p>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+interface ArmedConfirmProps {
+  label: string
+  confirmLabel: string
+  pending: boolean
+  onCancel: () => void
+  onConfirm: () => void
+  danger?: boolean
+}
+
+function ArmedConfirm({
+  label,
+  confirmLabel,
+  pending,
+  onCancel,
+  onConfirm,
+  danger,
+}: ArmedConfirmProps) {
+  // Both buttons are ghost — the destructive yes is tinted in `text-alert`
+  // when `danger`, but neither button reads as the dominant CTA. This
+  // resolves the "primary visual weight on the destructive action"
+  // mismatch where the safe action (no) was a quieter ghost and the
+  // confirm was a loud primary. Now the framing is: "two equally weighted
+  // options, one of which is clearly destructive."
+  //
+  // `role="group"` + `aria-label` groups the two confirm buttons with
+  // their question text as an accessible name. (Earlier `role="alertdialog"`
+  // claimed modal semantics this widget doesn't actually implement — it
+  // doesn't trap focus, it's inline within the dialog body.) The autoFocus
+  // on `no` still gives screen reader users the safe default after the
+  // group becomes the focused context.
+  return (
+    <span
+      role="group"
+      aria-label={label}
+      className="flex items-center gap-2 font-mono text-[12px] text-ink"
+    >
+      <span className={cn(danger && 'text-alert')}>{label}</span>
+      <Button
+        variant="ghost"
+        size="sm"
+        autoFocus
+        onClick={onCancel}
+        disabled={pending}
+      >
+        no
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={onConfirm}
+        disabled={pending}
+        className={cn(danger && 'text-alert hover:text-alert')}
+      >
+        {pending ? 'working...' : confirmLabel}
+      </Button>
+    </span>
+  )
+}

--- a/console/web/src/components/providers/StatusBadge.tsx
+++ b/console/web/src/components/providers/StatusBadge.tsx
@@ -1,0 +1,91 @@
+import type { AuthStatusResult } from '@/lib/providers'
+
+interface StatusBadgeProps {
+  status: AuthStatusResult | undefined
+  isLoading: boolean
+  /** True when the status query failed (e.g., harness unreachable). */
+  isError?: boolean
+  /** Env var name for tooltip context when source === 'environment'. */
+  envVar?: string
+}
+
+/**
+ * Four states: loading, error, configured, unconfigured. Each has
+ * accessible semantics: `role="status"` + `aria-live="polite"` on the
+ * loading state so screen readers announce when status arrives;
+ * `role="alert"` on error; `title` tooltips on the bracketed badges
+ * so operators who don't immediately know what `[stored]` vs `[env]`
+ * means get an inline explanation on hover. Distinguishing the error
+ * state from "not set" matters operationally — a network-partitioned
+ * machine would otherwise look like an unconfigured one.
+ */
+export function StatusBadge({
+  status,
+  isLoading,
+  isError,
+  envVar,
+}: StatusBadgeProps) {
+  if (isError) {
+    return (
+      <span
+        role="alert"
+        className="font-mono text-[11px] text-alert"
+        title="couldn't reach the harness to read this provider's status"
+      >
+        [unreachable]
+      </span>
+    )
+  }
+  if (isLoading) {
+    return (
+      <span
+        role="status"
+        aria-live="polite"
+        aria-label="loading provider status"
+        className="font-mono text-[11px] text-ink-faint inline-flex items-center gap-1"
+      >
+        <span
+          aria-hidden
+          className="inline-block w-1.5 h-1.5 rounded-full bg-ink-ghost animate-pulse"
+        />
+        loading
+      </span>
+    )
+  }
+
+  if (!status?.configured) {
+    return (
+      <span
+        className="font-mono text-[11px] text-ink-ghost"
+        title="no key is set for this provider yet"
+      >
+        not set
+      </span>
+    )
+  }
+
+  const isStored = status.source === 'stored'
+  // `[stored]` earns the accent. `[env-var]` was previously `text-ink-faint`,
+  // which made it visually indistinguishable from surrounding muted prose.
+  // Lift to full `text-ink` so the badge reads as a distinct token —
+  // operators scanning the column see "this provider's key source" as
+  // foreground content, not annotation noise.
+  const badgeClass = isStored ? 'text-accent' : 'text-ink'
+  const tooltip = isStored
+    ? 'you set this key here. the harness reads it from its own store.'
+    : envVar
+      ? `inherited from the ${envVar} environment variable; takes precedence over a stored key.`
+      : 'inherited from an environment variable; takes precedence over a stored key.'
+
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 font-mono text-[11px] min-w-0"
+      title={tooltip}
+    >
+      <span className={badgeClass}>[{isStored ? 'stored' : 'env-var'}]</span>
+      {status.label ? (
+        <span className="text-ink-faint truncate">{status.label}</span>
+      ) : null}
+    </span>
+  )
+}

--- a/console/web/src/components/providers/provider-registry.ts
+++ b/console/web/src/components/providers/provider-registry.ts
@@ -1,0 +1,154 @@
+/**
+ * Static provider metadata mirroring harness/src/auth-credentials/types.ts ENV_VAR_MAP.
+ * Hardcoded defaults confirmed against each provider's config.ts in the harness.
+ */
+
+export const ENV_VAR_MAP: ReadonlyArray<readonly [string, string]> = [
+  ['anthropic', 'ANTHROPIC_API_KEY'],
+  ['openai', 'OPENAI_API_KEY'],
+  ['openai-codex', 'OPENAI_API_KEY'],
+  ['azure-openai', 'AZURE_OPENAI_API_KEY'],
+  ['google', 'GOOGLE_API_KEY'],
+  ['google-vertex', 'GOOGLE_APPLICATION_CREDENTIALS'],
+  ['amazon-bedrock', 'AWS_ACCESS_KEY_ID'],
+  ['mistral', 'MISTRAL_API_KEY'],
+  ['groq', 'GROQ_API_KEY'],
+  ['cerebras', 'CEREBRAS_API_KEY'],
+  ['xai', 'XAI_API_KEY'],
+  ['deepseek', 'DEEPSEEK_API_KEY'],
+  ['openrouter', 'OPENROUTER_API_KEY'],
+  ['vercel-ai-gateway', 'VERCEL_AI_GATEWAY_API_KEY'],
+  ['zai', 'ZAI_API_KEY'],
+  ['minimax', 'MINIMAX_API_KEY'],
+  ['huggingface', 'HF_TOKEN'],
+  ['fireworks', 'FIREWORKS_API_KEY'],
+  ['kimi', 'MOONSHOT_API_KEY'],
+  ['kimi-coding', 'MOONSHOT_API_KEY'],
+  ['lmstudio', 'LMSTUDIO_API_KEY'],
+  ['llamacpp', 'LLAMACPP_API_KEY'],
+  ['opencode-zen', 'OPENCODE_ZEN_API_KEY'],
+  ['opencode-go', 'OPENCODE_GO_API_KEY'],
+] as const
+
+export const ACTIVE_PROVIDERS = [
+  'anthropic',
+  'openai',
+  'kimi',
+  'lmstudio',
+  'llamacpp',
+] as const
+export type ActiveProvider = (typeof ACTIVE_PROVIDERS)[number]
+
+/**
+ * Hardcoded defaults confirmed from each provider's config.ts:
+ *   anthropic  -> https://api.anthropic.com/v1/messages           (default_max_tokens: 8192)
+ *   openai     -> https://api.openai.com/v1/chat/completions      (default_max_tokens: 8192)
+ *   kimi       -> https://api.moonshot.ai/v1/chat/completions     (default_max_tokens: 8192)
+ *   lmstudio   -> http://localhost:1234/v1/chat/completions        (default_max_tokens: 8192)
+ *   llamacpp   -> http://localhost:8080/v1/chat/completions        (default_max_tokens: 8192)
+ */
+export const PROVIDER_DEFAULTS: Record<
+  ActiveProvider,
+  { default_api_url: string; default_max_tokens: number }
+> = {
+  anthropic: {
+    default_api_url: 'https://api.anthropic.com/v1/messages',
+    default_max_tokens: 8192,
+  },
+  openai: {
+    default_api_url: 'https://api.openai.com/v1/chat/completions',
+    default_max_tokens: 8192,
+  },
+  kimi: {
+    default_api_url: 'https://api.moonshot.ai/v1/chat/completions',
+    default_max_tokens: 8192,
+  },
+  lmstudio: {
+    default_api_url: 'http://localhost:1234/v1/chat/completions',
+    default_max_tokens: 8192,
+  },
+  llamacpp: {
+    default_api_url: 'http://localhost:8080/v1/chat/completions',
+    default_max_tokens: 8192,
+  },
+}
+
+export interface ProviderEntry {
+  id: string
+  envVar: string
+  isActive: boolean
+}
+
+export const PROVIDERS: ProviderEntry[] = ENV_VAR_MAP.map(([id, envVar]) => ({
+  id,
+  envVar,
+  isActive: (ACTIVE_PROVIDERS as readonly string[]).includes(id),
+}))
+
+/**
+ * Documentation URLs for where to obtain an API key per active provider.
+ * Shown as a discrete hint when the user opens the key editor with no key
+ * set, and as a permanent "key console" link once a key is stored (so
+ * operators rotating credentials don't have to leave the dialog to find
+ * the provider's key page again).
+ */
+export const PROVIDER_DOCS: Record<ActiveProvider, string> = {
+  anthropic: 'console.anthropic.com/settings/keys',
+  openai: 'platform.openai.com/api-keys',
+  kimi: 'platform.moonshot.cn/console/api-keys',
+  lmstudio: 'lmstudio.ai/docs/local-server',
+  llamacpp: 'github.com/ggml-org/llama.cpp/tree/master/tools/server',
+}
+
+/**
+ * Human-readable labels for `PROVIDER_DOCS` links. Renders as the visible
+ * link text instead of the bare domain, which truncated to unresolvable
+ * fragments on narrow viewports.
+ */
+export const PROVIDER_DOCS_LABEL: Record<ActiveProvider, string> = {
+  anthropic: 'anthropic console',
+  openai: 'openai platform',
+  kimi: 'moonshot platform',
+  lmstudio: 'lm studio docs',
+  llamacpp: 'llama.cpp server docs',
+}
+
+/**
+ * Display label for providers whose internal id doesn't immediately
+ * communicate the underlying service. `kimi` ≡ Moonshot AI; an operator
+ * scanning the list shouldn't have to know that out of band.
+ */
+export const PROVIDER_DISPLAY: Partial<Record<ActiveProvider, string>> = {
+  kimi: 'kimi (moonshot)',
+}
+
+/**
+ * Per-provider placeholder for the api key input. Hardcoded `sk-...`
+ * leaked OpenAI bias onto every provider; this gives operators a
+ * format cue specific to the provider they opened.
+ */
+export const PROVIDER_KEY_PLACEHOLDER: Record<ActiveProvider, string> = {
+  anthropic: 'sk-ant-api03-...',
+  openai: 'sk-proj-... or sk-...',
+  kimi: 'sk-...',
+  lmstudio: 'any string (local server usually accepts anything)',
+  llamacpp: 'any string (local server usually accepts anything)',
+}
+
+const LOCAL_PROVIDERS: ReadonlySet<ActiveProvider> = new Set([
+  'lmstudio',
+  'llamacpp',
+])
+
+const LOCAL_BASE_URL_ENV: Record<string, string> = {
+  lmstudio: 'LMSTUDIO_BASE_URL',
+  llamacpp: 'LLAMACPP_BASE_URL',
+}
+
+export function isLocalProvider(id: string): id is 'lmstudio' | 'llamacpp' {
+  return LOCAL_PROVIDERS.has(id as ActiveProvider)
+}
+
+export function localBaseUrlEnv(id: string): string | undefined {
+  return LOCAL_BASE_URL_ENV[id]
+}

--- a/console/web/src/components/ui/Dialog.tsx
+++ b/console/web/src/components/ui/Dialog.tsx
@@ -1,0 +1,59 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { X } from 'lucide-react'
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export const Dialog = DialogPrimitive.Root
+export const DialogTrigger = DialogPrimitive.Trigger
+export const DialogClose = DialogPrimitive.Close
+
+export const DialogContent = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPrimitive.Portal>
+    <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-ink/40 dark:bg-ink/70" />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2',
+        'w-full max-w-2xl max-h-[85vh] overflow-y-auto',
+        'border border-ink bg-bg dark:bg-bg-dark p-6 font-mono text-ink shadow-none',
+        'focus-visible:outline-none',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 text-ink-faint hover:text-ink transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent">
+        <X size={14} />
+        <span className="sr-only">close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPrimitive.Portal>
+))
+DialogContent.displayName = 'DialogContent'
+
+export const DialogTitle = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('font-mono text-[13px] text-ink', className)}
+    {...props}
+  />
+))
+DialogTitle.displayName = 'DialogTitle'
+
+export const DialogDescription = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('font-mono text-[12px] text-ink-faint', className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = 'DialogDescription'

--- a/console/web/src/components/ui/Input.tsx
+++ b/console/web/src/components/ui/Input.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+interface InputProps
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    'onChange' | 'value'
+  > {
+  value: string
+  onChange: (next: string) => void
+  /**
+   * Opt out of the default `lowercase` text-transform. Use for fields that
+   * carry verbatim user input (API keys, URLs with mixed case) where visual
+   * lowercasing would mislead even though the underlying value is preserved.
+   */
+  preserveCase?: boolean
+}
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, value, onChange, preserveCase, ...rest }, ref) => (
+    <input
+      ref={ref}
+      value={value}
+      onChange={(e) => onChange(e.currentTarget.value)}
+      className={cn(
+        'w-full border border-rule bg-bg px-3 h-9 text-ink font-mono text-[13px]',
+        !preserveCase && 'lowercase',
+        'placeholder:text-ink-faint',
+        'focus:outline-none focus:border-ink transition-colors',
+        'disabled:opacity-40 disabled:pointer-events-none',
+        className,
+      )}
+      {...rest}
+    />
+  ),
+)
+Input.displayName = 'Input'

--- a/console/web/src/components/ui/ModeToggle.tsx
+++ b/console/web/src/components/ui/ModeToggle.tsx
@@ -1,4 +1,5 @@
 import type * as React from 'react'
+import { useRef } from 'react'
 import { cn } from '@/lib/utils'
 
 interface ModeToggleOption<T extends string> {
@@ -6,11 +7,22 @@ interface ModeToggleOption<T extends string> {
   label: React.ReactNode
 }
 
+/**
+ * `tabs` (default): semantic tablist for view switching (top nav).
+ * `radio`: semantic radiogroup for persistent preferences (theme). Radio
+ * matches the "one persistent choice" meaning better than tab, which
+ * implies switching between panels.
+ */
+type ModeToggleVariant = 'tabs' | 'radio'
+
 interface ModeToggleProps<T extends string> {
   value: T
   onChange: (next: T) => void
   options: ModeToggleOption<T>[]
   className?: string
+  variant?: ModeToggleVariant
+  /** Accessible name for the group. Required for `variant="radio"`. */
+  'aria-label'?: string
 }
 
 export function ModeToggle<T extends string>({
@@ -18,21 +30,66 @@ export function ModeToggle<T extends string>({
   onChange,
   options,
   className,
+  variant = 'tabs',
+  'aria-label': ariaLabel,
 }: ModeToggleProps<T>) {
+  const groupRole = variant === 'radio' ? 'radiogroup' : 'tablist'
+  const itemRole = variant === 'radio' ? 'radio' : 'tab'
+  const buttonRefs = useRef<(HTMLButtonElement | null)[]>([])
+
+  // WAI-ARIA radiogroup pattern: arrow keys move between options AND
+  // update the selected value (radios commit on focus). Home/End jump
+  // to first/last. Tab focus is roving — only the selected radio is
+  // tabbable; others get tabIndex={-1} so Tab moves past the whole
+  // group as one stop. Tabs variant keeps Tab-between-options.
+  function handleRadioKeyDown(
+    e: React.KeyboardEvent<HTMLButtonElement>,
+    idx: number,
+  ) {
+    let nextIdx: number | null = null
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      nextIdx = (idx + 1) % options.length
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      nextIdx = (idx - 1 + options.length) % options.length
+    } else if (e.key === 'Home') {
+      nextIdx = 0
+    } else if (e.key === 'End') {
+      nextIdx = options.length - 1
+    }
+    if (nextIdx !== null) {
+      e.preventDefault()
+      onChange(options[nextIdx].value)
+      buttonRefs.current[nextIdx]?.focus()
+    }
+  }
+
   return (
     <div
-      role="tablist"
+      role={groupRole}
+      aria-label={ariaLabel}
       className={cn('inline-flex border border-rule p-[2px]', className)}
     >
-      {options.map((opt) => {
+      {options.map((opt, idx) => {
         const active = opt.value === value
+        const ariaState =
+          variant === 'radio'
+            ? { 'aria-checked': active }
+            : { 'aria-selected': active }
+        const isRadio = variant === 'radio'
         return (
           <button
             key={opt.value}
             type="button"
-            role="tab"
-            aria-selected={active}
+            role={itemRole}
+            {...ariaState}
+            ref={(el) => {
+              buttonRefs.current[idx] = el
+            }}
+            tabIndex={isRadio ? (active ? 0 : -1) : undefined}
             onClick={() => onChange(opt.value)}
+            onKeyDown={
+              isRadio ? (e) => handleRadioKeyDown(e, idx) : undefined
+            }
             className={cn(
               'font-mono text-[13px] px-3 py-1 transition-colors lowercase',
               active

--- a/console/web/src/components/ui/Select.tsx
+++ b/console/web/src/components/ui/Select.tsx
@@ -1,3 +1,4 @@
+import * as SelectPrimitive from '@radix-ui/react-select'
 import type * as React from 'react'
 import { cn } from '@/lib/utils'
 
@@ -11,84 +12,158 @@ interface SelectGroup<T extends string> {
   options: SelectOption<T>[]
 }
 
-interface SelectProps<T extends string>
-  extends Omit<
-    React.SelectHTMLAttributes<HTMLSelectElement>,
-    'onChange' | 'value' | 'defaultValue'
-  > {
+interface SelectProps<T extends string> {
   value: T
   options?: SelectOption<T>[]
   groups?: SelectGroup<T>[]
   onChange: (next: T) => void
+  disabled?: boolean
+  className?: string
+  /** Forwarded to the trigger for screen-readers. */
+  'aria-label'?: string
+  /** Forwarded to the trigger; used to indicate the option list is still loading. */
+  'aria-busy'?: boolean
+  /** Optional placeholder shown when no `value` matches an option. */
+  placeholder?: string
+  /**
+   * Replace the default `<Label>` rendering for each group. The returned
+   * node is mounted inside `<SelectPrimitive.Group>` so labelling
+   * semantics are preserved as long as the renderer includes a
+   * `SelectPrimitive.Label` (or another labelling element).
+   */
+  renderGroupHeader?: (group: SelectGroup<T>) => React.ReactNode
 }
 
 export type { SelectGroup, SelectOption }
 
+/**
+ * Radix-based dropdown. Replaces the native `<select>` so the panel can be
+ * themed consistently with the rest of the console (font-mono, lowercase,
+ * ink/bg/rule tokens) instead of inheriting the OS' dark-mode default look.
+ *
+ * Keeps the same external API the native version had: pass either `options`
+ * (flat list) or `groups` (sectioned). `value`, `onChange`, `disabled` and
+ * the two aria props flow through unchanged so existing consumers
+ * (`ModelPicker`, the primitives gallery) don't need to be touched.
+ */
 export function Select<T extends string>({
   value,
   options,
   groups,
   onChange,
-  className,
   disabled,
-  ...rest
+  className,
+  placeholder,
+  renderGroupHeader,
+  ...aria
 }: SelectProps<T>) {
+  // Pre-flatten so the trigger can resolve `value -> label` without an extra
+  // children-walk inside Radix.
+  const flatOptions: SelectOption<T>[] = groups
+    ? groups.flatMap((g) => g.options)
+    : (options ?? [])
+  const selected = flatOptions.find((o) => o.value === value)
+
   return (
-    <label
+    <SelectPrimitive.Root
+      value={value}
+      onValueChange={(next) => onChange(next as T)}
+      disabled={disabled}
+    >
+      <SelectPrimitive.Trigger
+        aria-label={aria['aria-label']}
+        aria-busy={aria['aria-busy']}
+        className={cn(
+          'inline-flex items-center justify-between gap-x-2 border border-rule bg-bg px-3 h-9 text-ink font-mono text-[13px] lowercase focus:outline-none focus:border-ink data-[state=open]:border-ink transition-colors',
+          disabled && 'opacity-40 pointer-events-none',
+          className,
+        )}
+      >
+        <SelectPrimitive.Value placeholder={placeholder}>
+          {selected?.label ?? value}
+        </SelectPrimitive.Value>
+        <SelectPrimitive.Icon asChild>
+          <span aria-hidden className="text-ink-faint">
+            <svg
+              width="8"
+              height="6"
+              viewBox="0 0 8 6"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1"
+            >
+              <path d="M1 1L4 5L7 1" />
+            </svg>
+          </span>
+        </SelectPrimitive.Icon>
+      </SelectPrimitive.Trigger>
+
+      <SelectPrimitive.Portal>
+        <SelectPrimitive.Content
+          position="popper"
+          sideOffset={4}
+          className={cn(
+            'z-50 min-w-[var(--radix-select-trigger-width)] overflow-hidden border border-rule bg-bg text-ink font-mono text-[13px] lowercase shadow-lg',
+            'data-[state=open]:animate-in data-[state=closed]:animate-out',
+            'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+          )}
+        >
+          <SelectPrimitive.ScrollUpButton className="flex items-center justify-center h-5 text-ink-faint cursor-default">
+            <svg width="8" height="6" viewBox="0 0 8 6" fill="none" stroke="currentColor" strokeWidth="1" aria-hidden>
+              <path d="M1 5L4 1L7 5" />
+            </svg>
+          </SelectPrimitive.ScrollUpButton>
+          <SelectPrimitive.Viewport className="p-1 max-h-[60vh]">
+            {groups
+              ? groups.map((g) => (
+                  <SelectPrimitive.Group key={g.label}>
+                    {renderGroupHeader ? (
+                      renderGroupHeader(g)
+                    ) : (
+                      <SelectPrimitive.Label className="px-3 pt-2 pb-1 text-[11px] uppercase tracking-[0.12em] text-ink-faint">
+                        {g.label}
+                      </SelectPrimitive.Label>
+                    )}
+                    {g.options.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value} label={opt.label} />
+                    ))}
+                  </SelectPrimitive.Group>
+                ))
+              : (options ?? []).map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value} label={opt.label} />
+                ))}
+          </SelectPrimitive.Viewport>
+          <SelectPrimitive.ScrollDownButton className="flex items-center justify-center h-5 text-ink-faint cursor-default">
+            <svg width="8" height="6" viewBox="0 0 8 6" fill="none" stroke="currentColor" strokeWidth="1" aria-hidden>
+              <path d="M1 1L4 5L7 1" />
+            </svg>
+          </SelectPrimitive.ScrollDownButton>
+        </SelectPrimitive.Content>
+      </SelectPrimitive.Portal>
+    </SelectPrimitive.Root>
+  )
+}
+
+interface SelectItemProps {
+  value: string
+  label: string
+}
+
+function SelectItem({ value, label }: SelectItemProps) {
+  return (
+    <SelectPrimitive.Item
+      value={value}
       className={cn(
-        'inline-flex items-center gap-x-2 border border-rule bg-bg px-3 h-9 text-ink font-mono text-[13px] lowercase relative focus-within:border-ink transition-colors',
-        disabled && 'opacity-40 pointer-events-none',
-        className,
+        'relative flex items-center pl-7 pr-3 py-1.5 cursor-pointer outline-none select-none',
+        'data-[highlighted]:bg-rule data-[highlighted]:text-ink',
+        'data-[state=checked]:text-ink',
+        'data-[disabled]:opacity-40 data-[disabled]:pointer-events-none',
       )}
     >
-      <select
-        {...rest}
-        value={value}
-        disabled={disabled}
-        onChange={(e) => onChange(e.currentTarget.value as T)}
-        className="appearance-none bg-transparent pr-5 outline-none cursor-pointer lowercase"
-      >
-        {groups
-          ? groups.map((g) => (
-              <optgroup key={g.label} label={g.label}>
-                {g.options.map((opt) => (
-                  <option
-                    key={opt.value}
-                    value={opt.value}
-                    className="text-ink bg-bg"
-                  >
-                    {opt.label}
-                  </option>
-                ))}
-              </optgroup>
-            ))
-          : (options ?? []).map((opt) => (
-              <option
-                key={opt.value}
-                value={opt.value}
-                className="text-ink bg-bg"
-              >
-                {opt.label}
-              </option>
-            ))}
-      </select>
-      <span
-        aria-hidden="true"
-        className="absolute right-2 top-1/2 -translate-y-1/2 text-ink-faint pointer-events-none"
-      >
-        {/* hand-drawn caret — a single ink chevron, no curves */}
-        <svg
-          width="8"
-          height="6"
-          viewBox="0 0 8 6"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1"
-          aria-hidden="true"
-        >
-          <path d="M1 1L4 5L7 1" />
-        </svg>
-      </span>
-    </label>
+      <SelectPrimitive.ItemIndicator className="absolute left-2 top-1/2 -translate-y-1/2 text-ink">
+        <span aria-hidden>✓</span>
+      </SelectPrimitive.ItemIndicator>
+      <SelectPrimitive.ItemText>{label}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
   )
 }

--- a/console/web/src/hooks/use-chat-dock.ts
+++ b/console/web/src/hooks/use-chat-dock.ts
@@ -1,7 +1,12 @@
 import { useCallback, useEffect, useState } from 'react'
 
-const OPEN_KEY = 'iii-chat-dock-open'
 const WIDTH_KEY = 'iii-chat-dock-width'
+const COLLAPSED_KEY = 'iii-chat-dock-collapsed'
+// Legacy: when the dock was first made toggleable we persisted an open/closed
+// flag under a different key. The collapse state now lives under
+// COLLAPSED_KEY; sweep the old key on first run so it doesn't linger in
+// users' localStorage forever.
+const LEGACY_OPEN_KEY = 'iii-chat-dock-open'
 
 export const DOCK_DEFAULT_WIDTH = 440
 export const DOCK_MIN_WIDTH = 320
@@ -28,15 +33,6 @@ function clampWidth(w: number, viewportWidth?: number): number {
   return Math.max(DOCK_MIN_WIDTH, Math.min(max, w))
 }
 
-function loadOpen(): boolean {
-  if (typeof window === 'undefined') return false
-  try {
-    return window.localStorage.getItem(OPEN_KEY) === '1'
-  } catch {
-    return false
-  }
-}
-
 function loadWidth(): number {
   if (typeof window === 'undefined') return DOCK_DEFAULT_WIDTH
   try {
@@ -53,15 +49,6 @@ function loadWidth(): number {
   }
 }
 
-function persistOpen(value: boolean) {
-  if (typeof window === 'undefined') return
-  try {
-    window.localStorage.setItem(OPEN_KEY, value ? '1' : '0')
-  } catch {
-    // best-effort persistence
-  }
-}
-
 function persistWidth(value: number) {
   if (typeof window === 'undefined') return
   try {
@@ -71,37 +58,71 @@ function persistWidth(value: number) {
   }
 }
 
+function sweepLegacyOpenKey(): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.removeItem(LEGACY_OPEN_KEY)
+  } catch {
+    // best-effort
+  }
+}
+
+function loadCollapsed(): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    return window.localStorage.getItem(COLLAPSED_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+function persistCollapsed(value: boolean): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(COLLAPSED_KEY, value ? '1' : '0')
+  } catch {
+    // best-effort persistence
+  }
+}
+
 export interface UseChatDockReturn {
-  open: boolean
-  setOpen: (value: boolean) => void
-  toggle: () => void
   width: number
   setWidth: (value: number) => void
+  collapsed: boolean
+  setCollapsed: (value: boolean) => void
+  toggleCollapsed: () => void
 }
 
 /**
- * Open/closed flag and resizable width for the side-by-side chat dock that
- * sits next to the traces / playground / examples routes. Both bits are
- * persisted to `localStorage` so the dock survives reloads, matching how
- * the conversation list collapse state behaves.
+ * Resizable, collapsible chat dock that sits next to the active route pane.
+ * Width and collapsed state are both persisted to `localStorage` so the dock
+ * survives reloads at whatever size and visibility the user left it in.
  *
  * The dock has no fixed upper width cap: it can be dragged as wide as the
  * user wants, with the only constraint being that the adjacent route
  * content keeps at least `DOCK_NEIGHBOR_MIN_WIDTH` pixels. If the viewport
  * shrinks below that envelope, the persisted width is re-clamped so the
- * dock doesn't overflow the screen.
+ * dock doesn't overflow the screen. When collapsed, the dock renders as a
+ * thin strip with a re-expand affordance — the previous width is preserved
+ * and restored on re-expand.
  */
 export function useChatDock(): UseChatDockReturn {
-  const [open, setOpenState] = useState<boolean>(loadOpen)
   const [width, setWidthState] = useState<number>(loadWidth)
-
-  useEffect(() => {
-    persistOpen(open)
-  }, [open])
+  const [collapsed, setCollapsedState] = useState<boolean>(loadCollapsed)
 
   useEffect(() => {
     persistWidth(width)
   }, [width])
+
+  useEffect(() => {
+    persistCollapsed(collapsed)
+  }, [collapsed])
+
+  /* One-shot cleanup of the legacy open/closed flag from a prior iteration
+     of the dock. Idempotent: removeItem on a missing key is a no-op. */
+  useEffect(() => {
+    sweepLegacyOpenKey()
+  }, [])
 
   /* Re-clamp on mount and on every viewport resize so a previously stored
      wide value (from a larger screen) shrinks to fit the current window,
@@ -116,17 +137,37 @@ export function useChatDock(): UseChatDockReturn {
     return () => window.removeEventListener('resize', reclamp)
   }, [])
 
-  const setOpen = useCallback((value: boolean) => {
-    setOpenState(value)
-  }, [])
-
-  const toggle = useCallback(() => {
-    setOpenState((v) => !v)
-  }, [])
-
   const setWidth = useCallback((value: number) => {
     setWidthState(clampWidth(value))
   }, [])
 
-  return { open, setOpen, toggle, width, setWidth }
+  const setCollapsed = useCallback((value: boolean) => {
+    setCollapsedState(value)
+  }, [])
+
+  const toggleCollapsed = useCallback(() => {
+    setCollapsedState((v) => !v)
+  }, [])
+
+  /* ⌘\ / Ctrl+\ toggles the dock. Listener lives in the hook so the
+     shortcut keeps working when the dock is collapsed and the panel
+     itself isn't mounted. Ignored when the user is typing into an
+     editable element so we don't fight composer input. */
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== '\\') return
+      if (!(e.metaKey || e.ctrlKey)) return
+      const target = e.target as HTMLElement | null
+      if (target?.isContentEditable) return
+      const tag = target?.tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
+      e.preventDefault()
+      toggleCollapsed()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [toggleCollapsed])
+
+  return { width, setWidth, collapsed, setCollapsed, toggleCollapsed }
 }

--- a/console/web/src/hooks/use-hash-route.ts
+++ b/console/web/src/hooks/use-hash-route.ts
@@ -1,23 +1,44 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-export type View = 'chat' | 'examples' | 'playground' | 'traces'
+// `chat` is no longer a routed view; it's always-rendered as the side dock
+// in App.tsx. Hash routes only pick which view fills the right pane.
+export type View = 'configuration' | 'examples' | 'playground' | 'traces'
 
 const PLAYGROUND_ENABLED = !!import.meta.env.VITE_PLAYGROUND
 
 function routeFromHash(hash: string): View | null {
-  if (hash === '' || hash === '#' || hash === '#/' || hash === '#/chat') {
-    return 'chat'
+  if (hash === '' || hash === '#' || hash === '#/' || hash === '#/traces') {
+    return 'traces'
   }
-  if (hash === '#/traces') return 'traces'
-  if (hash === '#/examples') return PLAYGROUND_ENABLED ? 'examples' : 'chat'
-  if (hash === '#/playground') return PLAYGROUND_ENABLED ? 'playground' : 'chat'
+  // Backwards compat: `#/chat` no longer exists as a view -- chat is the
+  // always-visible side dock now. Land legacy bookmarks on the default view.
+  if (hash === '#/chat') return 'traces'
+  if (hash === '#/configuration') return 'configuration'
+  // Backwards compat: `#/providers` was renamed to `#/configuration` when
+  // the page absorbed the theme toggle and any other future settings.
+  if (hash === '#/providers') return 'configuration'
+  if (hash === '#/examples') return PLAYGROUND_ENABLED ? 'examples' : 'traces'
+  if (hash === '#/playground') return PLAYGROUND_ENABLED ? 'playground' : 'traces'
   return null
+}
+
+function hashFor(view: View): string {
+  switch (view) {
+    case 'traces':
+      return '#/traces'
+    case 'configuration':
+      return '#/configuration'
+    case 'examples':
+      return '#/examples'
+    case 'playground':
+      return '#/playground'
+  }
 }
 
 export function useHashRoute(): [View, (next: View) => void] {
   const [view, setView] = useState<View>(() => {
-    if (typeof window === 'undefined') return 'chat'
-    return routeFromHash(window.location.hash) ?? 'chat'
+    if (typeof window === 'undefined') return 'traces'
+    return routeFromHash(window.location.hash) ?? 'traces'
   })
   const viewRef = useRef(view)
   viewRef.current = view
@@ -32,14 +53,7 @@ export function useHashRoute(): [View, (next: View) => void] {
   }, [])
 
   const navigate = useCallback((next: View) => {
-    const targetHash =
-      next === 'chat'
-        ? '#/'
-        : next === 'traces'
-          ? '#/traces'
-          : next === 'examples'
-            ? '#/examples'
-            : '#/playground'
+    const targetHash = hashFor(next)
     if (window.location.hash !== targetHash) {
       window.location.hash = targetHash
     } else {

--- a/console/web/src/hooks/use-providers.ts
+++ b/console/web/src/hooks/use-providers.ts
@@ -1,0 +1,109 @@
+/**
+ * TanStack Query hooks for provider auth and config.
+ * Each row in the providers dialog owns its own query; mutations
+ * invalidate the affected query key so the row re-fetches automatically.
+ */
+
+import {
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
+import {
+  clearProviderConfig,
+  deleteToken,
+  fetchAuthStatus,
+  fetchProviderConfig,
+  type SetProviderConfigPayload,
+  type SetTokenPayload,
+  setProviderConfig,
+  setToken,
+} from '@/lib/providers'
+
+/* ------------------------------------------------------------------ */
+/*  Queries                                                            */
+/* ------------------------------------------------------------------ */
+
+export function useAuthStatus(provider: string) {
+  return useQuery({
+    queryKey: ['provider', 'status', provider],
+    queryFn: () => fetchAuthStatus(provider),
+  })
+}
+
+export function useProviderConfig(provider: string) {
+  return useQuery({
+    queryKey: ['provider', 'config', provider],
+    queryFn: () => fetchProviderConfig(provider),
+  })
+}
+
+/**
+ * Fan-out of `useAuthStatus` across a set of providers. React Query
+ * dedupes by query key, so calling this at the page level alongside the
+ * per-row `useAuthStatus` calls does not trigger additional fetches —
+ * both share the same cache. Used by the Configuration page to detect
+ * the zero-config empty state.
+ */
+export function useProviderStatuses(providers: readonly string[]) {
+  return useQueries({
+    queries: providers.map((provider) => ({
+      queryKey: ['provider', 'status', provider],
+      queryFn: () => fetchAuthStatus(provider),
+    })),
+  })
+}
+
+/* ------------------------------------------------------------------ */
+/*  Mutations                                                          */
+/* ------------------------------------------------------------------ */
+
+export function useSetToken() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (payload: SetTokenPayload) => setToken(payload),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({
+        queryKey: ['provider', 'status', variables.provider],
+      })
+    },
+  })
+}
+
+export function useDeleteToken() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (provider: string) => deleteToken(provider),
+    onSuccess: (_data, provider) => {
+      qc.invalidateQueries({
+        queryKey: ['provider', 'status', provider],
+      })
+    },
+  })
+}
+
+export function useSetProviderConfig() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (payload: SetProviderConfigPayload) =>
+      setProviderConfig(payload),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({
+        queryKey: ['provider', 'config', variables.provider],
+      })
+    },
+  })
+}
+
+export function useClearProviderConfig() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (provider: string) => clearProviderConfig(provider),
+    onSuccess: (_data, provider) => {
+      qc.invalidateQueries({
+        queryKey: ['provider', 'config', provider],
+      })
+    },
+  })
+}

--- a/console/web/src/index.css
+++ b/console/web/src/index.css
@@ -19,7 +19,11 @@
   --color-rule: #d8d5d0;
   --color-rule-2: #e6e3df;
 
-  --color-accent: #ff5a1f;
+  /* Darker burnt orange so accent text on cream passes WCAG AA at 11px
+     (≈4.83:1 vs. previous ≈2.74:1 for #ff5a1f). Visually still firmly in
+     the iii Schematic warm-fiery family; the dark-mode cyan accent below
+     is unchanged. */
+  --color-accent: #b8420f;
   --color-accent-fg: #f2f0ed;
 
   --color-alert: #c43e1c;
@@ -113,6 +117,34 @@
   animation: pulse-dot 1.6s ease-out infinite;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .pulse-dot {
+    animation: none;
+  }
+}
+
+/* Square sibling of pulse-dot — same accent, same 1.6s ease-out cadence,
+   tuned 6px spread for 28×28 chrome buttons so the expanding ring keeps
+   square geometry instead of co-opting the dot vocabulary. */
+@keyframes pulse-square {
+  0% {
+    box-shadow: 0 0 0 0 var(--color-accent);
+  }
+  100% {
+    box-shadow: 0 0 0 6px transparent;
+  }
+}
+
+@utility pulse-square {
+  animation: pulse-square 1.6s ease-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pulse-square {
+    animation: none;
+  }
+}
+
 @keyframes blink {
   0%,
   49% {
@@ -126,6 +158,12 @@
 
 @utility blink {
   animation: blink 1s steps(1) infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .blink {
+    animation: none;
+  }
 }
 
 @keyframes wiggle {

--- a/console/web/src/lib/chat-activity.test.ts
+++ b/console/web/src/lib/chat-activity.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import { getDockSignal } from '@/lib/chat-activity'
+import type { Conversation, Message } from '@/types/chat'
+
+function conv(messages: Message[]): Conversation {
+  return {
+    id: 'test',
+    title: 't',
+    model: 'openai::gpt-5',
+    mode: 'agent',
+    autoAccept: false,
+    messages,
+    createdAt: 0,
+    updatedAt: 0,
+  }
+}
+
+describe('getDockSignal', () => {
+  it('returns null for missing or empty conversation', () => {
+    expect(getDockSignal(null)).toBeNull()
+    expect(getDockSignal(undefined)).toBeNull()
+    expect(getDockSignal(conv([]))).toBeNull()
+  })
+
+  it("returns 'active' when the assistant is streaming the last message", () => {
+    const m: Message = {
+      id: '1',
+      createdAt: 0,
+      role: 'assistant',
+      content: 'partial',
+      streaming: true,
+    }
+    expect(getDockSignal(conv([m]))).toBe('active')
+  })
+
+  it("returns 'active' when the thought stream is in flight", () => {
+    const m: Message = {
+      id: '1',
+      createdAt: 0,
+      role: 'thought',
+      content: 'thinking',
+      durationMs: 0,
+      streaming: true,
+    }
+    expect(getDockSignal(conv([m]))).toBe('active')
+  })
+
+  it("returns 'active' when a tool call is running", () => {
+    const m: Message = {
+      id: '1',
+      createdAt: 0,
+      role: 'function-call',
+      functionId: 'shell::run',
+      input: {},
+      running: true,
+    }
+    expect(getDockSignal(conv([m]))).toBe('active')
+  })
+
+  it("returns 'error' when the last message is a system/error", () => {
+    const m: Message = {
+      id: '1',
+      createdAt: 0,
+      role: 'system',
+      content: 'rate limited',
+      tone: 'error',
+    }
+    expect(getDockSignal(conv([m]))).toBe('error')
+  })
+
+  it("returns 'attention' when the last message is a system/warn", () => {
+    const m: Message = {
+      id: '1',
+      createdAt: 0,
+      role: 'system',
+      content: 'soft failure',
+      tone: 'warn',
+    }
+    expect(getDockSignal(conv([m]))).toBe('attention')
+  })
+
+  it('returns null for a settled assistant message (no streaming flag)', () => {
+    const m: Message = {
+      id: '1',
+      createdAt: 0,
+      role: 'assistant',
+      content: 'done',
+    }
+    expect(getDockSignal(conv([m]))).toBeNull()
+  })
+
+  it('pendency wins over freshness: pending approval anywhere overrides a later system error', () => {
+    const pending: Message = {
+      id: '1',
+      createdAt: 0,
+      role: 'function-call',
+      functionId: 'shell::write',
+      input: {},
+      pendingApproval: true,
+    }
+    const errLater: Message = {
+      id: '2',
+      createdAt: 1,
+      role: 'system',
+      content: 'context compacted',
+      tone: 'error',
+    }
+    expect(getDockSignal(conv([pending, errLater]))).toBe('active')
+  })
+})

--- a/console/web/src/lib/chat-activity.ts
+++ b/console/web/src/lib/chat-activity.ts
@@ -1,0 +1,43 @@
+import type { Conversation } from '@/types/chat'
+
+/**
+ * State surfaced by the chat-dock toggle when the dock is collapsed.
+ *
+ * - `active`: the assistant is producing output or waiting on the user
+ *   (streaming, pending approval, running tool call). Foregrounded with the
+ *   accent pulse so blocking events don't get buried.
+ * - `attention`: the most recent system message warns the user about
+ *   something they should look at (rate limit, soft failure, compaction
+ *   notice). Static warn-tinted border, no pulse — calmer than `active`.
+ * - `error`: the most recent system message is a hard failure. Static
+ *   alert-tinted border, no pulse — wrong moment to demand attention with
+ *   motion.
+ * - `null`: idle.
+ *
+ * Pendency wins over freshness: a `pendingApproval` anywhere in the
+ * history overrides a more recent warn/error system message so the user
+ * never misses a blocking gate.
+ */
+export type DockSignal = 'active' | 'attention' | 'error' | null
+
+export function getDockSignal(
+  active: Conversation | null | undefined,
+): DockSignal {
+  if (!active || active.messages.length === 0) return null
+
+  for (const m of active.messages) {
+    if (m.role === 'function-call' && m.pendingApproval) return 'active'
+  }
+
+  const last = active.messages[active.messages.length - 1]
+  if (!last) return null
+
+  if (last.role === 'assistant' && last.streaming) return 'active'
+  if (last.role === 'thought' && last.streaming) return 'active'
+  if (last.role === 'function-call' && last.running) return 'active'
+  if (last.role === 'system') {
+    if (last.tone === 'error') return 'error'
+    if (last.tone === 'warn') return 'attention'
+  }
+  return null
+}

--- a/console/web/src/lib/providers.test.ts
+++ b/console/web/src/lib/providers.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_TOKENS_LIMIT,
+  normalizeErrorMessage,
+  validateApiUrl,
+  validateMaxTokens,
+} from '@/lib/providers'
+import {
+  ACTIVE_PROVIDERS,
+  type ActiveProvider,
+  PROVIDER_DEFAULTS,
+  PROVIDERS,
+} from '@/components/providers/provider-registry'
+
+describe('provider-registry', () => {
+  it('partitions into 5 active and 19 env-var-only providers', () => {
+    const active = PROVIDERS.filter((p) => p.isActive)
+    const envOnly = PROVIDERS.filter((p) => !p.isActive)
+    expect(active).toHaveLength(5)
+    expect(envOnly).toHaveLength(19)
+    expect(active.length + envOnly.length).toBe(PROVIDERS.length)
+  })
+
+  it('active providers match ACTIVE_PROVIDERS list', () => {
+    const activeIds = PROVIDERS.filter((p) => p.isActive).map((p) => p.id)
+    expect(activeIds).toEqual([...ACTIVE_PROVIDERS])
+  })
+
+  it('anthropic entry has correct env var', () => {
+    const entry = PROVIDERS.find((p) => p.id === 'anthropic')
+    expect(entry).toBeDefined()
+    expect(entry?.envVar).toBe('ANTHROPIC_API_KEY')
+    expect(entry?.isActive).toBe(true)
+  })
+
+  it('openrouter entry is env-var-only', () => {
+    const entry = PROVIDERS.find((p) => p.id === 'openrouter')
+    expect(entry).toBeDefined()
+    expect(entry?.envVar).toBe('OPENROUTER_API_KEY')
+    expect(entry?.isActive).toBe(false)
+  })
+
+  it('PROVIDER_DEFAULTS has entries for all active providers', () => {
+    for (const id of ACTIVE_PROVIDERS) {
+      const defaults = PROVIDER_DEFAULTS[id as ActiveProvider]
+      expect(defaults).toBeDefined()
+      expect(typeof defaults.default_api_url).toBe('string')
+      expect(defaults.default_api_url.length).toBeGreaterThan(0)
+      expect(typeof defaults.default_max_tokens).toBe('number')
+      expect(defaults.default_max_tokens).toBeGreaterThan(0)
+    }
+  })
+
+  it('default URLs are valid', () => {
+    for (const id of ACTIVE_PROVIDERS) {
+      const { default_api_url } = PROVIDER_DEFAULTS[id as ActiveProvider]
+      expect(() => new URL(default_api_url)).not.toThrow()
+    }
+  })
+})
+
+describe('normalizeErrorMessage', () => {
+  it('returns "unknown error" for null/undefined', () => {
+    expect(normalizeErrorMessage(null)).toBe('unknown error')
+    expect(normalizeErrorMessage(undefined)).toBe('unknown error')
+  })
+
+  it('extracts message from Error instances and strips the "Error:" prefix', () => {
+    expect(normalizeErrorMessage(new Error('boom'))).toBe('boom')
+  })
+
+  it('strips the @fn(<id>) prefix that workers prepend to bus errors', () => {
+    expect(normalizeErrorMessage(new Error('@fn(auth::set_token) bad payload'))).toBe(
+      'bad payload',
+    )
+  })
+
+  it('renders plain-object bus rejections (the iii-browser-sdk shape) as "<code>: <message>"', () => {
+    // Regression: this object shape used to stringify to "[object Object]",
+    // which then lowercased to "[object object]" and hid every real bus error.
+    expect(
+      normalizeErrorMessage({
+        code: 'function_not_found',
+        message: 'provider_config::get not registered',
+      }),
+    ).toBe('function_not_found: provider_config::get not registered')
+  })
+
+  it('renders bus rejections with only a message field', () => {
+    expect(normalizeErrorMessage({ message: 'invalid url' })).toBe('invalid url')
+  })
+
+  it('renders bus rejections with only a code field', () => {
+    expect(normalizeErrorMessage({ code: 'timeout' })).toBe('timeout')
+  })
+
+  it('falls back to the .error field when there is no .message', () => {
+    expect(normalizeErrorMessage({ error: 'bad input' })).toBe('bad input')
+  })
+
+  it('falls back to String() for unrecognised object shapes', () => {
+    // Keeps the old behaviour as the floor: we never throw on weird inputs.
+    expect(normalizeErrorMessage({ unrelated: true })).toBe('[object object]')
+  })
+})
+
+describe('validateApiUrl', () => {
+  it('accepts http URLs', () => {
+    expect(validateApiUrl('http://localhost:1234/v1/chat/completions')).toEqual({
+      ok: true,
+      value: 'http://localhost:1234/v1/chat/completions',
+    })
+  })
+
+  it('accepts https URLs', () => {
+    const r = validateApiUrl('https://api.openai.com/v1/chat/completions')
+    expect(r.ok).toBe(true)
+  })
+
+  it('trims leading and trailing whitespace before validating', () => {
+    expect(validateApiUrl('  http://localhost:1234  ')).toEqual({
+      ok: true,
+      value: 'http://localhost:1234',
+    })
+  })
+
+  it('rejects unparseable input with a hint mentioning http(s)://', () => {
+    const r = validateApiUrl('not a url')
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.error).toMatch(/http:\/\/ or https:\/\//)
+    }
+  })
+
+  it('rejects non-http(s) schemes naming the offending protocol', () => {
+    const r = validateApiUrl('file:///etc/passwd')
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.error).toMatch(/file/)
+    }
+  })
+})
+
+describe('validateMaxTokens', () => {
+  it('accepts a positive integer within the harness ceiling', () => {
+    expect(validateMaxTokens('8192')).toEqual({ ok: true, value: 8192 })
+  })
+
+  it('rejects decimals', () => {
+    const r = validateMaxTokens('8192.5')
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.error).toMatch(/whole number/)
+    }
+  })
+
+  it('rejects zero and negative numbers', () => {
+    expect(validateMaxTokens('0').ok).toBe(false)
+    expect(validateMaxTokens('-1').ok).toBe(false)
+  })
+
+  it('rejects values above the harness ceiling', () => {
+    expect(validateMaxTokens(String(MAX_TOKENS_LIMIT + 1)).ok).toBe(false)
+  })
+
+  it('accepts the harness ceiling exactly', () => {
+    expect(validateMaxTokens(String(MAX_TOKENS_LIMIT))).toEqual({
+      ok: true,
+      value: MAX_TOKENS_LIMIT,
+    })
+  })
+
+  it('rejects non-numeric input', () => {
+    expect(validateMaxTokens('lots').ok).toBe(false)
+  })
+})

--- a/console/web/src/lib/providers.ts
+++ b/console/web/src/lib/providers.ts
@@ -1,0 +1,221 @@
+/**
+ * Typed wrappers over the iii bus for provider auth and config functions.
+ * Mirrors the pattern in `src/lib/models-catalog.ts`.
+ *
+ * NEVER call `auth::get_token` from the browser -- it returns the raw
+ * credential and would leak the key. Use `auth::status` for masked display.
+ */
+
+import { getIiiClient } from '@/lib/iii-client'
+
+/* ------------------------------------------------------------------ */
+/*  auth-credentials bus functions                                     */
+/* ------------------------------------------------------------------ */
+
+export interface AuthStatusResult {
+  configured: boolean
+  source?: 'stored' | 'environment'
+  label?: string
+}
+
+export async function fetchAuthStatus(
+  provider: string,
+): Promise<AuthStatusResult> {
+  const client = await getIiiClient()
+  return client.call<AuthStatusResult>('auth::status', { provider })
+}
+
+export interface ListProvidersResult {
+  providers: string[]
+}
+
+export async function fetchListProviders(): Promise<ListProvidersResult> {
+  const client = await getIiiClient()
+  return client.call<ListProvidersResult>('auth::list_providers', {})
+}
+
+export interface SetTokenPayload {
+  provider: string
+  credential: { type: 'api_key'; key: string }
+}
+
+export async function setToken(
+  payload: SetTokenPayload,
+): Promise<{ ok: true }> {
+  const client = await getIiiClient()
+  return client.call<{ ok: true }>(
+    'auth::set_token',
+    payload as unknown as Record<string, unknown>,
+  )
+}
+
+export async function deleteToken(provider: string): Promise<{ ok: true }> {
+  const client = await getIiiClient()
+  return client.call<{ ok: true }>('auth::delete_token', { provider })
+}
+
+/* ------------------------------------------------------------------ */
+/*  provider-config bus functions                                      */
+/* ------------------------------------------------------------------ */
+
+export interface ProviderConfigResult {
+  default_api_url?: string
+  default_max_tokens?: number
+}
+
+export async function fetchProviderConfig(
+  provider: string,
+): Promise<ProviderConfigResult> {
+  const client = await getIiiClient()
+  return client.call<ProviderConfigResult>('provider_config::get', {
+    provider,
+  })
+}
+
+export interface SetProviderConfigPayload {
+  provider: string
+  default_api_url?: string
+  default_max_tokens?: number
+}
+
+export async function setProviderConfig(
+  payload: SetProviderConfigPayload,
+): Promise<{ ok: true }> {
+  const client = await getIiiClient()
+  return client.call<{ ok: true }>(
+    'provider_config::set',
+    payload as unknown as Record<string, unknown>,
+  )
+}
+
+export async function clearProviderConfig(
+  provider: string,
+): Promise<{ ok: true }> {
+  const client = await getIiiClient()
+  return client.call<{ ok: true }>('provider_config::clear', { provider })
+}
+
+export interface ProviderConfigListEntry {
+  provider: string
+  overrides: { default_api_url?: string; default_max_tokens?: number }
+}
+
+export async function fetchProviderConfigList(): Promise<{
+  entries: ProviderConfigListEntry[]
+}> {
+  const client = await getIiiClient()
+  return client.call<{ entries: ProviderConfigListEntry[] }>(
+    'provider_config::list',
+    {},
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/*  Validation helpers (client-side error prevention)                  */
+/* ------------------------------------------------------------------ */
+
+export const MAX_TOKENS_LIMIT = 1_048_576
+
+export type ValidationResult<T = void> =
+  | { ok: true; value: T }
+  | { ok: false; error: string }
+
+/**
+ * Validation error strings include the recovery hint inline (e.g.
+ * "not a valid url — include http:// or https:// and the full path").
+ * This matches the message+hint pattern used by per-mutation errors so
+ * the operator gets the same level of recovery guidance whether the
+ * failure was client-side validation or a server-side mutation.
+ *
+ * Precondition: callers pass a non-empty trimmed string. An empty
+ * value is the operator's signal that they want the provider default
+ * (no override) — save() correctly skips the mutation in that case
+ * rather than calling validate. We therefore do not return a
+ * contradictory "required — clear the field" error for empty input;
+ * empty input is simply not a validation concern.
+ */
+export function validateApiUrl(raw: string): ValidationResult<string> {
+  const trimmed = raw.trim()
+  let parsed: URL
+  try {
+    parsed = new URL(trimmed)
+  } catch {
+    return {
+      ok: false,
+      error: 'not a valid url — include http:// or https:// and the full path (e.g. http://localhost:1234/v1/chat/completions)',
+    }
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return {
+      ok: false,
+      error: `must use http or https (got ${parsed.protocol.replace(':', '')})`,
+    }
+  }
+  return { ok: true, value: trimmed }
+}
+
+/**
+ * Precondition matches `validateApiUrl`: callers gate on non-empty.
+ * Empty input means "use the provider default cap" and is not a
+ * validation concern.
+ */
+export function validateMaxTokens(raw: string): ValidationResult<number> {
+  const trimmed = raw.trim()
+  const n = Number(trimmed)
+  if (!Number.isInteger(n)) {
+    return { ok: false, error: 'must be a whole number (no decimals)' }
+  }
+  if (n <= 0) {
+    return { ok: false, error: 'must be at least 1' }
+  }
+  if (n > MAX_TOKENS_LIMIT) {
+    return {
+      ok: false,
+      error: `must be ≤ ${MAX_TOKENS_LIMIT.toLocaleString()} (the harness ceiling)`,
+    }
+  }
+  return { ok: true, value: n }
+}
+
+/**
+ * Strip noise from raw error messages surfaced by the bus / SDK so the UI
+ * renders something quiet and terminal-shaped rather than `Error: foo`.
+ *
+ * Handles three shapes:
+ *   1. `Error` instances -> `.message`
+ *   2. iii-browser-sdk bus rejections -> plain object `{ code, message, stacktrace? }`
+ *      surfaced as-is from `onInvocationResult`. We render `"<code>: <message>"`
+ *      (or just one if the other is missing).
+ *   3. Anything else -> `String(err)`, then strip prefixes.
+ *
+ * Without the object branch, plain bus errors stringified to "[object Object]"
+ * and the UI showed `error: [object object]` (lowercased by the .toLowerCase
+ * step below) -- which hid the actual failure from the user.
+ */
+export function normalizeErrorMessage(err: unknown): string {
+  if (!err) return 'unknown error'
+  let raw: string
+  if (err instanceof Error) {
+    raw = err.message
+  } else if (typeof err === 'object') {
+    const o = err as { code?: unknown; message?: unknown; error?: unknown }
+    const code = typeof o.code === 'string' ? o.code : ''
+    const message =
+      typeof o.message === 'string'
+        ? o.message
+        : typeof o.error === 'string'
+          ? o.error
+          : ''
+    if (code && message) raw = `${code}: ${message}`
+    else if (message) raw = message
+    else if (code) raw = code
+    else raw = String(err)
+  } else {
+    raw = String(err)
+  }
+  return raw
+    .replace(/^Error:\s*/i, '')
+    .replace(/^@fn\([^)]+\)\s*/, '')
+    .trim()
+    .toLowerCase()
+}

--- a/console/web/src/pages/Chat.tsx
+++ b/console/web/src/pages/Chat.tsx
@@ -1,5 +1,0 @@
-import { ChatPanel } from '@/components/chat/ChatPanel'
-
-export function Chat() {
-  return <ChatPanel density="route" />
-}

--- a/console/web/src/pages/Configuration/index.tsx
+++ b/console/web/src/pages/Configuration/index.tsx
@@ -1,0 +1,227 @@
+import { useEffect } from 'react'
+import { ProviderRow } from '@/components/providers/ProviderRow'
+import {
+  ACTIVE_PROVIDERS,
+  ENV_VAR_MAP,
+} from '@/components/providers/provider-registry'
+import { ModeToggle } from '@/components/ui/ModeToggle'
+import { useProviderStatuses } from '@/hooks/use-providers'
+import type { Theme } from '@/hooks/use-theme'
+
+const ENV_VAR_BY_ID = new Map(ENV_VAR_MAP)
+
+interface ConfigurationProps {
+  theme: Theme
+  onThemeChange: (next: Theme) => void
+}
+
+export function Configuration({ theme, onThemeChange }: ConfigurationProps) {
+  // Aggregate provider statuses to detect the zero-config empty state.
+  // React Query dedupes by query key, so this shares cache with each row's
+  // own `useAuthStatus` call — no extra fetches.
+  const statuses = useProviderStatuses(ACTIVE_PROVIDERS)
+  const isStatusLoading = statuses.some((s) => s.isLoading)
+  const configuredCount = statuses.filter((s) => s.data?.configured).length
+  const showZeroConfig = !isStatusLoading && configuredCount === 0
+
+  // H7 — keyboard navigation for the provider list:
+  //   1–N           : open provider N's dialog directly
+  //   ↑ / ↓         : move focus between provider rows (when one is focused)
+  // Both are suppressed inside text inputs / contenteditable so operators
+  // can type freely in dialogs and the chat dock.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const target = e.target as HTMLElement | null
+      if (target) {
+        const tag = target.tagName
+        if (
+          tag === 'INPUT' ||
+          tag === 'TEXTAREA' ||
+          target.isContentEditable
+        ) {
+          return
+        }
+      }
+      if (e.metaKey || e.ctrlKey || e.altKey) return
+
+      // Arrow-nav between rows when a row currently has focus.
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+        const rows = Array.from(
+          document.querySelectorAll<HTMLElement>('[data-provider-row]'),
+        )
+        const activeIdx = target ? rows.indexOf(target) : -1
+        if (activeIdx === -1 || rows.length === 0) return
+        e.preventDefault()
+        const nextIdx =
+          e.key === 'ArrowDown'
+            ? Math.min(activeIdx + 1, rows.length - 1)
+            : Math.max(activeIdx - 1, 0)
+        rows[nextIdx]?.focus()
+        return
+      }
+
+      // Number-key open.
+      const idx = Number.parseInt(e.key, 10)
+      if (!Number.isFinite(idx) || idx < 1 || idx > ACTIVE_PROVIDERS.length) {
+        return
+      }
+      const provider = ACTIVE_PROVIDERS[idx - 1]
+      e.preventDefault()
+      window.dispatchEvent(
+        new CustomEvent('iii:open-provider', { detail: provider }),
+      )
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
+
+  return (
+    <main className="flex-1 overflow-y-auto" aria-label="configuration">
+      <div className="mx-auto max-w-3xl px-6 py-10">
+        <header className="pb-2">
+          <h1 className="font-mono text-[20px] text-ink lowercase tracking-[-0.01em]">
+            configuration
+          </h1>
+        </header>
+
+        <Section
+          title="appearance"
+          description="theme preference, stored per browser."
+        >
+          <Row
+            label="theme"
+            control={
+              <ModeToggle<Theme>
+                value={theme}
+                onChange={onThemeChange}
+                variant="radio"
+                aria-label="theme"
+                options={[
+                  { value: 'light', label: 'light' },
+                  { value: 'dark', label: 'dark' },
+                ]}
+              />
+            }
+          />
+        </Section>
+
+        <Section
+          title="providers"
+          description="api keys and runtime overrides."
+        >
+          {showZeroConfig ? (
+            <div
+              role="status"
+              aria-live="polite"
+              className="py-4 border-b border-rule"
+            >
+              <p className="font-mono text-[13px] text-ink">
+                <span className="text-accent" aria-hidden>
+                  ·
+                </span>{' '}
+                no api keys configured yet
+              </p>
+              <p className="font-mono text-[11px] text-ink-faint mt-1">
+                open any provider below to add a key. local providers
+                (lmstudio, llamacpp) don't need one.
+              </p>
+            </div>
+          ) : null}
+          {/* Legend renders BEFORE the rows so operators meet the
+              vocabulary (`[stored]`, `[env]`, `[local]`) before they
+              encounter the badges that use it. Lifted to `text-[12px]
+              text-ink` (from earlier `text-ink-faint`) so it reads as
+              instruction, not annotation — H6 critiques flagged the
+              ink-faint version as visually skipped.
+              The legend itself is where badge vocabulary is taught; the
+              keyboard shortcut hint shares the same block. Section
+              description (above) intentionally short ("api keys and
+              runtime overrides"); security/provenance details live in
+              the dialog where the operator is actually entering the
+              key, not as permanent header prose. */}
+          <div className="font-mono text-[12px] text-ink py-3 border-b border-rule space-y-1">
+            <p>
+              <span className="text-accent">[stored]</span> set here ·{' '}
+              <span className="text-ink">[env-var]</span> from environment
+              variable (takes precedence) ·{' '}
+              <span className="text-ink-ghost">[local]</span> no key needed
+              ·{' '}
+              <span className="text-ink">[overridden]</span> routes via
+              custom endpoint or max-tokens cap
+            </p>
+            <p className="text-ink-faint">
+              keyboard shortcuts: ↑↓ navigate rows · press 1–
+              {ACTIVE_PROVIDERS.length} to open a provider directly
+            </p>
+          </div>
+          {ACTIVE_PROVIDERS.map((id, idx) => (
+            <ProviderRow
+              key={id}
+              id={id}
+              envVar={ENV_VAR_BY_ID.get(id) ?? ''}
+              index={idx}
+            />
+          ))}
+        </Section>
+      </div>
+    </main>
+  )
+}
+
+/* ---------------------------------------------------------------------- */
+/*  Section + Row primitives                                              */
+/* ---------------------------------------------------------------------- */
+
+interface SectionProps {
+  title: string
+  description?: string
+  children: React.ReactNode
+}
+
+/**
+ * Settings-page section: a small heading + optional one-liner + a
+ * vertically-stacked list of rows underneath, joined by a thin top rule.
+ * The rule above the list visually anchors the heading to its content
+ * without the heavier "h1 + border" treatment used for the page header.
+ */
+function Section({ title, description, children }: SectionProps) {
+  return (
+    <section className="mt-10">
+      <h2 className="font-mono text-[12px] text-ink lowercase tracking-[0.06em] mb-1">
+        {title}
+      </h2>
+      {description ? (
+        <p className="font-mono text-[11px] text-ink-faint mb-3">
+          {description}
+        </p>
+      ) : null}
+      <div className="border-t border-rule">{children}</div>
+    </section>
+  )
+}
+
+interface RowProps {
+  label: string
+  control: React.ReactNode
+  meta?: React.ReactNode
+}
+
+/**
+ * Generic settings-page row. Mirrors the layout `ProviderRow` already
+ * uses (label on the left, optional meta in the middle, control on the
+ * right) so the appearance section and provider section read as one
+ * consistent settings document instead of two different idioms.
+ */
+function Row({ label, control, meta }: RowProps) {
+  return (
+    <div className="flex items-center gap-4 py-3 border-b border-rule last:border-b-0">
+      <span className="font-mono text-[13px] text-ink w-24 shrink-0 truncate">
+        {label}
+      </span>
+      <span className="flex-1 min-w-0 font-mono text-[11px] text-ink-faint truncate">
+        {meta}
+      </span>
+      <span className="shrink-0">{control}</span>
+    </div>
+  )
+}

--- a/harness/docs/storage.md
+++ b/harness/docs/storage.md
@@ -1,0 +1,74 @@
+# Harness storage
+
+Shared configuration for harness workers that persist data through the
+engine [`database`](https://github.com/iii-ai/iii/tree/main/workers/database)
+worker.
+
+## Purpose
+
+Several harness workers (`auth-credentials`, `provider-config`, and any
+future SQL-backed store) talk to the same logical SQLite pool via
+`database::query` and `database::execute`. Instead of repeating
+`database_name` in every worker section, operators can set it once under
+a top-level `storage:` block in [config.yaml](harness/config.yaml).
+
+## Configuration
+
+```yaml
+storage:
+  database_name: harness   # shared default for every DbStore consumer
+
+# optional per-worker override (highest precedence)
+auth_credentials:
+  database_name: harness_secrets
+```
+
+### Precedence
+
+When a worker resolves its pool name, this order applies:
+
+1. Worker section `database_name` (e.g. `auth_credentials.database_name`)
+2. Shared `storage.database_name`
+3. `"harness"` (built-in default)
+
+Existing configs that only set `auth_credentials.database_name` or
+`provider_config.database_name` keep working unchanged.
+
+## Mapping to the engine database worker
+
+The harness `database_name` is a **logical pool key**. It must match a
+key in the engine `database` worker's `databases:` map, which defines
+the actual connection URL (for example `sqlite:~/.iii/harness.db`).
+
+```yaml
+# engine database worker config (not harness config.yaml)
+databases:
+  harness:
+    url: sqlite:~/.iii/harness.db
+```
+
+Harness workers never open SQLite directly; they always route through
+the bus.
+
+## Adding a new DbStore consumer
+
+1. Add a table-backed store (or wrap `DbStore<T>`) in your worker.
+2. In `register.ts`, load config once with `loadConfig`, then construct
+   the store with `createDbStore`:
+
+```ts
+import { createDbStore } from '../runtime/database-store.js';
+
+const cfg = await loadConfig(ctx.configPath);
+const store = createDbStore<MyPayload>(iii, cfg, {
+  workerSection: 'my_worker',   // optional; omit to use only storage.database_name
+  tableName: 'my_worker_table',
+});
+await store.init();
+```
+
+3. Document any worker-specific overrides in your worker's doc page and
+   link back here for the shared `storage:` block.
+
+See [src/runtime/storage-config.ts](harness/src/runtime/storage-config.ts)
+and [src/runtime/database-store.ts](harness/src/runtime/database-store.ts).

--- a/harness/docs/workers/auth-credentials.md
+++ b/harness/docs/workers/auth-credentials.md
@@ -4,34 +4,34 @@ Multi-provider credential store on the iii bus (`auth::*`).
 
 ## Purpose
 
-Centralised storage for provider credentials — API keys and OAuth tokens
-— used by the provider workers (`provider-anthropic`, `provider-openai`)
-to authenticate outbound calls. Stored credentials live in a single JSON
-file at `~/.iii/auth-credentials.json` (path configurable). All mutations
-serialize through an in-process write queue and use atomic `tmp` +
-`rename` writes.
+Centralised storage for provider credentials -- API keys and OAuth tokens
+-- used by the provider workers (`provider-anthropic`, `provider-openai`,
+etc.) to authenticate outbound calls. Persistence is delegated to the
+[`database`](https://github.com/iii-ai/iii/tree/main/workers/database)
+worker; a single SQLite file (default `~/.iii/harness.db`) backs both
+`auth-credentials` and its sibling `provider-config`.
 
 `auth::get_token` is the resolver every consumer calls. It first looks up
 a stored credential; if none, it falls back to the per-provider
 environment variable defined in
 [src/auth-credentials/types.ts](harness/src/auth-credentials/types.ts)
-(`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `AWS_ACCESS_KEY_ID`,
-`HF_TOKEN`, etc.) and synthesises an `ApiKey` credential. `auth::status`
-reports `{ configured, source: "stored" | "environment", label }` without
+(`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `AWS_ACCESS_KEY_ID`, `HF_TOKEN`,
+etc.) and synthesises an `ApiKey` credential. `auth::status` reports
+`{ configured, source: "stored" | "environment", label }` without
 returning the secret material itself.
 
-[iii-permissions.yaml](iii-permissions.yaml) denies
-`auth::set_token` and `auth::delete_token` to in-run agents (kernel
-rules). `auth::get_token`, `auth::list_providers`, and `auth::status` are
-on the bare-string allow list.
+[iii-permissions.yaml](iii-permissions.yaml) denies `auth::set_token` and
+`auth::delete_token` to in-run agents (kernel rules). `auth::get_token`,
+`auth::list_providers`, and `auth::status` are on the bare-string allow
+list.
 
 ## Registered functions
 
-- `auth::get_token` — Fetch the stored credential for a provider.
-- `auth::set_token` — Persist a credential for a provider.
-- `auth::delete_token` — Remove the stored credential for a provider.
-- `auth::list_providers` — List every provider with a stored credential.
-- `auth::status` — Report stored vs. env credential status for a provider.
+- `auth::get_token` -- Fetch the stored credential for a provider.
+- `auth::set_token` -- Persist a credential for a provider.
+- `auth::delete_token` -- Remove the stored credential for a provider.
+- `auth::list_providers` -- List every provider with a stored credential.
+- `auth::status` -- Report stored vs. env credential status for a provider.
 
 ## Triggers
 
@@ -39,34 +39,50 @@ None.
 
 ## On-disk layout
 
-| Path | Format |
-|---|---|
-| `~/.iii/auth-credentials.json` (configurable) | `{ "<provider>": <Credential>, … }` with `<Credential>` being either `{ type: "api_key", key }` or `{ type: "oauth", access_token, refresh_token?, expires_at?, scopes?, provider_extra? }`. File mode 0600, parent dir 0700. |
+Backed by `database::query` / `database::execute` against the
+`auth_credentials` table:
+
+| Table | Columns | Purpose |
+|---|---|---|
+| `auth_credentials` | `provider TEXT PRIMARY KEY, payload TEXT NOT NULL, updated_at INTEGER NOT NULL` | One row per provider; `payload` is a `Credential` value serialized as JSON -- either `{ type: "api_key", key }` or `{ type: "oauth", access_token, refresh_token?, expires_at?, scopes?, provider_extra? }`. |
+
+Mutations use `INSERT ... ON CONFLICT(provider) DO UPDATE`, so each
+`set` / `delete` is atomic at the SQL layer.
 
 ## Configuration
 
-From the `auth_credentials` section of
-[config.yaml](harness/config.yaml):
+Shared pool name resolution is documented in
+[storage.md](../storage.md). From [config.yaml](harness/config.yaml):
 
-- `store_path` (default `~/.iii/auth-credentials.json`) — leading `~/` is
-  expanded against the OS home directory.
+```yaml
+storage:
+  database_name: harness   # default for auth-credentials and provider-config
+
+auth_credentials:
+  database_name: harness   # optional override (wins over storage.database_name)
+```
+
+- `storage.database_name` (default `harness`) -- shared logical pool for
+  every harness `DbStore` consumer.
+- `auth_credentials.database_name` (optional) -- per-worker override;
+  must match a key in the engine `database` worker's `databases:` map.
 
 ## Dependencies
 
-From
-[src/auth-credentials/iii.worker.yaml](harness/src/auth-credentials/iii.worker.yaml):
-no explicit dependency block; the worker only touches the local
-filesystem and the process environment.
+The `database` worker must be on the bus -- every read/write routes
+through `database::query` / `database::execute`. See
+[src/auth-credentials/iii.worker.yaml](harness/src/auth-credentials/iii.worker.yaml).
 
 ## Source layout
 
 | File | Purpose |
 |---|---|
 | [src/auth-credentials/main.ts](harness/src/auth-credentials/main.ts) | Binary entry point (`iii-auth-credentials`). |
-| [src/auth-credentials/register.ts](harness/src/auth-credentials/register.ts) | Composes the five handlers around a single `FileStore`. |
+| [src/auth-credentials/register.ts](harness/src/auth-credentials/register.ts) | Composes the five handlers around a `DbCredentialStore`; runs the JSON-import migration. |
 | [src/auth-credentials/config.ts](harness/src/auth-credentials/config.ts) | Loads the `auth_credentials` section. |
 | [src/auth-credentials/types.ts](harness/src/auth-credentials/types.ts) | `Credential`, `AuthStatus`, `AuthSource`, `EnvKeyMatch`, and the `ENV_VAR_MAP` per-provider env table. |
-| [src/auth-credentials/store.ts](harness/src/auth-credentials/store.ts) | `CredentialStore` interface + `InMemoryStore` + `FileStore` (atomic tmp+rename, in-process queue). |
+| [src/auth-credentials/store.ts](harness/src/auth-credentials/store.ts) | `CredentialStore` interface + `InMemoryStore` + `DbCredentialStore` (wraps the shared `DbStore<Credential>`). |
+| [src/runtime/database-store.ts](harness/src/runtime/database-store.ts) | Shared SQL-backed key-value store used by both `auth-credentials` and `provider-config`. |
 | [src/auth-credentials/resolve.ts](harness/src/auth-credentials/resolve.ts) | Pure `resolveCredential` / `statusFor` / `findEnvKeys` helpers. |
 | [src/auth-credentials/handlers/get-token.ts](harness/src/auth-credentials/handlers/get-token.ts) | `auth::get_token` handler. |
 | [src/auth-credentials/handlers/set-token.ts](harness/src/auth-credentials/handlers/set-token.ts) | `auth::set_token` handler. |

--- a/harness/docs/workers/provider-config.md
+++ b/harness/docs/workers/provider-config.md
@@ -1,0 +1,90 @@
+# provider-config
+
+Runtime provider settings store on the iii bus (`provider_config::*`).
+
+## Purpose
+
+Centralised storage for non-secret provider overrides -- base URL and max
+tokens -- that the five active provider workers read at completion time.
+Stored entries live in a single JSON file at
+`~/.iii/provider-config.json` (path configurable). All mutations serialize
+through an in-process write queue and use atomic `tmp` + `rename` writes.
+
+`provider_config::get` returns the overrides for a single provider (empty
+object when none are stored). Provider workers call this in parallel with
+`auth::get_token` so a runtime override takes precedence over the
+`config.yaml` value without requiring a restart.
+
+[iii-permissions.yaml](iii-permissions.yaml) denies
+`provider_config::set` and `provider_config::clear` to in-run agents
+(kernel rules). `provider_config::get` and `provider_config::list` are on
+the bare-string allow list.
+
+## Registered functions
+
+- `provider_config::get` -- Fetch runtime overrides for a provider.
+- `provider_config::set` -- Set runtime overrides for a provider.
+- `provider_config::clear` -- Remove runtime overrides for a provider.
+- `provider_config::list` -- List all providers with runtime overrides.
+
+## Triggers
+
+None.
+
+## On-disk layout
+
+Persistence is delegated to the [`database`](https://github.com/iii-ai/iii/tree/main/workers/database)
+worker via `database::query` / `database::execute`. A single SQLite file
+(default `~/.iii/harness.db`, configurable in the engine's `database`
+worker config) backs both `provider-config` and its sibling
+`auth-credentials`. Each worker owns one table.
+
+| Table | Columns | Purpose |
+|---|---|---|
+| `provider_config` | `provider TEXT PRIMARY KEY, payload TEXT NOT NULL, updated_at INTEGER NOT NULL` | One row per provider; `payload` is `{ "default_api_url"?: string, "default_max_tokens"?: number }` serialized as JSON. |
+
+Mutations use `INSERT ... ON CONFLICT(provider) DO UPDATE`, so a single
+`set` is atomic at the SQL layer. Partial-update (merge) semantics are
+preserved inside the worker via an in-process write queue around a
+read-modify-upsert sequence -- callers can still patch one field at a
+time without clobbering the rest of a row.
+
+## Configuration
+
+Shared pool name resolution is documented in
+[storage.md](../storage.md). From [config.yaml](harness/config.yaml):
+
+```yaml
+storage:
+  database_name: harness   # default for auth-credentials and provider-config
+
+provider_config:
+  database_name: harness   # optional override (wins over storage.database_name)
+```
+
+- `storage.database_name` (default `harness`) -- shared logical pool for
+  every harness `DbStore` consumer.
+- `provider_config.database_name` (optional) -- per-worker override;
+  must match a key in the engine `database` worker's `databases:` map.
+
+## Dependencies
+
+The `database` worker must be on the bus -- this worker calls
+`database::query` and `database::execute` on every read/write. See
+[src/provider-config/iii.worker.yaml](harness/src/provider-config/iii.worker.yaml).
+
+## Source layout
+
+| File | Purpose |
+|---|---|
+| [src/provider-config/main.ts](harness/src/provider-config/main.ts) | Binary entry point (`iii-provider-config`). |
+| [src/provider-config/register.ts](harness/src/provider-config/register.ts) | Composes the four handlers around a `DbOverridesStore`; runs the JSON-import migration. |
+| [src/provider-config/config.ts](harness/src/provider-config/config.ts) | Loads the `provider_config` section. |
+| [src/provider-config/types.ts](harness/src/provider-config/types.ts) | `ProviderOverrides` type definition. |
+| [src/provider-config/store.ts](harness/src/provider-config/store.ts) | `OverridesStore` interface + `InMemoryStore` + `DbOverridesStore` (wraps the shared `DbStore<ProviderOverrides>`). |
+| [src/runtime/database-store.ts](harness/src/runtime/database-store.ts) | Shared SQL-backed key-value store used by both `provider-config` and `auth-credentials`. |
+| [src/provider-config/handlers/get.ts](harness/src/provider-config/handlers/get.ts) | `provider_config::get` handler. |
+| [src/provider-config/handlers/set.ts](harness/src/provider-config/handlers/set.ts) | `provider_config::set` handler. |
+| [src/provider-config/handlers/clear.ts](harness/src/provider-config/handlers/clear.ts) | `provider_config::clear` handler. |
+| [src/provider-config/handlers/list.ts](harness/src/provider-config/handlers/list.ts) | `provider_config::list` handler. |
+| [src/provider-config/iii.worker.yaml](harness/src/provider-config/iii.worker.yaml) | Worker manifest. |

--- a/harness/package.json
+++ b/harness/package.json
@@ -33,7 +33,8 @@
     "dev:provider-openai": "tsx src/provider-openai/main.ts",
     "dev:provider-kimi": "tsx src/provider-kimi/main.ts",
     "dev:provider-lmstudio": "tsx src/provider-lmstudio/main.ts",
-    "dev:context-compaction": "tsx src/context-compaction/main.ts"
+    "dev:context-compaction": "tsx src/context-compaction/main.ts",
+    "dev:provider-config": "tsx src/provider-config/main.ts"
   },
   "bin": {
     "harness": "./dist/index.js",
@@ -49,7 +50,8 @@
     "iii-provider-openai": "./dist/provider-openai/main.js",
     "iii-provider-kimi": "./dist/provider-kimi/main.js",
     "iii-provider-lmstudio": "./dist/provider-lmstudio/main.js",
-    "iii-context-compaction": "./dist/context-compaction/main.js"
+    "iii-context-compaction": "./dist/context-compaction/main.js",
+    "iii-provider-config": "./dist/provider-config/main.js"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/harness/src/auth-credentials/register.ts
+++ b/harness/src/auth-credentials/register.ts
@@ -6,12 +6,13 @@ import { register as registerGet } from './handlers/get-token.js';
 import { register as registerList } from './handlers/list-providers.js';
 import { register as registerSet } from './handlers/set-token.js';
 import { register as registerStatus } from './handlers/status.js';
-import { FileStore } from './store.js';
+import { DbCredentialStore } from './store.js';
 
 export async function register(iii: ISdk, ctx: { configPath: string }): Promise<void> {
   const cfg = await loadConfig(ctx.configPath);
   const auth = loadAuthCredentialsConfig(cfg);
-  const store = new FileStore(auth.store_path);
+  const store = new DbCredentialStore(iii, { databaseName: auth.database_name });
+  await store.init();
   registerGet(iii, store);
   registerSet(iii, store);
   registerDelete(iii, store);

--- a/harness/src/auth-credentials/store.ts
+++ b/harness/src/auth-credentials/store.ts
@@ -3,22 +3,22 @@
  *
  * Two implementations:
  *
- * 1. `InMemoryStore` — used in tests and for local-only sessions.
- * 2. `FileStore` — JSON file at `~/.iii/auth-credentials.json` (path
- *    configurable). All mutations serialize through a single in-process
- *    promise queue so concurrent set/clear calls don't clobber each other.
- *    Atomic write via `tmp` + `rename`.
+ * 1. `InMemoryStore` -- used in tests and for local-only sessions.
+ * 2. `DbCredentialStore` -- SQL-backed. Wraps the shared `DbStore<Credential>`
+ *    (see `../runtime/database-store.ts`) which routes through the
+ *    `database::*` worker.
  *
- * The Rust crate uses iii-state CAS for multi-process safety. The Node
- * port is single-process by default — operators can run a single
- * `auth-credentials` worker that all other workers query via
- * `auth::get_token`.
+ * Multi-process posture is unchanged: a single `auth-credentials` worker
+ * owns the `auth_credentials` table; concurrent writes from inside the
+ * harness composite are atomic at the SQL UPSERT level.
  */
 
-import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
-import { dirname, resolve as resolvePath } from 'node:path';
+import { DbStore, type DbStoreOptions } from '../runtime/database-store.js';
+import type { ISdk } from '../runtime/iii.js';
 import type { Credential } from './types.js';
+
+/** Table that backs `DbCredentialStore`. */
+export const CREDENTIALS_TABLE = 'auth_credentials';
 
 export interface CredentialStore {
   get(provider: string): Promise<Credential | null>;
@@ -43,76 +43,40 @@ export class InMemoryStore implements CredentialStore {
   }
 }
 
-/** Resolve `~` in a path. */
-export function expandHome(p: string): string {
-  if (p.startsWith('~/')) return resolvePath(homedir(), p.slice(2));
-  if (p === '~') return homedir();
-  return resolvePath(p);
-}
+/**
+ * SQL-backed credential store. Construct, then `await init()` before
+ * serving any bus traffic so the underlying table exists.
+ */
+export class DbCredentialStore implements CredentialStore {
+  private readonly inner: DbStore<Credential>;
 
-export class FileStore implements CredentialStore {
-  private readonly path: string;
-  private writeChain: Promise<void> = Promise.resolve();
-
-  constructor(path: string) {
-    this.path = expandHome(path);
-  }
-
-  async get(provider: string): Promise<Credential | null> {
-    const map = await this.read();
-    return map[provider] ?? null;
-  }
-
-  async list(): Promise<Array<readonly [string, Credential]>> {
-    const map = await this.read();
-    return Object.entries(map).map(([k, v]) => [k, v] as const);
-  }
-
-  async set(provider: string, credential: Credential): Promise<void> {
-    await this.queue(async () => {
-      const map = await this.read();
-      map[provider] = credential;
-      await this.write(map);
+  constructor(iii: ISdk, opts: Pick<DbStoreOptions, 'databaseName'>) {
+    this.inner = new DbStore<Credential>(iii, {
+      databaseName: opts.databaseName,
+      tableName: CREDENTIALS_TABLE,
     });
   }
 
-  async clear(provider: string): Promise<void> {
-    await this.queue(async () => {
-      const map = await this.read();
-      if (provider in map) {
-        delete map[provider];
-        await this.write(map);
-      }
-    });
+  /** Idempotent -- safe to call on every worker startup. */
+  async init(): Promise<void> {
+    await this.inner.init();
   }
 
-  private queue<T>(op: () => Promise<T>): Promise<T> {
-    const next = this.writeChain.then(() => op());
-    this.writeChain = next.then(
-      () => undefined,
-      () => undefined,
-    );
-    return next;
+  /** Expose the underlying DbStore so the JSON-import migration can target it. */
+  unwrap(): DbStore<Credential> {
+    return this.inner;
   }
 
-  private async read(): Promise<Record<string, Credential>> {
-    try {
-      const text = await readFile(this.path, 'utf8');
-      const parsed = JSON.parse(text);
-      if (parsed && typeof parsed === 'object') {
-        return parsed as Record<string, Credential>;
-      }
-      return {};
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return {};
-      throw err;
-    }
+  get(provider: string): Promise<Credential | null> {
+    return this.inner.get(provider);
   }
-
-  private async write(map: Record<string, Credential>): Promise<void> {
-    await mkdir(dirname(this.path), { recursive: true, mode: 0o700 });
-    const tmp = `${this.path}.tmp-${process.pid}-${Date.now()}`;
-    await writeFile(tmp, `${JSON.stringify(map, null, 2)}\n`, { mode: 0o600 });
-    await rename(tmp, this.path);
+  set(provider: string, credential: Credential): Promise<void> {
+    return this.inner.set(provider, credential);
+  }
+  clear(provider: string): Promise<void> {
+    return this.inner.clear(provider);
+  }
+  list(): Promise<Array<readonly [string, Credential]>> {
+    return this.inner.list();
   }
 }

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -18,6 +18,7 @@ import { register as registerModelsCatalog } from './models-catalog/register.js'
 import { register as registerProviderAnthropic } from './provider-anthropic/register.js';
 import { register as registerProviderKimi } from './provider-kimi/register.js';
 import { register as registerProviderLlamacpp } from './provider-llamacpp/register.js';
+import { register as registerProviderConfig } from './provider-config/register.js';
 import { register as registerProviderLmstudio } from './provider-lmstudio/register.js';
 import { register as registerProviderOpenai } from './provider-openai/register.js';
 import { logger } from './runtime/otel.js';
@@ -67,6 +68,12 @@ const WORKERS: readonly WorkerDefinition[] = [
     name: 'auth-credentials',
     description: 'Credential store for provider API keys and OAuth tokens (auth::*).',
     register: (iii, ctx) => registerAuthCredentials(iii, ctx),
+  },
+  {
+    name: 'provider-config',
+    description:
+      'Runtime non-secret provider overrides on the iii bus (provider_config::*). Sibling to auth-credentials.',
+    register: (iii, ctx) => registerProviderConfig(iii, ctx),
   },
   {
     name: 'models-catalog',

--- a/harness/src/provider-anthropic/auth.ts
+++ b/harness/src/provider-anthropic/auth.ts
@@ -1,9 +1,11 @@
 /**
- * Bridge to `auth::get_token`. The provider asks the auth worker for a
- * resolved Credential, then turns it into an AnthropicConfig.
+ * Bridge to `auth::get_token` and `provider_config::get`. The provider
+ * asks the auth worker for a resolved Credential and the provider-config
+ * worker for runtime overrides, then turns them into an AnthropicConfig.
  */
 
 import type { Credential } from '../auth-credentials/types.js';
+import { fetchOverrides } from '../runtime/fetch-overrides.js';
 import type { ISdk } from '../runtime/iii.js';
 import type { WorkerConfig } from './config.js';
 import { type AnthropicConfig, configWithCredential } from './types.js';
@@ -25,6 +27,11 @@ export async function buildConfig(
   worker: WorkerConfig,
   model: string,
 ): Promise<AnthropicConfig> {
-  const cred = await fetchCredential(iii);
-  return configWithCredential(model, cred, worker.default_max_tokens, worker.default_api_url);
+  const [cred, overrides] = await Promise.all([
+    fetchCredential(iii),
+    fetchOverrides(iii, 'anthropic'),
+  ]);
+  const apiUrl = overrides.default_api_url ?? worker.default_api_url;
+  const maxTokens = overrides.default_max_tokens ?? worker.default_max_tokens;
+  return configWithCredential(model, cred, maxTokens, apiUrl);
 }

--- a/harness/src/provider-config/config.ts
+++ b/harness/src/provider-config/config.ts
@@ -1,13 +1,13 @@
 import { getSection } from '../runtime/config.js';
 import { loadStorageConfig, resolveDatabaseName } from '../runtime/storage-config.js';
 
-export type AuthCredentialsConfig = {
+export type ProviderConfigConfig = {
   /** Logical database pool name to use (must match a key in iii-database's `databases:` map). */
   database_name: string;
 };
 
-export function loadAuthCredentialsConfig(cfg: Record<string, unknown>): AuthCredentialsConfig {
-  const section = getSection(cfg, 'auth_credentials');
+export function loadProviderConfigConfig(cfg: Record<string, unknown>): ProviderConfigConfig {
+  const section = getSection(cfg, 'provider_config');
   const storage = loadStorageConfig(cfg);
   return {
     database_name: resolveDatabaseName(section, storage),

--- a/harness/src/provider-config/handlers/clear.ts
+++ b/harness/src/provider-config/handlers/clear.ts
@@ -1,0 +1,16 @@
+import { requireString } from '../../runtime/handler.js';
+import type { ISdk } from '../../runtime/iii.js';
+import type { OverridesStore } from '../store.js';
+
+export function register(iii: ISdk, store: OverridesStore): void {
+  iii.registerFunction(
+    'provider_config::clear',
+    async (payload: unknown) => {
+      const obj = (payload ?? {}) as Record<string, unknown>;
+      const provider = requireString(obj, 'provider');
+      await store.clear(provider);
+      return { ok: true };
+    },
+    { description: 'Remove runtime overrides for a provider.' },
+  );
+}

--- a/harness/src/provider-config/handlers/get.ts
+++ b/harness/src/provider-config/handlers/get.ts
@@ -1,0 +1,16 @@
+import { requireString } from '../../runtime/handler.js';
+import type { ISdk } from '../../runtime/iii.js';
+import type { OverridesStore } from '../store.js';
+
+export function register(iii: ISdk, store: OverridesStore): void {
+  iii.registerFunction(
+    'provider_config::get',
+    async (payload: unknown) => {
+      const obj = (payload ?? {}) as Record<string, unknown>;
+      const provider = requireString(obj, 'provider');
+      const overrides = await store.get(provider);
+      return overrides ?? {};
+    },
+    { description: 'Fetch runtime overrides for a provider.' },
+  );
+}

--- a/harness/src/provider-config/handlers/list.ts
+++ b/harness/src/provider-config/handlers/list.ts
@@ -1,0 +1,15 @@
+import type { ISdk } from '../../runtime/iii.js';
+import type { OverridesStore } from '../store.js';
+
+export function register(iii: ISdk, store: OverridesStore): void {
+  iii.registerFunction(
+    'provider_config::list',
+    async () => {
+      const entries = await store.list();
+      return {
+        entries: entries.map(([provider, overrides]) => ({ provider, overrides })),
+      };
+    },
+    { description: 'List all providers with runtime overrides.' },
+  );
+}

--- a/harness/src/provider-config/handlers/set.ts
+++ b/harness/src/provider-config/handlers/set.ts
@@ -1,0 +1,69 @@
+import { requireString } from '../../runtime/handler.js';
+import type { ISdk } from '../../runtime/iii.js';
+import type { OverridesStore } from '../store.js';
+import type { ProviderOverrides } from '../types.js';
+
+const MAX_TOKENS_LIMIT = 1_048_576;
+
+function validateUrl(raw: unknown): string {
+  if (typeof raw !== 'string' || raw.length === 0) {
+    throw new Error('default_api_url must be a non-empty string');
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error(`default_api_url is not a valid URL: ${raw}`);
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`default_api_url must use http or https scheme, got: ${parsed.protocol}`);
+  }
+  // Parity with normalizeChatCompletionsUrl: reject empty-hostname URLs like
+  // `http:///path`. Without this, set() accepts URLs that the normaliser
+  // later rejects, producing inconsistent failure modes.
+  if (parsed.hostname.length === 0) {
+    throw new Error('default_api_url must include a hostname');
+  }
+  return raw;
+}
+
+function validateMaxTokens(raw: unknown): number {
+  if (typeof raw !== 'number' || !Number.isInteger(raw)) {
+    throw new Error('default_max_tokens must be an integer');
+  }
+  if (raw <= 0) {
+    throw new Error('default_max_tokens must be a positive integer');
+  }
+  if (raw > MAX_TOKENS_LIMIT) {
+    throw new Error(`default_max_tokens must be <= ${MAX_TOKENS_LIMIT}`);
+  }
+  return raw;
+}
+
+export function register(iii: ISdk, store: OverridesStore): void {
+  iii.registerFunction(
+    'provider_config::set',
+    async (payload: unknown) => {
+      const obj = (payload ?? {}) as Record<string, unknown>;
+      const provider = requireString(obj, 'provider');
+
+      const hasUrl = obj.default_api_url !== undefined;
+      const hasMaxTokens = obj.default_max_tokens !== undefined;
+      if (!hasUrl && !hasMaxTokens) {
+        throw new Error('at least one of default_api_url or default_max_tokens must be provided');
+      }
+
+      const overrides: ProviderOverrides = {};
+      if (hasUrl) {
+        overrides.default_api_url = validateUrl(obj.default_api_url);
+      }
+      if (hasMaxTokens) {
+        overrides.default_max_tokens = validateMaxTokens(obj.default_max_tokens);
+      }
+
+      await store.set(provider, overrides);
+      return { ok: true };
+    },
+    { description: 'Set runtime overrides for a provider.' },
+  );
+}

--- a/harness/src/provider-config/iii.worker.yaml
+++ b/harness/src/provider-config/iii.worker.yaml
@@ -1,0 +1,14 @@
+iii: v1
+name: provider-config
+language: node
+deploy: binary
+manifest: package.json
+bin: iii-provider-config
+description: Runtime provider settings store on the iii bus (provider_config::*).
+
+runtime:
+  kind: node
+
+scripts:
+  install: pnpm install
+  start: node ./dist/provider-config/main.js --config ./config.yaml

--- a/harness/src/provider-config/main.ts
+++ b/harness/src/provider-config/main.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import { bootstrapWorker } from '../runtime/worker.js';
+import { register } from './register.js';
+
+await bootstrapWorker({
+  name: 'provider-config',
+  description: 'Runtime provider settings store on the iii bus (provider_config::*).',
+  register: (iii, ctx) => register(iii, ctx),
+});

--- a/harness/src/provider-config/register.ts
+++ b/harness/src/provider-config/register.ts
@@ -1,0 +1,19 @@
+import { loadConfig } from '../runtime/config.js';
+import type { ISdk } from '../runtime/iii.js';
+import { loadProviderConfigConfig } from './config.js';
+import { register as registerClear } from './handlers/clear.js';
+import { register as registerGet } from './handlers/get.js';
+import { register as registerList } from './handlers/list.js';
+import { register as registerSet } from './handlers/set.js';
+import { DbOverridesStore } from './store.js';
+
+export async function register(iii: ISdk, ctx: { configPath: string }): Promise<void> {
+  const cfg = await loadConfig(ctx.configPath);
+  const providerCfg = loadProviderConfigConfig(cfg);
+  const store = new DbOverridesStore(iii, { databaseName: providerCfg.database_name });
+  await store.init();
+  registerGet(iii, store);
+  registerSet(iii, store);
+  registerClear(iii, store);
+  registerList(iii, store);
+}

--- a/harness/src/provider-config/store.ts
+++ b/harness/src/provider-config/store.ts
@@ -1,0 +1,92 @@
+/**
+ * Provider overrides store backends.
+ *
+ * Two implementations:
+ *
+ * 1. `InMemoryStore` -- used in tests and for local-only sessions.
+ * 2. `DbOverridesStore` -- SQL-backed via the shared `DbStore<ProviderOverrides>`
+ *    (see `../runtime/database-store.ts`).
+ *
+ * `set()` preserves the legacy merge semantic -- partial overrides patch
+ * existing overrides for the same provider rather than replacing them. The
+ * merge happens in-process inside the underlying `DbStore.update`, which
+ * serializes through a queue and does a single SQL UPSERT per call.
+ */
+
+import { DbStore, type DbStoreOptions } from '../runtime/database-store.js';
+import type { ISdk } from '../runtime/iii.js';
+import type { ProviderOverrides } from './types.js';
+
+/** Table that backs `DbOverridesStore`. */
+export const PROVIDER_CONFIG_TABLE = 'provider_config';
+
+export interface OverridesStore {
+  get(provider: string): Promise<ProviderOverrides | null>;
+  set(provider: string, overrides: ProviderOverrides): Promise<void>;
+  clear(provider: string): Promise<void>;
+  list(): Promise<Array<readonly [string, ProviderOverrides]>>;
+}
+
+export class InMemoryStore implements OverridesStore {
+  private readonly store = new Map<string, ProviderOverrides>();
+  async get(provider: string): Promise<ProviderOverrides | null> {
+    return this.store.get(provider) ?? null;
+  }
+  async set(provider: string, overrides: ProviderOverrides): Promise<void> {
+    const existing = this.store.get(provider) ?? {};
+    this.store.set(provider, { ...existing, ...overrides });
+  }
+  async clear(provider: string): Promise<void> {
+    this.store.delete(provider);
+  }
+  async list(): Promise<Array<readonly [string, ProviderOverrides]>> {
+    return [...this.store.entries()];
+  }
+}
+
+/**
+ * SQL-backed overrides store. Construct, then `await init()` before
+ * serving any bus traffic so the underlying table exists.
+ */
+export class DbOverridesStore implements OverridesStore {
+  private readonly inner: DbStore<ProviderOverrides>;
+
+  constructor(iii: ISdk, opts: Pick<DbStoreOptions, 'databaseName'>) {
+    this.inner = new DbStore<ProviderOverrides>(iii, {
+      databaseName: opts.databaseName,
+      tableName: PROVIDER_CONFIG_TABLE,
+    });
+  }
+
+  /** Idempotent -- safe to call on every worker startup. */
+  async init(): Promise<void> {
+    await this.inner.init();
+  }
+
+  /** Expose the underlying DbStore so the JSON-import migration can target it. */
+  unwrap(): DbStore<ProviderOverrides> {
+    return this.inner;
+  }
+
+  get(provider: string): Promise<ProviderOverrides | null> {
+    return this.inner.get(provider);
+  }
+
+  /**
+   * Shallow-merge overrides into the existing row. Mirrors the legacy
+   * FileStore which did `{ ...existing, ...overrides }` so callers can
+   * patch one field (e.g. only `default_api_url`) without clobbering the
+   * rest.
+   */
+  set(provider: string, overrides: ProviderOverrides): Promise<void> {
+    return this.inner.update(provider, overrides);
+  }
+
+  clear(provider: string): Promise<void> {
+    return this.inner.clear(provider);
+  }
+
+  list(): Promise<Array<readonly [string, ProviderOverrides]>> {
+    return this.inner.list();
+  }
+}

--- a/harness/src/provider-config/types.ts
+++ b/harness/src/provider-config/types.ts
@@ -1,0 +1,10 @@
+/**
+ * Runtime provider overrides. Non-secret settings (base URL, max tokens)
+ * that can be changed at runtime without restarting the harness. The
+ * secret counterpart (API keys) lives in `auth-credentials`.
+ */
+
+export type ProviderOverrides = {
+  default_api_url?: string;
+  default_max_tokens?: number;
+};

--- a/harness/src/provider-kimi/auth.ts
+++ b/harness/src/provider-kimi/auth.ts
@@ -30,10 +30,7 @@ export async function buildConfig(
   worker: WorkerConfig,
   model: string,
 ): Promise<ChatCompletionsConfig> {
-  const [cred, overrides] = await Promise.all([
-    fetchCredential(iii),
-    fetchOverrides(iii, 'kimi'),
-  ]);
+  const [cred, overrides] = await Promise.all([fetchCredential(iii), fetchOverrides(iii, 'kimi')]);
   const apiUrl = overrides.default_api_url ?? worker.default_api_url;
   const maxTokens = overrides.default_max_tokens ?? worker.default_max_tokens;
   return configFromCredential(apiUrl, 'kimi', model, cred, maxTokens);

--- a/harness/src/provider-kimi/auth.ts
+++ b/harness/src/provider-kimi/auth.ts
@@ -1,11 +1,12 @@
 import type { Credential } from '../auth-credentials/types.js';
+import { fetchOverrides } from '../runtime/fetch-overrides.js';
 import type { ISdk } from '../runtime/iii.js';
 import type { WorkerConfig } from './config.js';
 import { type ChatCompletionsConfig, configFromCredential } from './types.js';
 
 // Look up the credential under `kimi-coding`. The compiled Rust
 // auth-credentials worker (the live handler on most engines today) maps
-// `kimi-coding → MOONSHOT_API_KEY` but does not know the bare `kimi` slug
+// `kimi-coding -> MOONSHOT_API_KEY` but does not know the bare `kimi` slug
 // our node port added. `kimi-coding` is the portable slug; the user-facing
 // provider name on the AssistantMessage stays `kimi` (see buildConfig).
 const CREDENTIAL_PROVIDER_SLUG = 'kimi-coding';
@@ -29,12 +30,11 @@ export async function buildConfig(
   worker: WorkerConfig,
   model: string,
 ): Promise<ChatCompletionsConfig> {
-  const cred = await fetchCredential(iii);
-  return configFromCredential(
-    worker.default_api_url,
-    'kimi',
-    model,
-    cred,
-    worker.default_max_tokens,
-  );
+  const [cred, overrides] = await Promise.all([
+    fetchCredential(iii),
+    fetchOverrides(iii, 'kimi'),
+  ]);
+  const apiUrl = overrides.default_api_url ?? worker.default_api_url;
+  const maxTokens = overrides.default_max_tokens ?? worker.default_max_tokens;
+  return configFromCredential(apiUrl, 'kimi', model, cred, maxTokens);
 }

--- a/harness/src/provider-llamacpp/auth.ts
+++ b/harness/src/provider-llamacpp/auth.ts
@@ -1,6 +1,8 @@
 import { logger } from '../runtime/otel.js';
 import type { Credential } from '../auth-credentials/types.js';
+import { fetchOverrides } from '../runtime/fetch-overrides.js';
 import type { ISdk } from '../runtime/iii.js';
+import { normalizeChatCompletionsUrl } from '../runtime/openai-compat-url.js';
 import type { WorkerConfig } from './config.js';
 import { type ChatCompletionsConfig, configFromCredential } from './types.js';
 
@@ -94,16 +96,27 @@ export async function buildConfig(
   worker: WorkerConfig,
   model: string,
 ): Promise<ChatCompletionsConfig> {
-  const cred = await fetchCredential(iii);
+  const [cred, overrides] = await Promise.all([
+    fetchCredential(iii),
+    fetchOverrides(iii, 'llamacpp'),
+  ]);
+  // Normalise the override URL so a base-URL save from the Providers UI
+  // (e.g. `http://host:8080`) gets `/v1/chat/completions` appended.
+  // worker.default_api_url is already normalised in resolveApiUrl.
+  const overrideUrl = overrides.default_api_url
+    ? normalizeChatCompletionsUrl(overrides.default_api_url)
+    : null;
+  const apiUrl = overrideUrl ?? worker.default_api_url;
+  const maxTokens = overrides.default_max_tokens ?? worker.default_max_tokens;
   // Pass the credential through verbatim so configFromCredential can
   // populate api_key (empty string when no credential). Header emission
   // is gated separately in buildAuthHeaders/the stream layer.
   return configFromCredential(
-    worker.default_api_url,
+    apiUrl,
     'llamacpp',
     model,
     extractKey(cred).length > 0 ? cred : null,
-    worker.default_max_tokens,
+    maxTokens,
   );
 }
 

--- a/harness/src/provider-lmstudio/auth.ts
+++ b/harness/src/provider-lmstudio/auth.ts
@@ -1,6 +1,8 @@
 import { logger } from '../runtime/otel.js';
 import type { Credential } from '../auth-credentials/types.js';
+import { fetchOverrides } from '../runtime/fetch-overrides.js';
 import type { ISdk } from '../runtime/iii.js';
+import { normalizeChatCompletionsUrl } from '../runtime/openai-compat-url.js';
 import type { WorkerConfig } from './config.js';
 import { type ChatCompletionsConfig, configFromCredential } from './types.js';
 
@@ -103,8 +105,19 @@ export async function buildConfig(
   worker: WorkerConfig,
   model: string,
 ): Promise<ChatCompletionsConfig> {
-  const cred = await fetchCredential(iii);
-  const key = selectAuthKey(cred, worker.default_api_url);
+  const [cred, overrides] = await Promise.all([
+    fetchCredential(iii),
+    fetchOverrides(iii, 'lmstudio'),
+  ]);
+  // Normalise the override URL so a base-URL save from the Providers UI
+  // (e.g. `http://host:1234`) gets `/v1/chat/completions` appended.
+  // worker.default_api_url is already normalised in resolveApiUrl.
+  const overrideUrl = overrides.default_api_url
+    ? normalizeChatCompletionsUrl(overrides.default_api_url)
+    : null;
+  const apiUrl = overrideUrl ?? worker.default_api_url;
+  const maxTokens = overrides.default_max_tokens ?? worker.default_max_tokens;
+  const key = selectAuthKey(cred, apiUrl);
   // configFromCredential expects a Credential. When no key is
   // available we still pass a synthetic api_key with the LM Studio
   // fallback string so the downstream interface stays uniform; the
@@ -117,13 +130,7 @@ export async function buildConfig(
         ? (cred as Credential)
         : { type: 'api_key', key }
       : { type: 'api_key', key: FALLBACK_API_KEY };
-  return configFromCredential(
-    worker.default_api_url,
-    'lmstudio',
-    model,
-    effective,
-    worker.default_max_tokens,
-  );
+  return configFromCredential(apiUrl, 'lmstudio', model, effective, maxTokens);
 }
 
 /**

--- a/harness/src/provider-openai/auth.ts
+++ b/harness/src/provider-openai/auth.ts
@@ -1,4 +1,5 @@
 import type { Credential } from '../auth-credentials/types.js';
+import { fetchOverrides } from '../runtime/fetch-overrides.js';
 import type { ISdk } from '../runtime/iii.js';
 import type { WorkerConfig } from './config.js';
 import { type ChatCompletionsConfig, configFromCredential } from './types.js';
@@ -20,12 +21,11 @@ export async function buildConfig(
   worker: WorkerConfig,
   model: string,
 ): Promise<ChatCompletionsConfig> {
-  const cred = await fetchCredential(iii);
-  return configFromCredential(
-    worker.default_api_url,
-    'openai',
-    model,
-    cred,
-    worker.default_max_tokens,
-  );
+  const [cred, overrides] = await Promise.all([
+    fetchCredential(iii),
+    fetchOverrides(iii, 'openai'),
+  ]);
+  const apiUrl = overrides.default_api_url ?? worker.default_api_url;
+  const maxTokens = overrides.default_max_tokens ?? worker.default_max_tokens;
+  return configFromCredential(apiUrl, 'openai', model, cred, maxTokens);
 }

--- a/harness/src/runtime/database-store.ts
+++ b/harness/src/runtime/database-store.ts
@@ -1,0 +1,231 @@
+/**
+ * SQL-backed per-provider key-value store. Backs both `auth-credentials`
+ * and `provider-config`: same shape (provider → JSON payload), same
+ * lifecycle, same on-bus call pattern via `database::query` and
+ * `database::execute`.
+ *
+ * Each store owns one table:
+ *
+ *   CREATE TABLE IF NOT EXISTS <name> (
+ *     provider   TEXT    PRIMARY KEY,
+ *     payload    TEXT    NOT NULL,    -- JSON
+ *     updated_at INTEGER NOT NULL     -- ms epoch
+ *   )
+ *
+ * Mutations use `INSERT ... ON CONFLICT(provider) DO UPDATE`, so a single
+ * `set(provider, value)` is atomic at the SQL layer — no read-modify-write
+ * race between concurrent callers.
+ *
+ * For callers that need merge-not-replace semantics (provider-config), the
+ * merge happens at the JS layer inside an in-process write queue. Same
+ * "single-process by default" guarantee the old FileStore had, with
+ * read/write IO replaced by SQL round-trips.
+ */
+
+import { getSection } from './config.js';
+import type { ISdk } from './iii.js';
+import { logger } from './otel.js';
+import { loadStorageConfig, resolveDatabaseName } from './storage-config.js';
+
+/** Shape of `database::query` response we care about. */
+interface QueryResp<TRow = Record<string, unknown>> {
+  rows: TRow[];
+  row_count: number;
+}
+
+/** Shape of `database::execute` response we care about. */
+interface ExecuteResp {
+  affected_rows: number;
+  last_insert_id: string | null;
+}
+
+/** Per-call timeout for talking to the database worker. */
+const DB_TIMEOUT_MS = 5_000;
+
+export interface DbStoreOptions {
+  /** Logical database name as configured in `iii-database` (matches the key in its `databases:` map). */
+  databaseName: string;
+  /** Table name for this store. Created on first `init()` call. */
+  tableName: string;
+}
+
+export interface CreateDbStoreOptions {
+  /** Top-level config section key for this worker (e.g. `auth_credentials`). When omitted, only `storage.database_name` applies. */
+  workerSection?: string;
+  /** Table name for this store. Created on first `init()` call. */
+  tableName: string;
+}
+
+/**
+ * Construct a `DbStore` from an already-loaded harness config. Resolves
+ * `database_name` via the shared storage helper so new workers opt in
+ * without re-plumbing config.
+ */
+export function createDbStore<T>(
+  iii: ISdk,
+  cfg: Record<string, unknown>,
+  opts: CreateDbStoreOptions,
+): DbStore<T> {
+  const storage = loadStorageConfig(cfg);
+  const workerSection = opts.workerSection ? getSection(cfg, opts.workerSection) : {};
+  const databaseName = resolveDatabaseName(workerSection, storage);
+  return new DbStore<T>(iii, { databaseName, tableName: opts.tableName });
+}
+
+/**
+ * Generic per-provider JSON store, backed by `database::*`.
+ *
+ * `T` is the JSON payload type — anything that round-trips through
+ * `JSON.stringify` / `JSON.parse`. The store never inspects the payload.
+ */
+export class DbStore<T> {
+  private readonly iii: ISdk;
+  private readonly db: string;
+  private readonly table: string;
+  private writeChain: Promise<void> = Promise.resolve();
+  private initialized = false;
+
+  constructor(iii: ISdk, opts: DbStoreOptions) {
+    // Defense-in-depth: table name is interpolated into SQL (SQLite has no
+    // parameter binding for identifiers). Callers today pass compile-time
+    // constants; this guard ensures a future caller can't accidentally
+    // open a SQL-injection surface.
+    if (!/^[a-z_][a-z0-9_]*$/i.test(opts.tableName)) {
+      throw new Error(`invalid table name: ${opts.tableName}`);
+    }
+    this.iii = iii;
+    this.db = opts.databaseName;
+    this.table = opts.tableName;
+  }
+
+  /** Create the table if it doesn't exist. Idempotent. */
+  async init(): Promise<void> {
+    if (this.initialized) return;
+    await this.execute(
+      `CREATE TABLE IF NOT EXISTS ${this.table} (
+         provider   TEXT    PRIMARY KEY,
+         payload    TEXT    NOT NULL,
+         updated_at INTEGER NOT NULL
+       )`,
+    );
+    this.initialized = true;
+  }
+
+  async get(provider: string): Promise<T | null> {
+    const { rows } = await this.query<{ payload: string }>(
+      `SELECT payload FROM ${this.table} WHERE provider = ? LIMIT 1`,
+      [provider],
+    );
+    if (rows.length === 0) return null;
+    return parseJsonOrNull<T>(rows[0]?.payload, { table: this.table, provider });
+  }
+
+  async list(): Promise<Array<readonly [string, T]>> {
+    const { rows } = await this.query<{ provider: string; payload: string }>(
+      `SELECT provider, payload FROM ${this.table} ORDER BY provider`,
+    );
+    const out: Array<readonly [string, T]> = [];
+    for (const row of rows) {
+      const parsed = parseJsonOrNull<T>(row.payload, {
+        table: this.table,
+        provider: row.provider,
+      });
+      if (parsed !== null) out.push([row.provider, parsed] as const);
+    }
+    return out;
+  }
+
+  /**
+   * Replace the entire payload for a provider. Atomic at the SQL layer.
+   * For merge-not-replace semantics, use `update()`.
+   */
+  async set(provider: string, value: T): Promise<void> {
+    const now = Date.now();
+    await this.execute(
+      `INSERT INTO ${this.table} (provider, payload, updated_at) VALUES (?, ?, ?)
+       ON CONFLICT(provider) DO UPDATE SET
+         payload = excluded.payload,
+         updated_at = excluded.updated_at`,
+      [provider, JSON.stringify(value), now],
+    );
+  }
+
+  /**
+   * Shallow-merge `patch` into the existing payload for `provider`. Reads
+   * the current row, merges in JS, then writes the result back. Serialized
+   * through an in-process write queue so concurrent updates within this
+   * Node process don't clobber each other. Multi-process safety relies on
+   * "one harness composite owns the table" — same posture as the old
+   * FileStore.
+   */
+  async update(provider: string, patch: Partial<T>): Promise<void> {
+    await this.queue(async () => {
+      const existing = (await this.get(provider)) ?? ({} as T);
+      const merged = { ...existing, ...patch } as T;
+      await this.set(provider, merged);
+    });
+  }
+
+  async clear(provider: string): Promise<void> {
+    await this.execute(`DELETE FROM ${this.table} WHERE provider = ?`, [provider]);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internals
+  // ---------------------------------------------------------------------------
+
+  private queue<R>(op: () => Promise<R>): Promise<R> {
+    const next = this.writeChain.then(() => op());
+    this.writeChain = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    return next;
+  }
+
+  private async query<TRow>(sql: string, params: unknown[] = []): Promise<QueryResp<TRow>> {
+    const result = await this.iii.trigger<unknown, QueryResp<TRow>>({
+      function_id: 'database::query',
+      payload: { db: this.db, sql, params },
+      timeoutMs: DB_TIMEOUT_MS,
+    });
+    if (!result || typeof result !== 'object' || !Array.isArray((result as QueryResp).rows)) {
+      throw new Error(`database::query returned unexpected shape for table=${this.table}`);
+    }
+    return result;
+  }
+
+  private async execute(sql: string, params: unknown[] = []): Promise<ExecuteResp> {
+    const result = await this.iii.trigger<unknown, ExecuteResp>({
+      function_id: 'database::execute',
+      payload: { db: this.db, sql, params },
+      timeoutMs: DB_TIMEOUT_MS,
+    });
+    if (!result || typeof result !== 'object') {
+      throw new Error(`database::execute returned unexpected shape for table=${this.table}`);
+    }
+    return result;
+  }
+}
+
+function parseJsonOrNull<T>(
+  text: string | undefined | null,
+  ctx: { table: string; provider?: string },
+): T | null {
+  if (typeof text !== 'string') return null;
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed && typeof parsed === 'object') return parsed as T;
+    logger.warn('DbStore: non-object payload, treating as missing', {
+      ...ctx,
+      kind: parsed === null ? 'null' : typeof parsed,
+    });
+    return null;
+  } catch (err) {
+    logger.warn('DbStore: corrupt JSON payload, treating as missing', {
+      ...ctx,
+      err: String(err),
+    });
+    return null;
+  }
+}

--- a/harness/src/runtime/fetch-overrides.ts
+++ b/harness/src/runtime/fetch-overrides.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared bridge to `provider_config::get`. Each provider's `buildConfig`
+ * uses this to layer runtime overrides on top of its config.yaml defaults.
+ *
+ * Lives in `runtime/` rather than `provider-config/` so the dependency arrow
+ * runs provider → runtime, not provider → sibling worker.
+ *
+ * Errors are swallowed by design: a missing or down provider-config worker
+ * means "no overrides", not "fail the chat request".
+ */
+
+import type { ProviderOverrides } from '../provider-config/types.js';
+import type { ISdk } from './iii.js';
+
+const FETCH_OVERRIDES_TIMEOUT_MS = 2_000;
+
+export async function fetchOverrides(iii: ISdk, provider: string): Promise<ProviderOverrides> {
+  try {
+    const result = await iii.trigger<unknown, ProviderOverrides | null>({
+      function_id: 'provider_config::get',
+      payload: { provider },
+      timeoutMs: FETCH_OVERRIDES_TIMEOUT_MS,
+    });
+    return result && typeof result === 'object' ? result : {};
+  } catch {
+    return {};
+  }
+}

--- a/harness/src/runtime/openai-compat-url.ts
+++ b/harness/src/runtime/openai-compat-url.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared URL normalisation for OpenAI-compatible local-server providers
+ * (lmstudio, llamacpp). Both providers accept a base URL (`host:port`)
+ * or a full chat-completions URL; we always POST to
+ * `/v1/chat/completions`, so a missing path here means the request
+ * lands on the server root and llama-server / LM Studio return 404.
+ *
+ * `resolveApiUrl` in each provider's `config.ts` historically applied
+ * this auto-append only to the `*_BASE_URL` env var path -- the
+ * config.yaml `default_api_url` was assumed to already be fully
+ * qualified, and the runtime override stored under
+ * `provider_config::set` was used verbatim. That left a sharp edge:
+ * users who saved a base URL (e.g. `http://192.168.1.206:8080`) from
+ * the Providers UI got 404s on every request. This helper closes the
+ * gap so the override path normalises the same way as the env-var
+ * path.
+ */
+
+/** Return `raw` with `/v1/chat/completions` appended if missing, or `null` if `raw` is not a usable http(s) URL. */
+export function normalizeChatCompletionsUrl(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  // Reject inputs that don't have a usable origin before we go appending
+  // a path -- `new URL("http://")` parses but with hostname "", which
+  // would then concat into the absurd `http://v1/chat/completions`.
+  let base: URL;
+  try {
+    base = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  if (base.protocol !== 'http:' && base.protocol !== 'https:') return null;
+  if (base.hostname.length === 0) return null;
+
+  // Work in URL space — string concatenation on the raw input mishandles
+  // query-string-only inputs. `http://host?foo=bar` would otherwise become
+  // `http://host?foo=bar/v1/chat/completions`, with the path segment buried
+  // inside the query string and every request hitting the server root.
+  const pathNoTrailing = base.pathname.replace(/\/+$/, '');
+  if (pathNoTrailing.endsWith('/chat/completions')) {
+    base.pathname = pathNoTrailing;
+  } else {
+    base.pathname = `${pathNoTrailing}/v1/chat/completions`;
+  }
+  return base.toString();
+}

--- a/harness/src/runtime/storage-config.ts
+++ b/harness/src/runtime/storage-config.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared harness storage configuration. Every worker that talks to
+ * `database::*` resolves its logical pool name through this helper so
+ * operators can set `storage.database_name` once in config.yaml.
+ */
+
+import { getSection, getString } from './config.js';
+
+export const DEFAULT_DATABASE_NAME = 'harness';
+
+export type StorageConfig = {
+  /** Logical database pool name (must match a key in the engine `database` worker's `databases:` map). */
+  database_name: string;
+};
+
+/** Read the top-level `storage:` section from an already-loaded config object. */
+export function loadStorageConfig(cfg: Record<string, unknown>): StorageConfig {
+  const section = getSection(cfg, 'storage');
+  return {
+    database_name: getString(section, 'database_name', DEFAULT_DATABASE_NAME),
+  };
+}
+
+/**
+ * Resolve the effective database pool name for a worker.
+ *
+ * Precedence: worker section `database_name` > `storage.database_name` > `"harness"`.
+ */
+export function resolveDatabaseName(
+  workerSection: Record<string, unknown>,
+  storage: StorageConfig,
+): string {
+  const workerOverride = optionalString(workerSection, 'database_name');
+  if (workerOverride) return workerOverride;
+  return storage.database_name;
+}
+
+function optionalString(cfg: Record<string, unknown>, key: string): string | undefined {
+  const v = cfg[key];
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}

--- a/harness/tests/auth-credentials/store.test.ts
+++ b/harness/tests/auth-credentials/store.test.ts
@@ -1,8 +1,8 @@
-import { mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { afterAll, describe, expect, it } from 'vitest';
-import { FileStore, InMemoryStore } from '../../src/auth-credentials/store.js';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { loadAuthCredentialsConfig } from '../../src/auth-credentials/config.js';
+import { CREDENTIALS_TABLE, DbCredentialStore, InMemoryStore } from '../../src/auth-credentials/store.js';
+import { createDbStore } from '../../src/runtime/database-store.js';
+import { FakeDatabaseSdk } from '../runtime/fake-database-sdk.js';
 
 describe('InMemoryStore', () => {
   it('round-trips set/get/clear/list', async () => {
@@ -16,39 +16,64 @@ describe('InMemoryStore', () => {
   });
 });
 
-describe('FileStore', () => {
-  let dir: string;
-  let path: string;
-  const setUp = async () => {
-    dir = await mkdtemp(join(tmpdir(), 'auth-creds-'));
-    path = join(dir, 'creds.json');
-    return new FileStore(path);
-  };
-  afterAll(async () => {
-    if (dir) await rm(dir, { recursive: true, force: true });
+describe('DbCredentialStore', () => {
+  let fake: FakeDatabaseSdk;
+  let store: DbCredentialStore;
+
+  beforeEach(async () => {
+    fake = new FakeDatabaseSdk();
+    store = new DbCredentialStore(fake.asSdk(), { databaseName: 'harness' });
+    await store.init();
   });
 
-  it('reads as empty when file missing', async () => {
-    const s = await setUp();
-    expect(await s.get('anthropic')).toBeNull();
-    expect(await s.list()).toEqual([]);
+  it('writes into the auth_credentials table', async () => {
+    await store.set('openai', { type: 'api_key', key: 'sk-op' });
+    expect(fake.table(CREDENTIALS_TABLE)?.size).toBe(1);
   });
 
-  it('persists set across instances', async () => {
-    const s = await setUp();
-    await s.set('openai', { type: 'api_key', key: 'sk-op' });
-    const s2 = new FileStore(path);
-    expect(await s2.get('openai')).toEqual({ type: 'api_key', key: 'sk-op' });
+  it('persists set across new wrapper instances on the same fake', async () => {
+    await store.set('openai', { type: 'api_key', key: 'sk-op' });
+    const store2 = new DbCredentialStore(fake.asSdk(), { databaseName: 'harness' });
+    await store2.init();
+    expect(await store2.get('openai')).toEqual({ type: 'api_key', key: 'sk-op' });
   });
 
-  it('serializes concurrent sets without losing entries', async () => {
-    const s = await setUp();
+  it('replace semantics on repeated set (no merge)', async () => {
+    await store.set('anthropic', { type: 'api_key', key: 'first' });
+    await store.set('anthropic', { type: 'api_key', key: 'second' });
+    expect(await store.get('anthropic')).toEqual({ type: 'api_key', key: 'second' });
+  });
+
+  it('concurrent sets are independent UPSERTs (no lost rows)', async () => {
     await Promise.all([
-      s.set('a', { type: 'api_key', key: '1' }),
-      s.set('b', { type: 'api_key', key: '2' }),
-      s.set('c', { type: 'api_key', key: '3' }),
+      store.set('a', { type: 'api_key', key: '1' }),
+      store.set('b', { type: 'api_key', key: '2' }),
+      store.set('c', { type: 'api_key', key: '3' }),
     ]);
-    const list = await s.list();
-    expect(list.length).toBe(3);
+    expect((await store.list()).length).toBe(3);
+  });
+
+  it('clear removes only the target row', async () => {
+    await store.set('a', { type: 'api_key', key: '1' });
+    await store.set('b', { type: 'api_key', key: '2' });
+    await store.clear('a');
+    expect(await store.get('a')).toBeNull();
+    expect(await store.get('b')).toEqual({ type: 'api_key', key: '2' });
+  });
+
+  it('resolves database_name from shared storage when worker section has no override', async () => {
+    const cfg = { storage: { database_name: 'shared-pool' } };
+    expect(loadAuthCredentialsConfig(cfg).database_name).toBe('shared-pool');
+
+    const sharedFake = new FakeDatabaseSdk();
+    const sharedStore = createDbStore<{ type: 'api_key'; key: string }>(sharedFake.asSdk(), cfg, {
+      workerSection: 'auth_credentials',
+      tableName: CREDENTIALS_TABLE,
+    });
+    await sharedStore.init();
+    await sharedStore.set('openai', { type: 'api_key', key: 'sk-op' });
+    for (const call of sharedFake.calls) {
+      expect((call.payload as { db: string }).db).toBe('shared-pool');
+    }
   });
 });

--- a/harness/tests/auth-credentials/store.test.ts
+++ b/harness/tests/auth-credentials/store.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { loadAuthCredentialsConfig } from '../../src/auth-credentials/config.js';
-import { CREDENTIALS_TABLE, DbCredentialStore, InMemoryStore } from '../../src/auth-credentials/store.js';
+import {
+  CREDENTIALS_TABLE,
+  DbCredentialStore,
+  InMemoryStore,
+} from '../../src/auth-credentials/store.js';
 import { createDbStore } from '../../src/runtime/database-store.js';
 import { FakeDatabaseSdk } from '../runtime/fake-database-sdk.js';
 

--- a/harness/tests/provider-config/handlers.test.ts
+++ b/harness/tests/provider-config/handlers.test.ts
@@ -96,9 +96,9 @@ describe('provider_config::set', () => {
 
   it('rejects invalid URL: not a URL', async () => {
     const { set } = setupAll();
-    await expect(
-      set({ provider: 'anthropic', default_api_url: 'not-a-url' }),
-    ).rejects.toThrow(/not a valid URL/);
+    await expect(set({ provider: 'anthropic', default_api_url: 'not-a-url' })).rejects.toThrow(
+      /not a valid URL/,
+    );
   });
 
   it('rejects invalid URL: wrong scheme', async () => {
@@ -110,37 +110,37 @@ describe('provider_config::set', () => {
 
   it('rejects empty URL string', async () => {
     const { set } = setupAll();
-    await expect(
-      set({ provider: 'anthropic', default_api_url: '' }),
-    ).rejects.toThrow(/non-empty string/);
+    await expect(set({ provider: 'anthropic', default_api_url: '' })).rejects.toThrow(
+      /non-empty string/,
+    );
   });
 
   it('rejects non-integer max_tokens', async () => {
     const { set } = setupAll();
-    await expect(
-      set({ provider: 'anthropic', default_max_tokens: 1.5 }),
-    ).rejects.toThrow(/integer/);
+    await expect(set({ provider: 'anthropic', default_max_tokens: 1.5 })).rejects.toThrow(
+      /integer/,
+    );
   });
 
   it('rejects negative max_tokens', async () => {
     const { set } = setupAll();
-    await expect(
-      set({ provider: 'anthropic', default_max_tokens: -1 }),
-    ).rejects.toThrow(/positive integer/);
+    await expect(set({ provider: 'anthropic', default_max_tokens: -1 })).rejects.toThrow(
+      /positive integer/,
+    );
   });
 
   it('rejects zero max_tokens', async () => {
     const { set } = setupAll();
-    await expect(
-      set({ provider: 'anthropic', default_max_tokens: 0 }),
-    ).rejects.toThrow(/positive integer/);
+    await expect(set({ provider: 'anthropic', default_max_tokens: 0 })).rejects.toThrow(
+      /positive integer/,
+    );
   });
 
   it('rejects max_tokens exceeding the limit', async () => {
     const { set } = setupAll();
-    await expect(
-      set({ provider: 'anthropic', default_max_tokens: 1_048_577 }),
-    ).rejects.toThrow(/<=/);
+    await expect(set({ provider: 'anthropic', default_max_tokens: 1_048_577 })).rejects.toThrow(
+      /<=/,
+    );
   });
 
   it('accepts max_tokens exactly at the limit', async () => {

--- a/harness/tests/provider-config/handlers.test.ts
+++ b/harness/tests/provider-config/handlers.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi } from 'vitest';
+import { register as registerClear } from '../../src/provider-config/handlers/clear.js';
+import { register as registerGet } from '../../src/provider-config/handlers/get.js';
+import { register as registerList } from '../../src/provider-config/handlers/list.js';
+import { register as registerSet } from '../../src/provider-config/handlers/set.js';
+import { InMemoryStore } from '../../src/provider-config/store.js';
+import type { ISdk } from '../../src/runtime/iii.js';
+
+type Handler = (payload: unknown) => Promise<unknown>;
+
+function makeSdk(): { iii: ISdk; handlers: Map<string, Handler> } {
+  const handlers = new Map<string, Handler>();
+  const iii = {
+    registerFunction: vi.fn((fnId: string, handler: Handler) => {
+      handlers.set(fnId, handler);
+    }),
+    trigger: vi.fn(),
+  } as unknown as ISdk;
+  return { iii, handlers };
+}
+
+function setupAll() {
+  const store = new InMemoryStore();
+  const { iii, handlers } = makeSdk();
+  registerGet(iii, store);
+  registerSet(iii, store);
+  registerClear(iii, store);
+  registerList(iii, store);
+  return {
+    store,
+    get: (payload: unknown) => handlers.get('provider_config::get')!(payload),
+    set: (payload: unknown) => handlers.get('provider_config::set')!(payload),
+    clear: (payload: unknown) => handlers.get('provider_config::clear')!(payload),
+    list: (payload?: unknown) => handlers.get('provider_config::list')!(payload),
+  };
+}
+
+describe('provider_config::get', () => {
+  it('returns stored overrides', async () => {
+    const { store, get } = setupAll();
+    await store.set('anthropic', {
+      default_api_url: 'https://api.anthropic.com/v1/messages',
+      default_max_tokens: 4096,
+    });
+    expect(await get({ provider: 'anthropic' })).toEqual({
+      default_api_url: 'https://api.anthropic.com/v1/messages',
+      default_max_tokens: 4096,
+    });
+  });
+
+  it('returns {} for unknown provider', async () => {
+    const { get } = setupAll();
+    expect(await get({ provider: 'nope' })).toEqual({});
+  });
+
+  it('throws when provider is missing', async () => {
+    const { get } = setupAll();
+    await expect(get({})).rejects.toThrow();
+  });
+});
+
+describe('provider_config::set', () => {
+  it('persists default_api_url alone', async () => {
+    const { store, set } = setupAll();
+    await set({ provider: 'anthropic', default_api_url: 'https://x/v1' });
+    expect(await store.get('anthropic')).toEqual({ default_api_url: 'https://x/v1' });
+  });
+
+  it('persists default_max_tokens alone', async () => {
+    const { store, set } = setupAll();
+    await set({ provider: 'openai', default_max_tokens: 4096 });
+    expect(await store.get('openai')).toEqual({ default_max_tokens: 4096 });
+  });
+
+  it('merges partial updates with existing entry', async () => {
+    const { store, set } = setupAll();
+    await set({ provider: 'anthropic', default_api_url: 'https://x/v1' });
+    await set({ provider: 'anthropic', default_max_tokens: 4096 });
+    expect(await store.get('anthropic')).toEqual({
+      default_api_url: 'https://x/v1',
+      default_max_tokens: 4096,
+    });
+  });
+
+  it('returns { ok: true }', async () => {
+    const { set } = setupAll();
+    expect(await set({ provider: 'anthropic', default_max_tokens: 4096 })).toEqual({ ok: true });
+  });
+
+  it('rejects when neither field is provided', async () => {
+    const { set } = setupAll();
+    await expect(set({ provider: 'anthropic' })).rejects.toThrow(
+      /at least one of default_api_url or default_max_tokens/,
+    );
+  });
+
+  it('rejects invalid URL: not a URL', async () => {
+    const { set } = setupAll();
+    await expect(
+      set({ provider: 'anthropic', default_api_url: 'not-a-url' }),
+    ).rejects.toThrow(/not a valid URL/);
+  });
+
+  it('rejects invalid URL: wrong scheme', async () => {
+    const { set } = setupAll();
+    await expect(
+      set({ provider: 'anthropic', default_api_url: 'ftp://example.com' }),
+    ).rejects.toThrow(/http or https/);
+  });
+
+  it('rejects empty URL string', async () => {
+    const { set } = setupAll();
+    await expect(
+      set({ provider: 'anthropic', default_api_url: '' }),
+    ).rejects.toThrow(/non-empty string/);
+  });
+
+  it('rejects non-integer max_tokens', async () => {
+    const { set } = setupAll();
+    await expect(
+      set({ provider: 'anthropic', default_max_tokens: 1.5 }),
+    ).rejects.toThrow(/integer/);
+  });
+
+  it('rejects negative max_tokens', async () => {
+    const { set } = setupAll();
+    await expect(
+      set({ provider: 'anthropic', default_max_tokens: -1 }),
+    ).rejects.toThrow(/positive integer/);
+  });
+
+  it('rejects zero max_tokens', async () => {
+    const { set } = setupAll();
+    await expect(
+      set({ provider: 'anthropic', default_max_tokens: 0 }),
+    ).rejects.toThrow(/positive integer/);
+  });
+
+  it('rejects max_tokens exceeding the limit', async () => {
+    const { set } = setupAll();
+    await expect(
+      set({ provider: 'anthropic', default_max_tokens: 1_048_577 }),
+    ).rejects.toThrow(/<=/);
+  });
+
+  it('accepts max_tokens exactly at the limit', async () => {
+    const { store, set } = setupAll();
+    await set({ provider: 'anthropic', default_max_tokens: 1_048_576 });
+    expect(await store.get('anthropic')).toEqual({ default_max_tokens: 1_048_576 });
+  });
+
+  it('throws when provider is missing', async () => {
+    const { set } = setupAll();
+    await expect(set({ default_max_tokens: 1 })).rejects.toThrow();
+  });
+});
+
+describe('provider_config::clear', () => {
+  it('removes the entry and leaves others intact', async () => {
+    const { store, clear } = setupAll();
+    await store.set('a', { default_max_tokens: 1 });
+    await store.set('b', { default_max_tokens: 2 });
+    await clear({ provider: 'a' });
+    expect(await store.get('a')).toBeNull();
+    expect(await store.get('b')).toEqual({ default_max_tokens: 2 });
+  });
+
+  it('is idempotent for unknown providers', async () => {
+    const { clear } = setupAll();
+    await expect(clear({ provider: 'nope' })).resolves.toEqual({ ok: true });
+  });
+
+  it('throws when provider is missing', async () => {
+    const { clear } = setupAll();
+    await expect(clear({})).rejects.toThrow();
+  });
+});
+
+describe('provider_config::list', () => {
+  it('returns all entries as { provider, overrides } pairs', async () => {
+    const { store, list } = setupAll();
+    await store.set('a', { default_max_tokens: 1 });
+    await store.set('b', { default_api_url: 'https://b/v1' });
+    const result = (await list()) as { entries: Array<{ provider: string; overrides: unknown }> };
+    expect(result.entries.length).toBe(2);
+    const byProvider = Object.fromEntries(result.entries.map((e) => [e.provider, e.overrides]));
+    expect(byProvider.a).toEqual({ default_max_tokens: 1 });
+    expect(byProvider.b).toEqual({ default_api_url: 'https://b/v1' });
+  });
+
+  it('returns an empty list when nothing is stored', async () => {
+    const { list } = setupAll();
+    expect(await list()).toEqual({ entries: [] });
+  });
+});

--- a/harness/tests/provider-config/store.test.ts
+++ b/harness/tests/provider-config/store.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { loadProviderConfigConfig } from '../../src/provider-config/config.js';
+import {
+  DbOverridesStore,
+  InMemoryStore,
+  PROVIDER_CONFIG_TABLE,
+} from '../../src/provider-config/store.js';
+import { createDbStore } from '../../src/runtime/database-store.js';
+import { FakeDatabaseSdk } from '../runtime/fake-database-sdk.js';
+
+describe('InMemoryStore (provider-config)', () => {
+  it('round-trips set/get/clear/list', async () => {
+    const s = new InMemoryStore();
+    await s.set('anthropic', { default_api_url: 'https://x/v1', default_max_tokens: 100 });
+    expect(await s.get('anthropic')).toEqual({
+      default_api_url: 'https://x/v1',
+      default_max_tokens: 100,
+    });
+    await s.set('openai', { default_max_tokens: 4096 });
+    expect((await s.list()).length).toBe(2);
+    await s.clear('anthropic');
+    expect(await s.get('anthropic')).toBeNull();
+    expect((await s.list()).length).toBe(1);
+  });
+
+  it('returns null for an unknown provider', async () => {
+    const s = new InMemoryStore();
+    expect(await s.get('unknown')).toBeNull();
+  });
+});
+
+describe('DbOverridesStore', () => {
+  let fake: FakeDatabaseSdk;
+  let store: DbOverridesStore;
+
+  beforeEach(async () => {
+    fake = new FakeDatabaseSdk();
+    store = new DbOverridesStore(fake.asSdk(), { databaseName: 'harness' });
+    await store.init();
+  });
+
+  it('writes into the provider_config table', async () => {
+    await store.set('openai', { default_max_tokens: 4096 });
+    expect(fake.table(PROVIDER_CONFIG_TABLE)?.size).toBe(1);
+  });
+
+  it('reads as empty before any writes', async () => {
+    expect(await store.get('anthropic')).toBeNull();
+    expect(await store.list()).toEqual([]);
+  });
+
+  it('persists set across new wrapper instances on the same fake', async () => {
+    await store.set('openai', { default_api_url: 'https://example.com/v1', default_max_tokens: 4096 });
+    const store2 = new DbOverridesStore(fake.asSdk(), { databaseName: 'harness' });
+    await store2.init();
+    expect(await store2.get('openai')).toEqual({
+      default_api_url: 'https://example.com/v1',
+      default_max_tokens: 4096,
+    });
+  });
+
+  it('merges partial updates into an existing entry (set is merge, not replace)', async () => {
+    await store.set('anthropic', {
+      default_api_url: 'https://api.anthropic.com/v1/messages',
+      default_max_tokens: 8192,
+    });
+    await store.set('anthropic', { default_max_tokens: 4096 });
+    expect(await store.get('anthropic')).toEqual({
+      default_api_url: 'https://api.anthropic.com/v1/messages',
+      default_max_tokens: 4096,
+    });
+  });
+
+  it('serializes concurrent sets without losing entries', async () => {
+    await Promise.all([
+      store.set('a', { default_max_tokens: 1 }),
+      store.set('b', { default_max_tokens: 2 }),
+      store.set('c', { default_max_tokens: 3 }),
+    ]);
+    const list = await store.list();
+    expect(list.length).toBe(3);
+    const byProvider = Object.fromEntries(list);
+    expect(byProvider.a?.default_max_tokens).toBe(1);
+    expect(byProvider.b?.default_max_tokens).toBe(2);
+    expect(byProvider.c?.default_max_tokens).toBe(3);
+  });
+
+  it('clear leaves other entries intact', async () => {
+    await store.set('a', { default_max_tokens: 1 });
+    await store.set('b', { default_max_tokens: 2 });
+    await store.clear('a');
+    expect(await store.get('a')).toBeNull();
+    expect(await store.get('b')).toEqual({ default_max_tokens: 2 });
+  });
+
+  it('resolves database_name from shared storage when worker section has no override', async () => {
+    const cfg = { storage: { database_name: 'shared-pool' } };
+    expect(loadProviderConfigConfig(cfg).database_name).toBe('shared-pool');
+
+    const sharedFake = new FakeDatabaseSdk();
+    const sharedStore = createDbStore<{ default_max_tokens?: number }>(sharedFake.asSdk(), cfg, {
+      workerSection: 'provider_config',
+      tableName: PROVIDER_CONFIG_TABLE,
+    });
+    await sharedStore.init();
+    await sharedStore.set('openai', { default_max_tokens: 4096 });
+    for (const call of sharedFake.calls) {
+      expect((call.payload as { db: string }).db).toBe('shared-pool');
+    }
+  });
+});

--- a/harness/tests/provider-config/store.test.ts
+++ b/harness/tests/provider-config/store.test.ts
@@ -50,7 +50,10 @@ describe('DbOverridesStore', () => {
   });
 
   it('persists set across new wrapper instances on the same fake', async () => {
-    await store.set('openai', { default_api_url: 'https://example.com/v1', default_max_tokens: 4096 });
+    await store.set('openai', {
+      default_api_url: 'https://example.com/v1',
+      default_max_tokens: 4096,
+    });
     const store2 = new DbOverridesStore(fake.asSdk(), { databaseName: 'harness' });
     await store2.init();
     expect(await store2.get('openai')).toEqual({

--- a/harness/tests/runtime/database-store.test.ts
+++ b/harness/tests/runtime/database-store.test.ts
@@ -18,7 +18,9 @@ describe('DbStore', () => {
     await s.init();
     await s.init();
     const createCalls = fake.calls.filter(
-      (c) => c.function_id === 'database::execute' && /CREATE TABLE/i.test(String((c.payload as { sql: string }).sql)),
+      (c) =>
+        c.function_id === 'database::execute' &&
+        /CREATE TABLE/i.test(String((c.payload as { sql: string }).sql)),
     );
     // First init runs CREATE; second init short-circuits without a bus call.
     expect(createCalls.length).toBe(1);

--- a/harness/tests/runtime/database-store.test.ts
+++ b/harness/tests/runtime/database-store.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { DbStore } from '../../src/runtime/database-store.js';
+import { FakeDatabaseSdk } from './fake-database-sdk.js';
+
+describe('DbStore', () => {
+  let fake: FakeDatabaseSdk;
+
+  beforeEach(() => {
+    fake = new FakeDatabaseSdk();
+  });
+
+  function newStore<T>(): DbStore<T> {
+    return new DbStore<T>(fake.asSdk(), { databaseName: 'harness', tableName: 'kv' });
+  }
+
+  it('init() creates the table once, idempotently', async () => {
+    const s = newStore();
+    await s.init();
+    await s.init();
+    const createCalls = fake.calls.filter(
+      (c) => c.function_id === 'database::execute' && /CREATE TABLE/i.test(String((c.payload as { sql: string }).sql)),
+    );
+    // First init runs CREATE; second init short-circuits without a bus call.
+    expect(createCalls.length).toBe(1);
+    expect(fake.table('kv')).toBeDefined();
+  });
+
+  it('get returns null for missing rows', async () => {
+    const s = newStore<{ key: string }>();
+    await s.init();
+    expect(await s.get('anthropic')).toBeNull();
+  });
+
+  it('set then get round-trips a payload', async () => {
+    const s = newStore<{ key: string }>();
+    await s.init();
+    await s.set('anthropic', { key: 'sk-ant' });
+    expect(await s.get('anthropic')).toEqual({ key: 'sk-ant' });
+  });
+
+  it('set replaces (does NOT merge) existing rows', async () => {
+    type V = { a?: number; b?: number };
+    const s = newStore<V>();
+    await s.init();
+    await s.set('p', { a: 1, b: 2 });
+    await s.set('p', { a: 9 });
+    expect(await s.get('p')).toEqual({ a: 9 });
+  });
+
+  it('update merges partial patches into the existing row', async () => {
+    type V = { a?: number; b?: number };
+    const s = newStore<V>();
+    await s.init();
+    await s.set('p', { a: 1, b: 2 });
+    await s.update('p', { b: 99 });
+    expect(await s.get('p')).toEqual({ a: 1, b: 99 });
+  });
+
+  it('clear removes the row; other rows untouched', async () => {
+    const s = newStore<{ k: number }>();
+    await s.init();
+    await s.set('a', { k: 1 });
+    await s.set('b', { k: 2 });
+    await s.clear('a');
+    expect(await s.get('a')).toBeNull();
+    expect(await s.get('b')).toEqual({ k: 2 });
+  });
+
+  it('list returns every row sorted by provider', async () => {
+    const s = newStore<{ k: number }>();
+    await s.init();
+    await s.set('c', { k: 3 });
+    await s.set('a', { k: 1 });
+    await s.set('b', { k: 2 });
+    const rows = await s.list();
+    expect(rows.map(([p]) => p)).toEqual(['a', 'b', 'c']);
+    expect(rows.map(([, v]) => v.k)).toEqual([1, 2, 3]);
+  });
+
+  it('serializes concurrent updates so all merges land', async () => {
+    type V = { x?: number; y?: number; z?: number };
+    const s = newStore<V>();
+    await s.init();
+    await s.set('p', { x: 1 });
+    await Promise.all([s.update('p', { y: 2 }), s.update('p', { z: 3 })]);
+    expect(await s.get('p')).toEqual({ x: 1, y: 2, z: 3 });
+  });
+
+  it('emits the configured db name on every call', async () => {
+    const s = newStore();
+    await s.init();
+    await s.set('a', { foo: 'bar' });
+    for (const call of fake.calls) {
+      const sql = (call.payload as { db: string }).db;
+      expect(sql).toBe('harness');
+    }
+  });
+});

--- a/harness/tests/runtime/fake-database-sdk.ts
+++ b/harness/tests/runtime/fake-database-sdk.ts
@@ -1,0 +1,136 @@
+/**
+ * In-memory mock for the subset of `database::*` that `DbStore` actually
+ * uses: CREATE TABLE, SELECT (by-provider, list-all), UPSERT, DELETE.
+ *
+ * Tests that exercise the SQL-backed stores construct a `FakeDatabaseSdk`,
+ * pass it into `new DbStore({ databaseName: 'test', ... }, fake)`, and get
+ * deterministic round-trip behaviour without spawning a real iii-database
+ * worker. The SQL parser is intentionally narrow -- it matches the exact
+ * statements `database-store.ts` issues. If you change the statements,
+ * update this helper.
+ */
+
+import type { ISdk, TriggerRequest } from 'iii-sdk';
+
+type Row = { provider: string; payload: string; updated_at: number };
+
+type DbTable = Map<string, Row>;
+
+interface QueryResp {
+  rows: Array<Record<string, unknown>>;
+  row_count: number;
+}
+
+interface ExecuteResp {
+  affected_rows: number;
+  last_insert_id: string | null;
+}
+
+const RX_CREATE = /CREATE TABLE IF NOT EXISTS\s+(\w+)/i;
+const RX_SELECT_ONE = /SELECT payload FROM\s+(\w+)\s+WHERE provider = \?/i;
+const RX_SELECT_ALL = /SELECT provider, payload FROM\s+(\w+)/i;
+const RX_INSERT_UPSERT = /INSERT INTO\s+(\w+)\s+\(provider, payload, updated_at\)/i;
+const RX_DELETE = /DELETE FROM\s+(\w+)\s+WHERE provider = \?/i;
+
+export class FakeDatabaseSdk {
+  private readonly tables = new Map<string, DbTable>();
+  /** Records every call routed through `trigger` for assertion in tests. */
+  readonly calls: Array<{ function_id: string; payload: unknown }> = [];
+
+  /** Mount as the `ISdk` a worker would use. */
+  asSdk(): ISdk {
+    // The full ISdk surface is large; tests only exercise `trigger`. Cast
+    // through unknown so type-checking still catches signature drift on the
+    // single method we implement.
+    return { trigger: this.trigger } as unknown as ISdk;
+  }
+
+  /** Reset all tables (between tests). */
+  reset(): void {
+    this.tables.clear();
+    this.calls.length = 0;
+  }
+
+  /** Inspect a table directly. */
+  table(name: string): DbTable | undefined {
+    return this.tables.get(name);
+  }
+
+  // Arrow so `asSdk().trigger(...)` keeps `this`.
+  private trigger = async <_TPayload, TResp>(req: TriggerRequest<_TPayload>): Promise<TResp> => {
+    this.calls.push({ function_id: req.function_id, payload: req.payload });
+    if (req.function_id === 'database::query') {
+      return this.handleQuery(req.payload) as TResp;
+    }
+    if (req.function_id === 'database::execute') {
+      return this.handleExecute(req.payload) as TResp;
+    }
+    throw new Error(`FakeDatabaseSdk: unsupported function ${req.function_id}`);
+  };
+
+  private handleQuery(payload: unknown): QueryResp {
+    const { sql, params } = parseSqlPayload(payload);
+    let match = sql.match(RX_SELECT_ONE);
+    if (match) {
+      const tbl = this.tableOf(match[1] ?? '');
+      const provider = String(params[0] ?? '');
+      const row = tbl.get(provider);
+      const rows = row ? [{ payload: row.payload }] : [];
+      return { rows, row_count: rows.length };
+    }
+    match = sql.match(RX_SELECT_ALL);
+    if (match) {
+      const tbl = this.tableOf(match[1] ?? '');
+      const rows = [...tbl.values()]
+        .sort((a, b) => a.provider.localeCompare(b.provider))
+        .map(({ provider, payload: p }) => ({ provider, payload: p }));
+      return { rows, row_count: rows.length };
+    }
+    throw new Error(`FakeDatabaseSdk: unrecognised query SQL\n${sql}`);
+  }
+
+  private handleExecute(payload: unknown): ExecuteResp {
+    const { sql, params } = parseSqlPayload(payload);
+    let match = sql.match(RX_CREATE);
+    if (match) {
+      const name = match[1] ?? '';
+      if (!this.tables.has(name)) this.tables.set(name, new Map());
+      return { affected_rows: 0, last_insert_id: null };
+    }
+    match = sql.match(RX_INSERT_UPSERT);
+    if (match) {
+      const tbl = this.tableOf(match[1] ?? '');
+      const provider = String(params[0] ?? '');
+      const payloadStr = String(params[1] ?? '');
+      const updatedAt = Number(params[2] ?? 0);
+      tbl.set(provider, { provider, payload: payloadStr, updated_at: updatedAt });
+      return { affected_rows: 1, last_insert_id: null };
+    }
+    match = sql.match(RX_DELETE);
+    if (match) {
+      const tbl = this.tableOf(match[1] ?? '');
+      const provider = String(params[0] ?? '');
+      const existed = tbl.delete(provider);
+      return { affected_rows: existed ? 1 : 0, last_insert_id: null };
+    }
+    throw new Error(`FakeDatabaseSdk: unrecognised execute SQL\n${sql}`);
+  }
+
+  private tableOf(name: string): DbTable {
+    let tbl = this.tables.get(name);
+    if (!tbl) {
+      tbl = new Map();
+      this.tables.set(name, tbl);
+    }
+    return tbl;
+  }
+}
+
+function parseSqlPayload(payload: unknown): { db: string; sql: string; params: unknown[] } {
+  const p = (payload ?? {}) as { db?: unknown; sql?: unknown; params?: unknown };
+  return {
+    db: String(p.db ?? ''),
+    sql: String(p.sql ?? ''),
+    params: Array.isArray(p.params) ? p.params : [],
+  };
+}

--- a/harness/tests/runtime/openai-compat-url.test.ts
+++ b/harness/tests/runtime/openai-compat-url.test.ts
@@ -29,9 +29,9 @@ describe('normalizeChatCompletionsUrl', () => {
   });
 
   it('leaves a fully-qualified URL unchanged', () => {
-    expect(
-      normalizeChatCompletionsUrl('http://localhost:8080/v1/chat/completions'),
-    ).toBe('http://localhost:8080/v1/chat/completions');
+    expect(normalizeChatCompletionsUrl('http://localhost:8080/v1/chat/completions')).toBe(
+      'http://localhost:8080/v1/chat/completions',
+    );
   });
 
   it('treats any path containing /chat/completions as already qualified', () => {

--- a/harness/tests/runtime/openai-compat-url.test.ts
+++ b/harness/tests/runtime/openai-compat-url.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeChatCompletionsUrl } from '../../src/runtime/openai-compat-url.js';
+
+describe('normalizeChatCompletionsUrl', () => {
+  // The regression this test exists for: a user who saved
+  // `http://192.168.1.206:8080` from the Providers UI got 404 on every
+  // chat request because the override URL was POSTed verbatim. The fix
+  // routes the override through this helper.
+  it('appends /v1/chat/completions to a bare base URL', () => {
+    expect(normalizeChatCompletionsUrl('http://192.168.1.206:8080')).toBe(
+      'http://192.168.1.206:8080/v1/chat/completions',
+    );
+  });
+
+  it('appends /v1/chat/completions to a base URL with a trailing slash', () => {
+    expect(normalizeChatCompletionsUrl('http://localhost:8080/')).toBe(
+      'http://localhost:8080/v1/chat/completions',
+    );
+  });
+
+  // Regression: substring matching on the raw input previously concatenated
+  // the path into the query string, producing `?foo=bar/v1/chat/completions`
+  // and 404s on every request. Routing through the parsed URL fixes the
+  // path placement and preserves the query.
+  it('places /v1/chat/completions on the path even when the input has only a query string', () => {
+    expect(normalizeChatCompletionsUrl('http://localhost:8080?foo=bar')).toBe(
+      'http://localhost:8080/v1/chat/completions?foo=bar',
+    );
+  });
+
+  it('leaves a fully-qualified URL unchanged', () => {
+    expect(
+      normalizeChatCompletionsUrl('http://localhost:8080/v1/chat/completions'),
+    ).toBe('http://localhost:8080/v1/chat/completions');
+  });
+
+  it('treats any path containing /chat/completions as already qualified', () => {
+    // Some forks of llama-server / LM Studio expose the endpoint at a
+    // non-/v1 path. Don't double-append.
+    expect(normalizeChatCompletionsUrl('http://host:8080/api/v2/chat/completions')).toBe(
+      'http://host:8080/api/v2/chat/completions',
+    );
+  });
+
+  it('accepts https URLs', () => {
+    expect(normalizeChatCompletionsUrl('https://tunnel.ngrok.io')).toBe(
+      'https://tunnel.ngrok.io/v1/chat/completions',
+    );
+  });
+
+  it('returns null for empty / whitespace strings', () => {
+    expect(normalizeChatCompletionsUrl('')).toBeNull();
+    expect(normalizeChatCompletionsUrl('   ')).toBeNull();
+  });
+
+  it('returns null for non-http(s) schemes', () => {
+    expect(normalizeChatCompletionsUrl('file:///etc/passwd')).toBeNull();
+    expect(normalizeChatCompletionsUrl('javascript:alert(1)')).toBeNull();
+  });
+
+  it('returns null for unparseable URLs', () => {
+    expect(normalizeChatCompletionsUrl('not a url')).toBeNull();
+    expect(normalizeChatCompletionsUrl('http://')).toBeNull();
+  });
+});

--- a/harness/tests/runtime/storage-config.test.ts
+++ b/harness/tests/runtime/storage-config.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_DATABASE_NAME,
+  loadStorageConfig,
+  resolveDatabaseName,
+} from '../../src/runtime/storage-config.js';
+
+describe('loadStorageConfig', () => {
+  it('defaults to harness when storage section is absent', () => {
+    expect(loadStorageConfig({})).toEqual({ database_name: DEFAULT_DATABASE_NAME });
+  });
+
+  it('reads storage.database_name when set', () => {
+    expect(loadStorageConfig({ storage: { database_name: 'shared-pool' } })).toEqual({
+      database_name: 'shared-pool',
+    });
+  });
+
+  it('falls back when storage.database_name is empty or non-string', () => {
+    expect(loadStorageConfig({ storage: { database_name: '' } })).toEqual({
+      database_name: DEFAULT_DATABASE_NAME,
+    });
+    expect(loadStorageConfig({ storage: { database_name: 42 } })).toEqual({
+      database_name: DEFAULT_DATABASE_NAME,
+    });
+  });
+});
+
+describe('resolveDatabaseName', () => {
+  const storage = { database_name: 'shared-pool' };
+
+  it('prefers worker section override over shared storage', () => {
+    expect(resolveDatabaseName({ database_name: 'worker-pool' }, storage)).toBe('worker-pool');
+  });
+
+  it('uses shared storage when worker section has no override', () => {
+    expect(resolveDatabaseName({}, storage)).toBe('shared-pool');
+  });
+
+  it('defaults to harness when neither worker nor storage set a name', () => {
+    expect(resolveDatabaseName({}, { database_name: DEFAULT_DATABASE_NAME })).toBe('harness');
+  });
+
+  it('treats empty worker override as absent and falls through to storage', () => {
+    expect(resolveDatabaseName({ database_name: '' }, storage)).toBe('shared-pool');
+    expect(resolveDatabaseName({ database_name: 0 }, storage)).toBe('shared-pool');
+  });
+});

--- a/harness/tests/turn-orchestrator/approval-resume.test.ts
+++ b/harness/tests/turn-orchestrator/approval-resume.test.ts
@@ -89,19 +89,21 @@ describe('approval resume handler', () => {
     const { iii, registered, stepCalls, stateStore } = makeIiiWithRegistry();
     registerApprovalResume(iii, 's1', 'fc-1');
     const entry = registered.get('turn::approval_resume::s1/fc-1');
-    expect(entry).toBeDefined();
-    await entry!.handler({ decision: 'allow', reason: null });
+    if (!entry) throw new Error('handler not registered');
+    await entry.handler({ decision: 'allow', reason: null });
 
     expect(stateStore.get('approvals/s1/fc-1')).toEqual({ decision: 'allow', reason: null });
     expect(stepCalls).toEqual([{ session_id: 's1' }]);
-    expect(entry!.unregister).toHaveBeenCalled();
+    expect(entry.unregister).toHaveBeenCalled();
   });
 
   it('does not overwrite an existing decision (idempotent persist)', async () => {
     const { iii, registered, stateStore } = makeIiiWithRegistry();
     stateStore.set('approvals/s1/fc-1', { decision: 'aborted', reason: 'session_aborted' });
     registerApprovalResume(iii, 's1', 'fc-1');
-    await registered.get('turn::approval_resume::s1/fc-1')!.handler({
+    const entry = registered.get('turn::approval_resume::s1/fc-1');
+    if (!entry) throw new Error('handler not registered');
+    await entry.handler({
       decision: 'allow',
       reason: null,
     });
@@ -114,7 +116,8 @@ describe('approval resume handler', () => {
   it('does not trigger turn::step again after unregister on second invoke', async () => {
     const { iii, registered, stepCalls } = makeIiiWithRegistry();
     registerApprovalResume(iii, 's1', 'fc-1');
-    const entry = registered.get('turn::approval_resume::s1/fc-1')!;
+    const entry = registered.get('turn::approval_resume::s1/fc-1');
+    if (!entry) throw new Error('handler not registered');
     await entry.handler({ decision: 'deny', reason: 'nope' });
     stepCalls.length = 0;
 

--- a/harness/tests/turn-orchestrator/estimate.test.ts
+++ b/harness/tests/turn-orchestrator/estimate.test.ts
@@ -26,7 +26,7 @@ describe('estimateMessages', () => {
       { role: 'user' as const, content: [{ type: 'text' as const, text: 'hello' }], timestamp: 1 },
       { role: 'user' as const, content: [{ type: 'text' as const, text: 'world' }], timestamp: 2 },
     ];
-    const single = estimateMessages([msgs[0]!]);
+    const single = estimateMessages(msgs.slice(0, 1));
     const both = estimateMessages(msgs);
     expect(both).toBeGreaterThan(single);
   });


### PR DESCRIPTION
## Summary

**Console**
- Chat is no longer a routed view -- it's the always-rendered side dock. Default landing view is `traces`; legacy `#/chat` redirects there.
- Collapsible chat dock: `>_` header toggle, `⌘\` shortcut, `Esc`-to-collapse, multi-state signal indicator (active / attention / error) with `pendingApproval`-beats-freshness so blocking gates aren't missed.
- Shortcuts dialog (`?`), auto-focus composer on expand, `prefers-reduced-motion` honored.
- New Configuration page (`#/configuration`, with `#/providers` back-compat) hosting the Providers UI; `Dialog` + `Input` primitives added.
- `ModelPicker`: per-provider gear icon opens `ProviderSettingsDialog` inline without closing the Radix Select unexpectedly.
- `pulse-square` / `blink` motion utilities; updates to `ModelPicker` / `Select` / `ModeToggle` / `use-hash-route`.
- `PRODUCT.md` and `DESIGN.md` context files.

**Harness**
- New `provider-config` worker (`get` / `set` / `list` / `clear` handlers).
- Database-backed runtime storage (`database-store`, `storage-config`) with defensive table-name regex guard and `parseJsonOrNull` warn-log for corrupt rows.
- Shared `fetch-overrides` helper used by all 5 provider `auth.ts` files (anthropic / kimi / llamacpp / lmstudio / openai), removing the 5× byte-for-byte duplication.
- OpenAI-compat URL normaliser fixes query-string-only inputs that previously produced silent 404s; hostname-parity validation on `set`.
- `auth-credentials` refactor: SQL-backed store sharing the new `DbStore`.
- Worker docs: `storage.md`, `provider-config.md`, `auth-credentials.md` updates.

**Tests** — 848 harness / 267 web, all green
- 21 new web tests: `getDockSignal` (8), `provider-registry` (6), `normalizeErrorMessage` (7)
- Query-string regression for `normalizeChatCompletionsUrl`
- `provider-config` handler + store tests (covers `validateUrl` / `validateMaxTokens` via the `set` handler)
- `database-store` + `fake-database-sdk` + `storage-config` tests

## Test plan

- [ ] `pnpm --filter chat-app test` (web) -- 267/267 green
- [ ] `pnpm --filter harness test` (harness) -- 848/848 green
- [ ] Manual: open the console, `⌘\` collapses dock, `?` opens shortcuts, signal indicator transitions through active/attention/error states
- [ ] Manual: open Configuration → Providers, save a base URL (`http://host:port`) for LM Studio / llama.cpp and confirm chat completions reach the server (no silent 404)
- [ ] Manual: legacy bookmarks `#/chat` and `#/providers` redirect cleanly to `#/traces` and `#/configuration`
- [ ] Manual: per-provider gear icon in the model picker opens settings dialog without dismissing the dropdown unexpectedly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Provider Configuration page for managing API keys and runtime settings (base URL, max tokens) with validation and undo support.
  * Added keyboard shortcuts (? to open shortcuts, Cmd+\ to toggle chat dock).
  * Added advanced provider override settings with per-provider status indicators and error/warning badges.

* **Improvements**
  * Improved chat dock collapse/expand behavior with auto-focus on composer when expanding.
  * Enhanced form validation for provider URLs and token limits with user-friendly error messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/workers/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->