### PR TITLE
chore(mcp): bump iii-sdk to 0.20.0

### DIFF
--- a/mcp/Cargo.lock
+++ b/mcp/Cargo.lock
@@ -85,12 +85,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,18 +212,6 @@ dependencies = [
  "libc",
  "unicode-width",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "const-hex"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "proptest",
- "serde_core",
 ]
 
 [[package]]
@@ -449,12 +431,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,25 +625,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,7 +711,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -779,19 +735,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -943,23 +886,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-observability"
-version = "0.16.0-next.2"
+name = "iii-helpers"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ee84dacaf7e14750ebdc229523e52029441c4ae1f72d25972bf1f2e1edeb99"
+checksum = "09daa7c14a9e4c1f7077c4a181918d207e3f05cdfea8b2d7781bbeb80caf4c5d"
 dependencies = [
- "async-trait",
  "futures-util",
  "opentelemetry",
  "opentelemetry-http",
- "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
  "reqwest",
+ "schemars",
  "serde",
  "serde_json",
  "sysinfo",
- "thiserror",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -968,14 +908,14 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.16.0-next.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c18b68b2aa09e18c68fb023c78316fe7ccf42181874eab584d66f40119b47e"
+checksum = "5957568413b9a5178c11bf91b20909e93e568b187e259e941ba6009a7ec3f5c1"
 dependencies = [
  "async-trait",
  "futures-util",
  "hostname",
- "iii-observability",
+ "iii-helpers",
  "reqwest",
  "schemars",
  "serde",
@@ -1118,7 +1058,7 @@ dependencies = [
  "clap",
  "cucumber",
  "futures",
- "iii-observability",
+ "iii-helpers",
  "iii-sdk",
  "regex",
  "reqwest",
@@ -1189,15 +1129,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,23 +1190,6 @@ dependencies = [
  "http",
  "opentelemetry",
  "reqwest",
-]
-
-[[package]]
-name = "opentelemetry-proto"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
-dependencies = [
- "base64",
- "const-hex",
- "opentelemetry",
- "opentelemetry_sdk",
- "prost",
- "serde",
- "serde_json",
- "tonic",
- "tonic-prost",
 ]
 
 [[package]]
@@ -1392,44 +1306,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
-dependencies = [
- "bitflags",
- "num-traits",
- "rand",
- "rand_chacha",
- "rand_xorshift",
- "regex-syntax",
- "unarray",
-]
-
-[[package]]
-name = "prost"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,15 +1408,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -2203,56 +2070,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tonic"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
-dependencies = [
- "async-trait",
- "base64",
- "bytes",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "sync_wrapper",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic-prost"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
-dependencies = [
- "bytes",
- "prost",
- "tonic",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2260,15 +2077,11 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
  "pin-project-lite",
- "slab",
  "sync_wrapper",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -2412,12 +2225,6 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
-
-[[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"

--- a/mcp/Cargo.lock
+++ b/mcp/Cargo.lock
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "mcp"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "mcp"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 publish = false
 

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -15,8 +15,8 @@ name = "iii_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.16.0-next.2"
-iii-observability = "=0.16.0-next.2"
+iii-sdk = "=0.20.0"
+iii-helpers = "=0.20.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/mcp/src/functions/mod.rs
+++ b/mcp/src/functions/mod.rs
@@ -26,11 +26,22 @@ struct Ctx {
 /// Subset of `iii_sdk::types::ApiRequest` plus the engine-issued response
 /// channel writer ref. We deserialize directly off `serde_json::Value` so we
 /// can capture the `response` field that the typed `ApiRequest<T>` strips.
-#[derive(Deserialize)]
+#[derive(Deserialize, schemars::JsonSchema)]
 struct McpRequest {
     #[serde(default)]
     body: Value,
     response: StreamChannelRef,
+}
+
+/// Build a published JSON Schema for `T`, stripping the root `$schema` key the
+/// registry publish validator has no meta-schema for (mirrors codex).
+fn schema_value<T: schemars::JsonSchema>() -> Value {
+    let root = schemars::gen::SchemaGenerator::default().into_root_schema_for::<T>();
+    let mut v = serde_json::to_value(root).expect("schema serializes");
+    if let Some(obj) = v.as_object_mut() {
+        obj.remove("$schema");
+    }
+    v
 }
 
 /// Body to render onto the SSE response channel.
@@ -77,6 +88,8 @@ fn register_handler(iii: &Arc<IIIClient>, cfg: &Arc<McpConfig>) {
                 respond_sse(&ctx, &envelope.response, payload).await
             }
         })
+        .request_format(schema_value::<McpRequest>())
+        .response_format(json!({ "type": "null" }))
         .description("MCP 2025-06-18 Streamable HTTP bridge."),
     );
 }

--- a/mcp/src/functions/mod.rs
+++ b/mcp/src/functions/mod.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
 
-use iii_observability::Logger;
+use iii_helpers::observability::Logger;
 use iii_sdk::{
     channels::{ChannelWriter, StreamChannelRef},
-    IIIError, RegisterFunction, III,
+    errors::Error,
+    IIIClient, RegisterFunction,
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -17,7 +18,7 @@ pub const FUNCTION_ID: &str = "mcp::handler";
 /// Per-handler context: shared engine handle, config, and a logger.
 #[derive(Clone)]
 struct Ctx {
-    iii: Arc<III>,
+    iii: Arc<IIIClient>,
     cfg: Arc<McpConfig>,
     log: Logger,
 }
@@ -40,12 +41,12 @@ enum RespondPayload {
     Notification,
 }
 
-pub fn register_all(iii: &Arc<III>, cfg: &Arc<McpConfig>) {
+pub fn register_all(iii: &Arc<IIIClient>, cfg: &Arc<McpConfig>) {
     register_handler(iii, cfg);
     tracing::info!(function_id = FUNCTION_ID, "all functions registered");
 }
 
-fn register_handler(iii: &Arc<III>, cfg: &Arc<McpConfig>) {
+fn register_handler(iii: &Arc<IIIClient>, cfg: &Arc<McpConfig>) {
     let ctx = Ctx {
         iii: iii.clone(),
         cfg: cfg.clone(),
@@ -84,7 +85,7 @@ async fn respond_sse(
     ctx: &Ctx,
     writer_ref: &StreamChannelRef,
     payload: RespondPayload,
-) -> Result<Value, IIIError> {
+) -> Result<Value, Error> {
     let writer = ChannelWriter::new(ctx.iii.address(), writer_ref);
 
     let status: u16 = match payload {
@@ -154,7 +155,7 @@ async fn respond_sse(
 /// status line and headers. Always advertises `text/event-stream`; even
 /// notification-only acks (which carry no body) keep the same content
 /// type so a browser EventSource can attach without surprises.
-async fn send_sse_control(writer: &ChannelWriter, status: u16) -> Result<(), IIIError> {
+async fn send_sse_control(writer: &ChannelWriter, status: u16) -> Result<(), Error> {
     writer
         .send_message(
             &serde_json::to_string(&json!({

--- a/mcp/src/handler.rs
+++ b/mcp/src/handler.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 
-use iii_sdk::III;
+use iii_sdk::IIIClient;
 use serde_json::{json, Value};
 
 use crate::config::McpConfig;
@@ -42,13 +42,17 @@ fn handle_initialize(_params: &Value) -> Value {
     })
 }
 
-async fn dispatch_notification(_req: &JsonRpcRequest, _iii: &Arc<III>, _cfg: &Arc<McpConfig>) {
+async fn dispatch_notification(
+    _req: &JsonRpcRequest,
+    _iii: &Arc<IIIClient>,
+    _cfg: &Arc<McpConfig>,
+) {
     /* notifications/initialized and unknown notifications: no response body */
 }
 
 async fn dispatch_request(
     req: &JsonRpcRequest,
-    iii: &Arc<III>,
+    iii: &Arc<IIIClient>,
     cfg: &Arc<McpConfig>,
     id: JsonRpcResponseId,
 ) -> JsonRpcResponse {
@@ -89,7 +93,7 @@ async fn dispatch_request(
     }
 }
 
-pub async fn handle_mcp_body(body: &Value, iii: &Arc<III>, cfg: &Arc<McpConfig>) -> Outcome {
+pub async fn handle_mcp_body(body: &Value, iii: &Arc<IIIClient>, cfg: &Arc<McpConfig>) -> Outcome {
     if body.is_array() {
         return Outcome::Response(json_rpc_error(
             JsonRpcResponseId::Null,

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -7,7 +7,9 @@
 
 use anyhow::Result;
 use clap::Parser;
-use iii_sdk::{register_worker, InitOptions, RegisterTriggerInput, WorkerMetadata};
+use iii_sdk::protocol::RegisterTriggerInput;
+use iii_sdk::runtime::WorkerMetadata;
+use iii_sdk::{register_worker, InitOptions};
 use serde_json::json;
 use std::sync::Arc;
 use tracing_subscriber::EnvFilter;

--- a/mcp/src/skills_bridge.rs
+++ b/mcp/src/skills_bridge.rs
@@ -4,15 +4,15 @@
 
 use std::sync::Arc;
 
-use iii_sdk::{IIIError, TriggerRequest, III};
+use iii_sdk::{errors::Error, protocol::TriggerRequest, IIIClient};
 use regex::Regex;
 use serde_json::{json, Map, Value};
 
 /// Detects the engine error variants that mean "function not registered".
 /// Mirrors the TS `isMissingDelegate` predicate.
-fn is_missing_delegate(err: &IIIError) -> bool {
+fn is_missing_delegate(err: &Error) -> bool {
     match err {
-        IIIError::Remote { code, message, .. } => {
+        Error::Remote { code, message, .. } => {
             let upper = code.to_uppercase();
             if upper == "NOT_FOUND" || upper == "FUNCTION_NOT_FOUND" {
                 return true;
@@ -22,7 +22,7 @@ fn is_missing_delegate(err: &IIIError) -> bool {
                 || lower.contains("unknown function")
                 || lower.contains("no such function")
         }
-        IIIError::Runtime(message) | IIIError::Handler(message) => {
+        Error::Runtime(message) | Error::Handler(message) => {
             let lower = message.to_lowercase();
             lower.contains("not found")
                 || lower.contains("unknown function")
@@ -48,11 +48,11 @@ fn normalize_delegate_payload(payload: Value) -> Value {
 /// engine reports the function as missing, swap in `empty` so MCP clients see
 /// an empty list instead of an error. Other errors propagate.
 async fn delegate_or_empty(
-    iii: &Arc<III>,
+    iii: &Arc<IIIClient>,
     function_id: &str,
     payload: Value,
     empty: Value,
-) -> Result<Value, IIIError> {
+) -> Result<Value, Error> {
     // Mirror the TS bridge's `payload ?? {}` coercion: skills/prompts workers
     // expect a JSON object payload and treat `null` as missing/invalid input,
     // which would silently turn populated MCP resources/prompts lists empty.
@@ -194,7 +194,7 @@ fn empty_messages() -> Value {
     Value::Object(m)
 }
 
-pub async fn mcp_resources_list(iii: &Arc<III>, params: &Value) -> Result<Value, IIIError> {
+pub async fn mcp_resources_list(iii: &Arc<IIIClient>, params: &Value) -> Result<Value, Error> {
     let result = delegate_or_empty(
         iii,
         "skills::resources-list",
@@ -205,7 +205,7 @@ pub async fn mcp_resources_list(iii: &Arc<III>, params: &Value) -> Result<Value,
     Ok(filter_resources_list_response(result))
 }
 
-pub async fn mcp_resources_read(iii: &Arc<III>, params: &Value) -> Result<Value, IIIError> {
+pub async fn mcp_resources_read(iii: &Arc<IIIClient>, params: &Value) -> Result<Value, Error> {
     let uri = read_uri_param(params);
     let result = delegate_or_empty(
         iii,
@@ -221,9 +221,9 @@ pub async fn mcp_resources_read(iii: &Arc<III>, params: &Value) -> Result<Value,
 }
 
 pub async fn mcp_resources_templates_list(
-    iii: &Arc<III>,
+    iii: &Arc<IIIClient>,
     params: &Value,
-) -> Result<Value, IIIError> {
+) -> Result<Value, Error> {
     delegate_or_empty(
         iii,
         "skills::resources-templates",
@@ -233,11 +233,11 @@ pub async fn mcp_resources_templates_list(
     .await
 }
 
-pub async fn mcp_prompts_list(iii: &Arc<III>, params: &Value) -> Result<Value, IIIError> {
+pub async fn mcp_prompts_list(iii: &Arc<IIIClient>, params: &Value) -> Result<Value, Error> {
     delegate_or_empty(iii, "prompts::mcp-list", params.clone(), empty_prompts()).await
 }
 
-pub async fn mcp_prompts_get(iii: &Arc<III>, params: &Value) -> Result<Value, IIIError> {
+pub async fn mcp_prompts_get(iii: &Arc<IIIClient>, params: &Value) -> Result<Value, Error> {
     delegate_or_empty(iii, "prompts::mcp-get", params.clone(), empty_messages()).await
 }
 
@@ -368,25 +368,25 @@ footer";
 
     #[test]
     fn is_missing_delegate_recognises_remote_codes() {
-        let e = IIIError::Remote {
+        let e = Error::Remote {
             code: "FUNCTION_NOT_FOUND".to_string(),
             message: String::new(),
             stacktrace: None,
         };
         assert!(is_missing_delegate(&e));
-        let e = IIIError::Remote {
+        let e = Error::Remote {
             code: "not_found".to_string(),
             message: String::new(),
             stacktrace: None,
         };
         assert!(is_missing_delegate(&e));
-        let e = IIIError::Remote {
+        let e = Error::Remote {
             code: "OTHER".to_string(),
             message: "function not found".to_string(),
             stacktrace: None,
         };
         assert!(is_missing_delegate(&e));
-        let e = IIIError::Remote {
+        let e = Error::Remote {
             code: "OTHER".to_string(),
             message: "Unknown function: foo".to_string(),
             stacktrace: None,
@@ -396,13 +396,13 @@ footer";
 
     #[test]
     fn is_missing_delegate_rejects_other_errors() {
-        let e = IIIError::Remote {
+        let e = Error::Remote {
             code: "INVALID_ARGUMENT".to_string(),
             message: "bad input".to_string(),
             stacktrace: None,
         };
         assert!(!is_missing_delegate(&e));
-        let e = IIIError::Timeout;
+        let e = Error::Timeout;
         assert!(!is_missing_delegate(&e));
     }
 

--- a/mcp/src/tools.rs
+++ b/mcp/src/tools.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 
-use iii_sdk::{IIIError, TriggerRequest, III};
+use iii_sdk::{errors::Error, protocol::TriggerRequest, IIIClient};
 use serde_json::{json, Map, Value};
 
 use crate::config::McpConfig;
@@ -94,7 +94,7 @@ fn unwrap_function_list(raw: &Value) -> Vec<Map<String, Value>> {
     Vec::new()
 }
 
-pub async fn mcp_tools_list(iii: &Arc<III>, cfg: &Arc<McpConfig>) -> Result<Value, IIIError> {
+pub async fn mcp_tools_list(iii: &Arc<IIIClient>, cfg: &Arc<McpConfig>) -> Result<Value, Error> {
     let raw = iii
         .trigger(TriggerRequest {
             function_id: ENGINE_LIST_FUNCTIONS.to_string(),
@@ -134,7 +134,7 @@ fn stringify_result(v: &Value) -> String {
 }
 
 pub async fn mcp_tools_call(
-    iii: &Arc<III>,
+    iii: &Arc<IIIClient>,
     cfg: &Arc<McpConfig>,
     params: &Value,
 ) -> Result<Value, McpToolsCallError> {

--- a/mcp/tests/common/engine.rs
+++ b/mcp/tests/common/engine.rs
@@ -15,7 +15,11 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use iii_sdk::{register_worker, IIIError, InitOptions, RegisterTriggerInput, TriggerRequest, III};
+use iii_sdk::{
+    errors::Error,
+    protocol::{RegisterTriggerInput, TriggerRequest},
+    register_worker, IIIClient, InitOptions,
+};
 use serde_json::json;
 use tokio::net::TcpStream;
 use tokio::sync::OnceCell;
@@ -28,7 +32,7 @@ use iii_mcp::{
 const DEFAULT_WS_URL: &str = "ws://127.0.0.1:49134";
 const DEFAULT_HTTP_URL: &str = "http://127.0.0.1:3000/mcp";
 
-static ENGINE: OnceCell<Option<Arc<III>>> = OnceCell::const_new();
+static ENGINE: OnceCell<Option<Arc<IIIClient>>> = OnceCell::const_new();
 
 pub fn ws_url() -> String {
     std::env::var("III_ENGINE_WS_URL").unwrap_or_else(|_| DEFAULT_WS_URL.to_string())
@@ -54,7 +58,7 @@ async fn http_reachable(url: &str) -> Option<String> {
 /// Probe the engine via the cheapest call we know of (`engine::workers::list`).
 /// Retries for ~5s while the WebSocket completes the handshake. Returns
 /// `None` and prints a single skip notice when the engine is unreachable.
-pub async fn try_connect_raw() -> Option<Arc<III>> {
+pub async fn try_connect_raw() -> Option<Arc<IIIClient>> {
     let url = ws_url();
     let iii = Arc::new(register_worker(&url, InitOptions::default()));
 
@@ -70,7 +74,7 @@ pub async fn try_connect_raw() -> Option<Arc<III>> {
             .await;
         match probe {
             Ok(_) => return Some(iii),
-            Err(IIIError::NotConnected) => continue,
+            Err(Error::NotConnected) => continue,
             Err(_) => continue,
         }
     }
@@ -89,7 +93,7 @@ pub async fn try_connect_raw() -> Option<Arc<III>> {
 /// logged but not propagated so a polluted engine (e.g. a stale `mcp`
 /// binary still running) degrades to a soft skip rather than a hard
 /// failure inside cucumber's `before` hook.
-async fn register_bridge(iii: &Arc<III>) {
+async fn register_bridge(iii: &Arc<IIIClient>) {
     let cfg = Arc::new(McpConfig::default());
     functions::register_all(iii, &cfg);
 
@@ -125,7 +129,7 @@ async fn register_bridge(iii: &Arc<III>) {
 ///     (default `http://127.0.0.1:3000/mcp`). The bridge always speaks
 ///     HTTP, so an `iii` whose HTTP listener is disabled or on a
 ///     different port can't drive the `@engine` scenarios either.
-pub async fn get_or_init() -> Option<Arc<III>> {
+pub async fn get_or_init() -> Option<Arc<IIIClient>> {
     ENGINE
         .get_or_init(|| async {
             let iii = try_connect_raw().await?;

--- a/mcp/tests/common/world.rs
+++ b/mcp/tests/common/world.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use cucumber::World;
-use iii_sdk::III;
+use iii_sdk::IIIClient;
 use serde_json::Value;
 use uuid::Uuid;
 
@@ -27,7 +27,7 @@ use crate::common::engine::http_url;
 #[derive(World)]
 #[world(init = Self::new)]
 pub struct McpWorld {
-    pub iii: Option<Arc<III>>,
+    pub iii: Option<Arc<IIIClient>>,
     pub http: reqwest::Client,
     pub http_url: String,
     pub unique_id: String,


### PR DESCRIPTION
Bump iii-sdk 0.16.0-next.2 → 0.20.0 + migrate observability to iii-helpers (iii-observability removed) per https://iii.dev/docs/upgrading/from-0-19-x.md. Build, fmt, clippy, tests green (104 steps); surface parity (1 function) 1:1. No import aliases. Note: mcp::handler stays Value-typed by design (captures the response channel field that typed ApiRequest strips) — a typed-schema/publish fix is a separate decision, out of scope for the SDK bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP request handling for better compatibility with the latest client library.
  * Empty or missing payloads are now handled more consistently, reducing errors in delegated actions.
  * Fallback behavior for unavailable delegated functions now returns clean empty responses instead of failing in supported cases.
  * Updated test coverage to reflect the latest connection and error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->