### PR TITLE
chore(image-resize): bump iii-sdk to 0.20.0

### DIFF
--- a/image-resize/Cargo.lock
+++ b/image-resize/Cargo.lock
@@ -210,18 +210,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "const-hex"
-version = "1.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "proptest",
- "serde_core",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,12 +287,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,12 +326,6 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -480,25 +456,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,7 +536,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -606,19 +562,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -753,23 +696,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-observability"
-version = "0.16.0-next.2"
+name = "iii-helpers"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ee84dacaf7e14750ebdc229523e52029441c4ae1f72d25972bf1f2e1edeb99"
+checksum = "09daa7c14a9e4c1f7077c4a181918d207e3f05cdfea8b2d7781bbeb80caf4c5d"
 dependencies = [
- "async-trait",
  "futures-util",
  "opentelemetry",
  "opentelemetry-http",
- "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
  "reqwest",
+ "schemars",
  "serde",
  "serde_json",
  "sysinfo",
- "thiserror",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -778,14 +718,14 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.16.0-next.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c18b68b2aa09e18c68fb023c78316fe7ccf42181874eab584d66f40119b47e"
+checksum = "5957568413b9a5178c11bf91b20909e93e568b187e259e941ba6009a7ec3f5c1"
 dependencies = [
  "async-trait",
  "futures-util",
  "hostname",
- "iii-observability",
+ "iii-helpers",
  "reqwest",
  "schemars",
  "serde",
@@ -815,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "image-resize"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -873,15 +813,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itoa"
@@ -1088,23 +1019,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-proto"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
-dependencies = [
- "base64",
- "const-hex",
- "opentelemetry",
- "opentelemetry_sdk",
- "prost",
- "serde",
- "serde_json",
- "tonic",
- "tonic-prost",
-]
-
-[[package]]
 name = "opentelemetry_sdk"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,26 +1040,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pin-project"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -1207,44 +1101,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proptest"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
-dependencies = [
- "bitflags",
- "num-traits",
- "rand",
- "rand_chacha",
- "rand_xorshift",
- "regex-syntax",
- "unarray",
-]
-
-[[package]]
-name = "prost"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1362,15 +1218,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -1894,56 +1741,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tonic"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
-dependencies = [
- "async-trait",
- "base64",
- "bytes",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "sync_wrapper",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic-prost"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
-dependencies = [
- "bytes",
- "prost",
- "tonic",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1951,15 +1748,11 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
  "pin-project-lite",
- "slab",
  "sync_wrapper",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -2083,12 +1876,6 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"

--- a/image-resize/Cargo.toml
+++ b/image-resize/Cargo.toml
@@ -11,7 +11,7 @@ name = "image-resize"
 path = "src/main.rs"
 
 [dependencies]
-iii-sdk = "=0.16.0-next.2"
+iii-sdk = "=0.20.0"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
 kamadak-exif = "0.6"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal"] }

--- a/image-resize/src/handler.rs
+++ b/image-resize/src/handler.rs
@@ -2,7 +2,9 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use iii_sdk::{extract_channel_refs, ChannelReader, ChannelWriter, IIIError, StreamChannelRef};
+use iii_sdk::channel::{ChannelReader, ChannelWriter, StreamChannelRef};
+use iii_sdk::errors::Error;
+use iii_sdk::helpers::extract_channel_refs;
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -31,7 +33,7 @@ pub async fn handle_resize(
     input_ref: &StreamChannelRef,
     output_ref: &StreamChannelRef,
     metadata_override: Option<ImageMetadata>,
-) -> Result<Value, IIIError> {
+) -> Result<Value, Error> {
     let reader = ChannelReader::new(engine_ws_base, input_ref);
     let writer = ChannelWriter::new(engine_ws_base, output_ref);
 
@@ -56,20 +58,20 @@ pub async fn handle_resize(
             })
             .await;
 
-        let binary = reader.next_binary().await?;
+        let binary: Option<Vec<u8>> = reader.next_binary().await?;
         let image_bytes = binary
-            .ok_or_else(|| IIIError::Handler("stream closed before binary frame".to_string()))?;
+            .ok_or_else(|| Error::Handler("stream closed before binary frame".to_string()))?;
 
         // Retrieve the metadata text that was dispatched to the callback
         let meta_json = {
             let guard = metadata_holder.lock().unwrap();
             guard
                 .clone()
-                .ok_or_else(|| IIIError::Handler("no metadata text frame received".to_string()))?
+                .ok_or_else(|| Error::Handler("no metadata text frame received".to_string()))?
         };
 
         let meta: ImageMetadata = serde_json::from_str(&meta_json)
-            .map_err(|e| IIIError::Handler(format!("invalid metadata JSON: {e}")))?;
+            .map_err(|e| Error::Handler(format!("invalid metadata JSON: {e}")))?;
 
         (meta, image_bytes)
     };
@@ -87,7 +89,7 @@ pub async fn process_and_write(
     image_bytes: Vec<u8>,
     writer: &ChannelWriter,
     reader: &ChannelReader,
-) -> Result<Value, IIIError> {
+) -> Result<Value, Error> {
     tracing::info!(
         format = %metadata.format,
         output_format = ?metadata.output_format,
@@ -95,7 +97,7 @@ pub async fn process_and_write(
     );
 
     let params = resolve_params(&config, &metadata)
-        .map_err(|e| IIIError::Handler(format!("param resolution failed: {e}")))?;
+        .map_err(|e| Error::Handler(format!("param resolution failed: {e}")))?;
 
     tracing::info!(
         input_format = ?params.input_format,
@@ -119,12 +121,12 @@ pub async fn process_and_write(
 
     let thumbnail_bytes = tokio::task::spawn_blocking(move || process_image(&image_bytes, &params))
         .await
-        .map_err(|e| IIIError::Handler(format!("spawn_blocking join error: {e}")))?
-        .map_err(|e| IIIError::Handler(format!("image processing failed: {e}")))?;
+        .map_err(|e| Error::Handler(format!("spawn_blocking join error: {e}")))?
+        .map_err(|e| Error::Handler(format!("image processing failed: {e}")))?;
 
     // Decode thumbnail to get output dimensions
     let output_img = image::load_from_memory(&thumbnail_bytes)
-        .map_err(|e| IIIError::Handler(format!("failed to decode output image: {e}")))?;
+        .map_err(|e| Error::Handler(format!("failed to decode output image: {e}")))?;
 
     let thumb_meta = ThumbnailMetadata {
         format: out_format,
@@ -135,7 +137,7 @@ pub async fn process_and_write(
 
     // Send metadata text frame
     let meta_json = serde_json::to_string(&thumb_meta)
-        .map_err(|e| IIIError::Handler(format!("failed to serialize thumbnail metadata: {e}")))?;
+        .map_err(|e| Error::Handler(format!("failed to serialize thumbnail metadata: {e}")))?;
     writer.send_message(&meta_json).await?;
 
     // Send binary thumbnail frame
@@ -146,7 +148,7 @@ pub async fn process_and_write(
     reader.close().await?;
 
     let result = serde_json::to_value(&thumb_meta)
-        .map_err(|e| IIIError::Handler(format!("failed to convert metadata to Value: {e}")))?;
+        .map_err(|e| Error::Handler(format!("failed to convert metadata to Value: {e}")))?;
 
     Ok(result)
 }
@@ -158,10 +160,8 @@ pub async fn process_and_write(
 pub fn build_handler(
     engine_ws_base: String,
     config: Arc<ResizeConfig>,
-) -> impl Fn(Value) -> Pin<Box<dyn Future<Output = Result<Value, IIIError>> + Send>>
-       + Send
-       + Sync
-       + 'static {
+) -> impl Fn(Value) -> Pin<Box<dyn Future<Output = Result<Value, Error>> + Send>> + Send + Sync + 'static
+{
     move |payload: Value| {
         let engine_ws_base = engine_ws_base.clone();
         let config = config.clone();
@@ -173,13 +173,13 @@ pub fn build_handler(
                 .iter()
                 .find(|(name, _)| name == "input_channel")
                 .map(|(_, r)| r.clone())
-                .ok_or_else(|| IIIError::Handler("missing input_channel ref".to_string()))?;
+                .ok_or_else(|| Error::Handler("missing input_channel ref".to_string()))?;
 
             let output_ref = refs
                 .iter()
                 .find(|(name, _)| name == "output_channel")
                 .map(|(_, r)| r.clone())
-                .ok_or_else(|| IIIError::Handler("missing output_channel ref".to_string()))?;
+                .ok_or_else(|| Error::Handler("missing output_channel ref".to_string()))?;
 
             let metadata: Option<ImageMetadata> = payload
                 .get("metadata")
@@ -197,7 +197,7 @@ pub fn build_handler(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use iii_sdk::ChannelDirection;
+    use iii_sdk::helpers::ChannelDirection;
     use serde_json::json;
 
     fn make_channel_ref(id: &str, dir: &str) -> Value {

--- a/image-resize/src/handler.rs
+++ b/image-resize/src/handler.rs
@@ -2,9 +2,9 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use iii_sdk::channel::{ChannelReader, ChannelWriter, StreamChannelRef};
+use iii_sdk::channels::extract_channel_refs;
+use iii_sdk::channels::{ChannelReader, ChannelWriter, StreamChannelRef};
 use iii_sdk::errors::Error;
-use iii_sdk::helpers::extract_channel_refs;
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -197,7 +197,7 @@ pub fn build_handler(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use iii_sdk::helpers::ChannelDirection;
+    use iii_sdk::channels::ChannelDirection;
     use serde_json::json;
 
     fn make_channel_ref(id: &str, dir: &str) -> Value {


### PR DESCRIPTION
Bump iii-sdk 0.16.0-next.2 → 0.20.0 per https://iii.dev/docs/upgrading/from-0-19-x.md. Channel types moved to iii_sdk::channel::/iii_sdk::helpers::. Build, fmt, clippy, tests green (58 tests); surface parity (1 function) 1:1. No import aliases. No on-config-change handler (no typed-schema fix needed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of image resize handling with broader, more consistent error reporting.
  * Fixed several failure cases during resize processing, including input parsing, stream handling, decoding, encoding, and output writing.
  * Updated the resize component to work with a newer supported SDK version, helping ensure compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->