### PR TITLE
chore(provider-openai): bump iii-sdk to 0.20.0

### DIFF
--- a/provider-openai/Cargo.lock
+++ b/provider-openai/Cargo.lock
@@ -668,16 +668,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-observability"
-version = "0.19.2"
+name = "iii-helpers"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11586fcd304a563c143837f67b2e5f3cb73d23f6c8452c9734ff18e4a1402bf"
+checksum = "09daa7c14a9e4c1f7077c4a181918d207e3f05cdfea8b2d7781bbeb80caf4c5d"
 dependencies = [
  "futures-util",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry_sdk",
  "reqwest",
+ "schemars",
+ "serde",
  "serde_json",
  "sysinfo",
  "tokio",
@@ -688,14 +690,14 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8490f2ad470d54cf7e0bc2f4105aca71bdb4c24752fcb406183f24b8dd328f80"
+checksum = "5957568413b9a5178c11bf91b20909e93e568b187e259e941ba6009a7ec3f5c1"
 dependencies = [
  "async-trait",
  "futures-util",
  "hostname",
- "iii-observability",
+ "iii-helpers",
  "reqwest",
  "schemars",
  "serde",
@@ -779,7 +781,7 @@ dependencies = [
  "async-trait",
  "clap",
  "futures",
- "iii-observability",
+ "iii-helpers",
  "iii-sdk",
  "regex",
  "schemars",

--- a/provider-openai/Cargo.toml
+++ b/provider-openai/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 
 [dependencies]
 llm-router = { path = "../llm-router" }
-iii-sdk = "=0.19.2"
+iii-sdk = "=0.20.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Must stay on the same schemars major as iii-sdk so the derived

--- a/provider-openai/src/discovery.rs
+++ b/provider-openai/src/discovery.rs
@@ -8,7 +8,8 @@ use crate::curated::{base_id, enrich, is_legacy_generation};
 use crate::errors::upstream_unavailable;
 use crate::{router_client, state};
 use futures::future::BoxFuture;
-use iii_sdk::{IIIError, III};
+use iii_sdk::errors::Error;
+use iii_sdk::IIIClient;
 use llm_router::types::model::Model;
 use llm_router::types::router::{RefreshModelsRequest, RefreshModelsResponse};
 use serde_json::Value;
@@ -115,7 +116,7 @@ async fn fetch_live_models(
 }
 
 /// The refresh flow; returns the reconciled slice size.
-pub async fn refresh_models(iii: &III, http: &reqwest::Client) -> Result<usize, IIIError> {
+pub async fn refresh_models(iii: &IIIClient, http: &reqwest::Client) -> Result<usize, Error> {
     let token = state::load_token(iii).await;
     let resolved = router_client::resolve(iii, token.as_deref()).await?;
 
@@ -145,9 +146,9 @@ pub async fn refresh_models(iii: &III, http: &reqwest::Client) -> Result<usize, 
 }
 
 pub fn make_refresh_models(
-    iii: III,
+    iii: IIIClient,
     http: reqwest::Client,
-) -> impl Fn(RefreshModelsRequest) -> BoxFuture<'static, Result<RefreshModelsResponse, IIIError>>
+) -> impl Fn(RefreshModelsRequest) -> BoxFuture<'static, Result<RefreshModelsResponse, Error>>
        + Send
        + Sync
        + 'static {

--- a/provider-openai/src/errors.rs
+++ b/provider-openai/src/errors.rs
@@ -1,6 +1,6 @@
 //! Upstream failure → shared ErrorKind taxonomy (spec § provider protocol
 //! rule 5: five providers MUST NOT invent five taxonomies).
-use iii_sdk::IIIError;
+use iii_sdk::errors::Error;
 use llm_router::types::events::ErrorKind;
 use serde_json::Value;
 
@@ -24,9 +24,9 @@ pub fn classify(status: Option<u16>, message: &str) -> ErrorKind {
 }
 
 /// Map router bus errors surfaced through `router::provider::resolve`.
-pub fn classify_bus_error(err: &IIIError) -> ErrorKind {
+pub fn classify_bus_error(err: &Error) -> ErrorKind {
     match err {
-        IIIError::Remote { code, .. } if code == "router/registration_rejected" => {
+        Error::Remote { code, .. } if code == "router/registration_rejected" => {
             ErrorKind::Permanent
         }
         _ => ErrorKind::Transient,
@@ -74,8 +74,8 @@ fn is_context_overflow_message(message: &str) -> bool {
 
 /// Invalid handler input surfaced on the bus in the `{ code, message }`
 /// convention (same shape RouterError uses on the router side).
-pub fn invalid_request(message: impl Into<String>) -> IIIError {
-    IIIError::Remote {
+pub fn invalid_request(message: impl Into<String>) -> Error {
+    Error::Remote {
         code: "provider/invalid_request".to_string(),
         message: message.into(),
         stacktrace: None,
@@ -86,13 +86,13 @@ pub fn invalid_request(message: impl Into<String>) -> IIIError {
 /// the provider's `invalid_request` wire error. Used with
 /// `RegisterFunction::new_async_with_bad_request` so typed schemas are emitted
 /// while the malformed-payload contract stays `provider/invalid_request`.
-pub fn invalid_request_from_serde(e: serde_json::Error) -> IIIError {
+pub fn invalid_request_from_serde(e: serde_json::Error) -> Error {
     invalid_request(format!("bad ProviderStreamInput: {e}"))
 }
 
 /// Discovery hit a transient upstream failure — caller keeps the old slice.
-pub fn upstream_unavailable(message: impl Into<String>) -> IIIError {
-    IIIError::Remote {
+pub fn upstream_unavailable(message: impl Into<String>) -> Error {
+    Error::Remote {
         code: "provider/upstream_unavailable".to_string(),
         message: message.into(),
         stacktrace: None,
@@ -147,13 +147,13 @@ mod tests {
 
     #[test]
     fn registration_rejected_is_permanent_on_the_bus() {
-        let err = IIIError::Remote {
+        let err = Error::Remote {
             code: "router/registration_rejected".into(),
             message: "bad token".into(),
             stacktrace: None,
         };
         assert_eq!(classify_bus_error(&err), ErrorKind::Permanent);
-        let err = IIIError::Remote {
+        let err = Error::Remote {
             code: "engine/timeout".into(),
             message: "t".into(),
             stacktrace: None,
@@ -164,11 +164,11 @@ mod tests {
     #[test]
     fn bus_error_codes_are_worker_prefixed() {
         match invalid_request("x") {
-            IIIError::Remote { code, .. } => assert_eq!(code, "provider/invalid_request"),
+            Error::Remote { code, .. } => assert_eq!(code, "provider/invalid_request"),
             other => panic!("want Remote, got {other:?}"),
         }
         match upstream_unavailable("x") {
-            IIIError::Remote { code, .. } => assert_eq!(code, "provider/upstream_unavailable"),
+            Error::Remote { code, .. } => assert_eq!(code, "provider/upstream_unavailable"),
             other => panic!("want Remote, got {other:?}"),
         }
     }

--- a/provider-openai/src/main.rs
+++ b/provider-openai/src/main.rs
@@ -7,7 +7,8 @@
 //! are warned about instead of silently dropped.
 
 use clap::Parser;
-use iii_sdk::{register_worker, InitOptions, WorkerMetadata};
+use iii_sdk::runtime::WorkerMetadata;
+use iii_sdk::{register_worker, InitOptions};
 use provider_openai::register::register_provider;
 
 #[derive(Parser, Debug)]

--- a/provider-openai/src/register.rs
+++ b/provider-openai/src/register.rs
@@ -6,7 +6,9 @@ use crate::errors::invalid_request_from_serde;
 use crate::stream_fn::make_stream;
 use crate::surface;
 use crate::{router_client, state, PROVIDER_ID};
-use iii_sdk::{IIIError, RegisterFunction, RegisterTriggerInput, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::RegisterTriggerInput;
+use iii_sdk::{IIIClient, RegisterFunction};
 use llm_router::types::router::{
     ProviderDeclaration, ProviderDefaults, ProviderReadyAck, RouterReadyEvent,
 };
@@ -37,7 +39,7 @@ pub fn declaration() -> ProviderDeclaration {
 
 /// One registration attempt: declare (with the persisted token when present)
 /// and persist the token the router returns.
-pub async fn declare_once(iii: &III) -> Result<(), IIIError> {
+pub async fn declare_once(iii: &IIIClient) -> Result<(), Error> {
     let token = state::load_token(iii).await;
     let mut payload = serde_json::to_value(declaration()).expect("serializable declaration");
     if let Some(t) = &token {
@@ -52,7 +54,7 @@ pub async fn declare_once(iii: &III) -> Result<(), IIIError> {
     Ok(())
 }
 
-async fn persist_registration_token(iii: &III, token: &str) -> Result<(), IIIError> {
+async fn persist_registration_token(iii: &IIIClient, token: &str) -> Result<(), Error> {
     let mut delay = Duration::from_millis(200);
     for attempt in 0..5 {
         match state::store_token(iii, token).await {
@@ -73,7 +75,7 @@ async fn persist_registration_token(iii: &III, token: &str) -> Result<(), IIIErr
 /// Retry until acknowledged: covers provider-before-router boot order.
 /// A token mismatch also lands here — it never resolves on its own and
 /// needs the operator to clear the binding (logged every attempt).
-pub async fn declare_with_backoff(iii: III) {
+pub async fn declare_with_backoff(iii: IIIClient) {
     let mut delay = Duration::from_millis(500);
     loop {
         match declare_once(&iii).await {
@@ -93,7 +95,7 @@ pub async fn declare_with_backoff(iii: III) {
 /// Register, then populate the catalog from the live API. The declaration
 /// carries no models, so the slice is empty until this refresh lands;
 /// failures are logged and left to the next config-change refresh.
-pub async fn declare_and_refresh(iii: III, http: reqwest::Client) {
+pub async fn declare_and_refresh(iii: IIIClient, http: reqwest::Client) {
     declare_with_backoff(iii.clone()).await;
     match refresh_models(&iii, &http).await {
         Ok(count) => println!("[provider-openai] catalog refreshed: {count} models"),
@@ -101,7 +103,7 @@ pub async fn declare_and_refresh(iii: III, http: reqwest::Client) {
     }
 }
 
-pub async fn register_provider(iii: III) -> Result<(), IIIError> {
+pub async fn register_provider(iii: IIIClient) -> Result<(), Error> {
     // Streaming uses no total timeout (the router owns stream budgets);
     // connect failures surface fast.
     let http = reqwest::Client::builder()
@@ -133,7 +135,7 @@ pub async fn register_provider(iii: III) -> Result<(), IIIError> {
                 let (iii, http) = (iii_ready.clone(), http_ready.clone());
                 async move {
                     tokio::spawn(declare_and_refresh(iii, http));
-                    Ok::<_, IIIError>(ProviderReadyAck { ok: true })
+                    Ok::<_, Error>(ProviderReadyAck { ok: true })
                 }
             })
             .description(surface::ON_ROUTER_READY_DESC),

--- a/provider-openai/src/router_client.rs
+++ b/provider-openai/src/router_client.rs
@@ -1,12 +1,14 @@
 //! Thin wrappers over the router's provider-protocol functions. All calls
 //! carry the registration token (identity binding, spec adaptation #1).
 use crate::PROVIDER_ID;
-use iii_sdk::{IIIError, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
 use llm_router::types::model::Model;
 use llm_router::types::router::ProviderResolveResponse;
 use serde_json::{json, Value};
 
-async fn call(iii: &III, function_id: &str, payload: Value) -> Result<Value, IIIError> {
+async fn call(iii: &IIIClient, function_id: &str, payload: Value) -> Result<Value, Error> {
     iii.trigger(TriggerRequest {
         function_id: function_id.into(),
         payload,
@@ -17,13 +19,16 @@ async fn call(iii: &III, function_id: &str, payload: Value) -> Result<Value, III
 }
 
 /// `router::provider::resolve` — credential + effective settings.
-pub async fn resolve(iii: &III, token: Option<&str>) -> Result<ProviderResolveResponse, IIIError> {
+pub async fn resolve(
+    iii: &IIIClient,
+    token: Option<&str>,
+) -> Result<ProviderResolveResponse, Error> {
     let mut payload = json!({ "id": PROVIDER_ID });
     if let Some(t) = token {
         payload["token"] = json!(t);
     }
     let raw = call(iii, "router::provider::resolve", payload).await?;
-    serde_json::from_value(raw).map_err(|e| IIIError::Remote {
+    serde_json::from_value(raw).map_err(|e| Error::Remote {
         code: "provider/bad_resolve_response".into(),
         message: e.to_string(),
         stacktrace: None,
@@ -31,7 +36,11 @@ pub async fn resolve(iii: &III, token: Option<&str>) -> Result<ProviderResolveRe
 }
 
 /// `router::models::reconcile` — replace this provider's catalog slice.
-pub async fn reconcile(iii: &III, models: Vec<Model>, token: Option<&str>) -> Result<(), IIIError> {
+pub async fn reconcile(
+    iii: &IIIClient,
+    models: Vec<Model>,
+    token: Option<&str>,
+) -> Result<(), Error> {
     let mut payload = json!({
         "provider": PROVIDER_ID,
         "models": serde_json::to_value(models).expect("serializable models"),
@@ -44,7 +53,7 @@ pub async fn reconcile(iii: &III, models: Vec<Model>, token: Option<&str>) -> Re
 }
 
 /// `router::models::get` — authoritative catalog record (None when absent).
-pub async fn models_get(iii: &III, model_id: &str) -> Option<Model> {
+pub async fn models_get(iii: &IIIClient, model_id: &str) -> Option<Model> {
     let raw = call(
         iii,
         "router::models::get",
@@ -56,6 +65,6 @@ pub async fn models_get(iii: &III, model_id: &str) -> Option<Model> {
 }
 
 /// `router::provider::register` — returns the registration token to persist.
-pub async fn register(iii: &III, declaration: Value) -> Result<Value, IIIError> {
+pub async fn register(iii: &IIIClient, declaration: Value) -> Result<Value, Error> {
     call(iii, "router::provider::register", declaration).await
 }

--- a/provider-openai/src/state.rs
+++ b/provider-openai/src/state.rs
@@ -1,13 +1,15 @@
 //! Registration-token persistence in iii-state (engine `state::*` functions,
 //! binary-worker.md § 7). The raw token lives here, under the provider's own
 //! scope; the router persists only its sha256 hash.
-use iii_sdk::{IIIError, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
 use serde_json::{json, Value};
 
 pub const STATE_SCOPE: &str = "provider-openai";
 const TOKEN_KEY: &str = "registration_token";
 
-pub async fn load_token(iii: &III) -> Option<String> {
+pub async fn load_token(iii: &IIIClient) -> Option<String> {
     let value = iii
         .trigger(TriggerRequest {
             function_id: "state::get".into(),
@@ -20,7 +22,7 @@ pub async fn load_token(iii: &III) -> Option<String> {
     value.as_str().map(String::from)
 }
 
-pub async fn store_token(iii: &III, token: &str) -> Result<(), IIIError> {
+pub async fn store_token(iii: &IIIClient, token: &str) -> Result<(), Error> {
     iii.trigger(TriggerRequest {
         function_id: "state::set".into(),
         payload: json!({ "scope": STATE_SCOPE, "key": TOKEN_KEY, "value": Value::from(token) }),

--- a/provider-openai/src/stream_fn.rs
+++ b/provider-openai/src/stream_fn.rs
@@ -9,7 +9,8 @@ use crate::sse::synthetic_error_event;
 use crate::upstream::{spawn_upstream, UpstreamArgs};
 use crate::{router_client, state};
 use futures::future::BoxFuture;
-use iii_sdk::{IIIError, III};
+use iii_sdk::errors::Error;
+use iii_sdk::IIIClient;
 use llm_router::channels::open_sink;
 use llm_router::chat::relay::FrameSink;
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind};
@@ -21,9 +22,9 @@ use tokio::sync::mpsc;
 pub const PING_INTERVAL: Duration = Duration::from_secs(30);
 
 pub fn make_stream(
-    iii: III,
+    iii: IIIClient,
     http: reqwest::Client,
-) -> impl Fn(ProviderStreamInput) -> BoxFuture<'static, Result<ProviderStreamOutput, IIIError>>
+) -> impl Fn(ProviderStreamInput) -> BoxFuture<'static, Result<ProviderStreamOutput, Error>>
        + Send
        + Sync
        + 'static {
@@ -45,7 +46,7 @@ fn send_event(sink: &dyn FrameSink, ev: &AssistantMessageEvent) -> Result<(), ()
 }
 
 async fn run_stream_call(
-    iii: &III,
+    iii: &IIIClient,
     http: reqwest::Client,
     input: ProviderStreamInput,
     sink: &dyn FrameSink,

--- a/provider-openai/tests/integration.rs
+++ b/provider-openai/tests/integration.rs
@@ -4,7 +4,8 @@ use std::io::Write as _;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use iii_sdk::{register_worker, InitOptions, TriggerRequest, III};
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::{register_worker, IIIClient, InitOptions};
 use llm_router::register::register_router;
 use provider_openai::register::register_provider;
 use serde_json::{json, Value};
@@ -137,7 +138,11 @@ macro_rules! engine_or_skip {
     };
 }
 
-async fn call(iii: &III, function_id: &str, payload: Value) -> Result<Value, iii_sdk::IIIError> {
+async fn call(
+    iii: &IIIClient,
+    function_id: &str,
+    payload: Value,
+) -> Result<Value, iii_sdk::errors::Error> {
     iii.trigger(TriggerRequest {
         function_id: function_id.into(),
         payload,
@@ -149,9 +154,9 @@ async fn call(iii: &III, function_id: &str, payload: Value) -> Result<Value, iii
 
 /// Consumer-side channel: collect frames + a pump that drives dispatch.
 async fn consumer_channel(
-    iii: &III,
+    iii: &IIIClient,
 ) -> (
-    iii_sdk::StreamChannelRef,
+    iii_sdk::channel::StreamChannelRef,
     Arc<std::sync::Mutex<Vec<String>>>,
     tokio::task::JoinHandle<()>,
 ) {
@@ -225,7 +230,7 @@ async fn stub_upstream(messages_response: &'static str) -> StubUpstream {
 // ── boot + config ───────────────────────────────────────────────────────────
 
 /// Boot router + provider on one engine; wait until the provider is listed.
-async fn boot_stack(engine_url: &str) -> (III, III) {
+async fn boot_stack(engine_url: &str) -> (IIIClient, IIIClient) {
     let router_iii = register_worker(engine_url, InitOptions::default());
     register_router(router_iii.clone())
         .await
@@ -256,7 +261,7 @@ async fn boot_stack(engine_url: &str) -> (III, III) {
 }
 
 /// Point the openai slice at the stub.
-async fn configure_stub_key(router_iii: &III, stub_url: &str) {
+async fn configure_stub_key(router_iii: &IIIClient, stub_url: &str) {
     call(
         router_iii,
         "configuration::set",
@@ -271,7 +276,7 @@ async fn configure_stub_key(router_iii: &III, stub_url: &str) {
 /// Pull the live (stubbed) list into the catalog and wait until routing can
 /// see it — the declaration carries no models, so tests that route by
 /// catalog ownership must refresh first.
-async fn refresh_and_wait(router_iii: &III, provider_iii: &III, expect_id: &str) {
+async fn refresh_and_wait(router_iii: &IIIClient, provider_iii: &IIIClient, expect_id: &str) {
     let res = call(provider_iii, "provider::openai::refresh_models", json!({}))
         .await
         .expect("refresh succeeds");


### PR DESCRIPTION
Bump iii-sdk to 0.20.0 per https://iii.dev/docs/upgrading/from-0-19-x.md. Branched on main after llm-router@0.20 merge (#334) — path dep requires it. Build, fmt, clippy, tests green (67 tests); function surface (3 fns provider::openai::*) unchanged. No import aliases.