### PR TITLE
fix(harness): register web::fetch worker in composite entry

### DIFF
--- a/harness/package.json
+++ b/harness/package.json
@@ -33,8 +33,10 @@
     "dev:provider-openai": "tsx src/provider-openai/main.ts",
     "dev:provider-kimi": "tsx src/provider-kimi/main.ts",
     "dev:provider-lmstudio": "tsx src/provider-lmstudio/main.ts",
+    "dev:provider-llamacpp": "tsx src/provider-llamacpp/main.ts",
     "dev:context-compaction": "tsx src/context-compaction/main.ts",
-    "dev:provider-config": "tsx src/provider-config/main.ts"
+    "dev:provider-config": "tsx src/provider-config/main.ts",
+    "dev:web": "tsx src/web/main.ts"
   },
   "bin": {
     "harness": "./dist/index.js",
@@ -50,8 +52,10 @@
     "iii-provider-openai": "./dist/provider-openai/main.js",
     "iii-provider-kimi": "./dist/provider-kimi/main.js",
     "iii-provider-lmstudio": "./dist/provider-lmstudio/main.js",
+    "iii-provider-llamacpp": "./dist/provider-llamacpp/main.js",
     "iii-context-compaction": "./dist/context-compaction/main.js",
-    "iii-provider-config": "./dist/provider-config/main.js"
+    "iii-provider-config": "./dist/provider-config/main.js",
+    "iii-web": "./dist/web/main.js"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -33,6 +33,7 @@ import {
 } from './runtime/worker.js';
 import { register as registerSession } from './session/register.js';
 import { register as registerTurnOrchestrator } from './turn-orchestrator/register.js';
+import { register as registerWeb } from './web/register.js';
 
 const WORKERS: readonly WorkerDefinition[] = [
   {
@@ -124,6 +125,11 @@ const WORKERS: readonly WorkerDefinition[] = [
     description:
       'Out-of-band session-history compactor. Subscribes to agent::events::TurnEnd and writes a session-tree Compaction entry when the running token count crosses the configured threshold.',
     register: (iii) => registerContextCompaction(iii),
+  },
+  {
+    name: 'web',
+    description: 'Outbound HTTP client on the iii bus (web::fetch).',
+    register: (iii, ctx) => registerWeb(iii, ctx),
   },
 ];
 

--- a/harness/tests/composite-manifest.test.ts
+++ b/harness/tests/composite-manifest.test.ts
@@ -1,0 +1,52 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..');
+const srcDir = join(repoRoot, 'src');
+const indexEntry = join(srcDir, 'index.ts');
+const tsxBin = join(repoRoot, 'node_modules', '.bin', 'tsx');
+
+const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8')) as {
+  scripts: Record<string, string>;
+  bin: Record<string, string>;
+};
+
+/**
+ * Every folder under `src/` that ships a `main.ts` is a worker meant to run
+ * standalone. The composite entry-point (`src/index.ts`, what `dev:all` and
+ * `start:all` run) must register every one of them — otherwise a worker
+ * silently never starts in the all-in-one process. Regression guard for #202,
+ * where the `web` worker was added but never wired into `index.ts`.
+ */
+function runnableWorkerFolders(): string[] {
+  return readdirSync(srcDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && existsSync(join(srcDir, e.name, 'main.ts')))
+    .map((e) => e.name)
+    .sort();
+}
+
+function compositeManifestNames(): string[] {
+  const out = execFileSync(tsxBin, [indexEntry, '--manifest'], { encoding: 'utf8' });
+  const manifest = JSON.parse(out) as Array<{ name: string }>;
+  return manifest.map((w) => w.name).sort();
+}
+
+describe('composite entry-point worker registration', () => {
+  it('registers every runnable worker folder in the WORKERS array', () => {
+    expect(compositeManifestNames()).toEqual(runnableWorkerFolders());
+  });
+
+  it('exposes a dev:<name> script for every runnable worker', () => {
+    const missing = runnableWorkerFolders().filter((name) => !pkg.scripts[`dev:${name}`]);
+    expect(missing).toEqual([]);
+  });
+
+  it('exposes an iii-<name> bin for every runnable worker', () => {
+    const missing = runnableWorkerFolders().filter((name) => !pkg.bin[`iii-${name}`]);
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

The `web::fetch` worker added in #202 shipped its source files and a standalone `src/web/main.ts`, but was never wired into `src/index.ts` — the composite all-in-one entry that `pnpm dev:all` (`bun --watch src/index.ts`) and `start:all` (`node dist/index.js`) run. As a result the web worker silently never started in the all-in-one process.

This registers it alongside the other 15 workers and backfills the wiring that #202 missed.

### Changes
- **`src/index.ts`**: import `registerWeb` and add the `web` worker to the `WORKERS` array. Composite manifest now reports 16 workers (was 15).
- **`package.json`**: add the missing `dev:web` script + `iii-web` bin. Also backfill the identical gap for `provider-llamacpp` (it was in the composite array but had no `dev:`/`iii-` entry either).
- **`tests/composite-manifest.test.ts`** (new): regression guard asserting every runnable worker folder (`src/*/main.ts`) is wired into (a) the composite `--manifest`, (b) a `dev:<name>` script, and (c) an `iii-<name>` bin. This is the check that was missing — per-folder tests existed, but nothing verified composite wiring.

### Root cause
`#202`'s diff touched only `src/web/*` and `tests/web/*`; `src/index.ts` was last modified in #195, before the web worker existed. The `WORKERS` array is a hardcoded list, so any new worker folder must be added manually — and there was no test catching the omission.

## Test plan
- [x] `pnpm test` — 1033 passing (121 files), including the new `composite-manifest` test
- [x] `pnpm run typecheck` — clean
- [x] Verified the regression test **fails** without the fix (flags exactly `web` and `provider-llamacpp`) and **passes** with it
- [x] `bun src/index.ts --manifest` lists `web`

> Note: `pnpm lint` currently fails on a pre-existing `biome.json` config error (an unrecognized `actions` key under biome 1.9.4) unrelated to this change — not touched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added development scripts for new provider and web components.
  * Added CLI tools for running new services.

* **Tests**
  * Added test suite validating system configuration and worker registration consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iii-hq/workers/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->