### PR TITLE
chore(telegram-bot): bump iii-sdk to 0.20.0

### DIFF
--- a/telegram-bot/Cargo.lock
+++ b/telegram-bot/Cargo.lock
@@ -678,16 +678,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-observability"
-version = "0.19.4"
+name = "iii-helpers"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a3002534a53d85c86e4be167cf7ae8c1de809ab3130ecfcb2d85eb4afd1272"
+checksum = "09daa7c14a9e4c1f7077c4a181918d207e3f05cdfea8b2d7781bbeb80caf4c5d"
 dependencies = [
  "futures-util",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry_sdk",
  "reqwest",
+ "schemars",
+ "serde",
  "serde_json",
  "sysinfo",
  "tokio",
@@ -698,14 +700,14 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.19.4"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebda94ffd347b173746edaccb6e8767c1c2afc4c2663c3a01756396de2660c32"
+checksum = "5957568413b9a5178c11bf91b20909e93e568b187e259e941ba6009a7ec3f5c1"
 dependencies = [
  "async-trait",
  "futures-util",
  "hostname",
- "iii-observability",
+ "iii-helpers",
  "reqwest",
  "schemars",
  "serde",
@@ -1527,12 +1529,12 @@ dependencies = [
 
 [[package]]
 name = "telegram-bot"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",
  "dashmap",
- "iii-observability",
+ "iii-helpers",
  "iii-sdk",
  "pulldown-cmark",
  "reqwest",

--- a/telegram-bot/Cargo.toml
+++ b/telegram-bot/Cargo.toml
@@ -15,8 +15,8 @@ name = "telegram_bot"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.19.4"
-iii-observability = "0.19.4"
+iii-sdk = "=0.20.0"
+iii-helpers = "=0.20.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/telegram-bot/src/approval_gate.rs
+++ b/telegram-bot/src/approval_gate.rs
@@ -7,7 +7,9 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use iii_sdk::{IIIError, RegisterFunction, RegisterTriggerInput, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::{IIIClient, RegisterFunction};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -61,7 +63,7 @@ pub fn is_approval_gate_available(status: &ApprovalGateStatus) -> bool {
 }
 
 /// One-time presence probe via `engine::workers::list`.
-pub async fn probe_presence(iii: &III) -> bool {
+pub async fn probe_presence(iii: &IIIClient) -> bool {
     match list_workers(iii).await {
         Ok(workers) => workers
             .iter()
@@ -94,7 +96,7 @@ struct WorkerLifecycleAck {
 /// `approval-gate` flips presence and invokes `on_present` when the gate
 /// connects.
 pub fn start_watch(
-    iii: Arc<III>,
+    iii: Arc<IIIClient>,
     status: Arc<ApprovalGateStatus>,
     on_present: Arc<dyn Fn() + Send + Sync>,
 ) {
@@ -105,7 +107,7 @@ pub fn start_watch(
             let on_present = on_present.clone();
             async move {
                 handle_worker_event(&status, &on_present, &event);
-                Ok::<_, IIIError>(WorkerLifecycleAck { ok: true })
+                Ok::<_, Error>(WorkerLifecycleAck { ok: true })
             }
         })
         .description("Internal: track approval-gate worker add/remove."),
@@ -191,7 +193,7 @@ struct EngineWorker {
     name: Option<String>,
 }
 
-async fn list_workers(iii: &III) -> Result<Vec<EngineWorker>, IIIError> {
+async fn list_workers(iii: &IIIClient) -> Result<Vec<EngineWorker>, Error> {
     let result = iii
         .trigger(TriggerRequest {
             function_id: "engine::workers::list".into(),

--- a/telegram-bot/src/clients/approval.rs
+++ b/telegram-bot/src/clients/approval.rs
@@ -1,4 +1,6 @@
-use iii_sdk::{IIIError, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -37,10 +39,10 @@ pub struct ListPendingResponse {
 }
 
 pub async fn resolve(
-    iii: &III,
+    iii: &IIIClient,
     req: ResolveRequest,
     timeout_ms: u64,
-) -> Result<ResolveResponse, IIIError> {
+) -> Result<ResolveResponse, Error> {
     let value = iii
         .trigger(TriggerRequest {
             function_id: "approval::resolve".into(),
@@ -49,15 +51,15 @@ pub async fn resolve(
             timeout_ms: Some(timeout_ms),
         })
         .await?;
-    serde_json::from_value(value).map_err(|e| IIIError::Handler(format!("approval::resolve: {e}")))
+    serde_json::from_value(value).map_err(|e| Error::Handler(format!("approval::resolve: {e}")))
 }
 
 pub async fn approve_always(
-    iii: &III,
+    iii: &IIIClient,
     session_id: &str,
     function_id: &str,
     timeout_ms: u64,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     iii.trigger(TriggerRequest {
         function_id: "approval::approve-always".into(),
         payload: json!({
@@ -72,10 +74,10 @@ pub async fn approve_always(
 }
 
 pub async fn list_pending(
-    iii: &III,
+    iii: &IIIClient,
     session_id: &str,
     timeout_ms: u64,
-) -> Result<Vec<PendingApprovalRecord>, IIIError> {
+) -> Result<Vec<PendingApprovalRecord>, Error> {
     let value = iii
         .trigger(TriggerRequest {
             function_id: "approval::list-pending".into(),
@@ -85,6 +87,6 @@ pub async fn list_pending(
         })
         .await?;
     let resp: ListPendingResponse = serde_json::from_value(value)
-        .map_err(|e| IIIError::Handler(format!("approval::list-pending: {e}")))?;
+        .map_err(|e| Error::Handler(format!("approval::list-pending: {e}")))?;
     Ok(resp.pending)
 }

--- a/telegram-bot/src/clients/harness.rs
+++ b/telegram-bot/src/clients/harness.rs
@@ -1,4 +1,6 @@
-use iii_sdk::{IIIError, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -95,10 +97,10 @@ pub struct HarnessStatusRequest {
 }
 
 pub async fn send(
-    iii: &III,
+    iii: &IIIClient,
     req: HarnessSendRequest,
     timeout_ms: u64,
-) -> Result<HarnessSendResponse, IIIError> {
+) -> Result<HarnessSendResponse, Error> {
     let value = iii
         .trigger(TriggerRequest {
             function_id: "harness::send".into(),
@@ -107,14 +109,14 @@ pub async fn send(
             timeout_ms: Some(timeout_ms),
         })
         .await?;
-    serde_json::from_value(value).map_err(|e| IIIError::Handler(format!("harness::send: {e}")))
+    serde_json::from_value(value).map_err(|e| Error::Handler(format!("harness::send: {e}")))
 }
 
 pub async fn stop(
-    iii: &III,
+    iii: &IIIClient,
     session_id: &str,
     timeout_ms: u64,
-) -> Result<HarnessStopResponse, IIIError> {
+) -> Result<HarnessStopResponse, Error> {
     let value = iii
         .trigger(TriggerRequest {
             function_id: "harness::stop".into(),
@@ -123,10 +125,14 @@ pub async fn stop(
             timeout_ms: Some(timeout_ms),
         })
         .await?;
-    serde_json::from_value(value).map_err(|e| IIIError::Handler(format!("harness::stop: {e}")))
+    serde_json::from_value(value).map_err(|e| Error::Handler(format!("harness::stop: {e}")))
 }
 
-pub async fn status_active(iii: &III, session_id: &str, timeout_ms: u64) -> Result<bool, IIIError> {
+pub async fn status_active(
+    iii: &IIIClient,
+    session_id: &str,
+    timeout_ms: u64,
+) -> Result<bool, Error> {
     let v = iii
         .trigger(TriggerRequest {
             function_id: "harness::status".into(),

--- a/telegram-bot/src/clients/router.rs
+++ b/telegram-bot/src/clients/router.rs
@@ -1,4 +1,6 @@
-use iii_sdk::{IIIError, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -24,7 +26,7 @@ pub struct ModelsListResponse {
     pub models: Vec<Model>,
 }
 
-pub async fn list_models(iii: &III, timeout_ms: u64) -> Result<Vec<Model>, IIIError> {
+pub async fn list_models(iii: &IIIClient, timeout_ms: u64) -> Result<Vec<Model>, Error> {
     let value = iii
         .trigger(TriggerRequest {
             function_id: "router::models::list".into(),
@@ -34,6 +36,6 @@ pub async fn list_models(iii: &III, timeout_ms: u64) -> Result<Vec<Model>, IIIEr
         })
         .await?;
     let resp: ModelsListResponse = serde_json::from_value(value)
-        .map_err(|e| IIIError::Handler(format!("router::models::list: {e}")))?;
+        .map_err(|e| Error::Handler(format!("router::models::list: {e}")))?;
     Ok(resp.models)
 }

--- a/telegram-bot/src/clients/state.rs
+++ b/telegram-bot/src/clients/state.rs
@@ -1,12 +1,14 @@
-use iii_sdk::{IIIError, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
 use serde_json::{json, Value};
 
 pub async fn get(
-    iii: &III,
+    iii: &IIIClient,
     scope: &str,
     key: &str,
     timeout_ms: Option<u64>,
-) -> Result<Value, IIIError> {
+) -> Result<Value, Error> {
     iii.trigger(TriggerRequest {
         function_id: "state::get".into(),
         payload: json!({ "scope": scope, "key": key }),
@@ -17,12 +19,12 @@ pub async fn get(
 }
 
 pub async fn set(
-    iii: &III,
+    iii: &IIIClient,
     scope: &str,
     key: &str,
     value: Value,
     timeout_ms: Option<u64>,
-) -> Result<Value, IIIError> {
+) -> Result<Value, Error> {
     iii.trigger(TriggerRequest {
         function_id: "state::set".into(),
         payload: json!({ "scope": scope, "key": key, "value": value }),
@@ -33,11 +35,11 @@ pub async fn set(
 }
 
 pub async fn delete(
-    iii: &III,
+    iii: &IIIClient,
     scope: &str,
     key: &str,
     timeout_ms: Option<u64>,
-) -> Result<Value, IIIError> {
+) -> Result<Value, Error> {
     iii.trigger(TriggerRequest {
         function_id: "state::delete".into(),
         payload: json!({ "scope": scope, "key": key }),
@@ -47,14 +49,19 @@ pub async fn delete(
     .await
 }
 
-pub async fn get_string(iii: &III, scope: &str, key: &str, timeout_ms: u64) -> Option<String> {
+pub async fn get_string(
+    iii: &IIIClient,
+    scope: &str,
+    key: &str,
+    timeout_ms: u64,
+) -> Option<String> {
     match get(iii, scope, key, Some(timeout_ms)).await {
         Ok(v) if v.is_string() => v.as_str().map(str::to_string),
         _ => None,
     }
 }
 
-pub async fn get_i64(iii: &III, scope: &str, key: &str, timeout_ms: u64) -> Option<i64> {
+pub async fn get_i64(iii: &IIIClient, scope: &str, key: &str, timeout_ms: u64) -> Option<i64> {
     match get(iii, scope, key, Some(timeout_ms)).await {
         Ok(v) if v.is_i64() => v.as_i64(),
         Ok(v) if v.is_u64() => v.as_u64().and_then(|n| i64::try_from(n).ok()),

--- a/telegram-bot/src/clients/telegram.rs
+++ b/telegram-bot/src/clients/telegram.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use iii_sdk::IIIError;
+use iii_sdk::errors::Error;
 use serde_json::{json, Value};
 use tokio_util::sync::CancellationToken;
 
@@ -15,7 +15,7 @@ pub async fn send_message(
     text: &str,
     reply_markup: Option<Value>,
     parse_mode: Option<&str>,
-) -> Result<i64, IIIError> {
+) -> Result<i64, Error> {
     let mut body = json!({
         "chat_id": chat_id,
         "text": text,
@@ -30,7 +30,7 @@ pub async fn send_message(
     message_id
         .get("message_id")
         .and_then(Value::as_i64)
-        .ok_or_else(|| IIIError::Handler("telegram sendMessage: missing message_id".into()))
+        .ok_or_else(|| Error::Handler("telegram sendMessage: missing message_id".into()))
 }
 
 pub async fn edit_message_text(
@@ -39,7 +39,7 @@ pub async fn edit_message_text(
     message_id: i64,
     text: &str,
     parse_mode: Option<&str>,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let mut body = json!({
         "chat_id": chat_id,
         "message_id": message_id,
@@ -56,7 +56,7 @@ pub async fn edit_message_reply_markup(
     deps: &Deps,
     chat_id: i64,
     message_id: i64,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let body = json!({
         "chat_id": chat_id,
         "message_id": message_id,
@@ -72,7 +72,7 @@ pub async fn send_message_draft(
     draft_id: i32,
     text: &str,
     message_thread_id: Option<i64>,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let mut body = json!({
         "chat_id": chat_id,
         "draft_id": draft_id,
@@ -91,7 +91,7 @@ pub async fn send_rich_message_draft(
     draft_id: i32,
     rich_message: &Value,
     message_thread_id: Option<i64>,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let mut body = json!({
         "chat_id": chat_id,
         "draft_id": draft_id,
@@ -109,7 +109,7 @@ pub async fn send_rich_message(
     chat_id: i64,
     rich_message: &Value,
     message_thread_id: Option<i64>,
-) -> Result<i64, IIIError> {
+) -> Result<i64, Error> {
     let mut body = json!({
         "chat_id": chat_id,
         "rich_message": rich_message,
@@ -121,7 +121,7 @@ pub async fn send_rich_message(
     result
         .get("message_id")
         .and_then(Value::as_i64)
-        .ok_or_else(|| IIIError::Handler("telegram sendRichMessage: missing message_id".into()))
+        .ok_or_else(|| Error::Handler("telegram sendRichMessage: missing message_id".into()))
 }
 
 pub fn rich_thinking_draft(thinking_text: &str) -> Value {
@@ -153,7 +153,7 @@ pub async fn answer_callback_query(
     deps: &Deps,
     callback_id: &str,
     text: Option<&str>,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let mut body = json!({ "callback_query_id": callback_id });
     if let Some(t) = text {
         body["text"] = json!(t);
@@ -162,7 +162,7 @@ pub async fn answer_callback_query(
     Ok(())
 }
 
-pub async fn set_my_commands(deps: &Deps) -> Result<(), IIIError> {
+pub async fn set_my_commands(deps: &Deps) -> Result<(), Error> {
     let commands = json!([
         { "command": "start", "description": "Start or pick a model" },
         { "command": "stop", "description": "Stop the current turn" },
@@ -176,11 +176,7 @@ pub async fn set_my_commands(deps: &Deps) -> Result<(), IIIError> {
     Ok(())
 }
 
-pub async fn set_webhook(
-    deps: &Deps,
-    url: &str,
-    secret_token: Option<&str>,
-) -> Result<(), IIIError> {
+pub async fn set_webhook(deps: &Deps, url: &str, secret_token: Option<&str>) -> Result<(), Error> {
     let mut body = json!({ "url": url });
     if let Some(secret) = secret_token {
         body["secret_token"] = json!(secret);
@@ -189,12 +185,12 @@ pub async fn set_webhook(
     Ok(())
 }
 
-pub async fn delete_webhook(deps: &Deps) -> Result<(), IIIError> {
+pub async fn delete_webhook(deps: &Deps) -> Result<(), Error> {
     api_call(deps, "deleteWebhook", json!({})).await?;
     Ok(())
 }
 
-pub async fn get_file(deps: &Deps, file_id: &str) -> Result<Value, IIIError> {
+pub async fn get_file(deps: &Deps, file_id: &str) -> Result<Value, Error> {
     api_call(deps, "getFile", json!({ "file_id": file_id })).await
 }
 
@@ -202,7 +198,7 @@ pub async fn get_updates(
     deps: &Deps,
     offset: i64,
     timeout_secs: u64,
-) -> Result<Vec<TelegramUpdate>, IIIError> {
+) -> Result<Vec<TelegramUpdate>, Error> {
     get_updates_with_cancel(deps, offset, timeout_secs, None).await
 }
 
@@ -211,7 +207,7 @@ pub async fn get_updates_with_cancel(
     offset: i64,
     timeout_secs: u64,
     cancel: Option<&CancellationToken>,
-) -> Result<Vec<TelegramUpdate>, IIIError> {
+) -> Result<Vec<TelegramUpdate>, Error> {
     let body = json!({
         "offset": offset,
         "timeout": timeout_secs,
@@ -222,7 +218,7 @@ pub async fn get_updates_with_cancel(
         let mut call = Box::pin(api_call_with_timeout(deps, "getUpdates", body, timeout));
         tokio::select! {
             _ = cancel.cancelled() => {
-                return Err(IIIError::Handler("getUpdates cancelled".into()));
+                return Err(Error::Handler("getUpdates cancelled".into()));
             }
             result = &mut call => result?,
         }
@@ -231,17 +227,17 @@ pub async fn get_updates_with_cancel(
     };
     let updates = result
         .as_array()
-        .ok_or_else(|| IIIError::Handler("telegram getUpdates: expected array".into()))?;
+        .ok_or_else(|| Error::Handler("telegram getUpdates: expected array".into()))?;
     let mut out = Vec::with_capacity(updates.len());
     for item in updates {
         let update: TelegramUpdate = serde_json::from_value(item.clone())
-            .map_err(|e| IIIError::Handler(format!("telegram getUpdates parse: {e}")))?;
+            .map_err(|e| Error::Handler(format!("telegram getUpdates parse: {e}")))?;
         out.push(update);
     }
     Ok(out)
 }
 
-async fn api_call(deps: &Deps, method: &str, body: Value) -> Result<Value, IIIError> {
+async fn api_call(deps: &Deps, method: &str, body: Value) -> Result<Value, Error> {
     api_call_with_timeout(deps, method, body, Duration::from_secs(30)).await
 }
 
@@ -250,7 +246,7 @@ async fn api_call_with_timeout(
     method: &str,
     body: Value,
     timeout: Duration,
-) -> Result<Value, IIIError> {
+) -> Result<Value, Error> {
     let cfg = deps.cfg().await;
     let token = cfg.bot_token.clone();
     let url = format!("{API_BASE}{token}/{method}");
@@ -262,13 +258,13 @@ async fn api_call_with_timeout(
         .json(&body)
         .send()
         .await
-        .map_err(|e| IIIError::Handler(format!("telegram http: {}", e.without_url())))?;
+        .map_err(|e| Error::Handler(format!("telegram http: {}", e.without_url())))?;
     let payload: Value = resp
         .json()
         .await
-        .map_err(|e| IIIError::Handler(format!("telegram json: {e}")))?;
+        .map_err(|e| Error::Handler(format!("telegram json: {e}")))?;
     if payload.get("ok").and_then(Value::as_bool) != Some(true) {
-        return Err(IIIError::Handler(format!(
+        return Err(Error::Handler(format!(
             "telegram {method} failed: {payload}"
         )));
     }

--- a/telegram-bot/src/configuration.rs
+++ b/telegram-bot/src/configuration.rs
@@ -4,7 +4,9 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use iii_sdk::{IIIError, RegisterFunction, RegisterTriggerInput, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::{json, Value};
 use tokio::sync::RwLock;
 
@@ -23,7 +25,7 @@ fn config_rpc_timeout_ms(seed: Option<&WorkerConfig>) -> u64 {
         .unwrap_or_else(|| WorkerConfig::default().timeout_ms)
 }
 
-pub async fn register_config(iii: &III, seed: Option<&WorkerConfig>) -> Result<(), String> {
+pub async fn register_config(iii: &IIIClient, seed: Option<&WorkerConfig>) -> Result<(), String> {
     let mut payload = json!({
         "id": CONFIG_ID,
         "name": "Telegram Worker",
@@ -45,11 +47,14 @@ pub async fn register_config(iii: &III, seed: Option<&WorkerConfig>) -> Result<(
     Ok(())
 }
 
-pub async fn fetch_config(iii: &III) -> Result<WorkerConfig, String> {
+pub async fn fetch_config(iii: &IIIClient) -> Result<WorkerConfig, String> {
     fetch_config_with_timeout(iii, WorkerConfig::default().timeout_ms).await
 }
 
-async fn fetch_config_with_timeout(iii: &III, timeout_ms: u64) -> Result<WorkerConfig, String> {
+async fn fetch_config_with_timeout(
+    iii: &IIIClient,
+    timeout_ms: u64,
+) -> Result<WorkerConfig, String> {
     let value = try_get_config_value(iii, timeout_ms)
         .await?
         .ok_or_else(|| format!("configuration `{CONFIG_ID}` not found"))?;
@@ -60,7 +65,7 @@ async fn fetch_config_with_timeout(iii: &III, timeout_ms: u64) -> Result<WorkerC
     WorkerConfig::from_json(&value)
 }
 
-async fn should_seed_default_value(iii: &III) -> Result<bool, String> {
+async fn should_seed_default_value(iii: &IIIClient) -> Result<bool, String> {
     match try_get_config_value(iii, WorkerConfig::default().timeout_ms).await? {
         None => Ok(true),
         Some(value) if value.is_null() => Ok(true),
@@ -68,7 +73,7 @@ async fn should_seed_default_value(iii: &III) -> Result<bool, String> {
     }
 }
 
-async fn try_get_config_value(iii: &III, timeout_ms: u64) -> Result<Option<Value>, String> {
+async fn try_get_config_value(iii: &IIIClient, timeout_ms: u64) -> Result<Option<Value>, String> {
     match trigger_with_retry(
         iii,
         "configuration::get",
@@ -101,10 +106,10 @@ pub async fn apply_config(cell: &ConfigCell, cfg: WorkerConfig) -> bool {
 }
 
 pub fn register_config_trigger(
-    iii: &III,
+    iii: &IIIClient,
     cell: ConfigCell,
     deps: Arc<Deps>,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let cell_for_fn = cell.clone();
     let engine = iii.clone();
     let deps_for_fn = deps.clone();
@@ -116,7 +121,7 @@ pub fn register_config_trigger(
             let deps = deps_for_fn.clone();
             async move {
                 on_config_change(&engine, &cell, &deps).await;
-                Ok::<_, IIIError>(ConfigChangeAck { ok: true })
+                Ok::<_, Error>(ConfigChangeAck { ok: true })
             }
         })
         .description(
@@ -136,7 +141,7 @@ pub fn register_config_trigger(
     Ok(())
 }
 
-async fn on_config_change(iii: &III, cell: &ConfigCell, deps: &Arc<Deps>) {
+async fn on_config_change(iii: &IIIClient, cell: &ConfigCell, deps: &Arc<Deps>) {
     let prev = cell.read().await.clone();
     let timeout_ms = prev.timeout_ms;
     let cfg = match fetch_config_with_timeout(iii, timeout_ms).await {
@@ -159,7 +164,7 @@ async fn on_config_change(iii: &III, cell: &ConfigCell, deps: &Arc<Deps>) {
 }
 
 async fn trigger_with_retry(
-    iii: &III,
+    iii: &IIIClient,
     function_id: &str,
     payload: Value,
     timeout_ms: u64,

--- a/telegram-bot/src/deps.rs
+++ b/telegram-bot/src/deps.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use dashmap::DashMap;
-use iii_sdk::{Trigger, III};
+use iii_sdk::trigger::Trigger;
+use iii_sdk::IIIClient;
 use reqwest::Client;
 use tokio::sync::{Mutex, Notify};
 use tokio::task::JoinHandle;
@@ -19,14 +20,18 @@ pub const STATE_SCOPE: &str = "telegram-bot";
 
 #[derive(Clone)]
 pub struct Deps {
-    pub iii: Arc<III>,
+    pub iii: Arc<IIIClient>,
     pub config: ConfigCell,
     pub runtime: Arc<RuntimeState>,
     pub approval_gate: Arc<ApprovalGateStatus>,
 }
 
 impl Deps {
-    pub fn new(iii: Arc<III>, config: ConfigCell, approval_gate: Arc<ApprovalGateStatus>) -> Self {
+    pub fn new(
+        iii: Arc<IIIClient>,
+        config: ConfigCell,
+        approval_gate: Arc<ApprovalGateStatus>,
+    ) -> Self {
         Self {
             iii,
             config,

--- a/telegram-bot/src/functions/bindings/message_added.rs
+++ b/telegram-bot/src/functions/bindings/message_added.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use iii_sdk::{IIIError, III};
+use iii_sdk::errors::Error;
+use iii_sdk::IIIClient;
 
 use crate::deps::Deps;
 use crate::render::stream;
@@ -12,7 +13,7 @@ pub struct BindingAck {
     pub ok: bool,
 }
 
-pub fn register(iii: &Arc<III>, deps: &Arc<Deps>) {
+pub fn register(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
     super::super::register(
         iii,
         deps,
@@ -22,7 +23,7 @@ pub fn register(iii: &Arc<III>, deps: &Arc<Deps>) {
     );
 }
 
-async fn handle(deps: &Deps, evt: MessageAddedEvent) -> Result<BindingAck, IIIError> {
+async fn handle(deps: &Deps, evt: MessageAddedEvent) -> Result<BindingAck, Error> {
     let message = match evt.message {
         Some(m) => m,
         None => return Ok(BindingAck { ok: true }),

--- a/telegram-bot/src/functions/bindings/message_updated.rs
+++ b/telegram-bot/src/functions/bindings/message_updated.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use iii_sdk::{IIIError, III};
+use iii_sdk::errors::Error;
+use iii_sdk::IIIClient;
 
 use crate::deps::Deps;
 use crate::render::stream;
@@ -9,7 +10,7 @@ use crate::types::MessageUpdatedEvent;
 
 use super::message_added::BindingAck;
 
-pub fn register(iii: &Arc<III>, deps: &Arc<Deps>) {
+pub fn register(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
     super::super::register(
         iii,
         deps,
@@ -19,7 +20,7 @@ pub fn register(iii: &Arc<III>, deps: &Arc<Deps>) {
     );
 }
 
-async fn handle(deps: &Deps, evt: MessageUpdatedEvent) -> Result<BindingAck, IIIError> {
+async fn handle(deps: &Deps, evt: MessageUpdatedEvent) -> Result<BindingAck, Error> {
     let session_id = evt.session_id.clone();
     let entry_id = evt.entry_id.clone();
     telemetry::with_session_baggage(deps, &session_id, Some(&entry_id), || async {

--- a/telegram-bot/src/functions/bindings/mod.rs
+++ b/telegram-bot/src/functions/bindings/mod.rs
@@ -7,11 +7,11 @@ pub mod turn_completed;
 
 use std::sync::Arc;
 
-use iii_sdk::III;
+use iii_sdk::IIIClient;
 
 use crate::deps::Deps;
 
-pub fn register(iii: &Arc<III>, deps: &Arc<Deps>) {
+pub fn register(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
     message_added::register(iii, deps);
     message_updated::register(iii, deps);
     status_changed::register(iii, deps);

--- a/telegram-bot/src/functions/bindings/pending_created.rs
+++ b/telegram-bot/src/functions/bindings/pending_created.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use iii_sdk::{IIIError, III};
+use iii_sdk::errors::Error;
+use iii_sdk::IIIClient;
 
 use crate::clients::telegram;
 use crate::deps::Deps;
@@ -9,7 +10,7 @@ use crate::types::PendingApprovalRecord;
 
 use super::message_added::BindingAck;
 
-pub fn register(iii: &Arc<III>, deps: &Arc<Deps>) {
+pub fn register(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
     super::super::register(
         iii,
         deps,
@@ -22,7 +23,7 @@ pub fn register(iii: &Arc<III>, deps: &Arc<Deps>) {
 pub async fn handle_internal(
     deps: &Deps,
     record: PendingApprovalRecord,
-) -> Result<BindingAck, IIIError> {
+) -> Result<BindingAck, Error> {
     let Some(chat_id) = kv::chat_id_for_session(deps, &record.session_id).await else {
         return Ok(BindingAck { ok: true });
     };

--- a/telegram-bot/src/functions/bindings/pending_resolved.rs
+++ b/telegram-bot/src/functions/bindings/pending_resolved.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use iii_sdk::{IIIError, III};
+use iii_sdk::errors::Error;
+use iii_sdk::IIIClient;
 
 use crate::clients::telegram;
 use crate::deps::Deps;
@@ -9,7 +10,7 @@ use crate::types::PendingResolvedEvent;
 
 use super::message_added::BindingAck;
 
-pub fn register(iii: &Arc<III>, deps: &Arc<Deps>) {
+pub fn register(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
     super::super::register(
         iii,
         deps,
@@ -19,7 +20,7 @@ pub fn register(iii: &Arc<III>, deps: &Arc<Deps>) {
     );
 }
 
-async fn handle(deps: &Deps, evt: PendingResolvedEvent) -> Result<BindingAck, IIIError> {
+async fn handle(deps: &Deps, evt: PendingResolvedEvent) -> Result<BindingAck, Error> {
     let Some(chat_id) = kv::chat_id_for_session(deps, &evt.session_id).await else {
         return Ok(BindingAck { ok: true });
     };

--- a/telegram-bot/src/functions/bindings/status_changed.rs
+++ b/telegram-bot/src/functions/bindings/status_changed.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use iii_sdk::{IIIError, III};
+use iii_sdk::errors::Error;
+use iii_sdk::IIIClient;
 
 use crate::deps::Deps;
 use crate::telemetry;
@@ -8,7 +9,7 @@ use crate::types::StatusChangedEvent;
 
 use super::message_added::BindingAck;
 
-pub fn register(iii: &Arc<III>, deps: &Arc<Deps>) {
+pub fn register(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
     super::super::register(
         iii,
         deps,
@@ -18,7 +19,7 @@ pub fn register(iii: &Arc<III>, deps: &Arc<Deps>) {
     );
 }
 
-async fn handle(deps: Arc<Deps>, evt: StatusChangedEvent) -> Result<BindingAck, IIIError> {
+async fn handle(deps: Arc<Deps>, evt: StatusChangedEvent) -> Result<BindingAck, Error> {
     telemetry::with_session_baggage(&deps, &evt.session_id, None, || async {
         tracing::debug!(
             status = %evt.status,

--- a/telegram-bot/src/functions/bindings/turn_completed.rs
+++ b/telegram-bot/src/functions/bindings/turn_completed.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use iii_sdk::{IIIError, III};
+use iii_sdk::errors::Error;
+use iii_sdk::IIIClient;
 
 use crate::config::SteeringMode;
 use crate::deps::Deps;
@@ -11,7 +12,7 @@ use crate::types::TurnCompletedEvent;
 
 use super::message_added::BindingAck;
 
-pub fn register(iii: &Arc<III>, deps: &Arc<Deps>) {
+pub fn register(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
     super::super::register(
         iii,
         deps,
@@ -21,7 +22,7 @@ pub fn register(iii: &Arc<III>, deps: &Arc<Deps>) {
     );
 }
 
-async fn handle(deps: &Deps, evt: TurnCompletedEvent) -> Result<BindingAck, IIIError> {
+async fn handle(deps: &Deps, evt: TurnCompletedEvent) -> Result<BindingAck, Error> {
     telemetry::with_baggage(&evt.session_id, &evt.turn_id, || async {
         let cfg = deps.cfg().await;
 
@@ -75,7 +76,7 @@ async fn drain_fifo(
     chat_id: i64,
     session_id: &str,
     cfg: &crate::config::WorkerConfig,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let text = deps
         .runtime
         .fifo_queues

--- a/telegram-bot/src/functions/mod.rs
+++ b/telegram-bot/src/functions/mod.rs
@@ -6,7 +6,10 @@ pub mod webhook;
 use std::future::Future;
 use std::sync::Arc;
 
-use iii_sdk::{IIIError, RegisterFunction, RegisterTriggerInput, Trigger, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::RegisterTriggerInput;
+use iii_sdk::trigger::Trigger;
+use iii_sdk::{IIIClient, RegisterFunction};
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -25,7 +28,7 @@ pub const ON_PENDING_CREATED_ID: &str = "telegram-bot::on-pending-created";
 pub const ON_PENDING_RESOLVED_ID: &str = "telegram-bot::on-pending-resolved";
 
 fn register<Req, Resp, F, Fut>(
-    iii: &Arc<III>,
+    iii: &Arc<IIIClient>,
     deps: &Arc<Deps>,
     id: &str,
     description: &str,
@@ -34,7 +37,7 @@ fn register<Req, Resp, F, Fut>(
     Req: DeserializeOwned + JsonSchema + Send + 'static,
     Resp: Serialize + JsonSchema + Send + 'static,
     F: Fn(Arc<Deps>, Req) -> Fut + Send + Sync + Clone + 'static,
-    Fut: Future<Output = Result<Resp, IIIError>> + Send + 'static,
+    Fut: Future<Output = Result<Resp, Error>> + Send + 'static,
 {
     let deps = deps.clone();
     iii.register_function(
@@ -48,7 +51,7 @@ fn register<Req, Resp, F, Fut>(
     );
 }
 
-pub fn register_all(iii: &Arc<III>, deps: &Arc<Deps>) {
+pub fn register_all(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
     webhook::register(iii, deps);
     set_webhook::register(iii, deps);
     notify::register(iii, deps);
@@ -56,7 +59,7 @@ pub fn register_all(iii: &Arc<III>, deps: &Arc<Deps>) {
     tracing::info!("all functions registered");
 }
 
-pub fn bind_triggers(iii: &Arc<III>) {
+pub fn bind_triggers(iii: &Arc<IIIClient>) {
     let bindings = [
         (
             "session::message-added",
@@ -78,7 +81,7 @@ pub fn bind_triggers(iii: &Arc<III>) {
 
 /// Bind approval trigger handlers. Only safe to call when the optional
 /// `approval-gate` worker is connected (registers `approval::pending-*`).
-pub fn bind_approval_triggers(iii: &Arc<III>) {
+pub fn bind_approval_triggers(iii: &Arc<IIIClient>) {
     let bindings = [
         (
             "approval::pending-created",
@@ -102,7 +105,7 @@ pub fn bind_approval_triggers(iii: &Arc<III>) {
 /// route is registered/unregistered dynamically by [`crate::ingress`] to follow
 /// the `updates` adapter (created on switch to webhook, removed on switch back
 /// to polling) — see [`register_webhook_trigger`].
-pub fn bind_http_triggers(iii: &Arc<III>) {
+pub fn bind_http_triggers(iii: &Arc<IIIClient>) {
     let http = [(SET_WEBHOOK_ID, "telegram-bot/set-webhook", "POST")];
     for (function_id, api_path, http_method) in http {
         match iii.register_trigger(RegisterTriggerInput {
@@ -121,7 +124,7 @@ pub fn bind_http_triggers(iii: &Arc<III>) {
 /// handle so the caller can later [`Trigger::unregister`] it. The route path is
 /// [`crate::config::WEBHOOK_API_PATH`] — the same constant used to derive the
 /// public URL handed to Telegram, so they cannot drift.
-pub fn register_webhook_trigger(iii: &III) -> Result<Trigger, IIIError> {
+pub fn register_webhook_trigger(iii: &IIIClient) -> Result<Trigger, Error> {
     iii.register_trigger(RegisterTriggerInput {
         trigger_type: "http".to_string(),
         function_id: WEBHOOK_ID.to_string(),
@@ -131,7 +134,7 @@ pub fn register_webhook_trigger(iii: &III) -> Result<Trigger, IIIError> {
 }
 
 fn bind_best_effort(
-    iii: &Arc<III>,
+    iii: &Arc<IIIClient>,
     trigger_type: &str,
     function_id: &str,
     config: serde_json::Value,

--- a/telegram-bot/src/functions/notify.rs
+++ b/telegram-bot/src/functions/notify.rs
@@ -11,7 +11,8 @@
 
 use std::sync::Arc;
 
-use iii_sdk::{IIIError, III};
+use iii_sdk::errors::Error;
+use iii_sdk::IIIClient;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -41,7 +42,7 @@ pub struct NotifyResponse {
     pub message_ids: Vec<i64>,
 }
 
-pub fn register(iii: &Arc<III>, deps: &Arc<Deps>) {
+pub fn register(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
     super::register(
         iii,
         deps,
@@ -53,13 +54,13 @@ pub fn register(iii: &Arc<III>, deps: &Arc<Deps>) {
     );
 }
 
-async fn handle(deps: &Deps, req: NotifyRequest) -> Result<NotifyResponse, IIIError> {
+async fn handle(deps: &Deps, req: NotifyRequest) -> Result<NotifyResponse, Error> {
     if req.text.is_empty() {
-        return Err(IIIError::Handler("notify: text is empty".into()));
+        return Err(Error::Handler("notify: text is empty".into()));
     }
 
     let Some(chat_id) = kv::chat_id_for_session(deps, &req.session_id).await else {
-        return Err(IIIError::Handler(format!(
+        return Err(Error::Handler(format!(
             "notify: no Telegram chat is bound to session {}",
             req.session_id
         )));
@@ -86,7 +87,7 @@ async fn send_chunk(
     chat_id: i64,
     text: &str,
     parse_mode: Option<&str>,
-) -> Result<i64, IIIError> {
+) -> Result<i64, Error> {
     let (body, mode): (String, Option<&str>) = match parse_mode {
         Some(explicit) => (text.to_string(), Some(explicit)),
         None => {

--- a/telegram-bot/src/functions/set_webhook.rs
+++ b/telegram-bot/src/functions/set_webhook.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use iii_sdk::{IIIError, III};
+use iii_sdk::errors::Error;
+use iii_sdk::IIIClient;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -17,7 +18,7 @@ pub struct SetWebhookResponse {
     pub url: String,
 }
 
-pub fn register(iii: &Arc<III>, deps: &Arc<Deps>) {
+pub fn register(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
     super::register(
         iii,
         deps,
@@ -27,15 +28,15 @@ pub fn register(iii: &Arc<III>, deps: &Arc<Deps>) {
     );
 }
 
-async fn handle(deps: &Deps) -> Result<SetWebhookResponse, IIIError> {
+async fn handle(deps: &Deps) -> Result<SetWebhookResponse, Error> {
     let cfg = deps.cfg().await;
     let UpdatesAdapter::Webhook(webhook) = &cfg.updates else {
-        return Err(IIIError::Handler(
+        return Err(Error::Handler(
             "set-webhook requires updates adapter name: webhook".into(),
         ));
     };
     let Some(url) = webhook.endpoint_url() else {
-        return Err(IIIError::Handler(
+        return Err(Error::Handler(
             "updates.webhook.config.base_url is not set in telegram-bot configuration".into(),
         ));
     };

--- a/telegram-bot/src/functions/webhook.rs
+++ b/telegram-bot/src/functions/webhook.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use iii_sdk::{IIIError, III};
+use iii_sdk::errors::Error;
+use iii_sdk::IIIClient;
 use schemars::JsonSchema;
 use serde::Serialize;
 use serde_json::Value;
@@ -23,7 +24,7 @@ pub struct WebhookResponse {
     pub ok: bool,
 }
 
-pub fn register(iii: &Arc<III>, deps: &Arc<Deps>) {
+pub fn register(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
     super::register(
         iii,
         deps,
@@ -33,7 +34,7 @@ pub fn register(iii: &Arc<III>, deps: &Arc<Deps>) {
     );
 }
 
-pub async fn handle(deps: &Deps, req: HttpTriggerRequest) -> Result<WebhookResponse, IIIError> {
+pub async fn handle(deps: &Deps, req: HttpTriggerRequest) -> Result<WebhookResponse, Error> {
     let cfg = deps.cfg().await;
     if let UpdatesAdapter::Webhook(webhook) = &cfg.updates {
         // Validate the secret token only when one is configured. A secret-less
@@ -43,7 +44,7 @@ pub async fn handle(deps: &Deps, req: HttpTriggerRequest) -> Result<WebhookRespo
         match webhook.secret.as_deref().filter(|s| !s.is_empty()) {
             Some(secret) => {
                 if !header_matches(&req.headers, secret) {
-                    return Err(IIIError::Handler("invalid webhook secret".into()));
+                    return Err(Error::Handler("invalid webhook secret".into()));
                 }
             }
             None => {
@@ -53,13 +54,13 @@ pub async fn handle(deps: &Deps, req: HttpTriggerRequest) -> Result<WebhookRespo
             }
         }
     } else {
-        return Err(IIIError::Handler(
+        return Err(Error::Handler(
             "webhook HTTP ingress is disabled; updates adapter is not webhook".into(),
         ));
     }
 
     let update: TelegramUpdate = serde_json::from_value(req.body)
-        .map_err(|e| IIIError::Handler(format!("invalid telegram update: {e}")))?;
+        .map_err(|e| Error::Handler(format!("invalid telegram update: {e}")))?;
 
     process_update_with_tracing(deps, update).await?;
     Ok(WebhookResponse { ok: true })
@@ -83,10 +84,7 @@ async fn baggage_session_for_update(deps: &Deps, update: &TelegramUpdate) -> Str
     "telegram-update".into()
 }
 
-pub async fn process_update_with_tracing(
-    deps: &Deps,
-    update: TelegramUpdate,
-) -> Result<(), IIIError> {
+pub async fn process_update_with_tracing(deps: &Deps, update: TelegramUpdate) -> Result<(), Error> {
     let session_id = baggage_session_for_update(deps, &update).await;
     let message_id = telemetry::telegram_message_id(update.update_id);
     telemetry::with_baggage(&session_id, &message_id, || async {
@@ -95,7 +93,7 @@ pub async fn process_update_with_tracing(
     .await
 }
 
-pub async fn process_update(deps: &Deps, update: TelegramUpdate) -> Result<(), IIIError> {
+pub async fn process_update(deps: &Deps, update: TelegramUpdate) -> Result<(), Error> {
     if let Some(cb) = update.callback_query {
         return handle_callback(deps, cb).await;
     }
@@ -112,7 +110,7 @@ async fn handle_message(
     deps: &Deps,
     update_id: i64,
     message: crate::types::TelegramMessage,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let chat_id = message.chat.id;
     let cfg = deps.cfg().await;
 
@@ -216,7 +214,7 @@ async fn handle_command(
     chat_id: i64,
     text: &str,
     cfg: &WorkerConfig,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let parts: Vec<&str> = text.split_whitespace().collect();
     let cmd = parts.first().copied().unwrap_or(text);
     let arg = parts.get(1).copied();
@@ -243,7 +241,7 @@ async fn handle_command(
     }
 }
 
-async fn help_message(deps: &Deps, chat_id: i64) -> Result<(), IIIError> {
+async fn help_message(deps: &Deps, chat_id: i64) -> Result<(), Error> {
     let text = "/start — start a new session and pick a model\n\
 /stop — stop the current turn\n\
 /model — change model\n\
@@ -255,7 +253,7 @@ async fn help_message(deps: &Deps, chat_id: i64) -> Result<(), IIIError> {
     Ok(())
 }
 
-async fn settings_message(deps: &Deps, chat_id: i64, cfg: &WorkerConfig) -> Result<(), IIIError> {
+async fn settings_message(deps: &Deps, chat_id: i64, cfg: &WorkerConfig) -> Result<(), Error> {
     let verbosity = preferences::effective_verbosity(deps, chat_id, cfg).await;
     let thinking = preferences::effective_thinking_level(deps, chat_id, cfg)
         .await
@@ -274,7 +272,7 @@ async fn thinking_command(
     chat_id: i64,
     arg: Option<&str>,
     cfg: &WorkerConfig,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let Some(arg) = arg else {
         let current = preferences::effective_thinking_level(deps, chat_id, cfg)
             .await
@@ -324,7 +322,7 @@ async fn verbosity_command(
     chat_id: i64,
     arg: Option<&str>,
     cfg: &WorkerConfig,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let Some(arg) = arg else {
         let current = preferences::effective_verbosity(deps, chat_id, cfg).await;
         telegram::send_message(
@@ -367,7 +365,7 @@ async fn start_flow(
     chat_id: i64,
     payload: Option<&str>,
     cfg: &WorkerConfig,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     if let Some(p) = payload {
         if !p.is_empty() {
             tracing::info!(chat_id, payload = p, "deep link /start payload");
@@ -391,11 +389,7 @@ async fn start_flow(
     show_model_picker(deps, chat_id, cfg).await
 }
 
-async fn reset_chat_for_start(
-    deps: &Deps,
-    chat_id: i64,
-    cfg: &WorkerConfig,
-) -> Result<(), IIIError> {
+async fn reset_chat_for_start(deps: &Deps, chat_id: i64, cfg: &WorkerConfig) -> Result<(), Error> {
     let old_session = kv::chat_session(deps, chat_id).await;
     if let Some(ref sid) = old_session {
         let _ = harness::stop(&deps.iii, sid, cfg.timeout_ms).await;
@@ -406,7 +400,7 @@ async fn reset_chat_for_start(
     Ok(())
 }
 
-async fn show_model_picker(deps: &Deps, chat_id: i64, cfg: &WorkerConfig) -> Result<(), IIIError> {
+async fn show_model_picker(deps: &Deps, chat_id: i64, cfg: &WorkerConfig) -> Result<(), Error> {
     if cfg.default_model.is_some() {
         telegram::send_message(
             deps,
@@ -455,7 +449,7 @@ async fn show_model_picker(deps: &Deps, chat_id: i64, cfg: &WorkerConfig) -> Res
 async fn handle_callback(
     deps: &Deps,
     cb: crate::types::TelegramCallbackQuery,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let cfg = deps.cfg().await;
     let data = cb.data.unwrap_or_default();
     let chat_id = cb
@@ -512,7 +506,7 @@ async fn resolve_callback(
     decision: ResolveDecision,
     approve_always: bool,
     cfg: &WorkerConfig,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     if !deps.approval_gate.is_available() {
         return Ok(());
     }
@@ -556,7 +550,7 @@ pub async fn send_user_message(
     idempotency_key: Option<i64>,
     cfg: &WorkerConfig,
     model: &ModelRef,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     // Resolve the session id, minting one bot-side for a brand-new chat. Doing
     // this up front means the channel-context prompt can carry a real
     // session_id from the very first message (so the agent can target this
@@ -655,7 +649,7 @@ fn compose_system_prompt(
     }
 }
 
-async fn bind_model(deps: &Deps, chat_id: i64, model: &ModelRef) -> Result<(), IIIError> {
+async fn bind_model(deps: &Deps, chat_id: i64, model: &ModelRef) -> Result<(), Error> {
     kv::set_chat_model(deps, chat_id, model).await?;
     kv::set_fsm(deps, chat_id, ChatFsm::Idle).await?;
     Ok(())
@@ -682,7 +676,7 @@ async fn catch_up_approvals(deps: &Deps, session_id: &str, cfg: &WorkerConfig) {
 async fn dispatch_pending_created(
     deps: &Deps,
     record: PendingApprovalRecord,
-) -> Result<BindingAck, IIIError> {
+) -> Result<BindingAck, Error> {
     super::bindings::pending_created::handle_internal(deps, record).await
 }
 

--- a/telegram-bot/src/ingress.rs
+++ b/telegram-bot/src/ingress.rs
@@ -3,7 +3,7 @@
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
-use iii_sdk::IIIError;
+use iii_sdk::errors::Error;
 use tokio::time::{sleep, Duration};
 use tokio_util::sync::CancellationToken;
 
@@ -73,7 +73,7 @@ async fn apply_updates_adapter(deps: &Arc<Deps>, _prev: Option<&WorkerConfig>, c
 /// retaining the [`iii_sdk::Trigger`] handle in [`Deps`]. Idempotent: a second
 /// call while the route is held (e.g. a webhook→webhook URL change) is a no-op,
 /// so the engine never accumulates duplicate UUID-keyed routes.
-async fn ensure_webhook_trigger(deps: &Arc<Deps>) -> Result<(), IIIError> {
+async fn ensure_webhook_trigger(deps: &Arc<Deps>) -> Result<(), Error> {
     let mut guard = deps.runtime.webhook_trigger.lock().await;
     if guard.is_some() {
         return Ok(());

--- a/telegram-bot/src/kv.rs
+++ b/telegram-bot/src/kv.rs
@@ -1,6 +1,6 @@
 //! Chat ↔ session KV helpers.
 
-use iii_sdk::IIIError;
+use iii_sdk::errors::Error;
 use serde_json::json;
 
 use crate::clients::state;
@@ -12,7 +12,7 @@ pub async fn chat_session(deps: &Deps, chat_id: i64) -> Option<String> {
     state::get_string(&deps.iii, STATE_SCOPE, &key, deps.cfg().await.timeout_ms).await
 }
 
-pub async fn set_chat_session(deps: &Deps, chat_id: i64, session_id: &str) -> Result<(), IIIError> {
+pub async fn set_chat_session(deps: &Deps, chat_id: i64, session_id: &str) -> Result<(), Error> {
     let timeout = deps.cfg().await.timeout_ms;
     let chat_key = format!("chat:{chat_id}:session");
     state::set(
@@ -63,7 +63,7 @@ pub async fn set_entry_message_id(
     session_id: &str,
     entry_id: &str,
     message_id: i64,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     state::set(
         &deps.iii,
         STATE_SCOPE,
@@ -96,7 +96,7 @@ pub async fn set_entry_chunk_message_id(
     entry_id: &str,
     chunk_idx: u32,
     message_id: i64,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     state::set(
         &deps.iii,
         STATE_SCOPE,
@@ -125,7 +125,7 @@ pub async fn set_entry_order(
     session_id: &str,
     entry_id: &str,
     order_key: i64,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     state::set(
         &deps.iii,
         STATE_SCOPE,
@@ -154,7 +154,7 @@ pub async fn set_entry_finalized(
     deps: &Deps,
     session_id: &str,
     entry_id: &str,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     state::set(
         &deps.iii,
         STATE_SCOPE,
@@ -185,7 +185,7 @@ pub async fn set_approval_message_id(
     session_id: &str,
     function_call_id: &str,
     message_id: i64,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     state::set(
         &deps.iii,
         STATE_SCOPE,
@@ -205,7 +205,7 @@ pub async fn get_fsm(deps: &Deps, chat_id: i64) -> ChatFsm {
     }
 }
 
-pub async fn set_fsm(deps: &Deps, chat_id: i64, fsm: ChatFsm) -> Result<(), IIIError> {
+pub async fn set_fsm(deps: &Deps, chat_id: i64, fsm: ChatFsm) -> Result<(), Error> {
     state::set(
         &deps.iii,
         STATE_SCOPE,
@@ -217,7 +217,7 @@ pub async fn set_fsm(deps: &Deps, chat_id: i64, fsm: ChatFsm) -> Result<(), IIIE
     Ok(())
 }
 
-pub async fn clear_chat_session(deps: &Deps, chat_id: i64) -> Result<Option<String>, IIIError> {
+pub async fn clear_chat_session(deps: &Deps, chat_id: i64) -> Result<Option<String>, Error> {
     let timeout = deps.cfg().await.timeout_ms;
     let old = chat_session(deps, chat_id).await;
     if let Some(ref sid) = old {
@@ -239,7 +239,7 @@ pub async fn clear_chat_session(deps: &Deps, chat_id: i64) -> Result<Option<Stri
     Ok(old)
 }
 
-pub async fn clear_chat_model(deps: &Deps, chat_id: i64) -> Result<(), IIIError> {
+pub async fn clear_chat_model(deps: &Deps, chat_id: i64) -> Result<(), Error> {
     let timeout = deps.cfg().await.timeout_ms;
     state::delete(
         &deps.iii,
@@ -255,7 +255,7 @@ pub async fn set_chat_model(
     deps: &Deps,
     chat_id: i64,
     model: &crate::config::ModelRef,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     state::set(
         &deps.iii,
         STATE_SCOPE,
@@ -283,7 +283,7 @@ pub async fn store_approval_callback(
     deps: &Deps,
     token: &str,
     data: &crate::types::ApprovalCallbackData,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     state::set(
         &deps.iii,
         STATE_SCOPE,
@@ -335,7 +335,7 @@ pub async fn set_thinking_message_id(
     session_id: &str,
     entry_id: &str,
     message_id: i64,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     state::set(
         &deps.iii,
         STATE_SCOPE,
@@ -366,7 +366,7 @@ pub async fn set_chat_verbosity(
     deps: &Deps,
     chat_id: i64,
     verbosity: crate::config::Verbosity,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     state::set(
         &deps.iii,
         STATE_SCOPE,
@@ -397,7 +397,7 @@ pub async fn set_chat_thinking_level(
     deps: &Deps,
     chat_id: i64,
     level: Option<crate::config::ThinkingLevel>,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let key = format!("chat:{chat_id}:thinking_level");
     let timeout = deps.cfg().await.timeout_ms;
     match level {

--- a/telegram-bot/src/main.rs
+++ b/telegram-bot/src/main.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use iii_sdk::{register_worker, InitOptions, WorkerMetadata};
+use iii_sdk::runtime::WorkerMetadata;
+use iii_sdk::{register_worker, InitOptions};
 use tokio::sync::RwLock;
 
 use telegram_bot::approval_gate::{self, ApprovalGateStatus};

--- a/telegram-bot/src/render/stream.rs
+++ b/telegram-bot/src/render/stream.rs
@@ -2,7 +2,7 @@
 
 use std::future::Future;
 
-use iii_sdk::IIIError;
+use iii_sdk::errors::Error;
 
 use crate::clients::telegram;
 use crate::config::{StreamTransport, WorkerConfig};
@@ -29,7 +29,7 @@ pub async fn on_message_added(
     entry_id: &str,
     message: &AgentMessage,
     timestamp: i64,
-) -> Result<Option<i64>, IIIError> {
+) -> Result<Option<i64>, Error> {
     let cfg = deps.cfg().await;
     let Some(chat_id) = kv::chat_id_for_session(deps, session_id).await else {
         return Ok(None);
@@ -87,7 +87,7 @@ async fn on_message_added_locked(
     timestamp: i64,
     chat_id: i64,
     cfg: &WorkerConfig,
-) -> Result<Option<i64>, IIIError> {
+) -> Result<Option<i64>, Error> {
     if is_entry_finalized(deps, session_id, entry_id).await {
         return Ok(kv::entry_message_id(deps, session_id, entry_id).await);
     }
@@ -149,7 +149,7 @@ async fn on_empty_assistant_added(
     timestamp: i64,
     chat_id: i64,
     cfg: &WorkerConfig,
-) -> Result<Option<i64>, IIIError> {
+) -> Result<Option<i64>, Error> {
     if is_entry_finalized(deps, session_id, entry_id).await {
         return Ok(kv::entry_message_id(deps, session_id, entry_id).await);
     }
@@ -172,7 +172,7 @@ async fn on_empty_assistant_added(
     Ok(None)
 }
 
-pub async fn on_message_updated(deps: &Deps, evt: MessageUpdatedEvent) -> Result<(), IIIError> {
+pub async fn on_message_updated(deps: &Deps, evt: MessageUpdatedEvent) -> Result<(), Error> {
     let cfg = deps.cfg().await;
     let Some(chat_id) = kv::chat_id_for_session(deps, &evt.session_id).await else {
         return Ok(());
@@ -209,7 +209,7 @@ async fn on_message_updated_locked(
     timestamp: i64,
     chat_id: i64,
     cfg: &WorkerConfig,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     if is_entry_finalized(deps, session_id, entry_id).await {
         return reconcile_finalized_update(
             deps, cfg, session_id, entry_id, &message, revision, timestamp, chat_id,
@@ -263,7 +263,7 @@ async fn reconcile_finalized_update(
     revision: u64,
     timestamp: i64,
     chat_id: i64,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let key = entry_key(session_id, entry_id);
     let finalized_revision = deps
         .runtime
@@ -306,7 +306,7 @@ async fn reconcile_finalized_update(
     .await
 }
 
-pub async fn finalize_session(deps: &Deps, session_id: &str) -> Result<(), IIIError> {
+pub async fn finalize_session(deps: &Deps, session_id: &str) -> Result<(), Error> {
     let cfg = deps.cfg().await;
 
     let mut ordered_keys: Vec<(i64, (String, String))> = deps
@@ -354,7 +354,7 @@ async fn finalize_entry_under_lock(
     cfg: &WorkerConfig,
     session_id: &str,
     entry_id: &str,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     if is_entry_finalized(deps, session_id, entry_id).await {
         return Ok(());
     }
@@ -393,7 +393,7 @@ async fn finalize_entry_locked(
     session_id: &str,
     entry_id: &str,
     session: &mut StreamSession,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     if is_entry_finalized(deps, session_id, entry_id).await {
         return Ok(());
     }
@@ -425,10 +425,10 @@ async fn with_entry_lock<F, Fut, T>(
     session_id: &str,
     entry_id: &str,
     f: F,
-) -> Result<T, IIIError>
+) -> Result<T, Error>
 where
     F: FnOnce() -> Fut,
-    Fut: Future<Output = Result<T, IIIError>>,
+    Fut: Future<Output = Result<T, Error>>,
 {
     let lock = deps.runtime.entry_lock(&entry_key(session_id, entry_id));
     let _guard = lock.lock().await;
@@ -497,7 +497,7 @@ async fn apply_render(
     revision: u64,
     order_key: i64,
     session: &mut StreamSession,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     if is_entry_finalized(deps, session_id, entry_id).await {
         return Ok(());
     }
@@ -583,7 +583,7 @@ async fn apply_draft_update(
     session: &mut StreamSession,
     text: &str,
     phase: MessagePhase,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     if !should_draft(deps, session, cfg.streaming.draft_throttle_ms) {
         return Ok(());
     }
@@ -625,7 +625,7 @@ async fn apply_edit_update(
     entry_id: &str,
     session: &mut StreamSession,
     text: &str,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let chat_id = session.chat_id;
     let revision = session.last_revision;
     let order_key = session.order_key;
@@ -656,7 +656,7 @@ async fn deliver_continuation_chunk(
     chunk_idx: u32,
     chunk: &str,
     settle_ms: u64,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     if let Some(id) = kv::entry_chunk_message_id(deps, session_id, entry_id, chunk_idx).await {
         if let Err(e) = edit_message_text_formatted(deps, chat_id, id, chunk).await {
             tracing::warn!(error = %e, message_id = id, chunk_idx, "editMessageText failed");
@@ -694,7 +694,7 @@ async fn deliver_text(
     revision: u64,
     throttle_edits: bool,
     order_key: i64,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let chunks = split_message(text, TELEGRAM_MAX_MESSAGE_LEN);
     if chunks.is_empty() || chunks.iter().all(|c| c.is_empty()) {
         return Ok(());
@@ -797,7 +797,7 @@ async fn finalize_entry(
     session_id: &str,
     entry_id: &str,
     session: &mut StreamSession,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     if session.finalized {
         return Ok(());
     }
@@ -850,7 +850,7 @@ async fn finalize_draft_messages(
     entry_id: &str,
     session: &mut StreamSession,
     text: &str,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let order_key = session.order_key;
     let chunks = split_message(text, TELEGRAM_MAX_MESSAGE_LEN);
 
@@ -925,7 +925,7 @@ async fn flush_edit_final(
     entry_id: &str,
     session: &mut StreamSession,
     text: &str,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let chat_id = session.chat_id;
     let revision = session.last_revision;
     let order_key = session.order_key;
@@ -949,7 +949,7 @@ async fn send_message_formatted(
     chat_id: i64,
     text: &str,
     reply_markup: Option<serde_json::Value>,
-) -> Result<i64, IIIError> {
+) -> Result<i64, Error> {
     let (formatted, parse_mode) = format::format_outgoing(text);
     match telegram::send_message(deps, chat_id, &formatted, reply_markup.clone(), parse_mode).await
     {
@@ -967,7 +967,7 @@ async fn edit_message_text_formatted(
     chat_id: i64,
     message_id: i64,
     text: &str,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let (formatted, parse_mode) = format::format_outgoing(text);
     match telegram::edit_message_text(deps, chat_id, message_id, &formatted, parse_mode).await {
         Ok(()) => Ok(()),
@@ -1069,7 +1069,7 @@ pub async fn send_chat_message_in_order(
     deps: &Deps,
     cfg: &WorkerConfig,
     msg: OrderedChatMessage<'_>,
-) -> Result<i64, IIIError> {
+) -> Result<i64, Error> {
     send_in_order(
         deps,
         msg.chat_id,
@@ -1096,10 +1096,10 @@ async fn send_in_order<F, Fut>(
     chunk_idx: u32,
     settle_ms: u64,
     make: F,
-) -> Result<i64, IIIError>
+) -> Result<i64, Error>
 where
     F: FnOnce() -> Fut,
-    Fut: Future<Output = Result<i64, IIIError>>,
+    Fut: Future<Output = Result<i64, Error>>,
 {
     let slot = (order_key, entry_id.to_string(), chunk_idx);
     await_create_slot(&deps.runtime, chat_id, &slot, settle_ms).await;
@@ -1264,7 +1264,7 @@ fn pin_edit_fallback(deps: &Deps, chat_id: i64) {
     deps.runtime.draft_disabled_chats.insert(chat_id, ());
 }
 
-fn is_draft_unsupported(err: &IIIError) -> bool {
+fn is_draft_unsupported(err: &Error) -> bool {
     let msg = format!("{err}");
     msg.contains("TEXTDRAFT_PEER_INVALID")
         || msg.contains("method not found")
@@ -1275,7 +1275,7 @@ async fn send_native_thinking_placeholder(
     deps: &Deps,
     session: &mut StreamSession,
     thinking_text: &str,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let rich = telegram::rich_thinking_draft(thinking_text);
     match telegram::send_rich_message_draft(deps, session.chat_id, session.draft_id, &rich, None)
         .await

--- a/telegram-bot/src/telemetry.rs
+++ b/telegram-bot/src/telemetry.rs
@@ -49,7 +49,7 @@ where
         ("iii.session.id", session_id),
         ("iii.message.id", message_id),
     ];
-    iii_observability::run_with_baggage(&baggage, f()).await
+    iii_helpers::observability::run_with_baggage(&baggage, f()).await
 }
 
 /// Correlation id for a Telegram update (matches harness idempotency / metadata).

--- a/telegram-bot/tests/integration.rs
+++ b/telegram-bot/tests/integration.rs
@@ -3,7 +3,8 @@
 use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
-use iii_sdk::{register_worker, InitOptions, TriggerRequest};
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::{register_worker, InitOptions};
 use serde_json::json;
 use tokio::time::{sleep, timeout};
 


### PR DESCRIPTION
Bump iii-sdk to 0.20.0 + migrate observability to iii-helpers (iii-observability removed) per https://iii.dev/docs/upgrading/from-0-19-x.md. Build, fmt, clippy, 93 unit tests green; surface parity (11 functions) 1:1. No import aliases. (The one integration test worker_registers_on_engine self-skips in CI when iii is absent; locally it is a pre-existing ~1.5s startup-timing flake, not a regression.)