### PR TITLE
feat(shell): make permissive exec the default policy

### DIFF
--- a/shell/README.md
+++ b/shell/README.md
@@ -39,20 +39,22 @@ The worker refuses to start unless `fs.host_root` is set, or `fs.allow_unjailed:
 By default, `mkdir`/`chmod`/`write` reject modes carrying setuid/setgid/sticky bits (the top octal digit, e.g. `4755`) with `S210`, since they are a privilege-escalation primitive when the worker runs as root inside the jail. Set `fs.allow_special_bits: true` only if your workload genuinely needs them.
 
 ```yaml
-max_timeout_ms: 30000        # foreground exec hard cap; per-call timeout_ms is clamped to this
+max_timeout_ms: 120000       # foreground exec hard cap; per-call timeout_ms is clamped to this
 max_bg_timeout_ms: 0         # host bg job hard cap in ms; 0 = unbounded (foreground uses max_timeout_ms)
 default_timeout_ms: 10000    # applied when the caller omits timeout_ms
 max_output_bytes: 1048576    # 1 MiB; stdout/stderr past this set *_truncated
-inherit_env: false           # when false, only allowed_env keys are forwarded
-allowed_env: [PATH, HOME, LANG, LC_ALL, TERM]  # also gates per-call `env` (dangerous keys never settable)
+inherit_env: true            # forward the worker's env to children; per-call dangerous keys still blocked
+allowed_env: [PATH, HOME, LANG, LC_ALL, TERM]  # gates per-call `env` (dangerous keys never settable)
 
 # exec gate. argv[0] is matched by basename or exact path; an empty
-# allowlist means open. denylist_patterns are advisory regex over
-# argv.join(" "), a tripwire for honest mistakes only.
-allowlist: [ls, cat, pwd, echo, grep, wc, head, tail, sort, uniq, cut, date]
+# allowlist means OPEN — the shipped default, so any command runs.
+# denylist_patterns are advisory regex over argv.join(" "), a tripwire for
+# catastrophic mistakes only, NOT a security boundary.
+allowlist: []
 denylist_patterns:
   - "rm\\s+-rf\\s+/"
   - "mkfs"
+  - "dd\\s+if="
 
 max_concurrent_jobs: 16      # exec_bg past this is rejected
 job_retention_secs: 3600     # finished jobs pruned after this

--- a/shell/config.yaml
+++ b/shell/config.yaml
@@ -1,69 +1,45 @@
-max_timeout_ms: 30000
+# Permissive dev default: 2 min foreground cap so a real build/test
+# (cargo build, cargo test, npm test) is not reaped at 30s. Long jobs should
+# still go through shell::exec_bg (unbounded by default).
+max_timeout_ms: 120000
 max_bg_timeout_ms: 0  # host bg job hard cap in ms; 0 = unbounded (foreground uses max_timeout_ms)
 default_timeout_ms: 10000
 max_output_bytes: 1048576
 working_dir: null
-inherit_env: false
+# Forward the worker's full environment to children so toolchains (cargo,
+# rustup, git, node) find their PATH/HOME/CARGO_HOME/etc. Per-call `env`
+# overrides are still gated: PATH/HOME/LD_*/DYLD_* and interpreter startup
+# keys can never be set per call (see exec/policy.rs DANGEROUS_ENV_KEYS).
+# NOTE: this also forwards any secrets in the worker's env to every command;
+# run the worker with a clean environment if that matters to you.
+inherit_env: true
 allowed_env:
   - PATH
   - HOME
   - LANG
   - LC_ALL
   - TERM
-# Default allowlist is intentionally read-only. Tools that can shell out
-# (git hooks, curl -o/file://, find -exec, awk system(), sed e/-i, Rust
-# build-script hooks, node -e, python3 -c, npm run, env <cmd>) are left out on
-# purpose; add them per deployment after you've decided on the threat
-# model. This worker is NOT a sandbox. Use `printenv` for read-only env
-# inspection; `env` is excluded because `env <cmd>` execs arbitrary
-# programs while passing argv[0]=="env" through the allowlist gate.
-allowlist:
-  - ls
-  - cat
-  - pwd
-  - echo
-  - grep
-  - wc
-  - head
-  - tail
-  - sort
-  - uniq
-  - cut
-  - date
-  - whoami
-  - hostname
-  - which
-  - jq
-  - uname
-  - df
-  - du
-  - ps
-  - printenv
-  - basename
-  - dirname
-# Denylist patterns are advisory, not a security boundary. They run as
-# regex against `argv.join(" ")`, so a caller invoking an allowlisted
-# shell or interpreter (sh, node, python, etc.) can bypass any pattern
-# by constructing the forbidden token at runtime (variables, eval,
-# IFS tricks, base64, etc.). Treat these as a tripwire for honest
-# mistakes; the security boundary is the sandbox backend.
+# PERMISSIVE DEFAULT: an EMPTY allowlist means every command is allowed
+# (cargo, git, bash, make, node, python3, …). This is deliberate — a coding
+# agent needs arbitrary build/test/VCS tooling, and a half-open list is
+# defeated the moment any shell/interpreter is on it. This worker is NOT a
+# sandbox: the security boundary is the fs jail (fs.host_root) plus the
+# optional sandbox backend, NOT this list. To re-scope exec to deny-by-default,
+# list the permitted argv[0] basenames here (a non-empty list flips the gate).
+allowlist: []
+# Advisory tripwire ONLY (regex over argv.join(" ")), trivially evadable via an
+# interpreter — NOT a security boundary. With an open allowlist the old
+# sub-execution escapes (find -exec, sed -i, node/python -c, npm run, env <cmd>)
+# are pure dev friction with no security value, so they were dropped; only
+# catastrophic, host-wrecking patterns are kept to catch honest mistakes.
 denylist_patterns:
   - "rm\\s+-rf\\s+/"
-  - ":\\(\\)\\s*\\{\\s*:\\|"
+  - ":\\(\\)\\s*\\{\\s*:\\|"   # fork bomb
   - "mkfs"
   - "dd\\s+if="
   - "shutdown"
   - "reboot"
-  - "/etc/passwd"
   - "/etc/shadow"
-  # Sub-execution / write escapes for commonly-added tools
-  - "\\bfind\\b[^|;&]*-exec(dir)?\\b"
-  - "\\bawk\\b[^|;&]*system\\s*\\("
-  - "\\bsed\\b[^|;&]*(-i\\b|\\be\\b)"
-  - "\\bcurl\\b[^|;&]*(file://|-o\\s|--output-dir\\b|-F\\s+@)"
-  - "\\bgit\\b[^|;&]*(--upload-pack|--receive-pack|core\\.pager|core\\.hooksPath|GIT_SSH_COMMAND)"
-  - "\\b(node|python3?)\\b[^|;&]*\\s-(e|c)\\b"
-  - "\\bnpm\\b[^|;&]*\\brun\\b"
 max_concurrent_jobs: 16
 job_retention_secs: 3600
 

--- a/shell/src/config.rs
+++ b/shell/src/config.rs
@@ -439,7 +439,10 @@ mod tests {
         let mut c: ShellConfig = serde_yaml::from_str(&content).expect("config.yaml parses");
         c.compile_denylist().expect("denylist compiles");
         // Empty allowlist == open: every command a coding agent needs is permitted.
-        assert!(c.allowlist.is_empty(), "shipped allowlist must be open (empty)");
+        assert!(
+            c.allowlist.is_empty(),
+            "shipped allowlist must be open (empty)"
+        );
         for cmd in ["cargo", "git", "bash", "make", "node", "python3"] {
             assert!(
                 c.is_command_allowed(&[cmd.into()]).is_ok(),
@@ -448,9 +451,7 @@ mod tests {
         }
         // The previously-blocked exec-escape (`env <cmd>`) is now permitted —
         // the open allowlist is the point of this standard.
-        assert!(c
-            .is_command_allowed(&["env".into(), "nmap".into()])
-            .is_ok());
+        assert!(c.is_command_allowed(&["env".into(), "nmap".into()]).is_ok());
         // The catastrophic denylist is still a live tripwire.
         let err = c
             .is_command_allowed(&["rm".into(), "-rf".into(), "/".into()])

--- a/shell/src/config.rs
+++ b/shell/src/config.rs
@@ -427,24 +427,35 @@ mod tests {
         assert!(err.contains("denylist"), "got: {err}");
     }
 
-    /// Loads the shipped `config.yaml` and asserts the default allowlist
-    /// preserves read-only env inspection (`printenv`) while rejecting the
-    /// `env <cmd>` exec-escape. `env` was removed from the default allowlist
-    /// because `is_command_allowed` only checks argv[0]; with `env`
-    /// allowlisted, `env nmap target` would have argv[0]=="env" and pass.
-    /// Parses the YAML directly (skipping the fs-jail check,
-    /// which is unrelated to the allowlist policy under test).
+    /// Loads the shipped `config.yaml` and pins the permissive standard: an
+    /// empty allowlist means arbitrary commands are allowed (cargo/git/bash/…),
+    /// while the catastrophic-only denylist still trips on host-wrecking
+    /// patterns. Parses the YAML directly (skipping the fs-jail check, which is
+    /// unrelated to the exec policy under test).
     #[test]
-    fn shipped_config_blocks_env_exec_escape() {
+    fn shipped_config_is_open_exec_with_catastrophic_denylist() {
         let path = concat!(env!("CARGO_MANIFEST_DIR"), "/config.yaml");
         let content = std::fs::read_to_string(path).expect("read config.yaml");
         let mut c: ShellConfig = serde_yaml::from_str(&content).expect("config.yaml parses");
         c.compile_denylist().expect("denylist compiles");
-        assert!(c.is_command_allowed(&["printenv".into()]).is_ok());
+        // Empty allowlist == open: every command a coding agent needs is permitted.
+        assert!(c.allowlist.is_empty(), "shipped allowlist must be open (empty)");
+        for cmd in ["cargo", "git", "bash", "make", "node", "python3"] {
+            assert!(
+                c.is_command_allowed(&[cmd.into()]).is_ok(),
+                "open allowlist must permit {cmd}"
+            );
+        }
+        // The previously-blocked exec-escape (`env <cmd>`) is now permitted —
+        // the open allowlist is the point of this standard.
+        assert!(c
+            .is_command_allowed(&["env".into(), "nmap".into()])
+            .is_ok());
+        // The catastrophic denylist is still a live tripwire.
         let err = c
-            .is_command_allowed(&["env".into(), "nmap".into(), "host".into()])
-            .expect_err("env <cmd> must be rejected");
-        assert!(err.contains("not in allowlist"));
+            .is_command_allowed(&["rm".into(), "-rf".into(), "/".into()])
+            .expect_err("rm -rf / must still trip the denylist");
+        assert!(err.contains("denylist"), "got: {err}");
     }
 
     #[test]


### PR DESCRIPTION
## What

Makes the shell worker's shipped default **permissive**: an empty command allowlist (which the gate treats as "open — any command runs"), `inherit_env: true`, a 120s foreground timeout, and a denylist trimmed to catastrophic-only patterns.

## Why

The read-only default allowlist (`ls`/`cat`/`grep`/…) blocks the tooling a coding agent actually needs — `cargo`, `git`, `bash`, `make`, `node`, `python3`. In practice that forces operators to allowlist commands one at a time, and a half-open list is defeated the moment any shell or interpreter is added to it. For a worker that already documents itself as "not a sandbox," the honest model is: leave exec open and rely on the real boundaries.

## Security posture (unchanged boundaries)

- **fs jail** (`fs.host_root`) still confines every `shell::fs::*` op and the per-call `cwd`.
- **sandbox backend** (`target: { kind: "sandbox" }`) is still the boundary for untrusted input.
- **per-call env gate** is untouched — `PATH`/`HOME`/`LD_*`/`DYLD_*` and interpreter startup keys can never be set per call (`DANGEROUS_ENV_KEYS`).
- **catastrophic denylist** kept as an advisory tripwire: `rm -rf /`, `dd if=`, `mkfs`, fork bomb, `shutdown`/`reboot`, `/etc/shadow`.

The sub-execution denylist entries (`find -exec`, `sed -i`, `node/python -c`, `npm run`, `env <cmd>`) were dropped — they only existed to plug holes in a non-empty allowlist and are pure friction once exec is open.

## Changes

- `config.yaml` — `allowlist: []`, `inherit_env: true`, `max_timeout_ms: 120000`, catastrophic-only denylist.
- `src/config.rs` — replaced the `shipped_config_blocks_env_exec_escape` test with `shipped_config_is_open_exec_with_catastrophic_denylist`, pinning the new contract (open exec permits `cargo`/`git`/`bash`; `rm -rf /` still trips the denylist).
- `README.md` — documents the open default.

## Test plan

- [x] `cargo test` — full shell crate suite green (548 passed).
- [x] New unit test asserts the shipped `config.yaml` parses, is open, and the catastrophic denylist still rejects `rm -rf /`.
- [ ] Note: this only changes the **first-registration seed**. An already-registered worker keeps its stored config (which wins over the file) and must be updated via `configuration::set shell` — it hot-reloads, no restart.

https://claude.ai/code/session_01Cy5KwY8y2NcPPnyo4LVste


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended execution timeout limits
  * Environment variables now available to executed commands by default
  * Broadened command execution permissions while preserving safety guardrails against destructive operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->