### PR TITLE
fix(provider-anthropic): coerce non-object tool_use input to an object

### DIFF
--- a/provider-anthropic/src/sse.rs
+++ b/provider-anthropic/src/sse.rs
@@ -109,10 +109,18 @@ fn push_block_content(
         }
         BlockKind::ToolUse => {
             if let Some(tc) = state.function_calls.get(idx) {
+                // An interrupted stream leaves `args_json` as a partial,
+                // unparseable blob (e.g. `{"cmd":`). A tool_use input must be a
+                // JSON object, so degrade anything that fails to parse to `{}`
+                // rather than null — a null input is a hard Anthropic 400 once
+                // the aborted turn is replayed.
                 let arguments = if tc.args_json.is_empty() {
                     serde_json::json!({})
                 } else {
-                    serde_json::from_str(&tc.args_json).unwrap_or(Value::Null)
+                    serde_json::from_str(&tc.args_json)
+                        .ok()
+                        .filter(Value::is_object)
+                        .unwrap_or_else(|| serde_json::json!({}))
                 };
                 out.push(ContentBlock::FunctionCall {
                     id: tc.id.clone(),
@@ -530,6 +538,27 @@ mod tests {
                 assert_eq!(function_id, "shell::exec");
                 assert_eq!(arguments["cmd"], "ls");
             }
+            other => panic!("want function_call, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn interrupted_tool_use_args_degrade_to_empty_object() {
+        // Stop hit mid tool-call: some partial_json arrived but the JSON never
+        // closed (no content_block_stop). The accumulated args must degrade to
+        // a valid object, never null — a null `tool_use.input` is a hard
+        // Anthropic 400 ("Input should be an object") when the aborted turn is
+        // replayed on the next request.
+        let (state, _events) = run(&[
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"shell__exec\"}}",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"cmd\\\":\"}}",
+        ]);
+        let final_msg = build_partial(&state, "claude-test");
+        match &final_msg.content[0] {
+            ContentBlock::FunctionCall { arguments, .. } => assert!(
+                arguments.is_object(),
+                "interrupted tool args must be an object, got {arguments}"
+            ),
             other => panic!("want function_call, got {other:?}"),
         }
     }

--- a/provider-anthropic/src/wire/messages.rs
+++ b/provider-anthropic/src/wire/messages.rs
@@ -27,12 +27,23 @@ pub fn content_block_to_wire(b: &ContentBlock) -> Option<Value> {
             id,
             function_id,
             arguments,
-        } => Some(json!({
-            "type": "tool_use",
-            "id": id,
-            "name": encode_tool_name(function_id),
-            "input": arguments,
-        })),
+        } => {
+            // Anthropic rejects any tool_use whose `input` is not an object
+            // ("tool_use.input: Input should be an object"). Interrupted/partial
+            // calls can persist a non-object value (null, string, …); coerce
+            // them to `{}` so a corrupted block never wedges the whole turn.
+            let input = if arguments.is_object() {
+                arguments.clone()
+            } else {
+                json!({})
+            };
+            Some(json!({
+                "type": "tool_use",
+                "id": id,
+                "name": encode_tool_name(function_id),
+                "input": input,
+            }))
+        }
         // During tool use Anthropic requires signed thinking blocks passed
         // back unmodified (400 otherwise); unsigned blocks (aborted/partial
         // stream) would fail signature verification and are dropped.
@@ -240,6 +251,47 @@ mod tests {
             function_id: "shell::exec".into(),
             arguments: json!({ "cmd": "ls" }),
         }
+    }
+
+    #[test]
+    fn non_object_tool_input_is_coerced_to_object() {
+        // Anthropic rejects any tool_use whose `input` is not an object
+        // ("messages.N.content.0.tool_use.input: Input should be an object").
+        // An interrupted/partial tool call can carry a non-object `arguments`
+        // (null from an unparseable partial, or any stray value), so the wire
+        // boundary must coerce it — this also unblocks sessions already holding
+        // a corrupted block.
+        for bad in [
+            Value::Null,
+            json!("partial"),
+            json!(7),
+            json!([1, 2]),
+            json!(true),
+        ] {
+            let wire = content_block_to_wire(&ContentBlock::FunctionCall {
+                id: "t1".into(),
+                function_id: "shell::exec".into(),
+                arguments: bad.clone(),
+            })
+            .expect("tool_use is emitted");
+            assert_eq!(wire["type"], "tool_use");
+            assert!(
+                wire["input"].is_object(),
+                "input must be an object, got {} for arguments {bad}",
+                wire["input"]
+            );
+        }
+    }
+
+    #[test]
+    fn object_tool_input_is_passed_through_unchanged() {
+        let wire = content_block_to_wire(&ContentBlock::FunctionCall {
+            id: "t1".into(),
+            function_id: "shell::exec".into(),
+            arguments: json!({ "cmd": "ls" }),
+        })
+        .unwrap();
+        assert_eq!(wire["input"], json!({ "cmd": "ls" }));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

When a tool call is interrupted (the user hits stop mid-stream), the streamed
arguments are a partial, unparseable JSON blob. The SSE accumulator fell back to
`null`, which was persisted into the transcript and replayed on every subsequent
turn. Anthropic rejects the request with
`messages.N.content.0.tool_use.input: Input should be an object`, so the error
recurs on every turn after the stop — the session is wedged.

## Root cause

- `provider-anthropic/src/sse.rs` — a non-empty but unparseable `args_json`
  became `Value::Null` instead of an object.
- `provider-anthropic/src/wire/messages.rs` — `content_block_to_wire` passed
  `arguments` straight into `tool_use.input` with no object guard, even though
  every other hazard in that boundary file is sanitized.

## Fix (two layers)

- **sse.rs**: partial/unparseable streamed args degrade to `{}` (a valid
  object), never `null` — prevents new corruption.
- **wire/messages.rs**: coerce any non-object `arguments` to `{}` at the wire
  boundary — unblocks sessions that already hold a corrupted block, and guards
  against any producer.

## Test plan

- [x] `cargo test` (provider-anthropic) — 72 lib tests pass
- [x] New: `interrupted_tool_use_args_degrade_to_empty_object` (sse),
  `non_object_tool_input_is_coerced_to_object` + `object_tool_input_is_passed_through_unchanged`
  (wire) — verified RED without the fix, GREEN with it
- [x] `cargo fmt --check` and `clippy` clean

https://claude.ai/code/session_01QeP5SgywVCxPxYrWWeHYNb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced robustness of tool function call handling to ensure tool arguments are always properly formatted as valid JSON objects. Improved graceful degradation for malformed or incomplete input streams, which previously resulted in null values instead of empty objects.

* **Tests**
  * Added tests to verify tool function call argument normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->