### PR TITLE
fix(database): typed schema for database::on-config-change

### DIFF
--- a/database/Cargo.lock
+++ b/database/Cargo.lock
@@ -584,7 +584,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "database"
-version = "0.2.7"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "database"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 publish = false
 

--- a/database/src/configuration.rs
+++ b/database/src/configuration.rs
@@ -94,18 +94,36 @@ pub async fn apply_config(state: &AppState, cfg: WorkerConfig) -> Result<(), Str
     Ok(())
 }
 
+/// Event delivered to the internal `database::on-config-change` handler. A struct
+/// (not `Value`) keeps the request schema concrete; the handler re-fetches the
+/// configuration id; unknown fields are ignored.
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+pub struct OnConfigChangeEvent {
+    /// Configuration id that changed (advisory; the handler re-fetches the value).
+    /// Schema-only: kept to publish a typed request schema; the handler ignores it.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub id: Option<String>,
+}
+
+/// Ack returned by the internal `database::on-config-change` handler.
+#[derive(Debug, serde::Serialize, schemars::JsonSchema)]
+pub struct OnConfigChangeResponse {
+    pub ok: bool,
+}
+
 /// Register the internal config-change handler and bind a `configuration` trigger.
 pub fn register_config_trigger(iii: &IIIClient, state: AppState) -> Result<(), Error> {
     let st = state.clone();
     let engine = iii.clone();
     iii.register_function(
         CONFIG_FN_ID,
-        RegisterFunction::new_async(move |_payload: Value| {
+        RegisterFunction::new_async(move |_event: OnConfigChangeEvent| {
             let st = st.clone();
             let engine = engine.clone();
             async move {
                 on_config_change(&engine, &st).await;
-                Ok::<Value, Error>(json!({ "ok": true }))
+                Ok::<OnConfigChangeResponse, Error>(OnConfigChangeResponse { ok: true })
             }
         })
         .description(


### PR DESCRIPTION
Release `database/v0.2.8` failed at publish: `untyped (AnyValue/empty) schemas in worker-interface.json: database::on-config-change.request_schema, database::on-config-change.response_schema`. The handler was registered over `serde_json::Value`. Replace with concrete `OnConfigChangeEvent` / `OnConfigChangeResponse` structs (same pattern as shell #342 / storage / session-manager). Confirmed: `collect_worker_interface.py --assert-typed-schemas` now exits 0; the function publishes a typed schema. Build, fmt, clippy, tests green. Patch-bump to 0.2.9.