### PR TITLE
chore(session-manager): bump iii-sdk to 0.20.0

### DIFF
--- a/session-manager/Cargo.lock
+++ b/session-manager/Cargo.lock
@@ -913,16 +913,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-observability"
-version = "0.19.2"
+name = "iii-helpers"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11586fcd304a563c143837f67b2e5f3cb73d23f6c8452c9734ff18e4a1402bf"
+checksum = "09daa7c14a9e4c1f7077c4a181918d207e3f05cdfea8b2d7781bbeb80caf4c5d"
 dependencies = [
  "futures-util",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry_sdk",
  "reqwest",
+ "schemars",
+ "serde",
  "serde_json",
  "sysinfo",
  "tokio",
@@ -933,14 +935,14 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8490f2ad470d54cf7e0bc2f4105aca71bdb4c24752fcb406183f24b8dd328f80"
+checksum = "5957568413b9a5178c11bf91b20909e93e568b187e259e941ba6009a7ec3f5c1"
 dependencies = [
  "async-trait",
  "futures-util",
  "hostname",
- "iii-observability",
+ "iii-helpers",
  "reqwest",
  "schemars",
  "serde",

--- a/session-manager/Cargo.toml
+++ b/session-manager/Cargo.toml
@@ -15,7 +15,7 @@ name = "session_manager"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.19.2"
+iii-sdk = "=0.20.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/session-manager/src/configuration.rs
+++ b/session-manager/src/configuration.rs
@@ -26,7 +26,9 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use iii_sdk::{IIIError, RegisterFunction, RegisterTriggerInput, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::{json, Value};
 use tokio::sync::{Mutex, RwLock};
 
@@ -134,7 +136,7 @@ impl ReloadStatus {
 /// `initial_value`. Otherwise, the built-in default is seeded only when no
 /// stored value exists yet (re-registration preserves the stored value, so
 /// this is safe to call every boot).
-pub async fn register_config(iii: &III, seed: Option<&WorkerConfig>) -> Result<(), String> {
+pub async fn register_config(iii: &IIIClient, seed: Option<&WorkerConfig>) -> Result<(), String> {
     let mut payload = json!({
         "id": CONFIG_ID,
         "name": "Session Manager",
@@ -154,7 +156,7 @@ pub async fn register_config(iii: &III, seed: Option<&WorkerConfig>) -> Result<(
 
 /// Read the live `session-manager` configuration (env-expanded by the
 /// configuration worker — `from_json` does NOT re-expand).
-pub async fn fetch_config(iii: &III) -> Result<WorkerConfig, String> {
+pub async fn fetch_config(iii: &IIIClient) -> Result<WorkerConfig, String> {
     let value = get_config_value(iii).await?;
     if value.is_null() {
         tracing::info!("no configuration value found; using built-in default configuration");
@@ -163,7 +165,7 @@ pub async fn fetch_config(iii: &III) -> Result<WorkerConfig, String> {
     WorkerConfig::from_json(&value)
 }
 
-async fn should_seed_default_value(iii: &III) -> Result<bool, String> {
+async fn should_seed_default_value(iii: &IIIClient) -> Result<bool, String> {
     match try_get_config_value(iii).await? {
         None => Ok(true),
         Some(value) if value.is_null() => Ok(true),
@@ -171,7 +173,7 @@ async fn should_seed_default_value(iii: &III) -> Result<bool, String> {
     }
 }
 
-async fn get_config_value(iii: &III) -> Result<Value, String> {
+async fn get_config_value(iii: &IIIClient) -> Result<Value, String> {
     try_get_config_value(iii)
         .await?
         .ok_or_else(|| format!("configuration `{CONFIG_ID}` not found"))
@@ -180,7 +182,7 @@ async fn get_config_value(iii: &III) -> Result<Value, String> {
 /// Returns `Ok(None)` when the entry does not exist. The engine's
 /// missing-entry codes vary in case (`function_not_found`,
 /// `STATEMENT_NOT_FOUND`, `NOT_FOUND`), so match case-insensitively.
-async fn try_get_config_value(iii: &III) -> Result<Option<Value>, String> {
+async fn try_get_config_value(iii: &IIIClient) -> Result<Option<Value>, String> {
     match trigger_with_retry(iii, "configuration::get", json!({ "id": CONFIG_ID })).await {
         Ok(resp) => Ok(resp.get("value").cloned()),
         Err(e) if e.to_ascii_uppercase().contains("NOT_FOUND") => Ok(None),
@@ -334,15 +336,15 @@ pub struct ConfigStatusRequest {}
 /// Register the internal config-change handler and bind a `configuration`
 /// trigger. On `configuration:updated` the handler rebuilds and swaps the
 /// runtime (or just the list limits) from the authoritative value.
-pub fn register_config_trigger(iii: &III, state: AppState) -> Result<(), IIIError> {
+pub fn register_config_trigger(iii: &IIIClient, state: AppState) -> Result<(), Error> {
     let st = state.clone();
     iii.register_function(
         CONFIG_FN_ID,
         RegisterFunction::new_async(move |_event: OnConfigChangeEvent| {
             let st = st.clone();
             async move {
-                on_config_change(&st).await.map_err(IIIError::Handler)?;
-                Ok::<OnConfigChangeResponse, IIIError>(OnConfigChangeResponse { ok: true })
+                on_config_change(&st).await.map_err(Error::Handler)?;
+                Ok::<OnConfigChangeResponse, Error>(OnConfigChangeResponse { ok: true })
             }
         })
         .description(
@@ -367,7 +369,7 @@ pub fn register_config_trigger(iii: &III, state: AppState) -> Result<(), IIIErro
 /// Register `session::config-status`, reporting the last hot-reload outcome so
 /// operators can detect when a stored config was rejected and the active
 /// adapter diverged from the central store.
-pub fn register_config_status(iii: &III, state: AppState) {
+pub fn register_config_status(iii: &IIIClient, state: AppState) {
     let st = state.clone();
     iii.register_function(
         CONFIG_STATUS_FN_ID,
@@ -378,7 +380,7 @@ pub fn register_config_status(iii: &III, state: AppState) {
             let st = st.clone();
             async move {
                 let status = { st.reload_status.read().await.clone() };
-                Ok::<ReloadStatus, IIIError>(status)
+                Ok::<ReloadStatus, Error>(status)
             }
         })
         .description(
@@ -403,7 +405,11 @@ async fn on_config_change(state: &AppState) -> Result<(), String> {
         .map(|_| ())
 }
 
-async fn trigger_with_retry(iii: &III, function_id: &str, payload: Value) -> Result<Value, String> {
+async fn trigger_with_retry(
+    iii: &IIIClient,
+    function_id: &str,
+    payload: Value,
+) -> Result<Value, String> {
     let mut last_err = String::new();
     for attempt in 1..=CONFIG_RETRIES {
         match iii

--- a/session-manager/src/error.rs
+++ b/session-manager/src/error.rs
@@ -2,7 +2,7 @@
 //! snake_case, worker-prefixed code in a `code: message` shape (see
 //! tech-specs/2026-06-agentic/README.md § Error conventions).
 
-use iii_sdk::IIIError;
+use iii_sdk::errors::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum SessionError {
@@ -60,9 +60,9 @@ impl SessionError {
     }
 }
 
-impl From<SessionError> for IIIError {
+impl From<SessionError> for Error {
     fn from(e: SessionError) -> Self {
-        IIIError::Handler(e.to_string())
+        Error::Handler(e.to_string())
     }
 }
 

--- a/session-manager/src/events.rs
+++ b/session-manager/src/events.rs
@@ -37,10 +37,10 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use iii_sdk::{
-    IIIError, RegisterTriggerType, TriggerAction, TriggerConfig, TriggerHandler, TriggerRequest,
-    III,
-};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::trigger::{TriggerConfig, TriggerHandler};
+use iii_sdk::{IIIClient, RegisterTriggerType, TriggerAction};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -548,11 +548,11 @@ struct SessionTriggerHandler {
 
 #[async_trait]
 impl TriggerHandler for SessionTriggerHandler {
-    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         let kind = self.set.kind();
         let id = config.id.clone();
         let function_id = config.function_id.clone();
-        self.set.add(config).map_err(IIIError::Handler)?;
+        self.set.add(config).map_err(Error::Handler)?;
         tracing::info!(
             trigger_type = kind.trigger_type(),
             id = %id,
@@ -562,7 +562,7 @@ impl TriggerHandler for SessionTriggerHandler {
         Ok(())
     }
 
-    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         tracing::info!(
             trigger_type = self.set.kind().trigger_type(),
             id = %config.id,
@@ -625,7 +625,7 @@ struct StoreEventsTriggerHandler {
 
 #[async_trait]
 impl TriggerHandler for StoreEventsTriggerHandler {
-    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         tracing::info!(
             trigger_type = STORE_EVENTS,
             id = %config.id,
@@ -636,7 +636,7 @@ impl TriggerHandler for StoreEventsTriggerHandler {
         Ok(())
     }
 
-    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         tracing::info!(
             trigger_type = STORE_EVENTS,
             id = %config.id,
@@ -650,7 +650,7 @@ impl TriggerHandler for StoreEventsTriggerHandler {
 /// Register the internal [`STORE_EVENTS`] trigger type (main/fs mode
 /// only). The engine replays existing registrations on re-register, so
 /// attached bridges survive a main restart.
-pub fn register_store_events_type(iii: &Arc<III>) -> BridgeSubscribers {
+pub fn register_store_events_type(iii: &Arc<IIIClient>) -> BridgeSubscribers {
     let subscribers = BridgeSubscribers::new();
     let _ = iii.register_trigger_type(
         RegisterTriggerType::new(
@@ -670,7 +670,7 @@ pub fn register_store_events_type(iii: &Arc<III>) -> BridgeSubscribers {
 /// Register the six custom trigger types with the engine. Must run
 /// **before** `functions::register_all` so handlers can capture the
 /// subscriber sets.
-pub fn register_trigger_types(iii: &Arc<III>) -> TriggerSets {
+pub fn register_trigger_types(iii: &Arc<IIIClient>) -> TriggerSets {
     let sets = TriggerSets::new();
 
     let _ = iii.register_trigger_type(
@@ -760,11 +760,11 @@ pub trait EventDeliverer: Send + Sync {
 /// Failures are logged and swallowed — a misbehaving subscriber must
 /// not break the write path.
 pub struct IiiDeliverer {
-    iii: Arc<III>,
+    iii: Arc<IIIClient>,
 }
 
 impl IiiDeliverer {
-    pub fn new(iii: Arc<III>) -> Self {
+    pub fn new(iii: Arc<IIIClient>) -> Self {
         Self { iii }
     }
 }
@@ -917,12 +917,12 @@ impl EventSink for Emitter {
 /// fire-and-forget local fan-out): the mutation itself already
 /// succeeded against the main store.
 pub struct RemotePublisher {
-    remote: Arc<III>,
+    remote: Arc<IIIClient>,
     timeout_ms: u64,
 }
 
 impl RemotePublisher {
-    pub fn new(remote: Arc<III>, timeout_ms: u64) -> Self {
+    pub fn new(remote: Arc<IIIClient>, timeout_ms: u64) -> Self {
         Self { remote, timeout_ms }
     }
 }
@@ -960,7 +960,7 @@ impl EventSink for RemotePublisher {
 /// re-emits each envelope through the **local** emitter — it never
 /// re-publishes, so there are no echo loops. Returns the relay
 /// function id.
-pub fn attach_bridge_relay(remote: &Arc<III>, local_emitter: Arc<Emitter>) -> String {
+pub fn attach_bridge_relay(remote: &Arc<IIIClient>, local_emitter: Arc<Emitter>) -> String {
     let relay_id = format!("session::bridge::recv::{}", uuid::Uuid::new_v4().simple());
 
     let emitter = local_emitter.clone();
@@ -972,13 +972,13 @@ pub fn attach_bridge_relay(remote: &Arc<III>, local_emitter: Arc<Emitter>) -> St
                 emitter
                     .emit_envelopes(std::slice::from_ref(&envelope))
                     .await;
-                Ok::<_, IIIError>(serde_json::json!({ "ok": true }))
+                Ok::<_, Error>(serde_json::json!({ "ok": true }))
             }
         })
         .description("Internal: session event relay for one bridged session-manager instance."),
     );
 
-    match remote.register_trigger(iii_sdk::RegisterTriggerInput {
+    match remote.register_trigger(iii_sdk::protocol::RegisterTriggerInput {
         trigger_type: STORE_EVENTS.to_string(),
         function_id: relay_id.clone(),
         config: serde_json::json!({}),

--- a/session-manager/src/functions/mod.rs
+++ b/session-manager/src/functions/mod.rs
@@ -26,7 +26,8 @@ pub mod update_message;
 use std::future::Future;
 use std::sync::Arc;
 
-use iii_sdk::{IIIError, RegisterFunction, III};
+use iii_sdk::errors::Error;
+use iii_sdk::{IIIClient, RegisterFunction};
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -51,7 +52,7 @@ pub struct Deps {
 /// runtime's `service` + `sink` from [`AppState`], so handlers never capture a
 /// stale adapter across a hot-reload.
 fn register<Req, Resp, F, Fut>(
-    iii: &Arc<III>,
+    iii: &Arc<IIIClient>,
     state: &AppState,
     id: &str,
     description: &str,
@@ -76,14 +77,14 @@ fn register<Req, Resp, F, Fut>(
                         sink: rt.sink.clone(),
                     })
                 };
-                handler(deps, req).await.map_err(IIIError::from)
+                handler(deps, req).await.map_err(Error::from)
             }
         })
         .description(description),
     );
 }
 
-pub fn register_all(iii: &Arc<III>, state: &AppState) {
+pub fn register_all(iii: &Arc<IIIClient>, state: &AppState) {
     register(
         iii,
         state,

--- a/session-manager/src/functions/store_protocol.rs
+++ b/session-manager/src/functions/store_protocol.rs
@@ -11,7 +11,8 @@
 
 use std::sync::Arc;
 
-use iii_sdk::{IIIError, RegisterFunction, III};
+use iii_sdk::errors::Error;
+use iii_sdk::{IIIClient, RegisterFunction};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -92,8 +93,8 @@ pub struct PublishEventsResponse {
     pub published: usize,
 }
 
-fn storage_err(e: crate::store::StoreError) -> IIIError {
-    IIIError::from(crate::error::SessionError::from(e))
+fn storage_err(e: crate::store::StoreError) -> Error {
+    Error::from(crate::error::SessionError::from(e))
 }
 
 /// Message returned when a non-authoritative (bridge-mode) instance is asked to
@@ -106,19 +107,19 @@ const BRIDGE_MODE_REJECT: &str =
 /// The live store, or a rejection when the instance is not fs-main. Snapshotted
 /// per call so a bridge->fs hot-reload re-enables the protocol (and fs->bridge
 /// disables it) without re-registering these functions.
-async fn fs_store(state: &AppState) -> Result<Arc<dyn SessionStore>, IIIError> {
+async fn fs_store(state: &AppState) -> Result<Arc<dyn SessionStore>, Error> {
     let rt = state.runtime.read().await;
     if rt.mode != AdapterMode::FsMain {
-        return Err(IIIError::Handler(BRIDGE_MODE_REJECT.to_string()));
+        return Err(Error::Handler(BRIDGE_MODE_REJECT.to_string()));
     }
     Ok(rt.store.clone())
 }
 
 /// The live local emitter, gated to fs-main like [`fs_store`].
-async fn fs_emitter(state: &AppState) -> Result<Arc<Emitter>, IIIError> {
+async fn fs_emitter(state: &AppState) -> Result<Arc<Emitter>, Error> {
     let rt = state.runtime.read().await;
     if rt.mode != AdapterMode::FsMain {
-        return Err(IIIError::Handler(BRIDGE_MODE_REJECT.to_string()));
+        return Err(Error::Handler(BRIDGE_MODE_REJECT.to_string()));
     }
     Ok(rt.local_emitter.clone())
 }
@@ -126,7 +127,7 @@ async fn fs_emitter(state: &AppState) -> Result<Arc<Emitter>, IIIError> {
 /// Register the raw store surface plus the `publish-events` ingest. Both read
 /// the live runtime per call (see [`fs_store`] / [`fs_emitter`]) and reject when
 /// the instance is in bridge mode, so the protocol follows adapter hot-reloads.
-pub fn register_store_protocol(iii: &Arc<III>, state: AppState) {
+pub fn register_store_protocol(iii: &Arc<IIIClient>, state: AppState) {
     let st = state.clone();
     iii.register_function(
         GET_META,
@@ -148,7 +149,7 @@ pub fn register_store_protocol(iii: &Arc<III>, state: AppState) {
             async move {
                 let store = fs_store(&st).await?;
                 store.put_meta(&req.meta).await.map_err(storage_err)?;
-                Ok::<_, IIIError>(OkResponse { ok: true })
+                Ok::<_, Error>(OkResponse { ok: true })
             }
         })
         .description("Internal store protocol: write one SessionMeta."),
@@ -165,7 +166,7 @@ pub fn register_store_protocol(iii: &Arc<III>, state: AppState) {
                     .delete_meta(&req.session_id)
                     .await
                     .map_err(storage_err)?;
-                Ok::<_, IIIError>(OkResponse { ok: true })
+                Ok::<_, Error>(OkResponse { ok: true })
             }
         })
         .description("Internal store protocol: delete one SessionMeta."),
@@ -179,7 +180,7 @@ pub fn register_store_protocol(iii: &Arc<III>, state: AppState) {
             async move {
                 let store = fs_store(&st).await?;
                 let metas = store.list_metas().await.map_err(storage_err)?;
-                Ok::<_, IIIError>(ListMetasResponse { metas })
+                Ok::<_, Error>(ListMetasResponse { metas })
             }
         })
         .description("Internal store protocol: list every SessionMeta."),
@@ -212,7 +213,7 @@ pub fn register_store_protocol(iii: &Arc<III>, state: AppState) {
                     .put_entry(&req.session_id, &req.entry)
                     .await
                     .map_err(storage_err)?;
-                Ok::<_, IIIError>(OkResponse { ok: true })
+                Ok::<_, Error>(OkResponse { ok: true })
             }
         })
         .description("Internal store protocol: write one SessionEntry."),
@@ -229,7 +230,7 @@ pub fn register_store_protocol(iii: &Arc<III>, state: AppState) {
                     .list_entries(&req.session_id)
                     .await
                     .map_err(storage_err)?;
-                Ok::<_, IIIError>(ListEntriesResponse { entries })
+                Ok::<_, Error>(ListEntriesResponse { entries })
             }
         })
         .description("Internal store protocol: list every entry of a session."),
@@ -246,7 +247,7 @@ pub fn register_store_protocol(iii: &Arc<III>, state: AppState) {
                     .delete_entries(&req.session_id)
                     .await
                     .map_err(storage_err)?;
-                Ok::<_, IIIError>(OkResponse { ok: true })
+                Ok::<_, Error>(OkResponse { ok: true })
             }
         })
         .description("Internal store protocol: delete every entry of a session."),
@@ -263,7 +264,7 @@ pub fn register_store_protocol(iii: &Arc<III>, state: AppState) {
                     .get_active_leaf(&req.session_id)
                     .await
                     .map_err(storage_err)?;
-                Ok::<_, IIIError>(ActiveLeafResponse { entry_id })
+                Ok::<_, Error>(ActiveLeafResponse { entry_id })
             }
         })
         .description("Internal store protocol: read a session's active leaf pointer."),
@@ -280,7 +281,7 @@ pub fn register_store_protocol(iii: &Arc<III>, state: AppState) {
                     .set_active_leaf(&req.session_id, &req.entry_id)
                     .await
                     .map_err(storage_err)?;
-                Ok::<_, IIIError>(OkResponse { ok: true })
+                Ok::<_, Error>(OkResponse { ok: true })
             }
         })
         .description("Internal store protocol: move a session's active leaf pointer."),
@@ -297,7 +298,7 @@ pub fn register_store_protocol(iii: &Arc<III>, state: AppState) {
                     .delete_active_leaf(&req.session_id)
                     .await
                     .map_err(storage_err)?;
-                Ok::<_, IIIError>(OkResponse { ok: true })
+                Ok::<_, Error>(OkResponse { ok: true })
             }
         })
         .description("Internal store protocol: clear a session's active leaf pointer."),
@@ -311,7 +312,7 @@ pub fn register_store_protocol(iii: &Arc<III>, state: AppState) {
             async move {
                 let emitter = fs_emitter(&st).await?;
                 let published = emitter.emit_envelopes(&req.events).await;
-                Ok::<_, IIIError>(PublishEventsResponse { published })
+                Ok::<_, Error>(PublishEventsResponse { published })
             }
         })
         .description(

--- a/session-manager/src/resync.rs
+++ b/session-manager/src/resync.rs
@@ -170,7 +170,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
-    use iii_sdk::TriggerConfig;
+    use iii_sdk::trigger::TriggerConfig;
     use serde_json::{json, Value};
 
     use crate::events::{EventDeliverer, EventKind, TriggerSets};

--- a/session-manager/src/runtime.rs
+++ b/session-manager/src/runtime.rs
@@ -16,7 +16,8 @@
 
 use std::sync::Arc;
 
-use iii_sdk::{register_worker, InitOptions, WorkerMetadata, III};
+use iii_sdk::runtime::WorkerMetadata;
+use iii_sdk::{register_worker, IIIClient, InitOptions};
 
 use crate::config::{StorageAdapter, WorkerConfig};
 use crate::configuration::ConfigCell;
@@ -57,14 +58,14 @@ pub struct SessionRuntime {
     pub mode: AdapterMode,
     /// The remote engine connection (bridge mode only); shut down when this
     /// runtime is retired.
-    pub bridge_remote: Option<Arc<III>>,
+    pub bridge_remote: Option<Arc<IIIClient>>,
 }
 
 /// The boot-time wiring `build_runtime` reuses on every rebuild: the engine
 /// handle, the six subscriber sets, the bridge relay registry, and the shared
 /// config snapshot the service reads list limits from.
 pub struct SessionBuildContext {
-    pub iii: Arc<III>,
+    pub iii: Arc<IIIClient>,
     /// This instance's own engine url; a bridge whose `url` equals it would
     /// defer storage to itself, so that is rejected.
     pub local_url: String,

--- a/session-manager/src/store/bridge.rs
+++ b/session-manager/src/store/bridge.rs
@@ -11,7 +11,8 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use iii_sdk::{TriggerRequest, III};
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
 use serde_json::{json, Value};
 
 use super::{SessionStore, StoreError};
@@ -19,13 +20,13 @@ use crate::functions::store_protocol;
 use crate::types::{SessionEntry, SessionMeta};
 
 pub struct BridgeStore {
-    remote: Arc<III>,
+    remote: Arc<IIIClient>,
     timeout_ms: u64,
 }
 
 impl BridgeStore {
     /// `remote` is a connection to the main instance's engine.
-    pub fn new(remote: Arc<III>, timeout_ms: u64) -> Self {
+    pub fn new(remote: Arc<IIIClient>, timeout_ms: u64) -> Self {
         Self { remote, timeout_ms }
     }
 

--- a/session-manager/tests/common/bridge.rs
+++ b/session-manager/tests/common/bridge.rs
@@ -9,7 +9,7 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use iii_sdk::III;
+use iii_sdk::IIIClient;
 
 use session_manager::config::WorkerConfig;
 use session_manager::events::{
@@ -35,7 +35,7 @@ pub struct BridgeStack {
 }
 
 /// Build one bridged-instance stack against `engine` (the main's bus).
-pub async fn build_bridge_stack(engine: &Arc<III>) -> BridgeStack {
+pub async fn build_bridge_stack(engine: &Arc<IIIClient>) -> BridgeStack {
     let recorder = Recorder::new();
     let emitter = Arc::new(Emitter::new(
         TriggerSets::new(),

--- a/session-manager/tests/common/engine.rs
+++ b/session-manager/tests/common/engine.rs
@@ -10,13 +10,15 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use iii_sdk::{register_worker, IIIError, InitOptions, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::{register_worker, IIIClient, InitOptions};
 use serde_json::{json, Value};
 use tokio::sync::OnceCell;
 
 const DEFAULT_WS_URL: &str = "ws://127.0.0.1:49134";
 
-static ENGINE: OnceCell<Option<Arc<III>>> = OnceCell::const_new();
+static ENGINE: OnceCell<Option<Arc<IIIClient>>> = OnceCell::const_new();
 
 /// Payloads received by engine-side recorder functions, keyed by the
 /// recorder function id.
@@ -26,7 +28,7 @@ pub fn ws_url() -> String {
     std::env::var("III_ENGINE_WS_URL").unwrap_or_else(|_| DEFAULT_WS_URL.to_string())
 }
 
-async fn try_connect_raw() -> Option<Arc<III>> {
+async fn try_connect_raw() -> Option<Arc<IIIClient>> {
     let url = ws_url();
     let iii = Arc::new(register_worker(&url, InitOptions::default()));
 
@@ -42,7 +44,7 @@ async fn try_connect_raw() -> Option<Arc<III>> {
             .await;
         match probe {
             Ok(_) => return Some(iii),
-            Err(IIIError::NotConnected) => continue,
+            Err(Error::NotConnected) => continue,
             Err(_) => continue,
         }
     }
@@ -57,7 +59,7 @@ async fn try_connect_raw() -> Option<Arc<III>> {
 
 /// Get-or-init the shared engine handle, registering the production
 /// session-manager surface in-process on first success.
-pub async fn get_or_init() -> Option<Arc<III>> {
+pub async fn get_or_init() -> Option<Arc<IIIClient>> {
     ENGINE
         .get_or_init(|| async {
             let iii = try_connect_raw().await?;
@@ -70,7 +72,7 @@ pub async fn get_or_init() -> Option<Arc<III>> {
 
 /// Register an engine-side recorder function that stashes every payload
 /// it receives. Returns the generated function id.
-pub fn register_recorder_function(iii: &Arc<III>) -> String {
+pub fn register_recorder_function(iii: &Arc<IIIClient>) -> String {
     let function_id = format!("test::session_recv::{}", uuid::Uuid::new_v4().simple());
     {
         let mut map = RECEIVED.lock().unwrap_or_else(|poison| poison.into_inner());
@@ -88,7 +90,7 @@ pub fn register_recorder_function(iii: &Arc<III>) -> String {
                     .entry(fid)
                     .or_default()
                     .push(payload);
-                Ok::<_, IIIError>(json!({ "ok": true }))
+                Ok::<_, Error>(json!({ "ok": true }))
             }
         })
         .description("BDD recorder: stashes received session events."),

--- a/session-manager/tests/common/workers.rs
+++ b/session-manager/tests/common/workers.rs
@@ -12,7 +12,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use iii_sdk::{TriggerRequest, III};
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
 use tokio::sync::{OnceCell, RwLock};
 
 use session_manager::config::{FsBackendConfig, StorageAdapter, WorkerConfig};
@@ -36,7 +37,7 @@ pub struct Shared {
 static SHARED: OnceCell<Arc<Shared>> = OnceCell::const_new();
 
 /// Idempotent: the first caller registers; subsequent callers reuse.
-pub async fn register_all(iii: &Arc<III>) -> Arc<Shared> {
+pub async fn register_all(iii: &Arc<IIIClient>) -> Arc<Shared> {
     SHARED
         .get_or_init(|| async {
             // Leaked tempdir that lives for the test binary lifetime.
@@ -86,7 +87,7 @@ pub fn shared() -> Option<Arc<Shared>> {
 /// Poll the engine until `function_id` is routable, panicking after a
 /// deadline. An `Err` carrying a `session/` code also counts as
 /// routable — it proves the call reached the production handler.
-async fn wait_until_routable(iii: &Arc<III>, function_id: &str) {
+async fn wait_until_routable(iii: &Arc<IIIClient>, function_id: &str) {
     let deadline = std::time::Instant::now() + Duration::from_secs(10);
     loop {
         let res = iii

--- a/session-manager/tests/common/world.rs
+++ b/session-manager/tests/common/world.rs
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use cucumber::World;
-use iii_sdk::III;
+use iii_sdk::IIIClient;
 use serde_json::Value;
 
 use session_manager::config::WorkerConfig;
@@ -64,7 +64,7 @@ pub struct SessionWorld {
     pub aliases: HashMap<String, String>,
 
     /// Shared engine connection; `None` soft-skips @engine steps.
-    pub engine: Option<Arc<III>>,
+    pub engine: Option<Arc<IIIClient>>,
     /// Alias -> recorder function id for engine subscribers.
     pub engine_subscribers: HashMap<String, String>,
     /// Named in-process bridged-instance stacks (@engine bridge tests).

--- a/session-manager/tests/steps/binding_steps.rs
+++ b/session-manager/tests/steps/binding_steps.rs
@@ -7,7 +7,7 @@
 
 use cucumber::gherkin::Step;
 use cucumber::{given, then, when};
-use iii_sdk::TriggerConfig;
+use iii_sdk::trigger::TriggerConfig;
 
 use session_manager::events::EventKind;
 

--- a/session-manager/tests/steps/bridge_steps.rs
+++ b/session-manager/tests/steps/bridge_steps.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use cucumber::gherkin::Step;
 use cucumber::{given, then, when};
-use iii_sdk::TriggerConfig;
+use iii_sdk::trigger::TriggerConfig;
 
 use session_manager::events::EventKind;
 

--- a/session-manager/tests/steps/engine_steps.rs
+++ b/session-manager/tests/steps/engine_steps.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use cucumber::gherkin::Step;
 use cucumber::{given, then, when};
-use iii_sdk::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
 use serde_json::Value;
 
 use super::common_steps::{lookup_path, parse_expected};


### PR DESCRIPTION
Bump iii-sdk to 0.20.0 per https://iii.dev/docs/upgrading/from-0-19-x.md. Build, fmt, clippy, tests green (117 BDD + unit/schema); surface parity (28 functions + 8 triggers) verified 1:1. No import aliases.