### PR TITLE
fix(shell): typed schema for shell::on-config-change

### DIFF
--- a/shell/src/configuration.rs
+++ b/shell/src/configuration.rs
@@ -244,16 +244,34 @@ async fn apply_config(state: &AppState, cfg: ShellConfig) -> Result<(), String> 
     Ok(())
 }
 
+/// Event delivered to the internal `shell::on-config-change` handler. A struct
+/// (not `Value`) keeps the request schema concrete; the handler re-fetches the
+/// configuration id; unknown fields are ignored.
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+pub struct OnConfigChangeEvent {
+    /// Configuration id that changed (advisory; the handler re-fetches the value).
+    /// Schema-only: kept to publish a typed request schema; the handler ignores it.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub id: Option<String>,
+}
+
+/// Ack returned by the internal `shell::on-config-change` handler.
+#[derive(Debug, serde::Serialize, schemars::JsonSchema)]
+pub struct OnConfigChangeResponse {
+    pub ok: bool,
+}
+
 /// Register the internal config-change handler and bind a `configuration` trigger.
 pub fn register_config_trigger(iii: &IIIClient, state: AppState) -> Result<(), Error> {
     let st = state.clone();
     iii.register_function(
         CONFIG_FN_ID,
-        RegisterFunction::new_async(move |_payload: Value| {
+        RegisterFunction::new_async(move |_event: OnConfigChangeEvent| {
             let st = st.clone();
             async move {
                 on_config_change(&st).await.map_err(Error::from)?;
-                Ok::<Value, Error>(json!({ "ok": true }))
+                Ok::<OnConfigChangeResponse, Error>(OnConfigChangeResponse { ok: true })
             }
         })
         .description("Internal: reload the security policy + fs backend on configuration change."),


### PR DESCRIPTION
shell::on-config-change registered with serde_json::Value, producing an AnyValue request/response schema that the new publish flow (--assert-typed-schemas) rejects. Replace with concrete OnConfigChangeEvent / OnConfigChangeResponse structs (same pattern as storage/session-manager/web). Confirmed: collect_worker_interface.py --assert-typed-schemas now exits 0; the function publishes a typed schema. Build, fmt, clippy, tests green.

https://github.com/iii-hq/workers/actions/runs/28184577804/job/83483713571