### PR TITLE
feat(harness): per-model output-token defaults and thinking/reasoning support

### DIFF
--- a/harness/docs/storage.md
+++ b/harness/docs/storage.md
@@ -28,6 +28,13 @@ worker self-declares its slice at startup via `harness::provider::register`,
 so the editable shape grows/shrinks with the set of running providers. The
 console renders this entry with its schema-driven configuration form.
 
+A configured `max_tokens` is an explicit override: it wins over the
+per-model default (`min(catalog max_output_tokens, 32_000)` — see
+[src/runtime/output-tokens.ts](../src/runtime/output-tokens.ts)) but is
+clamped down to the model's catalog ceiling when known, so a too-large
+value can't produce upstream 400s. The 32k default cap is overridable via
+the `HARNESS_OUTPUT_TOKEN_MAX` env var.
+
 > Secrets are stored as plaintext in the configuration value. Agents are
 > denied `configuration::get`/`set` and `harness::provider::resolve` in
 > [iii-permissions.yaml](../../iii-permissions.yaml); the console edits the

--- a/harness/docs/workers/provider-anthropic.md
+++ b/harness/docs/workers/provider-anthropic.md
@@ -45,10 +45,37 @@ by [src/provider-anthropic/cache.ts](harness/src/provider-anthropic/cache.ts).
 From the `provider_anthropic` section of
 [config.yaml](harness/config.yaml):
 
-- `default_max_tokens` (default `8192`) — upper bound for the request's
-  `max_tokens` field when the caller omits it.
+- `default_max_tokens` (default `8192`) — fallback for the request's
+  `max_tokens` field when the model is not in the catalog.
 - `default_api_url` (default `https://api.anthropic.com/v1/messages`) —
   endpoint for outbound calls.
+
+### Max output tokens
+
+Per request, `max_tokens` resolves as (see
+[src/runtime/output-tokens.ts](harness/src/runtime/output-tokens.ts)):
+
+1. A registry override (`providers.anthropic.max_tokens` in the `harness`
+   config entry) wins, clamped down to the model's catalog
+   `max_output_tokens` when known.
+2. Otherwise `min(model.max_output_tokens, 32_000)` — the catalog limit
+   comes from [models.dev](https://models.dev) at discovery time; the 32k
+   cap is overridable via the `HARNESS_OUTPUT_TOKEN_MAX` env var.
+3. Unknown model → `default_max_tokens`.
+
+### Extended thinking
+
+When the run request carries a `thinking_level`
+(`minimal|low|medium|high|xhigh`), the request body gains
+`thinking: { type: "enabled", budget_tokens }` plus the
+`anthropic-beta: interleaved-thinking-2025-05-14` header. Budgets come
+from the catalog's `thinking_budgets`, falling back to a formula on the
+model's output ceiling (`high` → `min(16000, output/2−1)`, `xhigh` →
+`min(31999, output−1)`). The budget always stays below `max_tokens`;
+when fewer than 1024 tokens of room remain, thinking is dropped instead
+of sending a request the API would reject. Thinking/redacted-thinking
+SSE blocks stream as `thinking_*` events and persist as a `thinking`
+content block.
 
 ## Dependencies
 

--- a/harness/docs/workers/provider-kimi.md
+++ b/harness/docs/workers/provider-kimi.md
@@ -42,8 +42,13 @@ None — the worker is stateless.
 From the `provider_kimi` section of
 [config.yaml](harness/config.yaml):
 
-- `default_max_tokens` (default `8192`) — upper bound for the request's
-  `max_completion_tokens` field when the caller omits it.
+- `default_max_tokens` (default `8192`) — fallback for the request's
+  `max_completion_tokens` field when the model is not in the catalog.
+  When the catalog knows the model (kimi maps to models.dev `moonshotai`),
+  the per-request value resolves as: registry override (clamped to the
+  model ceiling) → `min(catalog max_output_tokens, 32_000)` (env override
+  `HARNESS_OUTPUT_TOKEN_MAX`) → this fallback. See
+  [src/runtime/output-tokens.ts](harness/src/runtime/output-tokens.ts).
 - `default_api_url` (default
   `https://api.moonshot.ai/v1/chat/completions`) — endpoint for outbound
   calls. Override to target Moonshot's China endpoint

--- a/harness/docs/workers/provider-llamacpp.md
+++ b/harness/docs/workers/provider-llamacpp.md
@@ -48,6 +48,13 @@ provider_llamacpp:
 Default URL: `http://localhost:8080/v1/chat/completions` (llama-server's
 default port; LM Studio uses 1234).
 
+`default_max_tokens` is the fallback for `max_completion_tokens` when the
+model is not in the catalog. When the loaded model is registered in the
+catalog, the per-request value resolves as: registry override (clamped to
+the catalog ceiling) → `min(catalog max_output_tokens, 32_000)` (env
+override `HARNESS_OUTPUT_TOKEN_MAX`) → this fallback. See
+[src/runtime/output-tokens.ts](harness/src/runtime/output-tokens.ts).
+
 Both env and YAML values are validated as http(s) URLs; a malformed
 value falls back to the next tier. A WARN log fires when the resolved
 host is non-loopback so operators see they're shipping bearers to a

--- a/harness/docs/workers/provider-lmstudio.md
+++ b/harness/docs/workers/provider-lmstudio.md
@@ -88,8 +88,13 @@ None — the worker is stateless.
 From the `provider_lmstudio` section of
 [config.yaml](harness-node/config.yaml):
 
-- `default_max_tokens` (default `8192`) — upper bound for the request's
-  `max_completion_tokens` field.
+- `default_max_tokens` (default `8192`) — fallback for the request's
+  `max_completion_tokens` field when the model is not in the catalog.
+  When the local model is registered in the catalog, the per-request value
+  resolves as: registry override (clamped to the catalog ceiling) →
+  `min(catalog max_output_tokens, 32_000)` (env override
+  `HARNESS_OUTPUT_TOKEN_MAX`) → this fallback. See
+  [src/runtime/output-tokens.ts](harness-node/src/runtime/output-tokens.ts).
 - `default_api_url` (default
   `http://localhost:1234/v1/chat/completions`) — endpoint for outbound
   calls. Override if LM Studio is running on a non-default port or behind

--- a/harness/docs/workers/provider-openai.md
+++ b/harness/docs/workers/provider-openai.md
@@ -41,13 +41,43 @@ None — the worker is stateless.
 From the `provider_openai` section of
 [config.yaml](harness/config.yaml):
 
-- `default_max_tokens` (default `8192`) — upper bound for the request's
-  `max_tokens` field when the caller omits it.
+- `default_max_tokens` (default `8192`) — fallback for the request's
+  `max_completion_tokens` field when the model is not in the catalog.
 - `default_api_url` (default `https://api.openai.com/v1/chat/completions`)
   — endpoint for outbound calls. Override this to target
   `azure-openai`, `groq`, `openrouter`, or any other Chat-Completions
   compatible gateway; the harness registry looks up the credential by the
   `provider` field, so adjust the gateway and the credential together.
+
+### Max output tokens
+
+Per request, `max_completion_tokens` resolves as (see
+[src/runtime/output-tokens.ts](harness/src/runtime/output-tokens.ts)):
+
+1. A registry override (`providers.openai.max_tokens` in the `harness`
+   config entry) wins, clamped down to the model's catalog
+   `max_output_tokens` when known.
+2. Otherwise `min(model.max_output_tokens, 32_000)` — the catalog limit
+   comes from [models.dev](https://models.dev) at discovery time; the 32k
+   cap is overridable via the `HARNESS_OUTPUT_TOKEN_MAX` env var.
+3. Unknown model → `default_max_tokens`.
+
+Reasoning tokens count toward `max_completion_tokens`; the clamped
+default leaves ample room, but a very low registry override can starve
+output on reasoning models.
+
+### Reasoning effort
+
+Reasoning models (catalog `supports_thinking`, or ids matching
+`gpt-5*`/`o3*`/`o4*` — the o1 family is excluded, it rejects the param)
+get `reasoning_effort: "medium"` by default. Note for gateway routing
+(`default_api_url` overridden): the default applies to gpt-5-style ids
+there too; a gateway that rejects `reasoning_effort` can be opted out per
+model by setting `supports_thinking: false` in the catalog.
+A `thinking_level` on the run request maps onto the effort ladder for
+the model family (gpt-5.1: none–high; gpt-5.2+: adds xhigh; gpt-5-pro:
+high only; o-series: low–high; chat-tuned variants take no effort
+param). See [src/provider-openai/reasoning.ts](harness/src/provider-openai/reasoning.ts).
 
 ## Dependencies
 

--- a/harness/src/harness/providers/registry.ts
+++ b/harness/src/harness/providers/registry.ts
@@ -157,10 +157,12 @@ export class ProviderRegistry {
       typeof cfg.api_url === 'string' && cfg.api_url.length > 0
         ? cfg.api_url
         : (decl?.defaults?.api_url ?? null);
+    // Only a user-configured max_tokens counts. The declared default is NOT
+    // seeded here — the per-model clamp (runtime/output-tokens.ts) would
+    // treat it as a deliberate override and pin every request to 8192;
+    // providers apply their own fallback after the clamp.
     const max_tokens =
-      typeof cfg.max_tokens === 'number' && cfg.max_tokens > 0
-        ? cfg.max_tokens
-        : (decl?.defaults?.max_tokens ?? null);
+      typeof cfg.max_tokens === 'number' && cfg.max_tokens > 0 ? cfg.max_tokens : null;
 
     return { configured: credential !== null, source, credential, api_url, max_tokens };
   }

--- a/harness/src/index.ts
+++ b/harness/src/index.ts
@@ -72,7 +72,7 @@ const WORKERS: readonly WorkerDefinition[] = [
   {
     name: 'models-catalog',
     description: 'Model capabilities catalog on the iii bus (models::list/get/supports/register).',
-    register: (iii) => registerModelsCatalog(iii),
+    register: async (iii) => registerModelsCatalog(iii),
   },
   {
     name: 'provider-anthropic',

--- a/harness/src/models-catalog/main.ts
+++ b/harness/src/models-catalog/main.ts
@@ -5,5 +5,5 @@ import { register } from './register.js';
 await bootstrapWorker({
   name: 'models-catalog',
   description: 'Model capabilities catalog on the iii bus (models::list/get/supports/reconcile).',
-  register: (iii) => register(iii),
+  register: async (iii) => register(iii),
 });

--- a/harness/src/provider-anthropic/auth.ts
+++ b/harness/src/provider-anthropic/auth.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ISdk } from '../runtime/iii.js';
+import { clampOutputTokens, getCatalogModel } from '../runtime/output-tokens.js';
 import { resolveProvider } from '../runtime/provider-resolve.js';
 import type { WorkerConfig } from './config.js';
 import { type AnthropicConfig, configWithCredential } from './types.js';
@@ -25,6 +26,12 @@ export async function buildConfig(
     );
   }
   const apiUrl = resolved.api_url ?? worker.default_api_url;
-  const maxTokens = resolved.max_tokens ?? worker.default_max_tokens;
-  return configWithCredential(model, resolved.credential, maxTokens, apiUrl);
+  const catalog = await getCatalogModel(iii, PROVIDER_ID, model);
+  const maxTokens = clampOutputTokens({
+    modelMaxOutput: catalog?.max_output_tokens,
+    userOverride: resolved.max_tokens,
+    workerDefault: worker.default_max_tokens,
+  });
+  const cfg = configWithCredential(model, resolved.credential, maxTokens, apiUrl);
+  return catalog ? { ...cfg, catalog } : cfg;
 }

--- a/harness/src/provider-anthropic/cache.ts
+++ b/harness/src/provider-anthropic/cache.ts
@@ -46,8 +46,16 @@ export function applyMessagesCacheAnchor(wire: Record<string, unknown>[]): void 
   if (!msg) return;
   const content = msg.content;
   if (!Array.isArray(content) || content.length === 0) return;
-  const lastBlock = content[content.length - 1] as Record<string, unknown> | undefined;
-  if (lastBlock) lastBlock.cache_control = ephemeral();
+  // Anchor on the last block that accepts cache_control — Anthropic rejects
+  // it on thinking/redacted_thinking blocks, which can trail a turn under
+  // interleaved thinking.
+  for (let i = content.length - 1; i >= 0; i--) {
+    const block = content[i] as Record<string, unknown> | undefined;
+    if (!block) continue;
+    if (block.type === 'thinking' || block.type === 'redacted_thinking') continue;
+    block.cache_control = ephemeral();
+    return;
+  }
 }
 
 function isStableAssistant(wire: Record<string, unknown>[], idx: number): boolean {

--- a/harness/src/provider-anthropic/discover.ts
+++ b/harness/src/provider-anthropic/discover.ts
@@ -15,6 +15,7 @@ import {
   type ModelStub,
   reconcileModels,
 } from '../runtime/models-discovery.js';
+import { getModelsDevIndex, lookupModelsDev } from '../runtime/modelsdev.js';
 import { logger } from '../runtime/otel.js';
 import { resolveProvider } from '../runtime/provider-resolve.js';
 import { PROVIDER_ID } from './auth.js';
@@ -65,12 +66,14 @@ export async function discoverAndRegister(iii: ISdk, worker: WorkerConfig): Prom
   }
   if (fetchResult.kind !== 'ok') return [];
 
+  const modelsDev = await getModelsDevIndex();
   const models = parseStubs(fetchResult.json).map((stub) =>
     enrichModel({
       provider: PROVIDER_ID,
       api: 'anthropic-messages',
       stub,
       defaultContextWindow: DEFAULT_CONTEXT_WINDOW,
+      modelsDev: lookupModelsDev(modelsDev, PROVIDER_ID, stub.id),
     }),
   );
   const registered = await reconcileModels(iii, PROVIDER_ID, models);

--- a/harness/src/provider-anthropic/sse.ts
+++ b/harness/src/provider-anthropic/sse.ts
@@ -8,16 +8,32 @@
  * state, and yields `AssistantMessageEvent` values for the caller.
  */
 
+import { logger } from '../runtime/otel.js';
 import { type AssistantMessage, emptyAssistant } from '../types/agent-message.js';
-import type { ContentBlock, TextContent } from '../types/content.js';
+import type { ContentBlock, TextContent, ThinkingContent } from '../types/content.js';
 import type { AssistantMessageEvent, ErrorKind, StopReason, Usage } from '../types/stream-event.js';
 import { decodeToolName } from './wire-messages.js';
 
 type PartialFunctionCall = { id: string; function_id: string; args_json: string };
 
+type PartialThinking = { text: string; signature?: string };
+
+type BlockKind = 'text' | 'tool_use' | 'thinking';
+
+type OpenBlockKind = BlockKind | null;
+
 export type PartialState = {
   text_blocks: string[];
+  thinking_blocks: PartialThinking[];
   function_calls: PartialFunctionCall[];
+  /**
+   * Wire arrival order of content blocks ({kind, index-within-kind-array}).
+   * Replayed turns must keep thinking blocks in their original position
+   * relative to tool_use, so `buildContent` reconstructs in this order.
+   */
+  block_order: Array<{ kind: BlockKind; idx: number }>;
+  /** Kind of the currently open content block so `content_block_stop` emits the matching end event. */
+  open_block: OpenBlockKind;
   usage: Usage;
   stop_reason: StopReason;
   error_message: string | null;
@@ -26,36 +42,74 @@ export type PartialState = {
 export function emptyPartial(): PartialState {
   return {
     text_blocks: [],
+    thinking_blocks: [],
     function_calls: [],
+    block_order: [],
+    open_block: null,
     usage: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
     stop_reason: 'end',
     error_message: null,
   };
 }
 
-function buildContent(state: PartialState): ContentBlock[] {
-  const out: ContentBlock[] = [];
-  for (const t of state.text_blocks) {
-    if (t.length > 0) {
+function pushBlockContent(out: ContentBlock[], state: PartialState, kind: BlockKind, idx: number) {
+  if (kind === 'thinking') {
+    const th = state.thinking_blocks[idx];
+    if (th && th.text.length > 0) {
+      const tc: ThinkingContent = { type: 'thinking', text: th.text };
+      if (th.signature) tc.signature = th.signature;
+      out.push(tc);
+    }
+    return;
+  }
+  if (kind === 'text') {
+    const t = state.text_blocks[idx];
+    if (t !== undefined && t.length > 0) {
       const tc: TextContent = { type: 'text', text: t };
       out.push(tc);
     }
+    return;
   }
-  for (const tc of state.function_calls) {
-    let args: unknown = {};
-    if (tc.args_json.length > 0) {
-      try {
-        args = JSON.parse(tc.args_json);
-      } catch {
-        args = null;
-      }
+  const tc = state.function_calls[idx];
+  if (!tc) return;
+  let args: unknown = {};
+  if (tc.args_json.length > 0) {
+    try {
+      args = JSON.parse(tc.args_json);
+    } catch {
+      args = null;
     }
-    out.push({
-      type: 'function_call',
-      id: tc.id,
-      function_id: tc.function_id,
-      arguments: args,
-    });
+  }
+  out.push({
+    type: 'function_call',
+    id: tc.id,
+    function_id: tc.function_id,
+    arguments: args,
+  });
+}
+
+function buildContent(state: PartialState): ContentBlock[] {
+  const out: ContentBlock[] = [];
+  // Wire arrival order first; block indices not tracked in block_order
+  // (state built directly in tests) are appended grouped afterwards.
+  const seen = {
+    text: new Set<number>(),
+    thinking: new Set<number>(),
+    tool_use: new Set<number>(),
+  };
+  for (const e of state.block_order) {
+    if (seen[e.kind].has(e.idx)) continue;
+    seen[e.kind].add(e.idx);
+    pushBlockContent(out, state, e.kind, e.idx);
+  }
+  for (let i = 0; i < state.thinking_blocks.length; i++) {
+    if (!seen.thinking.has(i)) pushBlockContent(out, state, 'thinking', i);
+  }
+  for (let i = 0; i < state.text_blocks.length; i++) {
+    if (!seen.text.has(i)) pushBlockContent(out, state, 'text', i);
+  }
+  for (let i = 0; i < state.function_calls.length; i++) {
+    if (!seen.tool_use.has(i)) pushBlockContent(out, state, 'tool_use', i);
   }
   return out;
 }
@@ -131,16 +185,33 @@ export function handleSseEvent(
       const cb = parsed.content_block as Record<string, unknown> | undefined;
       const blockType = typeof cb?.type === 'string' ? cb.type : '';
       if (blockType === 'text') {
+        state.block_order.push({ kind: 'text', idx: state.text_blocks.length });
         state.text_blocks.push('');
+        state.open_block = 'text';
         events.push({ type: 'text_start', partial: buildPartial(state, model) });
       } else if (blockType === 'tool_use') {
         const id = typeof cb?.id === 'string' ? cb.id : '';
         const name = typeof cb?.name === 'string' ? decodeToolName(cb.name) : '';
+        state.block_order.push({ kind: 'tool_use', idx: state.function_calls.length });
         state.function_calls.push({ id, function_id: name, args_json: '' });
+        state.open_block = 'tool_use';
         events.push({
           type: 'functioncall_start',
           partial: buildPartial(state, model),
         });
+      } else if (blockType === 'thinking' || blockType === 'redacted_thinking') {
+        // Redacted thinking is opaque and not persisted/round-tripped
+        // (needs a ContentBlock extension — follow-up); logged because the
+        // API expects it back during tool use.
+        if (blockType === 'redacted_thinking') {
+          logger.warn('anthropic redacted_thinking block received; not persisted/round-tripped', {
+            model,
+          });
+        }
+        state.block_order.push({ kind: 'thinking', idx: state.thinking_blocks.length });
+        state.thinking_blocks.push({ text: '' });
+        state.open_block = 'thinking';
+        events.push({ type: 'thinking_start', partial: buildPartial(state, model) });
       }
       break;
     }
@@ -167,11 +238,34 @@ export function handleSseEvent(
           partial: buildPartial(state, model),
           delta: json,
         });
+      } else if (dt === 'thinking_delta') {
+        const text = typeof delta?.thinking === 'string' ? delta.thinking : '';
+        const last = state.thinking_blocks[state.thinking_blocks.length - 1];
+        if (last) last.text += text;
+        events.push({
+          type: 'thinking_delta',
+          partial: buildPartial(state, model),
+          delta: text,
+        });
+      } else if (dt === 'signature_delta') {
+        const sig = typeof delta?.signature === 'string' ? delta.signature : '';
+        const last = state.thinking_blocks[state.thinking_blocks.length - 1];
+        if (last && sig) last.signature = (last.signature ?? '') + sig;
       }
       break;
     }
     case 'content_block_stop': {
-      events.push({ type: 'text_end', partial: buildPartial(state, model) });
+      // Emit the end event matching the open block. Default to text_end for
+      // unknown/untracked blocks (preserves pre-thinking behavior).
+      const kind = state.open_block;
+      state.open_block = null;
+      if (kind === 'thinking') {
+        events.push({ type: 'thinking_end', partial: buildPartial(state, model) });
+      } else if (kind === 'tool_use') {
+        events.push({ type: 'functioncall_end', partial: buildPartial(state, model) });
+      } else {
+        events.push({ type: 'text_end', partial: buildPartial(state, model) });
+      }
       break;
     }
     case 'message_delta': {

--- a/harness/src/provider-anthropic/stream-fn.ts
+++ b/harness/src/provider-anthropic/stream-fn.ts
@@ -20,6 +20,7 @@ import { isTerminal } from '../types/stream-event.js';
 import { buildConfig } from './auth.js';
 import type { WorkerConfig } from './config.js';
 import { streamAnthropic } from './stream.js';
+import { buildThinkingConfig } from './thinking.js';
 
 export const FUNCTION_ID = 'provider::anthropic::stream';
 
@@ -34,12 +35,14 @@ export function register(iii: ISdk, worker: WorkerConfig): void {
       // (which no longer exists by the time we get here).
       const writer = input.writer_ref as ChannelWriter;
       const cfg = await buildConfig(iii, worker, input.model);
+      const thinking = buildThinkingConfig(input.thinking_level, cfg.max_tokens, cfg.catalog);
       try {
         const events = streamAnthropic({
           cfg,
           system_prompt: input.system_prompt ?? '',
           messages: input.messages as AgentMessage[],
           tools: input.tools as import('../types/function.js').AgentFunction[],
+          ...(thinking ? { thinking } : {}),
         });
         for await (const ev of events) {
           writer.sendMessage(JSON.stringify(ev));

--- a/harness/src/provider-anthropic/stream.ts
+++ b/harness/src/provider-anthropic/stream.ts
@@ -16,6 +16,7 @@ import {
   handleSseEvent,
   syntheticErrorEvent,
 } from './sse.js';
+import type { ThinkingConfig } from './thinking.js';
 import { type AnthropicConfig, authHeaderFor } from './types.js';
 import { toWireMessages } from './wire-messages.js';
 import { functionsToWire } from './wire-tools.js';
@@ -25,6 +26,8 @@ export type StreamArgs = {
   system_prompt: string;
   messages: AgentMessage[];
   tools: AgentFunction[];
+  /** Extended thinking; absent = off. See `thinking.ts`. */
+  thinking?: ThinkingConfig;
 };
 
 export async function* streamAnthropic({
@@ -32,14 +35,17 @@ export async function* streamAnthropic({
   system_prompt,
   messages,
   tools,
+  thinking,
 }: StreamArgs): AsyncGenerator<AssistantMessageEvent> {
   const wire_messages = toWireMessages(messages) as Record<string, unknown>[];
   applyMessagesCacheAnchor(wire_messages);
   const wire_tools = functionsToWire(tools) as Record<string, unknown>[];
   applyToolsCacheControl(wire_tools);
+  // No `temperature`: the API default applies (required when thinking is on).
   const body = {
     model: cfg.model,
     max_tokens: cfg.max_tokens,
+    ...(thinking ? { thinking } : {}),
     system: buildSystemField(system_prompt),
     messages: wire_messages,
     tools: wire_tools,
@@ -51,9 +57,10 @@ export async function* streamAnthropic({
     'anthropic-version': '2023-06-01',
     'content-type': 'application/json',
   };
-
-  console.log('headers', headers);
-  console.log('body', body);
+  if (thinking) {
+    // Lets thinking interleave with tool calls.
+    headers['anthropic-beta'] = 'interleaved-thinking-2025-05-14';
+  }
 
   const ac = new AbortController();
   let resp: Response;

--- a/harness/src/provider-anthropic/thinking.ts
+++ b/harness/src/provider-anthropic/thinking.ts
@@ -1,0 +1,99 @@
+/**
+ * Anthropic extended-thinking configuration. Maps an optional
+ * `thinking_level` onto the Messages API `thinking` request field, with
+ * budgets from the model catalog (`thinking_budgets`) when present and a
+ * formula on the model's max output tokens as fallback.
+ *
+ * Invariant: Anthropic requires `max_tokens > thinking.budget_tokens`
+ * (the budget counts toward max_tokens) and a minimum budget of 1024.
+ * When the clamped request budget leaves no room, thinking is dropped
+ * instead of sending a request the API would reject.
+ */
+
+import { logger } from '../runtime/otel.js';
+import type { Model, ThinkingBudgets } from '../models-catalog/types.js';
+
+export type ThinkingConfig = { type: 'enabled'; budget_tokens: number };
+
+/** Anthropic's documented minimum thinking budget. */
+export const MIN_THINKING_BUDGET = 1024;
+
+/**
+ * Tokens reserved for the visible answer. The thinking budget counts toward
+ * max_tokens; without a reserve an `xhigh` budget can consume the whole
+ * request budget and silently return an empty completion.
+ */
+export const OUTPUT_RESERVE_TOKENS = 1024;
+
+function budgetFromCatalog(
+  level: string,
+  budgets: ThinkingBudgets | undefined,
+): number | undefined {
+  if (!budgets) return undefined;
+  switch (level) {
+    case 'minimal':
+      return budgets.minimal;
+    case 'low':
+      return budgets.low;
+    case 'medium':
+      return budgets.medium;
+    case 'high':
+      return budgets.high;
+    default:
+      return undefined;
+  }
+}
+
+/** Budget formula from the model's max output tokens `output`. */
+function budgetFromFormula(level: string, output: number): number | undefined {
+  switch (level) {
+    case 'high':
+      return Math.min(16_000, Math.floor(output / 2 - 1));
+    case 'max':
+    case 'xhigh':
+      return Math.min(31_999, output - 1);
+    case 'medium':
+      return Math.min(8_000, Math.floor(output / 4));
+    case 'low':
+    case 'minimal':
+      return Math.min(4_000, Math.floor(output / 8));
+    default:
+      return undefined;
+  }
+}
+
+export function buildThinkingConfig(
+  level: string | undefined,
+  maxTokens: number,
+  catalog?: Model,
+): ThinkingConfig | undefined {
+  if (!level || level === 'off') return undefined;
+  // An explicit `supports_thinking: false` would 400; unknown stays permissive.
+  if (catalog?.supports_thinking === false) return undefined;
+  // Degrade xhigh to the high tier when the catalog says xhigh is unsupported.
+  const effective =
+    (level === 'xhigh' || level === 'max') && catalog?.supports_xhigh === false ? 'high' : level;
+
+  let budget = budgetFromCatalog(effective, catalog?.thinking_budgets);
+  if (budget === undefined || budget <= 0) {
+    const output = catalog?.max_output_tokens;
+    // The formula needs the model's output ceiling; unknown model -> no thinking.
+    if (typeof output !== 'number' || output <= 0) return undefined;
+    budget = budgetFromFormula(effective, output);
+  }
+  if (budget === undefined || budget <= 0) return undefined;
+
+  // Keep budget below max_tokens with room for the visible answer; drop
+  // thinking (logged) when less than the API minimum remains.
+  budget = Math.min(budget, maxTokens - OUTPUT_RESERVE_TOKENS);
+  if (budget < MIN_THINKING_BUDGET) {
+    logger.debug('thinking dropped: budget below API minimum after max_tokens clamp', {
+      level,
+      maxTokens,
+      budget,
+    });
+    return undefined;
+  }
+
+  return { type: 'enabled', budget_tokens: budget };
+}

--- a/harness/src/provider-anthropic/types.ts
+++ b/harness/src/provider-anthropic/types.ts
@@ -1,8 +1,11 @@
 /**
  * Anthropic provider config + auth-mode union. Mirrors
- * `provider-anthropic/src/lib.rs::{AnthropicConfig, AuthMode}`.
+ * `provider-anthropic/src/lib.rs::{AnthropicConfig, AuthMode}` for the
+ * wire-relevant fields; `catalog` is a harness-side, in-process-only
+ * addition with no Rust counterpart (never serialized).
  */
 
+import type { Model } from '../models-catalog/types.js';
 import type { Credential } from '../runtime/provider-resolve.js';
 import { DEFAULT_API_URL } from './config.js';
 
@@ -14,6 +17,8 @@ export type AnthropicConfig = {
   max_tokens: number;
   api_url: string;
   auth_mode: AuthMode;
+  /** Catalog entry for `model` when known; used for thinking budgets. */
+  catalog?: Model;
 };
 
 export function configWithCredential(

--- a/harness/src/provider-anthropic/wire-messages.ts
+++ b/harness/src/provider-anthropic/wire-messages.ts
@@ -44,6 +44,13 @@ export function contentBlockToWire(b: ContentBlock): unknown | null {
       input: b.arguments,
     };
   }
+  if (b.type === 'thinking') {
+    // During tool use Anthropic requires signed thinking blocks passed back
+    // unmodified (400 otherwise); unsigned blocks (aborted/partial stream)
+    // would fail signature verification and are dropped instead.
+    if (b.signature) return { type: 'thinking', thinking: b.text, signature: b.signature };
+    return null;
+  }
   return null;
 }
 

--- a/harness/src/provider-kimi/auth.ts
+++ b/harness/src/provider-kimi/auth.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ISdk } from '../runtime/iii.js';
+import { clampOutputTokens, getCatalogModel } from '../runtime/output-tokens.js';
 import { resolveProvider } from '../runtime/provider-resolve.js';
 import type { WorkerConfig } from './config.js';
 import { type ChatCompletionsConfig, configFromCredential } from './types.js';
@@ -25,6 +26,11 @@ export async function buildConfig(
     );
   }
   const apiUrl = resolved.api_url ?? worker.default_api_url;
-  const maxTokens = resolved.max_tokens ?? worker.default_max_tokens;
+  const catalog = await getCatalogModel(iii, PROVIDER_ID, model);
+  const maxTokens = clampOutputTokens({
+    modelMaxOutput: catalog?.max_output_tokens,
+    userOverride: resolved.max_tokens,
+    workerDefault: worker.default_max_tokens,
+  });
   return configFromCredential(apiUrl, PROVIDER_ID, model, resolved.credential, maxTokens);
 }

--- a/harness/src/provider-kimi/discover.ts
+++ b/harness/src/provider-kimi/discover.ts
@@ -14,6 +14,7 @@ import {
   type ModelStub,
   reconcileModels,
 } from '../runtime/models-discovery.js';
+import { getModelsDevIndex, lookupModelsDev } from '../runtime/modelsdev.js';
 import { logger } from '../runtime/otel.js';
 import { resolveProvider } from '../runtime/provider-resolve.js';
 import { PROVIDER_ID } from './auth.js';
@@ -55,12 +56,14 @@ export async function discoverAndRegister(iii: ISdk, worker: WorkerConfig): Prom
   }
   if (fetchResult.kind !== 'ok') return [];
 
+  const modelsDev = await getModelsDevIndex();
   const models = parseStubs(fetchResult.json).map((stub) =>
     enrichModel({
       provider: PROVIDER_ID,
       api: 'openai-completions',
       stub,
       defaultContextWindow: DEFAULT_CONTEXT_WINDOW,
+      modelsDev: lookupModelsDev(modelsDev, PROVIDER_ID, stub.id),
     }),
   );
   const registered = await reconcileModels(iii, PROVIDER_ID, models);

--- a/harness/src/provider-llamacpp/auth.ts
+++ b/harness/src/provider-llamacpp/auth.ts
@@ -1,6 +1,7 @@
 import type { ISdk } from '../runtime/iii.js';
 import { normalizeChatCompletionsUrl } from '../runtime/openai-compat-url.js';
 import { logger } from '../runtime/otel.js';
+import { clampOutputTokens, getCatalogModel } from '../runtime/output-tokens.js';
 import {
   type Credential,
   type ProviderResolveResult,
@@ -117,7 +118,12 @@ export async function buildConfig(
   // worker.default_api_url is already normalised in resolveApiUrl.
   const overrideUrl = resolved.api_url ? normalizeChatCompletionsUrl(resolved.api_url) : null;
   const apiUrl = overrideUrl ?? worker.default_api_url;
-  const maxTokens = resolved.max_tokens ?? worker.default_max_tokens;
+  const catalog = await getCatalogModel(iii, PROVIDER_ID, model);
+  const maxTokens = clampOutputTokens({
+    modelMaxOutput: catalog?.max_output_tokens,
+    userOverride: resolved.max_tokens,
+    workerDefault: worker.default_max_tokens,
+  });
   // Pass the credential through verbatim so configFromCredential can
   // populate api_key (empty string when no credential). Header emission
   // is gated separately in buildAuthHeaders/the stream layer.

--- a/harness/src/provider-lmstudio/auth.ts
+++ b/harness/src/provider-lmstudio/auth.ts
@@ -1,6 +1,7 @@
 import type { ISdk } from '../runtime/iii.js';
 import { normalizeChatCompletionsUrl } from '../runtime/openai-compat-url.js';
 import { logger } from '../runtime/otel.js';
+import { clampOutputTokens, getCatalogModel } from '../runtime/output-tokens.js';
 import {
   type Credential,
   type ProviderResolveResult,
@@ -124,7 +125,12 @@ export async function buildConfig(
   // worker.default_api_url is already normalised in resolveApiUrl.
   const overrideUrl = resolved.api_url ? normalizeChatCompletionsUrl(resolved.api_url) : null;
   const apiUrl = overrideUrl ?? worker.default_api_url;
-  const maxTokens = resolved.max_tokens ?? worker.default_max_tokens;
+  const catalog = await getCatalogModel(iii, PROVIDER_ID, model);
+  const maxTokens = clampOutputTokens({
+    modelMaxOutput: catalog?.max_output_tokens,
+    userOverride: resolved.max_tokens,
+    workerDefault: worker.default_max_tokens,
+  });
   const key = selectAuthKey(cred, apiUrl);
   // configFromCredential expects a Credential. When no key is
   // available we still pass a synthetic api_key with the LM Studio

--- a/harness/src/provider-openai/auth.ts
+++ b/harness/src/provider-openai/auth.ts
@@ -4,6 +4,7 @@
  */
 
 import type { ISdk } from '../runtime/iii.js';
+import { clampOutputTokens, getCatalogModel } from '../runtime/output-tokens.js';
 import { resolveProvider } from '../runtime/provider-resolve.js';
 import type { WorkerConfig } from './config.js';
 import { type ChatCompletionsConfig, configFromCredential } from './types.js';
@@ -23,6 +24,12 @@ export async function buildConfig(
     );
   }
   const apiUrl = resolved.api_url ?? worker.default_api_url;
-  const maxTokens = resolved.max_tokens ?? worker.default_max_tokens;
-  return configFromCredential(apiUrl, PROVIDER_ID, model, resolved.credential, maxTokens);
+  const catalog = await getCatalogModel(iii, PROVIDER_ID, model);
+  const maxTokens = clampOutputTokens({
+    modelMaxOutput: catalog?.max_output_tokens,
+    userOverride: resolved.max_tokens,
+    workerDefault: worker.default_max_tokens,
+  });
+  const cfg = configFromCredential(apiUrl, PROVIDER_ID, model, resolved.credential, maxTokens);
+  return catalog ? { ...cfg, catalog } : cfg;
 }

--- a/harness/src/provider-openai/discover.ts
+++ b/harness/src/provider-openai/discover.ts
@@ -15,6 +15,7 @@ import {
   type ModelStub,
   reconcileModels,
 } from '../runtime/models-discovery.js';
+import { getModelsDevIndex, lookupModelsDev } from '../runtime/modelsdev.js';
 import { logger } from '../runtime/otel.js';
 import { resolveProvider } from '../runtime/provider-resolve.js';
 import { PROVIDER_ID } from './auth.js';
@@ -63,12 +64,14 @@ export async function discoverAndRegister(iii: ISdk, worker: WorkerConfig): Prom
   }
   if (fetchResult.kind !== 'ok') return [];
 
+  const modelsDev = await getModelsDevIndex();
   const models = parseStubs(fetchResult.json).map((stub) =>
     enrichModel({
       provider: PROVIDER_ID,
       api: 'openai-responses',
       stub,
       defaultContextWindow: DEFAULT_CONTEXT_WINDOW,
+      modelsDev: lookupModelsDev(modelsDev, PROVIDER_ID, stub.id),
     }),
   );
   const registered = await reconcileModels(iii, PROVIDER_ID, models);

--- a/harness/src/provider-openai/reasoning.ts
+++ b/harness/src/provider-openai/reasoning.ts
@@ -1,0 +1,69 @@
+/**
+ * OpenAI reasoning-effort selection. Detects reasoning models (catalog
+ * `supports_thinking` flag first, id pattern fallback) and maps the
+ * harness `thinking_level` onto a `reasoning_effort` valid for the model
+ * family, defaulting to `medium`.
+ */
+
+const EFFORT_ORDER = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh'];
+
+export function isReasoningModel(model: string, catalogSupportsThinking?: boolean): boolean {
+  if (typeof catalogSupportsThinking === 'boolean') return catalogSupportsThinking;
+  return /^(gpt-5|o1|o3|o4)/i.test(model);
+}
+
+/** Efforts the model family accepts; empty = don't send the param. */
+function supportedEfforts(model: string): string[] {
+  const id = model.toLowerCase();
+  if (!/^(gpt-5|o1|o3|o4)/.test(id)) return [];
+  // The o1 family (o1, o1-mini, o1-preview, o1-pro) rejects
+  // reasoning_effort on Chat Completions with a 400 — even though
+  // catalogs flag it as a reasoning model. Omit the param entirely.
+  if (id.startsWith('o1')) return [];
+  // Chat-tuned variants only support the fixed default; omit the param.
+  if (id.includes('chat')) return [];
+  // gpt-5-pro / gpt-5.x-pro: high only.
+  if (id.includes('pro')) return ['high'];
+  const minorMatch = id.match(/^gpt-5\.(\d+)/);
+  if (minorMatch) {
+    const minor = Number(minorMatch[1]);
+    // gpt-5.1: none/low/medium/high; gpt-5.2+ adds xhigh.
+    return minor >= 2
+      ? ['none', 'low', 'medium', 'high', 'xhigh']
+      : ['none', 'low', 'medium', 'high'];
+  }
+  // gpt-5 base family (mini/nano/codex).
+  if (id.startsWith('gpt-5')) return ['minimal', 'low', 'medium', 'high'];
+  // o-series.
+  return ['low', 'medium', 'high'];
+}
+
+function normalizeLevel(level: string | undefined): string {
+  if (level === undefined) return 'medium';
+  if (level === 'off') return 'none';
+  if (level === 'max') return 'xhigh';
+  return level;
+}
+
+/**
+ * Effort for a reasoning model: the requested level when the family
+ * supports it, else the nearest supported effort below (then above).
+ * Returns undefined when the family takes no effort param.
+ */
+export function reasoningEffortFor(level: string | undefined, model: string): string | undefined {
+  const ladder = supportedEfforts(model);
+  if (ladder.length === 0) return undefined;
+  const want = normalizeLevel(level);
+  if (ladder.includes(want)) return want;
+  const wantIdx = EFFORT_ORDER.indexOf(want);
+  if (wantIdx < 0) return ladder.includes('medium') ? 'medium' : ladder[ladder.length - 1];
+  for (let i = wantIdx - 1; i >= 0; i--) {
+    const candidate = EFFORT_ORDER[i];
+    if (candidate !== undefined && ladder.includes(candidate)) return candidate;
+  }
+  for (let i = wantIdx + 1; i < EFFORT_ORDER.length; i++) {
+    const candidate = EFFORT_ORDER[i];
+    if (candidate !== undefined && ladder.includes(candidate)) return candidate;
+  }
+  return undefined;
+}

--- a/harness/src/provider-openai/stream-fn.ts
+++ b/harness/src/provider-openai/stream-fn.ts
@@ -31,6 +31,7 @@ export function register(iii: ISdk, worker: WorkerConfig): void {
           system_prompt: input.system_prompt ?? '',
           messages: input.messages as AgentMessage[],
           tools: input.tools as import('../types/function.js').AgentFunction[],
+          ...(input.thinking_level ? { thinking_level: input.thinking_level } : {}),
         });
         for await (const ev of events) {
           writer.sendMessage(JSON.stringify(ev));

--- a/harness/src/provider-openai/stream.ts
+++ b/harness/src/provider-openai/stream.ts
@@ -7,6 +7,7 @@ import { logger } from '../runtime/otel.js';
 import type { AgentMessage, AssistantMessage } from '../types/agent-message.js';
 import type { AgentFunction } from '../types/function.js';
 import type { AssistantMessageEvent } from '../types/stream-event.js';
+import { isReasoningModel, reasoningEffortFor } from './reasoning.js';
 import {
   buildFinal,
   classifyOpenaiError,
@@ -23,6 +24,8 @@ export type StreamArgs = {
   system_prompt: string;
   messages: AgentMessage[];
   tools: AgentFunction[];
+  /** Optional reasoning level; mapped onto `reasoning_effort` for reasoning models. */
+  thinking_level?: string;
 };
 
 export async function* streamOpenai({
@@ -30,7 +33,10 @@ export async function* streamOpenai({
   system_prompt,
   messages,
   tools,
+  thinking_level,
 }: StreamArgs): AsyncGenerator<AssistantMessageEvent> {
+  // `max_completion_tokens` stays set for reasoning models too: reasoning
+  // tokens count toward it, but the clamped default leaves ample room.
   const body: Record<string, unknown> = {
     model: cfg.model,
     max_completion_tokens: cfg.max_tokens,
@@ -38,6 +44,10 @@ export async function* streamOpenai({
     stream: true,
     stream_options: { include_usage: true },
   };
+  if (isReasoningModel(cfg.model, cfg.catalog?.supports_thinking)) {
+    const effort = reasoningEffortFor(thinking_level, cfg.model);
+    if (effort) body.reasoning_effort = effort;
+  }
   if (tools.length > 0) body.tools = functionsToOpenai(tools);
 
   const authName = cfg.auth_header_name ?? 'Authorization';

--- a/harness/src/provider-openai/types.ts
+++ b/harness/src/provider-openai/types.ts
@@ -1,3 +1,4 @@
+import type { Model } from '../models-catalog/types.js';
 import type { Credential } from '../runtime/provider-resolve.js';
 
 export type ChatCompletionsConfig = {
@@ -11,6 +12,8 @@ export type ChatCompletionsConfig = {
   auth_value_prefix?: string;
   extra_headers?: Array<readonly [string, string]>;
   max_tokens: number;
+  /** Catalog entry for `model` when known; used for reasoning detection. In-process only — never serialized, no Rust counterpart. */
+  catalog?: Model;
 };
 
 export function configFromCredential(

--- a/harness/src/runtime/models-discovery.ts
+++ b/harness/src/runtime/models-discovery.ts
@@ -11,6 +11,7 @@
 
 import type { Model } from '../models-catalog/types.js';
 import type { ISdk } from './iii.js';
+import type { ModelsDevModel } from './modelsdev.js';
 import { logger } from './otel.js';
 
 const DISCOVERY_TIMEOUT_MS = 8_000;
@@ -107,26 +108,30 @@ export type ModelStub = {
 
 /**
  * Build a catalog `Model` for a discovered id. Upstream `/v1/models`
- * endpoints expose little metadata, so we fill in a per-provider default
- * context window and conservative capability flags (tools on, the rest
- * left at their defaults).
+ * endpoints expose little metadata, so per-model limits and capability
+ * flags come from models.dev when available (`modelsDev`), with a
+ * per-provider default context window and conservative flags as fallback.
  */
 export function enrichModel(opts: {
   provider: string;
   api: string;
   stub: ModelStub;
   defaultContextWindow: number;
+  modelsDev?: ModelsDevModel;
 }): Model {
-  return {
+  const md = opts.modelsDev;
+  const model: Model = {
     id: opts.stub.id,
     provider: opts.provider,
     api: opts.api,
     display_name: opts.stub.display_name ?? opts.stub.id,
-    context_window: opts.defaultContextWindow,
-    max_output_tokens: 8_192,
-    supports_tools: true,
+    context_window: md?.limit?.context ?? opts.defaultContextWindow,
+    max_output_tokens: md?.limit?.output ?? 8_192,
+    supports_tools: md?.tool_call ?? true,
     transports: ['sse'],
   };
+  if (md?.reasoning !== undefined) model.supports_thinking = md.reasoning;
+  return model;
 }
 
 /**

--- a/harness/src/runtime/modelsdev.ts
+++ b/harness/src/runtime/modelsdev.ts
@@ -1,0 +1,169 @@
+/**
+ * models.dev catalog client.
+ *
+ * Fetches https://models.dev/api.json once per process (1h TTL, in-flight
+ * dedup) and exposes per-provider/model limits + capability flags used to
+ * enrich discovery. Best-effort by contract: any failure yields an empty
+ * index so discovery proceeds with its existing per-provider defaults.
+ */
+
+import { logger } from './otel.js';
+
+export type ModelsDevLimit = {
+  context?: number;
+  input?: number;
+  output?: number;
+};
+
+export type ModelsDevModel = {
+  id: string;
+  limit?: ModelsDevLimit;
+  reasoning?: boolean;
+  tool_call?: boolean;
+};
+
+/** providerKey -> (modelId -> ModelsDevModel) */
+export type ModelsDevIndex = Map<string, Map<string, ModelsDevModel>>;
+
+export const MODELSDEV_URL = 'https://models.dev/api.json';
+const FETCH_TIMEOUT_MS = 8_000;
+const CACHE_TTL_MS = 60 * 60 * 1000;
+// Failed fetches cache an empty index, but only briefly — a transient blip
+// at startup shouldn't strip catalog limits for a full hour.
+const FAILURE_TTL_MS = 5 * 60 * 1000;
+// Sanity bounds for externally-sourced token limits. models.dev is a
+// third-party feed; an absurd value (e.g. output: 1) would silently break
+// every request to that model, so out-of-range values are treated as absent.
+const LIMIT_MIN = 256;
+const LIMIT_MAX = 50_000_000;
+
+/** Harness provider id -> models.dev provider key. Local providers have no entry. */
+export const PROVIDER_KEY_MAP: Record<string, string> = {
+  anthropic: 'anthropic',
+  openai: 'openai',
+  kimi: 'moonshotai',
+};
+
+type CacheEntry = { index: ModelsDevIndex; fetchedAt: number };
+
+let cache: CacheEntry | null = null;
+let inflight: Promise<ModelsDevIndex> | null = null;
+
+/** Test hook: clear the module cache. */
+export function _resetModelsDevForTests(): void {
+  cache = null;
+  inflight = null;
+}
+
+function emptyIndex(): ModelsDevIndex {
+  return new Map();
+}
+
+function num(v: unknown): number | undefined {
+  return typeof v === 'number' && Number.isFinite(v) && v >= LIMIT_MIN && v <= LIMIT_MAX
+    ? v
+    : undefined;
+}
+
+function parseIndex(json: unknown): ModelsDevIndex {
+  const index = emptyIndex();
+  if (typeof json !== 'object' || json === null) return index;
+  for (const [providerKey, provider] of Object.entries(json as Record<string, unknown>)) {
+    if (typeof provider !== 'object' || provider === null) continue;
+    const models = (provider as Record<string, unknown>).models;
+    if (typeof models !== 'object' || models === null) continue;
+    const byId = new Map<string, ModelsDevModel>();
+    for (const [modelId, raw] of Object.entries(models as Record<string, unknown>)) {
+      if (typeof raw !== 'object' || raw === null) continue;
+      const m = raw as Record<string, unknown>;
+      const limit =
+        typeof m.limit === 'object' && m.limit !== null
+          ? (m.limit as Record<string, unknown>)
+          : undefined;
+      byId.set(modelId, {
+        id: modelId,
+        limit: limit
+          ? { context: num(limit.context), input: num(limit.input), output: num(limit.output) }
+          : undefined,
+        reasoning: typeof m.reasoning === 'boolean' ? m.reasoning : undefined,
+        tool_call: typeof m.tool_call === 'boolean' ? m.tool_call : undefined,
+      });
+    }
+    if (byId.size > 0) index.set(providerKey, byId);
+  }
+  return index;
+}
+
+async function fetchIndex(): Promise<ModelsDevIndex> {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const resp = await fetch(MODELSDEV_URL, { signal: ac.signal });
+    if (!resp.ok) {
+      logger.warn('modelsdev: non-200 response', { status: resp.status });
+      return emptyIndex();
+    }
+    const json: unknown = await resp.json();
+    const index = parseIndex(json);
+    logger.info('modelsdev: catalog fetched', { providers: index.size });
+    return index;
+  } catch (err) {
+    logger.warn('modelsdev: fetch failed', { err: String(err) });
+    return emptyIndex();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Cached models.dev index. Never throws — failures cache an empty index
+ * (with a shorter TTL) so a flaky network can't hammer models.dev or block
+ * discovery, while a transient blip recovers within minutes.
+ */
+export async function getModelsDevIndex(): Promise<ModelsDevIndex> {
+  if (cache) {
+    const ttl = cache.index.size > 0 ? CACHE_TTL_MS : FAILURE_TTL_MS;
+    if (Date.now() - cache.fetchedAt < ttl) return cache.index;
+  }
+  if (inflight) return inflight;
+  inflight = fetchIndex().then((index) => {
+    cache = { index, fetchedAt: Date.now() };
+    inflight = null;
+    return index;
+  });
+  return inflight;
+}
+
+/** Strip a trailing `-YYYYMMDD` date suffix (`claude-sonnet-4-20250514` -> `claude-sonnet-4`). */
+function stripDateSuffix(id: string): string {
+  return id.replace(/-\d{8}$/, '');
+}
+
+/**
+ * Look up a model's models.dev metadata for a harness provider id.
+ * Conservative matching: exact id, then date-suffix-normalized on both sides.
+ * No match -> undefined (caller keeps its defaults).
+ */
+export function lookupModelsDev(
+  index: ModelsDevIndex,
+  providerId: string,
+  modelId: string,
+): ModelsDevModel | undefined {
+  const key = PROVIDER_KEY_MAP[providerId];
+  if (!key) return undefined;
+  const models = index.get(key);
+  if (!models) return undefined;
+
+  const exact = models.get(modelId);
+  if (exact) return exact;
+
+  const normalized = stripDateSuffix(modelId);
+  if (normalized !== modelId) {
+    const byNormalized = models.get(normalized);
+    if (byNormalized) return byNormalized;
+  }
+  for (const [id, model] of models) {
+    if (stripDateSuffix(id) === normalized) return model;
+  }
+  return undefined;
+}

--- a/harness/src/runtime/output-tokens.ts
+++ b/harness/src/runtime/output-tokens.ts
@@ -1,0 +1,103 @@
+/**
+ * Per-request output-token resolution.
+ *
+ * The default request budget is `min(model.max_output_tokens, OUTPUT_TOKEN_MAX)`
+ * so high-output models (Claude 64k/128k, GPT-5 272k) don't burn latency/cost
+ * on every turn. An explicit registry override always wins, clamped only to the
+ * model's hard ceiling (never raised) to avoid upstream 400s.
+ */
+
+import type { Model } from '../models-catalog/types.js';
+import type { ISdk } from './iii.js';
+import { logger } from './otel.js';
+
+export const OUTPUT_TOKEN_MAX = 32_000;
+export const OUTPUT_TOKEN_MAX_ENV = 'HARNESS_OUTPUT_TOKEN_MAX';
+
+const MODELS_GET_TIMEOUT_MS = 5_000;
+
+let cachedCap: number | null = null;
+
+/** Cap from `HARNESS_OUTPUT_TOKEN_MAX` (strict positive integer) or 32_000. Cached per process. */
+export function outputTokenCap(): number {
+  if (cachedCap !== null) return cachedCap;
+  const v = process.env[OUTPUT_TOKEN_MAX_ENV];
+  if (!v) {
+    cachedCap = OUTPUT_TOKEN_MAX;
+    return cachedCap;
+  }
+  // Strict digits-only parse: parseInt would silently truncate values like
+  // "1e9" to 1, turning a fat-fingered env var into a 1-token output cap.
+  const n = /^\d+$/.test(v.trim()) ? Number.parseInt(v.trim(), 10) : Number.NaN;
+  cachedCap = Number.isFinite(n) && n > 0 ? n : OUTPUT_TOKEN_MAX;
+  return cachedCap;
+}
+
+/** Test hook: clear the cached env cap. */
+export function _resetOutputTokenCapForTests(): void {
+  cachedCap = null;
+}
+
+export type ClampArgs = {
+  /** Catalog `max_output_tokens` for the model (undefined/0 = unknown). */
+  modelMaxOutput: number | null | undefined;
+  /** Explicit registry override (`harness::provider::resolve` max_tokens). */
+  userOverride: number | null;
+  /** Provider worker default (`default_max_tokens`, 8192). */
+  workerDefault: number;
+  /** Defaults to `outputTokenCap()`. */
+  cap?: number;
+};
+
+/**
+ * Resolve the per-request max output tokens.
+ *
+ * Precedence:
+ * 1. `userOverride > 0` — wins; clamped down to the model ceiling when known
+ *    (deliberate choice is honored, so the 32k cap does NOT apply here).
+ * 2. `min(modelMaxOutput, cap)` — the per-model default.
+ * 3. `workerDefault` — unknown model, preserves pre-clamp behavior.
+ */
+export function clampOutputTokens(args: ClampArgs): number {
+  const cap = args.cap ?? outputTokenCap();
+  const modelMax =
+    typeof args.modelMaxOutput === 'number' && args.modelMaxOutput > 0
+      ? args.modelMaxOutput
+      : undefined;
+
+  // Floored: token counts must be integers upstream.
+  if (typeof args.userOverride === 'number' && args.userOverride > 0) {
+    return Math.floor(
+      modelMax !== undefined ? Math.min(args.userOverride, modelMax) : args.userOverride,
+    );
+  }
+  if (modelMax !== undefined) return Math.floor(Math.min(modelMax, cap));
+  return Math.floor(args.workerDefault);
+}
+
+/**
+ * Fetch the catalog entry for `(provider, model)` via `models::get`.
+ * Best-effort: returns null on miss, timeout, or any bus error — callers fall
+ * back to worker defaults so an empty catalog never breaks a request.
+ */
+export async function getCatalogModel(
+  iii: ISdk,
+  provider: string,
+  modelId: string,
+): Promise<Model | null> {
+  try {
+    const entry = await iii.trigger<unknown, Model | null>({
+      function_id: 'models::get',
+      payload: { provider, model_id: modelId },
+      timeoutMs: MODELS_GET_TIMEOUT_MS,
+    });
+    return entry ?? null;
+  } catch (err) {
+    logger.debug('output-tokens: models::get failed', {
+      provider,
+      model: modelId,
+      err: String(err),
+    });
+    return null;
+  }
+}

--- a/harness/src/turn-orchestrator/assistant-streaming/ports.ts
+++ b/harness/src/turn-orchestrator/assistant-streaming/ports.ts
@@ -23,6 +23,8 @@ export type StreamContext = {
   system_prompt: string;
   tools: AgentFunction[];
   messages: AgentMessage[];
+  /** Optional reasoning/thinking level from the run request. Absent = off. */
+  thinking_level?: string;
 };
 
 export type StreamTurnOutcome = {
@@ -93,7 +95,14 @@ export function createStreamingPorts(iii: ISdk): AssistantStreamingPorts {
         session_id: ctx.session_id,
         targetFn: targetFunctionId(ctx.decision),
         buildInput: (writerRef) =>
-          buildInput(ctx.decision, writerRef, ctx.system_prompt, ctx.messages, ctx.tools),
+          buildInput(
+            ctx.decision,
+            writerRef,
+            ctx.system_prompt,
+            ctx.messages,
+            ctx.tools,
+            ctx.thinking_level,
+          ),
         onDelta,
       });
       return { final, error };

--- a/harness/src/turn-orchestrator/assistant-streaming/run.ts
+++ b/harness/src/turn-orchestrator/assistant-streaming/run.ts
@@ -31,7 +31,7 @@ export async function prepareStreamContext(
 ): Promise<StreamContext> {
   const request = await ports.loadRunRequest(rec.session_id);
   let messages = await ports.loadMessages(rec.session_id);
-  const { provider, model, system_prompt, function_schemas } = request;
+  const { provider, model, system_prompt, function_schemas, thinking_level } = request;
   const decision = decide({ provider, model });
   const tools = parseFunctionSchemas(function_schemas);
 
@@ -47,6 +47,7 @@ export async function prepareStreamContext(
     system_prompt,
     tools,
     messages,
+    ...(thinking_level ? { thinking_level } : {}),
   };
 }
 

--- a/harness/src/turn-orchestrator/prompt/gpt.ts
+++ b/harness/src/turn-orchestrator/prompt/gpt.ts
@@ -1,8 +1,7 @@
 /**
  * Identity prompt for GPT-family models (openai provider) — pragmatic
  * senior-engineer voice with persistence/autonomy emphasis, flat lists, and
- * ## headers (opencode gpt.txt style). Carries the same rules as the
- * anthropic variant.
+ * ## headers. Carries the same rules as the anthropic variant.
  */
 
 export const PROMPT_GPT = `You are an iii agent worker.

--- a/harness/src/turn-orchestrator/prompt/index.ts
+++ b/harness/src/turn-orchestrator/prompt/index.ts
@@ -1,6 +1,5 @@
 /**
- * Per-model identity prompts, selected by the run's provider/model — the same
- * pattern opencode uses (anthropic.txt / gpt.txt / kimi.txt / default.txt).
+ * Per-model identity prompts, selected by the run's provider/model.
  * Routing reuses the provider-router's family heuristics.
  */
 

--- a/harness/src/turn-orchestrator/prompt/kimi.ts
+++ b/harness/src/turn-orchestrator/prompt/kimi.ts
@@ -1,7 +1,7 @@
 /**
  * Identity prompt for Kimi/Moonshot models (kimi provider) — direct MUST
- * imperatives, numbered guidelines, and an "Ultimate Reminders" close
- * (opencode kimi.txt style). Carries the same rules as the anthropic variant.
+ * imperatives, numbered guidelines, and an "Ultimate Reminders" close.
+ * Carries the same rules as the anthropic variant.
  */
 
 export const PROMPT_KIMI = `You are an iii agent worker.

--- a/harness/src/turn-orchestrator/provider-router.ts
+++ b/harness/src/turn-orchestrator/provider-router.ts
@@ -61,6 +61,7 @@ export function buildInput(
   system_prompt: string | null | undefined,
   messages: AgentMessage[],
   tools: AgentFunction[],
+  thinking_level?: string,
 ): ProviderStreamInput {
   return {
     writer_ref,
@@ -68,5 +69,6 @@ export function buildInput(
     model: d.model,
     messages: messages as unknown[],
     tools,
+    ...(thinking_level ? { thinking_level } : {}),
   };
 }

--- a/harness/src/turn-orchestrator/run-request.ts
+++ b/harness/src/turn-orchestrator/run-request.ts
@@ -16,6 +16,8 @@ const RunRequestSchema = z.object({
     .transform((v): Mode | null => (v === 'plan' || v === 'ask' || v === 'agent' ? v : null)),
   system_prompt: z.string().catch(''),
   function_schemas: z.array(z.unknown()).catch([]),
+  /** Optional reasoning/thinking level ('off'|'minimal'|'low'|'medium'|'high'|'xhigh'). */
+  thinking_level: z.string().optional().catch(undefined),
 });
 
 export type RunRequest = z.infer<typeof RunRequestSchema>;

--- a/harness/src/types/provider.ts
+++ b/harness/src/types/provider.ts
@@ -38,6 +38,12 @@ export const ProviderStreamInputSchema = z.object({
   /** Pass-through; the providers serialize this themselves. */
   messages: z.array(z.unknown()),
   tools: z.array(AgentFunctionSchema).default([]),
+  /**
+   * Optional reasoning/thinking level. Providers that support it map this
+   * onto their native parameter (Anthropic `thinking`, OpenAI
+   * `reasoning_effort`); others ignore it. Absent = off.
+   */
+  thinking_level: z.string().optional(),
 });
 export type ProviderStreamInput = z.infer<typeof ProviderStreamInputSchema>;
 

--- a/harness/tests/harness/providers/registry.test.ts
+++ b/harness/tests/harness/providers/registry.test.ts
@@ -100,10 +100,27 @@ describe('ProviderRegistry.resolve', () => {
       expect(r.credential).toEqual({ type: 'api_key', key: 'sk-env' });
       expect(r.source).toBe('environment');
       expect(r.api_url).toBe('https://default');
-      expect(r.max_tokens).toBe(1234);
+      // The declared default max_tokens is NOT seeded as an override —
+      // seeding it would pin every request to 8192 and defeat the clamp.
+      expect(r.max_tokens).toBeNull();
     } finally {
       process.env.III_TEST_PROVIDER_KEY = undefined;
     }
+  });
+
+  it('returns max_tokens only when the user actually configured it', async () => {
+    const { sdk } = makeConfigSdk({
+      permissions: { default_mode: 'manual' },
+      providers: { anthropic: { api_key: 'sk-abc' } },
+    });
+    const reg = new ProviderRegistry(sdk);
+    await reg.declare({
+      id: 'anthropic',
+      credential_env_var: 'ANTHROPIC_API_KEY',
+      defaults: { api_url: 'https://default', max_tokens: 8192 },
+    });
+    const r = await reg.resolve('anthropic');
+    expect(r.max_tokens).toBeNull();
   });
 
   it('reports unconfigured when neither stored nor env credential exists', async () => {

--- a/harness/tests/provider-anthropic/auth.test.ts
+++ b/harness/tests/provider-anthropic/auth.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildConfig } from '../../src/provider-anthropic/auth.js';
+import type { WorkerConfig } from '../../src/provider-anthropic/config.js';
+import type { ISdk } from '../../src/runtime/iii.js';
+
+const WORKER: WorkerConfig = {
+  default_api_url: 'https://api.anthropic.com/v1/messages',
+  default_max_tokens: 8192,
+};
+
+const { resolveProviderMock } = vi.hoisted(() => ({
+  resolveProviderMock: vi.fn(),
+}));
+
+vi.mock('../../src/runtime/provider-resolve.js', () => ({
+  resolveProvider: resolveProviderMock,
+}));
+
+function resolved(max_tokens: number | null) {
+  return {
+    configured: true,
+    credential: { type: 'api_key', key: 'sk-test' },
+    api_url: null,
+    max_tokens,
+    source: 'stored',
+  };
+}
+
+/** Fake ISdk whose models::get returns the given catalog entry (or throws). */
+function iiiWithCatalog(entry: unknown, opts: { throws?: boolean } = {}): ISdk {
+  const trigger = vi.fn().mockImplementation(async (req: { function_id: string }) => {
+    if (req.function_id === 'models::get') {
+      if (opts.throws) throw new Error('bus timeout');
+      return entry;
+    }
+    return null;
+  });
+  return { trigger } as unknown as ISdk;
+}
+
+describe('buildConfig max_tokens resolution', () => {
+  beforeEach(() => {
+    resolveProviderMock.mockReset();
+  });
+
+  it('defaults to min(catalog max, 32k) — 64k model clamps to 32k', async () => {
+    resolveProviderMock.mockResolvedValue(resolved(null));
+    const iii = iiiWithCatalog({ id: 'claude-sonnet-4-6', max_output_tokens: 64_000 });
+    const cfg = await buildConfig(iii, WORKER, 'claude-sonnet-4-6');
+    expect(cfg.max_tokens).toBe(32_000);
+    expect(cfg.catalog?.max_output_tokens).toBe(64_000);
+  });
+
+  it('uses the catalog max when below the cap', async () => {
+    resolveProviderMock.mockResolvedValue(resolved(null));
+    const iii = iiiWithCatalog({ id: 'claude-haiku-4-5', max_output_tokens: 16_000 });
+    const cfg = await buildConfig(iii, WORKER, 'claude-haiku-4-5');
+    expect(cfg.max_tokens).toBe(16_000);
+  });
+
+  it('registry override wins below the model ceiling', async () => {
+    resolveProviderMock.mockResolvedValue(resolved(50_000));
+    const iii = iiiWithCatalog({ id: 'claude-sonnet-4-6', max_output_tokens: 64_000 });
+    const cfg = await buildConfig(iii, WORKER, 'claude-sonnet-4-6');
+    expect(cfg.max_tokens).toBe(50_000);
+  });
+
+  it('registry override is clamped to the model ceiling', async () => {
+    resolveProviderMock.mockResolvedValue(resolved(100_000));
+    const iii = iiiWithCatalog({ id: 'claude-sonnet-4-6', max_output_tokens: 64_000 });
+    const cfg = await buildConfig(iii, WORKER, 'claude-sonnet-4-6');
+    expect(cfg.max_tokens).toBe(64_000);
+  });
+
+  it('falls back to the registry/worker default when the catalog lookup fails', async () => {
+    resolveProviderMock.mockResolvedValue(resolved(null));
+    const cfg = await buildConfig(iiiWithCatalog(null, { throws: true }), WORKER, 'claude-x');
+    expect(cfg.max_tokens).toBe(WORKER.default_max_tokens);
+    expect(cfg.catalog).toBeUndefined();
+  });
+
+  it('falls back to the worker default when the model is unknown', async () => {
+    resolveProviderMock.mockResolvedValue(resolved(null));
+    const cfg = await buildConfig(iiiWithCatalog(null), WORKER, 'claude-unknown');
+    expect(cfg.max_tokens).toBe(WORKER.default_max_tokens);
+  });
+
+  it('throws without a credential', async () => {
+    resolveProviderMock.mockResolvedValue({
+      configured: false,
+      credential: null,
+      api_url: null,
+      max_tokens: null,
+      source: null,
+    });
+    await expect(buildConfig(iiiWithCatalog(null), WORKER, 'claude-x')).rejects.toThrow(
+      /no credential/,
+    );
+  });
+});

--- a/harness/tests/provider-anthropic/cache.test.ts
+++ b/harness/tests/provider-anthropic/cache.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { applyMessagesCacheAnchor } from '../../src/provider-anthropic/cache.js';
+
+type WireMsg = Record<string, unknown>;
+
+function assistantTurn(content: Array<Record<string, unknown>>): WireMsg {
+  return { role: 'assistant', content };
+}
+
+describe('applyMessagesCacheAnchor', () => {
+  it('anchors cache_control on the last block of the last stable assistant turn', () => {
+    const wire: WireMsg[] = [
+      { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+      assistantTurn([{ type: 'text', text: 'answer' }]),
+    ];
+    applyMessagesCacheAnchor(wire);
+    const content = (wire[1] as { content: Array<Record<string, unknown>> }).content;
+    expect(content[0]?.cache_control).toEqual({ type: 'ephemeral' });
+  });
+
+  it('skips trailing thinking blocks (cache_control is rejected on them)', () => {
+    const wire: WireMsg[] = [
+      { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+      assistantTurn([
+        { type: 'text', text: 'answer' },
+        { type: 'thinking', thinking: 'why', signature: 'sig' },
+      ]),
+    ];
+    applyMessagesCacheAnchor(wire);
+    const content = (wire[1] as { content: Array<Record<string, unknown>> }).content;
+    expect(content[1]?.cache_control).toBeUndefined();
+    expect(content[0]?.cache_control).toEqual({ type: 'ephemeral' });
+  });
+
+  it('does nothing when the turn contains only thinking blocks', () => {
+    const wire: WireMsg[] = [
+      { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+      assistantTurn([{ type: 'thinking', thinking: 'why', signature: 'sig' }]),
+    ];
+    applyMessagesCacheAnchor(wire);
+    const content = (wire[1] as { content: Array<Record<string, unknown>> }).content;
+    expect(content[0]?.cache_control).toBeUndefined();
+  });
+});

--- a/harness/tests/provider-anthropic/sse.test.ts
+++ b/harness/tests/provider-anthropic/sse.test.ts
@@ -104,3 +104,133 @@ describe('handleSseEvent', () => {
     expect(partial.content[0]).toEqual({ type: 'text', text: 'hello' });
   });
 });
+
+describe('handleSseEvent thinking blocks', () => {
+  it('emits thinking_start + thinking_delta + thinking_end in order', () => {
+    const state = emptyPartial();
+    const out: string[] = [];
+    out.push(
+      ...handleSseEvent(
+        'data: {"type":"content_block_start","content_block":{"type":"thinking"}}',
+        state,
+        'm',
+      ).map((e) => e.type),
+    );
+    out.push(
+      ...handleSseEvent(
+        'data: {"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"let me think"}}',
+        state,
+        'm',
+      ).map((e) => e.type),
+    );
+    out.push(
+      ...handleSseEvent('data: {"type":"content_block_stop"}', state, 'm').map((e) => e.type),
+    );
+    expect(out).toEqual(['thinking_start', 'thinking_delta', 'thinking_end']);
+    expect(state.thinking_blocks[0]?.text).toBe('let me think');
+  });
+
+  it('accumulates signature_delta without emitting events', () => {
+    const state = emptyPartial();
+    handleSseEvent(
+      'data: {"type":"content_block_start","content_block":{"type":"thinking"}}',
+      state,
+      'm',
+    );
+    const events = handleSseEvent(
+      'data: {"type":"content_block_delta","delta":{"type":"signature_delta","signature":"sig123"}}',
+      state,
+      'm',
+    );
+    expect(events).toEqual([]);
+    expect(state.thinking_blocks[0]?.signature).toBe('sig123');
+  });
+
+  it('persists a leading ThinkingContent block in the assembled message', () => {
+    const state = emptyPartial();
+    handleSseEvent(
+      'data: {"type":"content_block_start","content_block":{"type":"thinking"}}',
+      state,
+      'm',
+    );
+    handleSseEvent(
+      'data: {"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"why"}}',
+      state,
+      'm',
+    );
+    handleSseEvent('data: {"type":"content_block_stop"}', state, 'm');
+    state.text_blocks.push('answer');
+    const partial = buildPartial(state, 'm');
+    expect(partial.content).toEqual([
+      { type: 'thinking', text: 'why' },
+      { type: 'text', text: 'answer' },
+    ]);
+  });
+
+  it('emits the end event matching the open block kind (regression: tool_use end)', () => {
+    const state = emptyPartial();
+    handleSseEvent(
+      'data: {"type":"content_block_start","content_block":{"type":"tool_use","id":"t1","name":"x"}}',
+      state,
+      'm',
+    );
+    const stop = handleSseEvent('data: {"type":"content_block_stop"}', state, 'm');
+    expect(stop[0]?.type).toBe('functioncall_end');
+  });
+
+  it('text block after a thinking block still emits text_end', () => {
+    const state = emptyPartial();
+    handleSseEvent(
+      'data: {"type":"content_block_start","content_block":{"type":"thinking"}}',
+      state,
+      'm',
+    );
+    handleSseEvent('data: {"type":"content_block_stop"}', state, 'm');
+    handleSseEvent(
+      'data: {"type":"content_block_start","content_block":{"type":"text"}}',
+      state,
+      'm',
+    );
+    const stop = handleSseEvent('data: {"type":"content_block_stop"}', state, 'm');
+    expect(stop[0]?.type).toBe('text_end');
+  });
+
+  it('preserves interleaved thinking/tool_use arrival order in the assembled message', () => {
+    const state = emptyPartial();
+    const feed = (line: string) => handleSseEvent(`data: ${line}`, state, 'm');
+    // thinking₁ → tool_use₁ → thinking₂ → tool_use₂ (interleaved-thinking beta shape)
+    feed('{"type":"content_block_start","content_block":{"type":"thinking"}}');
+    feed('{"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"plan A"}}');
+    feed('{"type":"content_block_stop"}');
+    feed('{"type":"content_block_start","content_block":{"type":"tool_use","id":"t1","name":"x"}}');
+    feed('{"type":"content_block_stop"}');
+    feed('{"type":"content_block_start","content_block":{"type":"thinking"}}');
+    feed('{"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"plan B"}}');
+    feed('{"type":"content_block_stop"}');
+    feed('{"type":"content_block_start","content_block":{"type":"tool_use","id":"t2","name":"y"}}');
+    feed('{"type":"content_block_stop"}');
+    const partial = buildPartial(state, 'm');
+    expect(partial.content.map((b) => b.type)).toEqual([
+      'thinking',
+      'function_call',
+      'thinking',
+      'function_call',
+    ]);
+    expect(partial.content[0]).toMatchObject({ text: 'plan A' });
+    expect(partial.content[2]).toMatchObject({ text: 'plan B' });
+  });
+
+  it('redacted_thinking does not crash and emits thinking events', () => {
+    const state = emptyPartial();
+    const start = handleSseEvent(
+      'data: {"type":"content_block_start","content_block":{"type":"redacted_thinking","data":"opaque"}}',
+      state,
+      'm',
+    );
+    expect(start[0]?.type).toBe('thinking_start');
+    const stop = handleSseEvent('data: {"type":"content_block_stop"}', state, 'm');
+    expect(stop[0]?.type).toBe('thinking_end');
+    // Opaque content is not persisted.
+    expect(buildPartial(state, 'm').content).toEqual([]);
+  });
+});

--- a/harness/tests/provider-anthropic/stream-request.test.ts
+++ b/harness/tests/provider-anthropic/stream-request.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { streamAnthropic } from '../../src/provider-anthropic/stream.js';
+import type { AnthropicConfig } from '../../src/provider-anthropic/types.js';
+
+function cfg(overrides: Partial<AnthropicConfig> = {}): AnthropicConfig {
+  return {
+    credential_value: 'sk-test',
+    model: 'claude-sonnet-4-6',
+    max_tokens: 32_000,
+    api_url: 'https://api.example/v1/messages',
+    auth_mode: 'api_key',
+    ...overrides,
+  };
+}
+
+type Captured = { body: Record<string, unknown>; headers: Record<string, string> };
+
+async function capture(args: Parameters<typeof streamAnthropic>[0]): Promise<Captured> {
+  let captured: Captured | null = null;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation(async (_url: string, init: RequestInit) => {
+      captured = {
+        body: JSON.parse(init.body as string) as Record<string, unknown>,
+        headers: init.headers as Record<string, string>,
+      };
+      return new Response('data: {"type":"message_stop"}\n\n', { status: 200 });
+    }),
+  );
+  for await (const _ev of streamAnthropic(args)) {
+    // drain
+  }
+  if (!captured) throw new Error('fetch was not called');
+  return captured;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('streamAnthropic request body', () => {
+  it('sends the resolved max_tokens and no temperature', async () => {
+    const { body } = await capture({ cfg: cfg(), system_prompt: 's', messages: [], tools: [] });
+    expect(body.max_tokens).toBe(32_000);
+    expect(body).not.toHaveProperty('temperature');
+    expect(body).not.toHaveProperty('thinking');
+  });
+
+  it('omits the anthropic-beta header when thinking is off', async () => {
+    const { headers } = await capture({ cfg: cfg(), system_prompt: 's', messages: [], tools: [] });
+    expect(headers).not.toHaveProperty('anthropic-beta');
+  });
+
+  it('sends thinking + interleaved-thinking beta header when enabled', async () => {
+    const { body, headers } = await capture({
+      cfg: cfg(),
+      system_prompt: 's',
+      messages: [],
+      tools: [],
+      thinking: { type: 'enabled', budget_tokens: 16_000 },
+    });
+    expect(body.thinking).toEqual({ type: 'enabled', budget_tokens: 16_000 });
+    expect(headers['anthropic-beta']).toBe('interleaved-thinking-2025-05-14');
+    expect(body).not.toHaveProperty('temperature');
+  });
+
+  it('keeps the thinking budget below max_tokens (invariant carried by the caller)', async () => {
+    const { body } = await capture({
+      cfg: cfg({ max_tokens: 32_000 }),
+      system_prompt: 's',
+      messages: [],
+      tools: [],
+      thinking: { type: 'enabled', budget_tokens: 31_999 },
+    });
+    expect(body.max_tokens).toBe(32_000);
+    const thinking = body.thinking as { budget_tokens: number };
+    expect(thinking.budget_tokens).toBeLessThan(body.max_tokens as number);
+  });
+});

--- a/harness/tests/provider-anthropic/thinking.test.ts
+++ b/harness/tests/provider-anthropic/thinking.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import type { Model } from '../../src/models-catalog/types.js';
+import { buildThinkingConfig, MIN_THINKING_BUDGET } from '../../src/provider-anthropic/thinking.js';
+
+function model(max_output_tokens?: number, extra: Partial<Model> = {}): Model {
+  return {
+    id: 'claude-sonnet-4-6',
+    provider: 'anthropic',
+    api: 'anthropic-messages',
+    display_name: 'Claude Sonnet 4.6',
+    context_window: 200_000,
+    ...(max_output_tokens !== undefined ? { max_output_tokens } : {}),
+    ...extra,
+  };
+}
+
+describe('buildThinkingConfig', () => {
+  it.each([undefined, 'off'])('returns undefined for level %s', (level) => {
+    expect(buildThinkingConfig(level, 32_000, model(64_000))).toBeUndefined();
+  });
+
+  it('returns undefined when the model output ceiling is unknown', () => {
+    expect(buildThinkingConfig('high', 32_000, model())).toBeUndefined();
+    expect(buildThinkingConfig('high', 32_000, undefined)).toBeUndefined();
+  });
+
+  describe('formula budgets (no catalog budgets)', () => {
+    // high -> min(16_000, floor(output/2 - 1))
+    it.each([
+      [8_192, 4_095],
+      [32_000, 15_999],
+      [64_000, 16_000],
+    ])('high with output %i -> budget %i', (output, budget) => {
+      expect(buildThinkingConfig('high', 32_000, model(output))).toEqual({
+        type: 'enabled',
+        budget_tokens: budget,
+      });
+    });
+
+    // max/xhigh -> min(31_999, output - 1), then clamped to leave output room
+    it('xhigh with output 64_000 reserves output room below max_tokens', () => {
+      expect(buildThinkingConfig('xhigh', 32_000, model(64_000))).toEqual({
+        type: 'enabled',
+        budget_tokens: 32_000 - 1_024,
+      });
+    });
+
+    it('medium with output 64_000 -> min(8_000, output/4)', () => {
+      expect(buildThinkingConfig('medium', 32_000, model(64_000))).toEqual({
+        type: 'enabled',
+        budget_tokens: 8_000,
+      });
+    });
+
+    it('low with output 64_000 -> min(4_000, output/8)', () => {
+      expect(buildThinkingConfig('low', 32_000, model(64_000))).toEqual({
+        type: 'enabled',
+        budget_tokens: 4_000,
+      });
+    });
+  });
+
+  it('prefers catalog thinking_budgets over the formula', () => {
+    const m = model(64_000, { thinking_budgets: { high: 20_000 } });
+    expect(buildThinkingConfig('high', 32_000, m)).toEqual({
+      type: 'enabled',
+      budget_tokens: 20_000,
+    });
+  });
+
+  it('never returns budget >= max_tokens and always reserves output room', () => {
+    const cfg = buildThinkingConfig('xhigh', 16_000, model(64_000));
+    expect(cfg).toEqual({ type: 'enabled', budget_tokens: 16_000 - 1_024 });
+  });
+
+  it('drops thinking when the clamped budget falls below the API minimum', () => {
+    // max_tokens 2047 leaves budget 1023 (< MIN_THINKING_BUDGET) after the reserve
+    expect(buildThinkingConfig('high', 2_047, model(64_000))).toBeUndefined();
+    expect(buildThinkingConfig('high', MIN_THINKING_BUDGET, model(64_000))).toBeUndefined();
+  });
+
+  it('drops thinking for unknown levels', () => {
+    expect(buildThinkingConfig('turbo', 32_000, model(64_000))).toBeUndefined();
+  });
+
+  it('drops thinking when the catalog says the model cannot think', () => {
+    expect(
+      buildThinkingConfig('high', 32_000, model(64_000, { supports_thinking: false })),
+    ).toBeUndefined();
+    // unknown flag stays permissive
+    expect(buildThinkingConfig('high', 32_000, model(64_000))).toBeDefined();
+  });
+
+  it('degrades xhigh to the high tier when the catalog says xhigh is unsupported', () => {
+    expect(buildThinkingConfig('xhigh', 32_000, model(64_000, { supports_xhigh: false }))).toEqual({
+      type: 'enabled',
+      budget_tokens: 16_000,
+    });
+    // unknown flag keeps the xhigh formula
+    expect(buildThinkingConfig('xhigh', 32_000, model(64_000))).toEqual({
+      type: 'enabled',
+      budget_tokens: 32_000 - 1_024,
+    });
+  });
+});

--- a/harness/tests/provider-anthropic/wire-messages.test.ts
+++ b/harness/tests/provider-anthropic/wire-messages.test.ts
@@ -39,6 +39,50 @@ describe('contentBlockToWire', () => {
       }),
     ).toBeNull();
   });
+
+  it('round-trips signed thinking blocks (required for thinking + tool use)', () => {
+    expect(
+      contentBlockToWire({ type: 'thinking', text: 'reasoning…', signature: 'sig123' }),
+    ).toEqual({ type: 'thinking', thinking: 'reasoning…', signature: 'sig123' });
+  });
+
+  it('drops unsigned thinking blocks (would fail signature verification)', () => {
+    expect(contentBlockToWire({ type: 'thinking', text: 'partial' })).toBeNull();
+  });
+});
+
+describe('toWireMessages thinking round-trip', () => {
+  it('keeps the signed thinking block before tool_use in the assistant turn', () => {
+    const msgs: AgentMessage[] = [
+      { role: 'user', content: [{ type: 'text', text: 'go' }], timestamp: 0 },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', text: 'plan it', signature: 'sig' },
+          { type: 'function_call', id: 't1', function_id: 'shell::exec', arguments: {} },
+        ],
+        stop_reason: 'function_call',
+        error_message: null,
+        error_kind: null,
+        usage: null,
+        model: 'm',
+        provider: 'anthropic',
+        timestamp: 1,
+      },
+      {
+        role: 'function_result',
+        function_call_id: 't1',
+        function_id: 'shell::exec',
+        content: [],
+        details: null,
+        is_error: false,
+        timestamp: 2,
+      },
+    ];
+    const wire = toWireMessages(msgs) as Array<{ role: string; content: Array<{ type: string }> }>;
+    const assistant = wire.find((m) => m.role === 'assistant');
+    expect(assistant?.content.map((b) => b.type)).toEqual(['thinking', 'tool_use']);
+  });
 });
 
 describe('toWireMessages', () => {

--- a/harness/tests/provider-openai/reasoning.test.ts
+++ b/harness/tests/provider-openai/reasoning.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { isReasoningModel, reasoningEffortFor } from '../../src/provider-openai/reasoning.js';
+
+describe('isReasoningModel', () => {
+  it.each([
+    'gpt-5',
+    'gpt-5-mini',
+    'gpt-5.2',
+    'o1-preview',
+    'o3-mini',
+    'o4-mini',
+  ])('detects %s by id pattern', (id) => {
+    expect(isReasoningModel(id)).toBe(true);
+  });
+
+  it.each(['gpt-4o', 'gpt-4.1', 'chatgpt-4o-latest'])('rejects %s by id pattern', (id) => {
+    expect(isReasoningModel(id)).toBe(false);
+  });
+
+  it('catalog flag wins over the id pattern', () => {
+    expect(isReasoningModel('gpt-4o', true)).toBe(true);
+    expect(isReasoningModel('gpt-5', false)).toBe(false);
+  });
+});
+
+describe('reasoningEffortFor', () => {
+  it('defaults to medium when no level is given', () => {
+    expect(reasoningEffortFor(undefined, 'gpt-5')).toBe('medium');
+    expect(reasoningEffortFor(undefined, 'o3-mini')).toBe('medium');
+  });
+
+  it('passes supported levels through', () => {
+    expect(reasoningEffortFor('high', 'gpt-5')).toBe('high');
+    expect(reasoningEffortFor('low', 'gpt-5.1')).toBe('low');
+  });
+
+  it('gpt-5-pro is clamped to high regardless of level', () => {
+    expect(reasoningEffortFor('low', 'gpt-5-pro')).toBe('high');
+    expect(reasoningEffortFor(undefined, 'gpt-5-pro')).toBe('high');
+    expect(reasoningEffortFor('xhigh', 'gpt-5-pro')).toBe('high');
+  });
+
+  it('xhigh only on gpt-5.2+ families', () => {
+    expect(reasoningEffortFor('xhigh', 'gpt-5.2')).toBe('xhigh');
+    expect(reasoningEffortFor('xhigh', 'gpt-5.3-codex')).toBe('xhigh');
+    expect(reasoningEffortFor('xhigh', 'gpt-5.1')).toBe('high');
+    expect(reasoningEffortFor('xhigh', 'gpt-5')).toBe('high');
+  });
+
+  it("maps 'off' to the lowest supported effort", () => {
+    expect(reasoningEffortFor('off', 'gpt-5.1')).toBe('none');
+    expect(reasoningEffortFor('off', 'gpt-5')).toBe('minimal');
+    expect(reasoningEffortFor('off', 'o3')).toBe('low');
+  });
+
+  it("maps 'max' to xhigh where supported", () => {
+    expect(reasoningEffortFor('max', 'gpt-5.2')).toBe('xhigh');
+    expect(reasoningEffortFor('max', 'o3')).toBe('high');
+  });
+
+  it('returns undefined for chat-tuned variants', () => {
+    expect(reasoningEffortFor('high', 'gpt-5-chat-latest')).toBeUndefined();
+    expect(reasoningEffortFor(undefined, 'gpt-5.2-chat-latest')).toBeUndefined();
+  });
+
+  it('returns undefined for non-reasoning families', () => {
+    expect(reasoningEffortFor('high', 'gpt-4o')).toBeUndefined();
+  });
+
+  it.each([
+    'o1',
+    'o1-mini',
+    'o1-preview',
+    'o1-pro',
+  ])('returns undefined for %s (o1 family rejects reasoning_effort)', (id) => {
+    expect(reasoningEffortFor(undefined, id)).toBeUndefined();
+    expect(reasoningEffortFor('high', id)).toBeUndefined();
+  });
+
+  it('falls back to medium for an unrecognized level on families that support it', () => {
+    expect(reasoningEffortFor('turbo', 'gpt-5')).toBe('medium');
+    expect(reasoningEffortFor('turbo', 'o3')).toBe('medium');
+  });
+
+  it('falls back to the only supported effort for an unrecognized level on single-effort families', () => {
+    expect(reasoningEffortFor('turbo', 'gpt-5-pro')).toBe('high');
+  });
+});

--- a/harness/tests/provider-openai/stream-request.test.ts
+++ b/harness/tests/provider-openai/stream-request.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Model } from '../../src/models-catalog/types.js';
+import { streamOpenai } from '../../src/provider-openai/stream.js';
+import type { ChatCompletionsConfig } from '../../src/provider-openai/types.js';
+
+function cfg(overrides: Partial<ChatCompletionsConfig> = {}): ChatCompletionsConfig {
+  return {
+    url: 'https://api.example/v1/chat/completions',
+    provider_name: 'openai',
+    model: 'gpt-5',
+    api_key: 'sk-test',
+    max_tokens: 32_000,
+    ...overrides,
+  };
+}
+
+function catalogModel(extra: Partial<Model> = {}): Model {
+  return {
+    id: 'gpt-4o',
+    provider: 'openai',
+    api: 'openai-responses',
+    display_name: 'GPT-4o',
+    context_window: 128_000,
+    ...extra,
+  };
+}
+
+async function captureBody(
+  args: Parameters<typeof streamOpenai>[0],
+): Promise<Record<string, unknown>> {
+  let captured: Record<string, unknown> | null = null;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation(async (_url: string, init: RequestInit) => {
+      captured = JSON.parse(init.body as string) as Record<string, unknown>;
+      return new Response('data: [DONE]\n\n', { status: 200 });
+    }),
+  );
+  for await (const _ev of streamOpenai(args)) {
+    // drain
+  }
+  if (!captured) throw new Error('fetch was not called');
+  return captured;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('streamOpenai request body', () => {
+  it('sends the resolved max_completion_tokens', async () => {
+    const body = await captureBody({ cfg: cfg(), system_prompt: 's', messages: [], tools: [] });
+    expect(body.max_completion_tokens).toBe(32_000);
+  });
+
+  it('defaults reasoning_effort to medium for reasoning models', async () => {
+    const body = await captureBody({ cfg: cfg(), system_prompt: 's', messages: [], tools: [] });
+    expect(body.reasoning_effort).toBe('medium');
+  });
+
+  it('maps thinking_level onto reasoning_effort', async () => {
+    const body = await captureBody({
+      cfg: cfg({ model: 'gpt-5.2' }),
+      system_prompt: 's',
+      messages: [],
+      tools: [],
+      thinking_level: 'xhigh',
+    });
+    expect(body.reasoning_effort).toBe('xhigh');
+  });
+
+  it('omits reasoning_effort for non-reasoning models', async () => {
+    const body = await captureBody({
+      cfg: cfg({ model: 'gpt-4o' }),
+      system_prompt: 's',
+      messages: [],
+      tools: [],
+    });
+    expect(body).not.toHaveProperty('reasoning_effort');
+  });
+
+  it('catalog supports_thinking=true enables reasoning_effort for non-pattern ids', async () => {
+    const body = await captureBody({
+      cfg: cfg({ model: 'o3-custom', catalog: catalogModel({ supports_thinking: true }) }),
+      system_prompt: 's',
+      messages: [],
+      tools: [],
+    });
+    expect(body.reasoning_effort).toBe('medium');
+  });
+
+  it('catalog supports_thinking=false disables reasoning_effort despite the id pattern', async () => {
+    const body = await captureBody({
+      cfg: cfg({ model: 'gpt-5', catalog: catalogModel({ supports_thinking: false }) }),
+      system_prompt: 's',
+      messages: [],
+      tools: [],
+    });
+    expect(body).not.toHaveProperty('reasoning_effort');
+  });
+});

--- a/harness/tests/runtime/models-discovery.test.ts
+++ b/harness/tests/runtime/models-discovery.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { fetchModelsForDiscovery, fetchModelsJson } from '../../src/runtime/models-discovery.js';
+import {
+  enrichModel,
+  fetchModelsForDiscovery,
+  fetchModelsJson,
+} from '../../src/runtime/models-discovery.js';
 
 describe('fetchModelsForDiscovery', () => {
   afterEach(() => {
@@ -41,5 +45,45 @@ describe('fetchModelsForDiscovery', () => {
       .fn()
       .mockResolvedValue(new Response('', { status: 401 })) as typeof globalThis.fetch;
     expect(await fetchModelsJson('https://api.example/v1/models', {})).toBeNull();
+  });
+});
+
+describe('enrichModel', () => {
+  const base = {
+    provider: 'anthropic',
+    api: 'anthropic-messages',
+    stub: { id: 'claude-sonnet-4-6' },
+    defaultContextWindow: 200_000,
+  };
+
+  it('falls back to provider defaults without models.dev metadata', () => {
+    const m = enrichModel(base);
+    expect(m.context_window).toBe(200_000);
+    expect(m.max_output_tokens).toBe(8_192);
+    expect(m.supports_tools).toBe(true);
+    expect(m.supports_thinking).toBeUndefined();
+  });
+
+  it('prefers models.dev limits and capability flags', () => {
+    const m = enrichModel({
+      ...base,
+      modelsDev: {
+        id: 'claude-sonnet-4-6',
+        limit: { context: 200_000, output: 64_000 },
+        reasoning: true,
+        tool_call: true,
+      },
+    });
+    expect(m.context_window).toBe(200_000);
+    expect(m.max_output_tokens).toBe(64_000);
+    expect(m.supports_thinking).toBe(true);
+    expect(m.supports_tools).toBe(true);
+  });
+
+  it('keeps defaults for fields models.dev omits', () => {
+    const m = enrichModel({ ...base, modelsDev: { id: 'claude-sonnet-4-6', reasoning: false } });
+    expect(m.max_output_tokens).toBe(8_192);
+    expect(m.context_window).toBe(200_000);
+    expect(m.supports_thinking).toBe(false);
   });
 });

--- a/harness/tests/runtime/modelsdev.test.ts
+++ b/harness/tests/runtime/modelsdev.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  _resetModelsDevForTests,
+  getModelsDevIndex,
+  lookupModelsDev,
+  MODELSDEV_URL,
+} from '../../src/runtime/modelsdev.js';
+
+const API_JSON = {
+  anthropic: {
+    id: 'anthropic',
+    models: {
+      'claude-sonnet-4-6': {
+        id: 'claude-sonnet-4-6',
+        reasoning: true,
+        tool_call: true,
+        limit: { context: 200_000, output: 64_000 },
+      },
+      'claude-sonnet-4': {
+        id: 'claude-sonnet-4',
+        reasoning: true,
+        tool_call: true,
+        limit: { context: 200_000, output: 64_000 },
+      },
+    },
+  },
+  openai: {
+    id: 'openai',
+    models: {
+      'gpt-5-pro': {
+        id: 'gpt-5-pro',
+        reasoning: true,
+        tool_call: true,
+        limit: { context: 400_000, output: 272_000 },
+      },
+    },
+  },
+  moonshotai: {
+    id: 'moonshotai',
+    models: {
+      'kimi-k2.6': { id: 'kimi-k2.6', reasoning: true, limit: { context: 256_000, output: 8_192 } },
+    },
+  },
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  _resetModelsDevForTests();
+});
+
+function stubFetch(impl: () => Promise<Response>): ReturnType<typeof vi.fn> {
+  const mock = vi.fn().mockImplementation(impl);
+  vi.stubGlobal('fetch', mock);
+  return mock;
+}
+
+describe('getModelsDevIndex', () => {
+  it('parses providers and model limits from api.json', async () => {
+    stubFetch(async () => new Response(JSON.stringify(API_JSON), { status: 200 }));
+    const index = await getModelsDevIndex();
+    const sonnet = lookupModelsDev(index, 'anthropic', 'claude-sonnet-4-6');
+    expect(sonnet?.limit).toEqual({ context: 200_000, input: undefined, output: 64_000 });
+    expect(sonnet?.reasoning).toBe(true);
+  });
+
+  it('returns an empty index on non-200', async () => {
+    stubFetch(async () => new Response('', { status: 503 }));
+    const index = await getModelsDevIndex();
+    expect(index.size).toBe(0);
+  });
+
+  it('returns an empty index when fetch throws', async () => {
+    stubFetch(async () => {
+      throw new Error('network down');
+    });
+    const index = await getModelsDevIndex();
+    expect(index.size).toBe(0);
+  });
+
+  it('returns an empty index on malformed JSON', async () => {
+    stubFetch(async () => new Response('not-json', { status: 200 }));
+    const index = await getModelsDevIndex();
+    expect(index.size).toBe(0);
+  });
+
+  it('caches the result: two calls, one fetch', async () => {
+    const mock = stubFetch(async () => new Response(JSON.stringify(API_JSON), { status: 200 }));
+    await getModelsDevIndex();
+    await getModelsDevIndex();
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock).toHaveBeenCalledWith(MODELSDEV_URL, expect.anything());
+  });
+
+  it('dedupes concurrent fetches in flight', async () => {
+    const mock = stubFetch(async () => new Response(JSON.stringify(API_JSON), { status: 200 }));
+    await Promise.all([getModelsDevIndex(), getModelsDevIndex(), getModelsDevIndex()]);
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches a failed fetch: does not re-hit models.dev within the failure TTL', async () => {
+    const mock = stubFetch(async () => new Response('', { status: 503 }));
+    const first = await getModelsDevIndex();
+    const second = await getModelsDevIndex();
+    expect(first.size).toBe(0);
+    expect(second.size).toBe(0);
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects out-of-range limit values (sanity bounds)', async () => {
+    const poisoned = {
+      anthropic: {
+        id: 'anthropic',
+        models: {
+          'claude-x': { id: 'claude-x', limit: { context: 200_000, output: 1 } },
+          'claude-y': { id: 'claude-y', limit: { context: 200_000, output: 99_000_000 } },
+        },
+      },
+    };
+    stubFetch(async () => new Response(JSON.stringify(poisoned), { status: 200 }));
+    const idx = await getModelsDevIndex();
+    expect(lookupModelsDev(idx, 'anthropic', 'claude-x')?.limit?.output).toBeUndefined();
+    expect(lookupModelsDev(idx, 'anthropic', 'claude-y')?.limit?.output).toBeUndefined();
+    // context within range still accepted
+    expect(lookupModelsDev(idx, 'anthropic', 'claude-x')?.limit?.context).toBe(200_000);
+  });
+});
+
+describe('lookupModelsDev', () => {
+  async function index() {
+    stubFetch(async () => new Response(JSON.stringify(API_JSON), { status: 200 }));
+    return getModelsDevIndex();
+  }
+
+  it('matches exact model ids', async () => {
+    const idx = await index();
+    expect(lookupModelsDev(idx, 'openai', 'gpt-5-pro')?.limit?.output).toBe(272_000);
+  });
+
+  it('matches date-suffixed ids against the undated catalog id', async () => {
+    const idx = await index();
+    expect(lookupModelsDev(idx, 'anthropic', 'claude-sonnet-4-20250514')?.id).toBe(
+      'claude-sonnet-4',
+    );
+  });
+
+  it('maps the kimi provider id to moonshotai', async () => {
+    const idx = await index();
+    expect(lookupModelsDev(idx, 'kimi', 'kimi-k2.6')?.limit?.context).toBe(256_000);
+  });
+
+  it.each(['lmstudio', 'llamacpp', 'unknown'])('returns undefined for provider %s', async (p) => {
+    const idx = await index();
+    expect(lookupModelsDev(idx, p, 'anything')).toBeUndefined();
+  });
+
+  it('returns undefined for unknown model ids', async () => {
+    const idx = await index();
+    expect(lookupModelsDev(idx, 'anthropic', 'claude-nonexistent-9')).toBeUndefined();
+  });
+
+  it('matches an undated lookup id against a date-suffixed catalog id (loop scan)', async () => {
+    const json = {
+      anthropic: {
+        id: 'anthropic',
+        models: {
+          'claude-opus-4-20251101': {
+            id: 'claude-opus-4-20251101',
+            limit: { context: 200_000, output: 32_000 },
+          },
+        },
+      },
+    };
+    stubFetch(async () => new Response(JSON.stringify(json), { status: 200 }));
+    const idx = await getModelsDevIndex();
+    expect(lookupModelsDev(idx, 'anthropic', 'claude-opus-4')?.id).toBe('claude-opus-4-20251101');
+  });
+});

--- a/harness/tests/runtime/output-tokens.test.ts
+++ b/harness/tests/runtime/output-tokens.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  _resetOutputTokenCapForTests,
+  clampOutputTokens,
+  getCatalogModel,
+  OUTPUT_TOKEN_MAX,
+  OUTPUT_TOKEN_MAX_ENV,
+  outputTokenCap,
+} from '../../src/runtime/output-tokens.js';
+import type { ISdk } from '../../src/runtime/iii.js';
+
+afterEach(() => {
+  delete process.env[OUTPUT_TOKEN_MAX_ENV];
+  _resetOutputTokenCapForTests();
+});
+
+describe('outputTokenCap', () => {
+  it('defaults to 32_000', () => {
+    expect(outputTokenCap()).toBe(OUTPUT_TOKEN_MAX);
+  });
+
+  it('reads a valid env override', () => {
+    process.env[OUTPUT_TOKEN_MAX_ENV] = '16000';
+    expect(outputTokenCap()).toBe(16_000);
+  });
+
+  it.each(['abc', '0', '-5', 'NaN'])('falls back to 32_000 on invalid env %s', (v) => {
+    process.env[OUTPUT_TOKEN_MAX_ENV] = v;
+    expect(outputTokenCap()).toBe(OUTPUT_TOKEN_MAX);
+  });
+});
+
+describe('clampOutputTokens precedence', () => {
+  const workerDefault = 8_192;
+
+  it('defaults to min(modelMax, cap): model below cap', () => {
+    expect(clampOutputTokens({ modelMaxOutput: 16_000, userOverride: null, workerDefault })).toBe(
+      16_000,
+    );
+  });
+
+  it('defaults to min(modelMax, cap): model above cap clamps to 32k', () => {
+    expect(clampOutputTokens({ modelMaxOutput: 64_000, userOverride: null, workerDefault })).toBe(
+      32_000,
+    );
+  });
+
+  it('user override wins below the model ceiling', () => {
+    expect(clampOutputTokens({ modelMaxOutput: 64_000, userOverride: 50_000, workerDefault })).toBe(
+      50_000,
+    );
+  });
+
+  it('user override is clamped down to the model ceiling', () => {
+    expect(
+      clampOutputTokens({ modelMaxOutput: 64_000, userOverride: 100_000, workerDefault }),
+    ).toBe(64_000);
+  });
+
+  it('user override is NOT capped to 32k (deliberate choice)', () => {
+    expect(
+      clampOutputTokens({ modelMaxOutput: 128_000, userOverride: 64_000, workerDefault }),
+    ).toBe(64_000);
+  });
+
+  it('user override passes through when model is unknown', () => {
+    expect(
+      clampOutputTokens({ modelMaxOutput: undefined, userOverride: 4_096, workerDefault }),
+    ).toBe(4_096);
+  });
+
+  it.each([0, undefined, null])('unknown model max (%s) falls back to workerDefault', (v) => {
+    expect(clampOutputTokens({ modelMaxOutput: v, userOverride: null, workerDefault })).toBe(
+      workerDefault,
+    );
+  });
+
+  it('honors an explicit cap argument over the env cap', () => {
+    expect(
+      clampOutputTokens({ modelMaxOutput: 64_000, userOverride: null, workerDefault, cap: 16_000 }),
+    ).toBe(16_000);
+  });
+
+  it('env cap raises the default for high-output models', () => {
+    process.env[OUTPUT_TOKEN_MAX_ENV] = '64000';
+    expect(clampOutputTokens({ modelMaxOutput: 128_000, userOverride: null, workerDefault })).toBe(
+      64_000,
+    );
+  });
+
+  it('floors fractional values so token counts stay integers', () => {
+    expect(clampOutputTokens({ modelMaxOutput: 64_000, userOverride: 1024.5, workerDefault })).toBe(
+      1024,
+    );
+    expect(clampOutputTokens({ modelMaxOutput: undefined, userOverride: 1.5, workerDefault })).toBe(
+      1,
+    );
+  });
+
+  it.each([0, -1])('ignores a non-positive userOverride (%s)', (ov) => {
+    expect(clampOutputTokens({ modelMaxOutput: 64_000, userOverride: ov, workerDefault })).toBe(
+      32_000,
+    );
+    expect(clampOutputTokens({ modelMaxOutput: undefined, userOverride: ov, workerDefault })).toBe(
+      workerDefault,
+    );
+  });
+
+  it('rejects scientific-notation env values instead of truncating them', () => {
+    // parseInt("1e9") === 1 — the strict digits-only parse must fall back to 32k.
+    process.env[OUTPUT_TOKEN_MAX_ENV] = '1e9';
+    expect(outputTokenCap()).toBe(OUTPUT_TOKEN_MAX);
+  });
+});
+
+describe('getCatalogModel', () => {
+  function fakeIii(trigger: (req: unknown) => Promise<unknown>): ISdk {
+    return { trigger } as unknown as ISdk;
+  }
+
+  it('returns the catalog entry from models::get', async () => {
+    const entry = { id: 'claude-sonnet-4-6', provider: 'anthropic', max_output_tokens: 64_000 };
+    const trigger = vi.fn().mockResolvedValue(entry);
+    const out = await getCatalogModel(fakeIii(trigger), 'anthropic', 'claude-sonnet-4-6');
+    expect(out).toEqual(entry);
+    expect(trigger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        function_id: 'models::get',
+        payload: { provider: 'anthropic', model_id: 'claude-sonnet-4-6' },
+      }),
+    );
+  });
+
+  it('returns null when the model is unknown', async () => {
+    const out = await getCatalogModel(fakeIii(vi.fn().mockResolvedValue(null)), 'anthropic', 'x');
+    expect(out).toBeNull();
+  });
+
+  it('returns null when the bus call throws', async () => {
+    const out = await getCatalogModel(
+      fakeIii(vi.fn().mockRejectedValue(new Error('timeout'))),
+      'anthropic',
+      'x',
+    );
+    expect(out).toBeNull();
+  });
+});

--- a/harness/tests/turn-orchestrator/provider-router.test.ts
+++ b/harness/tests/turn-orchestrator/provider-router.test.ts
@@ -97,4 +97,13 @@ describe('buildInput', () => {
     expect(input.tools).toHaveLength(1);
     expect(input.writer_ref.channel_id).toBe('c');
   });
+
+  it('carries thinking_level when provided and omits it when absent', () => {
+    const decision = { provider: 'anthropic', model: 'claude' } as const;
+    const writer = { channel_id: 'c', access_key: 'k', direction: 'write' } as const;
+    const withLevel = buildInput(decision, writer, 'sys', [], [], 'high');
+    expect(withLevel.thinking_level).toBe('high');
+    const withoutLevel = buildInput(decision, writer, 'sys', [], []);
+    expect(withoutLevel).not.toHaveProperty('thinking_level');
+  });
 });

--- a/harness/tests/turn-orchestrator/run-request.test.ts
+++ b/harness/tests/turn-orchestrator/run-request.test.ts
@@ -58,3 +58,18 @@ describe('parseRunRequest function_schemas', () => {
     expect(parseRunRequest({ function_schemas: [{ name: 'x' }] }).function_schemas).toHaveLength(1);
   });
 });
+
+describe('parseRunRequest thinking_level', () => {
+  it('passes through a string level', () => {
+    expect(parseRunRequest({ thinking_level: 'high' }).thinking_level).toBe('high');
+  });
+
+  it('is undefined when absent', () => {
+    expect(parseRunRequest({}).thinking_level).toBeUndefined();
+  });
+
+  it('coerces non-string values to undefined', () => {
+    expect(parseRunRequest({ thinking_level: 42 }).thinking_level).toBeUndefined();
+    expect(parseRunRequest({ thinking_level: { level: 'high' } }).thinking_level).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Providers currently send a flat `max_tokens` (8192) to every LLM regardless of model capability, and the catalog's `max_output_tokens` / `supports_thinking` / `thinking_budgets` fields were populated but never read at request time. This PR makes per-model limits the default and activates thinking/reasoning across all 5 providers.

### Per-model output tokens
- **models.dev enrichment at discovery**: real context/output limits and reasoning flags for anthropic/openai/kimi (kimi → `moonshotai`). 1h cache with 5min failure TTL; sanity bounds (256..50M) so a bad upstream value can't brick a model.
- **Per-request resolution** (`src/runtime/output-tokens.ts`): user-configured registry override wins (clamped to the model ceiling, never raised) → `min(catalog max_output_tokens, 32_000)` (`HARNESS_OUTPUT_TOKEN_MAX` env override) → `default_max_tokens` fallback for unknown models (previous behavior).
- **Registry fix**: `resolve()` no longer seeds the declared default `max_tokens` as a user override — it pinned every request to 8192 and silently defeated the per-model default.

### Thinking / reasoning
- Optional `thinking_level` plumbed run-request → orchestrator → `ProviderStreamInputSchema` (all fields optional; absent = off; old payloads unaffected).
- **Anthropic**: `thinking: {type: enabled, budget_tokens}` from catalog budgets with a formula fallback; 1024-token output reserve so high budgets can't starve the visible answer; `interleaved-thinking` beta header only when enabled; `supports_thinking`/`supports_xhigh` gating. SSE parser handles `thinking`/`redacted_thinking`/`signature_delta`, preserves wire arrival order (required for multi-turn tool-use replay), and signed thinking blocks round-trip on the wire. Cache anchor skips thinking blocks; `content_block_stop` now emits the end event matching the open block kind (fixes a latent always-`text_end` bug).
- **OpenAI**: `reasoning_effort` (default `medium`) with per-family ladders (gpt-5 / 5.1 / 5.2+ / pro, o-series); the o1 family is excluded — it rejects the param.
- kimi/lmstudio/llamacpp: clamp only, no reasoning params.

### Also
- **Security**: removed a `console.log` that printed API-key headers to stdout on every anthropic stream request.
- Fixed pre-existing `RegisterFn` type errors (`src/index.ts`, `models-catalog/main.ts`) that broke `tsc -b`.
- Docs: max-token resolution + thinking/reasoning sections for all five providers, `docs/storage.md` override semantics.

### Known limitation
`redacted_thinking` blocks are not persisted/round-tripped (needs a `ContentBlock` extension shared with the Rust `harness-types` mirror). Rare, safety-triggered case; logged with a warn for diagnosability.

## Test plan
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm build` clean
- [x] `pnpm test` — 1224 tests across 121 files (117 new): clamp precedence matrix, models.dev client (failure caching, sanity bounds, id matching), thinking budget matrix + invariants, reasoning-effort ladders, request-body capture for both providers, SSE thinking/interleaved-order parsing, signed-thinking wire round-trip, registry override semantics
- [ ] Live smoke: stream `claude-sonnet-*` → request body carries `max_tokens: 32000` (catalog 64k clamped); registry `max_tokens: 4096` → `4096`
- [ ] Live smoke: run request with `thinking_level: "high"` → body has `thinking.budget_tokens: 16000` + beta header; thinking deltas stream; follow-up tool-use turn succeeds (signed block replayed)
- [ ] Live smoke: `gpt-5*` request carries `reasoning_effort: "medium"`; `o1-*` carries none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added extended thinking support for Anthropic models with configurable thinking budgets.
  * Added reasoning effort support for OpenAI models with automatic effort mapping.
  * Integrated models.dev catalog for enhanced model metadata and capability detection.

* **Bug Fixes**
  * Improved output token limit resolution across all providers with proper clamping to model ceilings.
  * Fixed Anthropic cache anchor placement to handle thinking blocks correctly.

* **Documentation**
  * Enhanced provider documentation with detailed token resolution rules and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->