### PR TITLE
Replace llm-router pubsub events with worker-owned trigger types

### DIFF
--- a/llm-router/README.md
+++ b/llm-router/README.md
@@ -127,11 +127,11 @@ within seconds — no restart.
 
 ## Events
 
-The router publishes three events over the engine's `iii-pubsub` worker. Bind
-an iii function to a topic with the engine's `subscribe` trigger type; the
-handler receives the payload verbatim (no envelope).
+The router registers three custom trigger types and fans out to every bound
+handler. Bind with the standard two-step pattern; the handler receives the
+payload verbatim (no envelope).
 
-| Topic | Fires when | Payload |
+| Trigger type | Fires when | Payload |
 |---|---|---|
 | `router::models::changed` | a provider reconciles its catalog slice | `{ "provider": "<id>", "count": <n> }` |
 | `router::provider::changed` | the registry changes (declare / availability flip) | `{ "provider": "<id>", "op": "register" \| "available" \| "unavailable" }` |
@@ -144,9 +144,9 @@ iii.registerFunction({ id: 'my-worker::onModelsChanged' }, async (payload) => {
 });
 
 iii.registerTrigger({
-  type: 'subscribe',
+  type: 'router::models::changed',
   function_id: 'my-worker::onModelsChanged',
-  config: { topic: 'router::models::changed' },
+  config: {},
 });
 ```
 

--- a/llm-router/src/catalog/reconcile.rs
+++ b/llm-router/src/catalog/reconcile.rs
@@ -6,23 +6,23 @@ use std::sync::Arc;
 use crate::types::errors::{RouterCode, RouterError};
 use crate::types::router::{ModelsReconcileRequest, ModelsReconcileResponse};
 use futures::future::BoxFuture;
-use iii_sdk::{IIIError, III};
+use iii_sdk::IIIError;
 use serde_json::json;
 
 use crate::catalog::store::CatalogStore;
 use crate::registry::store::RegistryStore;
-use crate::triggers;
+use crate::triggers::{self, RouterEvents};
 
 pub fn make_models_reconcile(
-    iii: III,
     registry: Arc<RegistryStore>,
     catalog: Arc<CatalogStore>,
+    events: Arc<RouterEvents>,
 ) -> impl Fn(ModelsReconcileRequest) -> BoxFuture<'static, Result<ModelsReconcileResponse, IIIError>>
        + Send
        + Sync
        + 'static {
     move |req: ModelsReconcileRequest| {
-        let (iii, registry, catalog) = (iii.clone(), registry.clone(), catalog.clone());
+        let (registry, catalog, events) = (registry.clone(), catalog.clone(), events.clone());
         Box::pin(async move {
             let provider = req.provider;
             registry
@@ -44,12 +44,12 @@ pub fn make_models_reconcile(
             }
             let count = models.len();
             catalog.set_slice(&provider, models).await?;
-            triggers::publish(
-                &iii,
-                triggers::MODELS_CHANGED,
-                json!({ "provider": provider, "count": count }),
-            )
-            .await;
+            events
+                .emit(
+                    triggers::MODELS_CHANGED,
+                    json!({ "provider": provider, "count": count }),
+                )
+                .await;
             Ok(ModelsReconcileResponse { provider, count })
         })
     }

--- a/llm-router/src/chat/chat.rs
+++ b/llm-router/src/chat/chat.rs
@@ -24,7 +24,7 @@ use crate::config::entry::read_entry_value;
 use crate::registry::store::RegistryStore;
 use crate::routing::{decide, DecideInput};
 use crate::settings::{provider_slices, RouterSettings};
-use crate::triggers;
+use crate::triggers::{self, RouterEvents};
 
 use super::inflight::InflightMap;
 use super::output_tokens::resolve_max_output_tokens;
@@ -82,6 +82,7 @@ pub struct ChatPipeline {
     pub catalog: Arc<CatalogStore>,
     pub inflight: Arc<InflightMap>,
     pub settings: Arc<RwLock<RouterSettings>>,
+    pub events: Arc<RouterEvents>,
 }
 
 fn now_ms() -> i64 {
@@ -384,12 +385,12 @@ impl ChatPipeline {
                             }
                             if is_function_not_found(&err) {
                                 if self.registry.set_availability(provider, false).await {
-                                    triggers::publish(
-                                        &self.iii,
-                                        triggers::PROVIDER_CHANGED,
-                                        json!({ "provider": provider, "op": "unavailable" }),
-                                    )
-                                    .await;
+                                    self.events
+                                        .emit(
+                                            triggers::PROVIDER_CHANGED,
+                                            json!({ "provider": provider, "op": "unavailable" }),
+                                        )
+                                        .await;
                                 }
                                 return Err(RouterError::new(
                                     RouterCode::ProviderUnavailable,
@@ -560,17 +561,20 @@ mod tests {
         use crate::registry::store::RegistryStore;
         use crate::settings::RouterSettings;
         use crate::testkit::fake_channels::FakeChannel;
+        use crate::triggers::RouterEvents;
         use std::sync::RwLock;
         use std::time::Duration;
 
         // empty registry + empty catalog → nothing routes "ghost-model".
         let iii = iii_sdk::register_worker("ws://127.0.0.1:0", iii_sdk::InitOptions::default());
+        let events = RouterEvents::register(&iii);
         let pipeline = ChatPipeline {
             iii: iii.clone(),
             registry: Arc::new(RegistryStore::new(iii.clone())),
             catalog: Arc::new(CatalogStore::new(iii.clone())),
             inflight: Arc::new(InflightMap::default()),
             settings: Arc::new(RwLock::new(RouterSettings::default())),
+            events,
         };
 
         let ch = FakeChannel::new();

--- a/llm-router/src/register.rs
+++ b/llm-router/src/register.rs
@@ -1,12 +1,12 @@
-//! Wiring: boot order per the design doc — load stores → register iii
-//! functions → bind triggers → register the configuration entry → read
-//! settings → publish `router::ready`.
+//! Wiring: boot order per the design doc — load stores → register trigger
+//! types → register iii functions → bind triggers → register the configuration
+//! entry → read settings → emit `router::ready`.
 //!
 //! Every registration below is a direct `iii_sdk` call:
 //! `iii.register_function(id, RegisterFunction::new_async(...))` for the
 //! function surface and `iii.register_trigger(RegisterTriggerInput { .. })`
-//! for trigger bindings. Router events go out over the engine's `iii-pubsub`
-//! worker (`triggers::publish`).
+//! for trigger bindings. Router events fan out via worker-owned trigger types
+//! (`triggers::RouterEvents`).
 use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
 
@@ -30,7 +30,7 @@ use crate::registry::resolve::{make_provider_resolve, make_update_credential};
 use crate::registry::store::RegistryStore;
 use crate::settings::{parse_settings, RouterSettings};
 use crate::surface;
-use crate::triggers;
+use crate::triggers::RouterEvents;
 use crate::types::errors::invalid_request_from_serde;
 
 pub struct RouterRefs {
@@ -47,10 +47,11 @@ pub async fn register_router(iii: III) -> Result<RouterRefs, IIIError> {
     registry.load().await?;
     catalog.load().await?;
 
-    // 3. shared settings + inflight
+    // 3. shared settings + inflight + router event fan-out
     let settings = Arc::new(RwLock::new(RouterSettings::default()));
     let inflight = Arc::new(InflightMap::default());
     let entry_lock = EntryWriteLock::default();
+    let events = RouterEvents::register(&iii);
 
     let pipeline = Arc::new(ChatPipeline {
         iii: iii.clone(),
@@ -58,6 +59,7 @@ pub async fn register_router(iii: III) -> Result<RouterRefs, IIIError> {
         catalog: catalog.clone(),
         inflight: inflight.clone(),
         settings: settings.clone(),
+        events: events.clone(),
     });
 
     // 4. function surface
@@ -129,6 +131,7 @@ pub async fn register_router(iii: III) -> Result<RouterRefs, IIIError> {
                 registry.clone(),
                 catalog.clone(),
                 entry_lock.clone(),
+                events.clone(),
             ),
             invalid_request_from_serde,
         )
@@ -151,7 +154,7 @@ pub async fn register_router(iii: III) -> Result<RouterRefs, IIIError> {
     iii.register_function(
         surface::MODELS_RECONCILE_ID,
         RegisterFunction::new_async_with_bad_request(
-            make_models_reconcile(iii.clone(), registry.clone(), catalog.clone()),
+            make_models_reconcile(registry.clone(), catalog.clone(), events.clone()),
             invalid_request_from_serde,
         )
         .description(surface::MODELS_RECONCILE_DESC),
@@ -160,7 +163,7 @@ pub async fn register_router(iii: III) -> Result<RouterRefs, IIIError> {
     // 5. bound triggers: topology + configuration change (paste-a-key)
     iii.register_function(
         surface::ON_WORKER_AVAILABLE_ID,
-        RegisterFunction::new_async(make_on_worker_available(iii.clone(), registry.clone()))
+        RegisterFunction::new_async(make_on_worker_available(registry.clone(), events.clone()))
             .description(surface::ON_WORKER_AVAILABLE_DESC),
     );
     let _ = iii.register_trigger(RegisterTriggerInput {
@@ -214,7 +217,7 @@ pub async fn register_router(iii: III) -> Result<RouterRefs, IIIError> {
     *settings.write().unwrap() = parse_settings(&read_entry_value(&iii).await);
 
     // 7. ready — providers re-declare on this
-    triggers::publish(&iii, triggers::READY, json!({})).await;
+    events.emit(crate::triggers::READY, json!({})).await;
 
     Ok(RouterRefs {
         registry,

--- a/llm-router/src/registry/availability.rs
+++ b/llm-router/src/registry/availability.rs
@@ -15,17 +15,17 @@ use serde_json::json;
 
 use crate::registry::resolve::resolve_provider_config;
 use crate::registry::store::RegistryStore;
-use crate::triggers;
+use crate::triggers::{self, RouterEvents};
 
 pub fn make_on_worker_available(
-    iii: III,
     registry: Arc<RegistryStore>,
+    events: Arc<RouterEvents>,
 ) -> impl Fn(WorkerAvailableEvent) -> BoxFuture<'static, Result<RouterAck, IIIError>>
        + Send
        + Sync
        + 'static {
     move |event: WorkerAvailableEvent| {
-        let (iii, registry) = (iii.clone(), registry.clone());
+        let (registry, events) = (registry.clone(), events.clone());
         Box::pin(async move {
             let Some(worker_id) = event.worker_id.as_deref() else {
                 return Ok(RouterAck { ok: true }); // unknown shapes are ignored
@@ -38,12 +38,12 @@ pub fn make_on_worker_available(
             let available = !event_name.contains("disconnect");
             for id in providers {
                 if registry.set_availability(&id, available).await {
-                    triggers::publish(
-                        &iii,
-                        triggers::PROVIDER_CHANGED,
-                        json!({ "provider": id, "op": if available { "available" } else { "unavailable" } }),
-                    )
-                    .await;
+                    events
+                        .emit(
+                            triggers::PROVIDER_CHANGED,
+                            json!({ "provider": id, "op": if available { "available" } else { "unavailable" } }),
+                        )
+                        .await;
                 }
             }
             Ok(RouterAck { ok: true })

--- a/llm-router/src/registry/register.rs
+++ b/llm-router/src/registry/register.rs
@@ -17,7 +17,7 @@ use crate::catalog::store::CatalogStore;
 use crate::config::entry::{register_entry, EntryWriteLock};
 use crate::config::schema::{default_provider_schema, validate_custom_schema};
 use crate::registry::store::RegistryStore;
-use crate::triggers;
+use crate::triggers::{self, RouterEvents};
 
 fn valid_id(id: &str) -> bool {
     !id.is_empty()
@@ -32,16 +32,18 @@ pub fn make_provider_register(
     registry: Arc<RegistryStore>,
     catalog: Arc<CatalogStore>,
     entry_lock: EntryWriteLock,
+    events: Arc<RouterEvents>,
 ) -> impl Fn(ProviderRegisterRequest) -> BoxFuture<'static, Result<ProviderRegisterResponse, IIIError>>
        + Send
        + Sync
        + 'static {
     move |input: ProviderRegisterRequest| {
-        let (iii, registry, catalog, entry_lock) = (
+        let (iii, registry, catalog, entry_lock, events) = (
             iii.clone(),
             registry.clone(),
             catalog.clone(),
             entry_lock.clone(),
+            events.clone(),
         );
         Box::pin(async move {
             let declaration = input.declaration;
@@ -98,23 +100,23 @@ pub fn make_provider_register(
                 register_entry(&iii, &provider_schemas).await?;
             }
 
-            triggers::publish(
-                &iii,
-                triggers::PROVIDER_CHANGED,
-                json!({ "provider": id, "op": "register" }),
-            )
-            .await;
+            events
+                .emit(
+                    triggers::PROVIDER_CHANGED,
+                    json!({ "provider": id, "op": "register" }),
+                )
+                .await;
 
             // A down provider coming back up via re-registration is an
             // availability transition; emit it explicitly so subscribers tracking
             // op:"available"/"unavailable" don't stay stuck on the prior down state.
             if availability_recovered {
-                triggers::publish(
-                    &iii,
-                    triggers::PROVIDER_CHANGED,
-                    json!({ "provider": id, "op": "available" }),
-                )
-                .await;
+                events
+                    .emit(
+                        triggers::PROVIDER_CHANGED,
+                        json!({ "provider": id, "op": "available" }),
+                    )
+                    .await;
             }
 
             // Static catalog slice: reconciled at registration (spec § register).
@@ -122,12 +124,12 @@ pub fn make_provider_register(
                 if !models.is_empty() {
                     let count = models.len();
                     catalog.set_slice(&id, models).await?;
-                    triggers::publish(
-                        &iii,
-                        triggers::MODELS_CHANGED,
-                        json!({ "provider": id, "count": count }),
-                    )
-                    .await;
+                    events
+                        .emit(
+                            triggers::MODELS_CHANGED,
+                            json!({ "provider": id, "count": count }),
+                        )
+                        .await;
                 }
             }
 

--- a/llm-router/src/triggers.rs
+++ b/llm-router/src/triggers.rs
@@ -1,10 +1,26 @@
-//! Router events (README § Events) ride the engine's built-in `iii-pubsub`
-//! worker: `publish` fans each event out to every function bound to the topic
-//! through the `subscribe` trigger type. The engine delivers the payload
-//! verbatim (no envelope) and isolates subscriber failures per delivery, so
-//! the router only publishes.
-use iii_sdk::{TriggerRequest, III};
-use serde_json::{json, Value};
+//! The three custom trigger types this worker emits, and the fan-out
+//! machinery behind them (README § Events).
+//!
+//! Reactivity model: consumers bind handlers to these trigger types with the
+//! standard two-step pattern; the engine routes each registration to our
+//! [`TriggerHandler`]s. Delivery is fire-and-forget (`TriggerAction::Void`);
+//! failures are logged and swallowed so a misbehaving subscriber must not
+//! break the write path.
+//!
+//! After a worker restart the engine replays every existing trigger
+//! registration of a re-registered type back to its owner, so the
+//! subscriber sets rebuild themselves.
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use iii_sdk::{
+    IIIError, RegisterTriggerType, TriggerAction, TriggerConfig, TriggerHandler, TriggerRequest,
+    III,
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// Fires when a provider reconciles its catalog slice.
 pub const MODELS_CHANGED: &str = "router::models::changed";
@@ -13,15 +29,215 @@ pub const PROVIDER_CHANGED: &str = "router::provider::changed";
 /// Fires once when the router finishes booting; providers re-declare on it.
 pub const READY: &str = "router::ready";
 
-/// Publish one router event: awaits the engine's ack, swallows errors —
-/// delivery to subscribers is fire-and-forget either way.
-pub async fn publish(iii: &III, topic: &str, data: Value) {
-    let _ = iii
-        .trigger(TriggerRequest {
-            function_id: "publish".into(),
-            payload: json!({ "topic": topic, "data": data }),
-            action: None,
-            timeout_ms: None,
+const READY_DESC: &str =
+    "The router finished booting; providers bind here and re-declare after a restart.";
+const MODELS_CHANGED_DESC: &str =
+    "A provider reconciled its catalog slice. Payload: { provider, count }.";
+const PROVIDER_CHANGED_DESC: &str =
+    "The provider registry changed (declare / availability flip). Payload: { provider, op }.";
+
+/// Config accepted by all three router event bindings. No filters in v1.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct EventBindingConfig {}
+
+/// Thread-safe subscriber registry keyed by trigger-instance id.
+#[derive(Clone, Default)]
+pub struct SubscriberSet {
+    inner: Arc<Mutex<HashMap<String, TriggerConfig>>>,
+}
+
+impl SubscriberSet {
+    fn insert(&self, config: TriggerConfig) {
+        let mut map = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        map.insert(config.id.clone(), config);
+    }
+
+    fn remove(&self, id: &str) {
+        let mut map = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        map.remove(id);
+    }
+
+    /// Snapshot so the mutex isn't held across awaits.
+    pub fn function_ids(&self) -> Vec<String> {
+        let map = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        map.values().map(|c| c.function_id.clone()).collect()
+    }
+}
+
+struct RouterEventTriggerHandler {
+    name: String,
+    subscribers: SubscriberSet,
+}
+
+impl RouterEventTriggerHandler {
+    fn new(name: &str, subscribers: SubscriberSet) -> Self {
+        Self {
+            name: name.into(),
+            subscribers,
+        }
+    }
+}
+
+#[async_trait]
+impl TriggerHandler for RouterEventTriggerHandler {
+    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+        let raw = if config.config.is_null() {
+            Value::Object(serde_json::Map::new())
+        } else {
+            config.config.clone()
+        };
+        serde_json::from_value::<EventBindingConfig>(raw)
+            .map_err(|e| IIIError::Handler(format!("invalid {} config: {e}", self.name)))?;
+        tracing::info!(
+            trigger_type = %self.name,
+            id = %config.id,
+            function_id = %config.function_id,
+            "trigger subscription registered"
+        );
+        self.subscribers.insert(config);
+        Ok(())
+    }
+
+    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+        tracing::info!(
+            trigger_type = %self.name,
+            id = %config.id,
+            "trigger subscription unregistered"
+        );
+        self.subscribers.remove(&config.id);
+        Ok(())
+    }
+}
+
+/// Fan-out handle: register once at boot, clone into handlers that emit.
+pub struct RouterEvents {
+    iii: III,
+    ready: SubscriberSet,
+    models_changed: SubscriberSet,
+    provider_changed: SubscriberSet,
+}
+
+impl RouterEvents {
+    /// Register the three custom trigger types. Must run before emitting
+    /// `router::ready` so the engine can replay existing bindings first.
+    pub fn register(iii: &III) -> Arc<Self> {
+        let ready = SubscriberSet::default();
+        let models_changed = SubscriberSet::default();
+        let provider_changed = SubscriberSet::default();
+
+        let _ = iii.register_trigger_type(
+            RegisterTriggerType::new(
+                READY,
+                READY_DESC,
+                RouterEventTriggerHandler::new(READY, ready.clone()),
+            )
+            .trigger_request_format::<EventBindingConfig>(),
+        );
+        tracing::info!(trigger_type = READY, "registered trigger type");
+
+        let _ = iii.register_trigger_type(
+            RegisterTriggerType::new(
+                MODELS_CHANGED,
+                MODELS_CHANGED_DESC,
+                RouterEventTriggerHandler::new(MODELS_CHANGED, models_changed.clone()),
+            )
+            .trigger_request_format::<EventBindingConfig>(),
+        );
+        tracing::info!(trigger_type = MODELS_CHANGED, "registered trigger type");
+
+        let _ = iii.register_trigger_type(
+            RegisterTriggerType::new(
+                PROVIDER_CHANGED,
+                PROVIDER_CHANGED_DESC,
+                RouterEventTriggerHandler::new(PROVIDER_CHANGED, provider_changed.clone()),
+            )
+            .trigger_request_format::<EventBindingConfig>(),
+        );
+        tracing::info!(trigger_type = PROVIDER_CHANGED, "registered trigger type");
+
+        Arc::new(Self {
+            iii: iii.clone(),
+            ready,
+            models_changed,
+            provider_changed,
         })
-        .await;
+    }
+
+    fn subscribers_for(&self, trigger_type: &str) -> Option<&SubscriberSet> {
+        match trigger_type {
+            READY => Some(&self.ready),
+            MODELS_CHANGED => Some(&self.models_changed),
+            PROVIDER_CHANGED => Some(&self.provider_changed),
+            _ => None,
+        }
+    }
+
+    /// Fire `payload` to every subscriber bound to `trigger_type`.
+    pub async fn emit(&self, trigger_type: &str, payload: Value) {
+        let Some(set) = self.subscribers_for(trigger_type) else {
+            tracing::warn!(trigger_type, "unknown router event type");
+            return;
+        };
+        let targets = set.function_ids();
+        for function_id in targets {
+            let res = self
+                .iii
+                .trigger(TriggerRequest {
+                    function_id: function_id.clone(),
+                    payload: payload.clone(),
+                    action: Some(TriggerAction::Void),
+                    timeout_ms: None,
+                })
+                .await;
+            if let Err(e) = res {
+                tracing::warn!(
+                    trigger_type,
+                    function_id = %function_id,
+                    error = %e,
+                    "router event fan-out failed"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subscriber_set_insert_remove_and_snapshot() {
+        let set = SubscriberSet::default();
+        assert!(set.function_ids().is_empty());
+        set.insert(TriggerConfig {
+            id: "sub-1".into(),
+            function_id: "probe::on_ready".into(),
+            config: Value::Object(serde_json::Map::new()),
+            metadata: None,
+        });
+        set.insert(TriggerConfig {
+            id: "sub-2".into(),
+            function_id: "other::recv".into(),
+            config: Value::Object(serde_json::Map::new()),
+            metadata: None,
+        });
+        let mut fns = set.function_ids();
+        fns.sort();
+        assert_eq!(
+            fns,
+            vec!["other::recv".to_string(), "probe::on_ready".to_string()]
+        );
+        set.remove("sub-1");
+        assert_eq!(set.function_ids(), vec!["other::recv".to_string()]);
+    }
 }

--- a/llm-router/src/types/router.rs
+++ b/llm-router/src/types/router.rs
@@ -219,7 +219,7 @@ pub struct RefreshModelsResponse {
 }
 
 /// Event delivered to a provider's `provider::<id>::on_router_ready` (the
-/// `router::ready` pubsub payload, currently `{}`). Unknown fields are ignored.
+/// `router::ready` trigger payload, currently `{}`). Unknown fields are ignored.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct RouterReadyEvent {}
 
@@ -231,14 +231,14 @@ pub struct ProviderReadyAck {
 
 // ── event payloads ──────────────────────────────────────────────────────────
 
-/// Payload published on the `router::models::changed` pubsub topic.
+/// Payload emitted on the `router::models::changed` trigger type.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ModelsChangedPayload {
     pub provider: String,
     pub count: usize,
 }
 
-/// Payload published on the `router::provider::changed` pubsub topic.
+/// Payload emitted on the `router::provider::changed` trigger type.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ProviderChangedPayload {
     pub provider: String,

--- a/llm-router/tests/integration.rs
+++ b/llm-router/tests/integration.rs
@@ -855,7 +855,7 @@ async fn update_credential_persists_and_resolves_back() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn models_changed_event_reaches_a_pubsub_subscriber() {
+async fn models_changed_event_reaches_a_trigger_subscriber() {
     let engine = engine_or_skip!();
 
     let router_iii = register_worker(&engine.url, InitOptions::default());
@@ -863,8 +863,8 @@ async fn models_changed_event_reaches_a_pubsub_subscriber() {
         .await
         .expect("router boots");
 
-    // Probe worker bound to the topic through the engine's pubsub trigger type
-    // (README § Events): the handler must receive the raw payload, no envelope.
+    // Probe worker bound to the router-owned trigger type (README § Events):
+    // the handler must receive the raw payload, no envelope.
     let probe = register_worker(&engine.url, InitOptions::default());
     let received = Arc::new(std::sync::Mutex::new(Vec::<Value>::new()));
     let sink = received.clone();
@@ -880,12 +880,12 @@ async fn models_changed_event_reaches_a_pubsub_subscriber() {
     );
     probe
         .register_trigger(iii_sdk::RegisterTriggerInput {
-            trigger_type: "subscribe".into(),
+            trigger_type: "router::models::changed".into(),
             function_id: "probe::on_models_changed".into(),
-            config: json!({ "topic": "router::models::changed" }),
+            config: json!({}),
             metadata: None,
         })
-        .expect("subscribe trigger registered");
+        .expect("router::models::changed trigger registered");
 
     // Declare already emits count=1 from the static model; reconcile two
     // models so the explicit-reconcile emission is unambiguous.
@@ -901,15 +901,20 @@ async fn models_changed_event_reaches_a_pubsub_subscriber() {
     .await
     .expect("reconcile accepted");
 
-    let want = json!({ "provider": "real", "count": 2 });
+    let want_provider = "real";
+    let want_count = 2;
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
-        if received.lock().unwrap().iter().any(|p| p == &want) {
+        let matched = received.lock().unwrap().iter().any(|p| {
+            p.get("provider").and_then(Value::as_str) == Some(want_provider)
+                && p.get("count").and_then(Value::as_u64) == Some(want_count)
+        });
+        if matched {
             break;
         }
         assert!(
             Instant::now() < deadline,
-            "router::models::changed never reached the pubsub subscriber; got {:?}",
+            "router::models::changed never reached the trigger subscriber; got {:?}",
             received.lock().unwrap()
         );
         tokio::time::sleep(Duration::from_millis(100)).await;

--- a/provider-anthropic/src/register.rs
+++ b/provider-anthropic/src/register.rs
@@ -123,7 +123,7 @@ pub async fn register_provider(iii: III) -> Result<(), IIIError> {
             .description(surface::REFRESH_MODELS_DESC),
     );
 
-    // Re-declare when the router restarts: router::ready rides iii-pubsub.
+    // Re-declare when the router restarts: bind to the router::ready trigger type.
     {
         let iii_ready = iii.clone();
         let http_ready = http.clone();
@@ -140,9 +140,9 @@ pub async fn register_provider(iii: III) -> Result<(), IIIError> {
         );
     }
     let _ = iii.register_trigger(RegisterTriggerInput {
-        trigger_type: "subscribe".into(),
+        trigger_type: "router::ready".into(),
         function_id: surface::ON_ROUTER_READY_ID.into(),
-        config: json!({ "topic": "router::ready" }),
+        config: json!({}),
         metadata: None,
     });
 

--- a/provider-anthropic/tests/golden/schemas/provider.anthropic.on_router_ready.json
+++ b/provider-anthropic/tests/golden/schemas/provider.anthropic.on_router_ready.json
@@ -3,7 +3,7 @@
   "function_id": "provider::anthropic::on_router_ready",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "description": "Event delivered to a provider's `provider::<id>::on_router_ready` (the `router::ready` pubsub payload, currently `{}`). Unknown fields are ignored.",
+    "description": "Event delivered to a provider's `provider::<id>::on_router_ready` (the `router::ready` trigger payload, currently `{}`). Unknown fields are ignored.",
     "title": "RouterReadyEvent",
     "type": "object"
   },

--- a/provider-anthropic/tests/integration.rs
+++ b/provider-anthropic/tests/integration.rs
@@ -489,7 +489,7 @@ async fn provider_redeclares_on_router_ready() {
         .await
         .expect("router reboots");
 
-    // router::ready (pubsub) → provider re-declares with its persisted token
+    // router::ready trigger → provider re-declares with its persisted token
     let deadline = Instant::now() + Duration::from_secs(15);
     loop {
         let list = call(&router2, "router::provider::list", json!({}))

--- a/provider-openai/README.md
+++ b/provider-openai/README.md
@@ -11,7 +11,7 @@ chat/reasoning families ∪ curated capability snapshot →
 ## Behavior
 
 - **Registration:** self-declares via `router::provider::register` with
-  backoff until acked, and re-declares on the `router::ready` pubsub topic.
+  backoff until acked, and re-declares on the `router::ready` trigger type.
   The declaration ships a static curated `models` slice (no cold-catalog
   hole) and `credential_env_var: OPENAI_API_KEY`.
 - **Identity binding:** the router returns a `registration_token` on first

--- a/provider-openai/src/register.rs
+++ b/provider-openai/src/register.rs
@@ -123,7 +123,7 @@ pub async fn register_provider(iii: III) -> Result<(), IIIError> {
             .description(surface::REFRESH_MODELS_DESC),
     );
 
-    // Re-declare when the router restarts: router::ready rides iii-pubsub.
+    // Re-declare when the router restarts: bind to the router::ready trigger type.
     {
         let iii_ready = iii.clone();
         let http_ready = http.clone();
@@ -140,9 +140,9 @@ pub async fn register_provider(iii: III) -> Result<(), IIIError> {
         );
     }
     let _ = iii.register_trigger(RegisterTriggerInput {
-        trigger_type: "subscribe".into(),
+        trigger_type: "router::ready".into(),
         function_id: surface::ON_ROUTER_READY_ID.into(),
-        config: json!({ "topic": "router::ready" }),
+        config: json!({}),
         metadata: None,
     });
 

--- a/provider-openai/tests/golden/schemas/provider.openai.on_router_ready.json
+++ b/provider-openai/tests/golden/schemas/provider.openai.on_router_ready.json
@@ -3,7 +3,7 @@
   "function_id": "provider::openai::on_router_ready",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "description": "Event delivered to a provider's `provider::<id>::on_router_ready` (the `router::ready` pubsub payload, currently `{}`). Unknown fields are ignored.",
+    "description": "Event delivered to a provider's `provider::<id>::on_router_ready` (the `router::ready` trigger payload, currently `{}`). Unknown fields are ignored.",
     "title": "RouterReadyEvent",
     "type": "object"
   },

--- a/provider-openai/tests/integration.rs
+++ b/provider-openai/tests/integration.rs
@@ -489,7 +489,7 @@ async fn provider_redeclares_on_router_ready() {
         .await
         .expect("router reboots");
 
-    // router::ready (pubsub) → provider re-declares with its persisted token
+    // router::ready trigger → provider re-declares with its persisted token
     let deadline = Instant::now() + Duration::from_secs(15);
     loop {
         let list = call(&router2, "router::provider::list", json!({}))

--- a/tech-specs/2026-06-agentic/llm-router.md
+++ b/tech-specs/2026-06-agentic/llm-router.md
@@ -187,10 +187,10 @@ Provider protocol (router side):
 
 ## Triggers
 
-### Events published (pubsub topics)
+### Trigger types emitted
 
-The router publishes its events over the engine's `iii-pubsub` worker; handlers receive the
-payload verbatim (no envelope).
+The router registers three custom trigger types and fans out to bound handlers;
+payloads are delivered verbatim (no envelope).
 
 - **`router::models::changed`** — fires when the catalog changes (a provider reconciles). Payload:
   `{ provider: string; count: number }`. Lets pickers refresh reactively.
@@ -200,8 +200,8 @@ payload verbatim (no envelope).
   re-declare, so a router restart re-populates the registry without manual intervention (see
   [Registration lifecycle](#registration-lifecycle)).
 
-Bind any of these the standard two-step way (see [README § Reactive pattern](README.md#reactive-pattern))
-with the engine's `subscribe` trigger type: `{ type: "subscribe", config: { topic: "<event>" } }`.
+Bind any of these the standard two-step way (see [README § Reactive pattern](README.md#reactive-pattern)):
+`{ type: "router::models::changed", config: {} }` (and likewise for the other two types).
 
 ### Triggers bound
 


### PR DESCRIPTION
## Summary
- Replace iii-pubsub topic publishing with three worker-owned trigger types (`router::ready`, `router::models::changed`, `router::provider::changed`) and in-router fan-out via `RouterEvents`.
- Migrate provider-openai, provider-anthropic, and harness subscribers from `subscribe` + topic bindings to the new trigger types.
- Update docs/specs and integration coverage so router events deliver on bare engines without `iii-pubsub`.

## Test plan
- [x] `cargo test` in `llm-router` (unit + integration, incl. bare-engine and trigger subscriber)
- [x] `cargo test` in `provider-openai` (incl. `provider_redeclares_on_router_ready`)
- [x] `cargo test` in `provider-anthropic` (incl. `provider_redeclares_on_router_ready`)
- [ ] Harness TS typecheck (skipped locally: `node_modules` missing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Router now exposes custom trigger types for event subscriptions: `router::models::changed`, `router::provider::changed`, and `router::ready`.

* **Documentation**
  * Updated event binding guidance to show registration via trigger types instead of topic-based subscriptions.
  * Simplified trigger registration configuration with empty `config` objects.

* **Bug Fixes**
  * Event delivery now uses router-owned trigger fanout for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->