### PR TITLE
(MOT-3867) feat(harness): pause and ask to continue at max_turns

### DIFF
--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -668,6 +668,13 @@ export function ChatView({
     void backend.abortRun?.(sessionId).catch(() => {})
   }, [backend, sessionId])
 
+  // Resume a turn parked at max_turns (the ask-to-continue pause). A parked
+  // turn is non-terminal, so the input is blocked — the Continue button calls
+  // `harness::continue` instead of relying on a reply.
+  const handleContinue = useCallback(() => {
+    void backend.continueTurn?.(sessionId).catch(() => {})
+  }, [backend, sessionId])
+
   // Covers the gap between submit / fcall-end and the next streamed content,
   // where the assistant/thought shimmer hasn't yet rendered.
   const isThinking =
@@ -875,6 +882,8 @@ export function ChatView({
             }
             onSubmit={handleSubmit}
             onStop={handleStop}
+            onContinue={handleContinue}
+            waiting={conversation.status === 'waiting'}
             isStreaming={streamingIndicator}
             blocked={harnessBlocked}
             blockedPlaceholder={

--- a/console/web/src/components/chat/Composer.tsx
+++ b/console/web/src/components/chat/Composer.tsx
@@ -61,6 +61,10 @@ interface ComposerProps {
   onPermissionModeChange: (next: PermissionMode) => void
   onSubmit: (payload: ComposerSubmitPayload) => void
   onStop?: () => void
+  /** Resume a turn parked at max_turns (the ask-to-continue pause). */
+  onContinue?: () => void
+  /** The turn is parked awaiting the user's continue/stop decision. */
+  waiting?: boolean
   isStreaming?: boolean
   /** External lock (e.g. harness not installed). Editor + send disabled. */
   blocked?: boolean
@@ -92,6 +96,8 @@ export function Composer({
   onPermissionModeChange,
   onSubmit,
   onStop,
+  onContinue,
+  waiting,
   isStreaming,
   blocked,
   blockedPlaceholder = 'chat unavailable…',
@@ -105,7 +111,9 @@ export function Composer({
   const [clearToken, setClearToken] = useState(0)
   const textRef = useRef('')
 
-  const inputDisabled = isStreaming || blocked
+  // A turn parked at max_turns is non-terminal but NOT actively streaming, so
+  // the input stays usable: the user can press Continue or type to steer.
+  const inputDisabled = blocked || (!!isStreaming && !waiting)
 
   const handleSubmit = useCallback(() => {
     if (inputDisabled) return
@@ -147,11 +155,13 @@ export function Composer({
           onSubmit={handleSubmit}
           clearToken={clearToken}
           placeholder={
-            isStreaming
-              ? 'streaming response…'
-              : blocked
-                ? blockedPlaceholder
-                : 'send a message…'
+            waiting
+              ? 'press continue, or type to steer…'
+              : isStreaming
+                ? 'streaming response…'
+                : blocked
+                  ? blockedPlaceholder
+                  : 'send a message…'
           }
           disabled={inputDisabled}
           initialContent={initialContent}
@@ -196,7 +206,29 @@ export function Composer({
           disabled={inputDisabled}
           loading={catalogLoading}
         />
-        {isStreaming ? (
+        {waiting ? (
+          <>
+            <Button
+              type="button"
+              variant="pill"
+              size="sm"
+              onClick={onStop}
+              aria-label="stop turn"
+            >
+              stop
+            </Button>
+            <Button
+              type="button"
+              variant="primary"
+              size="sm"
+              onClick={onContinue}
+              aria-label="continue turn"
+            >
+              continue
+              <span aria-hidden>→</span>
+            </Button>
+          </>
+        ) : isStreaming ? (
           <Button
             type="button"
             variant="pill"

--- a/console/web/src/components/sidebar/ConversationRow.tsx
+++ b/console/web/src/components/sidebar/ConversationRow.tsx
@@ -154,6 +154,12 @@ export function ConversationRow({
       </div>
       {conversation.status === 'working' ? (
         <StatusDot tone="accent" pulse title="working" className="shrink-0" />
+      ) : conversation.status === 'waiting' ? (
+        <StatusDot
+          tone="accent"
+          title={conversation.statusReason ?? 'waiting for your reply'}
+          className="shrink-0"
+        />
       ) : conversation.status === 'error' ? (
         <StatusDot
           tone="alert"

--- a/console/web/src/lib/backend/harness-send.ts
+++ b/console/web/src/lib/backend/harness-send.ts
@@ -180,6 +180,26 @@ export async function stopTurn(
 }
 
 /**
+ * Trigger `harness::continue`: resume a turn parked at `max_turns` (the
+ * ask-to-continue pause) with a fresh budget. The explicit counterpart to
+ * replying — a parked turn is non-terminal, so the chat input is blocked.
+ */
+export async function continueTurn(
+  client: Pick<IiiClient, 'trigger'>,
+  sessionId: string,
+  turnId?: string,
+): Promise<boolean> {
+  const res = await client.trigger<{ continuing?: boolean }>(
+    'harness::continue',
+    {
+      session_id: sessionId,
+      ...(turnId ? { turn_id: turnId } : {}),
+    },
+  )
+  return Boolean(res?.continuing)
+}
+
+/**
  * Trigger `harness::status`: a point-in-time read of the session's turn
  * record. Returns `null` when no turn has ever run for the session.
  */

--- a/console/web/src/lib/backend/real.ts
+++ b/console/web/src/lib/backend/real.ts
@@ -25,6 +25,7 @@ import {
 } from './approval-events-live'
 import { loadApprovalGateDefaults } from './approval-gate-config'
 import {
+  continueTurn,
   getTurnStatus,
   type HarnessFunctionPolicy,
   type HarnessThinkingLevel,
@@ -277,6 +278,11 @@ async function realAbortRun(sessionId: string): Promise<void> {
   await stopTurn(client, sessionId)
 }
 
+async function realContinueTurn(sessionId: string): Promise<void> {
+  const client = await getIiiClient()
+  await continueTurn(client, sessionId)
+}
+
 /** `context::compact` response, discriminated on `status`. */
 type CompactResponse =
   | {
@@ -393,5 +399,6 @@ export const realBackend: ChatBackend = {
   stream: realStream,
   resolveApproval: realResolveApproval,
   abortRun: realAbortRun,
+  continueTurn: realContinueTurn,
   compactSession: realCompactSession,
 }

--- a/console/web/src/lib/backend/types.ts
+++ b/console/web/src/lib/backend/types.ts
@@ -188,6 +188,12 @@ export interface ChatBackend {
    */
   abortRun?(sessionId: string): Promise<void>
   /**
+   * Resume a turn parked at max_turns (the ask-to-continue pause) via
+   * `harness::continue`. A parked turn blocks the chat input, so the UI
+   * surfaces an explicit Continue button instead of a reply.
+   */
+  continueTurn?(sessionId: string): Promise<void>
+  /**
    * Powers `/compact`. Compacts the session-manager transcript (the single
    * source of truth) directly. `contextWindow` skips the server's
    * `models::get` lookup when known.

--- a/console/web/src/lib/chat-activity.ts
+++ b/console/web/src/lib/chat-activity.ts
@@ -29,6 +29,9 @@ export function getDockSignal(
     if (m.role === 'function-call' && m.pendingApproval) return 'active'
   }
 
+  // A turn parked awaiting the user's reply (e.g. max_turns) needs attention.
+  if (active.status === 'waiting') return 'attention'
+
   const last = active.messages[active.messages.length - 1]
   if (!last) return null
 

--- a/console/web/src/lib/sessions/types.ts
+++ b/console/web/src/lib/sessions/types.ts
@@ -3,7 +3,7 @@
  * `session-manager/architecture/integration.md` the console consumes.
  */
 
-export type SessionStatus = 'idle' | 'working' | 'done' | 'error'
+export type SessionStatus = 'idle' | 'working' | 'waiting' | 'done' | 'error'
 
 export type ContentBlock =
   | { type: 'text'; text: string }

--- a/console/web/src/types/chat.ts
+++ b/console/web/src/types/chat.ts
@@ -154,7 +154,12 @@ export interface MessagePatch {
 }
 
 /** Mirrors session-manager's SessionStatus. */
-export type ConversationStatus = 'idle' | 'working' | 'done' | 'error'
+export type ConversationStatus =
+  | 'idle'
+  | 'working'
+  | 'waiting'
+  | 'done'
+  | 'error'
 
 export interface Conversation {
   /**

--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -15,7 +15,7 @@ dependencies:
   iii-stream: "^0.19.0"
   iii-directory: "^1.0.0"
   llm-router: "^1.0.0"
-  session-manager: "^1.0.0"
+  session-manager: "^1.1.0"
   context-manager: "^1.0.0"
   provider-anthropic: "^1.0.0"
   provider-openai: "^1.0.0"

--- a/harness/src/clients/session.rs
+++ b/harness/src/clients/session.rs
@@ -140,6 +140,11 @@ impl SessionClient {
 
     /// Append a `custom` (kind: custom) bookkeeping entry — used for the
     /// compaction record. Idempotent on `entry_id`.
+    ///
+    /// `display`, when set, populates the custom message's `display` field (and
+    /// a mirroring text content block) so the entry RENDERS in the console; the
+    /// console drops custom entries whose `display`/`content` are both empty.
+    /// Bookkeeping entries the user never needs to see pass `None`.
     pub async fn append_custom(
         &self,
         session_id: &str,
@@ -147,20 +152,29 @@ impl SessionClient {
         data: Value,
         entry_id: &str,
         origin: Option<&Value>,
+        display: Option<&str>,
     ) -> Result<(), HarnessError> {
         // session-manager stores custom entries via a `custom` message wrapper
         // with no model wire mapping; the harness reads them back with
         // include_custom.
+        let content = match display {
+            Some(text) => json!([{ "type": "text", "text": text }]),
+            None => json!([]),
+        };
+        let mut message = json!({
+            "role": "custom",
+            "custom_type": custom_type,
+            "content": content,
+            "details": data,
+            "timestamp": AgentMessage::now_ms(),
+        });
+        if let Some(text) = display {
+            message["display"] = json!(text);
+        }
         let mut payload = json!({
             "session_id": session_id,
             "entry_id": entry_id,
-            "message": {
-                "role": "custom",
-                "custom_type": custom_type,
-                "content": [],
-                "details": data,
-                "timestamp": AgentMessage::now_ms(),
-            },
+            "message": message,
         });
         if let Some(o) = origin {
             payload["origin"] = o.clone();

--- a/harness/src/config.rs
+++ b/harness/src/config.rs
@@ -24,6 +24,14 @@ pub struct WorkerConfig {
     #[serde(default = "default_max_turns")]
     pub default_max_turns: u32,
 
+    /// When an interactive (`harness::send`) top-level turn reaches its
+    /// `max_turns` budget, pause and ask the user whether to continue instead
+    /// of silently ending. The next message resumes the turn with another
+    /// `default_max_turns` of budget. Sub-agents and `harness::run` turns always
+    /// auto-end. Set `false` to restore the legacy auto-end behavior.
+    #[serde(default = "default_ask_to_continue_on_max_turns")]
+    pub ask_to_continue_on_max_turns: bool,
+
     /// Default wait guard for a parked pending call (sub-agent / hook hold)
     /// before the sweep resolves it with an error. Milliseconds.
     #[serde(default = "default_pending_timeout_ms")]
@@ -147,6 +155,9 @@ pub struct BootSignature {
 fn default_max_turns() -> u32 {
     500
 }
+fn default_ask_to_continue_on_max_turns() -> bool {
+    true
+}
 fn default_pending_timeout_ms() -> u64 {
     1_800_000
 }
@@ -252,6 +263,7 @@ impl Default for WorkerConfig {
     fn default() -> Self {
         Self {
             default_max_turns: default_max_turns(),
+            ask_to_continue_on_max_turns: default_ask_to_continue_on_max_turns(),
             default_pending_timeout_ms: default_pending_timeout_ms(),
             max_depth: default_max_depth(),
             max_children: default_max_children(),
@@ -277,6 +289,7 @@ mod tests {
         let cfg = WorkerConfig::from_json(&serde_json::json!({})).unwrap();
         assert_eq!(cfg, WorkerConfig::default());
         assert_eq!(cfg.default_max_turns, 500);
+        assert!(cfg.ask_to_continue_on_max_turns);
         assert_eq!(cfg.max_depth, 3);
         assert_eq!(cfg.max_children, 5);
         assert_eq!(cfg.sweep_expression, "0 0 0 * * *");
@@ -309,6 +322,16 @@ mod tests {
         let cfg =
             WorkerConfig::from_json(&serde_json::json!({ "default_functions": null })).unwrap();
         assert!(cfg.default_functions.is_none());
+    }
+
+    #[test]
+    fn ask_to_continue_knob_round_trips_when_disabled() {
+        let cfg =
+            WorkerConfig::from_json(&serde_json::json!({ "ask_to_continue_on_max_turns": false }))
+                .unwrap();
+        assert!(!cfg.ask_to_continue_on_max_turns);
+        let back = WorkerConfig::from_json(&cfg.to_json()).unwrap();
+        assert_eq!(back, cfg);
     }
 
     #[test]

--- a/harness/src/functions/continue_turn.rs
+++ b/harness/src/functions/continue_turn.rs
@@ -1,0 +1,50 @@
+//! `harness::continue` — resume a turn parked at `max_turns` (the "ask to
+//! continue" pause). The explicit counterpart to replying via `harness::send`:
+//! a UI can wire a "Continue" button to this without composing a message, which
+//! matters because a parked turn is non-terminal and the chat input is blocked.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::deps::Deps;
+use crate::error::HarnessError;
+
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct ContinueRequest {
+    pub session_id: String,
+    /// Omit to continue the session's current turn.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ContinueResponse {
+    /// True when a parked turn was resumed; false when there was nothing to
+    /// continue (no turn, wrong turn, terminal, or not awaiting continuation).
+    pub continuing: bool,
+}
+
+/// Resume a parked-at-`max_turns` turn with a fresh budget. No-op (returns
+/// `continuing: false`) when the turn is missing, terminal, or not awaiting
+/// continuation, so a double-click or stale button is harmless.
+pub async fn handle(deps: &Deps, req: ContinueRequest) -> Result<ContinueResponse, HarnessError> {
+    let cfg = deps.cfg().await;
+    // Serialize against the loop / resolve / sends so the step and budget can't
+    // be double-bumped.
+    let _guard = deps.locks.guard(&req.session_id).await;
+    let Some(mut record) =
+        crate::state::get_turn(&deps.iii, &req.session_id, cfg.session_timeout_ms).await?
+    else {
+        return Ok(ContinueResponse { continuing: false });
+    };
+    if let Some(tid) = &req.turn_id {
+        if &record.turn_id != tid {
+            return Ok(ContinueResponse { continuing: false });
+        }
+    }
+    if record.status.is_terminal() || !record.awaiting_continue {
+        return Ok(ContinueResponse { continuing: false });
+    }
+    crate::functions::send::resume_awaiting_continue(deps, &cfg, &mut record).await?;
+    Ok(ContinueResponse { continuing: true })
+}

--- a/harness/src/functions/mod.rs
+++ b/harness/src/functions/mod.rs
@@ -3,6 +3,7 @@
 //! `pub async fn handle(deps, req)` the registration closure wraps; tests call
 //! the same `handle` functions directly (SOP §7).
 
+pub mod continue_turn;
 pub mod filesystem;
 pub mod function_resolve;
 pub mod function_trigger;
@@ -60,6 +61,11 @@ pub const STOP_DESC: &str =
 
 pub const STATUS_ID: &str = "harness::status";
 pub const STATUS_DESC: &str = "Read the current turn status for a session.";
+
+pub const CONTINUE_ID: &str = "harness::continue";
+pub const CONTINUE_DESC: &str =
+    "Resume a turn parked at max_turns (the ask-to-continue pause) with a fresh budget; the explicit \
+     counterpart to replying, for a UI Continue button.";
 
 pub const FILESYSTEM_GRANT_ID: &str = "harness::filesystem::grant";
 pub const FILESYSTEM_GRANT_DESC: &str =
@@ -155,6 +161,9 @@ pub fn register_all(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
     });
     register(iii, deps, STATUS_ID, STATUS_DESC, |d, r| async move {
         status::handle(&d, r).await
+    });
+    register(iii, deps, CONTINUE_ID, CONTINUE_DESC, |d, r| async move {
+        continue_turn::handle(&d, r).await
     });
 
     // Internal filesystem grant controls — registered for trusted callers, kept

--- a/harness/src/functions/send.rs
+++ b/harness/src/functions/send.rs
@@ -105,7 +105,9 @@ pub struct StartOutcome {
 }
 
 pub async fn handle(deps: &Deps, req: SendRequest) -> Result<SendResponse, HarnessError> {
-    let out = start(deps, req).await?;
+    // `harness::send` is the interactive chat entry point: a turn it starts may
+    // pause at `max_turns` to ask the user whether to continue.
+    let out = start(deps, req, true).await?;
     Ok(SendResponse {
         session_id: out.session_id,
         turn_id: out.turn_id,
@@ -116,7 +118,15 @@ pub async fn handle(deps: &Deps, req: SendRequest) -> Result<SendResponse, Harne
 }
 
 /// Ensure the session, persist the message, and seed/merge the turn.
-pub async fn start(deps: &Deps, req: SendRequest) -> Result<StartOutcome, HarnessError> {
+///
+/// `interactive` is `true` for `harness::send` (a chat turn that may pause at
+/// `max_turns`) and `false` for `harness::run` (auto-ends so the poller never
+/// hangs on a parked turn).
+pub async fn start(
+    deps: &Deps,
+    req: SendRequest,
+    interactive: bool,
+) -> Result<StartOutcome, HarnessError> {
     let cfg = deps.cfg().await;
     let session = deps.session().await;
 
@@ -165,8 +175,8 @@ pub async fn start(deps: &Deps, req: SendRequest) -> Result<StartOutcome, Harnes
         .append(&session_id, &message, entry_id.as_deref(), None, None)
         .await?;
 
-    // CAS-seed the turn (or take the merge path).
-    let outcome = seed_or_merge(deps, &cfg, &session_id, options).await?;
+    // CAS-seed the turn (or take the merge / resume path).
+    let outcome = seed_or_merge(deps, &cfg, &session_id, options, interactive).await?;
 
     // Record the idempotency mapping (TTL-bound by contract).
     if let Some(key) = &req.idempotency_key {
@@ -262,9 +272,40 @@ async fn seed_or_merge(
     cfg: &WorkerConfig,
     session_id: &str,
     options: TurnOptions,
+    interactive: bool,
 ) -> Result<StartOutcome, HarnessError> {
     let existing = crate::state::get_turn(&deps.iii, session_id, cfg.session_timeout_ms).await?;
     match existing {
+        Some(rec) if !rec.status.is_terminal() && rec.awaiting_continue => {
+            // Resume a turn parked at `max_turns`. Serialize against the loop /
+            // resolve / concurrent sends so the step and budget can't be
+            // double-bumped; re-read under the lock to settle the race.
+            let _guard = deps.locks.guard(session_id).await;
+            let recheck =
+                crate::state::get_turn(&deps.iii, session_id, cfg.session_timeout_ms).await?;
+            match recheck {
+                Some(mut r) if !r.status.is_terminal() && r.awaiting_continue => {
+                    // The user's message is already appended; the resumed loop
+                    // assembles it into context on its next step.
+                    resume_awaiting_continue(deps, cfg, &mut r).await?;
+                    Ok(StartOutcome {
+                        session_id: session_id.to_string(),
+                        turn_id: r.turn_id,
+                        merged: true,
+                        deduplicated: false,
+                    })
+                }
+                // Lost the race (another send resumed it, or it went terminal):
+                // fall back to a plain steering merge / fresh seed.
+                Some(r) if !r.status.is_terminal() => Ok(StartOutcome {
+                    session_id: session_id.to_string(),
+                    turn_id: r.turn_id,
+                    merged: true,
+                    deduplicated: false,
+                }),
+                _ => seed_new(deps, cfg, session_id, options, interactive).await,
+            }
+        }
         Some(rec) if !rec.status.is_terminal() => {
             // Merge path: the message is already appended; the running loop's
             // steering check folds it in. Double-check the record didn't go
@@ -284,11 +325,36 @@ async fn seed_or_merge(
                         deduplicated: false,
                     })
                 }
-                _ => seed_new(deps, cfg, session_id, options).await,
+                _ => seed_new(deps, cfg, session_id, options, interactive).await,
             }
         }
-        _ => seed_new(deps, cfg, session_id, options).await,
+        _ => seed_new(deps, cfg, session_id, options, interactive).await,
     }
+}
+
+/// Resume a turn parked at `max_turns`: clear the flag, extend the budget by a
+/// fresh allotment, bump the step, set Running, persist, and re-enqueue. Mirrors
+/// `deferred::persist_and_maybe_resume`; stale-step safe via the monotonic step.
+async fn resume_awaiting_continue(
+    deps: &Deps,
+    cfg: &WorkerConfig,
+    record: &mut TurnRecord,
+) -> Result<(), HarnessError> {
+    record.awaiting_continue = false;
+    record.options.max_turns = extended_max_turns(record.options.max_turns, cfg.default_max_turns);
+    record.step += 1;
+    record.status = TurnStatus::Running;
+    record.updated_at = AgentMessage::now_ms();
+    crate::state::put_turn(&deps.iii, record, cfg.session_timeout_ms).await?;
+    crate::turn_loop::enqueue_step(&deps.iii, &record.session_id, &record.turn_id, record.step)
+        .await?;
+    Ok(())
+}
+
+/// Extend a turn's `max_turns` budget by one fresh allotment, saturating.
+/// `turn_count` is left untouched (monotonic), so the guard clears immediately.
+fn extended_max_turns(current: u32, default: u32) -> u32 {
+    current.saturating_add(default)
 }
 
 async fn seed_new(
@@ -296,6 +362,7 @@ async fn seed_new(
     cfg: &WorkerConfig,
     session_id: &str,
     options: TurnOptions,
+    interactive: bool,
 ) -> Result<StartOutcome, HarnessError> {
     let turn_id = ids::new_turn_id();
     let now = AgentMessage::now_ms();
@@ -318,6 +385,8 @@ async fn seed_new(
         result: None,
         result_error: None,
         validation_retries: 0,
+        awaiting_continue: false,
+        interactive,
         created_at: now,
         updated_at: now,
     };
@@ -339,6 +408,13 @@ mod tests {
     fn string_message_becomes_user_text() {
         let m = normalize_message(MessageInput::Text("hi".into())).unwrap();
         assert!(matches!(m, AgentMessage::User(_)));
+    }
+
+    #[test]
+    fn extended_max_turns_adds_a_fresh_allotment_and_saturates() {
+        assert_eq!(extended_max_turns(500, 500), 1000);
+        assert_eq!(extended_max_turns(1, 500), 501);
+        assert_eq!(extended_max_turns(u32::MAX, 500), u32::MAX);
     }
 
     #[test]

--- a/harness/src/functions/send.rs
+++ b/harness/src/functions/send.rs
@@ -335,7 +335,9 @@ async fn seed_or_merge(
 /// Resume a turn parked at `max_turns`: clear the flag, extend the budget by a
 /// fresh allotment, bump the step, set Running, persist, and re-enqueue. Mirrors
 /// `deferred::persist_and_maybe_resume`; stale-step safe via the monotonic step.
-async fn resume_awaiting_continue(
+/// Shared with `harness::continue` (the explicit button path). The caller holds
+/// the per-session lock.
+pub(crate) async fn resume_awaiting_continue(
     deps: &Deps,
     cfg: &WorkerConfig,
     record: &mut TurnRecord,

--- a/harness/src/functions/send.rs
+++ b/harness/src/functions/send.rs
@@ -119,9 +119,11 @@ pub async fn handle(deps: &Deps, req: SendRequest) -> Result<SendResponse, Harne
 
 /// Ensure the session, persist the message, and seed/merge the turn.
 ///
-/// `interactive` is `true` for `harness::send` (a chat turn that may pause at
-/// `max_turns`) and `false` for `harness::run` (auto-ends so the poller never
-/// hangs on a parked turn).
+/// `interactive` is `true` for `harness::send` (a user-facing chat turn that
+/// may pause at `max_turns` to ask whether to continue). Autonomous turns —
+/// `harness::spawn` children, parentless/CLI spawns, and `harness::react`
+/// reactions — are seeded elsewhere with `interactive: false` and auto-end,
+/// so nothing parks waiting for a user who isn't there.
 pub async fn start(
     deps: &Deps,
     req: SendRequest,
@@ -212,20 +214,23 @@ pub async fn inject(
     let cfg = deps.cfg().await;
     let session = deps.session().await;
 
-    let options = crate::state::get_turn(&deps.iii, session_id, cfg.session_timeout_ms)
-        .await?
-        .map(|rec| rec.options)
-        .ok_or_else(|| {
-            HarnessError::InvalidRequest(format!(
-                "cannot deliver notification to session `{session_id}`: it has no prior turn to \
-                 inherit model/options from"
-            ))
-        })?;
+    let (options, interactive) =
+        crate::state::get_turn(&deps.iii, session_id, cfg.session_timeout_ms)
+            .await?
+            .map(|rec| (rec.options, rec.interactive))
+            .ok_or_else(|| {
+                HarnessError::InvalidRequest(format!(
+                    "cannot deliver notification to session `{session_id}`: it has no prior turn \
+                     to inherit model/options from"
+                ))
+            })?;
 
     session
         .append(session_id, &message, entry_id, None, origin)
         .await?;
-    seed_or_merge(deps, &cfg, session_id, options).await
+    // A woken turn keeps the session's interactivity: a user-facing chat may
+    // pause at `max_turns`; an autonomous (spawned/reactive) session auto-ends.
+    seed_or_merge(deps, &cfg, session_id, options, interactive).await
 }
 
 pub(crate) fn normalize_message(input: MessageInput) -> Result<AgentMessage, HarnessError> {

--- a/harness/src/functions/stop.rs
+++ b/harness/src/functions/stop.rs
@@ -98,7 +98,21 @@ pub async fn handle(deps: &Deps, req: StopRequest) -> Result<StopResponse, Harne
     }
     record.abort = true;
     record.updated_at = crate::types::message::AgentMessage::now_ms();
+
+    // A turn parked at max_turns has no enqueued step, so it would never observe
+    // the abort. Re-enqueue one (Running, next step) so the loop runs, hits the
+    // abort check, and finalises cancelled.
+    let parked = record.awaiting_continue;
+    if parked {
+        record.awaiting_continue = false;
+        record.step += 1;
+        record.status = crate::types::turn::TurnStatus::Running;
+    }
     crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
+    if parked {
+        crate::turn_loop::enqueue_step(&deps.iii, &record.session_id, &record.turn_id, record.step)
+            .await?;
+    }
 
     Ok(StopResponse { stopping: true })
 }

--- a/harness/src/subagent.rs
+++ b/harness/src/subagent.rs
@@ -295,6 +295,8 @@ mod tests {
             turn_count: 1,
             depth: 0,
             abort: false,
+            awaiting_continue: false,
+            interactive: false,
             watermark_entry_id: None,
             stream_request_id: None,
             options: TurnOptions {

--- a/harness/src/subagent.rs
+++ b/harness/src/subagent.rs
@@ -250,6 +250,9 @@ async fn seed_child(
         result: None,
         result_error: None,
         validation_retries: 0,
+        // Sub-agents have no interactive user: auto-end at max_turns, never pause.
+        awaiting_continue: false,
+        interactive: false,
         created_at: now,
         updated_at: now,
     };

--- a/harness/src/surface.rs
+++ b/harness/src/surface.rs
@@ -7,6 +7,7 @@
 //! of the agent-facing surface.
 
 use crate::functions::{
+    continue_turn::{ContinueRequest, ContinueResponse},
     function_resolve::{FunctionResolveRequest, FunctionResolveResponse},
     function_trigger::{FunctionTriggerRequest, FunctionTriggerResponse},
     send::{SendRequest, SendResponse},
@@ -15,7 +16,8 @@ use crate::functions::{
     stop::{StopRequest, StopResponse},
 };
 use crate::functions::{
-    FUNCTION_RESOLVE_ID, FUNCTION_TRIGGER_ID, SEND_ID, SPAWN_ID, STATUS_ID, STOP_ID, TURN_ID,
+    CONTINUE_ID, FUNCTION_RESOLVE_ID, FUNCTION_TRIGGER_ID, SEND_ID, SPAWN_ID, STATUS_ID, STOP_ID,
+    TURN_ID,
 };
 use crate::turn_loop::{TurnStepPayload, TurnStepResult};
 
@@ -62,5 +64,6 @@ pub fn catalog() -> Vec<FunctionSpec> {
         spec::<FunctionResolveRequest, FunctionResolveResponse>(FUNCTION_RESOLVE_ID),
         spec::<StopRequest, StopResponse>(STOP_ID),
         spec::<StatusRequest, Option<StatusReport>>(STATUS_ID),
+        spec::<ContinueRequest, ContinueResponse>(CONTINUE_ID),
     ]
 }

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -154,8 +154,12 @@ pub async fn run_step(
         }
     }
 
-    // max_turns guard: cap runaway loops with a synthetic notice.
+    // max_turns guard. An interactive top-level turn pauses and asks the user
+    // whether to continue; sub-agents and `harness::run` turns auto-end.
     if record.turn_count >= record.options.max_turns {
+        if record.interactive && record.parent.is_none() && cfg.ask_to_continue_on_max_turns {
+            return park_awaiting_continue(deps, &session, &mut record).await;
+        }
         let notice = format!(
             "max_turns ({}) reached; ending the turn.",
             record.options.max_turns
@@ -167,6 +171,7 @@ pub async fn run_step(
                 json!({ "reason": "max_turns", "message": notice }),
                 &format!("e_{}_max_turns", record.turn_id),
                 Some(&origin(&record.turn_id)),
+                None,
             )
             .await;
         let text = json!(notice);
@@ -721,6 +726,54 @@ async fn advance(deps: &Deps, record: &mut TurnRecord) -> Result<TurnStepResult,
     })
 }
 
+/// Park an interactive top-level turn that reached `max_turns`, asking the user
+/// whether to continue. Non-terminal (`AwaitingFunctions` + `awaiting_continue`)
+/// with no re-enqueue — the user's next `harness::send` resumes it (see
+/// `send::resume_awaiting_continue`). Idempotent on step redelivery: the notice
+/// uses a deterministic entry id and re-parking re-writes the same fields.
+async fn park_awaiting_continue(
+    deps: &Deps,
+    session: &SessionClient,
+    record: &mut TurnRecord,
+) -> Result<TurnStepResult, HarnessError> {
+    let cfg = deps.cfg().await;
+    let notice = format!(
+        "Reached the max-turns limit ({}). Reply to continue, or stop here.",
+        record.options.max_turns
+    );
+    // Key the entry id on the current budget so a second pause (after one
+    // continue raised the budget) writes a distinct entry rather than colliding.
+    let entry_id = format!(
+        "e_{}_await_continue_{}",
+        record.turn_id, record.options.max_turns
+    );
+    let _ = session
+        .append_custom(
+            &record.session_id,
+            "notice",
+            json!({ "reason": "max_turns_await_continue", "message": notice }),
+            &entry_id,
+            Some(&origin(&record.turn_id)),
+            Some(&notice),
+        )
+        .await;
+
+    record.status = TurnStatus::AwaitingFunctions;
+    record.awaiting_continue = true;
+    record.updated_at = AgentMessage::now_ms();
+    crate::state::put_turn(&deps.iii, record, cfg.session_timeout_ms).await?;
+    let _ = session
+        .set_status(&record.session_id, "waiting", Some("max_turns"))
+        .await;
+
+    Ok(TurnStepResult {
+        session_id: record.session_id.clone(),
+        status: TurnStatus::AwaitingFunctions,
+        next_step: None,
+        skipped: false,
+    })
+}
+
 async fn finalize_completed(
     deps: &Deps,
     session: &SessionClient,
@@ -781,6 +834,7 @@ async fn finalize_failed(
             json!({ "reason": reason }),
             &format!("e_{}_error", record.turn_id),
             Some(&origin(&record.turn_id)),
+            None,
         )
         .await;
     let _ = session
@@ -1114,6 +1168,7 @@ async fn assemble_context(
                             data,
                             &ids::compaction_entry_id(&record.turn_id, step),
                             Some(&origin(&record.turn_id)),
+                            None,
                         )
                         .await;
                 }

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -747,7 +747,11 @@ async fn park_awaiting_continue(
         "e_{}_await_continue_{}",
         record.turn_id, record.options.max_turns
     );
-    let _ = session
+    // Best-effort, but LOUD on failure: the console shows the continue/stop
+    // choice only off the notice + `waiting` status, so a silent failure here
+    // (e.g. a session-manager too old to know `waiting`) parks the turn with
+    // no visible way for the user to resume it.
+    if let Err(e) = session
         .append_custom(
             &record.session_id,
             "notice",
@@ -756,15 +760,30 @@ async fn park_awaiting_continue(
             Some(&origin(&record.turn_id)),
             Some(&notice),
         )
-        .await;
+        .await
+    {
+        tracing::warn!(
+            session_id = %record.session_id,
+            error = %e,
+            "failed to append the ask-to-continue notice; the pause is invisible in the console"
+        );
+    }
 
     record.status = TurnStatus::AwaitingFunctions;
     record.awaiting_continue = true;
     record.updated_at = AgentMessage::now_ms();
     crate::state::put_turn(&deps.iii, record, cfg.session_timeout_ms).await?;
-    let _ = session
+    if let Err(e) = session
         .set_status(&record.session_id, "waiting", Some("max_turns"))
-        .await;
+        .await
+    {
+        tracing::warn!(
+            session_id = %record.session_id,
+            error = %e,
+            "failed to set session status to `waiting` (session-manager < 1.1.0?); \
+             the console will not offer continue/stop for this parked turn"
+        );
+    }
 
     Ok(TurnStepResult {
         session_id: record.session_id.clone(),

--- a/harness/src/types/turn.rs
+++ b/harness/src/types/turn.rs
@@ -209,6 +209,16 @@ pub struct TurnRecord {
     pub result_error: Option<String>,
     #[serde(default)]
     pub validation_retries: u32,
+    /// A top-level interactive turn parked at `max_turns`, awaiting the user's
+    /// "continue or stop" reply. Non-terminal (status == `AwaitingFunctions`);
+    /// the next `harness::send` resumes it with an extended budget.
+    #[serde(default)]
+    pub awaiting_continue: bool,
+    /// Seeded `true` by `harness::send` (an interactive chat turn); `false` for
+    /// `harness::run` and `harness::spawn` turns, which auto-end at `max_turns`
+    /// rather than pausing to ask (no interactive user to answer).
+    #[serde(default)]
+    pub interactive: bool,
     pub created_at: i64,
     pub updated_at: i64,
 }
@@ -286,6 +296,8 @@ mod tests {
             result: None,
             result_error: None,
             validation_retries: 0,
+            awaiting_continue: false,
+            interactive: false,
             created_at: 1,
             updated_at: 1,
         }
@@ -375,6 +387,18 @@ mod tests {
         assert!(r.calls.is_empty());
         assert_eq!(r.options.max_validation_retries, 2);
         assert_eq!(r.options.output, OutputContract::Text);
+        // New flags default to false so legacy records keep the auto-end path.
+        assert!(!r.awaiting_continue);
+        assert!(!r.interactive);
+    }
+
+    #[test]
+    fn awaiting_continue_round_trips() {
+        let mut r = record();
+        r.awaiting_continue = true;
+        r.interactive = true;
+        let back: TurnRecord = serde_json::from_value(serde_json::to_value(&r).unwrap()).unwrap();
+        assert_eq!(back, r);
     }
 
     #[test]

--- a/harness/tests/golden/schemas/harness.continue.json
+++ b/harness/tests/golden/schemas/harness.continue.json
@@ -1,0 +1,37 @@
+{
+  "function_id": "harness::continue",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "session_id": {
+        "type": "string"
+      },
+      "turn_id": {
+        "description": "Omit to continue the session's current turn.",
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "required": [
+      "session_id"
+    ],
+    "title": "ContinueRequest",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "continuing": {
+        "description": "True when a parked turn was resumed; false when there was nothing to continue (no turn, wrong turn, terminal, or not awaiting continuation).",
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "continuing"
+    ],
+    "title": "ContinueResponse",
+    "type": "object"
+  }
+}

--- a/harness/tests/schemas.rs
+++ b/harness/tests/schemas.rs
@@ -40,6 +40,7 @@ fn catalog_lists_all_functions_in_registration_order() {
             "harness::function::resolve",
             "harness::stop",
             "harness::status",
+            "harness::continue",
         ]
     );
 }

--- a/session-manager/Cargo.lock
+++ b/session-manager/Cargo.lock
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "session-manager"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/session-manager/Cargo.toml
+++ b/session-manager/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "session-manager"
-version = "1.0.2"
+version = "1.1.0"
 edition = "2021"
 publish = false
 

--- a/session-manager/src/types.rs
+++ b/session-manager/src/types.rs
@@ -299,6 +299,9 @@ impl SessionEntry {
 pub enum SessionStatus {
     Idle,
     Working,
+    /// Parked mid-turn awaiting a user decision (e.g. the harness reached
+    /// `max_turns` and is asking whether to continue).
+    Waiting,
     Done,
     Error,
 }

--- a/session-manager/tests/features/status.feature
+++ b/session-manager/tests/features/status.feature
@@ -130,6 +130,29 @@ Feature: session::set-status — the coarse lifecycle status
     And delivery 1 to "ui::status" has "previous_status" = "working"
     And delivery 1 to "ui::status" has "status" = "done"
 
+  # Prevents: the "waiting" lifecycle status (a turn parked awaiting a user
+  # decision, e.g. the harness reached max_turns) being rejected by the enum.
+  Scenario: a turn can be parked in the waiting status
+    Given a binding "b1" on "session::status-changed" delivering to "ui::status" with config:
+      """
+      {}
+      """
+    When I call "session::set-status" with:
+      """
+      { "session_id": "s_001", "status": "working" }
+      """
+    And I call "session::set-status" with:
+      """
+      { "session_id": "s_001", "status": "waiting", "reason": "max_turns" }
+      """
+    And I call "session::get" with:
+      """
+      { "session_id": "s_001" }
+      """
+    Then the response field "meta.status" is "waiting"
+    And delivery 1 to "ui::status" has "status" = "waiting"
+    And delivery 1 to "ui::status" has "previous_status" = "working"
+
   # Prevents: setting status on sessions that don't exist.
   Scenario: set_status on an unknown session is rejected
     When I call "session::set-status" with:

--- a/session-manager/tests/golden/schemas/session.create.json
+++ b/session-manager/tests/golden/schemas/session.create.json
@@ -99,13 +99,24 @@
       },
       "SessionStatus": {
         "description": "Coarse session lifecycle status, rendered directly by consumers.",
-        "enum": [
-          "idle",
-          "working",
-          "done",
-          "error"
-        ],
-        "type": "string"
+        "oneOf": [
+          {
+            "enum": [
+              "idle",
+              "working",
+              "done",
+              "error"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Parked mid-turn awaiting a user decision (e.g. the harness reached `max_turns` and is asking whether to continue).",
+            "enum": [
+              "waiting"
+            ],
+            "type": "string"
+          }
+        ]
       }
     },
     "properties": {

--- a/session-manager/tests/golden/schemas/session.ensure.json
+++ b/session-manager/tests/golden/schemas/session.ensure.json
@@ -106,13 +106,24 @@
       },
       "SessionStatus": {
         "description": "Coarse session lifecycle status, rendered directly by consumers.",
-        "enum": [
-          "idle",
-          "working",
-          "done",
-          "error"
-        ],
-        "type": "string"
+        "oneOf": [
+          {
+            "enum": [
+              "idle",
+              "working",
+              "done",
+              "error"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Parked mid-turn awaiting a user decision (e.g. the harness reached `max_turns` and is asking whether to continue).",
+            "enum": [
+              "waiting"
+            ],
+            "type": "string"
+          }
+        ]
       }
     },
     "properties": {

--- a/session-manager/tests/golden/schemas/session.fork.json
+++ b/session-manager/tests/golden/schemas/session.fork.json
@@ -96,13 +96,24 @@
       },
       "SessionStatus": {
         "description": "Coarse session lifecycle status, rendered directly by consumers.",
-        "enum": [
-          "idle",
-          "working",
-          "done",
-          "error"
-        ],
-        "type": "string"
+        "oneOf": [
+          {
+            "enum": [
+              "idle",
+              "working",
+              "done",
+              "error"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Parked mid-turn awaiting a user decision (e.g. the harness reached `max_turns` and is asking whether to continue).",
+            "enum": [
+              "waiting"
+            ],
+            "type": "string"
+          }
+        ]
       }
     },
     "properties": {

--- a/session-manager/tests/golden/schemas/session.get.json
+++ b/session-manager/tests/golden/schemas/session.get.json
@@ -103,13 +103,24 @@
       },
       "SessionStatus": {
         "description": "Coarse session lifecycle status, rendered directly by consumers.",
-        "enum": [
-          "idle",
-          "working",
-          "done",
-          "error"
-        ],
-        "type": "string"
+        "oneOf": [
+          {
+            "enum": [
+              "idle",
+              "working",
+              "done",
+              "error"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Parked mid-turn awaiting a user decision (e.g. the harness reached `max_turns` and is asking whether to continue).",
+            "enum": [
+              "waiting"
+            ],
+            "type": "string"
+          }
+        ]
       }
     },
     "title": "Nullable_GetResponse"

--- a/session-manager/tests/golden/schemas/session.list.json
+++ b/session-manager/tests/golden/schemas/session.list.json
@@ -14,13 +14,24 @@
       },
       "SessionStatus": {
         "description": "Coarse session lifecycle status, rendered directly by consumers.",
-        "enum": [
-          "idle",
-          "working",
-          "done",
-          "error"
-        ],
-        "type": "string"
+        "oneOf": [
+          {
+            "enum": [
+              "idle",
+              "working",
+              "done",
+              "error"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Parked mid-turn awaiting a user decision (e.g. the harness reached `max_turns` and is asking whether to continue).",
+            "enum": [
+              "waiting"
+            ],
+            "type": "string"
+          }
+        ]
       }
     },
     "properties": {
@@ -144,13 +155,24 @@
       },
       "SessionStatus": {
         "description": "Coarse session lifecycle status, rendered directly by consumers.",
-        "enum": [
-          "idle",
-          "working",
-          "done",
-          "error"
-        ],
-        "type": "string"
+        "oneOf": [
+          {
+            "enum": [
+              "idle",
+              "working",
+              "done",
+              "error"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Parked mid-turn awaiting a user decision (e.g. the harness reached `max_turns` and is asking whether to continue).",
+            "enum": [
+              "waiting"
+            ],
+            "type": "string"
+          }
+        ]
       }
     },
     "properties": {

--- a/session-manager/tests/golden/schemas/session.set-meta.json
+++ b/session-manager/tests/golden/schemas/session.set-meta.json
@@ -105,13 +105,24 @@
       },
       "SessionStatus": {
         "description": "Coarse session lifecycle status, rendered directly by consumers.",
-        "enum": [
-          "idle",
-          "working",
-          "done",
-          "error"
-        ],
-        "type": "string"
+        "oneOf": [
+          {
+            "enum": [
+              "idle",
+              "working",
+              "done",
+              "error"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Parked mid-turn awaiting a user decision (e.g. the harness reached `max_turns` and is asking whether to continue).",
+            "enum": [
+              "waiting"
+            ],
+            "type": "string"
+          }
+        ]
       }
     },
     "properties": {

--- a/session-manager/tests/golden/schemas/session.set-status.json
+++ b/session-manager/tests/golden/schemas/session.set-status.json
@@ -5,13 +5,24 @@
     "definitions": {
       "SessionStatus": {
         "description": "Coarse session lifecycle status, rendered directly by consumers.",
-        "enum": [
-          "idle",
-          "working",
-          "done",
-          "error"
-        ],
-        "type": "string"
+        "oneOf": [
+          {
+            "enum": [
+              "idle",
+              "working",
+              "done",
+              "error"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Parked mid-turn awaiting a user decision (e.g. the harness reached `max_turns` and is asking whether to continue).",
+            "enum": [
+              "waiting"
+            ],
+            "type": "string"
+          }
+        ]
       }
     },
     "properties": {
@@ -46,13 +57,24 @@
     "definitions": {
       "SessionStatus": {
         "description": "Coarse session lifecycle status, rendered directly by consumers.",
-        "enum": [
-          "idle",
-          "working",
-          "done",
-          "error"
-        ],
-        "type": "string"
+        "oneOf": [
+          {
+            "enum": [
+              "idle",
+              "working",
+              "done",
+              "error"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Parked mid-turn awaiting a user decision (e.g. the harness reached `max_turns` and is asking whether to continue).",
+            "enum": [
+              "waiting"
+            ],
+            "type": "string"
+          }
+        ]
       }
     },
     "properties": {

--- a/session-manager/tests/golden/schemas/session.store.get-meta.json
+++ b/session-manager/tests/golden/schemas/session.store.get-meta.json
@@ -91,13 +91,24 @@
       },
       "SessionStatus": {
         "description": "Coarse session lifecycle status, rendered directly by consumers.",
-        "enum": [
-          "idle",
-          "working",
-          "done",
-          "error"
-        ],
-        "type": "string"
+        "oneOf": [
+          {
+            "enum": [
+              "idle",
+              "working",
+              "done",
+              "error"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Parked mid-turn awaiting a user decision (e.g. the harness reached `max_turns` and is asking whether to continue).",
+            "enum": [
+              "waiting"
+            ],
+            "type": "string"
+          }
+        ]
       }
     },
     "title": "Nullable_SessionMeta"

--- a/session-manager/tests/golden/schemas/session.store.list-metas.json
+++ b/session-manager/tests/golden/schemas/session.store.list-metas.json
@@ -75,13 +75,24 @@
       },
       "SessionStatus": {
         "description": "Coarse session lifecycle status, rendered directly by consumers.",
-        "enum": [
-          "idle",
-          "working",
-          "done",
-          "error"
-        ],
-        "type": "string"
+        "oneOf": [
+          {
+            "enum": [
+              "idle",
+              "working",
+              "done",
+              "error"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Parked mid-turn awaiting a user decision (e.g. the harness reached `max_turns` and is asking whether to continue).",
+            "enum": [
+              "waiting"
+            ],
+            "type": "string"
+          }
+        ]
       }
     },
     "properties": {

--- a/session-manager/tests/golden/schemas/session.store.put-meta.json
+++ b/session-manager/tests/golden/schemas/session.store.put-meta.json
@@ -70,13 +70,24 @@
       },
       "SessionStatus": {
         "description": "Coarse session lifecycle status, rendered directly by consumers.",
-        "enum": [
-          "idle",
-          "working",
-          "done",
-          "error"
-        ],
-        "type": "string"
+        "oneOf": [
+          {
+            "enum": [
+              "idle",
+              "working",
+              "done",
+              "error"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Parked mid-turn awaiting a user decision (e.g. the harness reached `max_turns` and is asking whether to continue).",
+            "enum": [
+              "waiting"
+            ],
+            "type": "string"
+          }
+        ]
       }
     },
     "properties": {


### PR DESCRIPTION
Fixes MOT-3867

## Summary

When a top-level turn hits `max_turns`, the harness now **pauses and asks whether to continue** instead of silently ending. The turn parks in a non-terminal `waiting` state with a visible prompt; the user resumes it (with a fresh budget) via a **Continue button** in the console — a parked turn blocks the chat input, so a button is the affordance — or by replying. Autonomous turns (spawn children, parentless/CLI spawns, reactive `harness::react` turns) auto-end: there is no interactive user to answer.

This also fixes a latent bug: harness `notice` entries were written with empty `content`, so the console dropped them — the existing max_turns notice was invisible.

## Behavior

- A turn that reaches the cap appends a visible notice (*"Reached the max-turns limit (N). Reply to continue, or stop here."*) and parks (`status: waiting`).
- Clicking **Continue** (or replying) resumes the same turn with `max_turns += default_max_turns`; the turn count keeps climbing.
- `harness::stop` cancels a parked turn cleanly.

## Changes

**Harness**
- The `max_turns` guard parks interactive top-level turns (reusing the non-terminal `AwaitingFunctions` state + an `awaiting_continue` flag on `TurnRecord`) with a visible notice and a `waiting` session status, instead of finalizing.
- An `interactive` flag on `TurnRecord` marks `harness::send` turns as the only ones that park. Autonomous turns — `harness::spawn` children, parentless/CLI spawns, and `harness::react` reactions — auto-end at the cap, so nothing parks waiting for a user who isn't there. Wake-injected turns (subscription notifications) inherit the session's interactivity.
- New public function **`harness::continue`** (`{session_id, turn_id?}` → `{continuing}`): resume a parked turn with a fresh budget, under the session lock; a no-op when there is nothing to continue. Added to the wire-surface catalog (+ golden).
- `harness::send` also resumes a parked turn (reply-to-continue).
- `harness::stop` enqueues a step so a parked turn observes the abort and finalizes cancelled.
- `append_custom` gains a `display` argument so the notice renders.
- New config knob `ask_to_continue_on_max_turns` (default `true`).
- Park-path failures are no longer silent: if the notice append or the `waiting` status update fails, the harness logs a warning naming the consequence (the console can't offer continue/stop).

**Waiting status (session-manager + console)**
- `SessionStatus::Waiting` variant (golden schemas regenerated). session-manager bumps to **1.1.0** and the harness manifest now requires `session-manager: "^1.1.0"`: an older session-manager rejects `set-status("waiting")` — silently, from the console's point of view — and also skips persisted `waiting` records as malformed on store replay, so the continue option never appears. This mismatch is exactly how the feature "didn't work" in earlier live testing.
- Console: `continue` + `stop` buttons shown when the session is `waiting` (wired to `harness::continue`); the composer input stays usable while parked ("press continue, or type to steer…"); `waiting` added to the status unions with a sidebar dot and a dock signal.

## Testing
- harness: `cargo test` — 175 passing.
- session-manager: `cargo test` — 66 passing (incl. a `waiting` set-status scenario); goldens regenerated.
- console/web: `tsc` typecheck and vitest — 884 passing.
- Verified end-to-end against a running engine (fresh validation after the rebase onto current main):
  - park at the cap → session `waiting`, visible notice;
  - resume via `harness::continue`, via the console Continue button, and via reply — all complete with a real model turn;
  - stop-while-parked → cancelled;
  - parentless `harness::spawn` at the cap → auto-ends (does not park);
  - negative check: pairing the new harness with a pre-1.1.0 session-manager reproduces the "no continue option" failure (status update rejected and swallowed), which the version requirement + warning now prevent/surface.
