### PR TITLE
fix(collect-worker-interface): collect function schemas from engine::functions::info

### DIFF
--- a/.github/scripts/build_publish_payload.py
+++ b/.github/scripts/build_publish_payload.py
@@ -253,8 +253,17 @@ def normalize_worker_interface(
             {
                 "name": derive_registry_function_name(function_id, metadata),
                 "description": _string_or_empty(details.get("description")),
-                "request_schema": _schema_or_empty(details.get("request_format")),
-                "response_schema": _schema_or_empty(details.get("response_format")),
+                # `engine::functions::info` surfaces the typed schemas under
+                # `request_schema`/`response_schema`; `engine::functions::list`
+                # rows carry neither (and the legacy `request_format` key never
+                # existed on the engine output). Prefer the info-API names and
+                # fall back to `request_format` for any older caller shape.
+                "request_schema": _schema_or_empty(
+                    details.get("request_schema", details.get("request_format"))
+                ),
+                "response_schema": _schema_or_empty(
+                    details.get("response_schema", details.get("response_format"))
+                ),
                 "metadata": _metadata_or_empty(metadata),
             }
         )

--- a/.github/scripts/collect_worker_interface.py
+++ b/.github/scripts/collect_worker_interface.py
@@ -59,6 +59,56 @@ def run_iii(function_path: str, payload: dict[str, object]) -> dict[str, object]
     return json.loads(completed.stdout)
 
 
+def _fetch_function_detail(function_id: str) -> dict[str, object] | None:
+    """`engine::functions::info` for one function, or None on any failure.
+
+    Unlike `engine::functions::list` (a `FunctionSummary`: id + worker_name +
+    description), `::info` returns the `FunctionDetail` that carries the typed
+    `request_schema`/`response_schema`. Best-effort: a failed lookup leaves the
+    row schema-less, which the `--assert-typed-schemas` check then flags."""
+    try:
+        return run_iii("engine::functions::info", {"function_id": function_id})
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        json.JSONDecodeError,
+    ) as exc:
+        print(
+            f"::warning::could not fetch engine::functions::info for {function_id}: {exc}",
+            file=sys.stderr,
+        )
+        return None
+
+
+def enrich_functions_with_schemas(
+    functions: list[dict[str, object]],
+    target_function_ids: list[str],
+    *,
+    fetch_detail=_fetch_function_detail,
+) -> list[dict[str, object]]:
+    """Merge each target function's typed schemas into its `::list` row in place.
+
+    `engine::functions::list` omits request/response schemas; only
+    `engine::functions::info` exposes them (as `request_schema`/`response_schema`,
+    plus `metadata`). Without this enrichment every collected schema normalizes
+    to the empty `{}` that blocks publish."""
+    rows_by_id = {
+        f.get("function_id"): f for f in functions if isinstance(f, dict)
+    }
+    for function_id in target_function_ids:
+        row = rows_by_id.get(function_id)
+        if row is None:
+            continue
+        detail = fetch_detail(function_id)
+        if not isinstance(detail, dict):
+            continue
+        for key in ("request_schema", "response_schema", "metadata", "description"):
+            value = detail.get(key)
+            if value is not None:
+                row[key] = value
+    return functions
+
+
 def wait_for_worker(
     worker_name: str,
     wait_seconds: int,
@@ -186,6 +236,29 @@ def main() -> int:
         args.wait_seconds,
         workers_baseline_json=workers_baseline_json,
     )
+
+    # `engine::functions::list` carries no schemas — pull each target function's
+    # typed request/response schema from `engine::functions::info` and merge it
+    # into the rows before normalizing. Best-effort worker resolution here;
+    # normalize_worker_interface remains the authority (and raises) if the
+    # worker can't be matched.
+    all_functions = functions_json.get("functions") or []
+    if isinstance(all_functions, list):
+        try:
+            target_worker_names = _resolve_target_worker_names(
+                workers=workers_json.get("workers") or [],
+                worker_name=args.worker,
+                functions=all_functions,
+                baseline_workers_json=workers_baseline_json,
+            )
+            target_function_ids = _function_ids_for_workers(
+                all_functions, target_worker_names
+            )
+        except ValueError:
+            target_function_ids = []
+        if target_function_ids:
+            enrich_functions_with_schemas(all_functions, target_function_ids)
+
     trigger_types_json = collect_trigger_types()
 
     interface = normalize_worker_interface(

--- a/.github/scripts/tests/test_enrich_function_schemas.py
+++ b/.github/scripts/tests/test_enrich_function_schemas.py
@@ -1,0 +1,82 @@
+"""Tests for enrich_functions_with_schemas in collect_worker_interface.py.
+
+`engine::functions::list` returns only `{function_id, worker_name, description}`
+(a `FunctionSummary`); the typed request/response schemas live solely on
+`engine::functions::info` (a `FunctionDetail`). The collector must fetch `::info`
+per target function and merge the schemas into the list rows before normalizing,
+or every function's schema collapses to the empty `{}` the publish-time
+`--assert-typed-schemas` check rejects.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from collect_worker_interface import enrich_functions_with_schemas  # noqa: E402
+
+REQ = {"type": "object", "properties": {"request_id": {"type": "string"}}}
+RESP = {"type": "object", "properties": {"aborted": {"type": "boolean"}}}
+
+
+def _details(mapping):
+    """Return a fetch_detail stub backed by a {function_id: detail} mapping."""
+    return lambda function_id: mapping.get(function_id)
+
+
+def test_merges_info_schemas_into_target_rows() -> None:
+    functions = [
+        {"function_id": "router::abort", "worker_name": "llm-router", "description": "abort"},
+    ]
+    details = {
+        "router::abort": {
+            "function_id": "router::abort",
+            "worker_name": "llm-router",
+            "description": "abort",
+            "request_schema": REQ,
+            "response_schema": RESP,
+            "metadata": {"registry_name": "abort"},
+        }
+    }
+
+    enrich_functions_with_schemas(
+        functions, ["router::abort"], fetch_detail=_details(details)
+    )
+
+    abort = functions[0]
+    assert abort["request_schema"] == REQ
+    assert abort["response_schema"] == RESP
+    assert abort["metadata"] == {"registry_name": "abort"}
+
+
+def test_leaves_untargeted_rows_untouched() -> None:
+    functions = [
+        {"function_id": "router::abort", "worker_name": "llm-router", "description": "abort"},
+        {"function_id": "engine::log", "worker_name": "engine", "description": "log"},
+    ]
+    details = {
+        "router::abort": {"request_schema": REQ, "response_schema": RESP},
+        "engine::log": {"request_schema": REQ, "response_schema": RESP},
+    }
+
+    enrich_functions_with_schemas(
+        functions, ["router::abort"], fetch_detail=_details(details)
+    )
+
+    assert "request_schema" in functions[0]
+    assert "request_schema" not in functions[1]
+
+
+def test_tolerates_missing_info_detail() -> None:
+    """A `::info` lookup that returns None (call failed / unknown id) must not
+    raise — the row keeps no schema and the typed-schema assertion flags it."""
+    functions = [
+        {"function_id": "router::abort", "worker_name": "llm-router", "description": "abort"},
+    ]
+
+    enrich_functions_with_schemas(
+        functions, ["router::abort"], fetch_detail=lambda _id: None
+    )
+
+    assert "request_schema" not in functions[0]

--- a/.github/scripts/tests/test_normalize_worker_interface.py
+++ b/.github/scripts/tests/test_normalize_worker_interface.py
@@ -53,6 +53,54 @@ def test_collects_functions_by_worker_name_with_workers_baseline() -> None:
     assert names == {"harness::trigger", "run::start"}
 
 
+def test_surfaces_typed_schemas_from_info_enriched_rows() -> None:
+    """`engine::functions::list` rows carry no schemas — only
+    `engine::functions::info` does, under `request_schema`/`response_schema`.
+    Once the collector enriches each row from `::info`, normalize must surface
+    those typed schemas (not the empty `{}` it produced when reading the
+    never-present `request_format` key)."""
+    workers_json = {
+        "workers": [{"id": "llm-router", "name": "llm-router", "runtime": "rust"}],
+    }
+    req = {
+        "type": "object",
+        "title": "AbortRequest",
+        "properties": {"request_id": {"type": "string"}},
+    }
+    resp = {
+        "type": "object",
+        "title": "AbortResponse",
+        "properties": {"aborted": {"type": "boolean"}},
+    }
+    functions_json = {
+        "functions": [
+            {
+                "function_id": "router::abort",
+                "worker_name": "llm-router",
+                "description": "abort",
+                "request_schema": req,
+                "response_schema": resp,
+            },
+        ]
+    }
+
+    interface = normalize_worker_interface(
+        worker_name="llm-router",
+        workers_json=workers_json,
+        functions_json=functions_json,
+    )
+
+    assert interface["functions"] == [
+        {
+            "name": "router::abort",
+            "description": "abort",
+            "request_schema": req,
+            "response_schema": resp,
+            "metadata": {},
+        }
+    ]
+
+
 def test_collects_single_worker_without_baseline() -> None:
     workers_json = {
         "workers": [{"id": "shell", "name": "shell", "runtime": "rust"}],


### PR DESCRIPTION
## Problem

The publish-time `--assert-typed-schemas` check (collect_worker_interface.py) fails for every worker, reporting all `request_schema`/`response_schema` as untyped (empty `{}`). It surfaced when releasing `llm-router/v0.2.3`, whose handlers are in fact correctly typed.

## Root cause

The collector gathers each function's schema from `engine::functions::list`, but that endpoint returns only a `FunctionSummary` — `function_id`, `worker_name`, `description`, with **no schema fields**. The typed request/response schemas are exposed solely by `engine::functions::info` (`FunctionDetail`), under the keys `request_schema`/`response_schema`. `normalize_worker_interface` also read the never-present `request_format` key.

Result: `details.get("request_format")` → `None` → `{}` for every function of every worker, so the assertion can never pass against a live engine. The schemas are correctly extracted by the SDK and stored by the engine — only the collection queried the wrong endpoint/keys.

Confirmed on a live engine: `functions::list` returns 3 keys (no schemas); `functions::info` returns the full typed schemas.

## Fix

- `collect_worker_interface.py`: enrich each target function's row from `engine::functions::info` (best-effort, per function) before normalizing.
- `build_publish_payload.py`: read `request_schema`/`response_schema` (info-API key names), falling back to `request_format` for back-compat.

## Verification

- 97/97 collector tests pass, including new coverage for the enrichment merge and the normalize path.
- Live end-to-end against a real engine + llm-router: all 14 functions resolve with typed request/response schemas and `--assert-typed-schemas` exits 0 (was 1).

## Note

The reusable publish workflow runs at the release tag's ref, so this needs a new tag (e.g. `llm-router/v0.2.4`) to take effect in the pipeline — re-running the old job re-runs the pre-fix script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced function metadata collection with automatic enrichment of typed schemas for improved completeness and accuracy
  * Improved schema field handling in build payload generation with better preference handling for strongly-typed schema definitions
  * Robust error handling for missing or unavailable schema information during collection

* **Tests**
  * Added comprehensive test coverage for schema enrichment, normalization, and edge case handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->