### PR TITLE
fix(storage): boot sidecar-free config for registry interface collection

### DIFF
--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -145,10 +145,23 @@ jobs:
               bin_path="/tmp/${bin_name}"
               chmod +x "$bin_path"
 
+              # Interface collection only needs the worker to connect and
+              # register its functions/trigger types — not a working backend.
+              # A worker may ship config.collect.yaml to boot a lighter copy
+              # for this. storage's default config.yaml declares a local
+              # bucket and spawns a rustfs sidecar the prebuilt binary doesn't
+              # bundle, which crashes startup with LOCAL_BACKEND_BIN_NOT_FOUND;
+              # config.collect.yaml gives it a sidecar-free config instead.
+              collect_args=()
+              if [[ -f "$WORKER/config.collect.yaml" ]]; then
+                echo "Using interface-collection config: $WORKER/config.collect.yaml"
+                collect_args+=(--config ./config.collect.yaml)
+              fi
+
               worker_log="worker-$WORKER.log"
               pushd "$WORKER" >/dev/null
-              echo "Starting local worker with: (cd $WORKER && $bin_path)"
-              "$bin_path" > "../$worker_log" 2>&1 &
+              echo "Starting local worker with: (cd $WORKER && $bin_path ${collect_args[*]})"
+              "$bin_path" "${collect_args[@]}" > "../$worker_log" 2>&1 &
               echo "$!" > ../worker.pid
               popd >/dev/null
 
@@ -203,6 +216,12 @@ jobs:
                 cargo_args+=(--bin "$BIN")
               fi
               cargo_args+=(--)
+              # Use the sidecar-free interface-collection config when shipped
+              # (see release-binary note above).
+              if [[ -f config.collect.yaml ]]; then
+                echo "Using interface-collection config: $WORKER/config.collect.yaml"
+                cargo_args+=(--config ./config.collect.yaml)
+              fi
 
               echo "Starting local worker with: (cd $WORKER && cargo ${cargo_args[*]})"
               cargo "${cargo_args[@]}" > "../$worker_log" 2>&1 &

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,12 +286,25 @@ jobs:
           bin=$(WORKER="$WORKER" python3 -c 'import os, sys, pathlib; sys.path.insert(0, ".github/scripts"); import _lib; m = _lib.read_iii_worker_yaml(pathlib.Path(os.environ["WORKER"])); print(m.bin or m.name)')
 
           worker_log="worker-$WORKER.log"
+          # Interface collection only needs the worker to connect and register
+          # its functions/trigger types — not a working backend. A worker may
+          # ship config.collect.yaml to boot a lighter copy for this. storage's
+          # default config.yaml declares a local bucket and spawns a rustfs
+          # sidecar that isn't available here, crashing startup with
+          # LOCAL_BACKEND_BIN_NOT_FOUND; config.collect.yaml gives it a
+          # sidecar-free config instead. Kept in lockstep with
+          # _publish-registry.yml so this smoke check mirrors the publish boot.
+          collect_args=()
+          if [[ -f "$WORKER/config.collect.yaml" ]]; then
+            echo "Using interface-collection config: $WORKER/config.collect.yaml"
+            collect_args+=(--config ./config.collect.yaml)
+          fi
           # Run from inside the worker dir — this is what makes a relative
           # default db path (sqlite:./data/iii.db) resolve against a clean
           # checkout with no data/ dir, reproducing the publish boot exactly.
           pushd "$WORKER" >/dev/null
-          echo "Starting local worker: (cd $WORKER && ./target/debug/$bin)"
-          "./target/debug/$bin" > "../$worker_log" 2>&1 &
+          echo "Starting local worker: (cd $WORKER && ./target/debug/$bin ${collect_args[*]})"
+          "./target/debug/$bin" "${collect_args[@]}" > "../$worker_log" 2>&1 &
           echo "$!" > ../worker.pid
           popd >/dev/null
 

--- a/storage/config.collect.yaml
+++ b/storage/config.collect.yaml
@@ -1,0 +1,31 @@
+# Interface-collection config for the registry publish workflow.
+#
+# The publish job (.github/workflows/_publish-registry.yml) boots a throwaway
+# copy of this worker purely to read back the functions and trigger types it
+# registers with the engine — the published "interface". That interface is
+# static: it does NOT depend on which buckets are configured.
+#
+# The default config.yaml declares a `provider: local` bucket, which makes the
+# worker spawn a rustfs sidecar at startup (see src/main.rs `needs_local`).
+# The prebuilt release binary ships WITHOUT a co-located rustfs, so booting it
+# with the default config in CI fails with LOCAL_BACKEND_BIN_NOT_FOUND before
+# the worker can connect and register — and the publish never happens.
+#
+# This config declares a single cloud bucket with dummy static credentials
+# instead. It passes config validation (which requires >=1 bucket), builds a
+# lazy S3 client with no network call and no sidecar at startup, and registers
+# the exact same interface. The publish workflow launches the worker with
+# `--config config.collect.yaml` whenever this file is present.
+
+buckets:
+  interface-collection:
+    provider: s3
+    region: us-east-1
+    # Dummy static credentials so startup skips the AWS default credential
+    # chain entirely. The client is never used for a real request here.
+    access_key_id: collect
+    secret_access_key: collect
+    # Unreachable endpoint: nothing should ever hit the network during
+    # interface collection, but if it did, fail fast on loopback rather than
+    # reach real AWS.
+    endpoint_url: http://127.0.0.1:1


### PR DESCRIPTION
## Problem

The `storage` worker's registry publish fails ([run 27064591120](https://github.com/iii-hq/workers/actions/runs/27064591120/job/79883815483)) at **Start local worker for interface collection** — never reaching `POST /publish`.

Worker log from the failed run:
```
INFO storage: starting name="storage" config=./config.yaml url=ws://127.0.0.1:49134/
Error: {"code":"LOCAL_BACKEND_BIN_NOT_FOUND","reason":"set $RUSTFS_BIN, place a rustfs binary next to storage, or install rustfs on PATH"}
```

## Root cause

`storage` spawns a `rustfs` sidecar at startup whenever its config declares a `provider: local` bucket (`src/main.rs` `needs_local`). The default `config.yaml` declares one (`scratch`). The prebuilt release binary bundles no `rustfs`, and in CI `$RUSTFS_BIN` is unset with `rustfs` off `PATH` — so the worker exits before it connects/registers with the engine. The publish job then sees a dead process and fails.

This is unique to `storage` (only worker with a boot-time sidecar) and surfaced on its first publish. Everywhere else `storage` runs (e2e), `rustfs` is provisioned externally via `run-tests.sh::ensure_rustfs()` — the publish workflow had no equivalent.

## Fix

Interface collection only needs the worker to connect and register its functions/trigger types — not a working backend. Those registrations are config-independent.

- **`storage/config.collect.yaml`** — sidecar-free collection config: one dummy S3 bucket, no `local` bucket → `needs_local=false` → no `rustfs` spawn. Passes config validation (requires ≥1 bucket) and builds a lazy S3 client with no network call at startup.
- **`.github/workflows/_publish-registry.yml`** — `release-binary` and `cargo-run` paths now launch with `--config config.collect.yaml` when a worker ships one. Opt-in and generic; only `storage` has the file today.

## Test plan

Verified locally with `rustfs` absent and `$RUSTFS_BIN` unset (identical to CI):

| Run | Config | Result |
|-----|--------|--------|
| Control | `config.yaml` | `exit=1` → `LOCAL_BACKEND_BIN_NOT_FOUND` (reproduces CI) |
| Fix | `config.collect.yaml` | survives startup, no `rustfs` touched, `backend ready … provider="s3"`, `storage registered 4 functions and 2 trigger types` |

The fix run connected to a live engine and registered fully, then shut down cleanly on SIGTERM — i.e. interface collection would now succeed.

## Notes
- To publish `storage`, cut a new tag (e.g. `storage/v0.1.3`) or re-create `storage/v0.1.2` after merge so the job picks up both files.
- Separate follow-up: confirm how `rustfs` reaches a **real** deployment — the e2e auto-fetch is test-only, so a user installing `storage` with the default local bucket would hit the same crash unless `rustfs` ships with it or `RUSTFS_BIN` is set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Workflows updated to optionally use a local collection configuration when present, improving reliability of the interface-collection step during publishing and CI.
  * Added a publish-workflow-specific no-network collection configuration (uses a static, unreachable storage endpoint) to prevent startup failures during automated interface registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->