### PR TITLE
feat(console): friendly chat views for shell::* function calls

### DIFF
--- a/console/web/src/components/chat/FunctionCallMessage.stories.tsx
+++ b/console/web/src/components/chat/FunctionCallMessage.stories.tsx
@@ -3,6 +3,7 @@ import { coderFixtures } from '@/stories/fixtures/coder-fixtures'
 import { directoryFixtures } from '@/stories/fixtures/directory-fixtures'
 import { engineFixtures } from '@/stories/fixtures/engine-fixtures'
 import { sandboxFixtures } from '@/stories/fixtures/sandbox-fixtures'
+import { shellFixtures } from '@/stories/fixtures/shell-fixtures'
 import { webFixtures } from '@/stories/fixtures/web-fixtures'
 import { workerFixtures } from '@/stories/fixtures/worker-fixtures'
 import type { FunctionCallMessage as FCallType } from '@/types/chat'
@@ -123,6 +124,11 @@ export const DoneMultiFieldExpanded: Story = {
 export const SandboxFamily: Story = {
   name: 'sandbox family',
   render: () => <FamilyGallery fixtures={sandboxFixtures} />,
+}
+
+export const ShellFamily: Story = {
+  name: 'shell family',
+  render: () => <FamilyGallery fixtures={shellFixtures} />,
 }
 
 export const DirectoryFamily: Story = {

--- a/console/web/src/components/chat/FunctionCallMessage.tsx
+++ b/console/web/src/components/chat/FunctionCallMessage.tsx
@@ -9,6 +9,7 @@ import {
   SandboxFunctionIdLabel,
   SandboxToolView,
 } from '@/components/chat/sandbox'
+import { ShellFunctionIdLabel, ShellToolView } from '@/components/chat/shell'
 import { WebFunctionIdLabel, WebToolView } from '@/components/chat/web'
 import { WorkerFunctionIdLabel, WorkerToolView } from '@/components/chat/worker'
 import { AlwaysAllowButton } from '@/components/permissions/AlwaysAllowButton'
@@ -118,6 +119,9 @@ function FunctionIdLabel({ functionId }: { functionId: string }) {
   if (SandboxToolView.isSandboxFunction(functionId)) {
     return <SandboxFunctionIdLabel functionId={functionId} />
   }
+  if (ShellToolView.isShellFunction(functionId)) {
+    return <ShellFunctionIdLabel functionId={functionId} />
+  }
   return <span className="text-ink">{functionId}</span>
 }
 
@@ -144,14 +148,16 @@ export function FunctionCallMessage({
     DirectoryToolView.tryRenderPreview(message) ??
     WorkerToolView.tryRenderPreview(message) ??
     WebToolView.tryRenderPreview(message) ??
-    CoderToolView.tryRenderPreview(message)
+    CoderToolView.tryRenderPreview(message) ??
+    ShellToolView.tryRenderPreview(message)
   const customTerminal = !pending
     ? (SandboxToolView.tryRender(message) ??
       EngineToolView.tryRender(message) ??
       DirectoryToolView.tryRender(message) ??
       WorkerToolView.tryRender(message) ??
       WebToolView.tryRender(message) ??
-      CoderToolView.tryRender(message))
+      CoderToolView.tryRender(message) ??
+      ShellToolView.tryRender(message))
     : null
   const hasCustomTerminal = customTerminal != null
   const showRequestPaneAbove =

--- a/console/web/src/components/chat/sandbox/FsGrepView.tsx
+++ b/console/web/src/components/chat/sandbox/FsGrepView.tsx
@@ -1,5 +1,6 @@
 import { renderWithHighlight } from './highlight'
 import {
+  type FsMatch,
   fsGrepRequestSchema,
   fsGrepResponseSchema,
   safeParseResponse,
@@ -35,35 +36,57 @@ export function FsGrepView({ input, output }: FsGrepViewProps) {
           · no matches
         </div>
       ) : (
-        <div className="font-mono text-[12px] leading-[1.55]">
-          {matches.map((m) => (
-            <div
-              /* path+line+content is collision-resistant in practice (two
-                 hits on the same line of the same file produce identical
-                 FsMatch records on the wire today). React will only warn
-                 if the daemon ever sends true duplicates, which would
-                 itself be a wire-shape bug worth surfacing. */
-              key={`${m.path}:${m.line}:${m.content}`}
-              className="border-b border-rule-2 last:border-b-0 px-3 py-1.5"
-            >
-              <div className="text-ink-faint">
-                <span className="text-accent">{m.path}</span>
-                <span className="text-ink-ghost">:</span>
-                <span className="tabular-nums">{m.line}</span>
-              </div>
-              <pre className="text-ink whitespace-pre-wrap break-words m-0 mt-0.5">
-                <code>
-                  {/* sandbox grep patterns are always regexes on the wire */}
-                  {renderWithHighlight(m.content, req.data.pattern, {
-                    isRegex: true,
-                    ignoreCase: !!req.data.ignore_case,
-                  })}
-                </code>
-              </pre>
-            </div>
-          ))}
-        </div>
+        <GrepMatchList
+          matches={matches}
+          pattern={req.data.pattern}
+          ignoreCase={!!req.data.ignore_case}
+        />
       )}
+    </div>
+  )
+}
+
+interface GrepMatchListProps {
+  matches: FsMatch[]
+  pattern: string
+  ignoreCase: boolean
+}
+
+/** Highlighted match list. Shared with the shell module's `fs::grep`
+    renderer — both wires speak `FsMatch` and regex-by-default patterns. */
+export function GrepMatchList({
+  matches,
+  pattern,
+  ignoreCase,
+}: GrepMatchListProps) {
+  return (
+    <div className="font-mono text-[12px] leading-[1.55]">
+      {matches.map((m) => (
+        <div
+          /* path+line+content is collision-resistant in practice (two
+             hits on the same line of the same file produce identical
+             FsMatch records on the wire today). React will only warn
+             if the daemon ever sends true duplicates, which would
+             itself be a wire-shape bug worth surfacing. */
+          key={`${m.path}:${m.line}:${m.content}`}
+          className="border-b border-rule-2 last:border-b-0 px-3 py-1.5"
+        >
+          <div className="text-ink-faint">
+            <span className="text-accent">{m.path}</span>
+            <span className="text-ink-ghost">:</span>
+            <span className="tabular-nums">{m.line}</span>
+          </div>
+          <pre className="text-ink whitespace-pre-wrap break-words m-0 mt-0.5">
+            <code>
+              {/* sandbox grep patterns are always regexes on the wire */}
+              {renderWithHighlight(m.content, pattern, {
+                isRegex: true,
+                ignoreCase,
+              })}
+            </code>
+          </pre>
+        </div>
+      ))}
     </div>
   )
 }

--- a/console/web/src/components/chat/sandbox/FsLsView.tsx
+++ b/console/web/src/components/chat/sandbox/FsLsView.tsx
@@ -1,6 +1,7 @@
 import { File, FileText, Folder, Link as LinkIcon } from 'lucide-react'
 import { formatBytes, formatMode, formatMtime } from './format'
 import {
+  type FsEntry,
   fsLsRequestSchema,
   fsLsResponseSchema,
   safeParseResponse,
@@ -30,39 +31,47 @@ export function FsLsView({ input, output }: FsLsViewProps) {
           · directory is empty
         </div>
       ) : (
-        <table className="w-full font-mono text-[12px] text-ink">
-          <tbody>
-            {entries.map((e) => {
-              const Icon = e.is_symlink
-                ? LinkIcon
-                : e.is_dir
-                  ? Folder
-                  : iconForFile(e.name)
-              return (
-                <tr
-                  key={`${e.name}:${e.size}:${e.mtime}`}
-                  className="border-b border-rule-2 last:border-b-0"
-                >
-                  <td className="pl-3 pr-1.5 py-1.5 w-5">
-                    <Icon aria-hidden className="w-3.5 h-3.5 text-ink-faint" />
-                  </td>
-                  <td className="px-1.5 py-1.5 text-ink">{e.name}</td>
-                  <td className="px-2 py-1.5 text-ink-faint tabular-nums text-right">
-                    {e.is_dir ? '—' : formatBytes(e.size)}
-                  </td>
-                  <td className="px-2 py-1.5 text-ink-faint tabular-nums">
-                    {`${e.is_dir ? 'd' : '-'}${formatMode(e.mode)}`}
-                  </td>
-                  <td className="pr-3 pl-2 py-1.5 text-ink-faint">
-                    {formatMtime(e.mtime)}
-                  </td>
-                </tr>
-              )
-            })}
-          </tbody>
-        </table>
+        <FsEntriesTable entries={entries} />
       )}
     </div>
+  )
+}
+
+/** Directory-listing table. Shared with the shell module's `fs::ls`
+    renderer — both wires speak `FsEntry`. */
+export function FsEntriesTable({ entries }: { entries: FsEntry[] }) {
+  return (
+    <table className="w-full font-mono text-[12px] text-ink">
+      <tbody>
+        {entries.map((e) => {
+          const Icon = e.is_symlink
+            ? LinkIcon
+            : e.is_dir
+              ? Folder
+              : iconForFile(e.name)
+          return (
+            <tr
+              key={`${e.name}:${e.size}:${e.mtime}`}
+              className="border-b border-rule-2 last:border-b-0"
+            >
+              <td className="pl-3 pr-1.5 py-1.5 w-5">
+                <Icon aria-hidden className="w-3.5 h-3.5 text-ink-faint" />
+              </td>
+              <td className="px-1.5 py-1.5 text-ink">{e.name}</td>
+              <td className="px-2 py-1.5 text-ink-faint tabular-nums text-right">
+                {e.is_dir ? '—' : formatBytes(e.size)}
+              </td>
+              <td className="px-2 py-1.5 text-ink-faint tabular-nums">
+                {`${e.is_dir ? 'd' : '-'}${formatMode(e.mode)}`}
+              </td>
+              <td className="pr-3 pl-2 py-1.5 text-ink-faint">
+                {formatMtime(e.mtime)}
+              </td>
+            </tr>
+          )
+        })}
+      </tbody>
+    </table>
   )
 }
 

--- a/console/web/src/components/chat/sandbox/FsSedView.tsx
+++ b/console/web/src/components/chat/sandbox/FsSedView.tsx
@@ -5,6 +5,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/Tooltip'
 import {
+  type FsSedFileResult,
   fsSedRequestSchema,
   fsSedResponseSchema,
   safeParseResponse,
@@ -42,60 +43,74 @@ export function FsSedView({ input, output }: FsSedViewProps) {
           · no files touched
         </div>
       ) : (
-        <table className="w-full font-mono text-[12px] text-ink">
-          <thead>
-            <tr className="border-b border-rule-2 text-[11px] uppercase tracking-[0.06em] text-ink-faint">
-              <th className="text-left font-normal px-3 py-1.5">path</th>
-              <th className="text-left font-normal px-2 py-1.5 w-20 tabular-nums">
-                replacements
-              </th>
-              <th className="text-left font-normal px-3 py-1.5 w-8">status</th>
-            </tr>
-          </thead>
-          <tbody>
-            {results.map((r) => (
-              <tr
-                key={r.path}
-                className="border-b border-rule-2 last:border-b-0"
-              >
-                <td className="px-3 py-1.5 text-ink">{r.path}</td>
-                <td className="px-2 py-1.5 text-ink-faint tabular-nums">
-                  {r.replacements}
-                </td>
-                <td className="px-3 py-1.5">
-                  {r.success ? (
-                    <span className="text-accent">ok</span>
-                  ) : r.error ? (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="inline-flex items-center gap-1 text-warn cursor-help">
-                          <TriangleAlert aria-hidden className="w-3.5 h-3.5" />
-                          err
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>{r.error}</TooltipContent>
-                    </Tooltip>
-                  ) : (
-                    <span className="text-warn">err</span>
-                  )}
-                </td>
-              </tr>
-            ))}
-            <tr className="bg-paper-2">
-              <td className="px-3 py-1.5 text-ink-faint uppercase tracking-[0.06em] text-[11px]">
-                total
-              </td>
-              <td className="px-2 py-1.5 tabular-nums" colSpan={2}>
-                <FooterPill
-                  tone={total_replacements > 0 ? 'accent' : 'default'}
-                >
-                  {`${total_replacements} replacements`}
-                </FooterPill>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        <SedResultsTable
+          results={results}
+          totalReplacements={total_replacements}
+        />
       )}
     </div>
+  )
+}
+
+interface SedResultsTableProps {
+  results: FsSedFileResult[]
+  totalReplacements: number
+}
+
+/** Per-file replacement table with the total pill. Shared with the shell
+    module's `fs::sed` renderer — both wires speak `FsSedFileResult`. */
+export function SedResultsTable({
+  results,
+  totalReplacements,
+}: SedResultsTableProps) {
+  return (
+    <table className="w-full font-mono text-[12px] text-ink">
+      <thead>
+        <tr className="border-b border-rule-2 text-[11px] uppercase tracking-[0.06em] text-ink-faint">
+          <th className="text-left font-normal px-3 py-1.5">path</th>
+          <th className="text-left font-normal px-2 py-1.5 w-20 tabular-nums">
+            replacements
+          </th>
+          <th className="text-left font-normal px-3 py-1.5 w-8">status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {results.map((r) => (
+          <tr key={r.path} className="border-b border-rule-2 last:border-b-0">
+            <td className="px-3 py-1.5 text-ink">{r.path}</td>
+            <td className="px-2 py-1.5 text-ink-faint tabular-nums">
+              {r.replacements}
+            </td>
+            <td className="px-3 py-1.5">
+              {r.success ? (
+                <span className="text-accent">ok</span>
+              ) : r.error ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex items-center gap-1 text-warn cursor-help">
+                      <TriangleAlert aria-hidden className="w-3.5 h-3.5" />
+                      err
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>{r.error}</TooltipContent>
+                </Tooltip>
+              ) : (
+                <span className="text-warn">err</span>
+              )}
+            </td>
+          </tr>
+        ))}
+        <tr className="bg-paper-2">
+          <td className="px-3 py-1.5 text-ink-faint uppercase tracking-[0.06em] text-[11px]">
+            total
+          </td>
+          <td className="px-2 py-1.5 tabular-nums" colSpan={2}>
+            <FooterPill tone={totalReplacements > 0 ? 'accent' : 'default'}>
+              {`${totalReplacements} replacements`}
+            </FooterPill>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   )
 }

--- a/console/web/src/components/chat/sandbox/parsers.ts
+++ b/console/web/src/components/chat/sandbox/parsers.ts
@@ -511,7 +511,12 @@ function invocationFromFunctionError(
   }
 }
 
-function collectErrorCandidates(value: unknown): unknown[] {
+/** Gather every sub-value that might carry an error payload: the value
+    itself, its unwrapped envelope, `value.error`, `error.details`,
+    `error.message`, and `content[]` text blocks. Shared with the shell
+    module's `parseShellErrorDisplay` — same harness wrapping, same
+    traversal. */
+export function collectErrorCandidates(value: unknown): unknown[] {
   const seen = new Set<unknown>()
   const out: unknown[] = []
   const push = (candidate: unknown) => {

--- a/console/web/src/components/chat/shell/ConfigStatusView.tsx
+++ b/console/web/src/components/chat/shell/ConfigStatusView.tsx
@@ -1,0 +1,65 @@
+import { StatusPill } from '@/components/chat/sandbox/shared'
+import { Chip, FooterPill } from '@/components/chat/sandbox/terminal/Terminal'
+import { cn } from '@/lib/utils'
+import { safeParseResponse, shellConfigStatusResponseSchema } from './parsers'
+
+interface ShellConfigStatusViewProps {
+  output: unknown
+  running?: boolean
+}
+
+/**
+ * `shell::config-status` — the worker's config-reload health. A slab
+ * with the last reload outcome, a rejected-reload counter (warn pill
+ * when non-zero), and the last rejection error verbatim. The request
+ * payload is ignored server-side, so nothing request-derived renders.
+ */
+export function ShellConfigStatusView({
+  output,
+  running,
+}: ShellConfigStatusViewProps) {
+  const resp =
+    output != null
+      ? safeParseResponse(shellConfigStatusResponseSchema, output)
+      : null
+
+  if (!resp) {
+    if (!running) return null
+    return (
+      <div className="border-t border-rule-2 bg-bg px-3 py-3 font-mono text-[12.5px] text-ink-faint italic">
+        checking config…
+      </div>
+    )
+  }
+
+  const applied = resp.last_outcome === 'applied'
+  return (
+    <div className="border-t border-rule-2 bg-bg">
+      <div
+        className={cn(
+          'px-3 py-3 flex flex-col gap-2 border-l-2',
+          applied ? 'border-accent' : 'border-alert',
+        )}
+      >
+        <div className="flex flex-wrap items-center gap-1.5">
+          <StatusPill
+            label={resp.last_outcome}
+            variant={applied ? 'accent' : 'alert'}
+          />
+          {resp.rejected_reloads > 0 ? (
+            <FooterPill tone="warn">
+              {`rejected reloads ${resp.rejected_reloads}`}
+            </FooterPill>
+          ) : (
+            <Chip label="rejected reloads">{resp.rejected_reloads}</Chip>
+          )}
+        </div>
+        {resp.last_error != null ? (
+          <pre className="font-mono text-[12.5px] leading-[1.55] text-warn whitespace-pre-wrap break-words m-0">
+            <code>{resp.last_error}</code>
+          </pre>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/console/web/src/components/chat/shell/ExecBgView.tsx
+++ b/console/web/src/components/chat/shell/ExecBgView.tsx
@@ -1,0 +1,91 @@
+import {
+  FooterPill,
+  Terminal,
+} from '@/components/chat/sandbox/terminal/Terminal'
+import { ShellExecChips, ShellExecPreviewRow } from './ExecView'
+import { formatArgv, formatShellCommand } from './format'
+import {
+  type ShellExecBgRequest,
+  type ShellExecBgResponse,
+  safeParseResponse,
+  shellExecBgRequestSchema,
+  shellExecBgResponseSchema,
+} from './parsers'
+import { isSandboxTarget } from './shared'
+
+interface ShellExecBgViewProps {
+  input: unknown
+  output: unknown
+  running?: boolean
+}
+
+export function ShellExecBgView({
+  input,
+  output,
+  running,
+}: ShellExecBgViewProps) {
+  const req = shellExecBgRequestSchema.safeParse(input)
+  if (!req.success) return null
+  const respData =
+    output != null ? safeParseResponse(shellExecBgResponseSchema, output) : null
+  return (
+    <Terminal
+      command={formatShellCommand(req.data)}
+      running={running}
+      chips={<ShellExecChips req={req.data} bg />}
+      footer={respData ? <ShellExecBgFooter req={req.data} /> : null}
+    >
+      {respData ? <BgStartedBody req={req.data} resp={respData} /> : null}
+    </Terminal>
+  )
+}
+
+/** Compact `$ cmd args` preview used in the pending-approval state —
+    the shared exec row plus the `bg` marker chip. */
+export function ShellExecBgPreview({ input }: { input: unknown }) {
+  return <ShellExecPreviewRow input={input} bg />
+}
+
+/** Success body — there is no stdout for a background spawn. The job_id
+    is the copy-handle for `shell::status`/`shell::kill`, so it renders
+    full and untruncated. The server-resolved argv appears as a faint
+    second line only when shell-words tokenization changed the spelling
+    of what was typed (that's when it's informative). */
+function BgStartedBody({
+  req,
+  resp,
+}: {
+  req: ShellExecBgRequest
+  resp: ShellExecBgResponse
+}) {
+  const resolved = formatArgv(resp.argv)
+  return (
+    <div className="bg-bg px-3 py-2 font-mono text-[12.5px] leading-[1.55]">
+      <div className="flex flex-wrap items-baseline gap-2">
+        <span className="text-accent">↻</span>
+        <span className="text-ink">started</span>
+        <code className="bg-paper-2 border border-rule-2 px-1.5 py-0.5 text-[12px] text-ink break-all">
+          {resp.job_id}
+        </code>
+      </div>
+      {resolved !== formatShellCommand(req) ? (
+        <div className="text-ink-faint mt-1 whitespace-pre-wrap break-all">
+          {`$ ${resolved}`}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function ShellExecBgFooter({ req }: { req: ShellExecBgRequest }) {
+  return (
+    <>
+      <FooterPill tone="accent">job started</FooterPill>
+      {/* Host-targeted background jobs IGNORE timeout_ms (wire semantic);
+          surface the silently-dropped knob. */}
+      {!isSandboxTarget(req.target) && typeof req.timeout_ms === 'number' ? (
+        <FooterPill tone="warn">timeout_ms ignored (host bg)</FooterPill>
+      ) : null}
+    </>
+  )
+}

--- a/console/web/src/components/chat/shell/ExecView.tsx
+++ b/console/web/src/components/chat/shell/ExecView.tsx
@@ -1,0 +1,126 @@
+import {
+  formatBytes,
+  pillForExit,
+  truncateMiddle,
+} from '@/components/chat/sandbox/format'
+import { AnsiOutput } from '@/components/chat/sandbox/terminal/AnsiOutput'
+import {
+  Chip,
+  FooterPill,
+  Terminal,
+} from '@/components/chat/sandbox/terminal/Terminal'
+import { Prompt } from '@/components/ui/Prompt'
+import { formatShellCommand } from './format'
+import {
+  type ShellExecRequest,
+  type ShellExecResponse,
+  safeParseResponse,
+  shellExecRequestSchema,
+  shellExecResponseSchema,
+} from './parsers'
+import { TargetChip } from './shared'
+
+interface ShellExecViewProps {
+  input: unknown
+  output: unknown
+  running?: boolean
+}
+
+export function ShellExecView({ input, output, running }: ShellExecViewProps) {
+  const req = shellExecRequestSchema.safeParse(input)
+  if (!req.success) return null
+  const respData =
+    output != null ? safeParseResponse(shellExecResponseSchema, output) : null
+  return (
+    <Terminal
+      command={formatShellCommand(req.data)}
+      running={running}
+      chips={<ShellExecChips req={req.data} />}
+      footer={respData ? <ShellExecFooter resp={respData} /> : null}
+    >
+      <AnsiOutput stdout={respData?.stdout} stderr={respData?.stderr} />
+    </Terminal>
+  )
+}
+
+/** Compact `$ cmd args` preview used in the pending-approval state. */
+export function ShellExecPreview({ input }: { input: unknown }) {
+  return <ShellExecPreviewRow input={input} />
+}
+
+/** Shared approval-surface row for exec and exec_bg previews (exec_bg
+    adds the `bg` marker chip). The chips carry the approval-relevant
+    facts: target (host is the privileged one), cwd, env keys, stdin
+    size. */
+export function ShellExecPreviewRow({
+  input,
+  bg,
+}: {
+  input: unknown
+  bg?: boolean
+}) {
+  const req = shellExecRequestSchema.safeParse(input)
+  if (!req.success) return null
+  return (
+    <div className="border-t border-rule-2 bg-paper-2 px-3 py-2 flex flex-wrap items-center gap-x-3 gap-y-1.5">
+      <span className="font-mono text-[12.5px] text-ink whitespace-pre-wrap break-all">
+        <Prompt symbol="$" />
+        <span className="ml-2">{formatShellCommand(req.data)}</span>
+      </span>
+      <span className="flex flex-wrap items-center gap-1.5 ml-auto">
+        <ShellExecChips req={req.data} bg={bg} />
+      </span>
+    </div>
+  )
+}
+
+/* `stdin.length` undercounts multibyte input — the server caps and pipes
+   bytes, so report the UTF-8 size. */
+const utf8 = new TextEncoder()
+
+/** Header chips shared by exec/exec_bg cards and both previews. `env`
+    surfaces sorted KEYS only — values can be secrets (the raw-json tab
+    still has them). */
+export function ShellExecChips({
+  req,
+  bg,
+}: {
+  req: ShellExecRequest
+  bg?: boolean
+}) {
+  const envKeys = req.env ? Object.keys(req.env).sort() : []
+  return (
+    <>
+      {bg ? <Chip>bg</Chip> : null}
+      <TargetChip target={req.target} explicitHost />
+      {req.cwd ? <Chip label="cwd">{truncateMiddle(req.cwd, 28)}</Chip> : null}
+      {typeof req.timeout_ms === 'number' ? (
+        <Chip label="timeout">{`${req.timeout_ms}ms`}</Chip>
+      ) : null}
+      {envKeys.length > 0 ? (
+        <Chip label="env">{truncateMiddle(envKeys.join(', '), 24)}</Chip>
+      ) : null}
+      {req.stdin != null ? (
+        <Chip label="stdin">{formatBytes(utf8.encode(req.stdin).length)}</Chip>
+      ) : null}
+    </>
+  )
+}
+
+function ShellExecFooter({ resp }: { resp: ShellExecResponse }) {
+  const exit = pillForExit(resp.exit_code)
+  return (
+    <>
+      <FooterPill tone={exit.tone}>{exit.label}</FooterPill>
+      <FooterPill>{`${resp.duration_ms}ms`}</FooterPill>
+      {resp.timed_out ? <FooterPill tone="warn">timed out</FooterPill> : null}
+      {/* Explicit wire flags — no length heuristic; the server says so. */}
+      {resp.stdout_truncated ? (
+        <FooterPill tone="warn">stdout truncated</FooterPill>
+      ) : null}
+      {resp.stderr_truncated ? (
+        <FooterPill tone="warn">stderr truncated</FooterPill>
+      ) : null}
+    </>
+  )
+}

--- a/console/web/src/components/chat/shell/FsChmodView.tsx
+++ b/console/web/src/components/chat/shell/FsChmodView.tsx
@@ -1,0 +1,44 @@
+import { formatMode } from '@/components/chat/sandbox/format'
+import { Chip } from '@/components/chat/sandbox/terminal/Terminal'
+import {
+  fsChmodRequestSchema,
+  fsChmodResponseSchema,
+  safeParseResponse,
+} from './parsers'
+import { displayPath, TargetChip } from './shared'
+
+interface FsChmodViewProps {
+  input: unknown
+  output: unknown
+}
+
+export function FsChmodView({ input, output }: FsChmodViewProps) {
+  const req = fsChmodRequestSchema.safeParse(input)
+  if (!req.success) return null
+  const resp = safeParseResponse(fsChmodResponseSchema, output)
+  if (!resp) return null
+  const ownership =
+    typeof req.data.uid === 'number' || typeof req.data.gid === 'number'
+      ? `${req.data.uid ?? '_'}:${req.data.gid ?? '_'}`
+      : null
+
+  return (
+    <div className="border-t border-rule-2 bg-bg">
+      <div className="px-3 py-3 flex flex-col gap-2">
+        <div className="font-mono text-[12.5px] flex flex-wrap items-baseline gap-2 text-ink">
+          <span className="text-ink-faint">chmod</span>
+          <span>{displayPath(req.data.path, resp.path)}</span>
+          <span className="text-ink-ghost">→</span>
+          <span className="tabular-nums">{req.data.mode}</span>
+          <span className="text-ink-faint">({formatMode(req.data.mode)})</span>
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          {ownership ? <Chip label="own">{ownership}</Chip> : null}
+          {req.data.recursive ? <Chip label="recursive">true</Chip> : null}
+          <Chip label="changed">{resp.entries_changed}</Chip>
+          <TargetChip target={req.data.target} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/console/web/src/components/chat/shell/FsGrepView.tsx
+++ b/console/web/src/components/chat/shell/FsGrepView.tsx
@@ -1,0 +1,61 @@
+import { GrepMatchList } from '@/components/chat/sandbox/FsGrepView'
+import { truncateMiddle } from '@/components/chat/sandbox/format'
+import { Chip, FooterPill } from '@/components/chat/sandbox/terminal/Terminal'
+import {
+  fsGrepRequestSchema,
+  fsGrepResponseSchema,
+  safeParseResponse,
+} from './parsers'
+import { TargetChip } from './shared'
+
+interface FsGrepViewProps {
+  input: unknown
+  output: unknown
+}
+
+export function FsGrepView({ input, output }: FsGrepViewProps) {
+  const req = fsGrepRequestSchema.safeParse(input)
+  if (!req.success) return null
+  const resp = safeParseResponse(fsGrepResponseSchema, output)
+  if (!resp) return null
+  const { matches, truncated } = resp
+
+  return (
+    <div className="border-t border-rule-2 bg-bg">
+      <div className="bg-paper-2 border-b border-rule-2 px-3 py-2 flex flex-wrap items-center gap-1.5">
+        <Chip label="path">{req.data.path}</Chip>
+        <Chip label="pattern">{req.data.pattern}</Chip>
+        <TargetChip target={req.data.target} />
+        {req.data.ignore_case ? <Chip>case-insensitive</Chip> : null}
+        {/* `recursive` defaults TRUE on the wire — chip the deviation only */}
+        {req.data.recursive === false ? <Chip>non-recursive</Chip> : null}
+        {req.data.include_glob?.length ? (
+          <Chip label="include">
+            {truncateMiddle(req.data.include_glob.join(' '), 40)}
+          </Chip>
+        ) : null}
+        {req.data.exclude_glob?.length ? (
+          <Chip label="exclude">
+            {truncateMiddle(req.data.exclude_glob.join(' '), 40)}
+          </Chip>
+        ) : null}
+        <FooterPill tone={matches.length > 0 ? 'default' : 'warn'}>
+          {`${matches.length} ${matches.length === 1 ? 'match' : 'matches'}`}
+        </FooterPill>
+        {truncated ? <FooterPill tone="warn">truncated</FooterPill> : null}
+      </div>
+
+      {matches.length === 0 ? (
+        <div className="px-3 py-3 font-mono text-[12.5px] text-ink-ghost">
+          · no matches
+        </div>
+      ) : (
+        <GrepMatchList
+          matches={matches}
+          pattern={req.data.pattern}
+          ignoreCase={!!req.data.ignore_case}
+        />
+      )}
+    </div>
+  )
+}

--- a/console/web/src/components/chat/shell/FsLsView.tsx
+++ b/console/web/src/components/chat/shell/FsLsView.tsx
@@ -1,0 +1,38 @@
+import { FsEntriesTable } from '@/components/chat/sandbox/FsLsView'
+import { Chip } from '@/components/chat/sandbox/terminal/Terminal'
+import {
+  fsLsRequestSchema,
+  fsLsResponseSchema,
+  safeParseResponse,
+} from './parsers'
+import { TargetChip } from './shared'
+
+interface FsLsViewProps {
+  input: unknown
+  output: unknown
+}
+
+export function FsLsView({ input, output }: FsLsViewProps) {
+  const req = fsLsRequestSchema.safeParse(input)
+  if (!req.success) return null
+  const resp = safeParseResponse(fsLsResponseSchema, output)
+  if (!resp) return null
+  const entries = resp.entries
+
+  return (
+    <div className="border-t border-rule-2 bg-bg">
+      <div className="bg-paper-2 border-b border-rule-2 px-3 py-2 flex flex-wrap items-center gap-1.5">
+        <Chip label="path">{req.data.path}</Chip>
+        <TargetChip target={req.data.target} />
+        <Chip label="entries">{entries.length}</Chip>
+      </div>
+      {entries.length === 0 ? (
+        <div className="px-3 py-3 font-mono text-[12.5px] text-ink-ghost">
+          · directory is empty
+        </div>
+      ) : (
+        <FsEntriesTable entries={entries} />
+      )}
+    </div>
+  )
+}

--- a/console/web/src/components/chat/shell/FsMkdirView.tsx
+++ b/console/web/src/components/chat/shell/FsMkdirView.tsx
@@ -1,0 +1,48 @@
+import { Chip } from '@/components/chat/sandbox/terminal/Terminal'
+import {
+  fsMkdirRequestSchema,
+  fsMkdirResponseSchema,
+  safeParseResponse,
+} from './parsers'
+import { displayPath, isSandboxTarget, TargetChip } from './shared'
+
+interface FsMkdirViewProps {
+  input: unknown
+  output: unknown
+}
+
+export function FsMkdirView({ input, output }: FsMkdirViewProps) {
+  const req = fsMkdirRequestSchema.safeParse(input)
+  if (!req.success) return null
+  const resp = safeParseResponse(fsMkdirResponseSchema, output)
+  if (!resp) return null
+  const created = resp.created
+  const sandboxed = isSandboxTarget(req.data.target)
+  // Sandbox-target responses default `already_existed` (serde fill-in,
+  // not a signal) — collapse to the plain created/exists wording there.
+  const verb = created
+    ? '+ created '
+    : sandboxed
+      ? '· exists '
+      : resp.already_existed
+        ? '· already exists '
+        : '· not created '
+
+  return (
+    <div className="border-t border-rule-2 bg-bg">
+      <div className="px-3 py-3 flex flex-col gap-2">
+        <div className="font-mono text-[12.5px] text-ink">
+          <span className={created ? 'text-accent' : 'text-ink-faint'}>
+            {verb}
+          </span>
+          <span>{displayPath(req.data.path, resp.path)}</span>
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Chip label="mode">{req.data.mode ?? '0755'}</Chip>
+          {req.data.parents ? <Chip label="parents">true</Chip> : null}
+          <TargetChip target={req.data.target} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/console/web/src/components/chat/shell/FsMvView.tsx
+++ b/console/web/src/components/chat/shell/FsMvView.tsx
@@ -1,0 +1,49 @@
+import { Chip, FooterPill } from '@/components/chat/sandbox/terminal/Terminal'
+import {
+  fsMvRequestSchema,
+  fsMvResponseSchema,
+  safeParseResponse,
+} from './parsers'
+import { displayPath, isSandboxTarget, TargetChip } from './shared'
+
+interface FsMvViewProps {
+  input: unknown
+  output: unknown
+}
+
+export function FsMvView({ input, output }: FsMvViewProps) {
+  const req = fsMvRequestSchema.safeParse(input)
+  if (!req.success) return null
+  const resp = safeParseResponse(fsMvResponseSchema, output)
+  if (!resp) return null
+  const moved = resp.moved
+  /* Sandbox-target responses default `overwrote` — a serde fill-in, not
+     a signal; only surface the warn pill for host moves. */
+  const showOverwrote = resp.overwrote && !isSandboxTarget(req.data.target)
+  const hasChips =
+    isSandboxTarget(req.data.target) || !!req.data.overwrite || showOverwrote
+
+  return (
+    <div className="border-t border-rule-2 bg-bg">
+      <div className="px-3 py-3 flex flex-col gap-2">
+        <div className="font-mono text-[12.5px] flex flex-wrap items-baseline gap-2 text-ink">
+          <span className={moved ? 'text-accent' : 'text-ink-faint'}>
+            {moved ? 'mv' : '·'}
+          </span>
+          <span>{displayPath(req.data.src, resp.src)}</span>
+          <span className="text-ink-ghost">→</span>
+          <span>{displayPath(req.data.dst, resp.dst)}</span>
+        </div>
+        {hasChips ? (
+          <div className="flex flex-wrap items-center gap-1.5">
+            <TargetChip target={req.data.target} />
+            {req.data.overwrite ? <Chip label="overwrite">true</Chip> : null}
+            {showOverwrote ? (
+              <FooterPill tone="warn">overwrote existing</FooterPill>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/console/web/src/components/chat/shell/FsReadView.tsx
+++ b/console/web/src/components/chat/shell/FsReadView.tsx
@@ -1,0 +1,58 @@
+import {
+  formatBytes,
+  formatMode,
+  formatMtime,
+  truncateMiddle,
+} from '@/components/chat/sandbox/format'
+import { Chip, FooterPill } from '@/components/chat/sandbox/terminal/Terminal'
+import {
+  fsReadRequestSchema,
+  fsReadResponseSchema,
+  safeParseResponse,
+} from './parsers'
+import { TargetChip } from './shared'
+
+interface FsReadViewProps {
+  input: unknown
+  output: unknown
+}
+
+/** shell::fs::read never inlines content — the response `content` is
+    always a channel ref, so the body is the stream row promoted to the
+    only branch (no CodeHighlight, no empty state). The console cannot
+    dereference the channel, so there is no "view content" affordance. */
+export function FsReadView({ input, output }: FsReadViewProps) {
+  const req = fsReadRequestSchema.safeParse(input)
+  if (!req.success) return null
+  const resp = safeParseResponse(fsReadResponseSchema, output)
+  if (!resp) return null
+
+  return (
+    <div className="border-t border-rule-2 bg-bg">
+      <div className="bg-paper-2 border-b border-rule-2 px-3 py-2 flex flex-wrap items-center gap-1.5">
+        <span className="font-mono text-[11px] uppercase tracking-[0.06em] text-ink-faint">
+          file
+        </span>
+        <code className="font-mono text-[12px] text-ink">{req.data.path}</code>
+        <TargetChip target={req.data.target} />
+      </div>
+
+      <div className="px-3 py-3 font-mono text-[12.5px] text-ink-faint flex flex-wrap items-center gap-1.5">
+        <span>content streamed via channel</span>
+        <code className="bg-paper-2 border border-rule-2 px-1.5 py-0.5 text-ink">
+          {truncateMiddle(resp.content.channel_id, 18)}
+        </code>
+        <span className="text-ink-ghost">
+          ({resp.content.direction ?? 'read'})
+        </span>
+      </div>
+
+      <div className="bg-paper-2 border-t border-rule-2 px-3 py-1.5 flex flex-wrap items-center gap-1.5">
+        <Chip label="size">{formatBytes(resp.size)}</Chip>
+        <Chip label="mode">{formatMode(resp.mode)}</Chip>
+        <Chip label="mtime">{formatMtime(resp.mtime)}</Chip>
+        <FooterPill tone="default">streamed</FooterPill>
+      </div>
+    </div>
+  )
+}

--- a/console/web/src/components/chat/shell/FsRmView.tsx
+++ b/console/web/src/components/chat/shell/FsRmView.tsx
@@ -1,0 +1,56 @@
+import { Chip } from '@/components/chat/sandbox/terminal/Terminal'
+import {
+  fsRmRequestSchema,
+  fsRmResponseSchema,
+  safeParseResponse,
+} from './parsers'
+import { displayPath, isSandboxTarget, TargetChip } from './shared'
+
+interface FsRmViewProps {
+  input: unknown
+  output: unknown
+}
+
+export function FsRmView({ input, output }: FsRmViewProps) {
+  const req = fsRmRequestSchema.safeParse(input)
+  if (!req.success) return null
+  const resp = safeParseResponse(fsRmResponseSchema, output)
+  if (!resp) return null
+  const removed = resp.removed
+  const sandboxed = isSandboxTarget(req.data.target)
+  // `was_present` is a host-only signal; sandbox-target responses default
+  // it (serde fill-in) — collapse to removed/not-removed wording there.
+  const wasAbsent = !sandboxed && !removed && !resp.was_present
+  const verb = removed
+    ? '− removed '
+    : wasAbsent
+      ? '· was not present '
+      : '· not removed '
+  const tone = removed
+    ? 'text-warn'
+    : wasAbsent
+      ? 'text-ink-ghost'
+      : 'text-ink-faint'
+  const recursive = req.data.recursive === true
+
+  return (
+    <div className="border-t border-rule-2 bg-bg">
+      <div className="px-3 py-3 flex flex-col gap-2">
+        <div className="font-mono text-[12.5px] text-ink">
+          <span className={tone}>{verb}</span>
+          <span>{displayPath(req.data.path, resp.path)}</span>
+        </div>
+        {recursive || sandboxed ? (
+          <div className="flex flex-wrap items-center gap-1.5">
+            {recursive ? (
+              <Chip label="recursive" className="border-warn text-warn">
+                true
+              </Chip>
+            ) : null}
+            <TargetChip target={req.data.target} />
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/console/web/src/components/chat/shell/FsSedView.tsx
+++ b/console/web/src/components/chat/shell/FsSedView.tsx
@@ -1,0 +1,66 @@
+import { SedResultsTable } from '@/components/chat/sandbox/FsSedView'
+import { truncateMiddle } from '@/components/chat/sandbox/format'
+import { Chip } from '@/components/chat/sandbox/terminal/Terminal'
+import {
+  fsSedRequestSchema,
+  fsSedResponseSchema,
+  safeParseResponse,
+} from './parsers'
+import { TargetChip } from './shared'
+
+interface FsSedViewProps {
+  input: unknown
+  output: unknown
+}
+
+export function FsSedView({ input, output }: FsSedViewProps) {
+  const req = fsSedRequestSchema.safeParse(input)
+  if (!req.success) return null
+  const resp = safeParseResponse(fsSedResponseSchema, output)
+  if (!resp) return null
+  const { results, total_replacements } = resp
+  const pathMode = req.data.path != null
+  const target =
+    req.data.path ??
+    (req.data.files?.length ? `${req.data.files.length} files` : '—')
+
+  return (
+    <div className="border-t border-rule-2 bg-bg">
+      <div className="bg-paper-2 border-b border-rule-2 px-3 py-2 flex flex-wrap items-center gap-1.5">
+        <Chip label="target">{target}</Chip>
+        <Chip label="pattern">{req.data.pattern}</Chip>
+        <Chip label="→">{req.data.replacement || "''"}</Chip>
+        {/* `regex`/`recursive` default TRUE on the wire — chip the
+            deviations ("literal", "non-recursive") only */}
+        {req.data.regex === false ? <Chip>literal</Chip> : null}
+        {req.data.first_only ? <Chip>first-only</Chip> : null}
+        {req.data.ignore_case ? <Chip>case-insensitive</Chip> : null}
+        {pathMode && req.data.recursive === false ? (
+          <Chip>non-recursive</Chip>
+        ) : null}
+        {req.data.include_glob?.length ? (
+          <Chip label="include">
+            {truncateMiddle(req.data.include_glob.join(' '), 40)}
+          </Chip>
+        ) : null}
+        {req.data.exclude_glob?.length ? (
+          <Chip label="exclude">
+            {truncateMiddle(req.data.exclude_glob.join(' '), 40)}
+          </Chip>
+        ) : null}
+        <TargetChip target={req.data.target} />
+      </div>
+
+      {results.length === 0 ? (
+        <div className="px-3 py-3 font-mono text-[12.5px] text-ink-ghost">
+          · no files touched
+        </div>
+      ) : (
+        <SedResultsTable
+          results={results}
+          totalReplacements={total_replacements}
+        />
+      )}
+    </div>
+  )
+}

--- a/console/web/src/components/chat/shell/FsStatView.tsx
+++ b/console/web/src/components/chat/shell/FsStatView.tsx
@@ -1,0 +1,44 @@
+import {
+  formatBytes,
+  formatMode,
+  formatMtime,
+} from '@/components/chat/sandbox/format'
+import { Chip, FooterPill } from '@/components/chat/sandbox/terminal/Terminal'
+import {
+  fsStatRequestSchema,
+  fsStatResponseSchema,
+  safeParseResponse,
+} from './parsers'
+import { TargetChip } from './shared'
+
+interface FsStatViewProps {
+  input: unknown
+  output: unknown
+}
+
+/** Response is the bare FsEntry (`StatResponse` is serde-transparent). */
+export function FsStatView({ input, output }: FsStatViewProps) {
+  const req = fsStatRequestSchema.safeParse(input)
+  if (!req.success) return null
+  const e = safeParseResponse(fsStatResponseSchema, output)
+  if (!e) return null
+
+  return (
+    <div className="border-t border-rule-2 bg-bg">
+      <div className="px-3 py-3 flex flex-col gap-2">
+        <div className="font-mono text-[12.5px] text-ink">
+          <span className="text-ink-faint">stat </span>
+          <span>{req.data.path}</span>
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Chip label="size">{e.is_dir ? '—' : formatBytes(e.size)}</Chip>
+          <Chip label="mode">{`${e.is_dir ? 'd' : '-'}${formatMode(e.mode)}`}</Chip>
+          <Chip label="mtime">{formatMtime(e.mtime)}</Chip>
+          <TargetChip target={req.data.target} />
+          {e.is_dir ? <FooterPill tone="default">dir</FooterPill> : null}
+          {e.is_symlink ? <FooterPill tone="warn">symlink</FooterPill> : null}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/console/web/src/components/chat/shell/FsWriteView.tsx
+++ b/console/web/src/components/chat/shell/FsWriteView.tsx
@@ -1,0 +1,129 @@
+import { formatBytes } from '@/components/chat/sandbox/format'
+import { Chip, FooterPill } from '@/components/chat/sandbox/terminal/Terminal'
+import {
+  contentRefSchema,
+  type FsWriteRequest,
+  type FsWriteResponse,
+  fsWriteRequestSchema,
+  fsWriteResponseSchema,
+  safeParseResponse,
+} from './parsers'
+import { displayPath, TargetChip } from './shared'
+
+interface FsWriteViewProps {
+  input: unknown
+  output: unknown
+}
+
+export function FsWriteView({ input, output }: FsWriteViewProps) {
+  const req = fsWriteRequestSchema.safeParse(input)
+  if (!req.success) return null
+  const resp = safeParseResponse(fsWriteResponseSchema, output)
+  if (!resp) return null
+
+  /* Request-side discriminator: batch when `files` is a non-empty array.
+     (The response-side `path === ''` heuristic is unreliable —
+     sandbox-target single writes blank it too.) */
+  if (req.data.files?.length) {
+    return <BatchWrite req={req.data} resp={resp} />
+  }
+
+  const streamed =
+    req.data.content != null &&
+    contentRefSchema.safeParse(req.data.content).success
+
+  return (
+    <div className="border-t border-rule-2 bg-bg">
+      <div className="px-3 py-3 flex flex-col gap-2">
+        <div className="font-mono text-[12.5px] text-ink">
+          <span className="text-accent">+ wrote</span>{' '}
+          <span className="tabular-nums">
+            {formatBytes(resp.bytes_written)}
+          </span>{' '}
+          <span className="text-ink-faint">to</span>{' '}
+          <span>{displayPath(req.data.path ?? '', resp.path)}</span>
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Chip label="mode">{req.data.mode ?? '0644'}</Chip>
+          {req.data.parents ? <Chip label="parents">true</Chip> : null}
+          {streamed ? (
+            <FooterPill tone="default">uploaded via channel</FooterPill>
+          ) : null}
+          <TargetChip target={req.data.target} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface BatchWriteProps {
+  req: FsWriteRequest
+  resp: FsWriteResponse
+}
+
+/** Batch layout — one row per written file. `resp.files` is authoritative
+    (worker preserves order); each row joins back to its request spec by
+    path (index fallback) for mode/content provenance. */
+function BatchWrite({ req, resp }: BatchWriteProps) {
+  const specs = req.files ?? []
+  const specByPath = new Map(specs.map((s) => [s.path, s] as const))
+
+  return (
+    <div className="border-t border-rule-2 bg-bg">
+      <div className="bg-paper-2 border-b border-rule-2 px-3 py-2 flex flex-wrap items-center gap-1.5">
+        <Chip label="files">{resp.files.length}</Chip>
+        <TargetChip target={req.target} />
+      </div>
+
+      <table className="w-full font-mono text-[12px] text-ink">
+        <thead>
+          <tr className="border-b border-rule-2 text-[11px] uppercase tracking-[0.06em] text-ink-faint">
+            <th className="text-left font-normal px-3 py-1.5">path</th>
+            <th className="text-right font-normal px-2 py-1.5 w-20">bytes</th>
+            <th className="text-left font-normal px-2 py-1.5 w-20">mode</th>
+            <th className="text-left font-normal px-3 py-1.5 w-16">content</th>
+          </tr>
+        </thead>
+        <tbody>
+          {resp.files.map((r, i) => {
+            const spec = specByPath.get(r.path) ?? specs[i]
+            return (
+              <tr
+                key={r.path}
+                className="border-b border-rule-2 last:border-b-0"
+              >
+                <td className="px-3 py-1.5 text-ink">{r.path}</td>
+                <td className="px-2 py-1.5 text-right text-ink-faint tabular-nums">
+                  {formatBytes(r.bytes_written)}
+                </td>
+                <td className="px-2 py-1.5 text-ink-faint">
+                  {spec ? (spec.mode ?? '0644') : '—'}
+                  {spec?.parents ? (
+                    <span className="text-ink-ghost"> +parents</span>
+                  ) : null}
+                </td>
+                <td className="px-3 py-1.5 text-ink-faint">
+                  {spec
+                    ? typeof spec.content === 'string'
+                      ? 'inline'
+                      : 'channel'
+                    : '—'}
+                </td>
+              </tr>
+            )
+          })}
+          <tr className="bg-paper-2">
+            <td className="px-3 py-1.5 text-ink-faint uppercase tracking-[0.06em] text-[11px]">
+              total
+            </td>
+            <td className="px-2 py-1.5" colSpan={3}>
+              <FooterPill tone="accent">
+                {`${formatBytes(resp.bytes_written)} · ${resp.files.length} ${resp.files.length === 1 ? 'file' : 'files'}`}
+              </FooterPill>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/console/web/src/components/chat/shell/KillView.tsx
+++ b/console/web/src/components/chat/shell/KillView.tsx
@@ -1,0 +1,77 @@
+import { truncateMiddle } from '@/components/chat/sandbox/format'
+import { ActionLine, StatusPill } from '@/components/chat/sandbox/shared'
+import { FooterPill } from '@/components/chat/sandbox/terminal/Terminal'
+import { jobStatusPill } from './format'
+import {
+  safeParseResponse,
+  shellKillRequestSchema,
+  shellKillResponseSchema,
+} from './parsers'
+
+interface ShellKillViewProps {
+  input: unknown
+  output: unknown
+  running?: boolean
+}
+
+/**
+ * `shell::kill` — warn slab in the sandbox StopView pattern. The
+ * `killed: false` case always arrives with `reason: "not running"`
+ * plus the job's terminal status; both render side by side so the
+ * outcome is unambiguous.
+ */
+export function ShellKillView({ input, output, running }: ShellKillViewProps) {
+  const req = shellKillRequestSchema.safeParse(input)
+  if (!req.success) return null
+  const resp =
+    output != null ? safeParseResponse(shellKillResponseSchema, output) : null
+  const status = resp ? jobStatusPill(resp.status) : null
+
+  return (
+    <div className="border-t border-rule-2 bg-bg">
+      <div className="px-3 py-3 flex flex-col gap-2 border-l-2 border-warn">
+        <div className="font-mono text-[12.5px] text-ink flex flex-wrap items-baseline gap-2">
+          <span className="text-warn">×</span>
+          <span>{running ? 'killing job…' : 'killed job'}</span>
+          <code className="bg-paper-2 border border-rule-2 px-1.5 py-0.5 text-[12px] text-ink">
+            {truncateMiddle(resp?.job_id ?? req.data.job_id, 24)}
+          </code>
+        </div>
+        {/* `reason` is long prose (e.g. the sandbox no-cancel-hook
+           message) — full-width faint line, not a pill. */}
+        {resp?.reason ? (
+          <div className="font-mono text-[12px] leading-[1.6] text-ink-faint italic">
+            {resp.reason}
+          </div>
+        ) : null}
+        {resp && status ? (
+          <div className="flex flex-wrap items-center gap-1.5">
+            <StatusPill label={status.label} variant={status.tone} />
+            <FooterPill tone={resp.killed ? 'accent' : 'warn'}>
+              {resp.killed ? 'killed' : 'not running'}
+            </FooterPill>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+/** Pending-approval preview — kill is destructive, so the approver
+    sees the exact job id on a single warn action line. */
+export function ShellKillPreview({ input }: { input: unknown }) {
+  const req = shellKillRequestSchema.safeParse(input)
+  if (!req.success) return null
+  return (
+    <div className="border-t border-rule-2 bg-bg">
+      <ActionLine symbol="×" tone="warn">
+        <span className="font-mono text-[12.5px]">
+          kill job{' '}
+          <code className="bg-paper-2 border border-rule-2 px-1.5 py-0.5 text-[12px]">
+            {req.data.job_id}
+          </code>
+        </span>
+      </ActionLine>
+    </div>
+  )
+}

--- a/console/web/src/components/chat/shell/ListView.tsx
+++ b/console/web/src/components/chat/shell/ListView.tsx
@@ -1,0 +1,107 @@
+import { Inbox } from 'lucide-react'
+import { formatAgeSecs, truncateMiddle } from '@/components/chat/sandbox/format'
+import { StatusPill } from '@/components/chat/sandbox/shared'
+import { EmptyState } from '@/components/ui/EmptyState'
+import { StatusDot } from '@/components/ui/StatusDot'
+import { formatEpochMs, jobDurationMs, jobStatusPill } from './format'
+import { safeParseResponse, shellListResponseSchema } from './parsers'
+
+interface ShellListViewProps {
+  output: unknown
+}
+
+/** `1234` → `"1234ms"`; ≥ 10 s humanize via `formatAgeSecs` so
+    long-lived jobs read as `2m`/`3h` instead of raw millis. */
+function formatDurationMs(ms: number): string {
+  return ms < 10_000 ? `${ms}ms` : formatAgeSecs(Math.floor(ms / 1000))
+}
+
+/**
+ * `shell::list` — background-job summary table. `JobSummary`
+ * deliberately omits argv/stdout/stderr (cross-caller secrecy), so
+ * there is no command column; the footer line points at
+ * `shell::status` for the full record. `count` is not rendered — it
+ * always equals `jobs.length` (the schema keeps it required as a
+ * contract canary). Request renders nothing (ignored server-side).
+ */
+export function ShellListView({ output }: ShellListViewProps) {
+  const parsed = safeParseResponse(shellListResponseSchema, output)
+  if (!parsed) return null
+  const jobs = parsed.jobs
+
+  if (jobs.length === 0) {
+    return (
+      <div className="border-t border-rule-2 bg-bg p-3">
+        <EmptyState
+          icon={Inbox}
+          title="no jobs"
+          description="no background jobs for this worker."
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="border-t border-rule-2 bg-bg overflow-x-auto">
+      <table className="w-full font-mono text-[12px] text-ink">
+        <thead>
+          <tr className="bg-paper-2 border-b border-rule-2 text-[11px] uppercase tracking-[0.06em] text-ink-faint">
+            <th className="text-left font-normal px-3 py-1.5">job</th>
+            <th className="text-left font-normal px-2 py-1.5">status</th>
+            <th className="text-left font-normal px-2 py-1.5">started</th>
+            <th className="text-left font-normal px-2 py-1.5">duration</th>
+            <th className="text-left font-normal px-2 py-1.5">exit</th>
+            <th className="text-left font-normal px-3 py-1.5">output</th>
+          </tr>
+        </thead>
+        <tbody>
+          {jobs.map((j) => {
+            const status = jobStatusPill(j.status)
+            const duration = jobDurationMs(j)
+            const truncated = j.stdout_truncated || j.stderr_truncated
+            return (
+              <tr key={j.id} className="border-b border-rule-2 last:border-b-0">
+                <td className="px-3 py-1.5">
+                  <code className="text-ink">{truncateMiddle(j.id, 18)}</code>
+                </td>
+                <td className="px-2 py-1.5">
+                  <span className="inline-flex items-center gap-1.5">
+                    {j.status === 'running' ? (
+                      <StatusDot tone="accent" pulse />
+                    ) : null}
+                    <StatusPill label={status.label} variant={status.tone} />
+                  </span>
+                </td>
+                <td className="px-2 py-1.5 text-ink-faint tabular-nums">
+                  {formatEpochMs(j.started_at_ms)}
+                </td>
+                <td className="px-2 py-1.5 text-ink-faint tabular-nums">
+                  {duration != null ? formatDurationMs(duration) : '—'}
+                </td>
+                <td className="px-2 py-1.5 tabular-nums">
+                  {j.exit_code == null ? (
+                    <span className="text-ink-faint">—</span>
+                  ) : (
+                    <span
+                      className={
+                        j.exit_code === 0 ? 'text-accent' : 'text-warn'
+                      }
+                    >
+                      {j.exit_code}
+                    </span>
+                  )}
+                </td>
+                <td className="px-3 py-1.5 text-ink-faint">
+                  {truncated ? '✂ truncated' : '—'}
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      <div className="px-3 py-1.5 font-mono text-[11px] text-ink-ghost border-t border-rule-2">
+        summaries only — full output via shell::status
+      </div>
+    </div>
+  )
+}

--- a/console/web/src/components/chat/shell/StatusView.tsx
+++ b/console/web/src/components/chat/shell/StatusView.tsx
@@ -1,0 +1,110 @@
+import {
+  formatAgeSecs,
+  pillForExit,
+  truncateMiddle,
+} from '@/components/chat/sandbox/format'
+import { AnsiOutput } from '@/components/chat/sandbox/terminal/AnsiOutput'
+import {
+  Chip,
+  FooterPill,
+  Terminal,
+} from '@/components/chat/sandbox/terminal/Terminal'
+import {
+  formatArgv,
+  formatEpochMs,
+  jobDurationMs,
+  jobStatusPill,
+} from './format'
+import {
+  type JobRecord,
+  safeParseResponse,
+  shellStatusRequestSchema,
+  shellStatusResponseSchema,
+} from './parsers'
+
+interface ShellStatusViewProps {
+  input: unknown
+  output: unknown
+  running?: boolean
+}
+
+/** `1234` → `"1234ms"`; ≥ 10 s humanize via `formatAgeSecs` so
+    long-lived jobs read as `2m`/`3h` instead of raw millis. */
+function formatDurationMs(ms: number): string {
+  return ms < 10_000 ? `${ms}ms` : formatAgeSecs(Math.floor(ms / 1000))
+}
+
+/**
+ * `shell::status` — the full JobRecord as real terminal chrome (the
+ * record carries argv + buffered stdout/stderr, unlike list's
+ * summaries). The frequent `S211 no such job` failure never reaches
+ * this view — the dispatch error pre-pass renders it as an error card.
+ */
+export function ShellStatusView({
+  input,
+  output,
+  running,
+}: ShellStatusViewProps) {
+  const req = shellStatusRequestSchema.safeParse(input)
+  if (!req.success) return null
+  const resp =
+    output != null ? safeParseResponse(shellStatusResponseSchema, output) : null
+
+  if (!resp) {
+    // The status call itself is in flight (or output is missing):
+    // chips-only header, `running` drives the executing shimmer.
+    return (
+      <Terminal
+        running={running}
+        chips={<Chip label="job">{truncateMiddle(req.data.job_id, 18)}</Chip>}
+      />
+    )
+  }
+
+  const job = resp.job
+  return (
+    <Terminal
+      command={formatArgv(job.argv)}
+      running={running}
+      chips={
+        <>
+          <Chip label="job">{truncateMiddle(job.id, 18)}</Chip>
+          <Chip label="started">{formatEpochMs(job.started_at_ms)}</Chip>
+          {job.finished_at_ms != null ? (
+            <Chip label="finished">{formatEpochMs(job.finished_at_ms)}</Chip>
+          ) : null}
+        </>
+      }
+      footer={<StatusFooter job={job} />}
+    >
+      <AnsiOutput stdout={job.stdout} stderr={job.stderr} />
+    </Terminal>
+  )
+}
+
+function StatusFooter({ job }: { job: JobRecord }) {
+  const status = jobStatusPill(job.status)
+  const exit = pillForExit(job.exit_code)
+  const duration = jobDurationMs(job)
+  return (
+    <>
+      <FooterPill tone={status.tone}>{status.label}</FooterPill>
+      {/* exit_code is null by definition while running — "no exit"/warn
+         would be misleading there, so the pill is terminal-only. */}
+      {job.status !== 'running' ? (
+        <FooterPill tone={exit.tone}>{exit.label}</FooterPill>
+      ) : null}
+      {/* No live-ticking duration for running jobs (no re-render
+         source); the `started` chip's relative time covers it. */}
+      {duration != null ? (
+        <FooterPill>{formatDurationMs(duration)}</FooterPill>
+      ) : null}
+      {job.stdout_truncated ? (
+        <FooterPill tone="warn">stdout truncated</FooterPill>
+      ) : null}
+      {job.stderr_truncated ? (
+        <FooterPill tone="warn">stderr truncated</FooterPill>
+      ) : null}
+    </>
+  )
+}

--- a/console/web/src/components/chat/shell/__tests__/format.test.ts
+++ b/console/web/src/components/chat/shell/__tests__/format.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatArgv,
+  formatEpochMs,
+  formatShellCommand,
+  jobDurationMs,
+  jobStatusPill,
+} from '../format'
+
+describe('formatShellCommand', () => {
+  it('renders the shell line verbatim when args are absent', () => {
+    expect(formatShellCommand({ command: 'echo "hi there" | wc -l' })).toBe(
+      'echo "hi there" | wc -l',
+    )
+  })
+
+  it('treats null args the same as absent', () => {
+    expect(formatShellCommand({ command: 'ls -la /tmp', args: null })).toBe(
+      'ls -la /tmp',
+    )
+  })
+
+  it('quote-joins the argv when args are present', () => {
+    expect(
+      formatShellCommand({ command: 'echo', args: ['hi there', '$HOME'] }),
+    ).toBe("echo 'hi there' '$HOME'")
+  })
+
+  it('keeps the []-vs-absent wire distinction visible', () => {
+    // Absent ⇒ shell line, displayed verbatim.
+    expect(formatShellCommand({ command: 'my program' })).toBe('my program')
+    // Present (even empty) ⇒ verbatim argv: the program slot gets quoted.
+    expect(formatShellCommand({ command: 'my program', args: [] })).toBe(
+      "'my program'",
+    )
+  })
+})
+
+describe('formatArgv', () => {
+  it('quote-joins a server-resolved argv into a paste-able line', () => {
+    expect(formatArgv(['node', '--eval', 'console.log(1)'])).toBe(
+      "node --eval 'console.log(1)'",
+    )
+  })
+
+  it('renders an empty argv as an empty string', () => {
+    expect(formatArgv([])).toBe('')
+  })
+})
+
+describe('jobStatusPill', () => {
+  it('maps every JobStatus to its tone', () => {
+    expect(jobStatusPill('running')).toEqual({
+      label: 'running',
+      tone: 'accent',
+    })
+    expect(jobStatusPill('finished')).toEqual({
+      label: 'finished',
+      tone: 'default',
+    })
+    expect(jobStatusPill('killed')).toEqual({ label: 'killed', tone: 'warn' })
+    expect(jobStatusPill('failed')).toEqual({ label: 'failed', tone: 'alert' })
+  })
+})
+
+describe('jobDurationMs', () => {
+  it('returns the wall-clock delta for finished jobs', () => {
+    expect(jobDurationMs({ started_at_ms: 1_000, finished_at_ms: 4_500 })).toBe(
+      3_500,
+    )
+  })
+
+  it('returns null while the job is still running', () => {
+    expect(
+      jobDurationMs({ started_at_ms: 1_000, finished_at_ms: null }),
+    ).toBeNull()
+  })
+
+  it('clamps negative clock skew to 0', () => {
+    expect(jobDurationMs({ started_at_ms: 2_000, finished_at_ms: 1_000 })).toBe(
+      0,
+    )
+  })
+})
+
+describe('formatEpochMs', () => {
+  it('treats epoch 0 as unknown', () => {
+    expect(formatEpochMs(0)).toBe('—')
+  })
+
+  it('floors millis to seconds before delegating to formatMtime', () => {
+    expect(formatEpochMs(Date.now())).toBe('just now')
+    expect(formatEpochMs(Date.now() - 120_000)).toBe('2m ago')
+  })
+})

--- a/console/web/src/components/chat/shell/__tests__/parsers.test.ts
+++ b/console/web/src/components/chat/shell/__tests__/parsers.test.ts
@@ -1,0 +1,715 @@
+import { describe, expect, it } from 'vitest'
+import {
+  extractEmbeddedSCode,
+  fsChmodRequestSchema,
+  fsChmodResponseSchema,
+  fsGrepRequestSchema,
+  fsGrepResponseSchema,
+  fsLsRequestSchema,
+  fsLsResponseSchema,
+  fsMkdirResponseSchema,
+  fsMvResponseSchema,
+  fsPathRequestSchema,
+  fsReadResponseSchema,
+  fsRmResponseSchema,
+  fsSedResponseSchema,
+  fsStatResponseSchema,
+  fsWriteRequestSchema,
+  fsWriteResponseSchema,
+  isShellFunction,
+  jobRecordSchema,
+  parseShellErrorDisplay,
+  SHELL_FUNCTION_IDS,
+  shellConfigStatusResponseSchema,
+  shellErrorWireSchema,
+  shellExecBgRequestSchema,
+  shellExecBgResponseSchema,
+  shellExecRequestSchema,
+  shellExecResponseSchema,
+  shellKillResponseSchema,
+  shellListRequestSchema,
+  shellListResponseSchema,
+  shellStatusRequestSchema,
+  shellStatusResponseSchema,
+  stripHandlerPrefix,
+  targetSchema,
+} from '../parsers'
+
+const SB = '00000000-0000-0000-0000-000000000000'
+
+/** Build a `{ content, details, terminate }` envelope identical to
+    what `harness/src/turn-orchestrator/agent-trigger.ts` produces. */
+function wrap<T>(details: T) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(details) }],
+    details,
+    terminate: false,
+  }
+}
+
+/** Canonical finished JobRecord — all 10 keys present. */
+const FINISHED_JOB = {
+  id: 'job-1',
+  argv: ['sleep', '5'],
+  started_at_ms: 1_700_000_000_000,
+  finished_at_ms: 1_700_000_005_000,
+  status: 'finished',
+  exit_code: 0,
+  stdout: 'done\n',
+  stderr: '',
+  stdout_truncated: false,
+  stderr_truncated: false,
+}
+
+/** Running record — `finished_at_ms`/`exit_code` are explicit nulls. */
+const RUNNING_JOB = {
+  ...FINISHED_JOB,
+  id: 'job-2',
+  finished_at_ms: null,
+  status: 'running',
+  exit_code: null,
+  stdout: '',
+}
+
+describe('isShellFunction', () => {
+  it('accepts all 16 shell ids', () => {
+    expect(SHELL_FUNCTION_IDS).toHaveLength(16)
+    for (const id of SHELL_FUNCTION_IDS) {
+      expect(isShellFunction(id)).toBe(true)
+    }
+  })
+
+  it('rejects near-misses from other families and misspellings', () => {
+    expect(isShellFunction('sandbox::exec')).toBe(false)
+    // The real id is dash-cased `shell::config-status`.
+    expect(isShellFunction('shell::config_status')).toBe(false)
+  })
+})
+
+describe('target schema', () => {
+  it('accepts host and sandbox variants', () => {
+    expect(targetSchema.safeParse({ kind: 'host' }).success).toBe(true)
+    expect(
+      targetSchema.safeParse({ kind: 'sandbox', sandbox_id: SB }).success,
+    ).toBe(true)
+  })
+
+  it('rejects unknown kinds and sandbox without an id', () => {
+    expect(targetSchema.safeParse({ kind: 'moon' }).success).toBe(false)
+    expect(targetSchema.safeParse({ kind: 'sandbox' }).success).toBe(false)
+  })
+
+  it('is optional on requests but NOT nullable (serde default on non-Option)', () => {
+    // Omitted ⇒ host default — fine.
+    expect(shellExecRequestSchema.safeParse({ command: 'ls' }).success).toBe(
+      true,
+    )
+    expect(fsPathRequestSchema.safeParse({ path: '/' }).success).toBe(true)
+    // Explicit null is a server-side deserialize error — pin the rejection.
+    expect(
+      shellExecRequestSchema.safeParse({ command: 'ls', target: null }).success,
+    ).toBe(false)
+    expect(
+      fsPathRequestSchema.safeParse({ path: '/', target: null }).success,
+    ).toBe(false)
+  })
+})
+
+describe('shell::exec request', () => {
+  it('accepts the canonical fully-populated example', () => {
+    const ok = shellExecRequestSchema.safeParse({
+      command: 'ls',
+      args: ['-la', '/tmp'],
+      timeout_ms: 30_000,
+      cwd: '/tmp',
+      env: { PATH: '/bin' },
+      stdin: 'hi',
+      target: { kind: 'sandbox', sandbox_id: SB },
+    })
+    expect(ok.success).toBe(true)
+  })
+
+  it('keeps `args: []` distinguishable from absent (shell-line vs verbatim argv)', () => {
+    const absent = shellExecRequestSchema.safeParse({ command: 'ls -la' })
+    expect(absent.success).toBe(true)
+    if (absent.success) expect(absent.data.args).toBeUndefined()
+
+    const empty = shellExecRequestSchema.safeParse({ command: 'ls', args: [] })
+    expect(empty.success).toBe(true)
+    if (empty.success) expect(empty.data.args).toEqual([])
+
+    const nul = shellExecRequestSchema.safeParse({ command: 'ls', args: null })
+    expect(nul.success).toBe(true)
+    if (nul.success) expect(nul.data.args).toBeNull()
+  })
+
+  it('swallows junk timeout_ms via .catch (server silently ignores non-u64)', () => {
+    for (const junk of ['soon', -5, 1.5]) {
+      const parsed = shellExecRequestSchema.safeParse({
+        command: 'ls',
+        timeout_ms: junk,
+      })
+      expect(parsed.success).toBe(true)
+      if (parsed.success) expect(parsed.data.timeout_ms).toBeUndefined()
+    }
+    const valid = shellExecRequestSchema.safeParse({
+      command: 'ls',
+      timeout_ms: 1500,
+    })
+    expect(valid.success).toBe(true)
+    if (valid.success) expect(valid.data.timeout_ms).toBe(1500)
+  })
+
+  it('accepts explicit nulls for cwd/env/stdin (Option + serde default)', () => {
+    const ok = shellExecRequestSchema.safeParse({
+      command: 'ls',
+      cwd: null,
+      env: null,
+      stdin: null,
+    })
+    expect(ok.success).toBe(true)
+  })
+
+  it('rejects an array command (string-only on the server)', () => {
+    expect(
+      shellExecRequestSchema.safeParse({ command: ['ls', '-la'] }).success,
+    ).toBe(false)
+  })
+
+  it('exec_bg request is the same schema object (alias, not copy)', () => {
+    expect(shellExecBgRequestSchema).toBe(shellExecRequestSchema)
+  })
+})
+
+describe('shell::exec / exec_bg responses', () => {
+  it('accepts the canonical 7-key ExecResponse', () => {
+    const ok = shellExecResponseSchema.safeParse({
+      exit_code: 0,
+      stdout: 'hi\n',
+      stderr: '',
+      duration_ms: 12,
+      timed_out: false,
+      stdout_truncated: false,
+      stderr_truncated: false,
+    })
+    expect(ok.success).toBe(true)
+  })
+
+  it('accepts null exit_code on timeout', () => {
+    const ok = shellExecResponseSchema.safeParse({
+      exit_code: null,
+      stdout: '',
+      stderr: '',
+      duration_ms: 1500,
+      timed_out: true,
+      stdout_truncated: false,
+      stderr_truncated: true,
+    })
+    expect(ok.success).toBe(true)
+  })
+
+  it('rejects a payload missing a truncation key (contract canary)', () => {
+    expect(
+      shellExecResponseSchema.safeParse({
+        exit_code: 0,
+        stdout: '',
+        stderr: '',
+        duration_ms: 1,
+        timed_out: false,
+        stderr_truncated: false,
+      }).success,
+    ).toBe(false)
+  })
+
+  it('ExecBgResponse round-trips through the harness envelope', () => {
+    const resp = { job_id: 'job-abc', argv: ['sleep', '5'] }
+    const parsed = shellExecBgResponseSchema.safeParse(wrap(resp).details)
+    expect(parsed.success).toBe(true)
+    if (parsed.success) expect(parsed.data.job_id).toBe('job-abc')
+  })
+})
+
+describe('shell::status / shell::kill', () => {
+  it('status request + full and running job records', () => {
+    expect(
+      shellStatusRequestSchema.safeParse({ job_id: 'job-1' }).success,
+    ).toBe(true)
+    expect(
+      shellStatusResponseSchema.safeParse({ job: FINISHED_JOB }).success,
+    ).toBe(true)
+    expect(
+      shellStatusResponseSchema.safeParse({ job: RUNNING_JOB }).success,
+    ).toBe(true)
+  })
+
+  it('rejects wrong-case status enums (serde lowercase)', () => {
+    expect(
+      jobRecordSchema.safeParse({ ...FINISHED_JOB, status: 'Finished' })
+        .success,
+    ).toBe(false)
+  })
+
+  it('kill: not-running combo carries a reason', () => {
+    const ok = shellKillResponseSchema.safeParse({
+      job_id: 'job-1',
+      killed: false,
+      status: 'finished',
+      reason: 'not running',
+    })
+    expect(ok.success).toBe(true)
+  })
+
+  it('kill: host kill omits the reason key entirely', () => {
+    const parsed = shellKillResponseSchema.safeParse({
+      job_id: 'job-1',
+      killed: true,
+      status: 'killed',
+    })
+    expect(parsed.success).toBe(true)
+    if (parsed.success) expect(parsed.data.reason).toBeUndefined()
+  })
+
+  it('kill: sandbox kill carries the no-cancel-hook reason', () => {
+    const ok = shellKillResponseSchema.safeParse({
+      job_id: 'job-1',
+      killed: true,
+      status: 'killed',
+      reason:
+        'sandbox::exec has no cancel hook; the in-VM process will run until its timeout_ms expires',
+    })
+    expect(ok.success).toBe(true)
+  })
+
+  it('kill: reason is skip_serializing_if — null is rejected', () => {
+    expect(
+      shellKillResponseSchema.safeParse({
+        job_id: 'job-1',
+        killed: true,
+        status: 'killed',
+        reason: null,
+      }).success,
+    ).toBe(false)
+  })
+})
+
+describe('shell::list / shell::config-status', () => {
+  it('list request tolerates the engine-injected _caller_worker_id', () => {
+    expect(
+      shellListRequestSchema.safeParse({ _caller_worker_id: 'w1' }).success,
+    ).toBe(true)
+  })
+
+  it('list response accepts empty and populated job tables', () => {
+    expect(
+      shellListResponseSchema.safeParse({ jobs: [], count: 0 }).success,
+    ).toBe(true)
+    expect(
+      shellListResponseSchema.safeParse({
+        jobs: [
+          {
+            id: 'job-2',
+            status: 'running',
+            started_at_ms: 1_700_000_000_000,
+            finished_at_ms: null,
+            exit_code: null,
+            stdout_truncated: false,
+            stderr_truncated: false,
+          },
+        ],
+        count: 1,
+      }).success,
+    ).toBe(true)
+  })
+
+  it('config-status accepts both outcomes; last_error is always present', () => {
+    expect(
+      shellConfigStatusResponseSchema.safeParse({
+        last_outcome: 'applied',
+        last_error: null,
+        rejected_reloads: 0,
+      }).success,
+    ).toBe(true)
+    expect(
+      shellConfigStatusResponseSchema.safeParse({
+        last_outcome: 'rejected',
+        last_error: 'invalid allowlist pattern',
+        rejected_reloads: 2,
+      }).success,
+    ).toBe(true)
+    expect(
+      shellConfigStatusResponseSchema.safeParse({
+        last_outcome: 'applied',
+        rejected_reloads: 0,
+      }).success,
+    ).toBe(false)
+  })
+})
+
+describe('fs schemas', () => {
+  const ENTRY = {
+    name: 'a',
+    is_dir: false,
+    size: 1,
+    mode: '0644',
+    mtime: 0,
+    is_symlink: false,
+  }
+
+  it('fs::ls request + response', () => {
+    expect(
+      fsLsRequestSchema.safeParse({
+        path: '/',
+        target: { kind: 'sandbox', sandbox_id: SB },
+      }).success,
+    ).toBe(true)
+    expect(fsLsResponseSchema.safeParse({ entries: [ENTRY] }).success).toBe(
+      true,
+    )
+  })
+
+  it('fs::stat response is serde(transparent) — bare entry, no wrapper', () => {
+    expect(fsStatResponseSchema.safeParse(ENTRY).success).toBe(true)
+    expect(fsStatResponseSchema.safeParse({ entry: ENTRY }).success).toBe(false)
+  })
+
+  it('fs::mkdir minimal response fills serde defaults', () => {
+    const parsed = fsMkdirResponseSchema.safeParse({ created: true })
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect(parsed.data.path).toBe('')
+      expect(parsed.data.already_existed).toBe(false)
+    }
+  })
+
+  it('fs::rm minimal response fills serde defaults', () => {
+    const parsed = fsRmResponseSchema.safeParse({ removed: true })
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect(parsed.data.path).toBe('')
+      expect(parsed.data.was_present).toBe(false)
+    }
+  })
+
+  it('fs::mv minimal response fills serde defaults', () => {
+    const parsed = fsMvResponseSchema.safeParse({ moved: true })
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect(parsed.data.src).toBe('')
+      expect(parsed.data.dst).toBe('')
+      expect(parsed.data.overwrote).toBe(false)
+    }
+  })
+
+  it('fs::chmod request requires mode; uid/gid accept null', () => {
+    expect(
+      fsChmodRequestSchema.safeParse({
+        path: '/a',
+        mode: '0755',
+        uid: null,
+        gid: null,
+      }).success,
+    ).toBe(true)
+    expect(fsChmodRequestSchema.safeParse({ path: '/a' }).success).toBe(false)
+  })
+
+  it('fs::chmod response accepts the legacy `updated` alias', () => {
+    const parsed = fsChmodResponseSchema.safeParse({ updated: 3 })
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect(parsed.data.entries_changed).toBe(3)
+      expect(parsed.data.path).toBe('')
+      expect(parsed.data.recursive).toBe(false)
+    }
+  })
+
+  it('fs::chmod response: entries_changed wins over updated; neither rejects', () => {
+    const parsed = fsChmodResponseSchema.safeParse({
+      entries_changed: 5,
+      updated: 3,
+      path: '/a',
+      recursive: true,
+    })
+    expect(parsed.success).toBe(true)
+    if (parsed.success) expect(parsed.data.entries_changed).toBe(5)
+    expect(fsChmodResponseSchema.safeParse({ path: '/a' }).success).toBe(false)
+  })
+
+  it('fs::grep request + response normalise the legacy `file` key', () => {
+    expect(
+      fsGrepRequestSchema.safeParse({ path: '/src', pattern: 'TODO' }).success,
+    ).toBe(true)
+    const parsed = fsGrepResponseSchema.safeParse({
+      matches: [{ file: '/legacy.ts', line: 7, content: 'TODO' }],
+      truncated: false,
+    })
+    expect(parsed.success).toBe(true)
+    if (parsed.success) expect(parsed.data.matches[0].path).toBe('/legacy.ts')
+  })
+
+  it('fs::sed response defaults absent per-file error to null', () => {
+    const parsed = fsSedResponseSchema.safeParse({
+      results: [{ path: '/a.ts', replacements: 2, success: true }],
+      total_replacements: 2,
+    })
+    expect(parsed.success).toBe(true)
+    if (parsed.success) expect(parsed.data.results[0].error).toBeNull()
+  })
+
+  it('fs::write accepts single inline, channel-ref, and batch request forms', () => {
+    expect(
+      fsWriteRequestSchema.safeParse({ path: '/a.txt', content: 'hello\n' })
+        .success,
+    ).toBe(true)
+    expect(
+      fsWriteRequestSchema.safeParse({
+        path: '/big.bin',
+        content: { channel_id: 'ch1', access_key: 'k', direction: 'write' },
+      }).success,
+    ).toBe(true)
+    expect(
+      fsWriteRequestSchema.safeParse({
+        files: [
+          { path: '/a', content: 'x' },
+          {
+            path: '/b',
+            content: { channel_id: 'ch2', access_key: 'k' },
+            mode: '0600',
+          },
+        ],
+      }).success,
+    ).toBe(true)
+  })
+
+  it('fs::write response defaults `files` to [] on single-file writes', () => {
+    const single = fsWriteResponseSchema.safeParse({
+      bytes_written: 6,
+      path: '/a.txt',
+    })
+    expect(single.success).toBe(true)
+    if (single.success) expect(single.data.files).toEqual([])
+
+    const batch = fsWriteResponseSchema.safeParse({
+      bytes_written: 10,
+      path: '',
+      files: [{ path: '/a', bytes_written: 4 }],
+    })
+    expect(batch.success).toBe(true)
+    if (batch.success) expect(batch.data.files).toHaveLength(1)
+  })
+
+  it('fs::read content is ALWAYS a channel ref — inline strings rejected', () => {
+    expect(
+      fsReadResponseSchema.safeParse({
+        content: 'hello',
+        size: 5,
+        mode: '0644',
+        mtime: 0,
+      }).success,
+    ).toBe(false)
+    expect(
+      fsReadResponseSchema.safeParse({
+        content: { channel_id: 'ch1', access_key: 'k', direction: 'read' },
+        size: 100,
+        mode: '0644',
+        mtime: 1_700_000_000,
+      }).success,
+    ).toBe(true)
+  })
+})
+
+describe('shellErrorWireSchema', () => {
+  it('accepts the SDK ErrorBody with an S-code', () => {
+    expect(
+      shellErrorWireSchema.safeParse({
+        code: 'S211',
+        message: 'no such job: job-7',
+        stacktrace: 'backtrace…',
+      }).success,
+    ).toBe(true)
+  })
+
+  it('rejects non-S codes (no false positives on {code,message} objects)', () => {
+    expect(
+      shellErrorWireSchema.safeParse({
+        code: 'invocation_failed',
+        message: 'handler error: argv: missing closing quote',
+      }).success,
+    ).toBe(false)
+  })
+})
+
+describe('parseShellErrorDisplay', () => {
+  it('lifts a flat S211 ErrorBody into the wire variant with its label', () => {
+    const out = parseShellErrorDisplay({
+      code: 'S211',
+      message: 'no such job: job-7',
+      stacktrace: 'backtrace…',
+    })
+    expect(out).toEqual({
+      variant: 'wire',
+      error: { type: 'not found', code: 'S211', message: 'no such job: job-7' },
+    })
+  })
+
+  it('finds the ErrorBody inside the harness envelope', () => {
+    const out = parseShellErrorDisplay(
+      wrap({ code: 'S210', message: 'cwd must be absolute' }),
+    )
+    expect(out?.variant).toBe('wire')
+    if (out?.variant === 'wire') {
+      expect(out.error.code).toBe('S210')
+      expect(out.error.type).toBe('bad request')
+    }
+  })
+
+  it('falls back to a generic label for undocumented S-codes', () => {
+    const out = parseShellErrorDisplay({ code: 'S999', message: 'mystery' })
+    expect(out?.variant).toBe('wire')
+    if (out?.variant === 'wire') expect(out.error.type).toBe('shell error')
+  })
+
+  it('text-scans the real-world denial envelope reason (the screenshot path)', () => {
+    const out = parseShellErrorDisplay({
+      error: {
+        kind: 'function_error',
+        message: 'trigger_failed: IIIInvocationError: invocation_failed',
+        details: {
+          schema_version: 1,
+          status: 'denied',
+          denied_by: 'gate_unavailable',
+          function_id: 'shell::status',
+          reason:
+            'trigger_failed: IIIInvocationError: S211: no such job: job-x',
+        },
+        content: [
+          {
+            type: 'text',
+            text: 'trigger_failed: IIIInvocationError: S211: no such job: job-x',
+          },
+        ],
+      },
+    })
+    expect(out).toEqual({
+      variant: 'wire',
+      error: { type: 'not found', code: 'S211', message: 'no such job: job-x' },
+    })
+  })
+
+  it('synthesizes S215 from an invocation_failed handler-error message (exec_bg path)', () => {
+    const out = parseShellErrorDisplay(
+      wrap({
+        code: 'invocation_failed',
+        message: 'handler error: S215: cwd escapes jail: /etc/passwd',
+        stacktrace: 'backtrace…',
+      }),
+    )
+    expect(out).toEqual({
+      variant: 'wire',
+      error: {
+        type: 'permission denied',
+        code: 'S215',
+        message: 'cwd escapes jail: /etc/passwd',
+      },
+    })
+  })
+
+  it('delegates S-code-free denials to the sandbox invocation variant', () => {
+    const out = parseShellErrorDisplay({
+      schema_version: 1,
+      status: 'denied',
+      denied_by: 'user',
+      function_id: 'shell::exec',
+      reason: 'denied from the console approval prompt',
+    })
+    expect(out?.variant).toBe('invocation')
+    if (out?.variant === 'invocation') {
+      expect(out.error.title).toBe('Denied by user')
+      expect(out.error.deniedBy).toBe('user')
+      expect(out.error.message).toBe('denied from the console approval prompt')
+    }
+  })
+
+  it('returns null on success payloads', () => {
+    // ExecResponse — flat.
+    expect(
+      parseShellErrorDisplay({
+        exit_code: 0,
+        stdout: 'ok\n',
+        stderr: '',
+        duration_ms: 12,
+        timed_out: false,
+        stdout_truncated: false,
+        stderr_truncated: false,
+      }),
+    ).toBeNull()
+    // KillResponse — its prose `reason` must not trip the text scan.
+    expect(
+      parseShellErrorDisplay({
+        job_id: 'job-1',
+        killed: false,
+        status: 'finished',
+        reason: 'not running',
+      }),
+    ).toBeNull()
+    // ExecBgResponse — wrapped in the harness envelope.
+    expect(
+      parseShellErrorDisplay(wrap({ job_id: 'job-abc', argv: ['sleep', '5'] })),
+    ).toBeNull()
+    // LsResponse.
+    expect(
+      parseShellErrorDisplay({
+        entries: [
+          {
+            name: 'a',
+            is_dir: false,
+            size: 1,
+            mode: '0644',
+            mtime: 0,
+            is_symlink: false,
+          },
+        ],
+      }),
+    ).toBeNull()
+  })
+})
+
+describe('extractEmbeddedSCode', () => {
+  it('pulls the first S-code out of free text', () => {
+    expect(
+      extractEmbeddedSCode(
+        'trigger_failed: IIIInvocationError: S211: no such job: job-x',
+      ),
+    ).toBe('S211')
+    expect(extractEmbeddedSCode('handler error: S215: cwd escapes jail')).toBe(
+      'S215',
+    )
+  })
+
+  it('returns null when no word-boundary S-code is present', () => {
+    expect(extractEmbeddedSCode('not running')).toBeNull()
+    expect(extractEmbeddedSCode('XS211: glued prefix')).toBeNull()
+  })
+})
+
+describe('stripHandlerPrefix', () => {
+  it('strips the SDK Display prefixes', () => {
+    expect(stripHandlerPrefix('handler error: S215: cwd escapes jail')).toBe(
+      'S215: cwd escapes jail',
+    )
+    expect(stripHandlerPrefix('serialization error: invalid type')).toBe(
+      'invalid type',
+    )
+  })
+
+  it('strips the harness trigger_failed class prefix', () => {
+    expect(
+      stripHandlerPrefix(
+        'trigger_failed: IIIInvocationError: S211: no such job',
+      ),
+    ).toBe('S211: no such job')
+  })
+
+  it('passes prefix-free messages through unchanged', () => {
+    expect(stripHandlerPrefix('plain message')).toBe('plain message')
+  })
+})

--- a/console/web/src/components/chat/shell/format.ts
+++ b/console/web/src/components/chat/shell/format.ts
@@ -1,0 +1,59 @@
+/* Pure formatting helpers shared by the shell renderers. No React, no
+   DOM access — deterministic transforms over the parsed shell payloads.
+   Generic byte/mode/time/quoting helpers come from sandbox/format. */
+
+import { formatMtime, quoteShellArg } from '@/components/chat/sandbox/format'
+import type { JobStatus } from './parsers'
+
+/** Render an ExecRequest command line for the terminal prompt.
+    `args` absent/null ⇒ `command` is a shell line the server shell-words
+    tokenizes — display verbatim. `args` present (even `[]`) ⇒ verbatim
+    argv — quote every slot including the program. Preserves the wire
+    semantic distinction. */
+export function formatShellCommand(req: {
+  command: string
+  args?: string[] | null
+}): string {
+  if (req.args == null) return req.command
+  return [req.command, ...req.args].map(quoteShellArg).join(' ')
+}
+
+/** Quote-join a server-resolved argv (`JobRecord.argv`,
+    `ExecBgResponse.argv`) into a paste-able shell line. */
+export function formatArgv(argv: string[]): string {
+  return argv.map(quoteShellArg).join(' ')
+}
+
+/** Epoch-millis (`started_at_ms`/`finished_at_ms`) → short relative
+    time, via sandbox `formatMtime` (which takes unix seconds). */
+export function formatEpochMs(ms: number): string {
+  return formatMtime(Math.floor(ms / 1000))
+}
+
+/** Job wall-clock duration. Null while running (`finished_at_ms` null);
+    clamps negative clock skew to 0. */
+export function jobDurationMs(rec: {
+  started_at_ms: number
+  finished_at_ms: number | null
+}): number | null {
+  return rec.finished_at_ms == null
+    ? null
+    : Math.max(0, rec.finished_at_ms - rec.started_at_ms)
+}
+
+/** Status pill mapping — single source of truth for status/kill/list. */
+export function jobStatusPill(status: JobStatus): {
+  label: string
+  tone: 'accent' | 'warn' | 'alert' | 'default'
+} {
+  switch (status) {
+    case 'running':
+      return { label: 'running', tone: 'accent' }
+    case 'finished':
+      return { label: 'finished', tone: 'default' }
+    case 'killed':
+      return { label: 'killed', tone: 'warn' }
+    case 'failed':
+      return { label: 'failed', tone: 'alert' }
+  }
+}

--- a/console/web/src/components/chat/shell/index.tsx
+++ b/console/web/src/components/chat/shell/index.tsx
@@ -1,0 +1,126 @@
+import { SandboxErrorView } from '@/components/chat/sandbox/ErrorView'
+import type { FunctionCallMessage } from '@/types/chat'
+import { ShellConfigStatusView } from './ConfigStatusView'
+import { ShellExecBgPreview, ShellExecBgView } from './ExecBgView'
+import { ShellExecPreview, ShellExecView } from './ExecView'
+import { FsChmodView } from './FsChmodView'
+import { FsGrepView } from './FsGrepView'
+import { FsLsView } from './FsLsView'
+import { FsMkdirView } from './FsMkdirView'
+import { FsMvView } from './FsMvView'
+import { FsReadView } from './FsReadView'
+import { FsRmView } from './FsRmView'
+import { FsSedView } from './FsSedView'
+import { FsStatView } from './FsStatView'
+import { FsWriteView } from './FsWriteView'
+import { ShellKillPreview, ShellKillView } from './KillView'
+import { ShellListView } from './ListView'
+import {
+  isShellFunction,
+  parseShellErrorDisplay,
+  unwrapEnvelope,
+} from './parsers'
+import { ShellStatusView } from './StatusView'
+
+/* The known shell::* set lives in parsers.ts (SHELL_FUNCTION_IDS) so
+   the dispatcher and the schemas share one source of truth. Re-exported
+   here for FCM symmetry with the sandbox module. */
+export { isShellFunction, SHELL_FUNCTION_IDS } from './parsers'
+
+/* Public surface mirrors the sandbox module exactly. Both helpers
+   return `null` for unknown function ids or unparseable payloads so
+   the caller can silently fall back to the existing JSON view. */
+export function ShellFunctionIdLabel({ functionId }: { functionId: string }) {
+  if (!functionId.startsWith('shell::')) {
+    return <span className="text-ink">{functionId}</span>
+  }
+  const tail = functionId.slice('shell::'.length)
+  return (
+    <>
+      <span className="text-ink-faint">shell::</span>
+      <span className="text-ink font-medium">{tail}</span>
+    </>
+  )
+}
+
+function tryRender(message: FunctionCallMessage): React.ReactNode | null {
+  if (!isShellFunction(message.functionId)) return null
+  if (message.pendingApproval) return null
+
+  // The done-state view is what tryRender owns; the pending preview
+  // lives in tryRenderPreview. Running-state cards are rendered by
+  // the per-tool view with `running=true` so the shell chrome stays
+  // identical and only the body swaps to the executing-shimmer.
+  const input = unwrapEnvelope(message.input)
+  const rawOutput = message.output
+  const output = rawOutput != null ? unwrapEnvelope(rawOutput) : undefined
+  const running = !!message.running
+
+  const errorDisplay =
+    !running && rawOutput != null ? parseShellErrorDisplay(rawOutput) : null
+  if (errorDisplay) {
+    return <SandboxErrorView display={errorDisplay} />
+  }
+
+  switch (message.functionId) {
+    case 'shell::exec':
+      return <ShellExecView input={input} output={output} running={running} />
+    case 'shell::exec_bg':
+      return <ShellExecBgView input={input} output={output} running={running} />
+    case 'shell::status':
+      return <ShellStatusView input={input} output={output} running={running} />
+    case 'shell::kill':
+      return <ShellKillView input={input} output={output} running={running} />
+    case 'shell::list':
+      return <ShellListView output={output} />
+    case 'shell::config-status':
+      return <ShellConfigStatusView output={output} running={running} />
+    case 'shell::fs::ls':
+      return <FsLsView input={input} output={output} />
+    case 'shell::fs::stat':
+      return <FsStatView input={input} output={output} />
+    case 'shell::fs::read':
+      return <FsReadView input={input} output={output} />
+    case 'shell::fs::write':
+      return <FsWriteView input={input} output={output} />
+    case 'shell::fs::mkdir':
+      return <FsMkdirView input={input} output={output} />
+    case 'shell::fs::rm':
+      return <FsRmView input={input} output={output} />
+    case 'shell::fs::mv':
+      return <FsMvView input={input} output={output} />
+    case 'shell::fs::chmod':
+      return <FsChmodView input={input} output={output} />
+    case 'shell::fs::grep':
+      return <FsGrepView input={input} output={output} />
+    case 'shell::fs::sed':
+      return <FsSedView input={input} output={output} />
+    default:
+      return null
+  }
+}
+
+function tryRenderPreview(
+  message: FunctionCallMessage,
+): React.ReactNode | null {
+  if (!isShellFunction(message.functionId)) return null
+  const input = unwrapEnvelope(message.input)
+  switch (message.functionId) {
+    case 'shell::exec':
+      return <ShellExecPreview input={input} />
+    case 'shell::exec_bg':
+      return <ShellExecBgPreview input={input} />
+    case 'shell::kill':
+      return <ShellKillPreview input={input} />
+    default:
+      return null
+  }
+}
+
+export const ShellToolView = {
+  isShellFunction,
+  tryRender,
+  /** Alias kept for FCM symmetry; running state lives inside `tryRender`. */
+  tryRenderRunning: tryRender,
+  tryRenderPreview,
+}

--- a/console/web/src/components/chat/shell/parsers.ts
+++ b/console/web/src/components/chat/shell/parsers.ts
@@ -1,0 +1,587 @@
+import { z } from 'zod'
+import {
+  collectErrorCandidates,
+  extractFirstJsonObject,
+  fsEntrySchema,
+  fsMatchSchema,
+  fsSedFileResultSchema,
+  parseSandboxErrorDisplay,
+  type SandboxErrorDisplay,
+  safeParseRequest,
+  safeParseResponse,
+  unwrapEnvelope,
+} from '@/components/chat/sandbox/parsers'
+
+/* Zod schemas mirroring the shell::* request/response shapes from
+   `workers/shell/src/{functions/types,jobs,target,configuration}.rs` and
+   `src/fs/{mod,wire,error}.rs`.
+
+   The Rust handlers deserialize plain JSON via serde, so wire payloads
+   always match these shapes. Every schema is intentionally non-strict
+   (no `.strict()`); forward-compat is preserved for unknown future
+   fields (notably the engine-injected `_caller_worker_id`) and the
+   renderers only read what they need. */
+
+// Re-exports so the shell views import everything from one place.
+export type {
+  FsEntry,
+  FsMatch,
+  FsSedFileResult,
+  SandboxErrorDisplay,
+} from '@/components/chat/sandbox/parsers'
+export {
+  extractFirstJsonObject,
+  fsEntrySchema,
+  fsMatchSchema,
+  fsSedFileResultSchema,
+  safeParseRequest,
+  safeParseResponse,
+  unwrapEnvelope,
+}
+
+// ---------------------------------------------------------------------------
+// Function ids
+// ---------------------------------------------------------------------------
+
+export const SHELL_FUNCTION_IDS = [
+  'shell::exec',
+  'shell::exec_bg',
+  'shell::status',
+  'shell::kill',
+  'shell::list',
+  'shell::config-status',
+  'shell::fs::ls',
+  'shell::fs::stat',
+  'shell::fs::mkdir',
+  'shell::fs::write',
+  'shell::fs::read',
+  'shell::fs::rm',
+  'shell::fs::chmod',
+  'shell::fs::mv',
+  'shell::fs::grep',
+  'shell::fs::sed',
+] as const
+
+export type ShellFunctionId = (typeof SHELL_FUNCTION_IDS)[number]
+
+const SHELL_FUNCTION_ID_SET: ReadonlySet<string> = new Set<string>(
+  SHELL_FUNCTION_IDS,
+)
+
+export function isShellFunction(id: string): id is ShellFunctionId {
+  return SHELL_FUNCTION_ID_SET.has(id)
+}
+
+// ---------------------------------------------------------------------------
+// Shared building blocks
+// ---------------------------------------------------------------------------
+
+/** `src/target.rs::Target` — internally tagged on `kind`, snake_case.
+    Requests carry `#[serde(default)]` on a non-Option field: an omitted
+    key means host, but an explicit `null` is a server-side deserialize
+    error — so the field is `.optional()`, NOT `.nullable()`. `sandbox_id`
+    is a UUID on the server; kept a lenient string here so a malformed id
+    still renders. Unknown `kind` values fail parse (raw-JSON fallback),
+    matching the server's deserialize error. */
+export const targetSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('host') }),
+  z.object({ kind: z.literal('sandbox'), sandbox_id: z.string() }),
+])
+export type ShellTarget = z.infer<typeof targetSchema>
+
+/** `src/jobs.rs::JobStatus` — `rename_all = "lowercase"`. */
+export const jobStatusSchema = z.enum([
+  'running',
+  'finished',
+  'killed',
+  'failed',
+])
+export type JobStatus = z.infer<typeof jobStatusSchema>
+
+/** `src/jobs.rs::JobRecord` — no renames, no skip_serializing_if: all 10
+    keys always present; `finished_at_ms`/`exit_code` are explicit JSON
+    null when unset ⇒ `.nullable()`, NOT `.optional()`. */
+export const jobRecordSchema = z.object({
+  id: z.string(),
+  argv: z.array(z.string()),
+  started_at_ms: z.number(),
+  finished_at_ms: z.number().nullable(),
+  status: jobStatusSchema,
+  exit_code: z.number().nullable(),
+  stdout: z.string(),
+  stderr: z.string(),
+  stdout_truncated: z.boolean(),
+  stderr_truncated: z.boolean(),
+})
+export type JobRecord = z.infer<typeof jobRecordSchema>
+
+/** `src/fs/mod.rs::ContentRef`. `direction` is optional on requests
+    (serde default "read") and always present on fs::read responses —
+    one schema covers both sides. */
+export const contentRefSchema = z.object({
+  channel_id: z.string(),
+  access_key: z.string(),
+  direction: z.enum(['read', 'write']).optional(),
+})
+export type ContentRef = z.infer<typeof contentRefSchema>
+
+/** `WriteContentWire` — `#[serde(untagged)]`: inline UTF-8 string
+    (host-only) or a streaming channel ref. */
+export const writeContentSchema = z.union([z.string(), contentRefSchema])
+export type WriteContent = z.infer<typeof writeContentSchema>
+
+// ---------------------------------------------------------------------------
+// shell::exec / shell::exec_bg
+// ---------------------------------------------------------------------------
+
+/** `ExecRequest`/`ExecBgRequest` (`src/functions/types.rs`).
+    - `command` is string-only on the server (array → recovery-hint
+      error), so `z.string()`; a request that errored server-side simply
+      won't render as a terminal card (raw-JSON fallback is correct there).
+    - `args`: absent/null ⇒ shell-words tokenization of `command`; present
+      (even `[]`) ⇒ verbatim argv. The null/[] distinction is semantic —
+      keep `.nullable().optional()` and DO NOT default to [].
+    - `timeout_ms` is permissive server-side (any non-u64 silently ⇒
+      default timeout, never an error) — mirror with `.catch(undefined)`
+      so junk values don't kill the whole card.
+    - `cwd`/`env`/`stdin` are `Option<T>` + `serde(default)` ⇒ both null
+      and absent are legal on the wire: `.nullable().optional()`.
+    - `env` is a BTreeMap, not sandbox's EnvShape union: plain record. */
+export const shellExecRequestSchema = z.object({
+  command: z.string(),
+  args: z.array(z.string()).nullable().optional(),
+  timeout_ms: z.number().int().nonnegative().optional().catch(undefined),
+  cwd: z.string().nullable().optional(),
+  env: z.record(z.string(), z.string()).nullable().optional(),
+  stdin: z.string().nullable().optional(),
+  target: targetSchema.optional(),
+})
+export type ShellExecRequest = z.infer<typeof shellExecRequestSchema>
+
+/** Same struct shape on the wire (`ExecBgRequest`). Alias, not copy. */
+export const shellExecBgRequestSchema = shellExecRequestSchema
+export type ShellExecBgRequest = ShellExecRequest
+
+/** `ExecResponse` — all 7 keys always present; `exit_code` null when
+    killed by signal/timeout. */
+export const shellExecResponseSchema = z.object({
+  exit_code: z.number().nullable(),
+  stdout: z.string(),
+  stderr: z.string(),
+  duration_ms: z.number(),
+  timed_out: z.boolean(),
+  stdout_truncated: z.boolean(),
+  stderr_truncated: z.boolean(),
+})
+export type ShellExecResponse = z.infer<typeof shellExecResponseSchema>
+
+/** `ExecBgResponse` — `job_id` is `"job-<uuid>"`. */
+export const shellExecBgResponseSchema = z.object({
+  job_id: z.string(),
+  argv: z.array(z.string()),
+})
+export type ShellExecBgResponse = z.infer<typeof shellExecBgResponseSchema>
+
+// ---------------------------------------------------------------------------
+// shell::status / shell::kill
+// ---------------------------------------------------------------------------
+
+export const shellStatusRequestSchema = z.object({ job_id: z.string() })
+export type ShellStatusRequest = z.infer<typeof shellStatusRequestSchema>
+
+export const shellStatusResponseSchema = z.object({ job: jobRecordSchema })
+export type ShellStatusResponse = z.infer<typeof shellStatusResponseSchema>
+
+export const shellKillRequestSchema = z.object({ job_id: z.string() })
+export type ShellKillRequest = z.infer<typeof shellKillRequestSchema>
+
+/** `KillResponse` — `reason` is the ONLY skip_serializing_if field in
+    the family: key ABSENT when none ⇒ `.optional()`, NOT `.nullable()`. */
+export const shellKillResponseSchema = z.object({
+  job_id: z.string(),
+  killed: z.boolean(),
+  status: jobStatusSchema,
+  reason: z.string().optional(),
+})
+export type ShellKillResponse = z.infer<typeof shellKillResponseSchema>
+
+// ---------------------------------------------------------------------------
+// shell::list / shell::config-status
+// ---------------------------------------------------------------------------
+
+/** Handler ignores the payload entirely; engine injects
+    `_caller_worker_id`. */
+export const shellListRequestSchema = z.object({}).passthrough()
+export type ShellListRequest = z.infer<typeof shellListRequestSchema>
+
+/** `JobSummary` — deliberately NO argv/stdout/stderr (cross-caller
+    secrecy; full record only via shell::status). */
+export const jobSummarySchema = z.object({
+  id: z.string(),
+  status: jobStatusSchema,
+  started_at_ms: z.number(),
+  finished_at_ms: z.number().nullable(),
+  exit_code: z.number().nullable(),
+  stdout_truncated: z.boolean(),
+  stderr_truncated: z.boolean(),
+})
+export type JobSummary = z.infer<typeof jobSummarySchema>
+
+export const shellListResponseSchema = z.object({
+  jobs: z.array(jobSummarySchema),
+  count: z.number(),
+})
+export type ShellListResponse = z.infer<typeof shellListResponseSchema>
+
+export const shellConfigStatusRequestSchema = z.object({}).passthrough()
+export type ShellConfigStatusRequest = z.infer<
+  typeof shellConfigStatusRequestSchema
+>
+
+/** `configuration.rs::ReloadStatus` — `last_error` always present,
+    explicit null. */
+export const shellConfigStatusResponseSchema = z.object({
+  last_outcome: z.enum(['applied', 'rejected']),
+  last_error: z.string().nullable(),
+  rejected_reloads: z.number(),
+})
+export type ShellConfigStatusResponse = z.infer<
+  typeof shellConfigStatusResponseSchema
+>
+
+// ---------------------------------------------------------------------------
+// Filesystem — shell::fs::* (`src/fs/mod.rs`). FsEntry/FsMatch/
+// FsSedFileResult are reused from sandbox/parsers — they already encode
+// the `file`→`path` alias and absent-`error`→null transforms.
+// ---------------------------------------------------------------------------
+
+/** ls / stat / read share one request shape. */
+export const fsPathRequestSchema = z.object({
+  target: targetSchema.optional(),
+  path: z.string(),
+})
+export type FsPathRequest = z.infer<typeof fsPathRequestSchema>
+
+export const fsLsRequestSchema = fsPathRequestSchema
+export const fsStatRequestSchema = fsPathRequestSchema
+export const fsReadRequestSchema = fsPathRequestSchema
+
+export const fsLsResponseSchema = z.object({
+  entries: z.array(fsEntrySchema),
+})
+export type FsLsResponse = z.infer<typeof fsLsResponseSchema>
+
+/** `StatResponse` is `#[serde(transparent)]` — a bare FsEntry at the top
+    level, no wrapper key. */
+export const fsStatResponseSchema = fsEntrySchema
+export type FsStatResponse = z.infer<typeof fsStatResponseSchema>
+
+export const fsMkdirRequestSchema = z.object({
+  target: targetSchema.optional(),
+  path: z.string(),
+  mode: z.string().optional(), // worker default "0755"
+  parents: z.boolean().optional(), // default false
+})
+export type FsMkdirRequest = z.infer<typeof fsMkdirRequestSchema>
+
+/** `path`/`already_existed` carry `#[serde(default)]` on the worker for
+    sandbox-engine round-trips; be equally lenient here. Sandbox-target
+    responses blank `path` and default the boolean — fill-ins, not
+    signals (views suppress the pills via `isSandboxTarget`). */
+export const fsMkdirResponseSchema = z.object({
+  created: z.boolean(),
+  path: z.string().optional().default(''),
+  already_existed: z.boolean().optional().default(false),
+})
+export type FsMkdirResponse = z.infer<typeof fsMkdirResponseSchema>
+
+export const fsRmRequestSchema = z.object({
+  target: targetSchema.optional(),
+  path: z.string(),
+  recursive: z.boolean().optional(), // default false
+})
+export type FsRmRequest = z.infer<typeof fsRmRequestSchema>
+
+export const fsRmResponseSchema = z.object({
+  removed: z.boolean(),
+  path: z.string().optional().default(''),
+  was_present: z.boolean().optional().default(false), // host-only signal
+})
+export type FsRmResponse = z.infer<typeof fsRmResponseSchema>
+
+export const fsChmodRequestSchema = z.object({
+  target: targetSchema.optional(),
+  path: z.string(),
+  mode: z.string(), // REQUIRED, octal e.g. "0755"
+  uid: z.number().nullable().optional(),
+  gid: z.number().nullable().optional(),
+  recursive: z.boolean().optional(), // default false
+})
+export type FsChmodRequest = z.infer<typeof fsChmodRequestSchema>
+
+/** Callers receive `entries_changed`; `updated` is the legacy engine
+    alias — accepted defensively (mirrors the worker's
+    `#[serde(alias = "updated")]`), `entries_changed` wins. */
+export const fsChmodResponseSchema = z
+  .object({
+    entries_changed: z.number().optional(),
+    updated: z.number().optional(),
+    path: z.string().optional().default(''),
+    recursive: z.boolean().optional().default(false),
+  })
+  .refine((r) => r.entries_changed != null || r.updated != null)
+  .transform((r) => ({
+    entries_changed: r.entries_changed ?? r.updated ?? 0,
+    path: r.path,
+    recursive: r.recursive,
+  }))
+export type FsChmodResponse = z.infer<typeof fsChmodResponseSchema>
+
+export const fsMvRequestSchema = z.object({
+  target: targetSchema.optional(),
+  src: z.string(),
+  dst: z.string(),
+  overwrite: z.boolean().optional(), // default false
+})
+export type FsMvRequest = z.infer<typeof fsMvRequestSchema>
+
+export const fsMvResponseSchema = z.object({
+  moved: z.boolean(),
+  src: z.string().optional().default(''),
+  dst: z.string().optional().default(''),
+  overwrote: z.boolean().optional().default(false), // host best-effort
+})
+export type FsMvResponse = z.infer<typeof fsMvResponseSchema>
+
+/** `recursive` defaults TRUE on the wire (unlike rm/chmod) — chips show
+    the deviation ("non-recursive"). */
+export const fsGrepRequestSchema = z.object({
+  target: targetSchema.optional(),
+  path: z.string(),
+  pattern: z.string(),
+  recursive: z.boolean().optional(), // default TRUE on the wire
+  ignore_case: z.boolean().optional(),
+  include_glob: z.array(z.string()).optional(),
+  exclude_glob: z.array(z.string()).optional(),
+  max_matches: z.number().optional(), // default 10000
+  max_line_bytes: z.number().optional(), // default 4096
+})
+export type FsGrepRequest = z.infer<typeof fsGrepRequestSchema>
+
+export const fsGrepResponseSchema = z.object({
+  matches: z.array(fsMatchSchema),
+  truncated: z.boolean(),
+})
+export type FsGrepResponse = z.infer<typeof fsGrepResponseSchema>
+
+/** `recursive` and `regex` both default TRUE on the wire — chips show
+    the deviations ("non-recursive", "literal"). */
+export const fsSedRequestSchema = z.object({
+  target: targetSchema.optional(),
+  files: z.array(z.string()).optional(),
+  path: z.string().nullable().optional(),
+  recursive: z.boolean().optional(), // default TRUE
+  include_glob: z.array(z.string()).optional(),
+  exclude_glob: z.array(z.string()).optional(),
+  pattern: z.string(),
+  replacement: z.string(),
+  regex: z.boolean().optional(), // default TRUE
+  first_only: z.boolean().optional(),
+  ignore_case: z.boolean().optional(),
+})
+export type FsSedRequest = z.infer<typeof fsSedRequestSchema>
+
+export const fsSedResponseSchema = z.object({
+  results: z.array(fsSedFileResultSchema),
+  total_replacements: z.number(),
+})
+export type FsSedResponse = z.infer<typeof fsSedResponseSchema>
+
+export const writeFileSpecSchema = z.object({
+  path: z.string(),
+  content: writeContentSchema,
+  mode: z.string().optional(), // default "0644"
+  parents: z.boolean().optional(),
+})
+export type WriteFileSpec = z.infer<typeof writeFileSpecSchema>
+
+/** Single-file and batch forms share one lenient schema; the view
+    branches on `files` being a non-empty array. (Mutual-exclusion is
+    enforced server-side via S210, not by serde.) */
+export const fsWriteRequestSchema = z.object({
+  target: targetSchema.optional(),
+  path: z.string().nullable().optional(),
+  content: writeContentSchema.nullable().optional(),
+  mode: z.string().nullable().optional(),
+  parents: z.boolean().nullable().optional(),
+  files: z.array(writeFileSpecSchema).nullable().optional(),
+})
+export type FsWriteRequest = z.infer<typeof fsWriteRequestSchema>
+
+export const writeFileResultSchema = z.object({
+  path: z.string(),
+  bytes_written: z.number(),
+})
+export type WriteFileResult = z.infer<typeof writeFileResultSchema>
+
+export const fsWriteResponseSchema = z.object({
+  bytes_written: z.number(),
+  path: z.string(),
+  files: z.array(writeFileResultSchema).optional().default([]),
+})
+export type FsWriteResponse = z.infer<typeof fsWriteResponseSchema>
+
+/** `ReadResponseWire` — `content` is ALWAYS a channel ref, never inline
+    (the handler converts before serializing). */
+export const fsReadResponseSchema = z.object({
+  content: contentRefSchema,
+  size: z.number(),
+  mode: z.string(),
+  mtime: z.number(),
+})
+export type FsReadResponse = z.infer<typeof fsReadResponseSchema>
+
+// ---------------------------------------------------------------------------
+// Errors — flat SDK ErrorBody `{ code, message, stacktrace? }` plus the
+// harness re-wrap that embeds the S-code into a denial-reason string.
+// ---------------------------------------------------------------------------
+
+/** The SDK `ErrorBody` carrying a typed shell S-code (`IIIError::Remote`).
+    No `type` field — sandbox's `sandboxErrorWireSchema` requires one, so
+    shell errors need this dedicated schema. The regex keeps it from
+    false-positiving on arbitrary `{ code, message }` objects. */
+export const shellErrorWireSchema = z.object({
+  code: z.string().regex(/^S\d{3}$/),
+  message: z.string(),
+  stacktrace: z.string().optional(),
+})
+export type ShellErrorWire = z.infer<typeof shellErrorWireSchema>
+
+/** Human labels for the S-codes documented in `shell/src/main.rs`. */
+export const S_CODE_LABEL: Record<string, string> = {
+  S200: 'in-VM failure',
+  S210: 'bad request',
+  S211: 'not found',
+  S212: 'wrong file type',
+  S213: 'already exists',
+  S214: 'directory not empty',
+  S215: 'permission denied',
+  S216: 'i/o error',
+  S217: 'bad regex',
+  S218: 'size cap exceeded',
+  S300: 'vm boot failed',
+}
+
+/** Lift a flat shell error into the existing `SandboxErrorDisplay` wire
+    variant so `SandboxErrorView` renders it unchanged (S-code Badge +
+    label + message). */
+function shellWire(e: { code: string; message: string }): SandboxErrorDisplay {
+  return {
+    variant: 'wire',
+    error: {
+      type: S_CODE_LABEL[e.code] ?? 'shell error',
+      code: e.code,
+      message: e.message,
+    },
+  }
+}
+
+/** exec_bg stringifies its S-code into the message ("S215: …"), and the
+    SDK Display impl prefixes "handler error: " / "serialization error: ".
+    Pull the embedded S-code out of free text. */
+export function extractEmbeddedSCode(message: string): string | null {
+  return message.match(/\b(S\d{3}):/)?.[1] ?? null
+}
+
+/** Strip the harness/SDK Display prefixes ("trigger_failed: <Class>: ",
+    "handler error: ", "serialization error: ") for the headline — the
+    raw text stays available in the raw-json tab. */
+export function stripHandlerPrefix(message: string): string {
+  return message
+    .replace(/^trigger_failed:.*?:\s*/, '')
+    .replace(/^(?:handler error|serialization error):\s*/, '')
+}
+
+/** Synthesize a wire display from an S-code embedded in free text —
+    `"trigger_failed: IIIInvocationError: S211: no such job: job-x"` →
+    `{ code: 'S211', message: 'no such job: job-x' }`. */
+function wireFromText(text: string): SandboxErrorDisplay | null {
+  const match = text.match(/\b(S\d{3}):\s*([\s\S]+)/)
+  if (!match) return null
+  return shellWire({
+    code: match[1],
+    message: stripHandlerPrefix(match[2].trim()),
+  })
+}
+
+/** Every string the harness might hide an S-code in: string candidates
+    from the shared traversal, plus `reason`/`message` fields of object
+    candidates (the gate-denial envelope keeps its prose in `reason`,
+    which the generic traversal surfaces only as an object). */
+function collectStringCandidates(value: unknown): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  const push = (candidate: unknown) => {
+    if (typeof candidate !== 'string' || candidate.length === 0) return
+    if (seen.has(candidate)) return
+    seen.add(candidate)
+    out.push(candidate)
+  }
+
+  for (const candidate of collectErrorCandidates(value)) {
+    for (const layer of [candidate, unwrapEnvelope(candidate)]) {
+      push(layer)
+      if (layer && typeof layer === 'object' && !Array.isArray(layer)) {
+        const obj = layer as Record<string, unknown>
+        push(obj.reason)
+        push(obj.message)
+      }
+    }
+  }
+
+  return out
+}
+
+/**
+ * Normalise every failure shape the console may receive for shell calls,
+ * in priority order:
+ *
+ * 1. Flat SDK `ErrorBody` with a typed S-code — direct objects anywhere
+ *    in the candidate traversal, or JSON embedded in strings.
+ * 2. S-codes stringified into prose (the load-bearing real-world path):
+ *    the harness re-wraps shell's plain-text errors into a gate-denial
+ *    envelope whose `reason` reads e.g. `"trigger_failed:
+ *    IIIInvocationError: S211: no such job: job-x"` — scan every string
+ *    candidate and synthesize the wire display from text.
+ * 3. Delegate to `parseSandboxErrorDisplay` for denials without S-codes,
+ *    generic function_error envelopes, and harness wrappers (identical
+ *    across families).
+ *
+ * Returns the existing `SandboxErrorDisplay` union, rendered by
+ * `SandboxErrorView` unchanged.
+ */
+export function parseShellErrorDisplay(
+  value: unknown,
+): SandboxErrorDisplay | null {
+  const candidates = collectErrorCandidates(value)
+
+  for (const candidate of candidates) {
+    const direct = shellErrorWireSchema.safeParse(candidate)
+    if (direct.success) return shellWire(direct.data)
+
+    if (typeof candidate === 'string') {
+      const embedded = extractFirstJsonObject(candidate)
+      if (embedded != null) {
+        const fromJson = shellErrorWireSchema.safeParse(embedded)
+        if (fromJson.success) return shellWire(fromJson.data)
+      }
+    }
+  }
+
+  for (const text of collectStringCandidates(value)) {
+    const synthesized = wireFromText(text)
+    if (synthesized) return synthesized
+  }
+
+  return parseSandboxErrorDisplay(value)
+}

--- a/console/web/src/components/chat/shell/shared.tsx
+++ b/console/web/src/components/chat/shell/shared.tsx
@@ -1,0 +1,43 @@
+import { truncateMiddle } from '@/components/chat/sandbox/format'
+import { Chip } from '@/components/chat/sandbox/terminal/Terminal'
+import type { ShellTarget } from './parsers'
+
+/** Narrow a request `target` to the sandbox variant. Also the views'
+    "suppress serde fill-ins" signal — sandbox-target responses blank
+    `path`/`src`/`dst` and default `already_existed`/`was_present`/
+    `overwrote`, so those pills are meaningless there. */
+export function isSandboxTarget(
+  target: ShellTarget | undefined,
+): target is Extract<ShellTarget, { kind: 'sandbox' }> {
+  return target?.kind === 'sandbox'
+}
+
+interface TargetChipProps {
+  target?: ShellTarget
+  /** exec/exec_bg (and their previews) set this: host is the privileged
+      execution surface approval decisions hinge on, so the default gets
+      an explicit chip. fs views omit it — host stays implicit and only
+      the sandbox deviation gets a chip. */
+  explicitHost?: boolean
+}
+
+/** Where the call runs. Label `on` (avoids colliding with sed's `target`
+    chip); neutral tone for both kinds — most calls are host, and a
+    permanently warn header reads as a perpetual alarm. `target` omitted
+    on the wire means host (serde default); normalised here so views
+    don't repeat the rule. */
+export function TargetChip({ target, explicitHost }: TargetChipProps) {
+  if (isSandboxTarget(target)) {
+    return (
+      <Chip label="on">{`sandbox ${truncateMiddle(target.sandbox_id, 12)}`}</Chip>
+    )
+  }
+  if (!explicitHost) return null
+  return <Chip label="on">host</Chip>
+}
+
+/** Sandbox-target responses fill `path`/`src`/`dst` with `""` — prefer
+    the canonicalised response path when present, else the request path. */
+export function displayPath(reqPath: string, respPath?: string): string {
+  return respPath && respPath.length > 0 ? respPath : reqPath
+}

--- a/console/web/src/stories/fixtures/shell-fixtures.ts
+++ b/console/web/src/stories/fixtures/shell-fixtures.ts
@@ -1,0 +1,478 @@
+import type { FunctionCallMessage } from '@/types/chat'
+import { wrapHarness } from './sandbox-fixtures'
+
+const now = Date.now()
+const JOB = 'job-9f8e7d6c-5b4a-4310-aedc-ba9876543210'
+const SANDBOX = 'a1b2c3d4-5e6f-4a8b-9c0d-e1f2a3b4c5d6'
+
+function base(
+  id: string,
+  functionId: string,
+  input: unknown,
+  output?: unknown,
+  extra?: Partial<FunctionCallMessage>,
+): FunctionCallMessage {
+  return {
+    id,
+    role: 'function-call',
+    functionId,
+    input,
+    output,
+    durationMs: 240,
+    createdAt: now,
+    ...extra,
+  }
+}
+
+export const shellExecDone = base(
+  'sh-exec',
+  'shell::exec',
+  {
+    command: 'ls -la',
+    cwd: '/srv/app',
+    timeout_ms: 30_000,
+  },
+  wrapHarness({
+    exit_code: 0,
+    stdout:
+      'total 8\ndrwxr-xr-x 2 app app 4096 May 26 10:00 .\ndrwxr-xr-x 1 app app 4096 May 26 09:58 ..\n-rw-r--r-- 1 app app   12 May 26 10:00 README.md\n',
+    stderr: '',
+    duration_ms: 142,
+    timed_out: false,
+    stdout_truncated: false,
+    stderr_truncated: false,
+  }),
+)
+
+export const shellExecArgvDone = base(
+  'sh-exec-argv',
+  'shell::exec',
+  {
+    command: 'git',
+    args: ['log', '--oneline', '-3'],
+    cwd: '/srv/app',
+    env: { GIT_PAGER: 'cat' },
+  },
+  {
+    exit_code: 0,
+    stdout:
+      '8fbe7a1 feat(console): friendly chat views\nab75f28 chore(coder): bump to v0.5.1\n82e1c5d chore(shell): bump to v0.5.0\n',
+    stderr: '',
+    duration_ms: 58,
+    timed_out: false,
+    stdout_truncated: false,
+    stderr_truncated: false,
+  },
+)
+
+export const shellExecSandboxDone = base(
+  'sh-exec-sandbox',
+  'shell::exec',
+  {
+    command: 'uname -a',
+    target: { kind: 'sandbox', sandbox_id: SANDBOX },
+  },
+  wrapHarness({
+    exit_code: 0,
+    stdout: 'Linux sandbox 6.1.0 #1 SMP x86_64 GNU/Linux\n',
+    stderr: '',
+    duration_ms: 35,
+    timed_out: false,
+    stdout_truncated: false,
+    stderr_truncated: false,
+  }),
+)
+
+export const shellExecRunning = base(
+  'sh-exec-running',
+  'shell::exec',
+  { command: 'npm test', cwd: '/srv/app' },
+  undefined,
+  { running: true },
+)
+
+export const shellExecPending = base(
+  'sh-exec-pending',
+  'shell::exec',
+  { command: 'rm -rf /tmp/scratch' },
+  undefined,
+  { pendingApproval: true },
+)
+
+export const shellExecBgDone = base(
+  'sh-exec-bg',
+  'shell::exec_bg',
+  { command: 'npm run build', cwd: '/srv/app' },
+  wrapHarness({ job_id: JOB, argv: ['npm', 'run', 'build'] }),
+)
+
+export const shellExecBgPending = base(
+  'sh-exec-bg-pending',
+  'shell::exec_bg',
+  { command: 'cargo build --release', cwd: '/srv/app' },
+  undefined,
+  { pendingApproval: true },
+)
+
+export const shellStatusFinishedDone = base(
+  'sh-status-finished',
+  'shell::status',
+  { job_id: JOB },
+  {
+    job: {
+      id: JOB,
+      argv: ['npm', 'run', 'build'],
+      started_at_ms: now - 9_500,
+      finished_at_ms: now - 1_200,
+      status: 'finished',
+      exit_code: 0,
+      stdout: '> build\n> vite build\n\ndist/index.html  0.46 kB\n',
+      stderr: '',
+      stdout_truncated: false,
+      stderr_truncated: false,
+    },
+  },
+)
+
+export const shellStatusRunningDone = base(
+  'sh-status-running',
+  'shell::status',
+  { job_id: JOB },
+  wrapHarness({
+    job: {
+      id: JOB,
+      argv: ['npm', 'run', 'build'],
+      started_at_ms: now - 3_000,
+      finished_at_ms: null,
+      status: 'running',
+      exit_code: null,
+      stdout: '> build\n> vite build\n',
+      stderr: '',
+      stdout_truncated: false,
+      stderr_truncated: false,
+    },
+  }),
+)
+
+export const shellKillDone = base(
+  'sh-kill',
+  'shell::kill',
+  { job_id: JOB },
+  wrapHarness({ job_id: JOB, killed: true, status: 'killed' }),
+)
+
+export const shellKillAlreadyFinished = base(
+  'sh-kill-finished',
+  'shell::kill',
+  { job_id: JOB },
+  {
+    job_id: JOB,
+    killed: false,
+    status: 'finished',
+    reason: 'job already finished',
+  },
+)
+
+export const shellKillPending = base(
+  'sh-kill-pending',
+  'shell::kill',
+  { job_id: JOB },
+  undefined,
+  { pendingApproval: true },
+)
+
+export const shellListDone = base(
+  'sh-list',
+  'shell::list',
+  {},
+  wrapHarness({
+    jobs: [
+      {
+        id: JOB,
+        status: 'running',
+        started_at_ms: now - 3_000,
+        finished_at_ms: null,
+        exit_code: null,
+        stdout_truncated: false,
+        stderr_truncated: false,
+      },
+      {
+        id: 'job-1a2b3c4d-0001-4000-8000-000000000001',
+        status: 'finished',
+        started_at_ms: now - 60_000,
+        finished_at_ms: now - 58_000,
+        exit_code: 0,
+        stdout_truncated: false,
+        stderr_truncated: false,
+      },
+      {
+        id: 'job-1a2b3c4d-0002-4000-8000-000000000002',
+        status: 'failed',
+        started_at_ms: now - 120_000,
+        finished_at_ms: now - 119_000,
+        exit_code: 1,
+        stdout_truncated: true,
+        stderr_truncated: false,
+      },
+    ],
+    count: 3,
+  }),
+)
+
+export const shellConfigStatusDone = base(
+  'sh-config-status',
+  'shell::config-status',
+  {},
+  { last_outcome: 'applied', last_error: null, rejected_reloads: 0 },
+)
+
+export const shellConfigStatusRejected = base(
+  'sh-config-status-rejected',
+  'shell::config-status',
+  {},
+  wrapHarness({
+    last_outcome: 'rejected',
+    last_error: 'jail_dir must be an absolute path',
+    rejected_reloads: 2,
+  }),
+)
+
+export const shellFsLsDone = base(
+  'sh-ls',
+  'shell::fs::ls',
+  { path: '/srv/app' },
+  {
+    entries: [
+      {
+        name: 'src',
+        is_dir: true,
+        size: 4096,
+        mode: '0755',
+        mtime: Math.floor(now / 1000) - 180,
+        is_symlink: false,
+      },
+      {
+        name: 'package.json',
+        is_dir: false,
+        size: 412,
+        mode: '0644',
+        mtime: Math.floor(now / 1000) - 60,
+        is_symlink: false,
+      },
+    ],
+  },
+)
+
+export const shellFsStatDone = base(
+  'sh-stat',
+  'shell::fs::stat',
+  { path: '/srv/app/package.json' },
+  // StatResponse is #[serde(transparent)] — a bare FsEntry, no wrapper key.
+  wrapHarness({
+    name: 'package.json',
+    is_dir: false,
+    size: 412,
+    mode: '0644',
+    mtime: Math.floor(now / 1000) - 60,
+    is_symlink: false,
+  }),
+)
+
+export const shellFsReadDone = base(
+  'sh-read',
+  'shell::fs::read',
+  { path: '/srv/app/src/index.ts' },
+  // ReadResponseWire: content is ALWAYS a streaming channel ref.
+  {
+    content: {
+      channel_id: 'chan-2f9c1b7e-aa00-4f00-9d00-7c6b5a493827',
+      access_key: 'ak_4f8e2d1c9b7a',
+      direction: 'read',
+    },
+    size: 48,
+    mode: '0644',
+    mtime: Math.floor(now / 1000) - 30,
+  },
+)
+
+export const shellFsWriteDone = base(
+  'sh-write',
+  'shell::fs::write',
+  { path: '/srv/app/out.txt', content: 'hello\n', parents: true },
+  wrapHarness({ bytes_written: 6, path: '/srv/app/out.txt', files: [] }),
+)
+
+export const shellFsWriteBatchDone = base(
+  'sh-write-batch',
+  'shell::fs::write',
+  {
+    files: [
+      { path: '/srv/app/a.txt', content: 'alpha\n' },
+      {
+        path: '/srv/app/b.txt',
+        content: {
+          channel_id: 'chan-77aa2bcd-bb11-4e22-8f33-9d44ee55ff66',
+          access_key: 'ak_streamed01',
+          direction: 'write',
+        },
+        mode: '0600',
+      },
+    ],
+  },
+  {
+    bytes_written: 26,
+    path: '',
+    files: [
+      { path: '/srv/app/a.txt', bytes_written: 6 },
+      { path: '/srv/app/b.txt', bytes_written: 20 },
+    ],
+  },
+)
+
+export const shellFsMkdirDone = base(
+  'sh-mkdir',
+  'shell::fs::mkdir',
+  { path: '/srv/app/nested/dir', parents: true, mode: '0755' },
+  { created: true, path: '/srv/app/nested/dir', already_existed: false },
+)
+
+export const shellFsRmDone = base(
+  'sh-rm',
+  'shell::fs::rm',
+  { path: '/srv/app/tmp', recursive: true },
+  wrapHarness({ removed: true, path: '/srv/app/tmp', was_present: true }),
+)
+
+export const shellFsMvDone = base(
+  'sh-mv',
+  'shell::fs::mv',
+  { src: '/srv/app/old.txt', dst: '/srv/app/new.txt', overwrite: true },
+  {
+    moved: true,
+    src: '/srv/app/old.txt',
+    dst: '/srv/app/new.txt',
+    overwrote: true,
+  },
+)
+
+export const shellFsChmodDone = base(
+  'sh-chmod',
+  'shell::fs::chmod',
+  { path: '/srv/app/scripts', mode: '0755', recursive: true },
+  { entries_changed: 3, path: '/srv/app/scripts', recursive: true },
+)
+
+export const shellFsGrepDone = base(
+  'sh-grep',
+  'shell::fs::grep',
+  {
+    path: '/srv/app',
+    pattern: 'TODO',
+    ignore_case: true,
+    include_glob: ['*.ts'],
+  },
+  wrapHarness({
+    matches: [
+      {
+        path: '/srv/app/src/app.ts',
+        line: 14,
+        content: '  // TODO: wire shell UI',
+      },
+      {
+        path: '/srv/app/src/jobs.ts',
+        line: 3,
+        content: '// TODO document job lifecycle',
+      },
+    ],
+    truncated: false,
+  }),
+)
+
+export const shellFsSedDone = base(
+  'sh-sed',
+  'shell::fs::sed',
+  {
+    files: ['/srv/app/a.txt', '/srv/app/b.txt'],
+    pattern: 'foo',
+    replacement: 'bar',
+    regex: false,
+  },
+  {
+    results: [
+      { path: '/srv/app/a.txt', replacements: 2, success: true },
+      {
+        path: '/srv/app/b.txt',
+        replacements: 0,
+        success: false,
+        error: 'permission denied',
+      },
+    ],
+    total_replacements: 2,
+  },
+)
+
+/** Flat SDK ErrorBody with a typed S-code (the direct error path). */
+export const shellExecJailError = base(
+  'sh-exec-jail-err',
+  'shell::exec',
+  { command: 'cat /etc/passwd', cwd: '/etc' },
+  wrapHarness({ code: 'S215', message: 'cwd escapes jail: /etc' }),
+)
+
+/** The real-world path: harness gate-denial envelope whose `reason`
+    embeds the S-code as text (`parseShellErrorDisplay` text-scan). */
+export const shellStatusGateError = base(
+  'sh-status-gate-err',
+  'shell::status',
+  { job_id: 'job-x' },
+  {
+    error: {
+      kind: 'function_error',
+      message: 'trigger_failed: IIIInvocationError: invocation_failed',
+      details: {
+        schema_version: 1,
+        status: 'denied',
+        denied_by: 'gate_unavailable',
+        function_id: 'shell::status',
+        reason: 'trigger_failed: IIIInvocationError: S211: no such job: job-x',
+      },
+      content: [
+        {
+          type: 'text',
+          text: 'trigger_failed: IIIInvocationError: S211: no such job: job-x',
+        },
+      ],
+    },
+  },
+)
+
+export const shellFixtures = [
+  shellExecDone,
+  shellExecArgvDone,
+  shellExecSandboxDone,
+  shellExecRunning,
+  shellExecPending,
+  shellExecBgDone,
+  shellExecBgPending,
+  shellStatusFinishedDone,
+  shellStatusRunningDone,
+  shellKillDone,
+  shellKillAlreadyFinished,
+  shellKillPending,
+  shellListDone,
+  shellConfigStatusDone,
+  shellConfigStatusRejected,
+  shellFsLsDone,
+  shellFsStatDone,
+  shellFsReadDone,
+  shellFsWriteDone,
+  shellFsWriteBatchDone,
+  shellFsMkdirDone,
+  shellFsRmDone,
+  shellFsMvDone,
+  shellFsChmodDone,
+  shellFsGrepDone,
+  shellFsSedDone,
+  shellExecJailError,
+  shellStatusGateError,
+] as const


### PR DESCRIPTION
## Summary

`shell::*` function calls in the console chat currently fall back to raw REQUEST/RESPONSE JSON panes. This adds a `shell/` renderer module covering all 16 shell worker functions with the same terminal-style visualization quality as the existing `sandbox`/`coder`/`web` modules.

## What's included

- **`console/web/src/components/chat/shell/`** — new module (`parsers.ts`, `format.ts`, `shared.tsx`, `index.tsx`, 16 view components, 2 test suites)
  - exec/job family: `ExecView` (+ approval preview), `ExecBgView` (`↻ started <job_id>` with copyable full job id, host-bg `timeout_ms ignored` hint), `StatusView` (full job record terminal), `KillView` (+ preview), `ListView` (jobs table), `ConfigStatusView`
  - fs family: ls / stat / mkdir / rm / chmod / mv / grep / sed / write (single + batch) / read (stream-only channel ref)
- **Wire-faithful schemas** — verified against the shell worker Rust source: `target` optional-not-nullable (serde default), kill `reason` skip-serialized, transparent `fs::stat`, chmod `updated`→`entries_changed` alias, `args` null-vs-`[]` tokenization semantics preserved, explicit `stdout_truncated`/`stderr_truncated` flags
- **Error rendering** — `parseShellErrorDisplay` recovers S-codes from flat `{code, message}` bodies *and* from harness gate-denial envelopes whose `reason` embeds the code as text (`trigger_failed: IIIInvocationError: S211: …`) — the path real shell errors take today; falls back to the shared sandbox error normalizer for denials
- **Sandbox refactors (additive only)** — export `collectErrorCandidates`, extract `FsEntriesTable`, `GrepMatchList`, `SedResultsTable` as reusable components; existing views become thin wrappers, suites stay green

## Test plan

- [x] `pnpm test` — 38 files, 717/717 (86 new tests pinning schema decisions + error paths)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — feature files clean
- [ ] Visual: run a conversation invoking `shell::exec` / `shell::exec_bg` and confirm terminal cards + S-code error cards (raw json tab still shows original payloads)

## Out of scope (flagged for follow-up)

`shell::fs::sed/mv/chmod/mkdir` are currently auto-acceptable in `lib/backend/auto-accept-policy.ts` despite mutating the host fs — intentionally left untouched per discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full shell tool UI: exec (foreground/background), status, kill, list, config-status, and rich filesystem ops (ls/stat/read/mkdir/rm/mv/chmod/grep/sed/write) with improved terminal/chips/footers and previews.
* **Refactor**
  * Extracted and reorganized view/table components for cleaner rendering and reuse.
* **Tests**
  * Added unit tests for shell formatting and parser/validation behavior.
* **Documentation**
  * Added Storybook fixtures and a Shell family story for visual testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->