### PR TITLE
docs: update configuration documentation for Path A and Path B integr…

### DIFF
--- a/docs/sops/README.md
+++ b/docs/sops/README.md
@@ -7,7 +7,7 @@ YAML, **the workflow wins** — update these docs.
 |---|---|
 | [`new-worker.md`](new-worker.md) | First read when adding any worker — naming, repo wiring, CI, release checklist |
 | [`binary-worker.md`](binary-worker.md) | Scaffolding a Rust `deploy: binary` daemon (layout, functions, triggers, tests) |
-| [`configuration.md`](configuration.md) | Integrating a worker with the `configuration` worker (schema-validated, hot-reloadable, shared config) |
+| [`configuration.md`](configuration.md) | Integrating a worker with the `configuration` worker (schema-validated, hot-reloadable, shared config). Workers on the configuration worker do not ship a `config.yaml`; the registry and console own live config. |
 | [`release.md`](release.md) | Cutting a version, re-running a failed release, troubleshooting publish |
 
 ## Typical flow

--- a/docs/sops/binary-worker.md
+++ b/docs/sops/binary-worker.md
@@ -46,10 +46,12 @@ prefix it with `iii-`.
 - `iii.worker.yaml` — registry manifest. See section 3.
 - `Cargo.toml` — crate manifest with one `[[bin]]`. See section 4.
 - `build.rs` — exposes the build-time `TARGET` triple to the binary. See section 4.
-- `config.yaml` — operator-facing runtime config (commit it; it is the default
-  loaded by `--config ./config.yaml`). See section 5.
+- `config.yaml` — **Path A only** (static config): operator-facing runtime
+  config, committed, loaded by `--config ./config.yaml`. **Path B** (configuration
+  worker): omit — see section 5 and [`configuration.md`](configuration.md).
 - `src/main.rs` — entry point. See section 6.
-- `src/config.rs` — `Config` struct + `load_config`. See section 5.
+- `src/config.rs` — `Config` struct; Path A adds `load_config`. Path B adds
+  `json_schema()` / `from_json` / `boot_signature()`. See section 5.
 - `src/manifest.rs` — `build_manifest()` for the `--manifest` subcommand. See section 5.
 - `src/state.rs` — thin `state::get` / `state::set` wrappers around `iii.trigger()`. Optional but recommended. See section 7.
 - `src/functions/mod.rs` — `register_all(...)` plus one `register_<verb>` per function. See section 7.
@@ -192,7 +194,27 @@ triple.
 
 ## 5. Config: `config.yaml` + `src/config.rs` + `src/manifest.rs`
 
-### `config.yaml`
+Two paths. Pick one per worker; do not mix them in production boot.
+
+**Path A (baseline — static config)** — for simple workers not on the
+configuration worker yet (e.g. `todo-worker`, unreleased scaffolds):
+
+- Committed `config.yaml` + `load_config()` + `--config` default `./config.yaml`
+- Sections below through "Reactive config" describe Path A.
+
+**Path B (configuration worker — preferred for production workers)** — see
+[`configuration.md`](configuration.md) for the full recipe:
+
+- **No** committed `config.yaml`
+- **No** `load_config()` in the production boot path
+- `--config` is `Option<String>` (no default path); optional one-time seed only
+- `register_config` + `fetch_config` are **required** boot dependencies
+- Choose reload tier: ConfigCell-only vs full runtime swap (+ resync)
+
+Reference: `session-manager` (Path B, full runtime + resync), `context-manager`
+(Path B, ConfigCell-only).
+
+### `config.yaml` (Path A only)
 
 Operator-facing defaults, committed alongside the worker:
 
@@ -268,18 +290,21 @@ You may **additionally** cover `--manifest` by spawning the binary from
 `tests/manifest.rs` (pattern A, section 9); that is optional if unit tests
 already enforce the JSON contract.
 
-### Reactive config via the `configuration` worker
+### Path B — reactive config via the `configuration` worker
 
-The static `config.yaml` + `load_config` pattern above is the baseline. When a
-worker needs a **schema-validated, observable, hot-reloadable** config that
-other workers and the operator console can read and edit on a live bus,
-migrate its block to the built-in **`configuration` worker** instead: register
-a JSON Schema, fetch the authoritative value at boot, and hot-reload on change.
-`config.yaml` then becomes a SEED, not the source of truth, and `src/config.rs`
-gains `json_schema()` / `to_json` / `from_json` / `boot_signature()` alongside
-`load_config`. See [`configuration.md`](configuration.md) for the full recipe;
+When a worker needs a **schema-validated, observable, hot-reloadable** config
+that other workers and the operator console can read and edit on a live bus,
+use **Path B**: migrate to the built-in **`configuration` worker**. Register a
+JSON Schema, fetch the authoritative value at boot, and hot-reload on change.
+
+Path B **does not ship** `config.yaml`. Defaults live in
+`WorkerConfig::default()` and are registered as `initial_value` only when
+nothing is stored yet. `src/config.rs` gains `json_schema()` / `to_json` /
+`from_json` / `boot_signature()`; production boot does not call `load_config()`.
+See [`configuration.md`](configuration.md) for reload tiers and boot order;
 `session-manager`, `context-manager`, `shell`, `storage`, `database`, and
-`coder` follow it.
+`coder` follow Path B (some older workers still ship a legacy seed file — do
+not mirror that for new integrations).
 
 ## 6. `src/main.rs`: the entry point
 
@@ -287,14 +312,21 @@ The entry point must:
 
 1. **Initialise tracing**: `tracing_subscriber::fmt().with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"))).init();`. Operators tune via `RUST_LOG`.
 2. **Parse CLI** with clap derive. Required flags:
-   - `--config <PATH>` (default `./config.yaml`)
+   - **Path A:** `--config <PATH>` (default `./config.yaml`)
+   - **Path B:** `--config <PATH>` optional seed only — no default path:
+
+     ```rust
+     #[arg(long)]
+     config: Option<String>,   // optional seed; no default path
+     ```
+
    - `--url <URL>` (default `ws://127.0.0.1:49134`)
    - `--manifest` (boolean)
 3. **Handle `--manifest`**: if set, print
    `serde_json::to_string_pretty(&manifest::build_manifest()).unwrap()` and
    `return Ok(())`. **No engine connection.** This path is what the registry
    publish pipeline calls; it must be fast and side-effect-free.
-4. **Load config**, falling back to defaults on error:
+4. **Load config** (Path A), falling back to defaults on error:
 
    ```rust
    let cfg = match config::load_config(&cli.config) {
@@ -306,6 +338,9 @@ The entry point must:
    };
    let cfg = std::sync::Arc::new(cfg);
    ```
+
+   **Path B:** connect first, then `register_config(cli.config.as_deref())` +
+   `fetch_config()` — see [`configuration.md`](configuration.md) §4c.
 
 5. **Connect to iii** with **`WorkerMetadata` required** — operators and the
    registry rely on a stable identity line for your process:
@@ -668,11 +703,14 @@ async fn boot() -> Option<Harness> {
     sleep(Duration::from_millis(800)).await;
 
     let worker_bin = env!("CARGO_BIN_EXE_<worker_underscored>");
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let config_path = format!("{manifest_dir}/config.yaml");
 
+    // Path A: pass --config with a test fixture or config.yaml.
+    // Path B (configuration worker): omit --config unless testing seed
+    // semantics — the engine's configuration worker holds authoritative config.
     let worker = Command::new(worker_bin)
-        .args(["--url", ENGINE_WS, "--config", &config_path])
+        .arg("--url")
+        .arg(ENGINE_WS)
+        // .args(["--config", &config_path])   // Path A only
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
@@ -939,7 +977,7 @@ fn main() {
 }
 ```
 
-### `<worker>/config.yaml`
+### `<worker>/config.yaml` (Path A only; omit for Path B)
 
 ```yaml
 greeting: "hello"
@@ -1261,11 +1299,11 @@ async fn boot() -> Option<Harness> {
     sleep(Duration::from_millis(800)).await;
 
     let worker_bin = env!("CARGO_BIN_EXE_<worker_underscored>");
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let config_path = format!("{manifest_dir}/config.yaml");
 
+    // Path A: pass --config. Path B: omit unless testing seed semantics.
     let worker = Command::new(worker_bin)
-        .args(["--url", ENGINE_WS, "--config", &config_path])
+        .arg("--url")
+        .arg(ENGINE_WS)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()

--- a/docs/sops/configuration.md
+++ b/docs/sops/configuration.md
@@ -1,13 +1,13 @@
 # Integrating a worker with the `configuration` worker
 
-How to move a worker's runtime config out of a static `config.yaml` and onto
-the built-in **`configuration`** worker: a schema-validated, reactive registry
-that other workers and the operator console can read, validate, and edit on a
-live bus.
+How to move a worker's runtime config off a static, committed `config.yaml` and
+onto the built-in **`configuration`** worker: a schema-validated, reactive
+registry that other workers and the operator console can read, validate, and
+edit on a live bus.
 
 This is the **advanced** alternative to the baseline static-config pattern in
-[`binary-worker.md`](binary-worker.md) §5. Reach for it when config must be
-observable, hot-reloadable, or shared. Reference implementations:
+[`binary-worker.md`](binary-worker.md) §5 Path A. Reach for it when config must
+be observable, hot-reloadable, or shared. Reference implementations:
 `session-manager`, `context-manager`, `shell`, `storage`, `database`, `coder`.
 
 ## 1. What the `configuration` worker is
@@ -42,7 +42,31 @@ by default in the engine.
 - Schemas are not version-checked across re-registrations — re-registering with
   an incompatible schema replaces it. Coordinate migrations out-of-band.
 
-## 2. Function surface
+## 2. Source of truth
+
+After first boot, the **`configuration` worker** is the only authoritative
+runtime config. Nothing in the worker repo is loaded by default at runtime.
+
+| What | Role |
+|------|------|
+| `./data/configuration/<id>.yaml` | Persisted value (configuration worker fs adapter) |
+| `WorkerConfig::default()` | Built-in defaults; registered as `initial_value` only when no stored value exists yet |
+| `--config <path>` (CLI) | **Optional one-time seed** for `initial_value` on first registration; never overwrites an existing stored value |
+| Console Configuration tab | Same store via `configuration::set` |
+| Committed `<worker>/config.yaml` | **Do not ship** once integrated — omit from the repo |
+
+Boot flow: `register_config` declares the schema (+ optional seed) →
+`fetch_config` reads the authoritative, env-expanded value → the worker builds
+its runtime from that. A failed register/fetch is **fatal** (required boot
+dependency).
+
+Optional `--config` behaviour (see [`session-manager/src/main.rs`](../../session-manager/src/main.rs)):
+
+- Parse failure **warns** and falls through to no seed (the stored value or
+  built-in default applies).
+- Re-registration on every boot is safe: an existing stored value is preserved.
+
+## 3. Function surface
 
 All ids are kebab-case (`<worker>::<verb>`), per [`binary-worker.md`](binary-worker.md) §7:
 
@@ -61,81 +85,123 @@ All ids are kebab-case (`<worker>::<verb>`), per [`binary-worker.md`](binary-wor
 `${VAR:default}` against the live process env on every call, so env changes
 propagate without a restart.
 
-## 3. The integration recipe (Rust binary)
+## 4. The integration recipe (Rust binary)
 
 ### a. `src/config.rs` — make the config schema-able and splittable
 
 Keep the `WorkerConfig` struct + `serde(default)` + `default_*()` +
-`impl Default` from [`binary-worker.md`](binary-worker.md) §5, then add:
+`impl Default` from [`binary-worker.md`](binary-worker.md) §5 Path A, then add:
 
 - Derive **`Serialize` + `JsonSchema`** (alongside `Deserialize`); keep
   `#[serde(deny_unknown_fields)]`.
 - `from_yaml(&str)` / `from_file(&str)` — env-expand `${NAME}` against the
-  process env, then parse. This is the SEED path only.
-- `from_json(&Value)` — parse a value already env-expanded by the worker (do
-  **not** re-expand).
+  process env, then parse. Used only for the optional `--config` seed path.
+- `from_json(&Value)` — parse a value already env-expanded by the
+  configuration worker (do **not** re-expand).
 - `to_json(&self) -> Value` and `json_schema() -> Value` (a
   `schemars::schema_for!` with the shipped defaults attached as `example`).
-- `boot_signature(&self) -> BootSignature` — the fields consumed **once at
-  boot** (adapters built then and never rebuilt). Everything else is a per-call
-  tuning knob that can hot-reload. If every field is boot-time, the signature is
-  the whole config and all changes are restart-required.
+- `boot_signature(&self) -> BootSignature` — a **comparison key** for the
+  adapter/topology half of config (see §6). On reload: equal signature → cheap
+  tuning-only path; different signature → runtime rebuild (if supported) or
+  refuse (if not).
+
+Path B workers do **not** need `load_config()` in the production boot path.
 
 ### b. `src/configuration.rs` — the integration module
 
-Mirror [`context-manager/src/configuration.rs`](../../context-manager/src/configuration.rs).
-Provide:
+Pick a **reload tier** (§6) and mirror the matching reference:
 
-- `pub type ConfigCell = Arc<RwLock<Arc<WorkerConfig>>>` — the hot-swappable
-  snapshot shared with handlers.
-- `CONFIG_ID = "<worker>"`, `CONFIG_FN_ID = "<worker>::on-config-change"`, and
-  retry/backoff constants.
+**Tier 1 — ConfigCell-only** ([`context-manager/src/configuration.rs`](../../context-manager/src/configuration.rs)):
+
+- `pub type ConfigCell = Arc<RwLock<Arc<WorkerConfig>>>`
+- `register_config(iii, seed)`, `fetch_config(iii)`
+- `apply_config(cell, cfg)` / `reloadable(cfg, boot_sig)` — swap the snapshot;
+  **refuse** boot-signature changes (restart required for adapter/topology).
+- `register_config_trigger(iii, cell, boot_sig)`
+
+**Tier 2 — Full runtime swap** ([`session-manager/src/configuration.rs`](../../session-manager/src/configuration.rs), [`shell/src/configuration.rs`](../../shell/src/configuration.rs)):
+
+- `AppState { runtime: Arc<RwLock<SessionRuntime>>, ctx, reload_lock, reload_status }`
+- `build_runtime(cfg, ctx) -> Result<SessionRuntime, String>` — pure wiring
+  extracted from `main.rs`
+- `apply_runtime(state, cfg)` / `reload_serialized` — fetch under lock, build,
+  swap; last-good on failure
+- Handlers read the live runtime per call (not captured at registration)
+- Optional `<worker>::config-status` exposing `ReloadStatus` (mirror shell)
+- **Post-reload resync** when subscribers reconcile from triggers
+  ([`session-manager/src/resync.rs`](../../session-manager/src/resync.rs)):
+  after an adapter swap, replay the new store's state through the local emitter
+  so open views stay live without a refetch
+
+Common to both tiers:
+
+- `CONFIG_ID = "<worker>"`, `CONFIG_FN_ID = "<worker>::on-config-change"`, retry/backoff constants.
 - `register_config(iii, seed)` — register `json_schema()`; install `seed` as
-  `initial_value` when present, else seed the built-in default only when no
+  `initial_value` when present, else seed `WorkerConfig::default()` only when no
   value is stored yet (safe to call every boot).
 - `fetch_config(iii)` — read the authoritative, env-expanded value
   (`NOT_FOUND` ⇒ built-in default).
-- `apply_config(cell, cfg)` / `reloadable(cfg, boot_sig)` — swap the snapshot,
-  refusing any change to the boot signature (restart required).
-- `register_config_trigger(iii, cell, boot_sig)` — register the
-  `<worker>::on-config-change` handler and bind a `configuration` trigger
-  filtered to this id (see §4). The handler **re-fetches** via
+- `register_config_trigger` — register `<worker>::on-config-change` and bind a
+  `configuration` trigger (see §5). The handler **re-fetches** via
   `configuration::get` and ignores the trigger payload, so a direct call can
   never inject config.
 
 ### c. `src/main.rs` — boot order
 
+**Tier 1 (ConfigCell-only):**
+
 ```text
-1. parse CLI (--config is now only a SEED)
+1. parse CLI (--config optional seed only)
 2. connect to the engine
 3. register_config(seed)  +  fetch_config()        # required boot dependency
-4. resolve adapters from the fetched config (capture boot_signature first)
+4. resolve adapters from the fetched config
 5. build the ConfigCell; register functions
-6. register_config_trigger(cell, boot_sig)         # LAST — closes over the cell
+6. register_config_trigger                         # LAST
+```
+
+**Tier 2 (full runtime swap):**
+
+```text
+1. parse CLI (--config optional seed only)
+2. connect
+3. register_config(seed) + fetch_config()         # fatal
+4. register trigger types (+ internal feeds if applicable)
+5. build_runtime → AppState
+6. register protocol handlers (mode-gated if applicable) + functions (read AppState per call)
+7. register_config_trigger + config-status
 ```
 
 `configuration` is a **required boot dependency**: a failed register/fetch
-aborts startup. Build the `ConfigCell` once and share it between the service
-and the trigger so a live `set` of a tuning knob is picked up per call. Bind the
-trigger **last** so its handler closes over the fully-built cell.
+aborts startup. Bind the configuration trigger **last** so handlers close over
+fully-built state.
 
-### d. `config.yaml` — now a SEED
+### d. No shipped `config.yaml`
 
-Add a header making clear it is not the source of truth: it only populates
-`initial_value` on the first `configuration::register` (when nothing is stored
-for the id). After that the stored value is authoritative; edit it with
-`configuration::set id=<worker>` or by editing the persisted file. Mirror
-[`coder/config.yaml`](../../coder/config.yaml).
+Integrated workers **omit** `config.yaml` from the repo. Defaults live in
+`WorkerConfig::default()` and appear in `json_schema()` as the top-level
+`example`.
 
-### e. `iii-permissions.yaml` — deny the reload hook
+Seeding options (pick one):
 
-`<worker>::on-config-change` must never be agent-callable; add
-`'!<worker>::on-config-change'` next to the existing
-`'!storage::on-config-change'` / `'!database::on-config-change'` denies. It is
-defense-in-depth: the handler already re-fetches from `configuration::get`, so a
-direct call cannot inject config.
+1. Built-in default on first `configuration::register` (when nothing stored).
+2. Optional `--config <path>` one-time seed at first boot.
+3. Operator `configuration::set` or edit of `./data/configuration/<id>.yaml`
+   before the worker starts.
 
-## 4. Reactive triggers
+A local seed file for development may exist but should stay **uncommitted** or
+live under docs/examples — it is not loaded by default at runtime. Some older
+workers (e.g. `coder`) still ship a `config.yaml`; treat that as legacy, not the
+pattern for new integrations.
+
+### e. `iii-permissions.yaml` — deny reload hooks
+
+Add defense-in-depth denies next to the existing storage/database/shell entries:
+
+- `'!<worker>::on-config-change'` — must never be agent-callable.
+- `'!<worker>::config-status'` — operator/automation health signal, not an
+  agent tool (precedent: `session-manager`, `shell`).
+
+## 5. Reactive triggers
 
 Bind a `configuration` trigger when a function should run on every
 register/set/delete — including external `fs` edits and bridge-forwarded events:
@@ -157,26 +223,74 @@ function that wrote it, `configuration::set` already returns
 `old_value` / `new_value` — bind a trigger only when a *different* component
 should react.
 
-## 5. Hot-reload vs restart-required
+## 6. Hot-reload tiers and outcomes
 
-The **boot signature** (§3a) is the contract: on `configuration:updated`,
-`on-config-change` re-fetches and, when the boot signature is unchanged, swaps
-the snapshot so handlers read new tuning knobs per call. A boot-signature change
-is **refused** (logged "restart required", the previous snapshot kept) — those
-adapters are built once at boot. Always keep the previous snapshot on any
-failure path; never serve a half-applied config.
+### Reload tiers by worker
 
-## 6. Checklist
+| Worker | Tier | Adapter / topology hot reload |
+|--------|------|-------------------------------|
+| `context-manager` | ConfigCell-only | restart required |
+| `storage` | partial runtime | topology frozen; connection settings reload |
+| `shell`, `database` | full runtime swap | yes |
+| **`session-manager`** | full runtime + **resync** | yes (fs/bridge, `data_dir`, bridge `url`/`timeout_ms`) |
+
+```mermaid
+sequenceDiagram
+    participant Config as configuration_worker
+    participant Handler as on_config_change
+    participant State as AppState
+    participant Build as build_runtime
+
+    Config->>Handler: configuration:updated
+    Handler->>State: reload_lock.acquire
+    Handler->>Config: fetch_config
+    alt adapter unchanged
+        Handler->>State: swap ConfigCell only
+    else adapter changed
+        Handler->>Build: build_runtime
+        Build->>State: swap SessionRuntime
+        Build->>State: resync_triggers
+    end
+```
+
+### Outcomes on `configuration:updated`
+
+1. **Applied** — the live runtime reflects the fetched config.
+2. **Tuning-only reload** — boot signature unchanged; `ConfigCell` swap only
+   (Tier 1, or Tier 2 list-limit fields).
+3. **Runtime rebuild** — boot signature changed; `build_runtime` + swap (+ resync
+   when subscribers reconcile from triggers).
+4. **Rejected** — build failed; previous runtime kept (last-good); surfaced via
+   `<worker>::config-status` (`last_outcome: rejected`, `last_error`, cumulative
+   `rejected_reloads`).
+
+Always keep the previous runtime/snapshot on any failure path; never serve a
+half-applied config. Reloads are serialized (`reload_lock`) and re-fetch inside
+the lock so overlapping events converge to the latest authoritative value.
+
+### Operator risks (Tier 2 + resync)
+
+- Changing `data_dir` or bridge `url` switches backing storage immediately; **no
+  data migration**.
+- fs→bridge on an instance acting as **main** for other bridges breaks attached
+  bridged instances.
+- Large stores may emit a brief trigger burst on resync (acceptable for rare
+  operator config changes).
+
+## 7. Checklist
 
 - [ ] `WorkerConfig` derives `Serialize` + `JsonSchema`; has
       `from_yaml`/`from_file`/`from_json`/`to_json`/`json_schema`/`boot_signature`.
-- [ ] `src/configuration.rs` mirrors the reference: register / fetch / trigger /
-      reloadable + a `ConfigCell`.
-- [ ] `main.rs`: connect → register+fetch (fatal on failure) → build adapters →
-      register functions → bind the `configuration` trigger last.
-- [ ] `config.yaml` carries a SEED header; it is no longer the source of truth.
-- [ ] `'!<worker>::on-config-change'` denied in `iii-permissions.yaml`.
-- [ ] README "Configuration" section documents the id, the hot-reload vs
-      restart-required split, and the seed semantics.
-- [ ] Unit tests cover `boot_signature` (tuning-only vs restart-required) and a
-      JSON round-trip; they run engine-free in CI.
+- [ ] **No committed `config.yaml`**; `WorkerConfig::default()` seeds first boot.
+- [ ] `src/configuration.rs` implements the chosen reload tier (Tier 1:
+      `ConfigCell` + `reloadable`; Tier 2: `AppState` + `build_runtime` +
+      `reload_serialized` + optional resync).
+- [ ] `main.rs`: connect → register+fetch (fatal) → build runtime → register
+      functions → bind configuration trigger (+ `config-status` for Tier 2) last.
+- [ ] `'!<worker>::on-config-change'` and `'!<worker>::config-status'` denied in
+      `iii-permissions.yaml`.
+- [ ] README "Configuration" section documents the id, reload tier, persistence
+      path, and operator risks.
+- [ ] Unit tests cover `boot_signature` (tuning-only vs adapter change), JSON
+      round-trip, and (Tier 2) adapter rebuild / rejected reload keeps runtime /
+      resync emits triggers; they run engine-free in CI.

--- a/docs/sops/new-worker.md
+++ b/docs/sops/new-worker.md
@@ -30,7 +30,7 @@ Every worker needs a top-level folder with:
 |---|---|---|
 | `iii.worker.yaml` | yes | Registry + CI metadata |
 | Version manifest | yes | `Cargo.toml`, `package.json`, or `pyproject.toml` per `manifest:` |
-| `config.yaml` | yes | Operator defaults (or equivalent for container workers). For schema-validated, hot-reloadable, or shared config, migrate to the [`configuration`](configuration.md) worker — `config.yaml` becomes a seed |
+| `config.yaml` | **Path A (static config):** yes — operator defaults, committed | **Path B (configuration worker):** **no** — omit; use `WorkerConfig::default()` + configuration worker; optional uncommitted local seed. See [`configuration.md`](configuration.md); `session-manager` is Path B |
 | `tests/` (non-empty) | yes | See §5 |
 | `README.md` | yes | Per [`worker-readme.md`](../../worker-readme.md) |
 


### PR DESCRIPTION
…ation

- Clarified the distinction between Path A (static config) and Path B (configuration worker) in `binary-worker.md`, emphasizing the removal of `config.yaml` for Path B.
- Enhanced the `configuration.md` to detail the authoritative role of the configuration worker and the boot flow for integrating workers.
- Updated `new-worker.md` to reflect the changes regarding `config.yaml` usage in both paths.
- Improved overall documentation for better understanding of the configuration management process in the context of worker integration.