### PR TITLE
fix(ci): publish worker trigger schemas instead of "unknown"

### DIFF
--- a/.github/scripts/build_publish_payload.py
+++ b/.github/scripts/build_publish_payload.py
@@ -199,11 +199,23 @@ def _match_worker(workers: list[dict[str, Any]], worker_name: str) -> dict[str, 
 
 
 def _normalize_registry_trigger_type(trigger_type: dict[str, Any]) -> dict[str, Any]:
+    # `engine::triggers::info` exposes the typed schemas under
+    # `configuration_schema` (the binding config, registered via the SDK's
+    # `.trigger_request_format::<T>()`) and `request_schema` (the delivered-event
+    # payload, registered via `.call_request_format::<T>()`). `engine::triggers::list`
+    # rows carry neither — they must be enriched from `::info` first (see
+    # collect_worker_interface.enrich_trigger_types_with_schemas) or these
+    # collapse to the empty `{}` that renders as 'unknown' in the registry.
+    # Fall back to the pre-rename engine keys for any older caller shape.
     return {
         "name": _string_or_empty(trigger_type.get("id")),
         "description": _string_or_empty(trigger_type.get("description")),
-        "invocation_schema": _schema_or_empty(trigger_type.get("trigger_request_format")),
-        "return_schema": _schema_or_empty(trigger_type.get("call_request_format")),
+        "invocation_schema": _schema_or_empty(
+            trigger_type.get("configuration_schema", trigger_type.get("trigger_request_format"))
+        ),
+        "return_schema": _schema_or_empty(
+            trigger_type.get("request_schema", trigger_type.get("call_request_format"))
+        ),
         "metadata": {},
     }
 

--- a/.github/scripts/collect_worker_interface.py
+++ b/.github/scripts/collect_worker_interface.py
@@ -42,6 +42,33 @@ def _typed_schema_violations(functions: list[dict[str, object]]) -> list[str]:
     return violations
 
 
+def _untyped_trigger_names(triggers: list[dict[str, object]]) -> list[str]:
+    """Trigger names whose `invocation_schema` is the empty/AnyValue ('unknown')
+    schema. Unlike functions, a schema-less trigger is NOT a hard publish blocker:
+    some trigger types legitimately take no binding config (e.g. iii-directory's
+    `directory::*::on-change`), so callers warn rather than fail."""
+    names: list[str] = []
+    for trigger in triggers:
+        if not isinstance(trigger, dict):
+            continue
+        if not _schema_is_typed(trigger.get("invocation_schema")):
+            names.append(str(trigger.get("name") or "<unknown>"))
+    return names
+
+
+def _warn_untyped_triggers(triggers: list[dict[str, object]], source: str) -> None:
+    untyped = _untyped_trigger_names(triggers)
+    if untyped:
+        print(
+            f"::warning::triggers in {source} publishing without a typed "
+            f"invocation_schema (renders 'unknown' in the registry): "
+            f"{', '.join(untyped)}. If the trigger takes a binding config, "
+            "register it with .trigger_request_format::<T>() "
+            "(see session-manager/src/events.rs).",
+            file=sys.stderr,
+        )
+
+
 def run_iii(function_path: str, payload: dict[str, object]) -> dict[str, object]:
     completed = subprocess.run(
         [
@@ -107,6 +134,61 @@ def enrich_functions_with_schemas(
             if value is not None:
                 row[key] = value
     return functions
+
+
+def _fetch_trigger_detail(trigger_id: str) -> dict[str, object] | None:
+    """`engine::triggers::info` for one trigger type, or None on any failure.
+
+    `engine::triggers::list` returns a `TriggerTypeSummary` (id + worker_name +
+    description only); only `::info` returns the `TriggerTypeDetail` carrying the
+    typed `configuration_schema`/`request_schema`/`response_schema`. Best-effort:
+    a failed lookup leaves the row schema-less, which publishes the empty
+    ("unknown") schema."""
+    try:
+        return run_iii("engine::triggers::info", {"id": trigger_id})
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        json.JSONDecodeError,
+    ) as exc:
+        print(
+            f"::warning::could not fetch engine::triggers::info for {trigger_id}: {exc}",
+            file=sys.stderr,
+        )
+        return None
+
+
+def enrich_trigger_types_with_schemas(
+    trigger_types: list[dict[str, object]],
+    target_trigger_ids: list[str],
+    *,
+    fetch_detail=_fetch_trigger_detail,
+) -> list[dict[str, object]]:
+    """Merge each target trigger type's typed schemas into its `::list` row in place.
+
+    `engine::triggers::list` omits the schemas; only `engine::triggers::info`
+    exposes them (`configuration_schema`/`request_schema`/`response_schema`).
+    Without this enrichment every collected trigger schema normalizes to the
+    empty `{}` that surfaces as 'unknown' in the registry. Mirrors
+    `enrich_functions_with_schemas` for the trigger-type surface."""
+    rows_by_id = {t.get("id"): t for t in trigger_types if isinstance(t, dict)}
+    for trigger_id in target_trigger_ids:
+        row = rows_by_id.get(trigger_id)
+        if row is None:
+            continue
+        detail = fetch_detail(trigger_id)
+        if not isinstance(detail, dict):
+            continue
+        for key in (
+            "configuration_schema",
+            "request_schema",
+            "response_schema",
+            "description",
+        ):
+            value = detail.get(key)
+            if value is not None:
+                row[key] = value
+    return trigger_types
 
 
 def wait_for_worker(
@@ -213,6 +295,7 @@ def main() -> int:
                     file=sys.stderr,
                 )
                 return 1
+            _warn_untyped_triggers(data.get("triggers") or [], args.assert_file)
         return 0
 
     if not args.worker:
@@ -261,6 +344,34 @@ def main() -> int:
 
     trigger_types_json = collect_trigger_types()
 
+    # `engine::triggers::list` carries no schemas — pull each publishable trigger
+    # type's typed schemas from `engine::triggers::info` and merge them into the
+    # rows before normalizing. Skip engine built-ins and trigger types already in
+    # the pre-worker baseline (they're dropped from the payload anyway), so we
+    # only spend `::info` calls on the worker's own trigger types.
+    if isinstance(trigger_types_json, dict):
+        collected_triggers = trigger_types_json.get("triggers")
+        if isinstance(collected_triggers, list):
+            baseline_trigger_ids = {
+                tt.get("id")
+                for tt in (
+                    baseline_json.get("triggers", [])
+                    if isinstance(baseline_json, dict)
+                    else []
+                )
+                if isinstance(tt, dict) and isinstance(tt.get("id"), str)
+            }
+            target_trigger_ids = [
+                tid
+                for t in collected_triggers
+                if isinstance(t, dict)
+                and isinstance((tid := t.get("id")), str)
+                and not tid.startswith("engine::")
+                and tid not in baseline_trigger_ids
+            ]
+            if target_trigger_ids:
+                enrich_trigger_types_with_schemas(collected_triggers, target_trigger_ids)
+
     interface = normalize_worker_interface(
         worker_name=args.worker,
         workers_json=workers_json,
@@ -290,6 +401,7 @@ def main() -> int:
                     file=sys.stderr,
                 )
                 return 1
+            _warn_untyped_triggers(data.get("triggers") or [], args.out)
 
     return 0
 

--- a/.github/scripts/tests/test_enrich_trigger_schemas.py
+++ b/.github/scripts/tests/test_enrich_trigger_schemas.py
@@ -1,0 +1,86 @@
+"""Tests for enrich_trigger_types_with_schemas in collect_worker_interface.py.
+
+`engine::triggers::list` returns only `{id, worker_name, description}`
+(a `TriggerTypeSummary`); the typed schemas live solely on
+`engine::triggers::info` (a `TriggerTypeDetail`), under `configuration_schema`
+(binding config) / `request_schema` (delivered payload) / `response_schema`.
+The collector must fetch `::info` per publishable trigger type and merge the
+schemas into the list rows before normalizing, or every trigger schema
+collapses to the empty `{}` that renders as 'unknown' in the registry.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from collect_worker_interface import enrich_trigger_types_with_schemas  # noqa: E402
+
+CFG = {"type": "object", "properties": {"session_id": {"type": "string"}}}
+REQ = {"type": "object", "properties": {"entry_id": {"type": "string"}}}
+
+
+def _details(mapping):
+    """Return a fetch_detail stub backed by a {trigger_id: detail} mapping."""
+    return lambda trigger_id: mapping.get(trigger_id)
+
+
+def test_merges_info_schemas_into_target_rows() -> None:
+    triggers = [
+        {
+            "id": "session::created",
+            "worker_name": "session-manager",
+            "description": "A new session exists.",
+        },
+    ]
+    details = {
+        "session::created": {
+            "id": "session::created",
+            "worker_name": "session-manager",
+            "description": "A new session exists.",
+            "configuration_schema": CFG,
+            "request_schema": REQ,
+            "instance_count": 0,
+        }
+    }
+
+    enrich_trigger_types_with_schemas(
+        triggers, ["session::created"], fetch_detail=_details(details)
+    )
+
+    created = triggers[0]
+    assert created["configuration_schema"] == CFG
+    assert created["request_schema"] == REQ
+
+
+def test_leaves_untargeted_rows_untouched() -> None:
+    triggers = [
+        {"id": "session::created", "worker_name": "session-manager", "description": "x"},
+        {"id": "engine::cron", "worker_name": "engine", "description": "builtin"},
+    ]
+    details = {
+        "session::created": {"configuration_schema": CFG},
+        "engine::cron": {"configuration_schema": CFG},
+    }
+
+    enrich_trigger_types_with_schemas(
+        triggers, ["session::created"], fetch_detail=_details(details)
+    )
+
+    assert "configuration_schema" in triggers[0]
+    assert "configuration_schema" not in triggers[1]
+
+
+def test_tolerates_missing_info_detail() -> None:
+    """A `::info` lookup that returns None (call failed / unknown id) must not
+    raise — the row keeps no schema and publishes the empty ('unknown') schema."""
+    triggers = [
+        {"id": "session::created", "worker_name": "session-manager", "description": "x"},
+    ]
+
+    enrich_trigger_types_with_schemas(
+        triggers, ["session::created"], fetch_detail=lambda _id: None
+    )
+
+    assert "configuration_schema" not in triggers[0]

--- a/.github/scripts/tests/test_normalize_worker_interface.py
+++ b/.github/scripts/tests/test_normalize_worker_interface.py
@@ -101,6 +101,122 @@ def test_surfaces_typed_schemas_from_info_enriched_rows() -> None:
     ]
 
 
+def _session_manager_args(trigger_types_json):
+    """Minimal workers/functions JSON so a session-manager trigger payload
+    resolves; the assertion under test is the triggers mapping."""
+    return {
+        "worker_name": "session-manager",
+        "workers_json": {
+            "workers": [{"id": "session-manager", "name": "session-manager", "runtime": "rust"}]
+        },
+        "functions_json": {
+            "functions": [
+                {
+                    "function_id": "session::append",
+                    "worker_name": "session-manager",
+                    "description": "append",
+                }
+            ]
+        },
+        "trigger_types_json": trigger_types_json,
+    }
+
+
+def test_surfaces_trigger_schemas_from_info_enriched_rows() -> None:
+    """`engine::triggers::list` rows carry no schemas — only `engine::triggers::info`
+    does, under `configuration_schema`/`request_schema`. Once the collector
+    enriches each row from `::info`, normalize must surface those typed schemas
+    (not the empty `{}` it produced when reading the never-present
+    `trigger_request_format`/`call_request_format` keys)."""
+    cfg = {
+        "type": "object",
+        "title": "CreatedBindingConfig",
+        "properties": {"session_id": {"type": "string"}},
+    }
+    req = {
+        "type": "object",
+        "title": "SessionEvent",
+        "properties": {"entry_id": {"type": "string"}},
+    }
+    interface = normalize_worker_interface(
+        **_session_manager_args(
+            {
+                "triggers": [
+                    {
+                        "id": "session::created",
+                        "worker_name": "session-manager",
+                        "description": "A new session exists.",
+                        "configuration_schema": cfg,
+                        "request_schema": req,
+                    }
+                ]
+            }
+        )
+    )
+
+    assert interface["triggers"] == [
+        {
+            "name": "session::created",
+            "description": "A new session exists.",
+            "invocation_schema": cfg,
+            "return_schema": req,
+            "metadata": {},
+        }
+    ]
+
+
+def test_untyped_trigger_surfaces_empty_schema() -> None:
+    """A trigger type registered without a binding config (e.g. iii-directory's
+    `directory::*::on-change`) has no schema in `::info` — normalize emits an
+    empty `{}`, which the publish step warns (not errors) about."""
+    interface = normalize_worker_interface(
+        **_session_manager_args(
+            {
+                "triggers": [
+                    {
+                        "id": "session::created",
+                        "worker_name": "session-manager",
+                        "description": "A new session exists.",
+                    }
+                ]
+            }
+        )
+    )
+
+    assert interface["triggers"] == [
+        {
+            "name": "session::created",
+            "description": "A new session exists.",
+            "invocation_schema": {},
+            "return_schema": {},
+            "metadata": {},
+        }
+    ]
+
+
+def test_trigger_schema_falls_back_to_legacy_engine_keys() -> None:
+    """Older engine output named the schemas `trigger_request_format` /
+    `call_request_format`; normalize still reads them as a fallback so a mixed
+    engine version doesn't silently drop schemas."""
+    cfg = {"type": "object", "properties": {"session_id": {"type": "string"}}}
+    interface = normalize_worker_interface(
+        **_session_manager_args(
+            {
+                "triggers": [
+                    {
+                        "id": "session::created",
+                        "worker_name": "session-manager",
+                        "description": "A new session exists.",
+                        "trigger_request_format": cfg,
+                    }
+                ]
+            }
+        )
+    )
+
+    assert interface["triggers"][0]["invocation_schema"] == cfg
+
+
 def test_collects_single_worker_without_baseline() -> None:
     workers_json = {
         "workers": [{"id": "shell", "name": "shell", "runtime": "rust"}],


### PR DESCRIPTION
## Problem

Every published worker trigger shows `invocation_schema: {}` and `return_schema: {}`, which the registry renders as **"unknown"**. Confirmed live across all workers — e.g. [session-manager `session::created`](https://workers.iii.dev/workers/session-manager?tab=api#trigger-session::created), llm-router, iii-directory. Trigger descriptions publish fine; only the schemas are empty.

## Root cause

The worker source and the engine are both correct — the workers register trigger types with `.trigger_request_format::<…>()`, and the engine exposes the schema. The bug is entirely in the publish scripts:

- The collector reads trigger types from `engine::triggers::list`, which returns a `TriggerTypeSummary` (`id`/`worker_name`/`description`) with **no schemas**. The typed schemas live solely on `engine::triggers::info` (`TriggerTypeDetail`).
- The engine renamed those fields: SDK `.trigger_request_format::<T>()` → `configuration_schema`, `.call_request_format::<T>()` → `request_schema`. `build_publish_payload.py` still read the obsolete `trigger_request_format`/`call_request_format` keys.

So every trigger normalized to `{}`. Nothing caught it: the `--assert-typed-schemas` gate only checks functions, and there was no trigger test coverage.

This is the trigger-side twin of #285, which enriched **functions** from `engine::functions::info` but left triggers on the schema-less `::list`.

## Fix

- **`collect_worker_interface.py`** — `enrich_trigger_types_with_schemas` fetches `engine::triggers::info` per publishable trigger type and merges the typed schemas into the rows before normalizing (mirrors the existing `enrich_functions_with_schemas`). Emits a non-fatal warning for any trigger still publishing without a typed `invocation_schema`.
- **`build_publish_payload.py`** — `_normalize_registry_trigger_type` reads `configuration_schema` → `invocation_schema` and `request_schema` → `return_schema`, keeping the legacy keys as a fallback.
- **Tests** — new `test_enrich_trigger_schemas.py` plus trigger field-mapping cases in `test_normalize_worker_interface.py`.

### Why a warning, not a hard gate
Some trigger types legitimately take no binding config (e.g. iii-directory's `directory::*::on-change` register no `trigger_request_format`), so a hard `--assert-typed-schemas` on triggers would block their release. Functions stay a hard gate.

## Verification

- End-to-end before/after against the real engine output shape: empty `{}` → the real typed schema.
- `pytest .github/scripts/tests/` → **107 passed**.
- Confirmed iii `0.17.0` (the version the publish workflow installs) already returns `configuration_schema`/`request_schema` from `engine::triggers::info`.

## Rollout note

This only affects the **next** publish. Already-published versions keep their "unknown" schemas until re-published. The collector runs at the **release tag ref**, so this needs a new release tag to take effect — re-running an old release run re-runs the old script.

https://claude.ai/code/session_017CciKnWZzsLprzZ6XFHZJ2