### PR TITLE
fix(ci): point rust-cache at the worker dir so the binary cache works

### DIFF
--- a/.github/workflows/_rust-binary.yml
+++ b/.github/workflows/_rust-binary.yml
@@ -225,10 +225,22 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # Workers live in subdirectories (no Cargo.toml at the repo root). Derive
+      # the worker's directory from manifest_path so rust-cache runs its
+      # `cargo metadata` there instead of the root.
+      - name: Resolve worker directory for cache
+        id: cache_workdir
+        shell: bash
+        run: printf 'dir=%s\n' "$(dirname '${{ inputs.manifest_path }}')" >> "$GITHUB_OUTPUT"
+
       - name: Cache cargo registry & build
         uses: Swatinem/rust-cache@v2
         with:
           key: ${{ inputs.bin_name }}-${{ matrix.target }}
+          # Without this, rust-cache defaults to the repo root, where there is no
+          # Cargo.toml — its `cargo metadata` exits 101 and the cache is never
+          # found or saved, so every build of every target ships cold.
+          workspaces: ${{ steps.cache_workdir.outputs.dir }}
 
       - name: Rewrite [package].version (bundle coordinated release)
         if: inputs.version_override != ''


### PR DESCRIPTION
## Problem

Release binary builds were running fully cold on every release — across all 9 cross-compile targets per worker — despite `Swatinem/rust-cache` being configured in `_rust-binary.yml`.

Root cause: the cache step left `workspaces` unset, so rust-cache defaults to the repo root to run its `cargo metadata` (to compute the cache key and enumerate the dependency tree). But workers live in subdirectories and there is **no `Cargo.toml` at the repo root**, so that `cargo metadata` exits 101. The cache is then never found *or saved*:

```
key: llm-router-x86_64-unknown-linux-gnu
Error: The process '/home/runner/.cargo/bin/cargo' failed with exit code 101
No cache found.
```

The actual build still succeeds (it uses `--manifest-path`), so this failed silently — the dependency tree recompiled from scratch on every target, every release.

## Fix

Derive the worker directory from `manifest_path` and pass it as rust-cache's `workspaces`, so it runs `cargo metadata` in the worker's own Cargo project:

```yaml
- name: Resolve worker directory for cache
  id: cache_workdir
  shell: bash
  run: printf 'dir=%s\n' "$(dirname '${{ inputs.manifest_path }}')" >> "$GITHUB_OUTPUT"

- uses: Swatinem/rust-cache@v2
  with:
    key: ${{ inputs.bin_name }}-${{ matrix.target }}
    workspaces: ${{ steps.cache_workdir.outputs.dir }}
```

Cross-platform (`dirname` via `shell: bash`, available on all GHA runners). The default target dir (`<worker>/target`) matches what the build produces with `--manifest-path`, so the cached `target/` lines up.

## Validation

Can only be confirmed by a real release: the first release after merge is still cold (it populates the cache), and the **next** release of the same worker/target should log a cache restore instead of `No cache found`. Low-risk — if the path were wrong, rust-cache simply stays cold as it is today.

## Note

Separately, the publish job's "Install iii CLI" step fetches the CLI via the **unauthenticated** GitHub API (60/hr) and tripped the rate limit during this batch of 7 parallel releases (one re-run fixed it). Passing `$GITHUB_TOKEN` there would remove that flake — not included here to keep this PR focused.

https://claude.ai/code/session_013LM3EaciHB9zGF8zRvjzxD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build system reliability and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->