### PR TITLE
fix(ci): migrate publish pipeline to engine::triggers::list

### DIFF
--- a/.github/scripts/build_publish_payload.py
+++ b/.github/scripts/build_publish_payload.py
@@ -172,13 +172,13 @@ def normalize_worker_interface(
 
     baseline_ids = {
         tt["id"]
-        for tt in _extract_array(baseline_trigger_types_json or {}, "trigger_types")
+        for tt in _extract_array(baseline_trigger_types_json or {}, "triggers")
         if isinstance(tt.get("id"), str)
     }
 
     triggers = []
     if trigger_types_json:
-        for trigger_type in _extract_array(trigger_types_json, "trigger_types"):
+        for trigger_type in _extract_array(trigger_types_json, "triggers"):
             tt_id = trigger_type.get("id")
             if not isinstance(tt_id, str) or tt_id.startswith("engine::"):
                 continue

--- a/.github/scripts/collect_worker_interface.py
+++ b/.github/scripts/collect_worker_interface.py
@@ -51,7 +51,7 @@ def wait_for_worker(worker_name: str, wait_seconds: int) -> dict[str, object]:
 
 def collect_trigger_types() -> dict[str, object] | None:
     try:
-        return run_iii("engine::trigger-types::list", {"include_internal": False})
+        return run_iii("engine::triggers::list", {"include_internal": False})
     except (
         subprocess.CalledProcessError,
         subprocess.TimeoutExpired,

--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           set -euo pipefail
           iii trigger \
-            'engine::trigger-types::list' \
+            'engine::triggers::list' \
             --json '{"include_internal": false}' \
             > trigger-types-baseline.json
           cat trigger-types-baseline.json


### PR DESCRIPTION
## Summary
- Update the publish registry workflow and interface collection script to call `engine::triggers::list` instead of the deprecated `engine::trigger-types::list`.
- Update `build_publish_payload.py` to read the new `triggers` response key when diffing baseline vs current trigger types for registry publishing.

## Test plan
- [x] Sanity-checked `normalize_worker_interface` with the new `{ "triggers": [...] }` response shape
- [ ] Verify publish-registry workflow succeeds on a worker publish run


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build and deployment automation to use updated data collection methods for registry publishing.
  * Revised registry publishing workflow to align baseline trigger information generation with current system specifications.
  * Adjusted internal build scripts to maintain consistency between data collection and processing stages.
  * Updated configuration for automated registry snapshot generation to use updated data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->