### PR TITLE
chore(llm-router): bump iii-sdk to 0.20.0

### DIFF
--- a/llm-router/Cargo.lock
+++ b/llm-router/Cargo.lock
@@ -668,16 +668,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-observability"
-version = "0.19.2"
+name = "iii-helpers"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11586fcd304a563c143837f67b2e5f3cb73d23f6c8452c9734ff18e4a1402bf"
+checksum = "09daa7c14a9e4c1f7077c4a181918d207e3f05cdfea8b2d7781bbeb80caf4c5d"
 dependencies = [
  "futures-util",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry_sdk",
  "reqwest",
+ "schemars",
+ "serde",
  "serde_json",
  "sysinfo",
  "tokio",
@@ -688,14 +690,14 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8490f2ad470d54cf7e0bc2f4105aca71bdb4c24752fcb406183f24b8dd328f80"
+checksum = "5957568413b9a5178c11bf91b20909e93e568b187e259e941ba6009a7ec3f5c1"
 dependencies = [
  "async-trait",
  "futures-util",
  "hostname",
- "iii-observability",
+ "iii-helpers",
  "reqwest",
  "schemars",
  "serde",
@@ -779,7 +781,7 @@ dependencies = [
  "async-trait",
  "clap",
  "futures",
- "iii-observability",
+ "iii-helpers",
  "iii-sdk",
  "regex",
  "schemars",

--- a/llm-router/Cargo.toml
+++ b/llm-router/Cargo.toml
@@ -18,10 +18,10 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.19.2"
+iii-sdk = "=0.20.0"
 # Re-exports the same `opentelemetry` the SDK uses, so we can carry the active
 # OTel context across `tokio::spawn` boundaries (shared `Context` global).
-iii-observability = "0.19.2"
+iii-helpers = "=0.20.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Must stay on the same schemars major as iii-sdk so the derived

--- a/llm-router/src/catalog/handlers.rs
+++ b/llm-router/src/catalog/handlers.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use futures::future::BoxFuture;
-use iii_sdk::IIIError;
+use iii_sdk::errors::Error;
 
 use crate::types::router::{
     ModelGetRequest, ModelGetResponse, ModelsListRequest, ModelsListResponse,
@@ -16,7 +16,7 @@ use super::store::CatalogStore;
 
 pub fn make_models_list(
     catalog: Arc<CatalogStore>,
-) -> impl Fn(ModelsListRequest) -> BoxFuture<'static, Result<ModelsListResponse, IIIError>>
+) -> impl Fn(ModelsListRequest) -> BoxFuture<'static, Result<ModelsListResponse, Error>>
        + Send
        + Sync
        + 'static {
@@ -32,7 +32,7 @@ pub fn make_models_list(
 
 pub fn make_models_get(
     catalog: Arc<CatalogStore>,
-) -> impl Fn(ModelGetRequest) -> BoxFuture<'static, Result<Option<ModelGetResponse>, IIIError>>
+) -> impl Fn(ModelGetRequest) -> BoxFuture<'static, Result<Option<ModelGetResponse>, Error>>
        + Send
        + Sync
        + 'static {
@@ -48,7 +48,7 @@ pub fn make_models_get(
 
 pub fn make_models_supports(
     catalog: Arc<CatalogStore>,
-) -> impl Fn(ModelsSupportsRequest) -> BoxFuture<'static, Result<ModelsSupportsResponse, IIIError>>
+) -> impl Fn(ModelsSupportsRequest) -> BoxFuture<'static, Result<ModelsSupportsResponse, Error>>
        + Send
        + Sync
        + 'static {

--- a/llm-router/src/catalog/reconcile.rs
+++ b/llm-router/src/catalog/reconcile.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use crate::types::errors::{RouterCode, RouterError};
 use crate::types::router::{ModelsReconcileRequest, ModelsReconcileResponse};
 use futures::future::BoxFuture;
-use iii_sdk::IIIError;
+use iii_sdk::errors::Error;
 use serde_json::json;
 
 use crate::catalog::store::CatalogStore;
@@ -17,7 +17,7 @@ pub fn make_models_reconcile(
     registry: Arc<RegistryStore>,
     catalog: Arc<CatalogStore>,
     events: Arc<RouterEvents>,
-) -> impl Fn(ModelsReconcileRequest) -> BoxFuture<'static, Result<ModelsReconcileResponse, IIIError>>
+) -> impl Fn(ModelsReconcileRequest) -> BoxFuture<'static, Result<ModelsReconcileResponse, Error>>
        + Send
        + Sync
        + 'static {
@@ -28,7 +28,7 @@ pub fn make_models_reconcile(
             registry
                 .verify_token(&provider, req.token.as_deref())
                 .await
-                .map_err(IIIError::from)?;
+                .map_err(Error::from)?;
             let models = req.models;
             for m in &models {
                 if m.provider != provider {

--- a/llm-router/src/catalog/store.rs
+++ b/llm-router/src/catalog/store.rs
@@ -8,25 +8,25 @@ use std::collections::HashMap;
 use crate::state::{state_get, state_set};
 use crate::types::errors::is_function_not_found;
 use crate::types::model::Model;
-use iii_sdk::{IIIError, III};
+use iii_sdk::{errors::Error, IIIClient};
 use tokio::sync::Mutex;
 
 const CATALOG_KEY: &str = "catalog";
 
 pub struct CatalogStore {
-    iii: III,
+    iii: IIIClient,
     slices: Mutex<HashMap<String, Vec<Model>>>,
 }
 
 impl CatalogStore {
-    pub fn new(iii: III) -> Self {
+    pub fn new(iii: IIIClient) -> Self {
         Self {
             iii,
             slices: Mutex::new(HashMap::new()),
         }
     }
 
-    pub async fn load(&self) -> Result<(), IIIError> {
+    pub async fn load(&self) -> Result<(), Error> {
         // No iii-state worker on this engine (the registry-publish flow boots
         // against a bare `workers: []` engine to collect the interface):
         // start empty. Safe to tolerate exactly this error class — with no
@@ -76,7 +76,7 @@ impl CatalogStore {
             .cloned()
     }
 
-    pub async fn set_slice(&self, provider: &str, models: Vec<Model>) -> Result<(), IIIError> {
+    pub async fn set_slice(&self, provider: &str, models: Vec<Model>) -> Result<(), Error> {
         let mut slices = self.slices.lock().await; // serialized writer
         slices.insert(provider.to_string(), models);
         let value = serde_json::to_value(&*slices).unwrap_or_default();

--- a/llm-router/src/channels.rs
+++ b/llm-router/src/channels.rs
@@ -14,7 +14,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use iii_sdk::{IIIError, StreamChannelRef, III};
+use iii_sdk::channel::{ChannelWriter, StreamChannelRef};
+use iii_sdk::{errors::Error, IIIClient};
 use tokio::sync::{mpsc, Notify};
 
 use crate::chat::relay::{CallerGone, FrameSink, ReadEvent, RelayRead, RouterChannel};
@@ -48,7 +49,7 @@ impl FrameSink for SdkSink {
 }
 
 /// Spawn the forwarder task that owns the async ChannelWriter.
-fn spawn_writer_forwarder(writer: iii_sdk::ChannelWriter) -> Arc<SdkSink> {
+fn spawn_writer_forwarder(writer: ChannelWriter) -> Arc<SdkSink> {
     let (tx, mut rx) = mpsc::unbounded_channel::<SinkMsg>();
     let closed = Arc::new(AtomicBool::new(false));
     let closed_for_task = closed.clone();
@@ -104,7 +105,7 @@ impl RelayRead for SdkReader {
 }
 
 /// Mint a fresh router-owned iii channel for one provider attempt.
-pub async fn create_router_channel(iii: &III) -> Result<RouterChannel, IIIError> {
+pub async fn create_router_channel(iii: &IIIClient) -> Result<RouterChannel, Error> {
     let channel = iii_sdk::helpers::create_channel(iii, None).await?;
 
     // reader: bridge on_message + a pump task into an mpsc the relay can
@@ -152,7 +153,7 @@ pub async fn create_router_channel(iii: &III) -> Result<RouterChannel, IIIError>
 }
 
 /// Build a sink for a caller-supplied writer_ref; same forwarder-task bridge.
-pub async fn open_sink(iii: &III, r: &StreamChannelRef) -> Result<Arc<dyn FrameSink>, IIIError> {
-    let writer = iii_sdk::ChannelWriter::new(iii.address(), r);
+pub async fn open_sink(iii: &IIIClient, r: &StreamChannelRef) -> Result<Arc<dyn FrameSink>, Error> {
+    let writer = ChannelWriter::new(iii.address(), r);
     Ok(spawn_writer_forwarder(writer))
 }

--- a/llm-router/src/chat/abort.rs
+++ b/llm-router/src/chat/abort.rs
@@ -2,7 +2,7 @@
 use std::sync::Arc;
 
 use futures::future::BoxFuture;
-use iii_sdk::IIIError;
+use iii_sdk::errors::Error;
 
 use crate::types::router::{AbortRequest, AbortResponse};
 
@@ -10,7 +10,7 @@ use super::inflight::InflightMap;
 
 pub fn make_abort(
     inflight: Arc<InflightMap>,
-) -> impl Fn(AbortRequest) -> BoxFuture<'static, Result<AbortResponse, IIIError>> + Send + Sync + 'static
+) -> impl Fn(AbortRequest) -> BoxFuture<'static, Result<AbortResponse, Error>> + Send + Sync + 'static
 {
     move |req: AbortRequest| {
         let inflight = inflight.clone();

--- a/llm-router/src/chat/chat.rs
+++ b/llm-router/src/chat/chat.rs
@@ -11,8 +11,11 @@ use std::sync::{Arc, RwLock};
 use crate::types::errors::{RouterCode, RouterError};
 use crate::types::events::{AssistantMessageEvent, ErrorKind, StopReason};
 use crate::types::router::{ChatResponse, ErrorShape};
-use iii_observability::opentelemetry::trace::FutureExt as _;
-use iii_sdk::{IIIError, StreamChannelRef, TriggerRequest, III};
+use iii_helpers::observability::opentelemetry::trace::FutureExt as _;
+use iii_sdk::channel::StreamChannelRef;
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -78,7 +81,7 @@ pub struct ChatFnInput {
 }
 
 pub struct ChatPipeline {
-    pub iii: III,
+    pub iii: IIIClient,
     pub registry: Arc<RegistryStore>,
     pub catalog: Arc<CatalogStore>,
     pub inflight: Arc<InflightMap>,
@@ -95,8 +98,8 @@ fn now_ms() -> i64 {
 
 use crate::types::errors::is_function_not_found;
 
-fn is_router_coded(err: &IIIError) -> bool {
-    matches!(err, IIIError::Remote { code, .. } if code.starts_with("router/"))
+fn is_router_coded(err: &Error) -> bool {
+    matches!(err, Error::Remote { code, .. } if code.starts_with("router/"))
 }
 
 impl ChatPipeline {
@@ -104,12 +107,12 @@ impl ChatPipeline {
         &self,
         call: ChatCall,
         sink: Arc<dyn FrameSink>,
-    ) -> Result<ChatResponse, IIIError> {
+    ) -> Result<ChatResponse, Error> {
         // A pre-stream failure must still leave exactly one terminal frame on
         // the sink. Without it, `router::complete`'s drain blocks for its full
         // reader budget and `router::chat` consumers never see a terminal.
         // (Regression: pre_stream_routing_failure_emits_one_error_terminal_frame.)
-        let fail_pre_stream = |provider: &str, code: RouterCode, message: String| -> IIIError {
+        let fail_pre_stream = |provider: &str, code: RouterCode, message: String| -> Error {
             // Pre-stream failures are permanent: a bad model or an unrouted
             // request won't succeed on retry. Mark the frame Permanent so a
             // streaming consumer inspecting error_kind doesn't retry it.
@@ -229,7 +232,7 @@ impl ChatPipeline {
         inflight: &super::inflight::InflightEntry,
         request_id: &str,
         sink: Arc<dyn FrameSink>,
-    ) -> Result<ChatResponse, IIIError> {
+    ) -> Result<ChatResponse, Error> {
         let pricing = model_meta.and_then(|m| m.pricing.clone());
         let mut last_partial = None;
         let mut last_usage = None;
@@ -277,7 +280,7 @@ impl ChatPipeline {
             // provider stream nests under `router::chat` instead of rooting a
             // detached trace. `with_context` (not `cx.attach()`) because the
             // `ContextGuard` is `!Send` and can't cross the `.await` below.
-            let parent_cx = iii_observability::opentelemetry::Context::current();
+            let parent_cx = iii_helpers::observability::opentelemetry::Context::current();
             let call_task = tokio::spawn(
                 async move {
                     let out = iii
@@ -308,7 +311,7 @@ impl ChatPipeline {
             .await;
             let call_outcome = call_task
                 .await
-                .unwrap_or(Err(IIIError::Handler("provider task panicked".into())));
+                .unwrap_or(Err(Error::Handler("provider task panicked".into())));
 
             match relay {
                 RelayResult::Done { terminal, .. } => {
@@ -539,8 +542,8 @@ fn insert_present(map: &mut serde_json::Map<String, Value>, key: &str, value: Op
 mod tests {
     use super::*;
 
-    fn remote(code: &str) -> IIIError {
-        IIIError::Remote {
+    fn remote(code: &str) -> Error {
+        Error::Remote {
             code: code.into(),
             message: "m".into(),
             stacktrace: None,
@@ -553,7 +556,7 @@ mod tests {
         assert!(is_function_not_found(&remote("FUNCTION_NOT_FOUND")));
         // the configuration worker's missing-entry code must NOT flip availability
         assert!(!is_function_not_found(&remote("NOT_FOUND")));
-        assert!(!is_function_not_found(&IIIError::Timeout));
+        assert!(!is_function_not_found(&Error::Timeout));
         assert!(is_router_coded(&remote("router/not_configured")));
         assert!(!is_router_coded(&remote("function_not_found")));
     }

--- a/llm-router/src/chat/complete.rs
+++ b/llm-router/src/chat/complete.rs
@@ -10,16 +10,16 @@ use crate::types::errors::{RouterCode, RouterError};
 use crate::types::events::AssistantMessageEvent;
 use crate::types::router::CompleteResponse;
 use futures::future::BoxFuture;
-use iii_sdk::{IIIError, III};
+use iii_sdk::{errors::Error, IIIClient};
 
 use super::chat::{ChatCall, ChatPipeline};
 use super::relay::ReadEvent;
 use crate::channels::create_router_channel;
 
 pub fn make_complete(
-    iii: III,
+    iii: IIIClient,
     pipeline: Arc<ChatPipeline>,
-) -> impl Fn(ChatCall) -> BoxFuture<'static, Result<CompleteResponse, IIIError>> + Send + Sync + 'static
+) -> impl Fn(ChatCall) -> BoxFuture<'static, Result<CompleteResponse, Error>> + Send + Sync + 'static
 {
     move |call: ChatCall| {
         let (iii, pipeline) = (iii.clone(), pipeline.clone());
@@ -55,10 +55,10 @@ pub fn make_complete(
                     // outer ≥ inner budget, always
                     ev = reader.next(Duration::from_secs(600)) => match ev {
                         ReadEvent::Msg(m) => collect(&mut terminal, &m),
-                        _ => break chat_task.await.map_err(|e| IIIError::Handler(e.to_string()))??,
+                        _ => break chat_task.await.map_err(|e| Error::Handler(e.to_string()))??,
                     },
                     res = &mut chat_task => {
-                        let response = res.map_err(|e| IIIError::Handler(e.to_string()))??;
+                        let response = res.map_err(|e| Error::Handler(e.to_string()))??;
                         // The pipeline is done; remaining frames are in-flight
                         // engine hops, not a live stream — finish the drain on
                         // a short budget instead of the streaming one.

--- a/llm-router/src/chat/relay.rs
+++ b/llm-router/src/chat/relay.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use iii_sdk::StreamChannelRef;
+use iii_sdk::channel::StreamChannelRef;
 
 #[derive(Debug)]
 pub enum ReadEvent {

--- a/llm-router/src/config/entry.rs
+++ b/llm-router/src/config/entry.rs
@@ -3,7 +3,9 @@
 //! initial_value, so operator-stored values survive every re-register.
 use std::collections::BTreeMap;
 
-use iii_sdk::{IIIError, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
 use serde_json::{json, Value};
 
 use super::schema::compose_entry_schema;
@@ -15,9 +17,9 @@ pub const ENTRY_ID: &str = "llm-router";
 pub type EntryWriteLock = std::sync::Arc<tokio::sync::Mutex<()>>;
 
 pub async fn register_entry(
-    iii: &III,
+    iii: &IIIClient,
     provider_schemas: &BTreeMap<String, Value>,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     iii.trigger(TriggerRequest {
         function_id: "configuration::register".into(),
         payload: json!({
@@ -34,8 +36,8 @@ pub async fn register_entry(
 }
 
 /// Null before the entry exists.
-pub async fn read_entry_value(iii: &III) -> Value {
-    let res = iii
+pub async fn read_entry_value(iii: &IIIClient) -> Value {
+    let res: Result<Value, _> = iii
         .trigger(TriggerRequest {
             function_id: "configuration::get".into(),
             payload: json!({ "id": ENTRY_ID }),
@@ -49,7 +51,7 @@ pub async fn read_entry_value(iii: &III) -> Value {
     }
 }
 
-pub async fn write_entry_value(iii: &III, value: Value) -> Result<(), IIIError> {
+pub async fn write_entry_value(iii: &IIIClient, value: Value) -> Result<(), Error> {
     iii.trigger(TriggerRequest {
         function_id: "configuration::set".into(),
         payload: json!({ "id": ENTRY_ID, "value": value }),

--- a/llm-router/src/config/on_changed.rs
+++ b/llm-router/src/config/on_changed.rs
@@ -10,7 +10,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex, RwLock};
 
 use futures::future::BoxFuture;
-use iii_sdk::{IIIError, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
 use serde_json::{json, Value};
 
 use super::fingerprint::{changed_slices, fingerprint_slices};
@@ -22,11 +24,11 @@ use crate::types::router::{ConfigChangedEvent, RouterAck};
 pub type ListingLookup = Arc<dyn Fn(&str) -> BoxFuture<'static, bool> + Send + Sync>;
 
 pub fn make_on_config_changed(
-    iii: III,
+    iii: IIIClient,
     supports_model_listing: ListingLookup,
     settings: Arc<RwLock<RouterSettings>>,
     debounce_ms: u64,
-) -> impl Fn(ConfigChangedEvent) -> BoxFuture<'static, Result<RouterAck, IIIError>> + Send + Sync + 'static
+) -> impl Fn(ConfigChangedEvent) -> BoxFuture<'static, Result<RouterAck, Error>> + Send + Sync + 'static
 {
     let last_fingerprints: Arc<Mutex<BTreeMap<String, String>>> = Arc::default();
     let pending: Arc<Mutex<BTreeSet<String>>> = Arc::default();

--- a/llm-router/src/main.rs
+++ b/llm-router/src/main.rs
@@ -7,7 +7,8 @@
 //! keys found there are warned about instead of silently dropped.
 
 use clap::Parser;
-use iii_sdk::{register_worker, InitOptions, WorkerMetadata};
+use iii_sdk::runtime::WorkerMetadata;
+use iii_sdk::{register_worker, InitOptions};
 use llm_router::register::register_router;
 
 #[derive(Parser, Debug)]

--- a/llm-router/src/register.rs
+++ b/llm-router/src/register.rs
@@ -10,7 +10,9 @@
 use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
 
-use iii_sdk::{IIIError, RegisterFunction, RegisterTriggerInput, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::RegisterTriggerInput;
+use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::{json, Value};
 
 use crate::catalog::handlers::{make_models_get, make_models_list, make_models_supports};
@@ -40,7 +42,7 @@ pub struct RouterRefs {
     pub settings: Arc<RwLock<RouterSettings>>,
 }
 
-pub async fn register_router(iii: III) -> Result<RouterRefs, IIIError> {
+pub async fn register_router(iii: IIIClient) -> Result<RouterRefs, Error> {
     // 1–2. restore durable stores
     let registry = Arc::new(RegistryStore::new(iii.clone()));
     let catalog = Arc::new(CatalogStore::new(iii.clone()));

--- a/llm-router/src/registry/availability.rs
+++ b/llm-router/src/registry/availability.rs
@@ -3,15 +3,15 @@ use std::sync::Arc;
 
 use crate::types::router::{ProviderInfo, ProviderListRequest, ProviderListResponse};
 use futures::future::BoxFuture;
-use iii_sdk::{IIIError, III};
+use iii_sdk::{errors::Error, IIIClient};
 
 use crate::registry::resolve::resolve_provider_config;
 use crate::registry::store::RegistryStore;
 
 pub fn make_provider_list(
-    iii: III,
+    iii: IIIClient,
     registry: Arc<RegistryStore>,
-) -> impl Fn(ProviderListRequest) -> BoxFuture<'static, Result<ProviderListResponse, IIIError>>
+) -> impl Fn(ProviderListRequest) -> BoxFuture<'static, Result<ProviderListResponse, Error>>
        + Send
        + Sync
        + 'static {

--- a/llm-router/src/registry/register.rs
+++ b/llm-router/src/registry/register.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use crate::types::errors::{RouterCode, RouterError};
 use crate::types::router::{ProviderRegisterRequest, ProviderRegisterResponse};
 use futures::future::BoxFuture;
-use iii_sdk::{IIIError, III};
+use iii_sdk::{errors::Error, IIIClient};
 use serde_json::{json, Value};
 
 use crate::catalog::store::CatalogStore;
@@ -28,12 +28,12 @@ fn valid_id(id: &str) -> bool {
 }
 
 pub fn make_provider_register(
-    iii: III,
+    iii: IIIClient,
     registry: Arc<RegistryStore>,
     catalog: Arc<CatalogStore>,
     entry_lock: EntryWriteLock,
     events: Arc<RouterEvents>,
-) -> impl Fn(ProviderRegisterRequest) -> BoxFuture<'static, Result<ProviderRegisterResponse, IIIError>>
+) -> impl Fn(ProviderRegisterRequest) -> BoxFuture<'static, Result<ProviderRegisterResponse, Error>>
        + Send
        + Sync
        + 'static {
@@ -56,7 +56,7 @@ pub fn make_provider_register(
                 .into());
             }
             if let Some(schema) = &declaration.config_schema {
-                validate_custom_schema(schema).map_err(IIIError::from)?;
+                validate_custom_schema(schema).map_err(Error::from)?;
             }
             if let Some(models) = &declaration.models {
                 for m in models {
@@ -79,7 +79,7 @@ pub fn make_provider_register(
             let upserted = registry
                 .upsert(declaration, worker_id, input.token)
                 .await
-                .map_err(IIIError::from)?;
+                .map_err(Error::from)?;
             let token = upserted.token;
             let availability_recovered = upserted.availability_recovered;
 

--- a/llm-router/src/registry/resolve.rs
+++ b/llm-router/src/registry/resolve.rs
@@ -13,7 +13,7 @@ use crate::types::router::{
     UpdateCredentialRequest, UpdateCredentialResponse,
 };
 use futures::future::BoxFuture;
-use iii_sdk::{IIIError, III};
+use iii_sdk::{errors::Error, IIIClient};
 use serde_json::{json, Value};
 
 use crate::config::entry::{read_entry_value, write_entry_value, EntryWriteLock};
@@ -22,7 +22,7 @@ use crate::settings::provider_slices;
 
 /// Core resolution — shared by the resolve handler, provider::list, and chat.
 pub async fn resolve_provider_config(
-    iii: &III,
+    iii: &IIIClient,
     declaration: &ProviderDeclaration,
 ) -> ProviderResolveResponse {
     let entry = read_entry_value(iii).await;
@@ -85,9 +85,9 @@ pub async fn resolve_provider_config(
 }
 
 pub fn make_provider_resolve(
-    iii: III,
+    iii: IIIClient,
     registry: Arc<RegistryStore>,
-) -> impl Fn(ProviderResolveRequest) -> BoxFuture<'static, Result<ProviderResolveResponse, IIIError>>
+) -> impl Fn(ProviderResolveRequest) -> BoxFuture<'static, Result<ProviderResolveResponse, Error>>
        + Send
        + Sync
        + 'static {
@@ -97,7 +97,7 @@ pub fn make_provider_resolve(
             let record = registry
                 .verify_token(&req.id, req.token.as_deref())
                 .await
-                .map_err(IIIError::from)?;
+                .map_err(Error::from)?;
             Ok(resolve_provider_config(&iii, &record.declaration).await)
         })
     }
@@ -106,10 +106,10 @@ pub fn make_provider_resolve(
 /// OAuth write-back (spec § update_credential): providers never write the
 /// configuration entry directly. Read-merge-write under the entry lock.
 pub fn make_update_credential(
-    iii: III,
+    iii: IIIClient,
     registry: Arc<RegistryStore>,
     entry_lock: EntryWriteLock,
-) -> impl Fn(UpdateCredentialRequest) -> BoxFuture<'static, Result<UpdateCredentialResponse, IIIError>>
+) -> impl Fn(UpdateCredentialRequest) -> BoxFuture<'static, Result<UpdateCredentialResponse, Error>>
        + Send
        + Sync
        + 'static {
@@ -119,7 +119,7 @@ pub fn make_update_credential(
             registry
                 .verify_token(&req.id, req.token.as_deref())
                 .await
-                .map_err(IIIError::from)?;
+                .map_err(Error::from)?;
             let credential = req.credential;
             if !credential.is_object() {
                 return Err(RouterError::new(

--- a/llm-router/src/registry/store.rs
+++ b/llm-router/src/registry/store.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use crate::state::{state_get, state_set};
 use crate::types::errors::{is_function_not_found, RouterCode, RouterError};
 use crate::types::router::ProviderDeclaration;
-use iii_sdk::{IIIError, III};
+use iii_sdk::{errors::Error, IIIClient};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
@@ -40,7 +40,7 @@ pub struct ProviderRecord {
 }
 
 pub struct RegistryStore {
-    iii: III,
+    iii: IIIClient,
     records: Mutex<HashMap<String, ProviderRecord>>,
 }
 
@@ -86,14 +86,14 @@ fn availability_recovered(existing: Option<&ProviderRecord>) -> bool {
 }
 
 impl RegistryStore {
-    pub fn new(iii: III) -> Self {
+    pub fn new(iii: IIIClient) -> Self {
         Self {
             iii,
             records: Mutex::new(HashMap::new()),
         }
     }
 
-    pub async fn load(&self) -> Result<(), IIIError> {
+    pub async fn load(&self) -> Result<(), Error> {
         // No iii-state worker on this engine (the registry-publish flow boots
         // against a bare `workers: []` engine to collect the interface):
         // start empty. Safe to tolerate exactly this error class — with no
@@ -110,7 +110,7 @@ impl RegistryStore {
         Ok(())
     }
 
-    async fn persist(&self, records: &HashMap<String, ProviderRecord>) -> Result<(), IIIError> {
+    async fn persist(&self, records: &HashMap<String, ProviderRecord>) -> Result<(), Error> {
         let value = serde_json::to_value(records).unwrap_or_default();
         state_set(&self.iii, REGISTRY_KEY, value).await
     }

--- a/llm-router/src/routing.rs
+++ b/llm-router/src/routing.rs
@@ -7,7 +7,7 @@
 use std::sync::{Arc, RwLock};
 
 use futures::future::BoxFuture;
-use iii_sdk::IIIError;
+use iii_sdk::errors::Error;
 
 use crate::catalog::store::CatalogStore;
 use crate::registry::store::RegistryStore;
@@ -102,7 +102,7 @@ pub fn make_route(
     registry: Arc<RegistryStore>,
     catalog: Arc<CatalogStore>,
     settings: Arc<RwLock<RouterSettings>>,
-) -> impl Fn(RouteRequest) -> BoxFuture<'static, Result<RouteResponse, IIIError>> + Send + Sync + 'static
+) -> impl Fn(RouteRequest) -> BoxFuture<'static, Result<RouteResponse, Error>> + Send + Sync + 'static
 {
     move |req: RouteRequest| {
         let (registry, catalog, settings) = (registry.clone(), catalog.clone(), settings.clone());
@@ -124,7 +124,7 @@ pub fn make_route(
                 heuristics,
                 default_provider,
             })
-            .map_err(IIIError::from)?;
+            .map_err(Error::from)?;
             Ok(RouteResponse {
                 provider: candidates[0].clone(),
                 candidates,

--- a/llm-router/src/state.rs
+++ b/llm-router/src/state.rs
@@ -1,12 +1,14 @@
 //! Thin `state::get` / `state::set` wrappers around `iii.trigger()`
 //! (binary-worker.md § 7). All router state lives under the "llm-router"
 //! scope; the router is the only writer of its keys (single-instance worker).
-use iii_sdk::{IIIError, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
 use serde_json::{json, Value};
 
 pub const STATE_SCOPE: &str = "llm-router";
 
-pub async fn state_get(iii: &III, key: &str) -> Result<Value, IIIError> {
+pub async fn state_get(iii: &IIIClient, key: &str) -> Result<Value, Error> {
     iii.trigger(TriggerRequest {
         function_id: "state::get".into(),
         payload: json!({ "scope": STATE_SCOPE, "key": key }),
@@ -16,7 +18,7 @@ pub async fn state_get(iii: &III, key: &str) -> Result<Value, IIIError> {
     .await
 }
 
-pub async fn state_set(iii: &III, key: &str, value: Value) -> Result<(), IIIError> {
+pub async fn state_set(iii: &IIIClient, key: &str, value: Value) -> Result<(), Error> {
     iii.trigger(TriggerRequest {
         function_id: "state::set".into(),
         payload: json!({ "scope": STATE_SCOPE, "key": key, "value": value }),

--- a/llm-router/src/testkit/fake_channels.rs
+++ b/llm-router/src/testkit/fake_channels.rs
@@ -6,8 +6,8 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use iii_sdk::channels::ChannelDirection;
-use iii_sdk::StreamChannelRef;
+use iii_sdk::channel::StreamChannelRef;
+use iii_sdk::helpers::ChannelDirection;
 use tokio::sync::Notify;
 use uuid::Uuid;
 

--- a/llm-router/src/triggers.rs
+++ b/llm-router/src/triggers.rs
@@ -14,10 +14,10 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use iii_sdk::{
-    IIIError, RegisterTriggerType, TriggerAction, TriggerConfig, TriggerHandler, TriggerRequest,
-    III,
-};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::{TriggerAction, TriggerRequest};
+use iii_sdk::trigger::{TriggerConfig, TriggerHandler};
+use iii_sdk::{IIIClient, RegisterTriggerType};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -90,14 +90,14 @@ impl RouterEventTriggerHandler {
 
 #[async_trait]
 impl TriggerHandler for RouterEventTriggerHandler {
-    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         let raw = if config.config.is_null() {
             Value::Object(serde_json::Map::new())
         } else {
             config.config.clone()
         };
         serde_json::from_value::<EventBindingConfig>(raw)
-            .map_err(|e| IIIError::Handler(format!("invalid {} config: {e}", self.name)))?;
+            .map_err(|e| Error::Handler(format!("invalid {} config: {e}", self.name)))?;
         tracing::info!(
             trigger_type = %self.name,
             id = %config.id,
@@ -108,7 +108,7 @@ impl TriggerHandler for RouterEventTriggerHandler {
         Ok(())
     }
 
-    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         tracing::info!(
             trigger_type = %self.name,
             id = %config.id,
@@ -121,7 +121,7 @@ impl TriggerHandler for RouterEventTriggerHandler {
 
 /// Fan-out handle: register once at boot, clone into handlers that emit.
 pub struct RouterEvents {
-    iii: III,
+    iii: IIIClient,
     ready: SubscriberSet,
     models_changed: SubscriberSet,
     provider_changed: SubscriberSet,
@@ -130,7 +130,7 @@ pub struct RouterEvents {
 impl RouterEvents {
     /// Register the three custom trigger types. Must run before emitting
     /// `router::ready` so the engine can replay existing bindings first.
-    pub fn register(iii: &III) -> Arc<Self> {
+    pub fn register(iii: &IIIClient) -> Arc<Self> {
         let ready = SubscriberSet::default();
         let models_changed = SubscriberSet::default();
         let provider_changed = SubscriberSet::default();

--- a/llm-router/src/types/errors.rs
+++ b/llm-router/src/types/errors.rs
@@ -47,9 +47,9 @@ impl RouterError {
 
 /// Typed pre-stream throws surface on the bus as `IIIError::Remote`
 /// (the engine's `{ code, message }` convention).
-impl From<RouterError> for iii_sdk::IIIError {
+impl From<RouterError> for iii_sdk::errors::Error {
     fn from(e: RouterError) -> Self {
-        iii_sdk::IIIError::Remote {
+        iii_sdk::errors::Error::Remote {
             code: e.code.as_str().to_string(),
             message: e.message,
             stacktrace: None,
@@ -61,15 +61,15 @@ impl From<RouterError> for iii_sdk::IIIError {
 /// the router's stable `invalid_request` wire error. Used with
 /// `RegisterFunction::new_async_with_bad_request` so typed schemas are emitted
 /// while the malformed-payload contract stays `router/invalid_request`.
-pub fn invalid_request_from_serde(e: serde_json::Error) -> iii_sdk::IIIError {
+pub fn invalid_request_from_serde(e: serde_json::Error) -> iii_sdk::errors::Error {
     RouterError::new(RouterCode::InvalidRequest, e.to_string()).into()
 }
 
 /// The engine's invocation path reports a missing function as
 /// `function_not_found` (engine/src/engine/mod.rs); bare `NOT_FOUND` is the
 /// configuration worker's missing-entry code and must not match here.
-pub fn is_function_not_found(err: &iii_sdk::IIIError) -> bool {
-    matches!(err, iii_sdk::IIIError::Remote { code, .. } if code.eq_ignore_ascii_case("function_not_found"))
+pub fn is_function_not_found(err: &iii_sdk::errors::Error) -> bool {
+    matches!(err, iii_sdk::errors::Error::Remote { code, .. } if code.eq_ignore_ascii_case("function_not_found"))
 }
 
 #[cfg(test)]

--- a/llm-router/src/types/router.rs
+++ b/llm-router/src/types/router.rs
@@ -7,7 +7,7 @@ use crate::types::credential::Credential;
 use crate::types::events::{StopReason, Usage};
 use crate::types::messages::{AgentMessage, AssistantMessage};
 use crate::types::model::{AgentFunction, Model, ThinkingLevel};
-use iii_sdk::StreamChannelRef;
+use iii_sdk::channel::StreamChannelRef;
 
 // ── consumer surface ────────────────────────────────────────────────────────
 

--- a/llm-router/tests/integration.rs
+++ b/llm-router/tests/integration.rs
@@ -9,7 +9,10 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use iii_sdk::{register_worker, InitOptions, RegisterFunction, TriggerRequest, III};
+use iii_sdk::channel::StreamChannelRef;
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::{register_worker, IIIClient, InitOptions, RegisterFunction};
 use llm_router::register::register_router;
 use serde_json::{json, Value};
 
@@ -181,7 +184,7 @@ macro_rules! bare_engine_or_skip {
     };
 }
 
-async fn call(iii: &III, function_id: &str, payload: Value) -> Result<Value, iii_sdk::IIIError> {
+async fn call(iii: &IIIClient, function_id: &str, payload: Value) -> Result<Value, Error> {
     iii.trigger(TriggerRequest {
         function_id: function_id.into(),
         payload,
@@ -191,9 +194,9 @@ async fn call(iii: &III, function_id: &str, payload: Value) -> Result<Value, iii
     .await
 }
 
-fn remote_code(err: &iii_sdk::IIIError) -> &str {
+fn remote_code(err: &Error) -> &str {
     match err {
-        iii_sdk::IIIError::Remote { code, .. } => code,
+        Error::Remote { code, .. } => code,
         _ => "",
     }
 }
@@ -210,7 +213,7 @@ struct ProviderOptions {
 }
 
 struct LiveProvider {
-    iii: III,
+    iii: IIIClient,
     token: String,
     write_failed: Arc<AtomicBool>,
     fail_at_ms: Arc<AtomicU64>,
@@ -234,16 +237,16 @@ async fn start_live_provider(url: &str, opts: ProviderOptions) -> LiveProvider {
             let address = address.clone();
             let (wf, fam) = (wf.clone(), fam.clone());
             async move {
-                let r: iii_sdk::StreamChannelRef =
+                let r: StreamChannelRef =
                     serde_json::from_value(input["writer_ref"].clone())
-                        .map_err(|e| iii_sdk::IIIError::Serde(e.to_string()))?;
-                let writer = iii_sdk::ChannelWriter::new(&address, &r);
+                        .map_err(|e| Error::Serde(e.to_string()))?;
+                let writer = iii_sdk::channel::ChannelWriter::new(&address, &r);
                 let model = input["model"].clone();
                 let start = json!({ "type": "start", "partial": { "role": "assistant", "content": [], "stop_reason": "end", "model": model, "provider": "real", "timestamp": 1 } });
                 writer
                     .send_message(&start.to_string())
                     .await
-                    .map_err(|e| iii_sdk::IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 if ping_forever {
                     let begun = Instant::now();
                     loop {
@@ -266,7 +269,7 @@ async fn start_live_provider(url: &str, opts: ProviderOptions) -> LiveProvider {
                 writer
                     .send_message(&json!({ "type": "done", "message": message }).to_string())
                     .await
-                    .map_err(|e| iii_sdk::IIIError::Handler(e.to_string()))?;
+                    .map_err(|e| Error::Handler(e.to_string()))?;
                 let _ = writer.close().await;
                 Ok(json!({ "ok": true }))
             }
@@ -294,7 +297,7 @@ async fn start_live_provider(url: &str, opts: ProviderOptions) -> LiveProvider {
                         timeout_ms: Some(5000),
                     })
                     .await?;
-                    Ok::<Value, iii_sdk::IIIError>(json!({ "ok": true }))
+                    Ok::<Value, Error>(json!({ "ok": true }))
                 }
             }),
         );
@@ -334,9 +337,9 @@ async fn start_live_provider(url: &str, opts: ProviderOptions) -> LiveProvider {
 
 /// Consumer-side channel: collect frames + a pump that drives dispatch.
 async fn consumer_channel(
-    iii: &III,
+    iii: &IIIClient,
 ) -> (
-    iii_sdk::StreamChannelRef,
+    StreamChannelRef,
     Arc<std::sync::Mutex<Vec<String>>>,
     tokio::task::JoinHandle<()>,
 ) {
@@ -874,12 +877,12 @@ async fn models_changed_event_reaches_a_trigger_subscriber() {
             let sink = sink.clone();
             async move {
                 sink.lock().unwrap().push(input);
-                Ok::<Value, iii_sdk::IIIError>(json!({}))
+                Ok::<Value, Error>(json!({}))
             }
         }),
     );
     probe
-        .register_trigger(iii_sdk::RegisterTriggerInput {
+        .register_trigger(RegisterTriggerInput {
             trigger_type: "router::models::changed".into(),
             function_id: "probe::on_models_changed".into(),
             config: json!({}),


### PR DESCRIPTION
Bump iii-sdk to 0.20.0 + migrate observability to iii-helpers (iii-observability dep removed) per https://iii.dev/docs/upgrading/from-0-19-x.md. Build, fmt, clippy, tests green (61 tests); surface parity (13 functions + 3 triggers) verified 1:1. No import aliases. Note: provider-anthropic and provider-openai depend on this via path dep and will be rebased after this merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the router to the latest SDK version and aligned related integrations with the new API.
  * Updated error handling and channel/state wiring to use the newer shared interfaces across routing, catalog, config, and registry flows.
  * Refreshed tests and helpers to match the updated SDK behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->