### PR TITLE
fix(claude-code): drop scripts.install from the bundle manifest

### DIFF
--- a/claude-code/iii.worker.yaml
+++ b/claude-code/iii.worker.yaml
@@ -9,8 +9,7 @@ runtime:
   kind: javascript
 
 scripts:
-  install: npm install && npm run build
-  start: node dist/index.js
+  start: node ./index.mjs
 
 dependencies:
   iii-state: "^0.17.0"


### PR DESCRIPTION
iii worker add claude-code fails at install: the engine rejects scripts.install for bundle workers (deps must be vendored, which esbuild already does). Match the harness bundle manifest — no install script, start: node ./index.mjs (the staged single-file artifact). Verified end to end: the bundle artifact boots via that command and runs a claude::run turn against a live engine. Unblocks the registry install.