### PR TITLE
chore(codex): bump iii-sdk to 0.20.0

### DIFF
--- a/codex/Cargo.lock
+++ b/codex/Cargo.lock
@@ -181,11 +181,11 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codex"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",
- "iii-observability",
+ "iii-helpers",
  "iii-sdk",
  "once_cell",
  "schemars",
@@ -671,16 +671,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-observability"
-version = "0.19.1-next.1"
+name = "iii-helpers"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7169861d75f52022881edf09657763c84299e935e60abe19faf98308dc4122e6"
+checksum = "09daa7c14a9e4c1f7077c4a181918d207e3f05cdfea8b2d7781bbeb80caf4c5d"
 dependencies = [
  "futures-util",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry_sdk",
  "reqwest",
+ "schemars",
+ "serde",
  "serde_json",
  "sysinfo",
  "tokio",
@@ -691,14 +693,14 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.19.1-next.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619bbf68e82f91fa54d23986f00958a5bd573a08751c89b6528d2e35916a8642"
+checksum = "5957568413b9a5178c11bf91b20909e93e568b187e259e941ba6009a7ec3f5c1"
 dependencies = [
  "async-trait",
  "futures-util",
  "hostname",
- "iii-observability",
+ "iii-helpers",
  "reqwest",
  "schemars",
  "serde",

--- a/codex/Cargo.toml
+++ b/codex/Cargo.toml
@@ -15,8 +15,8 @@ name = "codex"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.19.1-next.1"
-iii-observability = "=0.19.1-next.1"
+iii-sdk = "=0.20.0"
+iii-helpers = "=0.20.0"
 schemars = { version = "0.8", features = ["uuid1"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "process", "time", "io-util"] }
 serde = { version = "1", features = ["derive"] }

--- a/codex/src/codex/mod.rs
+++ b/codex/src/codex/mod.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::process::Stdio;
 use std::sync::Arc;
 
-use iii_sdk::III;
+use iii_sdk::IIIClient;
 use once_cell::sync::Lazy;
 use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -89,7 +89,7 @@ fn codex_bin(cfg: &Config) -> String {
 
 /// Run one Codex turn and return the result map. `iii_context_default` is the
 /// config-level toggle; the payload field overrides it.
-pub async fn run(iii: III, cfg: Arc<Config>, req: RunRequest) -> Value {
+pub async fn run(iii: IIIClient, cfg: Arc<Config>, req: RunRequest) -> Value {
     let session_id = req
         .session_id
         .clone()
@@ -270,7 +270,7 @@ struct Outcome {
 }
 
 async fn stream_turn(
-    iii: &III,
+    iii: &IIIClient,
     cfg: &Config,
     session_id: &str,
     child: &mut tokio::process::Child,

--- a/codex/src/configuration.rs
+++ b/codex/src/configuration.rs
@@ -7,7 +7,9 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use iii_sdk::{IIIError, RegisterFunction, RegisterTriggerInput, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::{json, Value};
 use tokio::sync::RwLock;
 
@@ -27,7 +29,7 @@ const CONFIG_RETRIES: u32 = 3;
 /// Register the `codex` configuration schema. When `seed` is present its value
 /// is installed as `initial_value`; otherwise the built-in default is seeded
 /// only when no stored value exists yet.
-pub async fn register_config(iii: &III, seed: Option<&Config>) -> Result<(), String> {
+pub async fn register_config(iii: &IIIClient, seed: Option<&Config>) -> Result<(), String> {
     let mut payload = json!({
         "id": CONFIG_ID,
         "name": "Codex",
@@ -44,7 +46,7 @@ pub async fn register_config(iii: &III, seed: Option<&Config>) -> Result<(), Str
 }
 
 /// Read the live `codex` configuration; built-in default when none stored.
-pub async fn fetch_config(iii: &III) -> Result<Config, String> {
+pub async fn fetch_config(iii: &IIIClient) -> Result<Config, String> {
     match try_get_value(iii).await? {
         Some(v) if !v.is_null() => Config::from_json(&v).map_err(|e| e.to_string()),
         _ => {
@@ -54,7 +56,7 @@ pub async fn fetch_config(iii: &III) -> Result<Config, String> {
     }
 }
 
-async fn should_seed_default(iii: &III) -> Result<bool, String> {
+async fn should_seed_default(iii: &IIIClient) -> Result<bool, String> {
     Ok(matches!(
         try_get_value(iii).await?,
         None | Some(Value::Null)
@@ -62,7 +64,7 @@ async fn should_seed_default(iii: &III) -> Result<bool, String> {
 }
 
 /// `Ok(None)` when the entry does not exist (`NOT_FOUND`).
-async fn try_get_value(iii: &III) -> Result<Option<Value>, String> {
+async fn try_get_value(iii: &IIIClient) -> Result<Option<Value>, String> {
     match trigger_with_retry(iii, "configuration::get", json!({ "id": CONFIG_ID })).await {
         Ok(resp) => Ok(resp.get("value").cloned()),
         Err(e) if e.contains("NOT_FOUND") => Ok(None),
@@ -76,7 +78,7 @@ pub async fn apply_config(cell: &ConfigCell, cfg: Config) {
 
 /// Register the internal config-change handler and bind the `configuration`
 /// trigger that wakes it.
-pub fn register_config_trigger(iii: &III, cell: ConfigCell) -> Result<(), IIIError> {
+pub fn register_config_trigger(iii: &IIIClient, cell: ConfigCell) -> Result<(), Error> {
     let engine = iii.clone();
     iii.register_function(
         CONFIG_FN_ID,
@@ -85,7 +87,7 @@ pub fn register_config_trigger(iii: &III, cell: ConfigCell) -> Result<(), IIIErr
             let engine = engine.clone();
             async move {
                 on_config_change(&engine, &cell).await;
-                Ok::<Value, IIIError>(json!({ "ok": true }))
+                Ok::<Value, Error>(json!({ "ok": true }))
             }
         })
         .request_format(json!({ "type": "object", "properties": {} }))
@@ -111,7 +113,7 @@ pub fn register_config_trigger(iii: &III, cell: ConfigCell) -> Result<(), IIIErr
 /// Re-fetch the authoritative value after trigger registration to close the
 /// boot race (an update that landed between the initial fetch and the trigger
 /// binding has no other listener).
-pub async fn reconcile(iii: &III, cell: &ConfigCell) {
+pub async fn reconcile(iii: &IIIClient, cell: &ConfigCell) {
     on_config_change(iii, cell).await;
 }
 
@@ -119,7 +121,7 @@ pub async fn reconcile(iii: &III, cell: &ConfigCell) {
 /// a discoverable bus function, so trusting `payload.new_value` would let any
 /// caller inject config without updating persisted state. Re-fetch the stored
 /// value instead. The previous snapshot is kept on any failure.
-async fn on_config_change(iii: &III, cell: &ConfigCell) {
+async fn on_config_change(iii: &IIIClient, cell: &ConfigCell) {
     match fetch_config(iii).await {
         Ok(cfg) => {
             apply_config(cell, cfg).await;
@@ -131,7 +133,11 @@ async fn on_config_change(iii: &III, cell: &ConfigCell) {
     }
 }
 
-async fn trigger_with_retry(iii: &III, function_id: &str, payload: Value) -> Result<Value, String> {
+async fn trigger_with_retry(
+    iii: &IIIClient,
+    function_id: &str,
+    payload: Value,
+) -> Result<Value, String> {
     let mut last_err = String::new();
     for attempt in 1..=CONFIG_RETRIES {
         match iii

--- a/codex/src/events.rs
+++ b/codex/src/events.rs
@@ -7,7 +7,8 @@
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-use iii_sdk::{TriggerRequest, III};
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
 use once_cell::sync::Lazy;
 use serde_json::{json, Value};
 use uuid::Uuid;
@@ -23,7 +24,7 @@ fn next_item_id(session_id: &str) -> String {
     format!("{session_id}-{}-{:08}", &*EPOCH, seq)
 }
 
-pub async fn emit(iii: &III, stream_name: &str, session_id: &str, data: Value) {
+pub async fn emit(iii: &IIIClient, stream_name: &str, session_id: &str, data: Value) {
     let item_id = next_item_id(session_id);
     let res = iii
         .trigger(TriggerRequest {

--- a/codex/src/functions/mod.rs
+++ b/codex/src/functions/mod.rs
@@ -4,7 +4,8 @@
 
 pub mod types;
 
-use iii_sdk::{IIIError, RegisterFunction, III};
+use iii_sdk::errors::Error;
+use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::{json, Value};
 
 use crate::codex;
@@ -41,7 +42,7 @@ fn run_response_schema() -> Value {
     })
 }
 
-pub fn register_all(iii: &III, cell: ConfigCell) {
+pub fn register_all(iii: &IIIClient, cell: ConfigCell) {
     // codex::run — run a turn and wait for the result.
     {
         let iii_h = iii.clone();
@@ -53,7 +54,7 @@ pub fn register_all(iii: &III, cell: ConfigCell) {
                 let cell_h = cell_h.clone();
                 async move {
                     let cfg = { cell_h.read().await.clone() };
-                    Ok::<Value, IIIError>(codex::run(iii_h, cfg, req).await)
+                    Ok::<Value, Error>(codex::run(iii_h, cfg, req).await)
                 }
             })
             .request_format(schema_value::<RunRequest>())
@@ -105,7 +106,7 @@ pub fn register_all(iii: &III, cell: ConfigCell) {
                             }
                         }
                     });
-                    Ok::<Value, IIIError>(json!({ "session_id": session_id, "started": true }))
+                    Ok::<Value, Error>(json!({ "session_id": session_id, "started": true }))
                 }
             })
             .request_format(schema_value::<RunRequest>())
@@ -125,7 +126,7 @@ pub fn register_all(iii: &III, cell: ConfigCell) {
         "codex::stop",
         RegisterFunction::new_async(move |req: SessionIdRequest| async move {
             let stopped = codex::stop(&req.session_id).await;
-            Ok::<Value, IIIError>(json!({
+            Ok::<Value, Error>(json!({
                 "session_id": req.session_id,
                 "stopped": stopped,
                 "reason": if stopped { Value::Null } else { json!("no live run") },
@@ -153,7 +154,7 @@ pub fn register_all(iii: &III, cell: ConfigCell) {
                 async move {
                     let record = load_session(&iii_h, &req.session_id).await.ok().flatten();
                     let live = codex::is_live(&req.session_id).await;
-                    Ok::<Value, IIIError>(json!({
+                    Ok::<Value, Error>(json!({
                         "session_id": req.session_id,
                         "live": live,
                         "record": record,
@@ -182,7 +183,7 @@ pub fn register_all(iii: &III, cell: ConfigCell) {
                 let iii_h = iii_h.clone();
                 async move {
                     let sessions = list_sessions(&iii_h).await.unwrap_or_default();
-                    Ok::<Value, IIIError>(json!({ "sessions": sessions }))
+                    Ok::<Value, Error>(json!({ "sessions": sessions }))
                 }
             })
             .request_format(json!({ "type": "object", "properties": {} }))

--- a/codex/src/main.rs
+++ b/codex/src/main.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use clap::Parser;
-use iii_observability::OtelConfig;
+use iii_helpers::observability::OtelConfig;
 use iii_sdk::{register_worker, InitOptions};
 use tokio::sync::RwLock;
 

--- a/codex/src/state.rs
+++ b/codex/src/state.rs
@@ -4,7 +4,8 @@
 //! ~/.codex/sessions). Trigger errors propagate (fail-fast); swallowing them
 //! would silently start a fresh conversation instead of resuming.
 
-use iii_sdk::{TriggerRequest, III};
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
 use serde_json::json;
 
 use crate::wire::SessionRecord;
@@ -12,7 +13,10 @@ use crate::wire::SessionRecord;
 const SCOPE: &str = "codex_sessions";
 const TIMEOUT_MS: u64 = 5_000;
 
-pub async fn load_session(iii: &III, session_id: &str) -> anyhow::Result<Option<SessionRecord>> {
+pub async fn load_session(
+    iii: &IIIClient,
+    session_id: &str,
+) -> anyhow::Result<Option<SessionRecord>> {
     let v = iii
         .trigger(TriggerRequest {
             function_id: "state::get".to_string(),
@@ -34,7 +38,7 @@ pub async fn load_session(iii: &III, session_id: &str) -> anyhow::Result<Option<
     Ok(Some(rec))
 }
 
-pub async fn save_session(iii: &III, record: &SessionRecord) -> anyhow::Result<()> {
+pub async fn save_session(iii: &IIIClient, record: &SessionRecord) -> anyhow::Result<()> {
     iii.trigger(TriggerRequest {
         function_id: "state::set".to_string(),
         payload: json!({ "scope": SCOPE, "key": record.session_id, "value": record }),
@@ -46,7 +50,7 @@ pub async fn save_session(iii: &III, record: &SessionRecord) -> anyhow::Result<(
     Ok(())
 }
 
-pub async fn list_sessions(iii: &III) -> anyhow::Result<Vec<SessionRecord>> {
+pub async fn list_sessions(iii: &IIIClient) -> anyhow::Result<Vec<SessionRecord>> {
     let v = iii
         .trigger(TriggerRequest {
             function_id: "state::list".to_string(),
@@ -68,7 +72,7 @@ pub async fn list_sessions(iii: &III) -> anyhow::Result<Vec<SessionRecord>> {
 
 /// Best-effort flip to `error` so a failed background run never leaves a
 /// record stuck in `working`. Swallows its own failure.
-pub async fn mark_error(iii: &III, session_id: &str) {
+pub async fn mark_error(iii: &IIIClient, session_id: &str) {
     match load_session(iii, session_id).await {
         Ok(Some(mut rec)) if matches!(rec.status, crate::wire::Status::Working) => {
             rec.status = crate::wire::Status::Error;


### PR DESCRIPTION
Bump iii-sdk to 0.20.0 + migrate observability to iii-helpers (iii-observability removed) per https://iii.dev/docs/upgrading/from-0-19-x.md. Build, fmt, clippy, tests green (32 tests); surface parity (6 functions) 1:1. No import aliases.