### PR TITLE
fix(ci): pin publish workflow to iii v0.17 for built-in configuration

### DIFF
--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install iii CLI
         env:
-          VERSION: '0.12.0'
+          VERSION: '0.17.0'
         run: |
           set -euo pipefail
           curl -fsSL https://install.iii.dev/iii/main/install.sh -o /tmp/install-iii.sh


### PR DESCRIPTION
## Summary
- Bump the iii CLI installed by `_publish-registry.yml` from v0.12.0 to v0.17.0.
- Restores the built-in `configuration` worker that `database` v0.2.4+ and `harness` require at startup (`configuration::register` / `configuration::get`).
- Fixes registry publish failures such as [database/v0.2.4 run #26838365916](https://github.com/iii-hq/workers/actions/runs/26838365916), where the worker exited before interface collection with `Function configuration::get not found`.

## Test plan
- [ ] Merge and re-run the failed `database/v0.2.4` publish job (or cut a patch tag) — "Start local worker for interface collection" should pass.
- [ ] Confirm harness bundle publish still succeeds with the updated engine (no separate `database` dependency boot step needed).
