### PR TITLE
feat(policy): support * wildcards in permission function patterns

### DIFF
--- a/harness/docs/architecture.md
+++ b/harness/docs/architecture.md
@@ -184,6 +184,25 @@ Bare-string allow rules: `state::get`, `state::list`,
 surface, and the `directory::skills::*` and `directory::prompts::*`
 lookups.
 
+A function pattern may use `*` to match any substring
+(`compileFunctionMatcher` in
+[policy/compile.ts](harness/src/harness/policy/compile.ts)). A pattern with
+no `*` matches by exact id; a pattern containing `*` compiles to an anchored
+regex (`^…$`) where `*` becomes `.*` and every other regex metacharacter is
+escaped — so `*` is the only wildcard. This unlocks namespace-scoped rules
+(in both the bare-string and `!`-deny forms):
+
+- `shell::*` — any function under the `shell` namespace.
+- `*::list` — any worker's `::list` leaf (end-anchored: `models::listing`
+  does not match).
+- `"*"` — catch-all; first match still wins, so place it last.
+- `"!state::*"` — deny the whole `state` namespace.
+
+Globs compose with arg constraints: a globbed `function` and its
+`matches:` / `equals:` constraints AND together. Globs are anchored, so a
+namespace deny protects the exact prefix only — `!shell::*` does not cover
+`Xshell::exec`.
+
 ## Shared modules
 
 | Folder | Purpose |

--- a/harness/docs/workers/harness.md
+++ b/harness/docs/workers/harness.md
@@ -80,7 +80,7 @@ From [src/harness/iii.worker.yaml](harness/src/harness/iii.worker.yaml):
 | [src/harness/policy/check-permissions.ts](harness/src/harness/policy/check-permissions.ts) | `registerPolicy` — registers `policy::check_permissions` and maps a `Decision` to the wire reply (`allow` / `deny` / `needs_approval`). |
 | [src/harness/policy/handle.ts](harness/src/harness/policy/handle.ts) | `PermissionsHandle` + `loadAndWatch` — loads `iii-permissions.yaml`, holds the current `Permissions`, and hot-reloads it via a debounced `chokidar` watcher. |
 | [src/harness/policy/permissions.ts](harness/src/harness/policy/permissions.ts) | `Permissions` — parses the YAML into compiled rules and evaluates a call via `check(function_id, args)` (first match wins → `Decision`). |
-| [src/harness/policy/compile.ts](harness/src/harness/policy/compile.ts) | `compileRule` / `matchConstraints` — compiles a `RuleSpec` into a `CompiledRule` and evaluates `equals` / `matches` (regex) arg constraints. |
+| [src/harness/policy/compile.ts](harness/src/harness/policy/compile.ts) | `compileRule` / `matchFunctionId` / `matchConstraints` — compiles a `RuleSpec` into a `CompiledRule`, matches a `function_id` by exact equality or `*` glob, and evaluates `equals` / `matches` (regex) arg constraints. |
 | [src/harness/policy/types.ts](harness/src/harness/policy/types.ts) | `RuleSpec`, `ConstraintSpec`, `Decision`, `MatchedConstraint` types for `iii-permissions.yaml` rules and evaluation results. |
 | [src/harness/fanout/index.ts](harness/src/harness/fanout/index.ts) | Spawns the two fan-out pumps. |
 | [src/harness/fanout/agent-events.ts](harness/src/harness/fanout/agent-events.ts) | `agent::events` stream subscriber → per-browser fan-out. |

--- a/harness/src/harness/policy/compile.ts
+++ b/harness/src/harness/policy/compile.ts
@@ -9,6 +9,8 @@ export type CompiledRule = {
   rule_id: string;
   function_id: string;
   action: Action;
+  /** Set when `function_id` contains `*`; otherwise match is exact. */
+  glob: RegExp | null;
   constraints: Array<readonly [string, CompiledConstraint]>;
 };
 
@@ -23,14 +25,51 @@ function argsRecord(args: unknown): Record<string, unknown> {
     : {};
 }
 
+/** Turn a glob pattern (`*` = any substring) into an anchored regex. */
+function compileFunctionGlob(pattern: string): RegExp {
+  let re = '^';
+  for (const ch of pattern) {
+    if (ch === '*') re += '.*';
+    else re += ch.replace(/[\\^$.|?+()[\]{}]/g, '\\$&');
+  }
+  re += '$';
+  return new RegExp(re);
+}
+
+function compileFunctionMatcher(pattern: string): Pick<CompiledRule, 'function_id' | 'glob'> {
+  if (!pattern.includes('*')) {
+    return { function_id: pattern, glob: null };
+  }
+  return { function_id: pattern, glob: compileFunctionGlob(pattern) };
+}
+
+/** Match a compiled rule pattern against a concrete iii function id. */
+export function matchFunctionId(
+  rule: Pick<CompiledRule, 'function_id' | 'glob'>,
+  function_id: string,
+): boolean {
+  if (rule.glob) return rule.glob.test(function_id);
+  return rule.function_id === function_id;
+}
+
 export function compileRule(spec: RuleSpec, idx: number): CompiledRule {
   if (typeof spec === 'string') {
     if (spec.startsWith('!')) {
       const function_id = spec.slice(1);
       if (!function_id) throw new Error(`rule ${idx}: deny shorthand must be !<function_id>`);
-      return { rule_id: function_id, function_id, action: 'deny', constraints: [] };
+      return {
+        rule_id: function_id,
+        ...compileFunctionMatcher(function_id),
+        action: 'deny',
+        constraints: [],
+      };
     }
-    return { rule_id: spec, function_id: spec, action: 'allow', constraints: [] };
+    return {
+      rule_id: spec,
+      ...compileFunctionMatcher(spec),
+      action: 'allow',
+      constraints: [],
+    };
   }
 
   if (typeof spec !== 'object' || spec === null) {
@@ -49,7 +88,12 @@ export function compileRule(spec: RuleSpec, idx: number): CompiledRule {
   );
   constraints.sort(([a], [b]) => a.localeCompare(b));
 
-  return { rule_id, function_id, action: spec.action, constraints };
+  return {
+    rule_id,
+    ...compileFunctionMatcher(function_id),
+    action: spec.action,
+    constraints,
+  };
 }
 
 function compileConstraint(rule_id: string, field: string, c: ConstraintSpec): CompiledConstraint {

--- a/harness/src/harness/policy/permissions.ts
+++ b/harness/src/harness/policy/permissions.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { parse as parseYaml } from 'yaml';
 import { logger } from '../../runtime/otel.js';
-import { compileRule, matchConstraints, type CompiledRule } from './compile.js';
+import { compileRule, matchConstraints, matchFunctionId, type CompiledRule } from './compile.js';
 import type { Decision, RuleSpec } from './types.js';
 
 export class Permissions {
@@ -40,7 +40,7 @@ export class Permissions {
 
   check(function_id: string, args: unknown): Decision {
     for (const rule of this.rules) {
-      if (rule.function_id !== function_id) continue;
+      if (!matchFunctionId(rule, function_id)) continue;
       const matched = matchConstraints(args, rule.constraints);
       if (matched.kind === 'mismatch') continue;
       if (rule.action === 'allow') {

--- a/harness/tests/harness/policy.test.ts
+++ b/harness/tests/harness/policy.test.ts
@@ -167,6 +167,155 @@ describe('allow fires only on the intended match', () => {
     expect(p('version: 1\nrules:\n  - f').check('f', ['anything', { x: 1 }]).kind).toBe('allow');
   });
 
+  it('catch-all * allows any function_id when no earlier rule matches', () => {
+    expect(p('version: 1\nrules:\n  - "*"').check('shell::exec', { command: 'rm -rf /' })).toEqual({
+      kind: 'allow',
+      rule_id: '*',
+    });
+  });
+
+  it('catch-all * after a deny still denies the blocked function', () => {
+    const yaml = `
+version: 1
+rules:
+  - "!state::set"
+  - "*"
+`;
+    expect(kind(yaml, 'state::set', {})).toBe('deny');
+    expect(kind(yaml, 'shell::exec', { command: 'anything' })).toBe('allow');
+  });
+
+  it('catch-all * before denies allows everything (dev foot-gun)', () => {
+    const yaml = `
+version: 1
+rules:
+  - "*"
+  - "!state::set"
+`;
+    expect(kind(yaml, 'state::set', {})).toBe('allow');
+  });
+
+  it('catch-all ::* matches only ids starting with ::', () => {
+    const perms = p('version: 1\nrules:\n  - "::*"');
+    expect(perms.check('::internal', {})).toEqual({ kind: 'allow', rule_id: '::*' });
+    expect(perms.check('shell::exec', {})).toEqual({ kind: 'needs_approval' });
+  });
+
+  it('a namespace glob is anchored — prefix/suffix lookalikes do not slip into allow', () => {
+    const yaml = `
+version: 1
+rules:
+  - shell::*
+`;
+    // Intended matches: the namespace itself and anything nested under it.
+    expect(kind(yaml, 'shell::exec', {})).toBe('allow');
+    expect(kind(yaml, 'shell::fs::read', {})).toBe('allow');
+    // Anchoring holds: a leading lookalike, a missing separator, or a bare
+    // prefix must NOT satisfy `^shell::.*$`.
+    for (const fid of ['Xshell::exec', 'shellexec', 'shell', 'not-shell::exec']) {
+      expect(kind(yaml, fid, {})).toBe('needs_approval');
+    }
+  });
+
+  it('a deny glob blocks every id under the namespace and cannot be dodged by appending levels', () => {
+    const yaml = `
+version: 1
+rules:
+  - "!shell::*"
+  - "*"
+`;
+    // No suffix — deeper nesting, hostile args, anything — escapes the deny.
+    for (const fid of ['shell::exec', 'shell::fs::read', 'shell::fs::sub::rm']) {
+      expect(kind(yaml, fid, { command: 'rm -rf /' })).toBe('deny');
+    }
+    // A different namespace is governed by the catch-all, not the deny.
+    expect(kind(yaml, 'state::get', {})).toBe('allow');
+    // FOOTGUN: the deny is anchored, so a prefixed lookalike (`Xshell::exec`)
+    // is NOT caught and falls through to the catch-all allow. A namespace deny
+    // protects the exact prefix only.
+    expect(kind(yaml, 'Xshell::exec', {})).toBe('allow');
+  });
+
+  it('a deny glob ignores args — it covers the namespace unconditionally', () => {
+    const yaml = 'version: 1\nrules:\n  - "!shell::*"';
+    for (const args of [{}, { command: 'ls' }, null, ['x'], JSON.parse('{"__proto__":{"x":1}}')]) {
+      expect(p(yaml).check('shell::exec', args).kind).toBe('deny');
+    }
+  });
+
+  it('mid- and suffix-position globs span separators but stay end-anchored', () => {
+    const yaml = `
+version: 1
+rules:
+  - shell::fs::*
+  - '*::list'
+`;
+    // `*` spans `::`, so deep nesting under the prefix matches.
+    expect(kind(yaml, 'shell::fs::read', {})).toBe('allow');
+    expect(kind(yaml, 'shell::fs::sub::deep', {})).toBe('allow');
+    // But the literal prefix is required verbatim — no separator, no match.
+    expect(kind(yaml, 'shell::fsread', {})).toBe('needs_approval');
+    expect(kind(yaml, 'shell::exec', {})).toBe('needs_approval');
+    // `*::list` is broad on the left but anchored on the right: only ids that
+    // END in `::list` match — any trailing suffix defeats it.
+    expect(kind(yaml, 'models::list', {})).toBe('allow');
+    expect(kind(yaml, 'evil::list', {})).toBe('allow');
+    expect(kind(yaml, 'models::listing', {})).toBe('needs_approval');
+    expect(kind(yaml, 'models::list::sub', {})).toBe('needs_approval');
+    expect(kind(yaml, 'models::get', {})).toBe('needs_approval');
+  });
+
+  it('only * is a wildcard — regex metacharacters in a pattern match literally', () => {
+    // If `.` leaked through as regex "any char", this allow would over-match
+    // (aXc::ping) and a symmetric deny could be evaded. Escaping must hold.
+    const yaml = "version: 1\nrules:\n  - 'a.c::*'";
+    expect(kind(yaml, 'a.c::ping', {})).toBe('allow');
+    expect(kind(yaml, 'aXc::ping', {})).toBe('needs_approval');
+  });
+
+  it('a newline in the function_id cannot tunnel a deny glob into a later allow', () => {
+    // The compiled regex is line-unaware (`.` does not cross `\n`), so an
+    // embedded newline makes BOTH the deny glob and the catch-all fail to
+    // match — the call fails closed to needs_approval instead of slipping
+    // through to the broad allow.
+    const yaml = `
+version: 1
+rules:
+  - "!shell::*"
+  - "*"
+`;
+    expect(kind(yaml, 'shell::exec\nrm -rf /', {})).toBe('needs_approval');
+  });
+
+  it('a constrained allow on an exact function still works — and composes with a glob', () => {
+    // Glob support is additive: an exact function id compiles to glob=null and
+    // matches by ===, with arg constraints AND-checked exactly as before.
+    const exact = `
+version: 1
+rules:
+  - function: shell::fs::write
+    action: allow
+    args:
+      path:
+        matches: '^/tmp/'
+`;
+    expect(kind(exact, 'shell::fs::write', { path: '/tmp/cache' })).toBe('allow');
+    expect(kind(exact, 'shell::fs::write', { path: '/etc/passwd' })).toBe('needs_approval');
+    // The SAME arg constraints compose with a globbed function id.
+    const globbed = `
+version: 1
+rules:
+  - function: shell::fs::*
+    action: allow
+    args:
+      path:
+        matches: '^/tmp/'
+`;
+    expect(kind(globbed, 'shell::fs::write', { path: '/tmp/x' })).toBe('allow');
+    expect(kind(globbed, 'shell::fs::read', { path: '/tmp/x' })).toBe('allow');
+    expect(kind(globbed, 'shell::fs::write', { path: '/root/.ssh' })).toBe('needs_approval');
+  });
+
   it('AND-combines multiple constraints — one miss is a full mismatch', () => {
     const yaml = `
 version: 1

--- a/iii-permissions.yaml
+++ b/iii-permissions.yaml
@@ -1,5 +1,8 @@
 # Default agent permissions (first match wins).
-#   bare string        → allow
+#   bare string        → allow (exact id, or glob when pattern contains *)
+#   '*'                → allow any function_id (catch-all; order matters)
+#   'worker::*'        → allow any id matching that glob (e.g. shell::fs::read)
+#   '*::list'          → allow any worker's ::list leaf
 #   '!function_id'     → deny (quote required — bare ! is YAML tag syntax)
 #   no match           → needs_approval
 # Harness loads via config `permissions_path` and hot-reloads on save.


### PR DESCRIPTION
## Summary

Permission rules in `iii-permissions.yaml` can now use `*` in the function
pattern to match any substring. Patterns without `*` keep matching exactly,
so every existing rule behaves identically.

This unlocks namespace-scoped rules:

```yaml
rules:
  - shell::*          # allow any function under the shell namespace
  - "*::list"         # allow any worker's ::list leaf
  - "!state::*"       # deny the whole state namespace
  - "*"               # catch-all (order matters)
```

Globs also compose with the existing constrained form:

```yaml
  - function: shell::fs::*
    action: allow
    args:
      path:
        matches: '^/tmp/'
```

## How it works

- `compileFunctionMatcher` (`harness/src/harness/policy/compile.ts`) turns a
  pattern containing `*` into an anchored regex (`^...$`). `*` becomes `.*`;
  every other regex metacharacter is escaped, so `*` is the only wildcard.
  A pattern with no `*` compiles to `glob: null` and matches by `===`.
- `matchFunctionId` resolves a rule against a concrete `function_id` via the
  glob when present, else exact equality.
- `Permissions.check` routes through `matchFunctionId`; arg constraints still
  AND-compose with a globbed function.

The engine remains fail-closed: anything not positively matched to an
allow/deny rule resolves to `needs_approval`.

## Tests

`harness/tests/harness/policy.test.ts` — 50 passing, full harness suite 902/0.
New adversarial coverage:

- Namespace globs are anchored — `Xshell::exec`, `shellexec`, `shell` do not
  satisfy `shell::*`.
- Only `*` is a wildcard — `.` and other metacharacters match literally
  (`a.c::*` does not match `aXc::ping`).
- Suffix-position globs stay end-anchored — `*::list` rejects `models::listing`.
- A deny glob covers the whole namespace regardless of args and can't be
  dodged by appending levels.
- A newline in a `function_id` fails closed to `needs_approval` instead of
  tunneling past a deny glob into a catch-all allow.
- A constrained allow on an exact function still works and composes with a glob.

## Known limitation

A single pattern with multiple `*` (e.g. `a*b*c*`) compiles to multiple `.*`
groups. Patterns are author-controlled (not attacker input) and the common
forms (`ns::*`, `*::leaf`) are single-`*` and linear, so this is a rule-author
footgun rather than an exploitable surface.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run` — 902 passing, 0 failing
- [x] `pnpm vitest run policy` — 50 passing, 0 failing