### PR TITLE
feat(harness): cache the function registry via engine::functions-available

### DIFF
--- a/harness/src/deps.rs
+++ b/harness/src/deps.rs
@@ -6,9 +6,12 @@ use std::sync::Arc;
 
 use iii_sdk::III;
 
-use crate::clients::{ContextClient, EngineClient, RouterClient, SessionClient};
+use crate::clients::{
+    ContextClient, EngineClient, FunctionDescriptor, RouterClient, SessionClient,
+};
 use crate::config::WorkerConfig;
 use crate::configuration::ConfigCell;
+use crate::discovery::FunctionsCell;
 use crate::events::TurnEvents;
 use crate::hooks::HookRegistry;
 use crate::locks::SessionLocks;
@@ -17,16 +20,24 @@ use crate::locks::SessionLocks;
 pub struct Deps {
     pub iii: Arc<III>,
     pub config: ConfigCell,
+    pub functions: FunctionsCell,
     pub events: TurnEvents,
     pub hooks: HookRegistry,
     pub locks: SessionLocks,
 }
 
 impl Deps {
-    pub fn new(iii: Arc<III>, config: ConfigCell, events: TurnEvents, hooks: HookRegistry) -> Self {
+    pub fn new(
+        iii: Arc<III>,
+        config: ConfigCell,
+        functions: FunctionsCell,
+        events: TurnEvents,
+        hooks: HookRegistry,
+    ) -> Self {
         Self {
             iii,
             config,
+            functions,
             events,
             hooks,
             locks: SessionLocks::new(),
@@ -36,6 +47,12 @@ impl Deps {
     /// The current config snapshot (cheap `Arc` clone).
     pub async fn cfg(&self) -> Arc<WorkerConfig> {
         self.config.read().await.clone()
+    }
+
+    /// The current cached function-registry snapshot (cheap `Arc` clone). Kept
+    /// live by the `engine::functions-available` trigger; see [`crate::discovery`].
+    pub async fn functions(&self) -> Arc<Vec<FunctionDescriptor>> {
+        self.functions.read().await.clone()
     }
 
     pub async fn session(&self) -> SessionClient {

--- a/harness/src/discovery.rs
+++ b/harness/src/discovery.rs
@@ -1,0 +1,140 @@
+//! Reactive function-registry cache. Native exposure needs the set of callable
+//! functions to build the model's tools; instead of re-listing the registry on
+//! every turn, the harness keeps a cached snapshot and lets the engine push
+//! changes. `engine::functions-available` fires when functions are
+//! registered/unregistered, and the handler re-fetches the authoritative
+//! `engine::functions::list` and swaps the snapshot. This mirrors the
+//! `configuration` hot-reload pattern (a shared cell + a targeted refresh).
+//!
+//! Re-fetching `engine::functions::list` on each change — rather than trusting
+//! the trigger's payload snapshot — keeps the cache identical to what the
+//! per-turn list returned (same internal-hiding filter), so the loop's read is
+//! an exact drop-in.
+//!
+//! The trigger only fires ON CHANGE, so the snapshot is seeded once at boot;
+//! after that the trigger keeps it live. [`build_tools`](crate::turn_loop)
+//! reads it under [`Deps::functions`](crate::deps::Deps::functions).
+
+use std::sync::Arc;
+
+use iii_sdk::{IIIError, RegisterFunction, RegisterTriggerInput, III};
+use serde_json::json;
+use tokio::sync::RwLock;
+
+use crate::clients::{EngineClient, FunctionDescriptor};
+
+/// Hot-swappable function-registry snapshot shared with the turn loop.
+pub type FunctionsCell = Arc<RwLock<Arc<Vec<FunctionDescriptor>>>>;
+
+const FUNCTIONS_FN_ID: &str = "harness::on-functions-change";
+const FUNCTIONS_TRIGGER_TYPE: &str = "engine::functions-available";
+
+/// An empty registry snapshot — seeded at boot, then kept live by the trigger.
+pub fn new_cell() -> FunctionsCell {
+    Arc::new(RwLock::new(Arc::new(Vec::new())))
+}
+
+/// Swap the snapshot under the write lock.
+pub async fn apply(cell: &FunctionsCell, functions: Vec<FunctionDescriptor>) {
+    *cell.write().await = Arc::new(functions);
+}
+
+/// Fetch the authoritative registry and swap the snapshot; returns the count.
+async fn reload(iii: &Arc<III>, cell: &FunctionsCell, timeout_ms: u64) -> usize {
+    let engine = EngineClient::new(iii.clone(), timeout_ms);
+    let functions = engine.functions_list().await;
+    let count = functions.len();
+    apply(cell, functions).await;
+    count
+}
+
+/// Seed the snapshot from the registry. The trigger fires only on change, so
+/// without this the cache would stay empty until the first change.
+pub async fn seed(iii: &Arc<III>, cell: &FunctionsCell, timeout_ms: u64) {
+    let count = reload(iii, cell, timeout_ms).await;
+    tracing::info!(count, "seeded function-registry cache");
+}
+
+/// Internal `harness::on-functions-change` payload. The handler re-fetches the
+/// authoritative registry, so the (advisory) event tag is the only field.
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+pub struct OnFunctionsChangeEvent {
+    /// Engine event tag (advisory; the handler re-fetches the full list).
+    #[serde(default)]
+    pub event: Option<String>,
+}
+
+/// Ack returned by the internal `harness::on-functions-change` handler.
+#[derive(Debug, serde::Serialize, schemars::JsonSchema)]
+pub struct OnFunctionsChangeResponse {
+    pub ok: bool,
+}
+
+/// Register the internal change handler and bind the
+/// `engine::functions-available` trigger. Best-effort: a failed bind warns (the
+/// seeded snapshot still serves — it just won't update until restart) rather
+/// than bricking boot. The handler is tagged `internal` so it stays off the
+/// public catalog (and out of the very cache it maintains).
+pub fn register_functions_trigger(iii: &Arc<III>, cell: FunctionsCell, timeout_ms: u64) {
+    let engine = iii.clone();
+    iii.register_function(
+        FUNCTIONS_FN_ID,
+        RegisterFunction::new_async(move |_event: OnFunctionsChangeEvent| {
+            let engine = engine.clone();
+            let cell = cell.clone();
+            async move {
+                let count = reload(&engine, &cell, timeout_ms).await;
+                tracing::debug!(count, "function-registry cache refreshed");
+                Ok::<OnFunctionsChangeResponse, IIIError>(OnFunctionsChangeResponse { ok: true })
+            }
+        })
+        .description(
+            "Internal: refresh the cached function-registry snapshot when functions are \
+             registered/unregistered (driven by the engine::functions-available trigger).",
+        )
+        .metadata(json!({ "internal": true })),
+    );
+
+    match iii.register_trigger(RegisterTriggerInput {
+        trigger_type: FUNCTIONS_TRIGGER_TYPE.to_string(),
+        function_id: FUNCTIONS_FN_ID.to_string(),
+        config: json!({}),
+        metadata: None,
+    }) {
+        Ok(_) => tracing::info!(
+            trigger_type = FUNCTIONS_TRIGGER_TYPE,
+            function_id = FUNCTIONS_FN_ID,
+            "function-registry change trigger bound"
+        ),
+        Err(e) => tracing::warn!(
+            trigger_type = FUNCTIONS_TRIGGER_TYPE,
+            error = %e,
+            "binding engine::functions-available failed; cache will not auto-refresh"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn apply_swaps_snapshot() {
+        let cell = new_cell();
+        assert!(cell.read().await.is_empty());
+
+        apply(
+            &cell,
+            vec![FunctionDescriptor {
+                function_id: "shell::run".into(),
+                description: Some("run a command".into()),
+                parameters: None,
+            }],
+        )
+        .await;
+
+        let snap = cell.read().await.clone();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].function_id, "shell::run");
+    }
+}

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -13,6 +13,7 @@ pub mod configuration;
 pub mod contract;
 pub mod deferred;
 pub mod deps;
+pub mod discovery;
 pub mod error;
 pub mod events;
 pub mod functions;

--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -11,9 +11,11 @@
 //!      five hook points) BEFORE functions so handlers capture subscriber sets.
 //!   5. Register the `harness::*` functions.
 //!   6. Bind the cron pending-sweep (retain its handle for live re-bind).
-//!   7. LAST: bind the configuration-change trigger so its handler closes over
+//!   7. Seed the function-registry cache and bind `engine::functions-available`
+//!      so native exposure reads a live snapshot instead of listing per turn.
+//!   8. LAST: bind the configuration-change trigger so its handler closes over
 //!      the fully-built snapshot cell + the cron handle.
-//!   8. Sleep on Ctrl+C, then `shutdown_async` cleanly.
+//!   9. Sleep on Ctrl+C, then `shutdown_async` cleanly.
 
 use std::sync::Arc;
 
@@ -26,7 +28,7 @@ use harness::configuration::{self, ConfigCell, TriggerHandles};
 use harness::deps::Deps;
 use harness::events::TurnEvents;
 use harness::hooks::HookRegistry;
-use harness::{config, functions, manifest};
+use harness::{config, discovery, functions, manifest};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -110,7 +112,14 @@ async fn main() -> Result<()> {
     let hooks = HookRegistry::register(&iii);
 
     let cell: ConfigCell = Arc::new(RwLock::new(Arc::new(cfg.clone())));
-    let deps = Arc::new(Deps::new(iii.clone(), cell.clone(), events, hooks));
+    let functions_cell = discovery::new_cell();
+    let deps = Arc::new(Deps::new(
+        iii.clone(),
+        cell.clone(),
+        functions_cell.clone(),
+        events,
+        hooks,
+    ));
 
     functions::register_all(&iii, &deps);
 
@@ -120,11 +129,16 @@ async fn main() -> Result<()> {
         sweep: std::sync::Mutex::new(configuration::bind_sweep(&iii, &cfg)),
     });
 
+    discovery::seed(&iii, &functions_cell, cfg.dispatch_timeout_ms).await;
+    discovery::register_functions_trigger(&iii, functions_cell, cfg.dispatch_timeout_ms);
+
     // LAST: bind the configuration-change trigger.
     configuration::register_config_trigger(&iii, cell, handles)
         .context("registering the configuration change trigger")?;
 
-    tracing::info!("harness ready: 8 harness::* functions + turn events + hook points");
+    tracing::info!(
+        "harness ready: 8 harness::* functions + turn events + hook points + reactive function-registry cache"
+    );
 
     tokio::signal::ctrl_c().await?;
     tracing::info!("harness shutting down");

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -1029,9 +1029,9 @@ async fn build_tools(deps: &Deps, record: &TurnRecord) -> Vec<crate::types::mode
         ExposeMode::AgentTrigger => vec![policy::agent_trigger_schema()],
         ExposeMode::Native => {
             let policy = CompiledPolicy::from(record.options.functions.as_ref());
-            let engine = deps.engine().await;
+            let snapshot = deps.functions().await;
             let mut tools = Vec::new();
-            for descriptor in engine.functions_list().await {
+            for descriptor in snapshot.iter() {
                 if !policy.allows(&descriptor.function_id) {
                     continue;
                 }


### PR DESCRIPTION
## What

Native exposure built the model's tools by calling `engine::functions::list` **on every turn**. This replaces that per-turn registry read with a cached snapshot that the engine keeps live via the `engine::functions-available` trigger.

## How

- **`discovery.rs`** (new): a `FunctionsCell` snapshot, a boot-time seed (the trigger only fires *on change*, so the cache must start populated), and an internal `harness::on-functions-change` handler bound to `engine::functions-available`. On each change it re-fetches `engine::functions::list` and swaps the snapshot. The bind is best-effort — a failure keeps the seeded snapshot serving and logs a warning rather than bricking boot.
- **`Deps`** holds the cell and exposes `functions()`.
- **`build_tools`** (native exposure) reads the cached snapshot instead of listing each turn.

## Why re-fetch instead of using the trigger payload

The `engine::functions-available` payload is built from the raw summaries (it includes engine-internal builtins), whereas `engine::functions::list` applies the internal-hiding filter. Re-fetching `functions::list` on each change keeps the cache **byte-identical** to what the per-turn call returned — a true drop-in with zero behavior change. (`FunctionSummary` never carried request schemas anyway — only `functions::info` does — so nothing is lost.)

## Scope

- Functions only. Worker availability (`engine::workers-available`) is intentionally **not** wired — there's no consumer in the harness today.
- Agent-initiated discovery (`engine::functions::list`/`info` the model calls) stays as live dispatch — that's the model explicitly asking for fresh data, not polling.
- Note: native exposure isn't the default mode (`AgentTrigger` is), so this removes the per-turn list for `ExposeMode::Native` sessions — the only repeated registry read in the harness.

## Test

- `cargo fmt --check`, `cargo clippy --all-targets`, `cargo test` all clean (incl. the new `discovery::apply_swaps_snapshot`).


---
Linear: MOT-3687
