### PR TITLE
feat(storage): add storage::headObject + GET-only presign response-overrides

### DIFF
--- a/storage/Cargo.lock
+++ b/storage/Cargo.lock
@@ -3386,7 +3386,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "storage"
-version = "0.1.5"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/storage/Cargo.lock
+++ b/storage/Cargo.lock
@@ -3386,7 +3386,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "storage"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "storage"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 publish = false
 

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "storage"
-version = "0.1.5"
+version = "0.1.4"
 edition = "2021"
 publish = false
 

--- a/storage/README.md
+++ b/storage/README.md
@@ -61,6 +61,14 @@ await iii.trigger({
     key: 'u/1/profile.jpg',
   },
 })                                  // idempotent: returns { deleted: false } if absent
+
+const { content_type, etag, size, last_modified } = await iii.trigger({
+  function_id: 'storage::headObject',
+  payload: {
+    bucket: 'uploads',
+    key: 'u/1/profile.jpg',
+  },
+})                                  // fetches metadata only — no body download
 ```
 
 From a Rust worker:
@@ -240,6 +248,32 @@ triggers:
 > redelivery or auth-scope edge cases in production, file an issue —
 > v1.1 will finalize the consume path.
 
+## RPC reference notes
+
+### `storage::presignUrl` — GET-only response-override params
+
+Two optional fields are accepted only when `method` is `"GET"`. Passing
+either on a `PUT` presign returns `INVALID_PRESIGN_PARAMS`.
+
+| Field | Type | Description |
+|---|---|---|
+| `response_content_disposition` | `string` (optional) | Override `Content-Disposition` header on the served response (e.g. `"attachment; filename=\"report.pdf\""`). |
+| `response_content_type` | `string` (optional) | Override `Content-Type` header on the served response (e.g. `"application/pdf"`). |
+
+```ts
+const { url } = await iii.trigger({
+  function_id: 'storage::presignUrl',
+  payload: {
+    bucket: 'uploads',
+    key: 'reports/q1.pdf',
+    method: 'GET',
+    expires_in_seconds: 300,
+    response_content_disposition: 'attachment; filename="q1.pdf"',
+    response_content_type: 'application/pdf',
+  },
+})
+```
+
 ## Local development & testing
 
 The committed `config.yaml` declares a single `scratch` bucket served by the
@@ -257,8 +291,9 @@ cargo run --release -- --url ws://127.0.0.1:49134 --config ./config.yaml
 The worker registers its schema with the `configuration` worker (seeding
 `config.yaml` if no stored value exists), fetches the live config, then spawns a
 rustfs process on a random port, waits for it to become healthy, and registers
-`storage::putObject`, `storage::getObject`, `storage::deleteObject`, and
-`storage::presignUrl`. Files land under `./data/storage/` (configurable via
+`storage::putObject`, `storage::getObject`, `storage::deleteObject`,
+`storage::presignUrl`, and `storage::headObject`. Files land under
+`./data/storage/` (configurable via
 `providers.local.data_dir`).
 
 Running `--manifest` prints the registry-publish JSON without touching the

--- a/storage/src/backend/gcs.rs
+++ b/storage/src/backend/gcs.rs
@@ -189,6 +189,36 @@ impl Backend for GcsBackend {
         })
     }
 
+    async fn head(&self, req: HeadReq) -> Result<HeadResp, BackendError> {
+        let mut get_req = GetObjectRequest {
+            bucket: self.bucket.clone(),
+            object: req.key.clone(),
+            ..Default::default()
+        };
+        if let Some(v) = req.version_id.as_deref() {
+            get_req.generation = v.parse::<i64>().ok();
+        }
+        let object = self
+            .client
+            .get_object(&get_req)
+            .await
+            .map_err(map_gcs_error)?;
+        let size = if object.size < 0 { 0 } else { object.size as u64 };
+        let last_modified = object
+            .updated
+            .and_then(|t| chrono::Utc.timestamp_opt(t.unix_timestamp(), 0).single())
+            .unwrap_or_else(Utc::now);
+        let content_type = object
+            .content_type
+            .unwrap_or_else(|| "application/octet-stream".to_string());
+        Ok(HeadResp {
+            content_type,
+            etag: object.etag,
+            last_modified,
+            size,
+        })
+    }
+
     async fn delete(&self, req: DeleteReq) -> Result<DeleteResp, BackendError> {
         let mut del_req = DeleteObjectRequest {
             bucket: self.bucket.clone(),
@@ -223,6 +253,14 @@ impl Backend for GcsBackend {
         };
         if matches!(req.method, PresignMethod::Put) {
             opts.content_type = req.content_type.clone();
+        }
+        if let Some(cd) = &req.response_content_disposition {
+            opts.query_parameters
+                .insert("response-content-disposition".to_string(), vec![cd.clone()]);
+        }
+        if let Some(ct) = &req.response_content_type {
+            opts.query_parameters
+                .insert("response-content-type".to_string(), vec![ct.clone()]);
         }
         let url = self
             .client

--- a/storage/src/backend/gcs.rs
+++ b/storage/src/backend/gcs.rs
@@ -203,7 +203,11 @@ impl Backend for GcsBackend {
             .get_object(&get_req)
             .await
             .map_err(map_gcs_error)?;
-        let size = if object.size < 0 { 0 } else { object.size as u64 };
+        let size = if object.size < 0 {
+            0
+        } else {
+            object.size as u64
+        };
         let last_modified = object
             .updated
             .and_then(|t| chrono::Utc.timestamp_opt(t.unix_timestamp(), 0).single())

--- a/storage/src/backend/mod.rs
+++ b/storage/src/backend/mod.rs
@@ -19,6 +19,7 @@ pub mod s3;
 pub trait Backend: Send + Sync {
     async fn put(&self, req: PutReq) -> Result<PutResp, BackendError>;
     async fn get(&self, req: GetReq) -> Result<GetResp, BackendError>;
+    async fn head(&self, req: HeadReq) -> Result<HeadResp, BackendError>;
     async fn delete(&self, req: DeleteReq) -> Result<DeleteResp, BackendError>;
     async fn presign(&self, req: PresignReq) -> Result<PresignResp, BackendError>;
 
@@ -62,6 +63,20 @@ pub struct GetResp {
     pub size: u64,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct HeadReq {
+    pub key: String,
+    pub version_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct HeadResp {
+    pub content_type: String,
+    pub etag: String,
+    pub last_modified: DateTime<Utc>,
+    pub size: u64,
+}
+
 #[derive(Debug, Clone)]
 pub struct DeleteReq {
     pub key: String,
@@ -85,6 +100,12 @@ pub struct PresignReq {
     pub method: PresignMethod,
     pub content_type: Option<String>,
     pub expires_in_seconds: u64,
+    /// GET-only: override the `Content-Disposition` header on the served response.
+    /// Ignored for `Put` presign; providers SHOULD return an error if set on a Put.
+    pub response_content_disposition: Option<String>,
+    /// GET-only: override the `Content-Type` header on the served response.
+    /// Ignored for `Put` presign; providers SHOULD return an error if set on a Put.
+    pub response_content_type: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -140,6 +161,7 @@ pub mod mock {
     pub enum MockCall {
         Put(PutReq),
         Get(GetReq),
+        Head(HeadReq),
         Delete(DeleteReq),
         Presign(PresignReq),
     }
@@ -148,6 +170,7 @@ pub mod mock {
     pub struct MockResponses {
         pub put: Option<Result<PutResp, BackendError>>,
         pub get: Option<Result<GetResp, BackendError>>,
+        pub head: Option<Result<HeadResp, BackendError>>,
         pub delete: Option<Result<DeleteResp, BackendError>>,
         pub presign: Option<Result<PresignResp, BackendError>>,
     }
@@ -191,6 +214,16 @@ pub mod mock {
                 }
             }
             Ok(resp)
+        }
+
+        async fn head(&self, req: HeadReq) -> Result<HeadResp, BackendError> {
+            self.calls.lock().unwrap().push(MockCall::Head(req));
+            self.responses
+                .lock()
+                .unwrap()
+                .head
+                .clone()
+                .unwrap_or(Err(BackendError::NotFound))
         }
 
         async fn delete(&self, req: DeleteReq) -> Result<DeleteResp, BackendError> {
@@ -282,5 +315,42 @@ mod backend_tests {
             .await
             .unwrap_err();
         assert!(matches!(err, BackendError::NotFound));
+    }
+
+    #[tokio::test]
+    async fn mock_head_returns_not_found_by_default() {
+        let m = MockBackend::default();
+        let err = m
+            .head(HeadReq {
+                key: "k".into(),
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, BackendError::NotFound));
+    }
+
+    #[tokio::test]
+    async fn mock_head_records_call_and_returns_canned_response() {
+        let m = MockBackend::default();
+        let canned = HeadResp {
+            content_type: "image/png".to_string(),
+            etag: "\"abc123\"".to_string(),
+            last_modified: Utc::now(),
+            size: 42,
+        };
+        m.responses.lock().unwrap().head = Some(Ok(canned.clone()));
+        let resp = m
+            .head(HeadReq {
+                key: "img.png".into(),
+                version_id: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(resp.size, 42);
+        assert_eq!(resp.content_type, "image/png");
+        let calls = m.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert!(matches!(calls[0], MockCall::Head(_)));
     }
 }

--- a/storage/src/backend/s3.rs
+++ b/storage/src/backend/s3.rs
@@ -165,11 +165,7 @@ impl Backend for S3Backend {
     }
 
     async fn head(&self, req: HeadReq) -> Result<HeadResp, BackendError> {
-        let mut h = self
-            .client
-            .head_object()
-            .bucket(&self.bucket)
-            .key(&req.key);
+        let mut h = self.client.head_object().bucket(&self.bucket).key(&req.key);
         if let Some(v) = req.version_id {
             h = h.version_id(v);
         }

--- a/storage/src/backend/s3.rs
+++ b/storage/src/backend/s3.rs
@@ -164,6 +164,40 @@ impl Backend for S3Backend {
         })
     }
 
+    async fn head(&self, req: HeadReq) -> Result<HeadResp, BackendError> {
+        let mut h = self
+            .client
+            .head_object()
+            .bucket(&self.bucket)
+            .key(&req.key);
+        if let Some(v) = req.version_id {
+            h = h.version_id(v);
+        }
+        let resp = h.send().await.map_err(map_s3_error)?;
+        let last_modified = resp
+            .last_modified
+            .and_then(|dt| {
+                chrono::Utc
+                    .timestamp_opt(dt.secs(), dt.subsec_nanos())
+                    .single()
+            })
+            .unwrap_or_else(Utc::now);
+        let content_type = resp
+            .content_type
+            .unwrap_or_else(|| "application/octet-stream".to_string());
+        let etag = resp.e_tag.unwrap_or_default();
+        let size = match resp.content_length {
+            Some(n) if n >= 0 => n as u64,
+            _ => 0,
+        };
+        Ok(HeadResp {
+            content_type,
+            etag,
+            last_modified,
+            size,
+        })
+    }
+
     async fn delete(&self, req: DeleteReq) -> Result<DeleteResp, BackendError> {
         let mut d = self
             .client
@@ -189,14 +223,16 @@ impl Backend for S3Backend {
                 message: format!("presign config: {e}"),
             })?;
         let presigned = match req.method {
-            PresignMethod::Get => self
-                .client
-                .get_object()
-                .bucket(&self.bucket)
-                .key(&req.key)
-                .presigned(cfg)
-                .await
-                .map_err(map_s3_error)?,
+            PresignMethod::Get => {
+                let mut get = self.client.get_object().bucket(&self.bucket).key(&req.key);
+                if let Some(cd) = req.response_content_disposition {
+                    get = get.response_content_disposition(cd);
+                }
+                if let Some(ct) = req.response_content_type {
+                    get = get.response_content_type(ct);
+                }
+                get.presigned(cfg).await.map_err(map_s3_error)?
+            }
             PresignMethod::Put => {
                 let mut put = self.client.put_object().bucket(&self.bucket).key(&req.key);
                 if let Some(ct) = &req.content_type {

--- a/storage/src/handlers/head_object.rs
+++ b/storage/src/handlers/head_object.rs
@@ -1,0 +1,119 @@
+//! `storage::headObject` — fetch object metadata without downloading the body.
+
+use super::{err_to_str, AppState};
+use crate::backend::HeadReq as BackendHeadReq;
+use crate::error::{backend_error_to_storage, StorageError};
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct HeadReq {
+    pub bucket: String,
+    pub key: String,
+    pub version_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct HeadResp {
+    pub content_type: String,
+    pub etag: String,
+    pub last_modified: DateTime<Utc>,
+    pub size: u64,
+}
+
+pub async fn handle(state: &AppState, req: HeadReq) -> Result<HeadResp, String> {
+    if req.key.is_empty() {
+        return Err(err_to_str(StorageError::ConfigError {
+            message: "key must not be empty".into(),
+        }));
+    }
+    let backend = state.backend(&req.bucket).await.map_err(err_to_str)?;
+    let resp = backend
+        .head(BackendHeadReq {
+            key: req.key.clone(),
+            version_id: req.version_id,
+        })
+        .await
+        .map_err(|e| {
+            err_to_str(backend_error_to_storage(
+                e,
+                backend.provider(),
+                &req.bucket,
+                &req.key,
+            ))
+        })?;
+    Ok(HeadResp {
+        content_type: resp.content_type,
+        etag: resp.etag,
+        last_modified: resp.last_modified,
+        size: resp.size,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::mock::MockBackend;
+    use crate::backend::{Backend, BackendError, HeadResp as BackendHeadResp};
+    use chrono::Utc;
+    use serde_json::json;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    fn state_with(
+        resp: Option<Result<BackendHeadResp, BackendError>>,
+    ) -> (AppState, Arc<MockBackend>) {
+        let m = Arc::new(MockBackend::default());
+        m.responses.lock().unwrap().head = resp;
+        let mut map = HashMap::new();
+        map.insert("uploads".to_string(), m.clone() as Arc<dyn Backend>);
+        (
+            AppState {
+                backends: Arc::new(RwLock::new(map)),
+                local_ctx: None,
+            },
+            m,
+        )
+    }
+
+    fn req(v: serde_json::Value) -> HeadReq {
+        serde_json::from_value(v).unwrap()
+    }
+
+    #[tokio::test]
+    async fn happy_path_returns_metadata() {
+        let now = Utc::now();
+        let (st, _m) = state_with(Some(Ok(BackendHeadResp {
+            content_type: "image/png".into(),
+            etag: "\"abc123\"".into(),
+            last_modified: now,
+            size: 42,
+        })));
+        let resp = super::handle(&st, req(json!({"bucket":"uploads","key":"img.png"})))
+            .await
+            .unwrap();
+        assert_eq!(resp.content_type, "image/png");
+        assert_eq!(resp.etag, "\"abc123\"");
+        assert_eq!(resp.size, 42);
+    }
+
+    #[tokio::test]
+    async fn not_found_maps_to_object_not_found() {
+        let (st, _m) = state_with(Some(Err(BackendError::NotFound)));
+        let err = super::handle(&st, req(json!({"bucket":"uploads","key":"k"})))
+            .await
+            .unwrap_err();
+        assert!(err.contains("OBJECT_NOT_FOUND"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn unknown_bucket_errors() {
+        let (st, _m) = state_with(None);
+        let err = super::handle(&st, req(json!({"bucket":"missing","key":"k"})))
+            .await
+            .unwrap_err();
+        assert!(err.contains("UNKNOWN_BUCKET"), "got: {err}");
+    }
+}

--- a/storage/src/handlers/head_object.rs
+++ b/storage/src/handlers/head_object.rs
@@ -117,7 +117,6 @@ mod tests {
         assert!(err.contains("UNKNOWN_BUCKET"), "got: {err}");
     }
 
-
     #[tokio::test]
     async fn empty_key_errors() {
         let (st, _m) = state_with(None);

--- a/storage/src/handlers/head_object.rs
+++ b/storage/src/handlers/head_object.rs
@@ -116,4 +116,40 @@ mod tests {
             .unwrap_err();
         assert!(err.contains("UNKNOWN_BUCKET"), "got: {err}");
     }
+
+
+    #[tokio::test]
+    async fn empty_key_errors() {
+        let (st, _m) = state_with(None);
+        let err = super::handle(&st, req(json!({"bucket": "uploads", "key": ""})))
+            .await
+            .unwrap_err();
+        assert!(
+            err.contains("CONFIG_ERROR") || err.contains("must not be empty"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn version_id_is_threaded_to_backend() {
+        let (st, mock) = state_with(Some(Ok(BackendHeadResp {
+            content_type: "application/octet-stream".into(),
+            etag: String::new(),
+            last_modified: Utc::now(),
+            size: 1,
+        })));
+        super::handle(
+            &st,
+            req(json!({"bucket": "uploads", "key": "k", "version_id": "v2"})),
+        )
+        .await
+        .unwrap();
+        let calls = mock.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        if let crate::backend::mock::MockCall::Head(h) = &calls[0] {
+            assert_eq!(h.version_id.as_deref(), Some("v2"));
+        } else {
+            panic!("expected Head call, got: {:?}", calls[0]);
+        }
+    }
 }

--- a/storage/src/handlers/mod.rs
+++ b/storage/src/handlers/mod.rs
@@ -9,6 +9,7 @@ use tokio::sync::RwLock;
 
 pub mod delete_object;
 pub mod get_object;
+pub mod head_object;
 pub mod presign_url;
 pub mod put_object;
 

--- a/storage/src/handlers/presign_url.rs
+++ b/storage/src/handlers/presign_url.rs
@@ -18,6 +18,12 @@ pub struct PresignReq {
     pub content_type: Option<String>,
     #[serde(default = "default_expires")]
     pub expires_in_seconds: u64,
+    /// GET-only: override `Content-Disposition` header on the served response.
+    /// Rejected with `INVALID_PRESIGN_PARAMS` if set on a PUT presign.
+    pub response_content_disposition: Option<String>,
+    /// GET-only: override `Content-Type` header on the served response.
+    /// Rejected with `INVALID_PRESIGN_PARAMS` if set on a PUT presign.
+    pub response_content_type: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema, Clone, Copy)]
@@ -60,6 +66,13 @@ pub async fn handle(state: &AppState, req: PresignReq) -> Result<PresignResp, St
             reason: "content_type is required for PUT presigns to prevent type smuggling".into(),
         }));
     }
+    if matches!(method, PresignMethod::Put)
+        && (req.response_content_disposition.is_some() || req.response_content_type.is_some())
+    {
+        return Err(err_to_str(StorageError::InvalidPresignParams {
+            reason: "response_content_disposition and response_content_type are only valid for GET presigns".into(),
+        }));
+    }
     let backend = state.backend(&req.bucket).await.map_err(err_to_str)?;
     let resp = backend
         .presign(BackendPresignReq {
@@ -67,8 +80,8 @@ pub async fn handle(state: &AppState, req: PresignReq) -> Result<PresignResp, St
             method,
             content_type: req.content_type,
             expires_in_seconds: req.expires_in_seconds,
-            response_content_disposition: None,
-            response_content_type: None,
+            response_content_disposition: req.response_content_disposition,
+            response_content_type: req.response_content_type,
         })
         .await
         .map_err(|e| {
@@ -164,5 +177,72 @@ mod tests {
         .await
         .unwrap_err();
         assert!(err.contains("INVALID_PRESIGN_PARAMS"), "got: {err}");
+    }
+
+    fn state_with_mock() -> (AppState, Arc<MockBackend>) {
+        let m = Arc::new(MockBackend::default());
+        let mut map = HashMap::new();
+        map.insert("uploads".to_string(), Arc::clone(&m) as Arc<dyn Backend>);
+        let st = AppState {
+            backends: Arc::new(RwLock::new(map)),
+            local_ctx: None,
+        };
+        (st, m)
+    }
+
+    #[tokio::test]
+    async fn presign_get_threads_response_overrides_to_backend() {
+        let (st, mock) = state_with_mock();
+        super::handle(
+            &st,
+            req(json!({
+                "bucket": "uploads",
+                "key": "file.pdf",
+                "method": "GET",
+                "expires_in_seconds": 600,
+                "response_content_disposition": "attachment; filename=\"file.pdf\"",
+                "response_content_type": "application/pdf"
+            })),
+        )
+        .await
+        .unwrap();
+
+        let calls = mock.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        if let crate::backend::mock::MockCall::Presign(presign_req) = &calls[0] {
+            assert_eq!(
+                presign_req.response_content_disposition.as_deref(),
+                Some("attachment; filename=\"file.pdf\"")
+            );
+            assert_eq!(
+                presign_req.response_content_type.as_deref(),
+                Some("application/pdf")
+            );
+        } else {
+            panic!("expected Presign call, got: {:?}", calls[0]);
+        }
+    }
+
+    #[tokio::test]
+    async fn presign_put_with_response_override_is_rejected() {
+        let st = state();
+        let err = super::handle(
+            &st,
+            req(json!({
+                "bucket": "uploads",
+                "key": "k",
+                "method": "PUT",
+                "content_type": "image/png",
+                "expires_in_seconds": 600,
+                "response_content_disposition": "attachment; filename=\"k\""
+            })),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("INVALID_PRESIGN_PARAMS"), "got: {err}");
+        assert!(
+            err.contains("response_content_disposition") || err.contains("GET"),
+            "got: {err}"
+        );
     }
 }

--- a/storage/src/handlers/presign_url.rs
+++ b/storage/src/handlers/presign_url.rs
@@ -67,6 +67,8 @@ pub async fn handle(state: &AppState, req: PresignReq) -> Result<PresignResp, St
             method,
             content_type: req.content_type,
             expires_in_seconds: req.expires_in_seconds,
+            response_content_disposition: None,
+            response_content_type: None,
         })
         .await
         .map_err(|e| {

--- a/storage/src/main.rs
+++ b/storage/src/main.rs
@@ -11,7 +11,9 @@ use storage::backend::factory::LocalBackendCtx;
 use storage::backend::local;
 use storage::config::{redact_url, BucketConfig as CfgBucket, WorkerConfig};
 use storage::configuration;
-use storage::handlers::{delete_object, get_object, head_object, presign_url, put_object, AppState};
+use storage::handlers::{
+    delete_object, get_object, head_object, presign_url, put_object, AppState,
+};
 use storage::rustfs::{health, spawn};
 use storage::triggers::dispatcher::EngineDispatcher;
 use storage::triggers::handler::{ObjectCreatedHandler, ObjectDeletedHandler};

--- a/storage/src/main.rs
+++ b/storage/src/main.rs
@@ -11,7 +11,7 @@ use storage::backend::factory::LocalBackendCtx;
 use storage::backend::local;
 use storage::config::{redact_url, BucketConfig as CfgBucket, WorkerConfig};
 use storage::configuration;
-use storage::handlers::{delete_object, get_object, presign_url, put_object, AppState};
+use storage::handlers::{delete_object, get_object, head_object, presign_url, put_object, AppState};
 use storage::rustfs::{health, spawn};
 use storage::triggers::dispatcher::EngineDispatcher;
 use storage::triggers::handler::{ObjectCreatedHandler, ObjectDeletedHandler};
@@ -385,7 +385,7 @@ async fn main() -> Result<()> {
         tracing::info!(queue_id = %queue_id, "cf-queue poller started");
     }
 
-    // Register the four storage::* RPC functions inline.
+    // Register the five storage::* RPC functions inline.
     {
         let st = state.clone();
         iii.register_function(
@@ -438,6 +438,19 @@ async fn main() -> Result<()> {
             ),
         );
     }
+    {
+        let st = state.clone();
+        iii.register_function(
+            "storage::headObject",
+            RegisterFunction::new_async(move |req: head_object::HeadReq| {
+                let st = st.clone();
+                async move { head_object::handle(&st, req).await.map_err(IIIError::from) }
+            })
+            .description(
+                "Fetch object metadata (size, ETag, content-type, last-modified) without downloading the body.",
+            ),
+        );
+    }
 
     let _ = iii.register_trigger_type(RegisterTriggerType::new(
         "storage::object-created",
@@ -459,7 +472,7 @@ async fn main() -> Result<()> {
     configuration::register_config_trigger(&iii, state.clone(), cfg.topology())
         .context("registering configuration change trigger")?;
 
-    tracing::info!("storage registered 4 functions and 2 trigger types, waiting for invocations");
+    tracing::info!("storage registered 5 functions and 2 trigger types, waiting for invocations");
     wait_for_shutdown_signal().await?;
     tracing::info!("storage shutting down");
     iii.shutdown_async().await;


### PR DESCRIPTION
## Summary

Adds two capabilities to the `storage` worker, bumping it to **v0.1.5**:

- **`storage::headObject`** — read object metadata (`size`, `content_type`, `etag`, `last_modified`) without downloading the body. Lets callers validate the *actual* stored object (e.g. enforce a real size/content-type after a presigned PUT, where the body bytes aren't otherwise re-checked).
- **GET-only presign response-overrides** — `storage::presignUrl` now accepts `response_content_disposition` and `response_content_type`, signed into the URL. Lets callers force `Content-Disposition: attachment` and a safe `Content-Type` on downloads, or constrain inline preview to known-safe types. Passing either on a `PUT` presign is rejected with `INVALID_PRESIGN_PARAMS`.

## Changes

- `backend/mod.rs`: new `Backend::head()` + `HeadReq`/`HeadResp`; `PresignReq` gains the two optional GET-only response-override fields; `MockBackend` support.
- `backend/s3.rs`: `head()` via `head_object()`; GET presign threads `.response_content_disposition()` / `.response_content_type()`. **R2 and local rustfs inherit both for free** (they delegate to `S3Backend`).
- `backend/gcs.rs`: `head()` reuses the metadata-only `get_object` call; presign overrides applied via `SignedURLOptions.query_parameters`.
- `handlers/head_object.rs`: new `storage::headObject` handler (`OBJECT_NOT_FOUND` on absent), registered as the 5th RPC in `main.rs`.
- `handlers/presign_url.rs`: thread the overrides + the GET-only validation guard.
- `README.md` + `Cargo.toml` (0.1.4 → 0.1.5).

## Design notes

- A SigV4 **presigned PUT does not sign `Content-Length`**, so an edge size/range pin is not reliably enforceable — the authoritative size check is a post-upload `headObject` on the consumer side. Intentionally no content-length condition.
- Response overrides are GET-only (they are S3/GCS response-header override params); rejected on PUT.

## Testing

- `cargo test` — 102 passed / 3 ignored (new unit tests: `head_object` happy/not-found/unknown-bucket; `presign_url` GET threads overrides + PUT-reject).
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo run -- --manifest` — valid.

## Follow-up (not in this PR)

- GCS response-override behavior is exercised only by the env-gated e2e suite; an explicit assertion that a GCS GET presign serves the overridden `Content-Disposition` is a good follow-up. (bequali, the in-repo consumer, is R2-only.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added object metadata retrieval capability without downloading the object body
  * Added support for custom response headers in presigned URLs for GET requests

* **Documentation**
  * Updated quickstart documentation with metadata retrieval example
  * Added reference notes on presigned URL response header customization constraints

* **Chores**
  * Version bump to 0.1.5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->