### PR TITLE
fix(observability): reconnect turn traces + stamp session/message baggage

### DIFF
--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -508,6 +508,7 @@ dependencies = [
  "async-trait",
  "clap",
  "globset",
+ "iii-observability",
  "iii-sdk",
  "jsonschema",
  "schemars",

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -16,6 +16,9 @@ path = "src/lib.rs"
 
 [dependencies]
 iii-sdk = "=0.19.2"
+# Re-exports the same `opentelemetry` the SDK uses, so we can carry the active
+# OTel context across `tokio::spawn` boundaries (shared `Context` global).
+iii-observability = "0.19.2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/harness/src/clients/router.rs
+++ b/harness/src/clients/router.rs
@@ -13,6 +13,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
+use iii_observability::opentelemetry::trace::FutureExt as _;
 use iii_sdk::helpers::create_channel;
 use iii_sdk::{TriggerRequest, III};
 use serde_json::{json, Value};
@@ -131,17 +132,28 @@ impl RouterClient {
         }
 
         // Run the held-open trigger concurrently with frame consumption.
+        //
+        // Carry the caller's OTel context into the spawned task so the SDK
+        // injects the turn's traceparent and `router::chat` nests under
+        // `harness::turn` instead of rooting a detached trace. `with_context`
+        // (not `cx.attach()`) because the `ContextGuard` is `!Send` and can't
+        // be held across the `.await` inside `tokio::spawn` — the same idiom
+        // the SDK uses to attach a handler's context.
         let iii = self.iii.clone();
         let timeout_ms = self.timeout_ms;
-        let trigger = tokio::spawn(async move {
-            iii.trigger(TriggerRequest {
-                function_id: "router::chat".into(),
-                payload,
-                action: None,
-                timeout_ms: Some(timeout_ms),
-            })
-            .await
-        });
+        let parent_cx = iii_observability::opentelemetry::Context::current();
+        let trigger = tokio::spawn(
+            async move {
+                iii.trigger(TriggerRequest {
+                    function_id: "router::chat".into(),
+                    payload,
+                    action: None,
+                    timeout_ms: Some(timeout_ms),
+                })
+                .await
+            }
+            .with_context(parent_cx),
+        );
 
         let coalesce = Duration::from_millis(self.coalesce_ms);
         let mut last_emit = Instant::now()

--- a/harness/src/functions/turn.rs
+++ b/harness/src/functions/turn.rs
@@ -7,6 +7,23 @@ use crate::error::HarnessError;
 use crate::turn_loop::{self, TurnStepPayload, TurnStepResult};
 
 pub async fn handle(deps: &Deps, payload: TurnStepPayload) -> Result<TurnStepResult, HarnessError> {
+    // Stamp this turn's identity into OTel baggage for the whole step. Every
+    // span the step spawns — session::*, router::chat, and (via the
+    // spawn-context propagation in the router/provider clients)
+    // provider::*::stream — then carries `iii.session.id`/`iii.message.id`
+    // (the BaggageSpanProcessor allowlist), so the turn's spans are
+    // attributable and groupable by session/message. `iii.message.id` is the
+    // turn id: one assistant turn is one grouped "message".
+    let session_id = payload.session_id.clone();
+    let turn_id = payload.turn_id.clone();
+    let baggage = [
+        ("iii.session.id", session_id.as_str()),
+        ("iii.message.id", turn_id.as_str()),
+    ];
+    iii_observability::run_with_baggage(&baggage, run(deps, payload)).await
+}
+
+async fn run(deps: &Deps, payload: TurnStepPayload) -> Result<TurnStepResult, HarnessError> {
     let (session_id, turn_id) = (payload.session_id.clone(), payload.turn_id.clone());
     match turn_loop::run_step(deps, payload).await {
         Ok(result) => Ok(result),

--- a/llm-router/Cargo.lock
+++ b/llm-router/Cargo.lock
@@ -774,11 +774,12 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "iii-observability",
  "iii-sdk",
  "regex",
  "schemars",

--- a/llm-router/Cargo.toml
+++ b/llm-router/Cargo.toml
@@ -19,6 +19,9 @@ path = "src/lib.rs"
 
 [dependencies]
 iii-sdk = "=0.19.2"
+# Re-exports the same `opentelemetry` the SDK uses, so we can carry the active
+# OTel context across `tokio::spawn` boundaries (shared `Context` global).
+iii-observability = "0.19.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Must stay on the same schemars major as iii-sdk so the derived

--- a/llm-router/src/chat/chat.rs
+++ b/llm-router/src/chat/chat.rs
@@ -11,6 +11,7 @@ use std::sync::{Arc, RwLock};
 use crate::types::errors::{RouterCode, RouterError};
 use crate::types::events::{AssistantMessageEvent, ErrorKind, StopReason};
 use crate::types::router::{ChatResponse, ErrorShape};
+use iii_observability::opentelemetry::trace::FutureExt as _;
 use iii_sdk::{IIIError, StreamChannelRef, TriggerRequest, III};
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -271,20 +272,28 @@ impl ChatPipeline {
             let function_id = format!("provider::{provider}::stream");
             let closer = reader.closer();
             let timeout = settings.stream_timeout_ms;
-            let call_task = tokio::spawn(async move {
-                let out = iii
-                    .trigger(TriggerRequest {
-                        function_id,
-                        payload: stream_input,
-                        action: None,
-                        timeout_ms: Some(timeout),
-                    })
-                    .await;
-                if out.is_err() {
-                    closer();
+            // Carry the caller's OTel context into the spawned task so the
+            // provider stream nests under `router::chat` instead of rooting a
+            // detached trace. `with_context` (not `cx.attach()`) because the
+            // `ContextGuard` is `!Send` and can't cross the `.await` below.
+            let parent_cx = iii_observability::opentelemetry::Context::current();
+            let call_task = tokio::spawn(
+                async move {
+                    let out = iii
+                        .trigger(TriggerRequest {
+                            function_id,
+                            payload: stream_input,
+                            action: None,
+                            timeout_ms: Some(timeout),
+                        })
+                        .await;
+                    if out.is_err() {
+                        closer();
+                    }
+                    out
                 }
-                out
-            });
+                .with_context(parent_cx),
+            );
 
             let relay = relay_frames(
                 &mut reader,


### PR DESCRIPTION
## Problem

A single chat turn fragmented into ~18 disconnected root traces instead of one waterfall. The held-open streaming triggers — `router::chat` (harness) and `provider::<id>::stream` (router) — run inside `tokio::spawn` so they execute concurrently with frame consumption. A spawned task does not inherit `OtelContext::current()`, so the SDK injected an empty `traceparent` and each call rooted its own detached trace.

Separately, `iii.session.id`/`iii.message.id` were never set in baggage anywhere (only `iii.function.id` was), so no span was attributable to a session or turn at the OTel layer.

## Changes

- **Carry OTel context across the streaming spawns.** Capture the caller's context before the spawn and wrap the spawned future with `with_context` — not `cx.attach()`, whose `ContextGuard` is `!Send` and cannot cross the `.await` inside the spawn (the same idiom the SDK uses at handler dispatch). Sites: `harness/src/clients/router.rs`, `llm-router/src/chat/chat.rs`.
- **Stamp turn identity into baggage.** Wrap the `harness::turn` step body in `run_with_baggage` so every span the step produces carries `iii.session.id` and `iii.message.id` (`iii.message.id` = the turn id). With the spawn fix, this propagates through both streaming boundaries.
- Add `iii-observability` as a direct dep of both crates (re-exports the same `opentelemetry` the SDK uses; both already lock opentelemetry 0.31.0, so the `Context` global is shared).

## Result

The turn is now a single connected trace:

```
execute harness::send
  fn_queue default
    execute harness::turn
      execute router::chat              [llm-router]
        execute provider::anthropic::stream   [provider-anthropic]
          execute router::provider::resolve   [llm-router]
```

Every span from `harness::turn` downward carries `iii.session.id`/`iii.message.id`.

### Known limitation

Spans created before the turn handler runs are not stamped: the `harness::send` root, its send-side `session::create`/`append` (the turn id is unknown until the turn is seeded), and the engine/SDK wrapper spans (`fn_queue`, `harness::turn` itself, `enqueue`). Stamping those would require setting baggage pre-enqueue and the engine carrying baggage across the queue hop.

## Verification

- `cargo build` clean on both crates.
- Live re-run against the running stack: a one-word turn produced a single 18-span trace with `router::chat` → `provider::anthropic::stream` nested, and both baggage keys present on every turn span across both spawn boundaries.
- `cargo test --lib`: harness 50 passed, llm-router 42 passed.

https://claude.ai/code/session_01FJd1oDVWb2tT2MCydydWGN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OpenTelemetry context propagation so concurrent chat/trigger operations keep the caller’s trace context, preserving correct trace nesting and correlation across async tasks.
  * Improved turn telemetry by attaching session and message identifiers to the active tracing context throughout the durable loop step.

* **Chores**
  * Added observability support dependencies to re-use the SDK’s OpenTelemetry context and enable consistent trace behavior across spawned async work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->