### PR TITLE
chore: bump engine worker deps to ^0.20.0 (manifest sweep)

### DIFF
--- a/approval-gate/Cargo.lock
+++ b/approval-gate/Cargo.lock
@@ -83,7 +83,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "approval-gate"
-version = "1.0.1"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "approval-gate",

--- a/approval-gate/Cargo.toml
+++ b/approval-gate/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "approval-gate"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 publish = false
 

--- a/approval-gate/iii.worker.yaml
+++ b/approval-gate/iii.worker.yaml
@@ -7,7 +7,7 @@ bin: approval-gate
 description: Policy and decision surface for human-held function calls — pre_trigger gate, pending inbox, per-session permission settings, and two notification trigger types.
 
 dependencies:
-  iii-state: "^0.19.0"
-  configuration: "^0.19.0"
+  iii-state: "^0.20.0"
+  configuration: "^0.20.0"
   iii-directory: "^1.0.0"
   session-manager: "^1.0.0"

--- a/context-manager/Cargo.lock
+++ b/context-manager/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "context-manager"
-version = "1.0.0"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/context-manager/Cargo.toml
+++ b/context-manager/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "context-manager"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 publish = false
 

--- a/context-manager/iii.worker.yaml
+++ b/context-manager/iii.worker.yaml
@@ -7,5 +7,5 @@ bin: context-manager
 description: Turns a raw conversation history plus a target model into a model-ready context — token counting, function-result pruning, and history compaction.
 
 dependencies:
-  configuration: "^0.19.0"
+  configuration: "^0.20.0"
   llm-router: "^1.0.0"

--- a/iii-directory/Cargo.lock
+++ b/iii-directory/Cargo.lock
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "iii-directory"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/iii-directory/Cargo.toml
+++ b/iii-directory/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "iii-directory"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 publish = false
 

--- a/iii-directory/iii.worker.yaml
+++ b/iii-directory/iii.worker.yaml
@@ -7,4 +7,4 @@ bin: iii-directory
 description: Engine introspection (functions / triggers / workers), workers registry proxy, and filesystem-backed skill + prompt reader.
 
 dependencies:
-  configuration: "^0.19.0"
+  configuration: "^0.20.0"

--- a/llm-router/Cargo.lock
+++ b/llm-router/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.0.0"
+version = "1.0.3"
 dependencies = [
  "async-trait",
  "clap",

--- a/llm-router/Cargo.toml
+++ b/llm-router/Cargo.toml
@@ -4,7 +4,7 @@
 # this lineage starts above them so Create Tag never collides.
 [package]
 name = "llm-router"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/llm-router/iii.worker.yaml
+++ b/llm-router/iii.worker.yaml
@@ -7,5 +7,5 @@ bin: llm-router
 description: One front door + provider protocol in front of every LLM provider.
 
 dependencies:
-  iii-state: "^0.19.0"
-  configuration: "^0.19.0"
+  iii-state: "^0.20.0"
+  configuration: "^0.20.0"

--- a/provider-anthropic/Cargo.lock
+++ b/provider-anthropic/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.0.0"
+version = "1.0.3"
 dependencies = [
  "async-trait",
  "clap",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "provider-anthropic"
-version = "1.0.0"
+version = "1.0.3"
 dependencies = [
  "clap",
  "futures",

--- a/provider-anthropic/Cargo.toml
+++ b/provider-anthropic/Cargo.toml
@@ -5,7 +5,7 @@
 # collides.
 [package]
 name = "provider-anthropic"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/provider-anthropic/iii.worker.yaml
+++ b/provider-anthropic/iii.worker.yaml
@@ -7,5 +7,5 @@ bin: provider-anthropic
 description: Anthropic Messages API provider worker; implements provider::anthropic::stream and provider::anthropic::refresh_models behind llm-router.
 
 dependencies:
-  iii-state: "^0.19.0"
+  iii-state: "^0.20.0"
   llm-router: "^1.0.0"

--- a/provider-openai/Cargo.lock
+++ b/provider-openai/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.0.0"
+version = "1.0.3"
 dependencies = [
  "async-trait",
  "clap",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "provider-openai"
-version = "1.0.0"
+version = "1.0.3"
 dependencies = [
  "clap",
  "futures",

--- a/provider-openai/Cargo.toml
+++ b/provider-openai/Cargo.toml
@@ -5,7 +5,7 @@
 # collides.
 [package]
 name = "provider-openai"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/provider-openai/iii.worker.yaml
+++ b/provider-openai/iii.worker.yaml
@@ -7,5 +7,5 @@ bin: provider-openai
 description: OpenAI Chat Completions provider worker; implements provider::openai::stream and provider::openai::refresh_models behind llm-router.
 
 dependencies:
-  iii-state: "^0.19.0"
+  iii-state: "^0.20.0"
   llm-router: "^1.0.0"

--- a/session-manager/Cargo.lock
+++ b/session-manager/Cargo.lock
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "session-manager"
-version = "1.0.0"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/session-manager/Cargo.toml
+++ b/session-manager/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "session-manager"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 publish = false
 

--- a/session-manager/iii.worker.yaml
+++ b/session-manager/iii.worker.yaml
@@ -7,4 +7,4 @@ bin: session-manager
 description: Durable, reactive, branching store of typed conversation entries with six emitted trigger types.
 
 dependencies:
-  configuration: "^0.19.0"
+  configuration: "^0.20.0"

--- a/telegram-bot/Cargo.lock
+++ b/telegram-bot/Cargo.lock
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "telegram-bot"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/telegram-bot/Cargo.toml
+++ b/telegram-bot/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "telegram-bot"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 publish = false
 

--- a/telegram-bot/iii.worker.yaml
+++ b/telegram-bot/iii.worker.yaml
@@ -7,8 +7,8 @@ bin: telegram-bot
 description: Telegram bridge to the harness stack — polling or webhook ingress, live message edits, approvals, and configurable verbosity.
 
 dependencies:
-  iii-state: "^0.19.0"
-  iii-queue: "^0.19.0"
-  configuration: "^0.19.0"
+  iii-state: "^0.20.0"
+  iii-queue: "^0.20.0"
+  configuration: "^0.20.0"
   session-manager: "^1.0.0"
   harness: "^1.0.0"

--- a/web/Cargo.lock
+++ b/web/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "web"
-version = "1.1.2"
+version = "1.1.5"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "web"
-version = "1.1.4"
+version = "1.1.5"
 edition = "2021"
 publish = false
 

--- a/web/iii.worker.yaml
+++ b/web/iii.worker.yaml
@@ -7,4 +7,4 @@ bin: web
 description: Outbound HTTP client on the iii bus (web::fetch).
 
 dependencies:
-  configuration: "^0.19.0"
+  configuration: "^0.20.0"


### PR DESCRIPTION
The 0.20 engine ships iii-state/iii-queue/iii-cron/configuration/iii-observability/iii-stream at 0.20.0, but 9 already-merged worker manifests still pinned these runtime deps at `^0.19.0` (caret on 0.x excludes 0.20.x). Bump to `^0.20.0` and patch-bump each worker: web 1.1.5, context-manager 1.0.3, session-manager 1.0.3, approval-gate 1.0.4, telegram-bot 0.2.3, llm-router 1.0.3, provider-anthropic 1.0.3, provider-openai 1.0.3, iii-directory 1.0.2. Cargo.lock refreshed; --locked builds pass.