### PR TITLE
chore(console): bump iii-sdk to 0.20.0

### DIFF
--- a/console/Cargo.lock
+++ b/console/Cargo.lock
@@ -763,16 +763,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-observability"
-version = "0.19.4"
+name = "iii-helpers"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a3002534a53d85c86e4be167cf7ae8c1de809ab3130ecfcb2d85eb4afd1272"
+checksum = "09daa7c14a9e4c1f7077c4a181918d207e3f05cdfea8b2d7781bbeb80caf4c5d"
 dependencies = [
  "futures-util",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry_sdk",
  "reqwest",
+ "schemars",
+ "serde",
  "serde_json",
  "sysinfo",
  "tokio",
@@ -783,14 +785,14 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.19.4"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebda94ffd347b173746edaccb6e8767c1c2afc4c2663c3a01756396de2660c32"
+checksum = "5957568413b9a5178c11bf91b20909e93e568b187e259e941ba6009a7ec3f5c1"
 dependencies = [
  "async-trait",
  "futures-util",
  "hostname",
- "iii-observability",
+ "iii-helpers",
  "reqwest",
  "schemars",
  "serde",

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.19.4"
+iii-sdk = "=0.20.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "net", "io-util", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/console/src/functions/mod.rs
+++ b/console/src/functions/mod.rs
@@ -8,7 +8,8 @@ pub mod status;
 
 use std::sync::Arc;
 
-use iii_sdk::{IIIError, RegisterFunction, III};
+use iii_sdk::errors::Error;
+use iii_sdk::{IIIClient, RegisterFunction};
 
 use crate::config::ConsoleConfig;
 use status::{StatusInput, StatusOutput};
@@ -16,12 +17,12 @@ use status::{StatusInput, StatusOutput};
 /// Register every `console::*` function. Called once from `main` after
 /// `register_worker`. Each handler captures the runtime knobs without
 /// re-parsing the YAML.
-pub fn register_all(iii: &Arc<III>, config: &Arc<ConsoleConfig>, engine_url: &str) {
+pub fn register_all(iii: &Arc<IIIClient>, config: &Arc<ConsoleConfig>, engine_url: &str) {
     register_status(iii, config, engine_url);
     tracing::info!("registered console::status");
 }
 
-fn register_status(iii: &Arc<III>, config: &Arc<ConsoleConfig>, engine_url: &str) {
+fn register_status(iii: &Arc<IIIClient>, config: &Arc<ConsoleConfig>, engine_url: &str) {
     let cfg = config.clone();
     let engine_url = engine_url.to_string();
     iii.register_function(
@@ -30,7 +31,7 @@ fn register_status(iii: &Arc<III>, config: &Arc<ConsoleConfig>, engine_url: &str
             let cfg = cfg.clone();
             let engine_url = engine_url.clone();
             async move {
-                Ok::<_, IIIError>(StatusOutput {
+                Ok::<_, Error>(StatusOutput {
                     http_port: cfg.http_port,
                     engine_url,
                     version: env!("CARGO_PKG_VERSION").to_string(),

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -13,7 +13,8 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use clap::Parser;
-use iii_sdk::{register_worker, InitOptions, WorkerMetadata};
+use iii_sdk::runtime::WorkerMetadata;
+use iii_sdk::{register_worker, InitOptions};
 use tokio::sync::oneshot;
 
 use console::{config, functions, manifest, server};


### PR DESCRIPTION
Bump iii-sdk to 0.20.0 per https://iii.dev/docs/upgrading/from-0-19-x.md. Build, fmt, clippy, tests green (17 tests); surface parity (1 function + 1 trigger) verified 1:1. No import aliases.