### PR TITLE
chore(database): bump iii-sdk to 0.20.0

### DIFF
--- a/database/Cargo.lock
+++ b/database/Cargo.lock
@@ -189,7 +189,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "regex",
@@ -438,18 +438,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "const-hex"
-version = "1.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "proptest",
- "serde_core",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,7 +594,7 @@ dependencies = [
  "clap",
  "deadpool-postgres",
  "futures-util",
- "iii-observability",
+ "iii-helpers",
  "iii-sdk",
  "mysql_async",
  "postgres-protocol",
@@ -807,12 +795,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,25 +943,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,7 +1076,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -1138,19 +1100,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -1310,23 +1259,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-observability"
-version = "0.16.0-next.2"
+name = "iii-helpers"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ee84dacaf7e14750ebdc229523e52029441c4ae1f72d25972bf1f2e1edeb99"
+checksum = "09daa7c14a9e4c1f7077c4a181918d207e3f05cdfea8b2d7781bbeb80caf4c5d"
 dependencies = [
- "async-trait",
  "futures-util",
  "opentelemetry",
  "opentelemetry-http",
- "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
  "reqwest",
+ "schemars",
  "serde",
  "serde_json",
  "sysinfo",
- "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -1335,14 +1281,14 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.16.0-next.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c18b68b2aa09e18c68fb023c78316fe7ccf42181874eab584d66f40119b47e"
+checksum = "5957568413b9a5178c11bf91b20909e93e568b187e259e941ba6009a7ec3f5c1"
 dependencies = [
  "async-trait",
  "futures-util",
  "hostname",
- "iii-observability",
+ "iii-helpers",
  "reqwest",
  "schemars",
  "serde",
@@ -1393,15 +1339,6 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1802,23 +1739,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-proto"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
-dependencies = [
- "base64 0.22.1",
- "const-hex",
- "opentelemetry",
- "opentelemetry_sdk",
- "prost",
- "serde",
- "serde_json",
- "tonic",
- "tonic-prost",
-]
-
-[[package]]
 name = "opentelemetry_sdk"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2002,44 +1922,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proptest"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
-dependencies = [
- "bitflags",
- "num-traits",
- "rand 0.9.4",
- "rand_chacha 0.9.0",
- "rand_xorshift",
- "regex-syntax",
- "unarray",
-]
-
-[[package]]
-name = "prost"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -2241,15 +2123,6 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
-dependencies = [
- "rand_core 0.9.5",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -3155,43 +3028,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "sync_wrapper",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic-prost"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
-dependencies = [
- "bytes",
- "prost",
- "tonic",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3199,15 +3035,11 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
  "pin-project-lite",
- "slab",
  "sync_wrapper",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -3342,12 +3174,6 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
-
-[[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.16.0-next.2"
-iii-observability = "=0.16.0-next.2"
+iii-sdk = "=0.20.0"
+iii-helpers = "=0.20.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/database/src/configuration.rs
+++ b/database/src/configuration.rs
@@ -4,7 +4,9 @@
 use crate::config::WorkerConfig;
 use crate::handlers::AppState;
 use crate::pool::{self, Pool};
-use iii_sdk::{IIIError, RegisterFunction, RegisterTriggerInput, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::time::Duration;
@@ -17,7 +19,7 @@ const CONFIG_RETRIES: u32 = 3;
 /// Register the `database` configuration schema with the configuration worker.
 /// When `seed` is present, its value is installed as `initial_value`. Otherwise,
 /// built-in defaults are seeded only when no stored value exists yet.
-pub async fn register_config(iii: &III, seed: Option<&WorkerConfig>) -> Result<(), String> {
+pub async fn register_config(iii: &IIIClient, seed: Option<&WorkerConfig>) -> Result<(), String> {
     let mut payload = json!({
         "id": CONFIG_ID,
         "name": "Database",
@@ -34,7 +36,7 @@ pub async fn register_config(iii: &III, seed: Option<&WorkerConfig>) -> Result<(
 }
 
 /// Read the live `database` configuration (env-expanded by the configuration worker).
-pub async fn fetch_config(iii: &III) -> Result<WorkerConfig, String> {
+pub async fn fetch_config(iii: &IIIClient) -> Result<WorkerConfig, String> {
     let value = get_config_value(iii).await?;
     if value.is_null() {
         tracing::info!("no configuration value found; using built-in default configuration");
@@ -43,7 +45,7 @@ pub async fn fetch_config(iii: &III) -> Result<WorkerConfig, String> {
     WorkerConfig::from_json(&value)
 }
 
-async fn should_seed_default_value(iii: &III) -> Result<bool, String> {
+async fn should_seed_default_value(iii: &IIIClient) -> Result<bool, String> {
     match try_get_config_value(iii).await? {
         None => Ok(true),
         Some(value) if value.is_null() => Ok(true),
@@ -51,14 +53,14 @@ async fn should_seed_default_value(iii: &III) -> Result<bool, String> {
     }
 }
 
-async fn get_config_value(iii: &III) -> Result<Value, String> {
+async fn get_config_value(iii: &IIIClient) -> Result<Value, String> {
     try_get_config_value(iii)
         .await?
         .ok_or_else(|| format!("configuration `{CONFIG_ID}` not found"))
 }
 
 /// Returns `Ok(None)` when the entry does not exist (`NOT_FOUND`).
-async fn try_get_config_value(iii: &III) -> Result<Option<Value>, String> {
+async fn try_get_config_value(iii: &IIIClient) -> Result<Option<Value>, String> {
     match trigger_with_retry(iii, "configuration::get", json!({ "id": CONFIG_ID })).await {
         Ok(resp) => Ok(resp.get("value").cloned()),
         Err(e) if e.contains("NOT_FOUND") => Ok(None),
@@ -93,7 +95,7 @@ pub async fn apply_config(state: &AppState, cfg: WorkerConfig) -> Result<(), Str
 }
 
 /// Register the internal config-change handler and bind a `configuration` trigger.
-pub fn register_config_trigger(iii: &III, state: AppState) -> Result<(), IIIError> {
+pub fn register_config_trigger(iii: &IIIClient, state: AppState) -> Result<(), Error> {
     let st = state.clone();
     let engine = iii.clone();
     iii.register_function(
@@ -103,7 +105,7 @@ pub fn register_config_trigger(iii: &III, state: AppState) -> Result<(), IIIErro
             let engine = engine.clone();
             async move {
                 on_config_change(&engine, &st).await;
-                Ok::<Value, IIIError>(json!({ "ok": true }))
+                Ok::<Value, Error>(json!({ "ok": true }))
             }
         })
         .description(
@@ -130,7 +132,7 @@ pub fn register_config_trigger(iii: &III, state: AppState) -> Result<(), IIIErro
 /// `payload.new_value` would let any caller replace the live connection pools
 /// (e.g. point them at an attacker-controlled database) without updating
 /// persisted state. Re-fetch the stored value via `configuration::get` instead.
-async fn on_config_change(iii: &III, state: &AppState) {
+async fn on_config_change(iii: &IIIClient, state: &AppState) {
     let cfg = match fetch_config(iii).await {
         Ok(cfg) => cfg,
         Err(e) => {
@@ -150,7 +152,11 @@ async fn on_config_change(iii: &III, state: &AppState) {
     }
 }
 
-async fn trigger_with_retry(iii: &III, function_id: &str, payload: Value) -> Result<Value, String> {
+async fn trigger_with_retry(
+    iii: &IIIClient,
+    function_id: &str,
+    payload: Value,
+) -> Result<Value, String> {
     let mut last_err = String::new();
     for attempt in 1..=CONFIG_RETRIES {
         match iii

--- a/database/src/error.rs
+++ b/database/src/error.rs
@@ -59,11 +59,11 @@ pub enum DbError {
     ConfigError { message: String },
 }
 
-impl From<DbError> for iii_sdk::IIIError {
+impl From<DbError> for iii_sdk::errors::Error {
     fn from(e: DbError) -> Self {
         let body = serde_json::to_string(&e)
             .expect("DbError serialization is infallible (only primitive fields)");
-        iii_sdk::IIIError::Handler(body)
+        iii_sdk::errors::Error::Handler(body)
     }
 }
 
@@ -135,7 +135,7 @@ mod tests {
             db: "primary".into(),
             timeout_ms: 30000,
         };
-        let iii_e: iii_sdk::IIIError = e.into();
+        let iii_e: iii_sdk::errors::Error = e.into();
         let body = format!("{iii_e:?}");
         assert!(body.contains("QUERY_TIMEOUT"));
     }

--- a/database/src/handlers/begin_transaction.rs
+++ b/database/src/handlers/begin_transaction.rs
@@ -122,7 +122,7 @@ pub(crate) mod tests {
     use crate::handlers::AppState;
     use crate::pool::{Pool, SqlitePool};
     use crate::transaction::TxRegistry;
-    use iii_observability::Logger;
+    use iii_helpers::observability::Logger;
     use serde_json::{json, Value};
     use std::collections::HashMap;
     use std::sync::Arc;

--- a/database/src/handlers/commit_transaction.rs
+++ b/database/src/handlers/commit_transaction.rs
@@ -162,7 +162,7 @@ mod tests {
             )),
             handles: std::sync::Arc::new(crate::handle::HandleRegistry::new()),
             transactions: crate::transaction::TxRegistry::new(),
-            log: iii_observability::Logger::new(),
+            log: iii_helpers::observability::Logger::new(),
         };
 
         crate::handlers::execute::handle(

--- a/database/src/handlers/execute.rs
+++ b/database/src/handlers/execute.rs
@@ -79,7 +79,7 @@ mod tests {
             config: Arc::new(RwLock::new(crate::config::WorkerConfig::default())),
             handles: Arc::new(HandleRegistry::new()),
             transactions: crate::transaction::TxRegistry::new(),
-            log: iii_observability::Logger::new(),
+            log: iii_helpers::observability::Logger::new(),
         }
     }
 

--- a/database/src/handlers/list_databases.rs
+++ b/database/src/handlers/list_databases.rs
@@ -90,7 +90,7 @@ mod tests {
             config: Arc::new(RwLock::new(cfg)),
             handles: Arc::new(HandleRegistry::new()),
             transactions: crate::transaction::TxRegistry::new(),
-            log: iii_observability::Logger::new(),
+            log: iii_helpers::observability::Logger::new(),
         }
     }
 

--- a/database/src/handlers/mod.rs
+++ b/database/src/handlers/mod.rs
@@ -7,7 +7,7 @@ use crate::error::DbError;
 use crate::handle::HandleRegistry;
 use crate::pool::Pool;
 use crate::transaction::TxRegistry;
-use iii_observability::Logger;
+use iii_helpers::observability::Logger;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;

--- a/database/src/handlers/prepare.rs
+++ b/database/src/handlers/prepare.rs
@@ -88,7 +88,7 @@ mod tests {
             config: Arc::new(RwLock::new(crate::config::WorkerConfig::default())),
             handles: Arc::new(HandleRegistry::new()),
             transactions: crate::transaction::TxRegistry::new(),
-            log: iii_observability::Logger::new(),
+            log: iii_helpers::observability::Logger::new(),
         }
     }
 

--- a/database/src/handlers/query.rs
+++ b/database/src/handlers/query.rs
@@ -115,7 +115,7 @@ mod tests {
             config: Arc::new(RwLock::new(crate::config::WorkerConfig::default())),
             handles: Arc::new(HandleRegistry::new()),
             transactions: crate::transaction::TxRegistry::new(),
-            log: iii_observability::Logger::new(),
+            log: iii_helpers::observability::Logger::new(),
         }
     }
 

--- a/database/src/handlers/rollback_transaction.rs
+++ b/database/src/handlers/rollback_transaction.rs
@@ -135,7 +135,7 @@ mod tests {
             )),
             handles: std::sync::Arc::new(crate::handle::HandleRegistry::new()),
             transactions: crate::transaction::TxRegistry::new(),
-            log: iii_observability::Logger::new(),
+            log: iii_helpers::observability::Logger::new(),
         };
 
         crate::handlers::execute::handle(

--- a/database/src/handlers/run_statement.rs
+++ b/database/src/handlers/run_statement.rs
@@ -62,7 +62,7 @@ mod tests {
             config: Arc::new(RwLock::new(crate::config::WorkerConfig::default())),
             handles: Arc::new(HandleRegistry::new()),
             transactions: crate::transaction::TxRegistry::new(),
-            log: iii_observability::Logger::new(),
+            log: iii_helpers::observability::Logger::new(),
         }
     }
 
@@ -79,7 +79,7 @@ mod tests {
             config: Arc::new(RwLock::new(crate::config::WorkerConfig::default())),
             handles: Arc::new(HandleRegistry::new()),
             transactions: crate::transaction::TxRegistry::new(),
-            log: iii_observability::Logger::new(),
+            log: iii_helpers::observability::Logger::new(),
         };
         (st, tmp)
     }

--- a/database/src/handlers/transaction.rs
+++ b/database/src/handlers/transaction.rs
@@ -138,7 +138,7 @@ mod tests {
             config: Arc::new(RwLock::new(crate::config::WorkerConfig::default())),
             handles: Arc::new(HandleRegistry::new()),
             transactions: crate::transaction::TxRegistry::new(),
-            log: iii_observability::Logger::new(),
+            log: iii_helpers::observability::Logger::new(),
         }
     }
 

--- a/database/src/handlers/transaction_execute.rs
+++ b/database/src/handlers/transaction_execute.rs
@@ -285,7 +285,7 @@ mod tests {
             )),
             handles: std::sync::Arc::new(crate::handle::HandleRegistry::new()),
             transactions: crate::transaction::TxRegistry::new(),
-            log: iii_observability::Logger::new(),
+            log: iii_helpers::observability::Logger::new(),
         };
 
         crate::handlers::execute::handle(

--- a/database/src/main.rs
+++ b/database/src/main.rs
@@ -19,7 +19,7 @@ use database::handlers::{
 };
 use database::transaction::TxRegistry;
 use database::triggers::handler::RowChangeTrigger;
-use iii_observability::{Logger, OtelConfig};
+use iii_helpers::observability::{Logger, OtelConfig};
 use iii_sdk::{register_worker, InitOptions, RegisterFunction, RegisterTriggerType};
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -120,7 +120,7 @@ async fn main() -> Result<()> {
                 async move {
                     query::handle(&st, req)
                         .await
-                        .map_err(iii_sdk::IIIError::from)
+                        .map_err(iii_sdk::errors::Error::from)
                 }
             })
             .description("Run a read-only SQL query and return the result rows."),
@@ -135,7 +135,7 @@ async fn main() -> Result<()> {
                 async move {
                     execute::handle(&st, req)
                         .await
-                        .map_err(iii_sdk::IIIError::from)
+                        .map_err(iii_sdk::errors::Error::from)
                 }
             })
             .description("Run a write statement (INSERT/UPDATE/DELETE/DDL)."),
@@ -150,7 +150,7 @@ async fn main() -> Result<()> {
                 async move {
                     prepare::handle(&st, req)
                         .await
-                        .map_err(iii_sdk::IIIError::from)
+                        .map_err(iii_sdk::errors::Error::from)
                 }
             })
             .description("Prepare a parameterized statement once."),
@@ -165,7 +165,7 @@ async fn main() -> Result<()> {
                 async move {
                     run_statement::handle(&st, req)
                         .await
-                        .map_err(iii_sdk::IIIError::from)
+                        .map_err(iii_sdk::errors::Error::from)
                 }
             })
             .description("Run a previously-prepared handle."),
@@ -180,7 +180,7 @@ async fn main() -> Result<()> {
                 async move {
                     transaction::handle(&st, req)
                         .await
-                        .map_err(iii_sdk::IIIError::from)
+                        .map_err(iii_sdk::errors::Error::from)
                 }
             })
             .description("Run a sequence of statements atomically."),
@@ -195,7 +195,7 @@ async fn main() -> Result<()> {
                 async move {
                     begin_transaction::handle(&st, req)
                         .await
-                        .map_err(iii_sdk::IIIError::from)
+                        .map_err(iii_sdk::errors::Error::from)
                 }
             })
             .description(
@@ -213,7 +213,7 @@ async fn main() -> Result<()> {
                 async move {
                     transaction_query::handle(&st, req)
                         .await
-                        .map_err(iii_sdk::IIIError::from)
+                        .map_err(iii_sdk::errors::Error::from)
                 }
             })
             .description("Run a read-only SQL query inside an interactive transaction."),
@@ -228,7 +228,7 @@ async fn main() -> Result<()> {
                 async move {
                     transaction_execute::handle(&st, req)
                         .await
-                        .map_err(iii_sdk::IIIError::from)
+                        .map_err(iii_sdk::errors::Error::from)
                 }
             })
             .description(
@@ -246,7 +246,7 @@ async fn main() -> Result<()> {
                 async move {
                     commit_transaction::handle(&st, req)
                         .await
-                        .map_err(iii_sdk::IIIError::from)
+                        .map_err(iii_sdk::errors::Error::from)
                 }
             })
             .description("Commit and finalize an interactive transaction."),
@@ -261,7 +261,7 @@ async fn main() -> Result<()> {
                 async move {
                     rollback_transaction::handle(&st, req)
                         .await
-                        .map_err(iii_sdk::IIIError::from)
+                        .map_err(iii_sdk::errors::Error::from)
                 }
             })
             .description("Rollback and finalize an interactive transaction."),
@@ -276,7 +276,7 @@ async fn main() -> Result<()> {
                 async move {
                     list_databases::handle(&st, req)
                         .await
-                        .map_err(iii_sdk::IIIError::from)
+                        .map_err(iii_sdk::errors::Error::from)
                 }
             })
             .description(

--- a/database/src/transaction.rs
+++ b/database/src/transaction.rs
@@ -19,7 +19,7 @@ use crate::driver;
 use crate::error::DbError;
 use crate::handle::PinnedConn;
 use chrono::{DateTime, Duration as CDuration, Utc};
-use iii_observability::Logger;
+use iii_helpers::observability::Logger;
 use schemars::JsonSchema;
 use serde::Serialize;
 use serde_json::json;

--- a/database/src/triggers/handler.rs
+++ b/database/src/triggers/handler.rs
@@ -2,10 +2,11 @@
 //! the worker via `iii.register_trigger_type` from main.rs.
 
 use async_trait::async_trait;
-use iii_sdk::{IIIError, TriggerConfig, TriggerHandler};
+use iii_sdk::errors::Error;
+use iii_sdk::trigger::{TriggerConfig, TriggerHandler};
 
-fn iii_err<T: serde::Serialize>(err: T) -> IIIError {
-    IIIError::Handler(serde_json::to_string(&err).unwrap_or_else(|_| "{}".into()))
+fn iii_err<T: serde::Serialize>(err: T) -> Error {
+    Error::Handler(serde_json::to_string(&err).unwrap_or_else(|_| "{}".into()))
 }
 
 /// `database::row-change` trigger handler. v1.0 stubs the streaming decoder
@@ -16,13 +17,13 @@ pub struct RowChangeTrigger;
 
 #[async_trait]
 impl TriggerHandler for RowChangeTrigger {
-    async fn register_trigger(&self, _config: TriggerConfig) -> Result<(), IIIError> {
+    async fn register_trigger(&self, _config: TriggerConfig) -> Result<(), Error> {
         Err(iii_err(crate::error::DbError::Unsupported {
             op: "row-change".into(),
             driver: "postgres (pending tokio-postgres replication API release)".into(),
         }))
     }
-    async fn unregister_trigger(&self, _config: TriggerConfig) -> Result<(), IIIError> {
+    async fn unregister_trigger(&self, _config: TriggerConfig) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/database/tests/integration.rs
+++ b/database/tests/integration.rs
@@ -13,7 +13,7 @@ use database::handlers::transaction::TxReq;
 use database::handlers::{execute, prepare, query, run_statement, transaction, AppState};
 use database::pool;
 use database::transaction::TxRegistry;
-use iii_observability::Logger;
+use iii_helpers::observability::Logger;
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;


### PR DESCRIPTION
Bump iii-sdk 0.16.0-next.2 → 0.20.0 + migrate observability to iii-helpers (iii-observability removed) per https://iii.dev/docs/upgrading/from-0-19-x.md. Build, fmt, clippy, tests green (208 tests); surface parity (12 functions + 1 trigger) 1:1. No import aliases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across database operations and configuration flows for more consistent failures.
  * Kept transaction, query, and trigger behavior unchanged while updating internal error translation.

* **Chores**
  * Updated database dependencies to newer compatible versions.
  * Replaced legacy observability wiring with the current shared helper setup across tests and runtime support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->