### PR TITLE
ci(lsp-vscode): support partial release retries

### DIFF
--- a/.github/workflows/release-lsp-vscode.yml
+++ b/.github/workflows/release-lsp-vscode.yml
@@ -10,12 +10,22 @@ on:
         description: 'Tag to release (e.g., lsp-vscode/v1.0.0)'
         required: true
         type: string
+      publish_target:
+        description: 'Publish target to run for an existing tag'
+        required: true
+        type: choice
+        options:
+          - all
+          - vscode-marketplace
+          - openvsx
+          - github-release
+        default: all
 
 permissions:
   contents: write
 
 concurrency:
-  group: release-vscode-${{ github.ref }}
+  group: release-lsp-vscode-${{ inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -27,20 +37,28 @@ jobs:
       version: ${{ steps.meta.outputs.version }}
       is_prerelease: ${{ steps.meta.outputs.is_prerelease }}
       dry_run: ${{ steps.meta.outputs.dry_run }}
+      publish_target: ${{ steps.resolve.outputs.publish_target }}
     steps:
       - name: Resolve tag
         id: resolve
         env:
           RAW_TAG: ${{ inputs.tag || github.ref_name }}
+          RAW_PUBLISH_TARGET: ${{ inputs.publish_target || 'all' }}
         run: |
           TAG=$(echo "$RAW_TAG" | xargs)
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "publish_target=$RAW_PUBLISH_TARGET" >> "$GITHUB_OUTPUT"
 
       - name: Extract metadata from tag
         id: meta
         env:
           TAG: ${{ steps.resolve.outputs.tag }}
         run: |
+          if [[ ! "$TAG" =~ ^lsp-vscode/v[0-9]+\.[0-9]+\.[0-9]+([-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid lsp-vscode release tag: $TAG"
+            exit 1
+          fi
+
           VERSION="${TAG#lsp-vscode/v}"
 
           if [[ "$VERSION" =~ -dry-run\.[0-9]+$ ]]; then
@@ -57,8 +75,8 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "::notice::lsp-vscode release -- tag=$TAG version=$VERSION"
 
-  publish:
-    name: Package & Publish
+  package:
+    name: Package VSIX
     needs: [setup]
     runs-on: ubuntu-latest
     defaults:
@@ -66,6 +84,8 @@ jobs:
         working-directory: lsp-vscode
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.setup.outputs.tag }}
 
       - uses: actions/setup-node@v4
         with:
@@ -91,20 +111,88 @@ jobs:
       - name: Package VSIX
         run: npx @vscode/vsce package --out iii-lsp-${{ needs.setup.outputs.version }}.vsix
 
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: iii-lsp-vsix-${{ needs.setup.outputs.version }}
+          path: lsp-vscode/iii-lsp-${{ needs.setup.outputs.version }}.vsix
+          if-no-files-found: error
+
+  publish-vscode:
+    name: Publish VS Code Marketplace
+    needs: [setup, package]
+    if: needs.setup.outputs.dry_run != 'true' && (needs.setup.outputs.publish_target == 'all' || needs.setup.outputs.publish_target == 'vscode-marketplace')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: lsp-vscode
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.setup.outputs.tag }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: iii-lsp-vsix-${{ needs.setup.outputs.version }}
+          path: lsp-vscode/dist
+
       - name: Publish to VS Code Marketplace
-        if: needs.setup.outputs.dry_run != 'true'
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: npx @vscode/vsce publish --pat "$VSCE_PAT"
+        run: npx @vscode/vsce publish --pat "$VSCE_PAT" --packagePath dist/iii-lsp-${{ needs.setup.outputs.version }}.vsix
+
+  publish-openvsx:
+    name: Publish OpenVSX
+    needs: [setup, package]
+    if: needs.setup.outputs.dry_run != 'true' && (needs.setup.outputs.publish_target == 'all' || needs.setup.outputs.publish_target == 'openvsx')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: lsp-vscode
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.setup.outputs.tag }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: iii-lsp-vsix-${{ needs.setup.outputs.version }}
+          path: lsp-vscode/dist
 
       - name: Publish to OpenVSX
-        if: needs.setup.outputs.dry_run != 'true'
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
-        run: npx ovsx publish iii-lsp-${{ needs.setup.outputs.version }}.vsix --pat "$OVSX_PAT"
+        run: npx ovsx publish dist/iii-lsp-${{ needs.setup.outputs.version }}.vsix --pat "$OVSX_PAT"
+
+  github-release:
+    name: Upload GitHub Release
+    needs: [setup, package]
+    if: needs.setup.outputs.dry_run != 'true' && (needs.setup.outputs.publish_target == 'all' || needs.setup.outputs.publish_target == 'github-release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: iii-lsp-vsix-${{ needs.setup.outputs.version }}
+          path: lsp-vscode/dist
 
       - name: Upload VSIX to GitHub Release
-        if: needs.setup.outputs.dry_run != 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.setup.outputs.tag }}
@@ -112,4 +200,4 @@ jobs:
           draft: false
           prerelease: ${{ needs.setup.outputs.is_prerelease == 'true' }}
           generate_release_notes: true
-          files: lsp-vscode/iii-lsp-${{ needs.setup.outputs.version }}.vsix
+          files: lsp-vscode/dist/iii-lsp-${{ needs.setup.outputs.version }}.vsix

--- a/docs/sops/release.md
+++ b/docs/sops/release.md
@@ -3,6 +3,7 @@
 **Sources of truth:**
 [`.github/workflows/create-tag.yml`](../../.github/workflows/create-tag.yml),
 [`.github/workflows/release.yml`](../../.github/workflows/release.yml),
+[`.github/workflows/release-lsp-vscode.yml`](../../.github/workflows/release-lsp-vscode.yml),
 [`.github/workflows/_rust-binary.yml`](../../.github/workflows/_rust-binary.yml),
 [`.github/workflows/_container.yml`](../../.github/workflows/_container.yml),
 [`.github/workflows/_bundle.yml`](../../.github/workflows/_bundle.yml),
@@ -133,10 +134,33 @@ Actions → **Publish worker skills** — worker must be in
 `ALLOWED_WORKERS` ([`parse_publish_workers_input.py`](../../.github/scripts/parse_publish_workers_input.py)).
 No version bump; updates skill markdown on the registry channel you pick.
 
-### Not via this pipeline
+### LSP VS Code extension
 
-`iii-lsp-vscode` uses [`release-lsp.yml`](../../.github/workflows/release-lsp.yml)
-(VS Code extension packaging, separate tag pattern `iii-lsp-vscode/v*`).
+`lsp-vscode` uses
+[`release-lsp-vscode.yml`](../../.github/workflows/release-lsp-vscode.yml)
+(VS Code extension packaging, separate tag pattern `lsp-vscode/v*`). The
+Marketplace/OpenVSX package name remains `iii-lsp`.
+
+The extension release workflow packages the VSIX once and then publishes it via
+separate jobs:
+
+| Job | External side effect |
+|---|---|
+| `publish-vscode` | Publishes the VSIX to VS Code Marketplace |
+| `publish-openvsx` | Publishes the same VSIX to OpenVSX |
+| `github-release` | Uploads the VSIX to the GitHub Release |
+
+If only one target fails, do **not** create another version bump. Either use
+GitHub Actions "Re-run failed jobs" for the same run, or dispatch **Release LSP
+VS Code** manually with the existing tag and the failed target:
+
+| Input | Example |
+|---|---|
+| `tag` | `lsp-vscode/v0.2.7` |
+| `publish_target` | `openvsx`, `vscode-marketplace`, or `github-release` |
+
+Use `publish_target=all` only for the first publish attempt or when all targets
+are known to be safe to run again.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- split lsp-vscode release into package, VS Code Marketplace, OpenVSX, and GitHub Release jobs
- add manual publish_target selection so a failed target can be retried without a new version bump
- document the partial retry flow in the release SOP

## Validation
- git diff --check
- yq eval '.name' .github/workflows/release-lsp-vscode.yml
- docker run --rm -v "/Users/doggao/personal/workers.refactor-rename-iii-lsp:/repo" -w /repo rhysd/actionlint:latest .github/workflows/release-lsp-vscode.yml
- docker build -t lsp-vscode-dev .
- docker run --rm -u "501:20" -e npm_config_cache=/tmp/npm-cache -v "/Users/doggao/personal/workers.refactor-rename-iii-lsp:/workspace" -w /workspace lsp-vscode-dev npm ci
- docker run --rm -u "501:20" -e npm_config_cache=/tmp/npm-cache -v "/Users/doggao/personal/workers.refactor-rename-iii-lsp:/workspace" -w /workspace lsp-vscode-dev npm run package:check
- docker run --rm -u "501:20" -e npm_config_cache=/tmp/npm-cache -v "/Users/doggao/personal/workers.refactor-rename-iii-lsp:/workspace" -w /workspace lsp-vscode-dev npm test