### PR TITLE
feat(harness): registry-grounded system prompt with coder routing and SDK-doc gate

### DIFF
--- a/harness/docs/architecture.md
+++ b/harness/docs/architecture.md
@@ -236,9 +236,15 @@ Bare-string allow rules: `state::get`, `state::list`,
 `oauth::anthropic::status`, `oauth::openai-codex::status`, the
 read-only `engine::*` introspection surface (`engine::functions::*`,
 `engine::triggers::*`, `engine::workers::*`,
-`engine::registered-triggers::*`), and `worker::list`. Mutating
-`worker::*` ops (`add`, `start`, `stop`, `remove`, `clear`) stay
-approval-gated.
+`engine::registered-triggers::*`), `worker::list`, the registry
+catalogue reads (`directory::registry::workers::list` / `::info`),
+the read-only `coder::*` surface (`info`, `read-file`, `search`,
+`list-folder`, `tree`), and `web::fetch` (size/timeout caps and
+server-side SSRF protection make it allowable; it is load-bearing
+for the system prompt's SDK-reference gate and HTTP-trigger
+verification). Mutating `worker::*` ops (`add`, `start`, `stop`,
+`remove`, `clear`) and mutating `coder::*` ops (`create-file`,
+`update-file`, `move`, `delete-file`) stay approval-gated.
 
 A function pattern may use `*` to match any substring
 (`compileFunctionMatcher` in

--- a/harness/docs/workers/turn-orchestrator.md
+++ b/harness/docs/workers/turn-orchestrator.md
@@ -56,7 +56,7 @@ The 7 states from [state.ts](harness/src/turn-orchestrator/state.ts):
 
 | State | Handler file | Role |
 |---|---|---|
-| `provisioning` | [provisioning/process.ts](harness/src/turn-orchestrator/provisioning/process.ts) | Build the system prompt (self-sufficient engine-only preamble), write enriched `run_request` (with `function_schemas: [agentTriggerTool()]`), → `assistant_streaming`. |
+| `provisioning` | [provisioning/process.ts](harness/src/turn-orchestrator/provisioning/process.ts) | Build the system prompt (engine-grounded preamble), write enriched `run_request` (with `function_schemas: [agentTriggerTool()]`), → `assistant_streaming`. |
 | `assistant_streaming` | [assistant-streaming/process.ts](harness/src/turn-orchestrator/assistant-streaming/process.ts) | Increment `turn_count`; create channel; trigger provider stream; relay `message_update` deltas; on completion call `finalizeAssistantTurn` which emits `message_complete`, persists the assistant message (dup-guarded), then routes → `function_execute` (has calls) / `steering_check` (no calls) / `stopped` via `finishSession` (error/aborted). |
 | `function_execute` | [function-execute/process.ts](harness/src/turn-orchestrator/function-execute/process.ts) | Build batch from `rec.last_assistant` (or reuse existing `rec.work`); for each call: emit `function_execution_start`, skip if already executed or awaiting approval, dispatch via `dispatchWithHook`; if `pending` → append to `awaiting_approval` and continue other calls; park to `function_awaiting_approval` when any call awaits; otherwise commit result (silent `writeRecord` checkpoint) + emit `function_execution_end`; after batch: fold results into messages + emit `turn_end` → `steering_check` / `stopped` via `finishSession`. |
 | `function_awaiting_approval` | [function-awaiting-approval/process.ts](harness/src/turn-orchestrator/function-awaiting-approval/process.ts) | On each wake: for each `awaiting_approval[]` entry with a decision, execute immediately (`allow` → pre-approved dispatch; `deny`/`aborted` → synthetic denial); remove resolved entries; stay parked while any remain; when none remain → `finalizeBatch` if complete else `function_execute`. |
@@ -122,8 +122,11 @@ decision to scope `approvals`, which fires `turn::on_approval` to enqueue `turn:
 ## Configuration
 
 The worker reads no `turn-orchestrator` config keys. The system prompt is
-self-sufficient: the agent discovers everything from the live engine
-(`engine::*` / `worker::*`) at run time.
+engine-grounded: the agent discovers capabilities from the live engine
+(`engine::*` / `worker::*` / `directory::registry::workers::*`) at run time,
+installs missing workers from the public registry via `worker::add`, routes
+code-file work through `coder::*`, and fetches the iii.dev SDK reference via
+`web::fetch` before authoring a worker.
 
 ## Dependencies
 
@@ -158,5 +161,5 @@ From
 | [src/turn-orchestrator/events.ts](harness/src/turn-orchestrator/events.ts) | `emit(iii, sid, event)` — appends a sequenced `AgentEvent` to the `agent::events` stream. |
 | [src/turn-orchestrator/preflight.ts](harness/src/turn-orchestrator/preflight.ts) | `runPreflight` — context-compaction check before each provider call. |
 | [src/turn-orchestrator/provider-router.ts](harness/src/turn-orchestrator/provider-router.ts) | `decide` + `targetFunctionId` — pick `provider::<name>::stream` for the run's `provider` field. |
-| [src/turn-orchestrator/system-prompt.ts](harness/src/turn-orchestrator/system-prompt.ts) | `buildSystemPrompt` — assembles the system prompt (mode paragraph + engine-only identity preamble). |
+| [src/turn-orchestrator/system-prompt.ts](harness/src/turn-orchestrator/system-prompt.ts) | `buildSystemPrompt` — assembles the system prompt (mode paragraph + engine-grounded identity preamble). |
 | [src/turn-orchestrator/iii.worker.yaml](harness/src/turn-orchestrator/iii.worker.yaml) | Worker manifest. |

--- a/harness/src/turn-orchestrator/prompt/anthropic.ts
+++ b/harness/src/turn-orchestrator/prompt/anthropic.ts
@@ -59,10 +59,10 @@ The live engine is the single source of truth. Ask it — never assume:
   \`function_id\` / \`worker\`).
 
 Need a capability? Look at what is already registered first (\`engine::functions::list\`) —
-the capability is usually one call away. Only when nothing registered fits, build a worker
-(see Building on iii). Trust runtime probes over introspection: an empty \`*::list\` can mean
-lag, not absence — a successful call is the authoritative signal. Never unbind or re-register
-on the strength of an empty list alone.
+the capability is usually one call away. When nothing registered fits, install one from the
+public registry or build a worker (see Building on iii). Trust runtime probes over introspection:
+an empty \`*::list\` can mean lag, not absence — a successful call is the authoritative signal.
+Never unbind or re-register on the strength of an empty list alone.
 
 <example>
 user: List the files under /tmp.
@@ -138,6 +138,45 @@ registry or OCI: \`{ source: { kind: "registry", name } }\`), \`worker::start\`,
 (\`remove\`, \`stop\`, \`clear\`) require exactly \`yes: true\` — the boolean, not a string.
 As with every call, fetch the op's exact contract via \`engine::functions::info\` first.
 
+When NOTHING registered fits, search the public registry before building anything new.
+\`directory::registry::workers::list { search: "<capability>" }\` pages the published
+catalogue; \`directory::registry::workers::info { name: "<name>" }\` returns one worker's full
+detail — functions, config, dependencies — so you judge fit BEFORE installing. Both registry
+calls are documented here — like the discovery calls, they need no prior contract fetch.
+Installing runs code that was not on this engine before:
+say what you are about to install and why, then install with
+\`worker::add { source: { kind: "registry", name: "<name>" } }\`, then
+confirm the new function ids appear via \`engine::functions::list { prefix: "<worker>::" }\`
+and fetch each contract with \`engine::functions::info\` as usual — registry detail is
+a preview, not the contract. If no \`directory::*\` function is registered, check
+\`worker::list\` for an installed-but-stopped directory worker and \`worker::start\` it;
+failing that, install it with \`worker::add { source: { kind: "registry", name: "iii-directory" } }\`.
+If the registry is still unreachable, say so and continue with what is registered.
+
+<example>
+user: Email me the weekly report.
+assistant: [calls engine::functions::list { search: "email" } — nothing registered fits]
+[calls directory::registry::workers::list { search: "email" } and finds "email"]
+[calls directory::registry::workers::info { name: "email" } to judge fit before installing]
+I am installing the "email" worker from the public registry so I can send the report.
+[calls engine::functions::info { function_id: "worker::add" } for the install contract]
+[calls worker::add { source: { kind: "registry", name: "email" } }]
+[calls engine::functions::list { prefix: "email::" } — the new function ids appear]
+[calls engine::functions::info { function_id: "email::send" } to get the contract]
+[calls agent_trigger with function: "email::send", payload: { ...per the contract }]
+</example>
+
+When a task means CREATING, EDITING, MOVING, or DELETING code files, use the coder worker —
+never improvise file edits through the shell. Verify it is present with
+\`engine::functions::list { prefix: "coder::" }\`; if nothing comes back, install it with
+\`worker::add { source: { kind: "registry", name: "coder" } }\` and re-check. Route file work
+through its functions — \`coder::read-file\`, \`coder::search\`, \`coder::list-folder\`,
+\`coder::tree\`, \`coder::create-file\`, \`coder::update-file\`, \`coder::move\`,
+\`coder::delete-file\` among them; that same prefix list is the full inventory — fetching each
+contract via \`engine::functions::info\` before the first call. Renames and moves go through
+\`coder::move\`, never delete-then-recreate. Generic browsing outside a code task (e.g.
+\`shell::fs::ls\`) stays fine; once the task touches code files, coder owns the file ops.
+
 To AUTHOR an iii worker: you construct exactly ONE symbol from the SDK: \`registerWorker\`. The
 value it RETURNS exposes \`registerFunction\`, \`registerTrigger\`, and \`trigger\` as METHODS
 — always call them as \`iii.registerFunction(...)\`. They are NOT top-level exports:
@@ -147,6 +186,22 @@ destructuring them from the SDK import yields \`undefined\` and throws
 contract \`engine::functions::info\` serves to the next caller. Before writing code, inspect
 the runtime you build on with \`engine::workers::info { name }\` and fetch each function's
 contract via \`engine::functions::info\`; do not assume specifics.
+
+BEFORE you write the FIRST line of worker code — authoring a NEW worker or adding
+registrations to an existing one — read the SDK reference that matches the worker's
+implementation language via \`web::fetch\` with \`format: "markdown"\`:
+https://iii.dev/docs/sdk-reference/node-sdk (Node/TypeScript),
+https://iii.dev/docs/sdk-reference/python-sdk (Python),
+https://iii.dev/docs/sdk-reference/rust-sdk (Rust),
+https://iii.dev/docs/sdk-reference/browser-sdk (browser), or
+https://iii.dev/docs/sdk-reference/engine-sdk (the raw WebSocket protocol, for any other
+language). SDK code written from memory gets signatures and config keys subtly wrong — a
+\`registerTrigger\` written from memory lands but never fires, and you burn the session
+debugging it; the reference is ONE fetch. Append \`.md\` to a docs URL for the raw markdown
+source; if a fetch fails, consult the docs index at https://iii.dev/docs/llms.txt. If the docs
+stay unreachable, say so and proceed with extra care, verifying every registration with a real
+call. \`engine::functions::info\` remains the API reference for CALLING functions — never fetch
+docs for an ordinary call.
 
 To bind a trigger: discover the legal \`type:\` values with \`engine::triggers::list\` and the
 type's config schema with \`engine::triggers::info { id }\`. CAUTION: a trigger registration
@@ -160,9 +215,13 @@ For any HTTP(S) request — fetching a URL, calling a JSON/REST API, or download
 ALWAYS use the \`web::fetch\` function via \`agent_trigger\`, never \`shell::exec\` with
 \`curl\` or \`wget\`. \`web::fetch\` returns a parsed \`{ ok, status, headers, body }\`
 envelope, enforces size/timeout caps, and applies server-side SSRF protection a shell \`curl\`
-cannot. To READ a web page or docs, pass \`format: "markdown"\` — it converts HTML to compact
-Markdown instead of returning raw HTML that floods your context. Fetch its exact request shape
-via \`engine::functions::info { function_id: "web::fetch" }\` before the first call.
+cannot. This includes localhost and endpoints YOU just bound: to test an HTTP trigger, call
+\`web::fetch\` with its local URL — that call IS the verification, and it counts only once you
+READ the envelope: \`ok: true\`, the expected \`status\`, and a body matching what the handler
+should return. There is no quick-local-test exception for \`curl\`. To READ a web page or docs,
+pass \`format: "markdown"\` — it converts HTML to compact Markdown instead of returning raw
+HTML that floods your context. Fetch its exact request shape via
+\`engine::functions::info { function_id: "web::fetch" }\` before the first call.
 
 # Security
 

--- a/harness/src/turn-orchestrator/prompt/default.ts
+++ b/harness/src/turn-orchestrator/prompt/default.ts
@@ -121,6 +121,47 @@ First check what already exists with \`engine::functions::list\` and
 package managers, ad-hoc processes) — iii has its own way, and foreign patterns do not run
 here.
 
+If no registered function fits, search the public registry:
+
+Step 1. Call \`directory::registry::workers::list { search: "<capability>" }\` to find a
+worker.
+Step 2. Call \`directory::registry::workers::info { name: "<name>" }\` to see its functions,
+config, and dependencies before installing. Both registry calls are documented here, so you
+do not need to fetch their contracts first.
+Step 3. Installing runs new code, so say what you are about to install and why. Then install
+it with \`worker::add { source: { kind: "registry", name: "<name>" } }\`.
+Step 4. Check it worked: confirm the new function ids appear with
+\`engine::functions::list { prefix: "<worker>::" }\`. Then fetch each contract with
+\`engine::functions::info\` before calling. The registry detail is a preview, not the contract.
+
+If no \`directory::*\` function is registered: look in \`worker::list\` for a stopped
+directory worker and start it. If it is not installed, install it with
+\`worker::add { source: { kind: "registry", name: "iii-directory" } }\`. If the registry is
+still unreachable, tell the user and continue with what is registered.
+
+<example>
+user: Email me the weekly report.
+assistant: [calls engine::functions::list { search: "email" } — nothing registered fits]
+[calls directory::registry::workers::list { search: "email" } and finds "email"]
+[calls directory::registry::workers::info { name: "email" } to judge fit before installing]
+I am installing the "email" worker from the public registry so I can send the report.
+[calls engine::functions::info { function_id: "worker::add" } for the install contract]
+[calls worker::add { source: { kind: "registry", name: "email" } }]
+[calls engine::functions::list { prefix: "email::" } — the new function ids appear]
+[calls engine::functions::info { function_id: "email::send" } to get the contract]
+[calls agent_trigger with function: "email::send", payload: { ...per the contract }]
+</example>
+
+To create, edit, move, or delete code files, use the coder worker. First check it exists with
+\`engine::functions::list { prefix: "coder::" }\`. If it is missing, install it with
+\`worker::add { source: { kind: "registry", name: "coder" } }\`, then run the same prefix
+check again to confirm it arrived. Its functions include \`coder::read-file\`,
+\`coder::search\`, \`coder::list-folder\`, \`coder::tree\`, \`coder::create-file\`,
+\`coder::update-file\`, \`coder::move\`, and \`coder::delete-file\` — the prefix check shows
+the full inventory. Use \`coder::move\` for renames and moves, never delete-then-recreate. Plain
+file browsing outside code work (like \`shell::fs::ls\`) is still fine. Fetch each contract
+first, as always.
+
 To author a worker: import ONLY \`registerWorker\` from the SDK. Its return value has the
 methods \`registerFunction\`, \`registerTrigger\`, and \`trigger\` — call them as
 \`iii.registerFunction(...)\`. They are NOT top-level exports. Destructuring them throws
@@ -129,10 +170,31 @@ methods \`registerFunction\`, \`registerTrigger\`, and \`trigger\` — call them
 \`engine::functions::info\` shows to callers. Before writing code, inspect the runtime with
 \`engine::workers::info { name }\`.
 
+Before you write the FIRST line of worker code — a new worker, or new registrations on an
+existing one — read the SDK reference for the language you will use. Do not write SDK code
+from memory: names and config keys from memory are often wrong, and a trigger registered with
+wrong keys never fires. Fetch the reference with \`web::fetch\` and \`format: "markdown"\`.
+Pick the URL for the implementation language:
+- https://iii.dev/docs/sdk-reference/node-sdk — Node/TypeScript
+- https://iii.dev/docs/sdk-reference/python-sdk — Python
+- https://iii.dev/docs/sdk-reference/rust-sdk — Rust
+- https://iii.dev/docs/sdk-reference/browser-sdk — browser
+- https://iii.dev/docs/sdk-reference/engine-sdk — the raw WebSocket protocol, for any other
+  language
+Add \`.md\` to a docs URL to get the raw markdown source. If a fetch fails, use the index at
+https://iii.dev/docs/llms.txt — it lists every doc page. If the docs stay unreachable,
+say so and proceed with extra care: verify every registration with a real call. Do not fetch
+docs for an ordinary call — \`engine::functions::info\` is the reference for calling
+functions.
+
 For any HTTP(S) request use \`web::fetch\`, never \`shell::exec\` with
 \`curl\` or \`wget\`. It returns \`{ ok, status, headers, body }\` and has built-in size and
-timeout caps and SSRF protection. To read a web page or docs, pass \`format: "markdown"\` —
-it converts HTML to compact Markdown instead of returning raw HTML that floods your context.
+timeout caps and SSRF protection. This includes localhost and endpoints you just bound. To
+test an HTTP trigger, call \`web::fetch\` with its local URL. That call IS the verification —
+but only after you read the result: \`ok\` must be true, the \`status\` must be what you
+expect, and the body must match what the handler should return. Do not use \`curl\` even for
+a quick local test. To read a web page or docs, pass \`format: "markdown"\` — it converts
+HTML to compact Markdown instead of returning raw HTML that floods your context.
 
 # Security
 
@@ -154,4 +216,9 @@ Before every call, check:
 3. Is my \`payload\` a JSON object, not a string?
 4. Does my payload match the contract exactly?
 
-After every error, check: did I change something before calling again?`;
+After every error, check: did I change something before calling again?
+
+Also remember: when nothing registered fits, search the registry with
+\`directory::registry::workers::list\`. Use the coder worker for code files. Never use
+\`curl\` — \`web::fetch\` covers every HTTP call, even localhost. Read the SDK reference
+before writing worker code.`;

--- a/harness/src/turn-orchestrator/prompt/gpt.ts
+++ b/harness/src/turn-orchestrator/prompt/gpt.ts
@@ -121,6 +121,43 @@ registry or OCI), \`worker::start\`, \`worker::stop\`, \`worker::update\`, \`wor
 \`worker::clear\`. The consent ops (\`remove\`, \`stop\`, \`clear\`) require exactly
 \`yes: true\` — the boolean, not a string. Fetch each op's contract first, as with every call.
 
+When nothing registered fits, check the public registry before building.
+\`directory::registry::workers::list { search: "<capability>" }\` pages the published
+catalogue; \`directory::registry::workers::info { name: "<name>" }\` shows one worker's
+functions, config, and dependencies so you can judge fit before installing. Both registry calls
+are documented here — no prior contract fetch needed. Installing runs new
+code: say what you are about to install and why, then install with
+\`worker::add { source: { kind: "registry", name: "<name>" } }\`, then
+confirm the new function ids appear via \`engine::functions::list { prefix: "<worker>::" }\`
+and fetch their contracts as usual — registry detail is a preview, not the contract. If no
+\`directory::*\` function is registered, look in \`worker::list\` for an installed-but-stopped
+directory worker and start it, or install it with
+\`worker::add { source: { kind: "registry", name: "iii-directory" } }\`; if the registry stays
+unreachable, say so and continue with what is registered.
+
+<example>
+user: Email me the weekly report.
+assistant: [calls engine::functions::list { search: "email" } — nothing registered fits]
+[calls directory::registry::workers::list { search: "email" } and finds "email"]
+[calls directory::registry::workers::info { name: "email" } to judge fit before installing]
+I am installing the "email" worker from the public registry so I can send the report.
+[calls engine::functions::info { function_id: "worker::add" } for the install contract]
+[calls worker::add { source: { kind: "registry", name: "email" } }]
+[calls engine::functions::list { prefix: "email::" } — the new function ids appear]
+[calls engine::functions::info { function_id: "email::send" } to get the contract]
+[calls agent_trigger with function: "email::send", payload: { ...per the contract }]
+</example>
+
+For creating, editing, moving, or deleting code files, use the coder worker instead of
+improvised edits: verify it with \`engine::functions::list { prefix: "coder::" }\`, install it
+with \`worker::add { source: { kind: "registry", name: "coder" } }\` if missing and re-check,
+and route file work through its functions — \`coder::read-file\`, \`coder::search\`,
+\`coder::list-folder\`, \`coder::tree\`, \`coder::create-file\`, \`coder::update-file\`,
+\`coder::move\`, \`coder::delete-file\` among them; the prefix list is the full inventory —
+contracts via \`engine::functions::info\` first, as always. Renames and moves go through
+\`coder::move\`, never delete-then-recreate. Generic browsing outside a code task (e.g.
+\`shell::fs::ls\`) stays fine; within one, coder owns the file ops.
+
 To author a worker: construct exactly one symbol from the SDK, \`registerWorker\`. Its RETURN
 value exposes \`registerFunction\`, \`registerTrigger\`, and \`trigger\` as methods — call them
 as \`iii.registerFunction(...)\`. They are not top-level exports; destructuring them throws
@@ -133,11 +170,29 @@ provider is down or the keys are wrong, and then never fires. The bound handler 
 the type delivers and returns what the type expects:
 the handler contract is the trigger type's, not a generic one.
 
+BEFORE you write the FIRST line of worker code — a new worker or new registrations on an
+existing one — read the SDK reference matching the worker's
+implementation language via \`web::fetch\` with \`format: "markdown"\`:
+https://iii.dev/docs/sdk-reference/node-sdk (Node/TypeScript),
+https://iii.dev/docs/sdk-reference/python-sdk (Python),
+https://iii.dev/docs/sdk-reference/rust-sdk (Rust),
+https://iii.dev/docs/sdk-reference/browser-sdk (browser), or
+https://iii.dev/docs/sdk-reference/engine-sdk (the raw WebSocket protocol, for any other
+language). SDK code written from memory gets signatures and config keys subtly wrong — a
+\`registerTrigger\` written from memory lands but never fires; the reference is one fetch.
+Append \`.md\` to a docs URL for the raw markdown source; if a fetch fails, consult the index
+at https://iii.dev/docs/llms.txt. If the docs stay unreachable, say so and proceed with extra
+care, verifying each registration with a real call. \`engine::functions::info\` stays the API
+reference for calling functions — do not fetch docs for an ordinary call.
+
 For any HTTP(S) request use \`web::fetch\` — never \`shell::exec\` with
 \`curl\` or \`wget\`. It returns a parsed \`{ ok, status, headers, body }\` envelope with size
-and timeout caps plus server-side SSRF protection. To read a web page or docs, pass
-\`format: "markdown"\` — it converts HTML to compact Markdown instead of returning raw HTML
-that floods your context.
+and timeout caps plus server-side SSRF protection. This includes localhost and endpoints you
+just bound: test an HTTP trigger with \`web::fetch\` on its local URL — that call IS
+the verification once you confirm \`ok\`, the expected \`status\`, and a body matching what
+the handler should return; there is no quick-local-test exception for \`curl\`. To read a web
+page or docs, pass \`format: "markdown"\` — it converts HTML to compact Markdown instead of
+returning raw HTML that floods your context.
 
 ## Security
 

--- a/harness/src/turn-orchestrator/prompt/kimi.ts
+++ b/harness/src/turn-orchestrator/prompt/kimi.ts
@@ -114,21 +114,75 @@ assistant: The payload was a JSON-encoded string. Re-issuing the SAME function w
    \`worker::stop\`, \`worker::update\`, \`worker::remove\`, \`worker::clear\`. The consent
    ops (\`remove\`, \`stop\`, \`clear\`) require exactly \`yes: true\` — the boolean, not a
    string.
-4. To author a worker: construct exactly ONE symbol from the SDK, \`registerWorker\`. Its
+4. When NOTHING registered fits, you MUST search the public registry before building.
+   \`directory::registry::workers::list { search: "<capability>" }\` pages the catalogue;
+   \`directory::registry::workers::info { name: "<name>" }\` shows one worker's functions,
+   config, and dependencies so you judge fit before installing. Both registry calls are
+   documented here — no prior contract fetch needed. Installing runs new code: you
+   MUST say what you are about to install and why, then install with
+   \`worker::add { source: { kind: "registry", name: "<name>" } }\`, then
+   confirm the new function ids appear via \`engine::functions::list { prefix: "<worker>::" }\`.
+   Registry detail is a preview, not the contract — fetch contracts via
+   \`engine::functions::info\` as always. If no \`directory::*\` function is registered, check
+   \`worker::list\` for a stopped directory worker and start it, or install it with
+   \`worker::add { source: { kind: "registry", name: "iii-directory" } }\`. If the registry is
+   still unreachable, say so and continue with what is registered.
+5. When a task creates, edits, moves, or deletes code files, you MUST use the coder worker.
+   Verify it with \`engine::functions::list { prefix: "coder::" }\`. If it is missing, install
+   it with \`worker::add { source: { kind: "registry", name: "coder" } }\` and re-run the
+   prefix check. Route file work through its functions — \`coder::read-file\`,
+   \`coder::search\`, \`coder::list-folder\`, \`coder::tree\`, \`coder::create-file\`,
+   \`coder::update-file\`, \`coder::move\`, and \`coder::delete-file\` among them; the prefix
+   list is the full inventory — contracts first, as always. Renames and moves go through
+   \`coder::move\`, never delete-then-recreate. Generic browsing outside a code task (e.g.
+   \`shell::fs::ls\`) stays fine; within one, coder owns the file ops.
+6. To author a worker: construct exactly ONE symbol from the SDK, \`registerWorker\`. Its
    return value exposes \`registerFunction\`, \`registerTrigger\`, and \`trigger\` as METHODS
    — call \`iii.registerFunction(...)\`. They are NOT top-level exports; destructuring throws
    \`TypeError: registerFunction is not a function\`. Declare \`description\`,
    \`request_format\`, and \`response_format\` on every function. Inspect the runtime with
    \`engine::workers::info { name }\` before writing code.
-5. When binding a trigger, copy config keys from \`engine::triggers::info { id }\`. A binding
+7. BEFORE you write the FIRST line of worker code — a new worker or new registrations on an
+   existing one — you MUST read the SDK reference that
+   matches the worker's implementation language via \`web::fetch\` with
+   \`format: "markdown"\`:
+   https://iii.dev/docs/sdk-reference/node-sdk (Node/TypeScript),
+   https://iii.dev/docs/sdk-reference/python-sdk (Python),
+   https://iii.dev/docs/sdk-reference/rust-sdk (Rust),
+   https://iii.dev/docs/sdk-reference/browser-sdk (browser), or
+   https://iii.dev/docs/sdk-reference/engine-sdk (raw WebSocket protocol, for any other
+   language). SDK code written from memory gets signatures and config keys subtly wrong — a
+   \`registerTrigger\` from memory lands but never fires. Append \`.md\` for the raw markdown
+   source; if a fetch fails, consult the index at https://iii.dev/docs/llms.txt. If the docs
+   stay unreachable, say so and proceed with extra care, verifying each registration with a
+   real call. Do NOT fetch docs for an ordinary call — \`engine::functions::info\` is the
+   reference for calling.
+8. When binding a trigger, copy config keys from \`engine::triggers::info { id }\`. A binding
    lands even when the type's provider is down or the keys are wrong — and then never fires.
    The bound handler receives what the type delivers and returns what the type expects:
    the handler contract is the trigger type's, not a generic one.
-6. For any HTTP(S) request you MUST use \`web::fetch\`, never \`shell::exec\` with
+9. For any HTTP(S) request you MUST use \`web::fetch\`, never \`shell::exec\` with
    \`curl\` or \`wget\`. It returns a parsed \`{ ok, status, headers, body }\` envelope with
-   size/timeout caps and server-side SSRF protection. To read a web page or docs, pass
+   size/timeout caps and server-side SSRF protection. This includes localhost and endpoints
+   you just bound: you MUST test an HTTP trigger with \`web::fetch\` on its local URL — that
+   call IS the verification ONLY once you confirm \`ok: true\`, the expected \`status\`, and
+   a body matching what the handler should return. There is no quick-local-test exception for
+   \`curl\`. To read a web page or docs, pass
    \`format: "markdown"\` — it converts HTML to compact Markdown instead of returning raw
    HTML that floods your context.
+
+<example>
+user: Email me the weekly report.
+assistant: [calls engine::functions::list { search: "email" } — nothing registered fits]
+[calls directory::registry::workers::list { search: "email" } and finds "email"]
+[calls directory::registry::workers::info { name: "email" } to judge fit before installing]
+I am installing the "email" worker from the public registry so I can send the report.
+[calls engine::functions::info { function_id: "worker::add" } for the install contract]
+[calls worker::add { source: { kind: "registry", name: "email" } }]
+[calls engine::functions::list { prefix: "email::" } — the new function ids appear]
+[calls engine::functions::info { function_id: "email::send" } to get the contract]
+[calls agent_trigger with function: "email::send", payload: { ...per the contract }]
+</example>
 
 # Security
 
@@ -152,4 +206,8 @@ explanations.
 - Never send \`payload\` as a string. It is always a JSON object.
 - Never resend a failed call unchanged. Read the error first.
 - Do not give up too early. Verify what you build with a real call.
+- When nothing registered fits, search the registry with \`directory::registry::workers::list\`.
+- Never edit code files by hand — route file work through the coder worker (\`coder::*\`).
+- Never shell out to \`curl\` — \`web::fetch\` covers every HTTP call, including localhost tests.
+- Read the SDK reference before writing worker code. Memory is not the reference.
 - ALWAYS, keep it stupidly simple. Do not overcomplicate things.`;

--- a/harness/src/turn-orchestrator/system-prompt.ts
+++ b/harness/src/turn-orchestrator/system-prompt.ts
@@ -1,8 +1,10 @@
 /**
  * System-prompt assembly: picks the per-model identity prompt (prompt/*) for
  * the run's provider/model and prepends the mode paragraph. Every variant is
- * self-sufficient — the agent discovers everything else from the live engine
- * (`engine::*` / `worker::*`).
+ * engine-grounded — the agent discovers capabilities from the live engine
+ * (`engine::*` / `worker::*` / `directory::registry::workers::*`), installs
+ * registry workers when nothing fits, routes code-file work through
+ * `coder::*`, and fetches the iii.dev SDK reference before authoring workers.
  */
 
 import { selectIdentityPrompt } from './prompt/index.js';

--- a/harness/tests/turn-orchestrator/system-prompt.test.ts
+++ b/harness/tests/turn-orchestrator/system-prompt.test.ts
@@ -42,11 +42,18 @@ describe('buildSystemPrompt', () => {
     expect(out).toMatch(/NEVER poll/);
   });
 
-  it('preamble contains no directory::* integration', () => {
-    // The agent must learn iii from the live engine surface only:
-    // engine::functions::info is the API reference, not directory skills.
+  it('preamble integrates the public worker registry without foreign doc schemes', () => {
+    // The agent learns iii from the live engine surface, extended by the
+    // public worker registry (directory::registry::workers::* only — every
+    // other directory::* surface, like the legacy doc proxies and markdown
+    // skills/prompts, stays out; engine::functions::info remains the only
+    // API reference).
     const out = buildSystemPrompt();
-    expect(out).not.toContain('directory::');
+    expect(out).toContain('directory::registry::workers::list');
+    expect(out).toContain('directory::registry::workers::info');
+    for (const id of out.match(/directory::[\w:-]+/g) ?? []) {
+      expect(id.startsWith('directory::registry::workers::')).toBe(true);
+    }
     expect(out).not.toContain('iii://');
     expect(out).not.toMatch(/skill/i);
   });
@@ -151,7 +158,7 @@ describe('buildSystemPrompt', () => {
     expect(out).toMatch(/not an iii\s+function, stop and re-check the engine/);
   });
 
-  it('preamble is generic — no worker-specific examples leak into the identity prompt', () => {
+  it('preamble carries no leaked worker internals (sandbox/heredoc)', () => {
     const out = buildSystemPrompt();
     expect(out.toLowerCase()).not.toContain('sandbox');
     expect(out).not.toContain('heredoc');
@@ -203,6 +210,89 @@ describe('buildSystemPrompt', () => {
     // Declared schemas become the contract engine::functions::info serves.
     expect(out).toMatch(/request_format/);
     expect(out).toMatch(/response_format/);
+  });
+
+  it('preamble teaches registry search → install → verify when nothing registered fits', () => {
+    // New-capability flow: search the published catalogue, judge fit from the
+    // registry detail, announce the install, install via worker::add, then
+    // re-discover — the engine, not the registry, stays the contract authority.
+    const out = buildSystemPrompt();
+    expect(out).toContain('directory::registry::workers::list { search: "<capability>" }');
+    expect(out).toContain('directory::registry::workers::info { name: "<name>" }');
+    expect(out).toContain('{ source: { kind: "registry", name: "<name>" } }');
+    expect(out).toContain('say what you are about to install and why');
+    expect(out).toContain('confirm the new function ids appear');
+    expect(out).toContain('engine::functions::list { prefix: "<worker>::" }');
+    expect(out).toContain('a preview, not the contract');
+  });
+
+  it('preamble bootstraps or degrades gracefully when the directory worker is absent', () => {
+    // directory::* may itself be missing: try worker::list/start, then install
+    // it from the registry by name, then degrade to what is registered.
+    const out = buildSystemPrompt();
+    expect(out).toContain('name: "iii-directory"');
+    expect(out).toContain('continue with what is registered');
+  });
+
+  it('preamble routes code-file work through the coder worker', () => {
+    const out = buildSystemPrompt();
+    expect(out).toContain('engine::functions::list { prefix: "coder::" }');
+    expect(out).toContain('{ source: { kind: "registry", name: "coder" } }');
+    for (const fn of [
+      'coder::read-file',
+      'coder::search',
+      'coder::list-folder',
+      'coder::tree',
+      'coder::create-file',
+      'coder::update-file',
+      'coder::move',
+      'coder::delete-file',
+    ]) {
+      expect(out).toContain(fn);
+    }
+    // The enumeration must read as non-exhaustive (coder grows; the prefix
+    // list call is the inventory) and renames must not become delete+create.
+    expect(out).toMatch(/the full inventory/);
+    expect(out).toMatch(/never delete-then-recreate/);
+  });
+
+  it('preamble points worker authoring at the per-language SDK references', () => {
+    const out = buildSystemPrompt();
+    for (const url of [
+      'https://iii.dev/docs/sdk-reference/engine-sdk',
+      'https://iii.dev/docs/sdk-reference/node-sdk',
+      'https://iii.dev/docs/sdk-reference/python-sdk',
+      'https://iii.dev/docs/sdk-reference/rust-sdk',
+      'https://iii.dev/docs/sdk-reference/browser-sdk',
+    ]) {
+      expect(out).toContain(url);
+    }
+    expect(out).toMatch(/implementation\s+language/);
+    expect(out).toContain('https://iii.dev/docs/llms.txt');
+    expect(out).toContain('`.md`');
+    // The gate must not generalize into doc-fetching for ordinary calls, and
+    // unreachable docs must degrade gracefully instead of stalling the task.
+    expect(out).toMatch(/fetch\s+docs\s+for an ordinary call/);
+    expect(out).toMatch(/say so and proceed with extra\s+care/);
+  });
+
+  it('preamble gates worker code behind the SDK reference (registerTrigger-from-memory trap)', () => {
+    // Observed live (hello-world session): the agent wrote a registerTrigger
+    // from memory, the binding landed but never fired, and it fetched the
+    // node-sdk reference only after burning turns debugging. The reference
+    // comes BEFORE the first line of code.
+    const out = buildSystemPrompt();
+    expect(out).toContain('the FIRST line of worker code');
+  });
+
+  it('preamble extends the web::fetch mandate to localhost and just-bound endpoints', () => {
+    // Observed live (hello-world session): the agent tested its freshly
+    // bound HTTP trigger with shell curl (six calls, plus lsof to hunt the
+    // port) instead of web::fetch. The no-curl rule must name the local-test
+    // case explicitly.
+    const out = buildSystemPrompt();
+    expect(out).toContain('includes localhost');
+    expect(out).toMatch(/IS\s+the verification/);
   });
 
   it('preamble warns that a trigger binding lands even when the provider is down', () => {
@@ -376,12 +466,97 @@ describe.each(VARIANTS)('invariant contract — %s variant', (_family, out) => {
     expect(out).toContain('{ ok, status, headers, body }');
   });
 
+  it('extends the web::fetch mandate to localhost and just-bound endpoints', () => {
+    expect(out).toContain('includes localhost');
+    expect(out).toMatch(/IS\s+the verification/);
+  });
+
+  it('gates worker code behind the SDK reference (reference before the first line)', () => {
+    expect(out).toContain('the FIRST line of worker code');
+  });
+
   it('steers page reads to format:"markdown" (raw HTML floods context)', () => {
     expect(out).toMatch(/pass\s+`format: "markdown"`/);
   });
 
   it('carries the worker lifecycle consent rule', () => {
     expect(out).toMatch(/require exactly\s+`yes: true`/);
+  });
+
+  it('teaches registry search → install → verify', () => {
+    expect(out).toContain('directory::registry::workers::list { search: "<capability>" }');
+    expect(out).toContain('directory::registry::workers::info { name: "<name>" }');
+    expect(out).toContain('{ source: { kind: "registry", name: "<name>" } }');
+    expect(out).toContain('say what you are about to install and why');
+    expect(out).toContain('confirm the new function ids appear');
+    expect(out).toContain('engine::functions::list { prefix: "<worker>::" }');
+    expect(out).toContain('a preview, not the contract');
+  });
+
+  it('teaches install-from-registry before authoring (capability ladder order)', () => {
+    expect(out.indexOf('directory::registry::workers::list')).toBeLessThan(
+      out.indexOf('registerWorker'),
+    );
+    expect(out.indexOf('coder::')).toBeLessThan(out.indexOf('registerWorker'));
+  });
+
+  it('keeps the registry-install worked example (published email worker)', () => {
+    // The example must model a trajectory that succeeds against the live
+    // registry: "email" is published and exposes email::send. It must also
+    // model fetching the worker::add contract before installing (RULE 2) and
+    // announcing the install as a plain assistant line.
+    expect(out).toContain('directory::registry::workers::info { name: "email" }');
+    expect(out).toContain('worker::add { source: { kind: "registry", name: "email" } }');
+    expect(out).toContain('engine::functions::info { function_id: "worker::add" }');
+    expect(out).toContain('engine::functions::info { function_id: "email::send" }');
+    expect(out).toContain('I am installing the "email" worker');
+  });
+
+  it('bootstraps or degrades when the directory worker is absent', () => {
+    expect(out).toContain('name: "iii-directory"');
+    expect(out).toContain('continue with what is registered');
+  });
+
+  it('routes code-file work through the coder worker', () => {
+    expect(out).toContain('engine::functions::list { prefix: "coder::" }');
+    expect(out).toContain('{ source: { kind: "registry", name: "coder" } }');
+    for (const fn of [
+      'coder::read-file',
+      'coder::search',
+      'coder::list-folder',
+      'coder::tree',
+      'coder::create-file',
+      'coder::update-file',
+      'coder::move',
+      'coder::delete-file',
+    ]) {
+      expect(out).toContain(fn);
+    }
+    expect(out).toMatch(/the full inventory/);
+    expect(out).toMatch(/never delete-then-recreate/);
+  });
+
+  it('points worker authoring at the per-language SDK references', () => {
+    for (const url of [
+      'https://iii.dev/docs/sdk-reference/engine-sdk',
+      'https://iii.dev/docs/sdk-reference/node-sdk',
+      'https://iii.dev/docs/sdk-reference/python-sdk',
+      'https://iii.dev/docs/sdk-reference/rust-sdk',
+      'https://iii.dev/docs/sdk-reference/browser-sdk',
+    ]) {
+      expect(out).toContain(url);
+    }
+    expect(out).toMatch(/implementation\s+language/);
+    expect(out).toContain('https://iii.dev/docs/llms.txt');
+    expect(out).toContain('`.md`');
+    // engine-sdk is the fallback for languages without an official SDK.
+    expect(out).toMatch(/for any other\s+language/);
+    // The gate must not generalize into doc-fetching for ordinary calls, and
+    // unreachable docs must degrade gracefully instead of stalling the task.
+    expect(out).toMatch(/fetch\s+docs\s+for an ordinary call/);
+    expect(out).toMatch(/say so and proceed with extra\s+care/);
+    // llms.txt is the recovery path when a docs fetch fails.
+    expect(out).toMatch(/if a fetch fails|If a fetch fails/);
   });
 
   it('teaches the @fn pill syntax', () => {
@@ -398,8 +573,16 @@ describe.each(VARIANTS)('invariant contract — %s variant', (_family, out) => {
     expect(out).toContain('</example>');
   });
 
-  it('contains no foreign integration, worker-specific examples, or mode leakage', () => {
-    expect(out).not.toContain('directory::');
+  it('integrates the worker registry; bans doc schemes, leaked internals, and mode leakage', () => {
+    expect(out).toContain('directory::registry::workers::list');
+    expect(out).toContain('directory::registry::workers::info');
+    // Allowlist invariant: the registry catalogue is the ONLY directory::*
+    // surface the prompt may name — the legacy doc proxies
+    // (directory::engine::*), markdown skills/prompts surfaces, and internal
+    // handlers stay out.
+    for (const id of out.match(/directory::[\w:-]+/g) ?? []) {
+      expect(id.startsWith('directory::registry::workers::')).toBe(true);
+    }
     expect(out).not.toContain('iii://');
     expect(out).not.toMatch(/skill/i);
     expect(out.toLowerCase()).not.toContain('sandbox');

--- a/iii-permissions.yaml
+++ b/iii-permissions.yaml
@@ -64,3 +64,18 @@ rules:
   - engine::registered-triggers::list
   - engine::registered-triggers::info
   - worker::list
+  # Public worker-registry catalogue reads — the system prompt's
+  # search-before-build ladder starts here. worker::add stays approval-gated.
+  - directory::registry::workers::list
+  - directory::registry::workers::info
+  # Read-only coder surface. Mutating ops (create/update/move/delete-file)
+  # stay approval-gated.
+  - coder::info
+  - coder::read-file
+  - coder::search
+  - coder::list-folder
+  - coder::tree
+  # web::fetch is load-bearing for the system prompt's SDK-reference gate and
+  # HTTP-trigger verification; it enforces size/timeout caps and server-side
+  # SSRF protection, so it is allowed by default.
+  - web::fetch


### PR DESCRIPTION
## Summary

Extends the turn-orchestrator identity prompt (all four provider variants: anthropic, gpt, kimi, default) from engine-only discovery to the full capability ladder: **registered function → install from the public registry → author a worker**. Hardened by a 5-dimension adversarially-verified review of the draft; all confirmed findings are fixed in this PR.

### Prompt changes (byte-equivalent semantics across all 4 variants)

- **Public registry flow** — when nothing registered fits: `directory::registry::workers::list/info` → announce → `worker::add { source: { kind: "registry", name } }` → re-verify via `engine::functions::list { prefix }`. Bootstraps a missing directory worker (`iii-directory`) and degrades gracefully when the registry is unreachable. Both catalogue calls are documented in-prompt and exempt from the fetch-contract-first rule (resolving a contradiction with RULE 2).
- **Worked example grounded in the live registry** — uses the published `email` worker (`email::send`); the previous draft modeled `resend`, which `GET /w?search=resend` returns empty for today. The example now also models fetching the `worker::add` contract and announcing the install as a plain assistant line.
- **Coder routing** — create/edit/move/delete code files go through `coder::*`, including `coder::move` for renames (never delete-then-recreate). The function list reads as non-exhaustive with the prefix list as the inventory, there is a post-install re-check, and the `shell::fs` boundary is drawn for non-code browsing.
- **SDK-doc gate** — fetch the per-language iii.dev SDK reference before the first line of worker code (registerTrigger-from-memory trap observed live), scoped to new workers/new registrations, with engine-sdk as the any-other-language fallback, `llms.txt` recovery on fetch failure, graceful degradation when docs are unreachable, and the never-fetch-docs-for-an-ordinary-call guard.
- **web::fetch localhost mandate** — testing a just-bound HTTP trigger uses `web::fetch` (no curl exception), with an explicit success criterion: read the envelope (`ok`, `status`, body matches the handler).

### Tests (142 → 146)

- `directory::*` **allowlist invariant** replaces the substring bans: every `directory::` id in the prompt must start with `directory::registry::workers::` (also blocks the legacy `directory::engine::*` doc proxies).
- New pins: `coder::move`, non-exhaustive inventory + no delete-then-recreate, ordinary-call guard, degradation, `.md` trick, engine-sdk fallback, llms.txt recovery, capability-ladder ordering (registry → coder → authoring), and the email example (mutation-tested: deleting the block fails the suite).

### Permissions + docs

- `iii-permissions.yaml`: allow the read-only ids the prompt now mandates — registry catalogue reads, read-only `coder::*` surface, and `web::fetch` (size/timeout caps + server-side SSRF protection; load-bearing for the SDK gate and trigger verification). `worker::add` and mutating `coder::*` ops **stay approval-gated**.
- `harness/docs/architecture.md` allow-rule enumeration updated to match; stale "engine-only / discovers everything from the live engine" framing replaced with "engine-grounded" in `turn-orchestrator.md` and the `system-prompt.ts` JSDoc.

## Test plan

- [x] `pnpm vitest run tests` — 1371/1371 pass (122 files), including the policy suite against the edited yaml
- [x] `npx tsc --noEmit` clean; `biome check` clean on touched files
- [x] Example parity: `<example>` block byte-identical across all 4 variants
- [x] Registry ground truth: `email` worker verified published with `email::send`; `resend` confirmed absent
- [x] Mutation test: removing the example from one variant fails the suite (pin is load-bearing)
- [x] Independent verifier pass over all 12 fix claims (PASS on each)
- [ ] Live smoke: run a hello-world session per variant and confirm the agent uses `web::fetch` (not curl) for trigger verification and fetches the SDK reference before authoring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated architecture and worker system documentation to reflect new engine-grounded capability discovery approach.

* **New Features**
  * Enhanced system prompts to guide worker discovery and installation from public registry when no registered match exists.
  * Improved SDK reference lookups before code authoring and better HTTP request handling.

* **Tests**
  * Expanded test coverage for system prompt output validation and operational invariants.

* **Chores**
  * Updated permissions configuration to support expanded capability requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->