### PR TITLE
fix(iii-lsp): align engine introspection with post-rework discovery builtins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,12 +193,32 @@ jobs:
 
       - run: pip install --quiet pyyaml
 
+      # Some workers can't be interface-smoked: stdio servers (e.g. iii-lsp)
+      # exit on stdin EOF while backgrounded, and pure discovery consumers
+      # register no interface to collect. They opt out with
+      # `interface_smoke: false` in iii.worker.yaml; every downstream step is
+      # gated on this so the rest of the matrix is unaffected.
+      - name: Check interface-smoke opt-out
+        id: optout
+        env:
+          WORKER: ${{ matrix.worker }}
+        run: |
+          set -euo pipefail
+          skip=$(WORKER="$WORKER" python3 -c 'import os, sys, pathlib; sys.path.insert(0, ".github/scripts"); import _lib; m = _lib.read_iii_worker_yaml(pathlib.Path(os.environ["WORKER"])); print("true" if m.raw.get("interface_smoke") is False else "false")')
+          echo "skip=$skip" >> "$GITHUB_OUTPUT"
+          if [[ "$skip" == "true" ]]; then
+            echo "::notice::$WORKER opts out of interface boot smoke (interface_smoke: false in iii.worker.yaml)"
+          fi
+
       - name: Rewrite SSH to HTTPS for public deps
+        if: steps.optout.outputs.skip != 'true'
         run: git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
 
       - uses: dtolnay/rust-toolchain@stable
+        if: steps.optout.outputs.skip != 'true'
 
       - uses: Swatinem/rust-cache@v2
+        if: steps.optout.outputs.skip != 'true'
         with:
           workspaces: ${{ matrix.worker }} -> target
 
@@ -229,10 +249,12 @@ jobs:
       # Build with default features so we boot the same artifact that ships
       # in the GitHub Release (`_rust-binary.yml` builds default features).
       - name: Build worker binary
+        if: steps.optout.outputs.skip != 'true'
         working-directory: ${{ matrix.worker }}
         run: cargo build
 
       - name: Install iii CLI + engine
+        if: steps.optout.outputs.skip != 'true'
         env:
           VERSION: '0.17.0'
         run: |
@@ -247,6 +269,7 @@ jobs:
           iii --version
 
       - name: Start III engine
+        if: steps.optout.outputs.skip != 'true'
         run: |
           set -euo pipefail
           printf 'workers: []\n' > config.yaml
@@ -270,6 +293,7 @@ jobs:
           exit 1
 
       - name: Snapshot engine baselines
+        if: steps.optout.outputs.skip != 'true'
         run: |
           set -euo pipefail
           iii trigger 'engine::triggers::list' --json '{"include_internal": false}' \
@@ -277,6 +301,7 @@ jobs:
           iii trigger 'engine::workers::list' --json '{}' > workers-baseline.json
 
       - name: Start worker from source
+        if: steps.optout.outputs.skip != 'true'
         env:
           WORKER: ${{ matrix.worker }}
         run: |
@@ -316,6 +341,7 @@ jobs:
           fi
 
       - name: Collect worker interface
+        if: steps.optout.outputs.skip != 'true'
         env:
           WORKER: ${{ matrix.worker }}
         run: |
@@ -328,6 +354,7 @@ jobs:
             --workers-baseline workers-baseline.json
 
       - name: Assert worker interface was collected
+        if: steps.optout.outputs.skip != 'true'
         run: |
           set -euo pipefail
           python3 .github/scripts/collect_worker_interface.py \

--- a/iii-lsp/Cargo.lock
+++ b/iii-lsp/Cargo.lock
@@ -85,12 +85,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,18 +192,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "const-hex"
-version = "1.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "proptest",
- "serde_core",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,12 +280,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,12 +311,6 @@ dependencies = [
  "ref-cast",
  "serde",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -495,25 +465,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,7 +551,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -626,19 +576,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -794,22 +731,17 @@ dependencies = [
 
 [[package]]
 name = "iii-observability"
-version = "0.16.0-next.2"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ee84dacaf7e14750ebdc229523e52029441c4ae1f72d25972bf1f2e1edeb99"
+checksum = "e11586fcd304a563c143837f67b2e5f3cb73d23f6c8452c9734ff18e4a1402bf"
 dependencies = [
- "async-trait",
  "futures-util",
  "opentelemetry",
  "opentelemetry-http",
- "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
  "reqwest",
- "serde",
  "serde_json",
  "sysinfo",
- "thiserror",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -818,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.16.0-next.2"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c18b68b2aa09e18c68fb023c78316fe7ccf42181874eab584d66f40119b47e"
+checksum = "8490f2ad470d54cf7e0bc2f4105aca71bdb4c24752fcb406183f24b8dd328f80"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -870,15 +802,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itoa"
@@ -1001,15 +924,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,23 +988,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-proto"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
-dependencies = [
- "base64",
- "const-hex",
- "opentelemetry",
- "opentelemetry_sdk",
- "prost",
- "serde",
- "serde_json",
- "tonic",
- "tonic-prost",
-]
-
-[[package]]
 name = "opentelemetry_sdk"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,26 +1022,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pin-project"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -1187,44 +1064,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proptest"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
-dependencies = [
- "bitflags",
- "num-traits",
- "rand",
- "rand_chacha",
- "rand_xorshift",
- "regex-syntax",
- "unarray",
-]
-
-[[package]]
-name = "prost"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1330,15 +1169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -1909,43 +1739,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
-dependencies = [
- "async-trait",
- "base64",
- "bytes",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "sync_wrapper",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic-prost"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
-dependencies = [
- "bytes",
- "prost",
- "tonic",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,15 +1746,11 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
  "pin-project-lite",
- "slab",
  "sync_wrapper",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -2154,12 +1943,6 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"

--- a/iii-lsp/Cargo.toml
+++ b/iii-lsp/Cargo.toml
@@ -9,7 +9,7 @@ name = "iii-lsp"
 path = "src/main.rs"
 
 [dependencies]
-iii-sdk = "=0.16.0-next.2"
+iii-sdk = "=0.19.2"
 tower-lsp-server = "0.23"
 tree-sitter = "0.24"
 tree-sitter-typescript = "0.23"

--- a/iii-lsp/Cargo.toml
+++ b/iii-lsp/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.1"
 edition = "2021"
 publish = false
 
+[lib]
+name = "iii_lsp"
+path = "src/lib.rs"
+
 [[bin]]
 name = "iii-lsp"
 path = "src/main.rs"

--- a/iii-lsp/iii.worker.yaml
+++ b/iii-lsp/iii.worker.yaml
@@ -5,3 +5,8 @@ deploy: binary
 manifest: Cargo.toml
 bin: iii-lsp
 description: III Language Server — autocompletion and hover for III engine functions and triggers
+# Opt out of the interface boot smoke. iii-lsp is a stdio language server:
+# it exits on stdin EOF (so it cannot stay alive while backgrounded) and it
+# only consumes engine discovery — it registers no functions or trigger
+# types, so there is no interface to collect.
+interface_smoke: false

--- a/iii-lsp/src/engine_introspection.rs
+++ b/iii-lsp/src/engine_introspection.rs
@@ -12,7 +12,7 @@ pub struct FunctionInfo {
     pub metadata: Option<Value>,
 }
 
-/// Trigger information returned by `engine::triggers::list`.
+/// Trigger instance information returned by `engine::registered-triggers::list`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TriggerInfo {
     pub id: String,
@@ -87,14 +87,14 @@ pub async fn list_triggers(
 ) -> Result<Vec<TriggerInfo>, IIIError> {
     let result = iii
         .trigger(TriggerRequest {
-            function_id: "engine::triggers::list".into(),
+            function_id: "engine::registered-triggers::list".into(),
             payload: serde_json::json!({ "include_internal": include_internal }),
             action: None,
             timeout_ms: None,
         })
         .await?;
     Ok(result
-        .get("triggers")
+        .get("registered_triggers")
         .and_then(|v| serde_json::from_value(v.clone()).ok())
         .unwrap_or_default())
 }

--- a/iii-lsp/src/engine_introspection.rs
+++ b/iii-lsp/src/engine_introspection.rs
@@ -22,7 +22,7 @@ pub struct TriggerInfo {
     pub metadata: Option<Value>,
 }
 
-/// Trigger type information returned by `engine::trigger-types::list`.
+/// Trigger type information returned by `engine::triggers::list`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TriggerTypeInfo {
     pub id: String,
@@ -105,14 +105,14 @@ pub async fn list_trigger_types(
 ) -> Result<Vec<TriggerTypeInfo>, IIIError> {
     let result = iii
         .trigger(TriggerRequest {
-            function_id: "engine::trigger-types::list".into(),
+            function_id: "engine::triggers::list".into(),
             payload: serde_json::json!({ "include_internal": include_internal }),
             action: None,
             timeout_ms: None,
         })
         .await?;
     Ok(result
-        .get("trigger_types")
+        .get("triggers")
         .and_then(|v| serde_json::from_value(v.clone()).ok())
         .unwrap_or_default())
 }

--- a/iii-lsp/src/lib.rs
+++ b/iii-lsp/src/lib.rs
@@ -1,0 +1,13 @@
+//! Library surface for `iii-lsp`.
+//!
+//! The binary (`src/main.rs`) keeps its own `mod` declarations; this lib
+//! target re-exports the same modules so integration tests under `tests/`
+//! can exercise the engine-introspection contract without spawning a
+//! language-server process.
+
+pub mod analyzer;
+pub mod completions;
+pub mod diagnostics;
+pub mod engine_client;
+pub mod engine_introspection;
+pub mod hover;

--- a/iii-lsp/tests/introspection.rs
+++ b/iii-lsp/tests/introspection.rs
@@ -1,0 +1,54 @@
+//! Guards the engine-introspection deserialization contract.
+//!
+//! The discovery rework changed which builtin each introspection helper
+//! must call and the envelope each returns. These tests pin the row shapes
+//! so a future engine/SDK bump that drifts the payload fails here instead
+//! of silently leaving the LSP caches empty.
+
+use iii_lsp::engine_introspection::{TriggerInfo, TriggerTypeInfo};
+use serde_json::json;
+
+/// `engine::triggers::list` returns trigger TYPES:
+/// `{ "triggers": [{ id, worker_name, description }] }`.
+/// `TriggerTypeInfo` must parse a row of that shape; the optional
+/// `*_format` fields are absent and must default to `None`.
+#[test]
+fn trigger_type_info_parses_triggers_list_row() {
+    let row = json!({
+        "id": "cron",
+        "worker_name": "iii-cron",
+        "description": "Cron trigger type",
+    });
+
+    let info: TriggerTypeInfo = serde_json::from_value(row).expect("row must deserialize");
+
+    assert_eq!(info.id, "cron");
+    assert_eq!(info.description, "Cron trigger type");
+    assert!(info.trigger_request_format.is_none());
+    assert!(info.call_request_format.is_none());
+}
+
+/// `engine::registered-triggers::list` returns trigger INSTANCES:
+/// `{ "registered_triggers": [{ id, trigger_type, function_id, worker_name,
+/// config, config_summary }] }`. `TriggerInfo` must parse a row of that
+/// shape — extra engine fields (`worker_name`, `config_summary`) are
+/// ignored and the absent `metadata` defaults to `None`.
+#[test]
+fn trigger_info_parses_registered_triggers_list_row() {
+    let row = json!({
+        "id": "70c0e45d",
+        "trigger_type": "http",
+        "function_id": "example::handler",
+        "worker_name": "example",
+        "config": { "api_path": "/hooks", "http_method": "POST" },
+        "config_summary": "POST /hooks",
+    });
+
+    let info: TriggerInfo = serde_json::from_value(row).expect("row must deserialize");
+
+    assert_eq!(info.id, "70c0e45d");
+    assert_eq!(info.trigger_type, "http");
+    assert_eq!(info.function_id, "example::handler");
+    assert_eq!(info.config["api_path"], "/hooks");
+    assert!(info.metadata.is_none());
+}


### PR DESCRIPTION
## Problem

Every engine startup logged this twice:

\`\`\`
[ERROR] iii::engine Function not found
    └ function_id: engine::trigger-types::list
\`\`\`

Not functional-breaking, but constant log spam on boot. Investigation also surfaced a second, silent breakage in the same file.

## Root cause

The engine_fn discovery rework changed the builtin surface:
- \`engine::trigger-types::list\` was **retired** → \`engine::triggers::list\` now returns trigger **types** (\`{ "triggers": [{ id, worker_name, description }] }\`).
- Trigger **instances** (subscriber rows) moved to \`engine::registered-triggers::list\` (\`{ "registered_triggers": [...] }\`).

\`iii-lsp/src/engine_introspection.rs\` was never updated:

1. **\`list_trigger_types\`** called the retired \`engine::trigger-types::list\`. Invoked from \`reseed_secondary_caches()\`, which runs on \`seed_cache()\` at startup **and** from the function-change poll task (fires as workers register during boot) — hence two identical errors at the same millisecond. Engine returned "Function not found"; \`from_value(...).ok()\` swallowed it, leaving the trigger-type cache empty.

2. **\`list_triggers\`** called \`engine::triggers::list\` but parsed rows as \`TriggerInfo\` (instance shape: \`id, trigger_type, function_id, config, metadata\`). Post-rework that endpoint returns *types*, so deserialization silently produced an empty \`Vec\` — no log, but \`extract_known_values\` had nothing to work with.

## Fix

| fn | function_id | response key |
|----|-------------|--------------|
| \`list_trigger_types\` | \`engine::trigger-types::list\` → \`engine::triggers::list\` | \`trigger_types\` → \`triggers\` |
| \`list_triggers\` | \`engine::triggers::list\` → \`engine::registered-triggers::list\` | \`triggers\` → \`registered_triggers\` |

Struct fields map directly onto the new payloads (\`TriggerInfo\` ← \`RegisteredTriggerSummary\`; \`TriggerTypeInfo\` ← \`TriggerTypeSummary\`, with optional \`*_format\` fields becoming \`None\` — per-type schemas come from \`engine::triggers::info\` if needed later).

Also bumps \`iii-sdk\` \`0.16.0-next.2\` → \`0.19.2\` (and \`iii-observability\` transitively) to align with the engine version whose discovery surface this targets.

## CI scaffolding (pre-existing gaps, surfaced because this is the first PR to touch iii-lsp source)

Prior iii-lsp PRs only changed metadata, so the strict per-worker checks never fired. This branch trips two of them:

- **\`tests/\` required** by \`validate_worker.py\`. Added a \`[lib]\` target (mirrors the \`acp\` worker layout — the binary keeps its own \`mod\` declarations; the lib exists only so tests can reach the modules) plus \`tests/introspection.rs\`, which pins the engine response shapes the introspection helpers deserialize — directly guarding the envelope/function_id changes above.
- **Interface boot smoke** boots each worker and asserts a non-empty interface. iii-lsp is a stdio language server: it exits on stdin EOF (can't stay alive while backgrounded) and registers no functions/trigger types (it only *consumes* discovery), so it can never pass. Added an opt-in \`interface_smoke: false\` key to \`iii.worker.yaml\` and gated the smoke job's steps on it; other workers are unaffected.

⚠️ **Follow-up (out of scope):** \`_publish-registry.yml\` runs the same boot+collect at release time and will need the same \`interface_smoke\` gate before iii-lsp can be published.

## Test

- \`cargo build\` clean on iii-sdk 0.19.2
- \`cargo test\` — 61 unit + 2 integration passed, 0 failed
- \`cargo clippy --all-targets -- -D warnings\` — clean
- All PR CI checks green (PR checks, rust lint + test, interface boot smoke)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * iii-lsp is now available as a reusable library module.

* **Chores**
  * Updated iii-sdk dependency to version 0.19.2.
  * Enhanced CI workflow to conditionally skip interface validation for workers that don't support it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->