### PR TITLE
chore(lsp): bump iii-sdk to 0.20.0

### DIFF
--- a/lsp/Cargo.lock
+++ b/lsp/Cargo.lock
@@ -711,16 +711,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-observability"
-version = "0.19.2"
+name = "iii-helpers"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11586fcd304a563c143837f67b2e5f3cb73d23f6c8452c9734ff18e4a1402bf"
+checksum = "09daa7c14a9e4c1f7077c4a181918d207e3f05cdfea8b2d7781bbeb80caf4c5d"
 dependencies = [
  "futures-util",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry_sdk",
  "reqwest",
+ "schemars",
+ "serde",
  "serde_json",
  "sysinfo",
  "tokio",
@@ -731,14 +733,14 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8490f2ad470d54cf7e0bc2f4105aca71bdb4c24752fcb406183f24b8dd328f80"
+checksum = "5957568413b9a5178c11bf91b20909e93e568b187e259e941ba6009a7ec3f5c1"
 dependencies = [
  "async-trait",
  "futures-util",
  "hostname",
- "iii-observability",
+ "iii-helpers",
  "reqwest",
  "schemars",
  "serde",
@@ -862,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "lsp"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "clap",
  "dashmap",

--- a/lsp/Cargo.toml
+++ b/lsp/Cargo.toml
@@ -13,7 +13,7 @@ name = "lsp"
 path = "src/main.rs"
 
 [dependencies]
-iii-sdk = "=0.19.2"
+iii-sdk = "=0.20.0"
 tower-lsp-server = "0.23"
 tree-sitter = "0.24"
 tree-sitter-typescript = "0.23"

--- a/lsp/src/engine_client.rs
+++ b/lsp/src/engine_client.rs
@@ -1,11 +1,12 @@
 use dashmap::{DashMap, DashSet};
-use iii_sdk::{register_worker, IIIConnectionState, InitOptions, WorkerMetadata, III};
+use iii_sdk::runtime::{IIIConnectionState, WorkerMetadata};
+use iii_sdk::{register_worker, IIIClient, InitOptions};
 use std::sync::{Arc, Mutex};
 
 use crate::engine_introspection::{self, FunctionInfo, TriggerInfo, TriggerTypeInfo, WorkerInfo};
 
 pub struct EngineClient {
-    iii: III,
+    iii: IIIClient,
     pub functions: DashMap<String, FunctionInfo>,
     pub trigger_types: DashMap<String, TriggerTypeInfo>,
     pub workers: DashMap<String, WorkerInfo>,

--- a/lsp/src/engine_introspection.rs
+++ b/lsp/src/engine_introspection.rs
@@ -1,4 +1,6 @@
-use iii_sdk::{IIIError, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -51,7 +53,7 @@ pub struct WorkerInfo {
     pub isolation: Option<String>,
 }
 
-pub async fn list_functions(iii: &III) -> Result<Vec<FunctionInfo>, IIIError> {
+pub async fn list_functions(iii: &IIIClient) -> Result<Vec<FunctionInfo>, Error> {
     let result = iii
         .trigger(TriggerRequest {
             function_id: "engine::functions::list".into(),
@@ -66,7 +68,7 @@ pub async fn list_functions(iii: &III) -> Result<Vec<FunctionInfo>, IIIError> {
         .unwrap_or_default())
 }
 
-pub async fn list_workers(iii: &III) -> Result<Vec<WorkerInfo>, IIIError> {
+pub async fn list_workers(iii: &IIIClient) -> Result<Vec<WorkerInfo>, Error> {
     let result = iii
         .trigger(TriggerRequest {
             function_id: "engine::workers::list".into(),
@@ -82,9 +84,9 @@ pub async fn list_workers(iii: &III) -> Result<Vec<WorkerInfo>, IIIError> {
 }
 
 pub async fn list_triggers(
-    iii: &III,
+    iii: &IIIClient,
     include_internal: bool,
-) -> Result<Vec<TriggerInfo>, IIIError> {
+) -> Result<Vec<TriggerInfo>, Error> {
     let result = iii
         .trigger(TriggerRequest {
             function_id: "engine::registered-triggers::list".into(),
@@ -100,9 +102,9 @@ pub async fn list_triggers(
 }
 
 pub async fn list_trigger_types(
-    iii: &III,
+    iii: &IIIClient,
     include_internal: bool,
-) -> Result<Vec<TriggerTypeInfo>, IIIError> {
+) -> Result<Vec<TriggerTypeInfo>, Error> {
     let result = iii
         .trigger(TriggerRequest {
             function_id: "engine::triggers::list".into(),


### PR DESCRIPTION
Bump iii-sdk to 0.20.0 per https://iii.dev/docs/upgrading/from-0-19-x.md. Build, fmt, clippy, tests green (63 tests). lsp is a stdio language server (no registered surface, interface_smoke:false) so no parity diff applies. No iii-helpers needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the engine integration to work with the latest supported SDK version.
  * Improved compatibility in language-server features that inspect functions, workers, triggers, and trigger types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->