### PR TITLE
fix(ci): boot iii-database before harness interface collection

### DIFF
--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -102,6 +102,100 @@ jobs:
           cat iii-engine.log || true
           exit 1
 
+      # The harness bundle contains sub-workers (auth-credentials,
+      # provider-config) that call `database::execute` during
+      # registration to CREATE TABLE their backing stores. Without a
+      # running `iii-database` worker the harness aborts at boot with
+      # `function_not_found`, so we never reach interface collection.
+      # Fetch the latest published `database` release binary and start
+      # it before the harness bundle so the trigger resolves.
+      #
+      # Snapshotting the trigger baseline AFTER this step keeps
+      # `database::*` out of the published harness interface.
+      - name: Start dependency workers (harness)
+        if: inputs.worker == 'harness'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Resolve the most recent non-prerelease `database/v*` tag.
+          # gh release list returns newest-first; the registry tag we
+          # publish under is what production consumers actually pull,
+          # so match it here too.
+          db_tag=$(gh release list \
+            --repo "$REPO" \
+            --limit 100 \
+            --exclude-drafts \
+            --exclude-pre-releases \
+            --json tagName \
+            --jq '[.[] | select(.tagName | startswith("database/v"))][0].tagName')
+
+          if [[ -z "$db_tag" || "$db_tag" == "null" ]]; then
+            echo "::error::could not resolve latest database/v* release tag"
+            exit 1
+          fi
+          echo "Using database release: $db_tag"
+
+          asset_url="https://github.com/$REPO/releases/download/$db_tag/database-x86_64-unknown-linux-gnu.tar.gz"
+          echo "Fetching database binary: $asset_url"
+          curl -fsSL "$asset_url" -o /tmp/database-bin.tar.gz
+
+          db_dir="/tmp/iii-database"
+          rm -rf "$db_dir"
+          mkdir -p "$db_dir"
+          tar -xzf /tmp/database-bin.tar.gz -C "$db_dir"
+          chmod +x "$db_dir/database"
+
+          # The pool name must match the harness database_name default
+          # (see harness/src/runtime/storage-config.ts DEFAULT_DATABASE_NAME).
+          # SQLite is sufficient for interface collection -- no data is
+          # persisted past the job.
+          cat > "$db_dir/config.yaml" <<'CFG'
+          databases:
+            harness:
+              url: sqlite:./iii.db
+              pool:
+                max: 4
+                idle_timeout_ms: 30000
+                acquire_timeout_ms: 5000
+          CFG
+
+          db_log="$PWD/iii-database.log"
+          pushd "$db_dir" >/dev/null
+          ./database > "$db_log" 2>&1 &
+          echo "$!" > "$PWD/database.pid"
+          popd >/dev/null
+          cp "$db_dir/database.pid" iii-database.pid
+
+          # Wait for the database worker to register database::execute
+          # by issuing a trivial roundtrip. The engine returns
+          # function_not_found until registration completes.
+          ready=0
+          for _ in {1..30}; do
+            if ! kill -0 "$(cat iii-database.pid)" 2>/dev/null; then
+              echo "::error::iii-database exited before becoming ready"
+              tail -n 200 "$db_log" || true
+              exit 1
+            fi
+            if iii trigger 'database::execute' \
+                 --json '{"db":"harness","sql":"SELECT 1","params":[]}' \
+                 >/tmp/iii-database-ping.json 2>/tmp/iii-database-ping.err; then
+              ready=1
+              break
+            fi
+            sleep 1
+          done
+
+          if [[ "$ready" != "1" ]]; then
+            echo "::error::iii-database did not register database::execute in time"
+            cat /tmp/iii-database-ping.err || true
+            tail -n 200 "$db_log" || true
+            exit 1
+          fi
+          echo "iii-database ready"
+
       - name: Snapshot engine trigger types baseline
         run: |
           set -euo pipefail
@@ -355,12 +449,24 @@ jobs:
             tail -n 200 worker-${{ inputs.worker }}.log || true
             echo "::endgroup::"
           fi
+          if [[ -f iii-database.log ]]; then
+            echo "::group::iii-database log"
+            tail -n 200 iii-database.log || true
+            echo "::endgroup::"
+          fi
 
       - name: Stop local worker
         if: always()
         run: |
           if [[ -f worker.pid ]]; then
             kill "$(cat worker.pid)" 2>/dev/null || true
+          fi
+
+      - name: Stop dependency workers
+        if: always()
+        run: |
+          if [[ -f iii-database.pid ]]; then
+            kill "$(cat iii-database.pid)" 2>/dev/null || true
           fi
 
       - name: Stop III engine

--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -15,3 +15,4 @@ dependencies:
   iii-state: "^0.11.0"
   iii-stream: "^0.11.0"
   iii-directory: "^0.5.1"
+  database: "^0.2.2"


### PR DESCRIPTION
## Summary

- `harness/v0.4.6` publish failed in `_publish-registry.yml` at "Start local worker for interface collection" — the harness bundle aborts with `IIIInvocationError: function_not_found: Function database::execute not found` ([failing job](https://github.com/iii-hq/workers/actions/runs/26461147302/job/77909147286)).
- Root cause: since #186, `auth-credentials` and `provider-config` eagerly call `DbStore.init()` during `register()` (`harness/src/auth-credentials/register.ts:15`, `harness/src/provider-config/register.ts:14`), which issues `database::execute` to `CREATE TABLE`. The publish workflow boots `iii` with `workers: []` and only launches the harness bundle, so no `iii-database` worker is present and the trigger returns `function_not_found` — the harness then tears down before the interface can be collected.
- Fix: fetch the latest published `database/v*` release binary and run it against the same engine before the baseline trigger snapshot, so `database::*` stays out of the published harness interface and the harness boot proceeds. Add matching teardown + log dump. Declare `database: "^0.2.2"` in `harness/iii.worker.yaml` so the registry sees the dependency.

## Files

- `.github/workflows/_publish-registry.yml` — new "Start dependency workers (harness)" step (gated on `inputs.worker == 'harness'`), matching "Stop dependency workers" cleanup, log dump on failure.
- `harness/iii.worker.yaml` — `database: "^0.2.2"` added to `dependencies`.

## Test plan

- [ ] Land on `main`.
- [ ] Cut `harness/v0.4.7` (a new tag is required — `_publish-registry.yml` is resolved from the tag ref, so re-running `harness/v0.4.6` would not pick up this change).
- [ ] Confirm the `Publish to registry / POST /publish (harness)` job reaches "Collect worker interface" and finishes green.
- [ ] Confirm the published interface in the registry does **not** include `database::execute` / `database::query` (baseline subtraction working).
- [ ] Confirm non-harness releases (`coder`, `console`, `database`, etc.) still publish unaffected — the new step is gated on `inputs.worker == 'harness'`.