### PR TITLE
chore(iii-directory): deprecate in favor of directory (final v1.0.1)

### DIFF
--- a/iii-directory/README.md
+++ b/iii-directory/README.md
@@ -1,5 +1,17 @@
 # iii-directory
 
+> [!WARNING]
+> **`iii-directory` is deprecated and has been renamed to `directory`.**
+> **This is the final release under the `iii-directory` name** — it will
+> receive no further updates. Migrate to the `directory` worker:
+>
+> ```bash
+> iii worker add directory
+> ```
+>
+> The public API is unchanged (the function namespace was already
+> `directory::*`); only the worker/package name changes.
+
 Workers registry HTTP proxy and filesystem-backed skill + prompt
 reader for the [iii engine](https://github.com/iii-hq/iii). Every
 public function sits under a single `directory::*` namespace, split

--- a/iii-directory/iii.worker.yaml
+++ b/iii-directory/iii.worker.yaml
@@ -4,7 +4,7 @@ language: rust
 deploy: binary
 manifest: Cargo.toml
 bin: iii-directory
-description: Engine introspection (functions / triggers / workers), workers registry proxy, and filesystem-backed skill + prompt reader.
+description: "[DEPRECATED — renamed to `directory`; final iii-directory release] Engine introspection (functions / triggers / workers), workers registry proxy, and filesystem-backed skill + prompt reader."
 
 dependencies:
   configuration: "^0.19.0"

--- a/iii-directory/src/main.rs
+++ b/iii-directory/src/main.rs
@@ -79,6 +79,16 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
+    // Deprecation banner. `iii-directory` has been renamed to `directory`;
+    // this is the final release under the old name. Emitted at boot (skipped
+    // in `--manifest` mode above so machine-readable output stays clean).
+    tracing::warn!(
+        "DEPRECATED: `iii-directory` is now `directory`. v{} is the FINAL \
+         release under the `iii-directory` name and will receive no further \
+         updates. Migrate to the `directory` worker: `iii worker add directory`.",
+        env!("CARGO_PKG_VERSION")
+    );
+
     // Connect to the engine first so the configuration RPCs are reachable.
     let iii = register_worker(
         &cli.url,


### PR DESCRIPTION
## What

Flag the `iii-directory` worker as deprecated so users migrate to `directory` (the renamed worker, see #266) before the rename lands. **Should merge before #266.**

## Changes

- **Startup banner** — deprecation `WARN` at boot (skipped in `--manifest` mode so machine output stays clean), pointing users to `iii worker add directory`. Version is read dynamically from `CARGO_PKG_VERSION`.
- **README** — deprecation `> [!WARNING]` notice at the top.
- **Registry description** — flagged `[DEPRECATED — renamed to directory; final iii-directory release]` in `iii.worker.yaml` (surfaces in registry / console / `iii worker info`).

**No manual version bump** — the `Create Tag` workflow bumps the manifest and cuts the final `iii-directory` release. No functional/API change (the namespace was already `directory::*`).

## Startup output

```
WARN iii_directory: DEPRECATED: `iii-directory` is now `directory`. v1.0.0 is the FINAL release under the `iii-directory` name and will receive no further updates. Migrate to the `directory` worker: `iii worker add directory`.
```
(the version shown reflects whatever the Create Tag release cuts)

## Verification

- `cargo fmt --check` ✓ · `cargo build` ✓ · 249 unit + 44/44 BDD ✓
- `validate_worker.py` EXIT=0 ✓
- startup banner confirmed by running the binary ✓

## Release

After merge: run **Create Tag** (worker=`iii-directory`, bump=`patch`) → cuts the final release; then merge #266.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deprecation notice: `iii-directory` has been renamed to `directory`. This is the final release under the old name. Users are instructed to migrate using `iii worker add directory`. The public API namespace remains unchanged.

* **Chores**
  * Added startup deprecation warning for end-users.
  * Updated manifest metadata to reflect the deprecation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->