### PR TITLE
chore(web): bump iii-sdk to 0.20.0

### DIFF
--- a/web/Cargo.lock
+++ b/web/Cargo.lock
@@ -757,16 +757,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-observability"
-version = "0.19.4"
+name = "iii-helpers"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a3002534a53d85c86e4be167cf7ae8c1de809ab3130ecfcb2d85eb4afd1272"
+checksum = "09daa7c14a9e4c1f7077c4a181918d207e3f05cdfea8b2d7781bbeb80caf4c5d"
 dependencies = [
  "futures-util",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry_sdk",
  "reqwest",
+ "schemars",
+ "serde",
  "serde_json",
  "sysinfo",
  "tokio",
@@ -777,14 +779,14 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8490f2ad470d54cf7e0bc2f4105aca71bdb4c24752fcb406183f24b8dd328f80"
+checksum = "5957568413b9a5178c11bf91b20909e93e568b187e259e941ba6009a7ec3f5c1"
 dependencies = [
  "async-trait",
  "futures-util",
  "hostname",
- "iii-observability",
+ "iii-helpers",
  "reqwest",
  "schemars",
  "serde",

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -15,7 +15,7 @@ name = "web"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.19.2"
+iii-sdk = "=0.20.0"
 arc-swap = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time", "net"] }
 serde = { version = "1", features = ["derive"] }

--- a/web/src/configuration.rs
+++ b/web/src/configuration.rs
@@ -5,7 +5,9 @@
 
 use std::time::Duration;
 
-use iii_sdk::{IIIError, RegisterFunction, RegisterTriggerInput, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::{json, Value};
 
 use crate::config::{SharedConfig, WebConfig};
@@ -20,7 +22,7 @@ pub struct SharedState {
     pub config: SharedConfig,
 }
 
-pub async fn register_config(iii: &III, seed: Option<&WebConfig>) -> Result<(), String> {
+pub async fn register_config(iii: &IIIClient, seed: Option<&WebConfig>) -> Result<(), String> {
     let mut payload = json!({
         "id": CONFIG_ID,
         "name": "web",
@@ -36,7 +38,7 @@ pub async fn register_config(iii: &III, seed: Option<&WebConfig>) -> Result<(), 
     Ok(())
 }
 
-pub async fn fetch_config(iii: &III) -> Result<WebConfig, String> {
+pub async fn fetch_config(iii: &IIIClient) -> Result<WebConfig, String> {
     match try_get_value(iii).await? {
         Some(v) if !v.is_null() => WebConfig::from_json(&v),
         _ => {
@@ -46,7 +48,7 @@ pub async fn fetch_config(iii: &III) -> Result<WebConfig, String> {
     }
 }
 
-async fn should_seed_default(iii: &III) -> Result<bool, String> {
+async fn should_seed_default(iii: &IIIClient) -> Result<bool, String> {
     match try_get_value(iii).await? {
         None => Ok(true),
         Some(v) if v.is_null() => Ok(true),
@@ -54,7 +56,7 @@ async fn should_seed_default(iii: &III) -> Result<bool, String> {
     }
 }
 
-async fn try_get_value(iii: &III) -> Result<Option<Value>, String> {
+async fn try_get_value(iii: &IIIClient) -> Result<Option<Value>, String> {
     match trigger_with_retry(iii, "configuration::get", json!({ "id": CONFIG_ID })).await {
         Ok(resp) => Ok(resp.get("value").cloned()),
         Err(e) if e.contains("NOT_FOUND") => Ok(None),
@@ -74,7 +76,7 @@ struct OnConfigChangeResponse {
     ok: bool,
 }
 
-pub fn register_config_trigger(iii: &III, state: SharedState) -> Result<(), IIIError> {
+pub fn register_config_trigger(iii: &IIIClient, state: SharedState) -> Result<(), Error> {
     let st = state.clone();
     let engine = iii.clone();
     iii.register_function(
@@ -84,7 +86,7 @@ pub fn register_config_trigger(iii: &III, state: SharedState) -> Result<(), IIIE
             let engine = engine.clone();
             async move {
                 on_config_change(&engine, &st).await;
-                Ok::<OnConfigChangeResponse, IIIError>(OnConfigChangeResponse { ok: true })
+                Ok::<OnConfigChangeResponse, Error>(OnConfigChangeResponse { ok: true })
             }
         })
         .description(
@@ -101,7 +103,7 @@ pub fn register_config_trigger(iii: &III, state: SharedState) -> Result<(), IIIE
     Ok(())
 }
 
-async fn on_config_change(iii: &III, state: &SharedState) {
+async fn on_config_change(iii: &IIIClient, state: &SharedState) {
     match fetch_config(iii).await {
         Ok(cfg) => {
             apply_config(state, cfg).await;
@@ -111,7 +113,11 @@ async fn on_config_change(iii: &III, state: &SharedState) {
     }
 }
 
-async fn trigger_with_retry(iii: &III, function_id: &str, payload: Value) -> Result<Value, String> {
+async fn trigger_with_retry(
+    iii: &IIIClient,
+    function_id: &str,
+    payload: Value,
+) -> Result<Value, String> {
     let mut last_err = String::new();
     for attempt in 1..=CONFIG_RETRIES {
         match iii

--- a/web/src/functions/fetch.rs
+++ b/web/src/functions/fetch.rs
@@ -7,7 +7,8 @@ use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 
 use futures::FutureExt;
-use iii_sdk::{IIIError, RegisterFunction, III};
+use iii_sdk::errors::Error;
+use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::{json, Value};
 
 use crate::config::{SharedConfig, WebConfig};
@@ -28,7 +29,7 @@ pub async fn handle(payload: Value, cfg: &WebConfig) -> Value {
     execute_fetch(parsed, cfg).await
 }
 
-pub fn register(iii: &Arc<III>, shared: &SharedConfig) {
+pub fn register(iii: &Arc<IIIClient>, shared: &SharedConfig) {
     let shared = shared.clone();
     iii.register_function(
         "web::fetch",
@@ -42,7 +43,7 @@ pub fn register(iii: &Arc<III>, shared: &SharedConfig) {
                 let envelope = result.unwrap_or_else(|_| {
                     json!({ "ok": false, "error": "transport_error", "message": "internal error" })
                 });
-                Ok::<Value, IIIError>(envelope)
+                Ok::<Value, Error>(envelope)
             }
         })
         .description(TOOL_DESCRIPTION)

--- a/web/src/functions/mod.rs
+++ b/web/src/functions/mod.rs
@@ -2,12 +2,12 @@
 
 use std::sync::Arc;
 
-use iii_sdk::III;
+use iii_sdk::IIIClient;
 
 use crate::config::SharedConfig;
 
 pub mod fetch;
 
-pub fn register_all(iii: &Arc<III>, shared: &SharedConfig) {
+pub fn register_all(iii: &Arc<IIIClient>, shared: &SharedConfig) {
     fetch::register(iii, shared);
 }

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use iii_sdk::{register_worker, InitOptions, WorkerMetadata};
+use iii_sdk::runtime::WorkerMetadata;
+use iii_sdk::{register_worker, InitOptions};
 
 use web::config::WebConfig;
 use web::{configuration, functions, manifest};


### PR DESCRIPTION
Bump iii-sdk to 0.20.0 per https://iii.dev/docs/upgrading/from-0-19-x.md. Build, fmt, clippy and tests green locally (55 tests); surface parity (7 functions) verified 1:1 via collect_worker_interface.py. No iii-helpers needed.