### PR TITLE
ci: fix fork PR checkout + add recheck-on-comment listener

### DIFF
--- a/.github/workflows/skill-check-recheck.yml
+++ b/.github/workflows/skill-check-recheck.yml
@@ -1,0 +1,34 @@
+name: skill-check recheck
+
+# Consumer of the reusable listener at
+# iii-hq/skills-and-validation/.github/workflows/recheck-on-comment.yml.
+# Fires when a maintainer ticks the "Re-render this branch and commit
+# rendered artifacts" box in the sticky skill-check comment, re-runs
+# the action with write: true on the PR head, and commits the fresh
+# render back.
+#
+# Constraints:
+#   - This workflow file MUST live on the default branch — GitHub runs
+#     issue_comment workflows from main only (security feature). Adding
+#     it on a feature branch is a no-op for that PR.
+#   - The reusable workflow's `permissions:` block is not inherited;
+#     the caller has to grant them explicitly or the job is rejected
+#     with a startup_failure.
+
+on:
+  issue_comment:
+    types: [edited]
+
+permissions:
+  contents: write          # push the auto-render commit to the PR branch
+  pull-requests: write     # update the sticky comment
+  actions: write           # AI skip-cache (actions/cache)
+
+jobs:
+  recheck:
+    uses: iii-hq/skills-and-validation/.github/workflows/recheck-on-comment.yml@v0.4
+    with:
+      config-path: .skill-check.yaml
+      action-ref: v0.4
+    secrets:
+      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/skill-check.yml
+++ b/.github/workflows/skill-check.yml
@@ -14,9 +14,11 @@ jobs:
   skill-check:
     runs-on: ubuntu-latest
     steps:
+      # No explicit ref — checkout defaults to refs/pull/N/merge on
+      # pull_request, which works for both same-repo and fork PRs.
+      # Setting `ref: github.head_ref` previously broke fork PRs (the
+      # head branch only exists in the fork, not in this repo).
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ github.head_ref }}    # check out the PR branch directly
       - uses: iii-hq/skills-and-validation@v0.4
         with:
           write: false


### PR DESCRIPTION
Re-opens the intent of the reverted #197 without touching any worker source content. **Two files only**:

- \`.github/workflows/skill-check.yml\` — drop the \`ref: \${{ github.head_ref }}\` line so fork PRs (e.g. #196) stop failing at the checkout step.
- \`.github/workflows/skill-check-recheck.yml\` (new) — wires the "Re-render this branch and commit" checkbox to the reusable listener in skills-and-validation@v0.4.

## Expected CI state

This PR's diff is just \`.github/workflows/\` — no worker file is touched, so no worker enters pr-diff scope. **However, the action's global drift check is not pr-diff-scoped** (by design, to keep stale rendered artifacts from accumulating on main), and \`shell/\`'s rendered artifacts are currently stale on workers main. So CI here will go red on drift until \`shell/\` is re-rendered.

That's a pre-existing problem orthogonal to this PR. Three options:
1. Land this PR first; open a follow-up \`chore: re-render shell artifacts (v0.4 single-file skill.md format)\`.
2. Re-render \`shell/\` on main in a chore PR first; then land this on a clean main.
3. Flip workers' \`write: true\` so the action auto-commits drift on the next PR.

Whichever order — the changes in this PR are independent and ready.

## Companion context

- The fork-PR fix unblocks #196 once that PR is rebased on the new main.
- The listener becomes active only after this PR lands (issue_comment workflows are read from the default branch). Once landed, the checkbox works on all open and future PRs with sticky skill-check comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a recheck capability allowing users to manually retrigger skill validation assessments through issue comments, improving workflow flexibility.

* **Bug Fixes**
  * Resolved skill validation compatibility issues affecting fork-based pull requests, ensuring consistent validation across all contribution methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/workers/pull/200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->