### PR TITLE
feat(console): introducing workers page

### DIFF
--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -21,12 +21,14 @@ import {
 import { cn } from '@/lib/utils'
 import { Configuration } from '@/pages/Configuration'
 import { Traces } from '@/pages/Traces'
+import { Workers } from '@/pages/Workers'
 
 /* The component spec sheet and the streaming-scenario playground now live in
    Storybook (`pnpm storybook`), not as in-app routes. The header keeps a
    single `traces` entry alongside the configuration gear. */
 const VIEW_OPTIONS: { value: View; label: string }[] = [
   { value: 'traces', label: 'traces' },
+  { value: 'workers', label: 'workers' },
 ]
 
 export function App() {
@@ -94,6 +96,8 @@ export function App() {
           <div className="flex-1 flex flex-col min-w-0 min-h-0">
             {view === 'configuration' ? (
               <Configuration theme={theme} onThemeChange={setTheme} />
+            ) : view === 'workers' ? (
+              <Workers />
             ) : (
               <Traces />
             )}

--- a/console/web/src/components/chat/engine/__tests__/parsers.test.ts
+++ b/console/web/src/components/chat/engine/__tests__/parsers.test.ts
@@ -226,6 +226,12 @@ describe('engine::workers::list', () => {
     ).toEqual({ runtime: 'rust', status: 'connected' })
   })
 
+  it('parses an optional tag filter', () => {
+    expect(
+      safeParseRequest(workersListRequestSchema, { tag: 'platform' }),
+    ).toEqual({ tag: 'platform' })
+  })
+
   it('parses a wrapped success payload', () => {
     const payload = {
       workers: [
@@ -242,12 +248,14 @@ describe('engine::workers::list', () => {
           active_invocations: 0,
           isolation: 'process',
           ip_address: '127.0.0.1',
+          tag: 'dev',
         },
       ],
     }
     const parsed = safeParseResponse(workersListResponseSchema, wrap(payload))
     expect(parsed?.workers).toHaveLength(1)
     expect(parsed?.workers[0].runtime).toBe('node')
+    expect(parsed?.workers[0].tag).toBe('dev')
   })
 
   it('parses an empty workers list', () => {

--- a/console/web/src/components/chat/engine/parsers.ts
+++ b/console/web/src/components/chat/engine/parsers.ts
@@ -149,6 +149,7 @@ export const workersListRequestSchema = z.object({
   search: z.string().optional(),
   runtime: z.string().optional(),
   status: z.string().optional(),
+  tag: z.string().optional(),
 })
 export type WorkersListRequest = z.infer<typeof workersListRequestSchema>
 
@@ -165,6 +166,7 @@ export const workerSummarySchema = z.object({
   active_invocations: z.number(),
   isolation: z.string().nullable().optional(),
   ip_address: z.string().nullable().optional(),
+  tag: z.string().nullable().optional(),
 })
 export type WorkerSummary = z.infer<typeof workerSummarySchema>
 

--- a/console/web/src/hooks/use-hash-route.ts
+++ b/console/web/src/hooks/use-hash-route.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 // in App.tsx. Hash routes only pick which view fills the right pane. The
 // component spec sheet + streaming playground moved to Storybook, so the
 // only routed views left are `traces` and `configuration`.
-export type View = 'configuration' | 'traces'
+export type View = 'configuration' | 'traces' | 'workers'
 
 /**
  * Sub-tab inside the Configuration page. URL-driven so deep links and the
@@ -27,6 +27,9 @@ function routeFromHash(hash: string): View | null {
   // Backwards compat: `#/chat` no longer exists as a view -- chat is the
   // always-visible side dock now. Land legacy bookmarks on the default view.
   if (hash === '#/chat') return 'traces'
+  if (hash === '#/workers') {
+    return 'workers'
+  }
   if (hash === '#/configuration' || hash.startsWith('#/configuration/')) {
     return 'configuration'
   }
@@ -43,6 +46,8 @@ function hashFor(view: View): string {
   switch (view) {
     case 'traces':
       return '#/traces'
+    case 'workers':
+      return '#/workers'
     case 'configuration':
       return '#/configuration'
   }

--- a/console/web/src/pages/Workers/api/workers.ts
+++ b/console/web/src/pages/Workers/api/workers.ts
@@ -1,0 +1,117 @@
+import { getIiiClient } from '@/lib/iii-client'
+import {
+  type WorkerInfoResponse,
+  type WorkersListResponse,
+  workerInfoResponseSchema,
+  workersListResponseSchema,
+} from '@/components/chat/engine/parsers'
+import {
+  type WorkerEntry,
+  type WorkerListResponse,
+  workerListResponseSchema,
+} from '@/components/chat/worker/parsers'
+import type { ConfigurationSchemaView } from '@/pages/Configuration/tabs/WorkersTab/api'
+import { listConfigurations } from '@/pages/Configuration/tabs/WorkersTab/api'
+
+export const WORKERS_RPC = {
+  engineList: 'engine::workers::list',
+  engineInfo: 'engine::workers::info',
+  supervisorList: 'worker::list',
+  supervisorStop: 'worker::stop',
+  configList: 'configuration::list',
+} as const
+
+export async function fetchEngineWorkersList(): Promise<WorkersListResponse> {
+  const client = await getIiiClient()
+  const raw = await client.trigger<unknown>(WORKERS_RPC.engineList, {})
+  const parsed = workersListResponseSchema.safeParse(raw)
+  return parsed.success ? parsed.data : { workers: [] }
+}
+
+export async function fetchEngineWorkerInfo(
+  name: string,
+): Promise<WorkerInfoResponse | null> {
+  const client = await getIiiClient()
+  const raw = await client.trigger<unknown>(WORKERS_RPC.engineInfo, { name })
+  const parsed = workerInfoResponseSchema.safeParse(raw)
+  return parsed.success ? parsed.data : null
+}
+
+export async function fetchSupervisorWorkersList(): Promise<WorkerListResponse> {
+  const client = await getIiiClient()
+  const raw = await client.trigger<unknown>(WORKERS_RPC.supervisorList, {})
+  const parsed = workerListResponseSchema.safeParse(raw)
+  return parsed.success ? parsed.data : { workers: [] }
+}
+
+export async function fetchConfigurationIds(): Promise<ConfigurationSchemaView[]> {
+  return listConfigurations()
+}
+
+export async function stopSupervisorWorker(name: string): Promise<void> {
+  const client = await getIiiClient()
+  await client.trigger(WORKERS_RPC.supervisorStop, { name, yes: true })
+}
+
+export interface RawWorkersSnapshot {
+  engineWorkers: WorkersListResponse['workers']
+  supervisorWorkers: WorkerEntry[]
+  configurations: ConfigurationSchemaView[]
+  infoByName: Map<string, WorkerInfoResponse['worker']>
+}
+
+/** Bounded parallel map — avoids stampeding the engine on large fleets. */
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length)
+  let index = 0
+
+  async function worker(): Promise<void> {
+    while (index < items.length) {
+      const i = index++
+      results[i] = await fn(items[i] as T)
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    () => worker(),
+  )
+  await Promise.all(workers)
+  return results
+}
+
+export async function fetchRawWorkersSnapshot(): Promise<RawWorkersSnapshot> {
+  const [engineList, supervisorList, configurations] = await Promise.all([
+    fetchEngineWorkersList(),
+    fetchSupervisorWorkersList(),
+    fetchConfigurationIds(),
+  ])
+
+  const connected = engineList.workers.filter(
+    (w) => w.status.toLowerCase() === 'connected' && w.name,
+  )
+  const names = connected
+    .map((w) => w.name as string)
+    .filter((name, i, arr) => arr.indexOf(name) === i)
+
+  const infoEntries = await mapWithConcurrency(names, 8, async (name) => {
+    const info = await fetchEngineWorkerInfo(name)
+    return [name, info?.worker ?? null] as const
+  })
+
+  const infoByName = new Map<string, WorkerInfoResponse['worker']>()
+  for (const [name, worker] of infoEntries) {
+    if (worker) infoByName.set(name, worker)
+  }
+
+  return {
+    engineWorkers: engineList.workers,
+    supervisorWorkers: supervisorList.workers,
+    configurations,
+    infoByName,
+  }
+}

--- a/console/web/src/pages/Workers/components/WorkersFilters.tsx
+++ b/console/web/src/pages/Workers/components/WorkersFilters.tsx
@@ -1,0 +1,127 @@
+import { Search, X } from 'lucide-react'
+import { Input } from '@/components/ui/Input'
+import { cn } from '@/lib/utils'
+import type { WorkersFilterState } from '../types'
+import { distinctRuntimes, distinctTags } from '../types'
+import type { WorkerRow } from '../types'
+
+interface WorkersFiltersProps {
+  rows: WorkerRow[]
+  filters: WorkersFilterState
+  onFilterChange: (next: Partial<WorkersFilterState>) => void
+  onClear: () => void
+  className?: string
+}
+
+export function WorkersFilters({
+  rows,
+  filters,
+  onFilterChange,
+  onClear,
+  className,
+}: WorkersFiltersProps) {
+  const tags = distinctTags(rows)
+  const runtimes = distinctRuntimes(rows)
+  const hasActive =
+    filters.search.trim() !== '' ||
+    filters.tag !== null ||
+    filters.runtime !== null
+
+  return (
+    <div className={cn('flex flex-col gap-3', className)}>
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative flex-1 min-w-[200px] max-w-md">
+          <Search
+            aria-hidden
+            className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-ink-faint pointer-events-none"
+          />
+          <Input
+            value={filters.search}
+            onChange={(next) => onFilterChange({ search: next })}
+            placeholder="search workers…"
+            aria-label="search workers"
+            preserveCase
+            className="pl-9"
+          />
+        </div>
+        {hasActive ? (
+          <button
+            type="button"
+            onClick={onClear}
+            className="inline-flex items-center gap-1 font-mono text-[12px] text-ink-faint hover:text-ink lowercase"
+          >
+            <X className="w-3 h-3" aria-hidden />
+            clear filters
+          </button>
+        ) : null}
+      </div>
+      {(tags.length > 0 || runtimes.length > 0) && (
+        <div className="flex flex-wrap items-center gap-2">
+          {tags.length > 0 ? (
+            <FilterChipGroup
+              label="tag"
+              options={tags}
+              selected={filters.tag}
+              onSelect={(tag) =>
+                onFilterChange({ tag: filters.tag === tag ? null : tag })
+              }
+            />
+          ) : null}
+          {runtimes.length > 0 ? (
+            <FilterChipGroup
+              label="runtime"
+              options={runtimes}
+              selected={filters.runtime}
+              onSelect={(runtime) =>
+                onFilterChange({
+                  runtime: filters.runtime === runtime ? null : runtime,
+                })
+              }
+            />
+          ) : null}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface FilterChipGroupProps {
+  label: string
+  options: string[]
+  selected: string | null
+  onSelect: (value: string) => void
+}
+
+function FilterChipGroup({
+  label,
+  options,
+  selected,
+  onSelect,
+}: FilterChipGroupProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span className="font-mono text-[10px] uppercase tracking-[0.06em] text-ink-ghost mr-1">
+        {label}
+      </span>
+      {options.map((opt) => {
+        const active = selected === opt
+        return (
+          <button
+            key={opt}
+            type="button"
+            onClick={() => onSelect(opt)}
+            aria-pressed={active}
+            className={cn(
+              'font-mono text-[11px] lowercase border px-2 py-0.5 transition-colors',
+              active
+                ? 'bg-ink text-bg border-ink'
+                : 'bg-bg text-ink-faint border-rule hover:border-ink hover:text-ink',
+            )}
+          >
+            {opt}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/console/web/src/pages/Workers/components/WorkersTable.stories.tsx
+++ b/console/web/src/pages/Workers/components/WorkersTable.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useMemo, useState } from 'react'
+import { TooltipProvider } from '@/components/ui/Tooltip'
+import {
+  WORKERS_FIXTURE_EMPTY,
+  WORKERS_FIXTURE_ROWS,
+} from '../fixtures/workers-fixtures'
+import type { WorkerRow } from '../types'
+import {
+  filterWorkerRows,
+  type WorkersFilterState,
+} from '../types'
+import { WorkersFilters } from './WorkersFilters'
+import { WorkersTable } from './WorkersTable'
+
+function WorkersHarness({
+  rows,
+  isLoading,
+  initialTag,
+  onStop,
+}: {
+  rows: WorkerRow[]
+  isLoading?: boolean
+  initialTag?: string | null
+  onStop?: (name: string) => void
+}) {
+  const [filters, setFilters] = useState<WorkersFilterState>({
+    search: '',
+    tag: initialTag ?? null,
+    runtime: null,
+  })
+  const filtered = useMemo(
+    () => filterWorkerRows(rows, filters),
+    [rows, filters],
+  )
+
+  return (
+    <TooltipProvider>
+      <div className="flex flex-col gap-4 p-6 bg-bg min-h-[420px]">
+        {!isLoading && rows.length > 0 ? (
+          <WorkersFilters
+            rows={rows}
+            filters={filters}
+            onFilterChange={(next) =>
+              setFilters((cur) => ({ ...cur, ...next }))
+            }
+            onClear={() =>
+              setFilters({ search: '', tag: null, runtime: null })
+            }
+          />
+        ) : null}
+        <WorkersTable
+          rows={filtered}
+          isLoading={isLoading}
+          onStop={onStop}
+        />
+      </div>
+    </TooltipProvider>
+  )
+}
+
+const meta = {
+  title: 'pages/Workers/WorkersTable',
+  component: WorkersHarness,
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof WorkersHarness>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    rows: WORKERS_FIXTURE_ROWS,
+  },
+}
+
+export const FilteredByTag: Story = {
+  args: {
+    rows: WORKERS_FIXTURE_ROWS,
+    initialTag: 'platform',
+  },
+}
+
+export const Empty: Story = {
+  args: {
+    rows: WORKERS_FIXTURE_EMPTY,
+  },
+}
+
+export const Loading: Story = {
+  args: {
+    rows: [],
+    isLoading: true,
+  },
+}
+
+const supervisorRows = WORKERS_FIXTURE_ROWS.filter(
+  (r) => r.managementKind === 'supervisor' && r.stopEnabled,
+)
+
+export const StopEnabled: Story = {
+  args: {
+    rows: supervisorRows,
+    onStop: () => undefined,
+  },
+}
+
+export const StandaloneNoStop: Story = {
+  args: {
+    rows: WORKERS_FIXTURE_ROWS.filter(
+      (r) => r.managementKind === 'standalone',
+    ),
+  },
+}

--- a/console/web/src/pages/Workers/components/WorkersTable.tsx
+++ b/console/web/src/pages/Workers/components/WorkersTable.tsx
@@ -1,0 +1,198 @@
+import { Square } from 'lucide-react'
+import { Badge } from '@/components/ui/Badge'
+import { Button } from '@/components/ui/Button'
+import { EmptyState } from '@/components/ui/EmptyState'
+import { Skeleton } from '@/components/ui/Skeleton'
+import { StatusDot } from '@/components/ui/StatusDot'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/Tooltip'
+import { cn } from '@/lib/utils'
+import type { WorkerManagementKind, WorkerRow } from '../types'
+
+interface WorkersTableProps {
+  rows: WorkerRow[]
+  isLoading?: boolean
+  stoppingName?: string | null
+  onStop?: (name: string) => void
+  className?: string
+}
+
+const MANAGEMENT_LABEL: Record<WorkerManagementKind, string> = {
+  config: 'config',
+  supervisor: 'managed',
+  standalone: 'standalone',
+  internal: 'internal',
+}
+
+const MANAGEMENT_VARIANT: Record<
+  WorkerManagementKind,
+  'default' | 'accent' | 'warn'
+> = {
+  config: 'default',
+  supervisor: 'accent',
+  standalone: 'warn',
+  internal: 'default',
+}
+
+function statusTone(
+  status: WorkerRow['status'],
+): 'accent' | 'alert' | 'warn' | 'ink' {
+  if (status === 'connected') return 'accent'
+  if (status === 'stopped') return 'ink'
+  return 'warn'
+}
+
+function formatCell(value: string | number | null | undefined): string {
+  if (value === null || value === undefined || value === '') return '—'
+  return String(value)
+}
+
+export function WorkersTable({
+  rows,
+  isLoading,
+  stoppingName,
+  onStop,
+  className,
+}: WorkersTableProps) {
+  if (isLoading) {
+    return <WorkersTableSkeleton className={className} />
+  }
+
+  if (rows.length === 0) {
+    return (
+      <EmptyState
+        icon={Square}
+        title="no workers"
+        description="no workers match the current filters. workers appear here when they connect to the engine or are installed via the supervisor."
+      />
+    )
+  }
+
+  return (
+    <div className={cn('-mx-4 -my-2 overflow-x-auto whitespace-nowrap sm:-mx-6 lg:-mx-8', className)}>
+      <div className="inline-block min-w-full px-4 py-2 align-middle sm:px-6 lg:px-8">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-rule-2">
+              <th className="py-2 pr-4 text-left font-mono text-[11px] font-medium text-ink-faint whitespace-nowrap">
+                Name
+              </th>
+              <th className="py-2 pr-4 text-left font-mono text-[11px] font-medium text-ink-faint whitespace-nowrap">
+                Runtime
+              </th>
+              <th className="py-2 pr-4 text-left font-mono text-[11px] font-medium text-ink-faint whitespace-nowrap">
+                IP address
+              </th>
+              <th className="py-2 pr-4 text-left font-mono text-[11px] font-medium text-ink-faint whitespace-nowrap">
+                Version
+              </th>
+              <th className="py-2 pr-4 text-left font-mono text-[11px] font-medium text-ink-faint whitespace-nowrap">
+                PID
+              </th>
+              <th className="py-2 pr-4 text-left font-mono text-[11px] font-medium text-ink-faint whitespace-nowrap">
+                Management
+              </th>
+              <th className="py-2 pr-4 text-left font-mono text-[11px] font-medium text-ink-faint whitespace-nowrap">
+                Tag
+              </th>
+              <th className="py-2 text-right font-mono text-[11px] font-medium text-ink-faint whitespace-nowrap">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <WorkerTableRow
+                key={row.id}
+                row={row}
+                stopping={stoppingName === row.name}
+                onStop={onStop}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+interface WorkerTableRowProps {
+  row: WorkerRow
+  stopping: boolean
+  onStop?: (name: string) => void
+}
+
+function WorkerTableRow({ row, stopping, onStop }: WorkerTableRowProps) {
+  const stopButton = (
+    <Button
+      variant="ghost"
+      size="sm"
+      disabled={!row.stopEnabled || stopping || !onStop}
+      onClick={() => onStop?.(row.name)}
+      className="text-alert border-alert/40 hover:bg-alert/10 hover:text-alert disabled:opacity-40"
+    >
+      {stopping ? 'stopping…' : 'stop'}
+    </Button>
+  )
+
+  return (
+    <tr className="border-b border-rule-2">
+      <td className="py-2.5 pr-4">
+        <div className="flex items-center gap-2">
+          <StatusDot
+            tone={statusTone(row.status)}
+            pulse={row.status === 'connected'}
+          />
+          <span className="font-mono text-[13px] text-ink lowercase">
+            {row.name}
+          </span>
+        </div>
+      </td>
+      <td className="py-2.5 pr-4 font-mono text-[13px] text-ink-faint lowercase">
+        {formatCell(row.runtime)}
+      </td>
+      <td className="py-2.5 pr-4 font-mono text-[13px] text-ink-faint tabular-nums">
+        {formatCell(row.ipAddress)}
+      </td>
+      <td className="py-2.5 pr-4 font-mono text-[13px] text-ink-faint tabular-nums">
+        {formatCell(row.version)}
+      </td>
+      <td className="py-2.5 pr-4 font-mono text-[13px] text-ink-faint tabular-nums">
+        {formatCell(row.pid)}
+      </td>
+      <td className="py-2.5 pr-4">
+        <Badge variant={MANAGEMENT_VARIANT[row.managementKind]}>
+          {MANAGEMENT_LABEL[row.managementKind]}
+        </Badge>
+      </td>
+      <td className="py-2.5 pr-4 font-mono text-[13px] text-ink-faint lowercase">
+        {formatCell(row.tag)}
+      </td>
+      <td className="py-2.5 text-right">
+        {row.stopEnabled || !row.stopDisabledReason ? (
+          stopButton
+        ) : (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-block">{stopButton}</span>
+            </TooltipTrigger>
+            <TooltipContent>{row.stopDisabledReason}</TooltipContent>
+          </Tooltip>
+        )}
+      </td>
+    </tr>
+  )
+}
+
+function WorkersTableSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn('space-y-2 px-4 sm:px-6 lg:px-8', className)}>
+      {[0, 1, 2, 3].map((i) => (
+        <Skeleton key={i} className="h-10 w-full" />
+      ))}
+    </div>
+  )
+}

--- a/console/web/src/pages/Workers/fixtures/workers-fixtures.ts
+++ b/console/web/src/pages/Workers/fixtures/workers-fixtures.ts
@@ -1,0 +1,74 @@
+import type { WorkerRow } from '../types'
+
+export const WORKERS_FIXTURE_ROWS: WorkerRow[] = [
+  {
+    id: '7fa8e8a4-1c3d-44b2-9a5f-1234567890ab',
+    name: 'harness',
+    runtime: 'rust',
+    ipAddress: '127.0.0.1',
+    version: '0.4.7',
+    pid: 48291,
+    tag: 'agent',
+    managementKind: 'config',
+    status: 'connected',
+    stopEnabled: false,
+    stopDisabledReason: 'workers declared in config.yaml are managed by the engine',
+  },
+  {
+    id: '00000000-0000-0000-0000-000000000aaa',
+    name: 'iii-directory',
+    runtime: 'rust',
+    ipAddress: '127.0.0.1',
+    version: '0.1.5',
+    pid: 48302,
+    tag: 'platform',
+    managementKind: 'supervisor',
+    status: 'connected',
+    stopEnabled: true,
+    stopDisabledReason: null,
+  },
+  {
+    id: '11111111-2222-3333-4444-555555555555',
+    name: 'todo-app',
+    runtime: 'node',
+    ipAddress: '192.168.1.42',
+    version: '0.4.7',
+    pid: 51003,
+    tag: 'dev',
+    managementKind: 'standalone',
+    status: 'connected',
+    stopEnabled: false,
+    stopDisabledReason:
+      'standalone workers must be stopped from the process that started them',
+  },
+  {
+    id: '22222222-3333-4444-5555-666666666666',
+    name: 'iii-engine-functions',
+    runtime: 'rust',
+    ipAddress: null,
+    version: '0.19.4',
+    pid: 1,
+    tag: null,
+    managementKind: 'internal',
+    status: 'connected',
+    stopEnabled: false,
+    stopDisabledReason: 'internal engine workers cannot be stopped from the console',
+  },
+  {
+    id: '33333333-4444-5555-6666-777777777777',
+    name: 'pdfkit',
+    runtime: 'rust',
+    ipAddress: null,
+    version: '0.2.0',
+    pid: null,
+    tag: 'platform',
+    managementKind: 'supervisor',
+    status: 'stopped',
+    stopEnabled: false,
+    stopDisabledReason: 'worker is not running',
+  },
+]
+
+export const WORKERS_FIXTURE_EMPTY: WorkerRow[] = []
+
+export const WORKERS_FIXTURE_LOADING: null = null

--- a/console/web/src/pages/Workers/hooks/useWorkersLive.ts
+++ b/console/web/src/pages/Workers/hooks/useWorkersLive.ts
@@ -1,0 +1,98 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMemo, useState } from 'react'
+import { useWorkerLifecycle } from '@/hooks/use-worker-lifecycle'
+import { getDefaultBackend } from '@/lib/backend'
+import { stopSupervisorWorker } from '../api/workers'
+import { fetchMergedWorkers } from '../lib/merge-workers'
+import {
+  filterWorkerRows,
+  type WorkersFilterState,
+} from '../types'
+
+export const workersKeys = {
+  all: ['workers'] as const,
+  runtime: () => [...workersKeys.all, 'runtime'] as const,
+}
+
+const WORKERS_RUNTIME_WATCH_FN = 'iii::console::workers_runtime'
+
+const RUNTIME_OPERATIONS = [
+  'add',
+  'remove',
+  'update',
+  'start',
+  'stop',
+  'clear',
+] as const
+
+const RUNTIME_STAGES = ['done', 'failed'] as const
+
+export function useWorkersLive() {
+  const qc = useQueryClient()
+  const enabled = getDefaultBackend().id === 'real'
+  const [filters, setFilters] = useState<WorkersFilterState>({
+    search: '',
+    tag: null,
+    runtime: null,
+  })
+  const [stoppingName, setStoppingName] = useState<string | null>(null)
+
+  const query = useQuery({
+    queryKey: workersKeys.runtime(),
+    queryFn: fetchMergedWorkers,
+    enabled,
+  })
+
+  useWorkerLifecycle({
+    enabled,
+    fnId: WORKERS_RUNTIME_WATCH_FN,
+    operations: RUNTIME_OPERATIONS,
+    stages: RUNTIME_STAGES,
+    onEvent: () => {
+      void qc.invalidateQueries({ queryKey: workersKeys.runtime() })
+    },
+  })
+
+  const rows = useMemo(() => {
+    const source = query.data ?? []
+    return filterWorkerRows(source, filters)
+  }, [query.data, filters])
+
+  const stopMutation = useMutation({
+    mutationFn: stopSupervisorWorker,
+    onMutate: (name) => {
+      setStoppingName(name)
+    },
+    onSettled: () => {
+      setStoppingName(null)
+      void qc.invalidateQueries({ queryKey: workersKeys.runtime() })
+    },
+  })
+
+  function updateFilters(next: Partial<WorkersFilterState>) {
+    setFilters((cur) => ({ ...cur, ...next }))
+  }
+
+  function clearFilters() {
+    setFilters({ search: '', tag: null, runtime: null })
+  }
+
+  function stopWorker(name: string) {
+    stopMutation.mutate(name)
+  }
+
+  return {
+    rows,
+    allRows: query.data ?? [],
+    filters,
+    updateFilters,
+    clearFilters,
+    isLoading: enabled && query.isLoading,
+    isError: query.isError,
+    error: query.error,
+    refetch: query.refetch,
+    stoppingName,
+    stopWorker,
+    stopError: stopMutation.error,
+  }
+}

--- a/console/web/src/pages/Workers/index.tsx
+++ b/console/web/src/pages/Workers/index.tsx
@@ -1,0 +1,90 @@
+import { AlertCircle, RefreshCw } from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import { StatusPanel } from '@/components/ui/StatusPanel'
+import { TooltipProvider } from '@/components/ui/Tooltip'
+import { cn } from '@/lib/utils'
+import { WorkersFilters } from './components/WorkersFilters'
+import { WorkersTable } from './components/WorkersTable'
+import { useWorkersLive } from './hooks/useWorkersLive'
+
+export function Workers() {
+  const {
+    rows,
+    allRows,
+    filters,
+    updateFilters,
+    clearFilters,
+    isLoading,
+    isError,
+    error,
+    refetch,
+    stoppingName,
+    stopWorker,
+  } = useWorkersLive()
+
+  const countLabel = isLoading
+    ? '…'
+    : String(allRows.length)
+
+  return (
+    <TooltipProvider>
+      <main
+        className="flex-1 flex flex-col min-h-0 overflow-hidden"
+        aria-label="workers"
+      >
+        <header className="shrink-0 px-4 sm:px-6 lg:px-8 py-4 border-b border-rule flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h1 className="font-mono text-[16px] font-semibold tracking-[-0.01em] text-ink lowercase">
+              workers
+            </h1>
+            <p className="font-mono text-[12px] text-ink-faint mt-0.5 lowercase">
+              {countLabel} connected or installed
+            </p>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => void refetch()}
+            disabled={isLoading}
+            className="gap-1.5"
+          >
+            <RefreshCw
+              className={cn('w-3.5 h-3.5', isLoading && 'animate-spin')}
+              aria-hidden
+            />
+            refresh
+          </Button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto px-4 sm:px-6 lg:px-8 py-4 space-y-4">
+          {isError ? (
+            <StatusPanel
+              variant="alert"
+              icon={<AlertCircle className="w-full h-full" />}
+              headline="failed to load workers"
+              detail={
+                error instanceof Error
+                  ? error.message
+                  : 'check that the engine is running and reachable.'
+              }
+            />
+          ) : null}
+
+          <WorkersFilters
+            rows={allRows}
+            filters={filters}
+            onFilterChange={updateFilters}
+            onClear={clearFilters}
+          />
+
+          <WorkersTable
+            rows={rows}
+            isLoading={isLoading}
+            stoppingName={stoppingName}
+            onStop={stopWorker}
+          />
+        </div>
+      </main>
+    </TooltipProvider>
+  )
+}

--- a/console/web/src/pages/Workers/lib/merge-workers.test.ts
+++ b/console/web/src/pages/Workers/lib/merge-workers.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest'
+import type { RawWorkersSnapshot } from '../api/workers'
+import { mergeWorkers } from './merge-workers'
+
+function snapshot(partial: Partial<RawWorkersSnapshot>): RawWorkersSnapshot {
+  return {
+    engineWorkers: [],
+    supervisorWorkers: [],
+    configurations: [],
+    infoByName: new Map(),
+    ...partial,
+  }
+}
+
+describe('mergeWorkers', () => {
+  it('classifies config-managed workers', () => {
+    const rows = mergeWorkers(
+      snapshot({
+        engineWorkers: [
+          {
+            id: 'w-1',
+            name: 'harness',
+            status: 'connected',
+            function_count: 1,
+            connected_at_ms: 0,
+            active_invocations: 0,
+          },
+        ],
+        configurations: [
+          {
+            id: 'harness',
+            name: 'harness',
+            description: '',
+            schema: {},
+          },
+        ],
+        infoByName: new Map([
+          [
+            'harness',
+            {
+              id: 'w-1',
+              name: 'harness',
+              status: 'connected',
+              function_count: 1,
+              connected_at_ms: 0,
+              active_invocations: 0,
+              internal: false,
+              pid: 100,
+            },
+          ],
+        ]),
+      }),
+    )
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.managementKind).toBe('config')
+    expect(rows[0]?.stopEnabled).toBe(false)
+    expect(rows[0]?.pid).toBe(100)
+  })
+
+  it('classifies supervisor-managed workers with stop enabled when running', () => {
+    const rows = mergeWorkers(
+      snapshot({
+        engineWorkers: [
+          {
+            id: 'w-2',
+            name: 'iii-directory',
+            runtime: 'rust',
+            status: 'connected',
+            function_count: 5,
+            connected_at_ms: 0,
+            active_invocations: 0,
+            ip_address: '127.0.0.1',
+          },
+        ],
+        supervisorWorkers: [
+          {
+            name: 'iii-directory',
+            running: true,
+            pid: 200,
+            version: '0.1.0',
+          },
+        ],
+        infoByName: new Map([
+          [
+            'iii-directory',
+            {
+              id: 'w-2',
+              name: 'iii-directory',
+              status: 'connected',
+              function_count: 5,
+              connected_at_ms: 0,
+              active_invocations: 0,
+              internal: false,
+              pid: 200,
+            },
+          ],
+        ]),
+      }),
+    )
+
+    expect(rows[0]?.managementKind).toBe('supervisor')
+    expect(rows[0]?.stopEnabled).toBe(true)
+  })
+
+  it('classifies standalone workers without stop', () => {
+    const rows = mergeWorkers(
+      snapshot({
+        engineWorkers: [
+          {
+            id: 'w-3',
+            name: 'todo-app',
+            runtime: 'node',
+            status: 'connected',
+            function_count: 2,
+            connected_at_ms: 0,
+            active_invocations: 0,
+          },
+        ],
+        infoByName: new Map([
+          [
+            'todo-app',
+            {
+              id: 'w-3',
+              name: 'todo-app',
+              status: 'connected',
+              function_count: 2,
+              connected_at_ms: 0,
+              active_invocations: 0,
+              internal: false,
+              pid: 300,
+            },
+          ],
+        ]),
+      }),
+    )
+
+    expect(rows[0]?.managementKind).toBe('standalone')
+    expect(rows[0]?.stopEnabled).toBe(false)
+    expect(rows[0]?.stopDisabledReason).toContain('standalone')
+  })
+
+  it('classifies internal engine workers', () => {
+    const rows = mergeWorkers(
+      snapshot({
+        engineWorkers: [
+          {
+            id: 'w-4',
+            name: 'iii-engine-functions',
+            runtime: 'rust',
+            status: 'connected',
+            function_count: 10,
+            connected_at_ms: 0,
+            active_invocations: 0,
+          },
+        ],
+        infoByName: new Map([
+          [
+            'iii-engine-functions',
+            {
+              id: 'w-4',
+              name: 'iii-engine-functions',
+              status: 'connected',
+              function_count: 10,
+              connected_at_ms: 0,
+              active_invocations: 0,
+              internal: true,
+              pid: 1,
+            },
+          ],
+        ]),
+      }),
+    )
+
+    expect(rows[0]?.managementKind).toBe('internal')
+    expect(rows[0]?.stopEnabled).toBe(false)
+  })
+
+  it('adds synthetic rows for supervisor-only daemon builtins', () => {
+    const rows = mergeWorkers(
+      snapshot({
+        supervisorWorkers: [
+          {
+            name: 'iii-http',
+            running: true,
+            pid: 400,
+            version: '0.1.0',
+          },
+        ],
+      }),
+    )
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.name).toBe('iii-http')
+    expect(rows[0]?.managementKind).toBe('supervisor')
+    expect(rows[0]?.runtime).toBeNull()
+  })
+
+  it('carries optional tag from engine info or list row', () => {
+    const rows = mergeWorkers(
+      snapshot({
+        engineWorkers: [
+          {
+            id: 'w-5',
+            name: 'console',
+            runtime: 'rust',
+            status: 'connected',
+            function_count: 1,
+            connected_at_ms: 0,
+            active_invocations: 0,
+            tag: 'platform',
+          },
+        ],
+        infoByName: new Map([
+          [
+            'console',
+            {
+              id: 'w-5',
+              name: 'console',
+              status: 'connected',
+              function_count: 1,
+              connected_at_ms: 0,
+              active_invocations: 0,
+              internal: false,
+              tag: 'agent',
+            },
+          ],
+        ]),
+      }),
+    )
+
+    expect(rows[0]?.tag).toBe('agent')
+  })
+})

--- a/console/web/src/pages/Workers/lib/merge-workers.ts
+++ b/console/web/src/pages/Workers/lib/merge-workers.ts
@@ -1,0 +1,169 @@
+import type { WorkerSummary } from '@/components/chat/engine/parsers'
+import type { WorkerEntry } from '@/components/chat/worker/parsers'
+import type { ConfigurationSchemaView } from '@/pages/Configuration/tabs/WorkersTab/api'
+import type { RawWorkersSnapshot } from '../api/workers'
+import type {
+  WorkerConnectionStatus,
+  WorkerManagementKind,
+  WorkerRow,
+} from '../types'
+
+const STOP_REASON = {
+  config: 'workers declared in config.yaml are managed by the engine',
+  internal: 'internal engine workers cannot be stopped from the console',
+  standalone:
+    'standalone workers must be stopped from the process that started them',
+  notRunning: 'worker is not running',
+} as const
+
+function configIdSet(configurations: ConfigurationSchemaView[]): Set<string> {
+  const ids = new Set<string>()
+  for (const c of configurations) {
+    ids.add(c.id)
+    if (c.name) ids.add(c.name)
+  }
+  return ids
+}
+
+function supervisorMap(
+  entries: WorkerEntry[],
+): Map<string, WorkerEntry> {
+  const map = new Map<string, WorkerEntry>()
+  for (const entry of entries) {
+    map.set(entry.name, entry)
+  }
+  return map
+}
+
+function deriveManagementKind(
+  name: string,
+  internal: boolean,
+  configIds: Set<string>,
+  supervisor: WorkerEntry | undefined,
+): WorkerManagementKind {
+  if (internal) return 'internal'
+  if (configIds.has(name)) return 'config'
+  if (supervisor) return 'supervisor'
+  return 'standalone'
+}
+
+function deriveConnectionStatus(
+  engineStatus: string | undefined,
+  supervisor: WorkerEntry | undefined,
+): WorkerConnectionStatus {
+  if (engineStatus?.toLowerCase() === 'connected') return 'connected'
+  if (supervisor?.running) return 'connected'
+  if (supervisor && !supervisor.running) return 'stopped'
+  return 'disconnected'
+}
+
+function deriveStopState(
+  kind: WorkerManagementKind,
+  status: WorkerConnectionStatus,
+  supervisor: WorkerEntry | undefined,
+): Pick<WorkerRow, 'stopEnabled' | 'stopDisabledReason'> {
+  if (kind === 'supervisor' && status === 'connected' && supervisor?.running) {
+    return { stopEnabled: true, stopDisabledReason: null }
+  }
+  if (kind === 'config') {
+    return { stopEnabled: false, stopDisabledReason: STOP_REASON.config }
+  }
+  if (kind === 'internal') {
+    return { stopEnabled: false, stopDisabledReason: STOP_REASON.internal }
+  }
+  if (kind === 'standalone') {
+    return { stopEnabled: false, stopDisabledReason: STOP_REASON.standalone }
+  }
+  return { stopEnabled: false, stopDisabledReason: STOP_REASON.notRunning }
+}
+
+function engineRowToWorkerRow(
+  summary: WorkerSummary,
+  configIds: Set<string>,
+  supervisors: Map<string, WorkerEntry>,
+  infoByName: Map<string, { pid?: number; internal: boolean; tag?: string | null }>,
+): WorkerRow {
+  const name = summary.name ?? summary.id
+  const info = infoByName.get(name)
+  const internal = info?.internal ?? false
+  const supervisor = supervisors.get(name)
+  const managementKind = deriveManagementKind(
+    name,
+    internal,
+    configIds,
+    supervisor,
+  )
+  const status = deriveConnectionStatus(summary.status, supervisor)
+  const stop = deriveStopState(managementKind, status, supervisor)
+
+  return {
+    id: summary.id,
+    name,
+    runtime: summary.runtime ?? null,
+    ipAddress: summary.ip_address ?? null,
+    version: summary.version ?? null,
+    pid: info?.pid ?? supervisor?.pid ?? null,
+    tag: info?.tag ?? summary.tag ?? null,
+    managementKind,
+    status,
+    ...stop,
+  }
+}
+
+function syntheticSupervisorRow(
+  entry: WorkerEntry,
+  configIds: Set<string>,
+): WorkerRow {
+  const managementKind = configIds.has(entry.name) ? 'config' : 'supervisor'
+  const status: WorkerConnectionStatus = entry.running ? 'connected' : 'stopped'
+  const stop = deriveStopState(managementKind, status, entry)
+
+  return {
+    id: `supervisor:${entry.name}`,
+    name: entry.name,
+    runtime: null,
+    ipAddress: null,
+    version: entry.version ?? null,
+    pid: entry.pid ?? null,
+    tag: null,
+    managementKind,
+    status,
+    ...stop,
+  }
+}
+
+/** Merge engine catalogue, supervisor list, and configuration registry into table rows. */
+export function mergeWorkers(snapshot: RawWorkersSnapshot): WorkerRow[] {
+  const configIds = configIdSet(snapshot.configurations)
+  const supervisors = supervisorMap(snapshot.supervisorWorkers)
+  const seen = new Set<string>()
+  const rows: WorkerRow[] = []
+
+  for (const engineWorker of snapshot.engineWorkers) {
+    const name = engineWorker.name ?? engineWorker.id
+    seen.add(name)
+    rows.push(
+      engineRowToWorkerRow(
+        engineWorker,
+        configIds,
+        supervisors,
+        snapshot.infoByName,
+      ),
+    )
+  }
+
+  for (const [name, entry] of supervisors) {
+    if (seen.has(name)) continue
+    rows.push(syntheticSupervisorRow(entry, configIds))
+    seen.add(name)
+  }
+
+  rows.sort((a, b) => a.name.localeCompare(b.name))
+  return rows
+}
+
+export async function fetchMergedWorkers(): Promise<WorkerRow[]> {
+  const { fetchRawWorkersSnapshot } = await import('../api/workers')
+  const snapshot = await fetchRawWorkersSnapshot()
+  return mergeWorkers(snapshot)
+}

--- a/console/web/src/pages/Workers/lib/worker-event.test.ts
+++ b/console/web/src/pages/Workers/lib/worker-event.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { parseWorkerEvent, workerEventSchema } from './worker-event'
+
+describe('workerEventSchema', () => {
+  it('parses a terminal worker lifecycle event', () => {
+    const payload = {
+      operation: 'stop',
+      stage: 'done',
+      worker: 'iii-directory',
+      timestamp_ms: 1_700_000_000_000,
+      caller_mode: 'cli',
+    }
+    expect(workerEventSchema.parse(payload)).toEqual(payload)
+    expect(parseWorkerEvent(payload)).toEqual(payload)
+  })
+
+  it('parses a failed event with structured error', () => {
+    const payload = {
+      operation: 'add',
+      stage: 'failed',
+      worker: 'harness',
+      timestamp_ms: 1_700_000_000_001,
+      caller_mode: 'trigger',
+      error: { code: 'W900', message: 'download failed' },
+    }
+    expect(parseWorkerEvent(payload)?.error?.message).toBe('download failed')
+  })
+
+  it('rejects incomplete payloads', () => {
+    expect(parseWorkerEvent({ operation: 'add' })).toBeNull()
+  })
+})

--- a/console/web/src/pages/Workers/lib/worker-event.ts
+++ b/console/web/src/pages/Workers/lib/worker-event.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod'
+
+/**
+ * Wire shape for the engine `worker` trigger type (`WorkerCallRequest`).
+ * Source of truth: `iii trigger engine::triggers::info id=worker`.
+ */
+export const workerEventSchema = z.object({
+  operation: z.string(),
+  stage: z.string(),
+  worker: z.string(),
+  timestamp_ms: z.number(),
+  caller_mode: z.enum(['cli', 'trigger']).optional(),
+  version: z.string().nullable().optional(),
+  status: z.string().nullable().optional(),
+  progress: z.number().nullable().optional(),
+  source: z
+    .object({
+      kind: z.enum(['registry', 'oci', 'local']),
+      ref: z.string(),
+    })
+    .nullable()
+    .optional(),
+  error: z
+    .object({
+      code: z.string(),
+      message: z.string(),
+    })
+    .nullable()
+    .optional(),
+})
+
+export type WorkerEvent = z.infer<typeof workerEventSchema>
+
+export function parseWorkerEvent(payload: unknown): WorkerEvent | null {
+  const parsed = workerEventSchema.safeParse(payload)
+  return parsed.success ? parsed.data : null
+}

--- a/console/web/src/pages/Workers/types.test.ts
+++ b/console/web/src/pages/Workers/types.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { filterWorkerRows, type WorkerRow } from './types'
+
+const rows: WorkerRow[] = [
+  {
+    id: '1',
+    name: 'harness',
+    runtime: 'rust',
+    ipAddress: '127.0.0.1',
+    version: '1.0',
+    pid: 1,
+    tag: 'agent',
+    managementKind: 'config',
+    status: 'connected',
+    stopEnabled: false,
+    stopDisabledReason: null,
+  },
+  {
+    id: '2',
+    name: 'todo-app',
+    runtime: 'node',
+    ipAddress: null,
+    version: '2.0',
+    pid: 2,
+    tag: 'dev',
+    managementKind: 'standalone',
+    status: 'connected',
+    stopEnabled: false,
+    stopDisabledReason: 'standalone',
+  },
+]
+
+describe('filterWorkerRows', () => {
+  it('filters by tag', () => {
+    const filtered = filterWorkerRows(rows, {
+      search: '',
+      tag: 'dev',
+      runtime: null,
+    })
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]?.name).toBe('todo-app')
+  })
+
+  it('filters by search across fields', () => {
+    const filtered = filterWorkerRows(rows, {
+      search: '127.0.0.1',
+      tag: null,
+      runtime: null,
+    })
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]?.name).toBe('harness')
+  })
+})

--- a/console/web/src/pages/Workers/types.ts
+++ b/console/web/src/pages/Workers/types.ts
@@ -1,0 +1,74 @@
+/** How the worker is managed — drives badge copy and stop affordance. */
+export type WorkerManagementKind =
+  | 'config'
+  | 'supervisor'
+  | 'standalone'
+  | 'internal'
+
+/** Connection / liveness status shown in the table. */
+export type WorkerConnectionStatus = 'connected' | 'disconnected' | 'stopped'
+
+/** View-model row for the runtime workers table (no transport types). */
+export interface WorkerRow {
+  /** Stable row key — engine id when present, otherwise worker name. */
+  id: string
+  name: string
+  runtime: string | null
+  ipAddress: string | null
+  version: string | null
+  pid: number | null
+  tag: string | null
+  managementKind: WorkerManagementKind
+  status: WorkerConnectionStatus
+  /** When true the stop action is enabled (supervisor-managed + running). */
+  stopEnabled: boolean
+  /** Shown when stop is disabled. */
+  stopDisabledReason: string | null
+}
+
+export interface WorkersFilterState {
+  search: string
+  tag: string | null
+  runtime: string | null
+}
+
+export function filterWorkerRows(
+  rows: WorkerRow[],
+  filters: WorkersFilterState,
+): WorkerRow[] {
+  const q = filters.search.trim().toLowerCase()
+  return rows.filter((row) => {
+    if (filters.tag && row.tag !== filters.tag) return false
+    if (filters.runtime && row.runtime !== filters.runtime) return false
+    if (!q) return true
+    const haystack = [
+      row.name,
+      row.runtime,
+      row.ipAddress,
+      row.version,
+      row.tag,
+      row.managementKind,
+      row.pid?.toString(),
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase()
+    return haystack.includes(q)
+  })
+}
+
+export function distinctTags(rows: WorkerRow[]): string[] {
+  const tags = new Set<string>()
+  for (const row of rows) {
+    if (row.tag) tags.add(row.tag)
+  }
+  return [...tags].sort()
+}
+
+export function distinctRuntimes(rows: WorkerRow[]): string[] {
+  const runtimes = new Set<string>()
+  for (const row of rows) {
+    if (row.runtime) runtimes.add(row.runtime)
+  }
+  return [...runtimes].sort()
+}


### PR DESCRIPTION
<img width="1824" height="1030" alt="image" src="https://github.com/user-attachments/assets/11359a9f-2928-498c-bdf0-36876f8eb8f6" />

### What it doesn't have due to iii engine limitations:
1. tags
2. can't stop non-managed workers
3. real-time updates on non-managed workers (when they connect, disconnect, etc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Workers view with its own route and header toggle.
  * Introduced a live workers page with refresh, filtering, and stop actions.
  * Added a workers table showing status, runtime, IP, version, PID, and management details.
* **Bug Fixes**
  * Workers now appear correctly when navigating directly to the workers route.
  * Added support for worker tags in filtering and display, improving search accuracy.
* **Tests**
  * Expanded test coverage for workers filtering, parsing, and row merging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->