### PR TITLE
fix(console): make the approval-gate worker optional

### DIFF
--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -158,10 +158,15 @@ export function ChatView({
     ) => fn(sessionId, functionCallId, decision)
   }, [backend])
 
+  // Approval UI + `approval::*` RPC require BOTH the harness AND the optional
+  // standalone approval-gate worker. The gate owns `approval::*`; without it,
+  // enabling approval would trigger "function not found", so we treat approval
+  // as off and let calls run ungated.
   const approvalEnabled =
     backend.id === 'real' &&
     (conversationsCtx
-      ? isHarnessAvailable(conversationsCtx.harnessStatus)
+      ? isHarnessAvailable(conversationsCtx.harnessStatus) &&
+        conversationsCtx.approvalGateAvailable
       : false)
   const approvalSettings = useApprovalSettings(sessionId, approvalEnabled)
 
@@ -310,7 +315,13 @@ export function ChatView({
           payload.text || '(attachments only)',
           conversation.mode,
           model,
-          { signal: controller.signal, sessionId, messageId, thinkingLevel },
+          {
+            signal: controller.signal,
+            sessionId,
+            messageId,
+            thinkingLevel,
+            approvalGateAvailable: approvalEnabled,
+          },
         )) {
           switch (event.kind) {
             case 'thought-start': {
@@ -688,6 +699,7 @@ export function ChatView({
             functionEntries={functionEntries}
             permissionMode={approvalSettings.settings.mode}
             permissionModeLoading={!approvalSettings.loaded}
+            showPermissionMode={approvalEnabled}
             thinkingLevel={thinkingLevel}
             onThinkingLevelChange={setThinkingLevel}
             onModeChange={(next) => onUpdateMode(conversation.id, next)}

--- a/console/web/src/components/chat/Composer.tsx
+++ b/console/web/src/components/chat/Composer.tsx
@@ -36,6 +36,12 @@ interface ComposerProps {
    */
   permissionMode: PermissionMode
   permissionModeLoading?: boolean
+  /**
+   * Whether to render the manual/auto/full permission-mode picker. Hidden when
+   * the optional approval-gate worker is absent (nothing to control). Defaults
+   * to `true` so existing callers / Storybook keep the picker.
+   */
+  showPermissionMode?: boolean
   thinkingLevel: ThinkingLevel
   onModeChange: (next: Mode) => void
   onModelChange: (next: ModelId) => void
@@ -62,6 +68,7 @@ export function Composer({
   catalogLoading,
   permissionMode,
   permissionModeLoading,
+  showPermissionMode = true,
   thinkingLevel,
   onModeChange,
   onModelChange,
@@ -139,11 +146,13 @@ export function Composer({
       <div className="flex items-center gap-2 flex-wrap px-3 py-2 border-t border-rule-2">
         <AttachmentButton onAttach={handleAttach} disabled={inputDisabled} />
         <ModePicker value={mode} onChange={onModeChange} />
-        <PermissionModePicker
-          value={permissionMode}
-          onChange={onPermissionModeChange}
-          disabled={inputDisabled || !!permissionModeLoading}
-        />
+        {showPermissionMode ? (
+          <PermissionModePicker
+            value={permissionMode}
+            onChange={onPermissionModeChange}
+            disabled={inputDisabled || !!permissionModeLoading}
+          />
+        ) : null}
         <div className="flex-1 min-w-0" />
         <Select<ThinkingLevel>
           value={thinkingLevel}

--- a/console/web/src/hooks/use-approval-gate-status.ts
+++ b/console/web/src/hooks/use-approval-gate-status.ts
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { z } from 'zod'
+import { getIiiClient, type IiiClient } from '@/lib/iii-client'
+import { useWorkerLifecycle } from './use-worker-lifecycle'
+
+/**
+ * Presence probe for the standalone `approval-gate` worker. The gate owns the
+ * `approval::*` functions; it is OPTIONAL — the console must run cleanly with or
+ * without it. This hook answers a single question: "is `approval-gate`
+ * connected right now?" so callers can gate the approval UI + RPC on it.
+ *
+ * Unlike `useHarnessStatus`, there is no install CTA: we never push the gate on
+ * the operator. Presence is fed by two signals, mirroring the harness probe:
+ *   1. An initial `engine::workers::list` read on mount.
+ *   2. A real-time `worker` add/remove lifecycle trigger, so the UI reacts the
+ *      instant the gate is added or removed — whether from the CLI
+ *      (`iii worker add approval-gate`) or another surface.
+ */
+
+/** Engine worker name for the standalone approval-gate worker. */
+const APPROVAL_GATE_WORKER_NAME = 'approval-gate'
+/** Base id for the browser-local handler bound to the `worker` trigger. */
+const APPROVAL_GATE_WATCH_FN = 'console::approval-gate-watch'
+
+export interface ApprovalGateStatus {
+  /** Whether the `approval-gate` worker is currently connected. */
+  present: boolean
+  /** Initial presence probe in flight. */
+  loading: boolean
+}
+
+const workerEventSchema = z.object({
+  operation: z.string().optional(),
+  stage: z.string().optional(),
+  worker: z.string().nullable().optional(),
+  source: z.unknown().optional(),
+})
+type WorkerEvent = z.infer<typeof workerEventSchema>
+
+function parseWorkerEvent(payload: unknown): WorkerEvent | null {
+  const parsed = workerEventSchema.safeParse(payload)
+  return parsed.success ? parsed.data : null
+}
+
+/** Loose match: is this lifecycle event about the approval-gate worker? */
+function isApprovalGateEvent(evt: WorkerEvent): boolean {
+  const w = typeof evt.worker === 'string' ? evt.worker.toLowerCase() : ''
+  if (w === APPROVAL_GATE_WORKER_NAME || w.includes(APPROVAL_GATE_WORKER_NAME)) {
+    return true
+  }
+  if (evt.source != null) {
+    try {
+      if (
+        JSON.stringify(evt.source)
+          .toLowerCase()
+          .includes(APPROVAL_GATE_WORKER_NAME)
+      ) {
+        return true
+      }
+    } catch {
+      // non-serialisable source; fall through
+    }
+  }
+  return false
+}
+
+async function checkWorkerPresent(
+  client: IiiClient,
+  name: string,
+): Promise<boolean> {
+  const res = await client.trigger<{ workers?: Array<{ name?: unknown }> }>(
+    'engine::workers::list',
+    {},
+  )
+  const workers = Array.isArray(res?.workers) ? res.workers : []
+  return workers.some((w) => w?.name === name)
+}
+
+/**
+ * @param enabled - only run against the real backend; pass `false` for the
+ *   mock/Storybook backend (treats the gate as present so the approval UI shows
+ *   in isolation, matching the mock fixtures).
+ */
+export function useApprovalGateStatus(enabled: boolean): ApprovalGateStatus {
+  const [present, setPresent] = useState<boolean>(!enabled)
+  const [loading, setLoading] = useState<boolean>(enabled)
+
+  // Live add/remove so installing or dropping the gate mid-session flips the UI
+  // without a reload. Functional setState only — no reactive deps.
+  const handleEvent = useCallback((payload: unknown) => {
+    const evt = parseWorkerEvent(payload)
+    if (!evt || !isApprovalGateEvent(evt) || evt.stage !== 'done') return
+    if (evt.operation === 'add') setPresent(true)
+    else if (evt.operation === 'remove') setPresent(false)
+  }, [])
+
+  useWorkerLifecycle({
+    enabled,
+    fnId: APPROVAL_GATE_WATCH_FN,
+    operations: ['add', 'remove'],
+    onEvent: handleEvent,
+  })
+
+  // One-time presence probe on mount. Live changes arrive through the `worker`
+  // trigger above; no polling.
+  useEffect(() => {
+    if (!enabled) {
+      setLoading(false)
+      setPresent(true)
+      return
+    }
+    let cancelled = false
+    void (async () => {
+      const client = await getIiiClient()
+      try {
+        const found = await checkWorkerPresent(client, APPROVAL_GATE_WORKER_NAME)
+        if (!cancelled) setPresent(found)
+      } catch {
+        if (!cancelled) setPresent(false)
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [enabled])
+
+  return useMemo(() => ({ present, loading }), [present, loading])
+}
+
+/**
+ * Whether the approval-gate's `approval::*` functions are registered and safe to
+ * trigger. False during the initial presence probe and while the gate is absent.
+ */
+export function isApprovalGateAvailable(status: ApprovalGateStatus): boolean {
+  return status.present && !status.loading
+}

--- a/console/web/src/hooks/use-harness-status.ts
+++ b/console/web/src/hooks/use-harness-status.ts
@@ -250,9 +250,13 @@ export function useHarnessStatus(enabled: boolean): HarnessStatus {
 }
 
 /**
- * Whether harness-owned bus functions (`router::models::list`, `approval::*`,
- * etc.) are registered and safe to trigger. False during the initial presence
- * probe and while the worker is absent.
+ * Whether harness-owned bus functions (`router::models::list`, etc.) are
+ * registered and safe to trigger. False during the initial presence probe and
+ * while the worker is absent.
+ *
+ * NOTE: `approval::*` is NOT harness-owned — it lives on the standalone,
+ * optional `approval-gate` worker. Gate approval logic on
+ * `useApprovalGateStatus` / `isApprovalGateAvailable`, not this.
  */
 export function isHarnessAvailable(status: HarnessStatus): boolean {
   return status.present && !status.loading

--- a/console/web/src/lib/backend/real.ts
+++ b/console/web/src/lib/backend/real.ts
@@ -91,6 +91,10 @@ async function* realStream(
   const client = await getIiiClient()
   const sessionId = opts?.sessionId ?? `console-${crypto.randomUUID()}`
   const messageId = opts?.messageId ?? newMessageId()
+  // The `approval::*` functions live on the optional standalone approval-gate
+  // worker. When it's absent, skip every approval subscription / read so we
+  // don't register triggers for unknown types or call missing functions.
+  const approvalGateAvailable = opts?.approvalGateAvailable !== false
 
   const queue: TurnSourceEvent[] = []
   let resolveNext: (() => void) | null = null
@@ -116,18 +120,16 @@ async function* realStream(
   const stopTurnEvents = startTurnEventsSubscription(client, sessionId, {
     onCompleted: (event) => push({ kind: 'turn-completed', event }),
   })
-  const stopApprovalEvents = startApprovalEventsSubscription(
-    client,
-    sessionId,
-    {
-      onCreated: (record) =>
-        pushPending(record.function_call_id, {
-          kind: 'approval-created',
-          record,
-        }),
-      onResolved: (event) => push({ kind: 'approval-resolved', event }),
-    },
-  )
+  const stopApprovalEvents = approvalGateAvailable
+    ? startApprovalEventsSubscription(client, sessionId, {
+        onCreated: (record) =>
+          pushPending(record.function_call_id, {
+            kind: 'approval-created',
+            record,
+          }),
+        onResolved: (event) => push({ kind: 'approval-resolved', event }),
+      })
+    : () => {}
 
   const onAbort = () => wake()
   signal?.addEventListener('abort', onAbort, { once: true })
@@ -137,21 +139,23 @@ async function* realStream(
     const { provider, model: modelId } = resolveRunParams(model)
 
     // Reconnect recovery: rebuild any pending-approval cards a prior turn left
-    // held (e.g. resending after a reload). Best-effort.
-    void listPendingApprovals(client, sessionId)
-      .then((records) => {
-        for (const record of records) {
-          pushPending(record.function_call_id, {
-            kind: 'approval-created',
-            record,
-          })
-        }
-      })
-      .catch((err) => {
-        if (import.meta.env.DEV) {
-          console.warn('[real-backend] approval::list-pending recovery', err)
-        }
-      })
+    // held (e.g. resending after a reload). Best-effort; skipped without the gate.
+    if (approvalGateAvailable) {
+      void listPendingApprovals(client, sessionId)
+        .then((records) => {
+          for (const record of records) {
+            pushPending(record.function_call_id, {
+              kind: 'approval-created',
+              record,
+            })
+          }
+        })
+        .catch((err) => {
+          if (import.meta.env.DEV) {
+            console.warn('[real-backend] approval::list-pending recovery', err)
+          }
+        })
+    }
 
     const thinkingLevel = toThinkingLevel(opts?.thinkingLevel)
 

--- a/console/web/src/lib/backend/types.ts
+++ b/console/web/src/lib/backend/types.ts
@@ -112,6 +112,14 @@ export interface ChatStreamOptions {
    * send) so callers that haven't been updated yet still work.
    */
   sessionId?: string
+  /**
+   * Whether the optional standalone `approval-gate` worker is connected. When
+   * `false`, the real backend skips the `approval::pending-*` trigger
+   * subscriptions and the `approval::list-pending` catch-up read — those
+   * functions don't exist without the gate. Defaults to `true` so callers that
+   * haven't been updated keep the approval surface.
+   */
+  approvalGateAvailable?: boolean
 }
 
 export type CompactResult =

--- a/console/web/src/lib/conversations-context.tsx
+++ b/console/web/src/lib/conversations-context.tsx
@@ -10,6 +10,10 @@ import {
   useConversations,
 } from '@/hooks/use-conversations'
 import {
+  isApprovalGateAvailable,
+  useApprovalGateStatus,
+} from '@/hooks/use-approval-gate-status'
+import {
   type HarnessStatus,
   isHarnessAvailable,
   useHarnessStatus,
@@ -44,6 +48,13 @@ interface ConversationsContextValue extends ConversationsApi {
    * the real backend.
    */
   harnessStatus: HarnessStatus
+  /**
+   * Whether the optional standalone `approval-gate` worker is connected. Gates
+   * all approval UI + `approval::*` RPC: false → the gate isn't installed, so
+   * the console hides the permission-mode picker and runs calls ungated rather
+   * than triggering "function not found". Only meaningful on the real backend.
+   */
+  approvalGateAvailable: boolean
 }
 
 const ConversationsContext = createContext<ConversationsContextValue | null>(
@@ -65,6 +76,9 @@ export function ConversationsProvider({
 }: ConversationsProviderProps) {
   const harnessStatus = useHarnessStatus(backend.id === 'real')
   const harnessAvailable = isHarnessAvailable(harnessStatus)
+  const approvalGateAvailable = isApprovalGateAvailable(
+    useApprovalGateStatus(backend.id === 'real'),
+  )
   const {
     modelOptions,
     catalogKeys,
@@ -109,6 +123,7 @@ export function ConversationsProvider({
     refreshModels,
     refreshingModels,
     harnessStatus,
+    approvalGateAvailable,
   }
 
   return (

--- a/console/web/src/pages/Configuration/tabs/ConsoleSettingsTab.tsx
+++ b/console/web/src/pages/Configuration/tabs/ConsoleSettingsTab.tsx
@@ -17,6 +17,7 @@ import {
   saveApprovalGateDefaults,
 } from '@/lib/backend/approval-gate-config'
 import type { PermissionMode } from '@/lib/backend/approval-settings'
+import { useConversationsCtxOptional } from '@/lib/conversations-context'
 import { filterAllowlistCandidates } from '@/lib/permissions/allowlist-filter'
 
 // Provider credentials + settings now live in the llm-router `configuration`
@@ -41,12 +42,20 @@ export function ConsoleSettingsTab({
   theme,
   onThemeChange,
 }: ConsoleSettingsTabProps) {
+  // The permissions section only applies when the optional approval-gate worker
+  // is connected (it owns `approval::*` + the config entry). Absent → hide the
+  // whole section and skip the config read so it can't error. Outside the
+  // provider (Storybook) the context is null; treat that as available.
+  const ctx = useConversationsCtxOptional()
+  const approvalGateAvailable = ctx ? ctx.approvalGateAvailable : true
+
   // Deployment defaults from the approval-gate configuration entry (single source).
   const [defaultMode, setDefaultMode] = useState<PermissionMode>('manual')
   const [allowlist, setAllowlist] = useState<string[]>([])
   const [loaded, setLoaded] = useState(false)
 
   useEffect(() => {
+    if (!approvalGateAvailable) return
     let cancelled = false
     void (async () => {
       try {
@@ -66,7 +75,7 @@ export function ConsoleSettingsTab({
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [approvalGateAvailable])
 
   const persistDefaults = useCallback(
     async (mode: PermissionMode, list: string[]) => {
@@ -128,104 +137,108 @@ export function ConsoleSettingsTab({
   return (
     <div className="flex-1 min-h-0 overflow-y-auto">
       <div className="mx-auto max-w-3xl px-6 py-10">
-      <Section
-        title="appearance"
-        description="theme preference, stored per browser."
-      >
-        <Row
-          label="theme"
-          control={
-            <ModeToggle<Theme>
-              value={theme}
-              onChange={onThemeChange}
-              variant="radio"
-              aria-label="theme"
-              options={[
-                { value: 'light', label: 'light' },
-                { value: 'dark', label: 'dark' },
-              ]}
-            />
-          }
-        />
-      </Section>
-
-      <Section
-        title="permissions"
-        description="default mode and auto allowlist stored in the approval-gate configuration entry. applies to NEW conversations only."
-      >
-        <Row
-          label="default mode"
-          control={
-            <DefaultPermissionModePicker
-              value={loaded ? defaultMode : undefined}
-              onChange={handleModeChange}
-            />
-          }
-          meta="manual prompts for everything · auto skips functions on your allowlist · full skips everything"
-        />
-        {defaultMode === 'auto' ? (
+        <Section
+          title="appearance"
+          description="theme preference, stored per browser."
+        >
           <Row
-            label="allowlist"
+            label="theme"
             control={
+              <ModeToggle<Theme>
+                value={theme}
+                onChange={onThemeChange}
+                variant="radio"
+                aria-label="theme"
+                options={[
+                  { value: 'light', label: 'light' },
+                  { value: 'dark', label: 'dark' },
+                ]}
+              />
+            }
+          />
+        </Section>
+
+        {approvalGateAvailable ? (
+          <Section
+            title="permissions"
+            description="default mode and auto allowlist stored in the approval-gate configuration entry. applies to NEW conversations only."
+          >
+            <Row
+              label="default mode"
+              control={
+                <DefaultPermissionModePicker
+                  value={loaded ? defaultMode : undefined}
+                  onChange={handleModeChange}
+                />
+              }
+              meta="manual prompts for everything · auto skips functions on your allowlist · full skips everything"
+            />
+            {defaultMode === 'auto' ? (
+              <Row
+                label="allowlist"
+                control={
+                  <button
+                    type="button"
+                    onClick={() => setAllowlistOpen(true)}
+                    className="font-mono text-[12px] px-3 py-1 border border-rule text-ink hover:border-ink transition-colors"
+                  >
+                    manage
+                    {allowlist.length > 0 ? ` (${allowlist.length})` : ''}
+                  </button>
+                }
+                meta="functions that auto-approve while a new conversation is in auto mode. edits apply to NEW conversations only."
+              />
+            ) : null}
+          </Section>
+        ) : null}
+
+        <Dialog open={allowlistOpen} onOpenChange={setAllowlistOpen}>
+          <DialogContent className="max-w-xl max-h-[80vh] overflow-hidden flex flex-col">
+            <DialogTitle className="text-[14px]">
+              auto-mode allowlist
+            </DialogTitle>
+            <DialogDescription className="mt-1">
+              checked functions auto-approve while a new conversation is in auto
+              mode. existing conversations keep their own snapshot.
+            </DialogDescription>
+            <div className="mt-4 flex-1 overflow-y-auto border border-rule-2 -mx-2 px-2 py-2 min-h-[280px]">
+              <FunctionAllowlistTree
+                functions={allowlistCandidates}
+                allowlist={allowlistSet}
+                onAdd={addAllow}
+                onRemove={removeAllow}
+                emptyHint="catalog hasn't loaded any functions yet."
+              />
+            </div>
+            <div className="mt-4 flex justify-end">
               <button
                 type="button"
-                onClick={() => setAllowlistOpen(true)}
+                onClick={() => setAllowlistOpen(false)}
+                className="font-mono text-[12px] px-3 py-1 border border-ink bg-ink text-bg hover:bg-bg hover:text-ink transition-colors"
+              >
+                done
+              </button>
+            </div>
+          </DialogContent>
+        </Dialog>
+
+        <Section
+          title="providers"
+          description="api keys, endpoints, and per-provider settings."
+        >
+          <Row
+            label="manage"
+            control={
+              <a
+                href={HARNESS_CONFIG_HASH}
                 className="font-mono text-[12px] px-3 py-1 border border-rule text-ink hover:border-ink transition-colors"
               >
-                manage
-                {allowlist.length > 0 ? ` (${allowlist.length})` : ''}
-              </button>
+                open provider settings
+              </a>
             }
-            meta="functions that auto-approve while a new conversation is in auto mode. edits apply to NEW conversations only."
+            meta="credentials + settings live in the harness configuration (workers tab). the form's shape grows with each provider that registers; api keys are masked."
           />
-        ) : null}
-      </Section>
-
-      <Dialog open={allowlistOpen} onOpenChange={setAllowlistOpen}>
-        <DialogContent className="max-w-xl max-h-[80vh] overflow-hidden flex flex-col">
-          <DialogTitle className="text-[14px]">auto-mode allowlist</DialogTitle>
-          <DialogDescription className="mt-1">
-            checked functions auto-approve while a new conversation is in auto
-            mode. existing conversations keep their own snapshot.
-          </DialogDescription>
-          <div className="mt-4 flex-1 overflow-y-auto border border-rule-2 -mx-2 px-2 py-2 min-h-[280px]">
-            <FunctionAllowlistTree
-              functions={allowlistCandidates}
-              allowlist={allowlistSet}
-              onAdd={addAllow}
-              onRemove={removeAllow}
-              emptyHint="catalog hasn't loaded any functions yet."
-            />
-          </div>
-          <div className="mt-4 flex justify-end">
-            <button
-              type="button"
-              onClick={() => setAllowlistOpen(false)}
-              className="font-mono text-[12px] px-3 py-1 border border-ink bg-ink text-bg hover:bg-bg hover:text-ink transition-colors"
-            >
-              done
-            </button>
-          </div>
-        </DialogContent>
-      </Dialog>
-
-      <Section
-        title="providers"
-        description="api keys, endpoints, and per-provider settings."
-      >
-        <Row
-          label="manage"
-          control={
-            <a
-              href={HARNESS_CONFIG_HASH}
-              className="font-mono text-[12px] px-3 py-1 border border-rule text-ink hover:border-ink transition-colors"
-            >
-              open provider settings
-            </a>
-          }
-          meta="credentials + settings live in the harness configuration (workers tab). the form's shape grows with each provider that registers; api keys are masked."
-        />
-      </Section>
+        </Section>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Makes the standalone `approval-gate` worker truly optional for the console.

The console gated all approval UI and `approval::*` RPC on **harness**
availability (`isHarnessAvailable`). But `approval-gate` is a **separate,
optional worker** that owns the `approval::*` functions. Running console +
harness *without* the gate caused two problems:

- the console called `approval::get-settings` / `approval::set-mode` (and
  subscribed to `approval::pending-*`, read `approval::list-pending`) →
  **"function not found"** errors;
- the manual/auto/full permission-mode picker rendered in the composer and the
  Configuration → permissions section, where every interaction failed.

## Changes

- **New** `useApprovalGateStatus` / `isApprovalGateAvailable`
  (`use-approval-gate-status.ts`) — detects the `approval-gate` worker
  independently, mirroring the existing `useHarnessStatus` worker-presence
  pattern (mount probe via `engine::workers::list` + live `worker` add/remove
  events). No install CTA — the gate is never pushed on the operator.
- `conversations-context.tsx` exposes `approvalGateAvailable`.
- `ChatView` requires the gate for `approvalEnabled`; this short-circuits
  `useApprovalSettings` (no `approval::*` RPC) and hides the picker via a new
  `showPermissionMode` prop on `Composer`.
- `ConsoleSettingsTab` hides the permissions section and skips the config read
  when the gate is absent.
- `real.ts` skips the `approval::pending-*` subscriptions and
  `approval::list-pending` read when the gate is absent (new
  `approvalGateAvailable` stream option).
- Fixed a stale comment in `use-harness-status.ts` that claimed harness owns
  `approval::*`.

Behavior: the picker is hidden **only when the gate is absent**; when present,
nothing changes. Without the gate, function calls run ungated (no approval
prompt), matching how the harness already treats the gate as an optional
`pre_trigger` hook.

## Test plan

Static:
- [x] `tsc -b --noEmit` clean
- [x] `biome check` clean on all changed files
- [x] `vitest run` — 752/752 pass

Live (dev server against a running engine + harness; approval-gate toggled via
`iii worker remove/add`):
- [x] **Gate present** — composer shows manual/auto/full; Configuration shows the
      permissions section; a turn ("reply with one word: pong") streams fine.
- [x] **Gate absent** — picker hidden in the composer AND the Configuration
      permissions section; a turn still streams ungated; **no "function not
      found"** in the browser console.
- [x] **Restore** — on reload with the gate back, the picker returns.

Note on live flip: the mount probe (`engine::workers::list`) is authoritative and
hides/shows correctly on every load. Adding the gate live flips the picker on via
the same `worker` add-event mechanism `useHarnessStatus` uses for `iii worker add`.
Re-adding by editing the engine `config.yaml` directly does not emit that event
(the file-watcher path is silent), so that specific path needs a reload — an
engine event-emission detail, not a console regression.

https://claude.ai/code/session_01Cy5KwY8y2NcPPnyo4LVste
