### PR TITLE
chore(approval-gate): bump iii-sdk to 0.20.0

### DIFF
--- a/approval-gate/Cargo.lock
+++ b/approval-gate/Cargo.lock
@@ -83,7 +83,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "approval-gate"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "approval-gate",
@@ -92,7 +92,7 @@ dependencies = [
  "clap",
  "futures",
  "harness",
- "iii-sdk",
+ "iii-sdk 0.20.0",
  "regex",
  "schemars",
  "serde",
@@ -545,14 +545,14 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
  "clap",
  "globset",
  "iii-observability",
- "iii-sdk",
+ "iii-sdk 0.19.2",
  "jsonschema",
  "schemars",
  "serde",
@@ -805,6 +805,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-helpers"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09daa7c14a9e4c1f7077c4a181918d207e3f05cdfea8b2d7781bbeb80caf4c5d"
+dependencies = [
+ "futures-util",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry_sdk",
+ "reqwest",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sysinfo",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "iii-observability"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,6 +854,27 @@ dependencies = [
  "futures-util",
  "hostname",
  "iii-observability",
+ "reqwest",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "iii-sdk"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5957568413b9a5178c11bf91b20909e93e568b187e259e941ba6009a7ec3f5c1"
+dependencies = [
+ "async-trait",
+ "futures-util",
+ "hostname",
+ "iii-helpers",
  "reqwest",
  "schemars",
  "serde",

--- a/approval-gate/Cargo.toml
+++ b/approval-gate/Cargo.toml
@@ -15,7 +15,7 @@ name = "approval_gate"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.19.2"
+iii-sdk = "=0.20.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/approval-gate/src/configuration.rs
+++ b/approval-gate/src/configuration.rs
@@ -14,7 +14,9 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use iii_sdk::{IIIError, RegisterFunction, RegisterTriggerInput, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::{json, Value};
 use tokio::sync::RwLock;
 
@@ -45,7 +47,7 @@ const HOOK_ON_ERROR: &str = "fail_closed";
 /// as `initial_value`. Otherwise, the built-in default is seeded only
 /// when no stored value exists yet (re-registration preserves the stored
 /// value, so this is safe to call every boot).
-pub async fn register_config(iii: &III, seed: Option<&WorkerConfig>) -> Result<(), String> {
+pub async fn register_config(iii: &IIIClient, seed: Option<&WorkerConfig>) -> Result<(), String> {
     let mut payload = json!({
         "id": CONFIG_ID,
         "name": "Approval Gate",
@@ -66,7 +68,7 @@ pub async fn register_config(iii: &III, seed: Option<&WorkerConfig>) -> Result<(
 
 /// Read the live `approval-gate` configuration (env-expanded by the
 /// configuration worker — `from_json` does NOT re-expand).
-pub async fn fetch_config(iii: &III) -> Result<WorkerConfig, String> {
+pub async fn fetch_config(iii: &IIIClient) -> Result<WorkerConfig, String> {
     let value = get_config_value(iii).await?;
     if value.is_null() {
         tracing::info!("no configuration value found; using built-in default configuration");
@@ -75,7 +77,7 @@ pub async fn fetch_config(iii: &III) -> Result<WorkerConfig, String> {
     WorkerConfig::from_json(&value)
 }
 
-async fn should_seed_default_value(iii: &III) -> Result<bool, String> {
+async fn should_seed_default_value(iii: &IIIClient) -> Result<bool, String> {
     match try_get_config_value(iii).await? {
         None => Ok(true),
         Some(value) if value.is_null() => Ok(true),
@@ -83,7 +85,7 @@ async fn should_seed_default_value(iii: &III) -> Result<bool, String> {
     }
 }
 
-async fn get_config_value(iii: &III) -> Result<Value, String> {
+async fn get_config_value(iii: &IIIClient) -> Result<Value, String> {
     try_get_config_value(iii)
         .await?
         .ok_or_else(|| format!("configuration `{CONFIG_ID}` not found"))
@@ -92,7 +94,7 @@ async fn get_config_value(iii: &III) -> Result<Value, String> {
 /// Returns `Ok(None)` when the entry does not exist. The engine's
 /// missing-entry codes vary in case (`function_not_found`,
 /// `STATEMENT_NOT_FOUND`, `NOT_FOUND`), so match case-insensitively.
-async fn try_get_config_value(iii: &III) -> Result<Option<Value>, String> {
+async fn try_get_config_value(iii: &IIIClient) -> Result<Option<Value>, String> {
     match trigger_with_retry(iii, "configuration::get", json!({ "id": CONFIG_ID })).await {
         Ok(resp) => Ok(resp.get("value").cloned()),
         Err(e) if e.to_ascii_uppercase().contains("NOT_FOUND") => Ok(None),
@@ -106,7 +108,7 @@ pub async fn apply_config(cell: &ConfigCell, cfg: WorkerConfig) {
 }
 
 /// Bind the fixed `harness::hook::pre-trigger` hook at worker startup.
-pub fn bind_hook(iii: &III) {
+pub fn bind_hook(iii: &IIIClient) {
     match iii.register_trigger(RegisterTriggerInput {
         trigger_type: "harness::hook::pre-trigger".to_string(),
         function_id: "approval::gate".to_string(),
@@ -151,7 +153,7 @@ pub struct OnConfigChangeResponse {
 /// Register the internal config-change handler and bind a `configuration`
 /// trigger. The handler re-fetches via `configuration::get` and ignores the
 /// trigger payload, so a direct call can never inject config.
-pub fn register_config_trigger(iii: &III, cell: ConfigCell) -> Result<(), IIIError> {
+pub fn register_config_trigger(iii: &IIIClient, cell: ConfigCell) -> Result<(), Error> {
     let cell_for_fn = cell.clone();
     let engine = iii.clone();
     iii.register_function(
@@ -161,7 +163,7 @@ pub fn register_config_trigger(iii: &III, cell: ConfigCell) -> Result<(), IIIErr
             let engine = engine.clone();
             async move {
                 on_config_change(&engine, &cell).await;
-                Ok::<OnConfigChangeResponse, IIIError>(OnConfigChangeResponse { ok: true })
+                Ok::<OnConfigChangeResponse, Error>(OnConfigChangeResponse { ok: true })
             }
         })
         .description(
@@ -189,7 +191,7 @@ pub fn register_config_trigger(iii: &III, cell: ConfigCell) -> Result<(), IIIErr
 /// trusting `payload.new_value` would let any caller inject arbitrary
 /// config without updating persisted state. Re-fetch the stored value via
 /// `configuration::get` instead.
-async fn on_config_change(iii: &III, cell: &ConfigCell) {
+async fn on_config_change(iii: &IIIClient, cell: &ConfigCell) {
     let cfg = match fetch_config(iii).await {
         Ok(cfg) => cfg,
         Err(e) => {
@@ -205,7 +207,11 @@ async fn on_config_change(iii: &III, cell: &ConfigCell) {
     tracing::info!("approval-gate configuration reloaded");
 }
 
-async fn trigger_with_retry(iii: &III, function_id: &str, payload: Value) -> Result<Value, String> {
+async fn trigger_with_retry(
+    iii: &IIIClient,
+    function_id: &str,
+    payload: Value,
+) -> Result<Value, String> {
     let mut last_err = String::new();
     for attempt in 1..=CONFIG_RETRIES {
         match iii

--- a/approval-gate/src/error.rs
+++ b/approval-gate/src/error.rs
@@ -2,7 +2,7 @@
 //! snake_case, worker-prefixed code in a `code: message` shape (see
 //! tech-specs/2026-06-agentic/README.md § Error conventions).
 
-use iii_sdk::IIIError;
+use iii_sdk::errors::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ApprovalError {
@@ -32,9 +32,9 @@ impl ApprovalError {
     }
 }
 
-impl From<ApprovalError> for IIIError {
+impl From<ApprovalError> for Error {
     fn from(e: ApprovalError) -> Self {
-        IIIError::Handler(e.to_string())
+        Error::Handler(e.to_string())
     }
 }
 

--- a/approval-gate/src/events.rs
+++ b/approval-gate/src/events.rs
@@ -15,10 +15,10 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use iii_sdk::{
-    IIIError, RegisterTriggerType, TriggerAction, TriggerConfig, TriggerHandler, TriggerRequest,
-    III,
-};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::trigger::{TriggerConfig, TriggerHandler};
+use iii_sdk::{IIIClient, RegisterTriggerType, TriggerAction};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -168,10 +168,10 @@ struct ApprovalTriggerHandler {
 
 #[async_trait]
 impl TriggerHandler for ApprovalTriggerHandler {
-    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         let id = config.id.clone();
         let function_id = config.function_id.clone();
-        self.set.add(config).map_err(IIIError::Handler)?;
+        self.set.add(config).map_err(Error::Handler)?;
         tracing::info!(
             trigger_type = self.set.trigger_type(),
             id = %id,
@@ -181,7 +181,7 @@ impl TriggerHandler for ApprovalTriggerHandler {
         Ok(())
     }
 
-    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         tracing::info!(
             trigger_type = self.set.trigger_type(),
             id = %config.id,
@@ -195,7 +195,7 @@ impl TriggerHandler for ApprovalTriggerHandler {
 /// Register both custom trigger types with the engine. Must run **before**
 /// `functions::register_all` so the handlers capture the subscriber sets
 /// they fan out to.
-pub fn register_trigger_types(iii: &Arc<III>) -> TriggerSets {
+pub fn register_trigger_types(iii: &Arc<IIIClient>) -> TriggerSets {
     let sets = TriggerSets::new();
 
     let _ = iii.register_trigger_type(
@@ -236,11 +236,11 @@ pub trait EventSink: Send + Sync {
 /// Filtered fire-and-forget fan-out to every matching binding.
 pub struct Emitter {
     sets: TriggerSets,
-    iii: Arc<III>,
+    iii: Arc<IIIClient>,
 }
 
 impl Emitter {
-    pub fn new(sets: TriggerSets, iii: Arc<III>) -> Self {
+    pub fn new(sets: TriggerSets, iii: Arc<IIIClient>) -> Self {
         Self { sets, iii }
     }
 

--- a/approval-gate/src/functions/gate.rs
+++ b/approval-gate/src/functions/gate.rs
@@ -201,7 +201,11 @@ mod tests {
         serde_json::from_value(test_hook_input("s_1", "c_1", function_id)).unwrap()
     }
 
-    async fn seed_settings(iii: &iii_sdk::III, session_id: &str, settings: &ApprovalSettings) {
+    async fn seed_settings(
+        iii: &iii_sdk::IIIClient,
+        session_id: &str,
+        settings: &ApprovalSettings,
+    ) {
         state_set(
             iii,
             SETTINGS_SCOPE,

--- a/approval-gate/src/functions/list_pending.rs
+++ b/approval-gate/src/functions/list_pending.rs
@@ -103,7 +103,13 @@ mod tests {
     use crate::pending::PENDING_SCOPE;
     use crate::testkit::{state_set, with_stack, BootOpts};
 
-    async fn seed(iii: &iii_sdk::III, sid: &str, cid: &str, pending_at: i64, owner: Option<&str>) {
+    async fn seed(
+        iii: &iii_sdk::IIIClient,
+        sid: &str,
+        cid: &str,
+        pending_at: i64,
+        owner: Option<&str>,
+    ) {
         let mut record = json!({
             "session_id": sid,
             "turn_id": "t_1",

--- a/approval-gate/src/functions/mod.rs
+++ b/approval-gate/src/functions/mod.rs
@@ -21,7 +21,8 @@ pub mod remove_always_allow;
 use std::future::Future;
 use std::sync::Arc;
 
-use iii_sdk::{IIIError, RegisterFunction, III};
+use iii_sdk::errors::Error;
+use iii_sdk::{IIIClient, RegisterFunction};
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -80,7 +81,7 @@ pub const ON_TURN_COMPLETED_DESC: &str =
 
 /// Everything a function handler needs.
 pub struct Deps {
-    pub iii: Arc<III>,
+    pub iii: Arc<IIIClient>,
     pub sink: Arc<dyn EventSink>,
     /// Hot-swappable config snapshot, sourced from the `configuration`
     /// worker and reloaded live (see [`crate::configuration`]).
@@ -100,7 +101,7 @@ impl Deps {
 /// Register one typed handler under `id`, mapping `ApprovalError` into
 /// the wire error shape (`code: message`).
 fn register<Req, Resp, F, Fut>(
-    iii: &Arc<III>,
+    iii: &Arc<IIIClient>,
     deps: &Arc<Deps>,
     id: &str,
     description: &str,
@@ -117,13 +118,13 @@ fn register<Req, Resp, F, Fut>(
         RegisterFunction::new_async(move |req: Req| {
             let deps = deps.clone();
             let handler = handler.clone();
-            async move { handler(deps, req).await.map_err(IIIError::from) }
+            async move { handler(deps, req).await.map_err(Error::from) }
         })
         .description(description),
     );
 }
 
-pub fn register_all(iii: &Arc<III>, deps: &Arc<Deps>) {
+pub fn register_all(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
     register(iii, deps, GATE_ID, GATE_DESC, |d, r| async move {
         gate::handle(&d, r).await
     });

--- a/approval-gate/src/functions/on_session_deleted.rs
+++ b/approval-gate/src/functions/on_session_deleted.rs
@@ -36,7 +36,7 @@ mod tests {
     use crate::settings::SETTINGS_SCOPE;
     use crate::testkit::{log_snapshot, state_get, state_set, with_stack, BootOpts};
 
-    async fn seed_pending(iii: &iii_sdk::III, sid: &str, cid: &str) {
+    async fn seed_pending(iii: &iii_sdk::IIIClient, sid: &str, cid: &str) {
         state_set(
             iii,
             PENDING_SCOPE,

--- a/approval-gate/src/functions/resolve.rs
+++ b/approval-gate/src/functions/resolve.rs
@@ -122,7 +122,7 @@ mod tests {
     use crate::testkit::{log_snapshot, state_get, state_set, with_stack, BootOpts};
     use crate::types::PendingApprovalRecord;
 
-    async fn seed_record(iii: &iii_sdk::III) {
+    async fn seed_record(iii: &iii_sdk::IIIClient) {
         let record = PendingApprovalRecord {
             session_id: "s_1".into(),
             turn_id: "t_9".into(),

--- a/approval-gate/src/harness.rs
+++ b/approval-gate/src/harness.rs
@@ -1,9 +1,11 @@
 //! Thin `harness::function::resolve` wrapper around `iii.trigger()`.
 
-use iii_sdk::{IIIError, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
 use serde_json::Value;
 
-pub async fn function_resolve(iii: &III, payload: Value) -> Result<Value, IIIError> {
+pub async fn function_resolve(iii: &IIIClient, payload: Value) -> Result<Value, Error> {
     iii.trigger(TriggerRequest {
         function_id: "harness::function::resolve".into(),
         payload,

--- a/approval-gate/src/main.rs
+++ b/approval-gate/src/main.rs
@@ -26,7 +26,9 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use iii_sdk::{register_worker, InitOptions, RegisterTriggerInput, WorkerMetadata, III};
+use iii_sdk::protocol::RegisterTriggerInput;
+use iii_sdk::runtime::WorkerMetadata;
+use iii_sdk::{register_worker, IIIClient, InitOptions};
 use serde_json::json;
 use tokio::sync::RwLock;
 
@@ -73,7 +75,7 @@ fn worker_metadata() -> WorkerMetadata {
 /// `trigger_type_not_found` error log, never as an `Err` here. Restart
 /// the worker after the sibling appears to re-bind.
 fn bind_best_effort(
-    iii: &Arc<III>,
+    iii: &Arc<IIIClient>,
     trigger_type: &str,
     function_id: &str,
     config: serde_json::Value,

--- a/approval-gate/src/pending.rs
+++ b/approval-gate/src/pending.rs
@@ -3,7 +3,8 @@
 //! Every record has an explicit deletion path (resolve, turn/session
 //! purge), which is what keeps `state::list` O(live holds).
 
-use iii_sdk::{IIIError, III};
+use iii_sdk::errors::Error;
+use iii_sdk::IIIClient;
 use serde_json::Value;
 
 use crate::state;
@@ -32,10 +33,10 @@ pub fn parse_record(value: &Value) -> Option<PendingApprovalRecord> {
 }
 
 pub async fn get(
-    iii: &III,
+    iii: &IIIClient,
     session_id: &str,
     function_call_id: &str,
-) -> Result<Option<PendingApprovalRecord>, IIIError> {
+) -> Result<Option<PendingApprovalRecord>, Error> {
     let reply = state::get(
         iii,
         PENDING_SCOPE,
@@ -48,7 +49,7 @@ pub async fn get(
 /// Write the record. Returns the previous value when one existed (a
 /// concurrent duplicate hold lost the race — the caller must not emit a
 /// second `pending_created`).
-pub async fn put(iii: &III, record: &PendingApprovalRecord) -> Result<Option<Value>, IIIError> {
+pub async fn put(iii: &IIIClient, record: &PendingApprovalRecord) -> Result<Option<Value>, Error> {
     let reply = state::set(
         iii,
         PENDING_SCOPE,
@@ -73,10 +74,10 @@ pub async fn put(iii: &III, record: &PendingApprovalRecord) -> Result<Option<Val
 /// list O(live). The delete is benign if it races: the gate already
 /// decided emission.
 pub async fn delete_with_gate(
-    iii: &III,
+    iii: &IIIClient,
     session_id: &str,
     function_call_id: &str,
-) -> Result<Option<PendingApprovalRecord>, IIIError> {
+) -> Result<Option<PendingApprovalRecord>, Error> {
     let key = pending_key(session_id, function_call_id);
     let reply = state::set(iii, PENDING_SCOPE, &key, Value::Null).await?;
     let old = reply.get("old_value").cloned().unwrap_or(Value::Null);
@@ -90,7 +91,7 @@ pub async fn delete_with_gate(
 
 /// Full-scope scan, values-only (the engine's `state::list` contract).
 /// Malformed/null values are skipped.
-pub async fn list_all(iii: &III) -> Result<Vec<PendingApprovalRecord>, IIIError> {
+pub async fn list_all(iii: &IIIClient) -> Result<Vec<PendingApprovalRecord>, Error> {
     let reply = state::list(iii, PENDING_SCOPE).await?;
     let values = match reply {
         Value::Array(items) => items,

--- a/approval-gate/src/session.rs
+++ b/approval-gate/src/session.rs
@@ -1,9 +1,11 @@
 //! Thin `session::get` wrapper around `iii.trigger()`.
 
-use iii_sdk::{IIIError, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
 use serde_json::{json, Value};
 
-pub async fn get(iii: &III, session_id: &str) -> Result<Value, IIIError> {
+pub async fn get(iii: &IIIClient, session_id: &str) -> Result<Value, Error> {
     iii.trigger(TriggerRequest {
         function_id: "session::get".into(),
         payload: json!({ "session_id": session_id }),

--- a/approval-gate/src/settings.rs
+++ b/approval-gate/src/settings.rs
@@ -3,7 +3,7 @@
 //! Reads never write — the *effective* settings are the stored record
 //! when one exists, else the configuration defaults computed in memory.
 
-use iii_sdk::III;
+use iii_sdk::IIIClient;
 use serde_json::Value;
 
 use crate::config::WorkerConfig;
@@ -63,7 +63,7 @@ pub fn effective(
 /// Hot-path read for the gate: any failure (state outage, absent record,
 /// garbage) degrades to `None` → configuration defaults. Safe because the
 /// default mode never widens beyond what the deployment configured.
-pub async fn read_tolerant(iii: &III, session_id: &str) -> Option<ApprovalSettings> {
+pub async fn read_tolerant(iii: &IIIClient, session_id: &str) -> Option<ApprovalSettings> {
     let reply = state::get(iii, SETTINGS_SCOPE, session_id).await;
     match reply {
         Ok(value) => parse_settings(&value),
@@ -77,7 +77,7 @@ pub async fn read_tolerant(iii: &III, session_id: &str) -> Option<ApprovalSettin
 /// Strict read for mutations: a state outage is an error — re-seeding
 /// over an unreadable record would clobber it.
 pub async fn read_strict(
-    iii: &III,
+    iii: &IIIClient,
     session_id: &str,
 ) -> Result<Option<ApprovalSettings>, ApprovalError> {
     let reply = state::get(iii, SETTINGS_SCOPE, session_id)
@@ -92,7 +92,7 @@ pub async fn read_strict(
 /// written in one `state::set` — mutations are human-driven and rare, so
 /// read-modify-write of one small record is sufficient.
 pub async fn materialize_and<F>(
-    iii: &III,
+    iii: &IIIClient,
     session_id: &str,
     cfg: &WorkerConfig,
     mutate: F,
@@ -119,7 +119,7 @@ where
 
 /// Drop the stored record (the session reverts to configuration
 /// defaults). Returns whether a record existed.
-pub async fn clear(iii: &III, session_id: &str) -> Result<bool, ApprovalError> {
+pub async fn clear(iii: &IIIClient, session_id: &str) -> Result<bool, ApprovalError> {
     validate_id("session_id", session_id)?;
     let old = state::delete(iii, SETTINGS_SCOPE, session_id)
         .await

--- a/approval-gate/src/state.rs
+++ b/approval-gate/src/state.rs
@@ -2,10 +2,12 @@
 //! wrappers around `iii.trigger()` (llm-router pattern). No explicit
 //! timeout — every call uses the SDK default.
 
-use iii_sdk::{IIIError, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
 use serde_json::{json, Value};
 
-pub async fn get(iii: &III, scope: &str, key: &str) -> Result<Value, IIIError> {
+pub async fn get(iii: &IIIClient, scope: &str, key: &str) -> Result<Value, Error> {
     iii.trigger(TriggerRequest {
         function_id: "state::get".into(),
         payload: json!({ "scope": scope, "key": key }),
@@ -15,7 +17,7 @@ pub async fn get(iii: &III, scope: &str, key: &str) -> Result<Value, IIIError> {
     .await
 }
 
-pub async fn set(iii: &III, scope: &str, key: &str, value: Value) -> Result<Value, IIIError> {
+pub async fn set(iii: &IIIClient, scope: &str, key: &str, value: Value) -> Result<Value, Error> {
     iii.trigger(TriggerRequest {
         function_id: "state::set".into(),
         payload: json!({ "scope": scope, "key": key, "value": value }),
@@ -25,7 +27,7 @@ pub async fn set(iii: &III, scope: &str, key: &str, value: Value) -> Result<Valu
     .await
 }
 
-pub async fn delete(iii: &III, scope: &str, key: &str) -> Result<Value, IIIError> {
+pub async fn delete(iii: &IIIClient, scope: &str, key: &str) -> Result<Value, Error> {
     iii.trigger(TriggerRequest {
         function_id: "state::delete".into(),
         payload: json!({ "scope": scope, "key": key }),
@@ -35,7 +37,7 @@ pub async fn delete(iii: &III, scope: &str, key: &str) -> Result<Value, IIIError
     .await
 }
 
-pub async fn list(iii: &III, scope: &str) -> Result<Value, IIIError> {
+pub async fn list(iii: &IIIClient, scope: &str) -> Result<Value, Error> {
     iii.trigger(TriggerRequest {
         function_id: "state::list".into(),
         payload: json!({ "scope": scope }),

--- a/approval-gate/src/testkit/engine.rs
+++ b/approval-gate/src/testkit/engine.rs
@@ -5,9 +5,8 @@ use std::io::Write as _;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use iii_sdk::{
-    register_worker, InitOptions, RegisterFunction, RegisterTriggerInput, TriggerRequest, III,
-};
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::{register_worker, IIIClient, InitOptions, RegisterFunction};
 use serde_json::{json, Value};
 use tokio::sync::{OnceCell, RwLock};
 
@@ -267,7 +266,7 @@ impl BootOpts {
 }
 
 pub struct TestStack {
-    pub iii: Arc<III>,
+    pub iii: Arc<IIIClient>,
     pub deps: Arc<Deps>,
     /// The live config snapshot the handlers read (same cell as
     /// `deps.config`); write to it to drive per-call tuning knobs and
@@ -302,7 +301,7 @@ fn spawn_harness_worker(engine_url: &str) -> Option<std::process::Child> {
         .ok()
 }
 
-async fn wait_for_harness(iii: &III) -> bool {
+async fn wait_for_harness(iii: &IIIClient) -> bool {
     let deadline = Instant::now() + Duration::from_secs(15);
     while Instant::now() < deadline {
         if iii
@@ -371,7 +370,9 @@ pub async fn boot(engine: &Engine, opts: BootOpts) -> TestStack {
                 let log = log.clone();
                 async move {
                     log_push(&log, req);
-                    Ok::<_, iii_sdk::IIIError>(json!({ "resolved": true, "turn_resumed": true }))
+                    Ok::<_, iii_sdk::errors::Error>(
+                        json!({ "resolved": true, "turn_resumed": true }),
+                    )
                 }
             }),
         );
@@ -384,7 +385,7 @@ pub async fn boot(engine: &Engine, opts: BootOpts) -> TestStack {
                 .get("session_id")
                 .and_then(Value::as_str)
                 .unwrap_or("s_1");
-            Ok::<_, iii_sdk::IIIError>(json!({ "meta": {
+            Ok::<_, iii_sdk::errors::Error>(json!({ "meta": {
                 "session_id": session_id,
                 "title": "Integration session",
                 "description": "",
@@ -402,7 +403,7 @@ pub async fn boot(engine: &Engine, opts: BootOpts) -> TestStack {
                 let log = log.clone();
                 async move {
                     log_push(&log, req);
-                    Ok::<_, iii_sdk::IIIError>(Value::Null)
+                    Ok::<_, iii_sdk::errors::Error>(Value::Null)
                 }
             }),
         );
@@ -416,7 +417,7 @@ pub async fn boot(engine: &Engine, opts: BootOpts) -> TestStack {
                 let log = log.clone();
                 async move {
                     log_push(&log, req);
-                    Ok::<_, iii_sdk::IIIError>(Value::Null)
+                    Ok::<_, iii_sdk::errors::Error>(Value::Null)
                 }
             }),
         );
@@ -466,10 +467,10 @@ pub async fn boot(engine: &Engine, opts: BootOpts) -> TestStack {
 }
 
 pub async fn call(
-    iii: &III,
+    iii: &IIIClient,
     function_id: &str,
     payload: Value,
-) -> Result<Value, iii_sdk::IIIError> {
+) -> Result<Value, iii_sdk::errors::Error> {
     iii.trigger(TriggerRequest {
         function_id: function_id.into(),
         payload,
@@ -479,13 +480,13 @@ pub async fn call(
     .await
 }
 
-pub async fn state_get(iii: &III, scope: &str, key: &str) -> Value {
+pub async fn state_get(iii: &IIIClient, scope: &str, key: &str) -> Value {
     call(iii, "state::get", json!({ "scope": scope, "key": key }))
         .await
         .expect("state::get")
 }
 
-pub async fn state_set(iii: &III, scope: &str, key: &str, value: Value) {
+pub async fn state_set(iii: &IIIClient, scope: &str, key: &str, value: Value) {
     call(
         iii,
         "state::set",

--- a/approval-gate/tests/harness_integration.rs
+++ b/approval-gate/tests/harness_integration.rs
@@ -93,7 +93,7 @@ async fn harness_pre_trigger_hold_then_resolve_allow() {
         iii.register_function(
             "shell::run",
             RegisterFunction::new_async(|_req: serde_json::Value| async {
-                Ok::<_, iii_sdk::IIIError>(json!({ "ok": true }))
+                Ok::<_, iii_sdk::errors::Error>(json!({ "ok": true }))
             }),
         );
 


### PR DESCRIPTION
Bump iii-sdk to 0.20.0 per https://iii.dev/docs/upgrading/from-0-19-x.md. Build, fmt, clippy, tests green (115 tests); surface parity (13 functions + 2 triggers) verified 1:1. No iii-helpers needed. No import aliases (real names used).