### PR TITLE
feat(harness): add dev Makefile to build + symlink local workers

### DIFF
--- a/harness/Makefile
+++ b/harness/Makefile
@@ -1,0 +1,23 @@
+III_WORKERS ?= $(HOME)/.iii/workers
+PROFILE     ?= release
+# ROOT = the workers/ parent dir (every worker is a sibling of harness/)
+ROOT        := $(abspath ..)
+WORKERS     := harness iii-directory session-manager context-manager \
+               provider-anthropic provider-openai shell web
+# add llm-router above to also build/link it (sibling, not a declared dep)
+CARGO_FLAG  := $(if $(filter release,$(PROFILE)),--release,)
+
+.DEFAULT_GOAL := harness
+.PHONY: harness clean
+
+harness:
+	@for w in $(WORKERS); do \
+	  echo "▶ building $$w ($(PROFILE))"; \
+	  cargo build $(CARGO_FLAG) --manifest-path $(ROOT)/$$w/Cargo.toml || exit 1; \
+	  ln -sfn "$(ROOT)/$$w/target/$(PROFILE)/$$w" "$(III_WORKERS)/$$w"; \
+	  echo "✔ linked $(III_WORKERS)/$$w"; \
+	done
+	@echo "↻ restart the engine (iii) to load the new binaries"
+
+clean:                                # remove symlinks; reinstall with `iii worker add`
+	@for w in $(WORKERS); do rm -f "$(III_WORKERS)/$$w"; done


### PR DESCRIPTION
## What

Adds `harness/Makefile` for a fast local dev loop.

`make harness` builds the harness and its 7 local dependency workers and **symlinks** each binary into `~/.iii/workers`:

```
harness  iii-directory  session-manager  context-manager
provider-anthropic  provider-openai  shell  web
```

Because they're symlinks, every later iteration is just `make` again — cargo recompiles only what changed and the symlink already points at the fresh binary, so there's no copy step. Then restart the engine to load the new binaries.

## Why

`iii worker add harness` fetches a **registry** binary, not your local build, so there was no first-class "build my source and run it" path — you had to build by hand and copy binaries into `~/.iii/workers` for harness and each dependency. This collapses that into one command.

## Usage

| Command | Effect |
| --- | --- |
| `make` / `make harness` | build + link harness and all 7 deps (release) |
| `make PROFILE=debug` | faster compiles, links `target/debug/...` |
| `make III_WORKERS=<path>` | retarget the install dir |
| `make clean` | remove the symlinks (restore with `iii worker add <name>`) |

The worker list is a single `WORKERS` variable — add `llm-router` (a sibling, not a declared dep) there if you want it linked too.

## Notes

- The engine isn't restarted automatically; `make` prints a reminder. A running worker holds the old binary in memory, so a restart is required for a new build to take effect.
- Engine-builtin `iii-*` deps (state/queue/cron/stream/observability) and `configuration` have no local source and are excluded.

## Test

- `make harness` builds all crates and creates symlinks in `~/.iii/workers/` (verified: `harness -> .../target/release/harness`).
- Both `PROFILE=debug` and default `release` paths verified end-to-end.

https://claude.ai/code/session_01PksehCCRrvaWs9pD1M8ojc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Implemented comprehensive build automation infrastructure for efficient compilation and deployment of worker components. Supports configurable build profiles and multiple worker crate management. Includes automated binary installation with symlink handling and streamlined cleanup procedures. Enables complete worker reinstallation and maintenance operations while improving development workflow and deployment efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->