### PR TITLE
docs(codex, claude-code): absolute raw URLs for README images

### DIFF
--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -68,11 +68,11 @@ iii trigger claude::run --help
 
 A turn from the CLI and the session record it leaves behind:
 
-![iii trigger claude::run returning the result with usage and cost](assets/cli-run.png)
+![iii trigger claude::run returning the result with usage and cost](https://raw.githubusercontent.com/iii-hq/workers/main/claude-code/assets/cli-run.png)
 
-![iii trigger claude::status showing the stored session record](assets/cli-status.png)
+![iii trigger claude::status showing the stored session record](https://raw.githubusercontent.com/iii-hq/workers/main/claude-code/assets/cli-status.png)
 
-![iii trigger claude::run --help printing the published request schema as a parameter table](assets/cli-help.png)
+![iii trigger claude::run --help printing the published request schema as a parameter table](https://raw.githubusercontent.com/iii-hq/workers/main/claude-code/assets/cli-help.png)
 
 Call `claude::run` again with the returned `session_id` to continue the same conversation: the worker maps iii session ids to Claude Code session ids in engine state and resumes automatically.
 
@@ -171,7 +171,7 @@ With `approval_gate: true` and the harness worker installed, every Claude Code t
 
 Every `claude::run` is an ordinary traced invocation on the engine: the trace carries the full input payload (prompt, cwd, caller worker id) and the output (result, stop reason, token usage, cost) as span events, with per-function p50/p95/p99 in the console's trace explorer — no extra instrumentation in the worker.
 
-![claude::run invocations in the iii console trace explorer, with input and output payloads](assets/console-traces.png)
+![claude::run invocations in the iii console trace explorer, with input and output payloads](https://raw.githubusercontent.com/iii-hq/workers/main/claude-code/assets/console-traces.png)
 
 ## How it maps
 

--- a/codex/README.md
+++ b/codex/README.md
@@ -68,9 +68,9 @@ iii trigger codex::run --help
 
 A turn from the CLI and the published schema:
 
-![iii trigger codex::run returning the result with usage and reasoning tokens](assets/cli-run.png)
+![iii trigger codex::run returning the result with usage and reasoning tokens](https://raw.githubusercontent.com/iii-hq/workers/main/codex/assets/cli-run.png)
 
-![iii trigger codex::run --help printing the published request schema as a parameter table](assets/cli-help.png)
+![iii trigger codex::run --help printing the published request schema as a parameter table](https://raw.githubusercontent.com/iii-hq/workers/main/codex/assets/cli-help.png)
 
 Call `codex::run` again with the returned `session_id` to continue the same conversation: the worker maps iii session ids to Codex thread ids in engine state and resumes automatically (threads persist in `~/.codex/sessions`).
 
@@ -159,7 +159,7 @@ The approval step is whatever sits between the two calls — a human reading the
 
 Every `codex::run` is an ordinary traced invocation on the engine: the trace carries the full input payload and the output (result, usage) as span events, with per-function p50/p95/p99 in the console's trace explorer — no extra instrumentation in the worker.
 
-![codex::run invocations in the iii console trace explorer, with input and output payloads](assets/console-traces.png)
+![codex::run invocations in the iii console trace explorer, with input and output payloads](https://raw.githubusercontent.com/iii-hq/workers/main/codex/assets/console-traces.png)
 
 ## How it maps
 


### PR DESCRIPTION
Relative assets/ paths render only on GitHub; the workers.iii.dev registry stores the README text alone, so the relative image links 404 there (broken-image icons). Point both workers' README images at raw.githubusercontent.com/iii-hq/workers/main/<worker>/assets so they resolve on GitHub and the registry alike.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all embedded screenshot and image references in project documentation files to use a more reliable and sustainable hosting solution. This enhances the availability and consistency of visual resources across all documentation, including CLI command guides, debugging tools documentation, and feature walkthroughs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->