### PR TITLE
perf: harness telemetry/span-volume reductions

### DIFF
--- a/harness/package.json
+++ b/harness/package.json
@@ -58,10 +58,11 @@
     "iii-web": "./dist/web/main.js"
   },
   "dependencies": {
+    "@iii-dev/observability": "^0.16.1",
     "@opentelemetry/api": "^1.9.0",
     "chokidar": "^3.6.0",
     "commander": "^12.1.0",
-    "iii-sdk": "^0.12.0",
+    "iii-sdk": "^0.16.1",
     "pino": "^9.5.0",
     "uuid": "^11.0.3",
     "yaml": "^2.6.1",

--- a/harness/pnpm-lock.yaml
+++ b/harness/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@iii-dev/observability':
+        specifier: ^0.16.1
+        version: 0.16.1
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1
@@ -18,8 +21,8 @@ importers:
         specifier: ^12.1.0
         version: 12.1.0
       iii-sdk:
-        specifier: ^0.12.0
-        version: 0.12.0
+        specifier: ^0.16.1
+        version: 0.16.1
       pino:
         specifier: ^9.5.0
         version: 9.14.0
@@ -416,6 +419,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@iii-dev/observability@0.16.1':
+    resolution: {integrity: sha512-uY9YCVtF9YO0xjzJbfQYcBfnrCqWci6UMviKaFHMPI1JzJ/uDJPFgb6Le0vEPallwP6mtyw8UKgQynbwphZ0kg==}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
@@ -497,10 +503,6 @@ packages:
     resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
     engines: {node: '>=14'}
 
-  '@opentelemetry/semantic-conventions@1.41.1':
-    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
-    engines: {node: '>=14'}
-
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
@@ -513,8 +515,8 @@ packages:
   '@protobufjs/codegen@2.0.5':
     resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
 
   '@protobufjs/fetch@1.1.1':
     resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
@@ -809,12 +811,12 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
-  hasown@2.0.3:
-    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  iii-sdk@0.12.0:
-    resolution: {integrity: sha512-Y638PCUeJVGkYjpIvkBgVFXB9WmmbGHsRiRo02E+oph1ShOwmTDJ1LlSFn2h/dZC6cxgOOFwsMTltpGM6j1A+w==}
+  iii-sdk@0.16.1:
+    resolution: {integrity: sha512-lRLgKbq32UEwztRJXemgaRRRxD1uk1Jpm35sDs3T1im/gxjzlsd/PESC7/f+5klz0JtIjORhKUtXLASEAMgxHA==}
 
   import-in-the-middle@1.15.0:
     resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
@@ -901,8 +903,8 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
-  protobufjs@7.5.9:
-    resolution: {integrity: sha512-Od4muIm3HW1AouyHF5lONOf1FWo3hY1NbFDoy191X9GzhpgW1clCoaFjfVs2rKJNFYpTNJbje4cbAIDBZJ63ZA==}
+  protobufjs@7.6.2:
+    resolution: {integrity: sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==}
     engines: {node: '>=12.0.0'}
 
   quick-format-unescaped@4.0.4:
@@ -1074,8 +1076,8 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -1283,6 +1285,25 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
+  '@iii-dev/observability@0.16.1':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@opentelemetry/api-logs@0.57.2':
@@ -1321,7 +1342,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
-      protobufjs: 7.5.9
+      protobufjs: 7.6.2
 
   '@opentelemetry/propagator-b3@1.30.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -1371,8 +1392,6 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.28.0': {}
 
-  '@opentelemetry/semantic-conventions@1.41.1': {}
-
   '@pinojs/redact@0.4.0': {}
 
   '@protobufjs/aspromise@1.1.2': {}
@@ -1381,7 +1400,7 @@ snapshots:
 
   '@protobufjs/codegen@2.0.5': {}
 
-  '@protobufjs/eventemitter@1.1.0': {}
+  '@protobufjs/eventemitter@1.1.1': {}
 
   '@protobufjs/fetch@1.1.1':
     dependencies:
@@ -1657,24 +1676,15 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  hasown@2.0.3:
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
-  iii-sdk@0.12.0:
+  iii-sdk@0.16.1:
     dependencies:
+      '@iii-dev/observability': 0.16.1
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.57.2
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-node': 1.30.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.41.1
-      ws: 8.20.1
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -1693,7 +1703,7 @@ snapshots:
 
   is-core-module@2.16.2:
     dependencies:
-      hasown: 2.0.3
+      hasown: 2.0.4
 
   is-extglob@2.1.1: {}
 
@@ -1759,12 +1769,12 @@ snapshots:
 
   process-warning@5.0.0: {}
 
-  protobufjs@7.5.9:
+  protobufjs@7.6.2:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
       '@protobufjs/codegen': 2.0.5
-      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/eventemitter': 1.1.1
       '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
       '@protobufjs/inquire': 1.1.2
@@ -1947,7 +1957,7 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  ws@8.20.1: {}
+  ws@8.21.0: {}
 
   yaml@2.9.0: {}
 

--- a/harness/src/context-compaction/handler-async.ts
+++ b/harness/src/context-compaction/handler-async.ts
@@ -4,7 +4,7 @@
  * ({group_id, data}) envelopes.
  */
 
-import { setCurrentSpanAttribute, withSpan } from 'iii-sdk/telemetry';
+import { setCurrentSpanAttribute, withSpan } from '@iii-dev/observability';
 import type { ISdk } from '../runtime/iii.js';
 import { logger } from '../runtime/otel.js';
 import { compactionConfig } from './config.js';

--- a/harness/src/context-compaction/handler-sync.ts
+++ b/harness/src/context-compaction/handler-sync.ts
@@ -5,7 +5,7 @@
  * Sequence: lease → prune → summarise → reinject replay → auto-continue.
  */
 
-import { setCurrentSpanAttribute, withSpan } from 'iii-sdk/telemetry';
+import { setCurrentSpanAttribute, withSpan } from '@iii-dev/observability';
 import type { ISdk } from '../runtime/iii.js';
 import { logger } from '../runtime/otel.js';
 import type { AgentMessage } from '../types/agent-message.js';

--- a/harness/src/context-compaction/prune.ts
+++ b/harness/src/context-compaction/prune.ts
@@ -1,4 +1,4 @@
-import { setCurrentSpanAttribute, withSpan } from 'iii-sdk/telemetry';
+import { setCurrentSpanAttribute, withSpan } from '@iii-dev/observability';
 import type { ISdk } from '../runtime/iii.js';
 import { logger } from '../runtime/otel.js';
 import type { AgentMessage } from '../types/agent-message.js';

--- a/harness/src/runtime/otel.ts
+++ b/harness/src/runtime/otel.ts
@@ -13,20 +13,15 @@
  * `engine/src/workers/observability/mod.rs:917-920`.
  */
 
-import { SpanKind, context as otelContext, propagation } from '@opentelemetry/api';
+import { context as otelContext, propagation } from '@opentelemetry/api';
 import {
   type OtelConfig,
   SeverityNumber,
   currentSpanIsRecording,
   getLogger as getOtelLogger,
   initOtel,
-  recordSpanEvent,
-  redactAndTruncate,
-  resolveMaxBytesFromEnv,
   setCurrentSpanAttribute,
-  setCurrentSpanError,
-  withSpan,
-} from 'iii-sdk/telemetry';
+} from '@iii-dev/observability';
 import pino from 'pino';
 
 const baseLogger = pino({
@@ -240,123 +235,58 @@ function getBaggage(key: string): string | undefined {
 export type Handler<TIn = unknown, TOut = unknown> = (input: TIn) => Promise<TOut>;
 
 /**
- * Wrap a function handler so every invocation runs inside an OTel span
- * tagged with `iii.session.id` / `iii.message.id` / `iii.function.id`,
- * and the same IDs are pushed as baggage so downstream `iii.trigger`
- * calls inherit them.
+ * Enrich the active OTel span for a handler invocation with harness
+ * correlation IDs, and seed those IDs as baggage for downstream calls.
  *
- * Also mirrors `iii-sdk-rust`'s auto-instrumentation (see
- * `motia/sdk/packages/rust/iii/src/iii.rs:1689-1773`) by recording
- * three lifecycle span events on the wrap span:
+ * This does NOT open its own span. The iii-sdk `registerFunction` wrapper
+ * already opens an INTERNAL `execute <fn>` span and records the
+ * `iii.invocation.input` / `iii.invocation.output` events, the `exception`
+ * event, and OK/ERROR status. Opening a second `harness.<fn>` span here only
+ * duplicated that work under the `harness` service. Instead we fold the
+ * harness-specific bits onto the SDK's span:
  *
- *   - `iii.invocation.input`  — redacted+truncated input JSON
- *   - `iii.invocation.output` — redacted+truncated result JSON (or
- *                                {error: ...} on failure)
- *   - `exception`             — only on throw, with type/message/stack
+ *   - stamp `iii.session.id` / `iii.message.id` / `iii.function.id` as
+ *     attributes on the active span (the SDK span is harness-agnostic and
+ *     does not know these IDs), so `engine::traces::group_by` can group by
+ *     Session / Message / Function; and
+ *   - push the same IDs as baggage so downstream `iii.trigger` calls inherit
+ *     them and the engine's BaggageSpanProcessor stamps them onto every child
+ *     span across the trace.
  *
- * This is what populates the "EVENTS" tab in the traces UI for
- * harness-emitted spans. Without it, harness spans look
- * "empty" compared to Rust harness spans, because the Rust harness
- * gets the same events for free via `iii-sdk-rust` (and via the
- * `tracing-opentelemetry::OpenTelemetryLayer` bridge, which doesn't
- * exist on the Node side because `pino` doesn't bridge to OTel).
- *
- * Gated on `III_DISABLE_TRACE_PAYLOADS` to match the Rust
- * `iii-sdk` semantics (set to `1` to suppress payload capture).
- *
- * The wrap is a no-op (just forwards to the handler) when OTel has not
- * been initialized — `currentSpanIsRecording()` returns false and the
- * `withSpan` itself is cheap.
+ * When OTel is not initialized the SDK opens no active span;
+ * `currentSpanIsRecording()` returns false and we skip attribute stamping
+ * (baggage seeding stays cheap and harmless).
  */
 export function instrumentHandler<TIn = unknown, TOut = unknown>(
   functionId: string,
   handler: Handler<TIn, TOut>,
 ): Handler<TIn, TOut> {
-  const spanName = `harness.${functionId}`;
   return async (input: TIn): Promise<TOut> => {
-    return withSpan(spanName, { kind: SpanKind.SERVER }, async () => {
-      const ids = extractHarnessIds(input);
+    const ids = extractHarnessIds(input);
 
-      if (currentSpanIsRecording()) {
-        if (ids.sessionId !== undefined) {
-          setCurrentSpanAttribute('iii.session.id', ids.sessionId);
-        }
-        if (ids.messageId !== undefined) {
-          setCurrentSpanAttribute('iii.message.id', ids.messageId);
-        }
-        setCurrentSpanAttribute('iii.function.id', functionId);
+    // Stamp the harness IDs onto the SDK's active `execute <fn>` span.
+    if (currentSpanIsRecording()) {
+      if (ids.sessionId !== undefined) {
+        setCurrentSpanAttribute('iii.session.id', ids.sessionId);
       }
-
-      // Match the iii-sdk-rust pattern: emit input/output events with
-      // the (redacted, truncated) payload JSON. The env-var override
-      // matches the Rust SDK's `III_DISABLE_TRACE_PAYLOADS` knob.
-      const tracePayloads = !isTracePayloadsDisabled();
-      const payloadMaxBytes = resolveMaxBytesFromEnv();
-
-      if (tracePayloads) {
-        const { json, truncated } = redactAndTruncate(input, payloadMaxBytes);
-        recordSpanEvent('iii.invocation.input', {
-          'iii.payload.json': json,
-          'iii.payload.truncated': truncated,
-        });
+      if (ids.messageId !== undefined) {
+        setCurrentSpanAttribute('iii.message.id', ids.messageId);
       }
+      setCurrentSpanAttribute('iii.function.id', functionId);
+    }
 
-      // Propagate the IDs as baggage so child spans created by downstream
-      // `iii.trigger` calls inherit them via BaggageSpanProcessor.
-      const entries: Record<string, { value: string }> = {
-        'iii.function.id': { value: functionId },
-      };
-      if (ids.sessionId !== undefined) entries['iii.session.id'] = { value: ids.sessionId };
-      if (ids.messageId !== undefined) entries['iii.message.id'] = { value: ids.messageId };
+    // Propagate the IDs as baggage so child spans created by downstream
+    // `iii.trigger` calls inherit them via BaggageSpanProcessor.
+    const entries: Record<string, { value: string }> = {
+      'iii.function.id': { value: functionId },
+    };
+    if (ids.sessionId !== undefined) entries['iii.session.id'] = { value: ids.sessionId };
+    if (ids.messageId !== undefined) entries['iii.message.id'] = { value: ids.messageId };
 
-      const baggage = propagation.createBaggage(entries);
-      const ctxWithBaggage = propagation.setBaggage(otelContext.active(), baggage);
-
-      try {
-        const result = await otelContext.with(ctxWithBaggage, () => handler(input));
-        if (tracePayloads) {
-          const { json, truncated } = redactAndTruncate(result, payloadMaxBytes);
-          recordSpanEvent('iii.invocation.output', {
-            'iii.payload.json': json,
-            'iii.payload.truncated': truncated,
-            'iii.payload.ok': true,
-          });
-        }
-        return result;
-      } catch (err) {
-        // Record both the iii-sdk-style output event (so the EVENTS
-        // tab shows the failure inline next to the success path) AND
-        // the standard OTel `exception` event (so the ERRORS tab can
-        // pick it up). Mirrors `iii.rs:1750-1773`.
-        const message = err instanceof Error ? err.message : String(err);
-        const stack = err instanceof Error ? (err.stack ?? '') : '';
-        const exceptionType =
-          err instanceof Error && err.constructor?.name ? err.constructor.name : 'Error';
-        if (tracePayloads) {
-          const { json, truncated } = redactAndTruncate({ error: message }, payloadMaxBytes);
-          recordSpanEvent('iii.invocation.output', {
-            'iii.payload.json': json,
-            'iii.payload.truncated': truncated,
-            'iii.payload.ok': false,
-          });
-        }
-        recordSpanEvent('exception', {
-          'exception.type': exceptionType,
-          'exception.message': message,
-          'exception.stacktrace': stack,
-        });
-        setCurrentSpanError(message);
-        throw err;
-      }
-    });
+    const baggage = propagation.createBaggage(entries);
+    const ctxWithBaggage = propagation.setBaggage(otelContext.active(), baggage);
+    return otelContext.with(ctxWithBaggage, () => handler(input));
   };
-}
-
-function isTracePayloadsDisabled(): boolean {
-  const raw = process.env.III_DISABLE_TRACE_PAYLOADS;
-  if (!raw) return false;
-  const v = raw.toLowerCase();
-  return v === '1' || v === 'true';
 }
 
 // =============================================================================

--- a/harness/src/turn-orchestrator/assistant-streaming/coalesce-deltas.ts
+++ b/harness/src/turn-orchestrator/assistant-streaming/coalesce-deltas.ts
@@ -35,9 +35,12 @@ export function createDeltaCoalescer(
   const flushMs = opts?.flushMs ?? DEFAULT_FLUSH_MS;
   const maxChars = opts?.maxChars ?? DEFAULT_MAX_CHARS;
 
-  let buf:
-    | { type: string; delta: string; last: AssistantMessageEvent; partial: AssistantMessage }
-    | null = null;
+  let buf: {
+    type: string;
+    delta: string;
+    last: AssistantMessageEvent;
+    partial: AssistantMessage;
+  } | null = null;
   let timer: ReturnType<typeof setTimeout> | null = null;
 
   function clearTimer(): void {
@@ -66,10 +69,7 @@ export function createDeltaCoalescer(
     }, flushMs);
   }
 
-  async function onEvent(
-    partial: AssistantMessage,
-    event: AssistantMessageEvent,
-  ): Promise<void> {
+  async function onEvent(partial: AssistantMessage, event: AssistantMessageEvent): Promise<void> {
     const d = event as { type: string; delta?: string };
     const coalescable = COALESCE_TYPES.has(d.type) && typeof d.delta === 'string';
 

--- a/harness/src/turn-orchestrator/assistant-streaming/coalesce-deltas.ts
+++ b/harness/src/turn-orchestrator/assistant-streaming/coalesce-deltas.ts
@@ -1,0 +1,95 @@
+/**
+ * Coalesce consecutive same-type provider stream deltas into a single
+ * `message_update` emit, to cut the per-token span/RPC explosion on the
+ * streaming path (see docs/superpowers/specs/2026-05-31-harness-streaming-
+ * delta-coalescing-design.md).
+ *
+ * The console renders streaming text by appending `llm_event.delta`
+ * (console/web/src/lib/backend/translate.ts), so merging N same-type deltas
+ * into one event whose `delta` is their concatenation — carrying the latest
+ * `partial` — is byte-for-byte equivalent on the wire. Discrete events
+ * (`*_start`/`*_end`, `usage`, `stop`, …) are flushed-through 1:1 and never
+ * merged, preserving ordering.
+ */
+
+import type { AssistantMessage } from '../../types/agent-message.js';
+import type { AssistantMessageEvent } from '../../types/stream-event.js';
+
+const COALESCE_TYPES = new Set(['text_delta', 'thinking_delta', 'functioncall_delta']);
+const DEFAULT_FLUSH_MS = 60;
+const DEFAULT_MAX_CHARS = 4096;
+
+type Emit = (partial: AssistantMessage, event: AssistantMessageEvent) => Promise<void>;
+
+export interface DeltaCoalescer {
+  /** Mirrors the provider onDelta contract: (partial, event). */
+  onEvent(partial: AssistantMessage, event: AssistantMessageEvent): Promise<void>;
+  /** Emit any buffered deltas now. Idempotent; safe to call on every exit path. */
+  flush(): Promise<void>;
+}
+
+export function createDeltaCoalescer(
+  emit: Emit,
+  opts?: { flushMs?: number; maxChars?: number },
+): DeltaCoalescer {
+  const flushMs = opts?.flushMs ?? DEFAULT_FLUSH_MS;
+  const maxChars = opts?.maxChars ?? DEFAULT_MAX_CHARS;
+
+  let buf:
+    | { type: string; delta: string; last: AssistantMessageEvent; partial: AssistantMessage }
+    | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  function clearTimer(): void {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  }
+
+  async function flush(): Promise<void> {
+    clearTimer();
+    if (!buf) return;
+    const merged = { ...buf.last, delta: buf.delta } as AssistantMessageEvent;
+    const { partial } = buf;
+    buf = null;
+    await emit(partial, merged);
+  }
+
+  // Periodic throttle, NOT a trailing debounce: a steady ~flushMs cadence keeps
+  // text appearing smoothly while continuous deltas arrive. A trailing debounce
+  // would withhold all text until the stream paused.
+  function arm(): void {
+    if (timer) return;
+    timer = setTimeout(() => {
+      void flush();
+    }, flushMs);
+  }
+
+  async function onEvent(
+    partial: AssistantMessage,
+    event: AssistantMessageEvent,
+  ): Promise<void> {
+    const d = event as { type: string; delta?: string };
+    const coalescable = COALESCE_TYPES.has(d.type) && typeof d.delta === 'string';
+
+    if (coalescable) {
+      if (buf && buf.type !== d.type) await flush(); // type switch is a boundary
+      buf = buf
+        ? { type: buf.type, delta: buf.delta + d.delta, last: event, partial }
+        : { type: d.type, delta: d.delta as string, last: event, partial };
+      if (flushMs <= 0 || buf.delta.length >= maxChars) {
+        await flush();
+      } else {
+        arm();
+      }
+      return;
+    }
+
+    // Discrete event: flush pending deltas first (preserve order), then 1:1.
+    await flush();
+    await emit(partial, event);
+  }
+
+  return { onEvent, flush };
+}

--- a/harness/src/turn-orchestrator/assistant-streaming/run.ts
+++ b/harness/src/turn-orchestrator/assistant-streaming/run.ts
@@ -8,6 +8,7 @@ import { syntheticAssistant } from '../synthetic-assistant.js';
 import { emitTurnEndOnce } from '../state-runtime/turn-end.js';
 import { enterFunctionExecute } from '../function-execute/run.js';
 import { transitionTo, type AssistantStreamingTurnRecord } from '../state.js';
+import { createDeltaCoalescer } from './coalesce-deltas.js';
 import {
   hasFunctionCalls,
   isErrorOrAborted,
@@ -56,12 +57,20 @@ export async function runStreamTurn(
 ): Promise<StreamTurnOutcome> {
   let body_streamed = false;
 
+  // Coalesce consecutive same-type provider deltas into one message_update to
+  // cut the per-token span/RPC explosion on the streaming path. Discrete
+  // events flush through 1:1; the final flush below guarantees the tail.
+  const coalescer = createDeltaCoalescer((partial, event) =>
+    ports.emitMessageUpdate(session_id, partial, event),
+  );
+
   const { final, error } = await ports.streamTurn(ctx, async (partial, event) => {
-    await ports.emitMessageUpdate(session_id, partial, event);
     if (event.type === 'text_delta' || event.type === 'thinking_delta') {
       body_streamed = true;
     }
+    await coalescer.onEvent(partial, event);
   });
+  await coalescer.flush();
 
   return { final, error, body_streamed };
 }

--- a/harness/src/turn-orchestrator/events.ts
+++ b/harness/src/turn-orchestrator/events.ts
@@ -2,13 +2,23 @@
  * Emit AgentEvent frames on `agent::events`, one per call with a per-session
  * monotonic sequence number. `turn_end` frames are additionally mirrored onto
  * the dedicated `agent::turn_end` stream (see TURN_END_STREAM).
+ *
+ * The sequence number is kept IN-PROCESS (not persisted): the old per-event
+ * `state::update` increment cost one engine state write — and thus one
+ * trigger-evaluation pass — per agent event (~66/turn). The seq only feeds the
+ * stream frame `item_id`, which is opaque to consumers: the console never reads
+ * it, the fanout strips it, and the engine delivers frames in insertion order
+ * (item_id is just a `<group_id, item_id>` dedup key). So a process-local
+ * counter is behavior-preserving. To keep item_ids unique across process
+ * restarts without any persisted write, every item_id is prefixed with a
+ * random per-process epoch — a fresh process can never collide with frames the
+ * previous one wrote for the same session.
  */
 
+import { uuidLike } from '../runtime/ids.js';
 import type { ISdk } from '../runtime/iii.js';
 import { logger } from '../runtime/otel.js';
 import type { AgentEvent } from '../types/agent-event.js';
-
-const EVENT_COUNTER_SCOPE = 'event_counter';
 
 export const EVENTS_STREAM = 'agent::events';
 /**
@@ -18,8 +28,28 @@ export const EVENTS_STREAM = 'agent::events';
  */
 export const TURN_END_STREAM = 'agent::turn_end';
 
+/** Unique per process run; prefixes every item_id so a restart can't collide. */
+const PROCESS_EPOCH = uuidLike();
+/**
+ * Per-session monotonic counter. One small integer per session seen by this
+ * process; never reset across turns (matching the old persisted counter's
+ * monotonic-per-session semantics), so item_ids stay unique within the process.
+ */
+const seqBySession = new Map<string, number>();
+
+function nextSeq(session_id: string): number {
+  const n = seqBySession.get(session_id) ?? 0;
+  seqBySession.set(session_id, n + 1);
+  return n;
+}
+
+/** Test seam: clear the in-process counters. Do not call in production. */
+export function _resetSeqForTests(): void {
+  seqBySession.clear();
+}
+
 function formatItemId(session_id: string, seq: number): string {
-  return `${session_id}-${seq.toString().padStart(8, '0')}`;
+  return `${session_id}-${PROCESS_EPOCH}-${seq.toString().padStart(8, '0')}`;
 }
 
 function isTurnEnd(event: AgentEvent): boolean {
@@ -48,28 +78,8 @@ async function setStream(
   }
 }
 
-async function nextSeq(iii: ISdk, session_id: string): Promise<number> {
-  try {
-    const resp = await iii.trigger<unknown, { old_value?: number }>({
-      function_id: 'state::update',
-      payload: {
-        scope: EVENT_COUNTER_SCOPE,
-        key: session_id,
-        ops: [{ type: 'increment', path: '', by: 1 }],
-      },
-    });
-    if (typeof resp?.old_value === 'number') return resp.old_value;
-  } catch (err) {
-    logger.warn('event_counter increment failed', {
-      session_id,
-      err: String(err),
-    });
-  }
-  return 0;
-}
-
 export async function emit(iii: ISdk, session_id: string, event: AgentEvent): Promise<void> {
-  const seq = await nextSeq(iii, session_id);
+  const seq = nextSeq(session_id);
   const item_id = formatItemId(session_id, seq);
   await setStream(iii, EVENTS_STREAM, session_id, item_id, event);
   if (isTurnEnd(event)) {

--- a/harness/src/turn-orchestrator/state-runtime/store.ts
+++ b/harness/src/turn-orchestrator/state-runtime/store.ts
@@ -93,13 +93,20 @@ async function persistRecord(
   const result = await scopedSet(iii, TURN_STATE_SCOPE, rec.session_id, rec);
   const prev = previous !== undefined ? previous : parseTurnStateRecord(result?.old_value ?? null);
 
-  await emitTurnStateChanged(
-    iii,
-    rec.session_id,
-    prev == null ? 'state:created' : 'state:updated',
-    toView(rec),
-    prev != null ? toView(prev) : undefined,
-  );
+  const nextView = toView(rec);
+  const prevView = prev != null ? toView(prev) : undefined;
+  const viewChanged =
+    prevView === undefined || JSON.stringify(prevView) !== JSON.stringify(nextView);
+
+  if (viewChanged) {
+    await emitTurnStateChanged(
+      iii,
+      rec.session_id,
+      prev == null ? 'state:created' : 'state:updated',
+      nextView,
+      prevView,
+    );
+  }
 
   return prev;
 }

--- a/harness/tests/runtime/log-bridge.test.ts
+++ b/harness/tests/runtime/log-bridge.test.ts
@@ -24,9 +24,8 @@ interface CapturedRecord {
 const captured: CapturedRecord[] = [];
 
 vi.mock('@iii-dev/observability', async () => {
-  const actual = await vi.importActual<typeof import('@iii-dev/observability')>(
-    '@iii-dev/observability',
-  );
+  const actual =
+    await vi.importActual<typeof import('@iii-dev/observability')>('@iii-dev/observability');
   return {
     ...actual,
     getLogger: () => ({

--- a/harness/tests/runtime/log-bridge.test.ts
+++ b/harness/tests/runtime/log-bridge.test.ts
@@ -23,8 +23,10 @@ interface CapturedRecord {
 
 const captured: CapturedRecord[] = [];
 
-vi.mock('iii-sdk/telemetry', async () => {
-  const actual = await vi.importActual<typeof import('iii-sdk/telemetry')>('iii-sdk/telemetry');
+vi.mock('@iii-dev/observability', async () => {
+  const actual = await vi.importActual<typeof import('@iii-dev/observability')>(
+    '@iii-dev/observability',
+  );
   return {
     ...actual,
     getLogger: () => ({
@@ -37,10 +39,10 @@ vi.mock('iii-sdk/telemetry', async () => {
 
 // Imported AFTER the mock so the mock is in effect when the module
 // resolves `getLogger`. `SeverityNumber` is re-exported from
-// iii-sdk/telemetry so we don't need a direct dependency on
+// @iii-dev/observability so we don't need a direct dependency on
 // @opentelemetry/api-logs in this package.
 const { logger } = await import('../../src/runtime/otel.js');
-const { SeverityNumber } = await import('iii-sdk/telemetry');
+const { SeverityNumber } = await import('@iii-dev/observability');
 
 beforeEach(() => {
   captured.length = 0;

--- a/harness/tests/turn-orchestrator/coalesce-deltas.test.ts
+++ b/harness/tests/turn-orchestrator/coalesce-deltas.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createDeltaCoalescer } from '../../src/turn-orchestrator/assistant-streaming/coalesce-deltas.js';
+import type {
+  AssistantStreamingPorts,
+  DeltaHandler,
+  StreamContext,
+} from '../../src/turn-orchestrator/assistant-streaming/ports.js';
+import { runStreamTurn } from '../../src/turn-orchestrator/assistant-streaming/run.js';
+import { emptyAssistant } from '../../src/types/agent-message.js';
+import type { AssistantMessageEvent } from '../../src/types/stream-event.js';
+
+const P = emptyAssistant('anthropic', 'claude');
+const td = (delta: string): AssistantMessageEvent => ({ type: 'text_delta', partial: P, delta });
+const thd = (delta: string): AssistantMessageEvent => ({
+  type: 'thinking_delta',
+  partial: P,
+  delta,
+});
+const fcd = (delta: string): AssistantMessageEvent => ({
+  type: 'functioncall_delta',
+  partial: P,
+  delta,
+});
+
+function recorder() {
+  const emits: AssistantMessageEvent[] = [];
+  const emit = async (_partial: unknown, event: AssistantMessageEvent) => {
+    emits.push(event);
+  };
+  return { emit, emits };
+}
+
+describe('createDeltaCoalescer — lossless merge', () => {
+  it('merges consecutive same-type deltas into one event whose delta is the concatenation', async () => {
+    const { emit, emits } = recorder();
+    const c = createDeltaCoalescer(emit, { flushMs: 60 });
+
+    await c.onEvent(P, td('Hel'));
+    await c.onEvent(P, td('lo, '));
+    await c.onEvent(P, td('world'));
+    expect(emits).toHaveLength(0); // still buffering
+
+    await c.flush();
+
+    expect(emits).toHaveLength(1);
+    expect(emits[0]).toMatchObject({ type: 'text_delta', delta: 'Hello, world' });
+  });
+
+  it('preserves every byte across many deltas (Σ in === merged out)', async () => {
+    const { emit, emits } = recorder();
+    const c = createDeltaCoalescer(emit, { flushMs: 60 });
+    const parts = Array.from({ length: 50 }, (_, i) => `t${i}-`);
+    for (const p of parts) await c.onEvent(P, td(p));
+    await c.flush();
+    const merged = emits.map((e) => (e as { delta: string }).delta).join('');
+    expect(merged).toBe(parts.join(''));
+  });
+});
+
+describe('createDeltaCoalescer — boundaries', () => {
+  it('flushes at a delta-type switch (text vs thinking vs functioncall never merge)', async () => {
+    const { emit, emits } = recorder();
+    const c = createDeltaCoalescer(emit, { flushMs: 60 });
+
+    await c.onEvent(P, td('a'));
+    await c.onEvent(P, td('b'));
+    await c.onEvent(P, thd('x'));
+    await c.onEvent(P, thd('y'));
+    await c.onEvent(P, fcd('{'));
+    await c.flush();
+
+    expect(emits.map((e) => [e.type, (e as { delta: string }).delta])).toEqual([
+      ['text_delta', 'ab'],
+      ['thinking_delta', 'xy'],
+      ['functioncall_delta', '{'],
+    ]);
+  });
+
+  it('flushes pending deltas before a discrete event and emits the discrete event 1:1, in order', async () => {
+    const { emit, emits } = recorder();
+    const c = createDeltaCoalescer(emit, { flushMs: 60 });
+
+    await c.onEvent(P, td('a'));
+    await c.onEvent(P, td('b'));
+    await c.onEvent(P, { type: 'text_end', partial: P });
+    await c.onEvent(P, td('c'));
+    await c.flush();
+
+    expect(emits.map((e) => e.type)).toEqual(['text_delta', 'text_end', 'text_delta']);
+    expect((emits[0] as { delta: string }).delta).toBe('ab');
+    expect((emits[2] as { delta: string }).delta).toBe('c');
+  });
+
+  it('force-flushes when a single batch reaches the char cap', async () => {
+    const { emit, emits } = recorder();
+    const c = createDeltaCoalescer(emit, { flushMs: 60, maxChars: 5 });
+
+    await c.onEvent(P, td('abc'));
+    await c.onEvent(P, td('def')); // 6 >= 5 → flush
+    expect(emits).toHaveLength(1);
+    expect((emits[0] as { delta: string }).delta).toBe('abcdef');
+
+    await c.flush(); // nothing buffered
+    expect(emits).toHaveLength(1);
+  });
+});
+
+describe('createDeltaCoalescer — flush triggers', () => {
+  it('emits trailing buffered deltas on flush()', async () => {
+    const { emit, emits } = recorder();
+    const c = createDeltaCoalescer(emit, { flushMs: 60 });
+    await c.onEvent(P, td('tail'));
+    expect(emits).toHaveLength(0);
+    await c.flush();
+    expect(emits).toHaveLength(1);
+    expect((emits[0] as { delta: string }).delta).toBe('tail');
+  });
+
+  describe('with fake timers', () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it('flushes on a periodic cadence while continuous deltas arrive (not a trailing debounce)', async () => {
+      const { emit, emits } = recorder();
+      const c = createDeltaCoalescer(emit, { flushMs: 60 });
+
+      await c.onEvent(P, td('a'));
+      await c.onEvent(P, td('b'));
+      expect(emits).toHaveLength(0);
+
+      await vi.advanceTimersByTimeAsync(60);
+      expect(emits).toHaveLength(1);
+      expect((emits[0] as { delta: string }).delta).toBe('ab');
+
+      await c.onEvent(P, td('c'));
+      await vi.advanceTimersByTimeAsync(60);
+      expect(emits).toHaveLength(2);
+      expect((emits[1] as { delta: string }).delta).toBe('c');
+    });
+  });
+
+  it('passthrough mode (flushMs: 0) emits each delta 1:1 immediately', async () => {
+    const { emit, emits } = recorder();
+    const c = createDeltaCoalescer(emit, { flushMs: 0 });
+    await c.onEvent(P, td('a'));
+    await c.onEvent(P, td('b'));
+    expect(emits.map((e) => (e as { delta: string }).delta)).toEqual(['a', 'b']);
+  });
+});
+
+describe('runStreamTurn wires the coalescer', () => {
+  function mkPorts(drive: (onDelta: DeltaHandler) => Promise<void>) {
+    const emits: AssistantMessageEvent[] = [];
+    const ports = {
+      streamTurn: async (_ctx: StreamContext, onDelta: DeltaHandler) => {
+        await drive(onDelta);
+        return { final: emptyAssistant(), error: null };
+      },
+      emitMessageUpdate: async (
+        _sid: string,
+        _msg: unknown,
+        event: AssistantMessageEvent,
+      ) => {
+        emits.push(event);
+      },
+    } as unknown as AssistantStreamingPorts;
+    return { ports, emits };
+  }
+
+  it('collapses a run of same-type deltas into a single emitMessageUpdate (via the final flush)', async () => {
+    const { ports, emits } = mkPorts(async (onDelta) => {
+      await onDelta(P, td('a'));
+      await onDelta(P, td('b'));
+      await onDelta(P, td('c'));
+    });
+
+    const outcome = await runStreamTurn(ports, 'sid', {} as StreamContext);
+
+    expect(emits).toHaveLength(1);
+    expect((emits[0] as { delta: string }).delta).toBe('abc');
+    expect(outcome.body_streamed).toBe(true);
+  });
+
+  it('passes discrete events through 1:1, in order, around coalesced text', async () => {
+    const { ports, emits } = mkPorts(async (onDelta) => {
+      await onDelta(P, td('a'));
+      await onDelta(P, td('b'));
+      await onDelta(P, { type: 'text_end', partial: P });
+      await onDelta(P, td('c'));
+    });
+
+    await runStreamTurn(ports, 'sid', {} as StreamContext);
+
+    expect(emits.map((e) => e.type)).toEqual(['text_delta', 'text_end', 'text_delta']);
+    expect((emits[0] as { delta: string }).delta).toBe('ab');
+    expect((emits[2] as { delta: string }).delta).toBe('c');
+  });
+
+  it('sets body_streamed=false when no text/thinking deltas were seen', async () => {
+    const { ports, emits } = mkPorts(async (onDelta) => {
+      await onDelta(P, { type: 'usage', usage: { output: 1 } });
+    });
+
+    const outcome = await runStreamTurn(ports, 'sid', {} as StreamContext);
+
+    expect(outcome.body_streamed).toBe(false);
+    expect(emits.map((e) => e.type)).toEqual(['usage']);
+  });
+});

--- a/harness/tests/turn-orchestrator/coalesce-deltas.test.ts
+++ b/harness/tests/turn-orchestrator/coalesce-deltas.test.ts
@@ -156,11 +156,7 @@ describe('runStreamTurn wires the coalescer', () => {
         await drive(onDelta);
         return { final: emptyAssistant(), error: null };
       },
-      emitMessageUpdate: async (
-        _sid: string,
-        _msg: unknown,
-        event: AssistantMessageEvent,
-      ) => {
+      emitMessageUpdate: async (_sid: string, _msg: unknown, event: AssistantMessageEvent) => {
         emits.push(event);
       },
     } as unknown as AssistantStreamingPorts;

--- a/harness/tests/turn-orchestrator/events.test.ts
+++ b/harness/tests/turn-orchestrator/events.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ISdk } from '../../src/runtime/iii.js';
-import { emit } from '../../src/turn-orchestrator/events.js';
+import { _resetSeqForTests, emit } from '../../src/turn-orchestrator/events.js';
 import type { AgentEvent } from '../../src/types/agent-event.js';
 
 function buildSdk() {
@@ -10,23 +10,29 @@ function buildSdk() {
       function_id: req.function_id,
       payload: (req.payload ?? {}) as Record<string, unknown>,
     });
-    if (req.function_id === 'state::update') return { old_value: 0 };
     return {};
   });
   return { iii: { trigger } as unknown as ISdk, calls };
 }
 
 const SID = 'sess-1';
+const UPDATE = (event = 'message_update') => ({ type: event }) as unknown as AgentEvent;
+const streamSets = (calls: Array<{ function_id: string; payload: Record<string, unknown> }>) =>
+  calls.filter((c) => c.function_id === 'stream::set');
+const itemIds = (calls: Array<{ function_id: string; payload: Record<string, unknown> }>) =>
+  streamSets(calls).map((c) => c.payload.item_id as string);
+
+beforeEach(() => {
+  _resetSeqForTests();
+});
 
 describe('emit (agent event producer)', () => {
   it('writes a non-turn_end event only to agent::events', async () => {
     const { iii, calls } = buildSdk();
-    const event = { type: 'message_update' } as unknown as AgentEvent;
 
-    await emit(iii, SID, event);
+    await emit(iii, SID, UPDATE());
 
-    const sets = calls.filter((c) => c.function_id === 'stream::set');
-    expect(sets.map((c) => c.payload.stream_name)).toEqual(['agent::events']);
+    expect(streamSets(calls).map((c) => c.payload.stream_name)).toEqual(['agent::events']);
   });
 
   it('mirrors a turn_end event onto the dedicated agent::turn_end stream', async () => {
@@ -39,7 +45,7 @@ describe('emit (agent event producer)', () => {
 
     await emit(iii, SID, event);
 
-    const sets = calls.filter((c) => c.function_id === 'stream::set');
+    const sets = streamSets(calls);
     const streams = sets.map((c) => c.payload.stream_name);
     expect(streams).toContain('agent::events');
     expect(streams).toContain('agent::turn_end');
@@ -47,5 +53,54 @@ describe('emit (agent event producer)', () => {
     const mirror = sets.find((c) => c.payload.stream_name === 'agent::turn_end');
     expect(mirror?.payload.group_id).toBe(SID);
     expect(mirror?.payload.data).toEqual(event);
+    // Same logical event → identical item_id on both streams (single seq per emit).
+    expect(new Set(sets.map((c) => c.payload.item_id)).size).toBe(1);
+  });
+});
+
+describe('emit (in-process sequence, no persisted counter)', () => {
+  it('does NOT issue a state::update — the seq is process-local', async () => {
+    const { iii, calls } = buildSdk();
+
+    await emit(iii, SID, UPDATE());
+
+    expect(calls.filter((c) => c.function_id === 'state::update')).toHaveLength(0);
+  });
+
+  it('produces a monotonic per-session seq starting at 0', async () => {
+    const { iii, calls } = buildSdk();
+
+    await emit(iii, SID, UPDATE());
+    await emit(iii, SID, UPDATE());
+
+    const ids = itemIds(calls);
+    expect(ids[0].endsWith('-00000000')).toBe(true);
+    expect(ids[1].endsWith('-00000001')).toBe(true);
+  });
+
+  it('counts each session independently (both start at 0)', async () => {
+    const { iii, calls } = buildSdk();
+
+    await emit(iii, 'sess-a', UPDATE());
+    await emit(iii, 'sess-b', UPDATE());
+
+    const a = itemIds(calls).find((id) => id.startsWith('sess-a-'));
+    const b = itemIds(calls).find((id) => id.startsWith('sess-b-'));
+    expect(a?.endsWith('-00000000')).toBe(true);
+    expect(b?.endsWith('-00000000')).toBe(true);
+  });
+
+  it('formats item_id as <session>-<process_epoch>-<8 digit seq> with a stable epoch', async () => {
+    const { iii, calls } = buildSdk();
+
+    await emit(iii, SID, UPDATE());
+    await emit(iii, SID, UPDATE());
+
+    const ids = itemIds(calls);
+    expect(ids[0]).toMatch(new RegExp(`^${SID}-.+-\\d{8}$`));
+    // epoch = substring between the `<sid>-` prefix and the trailing `-<8 digits>`
+    const epochOf = (id: string) => id.slice(`${SID}-`.length, id.length - '-00000000'.length);
+    expect(epochOf(ids[0]).length).toBeGreaterThan(0);
+    expect(epochOf(ids[0])).toBe(epochOf(ids[1])); // stable within a process
   });
 });

--- a/harness/tests/turn-orchestrator/store.test.ts
+++ b/harness/tests/turn-orchestrator/store.test.ts
@@ -89,6 +89,41 @@ describe('saveRecord turn_state_changed emission', () => {
   });
 });
 
+describe('saveRecord no-op suppression', () => {
+  it('does not emit turn_state_changed when the view is unchanged (timestamp-only delta)', async () => {
+    const { iii, emits } = fakeIii();
+    const store = createTurnStore(iii);
+    const rec = newRecord('sess-a');
+    // Same view; differs only in updated_at_ms (which toView drops).
+    const previous = { ...rec, updated_at_ms: rec.updated_at_ms + 1000 };
+
+    await store.saveRecord(rec, previous);
+
+    expect(emits).toHaveLength(0);
+  });
+
+  it('does not emit on an idempotent re-save (previous === current)', async () => {
+    const { iii, emits } = fakeIii();
+    const store = createTurnStore(iii);
+    const rec = newRecord('sess-a');
+
+    await store.saveRecord(rec, rec);
+
+    expect(emits).toHaveLength(0);
+  });
+
+  it('still emits when a view field other than state changes', async () => {
+    const { iii, emits } = fakeIii();
+    const store = createTurnStore(iii);
+    const rec = newRecord('sess-a');
+    const previous = { ...rec, turn_count: rec.turn_count + 1 };
+
+    await store.saveRecord(rec, previous);
+
+    expect(emits).toHaveLength(1);
+  });
+});
+
 describe('shouldWakeStep', () => {
   it('accepts first write to a stepable state', () => {
     expect(shouldWakeStep(null, 'provisioning')).toBe(true);


### PR DESCRIPTION
## Summary

Cut per-turn telemetry/span volume on the harness (streaming-delta coalescing, in-process event sequencing, no-op event suppression) plus a telemetry-import/deps housekeeping pass. All changes are observability-quality / cost reductions — no agent behavior change, no wire-contract or rendering change.

## Changes

- **Coalesce streaming deltas** (`turn-orchestrator/assistant-streaming/coalesce-deltas.ts`): merge consecutive same-type provider deltas (`text` / `thinking` / `functioncall`) into a single `message_update` on a ~60ms periodic flush. The console renders streaming text by appending `llm_event.delta`, so concatenating deltas is wire-identical — no console change. Cuts the per-token emits (and the spans/RPCs each generates) on streaming-heavy turns.
- **Localize the per-event sequence counter** (`turn-orchestrator/events.ts`): `nextSeq` no longer issues a persisted `state::update` per agent event; it uses an in-process per-session counter, with a random per-process epoch in the stream `item_id` so a restart can't collide with prior frames (`item_id` is opaque — never read by the console, stripped by the fanout, delivered in insertion order). Removes one engine state write (and its trigger evaluation) per event.
- **Skip `turn_state_changed` emit on no-op saves** (`turn-orchestrator/state-runtime/store.ts`): `persistRecord` only emits when the consumer-visible view (`toView`) changes — `transitionTo` bumps `updated_at_ms` on every write, which `toView` drops — removing a redundant `stream::set` (and its engine trigger-evaluation pass) per stale-skip / idempotent save. `state:created` is always emitted so a fresh session still seeds the console mirror.
- **Telemetry housekeeping**: migrate telemetry imports from `iii-sdk/telemetry` to `@iii-dev/observability` (0.16.1), `runtime/otel.ts` simplification, and the dependency bump.

## Behavior / compatibility

- No wire-contract or rendering change for streaming (delta coalescing concatenates; the console keys on `llm_event.type`).
- These changes (in-process counter, no-op suppression, coalescing) require a harness rebuild + restart to take effect at runtime.

## Test plan

- [x] Harness unit suite green (`pnpm test`, 1051 tests) + `pnpm typecheck`.
- [ ] Manual: confirm reduced span volume on a fresh trace (`engine::traces::tree`) — per-event `state::update` eliminated; coalesced streaming `message_update`s.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added delta coalescing for streaming message updates, merging consecutive deltas for improved response streaming performance.

* **Improvements**
  * State change detection now only emits updates when meaningful changes occur, reducing unnecessary event emissions.

* **Chores**
  * Updated SDK dependency to latest version for enhanced observability support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->