### PR TITLE
fix(storage): give on-config-change handler typed request/response schemas

### DIFF
--- a/storage/src/configuration.rs
+++ b/storage/src/configuration.rs
@@ -114,6 +114,23 @@ pub async fn apply_config(state: &AppState, cfg: WorkerConfig) -> Result<(), Str
     Ok(())
 }
 
+/// Internal `storage::on-config-change` trigger payload. The handler re-fetches
+/// the authoritative configuration, so this carries only the (advisory)
+/// configuration id; a struct (not `Value`) keeps the request schema concrete
+/// and unknown fields are ignored.
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+pub struct OnConfigChangeEvent {
+    /// Configuration id that changed (advisory; the handler re-fetches the value).
+    #[serde(default)]
+    pub id: Option<String>,
+}
+
+/// Ack returned by the internal `storage::on-config-change` handler.
+#[derive(Debug, serde::Serialize, schemars::JsonSchema)]
+pub struct OnConfigChangeResponse {
+    pub ok: bool,
+}
+
 /// Register the internal config-change handler and bind a `configuration` trigger.
 ///
 /// `boot_topology` is the bucket/notification topology captured at startup; any
@@ -127,13 +144,13 @@ pub fn register_config_trigger(
     let engine = iii.clone();
     iii.register_function(
         CONFIG_FN_ID,
-        RegisterFunction::new_async(move |_payload: Value| {
+        RegisterFunction::new_async(move |_event: OnConfigChangeEvent| {
             let st = st.clone();
             let engine = engine.clone();
             let boot_topology = boot_topology.clone();
             async move {
                 on_config_change(&engine, &st, &boot_topology).await;
-                Ok::<Value, IIIError>(json!({ "ok": true }))
+                Ok::<OnConfigChangeResponse, IIIError>(OnConfigChangeResponse { ok: true })
             }
         })
         .description(


### PR DESCRIPTION
## Problem

The `storage/v0.1.5` release [failed at the publish step](https://github.com/iii-hq/workers/actions/runs/27963875525/job/82755476199):

> `untyped (AnyValue/empty) schemas in worker-interface.json: storage::on-config-change.request_schema, storage::on-config-change.response_schema`

The `storage::on-config-change` handler was registered with an untyped signature (`|_payload: Value| -> Value`), so the SDK emitted the permissive `AnyValue` schema. The publish step runs `collect_worker_interface.py --assert-typed-schemas`, which rejects `AnyValue` schemas.

This handler has been untyped since #236, but the typed-schema assertion (added in #274) only runs at **publish time**, not in PR CI — so `storage/v0.1.5` was the first release to trip it.

## Fix

Mirror the pattern `context-manager` already uses (it passes the same assertion): typed `OnConfigChangeEvent` (request) and `OnConfigChangeResponse` (response) structs deriving `schemars::JsonSchema`. The handler still ignores the payload and re-fetches authoritative config; wire format is unchanged (`{"ok":true}`), but the emitted schemas are now typed objects.

## Verification

- `cargo build` — clean
- `cargo clippy --all-targets` — no issues
- `cargo test` — 104 passed, 3 ignored

After merge, cut a new `storage/v0.1.6` tag to get a green release (the `v0.1.5` tag points at the pre-fix commit and can't be salvaged by re-running).

https://claude.ai/code/session_019j48qhtMYE927TREcdYCnu