### PR TITLE
fix(turn-orchestrator): update TURN_STEP_QUEUE constant to 'default'

### DIFF
--- a/harness/src/turn-orchestrator/state-runtime/store.ts
+++ b/harness/src/turn-orchestrator/state-runtime/store.ts
@@ -15,7 +15,7 @@ import { toView, type TurnStateView } from '../schemas.js';
 import { mirrorMessagesToSessionTree } from '../session-tree-mirror.js';
 import { type TurnState, type TurnStateRecord, parseTurnStateRecord } from '../state.js';
 
-export const TURN_STEP_QUEUE = 'turn-step';
+export const TURN_STEP_QUEUE = 'default';
 
 const NON_STEPABLE_STATES = new Set<TurnState>(['stopped', 'failed', 'function_awaiting_approval']);
 

--- a/harness/tests/integration/on-record-written.e2e.test.ts
+++ b/harness/tests/integration/on-record-written.e2e.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import { TriggerAction } from '../../src/runtime/iii.js';
 import type { ISdk } from '../../src/runtime/iii.js';
-import { createTurnStore, TURN_STEP_QUEUE } from '../../src/turn-orchestrator/state-runtime/store.js';
+import {
+  createTurnStore,
+  TURN_STEP_QUEUE,
+} from '../../src/turn-orchestrator/state-runtime/store.js';
 import { TURN_STATE_SCOPE } from '../../src/turn-orchestrator/state.js';
 import { newRecord } from '../../src/turn-orchestrator/state.js';
 

--- a/harness/tests/integration/on-record-written.e2e.test.ts
+++ b/harness/tests/integration/on-record-written.e2e.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { TriggerAction } from '../../src/runtime/iii.js';
 import type { ISdk } from '../../src/runtime/iii.js';
-import { createTurnStore } from '../../src/turn-orchestrator/state-runtime/store.js';
+import { createTurnStore, TURN_STEP_QUEUE } from '../../src/turn-orchestrator/state-runtime/store.js';
 import { TURN_STATE_SCOPE } from '../../src/turn-orchestrator/state.js';
 import { newRecord } from '../../src/turn-orchestrator/state.js';
 
@@ -71,7 +71,7 @@ describe('saveRecord wake integration', () => {
       {
         session_id: 'sess-a',
         function_id: 'turn::provisioning',
-        action: TriggerAction.Enqueue({ queue: 'turn-step' }),
+        action: TriggerAction.Enqueue({ queue: TURN_STEP_QUEUE }),
       },
     ]);
   });
@@ -90,12 +90,12 @@ describe('saveRecord wake integration', () => {
       {
         session_id: 'sess-b',
         function_id: 'turn::provisioning',
-        action: TriggerAction.Enqueue({ queue: 'turn-step' }),
+        action: TriggerAction.Enqueue({ queue: TURN_STEP_QUEUE }),
       },
       {
         session_id: 'sess-b',
         function_id: 'turn::assistant_streaming',
-        action: TriggerAction.Enqueue({ queue: 'turn-step' }),
+        action: TriggerAction.Enqueue({ queue: TURN_STEP_QUEUE }),
       },
     ]);
   });

--- a/harness/tests/turn-orchestrator/function-awaiting-approval-state-trigger.test.ts
+++ b/harness/tests/turn-orchestrator/function-awaiting-approval-state-trigger.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { TriggerAction, type ISdk } from '../../src/runtime/iii.js';
 import { handleApprovalStateWrite } from '../../src/turn-orchestrator/function-awaiting-approval/process.js';
 import { ApprovalDecisionEventSchema } from '../../src/turn-orchestrator/schemas.js';
+import { TURN_STEP_QUEUE } from '../../src/turn-orchestrator/state-runtime/store.js';
 
 const matchingEvent = {
   event_type: 'state:created' as const,
@@ -33,7 +34,7 @@ describe('handleApprovalStateWrite', () => {
     expect(triggers).toHaveLength(1);
     expect(triggers[0]?.function_id).toBe('turn::function_awaiting_approval');
     expect(triggers[0]?.payload).toEqual({ session_id: 'sess-abc' });
-    expect(triggers[0]?.action).toEqual(TriggerAction.Enqueue({ queue: 'turn-step' }));
+    expect(triggers[0]?.action).toEqual(TriggerAction.Enqueue({ queue: TURN_STEP_QUEUE }));
   });
 
   it('no-ops on a non-matching event', async () => {

--- a/harness/tests/turn-orchestrator/run-start.test.ts
+++ b/harness/tests/turn-orchestrator/run-start.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { TriggerAction, type ISdk } from '../../src/runtime/iii.js';
 import { execute, register } from '../../src/turn-orchestrator/run-start.js';
 import { RunStartPayloadSchema } from '../../src/turn-orchestrator/schemas.js';
+import { TURN_STEP_QUEUE } from '../../src/turn-orchestrator/state-runtime/store.js';
 
 type TriggerCall = { function_id: string; payload: unknown; action?: unknown };
 
@@ -162,6 +163,6 @@ describe('execute', () => {
     const wake = calls.find((c) => c.function_id === 'turn::provisioning');
     expect(wake).toBeDefined();
     expect(wake?.payload).toEqual({ session_id: 'sess-1' });
-    expect(wake?.action).toEqual(TriggerAction.Enqueue({ queue: 'turn-step' }));
+    expect(wake?.action).toEqual(TriggerAction.Enqueue({ queue: TURN_STEP_QUEUE }));
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an internal queue reference used for orchestration step enqueuing.
* **Tests**
  * Adjusted integration and unit tests to match the revised queue reference and expected wake/enqueue behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->