### PR TITLE
fix(pi): strip the $schema meta-ref so publish succeeds

### DIFF
--- a/pi/src/config.ts
+++ b/pi/src/config.ts
@@ -30,9 +30,12 @@ export type Config = z.infer<typeof ConfigSchema>;
 export const RuntimeConfigSchema = ConfigSchema.omit({ engine_url: true });
 export type RuntimeConfig = z.infer<typeof RuntimeConfigSchema>;
 
-/** JSON Schema published to the configuration worker. */
+/** JSON Schema published to the configuration worker. The registry validator
+ *  has no `$schema` meta-schema, so strip the draft-2020-12 `$schema` key. */
 export function runtimeJsonSchema(): Record<string, unknown> {
-  return z.toJSONSchema(RuntimeConfigSchema) as Record<string, unknown>;
+  const out = z.toJSONSchema(RuntimeConfigSchema) as Record<string, unknown>;
+  delete out.$schema;
+  return out;
 }
 
 /** The runtime slice of a full config, for use as `initial_value`. */

--- a/pi/src/run.ts
+++ b/pi/src/run.ts
@@ -84,9 +84,18 @@ const SteerPayloadSchema = z.object({
   prompt: z.string().describe('Instruction to inject into the live run'),
 });
 
-const RUN_REQUEST_FORMAT = z.toJSONSchema(RunPayloadSchema);
-const SESSION_ID_FORMAT = z.toJSONSchema(SessionIdSchema);
-const STEER_REQUEST_FORMAT = z.toJSONSchema(SteerPayloadSchema);
+// The registry's publish validator has no `$schema` meta-schema registered, so
+// the draft-2020-12 `$schema` key z.toJSONSchema stamps at the root fails
+// publish. Strip it; the schema body is what the engine + registry consume.
+function jsonSchema(schema: z.ZodType): Record<string, unknown> {
+  const out = z.toJSONSchema(schema) as Record<string, unknown>;
+  delete out.$schema;
+  return out;
+}
+
+const RUN_REQUEST_FORMAT = jsonSchema(RunPayloadSchema);
+const SESSION_ID_FORMAT = jsonSchema(SessionIdSchema);
+const STEER_REQUEST_FORMAT = jsonSchema(SteerPayloadSchema);
 
 const UsageSchema = z.object({
   input_tokens: z.number(),
@@ -149,13 +158,13 @@ const SessionsResultSchema = z.object({
   sessions: z.array(SessionRecordSchema),
 });
 
-const RUN_RESPONSE_FORMAT = z.toJSONSchema(RunResultSchema);
-const START_RESPONSE_FORMAT = z.toJSONSchema(StartResultSchema);
-const STEER_RESPONSE_FORMAT = z.toJSONSchema(SteerResultSchema);
-const FOLLOWUP_RESPONSE_FORMAT = z.toJSONSchema(FollowUpResultSchema);
-const STOP_RESPONSE_FORMAT = z.toJSONSchema(StopResultSchema);
-const STATUS_RESPONSE_FORMAT = z.toJSONSchema(StatusResultSchema);
-const SESSIONS_RESPONSE_FORMAT = z.toJSONSchema(SessionsResultSchema);
+const RUN_RESPONSE_FORMAT = jsonSchema(RunResultSchema);
+const START_RESPONSE_FORMAT = jsonSchema(StartResultSchema);
+const STEER_RESPONSE_FORMAT = jsonSchema(SteerResultSchema);
+const FOLLOWUP_RESPONSE_FORMAT = jsonSchema(FollowUpResultSchema);
+const STOP_RESPONSE_FORMAT = jsonSchema(StopResultSchema);
+const STATUS_RESPONSE_FORMAT = jsonSchema(StatusResultSchema);
+const SESSIONS_RESPONSE_FORMAT = jsonSchema(SessionsResultSchema);
 
 type LiveRun = { session: AgentSession };
 const live = new Map<string, LiveRun>();


### PR DESCRIPTION
Builds on the typed response schemas from #317. pi still cannot publish: the registry validator has no draft-2020-12 meta-schema registered, so the `$schema` key `z.toJSONSchema` stamps at the root fails with `no schema with key or ref ...draft/2020-12/schema`.

A `jsonSchema()` helper strips the root `$schema` from every request and response format; `runtimeJsonSchema` does the same. Schemas stay typed (still pass the worker-interface gate) and now publish.

Two files. typecheck clean, lint clean, 69 tests pass.

Note: claude-code and codex emit `$schema` the same way and will need the same strip on their next release.