### PR TITLE
fix(harness): serialize harness::stop and observe a mid-generation stop

### DIFF
--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/harness/src/functions/stop.rs
+++ b/harness/src/functions/stop.rs
@@ -24,7 +24,14 @@ pub struct StopResponse {
 
 pub async fn handle(deps: &Deps, req: StopRequest) -> Result<StopResponse, HarnessError> {
     let cfg = deps.cfg().await;
-    let Some(mut record) =
+
+    // Lock-free pre-read: discover the in-flight stream + live children and
+    // fast-out for a missing/mismatched/terminal turn. This drives the prompt,
+    // lock-free part of cancellation (child cascade + router::abort) so
+    // generation is interrupted immediately, even while the running step holds
+    // the per-session lock across in-flight tool execution. The authoritative
+    // abort write happens under the lock below.
+    let Some(record) =
         crate::state::get_turn(&deps.iii, &req.session_id, cfg.session_timeout_ms).await?
     else {
         return Ok(StopResponse { stopping: false });
@@ -37,10 +44,16 @@ pub async fn handle(deps: &Deps, req: StopRequest) -> Result<StopResponse, Harne
     if record.status.is_terminal() {
         return Ok(StopResponse { stopping: false });
     }
+    // Pin the turn we observed so the write under the lock can't land on a newer
+    // turn that started in between (matters when `turn_id` was omitted).
+    let target_turn = record.turn_id.clone();
 
-    // Cascade to non-terminal spawned children first (harness.md § Cancellation
-    // cascade): each child stop resolves the child's parent call with an error
-    // when the child finalises.
+    // Cascade to non-terminal spawned children BEFORE taking this session's
+    // lock (harness.md § Cancellation cascade): each child stop acquires its
+    // OWN session lock, so holding the parent lock here could deadlock against a
+    // child→parent resolve. Holding at most one session lock at a time keeps
+    // cancellation lock-order-free. Each child stop resolves the child's parent
+    // call with an error when the child finalises.
     for child in record.live_children() {
         Box::pin(handle(
             deps,
@@ -53,15 +66,39 @@ pub async fn handle(deps: &Deps, req: StopRequest) -> Result<StopResponse, Harne
         .ok();
     }
 
-    record.abort = true;
-    record.updated_at = crate::types::message::AgentMessage::now_ms();
-    crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
-
-    // Abort an in-flight stream so the running step finalises promptly.
+    // Prompt stream interruption (lock-free): aborting a stale or already
+    // finished request_id is a harmless no-op, so the pre-read id is safe to
+    // use without the lock.
     if let Some(request_id) = &record.stream_request_id {
         let router = deps.router().await;
         router.abort(request_id).await;
     }
+
+    // Authoritative abort write UNDER the per-session lock (see locks.rs): the
+    // running step persists the whole turn record from a stale in-memory copy
+    // at several points, so a lock-free write here would be clobbered. Taking
+    // the lock — as `harness::function::resolve` and the pending sweep already
+    // do — serializes this read-modify-write with the step and closes the race.
+    // Re-read inside the lock so the flag is set on the freshest record rather
+    // than reverting the step's other updates.
+    let _guard = deps.locks.guard(&req.session_id).await;
+    let Some(mut record) =
+        crate::state::get_turn(&deps.iii, &req.session_id, cfg.session_timeout_ms).await?
+    else {
+        return Ok(StopResponse { stopping: false });
+    };
+    if record.turn_id != target_turn {
+        // A newer turn started between the pre-read and the lock — don't flag it.
+        return Ok(StopResponse { stopping: false });
+    }
+    if record.status.is_terminal() {
+        // The step finalised between the pre-read and acquiring the lock
+        // (possibly via the router::abort above) — nothing left to flag.
+        return Ok(StopResponse { stopping: false });
+    }
+    record.abort = true;
+    record.updated_at = crate::types::message::AgentMessage::now_ms();
+    crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
 
     Ok(StopResponse { stopping: true })
 }

--- a/harness/src/locks.rs
+++ b/harness/src/locks.rs
@@ -35,3 +35,54 @@ impl SessionLocks {
         lock.lock_owned().await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::SessionLocks;
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    /// The property the abort-write fix relies on: two holders of the SAME
+    /// session lock never overlap, so a read-modify-write under the guard can't
+    /// be clobbered by a concurrent one (e.g. harness::stop vs the turn loop).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn same_session_critical_sections_never_overlap() {
+        let locks = SessionLocks::new();
+        let inside = Arc::new(AtomicBool::new(false));
+        let overlaps = Arc::new(AtomicU32::new(0));
+
+        let tasks: Vec<_> = (0..16)
+            .map(|_| {
+                let (locks, inside, overlaps) = (locks.clone(), inside.clone(), overlaps.clone());
+                tokio::spawn(async move {
+                    let _g = locks.guard("s").await;
+                    // If mutual exclusion holds, `inside` is always false here.
+                    if inside.swap(true, Ordering::SeqCst) {
+                        overlaps.fetch_add(1, Ordering::SeqCst);
+                    }
+                    tokio::task::yield_now().await; // widen the window for a racer
+                    inside.store(false, Ordering::SeqCst);
+                })
+            })
+            .collect();
+        for t in tasks {
+            t.await.unwrap();
+        }
+        assert_eq!(
+            overlaps.load(Ordering::SeqCst),
+            0,
+            "critical sections overlapped"
+        );
+    }
+
+    /// Different sessions must NOT serialize — holding one session's guard can't
+    /// block another session's stop/step.
+    #[tokio::test]
+    async fn distinct_sessions_do_not_block_each_other() {
+        let locks = SessionLocks::new();
+        let held = locks.guard("a").await;
+        // A different session acquires without waiting on `held`.
+        let _other = locks.guard("b").await;
+        drop(held);
+    }
+}

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -76,6 +76,23 @@ fn origin_with(turn_id: &str, annotations: &serde_json::Map<String, Value>) -> V
     Value::Object(obj)
 }
 
+/// Whether the running step must finalise as cancelled after generation.
+///
+/// Three independent signals mean "cancel": the loop's own in-memory abort flag
+/// (a stop observed between steps), a `durable_abort` that a concurrent
+/// `harness::stop` wrote to state during generation while the in-memory copy
+/// stayed stale, or a stream that itself ended `Aborted`. The middle term is the
+/// fix for the post-generation race: a stop landing after a normal `Done` frame
+/// carries neither a stale-true local flag nor an `Aborted` stop_reason, so
+/// without re-reading durable state it would leak a step of tool execution.
+fn cancel_requested(
+    local_abort: bool,
+    durable_abort: bool,
+    stop_reason: crate::types::event::StopReason,
+) -> bool {
+    local_abort || durable_abort || stop_reason == crate::types::event::StopReason::Aborted
+}
+
 /// Run one durable loop step.
 pub async fn run_step(
     deps: &Deps,
@@ -242,6 +259,14 @@ pub async fn run_step(
     record.stream_request_id = Some(params.request_id.clone());
     crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
 
+    // Release the per-session lock across the generation RPC. The loop writes no
+    // turn record between here and the post-generation cancellation check
+    // (router::chat streams into the SESSION, not the turn record), so dropping
+    // the lock lets a concurrent harness::stop take it and set the durable abort
+    // flag — observed THIS step by the re-read below — instead of leaving the
+    // stop blocked behind the whole step and a step of tool execution leaking.
+    drop(_guard);
+
     let router = deps.router().await;
     let outcome = router.chat(params, &sink).await?;
 
@@ -265,10 +290,24 @@ pub async fn run_step(
         )
         .await;
 
+    // Re-acquire the lock before any further turn-record write, then re-read the
+    // durable abort flag under it (authoritative — no concurrent writer once
+    // held). A harness::stop that landed during generation set the flag on
+    // durable state while this in-memory `record` stayed stale; if the stream
+    // had already completed normally it carries stop_reason != Aborted, so
+    // without this re-read the stop would be missed until the next step.
+    let _guard = deps.locks.guard(&payload.session_id).await;
+    let durable_abort =
+        crate::state::get_turn(&deps.iii, &payload.session_id, cfg.session_timeout_ms)
+            .await?
+            .map(|r| r.abort)
+            .unwrap_or(false);
+
     record.turn_count += 1;
 
     // Cancellation during generation finalises the partial as cancelled.
-    if record.abort || outcome.message.stop_reason == crate::types::event::StopReason::Aborted {
+    if cancel_requested(record.abort, durable_abort, outcome.message.stop_reason) {
+        record.abort = true;
         return finalize_cancelled(deps, &session, &mut record, "cancelled").await;
     }
     if !outcome.ok {
@@ -1055,5 +1094,35 @@ impl Clone for SessionStreamSink {
             entry_id: self.entry_id.clone(),
             turn_id: self.turn_id.clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cancel_requested;
+    use crate::types::event::StopReason;
+
+    #[test]
+    fn durable_abort_is_observed_even_when_local_is_stale_and_stream_completed() {
+        // The post-generation race: a harness::stop landed after a normal `Done`
+        // frame, so the loop's in-memory flag is still false and the stream's
+        // stop_reason is End (not Aborted). Re-reading durable state must still
+        // cancel — otherwise this step's tool calls execute despite the stop.
+        assert!(cancel_requested(false, true, StopReason::End));
+        assert!(cancel_requested(false, true, StopReason::FunctionCall));
+    }
+
+    #[test]
+    fn local_abort_or_aborted_stream_still_cancels() {
+        // A stop observed between steps (local flag) or a stream the router tore
+        // down (Aborted) cancel regardless of durable state.
+        assert!(cancel_requested(true, false, StopReason::End));
+        assert!(cancel_requested(false, false, StopReason::Aborted));
+    }
+
+    #[test]
+    fn no_signal_does_not_cancel() {
+        assert!(!cancel_requested(false, false, StopReason::End));
+        assert!(!cancel_requested(false, false, StopReason::FunctionCall));
     }
 }


### PR DESCRIPTION
## Problem

Two windows where a user's Stop was dropped or delayed:

1. **Clobber** — `harness::stop` set the durable `abort` flag with a lock-free
   read-modify-write, while the running step persists the whole turn record from
   a stale in-memory copy after each tool call. The step's writes overwrote
   `abort=true`, so a stop during tool execution (no stream to interrupt) was
   silently dropped and the user had to click Stop again.
2. **Post-Done race** — a stop arriving after the stream's terminal `Done` frame
   but before the post-generation cancellation check was not observed (stale
   in-memory flag, `stop_reason != Aborted`), so that step's tool calls ran
   despite the pending stop.

## Fix

- `harness::stop` writes `abort` **under the per-session lock**, like
  `harness::function::resolve` and the pending sweep already do (`locks.rs`),
  serializing it with the running step so it can no longer be clobbered. The
  child cascade and `router::abort` run before the lock (at most one session
  lock held at a time → no lock-order deadlock; generation is still interrupted
  promptly). The observed turn id is pinned across the two reads so the flag
  can't land on a newer turn.
- `run_step` releases the per-session lock across the generation RPC (it writes
  no turn record there) and re-reads the durable `abort` flag on re-acquire,
  before the post-generation check, via a new `cancel_requested` helper.

## Out of scope

- Interrupting an already-running tool mid-flight (abort is only checked at step
  boundaries).
- Parked-at-`max_turns` stop racing resume; upstream teardown latency; restart-
  mid-step recovery for turns left `Running`.

## Test plan

- [x] `cargo test` (harness) — 91 tests pass
- [x] New: `cancel_requested` unit tests (durable abort observed when the local
  flag is stale and the stream completed normally) — verified RED without the
  `durable_abort` term; `SessionLocks` mutual-exclusion test (same-session
  critical sections never overlap; distinct sessions don't block)
- [x] `cargo fmt --check` and `clippy` clean

https://claude.ai/code/session_01QeP5SgywVCxPxYrWWeHYNb
