### PR TITLE
chore(context-manager): bump iii-sdk to 0.20.0

### DIFF
--- a/context-manager/Cargo.lock
+++ b/context-manager/Cargo.lock
@@ -938,16 +938,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-observability"
-version = "0.19.2"
+name = "iii-helpers"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11586fcd304a563c143837f67b2e5f3cb73d23f6c8452c9734ff18e4a1402bf"
+checksum = "09daa7c14a9e4c1f7077c4a181918d207e3f05cdfea8b2d7781bbeb80caf4c5d"
 dependencies = [
  "futures-util",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry_sdk",
  "reqwest",
+ "schemars",
+ "serde",
  "serde_json",
  "sysinfo",
  "tokio",
@@ -958,14 +960,14 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8490f2ad470d54cf7e0bc2f4105aca71bdb4c24752fcb406183f24b8dd328f80"
+checksum = "5957568413b9a5178c11bf91b20909e93e568b187e259e941ba6009a7ec3f5c1"
 dependencies = [
  "async-trait",
  "futures-util",
  "hostname",
- "iii-observability",
+ "iii-helpers",
  "reqwest",
  "schemars",
  "serde",

--- a/context-manager/Cargo.toml
+++ b/context-manager/Cargo.toml
@@ -15,7 +15,7 @@ name = "context_manager"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.19.2"
+iii-sdk = "=0.20.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/context-manager/src/adapters/router.rs
+++ b/context-manager/src/adapters/router.rs
@@ -10,8 +10,10 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
+use iii_sdk::errors::Error;
 use iii_sdk::helpers::create_channel;
-use iii_sdk::{IIIError, TriggerRequest, III};
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
 use serde_json::{json, Value};
 
 use crate::configuration::ConfigCell;
@@ -24,18 +26,18 @@ const MODELS_GET_TIMEOUT_MS: u64 = 5_000;
 /// trigger response, so this only covers socket latency.
 const READER_DRAIN_MS: u64 = 2_000;
 
-fn is_unroutable(err: &IIIError) -> bool {
+fn is_unroutable(err: &Error) -> bool {
     let msg = err.to_string().to_lowercase();
     msg.contains("function_not_found") || msg.contains("not found") || msg.contains("no function")
 }
 
 /// `router::models::get` — `{ model: Model } | null`.
 pub struct RouterModelResolver {
-    iii: Arc<III>,
+    iii: Arc<IIIClient>,
 }
 
 impl RouterModelResolver {
-    pub fn new(iii: Arc<III>) -> Self {
+    pub fn new(iii: Arc<IIIClient>) -> Self {
         Self { iii }
     }
 }
@@ -82,12 +84,12 @@ impl ModelResolver for RouterModelResolver {
 /// `summarizer_timeout_ms` change hot-applies on the next call with no
 /// rebuild.
 pub struct RouterSummarizer {
-    iii: Arc<III>,
+    iii: Arc<IIIClient>,
     config: ConfigCell,
 }
 
 impl RouterSummarizer {
-    pub fn new(iii: Arc<III>, config: ConfigCell) -> Self {
+    pub fn new(iii: Arc<IIIClient>, config: ConfigCell) -> Self {
         Self { iii, config }
     }
 }

--- a/context-manager/src/configuration.rs
+++ b/context-manager/src/configuration.rs
@@ -19,7 +19,9 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use iii_sdk::{IIIError, RegisterFunction, RegisterTriggerInput, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::{json, Value};
 use tokio::sync::RwLock;
 
@@ -47,7 +49,7 @@ const CONFIG_RETRY_BACKOFF_MS: u64 = 250;
 /// as `initial_value`. Otherwise, the built-in default is seeded only
 /// when no stored value exists yet (re-registration preserves the stored
 /// value, so this is safe to call every boot).
-pub async fn register_config(iii: &III, seed: Option<&WorkerConfig>) -> Result<(), String> {
+pub async fn register_config(iii: &IIIClient, seed: Option<&WorkerConfig>) -> Result<(), String> {
     let mut payload = json!({
         "id": CONFIG_ID,
         "name": "Context Manager",
@@ -67,7 +69,7 @@ pub async fn register_config(iii: &III, seed: Option<&WorkerConfig>) -> Result<(
 
 /// Read the live `context-manager` configuration (env-expanded by the
 /// configuration worker — `from_json` does NOT re-expand).
-pub async fn fetch_config(iii: &III) -> Result<WorkerConfig, String> {
+pub async fn fetch_config(iii: &IIIClient) -> Result<WorkerConfig, String> {
     let value = get_config_value(iii).await?;
     if value.is_null() {
         tracing::info!("no configuration value found; using built-in default configuration");
@@ -76,7 +78,7 @@ pub async fn fetch_config(iii: &III) -> Result<WorkerConfig, String> {
     WorkerConfig::from_json(&value)
 }
 
-async fn should_seed_default_value(iii: &III) -> Result<bool, String> {
+async fn should_seed_default_value(iii: &IIIClient) -> Result<bool, String> {
     match try_get_config_value(iii).await? {
         None => Ok(true),
         Some(value) if value.is_null() => Ok(true),
@@ -84,7 +86,7 @@ async fn should_seed_default_value(iii: &III) -> Result<bool, String> {
     }
 }
 
-async fn get_config_value(iii: &III) -> Result<Value, String> {
+async fn get_config_value(iii: &IIIClient) -> Result<Value, String> {
     try_get_config_value(iii)
         .await?
         .ok_or_else(|| format!("configuration `{CONFIG_ID}` not found"))
@@ -93,7 +95,7 @@ async fn get_config_value(iii: &III) -> Result<Value, String> {
 /// Returns `Ok(None)` when the entry does not exist. The engine's
 /// missing-entry codes vary in case (`function_not_found`,
 /// `STATEMENT_NOT_FOUND`, `NOT_FOUND`), so match case-insensitively.
-async fn try_get_config_value(iii: &III) -> Result<Option<Value>, String> {
+async fn try_get_config_value(iii: &IIIClient) -> Result<Option<Value>, String> {
     match trigger_with_retry(iii, "configuration::get", json!({ "id": CONFIG_ID })).await {
         Ok(resp) => Ok(resp.get("value").cloned()),
         Err(e) if e.to_ascii_uppercase().contains("NOT_FOUND") => Ok(None),
@@ -130,10 +132,10 @@ pub struct OnConfigChangeResponse {
 /// swaps when `lease_dir` changes; every other field is read per call, so
 /// nothing requires a restart.
 pub fn register_config_trigger(
-    iii: &III,
+    iii: &IIIClient,
     cell: ConfigCell,
     leases: LeaseCell,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let cell_for_fn = cell.clone();
     let leases_for_fn = leases.clone();
     let engine = iii.clone();
@@ -145,7 +147,7 @@ pub fn register_config_trigger(
             let engine = engine.clone();
             async move {
                 on_config_change(&engine, &cell, &leases).await;
-                Ok::<OnConfigChangeResponse, IIIError>(OnConfigChangeResponse { ok: true })
+                Ok::<OnConfigChangeResponse, Error>(OnConfigChangeResponse { ok: true })
             }
         })
         .description(
@@ -179,7 +181,7 @@ pub fn register_config_trigger(
 /// before swapping the snapshot. A rebuild failure (an unopenable dir)
 /// keeps the previous store AND config (last-good) so the live snapshot's
 /// `lease_dir` never diverges from the store actually in use.
-async fn on_config_change(iii: &III, cell: &ConfigCell, leases: &LeaseCell) {
+async fn on_config_change(iii: &IIIClient, cell: &ConfigCell, leases: &LeaseCell) {
     let cfg = match fetch_config(iii).await {
         Ok(cfg) => cfg,
         Err(e) => {
@@ -213,7 +215,11 @@ async fn on_config_change(iii: &III, cell: &ConfigCell, leases: &LeaseCell) {
     tracing::info!("context-manager configuration reloaded");
 }
 
-async fn trigger_with_retry(iii: &III, function_id: &str, payload: Value) -> Result<Value, String> {
+async fn trigger_with_retry(
+    iii: &IIIClient,
+    function_id: &str,
+    payload: Value,
+) -> Result<Value, String> {
     let mut last_err = String::new();
     for attempt in 1..=CONFIG_RETRIES {
         match iii

--- a/context-manager/src/error.rs
+++ b/context-manager/src/error.rs
@@ -6,7 +6,7 @@
 //! `could not resolve model limits` — are kept word-for-word in the
 //! message part so callers can match on the documented strings.
 
-use iii_sdk::IIIError;
+use iii_sdk::errors::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ContextError {
@@ -36,9 +36,9 @@ impl ContextError {
     }
 }
 
-impl From<ContextError> for IIIError {
+impl From<ContextError> for Error {
     fn from(e: ContextError) -> Self {
-        IIIError::Handler(e.to_string())
+        Error::Handler(e.to_string())
     }
 }
 

--- a/context-manager/src/functions/mod.rs
+++ b/context-manager/src/functions/mod.rs
@@ -14,7 +14,8 @@ pub mod prune;
 use std::future::Future;
 use std::sync::Arc;
 
-use iii_sdk::{IIIError, RegisterFunction, III};
+use iii_sdk::errors::Error;
+use iii_sdk::{IIIClient, RegisterFunction};
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -72,7 +73,7 @@ pub(crate) async fn resolve_model(
 /// Register one typed handler under `id`, mapping `ContextError` into
 /// the bus error shape (`code: message`).
 fn register<Req, Resp, F, Fut>(
-    iii: &Arc<III>,
+    iii: &Arc<IIIClient>,
     deps: &Arc<Deps>,
     id: &str,
     description: &str,
@@ -89,13 +90,13 @@ fn register<Req, Resp, F, Fut>(
         RegisterFunction::new_async(move |req: Req| {
             let deps = deps.clone();
             let handler = handler.clone();
-            async move { handler(deps, req).await.map_err(IIIError::from) }
+            async move { handler(deps, req).await.map_err(Error::from) }
         })
         .description(description),
     );
 }
 
-pub fn register_all(iii: &Arc<III>, deps: &Arc<Deps>) {
+pub fn register_all(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
     register(iii, deps, ASSEMBLE_ID, ASSEMBLE_DESC, |d, r| async move {
         assemble::handle(&d, r).await
     });

--- a/context-manager/src/main.rs
+++ b/context-manager/src/main.rs
@@ -24,7 +24,8 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use iii_sdk::{register_worker, InitOptions, WorkerMetadata};
+use iii_sdk::runtime::WorkerMetadata;
+use iii_sdk::{register_worker, InitOptions};
 use tokio::sync::RwLock;
 
 use context_manager::adapters::fs_lease::FsLeaseStore;

--- a/context-manager/tests/common/engine.rs
+++ b/context-manager/tests/common/engine.rs
@@ -8,19 +8,21 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use iii_sdk::{register_worker, IIIError, InitOptions, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::{register_worker, IIIClient, InitOptions};
 use serde_json::json;
 use tokio::sync::OnceCell;
 
 const DEFAULT_WS_URL: &str = "ws://127.0.0.1:49134";
 
-static ENGINE: OnceCell<Option<Arc<III>>> = OnceCell::const_new();
+static ENGINE: OnceCell<Option<Arc<IIIClient>>> = OnceCell::const_new();
 
 pub fn ws_url() -> String {
     std::env::var("III_ENGINE_WS_URL").unwrap_or_else(|_| DEFAULT_WS_URL.to_string())
 }
 
-async fn try_connect_raw() -> Option<Arc<III>> {
+async fn try_connect_raw() -> Option<Arc<IIIClient>> {
     let url = ws_url();
     let iii = Arc::new(register_worker(&url, InitOptions::default()));
 
@@ -36,7 +38,7 @@ async fn try_connect_raw() -> Option<Arc<III>> {
             .await;
         match probe {
             Ok(_) => return Some(iii),
-            Err(IIIError::NotConnected) => continue,
+            Err(Error::NotConnected) => continue,
             Err(_) => continue,
         }
     }
@@ -51,7 +53,7 @@ async fn try_connect_raw() -> Option<Arc<III>> {
 
 /// Get-or-init the shared engine handle, registering the production
 /// context-manager surface in-process on first success.
-pub async fn get_or_init() -> Option<Arc<III>> {
+pub async fn get_or_init() -> Option<Arc<IIIClient>> {
     ENGINE
         .get_or_init(|| async {
             let iii = try_connect_raw().await?;

--- a/context-manager/tests/common/workers.rs
+++ b/context-manager/tests/common/workers.rs
@@ -13,7 +13,8 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use iii_sdk::{TriggerRequest, III};
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
 use tokio::sync::{OnceCell, RwLock};
 
 use context_manager::adapters::fs_lease::FsLeaseStore;
@@ -25,7 +26,7 @@ use context_manager::ports::{lease_cell, Deps, SystemClock};
 static REGISTERED: OnceCell<()> = OnceCell::const_new();
 
 /// Idempotent: the first caller registers; subsequent callers reuse.
-pub async fn register_all(iii: &Arc<III>) {
+pub async fn register_all(iii: &Arc<IIIClient>) {
     REGISTERED
         .get_or_init(|| async {
             let cfg = WorkerConfig::default();
@@ -59,7 +60,7 @@ pub async fn register_all(iii: &Arc<III>) {
 /// Poll the engine until `function_id` is routable, panicking after a
 /// deadline. An `Err` carrying a `context/` code also counts as
 /// routable — it proves the call reached the production handler.
-async fn wait_until_routable(iii: &Arc<III>, function_id: &str) {
+async fn wait_until_routable(iii: &Arc<IIIClient>, function_id: &str) {
     let deadline = std::time::Instant::now() + Duration::from_secs(10);
     loop {
         let res = iii

--- a/context-manager/tests/common/world.rs
+++ b/context-manager/tests/common/world.rs
@@ -16,7 +16,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use cucumber::World;
-use iii_sdk::{TriggerRequest, III};
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
 use serde_json::Value;
 use tokio::sync::RwLock;
 
@@ -55,7 +56,7 @@ pub struct ContextWorld {
     pub aliases: HashMap<String, String>,
 
     /// Shared engine connection; `None` soft-skips @engine steps.
-    pub engine: Option<Arc<III>>,
+    pub engine: Option<Arc<IIIClient>>,
 }
 
 impl std::fmt::Debug for ContextWorld {

--- a/context-manager/tests/integration.rs
+++ b/context-manager/tests/integration.rs
@@ -5,7 +5,9 @@
 use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
-use iii_sdk::{register_worker, IIIError, InitOptions, TriggerRequest};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::{register_worker, InitOptions};
 use serde_json::json;
 use tokio::time::{sleep, timeout};
 
@@ -81,7 +83,7 @@ async fn end_to_end_via_iii_sdk() {
         .await;
         match attempt {
             Ok(Ok(v)) => break v,
-            Ok(Err(IIIError::NotConnected)) | Err(_) => {}
+            Ok(Err(Error::NotConnected)) | Err(_) => {}
             Ok(Err(_)) => {}
         }
         assert!(


### PR DESCRIPTION
Bump iii-sdk to 0.20.0 per https://iii.dev/docs/upgrading/from-0-19-x.md. Build, fmt, clippy, tests green (77 tests); surface parity (5 functions) verified 1:1 via collect_worker_interface.py. No iii-helpers needed. No import aliases (real names used).