### PR TITLE
feat: harness 1.0 tech spec

### DIFF
--- a/tech-specs/2026-06-agentic/README.md
+++ b/tech-specs/2026-06-agentic/README.md
@@ -99,9 +99,9 @@ plain LLM loop without `context-manager`).
    directly without harness".
 4. **`context-manager` does not own storage.** It operates on message arrays passed in and returns
    results; the caller persists them. This keeps it reusable by any harness or AI feature.
-5. **`session-manager` is the single reactive surface.** Consumers bind to its triggers (new session,
-   new message, message content updated, status changed) and render live — they never poll and never
-   need to know about the provider or the loop.
+5. **`session-manager` is the single reactive surface.** Consumers bind to its triggers (session
+   created, message added/updated, status changed, meta updated, session deleted) and render live —
+   they never poll and never need to know about the provider or the loop.
 
 ## Conventions
 
@@ -193,6 +193,11 @@ type ContentBlock =
   | FunctionResultContent;
 ```
 
+`FunctionResultMessage` (a `role`, below) is the **canonical transcript form** for function output;
+`FunctionResultContent` (a block) is the adapter-boundary form for providers whose wire format
+embeds tool results inside another message (e.g. Anthropic `tool_result` blocks in a `user` turn).
+Workers in this spec store the message form and let provider adapters map it.
+
 ### Messages (the "many message types")
 
 The canonical transcript message union. Owned by [session-manager](session-manager.md); consumed by
@@ -246,6 +251,12 @@ type AgentMessage =
   | CustomMessage;
 ```
 
+Provider wire mapping: providers serialise `user` / `assistant` / `function_result` messages to
+their native format. `custom` messages have **no** wire mapping — `context::assemble` (or the
+harness, in raw mode) strips them before the router sees them. Replayed `thinking` blocks follow
+each provider's rules (e.g. Anthropic requires the `signature`; providers drop blocks they cannot
+replay).
+
 ### Session entries
 
 How `session-manager` stores messages: each `AgentMessage` is wrapped in an entry envelope that gives
@@ -254,15 +265,28 @@ items (system notices, UI markers, attachments) use the `custom` kind.
 
 ```typescript
 type SessionEntry =
-  | { kind: "message"; id: string; parent_id: string | null; timestamp: number; message: AgentMessage }
-  | { kind: "custom";  id: string; parent_id: string | null; timestamp: number; custom_type: string; data: unknown };
+  | { kind: "message"; id: string; parent_id: string | null; timestamp: number;
+      revision: number; origin?: Record<string, unknown>; message: AgentMessage }
+  | { kind: "custom";  id: string; parent_id: string | null; timestamp: number;
+      revision: number; origin?: Record<string, unknown>; custom_type: string; data: unknown };
 ```
+
+`revision` starts at 0 and increments on every content update (streaming); events echo it so
+consumers can apply full-message snapshots last-write-wins. `origin` is opaque writer-supplied
+correlation — the harness sets `{ turn_id }` on everything its loop writes.
+
+When to use which custom shape: a **`custom` message** (`role: "custom"` inside a `kind: "message"`
+entry) is a transcript item — rendered in order, part of the conversation (system notices, UI
+markers). A **`custom` entry** (`kind: "custom"`) is bookkeeping *about* the conversation that is
+not a message at all (e.g. the harness's compaction record) — `session::messages` only returns it
+when asked (`include_custom`). Neither reaches the model: providers only ever receive `user` /
+`assistant` / `function_result` roles (see the wire-mapping note above).
 
 ### Streaming events
 
 The discriminated union providers stream over an iii channel, relayed verbatim by `llm-router` and
-the `harness`. Non-terminal frames carry a `partial` accumulator; `done`/`error` carry the final
-assembled message. `done` and `error` are terminal.
+the `harness`. Non-terminal content frames carry a `partial` accumulator (`usage`, `ping`, and
+`stop` do not); `done`/`error` carry the final assembled message. `done` and `error` are terminal.
 
 ```typescript
 type StopReason = "end" | "length" | "function_call" | "aborted" | "error";
@@ -270,7 +294,7 @@ type ErrorKind  = "auth_expired" | "rate_limited" | "context_overflow" | "transi
 type Usage = {
   input?: number; output?: number;
   cache_read?: number; cache_write?: number;
-  cost_usd?: number;
+  cost_usd?: number;   // filled by llm-router from catalog pricing; providers leave it unset
 };
 
 type AssistantMessageEvent =
@@ -285,6 +309,7 @@ type AssistantMessageEvent =
   | { type: "functioncall_delta";partial: AssistantMessage; delta: string }
   | { type: "functioncall_end";  partial: AssistantMessage }
   | { type: "usage";             usage: Usage }
+  | { type: "ping" }                              // liveness heartbeat; consumers ignore
   | { type: "stop";              stop_reason: StopReason; error_message?: string; error_kind?: ErrorKind }
   | { type: "done";              message: AssistantMessage }   // terminal
   | { type: "error";             error: AssistantMessage };    // terminal
@@ -295,6 +320,10 @@ type AssistantMessageEvent =
 The capability record `llm-router` serves and every worker reads to make budget/feature decisions.
 
 ```typescript
+// "minimal" requests the lowest reasoning effort and needs only `thinking` support;
+// levels map to provider-native knobs via Model.thinking_budgets.
+type ThinkingLevel = "minimal" | "low" | "medium" | "high" | "xhigh";
+
 type Capability =
   | "thinking" | "thinking:low" | "thinking:medium" | "thinking:high" | "thinking:xhigh"
   | "tools" | "vision" | "cache";
@@ -311,7 +340,7 @@ type Model = {
   supports_tools?: boolean;
   supports_vision?: boolean;
   supports_cache?: boolean;
-  thinking_budgets?: Record<string, number>;
+  thinking_budgets?: Partial<Record<ThinkingLevel, number>>;
   pricing?: { input?: number; output?: number; cache_read?: number; cache_write?: number };
 };
 ```
@@ -356,6 +385,55 @@ type Credential =
   | { type: "oauth";   access_token: string; refresh_token?: string; expires_at?: number };
 ```
 
+## Cross-cutting conventions
+
+### Observability
+
+Every worker wraps its registered functions in OTel spans (no-op when OTel is not initialised),
+named `<worker>.<verb>`, with `session_id` / `turn_id` / `request_id` attributes taken from the
+request or its `metadata` / `origin` passthrough. The notable spans: `harness.turn` (per step),
+`router.chat` (per stream: provider, model, usage), `context.assemble` (tokens before/after,
+pruned/compacted flags), `context.compact` (lease wait, tokens), and `session.append` /
+`session.update_message` (entry id, revision). Consumers propagate `metadata` so traces stitch
+end-to-end.
+
+### Error conventions
+
+Errors thrown across the bus carry a stable snake_case code, worker-prefixed, in a
+`{ code, message }` shape — e.g. `router/no_provider_for_model`, `router/ambiguous_model`,
+`session/not_found`, `context/model_unresolved`, `harness/invalid_message_role`. The prose "Errors"
+lists in each spec name the conditions; codes map 1:1 onto them. Failures *inside* a stream never
+throw — they arrive as `error` frames carrying an `ErrorKind`.
+
+### Trigger delivery
+
+Custom trigger types are evaluated by the **emitting** worker: it owns the type's handler, keeps the
+subscriber set, applies each binding's `config` filter, and dispatches. Delivery is at-least-once
+and unordered across entries — consumers reconcile via `revision` (message updates) and the parent
+chain (transcript order), never via arrival order. Subscriptions are engine registrations:
+subscribers re-register on reconnect, and an emitter rebuilds its subscriber set from the engine
+after a restart.
+
+## Security model
+
+Everything callable over the bus is callable by the model through `agent_trigger`, so security is a
+deployment property, not an option:
+
+- **Provenance.** Every `iii.trigger` issued on behalf of a model (i.e. from
+  `harness::function::dispatch`) carries agent provenance in its invocation metadata, and the engine
+  MUST propagate that mark through nested triggers — a function the agent calls cannot launder a
+  call by re-triggering. `iii-permissions.yaml` rules apply to any call whose chain carries the
+  mark; worker- and user-initiated calls bypass them. Without provenance propagation, agent-gating
+  is advisory — deployments MUST NOT expose credentials on engines that lack it.
+- **Fail closed.** The harness dispatch policy defaults to deny: when no `functions` allow-list is
+  supplied, every `agent_trigger` call is refused (see
+  [harness.md § Functions (the white box)](harness.md#functions-the-white-box)). Deployments opt
+  functions in via `allow` globs or an approval sibling.
+- **Agent exposure.** Each worker spec carries an "Agent exposure" section listing which of its
+  functions may be exposed to in-run agents. The short version: reads are generally safe (tenancy
+  caveats aside); every mutating surface of `session-manager`, the `harness` entry points, and the
+  router's provider/config plane is deny-by-default.
+
 ## Spec index
 
 - [context-manager.md](context-manager.md)
@@ -370,3 +448,19 @@ The existing [`harness/`](../../harness) package in this repo implements the sam
 `provider-*`, `approval-gate`, `llm-budget`, `hook-fanout`, …). This spec is a greenfield
 consolidation of that experience into four standalone workers; it borrows the proven wire types and
 streaming contract but is not bound to the current package's structure.
+
+### Migration map
+
+| Existing worker(s) | Replaced by |
+|---|---|
+| `turn-orchestrator` (`run::start`, `turn::*` FSM) | [harness](harness.md) (`harness::send`, `harness::turn`) |
+| `session` (`session-tree::*`) | [session-manager](session-manager.md) (`session::*`) |
+| `context-compaction` (`compact_now`, `prune_tool_outputs`) | [context-manager](context-manager.md) (`context::*`, storage-agnostic) |
+| `models-catalog` (`models::*`) + the orchestrator's provider routing | [llm-router](llm-router.md) (`router::*`) |
+| `provider-*` workers | same protocol shape, re-pointed at `router::provider::*` |
+| `approval-gate`, `llm-budget`, `hook-fanout` | out of scope in v1 — siblings (see [harness.md § Out of scope](harness.md#out-of-scope-future-sibling-workers)) |
+
+Function prefixes do not collide, so both stacks can run side by side during migration. Transcripts
+move with a one-shot copy from `session_tree:*` scopes into `session:*` (entry shapes are
+compatible modulo the new envelope fields: `revision`, `origin`); compaction entries become
+`custom_type: "compaction"` entries.

--- a/tech-specs/2026-06-agentic/README.md
+++ b/tech-specs/2026-06-agentic/README.md
@@ -41,6 +41,9 @@ flowchart LR
   harness --> funcs
   funcs --> chat
 
+  %% Sub-agents (spawn/join)
+  harness -->|"harness::spawn<br/>child sessions"| harness
+
   %% LLM routing
   harness -->|"send messages from<br/>context + last message"| router
 
@@ -68,8 +71,8 @@ flowchart LR
   the other three.
 - **White** (`trigger functions as needed`) is the **iii substrate itself**. Everything callable is a
   registered iii function; the harness invokes them with `iii.trigger(...)`. The model discovers what
-  exists at runtime via `engine::functions::list` (through the single `agent_trigger` invocation
-  surface — see [Terminology](#terminology)). There is no separate "tools" worker.
+  exists at runtime via `engine::functions::list` (through the `agent_trigger` invocation surface by
+  default — see [Terminology](#terminology)). There is no separate "tools" worker.
 
 ## The four workers
 
@@ -78,7 +81,7 @@ flowchart LR
 | [context-manager](context-manager.md) | Turn raw history + a model into a model-ready context (prune, summarise, fit the window). | Context-window management for any AI feature, not just this harness. | [context-manager.md](context-manager.md) |
 | [session-manager](session-manager.md) | Durable, reactive, branching store of typed conversation entries. | A real-time conversation store any app can subscribe to. | [session-manager.md](session-manager.md) |
 | [llm-router](llm-router.md) | One front door + a provider protocol in front of every LLM provider. | Call any model/provider through one stable surface, with or without an agent loop. | [llm-router.md](llm-router.md) |
-| [harness](harness.md) | A thin durable turn loop that wires the other three together. | The "assemble the agent" worker; deliberately minimal. | [harness.md](harness.md) |
+| [harness](harness.md) | A thin durable turn loop that wires the other three together; spawns sub-agents as child sessions. | The "assemble the agent" worker; deliberately minimal. | [harness.md](harness.md) |
 
 A consumer can install just one of these. `llm-router` on its own gives you provider-agnostic
 completions. `session-manager` on its own gives you a reactive chat store. `harness` is the only
@@ -91,8 +94,12 @@ plain LLM loop without `context-manager`).
    has a coherent purpose by itself. Cross-worker calls are explicit `iii.trigger` calls, never
    in-process coupling.
 2. **The harness is thin.** `harness` only sequences the other three plus function dispatch. Anything
-   that grows real logic — approval gating, spend budgets, compaction *scheduling*, multi-agent
-   handoff, hook fan-out — becomes its own sibling worker rather than bloating the harness. See
+   that grows real logic — approval gating, spend budgets, compaction *scheduling*,
+   orchestration beyond spawn/join — becomes its own sibling worker rather than bloating the
+   harness. The loop-coupled extension surfaces it does own — deferred function results,
+   [`harness::spawn`](harness.md#sub-agents-harnessspawn), and the synchronous
+   [hook points](harness.md#hooks) — exist so siblings and sub-agents plug in without loop changes:
+   the harness provides the points, siblings provide the policy. See
    [harness.md § Out of scope](harness.md#out-of-scope-future-sibling-workers).
 3. **`llm-router` is consumer-agnostic.** It never assumes a harness, a session, or a UI. It streams
    into a caller-supplied channel and returns. That is what lets a `third-party-worker` "use llm
@@ -101,7 +108,34 @@ plain LLM loop without `context-manager`).
    results; the caller persists them. This keeps it reusable by any harness or AI feature.
 5. **`session-manager` is the single reactive surface.** Consumers bind to its triggers (session
    created, message added/updated, status changed, meta updated, session deleted) and render live —
-   they never poll and never need to know about the provider or the loop.
+   they never poll and never need to know about the provider or the loop. The harness adds one
+   orchestration-grade exception: `harness::turn_started` / `harness::turn_completed` fire at turn
+   boundaries for consumers that react to outcomes rather than rendering transcripts.
+
+## Consumer cookbook
+
+Every consumer is the same triangle — **send** through the harness, **render** from
+`session-manager` triggers, **observe turn boundaries** via `harness::turn_completed` — with
+surface-specific wiring:
+
+- **Web chat** (streaming UI): pass `session.metadata` (tenancy, e.g. `{ owner }`) on the first
+  `harness::send`; bind `session::message_added` / `session::message_updated` /
+  `session::status_changed` filtered by that metadata; render deltas last-write-wins by `revision`.
+  Session status drives the spinner.
+- **Telegram / Slack / WhatsApp bot**: webhooks redeliver — always pass `idempotency_key` (the
+  platform update id) to `harness::send`. Map platform chat ↔ session via `session.metadata`
+  (e.g. `{ telegram_chat_id }`). Either bind `session::message_updated` and edit the platform
+  message throttled (~1/s), or skip streaming and bind `harness::turn_completed` to post one final
+  message.
+- **TUI / CLI**: the chat pattern for live rendering, or the blocking pattern —
+  [`harness::run`](harness.md#harnessrun), then print `final_message` / `result`.
+- **Backend event loops** (cron, system events, agent chains): `harness::run` with an
+  [`output` contract](harness.md#output-contract) is "call an agent like a function"; or fire
+  `harness::send` and bind `harness::turn_completed`. A chain (completed → send → completed …) must
+  carry its own termination condition — `max_turns` bounds a single turn, not the chain (hop
+  counter in `session.metadata`, or a budget sibling).
+
+See [harness.md](harness.md) for `send` / `run` / `spawn` semantics and the turn events.
 
 ## Conventions
 
@@ -134,8 +168,9 @@ via `iii.registerFunction` and invoked via `iii.trigger`. Message content uses *
 
 The one exception is at the **provider adapter boundary**: OpenAI, Anthropic, and similar APIs expose
 a `tools` array for function-calling. `llm-router` translates our invocation schema into that wire
-format. In the harness loop the model always sees a **single** provider tool — `agent_trigger` — which
-takes `{ function, payload }` and can reach any allowed iii function. See
+format. In the harness loop the model sees a **single** provider tool by default — `agent_trigger`,
+which takes `{ function, payload }` and can reach any allowed iii function — or one schema per
+allowed function when a turn opts into `functions.expose: "native"`. See
 [harness.md § Functions (the white box)](harness.md#functions-the-white-box).
 
 ### Reactive pattern
@@ -326,7 +361,7 @@ type ThinkingLevel = "minimal" | "low" | "medium" | "high" | "xhigh";
 
 type Capability =
   | "thinking" | "thinking:low" | "thinking:medium" | "thinking:high" | "thinking:xhigh"
-  | "tools" | "vision" | "cache";
+  | "tools" | "vision" | "cache" | "structured_output";
 
 type Model = {
   id: string;                 // e.g. "claude-sonnet-4"
@@ -340,6 +375,7 @@ type Model = {
   supports_tools?: boolean;
   supports_vision?: boolean;
   supports_cache?: boolean;
+  supports_structured_output?: boolean;
   thinking_budgets?: Partial<Record<ThinkingLevel, number>>;
   pricing?: { input?: number; output?: number; cache_read?: number; cache_write?: number };
 };
@@ -348,17 +384,34 @@ type Model = {
 ### Function invocation schema
 
 JSON-schema shape for a provider function-calling entry. `llm-router` passes it through to providers
-as a `tools` array entry (adapter boundary). In the harness loop this is always a **single** entry for
-`agent_trigger` — the model does not receive one schema per registered iii function.
+as a `tools` array entry (adapter boundary). In the harness loop this is a **single** entry for
+`agent_trigger` by default; a turn that opts into `functions.expose: "native"` attaches one entry
+per allowed function instead (see
+[harness.md § Functions (the white box)](harness.md#functions-the-white-box)).
 
 ```typescript
 type AgentFunction = {
-  name: string;            // invocation surface name (always "agent_trigger" in the harness loop)
+  name: string;            // invocation surface name ("agent_trigger", "submit_result", or a
+                           // function id in native exposure mode)
   description: string;
   parameters: unknown;     // JSON Schema: { function: string, payload?: object }
   label?: string;
   execution_mode?: "parallel" | "sequential";
 };
+```
+
+### Output contract
+
+What a turn must produce — the typed-deliverable surface for sub-agents and backend automations
+(see [harness.md § Output contract](harness.md#output-contract)). Free text by default; `json`
+constrains the final answer to a JSON value, validated against `schema` when supplied. Delivery is
+provider-native structured output when the model declares the `structured_output` capability, else
+the harness's `submit_result` fallback.
+
+```typescript
+type OutputContract =
+  | { type: "text" }
+  | { type: "json"; schema?: unknown };   // JSON Schema; validated when supplied
 ```
 
 ### Channel reference
@@ -429,6 +482,15 @@ deployment property, not an option:
   supplied, every `agent_trigger` call is refused (see
   [harness.md § Functions (the white box)](harness.md#functions-the-white-box)). Deployments opt
   functions in via `allow` globs or an approval sibling.
+- **Sub-agent chains.** [`harness::spawn`](harness.md#sub-agents-harnessspawn) is the only
+  model-reachable way to start new turns (`harness::send` / `harness::run` stay denied to in-run
+  agents). Children inherit agent provenance, their function policy is the parent's intersected
+  with the request (narrow, never escalate), and depth / fan-out / turn budgets bound the tree.
+- **Hooks are operator-trusted code.** [Hook](harness.md#hooks) bindings come only from deployment
+  configuration (never per-send, never from the model), run with worker privileges, and receive
+  model-controlled data as input — hook code must treat its payload as untrusted (confused-deputy
+  risk). Hook invocations carry the agent provenance mark of the work they wrap, and it propagates
+  through their nested triggers, so a hook cannot launder an agent-gated call.
 - **Agent exposure.** Each worker spec carries an "Agent exposure" section listing which of its
   functions may be exposed to in-run agents. The short version: reads are generally safe (tenancy
   caveats aside); every mutating surface of `session-manager`, the `harness` entry points, and the
@@ -458,7 +520,7 @@ streaming contract but is not bound to the current package's structure.
 | `context-compaction` (`compact_now`, `prune_tool_outputs`) | [context-manager](context-manager.md) (`context::*`, storage-agnostic) |
 | `models-catalog` (`models::*`) + the orchestrator's provider routing | [llm-router](llm-router.md) (`router::*`) |
 | `provider-*` workers | same protocol shape, re-pointed at `router::provider::*` |
-| `approval-gate`, `llm-budget`, `hook-fanout` | out of scope in v1 — siblings (see [harness.md § Out of scope](harness.md#out-of-scope-future-sibling-workers)) |
+| `approval-gate`, `llm-budget`, `hook-fanout` | [harness hooks](harness.md#hooks) + sibling policy/decision workers (see [harness.md § Out of scope](harness.md#out-of-scope-future-sibling-workers)); `hook-fanout`'s async side maps to the `harness::turn_*` events |
 
 Function prefixes do not collide, so both stacks can run side by side during migration. Transcripts
 move with a one-shot copy from `session_tree:*` scopes into `session:*` (entry shapes are

--- a/tech-specs/2026-06-agentic/README.md
+++ b/tech-specs/2026-06-agentic/README.md
@@ -23,6 +23,7 @@ flowchart LR
   tpTop["third-party-worker"]
   router["llm-router"]
   tpBottom["third-party-worker"]
+  gate["approval-gate"]
 
   %% Chat flow
   chat -->|"send message"| harness
@@ -44,6 +45,10 @@ flowchart LR
   %% Sub-agents (spawn/join)
   harness -->|"harness::spawn<br/>child sessions"| harness
 
+  %% Optional approval sibling (pre_dispatch hook + resolve)
+  harness -.->|"pre_dispatch hook"| gate
+  gate -.->|"function::resolve"| harness
+
   %% LLM routing
   harness -->|"send messages from<br/>context + last message"| router
 
@@ -56,10 +61,12 @@ flowchart LR
   classDef green fill:#111,stroke:#22c55e,color:#22c55e,stroke-width:2px;
   classDef red fill:#111,stroke:#ef4444,color:#ff6b6b,stroke-width:2px;
   classDef white fill:#111,stroke:#e5e7eb,color:#e5e7eb,stroke-width:2px;
+  classDef sibling fill:#111,stroke:#ef4444,color:#ff6b6b,stroke-width:2px,stroke-dasharray:5 4;
 
   class chat,tg,tpTop,tpBottom green;
   class ctx,harness,session,router red;
   class funcs white;
+  class gate sibling;
 ```
 
 ### How to read the diagram
@@ -73,6 +80,9 @@ flowchart LR
   registered iii function; the harness invokes them with `iii.trigger(...)`. The model discovers what
   exists at runtime via `engine::functions::list` (through the `agent_trigger` invocation surface by
   default — see [Terminology](#terminology)). There is no separate "tools" worker.
+- **Dashed** (`approval-gate`) is an **optional policy sibling**, specified in
+  [approval-gate.md](approval-gate.md): it plugs into the harness via a `pre_dispatch` hook and
+  `harness::function::resolve` — the four core workers run with or without it.
 
 ## The four workers
 
@@ -147,6 +157,7 @@ See [harness.md](harness.md) for `send` / `run` / `spawn` semantics and the turn
 - `session::*` — session-manager
 - `router::*` — llm-router (plus the `provider::<id>::*` protocol it defines for provider workers)
 - `harness::*` — harness
+- `approval::*` — approval-gate (optional sibling)
 
 ### Invocation modes
 
@@ -469,7 +480,9 @@ subscriber set, applies each binding's `config` filter, and dispatches. Delivery
 and unordered across entries — consumers reconcile via `revision` (message updates) and the parent
 chain (transcript order), never via arrival order. Subscriptions are engine registrations:
 subscribers re-register on reconnect, and an emitter rebuilds its subscriber set from the engine
-after a restart.
+after a restart. The harness's `harness::hook::*` types are the one deliberate exception to async
+delivery: the emitting worker invokes bound functions synchronously in-path, in deterministic
+order, and acts on their return values (see [harness.md § Hooks](harness.md#hooks)).
 
 ## Security model
 
@@ -490,11 +503,14 @@ deployment property, not an option:
   model-reachable way to start new turns (`harness::send` / `harness::run` stay denied to in-run
   agents). Children inherit agent provenance, their function policy is the parent's intersected
   with the request (narrow, never escalate), and depth / fan-out / turn budgets bound the tree.
-- **Hooks are operator-trusted code.** [Hook](harness.md#hooks) bindings come only from deployment
-  configuration (never per-send, never from the model), run with worker privileges, and receive
-  model-controlled data as input — hook code must treat its payload as untrusted (confused-deputy
-  risk). Hook invocations carry the agent provenance mark of the work they wrap, and it propagates
-  through their nested triggers, so a hook cannot launder an agent-gated call.
+- **Hooks are operator-trusted code.** [Hook](harness.md#hooks) bindings are worker-plane trigger
+  registrations on the harness's `harness::hook::*` trigger types — deployment code, never
+  per-send and never model-reachable (trigger registration is an SDK surface, not a function
+  `agent_trigger` can call), with `engine::triggers::list` as the audit surface. Hooks run with
+  worker privileges and receive model-controlled data as input — hook code must treat its payload
+  as untrusted (confused-deputy risk). Hook invocations carry the agent provenance mark of the
+  work they wrap, and it propagates through their nested triggers, so a hook cannot launder an
+  agent-gated call.
 - **Agent exposure.** Each worker spec carries an "Agent exposure" section listing which of its
   functions may be exposed to in-run agents. The short version: reads are generally safe (tenancy
   caveats aside); every mutating surface of `session-manager`, the `harness` entry points, and the
@@ -506,6 +522,8 @@ deployment property, not an option:
 - [session-manager.md](session-manager.md)
 - [llm-router.md](llm-router.md)
 - [harness.md](harness.md)
+- [approval-gate.md](approval-gate.md) — optional sibling: the policy + decision surface for
+  human-held function calls (hook + pending inbox + notification triggers)
 
 ## Prior art
 
@@ -524,9 +542,12 @@ streaming contract but is not bound to the current package's structure.
 | `context-compaction` (`compact_now`, `prune_tool_outputs`) | [context-manager](context-manager.md) (`context::*`, storage-agnostic) |
 | `models-catalog` (`models::*`) + the orchestrator's provider routing | [llm-router](llm-router.md) (`router::*`) |
 | `provider-*` workers | same protocol shape, re-pointed at `router::provider::*` |
-| `approval-gate`, `llm-budget`, `hook-fanout` | [harness hooks](harness.md#hooks) + sibling policy/decision workers (see [harness.md § Out of scope](harness.md#out-of-scope-future-sibling-workers)); `hook-fanout`'s async side maps to the `harness::turn_*` events |
+| `approval-gate` (`approval::*` + `consultBefore` / `turn::on_approval` in `turn-orchestrator`) | [approval-gate](approval-gate.md): the `approval::gate` `pre_dispatch` hook + `harness::function::resolve`; drops the write-only `approvals` state scope (see [approval-gate.md § Prior art & migration](approval-gate.md#prior-art--migration)) |
+| `llm-budget`, `hook-fanout` | [harness hooks](harness.md#hooks) + sibling policy/decision workers (see [harness.md § Out of scope](harness.md#out-of-scope-future-sibling-workers)); `hook-fanout`'s async side maps to the `harness::turn_*` events |
 
-Function prefixes do not collide, so both stacks can run side by side during migration. Transcripts
+Function prefixes do not collide, so both stacks can run side by side during migration — with one
+exception: `approval::*` is the same prefix in both stacks, so the old `approval-gate` worker is
+retired when the greenfield sibling deploys. Transcripts
 move with a one-shot copy from `session_tree:*` scopes into `session:*` (entry shapes are
 compatible modulo the new envelope fields: `revision`, `origin`); compaction entries become
 `custom_type: "compaction"` entries.

--- a/tech-specs/2026-06-agentic/README.md
+++ b/tech-specs/2026-06-agentic/README.md
@@ -66,9 +66,10 @@ flowchart LR
 - **Red** (`context-manager`, `session-manager`, `llm-router`, `harness`) are the four workers this
   spec defines. Each is **standalone**: installable and useful on its own, with no hard dependency on
   the other three.
-- **White** (`trigger functions as needed`) is the **iii substrate itself**. "Tools" are just
-  registered iii functions; the harness invokes them with `iii.trigger(...)` and discovers them from
-  the live engine registry (`engine::functions::list`). There is no separate "tools" worker.
+- **White** (`trigger functions as needed`) is the **iii substrate itself**. Everything callable is a
+  registered iii function; the harness invokes them with `iii.trigger(...)`. The model discovers what
+  exists at runtime via `engine::functions::list` (through the single `agent_trigger` invocation
+  surface — see [Terminology](#terminology)). There is no separate "tools" worker.
 
 ## The four workers
 
@@ -89,7 +90,7 @@ plain LLM loop without `context-manager`).
 1. **Standalone first.** Every red worker is independently installable (`iii worker add <name>`) and
    has a coherent purpose by itself. Cross-worker calls are explicit `iii.trigger` calls, never
    in-process coupling.
-2. **The harness is thin.** `harness` only sequences the other three plus tool dispatch. Anything
+2. **The harness is thin.** `harness` only sequences the other three plus function dispatch. Anything
    that grows real logic — approval gating, spend budgets, compaction *scheduling*, multi-agent
    handoff, hook fan-out — becomes its own sibling worker rather than bloating the harness. See
    [harness.md § Out of scope](harness.md#out-of-scope-future-sibling-workers).
@@ -124,6 +125,18 @@ Every function is invoked through one of the three iii modes (see `iii-core-prim
   loop steps).
 
 Each function's spec states its expected mode.
+
+### Terminology
+
+In iii there is no "tool" worker or domain concept — everything callable is a **function** registered
+via `iii.registerFunction` and invoked via `iii.trigger`. Message content uses **function_call** and
+**function_result** blocks.
+
+The one exception is at the **provider adapter boundary**: OpenAI, Anthropic, and similar APIs expose
+a `tools` array for function-calling. `llm-router` translates our invocation schema into that wire
+format. In the harness loop the model always sees a **single** provider tool — `agent_trigger` — which
+takes `{ function, payload }` and can reach any allowed iii function. See
+[harness.md § Functions (the white box)](harness.md#functions-the-white-box).
 
 ### Reactive pattern
 
@@ -303,16 +316,17 @@ type Model = {
 };
 ```
 
-### Tool schema
+### Function invocation schema
 
-How a tool (any iii function) is advertised to a model. The harness builds this list from the engine
-registry; `llm-router` passes it through to providers.
+JSON-schema shape for a provider function-calling entry. `llm-router` passes it through to providers
+as a `tools` array entry (adapter boundary). In the harness loop this is always a **single** entry for
+`agent_trigger` — the model does not receive one schema per registered iii function.
 
 ```typescript
 type AgentFunction = {
-  name: string;            // the iii function_id, exposed to the model as the tool name
+  name: string;            // invocation surface name (always "agent_trigger" in the harness loop)
   description: string;
-  parameters: unknown;     // JSON Schema of the arguments
+  parameters: unknown;     // JSON Schema: { function: string, payload?: object }
   label?: string;
   execution_mode?: "parallel" | "sequential";
 };

--- a/tech-specs/2026-06-agentic/README.md
+++ b/tech-specs/2026-06-agentic/README.md
@@ -251,8 +251,10 @@ type AssistantMessage = {
   role: "assistant";
   content: ContentBlock[];
   stop_reason: StopReason;
+  native_stop_reason?: string;     // provider's raw finish reason, passed through untouched
   error_message?: string | null;
   error_kind?: ErrorKind | null;
+  warnings?: string[];             // report-and-continue notices (e.g. dropped unsupported param)
   usage?: Usage | null;
   model: string;
   provider: string;
@@ -328,7 +330,8 @@ type StopReason = "end" | "length" | "function_call" | "aborted" | "error";
 type ErrorKind  = "auth_expired" | "rate_limited" | "context_overflow" | "transient" | "permanent";
 type Usage = {
   input?: number; output?: number;
-  cache_read?: number; cache_write?: number;
+  cache_read?: number; cache_write?: number;   // prompt-cache splits (cache reads bill ≈10% of input)
+  reasoning?: number;  // thinking/reasoning tokens, when the provider reports them separately
   cost_usd?: number;   // filled by llm-router from catalog pricing; providers leave it unset
 };
 
@@ -435,7 +438,8 @@ surfaces (see [llm-router.md § Security](llm-router.md#security)).
 ```typescript
 type Credential =
   | { type: "api_key"; key: string }
-  | { type: "oauth";   access_token: string; refresh_token?: string; expires_at?: number };
+  | { type: "oauth";   access_token: string; refresh_token?: string; expires_at?: number;
+      scopes?: string[]; provider_extra?: unknown };
 ```
 
 ## Cross-cutting conventions

--- a/tech-specs/2026-06-agentic/README.md
+++ b/tech-specs/2026-06-agentic/README.md
@@ -1,0 +1,358 @@
+# Agentic Workers
+
+A set of small, composable [iii](https://workers.iii.dev/) workers that, together, make up an
+agentic chat backend — and, taken individually, each solve one problem well enough to be used on
+their own.
+
+The design splits the classic "agent harness" monolith into four standalone workers that talk to
+each other only over the iii bus (functions, triggers, channels). Consumers (a web chat, a Telegram
+bridge, any third-party worker) compose them however they need: the full loop through the `harness`,
+or a single worker like `llm-router` directly.
+
+## The overall architecture
+
+```mermaid
+flowchart LR
+  %% Nodes
+  chat["chat"]
+  tg["telegram-worker"]
+  funcs["trigger functions<br/>as needed"]
+  ctx["context-manager"]
+  harness["harness"]
+  session["session-manager"]
+  tpTop["third-party-worker"]
+  router["llm-router"]
+  tpBottom["third-party-worker"]
+
+  %% Chat flow
+  chat -->|"send message"| harness
+  chat -->|"sync messages"| session
+
+  %% Telegram flow
+  tg -->|"send message"| harness
+
+  %% Harness orchestration
+  harness -->|"sync messages with<br/>context"| ctx
+  ctx --> harness
+
+  harness -->|"sync messages from<br/>llm-router"| session
+
+  %% Function trigger
+  harness --> funcs
+  funcs --> chat
+
+  %% LLM routing
+  harness -->|"send messages from<br/>context + last message"| router
+
+  %% Workers
+  tpTop --> harness
+  tpBottom -->|"use llm directly<br/>without harness"| router
+  router --> tpTop
+
+  %% Styling
+  classDef green fill:#111,stroke:#22c55e,color:#22c55e,stroke-width:2px;
+  classDef red fill:#111,stroke:#ef4444,color:#ff6b6b,stroke-width:2px;
+  classDef white fill:#111,stroke:#e5e7eb,color:#e5e7eb,stroke-width:2px;
+
+  class chat,tg,tpTop,tpBottom green;
+  class ctx,harness,session,router red;
+  class funcs white;
+```
+
+### How to read the diagram
+
+- **Green** (`chat`, `telegram-worker`, `third-party-worker`) are *example consumers*. They are not
+  part of this spec; they show who calls in and how. Any worker or client can take their place.
+- **Red** (`context-manager`, `session-manager`, `llm-router`, `harness`) are the four workers this
+  spec defines. Each is **standalone**: installable and useful on its own, with no hard dependency on
+  the other three.
+- **White** (`trigger functions as needed`) is the **iii substrate itself**. "Tools" are just
+  registered iii functions; the harness invokes them with `iii.trigger(...)` and discovers them from
+  the live engine registry (`engine::functions::list`). There is no separate "tools" worker.
+
+## The four workers
+
+| Worker | One-line role | Standalone value | Spec |
+|---|---|---|---|
+| [context-manager](context-manager.md) | Turn raw history + a model into a model-ready context (prune, summarise, fit the window). | Context-window management for any AI feature, not just this harness. | [context-manager.md](context-manager.md) |
+| [session-manager](session-manager.md) | Durable, reactive, branching store of typed conversation entries. | A real-time conversation store any app can subscribe to. | [session-manager.md](session-manager.md) |
+| [llm-router](llm-router.md) | One front door + a provider protocol in front of every LLM provider. | Call any model/provider through one stable surface, with or without an agent loop. | [llm-router.md](llm-router.md) |
+| [harness](harness.md) | A thin durable turn loop that wires the other three together. | The "assemble the agent" worker; deliberately minimal. | [harness.md](harness.md) |
+
+A consumer can install just one of these. `llm-router` on its own gives you provider-agnostic
+completions. `session-manager` on its own gives you a reactive chat store. `harness` is the only
+worker that depends on the other three — and even those dependencies are soft (it degrades to a
+plain LLM loop without `context-manager`).
+
+## Design principles
+
+1. **Standalone first.** Every red worker is independently installable (`iii worker add <name>`) and
+   has a coherent purpose by itself. Cross-worker calls are explicit `iii.trigger` calls, never
+   in-process coupling.
+2. **The harness is thin.** `harness` only sequences the other three plus tool dispatch. Anything
+   that grows real logic — approval gating, spend budgets, compaction *scheduling*, multi-agent
+   handoff, hook fan-out — becomes its own sibling worker rather than bloating the harness. See
+   [harness.md § Out of scope](harness.md#out-of-scope-future-sibling-workers).
+3. **`llm-router` is consumer-agnostic.** It never assumes a harness, a session, or a UI. It streams
+   into a caller-supplied channel and returns. That is what lets a `third-party-worker` "use llm
+   directly without harness".
+4. **`context-manager` does not own storage.** It operates on message arrays passed in and returns
+   results; the caller persists them. This keeps it reusable by any harness or AI feature.
+5. **`session-manager` is the single reactive surface.** Consumers bind to its triggers (new session,
+   new message, message content updated, status changed) and render live — they never poll and never
+   need to know about the provider or the loop.
+
+## Conventions
+
+### Function ids
+
+`<worker-prefix>::<verb>` or `<worker-prefix>::<namespace>::<verb>`. The prefixes are:
+
+- `context::*` — context-manager
+- `session::*` — session-manager
+- `router::*` — llm-router (plus the `provider::<id>::*` protocol it defines for provider workers)
+- `harness::*` — harness
+
+### Invocation modes
+
+Every function is invoked through one of the three iii modes (see `iii-core-primitives`):
+
+- **Sync** — `trigger({ function_id, payload })`: the caller needs the result (most reads, and
+  `router::chat` which streams over a channel while the call is open).
+- **Void** — `TriggerAction.Void()`: fire-and-forget side effects (e.g. notifications or metrics).
+- **Enqueue** — `TriggerAction.Enqueue({ queue })`: durable async work with retry (the harness turn
+  loop steps).
+
+Each function's spec states its expected mode.
+
+### Reactive pattern
+
+Workers expose reactivity in two shapes, and each worker spec separates them:
+
+- **Trigger types emitted** — a custom trigger type *this* worker registers so *other* workers/clients
+  can bind handlers to its events (e.g. `session::message_added`). Binding is always the two-step
+  pattern:
+
+```typescript
+iii.registerFunction("my-worker::on-message-added", handler);
+iii.registerTrigger({
+  type: "session::message_added",
+  function_id: "my-worker::on-message-added",
+  config: { session_id: "s_123" }, // optional filters
+});
+```
+
+- **Triggers bound** — event sources *this* worker subscribes to (engine `state` / `stream` /
+  `subscribe` / `cron`, or another worker's trigger type).
+
+## Cross-cutting contracts
+
+These types are defined once here and referenced by every worker spec. They are grounded in the
+field-proven shapes from the existing `harness/` package (`harness/src/types/*.ts`) so the design
+maps cleanly onto a real implementation.
+
+### Content blocks
+
+The atomic units of message content. A message's `content` is an ordered array of these.
+
+```typescript
+type TextContent     = { type: "text"; text: string };
+type ImageContent    = { type: "image"; mime: string; data: string }; // base64
+type ThinkingContent = { type: "thinking"; text: string; signature?: string };
+type FunctionCallContent = {
+  type: "function_call";
+  id: string;            // unique per call, echoed by the result
+  function_id: string;   // the iii function id to invoke
+  arguments: unknown;    // model-produced args (JSON)
+};
+type FunctionResultContent = {
+  type: "function_result";
+  function_call_id: string;
+  content: ContentBlock[];
+  is_error?: boolean;
+};
+
+type ContentBlock =
+  | TextContent
+  | ImageContent
+  | ThinkingContent
+  | FunctionCallContent
+  | FunctionResultContent;
+```
+
+### Messages (the "many message types")
+
+The canonical transcript message union. Owned by [session-manager](session-manager.md); consumed by
+`context-manager`, `llm-router`, and `harness`.
+
+```typescript
+type Role = "user" | "assistant" | "function_result" | "custom";
+
+type UserMessage = {
+  role: "user";
+  content: ContentBlock[];
+  timestamp: number;
+};
+
+type AssistantMessage = {
+  role: "assistant";
+  content: ContentBlock[];
+  stop_reason: StopReason;
+  error_message?: string | null;
+  error_kind?: ErrorKind | null;
+  usage?: Usage | null;
+  model: string;
+  provider: string;
+  timestamp: number;
+};
+
+type FunctionResultMessage = {
+  role: "function_result";
+  function_call_id: string;
+  function_id: string;
+  content: ContentBlock[];
+  details: unknown;
+  is_error: boolean;
+  timestamp: number;
+};
+
+// Escape hatch for app-specific entries (system notices, UI markers, attachments, …)
+type CustomMessage = {
+  role: "custom";
+  custom_type: string;       // app-defined discriminator
+  content: ContentBlock[];
+  display?: string;
+  details?: unknown;
+  timestamp: number;
+};
+
+type AgentMessage =
+  | UserMessage
+  | AssistantMessage
+  | FunctionResultMessage
+  | CustomMessage;
+```
+
+### Session entries
+
+How `session-manager` stores messages: each `AgentMessage` is wrapped in an entry envelope that gives
+it identity, ordering, and a parent link (used for forking). Apps that need to persist non-message
+items (system notices, UI markers, attachments) use the `custom` kind.
+
+```typescript
+type SessionEntry =
+  | { kind: "message"; id: string; parent_id: string | null; timestamp: number; message: AgentMessage }
+  | { kind: "custom";  id: string; parent_id: string | null; timestamp: number; custom_type: string; data: unknown };
+```
+
+### Streaming events
+
+The discriminated union providers stream over an iii channel, relayed verbatim by `llm-router` and
+the `harness`. Non-terminal frames carry a `partial` accumulator; `done`/`error` carry the final
+assembled message. `done` and `error` are terminal.
+
+```typescript
+type StopReason = "end" | "length" | "function_call" | "aborted" | "error";
+type ErrorKind  = "auth_expired" | "rate_limited" | "context_overflow" | "transient" | "permanent";
+type Usage = {
+  input?: number; output?: number;
+  cache_read?: number; cache_write?: number;
+  cost_usd?: number;
+};
+
+type AssistantMessageEvent =
+  | { type: "start";             partial: AssistantMessage }
+  | { type: "text_start";        partial: AssistantMessage }
+  | { type: "text_delta";        partial: AssistantMessage; delta: string }
+  | { type: "text_end";          partial: AssistantMessage }
+  | { type: "thinking_start";    partial: AssistantMessage }
+  | { type: "thinking_delta";    partial: AssistantMessage; delta: string }
+  | { type: "thinking_end";      partial: AssistantMessage }
+  | { type: "functioncall_start";partial: AssistantMessage }
+  | { type: "functioncall_delta";partial: AssistantMessage; delta: string }
+  | { type: "functioncall_end";  partial: AssistantMessage }
+  | { type: "usage";             usage: Usage }
+  | { type: "stop";              stop_reason: StopReason; error_message?: string; error_kind?: ErrorKind }
+  | { type: "done";              message: AssistantMessage }   // terminal
+  | { type: "error";             error: AssistantMessage };    // terminal
+```
+
+### Model descriptor
+
+The capability record `llm-router` serves and every worker reads to make budget/feature decisions.
+
+```typescript
+type Capability =
+  | "thinking" | "thinking:low" | "thinking:medium" | "thinking:high" | "thinking:xhigh"
+  | "tools" | "vision" | "cache";
+
+type Model = {
+  id: string;                 // e.g. "claude-sonnet-4"
+  provider: string;           // e.g. "anthropic"
+  display_name?: string;
+  context_window: number;     // total tokens
+  max_output_tokens: number;
+  input_limit?: number;       // usable input budget if distinct from context_window
+  supports_thinking?: boolean;
+  supports_xhigh?: boolean;
+  supports_tools?: boolean;
+  supports_vision?: boolean;
+  supports_cache?: boolean;
+  thinking_budgets?: Record<string, number>;
+  pricing?: { input?: number; output?: number; cache_read?: number; cache_write?: number };
+};
+```
+
+### Tool schema
+
+How a tool (any iii function) is advertised to a model. The harness builds this list from the engine
+registry; `llm-router` passes it through to providers.
+
+```typescript
+type AgentFunction = {
+  name: string;            // the iii function_id, exposed to the model as the tool name
+  description: string;
+  parameters: unknown;     // JSON Schema of the arguments
+  label?: string;
+  execution_mode?: "parallel" | "sequential";
+};
+```
+
+### Channel reference
+
+The wire shape of a streaming channel endpoint. The iii SDK hydrates a `write` ref into a live
+`ChannelWriter` and a `read` ref into a `ChannelReader` before the handler runs.
+
+```typescript
+type StreamChannelRef = {
+  channel_id: string;
+  access_key: string;
+  direction: "read" | "write";
+};
+```
+
+### Credential
+
+What `router::provider::resolve` returns to a provider worker. Secrets never transit agent-visible
+surfaces (see [llm-router.md § Security](llm-router.md#security)).
+
+```typescript
+type Credential =
+  | { type: "api_key"; key: string }
+  | { type: "oauth";   access_token: string; refresh_token?: string; expires_at?: number };
+```
+
+## Spec index
+
+- [context-manager.md](context-manager.md)
+- [session-manager.md](session-manager.md)
+- [llm-router.md](llm-router.md)
+- [harness.md](harness.md)
+
+## Prior art
+
+The existing [`harness/`](../../harness) package in this repo implements the same problem space as a
+"thick" stack of 15 workers (`turn-orchestrator`, `session`, `context-compaction`, `models-catalog`,
+`provider-*`, `approval-gate`, `llm-budget`, `hook-fanout`, …). This spec is a greenfield
+consolidation of that experience into four standalone workers; it borrows the proven wire types and
+streaming contract but is not bound to the current package's structure.

--- a/tech-specs/2026-06-agentic/approval-gate.md
+++ b/tech-specs/2026-06-agentic/approval-gate.md
@@ -1,0 +1,821 @@
+# approval-gate
+
+Worker prefix: `approval::*`
+
+## Definition
+
+`approval-gate` is the **policy and decision surface for human-held function calls**: which calls
+need a human, how the human answers, and how the decision reaches the parked turn. It is an
+optional sibling of the [harness](harness.md) — the harness ships the mechanics (a `pre_dispatch`
+[hook](harness.md#hooks) that can *hold* a call, and
+[`harness::function::resolve`](harness.md#harnessfunctionresolve) to deliver or release it); this
+worker ships the policy, the decision RPCs, the pending inbox, and the notification triggers. The
+harness never embeds approval logic (see
+[harness.md § Out of scope](harness.md#out-of-scope-future-sibling-workers)).
+
+Three surfaces, one worker:
+
+1. **The gate** — `approval::gate`, a `pre_dispatch` hook the worker binds itself at startup as
+   an iii trigger on the harness's `harness::hook::pre_dispatch` trigger type. It evaluates
+   per-session mode, allow-lists, and the yaml policy, and answers `continue`, `deny`, or `hold`.
+2. **The decision plane** — `approval::resolve` plus the per-session settings RPCs
+   (`set_mode`, `add_always_allow`, `approve_always`, …). Human/console-only.
+3. **The pending inbox** — a denormalized, **ephemeral** index of held calls
+   (`approval::list_pending` / `approval::get_pending`) plus two trigger types
+   (`approval::pending_created` / `approval::pending_resolved`) that notification workers and UIs
+   bind to.
+
+The inbox is deliberately ephemeral: a record exists only while a call is held. Every record has an
+explicit deletion path and a sweep as GC backstop (see [State lifecycle](#state-lifecycle)) — the
+worker keeps **no resolved-approval history**. The transcript's `function_result` and the
+`pending_resolved` event are the audit trail; a deployment that wants history binds the trigger and
+keeps its own log.
+
+## Role in the stack
+
+The gate sits *outside* the loop. It is called synchronously at one hook point, and it talks back
+to the harness through exactly one function (`harness::function::resolve`). It never mutates the
+turn record, never appends to the session, and never executes the held function itself — on
+approval, the **harness** runs the released call through its own dispatch pipeline
+(`action: "execute"`; see [Decision flow](#decision-flow-approvalresolve)).
+
+```mermaid
+sequenceDiagram
+  participant H as harness
+  participant AG as approval-gate
+  participant CFG as configuration
+  participant UI as console / inbox UI
+  participant N as notification worker
+
+  Note over H,AG: startup: registerTrigger harness::hook::pre_dispatch → approval::gate
+  Note over AG,CFG: startup: configuration::register id "approval-gate"<br/>bind configuration trigger
+  H->>AG: pre_dispatch hook approval::gate
+  alt policy allows
+    AG-->>H: decision continue
+  else policy denies
+    AG-->>H: decision deny + reason
+  else needs human
+    AG->>AG: write approval_pending record (sync, in-hook)
+    AG-->>H: decision hold + pending_timeout_ms
+    Note over H: call checkpoints pending, held_by approval::gate;<br/>turn parks
+    AG--)N: approval::pending_created (async)
+    UI->>AG: approval::resolve {decision}
+    alt allow
+      AG->>H: harness::function::resolve {action: "execute"}
+      Note over H: re-enqueue turn; run released call through<br/>remaining dispatch pipeline
+    else deny
+      AG->>H: harness::function::resolve {action: "deliver", is_error}
+    end
+    AG->>AG: delete approval_pending record
+    AG--)N: approval::pending_resolved (async)
+  end
+  UI->>CFG: configuration::set "approval-gate" entry
+  CFG--)AG: configuration:updated trigger
+  Note over AG: reload default_mode / always_allow_seed /<br/>pending_timeout_ms in memory
+```
+
+## Permission model
+
+Approval behaviour is governed per session by a **permission mode** plus two allow-lists. The
+semantics are ported unchanged from the proven implementation
+(`harness/src/turn-orchestrator/hook.ts` `consultBefore`, exercised by
+`mode-approval.e2e.test.ts`); only the wire mechanics differ.
+
+- **`manual`** (default) — everything prompts except yaml `allow` rules and `approved_always`
+  grants. The safe default.
+- **`auto`** — like manual, plus the session's curated `always_allow` list short-circuits to allow.
+- **`full`** — everything is allowed. No safety floor; UIs should render a persistent banner while
+  active.
+
+Two allow-lists with deliberately different semantics:
+
+- **`approved_always`** — per-session grants made from an approval prompt ("approve always"
+  button). They are *remembered human decisions*, not an auto-policy, so they hold in **every
+  mode** — including manual.
+- **`always_allow`** — a curated trust profile (seeded from the deployment's
+  [`always_allow_seed`](#configuration)), consulted **only in auto mode**. Dormant under manual:
+  the user can build it up, but it only takes effect when they opt into auto.
+
+### Evaluation order
+
+`approval::gate` evaluates each call against a single settings snapshot (race-safe — one read per
+call):
+
+```mermaid
+flowchart TD
+  start["approval::gate (pre_dispatch)"] --> humanOnly{"target is approval::* or configuration::*?"}
+  humanOnly -->|yes| deny1["deny (human_only_function)"]
+  humanOnly -->|no| snapshot["effective settings = stored record ?? configuration defaults"]
+  snapshot --> full{"mode full?"}
+  full -->|yes| allow[continue]
+  full -->|no| approvedAlways{"function_id in approved_always?"}
+  approvedAlways -->|yes| allow
+  approvedAlways -->|no| autoAllow{"mode auto AND function_id in always_allow?"}
+  autoAllow -->|yes| allow
+  autoAllow -->|no| yaml["policy::check_permissions (5s timeout)"]
+  yaml -->|allow| allow
+  yaml -->|deny| deny2["deny (permissions envelope reason)"]
+  yaml -->|needs_approval| hold["write pending record, hold"]
+  yaml -->|"error / timeout"| deny3["deny (gate_unavailable)"]
+```
+
+### Mode matrix
+
+| Mode | yaml `allow` | `approved_always` | `always_allow` | yaml `deny` | otherwise |
+|---|---|---|---|---|---|
+| `manual` | allow | allow | dormant | deny | hold |
+| `auto` | allow | allow | allow | deny | hold |
+| `full` | allow | allow | allow | allow | allow |
+
+Fail-closed reaffirmation (see [README § Security model](README.md#security-model)): manual mode
+never auto-allows anything except yaml `allow` rules and explicit `approved_always` grants. A
+policy outage degrades to **deny**, never to allow or to an unattended hold.
+
+## The `approval::gate` hook
+
+One function, bound to the harness's `pre_dispatch` point as an iii trigger. The worker registers
+the binding itself at startup — installing the gate is installing the hook (see
+[harness.md § Hooks › Registration](harness.md#registration)):
+
+```typescript
+iii.registerFunction("approval::gate", gate);
+iii.registerTrigger({
+  type: "harness::hook::pre_dispatch",
+  function_id: "approval::gate",
+  config: {
+    functions: ["shell::*", "harness::spawn"],
+    timeout_ms: 5000,
+    on_error: "fail_closed",
+  },
+});
+```
+
+`on_error: "fail_closed"` is already the `pre_*` default — a crashed gate must deny, not wave calls
+through. The `functions` globs narrow which dispatches consult the gate; omit them to consult on
+every call.
+
+**Ordering caveat.** `pre_dispatch` hooks run **after** the harness's fail-closed allow/deny globs —
+a hook narrows the policy, never widens it (see
+[harness.md § Hook points](harness.md#hook-points)). A call that matches no `allow` glob is denied
+before the gate ever sees it. A deployment that wants *everything* gated by approvals therefore
+sets a broad dispatch policy (`functions.allow: ["*"]`) and lets the gate hold/deny per this spec's
+permission model.
+
+Contract (maps `HookInput` → `HookOutput`, both defined in
+[harness.md § Hooks › Contract](harness.md#contract)):
+
+- **`{ decision: "continue" }`** — the permission model allows the call (mode / allow-lists / yaml
+  `allow`).
+- **`{ decision: "deny", reason }`** — yaml `deny` (the [`DenialEnvelope`](#denialenvelope)'s
+  human-readable `reason`), human-only defense, or fail-closed transport failure
+  (`gate_unavailable`). The harness answers the call with an `is_error` function_result carrying
+  the reason — the model sees it and can adapt.
+- **`{ decision: "hold", pending_timeout_ms }`** — yaml `needs_approval` (or any "no rule matched"
+  fallback). Before returning `hold`, the gate **synchronously writes** the
+  [`PendingApprovalRecord`](#pendingapprovalrecord) — a held call must never be invisible to the
+  inbox. If that state write fails, the gate returns `deny` (`gate_unavailable`) instead: fail
+  closed, never hold blind. `approval::pending_created` emits asynchronously *after* the record is
+  written — notification fan-out never blocks the hot path.
+
+The hook runs inside the harness's at-least-once steps and MUST be idempotent: a redelivered step
+re-runs the gate for the same `function_call_id`. Re-evaluating the policy is naturally idempotent;
+the pending-record write is keyed on `{ session_id, function_call_id }`, so a duplicate hold is a
+no-op on the existing record (and emits no second `pending_created`).
+
+Everything the record needs is on `HookInput` (`session_id`, `turn_id`, `depth`, `metadata`,
+`call`); session context (`title`, `description`, `metadata`) is soft-fetched via
+`session::get` at hold time — best-effort, fields are omitted on failure, and the fetch must
+respect the hook's `timeout_ms` budget.
+
+## Decision flow (`approval::resolve`)
+
+The human decision arrives at `approval::resolve { session_id, function_call_id, decision, reason? }`
+(console / inbox UI; human-only). The gate looks up the pending record (it carries the `turn_id`
+the harness needs), then:
+
+- **`decision: "allow"`** → `harness::function::resolve` with **`action: "execute"`** — the harness
+  marks the held call *released*, re-enqueues the turn, and the loop runs it through the
+  **remaining dispatch pipeline**: the `pre_dispatch` chain resumes after the holding hook, the
+  target is invoked with the original call's provenance, `post_dispatch` hooks run over the result,
+  and the checkpoint flips `pending → dispatched → done` with the existing at-most-once redelivery
+  protection (see [harness.md § `harness::function::resolve`](harness.md#harnessfunctionresolve)).
+  The gate never invokes the target itself — doing so would bypass `post_dispatch` redaction, the
+  per-call checkpoints, and provenance propagation.
+- **`decision: "deny"`** → `harness::function::resolve` with `action: "deliver"`,
+  `is_error: true`, content rendering a [`DenialEnvelope`](#denialenvelope)
+  (`denied_by: "user"`, the operator's `reason`, redacted `args_excerpt`), and the envelope as
+  `details`.
+
+Then, in order: delete the pending record (the [emit-once gate](#deletion-is-the-emit-gate)), and
+emit `approval::pending_resolved` with `outcome: "allow" | "deny"`.
+
+**No decision record is persisted — by design.** The prior implementation wrote every decision to a
+state row (`approvals/<session_id>/<function_call_id>` via `harness/src/approval-gate/resolve.ts`)
+that nothing ever deleted — one permanent row per resolved call, forever (the e2e suite even
+asserts the row survives the turn). Greenfield removes the scope entirely: the decision flows
+straight into `harness::function::resolve`, the turn record and transcript carry the durable
+outcome, and the only approval-gate state row (the pending record) dies with the resolution.
+
+**Idempotency.** Duplicate resolves are safe end to end: `harness::function::resolve` is
+idempotent on the deterministic entry id (`e_<turn_id>_<function_call_id>`), and only the resolve
+that actually deletes the pending record emits `pending_resolved`. A resolve for an unknown
+`{ session_id, function_call_id }` returns `{ resolved: false }` and emits nothing. Crash ordering:
+the gate calls `harness::function::resolve` *first*, then deletes, then emits — a crash between the
+two leaks one record until the [sweep](#sweep-the-gc-backstop) collects it; it can never lose a
+decision.
+
+## State lifecycle
+
+The sustainability contract. The state worker's interface is `{ scope, key, value }` — **no TTL,
+no expiry** is part of that contract, so correctness MUST NOT rely on backend expiry (whether the
+deployment backs `iii-state` with Redis, the file adapter, or anything else). Instead:
+
+> **Every record this worker writes has an explicit deletion path, and a periodic sweep is the GC
+> backstop for any path a crash interrupts.**
+
+```mermaid
+flowchart TD
+  hook["approval::gate decides hold"] --> write["write approval_pending record (sync, in-hook)"]
+  write --> emit["emit pending_created (async)"]
+  emit --> live["record live in inbox"]
+  live -->|"approval::resolve allow / deny"| del1["function::resolve, then delete record"]
+  live -->|"harness::turn_completed (turn went terminal)"| del2["purge turn's records"]
+  live -->|"session::deleted"| del3["purge session's records + settings"]
+  live -->|"sweep: now past expires_at"| del4["function::resolve is_error timeout, delete record"]
+  del1 --> emitR["emit pending_resolved (once, gated on delete)"]
+  del2 --> emitR
+  del3 --> emitR
+  del4 --> emitR
+```
+
+### `approval_pending/<session_id>/<function_call_id>` — the inbox record
+
+- **Created**: synchronously inside `approval::gate`, *before* the hook returns `hold`. Write
+  failure → fail-closed `deny`. There is never a held call without an inbox record.
+- **Deleted** (any one of):
+  1. **`approval::resolve`** — the primary path, immediately after `harness::function::resolve`
+     succeeds.
+  2. **`harness::turn_completed`** — the record's turn went terminal
+     (`cancelled` / `failed`, e.g. `harness::stop` cascaded an abort). Purge every record carrying
+     that `turn_id`; emit `pending_resolved` with `outcome: "aborted"`. (A `completed` turn has no
+     live holds by construction; the purge is a harmless stale-record cleanup if any survived a
+     crash.)
+  3. **`session::deleted`** — purge every pending record for the session (plus the settings record,
+     below); emit `pending_resolved` with `outcome: "aborted"` per record.
+  4. **The sweep** — see below.
+
+### Sweep (the GC backstop)
+
+A cron-bound handler (`approval::sweep`, every ~60s) lists the `approval_pending` scope and, for
+each record with `expires_at <= now`:
+
+1. `harness::function::resolve` (`action: "deliver"`, `is_error: true`, timeout denial) — a no-op
+   `{ resolved: false }` when the harness's own pending sweep or another path already resolved the
+   call.
+2. Delete the record.
+3. Emit `approval::pending_resolved` with `outcome: "timeout"` (gated on the delete, below).
+
+`expires_at = pending_at + pending_timeout_ms` — the same value the hook returned on `hold`, so the
+gate's sweep and the harness's pending sweep fire on the same deadline and coexist idempotently
+(deterministic entry ids make double-resolution a no-op; the harness sweep also remains the
+backstop for holds whose gate worker died). The sweep also collects records orphaned by a crash
+between resolve and delete — which is why no delete path needs to be transactional.
+
+### `approval_settings/<session_id>` — per-session settings
+
+- **Created lazily, on first mutation only.** Reads never write: the *effective* settings are the
+  stored record when one exists, else the configuration defaults (`default_mode`,
+  `always_allow_seed`) computed in memory. A session that never customizes its approvals writes
+  **zero** state rows. On the first mutation (`set_mode`, `add_always_allow`, `approve_always`, …)
+  the record is initialized from the current defaults — seed entries carry
+  `granted_by: "seed"` — and the mutation is applied; from then on the stored record wins (a later
+  seed change does not retroactively edit it).
+- **Deleted** on `session::deleted` (the trigger binding replaces the prior deployment's unwired
+  console-side cleanup), or explicitly via `approval::clear_settings`.
+
+### Deletion is the emit gate
+
+All four deletion paths delete through one helper: `state::set` with `value: null`, checking the
+returned `old_value`. Only the caller that observed a non-null `old_value` emits
+`pending_resolved` — concurrent paths (a resolve racing the sweep racing a turn abort) produce
+exactly one event per record. This also keeps `pending_resolved` honest as a badge-clearing signal
+for UIs.
+
+### Why this matters operationally
+
+Aggressive deletion is not just hygiene — it is what keeps the worker cheap. `state::list` returns
+a whole scope, values-only, with no pagination or prefix queries; `approval::list_pending` is a
+full-scope scan filtered in the worker. That stays O(live holds) — typically a handful — precisely
+*because* fulfilled approvals are deleted the moment they resolve. Records are fully
+self-describing (ids live inside the value) so the scan needs no key material.
+
+| Record | Created | Deleted by | Backstop |
+|---|---|---|---|
+| `approval_pending/<sid>/<cid>` | in-hook, before `hold` returns | resolve · turn terminal · session deleted | sweep on `expires_at` |
+| `approval_settings/<sid>` | first user mutation (lazy; reads never write) | `session::deleted` · `approval::clear_settings` | none needed — ≤1 row per session, dies with the session |
+| decision records | — none in greenfield — | — | — |
+
+## Configuration
+
+The worker owns one entry — id **`approval-gate`** — in the engine's built-in `configuration`
+worker, following the same pattern as [llm-router § Configuration](llm-router.md#configuration). At
+startup it calls `configuration::register` with the id, a JSON Schema, and an `initial_value`.
+Operators (and the console's Configuration screen, which renders the schema as a form) edit this
+entry — deployment approval defaults live here and nowhere else; the hook binding is a trigger
+registration, not configuration (see [The `approval::gate` hook](#the-approvalgate-hook)).
+
+```jsonc
+// configuration entry "approval-gate"
+{
+  "default_mode": "manual",            // manual | auto | full — sessions with no stored settings
+  "always_allow_seed": [               // deployment trust profile for auto mode
+    "state::get",
+    "engine::functions::list"
+  ],
+  "pending_timeout_ms": 1800000        // hold deadline; drives expires_at (default 30 min)
+}
+```
+
+| Field | Type | Purpose |
+|---|---|---|
+| `default_mode` | `"manual" \| "auto" \| "full"` | Effective mode for sessions with no stored `approval_settings` record. Default `"manual"`. |
+| `always_allow_seed` | `string[]` (function ids / globs) | Effective `always_allow` list for sessions with no stored record; copied into the record on first mutation (see [lazy seeding](#approval_settingssession_id--per-session-settings)). |
+| `pending_timeout_ms` | `number` | Returned as the hook's `pending_timeout_ms` on `hold`; sets `expires_at` on the pending record. Default `1_800_000` (matches the harness pending-sweep default). |
+
+Reactive reload — no polling:
+
+```typescript
+iii.registerFunction("approval::on_config_change", async () => reloadDefaults());
+iii.registerTrigger({
+  type: "configuration",
+  function_id: "approval::on_config_change",
+  config: {
+    configuration_id: "approval-gate",
+    event_types: ["configuration:registered", "configuration:updated"],
+  },
+});
+```
+
+Soft dependency: without the `configuration` worker the gate runs on built-in defaults
+(`{ default_mode: "manual", always_allow_seed: [], pending_timeout_ms: 1_800_000 }`) — fail-safe,
+never fail-open. Per the configuration worker's boundaries: the entry holds **deployment**
+defaults only (schema-validated, operator-editable); per-session data lives in `iii-state`, and
+`configuration::set` replaces the whole value — clients read-merge-write to edit one field.
+
+## Functions
+
+The gate (called by the harness only, via the `harness::hook::pre_dispatch` trigger binding):
+
+- `approval::gate` — the `pre_dispatch` hook: evaluate the permission model, answer
+  `continue` / `deny` / `hold`; writes the pending record on hold.
+
+Decision plane (human/console-only — see [Agent exposure](#agent-exposure)):
+
+- `approval::resolve` — apply a human decision to a held call: release it for execution (`allow`)
+  or deliver a denial (`deny`); deletes the pending record and emits `pending_resolved`.
+- `approval::set_mode` — set the session's permission mode (`manual` / `auto` / `full`).
+- `approval::add_always_allow` / `approval::remove_always_allow` — curate the session's auto-mode
+  trust list (idempotent add / remove).
+- `approval::approve_always` — record a per-session "approve always" grant (honoured in every mode).
+- `approval::get_settings` — read the session's *effective* settings (stored record or
+  configuration defaults); never writes.
+- `approval::clear_settings` — drop the session's stored settings record.
+
+Inbox reads (operator/console):
+
+- `approval::list_pending` — the pending inbox across sessions, with tenancy filters; the catch-up
+  path for notification workers after a restart.
+- `approval::get_pending` — read one pending record; `null` when resolved or unknown.
+
+Internal (trigger handlers; not called directly):
+
+- `approval::on_config_change` — configuration trigger handler (reload deployment defaults).
+- `approval::on_session_deleted` — `session::deleted` handler (purge settings + pending records).
+- `approval::on_turn_completed` — `harness::turn_completed` handler (purge the turn's pending
+  records).
+- `approval::sweep` — cron handler (expire pending records past `expires_at`).
+
+## Triggers
+
+### Trigger types emitted
+
+Two custom trigger types, registered by this worker and bound by consumers with the standard
+two-step pattern (see [README § Reactive pattern](README.md#reactive-pattern)). Both configs accept
+`{ session_id?: string; metadata?: Record<string, unknown> }` — `metadata` is an equality match
+against the denormalized `session_metadata` on the record, so a multi-tenant notification worker
+binds to only its own sessions (same convention as the
+[session-manager triggers](session-manager.md#trigger-types-emitted)). Delivery is at-least-once
+and unordered (see [README § Trigger delivery](README.md#trigger-delivery)); `list_pending` is the
+reconciliation read.
+
+- **`approval::pending_created`** — a call was held and its inbox record written. Fires
+  asynchronously after the hook returns `hold` — never on the dispatch hot path. Bind notification
+  workers here (push, email, Slack, PagerDuty, …).
+  - Payload: `PendingApprovalRecord & { status: "pending" }`.
+- **`approval::pending_resolved`** — a pending call left the inbox. Emitted exactly once per record
+  (gated on the record delete — see
+  [Deletion is the emit gate](#deletion-is-the-emit-gate)). Lets UIs clear badges and notification
+  workers send "resolved" follow-ups.
+  - Payload:
+
+```typescript
+type PendingResolvedEvent = {
+  session_id: string;
+  turn_id: string;
+  function_call_id: string;
+  function_id: string;
+  outcome: "allow" | "deny" | "timeout" | "aborted";
+  reason?: string;              // operator-supplied on deny
+  session_metadata?: Record<string, unknown>;  // tenancy routing, from the record
+  resolved_at: number;
+};
+```
+
+### Triggers bound
+
+Five bindings — the first is the gate itself; three of the rest exist to enforce the
+[state lifecycle](#state-lifecycle):
+
+- **`harness::hook::pre_dispatch`** ([harness](harness.md#hooks)) → `approval::gate` — the
+  synchronous hook binding itself (`functions` filter, `timeout_ms`, `on_error: "fail_closed"`;
+  see [The `approval::gate` hook](#the-approvalgate-hook)).
+- **`configuration`** on `configuration_id: "approval-gate"` → `approval::on_config_change` —
+  reload deployment defaults reactively (replaces the prior deployment's
+  `approval::on_harness_config` binding on the harness entry).
+- **`session::deleted`** ([session-manager](session-manager.md#trigger-types-emitted)) →
+  `approval::on_session_deleted` — purge `approval_settings/<sid>` and every
+  `approval_pending/<sid>/*` record. This is the cascade the prior deployment lacked (its
+  console-side `clearApprovalSettings` helper was never wired to a delete flow); session-manager
+  needs no change — the event already exists.
+- **`harness::turn_completed`** ([harness](harness.md#trigger-types-emitted)) →
+  `approval::on_turn_completed` — purge the turn's pending records when it goes terminal; covers
+  `harness::stop` cancellation cascades and failed turns without polling `harness::status`.
+- **`cron`** (engine trigger, ~60s) → `approval::sweep` — the expiry backstop.
+
+## Standalone use: notification workers
+
+The inbox triggers make "tell a human something needs them" a composition, not a feature of this
+worker:
+
+```typescript
+// notify-worker: bind at startup
+iii.registerFunction("notify::on_approval_pending", async (evt) => {
+  // evt is PendingApprovalRecord — self-sufficient for notification copy:
+  // function id, redacted args excerpt, session title, expiry.
+  await sendPush({
+    userId: evt.session_metadata?.owner,
+    title: `Approval needed: ${evt.function_id}`,
+    body: evt.session_title ?? evt.session_id,
+    expiresAt: evt.expires_at,
+  });
+});
+iii.registerTrigger({
+  type: "approval::pending_created",
+  function_id: "notify::on_approval_pending",
+  config: { metadata: { owner: "u_1" } },   // optional tenancy filter
+});
+```
+
+After a restart (missed events), a notification worker reconciles with one
+`approval::list_pending` call. Records carry everything a row needs (title, function, redacted
+args, expiry) — no per-row round-trips.
+
+---
+
+## API Reference
+
+Shared types (`ContentBlock`) are defined in
+[README.md § Cross-cutting contracts](README.md#cross-cutting-contracts).
+`HookInput` / `HookOutput` are defined in [harness.md § Hooks › Contract](harness.md#contract).
+
+### Wire types
+
+```typescript
+type PermissionMode = "manual" | "auto" | "full";
+
+type AlwaysAllowEntry = {
+  function_id: string;
+  granted_at: number;                    // ms epoch
+  granted_by: "user_click" | "seed";     // "seed": copied from always_allow_seed on first mutation
+};
+
+// The stored per-session record (scope approval_settings). Reads compute the
+// effective settings from configuration defaults when no record exists.
+type ApprovalSettings = {
+  mode: PermissionMode;
+  always_allow: AlwaysAllowEntry[];      // consulted only in auto mode
+  approved_always: AlwaysAllowEntry[];   // consulted in every mode
+  mode_set_at: number;                   // ms epoch
+};
+
+type ApprovalGateConfigValue = {
+  default_mode: PermissionMode;          // default "manual"
+  always_allow_seed: string[];           // default []
+  pending_timeout_ms: number;            // default 1_800_000
+};
+```
+
+### `DenialEnvelope`
+
+The structured denial shape, rendered into `is_error` function_results (resolve-deny delivers it as
+`details` plus a text rendering; hook-level denies surface its `reason` through the harness):
+
+```typescript
+type DenialEnvelope = {
+  schema_version: 1;
+  status: "denied";
+  denied_by: "permissions" | "user" | "gate_unavailable";
+  function_id: string;
+  rule_id?: string;                      // yaml rule id on permissions denials
+  rule_action?: "deny";
+  matched_constraint?: { field: string; operator: string; value: unknown };
+  args_excerpt?: unknown;                // redacted (see Redaction)
+  reason: string;                        // human/model-readable explanation
+};
+```
+
+`reason` strings are written for the model as much as the human ("… Try different arguments or use
+a different function.") — the denial is information the agent can adapt to, not just a wall.
+
+### `PendingApprovalRecord`
+
+The inbox payload — shared by both triggers, `list_pending`, and `get_pending`. Self-describing
+(all ids inside the value) and notification-safe (arguments pass through redaction):
+
+```typescript
+type PendingApprovalRecord = {
+  session_id: string;
+  turn_id: string;
+  function_call_id: string;
+  function_id: string;
+  arguments_excerpt: unknown;       // redacted — safe to forward to notification channels
+  pending_at: number;               // ms epoch
+  expires_at: number;               // pending_at + pending_timeout_ms
+
+  // Denormalized session context — soft-fetched via session::get at hold time;
+  // fields omitted when the fetch fails or session-manager is absent.
+  session_title?: string;
+  session_description?: string;
+  session_metadata?: Record<string, unknown>;  // tenancy + routing (trigger config filter target)
+
+  // Turn context, from HookInput.
+  depth: number;                    // sub-agent depth (0 = top-level)
+
+  // Optional: first text block of the assistant message that contained this
+  // function_call — notification copy without opening the transcript. Best-effort.
+  assistant_excerpt?: string;
+};
+```
+
+`session_id` and `function_call_id` MUST NOT contain `/` — it is the reserved key separator in the
+`approval_pending` scope; the gate validates at the boundary.
+
+### `approval::gate`
+
+The `pre_dispatch` hook (see [The `approval::gate` hook](#the-approvalgate-hook)). Called by the
+harness only; input/output are the harness hook contract.
+
+- Invocation: **sync** (in the harness dispatch path; budget = the binding's `timeout_ms`)
+
+### `approval::resolve`
+
+Apply a human decision to a held call (see [Decision flow](#decision-flow-approvalresolve)).
+
+- Invocation: **sync**
+
+```typescript
+type ResolveRequest = {
+  session_id: string;
+  function_call_id: string;
+  decision: "allow" | "deny";
+  reason?: string | null;          // surfaced to the model on deny
+};
+type ResolveResponse = {
+  resolved: boolean;               // false: unknown/already-resolved pending call
+  turn_resumed?: boolean;          // passthrough from harness::function::resolve
+};
+```
+
+Errors: `approval/invalid_payload` (bad shape, or `/` in ids). An unknown
+`{ session_id, function_call_id }` is **not** an error — it returns `{ resolved: false }`
+(duplicate decisions race benignly; see idempotency notes above).
+
+### `approval::list_pending`
+
+The pending inbox. Filters apply worker-side over the live scope (cheap — the scope only ever
+holds live records). `metadata` is an equality match against `session_metadata` (tenancy, same
+semantics as [`session::list`](session-manager.md#sessionlist)).
+
+- Invocation: **sync**
+
+```typescript
+type ListPendingRequest = {
+  session_id?: string;
+  metadata?: Record<string, unknown>;
+  limit?: number;                  // default 50
+  cursor?: string;                 // opaque
+};
+type ListPendingResponse = {
+  pending: PendingApprovalRecord[];   // ordered by pending_at ascending
+  next_cursor?: string;
+};
+```
+
+### `approval::get_pending`
+
+- Invocation: **sync**
+
+```typescript
+type GetPendingRequest = { session_id: string; function_call_id: string };
+type GetPendingResponse = { pending: PendingApprovalRecord } | null;  // null: resolved or unknown
+```
+
+### `approval::set_mode`
+
+Set the session's permission mode. First mutation materializes the settings record from the
+current configuration defaults (see
+[lazy seeding](#approval_settingssession_id--per-session-settings)).
+
+- Invocation: **sync**
+
+```typescript
+type SetModeRequest = { session_id: string; mode: PermissionMode };
+type SetModeResponse = { settings: ApprovalSettings };
+```
+
+### `approval::add_always_allow` / `approval::remove_always_allow`
+
+Curate the session's auto-mode trust list. Add is idempotent on `function_id`; remove of an absent
+entry is a no-op. Removing a `granted_by: "seed"` entry works like any other — the stored record
+overrides the deployment seed from first mutation on.
+
+- Invocation: **sync**
+
+```typescript
+type AlwaysAllowMutationRequest = { session_id: string; function_id: string };
+type AlwaysAllowMutationResponse = { settings: ApprovalSettings };
+```
+
+### `approval::approve_always`
+
+Record a per-session "approve always" grant (honoured in **every** mode). Typically called by the
+console from an approval prompt, immediately before `approval::resolve { decision: "allow" }`.
+
+- Invocation: **sync**
+
+```typescript
+type ApproveAlwaysRequest = { session_id: string; function_id: string };
+type ApproveAlwaysResponse = { settings: ApprovalSettings };
+```
+
+### `approval::get_settings`
+
+Read the session's **effective** settings. Never writes (lazy seeding happens on mutation, not on
+read).
+
+- Invocation: **sync**
+
+```typescript
+type GetSettingsRequest = { session_id: string };
+type GetSettingsResponse = {
+  settings: ApprovalSettings;
+  source: "stored" | "defaults";   // whether a per-session record exists
+};
+```
+
+### `approval::clear_settings`
+
+Drop the session's stored settings record (the session reverts to configuration defaults). Also
+invoked internally by `approval::on_session_deleted`.
+
+- Invocation: **sync**
+
+```typescript
+type ClearSettingsRequest = { session_id: string };
+type ClearSettingsResponse = { cleared: boolean };
+```
+
+---
+
+## Redaction
+
+`arguments_excerpt` on pending records and `args_excerpt` on denial envelopes pass through a
+recursive redaction walk before leaving the worker (ported from
+`harness/src/approval-gate/redact.ts`): secret-keyed values (`password`, `token`, `api_key`,
+`secret`, `authorization`, `*_key`, `*_token`, …) are replaced with `<redacted>`, strings are
+clipped to 256 code points, and recursion is depth-capped (hostile self-referential args cannot
+overflow). The walk never mutates its input. This is what makes pending records safe to forward to
+notification channels (push payloads, Slack messages) without leaking call arguments.
+
+## Human-only defense
+
+All `approval::*` and `configuration::*` functions are operator surfaces — an agent that could call
+`approval::set_mode` or `approval::resolve` would approve its own calls. Defense in depth:
+
+1. **Agent exposure** (primary): deny all `approval::*` and `configuration::*` to in-run agents
+   (below).
+2. **Inside the gate** (backstop): `approval::gate` unconditionally denies any dispatch targeting
+   `approval::*` or `configuration::*` with rule `human_only_function` — even under `mode: "full"`
+   and even when the dispatch policy is `allow: ["*"]`. The settings RPCs are reached only through
+   user-initiated console calls, which never pass through the dispatch pipeline.
+
+## Yaml policy dependency
+
+The fallback step consults `policy::check_permissions` (the deployment's `iii-permissions.yaml`
+rule engine) with `{ function_id, args }` under a 5s timeout. Replies map `allow` → continue,
+`deny` → deny (permissions envelope, with `rule_id` / `matched_constraint`), `needs_approval` →
+hold; **unparseable replies degrade to `needs_approval`** (a human look is the safe reading of
+"don't know") while **transport failures and timeouts fail closed** to `deny`
+(`gate_unavailable`) — a crashed policy worker must not wave calls through *or* pile up unattended
+holds.
+
+Soft dependency, with a sharp consequence: a deployment with **no** policy worker sees every
+non-short-circuited call denied as `gate_unavailable`. Such deployments should run a trivial
+policy worker (e.g. "everything `needs_approval`") or lean on `always_allow_seed` / per-session
+modes. The gate does not own or parse `iii-permissions.yaml` itself — the rule engine is its own
+surface.
+
+Note the layering: the harness's fail-closed **glob policy** runs before the hook (coarse,
+structural); the gate's **permission model** runs inside the hook (per-session, human-centric);
+the **yaml rules** are the gate's fallback (deployment-wide, argument-aware). Narrowing only, at
+every layer.
+
+## State
+
+| Scope | Key | Value | Written | Deleted |
+|---|---|---|---|---|
+| `approval_pending` | `<session_id>/<function_call_id>` | [`PendingApprovalRecord`](#pendingapprovalrecord) | in-hook, before `hold` returns | resolve · turn terminal · session deleted · sweep (`expires_at`) — see [State lifecycle](#state-lifecycle) |
+| `approval_settings` | `<session_id>` | [`ApprovalSettings`](#wire-types) | first user mutation (lazy — reads never write) | `session::deleted` · `approval::clear_settings` |
+
+The legacy `approvals` decision scope is gone (see [Decision flow](#decision-flow-approvalresolve));
+pending **dispatch** mechanics (`calls[id].state = "pending"`, `held_by`) live on the harness turn
+record, which remains the loop's source of truth (see
+[harness.md § State](harness.md#state)) — the inbox is a denormalized index over it, authoritative
+only for "what needs human attention right now".
+
+## Dependencies
+
+- `harness` — the `harness::hook::pre_dispatch` trigger type (the gate's binding) and
+  [`harness::function::resolve`](harness.md#harnessfunctionresolve) (`execute` on allow, `deliver`
+  on deny/timeout). Binds [`harness::turn_completed`](harness.md#trigger-types-emitted) for
+  terminal-turn cleanup.
+- `iii-state` — the two scopes above.
+- `configuration` (soft) — the `approval-gate` entry; built-in defaults apply without it.
+- `session-manager` (soft) — `session::get` for denormalized context at hold time;
+  [`session::deleted`](session-manager.md#trigger-types-emitted) for cascade cleanup. Without it,
+  records carry no session context and settings rely on `approval::clear_settings` for cleanup.
+- `policy::check_permissions` (soft) — the yaml rule engine; unreachable → fail-closed deny.
+- Engine `cron` trigger — the sweep.
+- Registers two custom trigger types (`approval::pending_created`, `approval::pending_resolved`)
+  and emits through the engine (see [README § Trigger delivery](README.md#trigger-delivery)).
+
+## Agent exposure
+
+Deny-by-default for in-run agents (see [README § Security model](README.md#security-model)):
+
+- **Deny: all `approval::*`** — `resolve` (an agent approving its own held calls), every settings
+  RPC (self-escalation: flip itself to `full`, allow-list its next call), `gate` (only the harness
+  invokes it, via the configured hook binding), and the internal trigger handlers.
+- **Deny: `configuration::*`** — the `approval-gate` entry is operator-controlled deployment
+  policy.
+- **Operator reads, not agent reads:** `approval::list_pending` / `approval::get_pending` are
+  console/notification surfaces. Read-only and redacted, but they enumerate held calls across
+  sessions — the same multi-tenant leak caveat as
+  [`session::list`](session-manager.md#agent-exposure); keep them off agent allow-lists.
+
+## Boundaries
+
+- Does **not** run the agent loop, park turns, or execute approved functions — the harness owns
+  dispatch end to end; the gate only answers hooks and calls `harness::function::resolve`.
+- Does **not** store transcripts, decisions, or resolved-approval history — the transcript and
+  `pending_resolved` events are the audit trail; the inbox holds live records only (see
+  [State lifecycle](#state-lifecycle)).
+- Does **not** own or evaluate `iii-permissions.yaml` — it consults `policy::check_permissions`
+  and treats the rule engine as a sibling surface.
+- Does **not** send notifications — it emits triggers; notification workers compose on top (see
+  [Standalone use](#standalone-use-notification-workers)).
+- Does **not** widen the dispatch policy — `pre_dispatch` runs after the harness's fail-closed
+  globs; gating "everything" is a dispatch-policy choice (`allow: ["*"]`), not a gate feature.
+
+## Prior art & migration
+
+The implemented stack (`harness/src/approval-gate/` + the consult/wake halves living in
+`turn-orchestrator`) proves the permission semantics this spec ports; its wire mechanics map onto
+greenfield primitives as follows. The implementation-era docs
+([`harness/docs/workers/approval-gate.md`](../../harness/docs/workers/approval-gate.md), including
+its "Pending-approval signalling" approach of deriving pending state from turn records) are
+superseded by this spec.
+
+| Current implementation | Greenfield |
+|---|---|
+| `consultBefore` inline in turn-orchestrator | `approval::gate` `pre_dispatch` hook, bound as a `harness::hook::pre_dispatch` trigger |
+| `approval::resolve` → `state::set approvals/<sid>/<cid>` (write-only scope, **never deleted**) | `approval::resolve` → `harness::function::resolve`; **no decision records** |
+| `turn::on_approval` state trigger + `function_awaiting_approval` FSM wake | harness deferred dispatch + `action: "execute"` release |
+| `awaiting_approval[]` on the turn record | `calls[id].state = "pending", held_by` on the harness turn record |
+| Approved call executed by the orchestrator's FSM | released call executed by the harness dispatch pipeline (`post_dispatch` hooks included) |
+| `harness.permissions.default_mode` (implementation-era harness entry) + `approval::on_harness_config` | own `approval-gate` configuration entry + `approval::on_config_change` |
+| Settings record written eagerly with defaults | lazy seeding — first mutation writes; reads never write |
+| Console `clearApprovalSettings` helper (defined, never wired) | `session::deleted` trigger binding purges settings + pending records |
+| No pending signal; console derives from `turn_state_changed` + `awaiting_approval[]` | `approval::pending_created` / `pending_resolved` triggers + `approval_pending` inbox |
+| No global pending list | `approval::list_pending` / `approval::get_pending` |
+| No timeout for abandoned holds (parked turns stuck forever) | `expires_at` + gate sweep, harness pending sweep as second backstop |

--- a/tech-specs/2026-06-agentic/context-manager.md
+++ b/tech-specs/2026-06-agentic/context-manager.md
@@ -54,12 +54,29 @@ the response sets `model_resolved: "fallback"` so callers can detect it.
 The usable input budget is model-adaptive, not a flat constant:
 
 ```
-usable = max(0, (input_limit || context_window - max_output_tokens) - reserved)
+usable = max(0, (input_limit ?? (context_window - max_output_tokens)) - reserved - thinking_budget)
 ```
 
-`reserved` defaults to `min(20000, 10% of context_window)` and is overridable per call. A 200k model
-with defaults yields ~180k usable; a 32k model yields ~12k. Compaction/pruning trigger when running
-tokens cross `usable`.
+`reserved` defaults to `min(20000, 10% of context_window)` and is overridable per call.
+`thinking_budget` is `thinking_budgets[thinking_level]` when the caller passes
+`options.thinking_level` and the model declares budgets, else 0 — this is how assemble leaves room
+for the reasoning tokens a thinking tier consumes. A 200k model with defaults yields ~180k usable; a
+32k model yields ~12k. Compaction/pruning trigger when running tokens cross `usable`.
+
+## Structural invariants
+
+Whatever pruning or compaction does, the returned context must still be accepted by providers:
+
+- **Call/result pairing.** A `function_call` and its `function_result` always land on the same side
+  of any boundary: the compaction tail never starts between an assistant's call and its result
+  (providers reject orphaned results), so tail selection only cuts at user/assistant turn
+  boundaries.
+- **Prune replaces, never removes.** Pruning rewrites a verbose output's content to a single text
+  placeholder (`[output pruned: was ~N tokens]`); the block, the message, and the
+  `function_call_id` linkage all survive.
+- **`custom` messages are app-facing.** `context::assemble` excludes `role: "custom"` messages from
+  the model-facing list (and their tokens from the count) — they have no provider wire mapping (see
+  [README § Messages](README.md#messages-the-many-message-types)).
 
 ## Functions
 
@@ -94,7 +111,7 @@ iii.registerFunction("context::on_message_added", async (evt) => {
   // Measure / pre-warm; no persistence. The harness still calls context::assemble on the hot path.
   await iii.trigger({
     function_id: "context::count_tokens",
-    payload: { messages, model: { id: "<model>" } },
+    payload: { messages: messages.map((m) => m.message), model: { id: "<model>" } },
   });
 });
 
@@ -111,8 +128,8 @@ Future extension: a `cron`-bound `context::on_tick` for periodic long-term memor
 
 ## API Reference
 
-Shared types (`AgentMessage`, `ContentBlock`, `AgentFunction`, `Model`) are defined in
-[README.md § Cross-cutting contracts](README.md#cross-cutting-contracts).
+Shared types (`AgentMessage`, `ContentBlock`, `AgentFunction`, `Model`, `ThinkingLevel`) are defined
+in [README.md § Cross-cutting contracts](README.md#cross-cutting-contracts).
 
 ### `context::assemble`
 
@@ -134,6 +151,9 @@ type AssembleRequest = {
     allow_compaction?: boolean;    // default true
     allow_prune?: boolean;         // default true
     protected_functions?: string[];    // function_ids whose outputs are never pruned
+    thinking_level?: ThinkingLevel;    // reserve the model's thinking budget for this tier
+    lease_key?: string;            // compaction mutual-exclusion key (e.g. a session id); default: hash of the message set
+    previous_summary?: string;     // persisted summary from a prior compaction (see "The compaction round trip")
   };
 };
 ```
@@ -151,8 +171,8 @@ type AssembleResponse = {
     pruned: boolean;
     pruned_tokens: number;
     compacted: boolean;
-    summary?: string;              // present when compacted; transient, caller may cache
-    tail_start_id?: string | null;
+    summary?: string;              // present when compacted; the caller should persist it (see below)
+    tail_start_index?: number | null; // index into the request messages where the verbatim tail begins
     tokens_before?: number;
   };
 };
@@ -181,6 +201,24 @@ Example:
 }
 ```
 
+#### The compaction round trip
+
+`context-manager` never persists a summary — but the caller **must**, or every call past the budget
+re-runs a full LLM summarisation (one extra model call per request) and summaries never converge.
+The contract:
+
+1. When `applied.compacted` is true, persist `applied.summary` and whatever your storage maps
+   `applied.tail_start_index` to (the [harness](harness.md#compaction-persistence) stores both in a
+   `custom` session entry with `custom_type: "compaction"`).
+2. On later calls, pass only the post-compaction window as `messages` (the verbatim tail and
+   everything after it) plus the stored summary as `options.previous_summary`.
+3. `assemble` renders `previous_summary` into the system prompt under a `# Conversation summary`
+   heading; if compaction triggers again, the summariser **updates** that summary instead of
+   starting over, so it converges instead of growing.
+
+Callers that skip step 1 still get correct output — at the cost of one summariser call per request
+once over budget.
+
 ### `context::compact`
 
 Summarise the head of a history into a single compaction summary, keeping a recent tail verbatim.
@@ -200,6 +238,7 @@ type CompactRequest = {
     tail_turns?: number;             // default 2
     previous_summary?: string;       // anchor so summaries converge instead of growing
     preserve_recent_tokens?: number; // override adaptive tail budget
+    lease_key?: string;              // mutual-exclusion key; default: hash of the message set
   };
 };
 ```
@@ -208,12 +247,17 @@ Response (discriminated union):
 
 ```typescript
 type CompactResponse =
-  | { status: "ok"; summary: string; tail_start_id: string | null;
+  | { status: "ok"; summary: string; tail_start_index: number | null;
       tokens_before: number; tokens_after: number; used_prior_summary: boolean }
   | { status: "busy" }      // a compaction lease is held; caller may retry
   | { status: "empty" }     // nothing to compact
   | { status: "overflow" }; // the summariser itself overflowed
 ```
+
+`tail_start_index` is an index into the request `messages` array — this worker never sees storage
+entry ids. Callers that persist compaction results map the index onto their own ids (see
+[harness.md § Compaction persistence](harness.md#compaction-persistence)). Tail selection respects
+the [structural invariants](#structural-invariants).
 
 The summary follows a fixed Markdown template (Goal / Constraints / Progress / Key Decisions /
 Actions Taken / Next Steps / Critical Context / Relevant Files). When `previous_summary` is supplied the
@@ -226,8 +270,10 @@ worker log and callers should treat it as "compaction unavailable".
 
 ### `context::prune`
 
-Strip or truncate verbose function outputs without summarising. Walks `function_result` content newest to
-oldest, freeing outputs outside a protected token window.
+Replace verbose function outputs with placeholders without summarising. Walks `function_result`
+content newest to oldest, freeing outputs outside a protected token window. Per the
+[structural invariants](#structural-invariants), pruning rewrites content in place — it never
+removes a block or message, so call/result pairing survives.
 
 - Invocation: **sync**
 
@@ -250,7 +296,7 @@ Response:
 
 ```typescript
 type PruneResponse = {
-  messages: AgentMessage[];   // same array with pruned outputs nulled/truncated
+  messages: AgentMessage[];   // same array with pruned outputs replaced by placeholders
   pruned_tokens: number;
   pruned_parts: number;
   scanned_parts: number;
@@ -291,7 +337,7 @@ type CountTokensResponse = {
 
 | Scope | Key | Value | Purpose |
 |---|---|---|---|
-| `context_lease` | `<lease_key>` | `{ nonce, ts }` | Compaction mutual exclusion; TTL ~300s. `<lease_key>` is caller-supplied (e.g. a session id) or a hash of the message set. |
+| `context_lease` | `<lease_key>` | `{ nonce, ts }` | Compaction mutual exclusion; TTL ~300s. `<lease_key>` comes from `options.lease_key` (e.g. a session id) or defaults to a hash of the message set. |
 
 `context-manager` writes no conversation data.
 
@@ -300,6 +346,13 @@ type CountTokensResponse = {
 - `iii-state` — compaction leases only.
 - `llm-router` (soft) — model limit resolution (`router::models::get`) and the summariser
   (`router::chat`). Pure token/prune calls work without it when inline `limits` are supplied.
+
+## Agent exposure
+
+All functions are pure transforms over caller-supplied messages — nothing secret to leak (see
+[README § Security model](README.md#security-model)). The only caveat is cost: `context::assemble`
+and `context::compact` can trigger a summariser LLM call. `context::count_tokens` and
+`context::prune` are safe; deny the other two in cost-sensitive deployments.
 
 ## Boundaries
 

--- a/tech-specs/2026-06-agentic/context-manager.md
+++ b/tech-specs/2026-06-agentic/context-manager.md
@@ -1,0 +1,310 @@
+# context-manager
+
+Worker prefix: `context::*`
+
+## Definition
+
+`context-manager` turns a raw conversation history plus a target model into a **model-ready
+context**: a system prompt and an ordered `AgentMessage[]` that fits inside the model's usable token
+budget. It owns the policy for *what the model sees this turn* — token counting, tool-output pruning,
+and history compaction (summarisation) — and nothing else.
+
+It is **stateless with respect to conversation storage**. Callers pass message arrays in and get
+results back; persisting anything (a compaction summary, a pruned message) is the caller's job. This
+is the deliberate boundary that makes the worker reusable: a chat harness, a batch document
+summariser, a RAG pipeline, or another team's bespoke agent can all call `context::assemble` without
+adopting `session-manager` or any particular storage model.
+
+The only state it keeps is operational, not conversational: short-lived compaction **leases** (so two
+callers don't summarise the same logical session concurrently) under its own iii state scope.
+
+## Standalone use
+
+- A non-chat feature that needs "summarise these messages to fit model X" calls `context::compact`
+  directly.
+- A cost-sensitive caller calls `context::count_tokens` before deciding which model to use, with no
+  agent loop involved.
+- A different harness implementation reuses `context::assemble` as its pre-flight step and persists
+  results into its own store.
+
+## Model input
+
+Functions that need model limits accept a `ModelInput`. Provide inline `limits` to stay fully
+standalone; provide only `id`/`provider` to have the worker resolve limits via
+[`router::models::get`](llm-router.md#routermodelsget) when `llm-router` is installed.
+
+```typescript
+type ModelInput = {
+  id: string;
+  provider?: string;
+  limits?: {
+    context_window: number;
+    max_output_tokens: number;
+    input_limit?: number;
+  };
+};
+```
+
+Resolution order for limits: inline `limits` -> `router::models::get(provider, id)` ->
+conservative fallback (`context_window: 8192`, `max_output_tokens: 1024`). When a fallback is used,
+the response sets `model_resolved: "fallback"` so callers can detect it.
+
+## Token budget model
+
+The usable input budget is model-adaptive, not a flat constant:
+
+```
+usable = max(0, (input_limit || context_window - max_output_tokens) - reserved)
+```
+
+`reserved` defaults to `min(20000, 10% of context_window)` and is overridable per call. A 200k model
+with defaults yields ~180k usable; a 32k model yields ~12k. Compaction/pruning trigger when running
+tokens cross `usable`.
+
+## Functions
+
+- `context::assemble` — Build the model-ready context (system prompt + budgeted messages) from a
+  history. The main "sync messages with context" entry point.
+- `context::compact` — Summarise older history into a single compaction summary and return the
+  preserved tail. Transient: the caller uses the result; the session keeps its full transcript.
+- `context::prune` — Strip/truncate verbose tool outputs without summarising. A cheaper first pass.
+- `context::count_tokens` — Estimate token usage for a set of messages (+ optional tools/system) vs a
+  model.
+
+## Triggers
+
+### Trigger types emitted
+
+None. `context-manager` is a request/response capability worker.
+
+### Triggers bound
+
+None by default. **Optional reactive integration:** when paired with `session-manager`, a deployment
+may bind a handler to `session::message_added` to pre-warm an assembled context off the turn's hot
+path (for example, to warm a cache or surface a token-usage metric). This is opt-in and lives in the
+consumer, which is what keeps `context-manager` decoupled from any store — it never reaches into a
+session on its own.
+
+```typescript
+iii.registerFunction("context::on_message_added", async (evt) => {
+  const { messages } = await iii.trigger({
+    function_id: "session::messages",
+    payload: { session_id: evt.session_id },
+  });
+  // Measure / pre-warm; no persistence. The harness still calls context::assemble on the hot path.
+  await iii.trigger({
+    function_id: "context::count_tokens",
+    payload: { messages, model: { id: "<model>" } },
+  });
+});
+
+iii.registerTrigger({
+  type: "session::message_added",
+  function_id: "context::on_message_added",
+  config: { /* optional: session_id, roles */ },
+});
+```
+
+Future extension: a `cron`-bound `context::on_tick` for periodic long-term memory consolidation.
+
+---
+
+## API Reference
+
+Shared types (`AgentMessage`, `ContentBlock`, `AgentFunction`, `Model`) are defined in
+[README.md § Cross-cutting contracts](README.md#cross-cutting-contracts).
+
+### `context::assemble`
+
+Build a model-ready context. Applies prune and/or compaction as needed to fit `usable`, in this
+order: count -> (if over) prune tool outputs -> (if still over) compact head -> assemble final list.
+
+- Invocation: **sync**
+
+Request:
+
+```typescript
+type AssembleRequest = {
+  messages: AgentMessage[];        // full candidate history, oldest first
+  model: ModelInput;
+  system_prompt?: string;          // base system prompt to prepend/merge
+  options?: {
+    reserved_tokens?: number;      // override the default reserve
+    tail_turns?: number;           // user+assistant pairs always kept verbatim (default 2)
+    allow_compaction?: boolean;    // default true
+    allow_prune?: boolean;         // default true
+    protected_tools?: string[];    // function_ids whose outputs are never pruned
+  };
+};
+```
+
+Response:
+
+```typescript
+type AssembleResponse = {
+  system_prompt: string;
+  messages: AgentMessage[];        // budgeted, ready to send to llm-router
+  token_count: number;             // estimated tokens of the returned context
+  usable: number;                  // the budget it was fit into
+  model_resolved: "inline" | "router" | "fallback";
+  applied: {
+    pruned: boolean;
+    pruned_tokens: number;
+    compacted: boolean;
+    summary?: string;              // present when compacted; transient, caller may cache
+    tail_start_id?: string | null;
+    tokens_before?: number;
+  };
+};
+```
+
+Errors (thrown): `messages is required`; `could not resolve model limits` (only when neither inline
+limits nor `llm-router` are available and the fallback is explicitly disabled).
+
+Example:
+
+```jsonc
+// request
+{
+  "messages": [{ "role": "user", "content": [{ "type": "text", "text": "hi" }], "timestamp": 1 }],
+  "model": { "id": "claude-sonnet-4", "provider": "anthropic" },
+  "system_prompt": "You are a helpful assistant."
+}
+// response
+{
+  "system_prompt": "You are a helpful assistant.",
+  "messages": [/* … possibly unchanged … */],
+  "token_count": 24,
+  "usable": 180000,
+  "model_resolved": "router",
+  "applied": { "pruned": false, "pruned_tokens": 0, "compacted": false }
+}
+```
+
+### `context::compact`
+
+Summarise the head of a history into a single compaction summary, keeping a recent tail verbatim.
+Transient and storage-agnostic: it returns the summary for the caller to use (typically
+`context::assemble` applies compaction inline, so most callers never call this directly). It does not
+write to any session — the durable transcript in [session-manager](session-manager.md) is untouched.
+
+- Invocation: **sync**
+
+Request:
+
+```typescript
+type CompactRequest = {
+  messages: AgentMessage[];
+  model: ModelInput;
+  options?: {
+    tail_turns?: number;             // default 2
+    previous_summary?: string;       // anchor so summaries converge instead of growing
+    preserve_recent_tokens?: number; // override adaptive tail budget
+  };
+};
+```
+
+Response (discriminated union):
+
+```typescript
+type CompactResponse =
+  | { status: "ok"; summary: string; tail_start_id: string | null;
+      tokens_before: number; tokens_after: number; used_prior_summary: boolean }
+  | { status: "busy" }      // a compaction lease is held; caller may retry
+  | { status: "empty" }     // nothing to compact
+  | { status: "overflow" }; // the summariser itself overflowed
+```
+
+The summary follows a fixed Markdown template (Goal / Constraints / Progress / Key Decisions / Tool
+Calls Made / Next Steps / Critical Context / Relevant Files). When `previous_summary` is supplied the
+summariser updates it rather than starting over.
+
+Summariser model/provider: by default the same `model` passed in (routed through
+[`router::chat`](llm-router.md#routerchat)). Compaction therefore requires `llm-router` to be present;
+without it, `context::compact` returns `{ status: "overflow" }` with `error_kind: "permanent"` in the
+worker log and callers should treat it as "compaction unavailable".
+
+### `context::prune`
+
+Strip or truncate verbose tool outputs without summarising. Walks `function_result` content newest to
+oldest, freeing outputs outside a protected token window.
+
+- Invocation: **sync**
+
+Request:
+
+```typescript
+type PruneRequest = {
+  messages: AgentMessage[];
+  model?: ModelInput;              // only needed for token math; optional
+  options?: {
+    protect_recent_tokens?: number; // default 40000
+    min_free_tokens?: number;       // skip if it would free less (default 20000)
+    max_output_chars?: number;      // per-output truncation cap (default 2000)
+    protected_tools?: string[];     // function_ids never pruned
+  };
+};
+```
+
+Response:
+
+```typescript
+type PruneResponse = {
+  messages: AgentMessage[];   // same array with pruned outputs nulled/truncated
+  pruned_tokens: number;
+  pruned_parts: number;
+  scanned_parts: number;
+};
+```
+
+### `context::count_tokens`
+
+Estimate token usage for a set of messages, optionally including tool schemas and a system prompt.
+
+- Invocation: **sync**
+
+Request:
+
+```typescript
+type CountTokensRequest = {
+  messages: AgentMessage[];
+  system_prompt?: string;
+  tools?: AgentFunction[];
+  model: ModelInput;          // tokenizer selection; falls back to a generic estimator
+};
+```
+
+Response:
+
+```typescript
+type CountTokensResponse = {
+  tokens: number;
+  by_role?: { user: number; assistant: number; function_result: number; custom: number };
+  estimator: "tokenizer" | "heuristic";
+};
+```
+
+---
+
+## State
+
+| Scope | Key | Value | Purpose |
+|---|---|---|---|
+| `context_lease` | `<lease_key>` | `{ nonce, ts }` | Compaction mutual exclusion; TTL ~300s. `<lease_key>` is caller-supplied (e.g. a session id) or a hash of the message set. |
+
+`context-manager` writes no conversation data.
+
+## Dependencies
+
+- `iii-state` — compaction leases only.
+- `llm-router` (soft) — model limit resolution (`router::models::get`) and the summariser
+  (`router::chat`). Pure token/prune calls work without it when inline `limits` are supplied.
+
+## Boundaries
+
+- Does **not** store conversations — pass messages in, persist results yourself (or use
+  `session-manager`).
+- Does **not** decide *when* to compact a live session on its own — that is the caller's policy (the
+  harness pre-flight, or the optional reactive trigger above).
+- Does **not** talk to LLM providers directly — summarisation goes through `llm-router`.
+- Does **not** implement long-term/vector memory in v1; that belongs in a dedicated sibling worker.

--- a/tech-specs/2026-06-agentic/context-manager.md
+++ b/tech-specs/2026-06-agentic/context-manager.md
@@ -6,8 +6,8 @@ Worker prefix: `context::*`
 
 `context-manager` turns a raw conversation history plus a target model into a **model-ready
 context**: a system prompt and an ordered `AgentMessage[]` that fits inside the model's usable token
-budget. It owns the policy for *what the model sees this turn* — token counting, tool-output pruning,
-and history compaction (summarisation) — and nothing else.
+budget. It owns the policy for *what the model sees this turn* — token counting, function-result
+pruning, and history compaction (summarisation) — and nothing else.
 
 It is **stateless with respect to conversation storage**. Callers pass message arrays in and get
 results back; persisting anything (a compaction summary, a pruned message) is the caller's job. This
@@ -67,9 +67,9 @@ tokens cross `usable`.
   history. The main "sync messages with context" entry point.
 - `context::compact` — Summarise older history into a single compaction summary and return the
   preserved tail. Transient: the caller uses the result; the session keeps its full transcript.
-- `context::prune` — Strip/truncate verbose tool outputs without summarising. A cheaper first pass.
-- `context::count_tokens` — Estimate token usage for a set of messages (+ optional tools/system) vs a
-  model.
+- `context::prune` — Strip/truncate verbose function outputs without summarising. A cheaper first pass.
+- `context::count_tokens` — Estimate token usage for a set of messages (+ optional invocation schema /
+  system) vs a model.
 
 ## Triggers
 
@@ -117,7 +117,7 @@ Shared types (`AgentMessage`, `ContentBlock`, `AgentFunction`, `Model`) are defi
 ### `context::assemble`
 
 Build a model-ready context. Applies prune and/or compaction as needed to fit `usable`, in this
-order: count -> (if over) prune tool outputs -> (if still over) compact head -> assemble final list.
+order: count -> (if over) prune function outputs -> (if still over) compact head -> assemble final list.
 
 - Invocation: **sync**
 
@@ -133,7 +133,7 @@ type AssembleRequest = {
     tail_turns?: number;           // user+assistant pairs always kept verbatim (default 2)
     allow_compaction?: boolean;    // default true
     allow_prune?: boolean;         // default true
-    protected_tools?: string[];    // function_ids whose outputs are never pruned
+    protected_functions?: string[];    // function_ids whose outputs are never pruned
   };
 };
 ```
@@ -215,8 +215,8 @@ type CompactResponse =
   | { status: "overflow" }; // the summariser itself overflowed
 ```
 
-The summary follows a fixed Markdown template (Goal / Constraints / Progress / Key Decisions / Tool
-Calls Made / Next Steps / Critical Context / Relevant Files). When `previous_summary` is supplied the
+The summary follows a fixed Markdown template (Goal / Constraints / Progress / Key Decisions /
+Actions Taken / Next Steps / Critical Context / Relevant Files). When `previous_summary` is supplied the
 summariser updates it rather than starting over.
 
 Summariser model/provider: by default the same `model` passed in (routed through
@@ -226,7 +226,7 @@ worker log and callers should treat it as "compaction unavailable".
 
 ### `context::prune`
 
-Strip or truncate verbose tool outputs without summarising. Walks `function_result` content newest to
+Strip or truncate verbose function outputs without summarising. Walks `function_result` content newest to
 oldest, freeing outputs outside a protected token window.
 
 - Invocation: **sync**
@@ -241,7 +241,7 @@ type PruneRequest = {
     protect_recent_tokens?: number; // default 40000
     min_free_tokens?: number;       // skip if it would free less (default 20000)
     max_output_chars?: number;      // per-output truncation cap (default 2000)
-    protected_tools?: string[];     // function_ids never pruned
+    protected_functions?: string[];     // function_ids never pruned
   };
 };
 ```
@@ -259,7 +259,8 @@ type PruneResponse = {
 
 ### `context::count_tokens`
 
-Estimate token usage for a set of messages, optionally including tool schemas and a system prompt.
+Estimate token usage for a set of messages, optionally including the invocation schema (typically the
+single `agent_trigger` entry) and a system prompt.
 
 - Invocation: **sync**
 
@@ -269,7 +270,7 @@ Request:
 type CountTokensRequest = {
   messages: AgentMessage[];
   system_prompt?: string;
-  tools?: AgentFunction[];
+  tools?: AgentFunction[];   // invocation schema(s) for token counting (typically [agent_trigger])
   model: ModelInput;          // tokenizer selection; falls back to a generic estimator
 };
 ```

--- a/tech-specs/2026-06-agentic/harness.md
+++ b/tech-specs/2026-06-agentic/harness.md
@@ -36,6 +36,9 @@ sequenceDiagram
   H->>S: session::set_status working
   H->>S: session::messages
   H->>X: context::assemble
+  opt assemble compacted the head
+    H->>S: session::append (custom compaction entry)
+  end
   H->>R: router::chat (over channel)
   R-->>H: AssistantMessageEvent frames
   H->>S: session::append (assistant) then session::update_message (stream deltas)
@@ -52,34 +55,119 @@ sequenceDiagram
 ## The loop
 
 `harness::send` is the entry point; it ensures the session, persists the user message, and enqueues
-the first `harness::turn` step, then returns immediately. The loop runs as durable enqueued steps so a
-crash or restart resumes mid-turn. One `harness::turn` step does:
+the first `harness::turn` step, then returns immediately — or merges into a turn that is already
+running (see [Concurrency & steering](#concurrency--steering)). The loop runs as durable enqueued
+steps so a crash or restart resumes mid-turn (see
+[Durability & idempotency](#durability--idempotency)). Every `session::append` /
+`session::update_message` the loop issues carries `origin: { turn_id }`, so session events are
+attributable to a turn. One `harness::turn` step does:
 
 1. Mark working: `session::set_status working` (first step of a turn).
-2. Load active path: `session::messages`.
-3. Assemble context: `context::assemble` (skipped if `context-manager` absent -> raw messages + base
-   system prompt). Attach the single `agent_trigger` invocation schema to the router request (see
-   [Functions (the white box)](#functions-the-white-box)); function discovery is runtime — the model
-   calls `engine::functions::list` / `engine::functions::info` through `agent_trigger`.
-4. Generate: open a channel, call `router::chat`; `session::append` an assistant message, then
-   `session::update_message` as deltas arrive (each fires `session::message_updated`). Deltas may be
-   batched to throttle update frequency; the final update writes the complete `AssistantMessage`.
+2. Load active path: `session::messages` with `include_custom: true` (custom entries carry the
+   compaction record, below).
+3. Assemble context: read the latest compaction entry (if any) on the active path, reduce the
+   candidate window to it, and call `context::assemble` with `previous_summary` set (see
+   [Compaction persistence](#compaction-persistence)); skipped if `context-manager` absent -> raw
+   messages + base system prompt. If the response reports `applied.compacted`, persist the new
+   summary (same section). Attach the single `agent_trigger` invocation schema to the router request
+   (see [Functions (the white box)](#functions-the-white-box)); function discovery is runtime — the
+   model calls `engine::functions::list` / `engine::functions::info` through `agent_trigger`.
+4. Generate: open a channel, call `router::chat` with `request_id = <turn_id>:<step>` (recorded on
+   the turn record as `stream_request_id` for [`harness::stop`](#harnessstop)); `session::append` an
+   assistant message, then `session::update_message` as deltas arrive (each fires
+   `session::message_updated`). Deltas may be batched to throttle update frequency; the final update
+   writes the complete `AssistantMessage`.
 5. If the message has `function_call` content: unwrap each `agent_trigger` call, dispatch via
-   `harness::function::dispatch`, append each `function_result`, then re-enqueue `harness::turn` to
-   let the model react.
-6. Else, steering check: re-read `session::messages` for any user message appended after this turn
-   started (see [Triggers](#triggers)); if present, continue with another generate step; otherwise
-   mark the turn `completed`, `session::set_status done`, and stop.
+   `harness::function::dispatch` sequentially in content order (the `agent_trigger` schema declares
+   `execution_mode: "sequential"`), append each `function_result` — checkpointing per call (see
+   [Durability & idempotency](#durability--idempotency)) — then re-enqueue `harness::turn` to let
+   the model react.
+6. Else, steering check: re-read `session::messages` for user-role entries after the turn record's
+   `watermark_entry_id` (see [Concurrency & steering](#concurrency--steering)); if present, continue
+   with another generate step; otherwise mark the turn `completed`, `session::set_status done`, and
+   stop.
 
 A `max_turns` guard caps runaway loops (turn ends `completed` with a synthetic notice). Cancellation
-is cooperative: `harness::stop` sets an abort flag the next step checks, records `TurnStatus`
-`cancelled`, then sets `session::set_status done`.
+is cooperative *between* steps and explicit *during* generation: `harness::stop` sets an abort flag
+the next step checks, and when a stream is in flight it also calls
+[`router::abort`](llm-router.md#routerabort) with the `stream_request_id` recorded on the turn
+record. The generate step then finalises the partial assistant message (`stop_reason: "aborted"`),
+records `TurnStatus` `cancelled`, and sets `session::set_status done`.
 
 The harness maps the turn lifecycle onto the session's coarse status: `working` while a turn is
-running or awaiting functions, `done` once it ends (`completed`, `cancelled`, or `failed`). The
-internal `TurnStatus` (below) is finer-grained and stays inside the harness; consumers watch the
-session status for idle/working/done, and call `harness::status` when they need to distinguish
-completion from cancellation.
+running or awaiting functions, `done` when it ends `completed` or `cancelled`, and `error` (with a
+short `reason`) when it ends `failed`. The internal `TurnStatus` (below) is finer-grained and stays
+inside the harness; consumers watch the session status, and call `harness::status` when they need to
+distinguish completion from cancellation.
+
+## Compaction persistence
+
+`context-manager` is stateless — if nobody persists its compaction output, every turn past the
+budget re-summarises the whole head (one extra LLM call per turn) and summaries never converge. The
+harness is the caller, so the harness persists:
+
+- When `context::assemble` returns `applied.compacted: true`, the harness appends a `custom` session
+  entry — `{ custom_type: "compaction", data: { summary, tail_start_entry_id, tokens_before } }` —
+  mapping `applied.tail_start_index` onto the entry id of the loaded active path.
+- At the start of every assemble (loop step 3), the harness scans the loaded path for the **latest**
+  compaction entry. When present, the candidate window passed to `context::assemble` is only the
+  messages from `tail_start_entry_id` onward (compaction entries themselves are never sent), with
+  `options.previous_summary` set to the stored summary so a re-compaction updates it in place.
+- `options.lease_key` is always the `session_id`, so concurrent compactions of one session are
+  mutually excluded across workers.
+
+Result: one summarisation per overflow, amortised — not one per turn. The durable transcript is
+untouched; the compaction entry is loop bookkeeping the harness owns (see
+[context-manager.md § The compaction round trip](context-manager.md#the-compaction-round-trip)).
+
+## Durability & idempotency
+
+The `harness-turn` queue is **at-least-once**: any step may be redelivered after a crash, and every
+step must tolerate it. The rules:
+
+- **Stale-step guard.** Each dequeue compares `payload.step` to the turn record's current `step`; a
+  lower step is acked and dropped. The guard only catches *old* steps — redelivery of the *current*
+  step while it is still executing is indistinguishable from a resume, so the queue's
+  visibility/processing timeout MUST exceed the worst-case step duration (which the router's stream
+  idle timeout bounds — see
+  [llm-router.md § Stream liveness](llm-router.md#stream-liveness-and-cancellation)).
+- **Deterministic entry ids.** Every entry a step writes uses a deterministic id supplied via
+  `session::append`'s `entry_id` (idempotent: appending an existing id is a no-op). The assistant
+  message of a generate step is `e_<turn_id>_<step>_assistant`; a `function_result` is
+  `e_<turn_id>_<function_call_id>`. A redelivered step therefore writes into the same entries
+  instead of duplicating them: if the deterministic assistant entry already exists, the resumed
+  generate step streams into it via `session::update_message` rather than appending a second
+  message — a crash never yields two assistant messages.
+- **Per-call checkpoints.** The turn record carries
+  `calls: Record<function_call_id, { state: "dispatched" | "done"; entry_id?: string }>`. The
+  dispatch loop checkpoints `dispatched` *before* invoking the target function and `done` *after*
+  the `function_result` entry is appended. On redelivery: `done` calls are skipped; a call found
+  `dispatched` but not `done` is **not re-invoked** — the side effect may or may not have happened,
+  so the harness appends a synthetic `function_result` with `is_error: true`
+  (`"interrupted: executed at most once, result unknown (restart during execution)"`) and lets the
+  model decide whether to retry. Step delivery is at-least-once; function side effects are
+  at-most-once.
+- **Status writes** (`session::set_status`, turn record transitions) are naturally idempotent —
+  re-setting the same value is a no-op and fires no event.
+
+## Concurrency & steering
+
+One turn per session, enforced at the entry point:
+
+- **Turn CAS.** `harness::send` seeds the turn record with an atomic check-and-set: it creates a new
+  turn only if no record exists or the existing record is terminal (`completed` / `cancelled` /
+  `failed`). Two concurrent sends create exactly one turn — the loser of the CAS takes the merge
+  path.
+- **Merge path.** If a turn is already `running` / `awaiting_functions`, `harness::send` only
+  appends the user message and returns the running turn's id with `merged: true`. The running loop's
+  steering check folds the message in. A merged send never changes the running turn's `model`,
+  `system_prompt`, or `functions` policy — per-send options are stored on the turn record when the
+  turn is created and apply unchanged until it ends.
+- **Steering watermark.** The turn record stores `watermark_entry_id` — the active-path leaf
+  observed when the latest generate step assembled its context. The steering check (loop step 6)
+  asks `session::messages` for user-role entries **after the watermark**; if any exist it continues
+  with another generate step (advancing the watermark), otherwise the turn completes. "Arrived after
+  this turn started" is defined by entry position, never wall-clock time.
 
 ## Functions (the white box)
 
@@ -91,12 +179,21 @@ The harness:
 - Attaches **one** invocation schema (`agent_trigger`) to each `router::chat` request so the model
   can trigger any allowed function via `{ function, payload }`.
 - On `function_call` content: unwraps `agent_trigger` → target `function_id` + `payload`, enforces
-  allow/deny policy (see `harness::send` options or an approval sibling in v1), dispatches via
-  `iii.trigger({ function_id, payload })` through `harness::function::dispatch`, and captures the
-  result as a `function_result` message.
+  the dispatch policy below, dispatches via `iii.trigger({ function_id, payload })` through
+  `harness::function::dispatch`, and captures the result as a `function_result` message.
+
+The dispatch policy is **fail-closed**: a call is dispatched only if the target matches an `allow`
+glob and no `deny` glob (see `harness::send` options). When `options.functions` is omitted entirely,
+every call is denied with an `is_error` function_result explaining the policy — a default install is
+a plain chat loop until functions are explicitly allowed, or until an approval sibling upgrades "no
+match" from deny to a held approval (see
+[Out of scope](#out-of-scope-future-sibling-workers)).
 
 `engine::functions::list` is how the **model** discovers what's callable — by triggering it through
-`agent_trigger` at runtime — not how the harness builds a schema list at turn start.
+`agent_trigger` at runtime — not how the harness builds a schema list at turn start. The harness
+post-filters `engine::functions::list` / `engine::functions::info` results through the same
+allow/deny globs before folding them into the `function_result`, so the model only discovers
+functions it can actually call.
 
 A function can do anything an iii function can, including calling back to the consumer (the diagram's
 `funcs -> chat` edge) — that is the function's own behaviour, not the harness's.
@@ -111,6 +208,16 @@ Terminology: see [README.md § Terminology](README.md#terminology).
   function; capture its result.
 - `harness::stop` — Request cancellation of an in-flight turn.
 - `harness::status` — Read the current turn status for a session.
+
+## Agent exposure
+
+Deny-by-default for in-run agents (see [README § Security model](README.md#security-model)):
+
+- **Deny:** `harness::send` — self-invocation: a model that can start turns can fork unbounded loops
+  outside any `max_turns` guard (the prior deployment denies `run::start` for the same reason);
+  `harness::turn` (internal); `harness::function::dispatch` (forged call ids, policy re-entry);
+  `harness::stop`.
+- **Safe:** `harness::status` (read-only).
 
 ## Triggers
 
@@ -139,12 +246,13 @@ iii.registerFunction("harness::on_steering", async (evt) => {
     status.status === "cancelled" ||
     status.status === "failed"
   ) {
+    // model/options for the fresh turn come from app config — a merged send ignores them anyway.
     await iii.trigger({
       function_id: "harness::send",
       payload: { session_id: evt.session_id, message: evt.message, model: "<model>" },
     });
   }
-  // else: a turn is running; its steering check re-reads session::messages and folds this in.
+  // else: a turn is running; its steering check (watermark) folds this message in.
 });
 
 iii.registerTrigger({
@@ -160,8 +268,8 @@ This is opt-in; the default harness has no bound triggers.
 
 ## API Reference
 
-Shared types (`AgentMessage`, `ContentBlock`, `AssistantMessage`, `AgentFunction`) are defined in
-[README.md § Cross-cutting contracts](README.md#cross-cutting-contracts).
+Shared types (`AgentMessage`, `ContentBlock`, `AssistantMessage`, `AgentFunction`, `ThinkingLevel`)
+are defined in [README.md § Cross-cutting contracts](README.md#cross-cutting-contracts).
 
 ```typescript
 type TurnStatus =
@@ -175,7 +283,9 @@ type TurnStatus =
 ### `harness::send`
 
 Accept an incoming message, ensure the session, append the user message, and enqueue the first turn
-step. Returns before the turn runs.
+step. Returns before the turn runs. If a turn is already running for the session, the message is
+appended and folded into it instead — no second turn starts (see
+[Concurrency & steering](#concurrency--steering)).
 
 - Invocation: **sync** (kicks an async/enqueued loop)
 
@@ -184,13 +294,14 @@ Request:
 ```typescript
 type SendRequest = {
   session_id?: string;            // omit to create a new session
-  message: AgentMessage | string; // string is sugar for a user text message
+  message: AgentMessage | string; // string is sugar for a user text message;
+                                  // role must be "user" or "custom" (else harness/invalid_message_role)
   model: string;
   provider?: string;
   options?: {
     system_prompt?: string;
     max_turns?: number;           // default 16
-    thinking_level?: string;
+    thinking_level?: ThinkingLevel;
     functions?: {
       allow?: string[];           // function_id globs the agent may dispatch to (e.g. "shell::*")
       deny?: string[];
@@ -205,8 +316,9 @@ Response:
 ```typescript
 type SendResponse = {
   session_id: string;
-  turn_id: string;     // identifies this loop invocation
+  turn_id: string;     // the new turn — or the running turn when merged
   accepted: true;
+  merged?: boolean;    // true when folded into an in-flight turn (steering)
 };
 ```
 
@@ -222,8 +334,9 @@ Example:
 
 ### `harness::turn`
 
-Internal durable loop step. Documented for completeness; consumers do not call it. Enqueued onto a
-FIFO `harness-turn` queue; each run advances one step of [the loop](#the-loop).
+Internal durable loop step. Documented for completeness; consumers do not call it. Enqueued onto the
+`harness-turn` queue (FIFO per session, parallel across sessions — see
+[Dependencies](#dependencies)); each run advances one step of [the loop](#the-loop).
 
 - Invocation: **enqueue** (`TriggerAction.Enqueue({ queue: "harness-turn" })`)
 
@@ -240,9 +353,10 @@ type TurnStepResult = {
 };
 ```
 
-Failure handling: an unexpected throw marks the turn `failed` and appends a `custom`
-(`custom_type: "error"`) entry so the UI sees the reason. A step may opt into queue retry/backoff for
-transient provider errors instead of failing the turn.
+Failure handling: an unexpected throw marks the turn `failed`, appends a `custom`
+(`custom_type: "error"`) entry so the UI sees the reason, and sets `session::set_status error` with
+a short `reason`. A step may opt into queue retry/backoff for transient provider errors instead of
+failing the turn (subject to [Durability & idempotency](#durability--idempotency)).
 
 ### `harness::function::dispatch`
 
@@ -271,14 +385,15 @@ type FunctionDispatchResponse = {
 };
 ```
 
-The harness performs no approval check here in v1; gating is delegated to an optional approval sibling
-that can wrap or precede dispatch (see [Out of scope](#out-of-scope-future-sibling-workers)).
+v1 enforces the fail-closed allow/deny globs only — there is no *hold* state. Approval-with-hold
+(park the call, resume on a decision) is delegated to an optional approval sibling that can wrap or
+precede dispatch (see [Out of scope](#out-of-scope-future-sibling-workers)).
 
 ### `harness::stop`
 
-Request cancellation. Sets an abort flag the next `harness::turn` step observes; an in-flight provider
-stream is closed best-effort. The turn record transitions to `cancelled` before `session::set_status
-done`.
+Request cancellation. Sets an abort flag the next `harness::turn` step observes, and aborts an
+in-flight stream via [`router::abort`](llm-router.md#routerabort) using the `stream_request_id` on
+the turn record. The turn record transitions to `cancelled` before `session::set_status done`.
 
 - Invocation: **sync**
 
@@ -310,7 +425,7 @@ type StatusResponse = {
 
 | Scope | Key | Value | Purpose |
 |---|---|---|---|
-| `harness_turn` | `<session_id>` | turn record `{ turn_id, status, step, turn_count, abort? }` | Loop progress; survives restart. |
+| `harness_turn` | `<session_id>` | turn record `{ turn_id, status, step, turn_count, abort?, watermark_entry_id?, stream_request_id?, options, calls }` | Loop progress, per-send options, per-call checkpoints, steering watermark; survives restart. Seeded by CAS from `harness::send` (see [Concurrency & steering](#concurrency--steering)). |
 
 Transcript truth lives in [session-manager](session-manager.md); the harness keeps only loop
 bookkeeping.
@@ -321,7 +436,9 @@ bookkeeping.
   and set status. Required.
 - `llm-router` (`router::chat`) — generation. Required.
 - `context-manager` (`context::assemble`) — context budgeting. Soft; degrades to raw history.
-- `iii-queue` — the durable `harness-turn` loop.
+- `iii-queue` — the durable `harness-turn` loop. The queue MUST provide per-session ordering with
+  cross-session parallelism (partition by `session_id`); a single global FIFO would head-of-line
+  block every session behind one long stream step.
 - iii engine `iii.trigger` — function dispatch (`agent_trigger` unwrap → target function).
 
 ## Out of scope (future sibling workers)

--- a/tech-specs/2026-06-agentic/harness.md
+++ b/tech-specs/2026-06-agentic/harness.md
@@ -6,7 +6,7 @@ Worker prefix: `harness::*`
 
 `harness` is the thin worker that wires the other three into an agent loop. It owns sequencing and
 nothing else: take an incoming message, persist it, assemble a context, stream a completion, persist
-the result, run any tool calls, and repeat until the turn stops.
+the result, execute any function calls, and repeat until the turn stops.
 
 It is deliberately minimal. The rule of thumb: **if a concern grows real logic, it becomes its own
 worker** rather than living in the harness. Approval gating, spend budgets, compaction *scheduling*,
@@ -14,7 +14,7 @@ hook fan-out, and multi-agent handoff are all out of scope here — they are sib
 call or that can subscribe around it (see [Out of scope](#out-of-scope-future-sibling-workers)).
 
 The harness is the only worker in this spec that depends on the other three, and even those are soft:
-without `context-manager` it sends raw history; without tool functions it is a plain chat loop. It
+without `context-manager` it sends raw history; without function dispatch it is a plain chat loop. It
 needs `session-manager` (to persist/stream) and `llm-router` (to generate).
 
 ## What it wires
@@ -26,7 +26,7 @@ sequenceDiagram
   participant S as session-manager
   participant X as context-manager
   participant R as llm-router
-  participant F as iii function (tool)
+  participant F as iii function
 
   C->>H: harness::send {message, model}
   H->>S: session::create or ensure
@@ -39,12 +39,12 @@ sequenceDiagram
   H->>R: router::chat (over channel)
   R-->>H: AssistantMessageEvent frames
   H->>S: session::append (assistant) then session::update_message (stream deltas)
-  alt assistant requested tool calls
+  alt assistant requested function calls
     H->>F: iii.trigger(function_id, args)
     F-->>H: result
     H->>S: session::append (function_result)
     Note over H: re-enqueue harness::turn
-  else no tool calls
+  else no function calls
     H->>S: session::set_status done
   end
 ```
@@ -58,41 +58,57 @@ crash or restart resumes mid-turn. One `harness::turn` step does:
 1. Mark working: `session::set_status working` (first step of a turn).
 2. Load active path: `session::messages`.
 3. Assemble context: `context::assemble` (skipped if `context-manager` absent -> raw messages + base
-   system prompt). Tools come from the engine registry (see [Tools](#tools-the-white-box)).
+   system prompt). Attach the single `agent_trigger` invocation schema to the router request (see
+   [Functions (the white box)](#functions-the-white-box)); function discovery is runtime — the model
+   calls `engine::functions::list` / `engine::functions::info` through `agent_trigger`.
 4. Generate: open a channel, call `router::chat`; `session::append` an assistant message, then
    `session::update_message` as deltas arrive (each fires `session::message_updated`). Deltas may be
    batched to throttle update frequency; the final update writes the complete `AssistantMessage`.
-5. If the message has `function_call` content: dispatch each via `harness::tool::dispatch`, append
-   each `function_result`, then re-enqueue `harness::turn` to let the model react.
+5. If the message has `function_call` content: unwrap each `agent_trigger` call, dispatch via
+   `harness::function::dispatch`, append each `function_result`, then re-enqueue `harness::turn` to
+   let the model react.
 6. Else, steering check: re-read `session::messages` for any user message appended after this turn
    started (see [Triggers](#triggers)); if present, continue with another generate step; otherwise
-   `session::set_status done` and stop.
+   mark the turn `completed`, `session::set_status done`, and stop.
 
-A `max_turns` guard caps runaway loops. Cancellation is cooperative: `harness::stop` sets an abort
-flag the next step checks, then sets `session::set_status done`.
+A `max_turns` guard caps runaway loops (turn ends `completed` with a synthetic notice). Cancellation
+is cooperative: `harness::stop` sets an abort flag the next step checks, records `TurnStatus`
+`cancelled`, then sets `session::set_status done`.
 
 The harness maps the turn lifecycle onto the session's coarse status: `working` while a turn is
-running or awaiting tools, `done` once it stops. The internal `TurnStatus` (below) is finer-grained
-and stays inside the harness; consumers watch the session status instead.
+running or awaiting functions, `done` once it ends (`completed`, `cancelled`, or `failed`). The
+internal `TurnStatus` (below) is finer-grained and stays inside the harness; consumers watch the
+session status for idle/working/done, and call `harness::status` when they need to distinguish
+completion from cancellation.
 
-## Tools (the white box)
+## Functions (the white box)
 
-"Tools" are not a harness feature — they are the **iii substrate**. Any registered iii function is a
-candidate tool. The harness:
+Functions are not a harness feature — they are the **iii substrate**. Any registered iii function is
+callable; the harness **does not** map registry entries into provider tool schemas.
 
-- Discovers them via `engine::functions::list` and builds the `AgentFunction[]` tool schema
-  (filtered by an allow-list/namespace policy supplied in `options`).
-- Dispatches a model-chosen call with `iii.trigger({ function_id, payload })` via
-  `harness::tool::dispatch`, capturing the result as a `function_result` message.
+The harness:
 
-A tool can do anything an iii function can, including calling back to the consumer (the diagram's
-`funcs -> chat` edge) — that is the tool's own behaviour, not the harness's.
+- Attaches **one** invocation schema (`agent_trigger`) to each `router::chat` request so the model
+  can trigger any allowed function via `{ function, payload }`.
+- On `function_call` content: unwraps `agent_trigger` → target `function_id` + `payload`, enforces
+  allow/deny policy (see `harness::send` options or an approval sibling in v1), dispatches via
+  `iii.trigger({ function_id, payload })` through `harness::function::dispatch`, and captures the
+  result as a `function_result` message.
 
-## Functions
+`engine::functions::list` is how the **model** discovers what's callable — by triggering it through
+`agent_trigger` at runtime — not how the harness builds a schema list at turn start.
+
+A function can do anything an iii function can, including calling back to the consumer (the diagram's
+`funcs -> chat` edge) — that is the function's own behaviour, not the harness's.
+
+Terminology: see [README.md § Terminology](README.md#terminology).
+
+## Registered functions
 
 - `harness::send` — Entry point: persist the incoming message and kick off a turn; returns fast.
 - `harness::turn` — Internal durable loop step (enqueued); not called directly by consumers.
-- `harness::tool::dispatch` — Internal: invoke one iii function as a tool and capture its result.
+- `harness::function::dispatch` — Internal: unwrap an `agent_trigger` call and invoke the target iii
+  function; capture its result.
 - `harness::stop` — Request cancellation of an in-flight turn.
 - `harness::status` — Read the current turn status for a session.
 
@@ -117,7 +133,12 @@ iii.registerFunction("harness::on_steering", async (evt) => {
     function_id: "harness::status",
     payload: { session_id: evt.session_id },
   });
-  if (!status || status.status === "stopped" || status.status === "failed") {
+  if (
+    !status ||
+    status.status === "completed" ||
+    status.status === "cancelled" ||
+    status.status === "failed"
+  ) {
     await iii.trigger({
       function_id: "harness::send",
       payload: { session_id: evt.session_id, message: evt.message, model: "<model>" },
@@ -143,7 +164,12 @@ Shared types (`AgentMessage`, `ContentBlock`, `AssistantMessage`, `AgentFunction
 [README.md § Cross-cutting contracts](README.md#cross-cutting-contracts).
 
 ```typescript
-type TurnStatus = "running" | "awaiting_tools" | "stopped" | "failed";
+type TurnStatus =
+  | "running"              // generating or between durable steps
+  | "awaiting_functions"   // dispatching function calls / collecting results
+  | "completed"            // turn finished normally (incl. max_turns cap)
+  | "cancelled"            // harness::stop observed
+  | "failed";              // unexpected error; turn record carries reason
 ```
 
 ### `harness::send`
@@ -165,8 +191,8 @@ type SendRequest = {
     system_prompt?: string;
     max_turns?: number;           // default 16
     thinking_level?: string;
-    tools?: {
-      allow?: string[];           // function_id globs to expose (e.g. "shell::*")
+    functions?: {
+      allow?: string[];           // function_id globs the agent may dispatch to (e.g. "shell::*")
       deny?: string[];
     };
     metadata?: Record<string, unknown>; // tracing passthrough (session_id/message_id propagate)
@@ -189,7 +215,7 @@ Example:
 ```jsonc
 // request
 { "message": "Summarise the repo README", "model": "claude-sonnet-4", "provider": "anthropic",
-  "options": { "tools": { "allow": ["shell::*", "fs::*"] } } }
+  "options": { "functions": { "allow": ["shell::*", "fs::*"] } } }
 // response
 { "session_id": "s_7a1", "turn_id": "t_001", "accepted": true }
 ```
@@ -218,15 +244,16 @@ Failure handling: an unexpected throw marks the turn `failed` and appends a `cus
 (`custom_type: "error"`) entry so the UI sees the reason. A step may opt into queue retry/backoff for
 transient provider errors instead of failing the turn.
 
-### `harness::tool::dispatch`
+### `harness::function::dispatch`
 
-Invoke a single iii function as a tool and return a normalised result. Internal to the loop but also
-callable directly to execute a one-off tool with the same result shape.
+Invoke a single iii function and return a normalised result. The loop unwraps `agent_trigger` before
+calling this; it can also be called directly with an already-unwrapped target `function_id` +
+`arguments`.
 
 - Invocation: **sync**
 
 ```typescript
-type ToolDispatchRequest = {
+type FunctionDispatchRequest = {
   session_id: string;
   call: {
     id: string;            // function_call id, echoed into the result
@@ -234,10 +261,10 @@ type ToolDispatchRequest = {
     arguments: unknown;
   };
 };
-type ToolDispatchResponse = {
+type FunctionDispatchResponse = {
   function_call_id: string;
   function_id: string;
-  content: ContentBlock[]; // tool output, normalised to content blocks
+  content: ContentBlock[]; // function output, normalised to content blocks
   is_error: boolean;
   details?: unknown;
   duration_ms: number;
@@ -250,7 +277,8 @@ that can wrap or precede dispatch (see [Out of scope](#out-of-scope-future-sibli
 ### `harness::stop`
 
 Request cancellation. Sets an abort flag the next `harness::turn` step observes; an in-flight provider
-stream is closed best-effort.
+stream is closed best-effort. The turn record transitions to `cancelled` before `session::set_status
+done`.
 
 - Invocation: **sync**
 
@@ -272,7 +300,7 @@ type StatusResponse = {
   step: number;
   turn_count: number;
   max_turns: number;
-  pending_tool_calls: string[];   // function_call ids awaiting results
+  pending_function_calls: string[];   // function_call ids awaiting results
 } | null;                          // null for unknown sessions
 ```
 
@@ -294,18 +322,18 @@ bookkeeping.
 - `llm-router` (`router::chat`) — generation. Required.
 - `context-manager` (`context::assemble`) — context budgeting. Soft; degrades to raw history.
 - `iii-queue` — the durable `harness-turn` loop.
-- iii engine `engine::functions::list` + `iii.trigger` — tool discovery and dispatch.
+- iii engine `iii.trigger` — function dispatch (`agent_trigger` unwrap → target function).
 
 ## Out of scope (future sibling workers)
 
 Kept out to preserve thinness; each is a clean add-on that wraps the loop or subscribes to its events:
 
-- **approval-gate** — intercept `harness::tool::dispatch` (or a pre-dispatch hook) to allow / deny /
-  hold tool calls against a policy; resume via a state trigger.
+- **approval-gate** — intercept `harness::function::dispatch` (or a pre-dispatch hook) to allow / deny /
+  hold function calls against a policy; resume via a state trigger.
 - **llm-budget** — track spend from `router` usage and cap per workspace/agent.
 - **context-scheduler** — decide *when* to compact (the optional reactive trigger in
   [context-manager](context-manager.md#triggers)); the harness only compacts inline on overflow.
-- **hook-fanout** — publish-and-collect lifecycle hooks around turns/tools.
+- **hook-fanout** — publish-and-collect lifecycle hooks around turns and function dispatch.
 - **multi-agent / orchestrator** — agent-to-agent handoff via queues; the harness runs one agent
   loop.
 
@@ -317,5 +345,5 @@ harness calls (config-driven) over embedding the logic.
 - Does **not** store the transcript, build context, or talk to providers itself — it calls the other
   three.
 - Does **not** gate approvals, meter cost, or schedule compaction in v1.
-- Does **not** define tools — tools are any iii function; the harness only discovers and dispatches
-  them.
+- Does **not** define functions — functions are the iii substrate; the harness only exposes the
+  `agent_trigger` invocation surface and dispatches what the model requests.

--- a/tech-specs/2026-06-agentic/harness.md
+++ b/tech-specs/2026-06-agentic/harness.md
@@ -9,9 +9,16 @@ nothing else: take an incoming message, persist it, assemble a context, stream a
 the result, execute any function calls, and repeat until the turn stops.
 
 It is deliberately minimal. The rule of thumb: **if a concern grows real logic, it becomes its own
-worker** rather than living in the harness. Approval gating, spend budgets, compaction *scheduling*,
-hook fan-out, and multi-agent handoff are all out of scope here — they are siblings the harness can
-call or that can subscribe around it (see [Out of scope](#out-of-scope-future-sibling-workers)).
+worker** rather than living in the harness. Approval gating, spend budgets, and compaction
+*scheduling* are all out of scope here — they are siblings the harness can call or that can
+subscribe around it (see [Out of scope](#out-of-scope-future-sibling-workers)). Three extension
+surfaces do live here, because they need the loop's durability machinery: **deferred function
+results** (a dispatch may park the turn and resolve later — see
+[Deferred dispatch](#deferred-dispatch-pending-function-results)), **sub-agent spawning** built on
+top of it (see [Sub-agents](#sub-agents-harnessspawn)), and **hooks** (the synchronous points where
+siblings veto, hold, or mutate in-path — see [Hooks](#hooks)). Children are ordinary harness
+sessions/turns; orchestration beyond spawn/join stays out of scope, and hook *logic* (the policy
+itself) always lives in the sibling that registers it.
 
 The harness is the only worker in this spec that depends on the other three, and even those are soft:
 without `context-manager` it sends raw history; without function dispatch it is a plain chat loop. It
@@ -47,6 +54,8 @@ sequenceDiagram
     F-->>H: result
     H->>S: session::append (function_result)
     Note over H: re-enqueue harness::turn
+  else pending dispatch (e.g. harness::spawn)
+    Note over H: park turn — child session runs its own loop;<br/>harness::function::resolve re-enqueues
   else no function calls
     H->>S: session::set_status done
   end
@@ -54,51 +63,82 @@ sequenceDiagram
 
 ## The loop
 
-`harness::send` is the entry point; it ensures the session, persists the user message, and enqueues
-the first `harness::turn` step, then returns immediately — or merges into a turn that is already
-running (see [Concurrency & steering](#concurrency--steering)). The loop runs as durable enqueued
+`harness::send` is the entry point; it ensures the session (applying `session.metadata`, the
+tenancy hook), persists the user message, and enqueues the first `harness::turn` step, then returns
+immediately — or merges into a turn that is already running (see
+[Concurrency & steering](#concurrency--steering)). [`harness::run`](#harnessrun) is the same path
+with the call held open until the turn ends; [`harness::spawn`](#harnessspawn) seeds a child
+session through the same CAS. The loop runs as durable enqueued
 steps so a crash or restart resumes mid-turn (see
 [Durability & idempotency](#durability--idempotency)). Every `session::append` /
 `session::update_message` the loop issues carries `origin: { turn_id }`, so session events are
 attributable to a turn. One `harness::turn` step does:
 
-1. Mark working: `session::set_status working` (first step of a turn).
+1. Mark working: `session::set_status working` and emit
+   [`harness::turn_started`](#trigger-types-emitted) (first step of a turn), then run the
+   `pre_turn` [hook chain](#hooks) — a `deny` ends the turn (`failed`, with the hook's reason)
+   before any model spend.
 2. Load active path: `session::messages` with `include_custom: true` (custom entries carry the
    compaction record, below).
 3. Assemble context: read the latest compaction entry (if any) on the active path, reduce the
    candidate window to it, and call `context::assemble` with `previous_summary` set (see
    [Compaction persistence](#compaction-persistence)); skipped if `context-manager` absent -> raw
    messages + base system prompt. If the response reports `applied.compacted`, persist the new
-   summary (same section). Attach the single `agent_trigger` invocation schema to the router request
-   (see [Functions (the white box)](#functions-the-white-box)); function discovery is runtime — the
-   model calls `engine::functions::list` / `engine::functions::info` through `agent_trigger`.
+   summary (same section). Attach the invocation schemas to the router request: the single
+   `agent_trigger` schema by default (function discovery is runtime — the model calls
+   `engine::functions::list` / `engine::functions::info` through it), or one schema per allowed
+   function when `functions.expose: "native"` (see
+   [Functions (the white box)](#functions-the-white-box)) — plus the synthetic `submit_result`
+   schema when an [output contract](#output-contract) uses the fallback strategy. Finally run the
+   `pre_generate` [hook chain](#hooks) over the assembled context — hooks may extend the system
+   prompt or append bounded messages (memory, RAG, guardrails); a `deny` ends the turn as in
+   step 1.
 4. Generate: open a channel, call `router::chat` with `request_id = <turn_id>:<step>` (recorded on
-   the turn record as `stream_request_id` for [`harness::stop`](#harnessstop)); `session::append` an
+   the turn record as `stream_request_id` for [`harness::stop`](#harnessstop)) and — when the
+   [output contract](#output-contract) rides provider-native structured output —
+   `response_format`; `session::append` an
    assistant message, then `session::update_message` as deltas arrive (each fires
    `session::message_updated`). Deltas may be batched to throttle update frequency; the final update
-   writes the complete `AssistantMessage`.
-5. If the message has `function_call` content: unwrap each `agent_trigger` call, dispatch via
-   `harness::function::dispatch` sequentially in content order (the `agent_trigger` schema declares
-   `execution_mode: "sequential"`), append each `function_result` — checkpointing per call (see
-   [Durability & idempotency](#durability--idempotency)) — then re-enqueue `harness::turn` to let
-   the model react.
+   writes the complete `AssistantMessage`. After the final update, run the read-only
+   `post_generate` [hook chain](#hooks) (usage accounting, safety logging).
+5. If the message has `function_call` content: a `submit_result` call (present only when an
+   [output contract](#output-contract) is active) is consumed by the harness itself — validate,
+   record the result on the turn record, and finalise as in step 6. Everything else is an
+   `agent_trigger` call: unwrap each, dispatch via `harness::function::dispatch` sequentially in
+   content order (the schema declares `execution_mode: "sequential"`) — each dispatch runs the
+   glob policy, then the `pre_dispatch` [hook chain](#hooks), then the target, then the
+   `post_dispatch` chain over the result — and append each
+   `function_result` — checkpointing per call (see
+   [Durability & idempotency](#durability--idempotency)). A dispatch may report **pending** instead
+   of returning a result (a `pre_dispatch` *hold*, or e.g.
+   [`harness::spawn`](#harnessspawn)): the call checkpoints as
+   `pending` and, once the dispatch pass ends, the turn **parks** — the step ends without
+   re-enqueueing, and [`harness::function::resolve`](#harnessfunctionresolve) resumes the loop
+   later (see [Deferred dispatch](#deferred-dispatch-pending-function-results)). With no pending
+   calls, re-enqueue `harness::turn` to let the model react.
 6. Else, steering check: re-read `session::messages` for user-role entries after the turn record's
    `watermark_entry_id` (see [Concurrency & steering](#concurrency--steering)); if present, continue
-   with another generate step; otherwise mark the turn `completed`, `session::set_status done`, and
-   stop.
+   with another generate step. Otherwise finalise: resolve the turn `result` per the
+   [output contract](#output-contract) (a schema-bearing contract with no valid result yet nudges
+   instead, bounded), mark the turn `completed`, `session::set_status done`, emit
+   [`harness::turn_completed`](#trigger-types-emitted), and — for a sub-agent turn — resolve the
+   parent's pending call (see [Sub-agents](#sub-agents-harnessspawn)).
 
 A `max_turns` guard caps runaway loops (turn ends `completed` with a synthetic notice). Cancellation
 is cooperative *between* steps and explicit *during* generation: `harness::stop` sets an abort flag
 the next step checks, and when a stream is in flight it also calls
 [`router::abort`](llm-router.md#routerabort) with the `stream_request_id` recorded on the turn
 record. The generate step then finalises the partial assistant message (`stop_reason: "aborted"`),
-records `TurnStatus` `cancelled`, and sets `session::set_status done`.
+records `TurnStatus` `cancelled`, and sets `session::set_status done`. When the turn has live
+spawned children, the stop cascades to them before the turn finalises (see
+[Sub-agents](#sub-agents-harnessspawn)).
 
 The harness maps the turn lifecycle onto the session's coarse status: `working` while a turn is
 running or awaiting functions, `done` when it ends `completed` or `cancelled`, and `error` (with a
 short `reason`) when it ends `failed`. The internal `TurnStatus` (below) is finer-grained and stays
-inside the harness; consumers watch the session status, and call `harness::status` when they need to
-distinguish completion from cancellation.
+inside the harness; consumers watch the session status, bind
+[`harness::turn_completed`](#trigger-types-emitted) for turn outcomes (terminal status + result),
+or call `harness::status` when they need a point-in-time read.
 
 ## Compaction persistence
 
@@ -130,7 +170,9 @@ step must tolerate it. The rules:
   step while it is still executing is indistinguishable from a resume, so the queue's
   visibility/processing timeout MUST exceed the worst-case step duration (which the router's stream
   idle timeout bounds — see
-  [llm-router.md § Stream liveness](llm-router.md#stream-liveness-and-cancellation)).
+  [llm-router.md § Stream liveness](llm-router.md#stream-liveness-and-cancellation)). [Hook](#hooks)
+  chains run inside the step, so their `timeout_ms` budgets count toward this bound too; a
+  `pre_dispatch` *hold* does not — it parks the turn instead of blocking the step.
 - **Deterministic entry ids.** Every entry a step writes uses a deterministic id supplied via
   `session::append`'s `entry_id` (idempotent: appending an existing id is a no-op). The assistant
   message of a generate step is `e_<turn_id>_<step>_assistant`; a `function_result` is
@@ -139,11 +181,15 @@ step must tolerate it. The rules:
   generate step streams into it via `session::update_message` rather than appending a second
   message — a crash never yields two assistant messages.
 - **Per-call checkpoints.** The turn record carries
-  `calls: Record<function_call_id, { state: "dispatched" | "done"; entry_id?: string }>`. The
-  dispatch loop checkpoints `dispatched` *before* invoking the target function and `done` *after*
-  the `function_result` entry is appended. On redelivery: `done` calls are skipped; a call found
-  `dispatched` but not `done` is **not re-invoked** — the side effect may or may not have happened,
-  so the harness appends a synthetic `function_result` with `is_error: true`
+  `calls: Record<function_call_id, { state: "dispatched" | "pending" | "done"; entry_id?: string;
+  child_session_id?: string; child_turn_id?: string; held_by?: string }>`. The dispatch loop
+  checkpoints `dispatched`
+  *before* invoking the target function, `pending` when the dispatch defers its result (see
+  [Deferred dispatch](#deferred-dispatch-pending-function-results)), and `done` *after* the
+  `function_result` entry is appended. On redelivery: `done` calls are skipped; `pending` calls stay
+  parked (their result arrives via `harness::function::resolve`, idempotent on the deterministic
+  entry id); a call found `dispatched` but not `done` is **not re-invoked** — the side effect may or
+  may not have happened, so the harness appends a synthetic `function_result` with `is_error: true`
   (`"interrupted: executed at most once, result unknown (restart during execution)"`) and lets the
   model decide whether to retry. Step delivery is at-least-once; function side effects are
   at-most-once.
@@ -163,6 +209,11 @@ One turn per session, enforced at the entry point:
   steering check folds the message in. A merged send never changes the running turn's `model`,
   `system_prompt`, or `functions` policy — per-send options are stored on the turn record when the
   turn is created and apply unchanged until it ends.
+  **Merge double-check.** The append races the loop's completion: the steering check (step 6) may
+  read before the append and complete after it, which would strand the message until the next send.
+  So after appending, the merge path re-reads the turn record — if the turn went terminal in that
+  window, it re-runs the CAS and starts a fresh turn for the appended message. A merged send is
+  never silently dropped.
 - **Steering watermark.** The turn record stores `watermark_entry_id` — the active-path leaf
   observed when the latest generate step assembled its context. The steering check (loop step 6)
   asks `session::messages` for user-role entries **after the watermark**; if any exist it continues
@@ -176,8 +227,9 @@ callable; the harness **does not** map registry entries into provider tool schem
 
 The harness:
 
-- Attaches **one** invocation schema (`agent_trigger`) to each `router::chat` request so the model
-  can trigger any allowed function via `{ function, payload }`.
+- Attaches **one** invocation schema (`agent_trigger`) to each `router::chat` request by default,
+  so the model can trigger any allowed function via `{ function, payload }` (per-function schemas
+  in native exposure mode — see [Exposure modes](#functions-the-white-box) below).
 - On `function_call` content: unwraps `agent_trigger` → target `function_id` + `payload`, enforces
   the dispatch policy below, dispatches via `iii.trigger({ function_id, payload })` through
   `harness::function::dispatch`, and captures the result as a `function_result` message.
@@ -195,36 +247,397 @@ post-filters `engine::functions::list` / `engine::functions::info` results throu
 allow/deny globs before folding them into the `function_result`, so the model only discovers
 functions it can actually call.
 
+**Exposure modes.** `options.functions.expose` selects how allowed functions reach the model:
+
+- `"agent_trigger"` (default) — the single generic schema above. Zero per-function schema tokens;
+  discovery happens at runtime.
+- `"native"` — at turn start the harness expands the `allow` globs against the registry
+  (`engine::functions::list` / `engine::functions::info`) and attaches one provider tool schema per
+  allowed function. Models follow concrete per-function schemas more reliably than a generic
+  `{ function, payload }` wrapper, and no turns are spent on discovery — the right mode for narrow
+  agents (sub-agents especially) with small fixed toolsets. Costs registry reads at turn start and
+  schema tokens per function, so keep the allow-list tight.
+
+Both modes enforce the same fail-closed allow/deny policy at dispatch time; `expose` changes only
+what the model sees. The synthetic `submit_result` schema (see [Output contract](#output-contract))
+is harness-internal in either mode and is never dispatched through `iii.trigger`.
+
 A function can do anything an iii function can, including calling back to the consumer (the diagram's
 `funcs -> chat` edge) — that is the function's own behaviour, not the harness's.
 
 Terminology: see [README.md § Terminology](README.md#terminology).
 
+## Deferred dispatch (pending function results)
+
+Some calls cannot resolve inside a dispatch: a sub-agent that runs for minutes, or an approval that
+waits for a human. Holding the queue step open would break the durability contract (the visibility
+timeout must exceed the worst-case step duration) and would serialise independent work. Dispatch
+may therefore defer:
+
+- `harness::function::dispatch` may return `{ pending: true }` instead of a result. The dispatch
+  loop checkpoints the call as `state: "pending"` and continues with the remaining calls in the
+  message.
+- When the dispatch pass ends with unresolved pending calls, the turn **parks**: the step ends
+  *without* re-enqueueing `harness::turn`, the turn stays `awaiting_functions`, and **no queue step
+  is held** while the deferred work runs — pending calls never stretch the visibility-timeout
+  bound.
+- [`harness::function::resolve`](#harnessfunctionresolve) delivers the result later: it appends the
+  `function_result` under the same deterministic entry id a direct dispatch would have used
+  (`e_<turn_id>_<function_call_id>`), flips the checkpoint to `done`, and — when it resolved the
+  last pending call — re-enqueues `harness::turn` so the model reacts. Duplicate resolves hit the
+  existing entry id and are no-ops.
+- Every pending call carries a `pending_timeout_ms` (default 30 minutes). A periodic sweep resolves
+  expired calls with `is_error: true` (`"pending call timed out"`), so a lost child or an abandoned
+  approval can never park a turn forever.
+- Steering still works while parked: user messages appended in the meantime sit after the
+  watermark and fold in on resume (see [Concurrency & steering](#concurrency--steering)).
+
+[`harness::spawn`](#sub-agents-harnessspawn) is the built-in pending dispatch. The mechanism is
+deliberately general: an approval sibling implements *hold* by returning `pending` from a
+pre-dispatch hook and calling `harness::function::resolve` on the human decision — no new loop
+machinery (see [Out of scope](#out-of-scope-future-sibling-workers)).
+
+## Sub-agents (`harness::spawn`)
+
+A sub-agent is an ordinary harness run in a **child session**, spawned as a function call from a
+parent turn. Each child gets its own goal (the spawn `task`), its own policy, and — via the
+[output contract](#output-contract) — its own typed deliverable: free text, JSON, or
+schema-validated JSON. The model calls `harness::spawn` through `agent_trigger`; the dispatch
+reports the call **pending**, the parent parks, the child runs its own turns on the `harness-turn`
+queue (parallel across sessions by construction — spawn three children and they run concurrently),
+and the child's completion resolves the parent's call with the child's result.
+
+The spawn dispatch, step by step:
+
+1. **Guards** — violations fail the call with an `is_error` function_result, never a throw:
+   `harness::spawn` must match the parent's allow globs (fail-closed, like any target);
+   `depth + 1 > max_depth` (default 3) is refused (`harness/spawn_depth_exceeded`); non-terminal
+   children of this turn at or above `max_children` (default 5) is refused
+   (`harness/spawn_fanout_exceeded`).
+2. **Policy subsetting.** The child's function policy is the requested one **intersected with the
+   parent's**: a child `allow` matches only what the parent's `allow` also matches, and parent
+   `deny` globs are inherited. A child can narrow, never escalate. The child's `max_turns` is
+   capped at the parent's remaining turn budget.
+3. **Create the child session** with linkage metadata merged into `SessionMeta.metadata` —
+   `{ parent_session_id, parent_turn_id, function_call_id, depth }` — so UIs reconstruct the tree
+   and trigger configs can filter on it (see
+   [session-manager.md § Sub-agent linkage](session-manager.md#sub-agent-linkage)).
+4. **CAS-create the child turn** (the same seed path as `harness::send`) with the subset policy,
+   `depth = parent.depth + 1`, the `task` as the opening user message, and the requested output
+   contract. Record `calls[call_id] = { state: "pending", child_session_id, child_turn_id }` on the
+   parent turn record and report pending — the parent parks.
+5. **Child completion.** The child's finalise step (any terminal status) reads the parent linkage
+   off its turn record and calls `harness::function::resolve` on the parent: `completed` delivers
+   the child's result (structured result in `details`, text rendering in `content`);
+   `failed` / `cancelled` deliver `is_error: true` with the reason. The deterministic entry id
+   makes a redelivered child step unable to double-resolve.
+
+**Cancellation cascade.** `harness::stop` on the parent walks `calls` for non-terminal children and
+stops each child session, recursively. A child stopped this way resolves its parent call with
+`is_error: true` (`"cancelled"`).
+
+**Context inheritance.** Fresh by default: the child sees only its `system_prompt` and `task`. A
+caller that wants parent history can `session::fork` first and spawn into the fork
+(`SpawnRequest.session_id`) — supported, not default (inherited transcripts inflate child context
+and cost).
+
+**What spawn is not.** Not agent-to-agent messaging, not a workflow engine, not a shared
+blackboard — those compose on top as siblings (see
+[Out of scope](#out-of-scope-future-sibling-workers)). One parent turn fans out to bounded children
+and joins on their results; that is the whole feature.
+
+## Output contract
+
+A turn can declare what it must produce — free text (default) or JSON, optionally validated against
+a JSON Schema. This is what turns a sub-agent or a backend [`harness::run`](#harnessrun) call into a
+typed unit of work instead of "parse the transcript yourself". The shape (`OutputContract`) is
+shared — see [README § Output contract](README.md#output-contract).
+
+- `{ type: "text" }` (default) — the result is the final assistant message's text; nothing is
+  enforced.
+- `{ type: "json", schema? }` — the result is a JSON value, validated against `schema` when
+  supplied. The harness picks a strategy per turn:
+  - **Provider-native** — when `router::models::supports(model, "structured_output")` is true, the
+    harness passes `response_format: { type: "json", schema }` on
+    [`router::chat`](llm-router.md#routerchat) and parses the final assistant text as the result.
+  - **`submit_result` fallback** — otherwise the harness injects a synthetic `submit_result`
+    invocation schema (its `parameters` are the output schema) alongside the normal exposure mode.
+    The model ends the job by calling it; the harness validates the arguments, records them as the
+    turn result, and finalises — the call is consumed by the harness, never dispatched through
+    `iii.trigger`. `submit_result` is terminal: other calls in the same message dispatch first
+    (their results still land in the transcript), then the turn finalises.
+  - **Validation retries** — if the model stops without a valid result (no `submit_result`, schema
+    mismatch, unparseable JSON), the harness appends a synthetic user nudge carrying the validation
+    errors and re-enqueues a generate step, at most `max_validation_retries` times (default 2).
+    After that the turn ends `completed` with `result_error` set and the raw final text as a
+    best-effort `result`.
+
+The result is stored on the turn record, returned by [`harness::run`](#harnessrun) and
+[`harness::status`](#harnessstatus), carried on the
+[`harness::turn_completed`](#trigger-types-emitted) event, and — for sub-agents — delivered to the
+parent in the `function_result` (`details` carries the structured value; `content` a text
+rendering).
+
+## Agent profiles
+
+Per-send configuration repeated across consumer surfaces (web chat, Telegram, TUI, backend loops)
+drifts. A **profile** is a named bundle of the per-send options, stored under the harness's entry
+in the engine's built-in `configuration` worker:
+
+```jsonc
+// configuration entry "harness"
+{
+  "profiles": {
+    "researcher": {
+      "model": "claude-sonnet-4",
+      "provider": "anthropic",
+      "system_prompt": "You research and cite sources…",
+      "functions": { "allow": ["web::*", "harness::spawn"], "expose": "native" },
+      "output": { "type": "json", "schema": { /* … */ } },
+      "max_turns": 12,
+      "hooks": [{ "point": "pre_dispatch", "function_id": "approvals::gate" }]
+    }
+  }
+}
+```
+
+`harness::send` / [`run`](#harnessrun) / [`spawn`](#harnessspawn) accept `agent: "<profile>"`.
+Explicit per-send fields override profile fields; for `harness::spawn` the effective function
+policy is additionally intersected with the parent's, whatever the profile says (see
+[Sub-agents](#sub-agents-harnessspawn)). A profile's `hooks` are appended after the global config
+hooks to form the effective chain (see [Hooks](#hooks)); per-send requests cannot add or remove
+hooks. Profiles are resolved when the turn is created and frozen onto the turn record like every
+other per-send option — a profile edit never changes a running turn. An unknown profile throws
+`harness/unknown_profile`.
+
+Soft dependency: without the `configuration` worker, profiles are unavailable and inline options
+are the only path.
+
+## Hooks
+
+Hooks are the **synchronous** counterpart to the turn events: iii functions the harness calls
+*in-path* at fixed points of the loop, which can veto, hold, or mutate what happens next. The rule
+for choosing between them: if you only need to *know*, bind an event
+([`harness::turn_started` / `turn_completed`](#trigger-types-emitted), or the session triggers); if
+you must *block or change* something, register a hook. Every hook adds latency and a failure mode
+to the hot path — events are always the cheaper tool.
+
+### Hook points
+
+| Point | Runs | May do |
+|---|---|---|
+| `pre_turn` | first step of a turn, after `working` is set, before any model spend | veto (`deny` ends the turn with the reason) |
+| `pre_generate` | after `context::assemble`, before `router::chat` | replace/extend `system_prompt`; **append-only** message injection; veto |
+| `post_generate` | after the final `AssistantMessage` update of a generate step | observe only (usage accounting, safety logging) |
+| `pre_dispatch` | after the fail-closed glob policy passes, before the target is invoked | `deny` (is_error result), `hold` (park via deferred dispatch), rewrite `arguments` |
+| `post_dispatch` | after the target returns, before the `function_result` is appended | rewrite result `content` / `details` / `is_error` (redaction, truncation) |
+
+The asymmetries are deliberate:
+
+- `post_generate` cannot mutate — the message already streamed to consumers
+  (`session::message_updated` fired per delta); redacting after the fact would lie to the UI. Strip
+  secrets where they *enter* instead: `post_dispatch` runs before the result is persisted, so the
+  transcript and the model both see the rewritten version.
+- `pre_generate` injection is **append-only** (plus the system prompt): rewriting history would
+  break the call/result pairing invariants `context::assemble` guarantees (see
+  [context-manager.md § Structural invariants](context-manager.md#structural-invariants)) and
+  invalidate provider prompt caches. Injected content rides the `reserved_tokens` headroom of the
+  token budget (default `min(20000, 10% of context_window)` — see
+  [context-manager.md § Token budget model](context-manager.md#token-budget-model)); keep it small
+  and bounded.
+- `pre_dispatch` runs **after** the allow/deny globs: a hook can narrow the policy, never bypass it.
+
+### Registration
+
+Hooks are **operator configuration, not a runtime surface**: a `hooks` array in the harness's
+`configuration` entry, plus an optional per-profile `hooks` array (see
+[Agent profiles](#agent-profiles)). The effective chain per point is the global hooks first, then
+the profile's, in array order. There is no per-send hook injection and no dynamic register call —
+the set of code allowed inside the loop must be auditable, and a stale registration from a dead
+worker must never be able to brick every dispatch.
+
+```jsonc
+// configuration entry "harness"
+{
+  "hooks": [
+    { "point": "pre_dispatch", "function_id": "approvals::gate",
+      "filter": { "functions": ["shell::*", "harness::spawn"] }, "timeout_ms": 5000 },
+    { "point": "post_dispatch", "function_id": "redactor::scrub" },
+    { "point": "post_generate", "function_id": "budget::record", "on_error": "fail_open" }
+  ]
+}
+```
+
+### Contract
+
+```typescript
+type HookPoint = "pre_turn" | "pre_generate" | "post_generate" | "pre_dispatch" | "post_dispatch";
+
+type HookBinding = {
+  point: HookPoint;
+  function_id: string;                // the iii function the harness calls (sync)
+  filter?: { functions?: string[] };  // pre/post_dispatch only: target function_id globs
+  timeout_ms?: number;                // default 5_000
+  on_error?: "fail_closed" | "fail_open"; // default: fail_closed for pre_*, fail_open for post_*
+};
+
+type HookInput = {
+  point: HookPoint;
+  session_id: string;
+  turn_id: string;
+  step: number;
+  depth: number;                       // sub-agent depth (hooks run for child turns too)
+  agent?: string;                      // profile name, when one was used
+  metadata?: Record<string, unknown>;  // the per-send tracing metadata
+  // point-specific payload (pre_turn carries only the envelope):
+  generate?: { system_prompt: string; messages: AgentMessage[]; model: string; provider: string };
+  generated?: { message: AssistantMessage };                       // post_generate (read-only)
+  call?: { id: string; function_id: string; arguments: unknown };  // pre_dispatch
+  result?: { function_call_id: string; function_id: string;        // post_dispatch
+             content: ContentBlock[]; is_error: boolean; details?: unknown };
+};
+
+type HookOutput =
+  | { decision: "continue";
+      mutations?: {
+        system_prompt?: string;           // pre_generate
+        append_messages?: AgentMessage[]; // pre_generate (appended after the candidate window)
+        arguments?: unknown;              // pre_dispatch
+        content?: ContentBlock[];         // post_dispatch
+        details?: unknown;                // post_dispatch
+        is_error?: boolean;               // post_dispatch
+      };
+      annotations?: Record<string, unknown> } // merged into the written entry's origin (audit trail)
+  | { decision: "deny"; reason: string }      // pre_turn / pre_generate / pre_dispatch
+  | { decision: "hold"; pending_timeout_ms?: number } // pre_dispatch only
+  | void;                                     // = continue, no changes
+```
+
+### Chain, hold, and failure semantics
+
+- **Middleware chain.** Hooks for a point run in order; each receives the payload as mutated by the
+  previous one; the first `deny` or `hold` short-circuits the rest. Mutations from different hooks
+  can conflict — keep chains short and order them deliberately.
+- **Deny.** At `pre_turn` / `pre_generate` the turn ends `failed` with the hook's `reason` (a
+  `custom` error entry + `harness::turn_completed`, like any failure). At `pre_dispatch` the call
+  is answered with an `is_error` function_result carrying the reason — the model sees it and can
+  adapt.
+- **Hold** (`pre_dispatch` only) reuses
+  [deferred dispatch](#deferred-dispatch-pending-function-results) wholesale: the call checkpoints
+  as `pending` with `held_by: <hook function_id>`, the turn parks, and whoever owns the decision
+  calls [`harness::function::resolve`](#harnessfunctionresolve). The pending sweep timeout still
+  applies. An approval gate is exactly this: a `pre_dispatch` hook that returns `hold`, a decision
+  UI, and a `resolve` call — no loop changes (see
+  [Out of scope](#out-of-scope-future-sibling-workers)).
+- **Failure policy.** A hook that throws, times out (`timeout_ms`, default 5s), or is unavailable
+  is resolved by its `on_error`: `fail_closed` treats it as `deny` (default for `pre_*` — a crashed
+  approval hook must not wave calls through); `fail_open` skips it (default for `post_*` — a
+  logging outage must not kill the agent).
+- **Replays.** Hooks run inside at-least-once steps: a redelivered step re-runs its hooks. Hooks
+  MUST be idempotent; key side effects on `turn_id + step` or `function_call_id`.
+- **Provenance.** Hook invocations carry the agent provenance mark of the work they wrap, and the
+  engine propagates it through any nested triggers the hook makes — a hook cannot launder an
+  agent-gated call (see [README § Security model](README.md#security-model)).
+
+### Cautions
+
+For operators wiring hooks and developers writing them:
+
+1. **You are on the hot path.** Hook time extends step duration, which the queue's visibility
+   timeout must cover (see [Durability & idempotency](#durability--idempotency)) — and a spawn
+   tree pays your chain on every child step. Keep hooks fast; never wait for a human inline —
+   return `hold`.
+2. **`on_error` is a security decision.** Fail-closed on an observability hook turns a logging
+   outage into a dead agent; fail-open on a policy hook turns an approval outage into a bypass.
+   The defaults encode the safe choice per point — change them knowingly.
+3. **Treat hook input as untrusted.** `arguments`, generated text, and function output are
+   model-controlled. Never execute or forward them blindly from hook code — the hook runs with
+   worker privileges and is a textbook confused-deputy target.
+4. **Mutations are silent.** The transcript stores the *effective* (rewritten) values. Return
+   `annotations` (merged into the entry's `origin`) or log originals yourself, or audits will show
+   data that never matched what actually ran.
+5. **Don't start turns from hooks.** A hook calling `harness::send` / `run` can loop
+   (hook -> turn -> hook). If a hook must trigger follow-up work, emit through a queue or carry a
+   hop counter in `session.metadata`.
+6. **Reach for events first.** If observe-only is enough, bind
+   [`harness::turn_completed`](#trigger-types-emitted) or the session triggers instead — hooks are
+   for the cases that must block or change the loop.
+
 ## Registered functions
 
 - `harness::send` — Entry point: persist the incoming message and kick off a turn; returns fast.
+- `harness::run` — `send` with the call held open until the turn ends; returns the result (the
+  backend/automation entry point).
+- `harness::spawn` — Spawn a sub-agent in a child session; the model-facing pending dispatch (see
+  [Sub-agents](#sub-agents-harnessspawn)).
 - `harness::turn` — Internal durable loop step (enqueued); not called directly by consumers.
 - `harness::function::dispatch` — Internal: unwrap an `agent_trigger` call and invoke the target iii
-  function; capture its result.
-- `harness::stop` — Request cancellation of an in-flight turn.
+  function; capture its result — or report it `pending`.
+- `harness::function::resolve` — Internal: deliver a pending call's result and resume the parked
+  turn.
+- `harness::stop` — Request cancellation of an in-flight turn (cascades to spawned children).
 - `harness::status` — Read the current turn status for a session.
 
 ## Agent exposure
 
 Deny-by-default for in-run agents (see [README § Security model](README.md#security-model)):
 
-- **Deny:** `harness::send` — self-invocation: a model that can start turns can fork unbounded loops
-  outside any `max_turns` guard (the prior deployment denies `run::start` for the same reason);
-  `harness::turn` (internal); `harness::function::dispatch` (forged call ids, policy re-entry);
-  `harness::stop`.
+- **Deny:** `harness::send` and `harness::run` — self-invocation: a model that can start arbitrary
+  turns can fork unbounded loops outside any `max_turns` guard (the prior deployment denies
+  `run::start` for the same reason); `harness::turn` (internal); `harness::function::dispatch`
+  (forged call ids, policy re-entry); `harness::function::resolve` (forged results for parked
+  calls); `harness::stop`.
+- **Allow (gated):** `harness::spawn` — the controlled alternative to `send`: the harness itself
+  enforces depth / fan-out / turn budgets and policy subsetting (see
+  [Sub-agents](#sub-agents-harnessspawn)), and the fail-closed dispatch policy still applies — a
+  deployment turns it on per agent by adding `harness::spawn` to the `allow` globs.
 - **Safe:** `harness::status` (read-only).
 
 ## Triggers
 
 ### Trigger types emitted
 
-None. The harness drives itself through the durable queue (an invocation mode, not a trigger) and
-relies on `session-manager` for consumer-facing reactivity.
+Session events remain the rendering surface (live transcripts, spinners); these two types are the
+**orchestration surface** — they fire at turn boundaries so consumers and siblings react without
+polling `harness::status`. Events are async and observe-only; a sibling that must *block or
+mutate* the loop registers a [hook](#hooks) instead. Bind with the standard two-step pattern (see
+[README § Reactive pattern](README.md#reactive-pattern)).
+
+- **`harness::turn_started`** — a turn began executing (first loop step).
+  - Config: `{ session_id?: string; parent_session_id?: string }`.
+  - Payload:
+
+```typescript
+type TurnStartedEvent = {
+  session_id: string;
+  turn_id: string;
+  parent?: { session_id: string; turn_id: string; function_call_id: string }; // sub-agent turns only
+  timestamp: number;
+};
+```
+
+- **`harness::turn_completed`** — a turn reached a terminal status.
+  - Config: `{ session_id?: string; parent_session_id?: string }`.
+  - Payload:
+
+```typescript
+type TurnCompletedEvent = {
+  session_id: string;
+  turn_id: string;
+  status: "completed" | "cancelled" | "failed";
+  result?: unknown;        // output-contract result (see Output contract)
+  result_error?: string;   // set when the contract could not be satisfied
+  reason?: string;         // failure cause when status is "failed"
+  parent?: { session_id: string; turn_id: string; function_call_id: string };
+  timestamp: number;
+};
+```
+
+A backend worker that chains agents binds `harness::turn_completed` and calls `harness::send` /
+`harness::run` from the handler — that is the supported way to build event-driven loops. **The
+loop guard is the consumer's:** `max_turns` bounds one turn, not a chain of turns; an event loop
+(completed -> send -> completed -> …) must carry its own termination condition — a hop counter in
+`session.metadata`, a budget sibling, or a terminal check in the handler.
 
 ### Triggers bound
 
@@ -262,19 +675,23 @@ iii.registerTrigger({
 });
 ```
 
-This is opt-in; the default harness has no bound triggers.
+This is opt-in; the default harness binds no triggers. Prefer routing inbound messages through
+`harness::send` rather than raw `session::append` where possible — the merge path double-checks the
+turn record after appending (see [Concurrency & steering](#concurrency--steering)), closing the
+read/complete race this handler otherwise has between `harness::status` and `harness::send`.
 
 ---
 
 ## API Reference
 
-Shared types (`AgentMessage`, `ContentBlock`, `AssistantMessage`, `AgentFunction`, `ThinkingLevel`)
-are defined in [README.md § Cross-cutting contracts](README.md#cross-cutting-contracts).
+Shared types (`AgentMessage`, `ContentBlock`, `AssistantMessage`, `AgentFunction`, `ThinkingLevel`,
+`OutputContract`) are defined in
+[README.md § Cross-cutting contracts](README.md#cross-cutting-contracts).
 
 ```typescript
 type TurnStatus =
   | "running"              // generating or between durable steps
-  | "awaiting_functions"   // dispatching function calls / collecting results
+  | "awaiting_functions"   // dispatching function calls / parked on pending results
   | "completed"            // turn finished normally (incl. max_turns cap)
   | "cancelled"            // harness::stop observed
   | "failed";              // unexpected error; turn record carries reason
@@ -287,6 +704,15 @@ step. Returns before the turn runs. If a turn is already running for the session
 appended and folded into it instead — no second turn starts (see
 [Concurrency & steering](#concurrency--steering)).
 
+**Idempotency.** Webhook sources redeliver (Telegram updates, Slack retries). When
+`idempotency_key` is set, the user entry id derives from it (the duplicate append is a no-op) and
+the key maps to the `{ session_id, turn_id }` it first produced (see [State](#state), TTL-bound);
+a redelivered send returns the same response with `deduplicated: true` and changes nothing.
+
+**Profiles and sessions.** `agent` resolves a [profile](#agent-profiles); explicit per-send fields
+override it. `session.metadata` lands on `SessionMeta.metadata` when the send creates/ensures the
+session — the tenancy hook session trigger configs and `session::list` filter on.
+
 - Invocation: **sync** (kicks an async/enqueued loop)
 
 Request:
@@ -295,16 +721,27 @@ Request:
 type SendRequest = {
   session_id?: string;            // omit to create a new session
   message: AgentMessage | string; // string is sugar for a user text message;
-                                  // role must be "user" or "custom" (else harness/invalid_message_role)
-  model: string;
+                                  // role must be "user" or "custom" (else harness/invalid_message_role).
+                                  // "custom" content never reaches the model (no wire mapping) —
+                                  // such a send kicks a turn over the existing history only
+  agent?: string;                 // named profile (see Agent profiles); per-send fields override it
+  model?: string;                 // required unless the profile supplies it
   provider?: string;
+  idempotency_key?: string;       // webhook dedupe: a repeated key returns the original
+                                  // {session_id, turn_id} and appends nothing
+  session?: {                     // applied when this send creates/ensures the session
+    title?: string;
+    metadata?: Record<string, unknown>; // -> SessionMeta.metadata (the tenancy hook)
+  };
   options?: {
     system_prompt?: string;
     max_turns?: number;           // default 16
     thinking_level?: ThinkingLevel;
+    output?: OutputContract;      // the turn's deliverable; default { type: "text" } (see Output contract)
     functions?: {
       allow?: string[];           // function_id globs the agent may dispatch to (e.g. "shell::*")
       deny?: string[];
+      expose?: "agent_trigger" | "native"; // default "agent_trigger" (see Functions (the white box))
     };
     metadata?: Record<string, unknown>; // tracing passthrough (session_id/message_id propagate)
   };
@@ -319,6 +756,7 @@ type SendResponse = {
   turn_id: string;     // the new turn — or the running turn when merged
   accepted: true;
   merged?: boolean;    // true when folded into an in-flight turn (steering)
+  deduplicated?: boolean; // true when idempotency_key matched an earlier send
 };
 ```
 
@@ -331,6 +769,87 @@ Example:
 // response
 { "session_id": "s_7a1", "turn_id": "t_001", "accepted": true }
 ```
+
+### `harness::run`
+
+`harness::send` with the call held open until the turn ends — "call an agent like a function" for
+backend automations and scripts. Held-open sync calls are an established bus pattern
+([`router::chat`](llm-router.md#routerchat) streams the same way). On timeout the turn is **not**
+aborted — the caller re-attaches via [`harness::status`](#harnessstatus) or the
+[`harness::turn_completed`](#trigger-types-emitted) event (or calls [`harness::stop`](#harnessstop)
+to actually cancel). A `run` that merges into an in-flight turn waits on that turn.
+
+- Invocation: **sync** (open until the turn ends or `timeout_ms` elapses)
+
+```typescript
+type RunRequest = SendRequest & { timeout_ms?: number }; // default 300_000
+type RunResponse = {
+  session_id: string;
+  turn_id: string;
+  status: TurnStatus;          // terminal status — or the live one when timed_out
+  timed_out?: boolean;
+  result?: unknown;            // output-contract result (see Output contract)
+  result_error?: string;
+  final_message?: AssistantMessage; // the turn's last assistant message
+};
+```
+
+Example:
+
+```jsonc
+// request — classify a ticket, get typed JSON back
+{ "message": "Classify: 'Refund not received after 14 days'", "agent": "classifier",
+  "options": { "output": { "type": "json", "schema": { "type": "object", "properties": {
+    "category": { "type": "string" }, "urgency": { "type": "string" } } } } }
+// response
+{ "session_id": "s_9f2", "turn_id": "t_001", "status": "completed",
+  "result": { "category": "billing", "urgency": "high" } }
+```
+
+### `harness::spawn`
+
+Spawn a sub-agent in a child session (see [Sub-agents](#sub-agents-harnessspawn)). Designed to be
+called **by the model** through `agent_trigger` — the controlled, guarded alternative to exposing
+`harness::send`. Dispatched from a turn, the dispatch layer records the child linkage and reports
+the call `pending`; the child's result arrives as the call's `function_result` when it finishes.
+(Called directly by a consumer, it simply starts a linked child and returns — `send` and `run` are
+usually what consumers want.)
+
+- Invocation: **sync** (kicks the child's enqueued loop; the *call result* is deferred)
+
+```typescript
+type SpawnRequest = {
+  task: string | AgentMessage;    // the child's goal — its opening user message
+  agent?: string;                 // child profile (see Agent profiles)
+  model?: string;                 // required unless the profile/parent default supplies it
+  provider?: string;
+  session_id?: string;            // spawn into an existing session (e.g. a fork); default: create fresh
+  options?: {
+    system_prompt?: string;
+    max_turns?: number;           // capped at the parent's remaining turn budget
+    thinking_level?: ThinkingLevel;
+    output?: OutputContract;      // the child's deliverable: text / json / json+schema
+    functions?: {                 // intersected with the parent policy — narrow, never escalate
+      allow?: string[];
+      deny?: string[];
+      expose?: "agent_trigger" | "native";
+    };
+    max_children?: number;        // fan-out guard for the child's own spawns (default 5)
+    pending_timeout_ms?: number;  // parent-side wait guard for this child (default 1_800_000)
+  };
+  // Parent linkage (parent_session_id / parent_turn_id / function_call_id / depth) is injected by
+  // the dispatching harness from the turn record — never trusted from model-supplied arguments.
+};
+type SpawnResponse = {
+  child_session_id: string;
+  child_turn_id: string;
+};
+```
+
+Guard failures surface as `is_error` function_results, not throws: `harness/spawn_depth_exceeded`,
+`harness/spawn_fanout_exceeded`, or the standard policy denial when `harness::spawn` is not
+allowed. The child's transcript is a normal session — bind `session::message_updated` with
+`{ metadata: { parent_session_id } }` to render sub-agent progress live.
 
 ### `harness::turn`
 
@@ -354,9 +873,12 @@ type TurnStepResult = {
 ```
 
 Failure handling: an unexpected throw marks the turn `failed`, appends a `custom`
-(`custom_type: "error"`) entry so the UI sees the reason, and sets `session::set_status error` with
-a short `reason`. A step may opt into queue retry/backoff for transient provider errors instead of
-failing the turn (subject to [Durability & idempotency](#durability--idempotency)).
+(`custom_type: "error"`) entry so the UI sees the reason, sets `session::set_status error` with a
+short `reason`, and emits [`harness::turn_completed`](#trigger-types-emitted)
+(`status: "failed"`) — resolving the parent's pending call with `is_error: true` when the turn is a
+sub-agent (see [Sub-agents](#sub-agents-harnessspawn)). A step may opt into queue retry/backoff for
+transient provider errors instead of failing the turn (subject to
+[Durability & idempotency](#durability--idempotency)).
 
 ### `harness::function::dispatch`
 
@@ -375,25 +897,67 @@ type FunctionDispatchRequest = {
     arguments: unknown;
   };
 };
-type FunctionDispatchResponse = {
-  function_call_id: string;
-  function_id: string;
-  content: ContentBlock[]; // function output, normalised to content blocks
-  is_error: boolean;
-  details?: unknown;
-  duration_ms: number;
-};
+type FunctionDispatchResponse =
+  | {
+      function_call_id: string;
+      function_id: string;
+      content: ContentBlock[]; // function output, normalised to content blocks
+      is_error: boolean;
+      details?: unknown;
+      duration_ms: number;
+    }
+  | {
+      function_call_id: string;
+      function_id: string;
+      pending: true;           // result arrives later via harness::function::resolve
+      pending_timeout_ms?: number;
+    };
 ```
 
-v1 enforces the fail-closed allow/deny globs only — there is no *hold* state. Approval-with-hold
-(park the call, resume on a decision) is delegated to an optional approval sibling that can wrap or
-precede dispatch (see [Out of scope](#out-of-scope-future-sibling-workers)).
+Dispatch is a pipeline: the fail-closed allow/deny globs first, then the `pre_dispatch`
+[hook chain](#hooks) (deny -> `is_error` result; hold -> `pending`; argument rewrite), then the
+target invocation, then the `post_dispatch` chain over the result (redaction, truncation) before it
+is returned and appended. Policy denials and the synthetic "interrupted" results from redelivery
+skip `post_dispatch` — nothing executed. A dispatch therefore either returns the (possibly
+rewritten) result inline or reports the call **pending** (see
+[Deferred dispatch](#deferred-dispatch-pending-function-results)): `harness::spawn` is the built-in
+pending dispatch, and a `pre_dispatch` hook returning `hold` is the pluggable one — an approval
+gate is that hook plus a `harness::function::resolve` call on the decision (see
+[Out of scope](#out-of-scope-future-sibling-workers)).
+
+### `harness::function::resolve`
+
+Deliver the result of a `pending` call and resume the parked turn (see
+[Deferred dispatch](#deferred-dispatch-pending-function-results)). Called by the harness itself
+(child completion) or by a trusted sibling (an approval decision); denied to in-run agents.
+Idempotent: the `function_result` entry id is deterministic (`e_<turn_id>_<function_call_id>`), so
+duplicate resolves change nothing.
+
+- Invocation: **sync**
+
+```typescript
+type FunctionResolveRequest = {
+  session_id: string;
+  turn_id: string;
+  function_call_id: string;
+  content: ContentBlock[];
+  is_error?: boolean;
+  details?: unknown;          // structured payload (e.g. a child's output-contract result)
+};
+type FunctionResolveResponse = {
+  resolved: boolean;          // false when the call is unknown or already done
+  turn_resumed: boolean;      // true when this was the last pending call and the turn re-enqueued
+};
+```
 
 ### `harness::stop`
 
 Request cancellation. Sets an abort flag the next `harness::turn` step observes, and aborts an
 in-flight stream via [`router::abort`](llm-router.md#routerabort) using the `stream_request_id` on
-the turn record. The turn record transitions to `cancelled` before `session::set_status done`.
+the turn record. Non-terminal spawned children recorded in `calls` are stopped first, recursively —
+each resolves its parent call with `is_error: true` (see [Sub-agents](#sub-agents-harnessspawn)).
+The turn record transitions to `cancelled` before `session::set_status done`, and
+[`harness::turn_completed`](#trigger-types-emitted) fires with `status: "cancelled"`.
 
 - Invocation: **sync**
 
@@ -415,7 +979,15 @@ type StatusResponse = {
   step: number;
   turn_count: number;
   max_turns: number;
-  pending_function_calls: string[];   // function_call ids awaiting results
+  depth: number;                      // 0 for top-level turns; >0 for sub-agents
+  pending_function_calls: string[];   // function_call ids awaiting results (incl. parked children)
+  children: Array<{                   // live spawned children of the current turn
+    function_call_id: string;
+    session_id: string;
+    turn_id: string;
+  }>;
+  result?: unknown;                   // output-contract result (terminal turns)
+  result_error?: string;
 } | null;                          // null for unknown sessions
 ```
 
@@ -425,7 +997,8 @@ type StatusResponse = {
 
 | Scope | Key | Value | Purpose |
 |---|---|---|---|
-| `harness_turn` | `<session_id>` | turn record `{ turn_id, status, step, turn_count, abort?, watermark_entry_id?, stream_request_id?, options, calls }` | Loop progress, per-send options, per-call checkpoints, steering watermark; survives restart. Seeded by CAS from `harness::send` (see [Concurrency & steering](#concurrency--steering)). |
+| `harness_turn` | `<session_id>` | turn record `{ turn_id, status, step, turn_count, depth, abort?, watermark_entry_id?, stream_request_id?, options, calls, parent?, result?, result_error? }` | Loop progress, per-send options (incl. output contract), per-call checkpoints (`dispatched` / `pending` / `done` + child linkage + `held_by` for [hook](#hooks) holds), steering watermark, sub-agent linkage, turn result; survives restart. Seeded by CAS from `harness::send` / `harness::run` / `harness::spawn` (see [Concurrency & steering](#concurrency--steering)). |
+| `harness_idem` | `<idempotency_key>` | `{ session_id, turn_id, entry_id, ts }` | `harness::send` webhook dedupe (TTL ~24h). |
 
 Transcript truth lives in [session-manager](session-manager.md); the harness keeps only loop
 bookkeeping.
@@ -436,31 +1009,50 @@ bookkeeping.
   and set status. Required.
 - `llm-router` (`router::chat`) — generation. Required.
 - `context-manager` (`context::assemble`) — context budgeting. Soft; degrades to raw history.
+- `configuration` (soft) — the `harness` entry holding [agent profiles](#agent-profiles) and the
+  [hook bindings](#hooks); without it, inline per-send options work and no hooks run.
 - `iii-queue` — the durable `harness-turn` loop. The queue MUST provide per-session ordering with
   cross-session parallelism (partition by `session_id`); a single global FIFO would head-of-line
-  block every session behind one long stream step.
-- iii engine `iii.trigger` — function dispatch (`agent_trigger` unwrap → target function).
+  block every session behind one long stream step. Sub-agent turns are ordinary entries on this
+  queue under their child `session_id` — which is what makes spawned children run in parallel.
+- iii engine `iii.trigger` — function dispatch (`agent_trigger` unwrap → target function) and
+  registry reads (`engine::functions::list` / `engine::functions::info`) for runtime discovery and
+  `expose: "native"` schema mapping.
 
 ## Out of scope (future sibling workers)
 
 Kept out to preserve thinness; each is a clean add-on that wraps the loop or subscribes to its events:
 
-- **approval-gate** — intercept `harness::function::dispatch` (or a pre-dispatch hook) to allow / deny /
-  hold function calls against a policy; resume via a state trigger.
-- **llm-budget** — track spend from `router` usage and cap per workspace/agent.
+- **approval-gate** — the *policy and decision surface* for holding function calls: which calls
+  need a human, who may approve, where decisions land. The mechanics are already in core — a
+  `pre_dispatch` [hook](#hooks) returning `hold` plus
+  [`harness::function::resolve`](#harnessfunctionresolve) on the decision; the sibling ships the
+  hook function and the UI, never loop changes.
+- **llm-budget** — track spend from `router` usage and cap per workspace/agent: a `pre_turn` /
+  `pre_generate` [hook](#hooks) enforces the cap, and
+  [`harness::turn_completed`](#trigger-types-emitted) plus the sub-agent linkage metadata give it
+  per-tree aggregation.
 - **context-scheduler** — decide *when* to compact (the optional reactive trigger in
   [context-manager](context-manager.md#triggers)); the harness only compacts inline on overflow.
-- **hook-fanout** — publish-and-collect lifecycle hooks around turns and function dispatch.
-- **multi-agent / orchestrator** — agent-to-agent handoff via queues; the harness runs one agent
-  loop.
+- **orchestration beyond spawn/join** — agent-to-agent messaging, shared blackboards, workflow
+  graphs, supervisor pools. The harness ships [`harness::spawn`](#sub-agents-harnessspawn) (bounded
+  fan-out/join) only; richer patterns compose on top of spawn and the turn events.
 
-If any of these needs to sit *inside* the critical path, prefer a pre/post hook function id the
-harness calls (config-driven) over embedding the logic.
+(The previously planned **hook-fanout** sibling is superseded: synchronous lifecycle interception
+is the core [Hooks](#hooks) surface, and async observation is the turn events.) Siblings that need
+to sit *inside* the critical path register a [hook](#hooks); everything else binds events.
 
 ## Boundaries
 
 - Does **not** store the transcript, build context, or talk to providers itself — it calls the other
   three.
-- Does **not** gate approvals, meter cost, or schedule compaction in v1.
+- Does **not** gate approvals, meter cost, or schedule compaction in v1 — it provides the
+  [hook points](#hooks) and the
+  [deferred dispatch](#deferred-dispatch-pending-function-results) primitive; the policy logic
+  (who approves, how much to spend) always lives in the sibling that registers the hook.
+- Does **not** orchestrate beyond spawn/join: `harness::spawn` bounds the multi-agent surface to
+  child sessions that resolve a single parent call; messaging, blackboards, and workflow graphs are
+  siblings.
 - Does **not** define functions — functions are the iii substrate; the harness only exposes the
-  `agent_trigger` invocation surface and dispatches what the model requests.
+  `agent_trigger` / native invocation surfaces and dispatches what the model requests
+  (`submit_result` being the one synthetic, never-dispatched exception).

--- a/tech-specs/2026-06-agentic/harness.md
+++ b/tech-specs/2026-06-agentic/harness.md
@@ -1,0 +1,321 @@
+# harness
+
+Worker prefix: `harness::*`
+
+## Definition
+
+`harness` is the thin worker that wires the other three into an agent loop. It owns sequencing and
+nothing else: take an incoming message, persist it, assemble a context, stream a completion, persist
+the result, run any tool calls, and repeat until the turn stops.
+
+It is deliberately minimal. The rule of thumb: **if a concern grows real logic, it becomes its own
+worker** rather than living in the harness. Approval gating, spend budgets, compaction *scheduling*,
+hook fan-out, and multi-agent handoff are all out of scope here — they are siblings the harness can
+call or that can subscribe around it (see [Out of scope](#out-of-scope-future-sibling-workers)).
+
+The harness is the only worker in this spec that depends on the other three, and even those are soft:
+without `context-manager` it sends raw history; without tool functions it is a plain chat loop. It
+needs `session-manager` (to persist/stream) and `llm-router` (to generate).
+
+## What it wires
+
+```mermaid
+sequenceDiagram
+  participant C as consumer (chat/tg)
+  participant H as harness
+  participant S as session-manager
+  participant X as context-manager
+  participant R as llm-router
+  participant F as iii function (tool)
+
+  C->>H: harness::send {message, model}
+  H->>S: session::create or ensure
+  H->>S: session::append (user message)
+  H-->>C: {session_id, turn_id}
+  Note over H: enqueue harness::turn (durable)
+  H->>S: session::set_status working
+  H->>S: session::messages
+  H->>X: context::assemble
+  H->>R: router::chat (over channel)
+  R-->>H: AssistantMessageEvent frames
+  H->>S: session::append (assistant) then session::update_message (stream deltas)
+  alt assistant requested tool calls
+    H->>F: iii.trigger(function_id, args)
+    F-->>H: result
+    H->>S: session::append (function_result)
+    Note over H: re-enqueue harness::turn
+  else no tool calls
+    H->>S: session::set_status done
+  end
+```
+
+## The loop
+
+`harness::send` is the entry point; it ensures the session, persists the user message, and enqueues
+the first `harness::turn` step, then returns immediately. The loop runs as durable enqueued steps so a
+crash or restart resumes mid-turn. One `harness::turn` step does:
+
+1. Mark working: `session::set_status working` (first step of a turn).
+2. Load active path: `session::messages`.
+3. Assemble context: `context::assemble` (skipped if `context-manager` absent -> raw messages + base
+   system prompt). Tools come from the engine registry (see [Tools](#tools-the-white-box)).
+4. Generate: open a channel, call `router::chat`; `session::append` an assistant message, then
+   `session::update_message` as deltas arrive (each fires `session::message_updated`). Deltas may be
+   batched to throttle update frequency; the final update writes the complete `AssistantMessage`.
+5. If the message has `function_call` content: dispatch each via `harness::tool::dispatch`, append
+   each `function_result`, then re-enqueue `harness::turn` to let the model react.
+6. Else, steering check: re-read `session::messages` for any user message appended after this turn
+   started (see [Triggers](#triggers)); if present, continue with another generate step; otherwise
+   `session::set_status done` and stop.
+
+A `max_turns` guard caps runaway loops. Cancellation is cooperative: `harness::stop` sets an abort
+flag the next step checks, then sets `session::set_status done`.
+
+The harness maps the turn lifecycle onto the session's coarse status: `working` while a turn is
+running or awaiting tools, `done` once it stops. The internal `TurnStatus` (below) is finer-grained
+and stays inside the harness; consumers watch the session status instead.
+
+## Tools (the white box)
+
+"Tools" are not a harness feature — they are the **iii substrate**. Any registered iii function is a
+candidate tool. The harness:
+
+- Discovers them via `engine::functions::list` and builds the `AgentFunction[]` tool schema
+  (filtered by an allow-list/namespace policy supplied in `options`).
+- Dispatches a model-chosen call with `iii.trigger({ function_id, payload })` via
+  `harness::tool::dispatch`, capturing the result as a `function_result` message.
+
+A tool can do anything an iii function can, including calling back to the consumer (the diagram's
+`funcs -> chat` edge) — that is the tool's own behaviour, not the harness's.
+
+## Functions
+
+- `harness::send` — Entry point: persist the incoming message and kick off a turn; returns fast.
+- `harness::turn` — Internal durable loop step (enqueued); not called directly by consumers.
+- `harness::tool::dispatch` — Internal: invoke one iii function as a tool and capture its result.
+- `harness::stop` — Request cancellation of an in-flight turn.
+- `harness::status` — Read the current turn status for a session.
+
+## Triggers
+
+### Trigger types emitted
+
+None. The harness drives itself through the durable queue (an invocation mode, not a trigger) and
+relies on `session-manager` for consumer-facing reactivity.
+
+### Triggers bound
+
+- **Optional** `harness::on_steering` — bind to [`session::message_added`](session-manager.md#trigger-types-emitted)
+  so a user message that arrives mid-turn is folded into the running turn rather than dropped. If a
+  turn is already running, the loop's steering check (step 6) picks the new message up on its own; if
+  none is running, the handler kicks a fresh turn:
+
+```typescript
+iii.registerFunction("harness::on_steering", async (evt) => {
+  if (evt.message.role !== "user") return;
+  const status = await iii.trigger({
+    function_id: "harness::status",
+    payload: { session_id: evt.session_id },
+  });
+  if (!status || status.status === "stopped" || status.status === "failed") {
+    await iii.trigger({
+      function_id: "harness::send",
+      payload: { session_id: evt.session_id, message: evt.message, model: "<model>" },
+    });
+  }
+  // else: a turn is running; its steering check re-reads session::messages and folds this in.
+});
+
+iii.registerTrigger({
+  type: "session::message_added",
+  function_id: "harness::on_steering",
+  config: { roles: ["user"] },
+});
+```
+
+This is opt-in; the default harness has no bound triggers.
+
+---
+
+## API Reference
+
+Shared types (`AgentMessage`, `ContentBlock`, `AssistantMessage`, `AgentFunction`) are defined in
+[README.md § Cross-cutting contracts](README.md#cross-cutting-contracts).
+
+```typescript
+type TurnStatus = "running" | "awaiting_tools" | "stopped" | "failed";
+```
+
+### `harness::send`
+
+Accept an incoming message, ensure the session, append the user message, and enqueue the first turn
+step. Returns before the turn runs.
+
+- Invocation: **sync** (kicks an async/enqueued loop)
+
+Request:
+
+```typescript
+type SendRequest = {
+  session_id?: string;            // omit to create a new session
+  message: AgentMessage | string; // string is sugar for a user text message
+  model: string;
+  provider?: string;
+  options?: {
+    system_prompt?: string;
+    max_turns?: number;           // default 16
+    thinking_level?: string;
+    tools?: {
+      allow?: string[];           // function_id globs to expose (e.g. "shell::*")
+      deny?: string[];
+    };
+    metadata?: Record<string, unknown>; // tracing passthrough (session_id/message_id propagate)
+  };
+};
+```
+
+Response:
+
+```typescript
+type SendResponse = {
+  session_id: string;
+  turn_id: string;     // identifies this loop invocation
+  accepted: true;
+};
+```
+
+Example:
+
+```jsonc
+// request
+{ "message": "Summarise the repo README", "model": "claude-sonnet-4", "provider": "anthropic",
+  "options": { "tools": { "allow": ["shell::*", "fs::*"] } } }
+// response
+{ "session_id": "s_7a1", "turn_id": "t_001", "accepted": true }
+```
+
+### `harness::turn`
+
+Internal durable loop step. Documented for completeness; consumers do not call it. Enqueued onto a
+FIFO `harness-turn` queue; each run advances one step of [the loop](#the-loop).
+
+- Invocation: **enqueue** (`TriggerAction.Enqueue({ queue: "harness-turn" })`)
+
+```typescript
+type TurnStepPayload = {
+  session_id: string;
+  turn_id: string;
+  step: number;          // monotonic; guards against stale/duplicate dequeues
+};
+type TurnStepResult = {
+  session_id: string;
+  status: TurnStatus;
+  next_step?: number;    // present while the loop continues
+};
+```
+
+Failure handling: an unexpected throw marks the turn `failed` and appends a `custom`
+(`custom_type: "error"`) entry so the UI sees the reason. A step may opt into queue retry/backoff for
+transient provider errors instead of failing the turn.
+
+### `harness::tool::dispatch`
+
+Invoke a single iii function as a tool and return a normalised result. Internal to the loop but also
+callable directly to execute a one-off tool with the same result shape.
+
+- Invocation: **sync**
+
+```typescript
+type ToolDispatchRequest = {
+  session_id: string;
+  call: {
+    id: string;            // function_call id, echoed into the result
+    function_id: string;   // the iii function to invoke
+    arguments: unknown;
+  };
+};
+type ToolDispatchResponse = {
+  function_call_id: string;
+  function_id: string;
+  content: ContentBlock[]; // tool output, normalised to content blocks
+  is_error: boolean;
+  details?: unknown;
+  duration_ms: number;
+};
+```
+
+The harness performs no approval check here in v1; gating is delegated to an optional approval sibling
+that can wrap or precede dispatch (see [Out of scope](#out-of-scope-future-sibling-workers)).
+
+### `harness::stop`
+
+Request cancellation. Sets an abort flag the next `harness::turn` step observes; an in-flight provider
+stream is closed best-effort.
+
+- Invocation: **sync**
+
+```typescript
+type StopRequest = { session_id: string; turn_id?: string }; // turn_id omitted = current turn
+type StopResponse = { stopping: boolean };
+```
+
+### `harness::status`
+
+- Invocation: **sync**
+
+```typescript
+type StatusRequest = { session_id: string };
+type StatusResponse = {
+  session_id: string;
+  turn_id: string | null;
+  status: TurnStatus;
+  step: number;
+  turn_count: number;
+  max_turns: number;
+  pending_tool_calls: string[];   // function_call ids awaiting results
+} | null;                          // null for unknown sessions
+```
+
+---
+
+## State
+
+| Scope | Key | Value | Purpose |
+|---|---|---|---|
+| `harness_turn` | `<session_id>` | turn record `{ turn_id, status, step, turn_count, abort? }` | Loop progress; survives restart. |
+
+Transcript truth lives in [session-manager](session-manager.md); the harness keeps only loop
+bookkeeping.
+
+## Dependencies
+
+- `session-manager` (`session::*`) — persist messages, stream content via `session::update_message`,
+  and set status. Required.
+- `llm-router` (`router::chat`) — generation. Required.
+- `context-manager` (`context::assemble`) — context budgeting. Soft; degrades to raw history.
+- `iii-queue` — the durable `harness-turn` loop.
+- iii engine `engine::functions::list` + `iii.trigger` — tool discovery and dispatch.
+
+## Out of scope (future sibling workers)
+
+Kept out to preserve thinness; each is a clean add-on that wraps the loop or subscribes to its events:
+
+- **approval-gate** — intercept `harness::tool::dispatch` (or a pre-dispatch hook) to allow / deny /
+  hold tool calls against a policy; resume via a state trigger.
+- **llm-budget** — track spend from `router` usage and cap per workspace/agent.
+- **context-scheduler** — decide *when* to compact (the optional reactive trigger in
+  [context-manager](context-manager.md#triggers)); the harness only compacts inline on overflow.
+- **hook-fanout** — publish-and-collect lifecycle hooks around turns/tools.
+- **multi-agent / orchestrator** — agent-to-agent handoff via queues; the harness runs one agent
+  loop.
+
+If any of these needs to sit *inside* the critical path, prefer a pre/post hook function id the
+harness calls (config-driven) over embedding the logic.
+
+## Boundaries
+
+- Does **not** store the transcript, build context, or talk to providers itself — it calls the other
+  three.
+- Does **not** gate approvals, meter cost, or schedule compaction in v1.
+- Does **not** define tools — tools are any iii function; the harness only discovers and dispatches
+  them.

--- a/tech-specs/2026-06-agentic/harness.md
+++ b/tech-specs/2026-06-agentic/harness.md
@@ -237,8 +237,10 @@ The harness:
 The dispatch policy is **fail-closed**: a call is dispatched only if the target matches an `allow`
 glob and no `deny` glob (see `harness::send` options). When `options.functions` is omitted entirely,
 every call is denied with an `is_error` function_result explaining the policy — a default install is
-a plain chat loop until functions are explicitly allowed, or until an approval sibling upgrades "no
-match" from deny to a held approval (see
+a plain chat loop until functions are explicitly allowed. The globs are structural and final: hooks
+run only *after* they pass, so an approval sibling cannot intercept a no-match denial — a deployment
+that wants every call human-gated instead allows broadly (`allow: ["*"]`) and lets the
+[approval-gate](approval-gate.md) hook hold or deny per its policy (see
 [Out of scope](#out-of-scope-future-sibling-workers)).
 
 `engine::functions::list` is how the **model** discovers what's callable — by triggering it through
@@ -281,21 +283,26 @@ may therefore defer:
   *without* re-enqueueing `harness::turn`, the turn stays `awaiting_functions`, and **no queue step
   is held** while the deferred work runs — pending calls never stretch the visibility-timeout
   bound.
-- [`harness::function::resolve`](#harnessfunctionresolve) delivers the result later: it appends the
-  `function_result` under the same deterministic entry id a direct dispatch would have used
-  (`e_<turn_id>_<function_call_id>`), flips the checkpoint to `done`, and — when it resolved the
-  last pending call — re-enqueues `harness::turn` so the model reacts. Duplicate resolves hit the
+- [`harness::function::resolve`](#harnessfunctionresolve) settles the call later — either
+  **delivering** a result (appended under the same deterministic entry id a direct dispatch would
+  have used, `e_<turn_id>_<function_call_id>`, checkpoint flipped to `done`) or, for hook-held
+  calls, **releasing** it for execution (`action: "execute"` — on resume the loop runs the call
+  through the remaining dispatch pipeline). When it settled the last pending call — or a release
+  needs the loop — it re-enqueues `harness::turn` so the model reacts. Duplicate resolves hit the
   existing entry id and are no-ops.
 - Every pending call carries a `pending_timeout_ms` (default 30 minutes). A periodic sweep resolves
   expired calls with `is_error: true` (`"pending call timed out"`), so a lost child or an abandoned
-  approval can never park a turn forever.
+  approval can never park a turn forever. A hold's owner typically settles expiry itself first with
+  a richer denial (see [approval-gate.md](approval-gate.md#sweep-the-gc-backstop)); this sweep is
+  the backstop when no owner is alive — double resolution is a no-op either way.
 - Steering still works while parked: user messages appended in the meantime sit after the
   watermark and fold in on resume (see [Concurrency & steering](#concurrency--steering)).
 
 [`harness::spawn`](#sub-agents-harnessspawn) is the built-in pending dispatch. The mechanism is
-deliberately general: an approval sibling implements *hold* by returning `pending` from a
-pre-dispatch hook and calling `harness::function::resolve` on the human decision — no new loop
-machinery (see [Out of scope](#out-of-scope-future-sibling-workers)).
+deliberately general: an approval sibling implements *hold* by returning `hold` from a
+pre-dispatch hook and calling `harness::function::resolve` on the human decision (`execute` to
+release the call, `deliver` to answer it with a denial) — no new loop machinery (see
+[approval-gate.md](approval-gate.md)).
 
 ## Sub-agents (`harness::spawn`)
 
@@ -378,48 +385,13 @@ The result is stored on the turn record, returned by [`harness::run`](#harnessru
 parent in the `function_result` (`details` carries the structured value; `content` a text
 rendering).
 
-## Agent profiles
-
-Per-send configuration repeated across consumer surfaces (web chat, Telegram, TUI, backend loops)
-drifts. A **profile** is a named bundle of the per-send options, stored under the harness's entry
-in the engine's built-in `configuration` worker:
-
-```jsonc
-// configuration entry "harness"
-{
-  "profiles": {
-    "researcher": {
-      "model": "claude-sonnet-4",
-      "provider": "anthropic",
-      "system_prompt": "You research and cite sources…",
-      "functions": { "allow": ["web::*", "harness::spawn"], "expose": "native" },
-      "output": { "type": "json", "schema": { /* … */ } },
-      "max_turns": 12,
-      "hooks": [{ "point": "pre_dispatch", "function_id": "approvals::gate" }]
-    }
-  }
-}
-```
-
-`harness::send` / [`run`](#harnessrun) / [`spawn`](#harnessspawn) accept `agent: "<profile>"`.
-Explicit per-send fields override profile fields; for `harness::spawn` the effective function
-policy is additionally intersected with the parent's, whatever the profile says (see
-[Sub-agents](#sub-agents-harnessspawn)). A profile's `hooks` are appended after the global config
-hooks to form the effective chain (see [Hooks](#hooks)); per-send requests cannot add or remove
-hooks. Profiles are resolved when the turn is created and frozen onto the turn record like every
-other per-send option — a profile edit never changes a running turn. An unknown profile throws
-`harness/unknown_profile`.
-
-Soft dependency: without the `configuration` worker, profiles are unavailable and inline options
-are the only path.
-
 ## Hooks
 
 Hooks are the **synchronous** counterpart to the turn events: iii functions the harness calls
 *in-path* at fixed points of the loop, which can veto, hold, or mutate what happens next. The rule
 for choosing between them: if you only need to *know*, bind an event
 ([`harness::turn_started` / `turn_completed`](#trigger-types-emitted), or the session triggers); if
-you must *block or change* something, register a hook. Every hook adds latency and a failure mode
+you must *block or change* something, bind a hook. Every hook adds latency and a failure mode
 to the hot path — events are always the cheaper tool.
 
 ### Hook points
@@ -449,34 +421,58 @@ The asymmetries are deliberate:
 
 ### Registration
 
-Hooks are **operator configuration, not a runtime surface**: a `hooks` array in the harness's
-`configuration` entry, plus an optional per-profile `hooks` array (see
-[Agent profiles](#agent-profiles)). The effective chain per point is the global hooks first, then
-the profile's, in array order. There is no per-send hook injection and no dynamic register call —
-the set of code allowed inside the loop must be auditable, and a stale registration from a dead
-worker must never be able to brick every dispatch.
+Hooks are **iii triggers**. The harness registers one custom trigger type per hook point —
+`harness::hook::pre_turn`, `harness::hook::pre_generate`, `harness::hook::post_generate`,
+`harness::hook::pre_dispatch`, `harness::hook::post_dispatch` — alongside its async
+[turn events](#trigger-types-emitted), and a sibling binds a hook with the standard two-step
+pattern (see [README § Reactive pattern](README.md#reactive-pattern)): register the hook function,
+then register a trigger of the point's type. A sibling wires itself at startup — installing the
+worker is installing the hook; there is no hook block in any configuration entry.
 
-```jsonc
-// configuration entry "harness"
-{
-  "hooks": [
-    { "point": "pre_dispatch", "function_id": "approvals::gate",
-      "filter": { "functions": ["shell::*", "harness::spawn"] }, "timeout_ms": 5000 },
-    { "point": "post_dispatch", "function_id": "redactor::scrub" },
-    { "point": "post_generate", "function_id": "budget::record", "on_error": "fail_open" }
-  ]
-}
+```typescript
+iii.registerFunction("approval::gate", gateHandler);
+iii.registerTrigger({
+  type: "harness::hook::pre_dispatch",
+  function_id: "approval::gate",
+  config: { functions: ["shell::*", "harness::spawn"], timeout_ms: 5000 },
+});
+
+iii.registerTrigger({
+  type: "harness::hook::post_dispatch",
+  function_id: "redactor::scrub",
+  config: {},
+});
+iii.registerTrigger({
+  type: "harness::hook::post_generate",
+  function_id: "budget::record",
+  config: { on_error: "fail_open" },
+});
 ```
+
+Unlike the turn events, delivery is **synchronous and result-bearing**: the harness owns these
+trigger types (see [README § Trigger delivery](README.md#trigger-delivery)) and invokes each bound
+function *in-path* via `iii.trigger`, treating the return value as a [`HookOutput`](#contract).
+Trigger registration is only the binding surface; the delivery semantics are the
+[chain semantics](#chain-hold-and-failure-semantics) below, not async fan-out.
+
+There is still no per-send hook injection, and the model cannot bind hooks — trigger registration
+is a worker/SDK surface, never an iii function reachable through `agent_trigger`. The effective
+set stays auditable: `engine::triggers::list` enumerates every binding, and the harness rebuilds
+its subscriber set from the engine after a restart. A binding whose worker is dead or slow cannot
+brick the loop silently: every hook invocation is bounded by its `timeout_ms` and resolved by its
+`on_error` policy (a fail-closed `pre_*` hook denies rather than waving through — see
+[failure semantics](#chain-hold-and-failure-semantics)); unbinding is `unregisterTrigger`.
 
 ### Contract
 
 ```typescript
 type HookPoint = "pre_turn" | "pre_generate" | "post_generate" | "pre_dispatch" | "post_dispatch";
 
-type HookBinding = {
-  point: HookPoint;
-  function_id: string;                // the iii function the harness calls (sync)
-  filter?: { functions?: string[] };  // pre/post_dispatch only: target function_id globs
+// the `config` of a `harness::hook::<point>` trigger binding;
+// the binding's function_id is the hook the harness calls (sync)
+type HookTriggerConfig = {
+  functions?: string[];               // pre/post_dispatch only: target function_id globs
+  priority?: number;                  // chain order: ascending, ties by function_id (default 0)
   timeout_ms?: number;                // default 5_000
   on_error?: "fail_closed" | "fail_open"; // default: fail_closed for pre_*, fail_open for post_*
 };
@@ -487,7 +483,6 @@ type HookInput = {
   turn_id: string;
   step: number;
   depth: number;                       // sub-agent depth (hooks run for child turns too)
-  agent?: string;                      // profile name, when one was used
   metadata?: Record<string, unknown>;  // the per-send tracing metadata
   // point-specific payload (pre_turn carries only the envelope):
   generate?: { system_prompt: string; messages: AgentMessage[]; model: string; provider: string };
@@ -515,9 +510,10 @@ type HookOutput =
 
 ### Chain, hold, and failure semantics
 
-- **Middleware chain.** Hooks for a point run in order; each receives the payload as mutated by the
+- **Middleware chain.** Hooks for a point run in deterministic order — ascending `priority`
+  (default 0), ties broken by `function_id` — each receiving the payload as mutated by the
   previous one; the first `deny` or `hold` short-circuits the rest. Mutations from different hooks
-  can conflict — keep chains short and order them deliberately.
+  can conflict — keep chains short and set `priority` deliberately.
 - **Deny.** At `pre_turn` / `pre_generate` the turn ends `failed` with the hook's `reason` (a
   `custom` error entry + `harness::turn_completed`, like any failure). At `pre_dispatch` the call
   is answered with an `is_error` function_result carrying the reason — the model sees it and can
@@ -525,10 +521,11 @@ type HookOutput =
 - **Hold** (`pre_dispatch` only) reuses
   [deferred dispatch](#deferred-dispatch-pending-function-results) wholesale: the call checkpoints
   as `pending` with `held_by: <hook function_id>`, the turn parks, and whoever owns the decision
-  calls [`harness::function::resolve`](#harnessfunctionresolve). The pending sweep timeout still
-  applies. An approval gate is exactly this: a `pre_dispatch` hook that returns `hold`, a decision
-  UI, and a `resolve` call — no loop changes (see
-  [Out of scope](#out-of-scope-future-sibling-workers)).
+  calls [`harness::function::resolve`](#harnessfunctionresolve) — `action: "execute"` to release
+  the call through the remaining dispatch pipeline, or `deliver` to answer it (e.g. a denial). The
+  pending sweep timeout still applies. An approval gate is exactly this: a `pre_dispatch` hook that
+  returns `hold`, a decision UI, and a `resolve` call — no loop changes (see
+  [approval-gate.md](approval-gate.md)).
 - **Failure policy.** A hook that throws, times out (`timeout_ms`, default 5s), or is unavailable
   is resolved by its `on_error`: `fail_closed` treats it as `deny` (default for `pre_*` — a crashed
   approval hook must not wave calls through); `fail_open` skips it (default for `post_*` — a
@@ -600,7 +597,7 @@ Deny-by-default for in-run agents (see [README § Security model](README.md#secu
 Session events remain the rendering surface (live transcripts, spinners); these two types are the
 **orchestration surface** — they fire at turn boundaries so consumers and siblings react without
 polling `harness::status`. Events are async and observe-only; a sibling that must *block or
-mutate* the loop registers a [hook](#hooks) instead. Bind with the standard two-step pattern (see
+mutate* the loop binds a [hook](#hooks) instead. Bind with the standard two-step pattern (see
 [README § Reactive pattern](README.md#reactive-pattern)).
 
 - **`harness::turn_started`** — a turn began executing (first loop step).
@@ -638,6 +635,15 @@ A backend worker that chains agents binds `harness::turn_completed` and calls `h
 loop guard is the consumer's:** `max_turns` bounds one turn, not a chain of turns; an event loop
 (completed -> send -> completed -> …) must carry its own termination condition — a hop counter in
 `session.metadata`, a budget sibling, or a terminal check in the handler.
+
+### Hook trigger types (synchronous)
+
+The five `harness::hook::*` types — `pre_turn`, `pre_generate`, `post_generate`, `pre_dispatch`,
+`post_dispatch` — are registered trigger types too, but binding one puts the function **in-path**:
+the harness invokes it synchronously at the hook point, in `priority` order, and acts on its
+return value (veto / hold / mutate), under the per-binding timeout and `on_error` policy. Config
+shape, chain order, and failure semantics are specified in [Hooks](#hooks); the async types above
+remain the right surface for anything observe-only.
 
 ### Triggers bound
 
@@ -709,8 +715,7 @@ appended and folded into it instead — no second turn starts (see
 the key maps to the `{ session_id, turn_id }` it first produced (see [State](#state), TTL-bound);
 a redelivered send returns the same response with `deduplicated: true` and changes nothing.
 
-**Profiles and sessions.** `agent` resolves a [profile](#agent-profiles); explicit per-send fields
-override it. `session.metadata` lands on `SessionMeta.metadata` when the send creates/ensures the
+**Sessions.** `session.metadata` lands on `SessionMeta.metadata` when the send creates/ensures the
 session — the tenancy hook session trigger configs and `session::list` filter on.
 
 - Invocation: **sync** (kicks an async/enqueued loop)
@@ -724,8 +729,7 @@ type SendRequest = {
                                   // role must be "user" or "custom" (else harness/invalid_message_role).
                                   // "custom" content never reaches the model (no wire mapping) —
                                   // such a send kicks a turn over the existing history only
-  agent?: string;                 // named profile (see Agent profiles); per-send fields override it
-  model?: string;                 // required unless the profile supplies it
+  model: string;
   provider?: string;
   idempotency_key?: string;       // webhook dedupe: a repeated key returns the original
                                   // {session_id, turn_id} and appends nothing
@@ -798,7 +802,8 @@ Example:
 
 ```jsonc
 // request — classify a ticket, get typed JSON back
-{ "message": "Classify: 'Refund not received after 14 days'", "agent": "classifier",
+{ "message": "Classify: 'Refund not received after 14 days'",
+  "model": "claude-sonnet-4", "provider": "anthropic",
   "options": { "output": { "type": "json", "schema": { "type": "object", "properties": {
     "category": { "type": "string" }, "urgency": { "type": "string" } } } } }
 // response
@@ -820,8 +825,7 @@ usually what consumers want.)
 ```typescript
 type SpawnRequest = {
   task: string | AgentMessage;    // the child's goal — its opening user message
-  agent?: string;                 // child profile (see Agent profiles)
-  model?: string;                 // required unless the profile/parent default supplies it
+  model?: string;                 // defaults to the parent turn's model
   provider?: string;
   session_id?: string;            // spawn into an existing session (e.g. a fork); default: create fresh
   options?: {
@@ -923,15 +927,32 @@ rewritten) result inline or reports the call **pending** (see
 [Deferred dispatch](#deferred-dispatch-pending-function-results)): `harness::spawn` is the built-in
 pending dispatch, and a `pre_dispatch` hook returning `hold` is the pluggable one — an approval
 gate is that hook plus a `harness::function::resolve` call on the decision (see
-[Out of scope](#out-of-scope-future-sibling-workers)).
+[approval-gate.md](approval-gate.md)).
 
 ### `harness::function::resolve`
 
-Deliver the result of a `pending` call and resume the parked turn (see
+Settle a `pending` call and resume the parked turn (see
 [Deferred dispatch](#deferred-dispatch-pending-function-results)). Called by the harness itself
-(child completion) or by a trusted sibling (an approval decision); denied to in-run agents.
-Idempotent: the `function_result` entry id is deterministic (`e_<turn_id>_<function_call_id>`), so
-duplicate resolves change nothing.
+(child completion) or by a trusted sibling (an approval decision — see
+[approval-gate.md](approval-gate.md)); denied to in-run agents. Two actions:
+
+- **`deliver`** (default) — the caller supplies the call's result: the harness appends the
+  `function_result` under the deterministic entry id and flips the checkpoint to `done`. This is
+  how child completions, approval denials, and timeout sweeps settle a call.
+- **`execute`** — valid only for calls held by a `pre_dispatch` hook (`held_by` set): the caller
+  supplies no result; the harness marks the call *released* and re-enqueues the turn, and the loop
+  step runs the call through the **remaining dispatch pipeline** — the `pre_dispatch` chain
+  resumes after the holding hook (the glob policy and earlier hooks already passed), the target is
+  invoked with the original call's provenance, the `post_dispatch` chain runs over the result, and
+  the result is appended as if the call had never been held. The checkpoint flips
+  `pending → dispatched → done`, so the at-most-once redelivery rule applies unchanged (see
+  [Durability & idempotency](#durability--idempotency)). This is how an approval *allow* releases
+  a held call without the approver re-implementing dispatch — invoking the target itself would
+  bypass `post_dispatch` redaction, the per-call checkpoints, and provenance.
+
+Idempotent in both modes: `deliver` writes the deterministic entry id
+(`e_<turn_id>_<function_call_id>`), so duplicates change nothing; a duplicate `execute` finds the
+checkpoint no longer `pending` and returns `resolved: false`.
 
 - Invocation: **sync**
 
@@ -940,13 +961,16 @@ type FunctionResolveRequest = {
   session_id: string;
   turn_id: string;
   function_call_id: string;
-  content: ContentBlock[];
+  action?: "deliver" | "execute"; // default "deliver"; "execute" only for held calls (held_by set)
+  // deliver only (required then; ignored on execute):
+  content?: ContentBlock[];
   is_error?: boolean;
   details?: unknown;          // structured payload (e.g. a child's output-contract result)
 };
 type FunctionResolveResponse = {
-  resolved: boolean;          // false when the call is unknown or already done
-  turn_resumed: boolean;      // true when this was the last pending call and the turn re-enqueued
+  resolved: boolean;          // false when the call is unknown, already done, or (execute) not held
+  turn_resumed: boolean;      // true when this resolve re-enqueued the turn
+                              // (deliver: last pending call settled; execute: always)
 };
 ```
 
@@ -1001,7 +1025,10 @@ type StatusResponse = {
 | `harness_idem` | `<idempotency_key>` | `{ session_id, turn_id, entry_id, ts }` | `harness::send` webhook dedupe (TTL ~24h). |
 
 Transcript truth lives in [session-manager](session-manager.md); the harness keeps only loop
-bookkeeping.
+bookkeeping. Neither scope expires on its own: `harness_idem` rows are TTL-bound by contract, and a
+deployment that deletes sessions can purge the corresponding `harness_turn/<session_id>` record
+from a [`session::deleted`](session-manager.md#trigger-types-emitted) binding — the same cascade
+pattern [approval-gate](approval-gate.md#state-lifecycle) mandates for its own scopes.
 
 ## Dependencies
 
@@ -1009,25 +1036,27 @@ bookkeeping.
   and set status. Required.
 - `llm-router` (`router::chat`) — generation. Required.
 - `context-manager` (`context::assemble`) — context budgeting. Soft; degrades to raw history.
-- `configuration` (soft) — the `harness` entry holding [agent profiles](#agent-profiles) and the
-  [hook bindings](#hooks); without it, inline per-send options work and no hooks run.
 - `iii-queue` — the durable `harness-turn` loop. The queue MUST provide per-session ordering with
   cross-session parallelism (partition by `session_id`); a single global FIFO would head-of-line
   block every session behind one long stream step. Sub-agent turns are ordinary entries on this
   queue under their child `session_id` — which is what makes spawned children run in parallel.
-- iii engine `iii.trigger` — function dispatch (`agent_trigger` unwrap → target function) and
+- iii engine — `iii.trigger` for function dispatch (`agent_trigger` unwrap → target function);
   registry reads (`engine::functions::list` / `engine::functions::info`) for runtime discovery and
-  `expose: "native"` schema mapping.
+  `expose: "native"` schema mapping; custom trigger-type registration (`registerTriggerType`) for
+  the [turn events](#trigger-types-emitted) and the [hook points](#hooks), with subscriber sets
+  rebuilt from the engine after a restart.
 
 ## Out of scope (future sibling workers)
 
 Kept out to preserve thinness; each is a clean add-on that wraps the loop or subscribes to its events:
 
 - **approval-gate** — the *policy and decision surface* for holding function calls: which calls
-  need a human, who may approve, where decisions land. The mechanics are already in core — a
-  `pre_dispatch` [hook](#hooks) returning `hold` plus
-  [`harness::function::resolve`](#harnessfunctionresolve) on the decision; the sibling ships the
-  hook function and the UI, never loop changes.
+  need a human, who may approve, where decisions land. Specified in
+  [approval-gate.md](approval-gate.md). The mechanics are already in core — a `pre_dispatch`
+  [hook](#hooks) returning `hold` plus
+  [`harness::function::resolve`](#harnessfunctionresolve) on the decision (`execute` to release,
+  `deliver` to deny); the sibling ships the hook function and its trigger binding, the pending
+  inbox and its triggers, and the UI — never loop changes.
 - **llm-budget** — track spend from `router` usage and cap per workspace/agent: a `pre_turn` /
   `pre_generate` [hook](#hooks) enforces the cap, and
   [`harness::turn_completed`](#trigger-types-emitted) plus the sub-agent linkage metadata give it
@@ -1037,10 +1066,14 @@ Kept out to preserve thinness; each is a clean add-on that wraps the loop or sub
 - **orchestration beyond spawn/join** — agent-to-agent messaging, shared blackboards, workflow
   graphs, supervisor pools. The harness ships [`harness::spawn`](#sub-agents-harnessspawn) (bounded
   fan-out/join) only; richer patterns compose on top of spawn and the turn events.
+- **agent presets** — named bundles of per-send options (model, system prompt, function policy,
+  output contract) shared across consumer surfaces. Consumers own their per-send options; a preset
+  sibling can resolve a name into a `SendRequest` and call `harness::send` itself — the harness
+  resolves nothing.
 
 (The previously planned **hook-fanout** sibling is superseded: synchronous lifecycle interception
 is the core [Hooks](#hooks) surface, and async observation is the turn events.) Siblings that need
-to sit *inside* the critical path register a [hook](#hooks); everything else binds events.
+to sit *inside* the critical path bind a [hook](#hooks); everything else binds events.
 
 ## Boundaries
 

--- a/tech-specs/2026-06-agentic/llm-router.md
+++ b/tech-specs/2026-06-agentic/llm-router.md
@@ -78,6 +78,8 @@ type ProviderStreamInput = {
   model: string;
   messages: AgentMessage[];         // provider serialises to its own wire format
   tools?: AgentFunction[];          // provider adapter: maps to OpenAI/Anthropic "tools" array
+  response_format?: { type: "json"; schema?: unknown }; // structured output; only sent to models
+                                    // that declare the "structured_output" capability
   thinking_level?: ThinkingLevel;   // provider maps to its native knob or ignores
 };
 
@@ -163,7 +165,8 @@ the provider for `model`, calls `provider::<id>::stream`, and relays frames to t
 (or pipes the provider's writer through, implementation's choice). The call resolves when the stream
 terminates.
 
-- Invocation: **sync** (open while streaming)
+- Invocation: **sync** (open while streaming — the bus's long-call pattern;
+  [`harness::run`](harness.md#harnessrun) holds its call open the same way)
 
 Request:
 
@@ -176,6 +179,9 @@ type ChatRequest = {
   system_prompt?: string | null;
   messages: AgentMessage[];
   tools?: AgentFunction[];          // provider adapter: maps to OpenAI/Anthropic "tools" array
+  response_format?: { type: "json"; schema?: unknown };
+                                    // provider-native structured output; requires the
+                                    // "structured_output" capability (see Model capabilities)
   thinking_level?: ThinkingLevel;
   metadata?: Record<string, unknown>; // passthrough for tracing (session_id, message_id, …)
 };
@@ -183,8 +189,15 @@ type ChatRequest = {
 
 The `tools` field is the **provider adapter boundary** — it maps to each provider's native
 function-calling / tool-use API. In iii domain language these are [function invocation
-schemas](README.md#function-invocation-schema), not "tools". The harness always passes a single
-`AgentFunction` entry for `agent_trigger`; other callers may pass an empty array or their own schemas.
+schemas](README.md#function-invocation-schema), not "tools". The harness passes a single
+`AgentFunction` entry for `agent_trigger` by default (per-function schemas in native exposure
+mode); other callers may pass an empty array or their own schemas.
+
+`response_format` is the same kind of boundary for structured output: providers map it to their
+native JSON / JSON-Schema mode (e.g. OpenAI `response_format: json_schema`). Callers check
+`router::models::supports(model, "structured_output")` first — supplying it for a model without the
+capability throws before streaming starts, so callers can fall back (the harness falls back to its
+`submit_result` strategy — see [harness.md § Output contract](harness.md#output-contract)).
 
 Response:
 
@@ -203,8 +216,10 @@ final `AssistantMessage`) or `error`. The router fills `usage.cost_usd` (on the 
 final message) from the catalog's `pricing` when the provider reports token counts but no cost.
 
 Errors (thrown before streaming starts): `model is required`; `no provider registered for model
-<id>`; `ambiguous model <id> (providers: …)`; `provider <id> unavailable`. Mid-stream failures
-arrive as an `error` frame, not a thrown error.
+<id>`; `ambiguous model <id> (providers: …)`; `provider <id> unavailable`;
+`structured output unsupported for model <id>` (a `response_format` was supplied but the model
+lacks the `structured_output` capability). Mid-stream failures arrive as an `error` frame, not a
+thrown error.
 
 Example:
 
@@ -401,6 +416,10 @@ strings, each mapping to a field on `Model`:
   or textually describe images first.
 - `cache` -> `supports_cache` — the provider supports prompt caching; the provider may insert cache
   markers to cut cost/latency on repeated prefixes.
+- `structured_output` -> `supports_structured_output` — the provider can constrain decoding to JSON
+  (optionally schema-guided) via a native `response_format`-style knob. If false, callers needing
+  typed output use a function-calling fallback instead (the harness injects `submit_result` — see
+  [harness.md § Output contract](harness.md#output-contract)).
 - `thinking` -> `supports_thinking` — the model exposes a reasoning/thinking budget at all (a
   `thinking_level` of `"minimal"` likewise needs only this flag).
 - `thinking:low` | `thinking:medium` | `thinking:high` -> still `supports_thinking` — the level picks
@@ -417,8 +436,11 @@ Unknown strings return `{ supported: false }` and match no models.
   `{ capability: "vision" }` for an image task.
 - **Request shaping (harness)** — before a turn the harness checks `supports_tools` to decide whether
   to attach the `agent_trigger` invocation schema, `supports_vision` to decide whether to keep image
-  blocks, and `supports_thinking`/`supports_xhigh` to decide whether a requested `thinking_level` is
-  honoured or dropped. This is how one harness drives many models without per-model branches.
+  blocks, `supports_thinking`/`supports_xhigh` to decide whether a requested `thinking_level` is
+  honoured or dropped, and `supports_structured_output` to choose between provider-native
+  `response_format` and the `submit_result` fallback for an
+  [output contract](harness.md#output-contract). This is how one harness drives many models without
+  per-model branches.
 - **Budgeting (context-manager)** — `context::assemble` reads `context_window` / `input_limit` /
   `max_output_tokens` to size the usable window, and `thinking_budgets` to leave room for the
   reasoning tokens a thinking tier consumes.

--- a/tech-specs/2026-06-agentic/llm-router.md
+++ b/tech-specs/2026-06-agentic/llm-router.md
@@ -736,7 +736,9 @@ catalog.
 - `configuration` — the `llm-router` entry (credentials/settings) and its change trigger (the
   paste-a-key discovery binding).
 - `iii-state` — model catalog and provider registry (both durable across router restarts).
-- `iii-stream` / channels — `router::chat` streaming.
+- Engine channels (`engine::channels::create`, `StreamChannelRef`) — `router::chat` streaming.
+  Not `iii-stream` (the durable `stream::*` store): the router uses only ephemeral
+  point-to-point channels.
 - Provider workers — one per upstream; discovered at runtime, not a build dependency.
 
 ## Boundaries

--- a/tech-specs/2026-06-agentic/llm-router.md
+++ b/tech-specs/2026-06-agentic/llm-router.md
@@ -76,7 +76,7 @@ type ProviderStreamInput = {
   system_prompt?: string | null;
   model: string;
   messages: AgentMessage[];         // provider serialises to its own wire format
-  tools?: AgentFunction[];
+  tools?: AgentFunction[];          // provider adapter: maps to OpenAI/Anthropic "tools" array
   thinking_level?: string;          // "minimal"|"low"|"medium"|"high"|"xhigh"; provider maps or ignores
 };
 
@@ -157,11 +157,16 @@ type ChatRequest = {
   provider?: string;                // disambiguate when a model id exists on multiple providers
   system_prompt?: string | null;
   messages: AgentMessage[];
-  tools?: AgentFunction[];
+  tools?: AgentFunction[];          // provider adapter: maps to OpenAI/Anthropic "tools" array
   thinking_level?: string;
   metadata?: Record<string, unknown>; // passthrough for tracing (session_id, message_id, …)
 };
 ```
+
+The `tools` field is the **provider adapter boundary** — it maps to each provider's native
+function-calling / tool-use API. In iii domain language these are [function invocation
+schemas](README.md#function-invocation-schema), not "tools". The harness always passes a single
+`AgentFunction` entry for `agent_trigger`; other callers may pass an empty array or their own schemas.
 
 Response:
 
@@ -292,7 +297,7 @@ type ProviderRegisterResponse = { ok: true; id: string };
 ### `router::provider::resolve`
 
 Called by a provider worker per request to get its credential + effective settings. **Agent-gated**:
-denied to in-run agents so a credential can't be exfiltrated through tool calls (see
+denied to in-run agents so a credential can't be exfiltrated through function calls (see
 [Security](#security)). Worker-to-worker calls bypass the agent gate.
 
 - Invocation: **sync**
@@ -335,8 +340,8 @@ consumer adapts the request to the chosen model instead of hardcoding per-model 
 `router::models::supports` and the `capability` filter on `router::models::list` accept these
 strings, each mapping to a field on `Model`:
 
-- `tools` -> `supports_tools` — the model accepts an `AgentFunction[]` and can emit `function_call`
-  content. If false, callers must not attach tools.
+- `tools` -> `supports_tools` — the model accepts function-calling (provider `tools` / tool-use API)
+  and can emit `function_call` content. If false, callers must not attach invocation schemas.
 - `vision` -> `supports_vision` — the model accepts `image` content blocks. If false, callers strip
   or textually describe images first.
 - `cache` -> `supports_cache` — the provider supports prompt caching; the provider may insert cache
@@ -352,12 +357,12 @@ Unknown strings return `{ supported: false }` and match no models.
 ### How callers use it
 
 - **Discovery / model picker** — a UI lists only relevant models:
-  `router::models::list({ capability: "tools" })` for an agent that needs tools, or
+  `router::models::list({ capability: "tools" })` for an agent that needs function-calling, or
   `{ capability: "vision" }` for an image task.
 - **Request shaping (harness)** — before a turn the harness checks `supports_tools` to decide whether
-  to attach the tool schema, `supports_vision` to decide whether to keep image blocks, and
-  `supports_thinking`/`supports_xhigh` to decide whether a requested `thinking_level` is honoured or
-  dropped. This is how one harness drives many models without per-model branches.
+  to attach the `agent_trigger` invocation schema, `supports_vision` to decide whether to keep image
+  blocks, and `supports_thinking`/`supports_xhigh` to decide whether a requested `thinking_level` is
+  honoured or dropped. This is how one harness drives many models without per-model branches.
 - **Budgeting (context-manager)** — `context::assemble` reads `context_window` / `input_limit` /
   `max_output_tokens` to size the usable window, and `thinking_budgets` to leave room for the
   reasoning tokens a thinking tier consumes.
@@ -401,7 +406,7 @@ change.
 
 - `router::provider::resolve` and `configuration::*` MUST be denied to in-run agents in the
   deployment's `iii-permissions.yaml`. Credentials live in plaintext in the configuration value;
-  these denials keep an agent from reading them via a tool call. Provider workers (and operator UIs)
+  these denials keep an agent from reading them via a function call. Provider workers (and operator UIs)
   call them as worker/user-initiated calls, which bypass the agent gate.
 - `router::chat` / `router::complete` / `router::models::*` / `router::provider::list` are safe to
   expose to consumers.
@@ -433,7 +438,7 @@ catalog.
 
 - Does **not** persist conversations or build context — pass full `messages` in each call (use
   [session-manager](session-manager.md) / [context-manager](context-manager.md) upstream).
-- Does **not** run the agent loop, dispatch tools, or gate approvals — that is the
+- Does **not** run the agent loop, dispatch functions, or gate approvals — that is the
   [harness](harness.md).
 - Does **not** seed models from a static list — the catalog is provider-sourced via
   `router::models::reconcile`.

--- a/tech-specs/2026-06-agentic/llm-router.md
+++ b/tech-specs/2026-06-agentic/llm-router.md
@@ -57,11 +57,12 @@ A provider worker MUST:
 1. Register `provider::<id>::stream` honouring the channel-writer contract below.
 2. Self-declare to the router at startup via `router::provider::register`.
 3. Resolve credentials per request via `router::provider::resolve` (never read keys directly).
+4. Treat closure of its stream channel as cancellation: abort the upstream request and stop writing
+   frames (see [Stream liveness and cancellation](#stream-liveness-and-cancellation)).
 
 A provider worker MAY:
 
-4. Register `provider::<id>::complete` (legacy non-streaming) and
-   `provider::<id>::refresh_models` (live model discovery into the catalog).
+5. Register `provider::<id>::refresh_models` (live model discovery into the catalog).
 
 ### Provider stream contract
 
@@ -77,7 +78,7 @@ type ProviderStreamInput = {
   model: string;
   messages: AgentMessage[];         // provider serialises to its own wire format
   tools?: AgentFunction[];          // provider adapter: maps to OpenAI/Anthropic "tools" array
-  thinking_level?: string;          // "minimal"|"low"|"medium"|"high"|"xhigh"; provider maps or ignores
+  thinking_level?: ThinkingLevel;   // provider maps to its native knob or ignores
 };
 
 type ProviderStreamOutput = { ok: boolean; status?: string };
@@ -85,6 +86,19 @@ type ProviderStreamOutput = { ok: boolean; status?: string };
 
 The router treats `provider::<id>::*` as an interface it *calls*, not functions it registers. See
 [Authoring a provider](#authoring-a-provider).
+
+### Stream liveness and cancellation
+
+- **Heartbeat.** A provider SHOULD write `{ type: "ping" }` at least every 30s when the upstream is
+  alive but producing no frames (long thinking stretches, queued requests). Consumers ignore `ping`.
+- **Idle timeout.** The router applies an idle timeout per stream (default 120s without any frame;
+  configurable in the `llm-router` entry). On expiry it cancels the provider call and writes a
+  terminal `error` frame (`error_kind: "transient"`) to the caller's channel — a provider crash
+  mid-stream can therefore never hang a consumer.
+- **Cancellation.** [`router::abort`](#routerabort) (or the caller closing its read side) closes the
+  provider's stream channel; channel closure **is** the abort signal, which a provider MUST honour
+  by cancelling its upstream HTTP call. The router synthesizes the terminal frame if the provider
+  exits without one.
 
 ## Functions
 
@@ -94,6 +108,7 @@ Consumer-facing:
   `AssistantMessageEvent` frames.
 - `router::complete` — Non-streaming: return the final `AssistantMessage` (drains the stream
   internally).
+- `router::abort` — Abort an in-flight `router::chat` stream by `request_id`.
 - `router::models::list` — List available models, optionally filtered by provider/capability.
 - `router::models::get` — Look up one model's capabilities by `(provider, id)`.
 - `router::models::supports` — Check whether a model supports a capability.
@@ -104,6 +119,8 @@ Provider protocol (router side):
 - `router::provider::register` — A provider self-declares its id, config schema, and defaults.
 - `router::provider::resolve` — A provider resolves its credential + settings at request time.
   **Agent-gated** (see [Security](#security)).
+- `router::provider::update_credential` — A provider persists a refreshed/rotated credential
+  (OAuth). **Agent-gated.**
 - `router::models::reconcile` — A provider replaces its catalog slice in one write.
 
 ## Triggers
@@ -136,7 +153,7 @@ iii.registerTrigger({
 ## API Reference
 
 Shared types (`AgentMessage`, `AssistantMessage`, `AssistantMessageEvent`, `AgentFunction`, `Model`,
-`StreamChannelRef`, `Credential`, `Usage`) are defined in
+`ThinkingLevel`, `StreamChannelRef`, `Credential`, `Usage`) are defined in
 [README.md § Cross-cutting contracts](README.md#cross-cutting-contracts).
 
 ### `router::chat`
@@ -153,12 +170,13 @@ Request:
 ```typescript
 type ChatRequest = {
   writer_ref: StreamChannelRef;     // direction "write"; the caller's channel
+  request_id?: string;              // correlation id for router::abort + tracing; generated when omitted
   model: string;
   provider?: string;                // disambiguate when a model id exists on multiple providers
   system_prompt?: string | null;
   messages: AgentMessage[];
   tools?: AgentFunction[];          // provider adapter: maps to OpenAI/Anthropic "tools" array
-  thinking_level?: string;
+  thinking_level?: ThinkingLevel;
   metadata?: Record<string, unknown>; // passthrough for tracing (session_id, message_id, …)
 };
 ```
@@ -181,11 +199,12 @@ type ChatResponse = {
 ```
 
 Streamed over the channel: a sequence of `AssistantMessageEvent`, terminating in `done` (carrying the
-final `AssistantMessage`) or `error`.
+final `AssistantMessage`) or `error`. The router fills `usage.cost_usd` (on the `usage` frame and the
+final message) from the catalog's `pricing` when the provider reports token counts but no cost.
 
 Errors (thrown before streaming starts): `model is required`; `no provider registered for model
-<id>`; `provider <id> unavailable`. Mid-stream failures arrive as an `error` frame, not a thrown
-error.
+<id>`; `ambiguous model <id> (providers: …)`; `provider <id> unavailable`. Mid-stream failures
+arrive as an `error` frame, not a thrown error.
 
 Example:
 
@@ -223,6 +242,21 @@ type CompleteResponse = {
   provider: string;
   model: string;
 };
+```
+
+### `router::abort`
+
+Abort an in-flight stream. The router closes the provider's stream channel (closure **is** the
+cancellation signal — see [Stream liveness and cancellation](#stream-liveness-and-cancellation))
+and, if the provider has not already terminated, synthesizes a terminal `done` frame on the caller's
+channel carrying the partial message with `stop_reason: "aborted"`. The original `router::chat` call
+then resolves normally.
+
+- Invocation: **sync**
+
+```typescript
+type AbortRequest = { request_id: string };
+type AbortResponse = { aborted: boolean }; // false when unknown or already terminal
 ```
 
 ### `router::models::list`
@@ -290,9 +324,17 @@ type ProviderDeclaration = {
   defaults?: { api_url?: string; max_tokens?: number; [k: string]: unknown };
   config_schema?: Record<string, unknown>; // custom JSON Schema; omit for the standard one
   supports_model_listing?: boolean;
+  models?: Model[];                 // static catalog slice; reconciled at registration
 };
 type ProviderRegisterResponse = { ok: true; id: string };
 ```
+
+When the declaration carries `models`, the router runs `router::models::reconcile` with them
+immediately. A provider without live listing MUST declare its routable models here, so the catalog
+never has silent holes — model-only routing and `context-manager`'s budget resolution
+(`router::models::get`) both depend on catalog coverage; a missing record silently degrades a 200k
+model to the conservative 8k fallback budget. Later `provider::<id>::refresh_models` discovery
+replaces the slice.
 
 ### `router::provider::resolve`
 
@@ -311,6 +353,19 @@ type ProviderResolveResponse = {
   api_url?: string;
   max_tokens?: number;
 };
+```
+
+### `router::provider::update_credential`
+
+The write-back path for rotating credentials: an OAuth provider that refreshes an expired token
+persists the new credential here — provider workers never write the configuration entry directly.
+**Agent-gated** like `resolve` (see [Security](#security)).
+
+- Invocation: **sync**
+
+```typescript
+type ProviderUpdateCredentialRequest = { id: string; credential: Credential };
+type ProviderUpdateCredentialResponse = { ok: true };
 ```
 
 ### `router::models::reconcile`
@@ -346,7 +401,8 @@ strings, each mapping to a field on `Model`:
   or textually describe images first.
 - `cache` -> `supports_cache` — the provider supports prompt caching; the provider may insert cache
   markers to cut cost/latency on repeated prefixes.
-- `thinking` -> `supports_thinking` — the model exposes a reasoning/thinking budget at all.
+- `thinking` -> `supports_thinking` — the model exposes a reasoning/thinking budget at all (a
+  `thinking_level` of `"minimal"` likewise needs only this flag).
 - `thinking:low` | `thinking:medium` | `thinking:high` -> still `supports_thinking` — the level picks
   a budget tier (mapped to the provider's native knob; see `thinking_budgets`).
 - `thinking:xhigh` -> `supports_xhigh` — the model supports the extra-high reasoning tier specifically
@@ -395,8 +451,12 @@ ceiling when known, so an over-large value can't cause upstream 400s.
 `decide(model, provider?)` resolves a target `provider::<id>::stream`:
 
 1. If `provider` is given and registered -> that provider.
-2. Else, the unique provider whose catalog contains `model`.
-3. Else, an optional model-name heuristic (prefix/regex per provider).
+2. Else, the unique provider whose catalog contains `model`. If **several** providers serve the same
+   model id, the call fails with `ambiguous model <id> (providers: a, b)` — the caller must pass
+   `provider`; the router never picks silently.
+3. Else, an optional model-name heuristic from the `llm-router` configuration entry —
+   `routing_heuristics: [{ pattern, provider }]`, first match wins (e.g.
+   `{ "pattern": "^gpt-", "provider": "openai" }`).
 4. Else -> throw `no provider registered for model <id>`.
 
 Routing reads the live registry; adding a provider worker makes its models routable with no router
@@ -404,12 +464,21 @@ change.
 
 ## Security
 
-- `router::provider::resolve` and `configuration::*` MUST be denied to in-run agents in the
-  deployment's `iii-permissions.yaml`. Credentials live in plaintext in the configuration value;
-  these denials keep an agent from reading them via a function call. Provider workers (and operator UIs)
-  call them as worker/user-initiated calls, which bypass the agent gate.
-- `router::chat` / `router::complete` / `router::models::*` / `router::provider::list` are safe to
-  expose to consumers.
+Agent-gating relies on provenance propagation through nested triggers — see
+[README § Security model](README.md#security-model).
+
+Agent exposure (`iii-permissions.yaml`):
+
+- **Deny to in-run agents:** `router::provider::resolve` and `router::provider::update_credential`
+  (credential read/write), `router::provider::register` (provider spoofing),
+  `router::models::reconcile` (catalog poisoning), and all of `configuration::*` (the entry carries
+  plaintext keys). Provider workers and operator UIs call these as worker/user-initiated calls,
+  which bypass the agent gate.
+- **Deny by default:** `router::chat` / `router::complete` / `router::abort` — not secret-bearing,
+  but an agent that can call the router directly generates spend outside the harness loop's
+  accounting and `max_turns` guard.
+- **Safe:** `router::models::list` / `router::models::get` / `router::models::supports` /
+  `router::provider::list`.
 
 ## Authoring a provider
 
@@ -417,10 +486,15 @@ To add a provider `foo`:
 
 1. Implement `provider::foo::stream` honouring [the provider stream contract](#provider-stream-contract);
    write `AssistantMessageEvent` frames to the hydrated `writer_ref`, end with `done`/`error`, close.
+   Honour [liveness and cancellation](#stream-liveness-and-cancellation): emit `ping` through silent
+   stretches, abort the upstream request when the channel closes.
 2. At startup, call `router::provider::register` with
-   `{ id: "foo", credential_env_var: "FOO_API_KEY", defaults, supports_model_listing }`.
+   `{ id: "foo", credential_env_var: "FOO_API_KEY", defaults, supports_model_listing, models }` —
+   include the static `models` slice unless step 4 is implemented.
 3. In the stream handler, call `router::provider::resolve({ id: "foo" })` for the credential +
    `api_url`/`max_tokens`. Cloud providers throw on `credential: null`; local providers tolerate it.
+   OAuth providers refresh expired tokens themselves and persist the result via
+   `router::provider::update_credential`.
 4. (Optional) Implement `provider::foo::refresh_models` -> `router::models::reconcile` for live model
    discovery.
 
@@ -440,5 +514,6 @@ catalog.
   [session-manager](session-manager.md) / [context-manager](context-manager.md) upstream).
 - Does **not** run the agent loop, dispatch functions, or gate approvals — that is the
   [harness](harness.md).
-- Does **not** seed models from a static list — the catalog is provider-sourced via
-  `router::models::reconcile`.
+- Does **not** seed models from a static list of its own — the catalog is provider-sourced via
+  `router::models::reconcile` (live discovery, or the static `models` slice in a provider's
+  declaration).

--- a/tech-specs/2026-06-agentic/llm-router.md
+++ b/tech-specs/2026-06-agentic/llm-router.md
@@ -10,18 +10,23 @@ provider workers. A consumer never talks to a provider directly; it calls `route
 provider never talks to a consumer; it implements a narrow contract (`provider::<id>::stream`),
 self-registers, and only ever talks back to the router.
 
-The router owns four things:
+The router owns five things:
 
 1. **Routing** — map a `model` (and/or `provider`) to a `provider::<id>::stream` handler, from the
    live registry of declared providers. No hardcoded provider list.
 2. **The provider registry** — providers self-declare at startup (`router::provider::register`); the
    router composes their config slices and resolves credentials per request
-   (`router::provider::resolve`).
+   (`router::provider::resolve`). Registration is identity-bound, idempotent, and survives boot
+   ordering (see [Registration lifecycle](#registration-lifecycle)).
 3. **Credentials & settings** — stored in the engine's built-in `configuration` worker under one
    `llm-router` entry; resolved centrally with env-var fallback. Provider workers never read keys
    from disk/env themselves.
 4. **The model catalog** — capability records served from `router::models::*`, populated exclusively
-   by provider discovery (`router::models::reconcile`); no baked-in seed.
+   by provider discovery (`router::models::reconcile`); no baked-in seed of the router's own.
+5. **The failure contract** — typed errors, timeouts, bounded retries, and cancellation are defined
+   once, in the router (see [Stream liveness and cancellation](#stream-liveness-and-cancellation)
+   and [Retries](#retries)). Providers implement protocol-specific recovery only; generic transport
+   retries live in the router and nowhere else.
 
 It is **consumer-agnostic**: it assumes no harness, session, or UI. It streams into a caller-supplied
 channel and returns. That is exactly what lets a `third-party-worker` "use llm directly without
@@ -55,14 +60,21 @@ flowchart TB
 A provider worker MUST:
 
 1. Register `provider::<id>::stream` honouring the channel-writer contract below.
-2. Self-declare to the router at startup via `router::provider::register`.
+2. Self-declare to the router at startup via `router::provider::register`, **retrying with backoff
+   until acknowledged** (covers provider-before-router boot ordering), and **re-declare on
+   `router::ready`** after a router restart (see [Registration lifecycle](#registration-lifecycle)).
 3. Resolve credentials per request via `router::provider::resolve` (never read keys directly).
 4. Treat closure of its stream channel as cancellation: abort the upstream request and stop writing
    frames (see [Stream liveness and cancellation](#stream-liveness-and-cancellation)).
+5. Map upstream failures to the shared `ErrorKind` taxonomy on its `error` frames — five providers
+   MUST NOT invent five taxonomies.
+6. **Not** implement generic transport retries (429 / 5xx / connect errors) — retry policy is owned
+   by the router (see [Retries](#retries)). Protocol-specific recovery stays provider-side (e.g. a
+   local runtime auto-loading a cold model before re-issuing its own upstream request).
 
 A provider worker MAY:
 
-5. Register `provider::<id>::refresh_models` (live model discovery into the catalog).
+7. Register `provider::<id>::refresh_models` (live model discovery into the catalog).
 
 ### Provider stream contract
 
@@ -81,10 +93,35 @@ type ProviderStreamInput = {
   response_format?: { type: "json"; schema?: unknown }; // structured output; only sent to models
                                     // that declare the "structured_output" capability
   thinking_level?: ThinkingLevel;   // provider maps to its native knob or ignores
+  max_output_tokens?: number;       // effective output budget, resolved + clamped by the router
+                                    // (see Configuration § Output-token defaults)
+  provider_options?: Record<string, unknown>; // this provider's passthrough slice, forwarded verbatim
+  model_meta?: Model;               // optional hint: the catalog record at routing time
+  resolution_key?: string;          // optional hint: lets the provider skip redundant resolve calls
 };
 
 type ProviderStreamOutput = { ok: boolean; status?: string };
 ```
+
+`model_meta` and `resolution_key` are **optimizations, never sources of truth**: a provider MUST
+behave identically when they are absent, and `router::provider::resolve` / `router::models::get`
+remain authoritative. They exist so a many-call turn doesn't pay a resolve + catalog round-trip per
+request — the router resolves once and forwards.
+
+The `AssistantMessageEvent` union (see [README § Streaming events](README.md#streaming-events)) is
+the **frozen, normative vocabulary** — new frame types are a contract revision, not a provider
+choice. Per stream: `start` MUST come first and exactly one terminal `done`/`error` MUST come last
+(the router synthesizes the terminal frame if the provider dies); the `*_start`/`*_delta`/`*_end`
+triplets MUST be emitted for their block types; `usage` SHOULD be emitted as soon as usage is known
+(including on streams that later fail); `ping` and `stop` MAY be emitted. Where a value appears both
+mid-stream and on the terminal frame (`stop_reason`, `usage`), **the terminal frame is
+authoritative** — `ChatResponse` copies are populated from it.
+
+When a provider drops or degrades an unsupported request parameter (e.g. ignoring `thinking_level`
+on a non-thinking model during a cold-catalog window) it SHOULD report-and-continue by appending to
+`warnings` on the final `AssistantMessage` rather than failing the request, and MAY set
+`native_stop_reason` to preserve the upstream's raw finish reason alongside the normalized
+`StopReason`.
 
 The router treats `provider::<id>::*` as an interface it *calls*, not functions it registers. See
 [Authoring a provider](#authoring-a-provider).
@@ -99,8 +136,31 @@ The router treats `provider::<id>::*` as an interface it *calls*, not functions 
   mid-stream can therefore never hang a consumer.
 - **Cancellation.** [`router::abort`](#routerabort) (or the caller closing its read side) closes the
   provider's stream channel; channel closure **is** the abort signal, which a provider MUST honour
-  by cancelling its upstream HTTP call. The router synthesizes the terminal frame if the provider
-  exits without one.
+  by cancelling its upstream HTTP call — "the upstream keeps generating and billing to `max_tokens`
+  after the user hit stop" is a contract violation. The router synthesizes the terminal frame if
+  the provider exits without one.
+- **Total budget.** The chain `consumer → router::chat → provider::<id>::stream` is two nested
+  **sync** calls; SDK defaults (~30s) would kill any real turn. The router MUST set an explicit
+  total-stream budget on its `provider::<id>::stream` call — default **300s**, configurable in the
+  `llm-router` entry — and a consumer calling `router::chat` MUST use an outer timeout **≥ the
+  router's inner budget** (outer ≥ inner, always; otherwise the consumer kills turns the router
+  considers healthy). On expiry the router cancels the provider call and synthesizes the terminal
+  `error` frame (`error_kind: "transient"`), exactly like the idle case.
+
+### Retries
+
+One retry policy, in the router, nowhere else:
+
+- **What retries:** only `rate_limited` and `transient` failures (HTTP 429 / 5xx / connect errors).
+  `auth_expired`, `context_overflow`, `permanent`, and all routing errors never retry.
+- **When:** only **before the first frame has been relayed to the caller**. Once bytes have
+  streamed, the failure is delivered as the `error` frame as specced — no silent restart of a
+  half-delivered stream.
+- **How much:** bounded — default 2 further attempts with capped exponential backoff + jitter,
+  configurable in the `llm-router` entry.
+- **Providers MUST NOT** layer generic retries underneath (stacked retry layers multiply worst-case
+  latency unboundedly); protocol-specific recovery — a local runtime loading a cold model and
+  re-issuing its own request — is allowed and stays inside the provider.
 
 ## Functions
 
@@ -133,8 +193,11 @@ Provider protocol (router side):
   `{ provider: string; count: number }`. Lets pickers refresh reactively.
 - **`router::provider::changed`** — fires when the provider registry changes (declare / availability
   flip). Payload: `{ provider: string; op: "register" | "available" | "unavailable" }`.
+- **`router::ready`** — fires once when the router finishes booting. Providers bind to it and
+  re-declare, so a router restart re-populates the registry without manual intervention (see
+  [Registration lifecycle](#registration-lifecycle)).
 
-Bind either the standard two-step way (see [README § Reactive pattern](README.md#reactive-pattern)).
+Bind any of these the standard two-step way (see [README § Reactive pattern](README.md#reactive-pattern)).
 
 ### Triggers bound
 
@@ -149,6 +212,20 @@ iii.registerTrigger({
   config: { topic: "engine::workers-available" },
 });
 ```
+
+  Topology events carry **worker ids**, not provider ids. The router maps between them using the
+  worker-identity binding captured at `register` time (see
+  [Registration lifecycle](#registration-lifecycle)). A worker connecting that has not registered
+  any provider does **not** create an available provider; a provider flips `available: true` only
+  when its bound worker is connected **and** its registration is complete.
+
+- **`router::on_config_changed`** bound to the `configuration` worker's change trigger for the
+  `llm-router` entry. The handler fingerprints each provider's config slice, diffs against the last
+  seen fingerprint, and — debounced (~2s) — calls `provider::<id>::refresh_models` for each provider
+  whose slice changed and that declared `supports_model_listing`. This is the **paste-a-key flow**:
+  an operator adds an API key in the config UI → discovery runs → `router::models::reconcile` →
+  `router::models::changed` → the picker populates within seconds, with no worker restart. Without
+  this binding a key added at runtime would populate nothing until the provider worker restarts.
 
 ---
 
@@ -183,6 +260,12 @@ type ChatRequest = {
                                     // provider-native structured output; requires the
                                     // "structured_output" capability (see Model capabilities)
   thinking_level?: ThinkingLevel;
+  max_output_tokens?: number;       // optional override; clamped to the model's catalog ceiling
+                                    // (see Configuration § Output-token defaults)
+  provider_options?: Record<string, Record<string, unknown>>;
+                                    // escape hatch, namespaced by provider id; the router forwards
+                                    // only the routed provider's slice, verbatim. Keeps new provider
+                                    // knobs from becoming protocol revs.
   metadata?: Record<string, unknown>; // passthrough for tracing (session_id, message_id, …)
 };
 ```
@@ -208,18 +291,28 @@ type ChatResponse = {
   model: string;
   stop_reason?: StopReason;
   usage?: Usage;
+  error?: { code: string; message: string };  // present when ok === false; mirrors the throw code
+                                              // or the error frame's error_kind
 };
 ```
 
 Streamed over the channel: a sequence of `AssistantMessageEvent`, terminating in `done` (carrying the
 final `AssistantMessage`) or `error`. The router fills `usage.cost_usd` (on the `usage` frame and the
-final message) from the catalog's `pricing` when the provider reports token counts but no cost.
+final message) from the catalog's `pricing` when the provider reports token counts but no cost. The
+terminal frame is **authoritative** for `stop_reason`/`usage`; `ChatResponse` copies them from it
+(including when the router relays rather than pipes through). On failed streams the final `error`
+message SHOULD still carry the partial `Usage` when the provider reported it before dying.
 
-Errors (thrown before streaming starts): `model is required`; `no provider registered for model
-<id>`; `ambiguous model <id> (providers: …)`; `provider <id> unavailable`;
-`structured output unsupported for model <id>` (a `response_format` was supplied but the model
-lacks the `structured_output` capability). Mid-stream failures arrive as an `error` frame, not a
-thrown error.
+Errors (thrown before streaming starts, in the
+[`{ code, message }` convention](README.md#error-conventions)): `model is required`
+(`router/invalid_request`); `no provider registered for model <id>`
+(`router/no_provider_for_model`); `ambiguous model <id> (providers: …)` (`router/ambiguous_model`);
+`unknown provider <id>` (`router/unknown_provider` — an explicit `provider` that is not registered
+fails loudly, including typos); `provider <id> unavailable` (`router/provider_unavailable`);
+`provider <id> not configured` (`router/not_configured` — a cloud provider with no usable
+credential); `structured output unsupported for model <id>` (`router/structured_output_unsupported`
+— a `response_format` was supplied but the model lacks the `structured_output` capability).
+Mid-stream failures arrive as an `error` frame carrying an `ErrorKind`, not a thrown error.
 
 Example:
 
@@ -304,7 +397,9 @@ type ModelsSupportsRequest = { provider: string; id: string; capability: Capabil
 type ModelsSupportsResponse = { supported: boolean };
 ```
 
-Unknown model or capability returns `{ supported: false }`. See
+Unknown model or capability returns `{ supported: false }` — but for *request shaping* an unknown
+model means "unknown", not "unsupported": see
+[Capability defaults](#capability-defaults) for the cold-window rule. See
 [Model capabilities](#model-capabilities) for what each capability means and how callers use it.
 
 ### `router::provider::list`
@@ -316,11 +411,15 @@ type ProviderInfo = {
   id: string;
   display_name: string;
   configured: boolean;          // has a usable credential (stored or via env)
-  available: boolean;           // the provider worker is currently connected
+  available: boolean;           // the provider worker is currently connected and registered
   supports_model_listing: boolean;
 };
 type ProviderListResponse = { providers: ProviderInfo[] };
 ```
+
+`available` means the provider *worker* is reachable, not that the upstream API is healthy —
+upstream health probes and cooldowns are out of MVP scope; an `available` provider can still fail a
+request with a typed error.
 
 ### `router::provider::register`
 
@@ -350,6 +449,19 @@ never has silent holes — model-only routing and `context-manager`'s budget res
 (`router::models::get`) both depend on catalog coverage; a missing record silently degrades a 200k
 model to the conservative 8k fallback budget. Later `provider::<id>::refresh_models` discovery
 replaces the slice.
+
+Registration semantics (see [Registration lifecycle](#registration-lifecycle) for the full rules):
+
+- **Idempotent** — re-registering the same id merges the declaration and **preserves operator-set
+  config values**; declaration `defaults` never overwrite stored configuration.
+- **Serialized** — the router serializes all registry/config-entry mutations through a single
+  writer, so N providers booting concurrently cannot drop each other's schema slices via
+  read-merge-write races.
+- **Identity-bound** — the first registration binds the provider id to the calling worker's
+  identity; later calls for that id from a different worker are rejected.
+
+Secret-bearing fields in a custom `config_schema` MUST be marked write-only (`writeOnly: true` /
+`format: "password"`), matching the default schema, so config UIs never echo stored keys.
 
 ### `router::provider::resolve`
 
@@ -395,6 +507,16 @@ type ModelsReconcileResponse = { provider: string; count: number };
 ```
 
 Fires `router::models::changed`.
+
+**Reconcile-to-empty guidance.** A provider MUST distinguish failure classes during discovery:
+
+- **Auth failure** (invalid/revoked key) → reconcile to an **empty** slice; the models are genuinely
+  unusable and the picker should reflect that.
+- **Transient failure** (timeout, 5xx, network) → **do not reconcile**; keep the previous slice so a
+  blip doesn't wipe a working catalog.
+
+The empty reconcile doubles as the eviction path: catalog slices are not immortal, and removing a
+provider's config slice (or letting an auth-failed discovery run) clears its models.
 
 ---
 
@@ -446,9 +568,29 @@ Unknown strings return `{ supported: false }` and match no models.
   reasoning tokens a thinking tier consumes.
 - **Cost (a budget sibling)** — `pricing` lets a spend-tracking worker turn `Usage` into `cost_usd`.
 
-Capabilities come exclusively from provider discovery (`router::models::reconcile`). A provider that
-does not report a flag leaves it absent/false, and callers must treat "unknown" as "unsupported"
-rather than assuming a default.
+### Catalog metadata sources
+
+Live `/models` endpoints return little more than bare ids; nobody gets context windows, output
+ceilings, thinking budgets, or pricing from them. Each provider is therefore expected to **embed
+curated capability metadata** (e.g. a models.dev-derived snapshot, or the hand-maintained static
+`models` slice in its declaration) and merge it with the live id list during discovery, submitting
+the enriched records through the single `router::models::reconcile` write path. A provider that
+reconciles bare ids degrades every downstream consumer — preflight sizing, output clamping,
+thinking budgets — and should be treated as incomplete.
+
+### Capability defaults
+
+Capabilities come exclusively from provider discovery (`router::models::reconcile`) plus the static
+declaration slice. For a **known** model, an absent flag reads as false: callers gate on the record.
+
+For an **unknown** model (`models::get` → null — a cold window before a provider has registered, or
+a slice pruned after a key outage), "unknown" means **unknown, not unsupported**. Request-shaping
+callers MUST fail open — keep invocation schemas attached, keep image blocks, pass the requested
+`thinking_level` through (providers MAY apply id-based heuristics, e.g. an OpenAI reasoning-model
+id pattern) — and let the provider, the final arbiter, degrade or error. A literal
+unknown-as-unsupported reading would strip images everywhere and drop thinking during every cold
+window, including dropping the harness's own `agent_trigger` schema. Pickers and capability filters
+simply don't list unknown models; only request shaping gets the permissive default.
 
 ## Configuration
 
@@ -457,32 +599,84 @@ settings. Its `providers` JSON Schema is composed dynamically from each provider
 
 ```jsonc
 {
+  "default_provider": "anthropic",   // optional; makes routing total (see Routing)
   "providers": {
     "anthropic": { "api_key": "sk-ant-…", "api_url": "https://api.anthropic.com/v1/messages", "max_tokens": 8192 },
     "openai":    { "api_key": "sk-…" },
     "lmstudio":  { "max_tokens": 8192 }   // local; no key needed
-  }
+  },
+  "routing_heuristics": [{ "pattern": "^gpt-", "provider": "openai" }]
 }
 ```
 
-A configured `max_tokens` overrides the per-model default but is clamped to the model's catalog
-ceiling when known, so an over-large value can't cause upstream 400s.
+> **Entry migration note.** In the previous-generation harness this content lived inside the single
+> `harness` configuration entry, alongside a `permissions` block (`permissions.default_mode`). The
+> split moves only the provider credentials/settings here; the permissions block is **re-homed to
+> the harness's own configuration entry** — see [harness.md § Configuration](harness.md#configuration).
+> Neither block may be silently dropped during migration.
+
+### Output-token defaults
+
+The effective `max_output_tokens` for a request is resolved by the router, once, with this
+precedence — and forwarded as `ProviderStreamInput.max_output_tokens`:
+
+1. **Explicit override** (request `max_output_tokens`, or the provider's configured `max_tokens`) —
+   wins, clamped **down** to the model's catalog ceiling when known (a deliberate choice is
+   honoured; the soft cap below does not apply), so an over-large value can't cause upstream 400s.
+2. **Per-model default** — `min(model.max_output_tokens, soft cap)`. The soft cap defaults to
+   **32 000** tokens (configurable in the `llm-router` entry), so high-output models (Claude
+   64k/128k, GPT-5 272k) don't burn latency and cost on every routine turn.
+3. **Unknown model** (cold catalog) — the provider's declared default (e.g. 8192).
 
 ## Routing
 
-`decide(model, provider?)` resolves a target `provider::<id>::stream`:
+`decide(model, provider?)` resolves an **ordered candidate list** of `provider::<id>::stream`
+targets — the MVP consumes `candidates[0]` only, but the list shape is specced now so fallback
+chains can arrive later without a contract rev:
 
-1. If `provider` is given and registered -> that provider.
+1. If `provider` is given and registered -> that provider (sole candidate). This MUST work on a
+   **cold catalog**: an explicit-provider chat is routed with provider defaults even when the model
+   id is not (yet) in the catalog. If `provider` is given but **not** registered -> throw
+   `router/unknown_provider` (typo'd provider strings fail loudly — a deliberate change from the
+   old silent-default behaviour).
 2. Else, the unique provider whose catalog contains `model`. If **several** providers serve the same
    model id, the call fails with `ambiguous model <id> (providers: a, b)` — the caller must pass
    `provider`; the router never picks silently.
 3. Else, an optional model-name heuristic from the `llm-router` configuration entry —
    `routing_heuristics: [{ pattern, provider }]`, first match wins (e.g.
    `{ "pattern": "^gpt-", "provider": "openai" }`).
-4. Else -> throw `no provider registered for model <id>`.
+4. Else, the configured `default_provider` when set.
+5. Else -> throw `no provider registered for model <id>`.
+
+With `default_provider` set, routing is a **total function** — cold boots, failed discovery, and
+brand-new model ids degrade to the default provider instead of failing the turn. Deployments that
+prefer loud failures simply leave it unset.
 
 Routing reads the live registry; adding a provider worker makes its models routable with no router
-change.
+change. Catalog uniqueness (step 2) applies to local runtimes too: a model that exists only in
+lmstudio's slice routes to lmstudio implicitly — this deliberately revokes the old "never implicitly
+route to local runtimes" guard. A local provider that doesn't want implicit traffic should simply
+not reconcile those models into the catalog.
+
+## Registration lifecycle
+
+Three rules close the races and takeover surfaces inherent in self-registration:
+
+1. **Identity binding.** The first successful `router::provider::register` for an id binds that
+   provider id to the **calling worker's identity** (the engine-assigned worker identity on the
+   call). Subsequent `register`, `reconcile`, `resolve`, and `update_credential` calls for that id
+   MUST come from the same worker identity; mismatches are rejected. Re-binding to a new worker
+   identity is an explicit operator action (config edit), not last-writer-wins. This also bounds
+   `credential_env_var` as an env-read surface: a declaration can only name an env fallback for an
+   id its own worker legitimately owns, so the registry can't be used to read arbitrary env vars
+   (e.g. registering `id: "anthropic"` with `credential_env_var: "AWS_SECRET_ACCESS_KEY"`).
+2. **Serialized merges.** All registry and `llm-router`-entry mutations funnel through one
+   serialized writer in the router. Concurrent provider boots compose; no read-merge-write slice
+   loss.
+3. **Boot-order recovery.** Registration is not one-shot: providers retry `register` with backoff
+   until acknowledged, and re-declare on `router::ready` after a router restart. The registry and
+   catalog are durable in `iii-state`, so a restart restores the last known registry immediately
+   and the re-declare pass reconciles it with reality.
 
 ## Security
 
@@ -493,14 +687,22 @@ Agent exposure (`iii-permissions.yaml`):
 
 - **Deny to in-run agents:** `router::provider::resolve` and `router::provider::update_credential`
   (credential read/write), `router::provider::register` (provider spoofing),
-  `router::models::reconcile` (catalog poisoning), and all of `configuration::*` (the entry carries
-  plaintext keys). Provider workers and operator UIs call these as worker/user-initiated calls,
-  which bypass the agent gate.
+  `router::models::reconcile` (catalog poisoning — it is the only catalog write path, deliberately
+  carved out of the otherwise-safe `router::models::*` reads), and all of `configuration::*` (the
+  entry carries plaintext keys). Provider workers and operator UIs call these as
+  worker/user-initiated calls, which bypass the agent gate. The same four provider-protocol
+  surfaces are additionally **identity-bound** (see
+  [Registration lifecycle](#registration-lifecycle)), so even a trusted worker can't act on another
+  worker's provider id.
 - **Deny by default:** `router::chat` / `router::complete` / `router::abort` — not secret-bearing,
   but an agent that can call the router directly generates spend outside the harness loop's
   accounting and `max_turns` guard.
 - **Safe:** `router::models::list` / `router::models::get` / `router::models::supports` /
   `router::provider::list`.
+
+**Known limitation:** credentials are plaintext at rest inside the `llm-router` configuration entry
+(parity with the previous harness; mitigated by the same deny rules above). Encryption at rest is
+explicitly out of MVP scope and tracked as a future hardening item.
 
 ## Authoring a provider
 
@@ -509,24 +711,31 @@ To add a provider `foo`:
 1. Implement `provider::foo::stream` honouring [the provider stream contract](#provider-stream-contract);
    write `AssistantMessageEvent` frames to the hydrated `writer_ref`, end with `done`/`error`, close.
    Honour [liveness and cancellation](#stream-liveness-and-cancellation): emit `ping` through silent
-   stretches, abort the upstream request when the channel closes.
+   stretches, abort the upstream request when the channel closes. Map upstream failures to
+   `ErrorKind` on `error` frames, and leave generic retries to the router (see [Retries](#retries)).
 2. At startup, call `router::provider::register` with
    `{ id: "foo", credential_env_var: "FOO_API_KEY", defaults, supports_model_listing, models }` —
-   include the static `models` slice unless step 4 is implemented.
+   include the static `models` slice unless step 4 is implemented. Retry with backoff until
+   acknowledged, and bind to `router::ready` to re-declare after router restarts.
 3. In the stream handler, call `router::provider::resolve({ id: "foo" })` for the credential +
-   `api_url`/`max_tokens`. Cloud providers throw on `credential: null`; local providers tolerate it.
+   `api_url`/`max_tokens` (or use the forwarded `resolution_key`/`model_meta` hints when present).
+   Cloud providers throw `router/not_configured` on `credential: null`; local providers tolerate it.
    OAuth providers refresh expired tokens themselves and persist the result via
-   `router::provider::update_credential`.
+   `router::provider::update_credential`; on an upstream 401 (`auth_expired`), re-resolve once
+   before failing the request — covering the race where a refresh landed mid-flight.
 4. (Optional) Implement `provider::foo::refresh_models` -> `router::models::reconcile` for live model
-   discovery.
+   discovery, merging curated metadata per
+   [Catalog metadata sources](#catalog-metadata-sources) and honouring the
+   [reconcile-to-empty guidance](#routermodelsreconcile).
 
 No router code changes: routing, config schema, and the picker all update from the declaration and
 catalog.
 
 ## Dependencies
 
-- `configuration` — the `llm-router` entry (credentials/settings).
-- `iii-state` — model catalog and provider registry.
+- `configuration` — the `llm-router` entry (credentials/settings) and its change trigger (the
+  paste-a-key discovery binding).
+- `iii-state` — model catalog and provider registry (both durable across router restarts).
 - `iii-stream` / channels — `router::chat` streaming.
 - Provider workers — one per upstream; discovered at runtime, not a build dependency.
 
@@ -539,3 +748,8 @@ catalog.
 - Does **not** seed models from a static list of its own — the catalog is provider-sourced via
   `router::models::reconcile` (live discovery, or the static `models` slice in a provider's
   declaration).
+- Does **not** ship multi-tenant gateway machinery — virtual keys, per-key budgets, tpm/rpm rate
+  limits, load-balancing strategies, response/semantic caching, guardrails hooks, spend dashboards,
+  active health probes. Those exist to serve many untrusted tenants over HTTP; the single-tenant
+  equivalents are covered by iii-permissions gating, the one credential store, and the `metadata`
+  tracing seam.

--- a/tech-specs/2026-06-agentic/llm-router.md
+++ b/tech-specs/2026-06-agentic/llm-router.md
@@ -1,0 +1,439 @@
+# llm-router
+
+Worker prefix: `router::*` — plus the `provider::<id>::*` protocol it defines for provider workers.
+
+## Definition
+
+`llm-router` is the single front door to every LLM, and the protocol layer between consumers and
+provider workers. A consumer never talks to a provider directly; it calls `router::chat` /
+`router::complete` with a `model` and messages, and the router dispatches to the right provider. A
+provider never talks to a consumer; it implements a narrow contract (`provider::<id>::stream`),
+self-registers, and only ever talks back to the router.
+
+The router owns four things:
+
+1. **Routing** — map a `model` (and/or `provider`) to a `provider::<id>::stream` handler, from the
+   live registry of declared providers. No hardcoded provider list.
+2. **The provider registry** — providers self-declare at startup (`router::provider::register`); the
+   router composes their config slices and resolves credentials per request
+   (`router::provider::resolve`).
+3. **Credentials & settings** — stored in the engine's built-in `configuration` worker under one
+   `llm-router` entry; resolved centrally with env-var fallback. Provider workers never read keys
+   from disk/env themselves.
+4. **The model catalog** — capability records served from `router::models::*`, populated exclusively
+   by provider discovery (`router::models::reconcile`); no baked-in seed.
+
+It is **consumer-agnostic**: it assumes no harness, session, or UI. It streams into a caller-supplied
+channel and returns. That is exactly what lets a `third-party-worker` "use llm directly without
+harness".
+
+## Standalone use
+
+- Any worker calls `router::chat` to stream a completion from whatever provider/model is configured,
+  through one stable surface, swapping providers with zero call-site changes.
+- A batch job calls `router::complete` for non-streaming one-shots.
+- A model picker UI reads `router::models::list` and `router::provider::list`.
+
+## The provider protocol
+
+```mermaid
+flowchart TB
+  subgraph prov [provider worker]
+    decl["startup: router::provider::register"]
+    stream["provider::id::stream (required)"]
+    refresh["provider::id::refresh_models (optional)"]
+  end
+  decl -->|"register declaration"| reg[router registry]
+  reg -->|"configuration::register entry=llm-router"| cfg[(configuration worker)]
+  stream -->|"router::provider::resolve (per request)"| reg
+  reg -->|"configuration::get entry=llm-router"| cfg
+  consumer["any consumer / harness"] -->|"router::chat"| route[router routing]
+  route -->|"provider::id::stream"| stream
+  refresh -->|"router::models::reconcile"| cat[router catalog]
+```
+
+A provider worker MUST:
+
+1. Register `provider::<id>::stream` honouring the channel-writer contract below.
+2. Self-declare to the router at startup via `router::provider::register`.
+3. Resolve credentials per request via `router::provider::resolve` (never read keys directly).
+
+A provider worker MAY:
+
+4. Register `provider::<id>::complete` (legacy non-streaming) and
+   `provider::<id>::refresh_models` (live model discovery into the catalog).
+
+### Provider stream contract
+
+The router opens a channel and calls `provider::<id>::stream`. The iii SDK hydrates `writer_ref` into
+a live `ChannelWriter` before the handler runs. The provider writes each `AssistantMessageEvent` as a
+JSON text message, then closes. Terminal event is `done` or `error`.
+
+```typescript
+// Input (wire shape; writer_ref arrives hydrated as a ChannelWriter)
+type ProviderStreamInput = {
+  writer_ref: StreamChannelRef;     // direction "write"
+  system_prompt?: string | null;
+  model: string;
+  messages: AgentMessage[];         // provider serialises to its own wire format
+  tools?: AgentFunction[];
+  thinking_level?: string;          // "minimal"|"low"|"medium"|"high"|"xhigh"; provider maps or ignores
+};
+
+type ProviderStreamOutput = { ok: boolean; status?: string };
+```
+
+The router treats `provider::<id>::*` as an interface it *calls*, not functions it registers. See
+[Authoring a provider](#authoring-a-provider).
+
+## Functions
+
+Consumer-facing:
+
+- `router::chat` — Stream a single assistant turn for a model into a caller-supplied channel; relays
+  `AssistantMessageEvent` frames.
+- `router::complete` — Non-streaming: return the final `AssistantMessage` (drains the stream
+  internally).
+- `router::models::list` — List available models, optionally filtered by provider/capability.
+- `router::models::get` — Look up one model's capabilities by `(provider, id)`.
+- `router::models::supports` — Check whether a model supports a capability.
+- `router::provider::list` — Enumerate declared providers and their configured/available state.
+
+Provider protocol (router side):
+
+- `router::provider::register` — A provider self-declares its id, config schema, and defaults.
+- `router::provider::resolve` — A provider resolves its credential + settings at request time.
+  **Agent-gated** (see [Security](#security)).
+- `router::models::reconcile` — A provider replaces its catalog slice in one write.
+
+## Triggers
+
+### Trigger types emitted
+
+- **`router::models::changed`** — fires when the catalog changes (a provider reconciles). Payload:
+  `{ provider: string; count: number }`. Lets pickers refresh reactively.
+- **`router::provider::changed`** — fires when the provider registry changes (declare / availability
+  flip). Payload: `{ provider: string; op: "register" | "available" | "unavailable" }`.
+
+Bind either the standard two-step way (see [README § Reactive pattern](README.md#reactive-pattern)).
+
+### Triggers bound
+
+- **`router::on_worker_available`** bound to the engine topology trigger so the router notices
+  provider workers connecting/disconnecting and flips availability (and can kick discovery):
+
+```typescript
+iii.registerFunction("router::on_worker_available", handler);
+iii.registerTrigger({
+  type: "subscribe",
+  function_id: "router::on_worker_available",
+  config: { topic: "engine::workers-available" },
+});
+```
+
+---
+
+## API Reference
+
+Shared types (`AgentMessage`, `AssistantMessage`, `AssistantMessageEvent`, `AgentFunction`, `Model`,
+`StreamChannelRef`, `Credential`, `Usage`) are defined in
+[README.md § Cross-cutting contracts](README.md#cross-cutting-contracts).
+
+### `router::chat`
+
+Stream one assistant turn. The caller opens a channel and passes its `writer_ref`; the router resolves
+the provider for `model`, calls `provider::<id>::stream`, and relays frames to the caller's channel
+(or pipes the provider's writer through, implementation's choice). The call resolves when the stream
+terminates.
+
+- Invocation: **sync** (open while streaming)
+
+Request:
+
+```typescript
+type ChatRequest = {
+  writer_ref: StreamChannelRef;     // direction "write"; the caller's channel
+  model: string;
+  provider?: string;                // disambiguate when a model id exists on multiple providers
+  system_prompt?: string | null;
+  messages: AgentMessage[];
+  tools?: AgentFunction[];
+  thinking_level?: string;
+  metadata?: Record<string, unknown>; // passthrough for tracing (session_id, message_id, …)
+};
+```
+
+Response:
+
+```typescript
+type ChatResponse = {
+  ok: boolean;
+  provider: string;
+  model: string;
+  stop_reason?: StopReason;
+  usage?: Usage;
+};
+```
+
+Streamed over the channel: a sequence of `AssistantMessageEvent`, terminating in `done` (carrying the
+final `AssistantMessage`) or `error`.
+
+Errors (thrown before streaming starts): `model is required`; `no provider registered for model
+<id>`; `provider <id> unavailable`. Mid-stream failures arrive as an `error` frame, not a thrown
+error.
+
+Example:
+
+```jsonc
+// request
+{
+  "writer_ref": { "channel_id": "ch_1", "access_key": "…", "direction": "write" },
+  "model": "claude-sonnet-4",
+  "provider": "anthropic",
+  "system_prompt": "You are concise.",
+  "messages": [{ "role": "user", "content": [{ "type": "text", "text": "hi" }], "timestamp": 1 }],
+  "tools": []
+}
+// channel frames (abbreviated)
+{ "type": "start", "partial": { "role": "assistant", "content": [], "...": "..." } }
+{ "type": "text_delta", "delta": "He", "partial": { "...": "..." } }
+{ "type": "text_delta", "delta": "llo", "partial": { "...": "..." } }
+{ "type": "usage", "usage": { "input": 12, "output": 2 } }
+{ "type": "done", "message": { "role": "assistant", "content": [{ "type": "text", "text": "Hello" }], "stop_reason": "end", "model": "claude-sonnet-4", "provider": "anthropic", "timestamp": 2 } }
+// response (after stream closes)
+{ "ok": true, "provider": "anthropic", "model": "claude-sonnet-4", "stop_reason": "end", "usage": { "input": 12, "output": 2 } }
+```
+
+### `router::complete`
+
+Non-streaming. Internally opens a channel, drains `router::chat`, returns the final message.
+
+- Invocation: **sync**
+
+```typescript
+type CompleteRequest = Omit<ChatRequest, "writer_ref">;
+type CompleteResponse = {
+  message: AssistantMessage;
+  usage?: Usage;
+  provider: string;
+  model: string;
+};
+```
+
+### `router::models::list`
+
+- Invocation: **sync**
+
+```typescript
+type ModelsListRequest = {
+  provider?: string;
+  capability?: Capability;   // filter to models supporting it
+};
+type ModelsListResponse = { models: Model[] };
+```
+
+### `router::models::get`
+
+- Invocation: **sync**
+
+```typescript
+type ModelsGetRequest = { provider: string; id: string };
+type ModelsGetResponse = { model: Model } | null; // null when unregistered
+```
+
+### `router::models::supports`
+
+- Invocation: **sync**
+
+```typescript
+type ModelsSupportsRequest = { provider: string; id: string; capability: Capability };
+type ModelsSupportsResponse = { supported: boolean };
+```
+
+Unknown model or capability returns `{ supported: false }`. See
+[Model capabilities](#model-capabilities) for what each capability means and how callers use it.
+
+### `router::provider::list`
+
+- Invocation: **sync**
+
+```typescript
+type ProviderInfo = {
+  id: string;
+  display_name: string;
+  configured: boolean;          // has a usable credential (stored or via env)
+  available: boolean;           // the provider worker is currently connected
+  supports_model_listing: boolean;
+};
+type ProviderListResponse = { providers: ProviderInfo[] };
+```
+
+### `router::provider::register`
+
+Called by a provider worker at startup. The router merges the declaration's `config_schema` (or a
+default `{ api_key (password), api_url, max_tokens }` derived from `defaults`) into the `llm-router`
+configuration entry and (re)registers it, so the editable config shape grows with the running set of
+providers.
+
+- Invocation: **sync**
+
+```typescript
+type ProviderDeclaration = {
+  id: string;                       // also the provider::<id>::* prefix and config key
+  display_name?: string;
+  credential_env_var?: string;      // fallback env var when no api_key configured (e.g. FOO_API_KEY)
+  defaults?: { api_url?: string; max_tokens?: number; [k: string]: unknown };
+  config_schema?: Record<string, unknown>; // custom JSON Schema; omit for the standard one
+  supports_model_listing?: boolean;
+};
+type ProviderRegisterResponse = { ok: true; id: string };
+```
+
+### `router::provider::resolve`
+
+Called by a provider worker per request to get its credential + effective settings. **Agent-gated**:
+denied to in-run agents so a credential can't be exfiltrated through tool calls (see
+[Security](#security)). Worker-to-worker calls bypass the agent gate.
+
+- Invocation: **sync**
+
+```typescript
+type ProviderResolveRequest = { id: string };
+type ProviderResolveResponse = {
+  configured: boolean;
+  source: "config" | "env" | "none";
+  credential: Credential | null;   // null when neither stored key nor env var present
+  api_url?: string;
+  max_tokens?: number;
+};
+```
+
+### `router::models::reconcile`
+
+Called by a provider to replace its catalog slice in one state write — the only catalog write path.
+
+- Invocation: **sync**
+
+```typescript
+type ModelsReconcileRequest = { provider: string; models: Model[] };
+type ModelsReconcileResponse = { provider: string; count: number };
+```
+
+Fires `router::models::changed`.
+
+---
+
+## Model capabilities
+
+A `Model` (see [README § Model descriptor](README.md#model-descriptor)) is mostly a *capability
+record*. Beyond `context_window` and `max_output_tokens`, it carries boolean flags and a few
+quantitative fields that tell a caller what a model can do **before** a request is sent — so a
+consumer adapts the request to the chosen model instead of hardcoding per-model behaviour.
+
+### Capability strings
+
+`router::models::supports` and the `capability` filter on `router::models::list` accept these
+strings, each mapping to a field on `Model`:
+
+- `tools` -> `supports_tools` — the model accepts an `AgentFunction[]` and can emit `function_call`
+  content. If false, callers must not attach tools.
+- `vision` -> `supports_vision` — the model accepts `image` content blocks. If false, callers strip
+  or textually describe images first.
+- `cache` -> `supports_cache` — the provider supports prompt caching; the provider may insert cache
+  markers to cut cost/latency on repeated prefixes.
+- `thinking` -> `supports_thinking` — the model exposes a reasoning/thinking budget at all.
+- `thinking:low` | `thinking:medium` | `thinking:high` -> still `supports_thinking` — the level picks
+  a budget tier (mapped to the provider's native knob; see `thinking_budgets`).
+- `thinking:xhigh` -> `supports_xhigh` — the model supports the extra-high reasoning tier specifically
+  (a separate flag because not every thinking-capable model offers it).
+
+Unknown strings return `{ supported: false }` and match no models.
+
+### How callers use it
+
+- **Discovery / model picker** — a UI lists only relevant models:
+  `router::models::list({ capability: "tools" })` for an agent that needs tools, or
+  `{ capability: "vision" }` for an image task.
+- **Request shaping (harness)** — before a turn the harness checks `supports_tools` to decide whether
+  to attach the tool schema, `supports_vision` to decide whether to keep image blocks, and
+  `supports_thinking`/`supports_xhigh` to decide whether a requested `thinking_level` is honoured or
+  dropped. This is how one harness drives many models without per-model branches.
+- **Budgeting (context-manager)** — `context::assemble` reads `context_window` / `input_limit` /
+  `max_output_tokens` to size the usable window, and `thinking_budgets` to leave room for the
+  reasoning tokens a thinking tier consumes.
+- **Cost (a budget sibling)** — `pricing` lets a spend-tracking worker turn `Usage` into `cost_usd`.
+
+Capabilities come exclusively from provider discovery (`router::models::reconcile`). A provider that
+does not report a flag leaves it absent/false, and callers must treat "unknown" as "unsupported"
+rather than assuming a default.
+
+## Configuration
+
+One entry — id `llm-router` — in the built-in `configuration` worker holds provider credentials and
+settings. Its `providers` JSON Schema is composed dynamically from each provider's declaration:
+
+```jsonc
+{
+  "providers": {
+    "anthropic": { "api_key": "sk-ant-…", "api_url": "https://api.anthropic.com/v1/messages", "max_tokens": 8192 },
+    "openai":    { "api_key": "sk-…" },
+    "lmstudio":  { "max_tokens": 8192 }   // local; no key needed
+  }
+}
+```
+
+A configured `max_tokens` overrides the per-model default but is clamped to the model's catalog
+ceiling when known, so an over-large value can't cause upstream 400s.
+
+## Routing
+
+`decide(model, provider?)` resolves a target `provider::<id>::stream`:
+
+1. If `provider` is given and registered -> that provider.
+2. Else, the unique provider whose catalog contains `model`.
+3. Else, an optional model-name heuristic (prefix/regex per provider).
+4. Else -> throw `no provider registered for model <id>`.
+
+Routing reads the live registry; adding a provider worker makes its models routable with no router
+change.
+
+## Security
+
+- `router::provider::resolve` and `configuration::*` MUST be denied to in-run agents in the
+  deployment's `iii-permissions.yaml`. Credentials live in plaintext in the configuration value;
+  these denials keep an agent from reading them via a tool call. Provider workers (and operator UIs)
+  call them as worker/user-initiated calls, which bypass the agent gate.
+- `router::chat` / `router::complete` / `router::models::*` / `router::provider::list` are safe to
+  expose to consumers.
+
+## Authoring a provider
+
+To add a provider `foo`:
+
+1. Implement `provider::foo::stream` honouring [the provider stream contract](#provider-stream-contract);
+   write `AssistantMessageEvent` frames to the hydrated `writer_ref`, end with `done`/`error`, close.
+2. At startup, call `router::provider::register` with
+   `{ id: "foo", credential_env_var: "FOO_API_KEY", defaults, supports_model_listing }`.
+3. In the stream handler, call `router::provider::resolve({ id: "foo" })` for the credential +
+   `api_url`/`max_tokens`. Cloud providers throw on `credential: null`; local providers tolerate it.
+4. (Optional) Implement `provider::foo::refresh_models` -> `router::models::reconcile` for live model
+   discovery.
+
+No router code changes: routing, config schema, and the picker all update from the declaration and
+catalog.
+
+## Dependencies
+
+- `configuration` — the `llm-router` entry (credentials/settings).
+- `iii-state` — model catalog and provider registry.
+- `iii-stream` / channels — `router::chat` streaming.
+- Provider workers — one per upstream; discovered at runtime, not a build dependency.
+
+## Boundaries
+
+- Does **not** persist conversations or build context — pass full `messages` in each call (use
+  [session-manager](session-manager.md) / [context-manager](context-manager.md) upstream).
+- Does **not** run the agent loop, dispatch tools, or gate approvals — that is the
+  [harness](harness.md).
+- Does **not** seed models from a static list — the catalog is provider-sourced via
+  `router::models::reconcile`.

--- a/tech-specs/2026-06-agentic/session-manager.md
+++ b/tech-specs/2026-06-agentic/session-manager.md
@@ -1,0 +1,425 @@
+# session-manager
+
+Worker prefix: `session::*`
+
+## Definition
+
+`session-manager` is the durable, reactive store for conversations. A session is an append-only log
+of typed message entries (with optional fork branches; see [README § Session entries](README.md#session-entries)).
+It carries a small amount of metadata — a `title`, a `description`, and a coarse `status` — and the
+ordered messages that make up the conversation.
+
+Two properties define it:
+
+1. **Many message types.** It stores the full `AgentMessage` union — user, assistant,
+   `function_result`, and `custom` — where content is the rich `ContentBlock[]` (text, image,
+   thinking, function calls, function results). One transcript carries tool calls, reasoning, images,
+   and app-defined markers without a second store.
+2. **Reactive.** State changes are exposed as **triggers other workers bind to** — not as a stream a
+   caller has to publish into. The worker emits four trigger types: a session was created, a message
+   was added, a message's content was updated, and a session's status changed. Consumers subscribe
+   once and render live — no polling, no separate publish call.
+
+It is a **pure storage + notification surface**: it binds no triggers of its own and runs no agent
+logic. It is independently useful as a real-time conversation database for any app.
+
+## Session status
+
+Every session has a coarse lifecycle status that consumers can render directly (a spinner, a "done"
+badge, a list filter):
+
+- `idle` — created and waiting; no work in progress.
+- `working` — the agent is thinking/responding (a turn is running).
+- `done` — the agent finished the job and the session is at rest.
+
+`session::create` starts a session at `idle`. The driver (typically the [harness](harness.md)) sets
+`working` when a turn starts and `done` when it ends, via [`session::set_status`](#sessionset_status),
+which fires [`session::status_changed`](#trigger-types-emitted).
+
+## Standalone use
+
+- A web/mobile chat app uses it as the source of truth and binds the four trigger types for real-time
+  UI, with or without the harness.
+- A multi-channel bot stores every conversation here and forks sessions to explore alternatives.
+- A dashboard binds `session::status_changed` to show which sessions are working vs done.
+
+## Reactivity model
+
+There is no "subscribe" or "publish" function. Reactivity is entirely via the four emitted trigger
+types; a consumer binds handlers with the standard two-step pattern (see
+[README § Reactive pattern](README.md#reactive-pattern)).
+
+Streaming an assistant reply uses the same primitives as everything else: the driver appends an
+(initially empty) assistant message — which fires `session::message_added` — then calls
+`session::update_message` as tokens arrive — each firing `session::message_updated`. Updates may be
+batched/throttled by the driver. Consumers render the growing message from those updates.
+
+```mermaid
+sequenceDiagram
+  participant UI as chat client
+  participant H as harness (driver)
+  participant S as session-manager
+  UI->>S: bind created / message_added / message_updated / status_changed
+  H->>S: session::create (title, description)
+  S-->>UI: session::created
+  H->>S: session::set_status working
+  S-->>UI: session::status_changed (working)
+  H->>S: session::append (assistant message, empty)
+  S-->>UI: session::message_added
+  loop streaming deltas
+    H->>S: session::update_message (grow content)
+    S-->>UI: session::message_updated
+  end
+  H->>S: session::set_status done
+  S-->>UI: session::status_changed (done)
+```
+
+## Functions
+
+Lifecycle:
+
+- `session::create` — Create a session with a `title` + `description` at status `idle`; fires
+  `session::created`.
+- `session::ensure` — Idempotently ensure a session with a given id exists.
+- `session::get` — Read one session's metadata.
+- `session::list` — List sessions with pagination/ordering.
+- `session::set_meta` — Update a session's `title`/`description` (e.g. an auto-generated title).
+- `session::set_status` — Set status `idle`/`working`/`done`; fires `session::status_changed`.
+- `session::delete` — Delete a session and its entries.
+
+Messages:
+
+- `session::append` — Append one message entry; fires `session::message_added`.
+- `session::append_many` — Append several message entries; fires `session::message_added` per entry.
+- `session::update_message` — Replace the content of a message entry; fires `session::message_updated`.
+- `session::messages` — Load the active-path `AgentMessage[]` (with entry ids), oldest first;
+  supports pagination and role filtering.
+- `session::get_message` — Read a single entry by id.
+
+Branching:
+
+- `session::fork` — Fork a session at an entry into a new session sharing history up to that point;
+  fires `session::created` for the new session.
+
+## Triggers
+
+### Trigger types emitted
+
+All four are custom trigger types this worker registers. Bind a handler with the two-step pattern
+(see [README § Reactive pattern](README.md#reactive-pattern)); the config object filters which events
+reach the handler.
+
+```typescript
+type SessionStatus = "idle" | "working" | "done";
+```
+
+- **`session::created`** — a new session exists (via `session::create` or `session::fork`).
+  - Config: `{}` (no filters).
+  - Payload:
+
+```typescript
+type SessionCreatedEvent = {
+  session_id: string;
+  title: string;
+  description: string;
+  status: SessionStatus;        // "idle" on create
+  forked_from?: string | null;  // source session id when created by fork
+  created_at: number;
+};
+```
+
+- **`session::message_added`** — a message was appended.
+  - Config: `{ session_id?: string; roles?: Role[] }`.
+  - Payload:
+
+```typescript
+type MessageAddedEvent = {
+  session_id: string;
+  entry_id: string;
+  parent_id: string | null;
+  message: AgentMessage;
+  timestamp: number;
+};
+```
+
+- **`session::message_updated`** — a message's content changed (e.g. streaming deltas, edited
+  tool output).
+  - Config: `{ session_id?: string; roles?: Role[] }`.
+  - Payload:
+
+```typescript
+type MessageUpdatedEvent = {
+  session_id: string;
+  entry_id: string;
+  message: AgentMessage;        // the full updated message
+  timestamp: number;
+};
+```
+
+- **`session::status_changed`** — a session's status changed.
+  - Config: `{ session_id?: string }`.
+  - Payload:
+
+```typescript
+type StatusChangedEvent = {
+  session_id: string;
+  status: SessionStatus;
+  previous_status: SessionStatus;
+  timestamp: number;
+};
+```
+
+Example binding (live-render every assistant delta for one session):
+
+```typescript
+iii.registerFunction("ui::on_message_updated", async (evt) => render(evt.entry_id, evt.message));
+iii.registerTrigger({
+  type: "session::message_updated",
+  function_id: "ui::on_message_updated",
+  config: { session_id: "s_123", roles: ["assistant"] },
+});
+```
+
+### Triggers bound
+
+None. `session-manager` only emits; it subscribes to nothing.
+
+---
+
+## API Reference
+
+Shared types (`AgentMessage`, `SessionEntry`, `ContentBlock`, `Role`) are defined in
+[README.md § Cross-cutting contracts](README.md#cross-cutting-contracts).
+
+```typescript
+type SessionMeta = {
+  session_id: string;
+  title: string;
+  description: string;
+  status: SessionStatus;          // "idle" | "working" | "done"
+  forked_from?: string | null;
+  created_at: number;
+  updated_at: number;
+  message_count: number;
+};
+```
+
+### `session::create`
+
+Create a session at status `idle`. `title`/`description` may be supplied up front (e.g. derived from
+the opening message) and refined later with `session::set_meta`. Fires `session::created`.
+
+- Invocation: **sync**
+
+```typescript
+type CreateRequest = {
+  title?: string;                 // default ""
+  description?: string;           // default ""
+  metadata?: Record<string, unknown>;
+};
+type CreateResponse = { session_id: string; meta: SessionMeta };
+```
+
+Example:
+
+```jsonc
+// request
+{ "title": "Weather question", "description": "User asks about today's forecast." }
+// response
+{ "session_id": "s_123", "meta": { "session_id": "s_123", "title": "Weather question",
+  "description": "User asks about today's forecast.", "status": "idle", "created_at": 1717800000000,
+  "updated_at": 1717800000000, "message_count": 0 } }
+```
+
+### `session::ensure`
+
+- Invocation: **sync**. Fires `session::created` only when it creates the session.
+
+```typescript
+type EnsureRequest = { session_id: string; title?: string; description?: string };
+type EnsureResponse = { session_id: string; meta: SessionMeta; created: boolean };
+```
+
+### `session::get`
+
+- Invocation: **sync**
+
+```typescript
+type GetRequest = { session_id: string };
+type GetResponse = { meta: SessionMeta } | null; // null when unknown
+```
+
+### `session::list`
+
+- Invocation: **sync**
+
+```typescript
+type ListRequest = {
+  limit?: number;        // default 50
+  cursor?: string;       // opaque pagination cursor
+  status?: SessionStatus; // optional filter
+  order?: "created_asc" | "created_desc" | "updated_desc"; // default updated_desc
+};
+type ListResponse = { sessions: SessionMeta[]; next_cursor?: string };
+```
+
+### `session::set_meta`
+
+Update `title`/`description` (e.g. once a titling worker generates them from the first exchange). Does
+not change status or messages. Updates `SessionMeta`; surfaced to consumers via `session::get`.
+
+- Invocation: **sync**
+
+```typescript
+type SetMetaRequest = { session_id: string; title?: string; description?: string };
+type SetMetaResponse = { meta: SessionMeta };
+```
+
+### `session::set_status`
+
+Set the session status. Fires `session::status_changed`. No-op (no event) if the status is unchanged.
+
+- Invocation: **sync**
+
+```typescript
+type SetStatusRequest = { session_id: string; status: SessionStatus };
+type SetStatusResponse = { status: SessionStatus; previous_status: SessionStatus };
+```
+
+### `session::delete`
+
+- Invocation: **sync**
+
+```typescript
+type DeleteRequest = { session_id: string };
+type DeleteResponse = { deleted: boolean };
+```
+
+### `session::append`
+
+Append one message entry. The entry id and `parent_id` are assigned by the worker (parent = current
+active leaf) unless `parent_id` is provided. Fires `session::message_added`.
+
+- Invocation: **sync**
+
+```typescript
+type AppendRequest = {
+  session_id: string;
+  message: AgentMessage;
+  parent_id?: string;           // override the parent (default: active leaf)
+};
+type AppendResponse = { entry_id: string; parent_id: string | null; timestamp: number };
+```
+
+Example:
+
+```jsonc
+// request
+{
+  "session_id": "s_123",
+  "message": {
+    "role": "user",
+    "content": [{ "type": "text", "text": "What's the weather?" }],
+    "timestamp": 1717800000000
+  }
+}
+// response
+{ "entry_id": "e_001", "parent_id": null, "timestamp": 1717800000000 }
+```
+
+### `session::append_many`
+
+- Invocation: **sync**. Fires `session::message_added` for each appended entry, in order.
+
+```typescript
+type AppendManyRequest = { session_id: string; messages: AgentMessage[]; parent_id?: string };
+type AppendManyResponse = { entry_ids: string[]; last_entry_id: string };
+```
+
+### `session::update_message`
+
+Replace the content (and optionally `details`) of an existing message entry. Used for streaming
+assistant deltas and for edited tool output. Fires `session::message_updated`.
+
+- Invocation: **sync**
+
+```typescript
+type UpdateMessageRequest = {
+  session_id: string;
+  entry_id: string;
+  content: ContentBlock[];   // new content for the message
+  details?: unknown;         // for function_result entries
+};
+type UpdateMessageResponse = { updated: boolean };
+```
+
+### `session::messages`
+
+Load the active path as `AgentMessage[]`, each paired with its `entry_id`, oldest first.
+
+- Invocation: **sync**
+
+```typescript
+type MessagesRequest = {
+  session_id: string;
+  limit?: number;
+  cursor?: string;
+  roles?: Role[];                 // filter by role
+  from_entry_id?: string;         // start the active path at a specific leaf (branch view)
+};
+type MessagesResponse = {
+  messages: Array<{ entry_id: string; message: AgentMessage }>;
+  next_cursor?: string;
+};
+```
+
+### `session::get_message`
+
+- Invocation: **sync**
+
+```typescript
+type GetMessageRequest = { session_id: string; entry_id: string };
+type GetMessageResponse = { entry: SessionEntry } | null;
+```
+
+### `session::fork`
+
+Create a new session that shares history up to `entry_id`, then diverges. Fires `session::created`
+for the new session (`forked_from` set to the source).
+
+- Invocation: **sync**
+
+```typescript
+type ForkRequest = { session_id: string; entry_id: string; title?: string };
+type ForkResponse = { session_id: string; meta: SessionMeta };
+```
+
+---
+
+## State
+
+| Scope | Key shape | Value |
+|---|---|---|
+| `session:<session_id>` | `<entry_id>` | `SessionEntry` (`message` or `custom`) |
+| `session_meta` | `<session_id>` | `SessionMeta` (incl. `title`, `description`, `status`) |
+| `session_active_leaf` | `<session_id>` | `<entry_id>` (current active-path leaf) |
+
+Entries are re-sorted by `(timestamp, id)` on load, so resumed/out-of-order writes keep their
+transcript position. Backends are pluggable: an iii-state backend (default) and an in-memory backend
+for tests; a future SQL/blob backend can implement the same interface.
+
+## Dependencies
+
+- `iii-state` — entry / meta / active-leaf storage.
+- Registers four custom trigger types (`session::created`, `session::message_added`,
+  `session::message_updated`, `session::status_changed`) and emits their events through the engine on
+  every relevant mutation.
+
+## Boundaries
+
+- Does **not** run agent logic, call LLMs, or build context — it only stores and notifies.
+- Does **not** compact or summarise history — the full transcript is kept; condensing it for the
+  model window is a transient concern of [context-manager](context-manager.md).
+- Does **not** export or render transcripts (HTML/PDF/etc.) — that is a separate worker's concern.
+- `custom` entries are an app escape hatch — keep large blobs in a blob store and reference them, not
+  inline, to keep entries small.

--- a/tech-specs/2026-06-agentic/session-manager.md
+++ b/tech-specs/2026-06-agentic/session-manager.md
@@ -6,8 +6,8 @@ Worker prefix: `session::*`
 
 `session-manager` is the durable, reactive store for conversations. A session is an append-only log
 of typed message entries (with optional fork branches; see [README § Session entries](README.md#session-entries)).
-It carries a small amount of metadata — a `title`, a `description`, and a coarse `status` — and the
-ordered messages that make up the conversation.
+It carries a small amount of metadata — a `title`, a `description`, a coarse `status`, and an
+app-defined `metadata` object — and the ordered messages that make up the conversation.
 
 Two properties define it:
 
@@ -16,9 +16,9 @@ Two properties define it:
    thinking, function calls, function results). One transcript carries function calls, reasoning, images,
    and app-defined markers without a second store.
 2. **Reactive.** State changes are exposed as **triggers other workers bind to** — not as a stream a
-   caller has to publish into. The worker emits four trigger types: a session was created, a message
-   was added, a message's content was updated, and a session's status changed. Consumers subscribe
-   once and render live — no polling, no separate publish call.
+   caller has to publish into. The worker emits six trigger types: session created, message added,
+   message updated, status changed, meta updated, and session deleted. **Every mutation has an
+   event** — consumers subscribe once and render live with no polling and no separate publish call.
 
 It is a **pure storage + notification surface**: it binds no triggers of its own and runs no agent
 logic. It is independently useful as a real-time conversation database for any app.
@@ -28,38 +28,43 @@ logic. It is independently useful as a real-time conversation database for any a
 Every session has a coarse lifecycle status that consumers can render directly (a spinner, a "done"
 badge, a list filter):
 
-- `idle` — created and waiting; no work in progress.
+- `idle` — created and waiting; no work has run yet.
 - `working` — the agent is thinking/responding (a turn is running).
-- `done` — the agent finished the job and the session is at rest.
+- `done` — the agent finished the job (completed or cancelled) and the session is at rest.
+- `error` — the last turn failed; the optional `status_reason` carries a short cause. Distinct from
+  `done` so a **standalone** UI can render failures without asking the harness.
 
 `session::create` starts a session at `idle`. The driver (typically the [harness](harness.md)) sets
-`working` when a turn starts and `done` when it ends, via [`session::set_status`](#sessionset_status),
-which fires [`session::status_changed`](#trigger-types-emitted).
+`working` when a turn starts, `done` when it completes or is cancelled, and `error` when it fails,
+via [`session::set_status`](#sessionset_status), which fires
+[`session::status_changed`](#trigger-types-emitted).
 
 ## Standalone use
 
-- A web/mobile chat app uses it as the source of truth and binds the four trigger types for real-time
+- A web/mobile chat app uses it as the source of truth and binds the trigger types for real-time
   UI, with or without the harness.
 - A multi-channel bot stores every conversation here and forks sessions to explore alternatives.
 - A dashboard binds `session::status_changed` to show which sessions are working vs done.
 
 ## Reactivity model
 
-There is no "subscribe" or "publish" function. Reactivity is entirely via the four emitted trigger
+There is no "subscribe" or "publish" function. Reactivity is entirely via the six emitted trigger
 types; a consumer binds handlers with the standard two-step pattern (see
 [README § Reactive pattern](README.md#reactive-pattern)).
 
 Streaming an assistant reply uses the same primitives as everything else: the driver appends an
 (initially empty) assistant message — which fires `session::message_added` — then calls
 `session::update_message` as tokens arrive — each firing `session::message_updated`. Updates may be
-batched/throttled by the driver. Consumers render the growing message from those updates.
+batched/throttled by the driver. Consumers render the growing message from those updates. Each
+update carries a server-assigned monotonic `revision`; trigger deliveries may arrive out of order,
+so consumers keep the highest revision per entry (last-write-wins on full-message snapshots).
 
 ```mermaid
 sequenceDiagram
   participant UI as chat client
   participant H as harness (driver)
   participant S as session-manager
-  UI->>S: bind created / message_added / message_updated / status_changed
+  UI->>S: bind created / message_added / message_updated / status_changed / meta_updated / deleted
   H->>S: session::create (title, description)
   S-->>UI: session::created
   H->>S: session::set_status working
@@ -83,9 +88,10 @@ Lifecycle:
 - `session::ensure` — Idempotently ensure a session with a given id exists.
 - `session::get` — Read one session's metadata.
 - `session::list` — List sessions with pagination/ordering.
-- `session::set_meta` — Update a session's `title`/`description` (e.g. an auto-generated title).
-- `session::set_status` — Set status `idle`/`working`/`done`; fires `session::status_changed`.
-- `session::delete` — Delete a session and its entries.
+- `session::set_meta` — Update a session's `title`/`description`/`metadata` (e.g. an auto-generated
+  title); fires `session::meta_updated`.
+- `session::set_status` — Set status `idle`/`working`/`done`/`error`; fires `session::status_changed`.
+- `session::delete` — Delete a session and its entries; fires `session::deleted`.
 
 Messages:
 
@@ -98,19 +104,22 @@ Messages:
 
 Branching:
 
-- `session::fork` — Fork a session at an entry into a new session sharing history up to that point;
+- `session::fork` — Copy history up to an entry into a new session (copy-on-fork: fresh entry ids);
   fires `session::created` for the new session.
+- `session::set_active_leaf` — Move the active path to end at a given entry (branch switch).
 
 ## Triggers
 
 ### Trigger types emitted
 
-All four are custom trigger types this worker registers. Bind a handler with the two-step pattern
+All six are custom trigger types this worker registers. Bind a handler with the two-step pattern
 (see [README § Reactive pattern](README.md#reactive-pattern)); the config object filters which events
-reach the handler.
+reach the handler. Every config additionally accepts `metadata?: Record<string, unknown>` — an
+equality match against `SessionMeta.metadata` — so a multi-tenant consumer binds to only its own
+sessions (e.g. `{ metadata: { owner: "u_1" } }`).
 
 ```typescript
-type SessionStatus = "idle" | "working" | "done";
+type SessionStatus = "idle" | "working" | "done" | "error";
 ```
 
 - **`session::created`** — a new session exists (via `session::create` or `session::fork`).
@@ -138,6 +147,7 @@ type MessageAddedEvent = {
   entry_id: string;
   parent_id: string | null;
   message: AgentMessage;
+  origin?: Record<string, unknown>; // writer-supplied correlation (e.g. { turn_id })
   timestamp: number;
 };
 ```
@@ -152,6 +162,8 @@ type MessageUpdatedEvent = {
   session_id: string;
   entry_id: string;
   message: AgentMessage;        // the full updated message
+  revision: number;             // monotonic per entry; consumers keep the highest
+  origin?: Record<string, unknown>; // writer-supplied correlation (e.g. { turn_id })
   timestamp: number;
 };
 ```
@@ -165,8 +177,31 @@ type StatusChangedEvent = {
   session_id: string;
   status: SessionStatus;
   previous_status: SessionStatus;
+  status_reason?: string;       // short cause, set on "error"
   timestamp: number;
 };
+```
+
+- **`session::meta_updated`** — a session's `title`/`description`/`metadata` changed.
+  - Config: `{ session_id?: string }`.
+  - Payload:
+
+```typescript
+type MetaUpdatedEvent = {
+  session_id: string;
+  title: string;
+  description: string;
+  metadata?: Record<string, unknown>;
+  timestamp: number;
+};
+```
+
+- **`session::deleted`** — a session and its entries were removed.
+  - Config: `{ session_id?: string }`.
+  - Payload:
+
+```typescript
+type SessionDeletedEvent = { session_id: string; timestamp: number };
 ```
 
 Example binding (live-render every assistant delta for one session):
@@ -196,7 +231,9 @@ type SessionMeta = {
   session_id: string;
   title: string;
   description: string;
-  status: SessionStatus;          // "idle" | "working" | "done"
+  status: SessionStatus;          // "idle" | "working" | "done" | "error"
+  status_reason?: string;         // short cause, set on "error"
+  metadata?: Record<string, unknown>; // app-defined; the tenancy hook (e.g. { owner: "u_1" })
   forked_from?: string | null;
   created_at: number;
   updated_at: number;
@@ -207,7 +244,9 @@ type SessionMeta = {
 ### `session::create`
 
 Create a session at status `idle`. `title`/`description` may be supplied up front (e.g. derived from
-the opening message) and refined later with `session::set_meta`. Fires `session::created`.
+the opening message) and refined later with `session::set_meta`. `metadata` is persisted onto
+`SessionMeta` — it is the tenancy hook (e.g. `{ owner: "u_1" }`) that `session::list` and every
+trigger config can filter on. Fires `session::created`.
 
 - Invocation: **sync**
 
@@ -236,7 +275,12 @@ Example:
 - Invocation: **sync**. Fires `session::created` only when it creates the session.
 
 ```typescript
-type EnsureRequest = { session_id: string; title?: string; description?: string };
+type EnsureRequest = {
+  session_id: string;
+  title?: string;
+  description?: string;
+  metadata?: Record<string, unknown>; // applied only when the session is created
+};
 type EnsureResponse = { session_id: string; meta: SessionMeta; created: boolean };
 ```
 
@@ -258,6 +302,7 @@ type ListRequest = {
   limit?: number;        // default 50
   cursor?: string;       // opaque pagination cursor
   status?: SessionStatus; // optional filter
+  metadata?: Record<string, unknown>; // equality filter against SessionMeta.metadata (tenancy)
   order?: "created_asc" | "created_desc" | "updated_desc"; // default updated_desc
 };
 type ListResponse = { sessions: SessionMeta[]; next_cursor?: string };
@@ -265,28 +310,39 @@ type ListResponse = { sessions: SessionMeta[]; next_cursor?: string };
 
 ### `session::set_meta`
 
-Update `title`/`description` (e.g. once a titling worker generates them from the first exchange). Does
-not change status or messages. Updates `SessionMeta`; surfaced to consumers via `session::get`.
+Update `title`/`description`/`metadata` (e.g. once a titling worker generates them from the first
+exchange). Does not change status or messages. Fires `session::meta_updated`, so consumers render
+new titles live instead of polling `session::get`. A supplied `metadata` object replaces the stored
+one.
 
 - Invocation: **sync**
 
 ```typescript
-type SetMetaRequest = { session_id: string; title?: string; description?: string };
+type SetMetaRequest = {
+  session_id: string;
+  title?: string;
+  description?: string;
+  metadata?: Record<string, unknown>;
+};
 type SetMetaResponse = { meta: SessionMeta };
 ```
 
 ### `session::set_status`
 
 Set the session status. Fires `session::status_changed`. No-op (no event) if the status is unchanged.
+`reason` is stored as `status_reason` (typically set with `error`, cleared on any other status).
 
 - Invocation: **sync**
 
 ```typescript
-type SetStatusRequest = { session_id: string; status: SessionStatus };
+type SetStatusRequest = { session_id: string; status: SessionStatus; reason?: string };
 type SetStatusResponse = { status: SessionStatus; previous_status: SessionStatus };
 ```
 
 ### `session::delete`
+
+Delete a session and its entries. Fires `session::deleted`. Forks are copies (see
+[`session::fork`](#sessionfork)), so deleting a source session never affects sessions forked from it.
 
 - Invocation: **sync**
 
@@ -298,7 +354,10 @@ type DeleteResponse = { deleted: boolean };
 ### `session::append`
 
 Append one message entry. The entry id and `parent_id` are assigned by the worker (parent = current
-active leaf) unless `parent_id` is provided. Fires `session::message_added`.
+active leaf) unless provided. Appending moves the active leaf to the new entry. Fires
+`session::message_added`. **Idempotent on `entry_id`**: appending an id that already exists is a
+no-op — the existing entry is returned and no event fires (this is what makes the harness's
+redelivered steps safe; see [harness.md § Durability & idempotency](harness.md#durability--idempotency)).
 
 - Invocation: **sync**
 
@@ -306,7 +365,9 @@ active leaf) unless `parent_id` is provided. Fires `session::message_added`.
 type AppendRequest = {
   session_id: string;
   message: AgentMessage;
-  parent_id?: string;           // override the parent (default: active leaf)
+  parent_id?: string;           // override the parent (default: active leaf); also moves the active leaf
+  entry_id?: string;            // caller-supplied id for idempotent appends
+  origin?: Record<string, unknown>; // opaque correlation (e.g. { turn_id }), echoed on events
 };
 type AppendResponse = { entry_id: string; parent_id: string | null; timestamp: number };
 ```
@@ -329,17 +390,26 @@ Example:
 
 ### `session::append_many`
 
-- Invocation: **sync**. Fires `session::message_added` for each appended entry, in order.
+- Invocation: **sync**. Fires `session::message_added` for each appended entry, in order. Not
+  idempotent — use `session::append` with `entry_id` where redelivery is possible.
 
 ```typescript
-type AppendManyRequest = { session_id: string; messages: AgentMessage[]; parent_id?: string };
+type AppendManyRequest = {
+  session_id: string;
+  messages: AgentMessage[];
+  parent_id?: string;
+  origin?: Record<string, unknown>;
+};
 type AppendManyResponse = { entry_ids: string[]; last_entry_id: string };
 ```
 
 ### `session::update_message`
 
 Replace the content (and optionally `details`) of an existing message entry. Used for streaming
-assistant deltas and for edited function output. Fires `session::message_updated`.
+assistant deltas and for edited function output. Fires `session::message_updated`. Each successful
+update increments the entry's `revision` (echoed on the event). Pass `expected_revision` for
+optimistic concurrency: on mismatch nothing is written and `{ updated: false, revision }` returns
+the current revision.
 
 - Invocation: **sync**
 
@@ -349,13 +419,18 @@ type UpdateMessageRequest = {
   entry_id: string;
   content: ContentBlock[];   // new content for the message
   details?: unknown;         // for function_result entries
+  expected_revision?: number; // optimistic concurrency: no-op on mismatch
+  origin?: Record<string, unknown>; // correlation echoed on the event
 };
-type UpdateMessageResponse = { updated: boolean };
+type UpdateMessageResponse = { updated: boolean; revision: number };
 ```
 
 ### `session::messages`
 
-Load the active path as `AgentMessage[]`, each paired with its `entry_id`, oldest first.
+Load the active path as `AgentMessage[]`, each paired with its `entry_id`, oldest first. By default
+only `kind: "message"` entries are returned; `include_custom` interleaves `kind: "custom"` entries
+at their path position (how the harness finds its compaction record — see
+[harness.md § Compaction persistence](harness.md#compaction-persistence)).
 
 - Invocation: **sync**
 
@@ -365,10 +440,16 @@ type MessagesRequest = {
   limit?: number;
   cursor?: string;
   roles?: Role[];                 // filter by role
-  from_entry_id?: string;         // start the active path at a specific leaf (branch view)
+  from_entry_id?: string;         // treat this entry as the leaf: return its parent chain,
+                                  // root -> entry, oldest first (branch view)
+  include_custom?: boolean;       // default false
 };
 type MessagesResponse = {
-  messages: Array<{ entry_id: string; message: AgentMessage }>;
+  messages: Array<{
+    entry_id: string;
+    message?: AgentMessage;                          // kind "message"
+    custom?: { custom_type: string; data: unknown }; // kind "custom" (with include_custom)
+  }>;
   next_cursor?: string;
 };
 ```
@@ -384,14 +465,30 @@ type GetMessageResponse = { entry: SessionEntry } | null;
 
 ### `session::fork`
 
-Create a new session that shares history up to `entry_id`, then diverges. Fires `session::created`
-for the new session (`forked_from` set to the source).
+**Copy-on-fork**: copy every entry on the path from the root to `entry_id` into a new session with
+fresh entry ids (the parent chain is preserved structurally); the new session's active leaf is the
+copy of `entry_id`. After the fork the two sessions are fully independent — mutating or deleting one
+never affects the other. Shared-structure storage is a permitted backend optimisation, not part of
+the contract. Fires `session::created` for the new session (`forked_from` set to the source).
 
 - Invocation: **sync**
 
 ```typescript
 type ForkRequest = { session_id: string; entry_id: string; title?: string };
 type ForkResponse = { session_id: string; meta: SessionMeta };
+```
+
+### `session::set_active_leaf`
+
+Switch the active path to end at `entry_id` (switching to a non-leaf makes the chain above it the
+active path). Subsequent `session::append` without `parent_id` chains from here. Appending with an
+explicit `parent_id` also moves the active leaf to the new entry.
+
+- Invocation: **sync**
+
+```typescript
+type SetActiveLeafRequest = { session_id: string; entry_id: string };
+type SetActiveLeafResponse = { active_leaf: string };
 ```
 
 ---
@@ -404,16 +501,30 @@ type ForkResponse = { session_id: string; meta: SessionMeta };
 | `session_meta` | `<session_id>` | `SessionMeta` (incl. `title`, `description`, `status`) |
 | `session_active_leaf` | `<session_id>` | `<entry_id>` (current active-path leaf) |
 
-Entries are re-sorted by `(timestamp, id)` on load, so resumed/out-of-order writes keep their
-transcript position. Backends are pluggable: an iii-state backend (default) and an in-memory backend
+The **parent chain is the order**: the active path is the walk from the active leaf to the root,
+reversed. `timestamp` is informational, never authoritative (an implementation on a key-less state
+listing may re-sort by `(timestamp, id)` internally while rebuilding the chain, but that is not part
+of the contract). Backends are pluggable: an iii-state backend (default) and an in-memory backend
 for tests; a future SQL/blob backend can implement the same interface.
 
 ## Dependencies
 
 - `iii-state` — entry / meta / active-leaf storage.
-- Registers four custom trigger types (`session::created`, `session::message_added`,
-  `session::message_updated`, `session::status_changed`) and emits their events through the engine on
-  every relevant mutation.
+- Registers six custom trigger types (`session::created`, `session::message_added`,
+  `session::message_updated`, `session::status_changed`, `session::meta_updated`,
+  `session::deleted`) and emits their events through the engine on every relevant mutation.
+
+## Agent exposure
+
+Deny-by-default for in-run agents (see [README § Security model](README.md#security-model)). An
+agent that can write here can rewrite its own transcript, flip session status, or destroy history:
+
+- **Deny:** `session::create`, `session::ensure`, `session::append`, `session::append_many`,
+  `session::update_message`, `session::set_status`, `session::set_meta`, `session::set_active_leaf`,
+  `session::fork`, `session::delete`.
+- **Allow with care:** `session::get`, `session::list`, `session::messages`, `session::get_message`
+  — read-only, but in multi-tenant deployments they leak other owners' sessions; deny unless the
+  deployment is single-tenant.
 
 ## Boundaries
 
@@ -423,3 +534,6 @@ for tests; a future SQL/blob backend can implement the same interface.
 - Does **not** export or render transcripts (HTML/PDF/etc.) — that is a separate worker's concern.
 - `custom` entries are an app escape hatch — keep large blobs in a blob store and reference them, not
   inline, to keep entries small.
+- Does **not** authenticate callers or enforce tenancy — `SessionMeta.metadata` is the hook
+  consumers filter on (list + trigger configs); access control lives in the deployment's permissions
+  (see [README § Security model](README.md#security-model)).

--- a/tech-specs/2026-06-agentic/session-manager.md
+++ b/tech-specs/2026-06-agentic/session-manager.md
@@ -46,6 +46,16 @@ via [`session::set_status`](#sessionset_status), which fires
 - A multi-channel bot stores every conversation here and forks sessions to explore alternatives.
 - A dashboard binds `session::status_changed` to show which sessions are working vs done.
 
+## Sub-agent linkage
+
+When the [harness](harness.md#sub-agents-harnessspawn) spawns a sub-agent, the child is a normal
+session whose relationship to its parent lives in `SessionMeta.metadata`:
+`{ parent_session_id, parent_turn_id, function_call_id, depth }`. This is a convention, not new API
+surface — `session::list` filters on it to reconstruct the agent tree, and trigger configs filter
+on it to render a child's transcript live (e.g. `{ metadata: { parent_session_id: "s_7a1" } }` on
+`session::message_updated`). Children are fully independent sessions: deleting the parent does not
+cascade (a cleanup worker can walk the linkage metadata when a deployment wants that).
+
 ## Reactivity model
 
 There is no "subscribe" or "publish" function. Reactivity is entirely via the six emitted trigger

--- a/tech-specs/2026-06-agentic/session-manager.md
+++ b/tech-specs/2026-06-agentic/session-manager.md
@@ -13,7 +13,7 @@ Two properties define it:
 
 1. **Many message types.** It stores the full `AgentMessage` union — user, assistant,
    `function_result`, and `custom` — where content is the rich `ContentBlock[]` (text, image,
-   thinking, function calls, function results). One transcript carries tool calls, reasoning, images,
+   thinking, function calls, function results). One transcript carries function calls, reasoning, images,
    and app-defined markers without a second store.
 2. **Reactive.** State changes are exposed as **triggers other workers bind to** — not as a stream a
    caller has to publish into. The worker emits four trigger types: a session was created, a message
@@ -143,7 +143,7 @@ type MessageAddedEvent = {
 ```
 
 - **`session::message_updated`** — a message's content changed (e.g. streaming deltas, edited
-  tool output).
+  function output).
   - Config: `{ session_id?: string; roles?: Role[] }`.
   - Payload:
 
@@ -339,7 +339,7 @@ type AppendManyResponse = { entry_ids: string[]; last_entry_id: string };
 ### `session::update_message`
 
 Replace the content (and optionally `details`) of an existing message entry. Used for streaming
-assistant deltas and for edited tool output. Fires `session::message_updated`.
+assistant deltas and for edited function output. Fires `session::message_updated`.
 
 - Invocation: **sync**
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive technical specs for an agentic chat backend: component roles (session store, context assembler, LLM router, lightweight orchestrator), architecture diagram, and migration guidance.
  * Documented durable session/branching semantics, token-budgeted context assembly and compaction, streaming/router contracts, agent run-loop behavior (function calls, cancellation, idempotency), observability, error-code conventions, and security/provenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->