### PR TITLE
feat(coder): add on-config-change event handling and bump version to …

### DIFF
--- a/coder/Cargo.lock
+++ b/coder/Cargo.lock
@@ -204,7 +204,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "coder"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/coder/src/configuration.rs
+++ b/coder/src/configuration.rs
@@ -111,6 +111,23 @@ pub async fn apply_config(cell: &ConfigCell, cfg: CoderConfig) {
     *cell.write().await = Arc::new(cfg);
 }
 
+/// Internal `coder::on-config-change` trigger payload. The handler re-fetches
+/// the authoritative configuration, so this carries only the (advisory)
+/// configuration id; a struct (not `Value`) keeps the request schema concrete
+/// and unknown fields are ignored.
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+pub struct OnConfigChangeEvent {
+    /// Configuration id that changed (advisory; the handler re-fetches the value).
+    #[serde(default)]
+    pub id: Option<String>,
+}
+
+/// Ack returned by the internal `coder::on-config-change` handler.
+#[derive(Debug, serde::Serialize, schemars::JsonSchema)]
+pub struct OnConfigChangeResponse {
+    pub ok: bool,
+}
+
 /// Register the internal config-change handler and bind a `configuration`
 /// trigger.
 ///
@@ -126,13 +143,13 @@ pub fn register_config_trigger(
     let engine = iii.clone();
     iii.register_function(
         CONFIG_FN_ID,
-        RegisterFunction::new_async(move |_payload: Value| {
+        RegisterFunction::new_async(move |_event: OnConfigChangeEvent| {
             let cell = cell_for_fn.clone();
             let engine = engine.clone();
             let boot_sig = boot_sig.clone();
             async move {
                 on_config_change(&engine, &cell, &boot_sig).await;
-                Ok::<Value, IIIError>(json!({ "ok": true }))
+                Ok::<OnConfigChangeResponse, IIIError>(OnConfigChangeResponse { ok: true })
             }
         })
         .description(

--- a/iii-permissions.yaml
+++ b/iii-permissions.yaml
@@ -83,6 +83,7 @@ rules:
   - '!storage::on-config-change'
   - '!database::on-config-change'
   - '!session::on-config-change'
+  - '!coder::on-config-change'
   # harness: deny-by-default for in-run agents (harness.md § Agent exposure).
   # send/run let a model start arbitrary turns outside any max_turns guard;
   # turn is the internal loop step; function::trigger/resolve forge call ids


### PR DESCRIPTION
…0.5.1

- Introduced OnConfigChangeEvent and OnConfigChangeResponse structs for typed request/response handling in the coder module.
- Updated the iii-permissions.yaml to include the new coder::on-config-change rule.
- Bumped coder version to 0.5.1 to reflect these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Removed agent access to the configuration change hook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->