### PR TITLE
fix(web): publish a typed response schema for web::fetch

### DIFF
--- a/web/src/functions/fetch.rs
+++ b/web/src/functions/fetch.rs
@@ -12,7 +12,7 @@ use serde_json::{json, Value};
 
 use crate::config::{SharedConfig, WebConfig};
 use crate::fetch::execute_fetch;
-use crate::schemas::{request_schema, FetchPayload, TOOL_DESCRIPTION};
+use crate::schemas::{request_schema, response_schema, FetchPayload, TOOL_DESCRIPTION};
 
 /// Parse + validate + execute. Always returns an envelope (never errors).
 pub async fn handle(payload: Value, cfg: &WebConfig) -> Value {
@@ -46,7 +46,8 @@ pub fn register(iii: &Arc<III>, shared: &SharedConfig) {
             }
         })
         .description(TOOL_DESCRIPTION)
-        .request_format(request_schema()),
+        .request_format(request_schema())
+        .response_format(response_schema()),
     );
 }
 

--- a/web/src/schemas.rs
+++ b/web/src/schemas.rs
@@ -99,6 +99,38 @@ pub fn request_schema() -> serde_json::Value {
         .expect("FetchPayload schema serializes")
 }
 
+/// Typed schema for the `web::fetch` response envelope. The handler returns a
+/// raw `Value` (its shape is request-dependent), so this type exists only to
+/// publish a concrete response schema: the SDK would otherwise emit the
+/// permissive `AnyValue` schema, which the registry rejects. Every field is
+/// optional because no single response carries all of them — success carries
+/// `ok`/`status`/`headers`/`body`/…, the page-mode viewable-image variant
+/// carries `content`+`details`, and failures carry `ok=false`/`error`/`message`.
+#[derive(JsonSchema)]
+pub struct FetchResponse {
+    pub ok: Option<bool>,
+    pub error: Option<String>,
+    pub message: Option<String>,
+    pub status: Option<u16>,
+    pub status_text: Option<String>,
+    pub headers: Option<BTreeMap<String, String>>,
+    pub body: Option<String>,
+    pub response_format: Option<String>,
+    pub bytes_truncated: Option<bool>,
+    pub content_type: Option<String>,
+    pub transformed: Option<String>,
+    pub json: Option<serde_json::Value>,
+    pub parse_error: Option<String>,
+    pub redirect_chain: Option<Vec<String>>,
+    pub content: Option<serde_json::Value>,
+    pub details: Option<serde_json::Value>,
+}
+
+pub fn response_schema() -> serde_json::Value {
+    serde_json::to_value(schemars::schema_for!(FetchResponse))
+        .expect("FetchResponse schema serializes")
+}
+
 pub const TOOL_DESCRIPTION: &str = concat!(
     "Fetch a URL over HTTP(S) and return the response as a structured envelope. ",
     "Use this INSTEAD of `shell::exec` with curl for any HTTP request — it ",
@@ -178,5 +210,16 @@ mod tests {
         let s = request_schema();
         assert_eq!(s["type"], "object");
         assert!(s["properties"].get("url").is_some());
+    }
+
+    // The registry's publish gate rejects untyped (AnyValue/empty) schemas,
+    // so the response schema must be a concrete object. Guards against the
+    // handler's raw-`Value` return leaking an AnyValue schema again.
+    #[test]
+    fn response_schema_is_typed_object() {
+        let s = response_schema();
+        assert_eq!(s["type"], "object");
+        assert!(s["properties"].get("ok").is_some());
+        assert!(s["properties"].get("error").is_some());
     }
 }


### PR DESCRIPTION
## Problem

The `web/v1.1.0` release ([run 27841712523](https://github.com/iii-hq/workers/actions/runs/27841712523/job/82402692354)) built fine but **failed at the registry publish step**:

```
untyped (AnyValue/empty) schemas in worker-interface.json: web::fetch.response_schema.
Register the handler with a typed struct deriving schemars::JsonSchema
```

`web::fetch` registers a raw `serde_json::Value` handler (deliberate: it owns the `invalid_payload` error contract and returns a polymorphic envelope). The SDK therefore emitted the permissive `AnyValue` schema for the **response**, which the publish gate (`collect_worker_interface.py --assert-typed-schemas`) rejects. The request schema was already typed via `.request_format(request_schema())`; only the response was untyped.

## Fix

- Add a `FetchResponse` struct deriving `JsonSchema` that documents the envelope (success / page-image / error variants; all fields optional since no single response carries all of them).
- Wire it with `.response_format(response_schema())` — symmetric with the existing `.request_format(request_schema())`, keeping the deliberate `Value`-handler design rather than rewriting the polymorphic envelope construction.
- Add a unit test asserting the response schema is a concrete object (`type`/`properties`), so this can't regress before CI.

`cargo test` (55), `clippy -D warnings`, and `cargo fmt --check` all pass.

## Follow-up after merge

`web/v1.1.0` was built from a commit without this fix, so re-running that release would fail again. After merging, cut a **new** web release (Create Tag → worker `web`, e.g. `v1.1.1`) to produce a passing publish.

https://claude.ai/code/session_01QY5uCFgwr4wXR7ZcAKanaR