### PR TITLE
fix(hermes): install jq (and ripgrep) so the container release builds

### DIFF
--- a/hermes/Dockerfile
+++ b/hermes/Dockerfile
@@ -1,9 +1,10 @@
 FROM python:3.11-slim
 
-# Hermes installer prerequisites (Python 3.11 is the base; the installer pulls
-# its own uv venv, a Node 22 bridge, ripgrep, and ffmpeg).
+# Prerequisites. The Hermes installer needs git/curl/xz/build tools; the iii
+# installer needs jq; ripgrep gives the agent fast in-repo search (Hermes warns
+# when it is absent).
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      git curl xz-utils build-essential ca-certificates \
+      git curl xz-utils build-essential ca-certificates jq ripgrep \
     && rm -rf /var/lib/apt/lists/*
 
 # Install the Hermes agent CLI. The installer sets up `hermes` on PATH.


### PR DESCRIPTION
The hermes container release failed at the iii CLI install step:

```
RUN curl -fsSL https://install.iii.dev/iii/main/install.sh | sh
error: jq is required (apt-get install -y jq)
```

The iii installer's only hard dependencies are curl (present) and jq (missing). Add jq to the apt layer, plus ripgrep so the Hermes agent gets fast in-repo search instead of the grep fallback it warns about on install.

One-line apt change; unblocks the container build / re-release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the runtime/build environment to include additional command-line tools, improving availability of common utilities during setup and development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->