### PR TITLE
fix(web): name the release binary after the worker so `iii worker add` resolves it

### DIFF
--- a/.github/scripts/tests/test_validate_worker.py
+++ b/.github/scripts/tests/test_validate_worker.py
@@ -101,6 +101,28 @@ class TestValidateWorker:
         assert r.returncode != 0
         assert "deploy" in r.stdout + r.stderr
 
+    def test_binary_bin_name_mismatch_fails(self, tmp_path):
+        # A binary worker whose `bin` differs from the worker name ships a
+        # release archive the resolver can't find (web/v1.1.x regression).
+        repo = make_worker(tmp_path, "smoke", deploy="binary")
+        meta = repo / "smoke" / "iii.worker.yaml"
+        meta.write_text(meta.read_text() + "bin: iii-smoke\n")
+        init_git(repo)
+        r = run_script(repo, "smoke", source_changed=["smoke"])
+        assert r.returncode != 0, r.stdout + r.stderr
+        assert "iii-smoke" in r.stdout + r.stderr
+        assert "not found in archive" in r.stdout + r.stderr
+
+    def test_binary_bin_name_exception_allowlisted_passes(self, tmp_path):
+        # `acp` intentionally ships a user-facing `iii-acp` binary; the
+        # allowlist exempts it from the bin==name gate.
+        repo = make_worker(tmp_path, "acp", deploy="binary")
+        meta = repo / "acp" / "iii.worker.yaml"
+        meta.write_text(meta.read_text() + "bin: iii-acp\n")
+        init_git(repo)
+        r = run_script(repo, "acp", source_changed=["acp"])
+        assert r.returncode == 0, r.stdout + r.stderr
+
     def test_missing_name_field_fails(self, tmp_path):
         repo = make_worker(tmp_path, "smoke")
         meta = repo / "smoke" / "iii.worker.yaml"

--- a/.github/scripts/validate_worker.py
+++ b/.github/scripts/validate_worker.py
@@ -39,6 +39,19 @@ BOOTSTRAP_WORKERS = frozenset({
 
 SKILL_MD_SIZE_CAP = 256 * 1024  # 256 KiB
 
+# `iii worker add <worker>` downloads the release archive and looks for a
+# binary named after the WORKER (see iii crates/iii-worker binary_download.rs:
+# extract_binary_from_targz(worker_name, ...)). The registry payload carries
+# only the worker name, never the cargo [[bin]] name, so the packaged binary
+# MUST be named after the worker or the resolver fails with
+# "Binary '<worker>' not found in archive" (web/v1.1.x shipped this bug).
+# Workers below intentionally ship a differently-named, user-facing binary and
+# are known-broken on fresh `iii worker add` until the resolver carries the
+# bin name through the registry; do not silently extend this list.
+BINARY_NAME_EXCEPTIONS = frozenset({
+    "acp",  # editors launch the `iii-acp` binary by name (ACP subprocess)
+})
+
 
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser()
@@ -96,6 +109,18 @@ def main(argv: list[str] | None = None) -> int:
             hard(
                 f"{worker}/iii.worker.yaml language must be 'rust' | 'node' | 'python' | 'javascript'"
             )
+        # The release archive's binary is named after `bin` (defaulting to the
+        # worker name); the resolver looks it up by worker name. They must match
+        # or `iii worker add {worker}` fails with "Binary not found in archive".
+        if m.deploy == "binary":
+            effective_bin = m.bin or m.name
+            if effective_bin != worker and worker not in BINARY_NAME_EXCEPTIONS:
+                hard(
+                    f"{worker}/iii.worker.yaml bin={effective_bin!r} must equal the "
+                    f"worker name {worker!r} for binary deploys: `iii worker add` "
+                    f"extracts the release archive by worker name and would fail "
+                    f"with \"Binary '{worker}' not found in archive\""
+                )
 
     # 3. Manifest version >= base
     if m is not None and m.manifest:

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [[bin]]
-name = "iii-web"
+name = "web"
 path = "src/main.rs"
 
 [lib]

--- a/web/README.md
+++ b/web/README.md
@@ -29,7 +29,7 @@ existing callers and the harness consumer are unaffected.
 iii worker add web
 ```
 
-`iii worker add` fetches the binary (`iii-web`), writes a config block into
+`iii worker add` fetches the binary (`web`), writes a config block into
 `~/.iii/config.yaml`, and the engine starts the worker on the next
 `iii start`.
 
@@ -188,7 +188,7 @@ which loopback returns `blocked_host`.
 ## Local development & testing
 
 ```bash
-cargo build                  # build the iii-web binary
+cargo build                  # build the web binary
 cargo test                   # unit + wiremock integration + adversarial SSRF tests
 cargo clippy -- -D warnings  # lints
 cargo fmt --check            # formatting

--- a/web/iii.worker.yaml
+++ b/web/iii.worker.yaml
@@ -3,7 +3,7 @@ name: web
 language: rust
 deploy: binary
 manifest: Cargo.toml
-bin: iii-web
+bin: web
 description: Outbound HTTP client on the iii bus (web::fetch).
 
 dependencies:

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -1,4 +1,4 @@
-//! `iii-web` binary entry: connect, register configuration + fetch the
+//! `web` binary entry: connect, register configuration + fetch the
 //! authoritative value, register `web::fetch`, bind the config-change
 //! trigger for hot-reload, then sleep until Ctrl+C.
 
@@ -13,7 +13,7 @@ use web::{configuration, functions, manifest};
 
 #[derive(Parser, Debug)]
 #[command(
-    name = "iii-web",
+    name = "web",
     about = "Outbound HTTP client on the iii bus (web::fetch)."
 )]
 struct Cli {


### PR DESCRIPTION
## Symptom

`iii worker add web` fails:

```
✓ Resolved to binary v1.1.1
✗ Download failed: Binary 'web' not found in archive
```

## Root cause

The TS→Rust migration (#295) named web's binary `iii-web` — both `web/Cargo.toml` `[[bin]] name` and `web/iii.worker.yaml` `bin`. But `iii worker add <worker>` downloads the release archive and looks for a binary named after the **worker** (`web`):

- `iii-worker/src/cli/binary_download.rs:358` → `extract_binary_from_targz(worker_name, …)` (worker_name = `web`)
- `binary_download.rs:113` → `Err("Binary '{}' not found in archive")`

The registry publish payload carries only the worker name + archive URLs, never the cargo `[[bin]]` name (`build_publish_payload.py:331-354`, `resolve_binary_artifacts.py:44-47`, `registry.rs` `BinaryInfo{url,sha256}`). So for `deploy: binary` workers the packaged binary **must** be named after the worker. 21 of 23 workers already follow this; `web` was the lone deviation reachable purely via `iii worker add`.

## Fix

Rename web's binary to `web`:

- `web/Cargo.toml` `[[bin]] name`: `iii-web` → `web`
- `web/iii.worker.yaml` `bin`: `iii-web` → `web`
- `web/src/main.rs` doc comment + clap `name` (cosmetic)
- `web/README.md` references (cosmetic)

Runtime identity is unchanged — `main.rs:53` registers `name: "web"` and `manifest.rs:18` uses `CARGO_PKG_NAME`. Cargo allows `[lib]` and `[[bin]]` to both be `web`.

## Regression guard

`.github/scripts/validate_worker.py`: for `deploy: binary` workers, `bin` (defaulting to the worker name) must equal the worker name, or the release archive can't be unpacked by `iii worker add`. Fires with the exact "Binary not found in archive" message at PR time.

`acp` is allowlisted: its `iii-acp` binary is **user-facing** (editors launch it by name as an ACP subprocess), so it needs a resolver-side fix (carry the bin name through the registry payload), not a rename. It has the same latent bug today on `iii worker add acp`.

## Verification

- `cargo metadata`: bin target is now `web` (no `iii-web`).
- `.github/scripts` tests: **105 passed**, including 2 new regression tests (`test_binary_bin_name_mismatch_fails`, `test_binary_bin_name_exception_allowlisted_passes`).
- Reintroducing `bin: iii-web` makes the guard fail with the exact reported error and exit 1.

## Follow-ups (not in this PR)

- **Cut a new release** (web → v1.1.2) via the Create Tag action — the source rename does not fix the already-published v1.1.1 artifact.
- **`acp`**: needs the resolver-side bin-name fix in the `iii` CLI repo + registry payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected web binary name from `iii-web` to `web` in configuration and implementation.

* **Documentation**
  * Updated build and installation instructions to reference the updated binary name.

* **Tests**
  * Enhanced worker validation to enforce binary name consistency with worker configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->