### PR TITLE
Turn-orchestrator tests: shared harness + retire approval-overlap cases

### DIFF
--- a/harness/tests/integration/on-record-written.e2e.test.ts
+++ b/harness/tests/integration/on-record-written.e2e.test.ts
@@ -1,62 +1,9 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { TriggerAction } from '../../src/runtime/iii.js';
-import type { ISdk } from '../../src/runtime/iii.js';
 import { createTurnStore } from '../../src/turn-orchestrator/state-runtime/store.js';
 import { TURN_STATE_SCOPE } from '../../src/turn-orchestrator/state.js';
 import { newRecord } from '../../src/turn-orchestrator/state.js';
-
-function fakeIii(): {
-  iii: ISdk;
-  wakeInvocations: Array<{ session_id: string; function_id: string; action?: unknown }>;
-  stateStore: Map<string, unknown>;
-} {
-  const stateStore = new Map<string, unknown>();
-  const wakeInvocations: Array<{ session_id: string; function_id: string; action?: unknown }> = [];
-  const iii = {
-    trigger: vi.fn(
-      async ({
-        function_id,
-        payload,
-        action,
-      }: {
-        function_id: string;
-        payload: unknown;
-        action?: unknown;
-      }) => {
-        if (function_id === 'state::get') {
-          const p = payload as { scope: string; key: string };
-          const v = stateStore.get(`${p.scope}/${p.key}`);
-          return v === undefined ? null : structuredClone(v);
-        }
-
-        if (function_id === 'state::set') {
-          const p = payload as { scope: string; key: string; value: unknown };
-          const storeKey = `${p.scope}/${p.key}`;
-          const old_value = stateStore.has(storeKey)
-            ? structuredClone(stateStore.get(storeKey))
-            : null;
-          const new_value = structuredClone(p.value);
-          stateStore.set(storeKey, new_value);
-          return { old_value, new_value };
-        }
-
-        if (function_id === 'state::update') {
-          return { old_value: 0 };
-        }
-
-        if (function_id.startsWith('turn::')) {
-          const p = payload as { session_id: string };
-          wakeInvocations.push({ session_id: p.session_id, function_id, action });
-          return null;
-        }
-
-        return null;
-      },
-    ),
-  };
-
-  return { iii: iii as unknown as ISdk, wakeInvocations, stateStore };
-}
+import { fakeIiiWithStateStore as fakeIii } from '../turn-orchestrator/_helpers/stateStoreIii.js';
 
 describe('saveRecord wake integration', () => {
   it('writing a new stepable turn_state enqueues turn::provisioning', async () => {

--- a/harness/tests/turn-orchestrator/_helpers/builders.ts
+++ b/harness/tests/turn-orchestrator/_helpers/builders.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared message-builder helpers for turn-orchestrator tests.
+ *
+ * Three flavors:
+ *   - `makeAssistant(calls)`           — bare `function_call` blocks (legacy unit-test shape).
+ *   - `makeAssistantWithCalls(calls)`  — `agent_trigger`-wrapped calls (production wire shape).
+ *   - `agentTriggerCall(id, fn, payload)` — single `agent_trigger` envelope block, for unit tests
+ *     that want to mix one wrapped call into the bare-shape builder.
+ */
+
+import type { AssistantMessage } from '../../../src/types/agent-message.js';
+
+type RawCall = { id: string; function_id: string; arguments?: unknown };
+type AgentTriggerCallSpec = { id: string; functionId: string; payload?: unknown };
+
+const ASSISTANT_SKELETON = {
+  role: 'assistant' as const,
+  stop_reason: 'function_call' as const,
+  error_message: null,
+  error_kind: null,
+  usage: null,
+  model: 'm',
+  provider: 'p',
+  timestamp: 1,
+};
+
+/** Build an `AssistantMessage` with raw `function_call` blocks (target function_id stays untouched). */
+export function makeAssistant(calls: RawCall[] = []): AssistantMessage {
+  return {
+    ...ASSISTANT_SKELETON,
+    content: calls.map((c) => ({
+      type: 'function_call' as const,
+      id: c.id,
+      function_id: c.function_id,
+      arguments: c.arguments ?? {},
+    })),
+  };
+}
+
+/** Build a single `agent_trigger`-wrapped function_call content block. */
+export function agentTriggerCall(
+  id: string,
+  functionId: string,
+  payload: unknown = {},
+): { type: 'function_call'; id: string; function_id: string; arguments: unknown } {
+  return {
+    type: 'function_call',
+    id,
+    function_id: 'agent_trigger',
+    arguments: { function: functionId, payload },
+  };
+}
+
+/** Build an `AssistantMessage` whose calls are all wrapped in the `agent_trigger` envelope. */
+export function makeAssistantWithCalls(calls: AgentTriggerCallSpec[]): AssistantMessage {
+  return {
+    ...ASSISTANT_SKELETON,
+    content: calls.map((c) => agentTriggerCall(c.id, c.functionId, c.payload ?? {})),
+  };
+}

--- a/harness/tests/turn-orchestrator/_helpers/fakeIii.ts
+++ b/harness/tests/turn-orchestrator/_helpers/fakeIii.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared fake `ISdk` builder for turn-orchestrator tests.
+ *
+ * Covers the canonical "`{ iii, calls }`" pattern duplicated across most
+ * unit tests: every `iii.trigger(...)` is captured into `calls[]`. Pass
+ * any `Partial<ISdk>` fields (e.g. `createChannel`, `registerFunction`)
+ * directly; pass a `responder` to control what `trigger()` returns.
+ *
+ * For the heavier "state-store + event-capture" shape (used by the e2e
+ * tests under `tests/integration/`), keep the per-file implementations
+ * — this helper deliberately stays narrow.
+ */
+
+import { vi } from 'vitest';
+import type { ISdk } from '../../../src/runtime/iii.js';
+
+export type TriggerCall = {
+  function_id: string;
+  payload: unknown;
+  action?: unknown;
+  timeoutMs?: number;
+};
+
+/** Responder: either a `function_id`-keyed lookup or a callback. */
+export type FakeIiiResponder =
+  | Record<string, unknown>
+  | ((req: { function_id: string; payload: unknown }) => unknown | Promise<unknown>);
+
+export type FakeIiiOptions = Partial<ISdk> & {
+  responder?: FakeIiiResponder;
+};
+
+export function fakeIii(opts: FakeIiiOptions = {}): { iii: ISdk; calls: TriggerCall[] } {
+  const calls: TriggerCall[] = [];
+  const { responder, ...overrides } = opts;
+
+  const iii = {
+    trigger: async <T, R>(req: {
+      function_id: string;
+      payload: T;
+      action?: unknown;
+      timeoutMs?: number;
+    }): Promise<R> => {
+      calls.push({
+        function_id: req.function_id,
+        payload: req.payload,
+        action: req.action,
+        timeoutMs: req.timeoutMs,
+      });
+      if (!responder) return null as R;
+      if (typeof responder === 'function') {
+        return (await responder({ function_id: req.function_id, payload: req.payload })) as R;
+      }
+      return ((responder as Record<string, unknown>)[req.function_id] ?? null) as R;
+    },
+    registerFunction: vi.fn(),
+    ...overrides,
+  } as unknown as ISdk;
+
+  return { iii, calls };
+}

--- a/harness/tests/turn-orchestrator/_helpers/stateStoreIii.ts
+++ b/harness/tests/turn-orchestrator/_helpers/stateStoreIii.ts
@@ -1,0 +1,73 @@
+/**
+ * Richer fake `ISdk` for tests that drive `createTurnStore` end-to-end:
+ * implements an in-memory `state::get` / `state::set` / `state::update`
+ * surface (matching the engine's semantics for `saveRecord`) and captures
+ * every `turn::*` wake into `wakeInvocations`.
+ *
+ * Use this for FSM-wake integration tests; for pure unit tests, use the
+ * lighter `fakeIii` helper.
+ */
+
+import { vi } from 'vitest';
+import type { ISdk } from '../../../src/runtime/iii.js';
+
+export type WakeInvocation = {
+  session_id: string;
+  function_id: string;
+  action?: unknown;
+};
+
+export type StateStoreIii = {
+  iii: ISdk;
+  wakeInvocations: WakeInvocation[];
+  stateStore: Map<string, unknown>;
+};
+
+export function fakeIiiWithStateStore(): StateStoreIii {
+  const stateStore = new Map<string, unknown>();
+  const wakeInvocations: WakeInvocation[] = [];
+  const iii = {
+    trigger: vi.fn(
+      async ({
+        function_id,
+        payload,
+        action,
+      }: {
+        function_id: string;
+        payload: unknown;
+        action?: unknown;
+      }) => {
+        if (function_id === 'state::get') {
+          const p = payload as { scope: string; key: string };
+          const v = stateStore.get(`${p.scope}/${p.key}`);
+          return v === undefined ? null : structuredClone(v);
+        }
+
+        if (function_id === 'state::set') {
+          const p = payload as { scope: string; key: string; value: unknown };
+          const storeKey = `${p.scope}/${p.key}`;
+          const old_value = stateStore.has(storeKey)
+            ? structuredClone(stateStore.get(storeKey))
+            : null;
+          const new_value = structuredClone(p.value);
+          stateStore.set(storeKey, new_value);
+          return { old_value, new_value };
+        }
+
+        if (function_id === 'state::update') {
+          return { old_value: 0 };
+        }
+
+        if (function_id.startsWith('turn::')) {
+          const p = payload as { session_id: string };
+          wakeInvocations.push({ session_id: p.session_id, function_id, action });
+          return null;
+        }
+
+        return null;
+      },
+    ),
+  };
+
+  return { iii: iii as unknown as ISdk, wakeInvocations, stateStore };
+}

--- a/harness/tests/turn-orchestrator/assistant.test.ts
+++ b/harness/tests/turn-orchestrator/assistant.test.ts
@@ -1,32 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ISdk } from '../../src/runtime/iii.js';
 import type { AssistantMessage } from '../../src/types/agent-message.js';
+import { fakeIii, type FakeIiiOptions, type TriggerCall } from './_helpers/fakeIii.js';
 import { installMockTurnStore } from './_helpers/mockTurnStore.js';
 import * as preflightModule from '../../src/turn-orchestrator/preflight.js';
 import { type TurnStateRecord, newRecord } from '../../src/turn-orchestrator/state.js';
 import { handleStreaming } from '../../src/turn-orchestrator/assistant-streaming/process.js';
-
-type TriggerCall = { function_id: string; payload: unknown; timeoutMs?: number };
-
-function fakeIii(overrides?: Partial<ISdk>): { iii: ISdk; calls: TriggerCall[] } {
-  const calls: TriggerCall[] = [];
-  const iii = {
-    trigger: async <T, R>(req: {
-      function_id: string;
-      payload: T;
-      timeoutMs?: number;
-    }): Promise<R> => {
-      calls.push({
-        function_id: req.function_id,
-        payload: req.payload,
-        timeoutMs: req.timeoutMs,
-      });
-      return null as R;
-    },
-    ...overrides,
-  } as unknown as ISdk;
-  return { iii, calls };
-}
 
 function assistant(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
   return {
@@ -62,7 +41,7 @@ function fakeIiiWithDone(finalMsg: AssistantMessage): { iii: ISdk; calls: Trigge
         },
       };
     },
-  });
+  } as FakeIiiOptions);
 }
 
 afterEach(() => {
@@ -90,7 +69,7 @@ describe('handleStreaming turn start', () => {
       createChannel: async () => {
         throw new Error('channel unavailable');
       },
-    });
+    } as FakeIiiOptions);
     mockStreamingStore();
     vi.spyOn(preflightModule, 'runPreflight').mockResolvedValue('ok');
 
@@ -112,7 +91,7 @@ describe('handleStreaming', () => {
       createChannel: async () => {
         throw new Error('channel unavailable');
       },
-    });
+    } as FakeIiiOptions);
     mockStreamingStore();
     vi.spyOn(preflightModule, 'runPreflight').mockResolvedValue('ok');
 

--- a/harness/tests/turn-orchestrator/function-awaiting-approval.test.ts
+++ b/harness/tests/turn-orchestrator/function-awaiting-approval.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { ISdk } from '../../src/runtime/iii.js';
 import * as events from '../../src/turn-orchestrator/events.js';
 import { makeAssistant } from './_helpers/builders.js';
+import { fakeIii } from './_helpers/fakeIii.js';
 import { installMockTurnStore } from './_helpers/mockTurnStore.js';
 import {
   applyDecisionToPrepared,
@@ -33,15 +33,14 @@ function seedFunctionAwaitingApproval(
   rec.state = 'function_awaiting_approval';
 }
 
-function makeIii(approvalStore: Map<string, unknown>): ISdk {
-  return {
-    trigger: vi.fn(async (req: { function_id: string; payload: unknown }) => {
+function approvalsIii(approvalStore: Map<string, unknown>) {
+  return fakeIii({
+    responder: (req) => {
       if (req.function_id === 'state::get') {
         const p = req.payload as { scope: string; key: string };
         return approvalStore.get(`${p.scope}/${p.key}`) ?? null;
       }
       if (req.function_id === 'state::update') return { old_value: 0 };
-      if (req.function_id === 'stream::set') return null;
       if (req.function_id === 'shell::run') {
         return {
           content: [{ type: 'text' as const, text: 'ok' }],
@@ -50,8 +49,8 @@ function makeIii(approvalStore: Map<string, unknown>): ISdk {
         };
       }
       return null;
-    }),
-  } as unknown as ISdk;
+    },
+  }).iii;
 }
 
 describe('applyDecisionToPrepared', () => {
@@ -76,54 +75,15 @@ describe('applyDecisionToPrepared', () => {
   });
 });
 
+// The allow→steering_check and undecided-parking cases are exercised end-to-end by
+// `tests/integration/parallel-approval.e2e.test.ts` (with the dedicated harness). This file
+// keeps only the case that the e2e does not cover: returning to `function_execute` when a
+// resolved batch still has unprepared siblings to dispatch.
 describe('handleAwaitingApproval', () => {
-  it('executes allow decision and finalizes when batch completes', async () => {
-    const approvalStore = new Map<string, unknown>();
-    approvalStore.set('approvals/s1/fc-1', { decision: 'allow', reason: null });
-    const iii = makeIii(approvalStore);
-    const rec = newRecord('s1');
-    const fc = { id: 'fc-1', function_id: 'shell::run', arguments: { command: 'ls' } };
-    seedFunctionAwaitingApproval(
-      rec,
-      { prepared: [{ route: 'dispatch', call: fc }], executed: {} },
-      [{ function_call_id: 'fc-1', function_id: 'shell::run' }],
-    );
-
-    installMockTurnStore({
-      loadMessages: vi.fn(async () => []),
-      appendMessages: vi.fn(async () => {}),
-    });
-    vi.spyOn(events, 'emit').mockResolvedValue(undefined);
-
-    await handleAwaitingApproval(iii, rec);
-
-    expect(rec.awaiting_approval).toEqual([]);
-    expect(rec.state).toBe('steering_check');
-    expect(rec.work).toBeUndefined();
-    expect(rec.function_results).toHaveLength(1);
-  });
-
-  it('leaves state parked when awaiting entries remain undecided', async () => {
-    const iii = makeIii(new Map());
-    const rec = newRecord('s1');
-    const fc = { id: 'fc-1', function_id: 'shell::run', arguments: {} };
-    seedFunctionAwaitingApproval(
-      rec,
-      { prepared: [{ route: 'dispatch', call: fc }], executed: {} },
-      [{ function_call_id: 'fc-1', function_id: 'shell::run' }],
-    );
-    installMockTurnStore();
-
-    await handleAwaitingApproval(iii, rec);
-
-    expect(rec.state).toBe('function_awaiting_approval');
-    expect(rec.awaiting_approval).toHaveLength(1);
-  });
-
   it('returns to function_execute when approvals done but batch incomplete', async () => {
     const approvalStore = new Map<string, unknown>();
     approvalStore.set('approvals/s1/fc-2', { decision: 'deny', reason: null });
-    const iii = makeIii(approvalStore);
+    const iii = approvalsIii(approvalStore);
     const rec = newRecord('s1');
     const fc1 = { id: 'fc-1', function_id: 'shell::run', arguments: {} };
     const fc2 = { id: 'fc-2', function_id: 'shell::run', arguments: {} };

--- a/harness/tests/turn-orchestrator/function-awaiting-approval.test.ts
+++ b/harness/tests/turn-orchestrator/function-awaiting-approval.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ISdk } from '../../src/runtime/iii.js';
 import * as events from '../../src/turn-orchestrator/events.js';
+import { makeAssistant } from './_helpers/builders.js';
 import { installMockTurnStore } from './_helpers/mockTurnStore.js';
 import {
   applyDecisionToPrepared,
@@ -15,27 +16,6 @@ import type { AssistantMessage } from '../../src/types/agent-message.js';
 afterEach(() => {
   vi.restoreAllMocks();
 });
-
-function makeAssistant(
-  calls: Array<{ id: string; function_id: string; arguments?: unknown }> = [],
-): AssistantMessage {
-  return {
-    role: 'assistant',
-    content: calls.map((c) => ({
-      type: 'function_call' as const,
-      id: c.id,
-      function_id: c.function_id,
-      arguments: c.arguments ?? {},
-    })),
-    stop_reason: 'function_call',
-    error_message: null,
-    error_kind: null,
-    usage: null,
-    model: 'm',
-    provider: 'p',
-    timestamp: 1,
-  };
-}
 
 function seedFunctionAwaitingApproval(
   rec: TurnStateRecord,

--- a/harness/tests/turn-orchestrator/function-execute.test.ts
+++ b/harness/tests/turn-orchestrator/function-execute.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { makeAssistant } from './_helpers/builders.js';
 import {
   missingFunctionResult,
   unwrapAgentTrigger,
@@ -13,27 +14,6 @@ import type { FunctionExecutePorts } from '../../src/turn-orchestrator/function-
 import type { ExecutedCall } from '../../src/turn-orchestrator/function-execute/types.js';
 import { newRecord } from '../../src/turn-orchestrator/state.js';
 import type { AssistantMessage } from '../../src/types/agent-message.js';
-
-function makeAssistant(
-  calls: Array<{ id: string; function_id: string; arguments?: unknown }>,
-): AssistantMessage {
-  return {
-    role: 'assistant',
-    content: calls.map((c) => ({
-      type: 'function_call' as const,
-      id: c.id,
-      function_id: c.function_id,
-      arguments: c.arguments ?? {},
-    })),
-    stop_reason: 'function_call',
-    error_message: null,
-    error_kind: null,
-    usage: null,
-    model: 'm',
-    provider: 'p',
-    timestamp: 1,
-  };
-}
 
 function stubPorts(overrides: Partial<FunctionExecutePorts> = {}): FunctionExecutePorts {
   return {

--- a/harness/tests/turn-orchestrator/functions.test.ts
+++ b/harness/tests/turn-orchestrator/functions.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ISdk } from '../../src/runtime/iii.js';
 import * as events from '../../src/turn-orchestrator/events.js';
 import * as hookModule from '../../src/turn-orchestrator/hook.js';
+import { agentTriggerCall, makeAssistant } from './_helpers/builders.js';
 import { installMockTurnStore } from './_helpers/mockTurnStore.js';
 import type { TurnStateRecord } from '../../src/turn-orchestrator/state.js';
 import { newRecord } from '../../src/turn-orchestrator/state.js';
@@ -21,28 +22,6 @@ function mockFinalizePersistence(): void {
     loadMessages: vi.fn(async () => []),
     appendMessages: vi.fn(async () => {}),
   });
-}
-
-/** Build a minimal AssistantMessage with the given function_call content blocks. */
-function makeAssistant(
-  calls: Array<{ id: string; function_id: string; arguments?: unknown }>,
-): AssistantMessage {
-  return {
-    role: 'assistant',
-    content: calls.map((c) => ({
-      type: 'function_call' as const,
-      id: c.id,
-      function_id: c.function_id,
-      arguments: c.arguments ?? {},
-    })),
-    stop_reason: 'function_call',
-    error_message: null,
-    error_kind: null,
-    usage: null,
-    model: 'm',
-    provider: 'p',
-    timestamp: 1,
-  };
 }
 
 describe('parseApprovalDecision', () => {
@@ -87,15 +66,6 @@ function seedFunctionExecute(
   enterFunctionExecute(rec, asst ?? makeAssistant([]));
   rec.work = work;
   rec.state = 'function_execute';
-}
-
-/** Wrap a target function id in the agent_trigger envelope (production shape). */
-function agentTriggerCall(
-  id: string,
-  functionId: string,
-  payload: unknown = {},
-): { id: string; function_id: string; arguments: unknown } {
-  return { id, function_id: 'agent_trigger', arguments: { function: functionId, payload } };
 }
 
 describe('handleExecute new flow', () => {

--- a/harness/tests/turn-orchestrator/hook.test.ts
+++ b/harness/tests/turn-orchestrator/hook.test.ts
@@ -4,26 +4,25 @@ import type {
   PolicyCheckReply,
 } from '../../src/harness/policy/check-permissions.js';
 import type { ISdk } from '../../src/runtime/iii.js';
+import { fakeIii } from './_helpers/fakeIii.js';
 import { consultBefore } from '../../src/turn-orchestrator/hook.js';
 
-function fakeIii(
-  triggerImpl: (req: {
+function policyIii(
+  reply: (req: {
     function_id: string;
     payload: CheckPermissionsPayload;
   }) => PolicyCheckReply | Promise<PolicyCheckReply>,
-) {
-  return {
-    trigger: vi.fn(async (req: { function_id: string; payload: CheckPermissionsPayload }) =>
-      triggerImpl(req),
-    ),
-  } as unknown as ISdk;
+): ISdk {
+  return fakeIii({
+    responder: (req) => reply(req as { function_id: string; payload: CheckPermissionsPayload }),
+  }).iii;
 }
 
 describe('consultBefore (direct policy call)', () => {
   const fc = { id: 'fc-1', function_id: 'shell::fs::write', arguments: { path: '/tmp/x' } };
 
   it('returns allow when policy decides allow', async () => {
-    const iii = fakeIii(({ function_id }) => {
+    const iii = policyIii(({ function_id }) => {
       expect(function_id).toBe('policy::check_permissions');
       return { decision: 'allow', rule_id: 'allow-tmp' };
     });
@@ -32,7 +31,7 @@ describe('consultBefore (direct policy call)', () => {
   });
 
   it('returns deny with a permissions envelope when policy decides deny', async () => {
-    const iii = fakeIii(() => ({
+    const iii = policyIii(() => ({
       decision: 'deny',
       rule_id: 'deny-rm-rf',
       rule_action: 'deny',
@@ -46,13 +45,13 @@ describe('consultBefore (direct policy call)', () => {
   });
 
   it('returns pending when policy says needs_approval', async () => {
-    const iii = fakeIii(() => ({ decision: 'needs_approval' }));
+    const iii = policyIii(() => ({ decision: 'needs_approval' }));
     const outcome = await consultBefore(iii, fc);
     expect(outcome.kind).toBe('pending');
   });
 
   it('fails closed (deny gate_unavailable) when policy is unreachable', async () => {
-    const iii = fakeIii(() => {
+    const iii = policyIii(() => {
       throw new Error('policy worker down');
     });
     const outcome = await consultBefore(iii, fc);

--- a/harness/tests/turn-orchestrator/preflight.test.ts
+++ b/harness/tests/turn-orchestrator/preflight.test.ts
@@ -7,37 +7,27 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import type { ISdk } from '../../src/runtime/iii.js';
 import { CompactionBusyError, ContextOverflowError } from '../../src/turn-orchestrator/errors.js';
 import { runPreflight } from '../../src/turn-orchestrator/preflight.js';
-
-type TriggerCall = { function_id: string; payload: unknown };
+import { fakeIii, type TriggerCall } from './_helpers/fakeIii.js';
 
 function makeIii(overrides?: {
   modelsGetResult?: unknown;
   sessionTreeResult?: unknown;
   compactNowResult?: unknown;
-}): { iii: ISdk; calls: TriggerCall[] } {
-  const calls: TriggerCall[] = [];
-
-  const iii = {
-    trigger: async <_T, R>(req: { function_id: string; payload: unknown }): Promise<R> => {
-      calls.push({ function_id: req.function_id, payload: req.payload });
-
-      if (req.function_id === 'models::get') {
-        return (overrides?.modelsGetResult ?? null) as R;
-      }
+}): { iii: ReturnType<typeof fakeIii>['iii']; calls: TriggerCall[] } {
+  return fakeIii({
+    responder: (req) => {
+      if (req.function_id === 'models::get') return overrides?.modelsGetResult ?? null;
       if (req.function_id === 'session-tree::messages') {
-        return (overrides?.sessionTreeResult ?? { messages: [] }) as R;
+        return overrides?.sessionTreeResult ?? { messages: [] };
       }
       if (req.function_id === 'context-compaction::compact_now') {
-        return (overrides?.compactNowResult ?? { status: 'ok' }) as R;
+        return overrides?.compactNowResult ?? { status: 'ok' };
       }
-      return null as R;
+      return null;
     },
-  } as unknown as ISdk;
-
-  return { iii, calls };
+  });
 }
 
 const smallMessage = { role: 'user' as const, content: [] as never[], timestamp: 0 };

--- a/harness/tests/turn-orchestrator/provisioning.test.ts
+++ b/harness/tests/turn-orchestrator/provisioning.test.ts
@@ -1,32 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { ISdk } from '../../src/runtime/iii.js';
 import type { TurnOrchestratorConfig } from '../../src/turn-orchestrator/config.js';
+import { fakeIii } from './_helpers/fakeIii.js';
 import { defaultRunRequest, installMockTurnStore } from './_helpers/mockTurnStore.js';
 import { type TurnStateRecord, newRecord } from '../../src/turn-orchestrator/state.js';
 import { TurnStepPayloadSchema } from '../../src/turn-orchestrator/schemas.js';
 import { parseDirectoryBody } from '../../src/turn-orchestrator/provisioning/ports.js';
 import { handleProvisioning, register } from '../../src/turn-orchestrator/provisioning/process.js';
-
-type TriggerCall = { function_id: string; payload: unknown; timeoutMs?: number };
-
-function fakeIii(responses: Record<string, unknown> = {}): { iii: ISdk; calls: TriggerCall[] } {
-  const calls: TriggerCall[] = [];
-  const iii = {
-    trigger: async <T, R>(req: {
-      function_id: string;
-      payload: T;
-      timeoutMs?: number;
-    }): Promise<R> => {
-      calls.push({
-        function_id: req.function_id,
-        payload: req.payload,
-        timeoutMs: req.timeoutMs,
-      });
-      return (responses[req.function_id] ?? null) as R;
-    },
-  } as unknown as ISdk;
-  return { iii, calls };
-}
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -49,8 +28,10 @@ describe('handleProvisioning', () => {
   it('materializes schemas, persists built prompt, and advances to assistant_streaming', async () => {
     const rec: TurnStateRecord = { ...newRecord('s1'), state: 'provisioning' };
     const { iii, calls } = fakeIii({
-      'directory::skills::index': { body: 'INDEX' },
-      'directory::skills::get': { body: 'SKILL' },
+      responder: {
+        'directory::skills::index': { body: 'INDEX' },
+        'directory::skills::get': { body: 'SKILL' },
+      },
     });
     const cfg = { system_default_skills: ['iii://iii-directory/index'] };
 

--- a/harness/tests/turn-orchestrator/run-start.test.ts
+++ b/harness/tests/turn-orchestrator/run-start.test.ts
@@ -1,25 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import { TriggerAction, type ISdk } from '../../src/runtime/iii.js';
+import { fakeIii } from './_helpers/fakeIii.js';
 import { execute, register } from '../../src/turn-orchestrator/run-start.js';
 import { RunStartPayloadSchema } from '../../src/turn-orchestrator/schemas.js';
-
-type TriggerCall = { function_id: string; payload: unknown; action?: unknown };
-
-function fakeIii(): { iii: ISdk; calls: TriggerCall[] } {
-  const calls: TriggerCall[] = [];
-  const iii = {
-    trigger: async <T, R>(req: {
-      function_id: string;
-      payload: T;
-      action?: unknown;
-    }): Promise<R> => {
-      calls.push({ function_id: req.function_id, payload: req.payload, action: req.action });
-      return null as R;
-    },
-    registerFunction: vi.fn(),
-  } as unknown as ISdk;
-  return { iii, calls };
-}
 
 /** Shape console/web sends inside harness::trigger payload (real.ts). */
 const consoleRunStartPayload = {

--- a/harness/tests/turn-orchestrator/run-transition.test.ts
+++ b/harness/tests/turn-orchestrator/run-transition.test.ts
@@ -8,6 +8,7 @@ import {
   newRecord,
   transitionTo,
 } from '../../src/turn-orchestrator/state.js';
+import { fakeIii } from './_helpers/fakeIii.js';
 import { installMockTurnStore } from './_helpers/mockTurnStore.js';
 
 afterEach(() => {
@@ -97,21 +98,16 @@ describe('runTransition', () => {
   });
 });
 
-function fakeIii(record: unknown) {
-  const writes: Array<{ function_id: string; payload: any }> = [];
-  const iii = {
-    trigger: vi.fn(async ({ function_id, payload }: any) => {
-      writes.push({ function_id, payload });
-      if (
-        function_id === 'state::get' &&
-        payload.scope === TURN_STATE_SCOPE &&
-        payload.key === 's1'
-      ) {
+function fakeIiiForRecord(record: unknown) {
+  const { iii, calls: writes } = fakeIii({
+    responder: (req) => {
+      const p = req.payload as { scope?: string; key?: string };
+      if (req.function_id === 'state::get' && p?.scope === TURN_STATE_SCOPE && p?.key === 's1') {
         return record;
       }
       return null;
-    }),
-  } as any;
+    },
+  });
   return { iii, writes };
 }
 
@@ -127,7 +123,7 @@ describe('runTransition error model', () => {
   };
 
   it('routes an unexpected throw to failed and does not re-throw', async () => {
-    const { iii, writes } = fakeIii({ ...base });
+    const { iii, writes } = fakeIiiForRecord({ ...base });
     const res = await runTransition(
       iii,
       'function_execute',
@@ -159,7 +155,7 @@ describe('runTransition error model', () => {
   });
 
   it('re-throws TransientError so the queue retries', async () => {
-    const { iii } = fakeIii({ ...base });
+    const { iii } = fakeIiiForRecord({ ...base });
     await expect(
       runTransition(
         iii,

--- a/harness/tests/turn-orchestrator/state.test.ts
+++ b/harness/tests/turn-orchestrator/state.test.ts
@@ -5,34 +5,9 @@ import {
   parseFunctionBatchRecord,
   parseSteeringCheckRecord,
 } from '../../src/turn-orchestrator/schemas.js';
-import {
-  type TurnStateRecord,
-  newRecord,
-  transitionTo,
-} from '../../src/turn-orchestrator/state.js';
+import { type TurnStateRecord, newRecord } from '../../src/turn-orchestrator/state.js';
 import { enterFunctionExecute } from '../../src/turn-orchestrator/function-execute/run.js';
 import type { AssistantMessage } from '../../src/types/agent-message.js';
-
-describe('TurnStateRecord', () => {
-  it('starts in provisioning with no work and the given max_turns', () => {
-    const r = newRecord('s1', 32);
-    expect(r.state).toBe('provisioning');
-    expect(r.session_id).toBe('s1');
-    expect(r.max_turns).toBe(32);
-    expect(r.work).toBeUndefined();
-  });
-
-  it('transitionTo stopped marks terminal', () => {
-    const r = newRecord('s1');
-    transitionTo(r, 'stopped');
-    expect(r.state).toBe('stopped');
-  });
-
-  it('awaiting_approval defaults to undefined on fresh records', () => {
-    const rec: TurnStateRecord = newRecord('s1');
-    expect(rec.awaiting_approval).toBeUndefined();
-  });
-});
 
 describe('parseFunctionBatchRecord', () => {
   const asst: AssistantMessage = {

--- a/harness/tests/turn-orchestrator/steering.test.ts
+++ b/harness/tests/turn-orchestrator/steering.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { ISdk } from '../../src/runtime/iii.js';
 import type { AgentMessage } from '../../src/types/agent-message.js';
 import * as events from '../../src/turn-orchestrator/events.js';
+import { fakeIii } from './_helpers/fakeIii.js';
 import { installMockTurnStore } from './_helpers/mockTurnStore.js';
 import { newRecord, type TurnStateRecord } from '../../src/turn-orchestrator/state.js';
 import { handleSteering } from '../../src/turn-orchestrator/steering-check/process.js';
@@ -32,9 +32,8 @@ function makeIii(opts: { steeringItems?: AgentMessage[]; followupItems?: AgentMe
   const { steeringItems = [], followupItems = [] } = opts;
   const drainCalls: Array<{ name: string; session_id: string }> = [];
 
-  const iii = {
-    trigger: vi.fn(async (req: { function_id: string; payload: unknown }) => {
-      if (req.function_id === 'state::get') return null;
+  const { iii } = fakeIii({
+    responder: (req) => {
       if (req.function_id === 'session-inbox::drain') {
         const p = req.payload as { name: string; session_id: string };
         drainCalls.push(p);
@@ -43,10 +42,9 @@ function makeIii(opts: { steeringItems?: AgentMessage[]; followupItems?: AgentMe
         return { items: [] };
       }
       if (req.function_id === 'state::update') return { old_value: 0 };
-      if (req.function_id === 'stream::set') return null;
       return null;
-    }),
-  } as unknown as ISdk;
+    },
+  });
 
   return { iii, drainCalls };
 }


### PR DESCRIPTION
## Summary

Test-side follow-up to #185. Consolidates duplicated mock harnesses and retires tests already covered end-to-end by the new parallel-approval e2e. Production code is untouched.

Stacked on `refactor/turn-orchestrator-cleanup` (#185) — review/merge after that one.

## Cuts

- **Shared message-builder helper** (`_helpers/builders.ts`): a single `makeAssistant` / `makeAssistantWithCalls` / `agentTriggerCall` replaces three near-identical inline builders across `functions.test.ts`, `function-execute.test.ts`, and `function-awaiting-approval.test.ts`.
- **Shared `fakeIii` helper** (`_helpers/fakeIii.ts`): the canonical `{ iii, calls }` fake used by `assistant.test.ts`, `provisioning.test.ts`, `hook.test.ts`, `run-start.test.ts`, `preflight.test.ts`, `steering.test.ts`, and `run-transition.test.ts`. Responder option covers both static-map and per-call-callback shapes.
- **Shared state-store fake** (`_helpers/stateStoreIii.ts`): the richer fake (in-memory `state::get` / `state::set` / `state::update` + `turn::*` wake capture) used by `on-record-written.e2e.test.ts` — was a 60-line inline implementation.
- **Retired tautological cases in `state.test.ts`**: three tests that just restated the `newRecord` builder defaults. The invariant validators below them stay — those test real error paths.
- **Retired overlap in `function-awaiting-approval.test.ts`**: dropped the `handleAwaitingApproval` allow→steering_check and undecided-parking cases — both are exercised end-to-end by `tests/integration/parallel-approval.e2e.test.ts` (with the dedicated harness from #185). Kept the `function_execute` resume case (no e2e counterpart) and the `applyDecisionToPrepared` unit tests.

## What's left untouched

- `provider-stream.test.ts`, `store.test.ts`, the per-state `stubPorts` helpers — each is genuinely specialized (channel logic, emit capture, distinct Ports types). Consolidating them would add complexity without a real win.
- `parallel-approval-harness.ts` and `parallel-approval.e2e.test.ts` — the reference implementation everything else now leans on.

## Test plan

- [x] `pnpm -C harness exec vitest run` — full suite green (937 tests; -5 vs. main, all retired duplicates/tautologies)
- [x] `pnpm -C harness typecheck` — clean
- [x] biome 2.4.10 formatting applied
- [ ] CI green
