### PR TITLE
chore(storage): bump iii-sdk to 0.20.0

### DIFF
--- a/storage/Cargo.lock
+++ b/storage/Cargo.lock
@@ -1921,16 +1921,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-observability"
-version = "0.19.0"
+name = "iii-helpers"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ddb7c5dc5a7cac2da5250d623a960b1dbd7de956caa57c986f6895fe905c22"
+checksum = "09daa7c14a9e4c1f7077c4a181918d207e3f05cdfea8b2d7781bbeb80caf4c5d"
 dependencies = [
  "futures-util",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry_sdk",
  "reqwest 0.12.28",
+ "schemars",
+ "serde",
  "serde_json",
  "sysinfo",
  "tokio",
@@ -1941,14 +1943,14 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdad3fb4a9abff08e1a384db2b8dd75a780c5cc25b07e3fc4fd3179e55439d28"
+checksum = "5957568413b9a5178c11bf91b20909e93e568b187e259e941ba6009a7ec3f5c1"
 dependencies = [
  "async-trait",
  "futures-util",
  "hostname",
- "iii-observability",
+ "iii-helpers",
  "reqwest 0.12.28",
  "schemars",
  "serde",
@@ -3386,7 +3388,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "storage"
-version = "0.1.4"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.19.0"
+iii-sdk = "=0.20.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time", "process", "io-util", "net"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/storage/src/configuration.rs
+++ b/storage/src/configuration.rs
@@ -5,7 +5,9 @@ use crate::backend::factory::{self, LocalBackendCtx};
 use crate::backend::Backend;
 use crate::config::{Topology, WorkerConfig};
 use crate::handlers::AppState;
-use iii_sdk::{IIIError, RegisterFunction, RegisterTriggerInput, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -19,7 +21,7 @@ const CONFIG_RETRIES: u32 = 3;
 /// Register the `storage` configuration schema with the configuration worker.
 /// When `seed` is present, its value is installed as `initial_value`. Otherwise,
 /// the built-in default is seeded only when no stored value exists yet.
-pub async fn register_config(iii: &III, seed: Option<&WorkerConfig>) -> Result<(), String> {
+pub async fn register_config(iii: &IIIClient, seed: Option<&WorkerConfig>) -> Result<(), String> {
     let mut payload = json!({
         "id": CONFIG_ID,
         "name": "Storage",
@@ -36,7 +38,7 @@ pub async fn register_config(iii: &III, seed: Option<&WorkerConfig>) -> Result<(
 }
 
 /// Read the live `storage` configuration (env-expanded by the configuration worker).
-pub async fn fetch_config(iii: &III) -> Result<WorkerConfig, String> {
+pub async fn fetch_config(iii: &IIIClient) -> Result<WorkerConfig, String> {
     let value = get_config_value(iii).await?;
     if value.is_null() {
         tracing::info!("no configuration value found; using built-in default configuration");
@@ -45,7 +47,7 @@ pub async fn fetch_config(iii: &III) -> Result<WorkerConfig, String> {
     WorkerConfig::from_json(&value)
 }
 
-async fn should_seed_default_value(iii: &III) -> Result<bool, String> {
+async fn should_seed_default_value(iii: &IIIClient) -> Result<bool, String> {
     match try_get_config_value(iii).await? {
         None => Ok(true),
         Some(value) if value.is_null() => Ok(true),
@@ -53,14 +55,14 @@ async fn should_seed_default_value(iii: &III) -> Result<bool, String> {
     }
 }
 
-async fn get_config_value(iii: &III) -> Result<Value, String> {
+async fn get_config_value(iii: &IIIClient) -> Result<Value, String> {
     try_get_config_value(iii)
         .await?
         .ok_or_else(|| format!("configuration `{CONFIG_ID}` not found"))
 }
 
 /// Returns `Ok(None)` when the entry does not exist (`NOT_FOUND`).
-async fn try_get_config_value(iii: &III) -> Result<Option<Value>, String> {
+async fn try_get_config_value(iii: &IIIClient) -> Result<Option<Value>, String> {
     match trigger_with_retry(iii, "configuration::get", json!({ "id": CONFIG_ID })).await {
         Ok(resp) => Ok(resp.get("value").cloned()),
         Err(e) if e.contains("NOT_FOUND") => Ok(None),
@@ -136,10 +138,10 @@ pub struct OnConfigChangeResponse {
 /// `boot_topology` is the bucket/notification topology captured at startup; any
 /// reload that would change it is refused (those require a worker restart).
 pub fn register_config_trigger(
-    iii: &III,
+    iii: &IIIClient,
     state: AppState,
     boot_topology: Topology,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let st = state.clone();
     let engine = iii.clone();
     iii.register_function(
@@ -150,7 +152,7 @@ pub fn register_config_trigger(
             let boot_topology = boot_topology.clone();
             async move {
                 on_config_change(&engine, &st, &boot_topology).await;
-                Ok::<OnConfigChangeResponse, IIIError>(OnConfigChangeResponse { ok: true })
+                Ok::<OnConfigChangeResponse, Error>(OnConfigChangeResponse { ok: true })
             }
         })
         .description(
@@ -178,7 +180,7 @@ pub fn register_config_trigger(
 /// (redirecting writes or wiping backends) without updating persisted state.
 /// Instead we re-fetch the stored value via `configuration::get`. A
 /// topology-changing update is refused (it requires a restart).
-async fn on_config_change(iii: &III, state: &AppState, boot_topology: &Topology) {
+async fn on_config_change(iii: &IIIClient, state: &AppState, boot_topology: &Topology) {
     let cfg = match fetch_config(iii).await {
         Ok(cfg) => cfg,
         Err(e) => {
@@ -210,7 +212,11 @@ async fn on_config_change(iii: &III, state: &AppState, boot_topology: &Topology)
     }
 }
 
-async fn trigger_with_retry(iii: &III, function_id: &str, payload: Value) -> Result<Value, String> {
+async fn trigger_with_retry(
+    iii: &IIIClient,
+    function_id: &str,
+    payload: Value,
+) -> Result<Value, String> {
     let mut last_err = String::new();
     for attempt in 1..=CONFIG_RETRIES {
         match iii

--- a/storage/src/error.rs
+++ b/storage/src/error.rs
@@ -88,9 +88,9 @@ impl StorageError {
     }
 }
 
-impl From<StorageError> for iii_sdk::IIIError {
+impl From<StorageError> for iii_sdk::errors::Error {
     fn from(e: StorageError) -> Self {
-        iii_sdk::IIIError::Handler(e.to_wire_string())
+        iii_sdk::errors::Error::Handler(e.to_wire_string())
     }
 }
 
@@ -189,7 +189,7 @@ mod tests {
     #[test]
     fn into_iii_error_carries_wire_body() {
         let e = StorageError::UnknownBucket { bucket: "x".into() };
-        let iii_e: iii_sdk::IIIError = e.into();
+        let iii_e: iii_sdk::errors::Error = e.into();
         let body = format!("{iii_e:?}");
         assert!(body.contains("UNKNOWN_BUCKET"));
     }

--- a/storage/src/main.rs
+++ b/storage/src/main.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result};
 use clap::Parser;
-use iii_sdk::{
-    register_worker, IIIError, InitOptions, RegisterFunction, RegisterTriggerType, WorkerMetadata,
-};
+use iii_sdk::errors::Error;
+use iii_sdk::runtime::WorkerMetadata;
+use iii_sdk::{register_worker, InitOptions, RegisterFunction, RegisterTriggerType};
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -394,7 +394,7 @@ async fn main() -> Result<()> {
             "storage::putObject",
             RegisterFunction::new_async(move |req: put_object::PutReq| {
                 let st = st.clone();
-                async move { put_object::handle(&st, req).await.map_err(IIIError::from) }
+                async move { put_object::handle(&st, req).await.map_err(Error::from) }
             })
             .description(
                 "Write an object to a configured bucket. Body is base64; max 10MB inline.",
@@ -407,7 +407,7 @@ async fn main() -> Result<()> {
             "storage::getObject",
             RegisterFunction::new_async(move |req: get_object::GetReq| {
                 let st = st.clone();
-                async move { get_object::handle(&st, req).await.map_err(IIIError::from) }
+                async move { get_object::handle(&st, req).await.map_err(Error::from) }
             })
             .description("Read an object. Body is base64; for large objects use presignUrl."),
         );
@@ -418,11 +418,7 @@ async fn main() -> Result<()> {
             "storage::deleteObject",
             RegisterFunction::new_async(move |req: delete_object::DeleteReq| {
                 let st = st.clone();
-                async move {
-                    delete_object::handle(&st, req)
-                        .await
-                        .map_err(IIIError::from)
-                }
+                async move { delete_object::handle(&st, req).await.map_err(Error::from) }
             })
             .description("Delete an object. No-op when the object does not exist."),
         );
@@ -433,7 +429,7 @@ async fn main() -> Result<()> {
             "storage::presignUrl",
             RegisterFunction::new_async(move |req: presign_url::PresignReq| {
                 let st = st.clone();
-                async move { presign_url::handle(&st, req).await.map_err(IIIError::from) }
+                async move { presign_url::handle(&st, req).await.map_err(Error::from) }
             })
             .description(
                 "Issue a short-lived URL the browser can hit directly to PUT or GET an object.",
@@ -446,7 +442,7 @@ async fn main() -> Result<()> {
             "storage::headObject",
             RegisterFunction::new_async(move |req: head_object::HeadReq| {
                 let st = st.clone();
-                async move { head_object::handle(&st, req).await.map_err(IIIError::from) }
+                async move { head_object::handle(&st, req).await.map_err(Error::from) }
             })
             .description(
                 "Fetch object metadata (size, ETag, content-type, last-modified) without downloading the body.",

--- a/storage/src/triggers/dispatcher.rs
+++ b/storage/src/triggers/dispatcher.rs
@@ -7,7 +7,7 @@ use crate::triggers::normalize::{EventKind, ObjectEventNormalized};
 use crate::triggers::registry::TriggerRegistry;
 use crate::triggers::{object_created, object_deleted};
 use iii_sdk::protocol::TriggerRequest;
-use iii_sdk::III;
+use iii_sdk::IIIClient;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::timeout;
@@ -21,12 +21,12 @@ pub trait EventDispatcher: Send + Sync {
 }
 
 pub struct EngineDispatcher {
-    pub iii: III,
+    pub iii: IIIClient,
     pub registry: Arc<TriggerRegistry>,
 }
 
 impl EngineDispatcher {
-    pub fn new(iii: III, registry: Arc<TriggerRegistry>) -> Self {
+    pub fn new(iii: IIIClient, registry: Arc<TriggerRegistry>) -> Self {
         Self { iii, registry }
     }
 }

--- a/storage/src/triggers/handler.rs
+++ b/storage/src/triggers/handler.rs
@@ -9,7 +9,8 @@ use crate::triggers::object_created::TriggerConfig as CreatedConfig;
 use crate::triggers::object_deleted::TriggerConfig as DeletedConfig;
 use crate::triggers::registry::TriggerRegistry;
 use async_trait::async_trait;
-use iii_sdk::{IIIError, TriggerConfig, TriggerHandler};
+use iii_sdk::errors::Error;
+use iii_sdk::trigger::{TriggerConfig, TriggerHandler};
 use std::sync::Arc;
 
 pub struct ObjectCreatedHandler {
@@ -22,12 +23,12 @@ pub struct ObjectCreatedHandler {
 
 #[async_trait]
 impl TriggerHandler for ObjectCreatedHandler {
-    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         let cfg: CreatedConfig = serde_json::from_value(config.config.clone()).map_err(|e| {
             // Build the envelope through serde_json so internal quotes,
             // newlines, and other JSON-special chars in `e` are escaped
             // rather than producing malformed JSON.
-            IIIError::Handler(
+            Error::Handler(
                 serde_json::json!({
                     "code": "CONFIG_ERROR",
                     "message": format!("object-created config: {e}"),
@@ -36,7 +37,7 @@ impl TriggerHandler for ObjectCreatedHandler {
             )
         })?;
         if !self.wired_buckets.contains(&cfg.bucket) {
-            return Err(IIIError::Handler(
+            return Err(Error::Handler(
                 serde_json::json!({
                     "code": "CONFIG_ERROR",
                     "message": format!(
@@ -62,7 +63,7 @@ impl TriggerHandler for ObjectCreatedHandler {
         Ok(())
     }
 
-    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         self.registry.unregister(&config.id);
         tracing::info!(instance = %config.id, "object-created trigger unregistered");
         Ok(())
@@ -76,9 +77,9 @@ pub struct ObjectDeletedHandler {
 
 #[async_trait]
 impl TriggerHandler for ObjectDeletedHandler {
-    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         let cfg: DeletedConfig = serde_json::from_value(config.config.clone()).map_err(|e| {
-            IIIError::Handler(
+            Error::Handler(
                 serde_json::json!({
                     "code": "CONFIG_ERROR",
                     "message": format!("object-deleted config: {e}"),
@@ -87,7 +88,7 @@ impl TriggerHandler for ObjectDeletedHandler {
             )
         })?;
         if !self.wired_buckets.contains(&cfg.bucket) {
-            return Err(IIIError::Handler(
+            return Err(Error::Handler(
                 serde_json::json!({
                     "code": "CONFIG_ERROR",
                     "message": format!(
@@ -113,7 +114,7 @@ impl TriggerHandler for ObjectDeletedHandler {
         Ok(())
     }
 
-    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         self.registry.unregister(&config.id);
         tracing::info!(instance = %config.id, "object-deleted trigger unregistered");
         Ok(())

--- a/storage/tests/integration.rs
+++ b/storage/tests/integration.rs
@@ -11,7 +11,8 @@ use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
-use iii_sdk::{register_worker, InitOptions, TriggerRequest};
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::{register_worker, InitOptions};
 use serde_json::json;
 use tokio::time::{sleep, timeout};
 
@@ -80,7 +81,10 @@ async fn boot() -> Option<Harness> {
 /// Returns the last response value (or panics with the last error). The worker
 /// spawns rustfs and waits for the sidecar to become healthy before
 /// registering functions, so there's a non-trivial readiness window.
-async fn put_when_ready(client: &iii_sdk::III, payload: serde_json::Value) -> serde_json::Value {
+async fn put_when_ready(
+    client: &iii_sdk::IIIClient,
+    payload: serde_json::Value,
+) -> serde_json::Value {
     let deadline = std::time::Instant::now() + Duration::from_secs(30);
     let mut last_err: Option<String> = None;
     while std::time::Instant::now() < deadline {
@@ -139,7 +143,7 @@ async fn put_then_get_round_trips_via_rustfs() {
 
     assert!(put.is_object(), "putObject should return an object");
 
-    let get = timeout(
+    let get: serde_json::Value = timeout(
         Duration::from_secs(10),
         client.trigger(TriggerRequest {
             function_id: "storage::getObject".into(),


### PR DESCRIPTION
Bump iii-sdk to 0.20.0 per https://iii.dev/docs/upgrading/from-0-19-x.md. Build, fmt, clippy and tests green locally; surface parity (functions + triggers) verified 1:1 via collect_worker_interface.py. No iii-helpers needed (storage uses no moved/helpers types).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SDK dependency to the latest compatible version.
  * Aligned imports and type usage with the newer SDK API across storage components.
* **Bug Fixes**
  * Adjusted error conversion to match the updated error type, preserving expected error reporting.
  * Updated trigger and integration handling to work with the new client type without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->