### PR TITLE
docs(workers): skills install instructions in worker READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Each worker ships an agent skill under `<worker>/skills/`. Install them with the
 npx skills add iii-hq/workers --list
 
 # Install one worker's skill
-npx skills add iii-hq/workers --skill email
+npx skills add iii-hq/workers --skill database
 
 # Install several
-npx skills add iii-hq/workers --skill email,coder,shell
+npx skills add iii-hq/workers --skill database,coder,shell
 
 # Install all worker skills at once
 npx skills add iii-hq/workers --all

--- a/README.md
+++ b/README.md
@@ -8,6 +8,32 @@ useful.
 Workers are installed via `iii worker add <name>`, which resolves the matching
 asset for the host from the workers registry API.
 
+## Skills
+
+Each worker ships an agent skill under `<worker>/skills/`. Install them with the
+`skills` CLI (works with Claude Code, Cursor, and 30+ other agents).
+
+```bash
+# List every worker skill in this repo
+npx skills add iii-hq/workers --list
+
+# Install one worker's skill
+npx skills add iii-hq/workers --skill email
+
+# Install several
+npx skills add iii-hq/workers --skill email,coder,shell
+
+# Install all worker skills at once
+npx skills add iii-hq/workers --all
+```
+
+For the iii engine's top-level skills (mental model, SDKs, config, patterns),
+see [`iii-hq/iii`](https://github.com/iii-hq/iii):
+
+```bash
+npx skills add iii-hq/iii --all
+```
+
 ## Modules
 
 | Worker | Kind | Summary |

--- a/coder/README.md
+++ b/coder/README.md
@@ -17,6 +17,21 @@ iii worker add coder
 `~/.iii/config.yaml`, and the engine starts the worker on the next
 `iii start`.
 
+## Skills
+
+Install the `coder` agent skill for Claude Code, Cursor, and 30+ other agents:
+
+```bash
+npx skills add iii-hq/workers --skill coder
+```
+
+Browse or install every worker skill at once:
+
+```bash
+npx skills add iii-hq/workers --list
+npx skills add iii-hq/workers --all
+```
+
 ## Quickstart
 
 ```rust

--- a/database/README.md
+++ b/database/README.md
@@ -15,6 +15,21 @@
 iii worker add database@1.0.0
 ```
 
+## Skills
+
+Install the `database` agent skill for Claude Code, Cursor, and 30+ other agents:
+
+```bash
+npx skills add iii-hq/workers --skill database
+```
+
+Browse or install every worker skill at once:
+
+```bash
+npx skills add iii-hq/workers --list
+npx skills add iii-hq/workers --all
+```
+
 ## Configure
 
 Runtime settings live in the **`configuration` worker** under id **`database`**. The worker registers its JSON Schema at startup, reads the live value via `configuration::get`, and hot-reloads connection pools when the value changes.

--- a/email/README.md
+++ b/email/README.md
@@ -16,6 +16,21 @@ iii worker add harness/auth-credentials
 iii worker add email
 ```
 
+## Skills
+
+Install the `email` agent skill for Claude Code, Cursor, and 30+ other agents:
+
+```bash
+npx skills add iii-hq/workers --skill email
+```
+
+Browse or install every worker skill at once:
+
+```bash
+npx skills add iii-hq/workers --list
+npx skills add iii-hq/workers --all
+```
+
 ## Quickstart
 
 ```rust

--- a/iii-directory/README.md
+++ b/iii-directory/README.md
@@ -59,6 +59,23 @@ iii worker add iii-directory
 
 ---
 
+## Skills
+
+Install the `iii-directory` agent skill for Claude Code, Cursor, and 30+ other agents:
+
+```bash
+npx skills add iii-hq/workers --skill iii-directory
+```
+
+Browse or install every worker skill at once:
+
+```bash
+npx skills add iii-hq/workers --list
+npx skills add iii-hq/workers --all
+```
+
+---
+
 ## Configuration
 
 ```yaml

--- a/shell/README.md
+++ b/shell/README.md
@@ -15,6 +15,21 @@ iii worker add iii-sandbox
 iii worker add iii-directory
 ```
 
+## Skills
+
+Install the `shell` agent skill for Claude Code, Cursor, and 30+ other agents:
+
+```bash
+npx skills add iii-hq/workers --skill shell
+```
+
+Browse or install every worker skill at once:
+
+```bash
+npx skills add iii-hq/workers --list
+npx skills add iii-hq/workers --all
+```
+
 ## Configure
 
 Settings load from a YAML file passed with `--config <path>` (default `./config.yaml`). The worker refuses to start unless `fs.host_root` is set, or `fs.allow_unjailed: true` is explicitly opted in, because an unset root exposes the whole host filesystem behind only the advisory denylist.


### PR DESCRIPTION
## What

Adds a `## Skills` section to every worker README that ships an agent skill, plus the repo root README, so users can install worker skills with the `skills` CLI.

## Changes

- Per-worker `## Skills` block in `coder`, `database`, `email`, `iii-directory`, `shell` READMEs, each with `npx skills add iii-hq/workers --skill <name>`.
- Root `README.md` gains a `## Skills` section covering list, single, multi, and all-at-once installs, with a pointer to `iii-hq/iii` for engine top-level skills.

## Notes

- Documentation only. No code or worker behavior changes.
- Worker skills live at `<worker>/skills/SKILL.md`. The repo has no root `SKILL.md`, so default `skills` CLI discovery picks them up. Worth a `npx skills add iii-hq/workers --list` smoke test before merge to confirm the names resolve.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Skills" sections to the main README and all worker READMEs describing how to install and manage agent skills via the skills CLI, including commands to list available skills, install a specific worker skill, install multiple skills, and install all worker skills at once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->