### PR TITLE
chore(email): add email worker to release + create-tag publish lists

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -12,6 +12,7 @@ on:
           - coder
           - console
           - database
+          - email
           - harness
           - iii-directory
           - iii-lsp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
       - 'coder/v*'
       - 'console/v*'
       - 'database/v*'
+      - 'email/v*'
       - 'harness/v*'
       - 'iii-directory/v*'
       - 'iii-lsp/v*'


### PR DESCRIPTION
Wires the email worker (merged in #196) into the release pipeline.

- `create-tag.yml`: adds `email` to the worker choice options so it can be selected for a version bump + tag.
- `release.yml`: adds `email/v*` to the push-tag triggers so tagging fires the build + registry publish.

Placed alphabetically (between database and harness) in both lists. No other behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added email module as an available option for manual release workflows.
  * Extended release automation to trigger when email version tags are pushed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->