### PR TITLE
chore(email): bump iii-sdk to 0.20.0

### DIFF
--- a/email/Cargo.lock
+++ b/email/Cargo.lock
@@ -367,18 +367,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-hex"
-version = "1.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "proptest",
- "serde_core",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,7 +454,7 @@ dependencies = [
  "globwalk",
  "humantime",
  "inventory",
- "itertools 0.13.0",
+ "itertools",
  "lazy-regex",
  "linked-hash-map",
  "once_cell",
@@ -484,7 +472,7 @@ checksum = "9e19cd9e8e7cfd79fbf844eb6a7334117973c01f6bad35571262b00891e60f1c"
 dependencies = [
  "cucumber-expressions",
  "inflections",
- "itertools 0.13.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "regex",
@@ -584,7 +572,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "email"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-imap",
@@ -710,12 +698,6 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -918,25 +900,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,7 +1004,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -1066,19 +1028,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -1254,23 +1203,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-observability"
-version = "0.16.0-next.4"
+name = "iii-helpers"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fd33ac8c9456bc20ebccbc4c54ba0347de0aa568726f9d789a3095ca93e27d"
+checksum = "09daa7c14a9e4c1f7077c4a181918d207e3f05cdfea8b2d7781bbeb80caf4c5d"
 dependencies = [
- "async-trait",
  "futures-util",
  "opentelemetry",
  "opentelemetry-http",
- "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
  "reqwest",
+ "schemars",
  "serde",
  "serde_json",
  "sysinfo",
- "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -1279,14 +1225,14 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.16.0-next.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c18b68b2aa09e18c68fb023c78316fe7ccf42181874eab584d66f40119b47e"
+checksum = "5957568413b9a5178c11bf91b20909e93e568b187e259e941ba6009a7ec3f5c1"
 dependencies = [
  "async-trait",
  "futures-util",
  "hostname",
- "iii-observability",
+ "iii-helpers",
  "reqwest",
  "schemars",
  "serde",
@@ -1351,15 +1297,6 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1678,23 +1615,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-proto"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
-dependencies = [
- "base64",
- "const-hex",
- "opentelemetry",
- "opentelemetry_sdk",
- "prost",
- "serde",
- "serde_json",
- "tonic",
- "tonic-prost",
-]
-
-[[package]]
 name = "opentelemetry_sdk"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,44 +1753,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
-dependencies = [
- "bitflags",
- "num-traits",
- "rand",
- "rand_chacha",
- "rand_xorshift",
- "regex-syntax 0.8.10",
- "unarray",
-]
-
-[[package]]
-name = "prost"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,15 +1861,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -2704,56 +2577,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tonic"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
-dependencies = [
- "async-trait",
- "base64",
- "bytes",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "sync_wrapper",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic-prost"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
-dependencies = [
- "bytes",
- "prost",
- "tonic",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2761,15 +2584,11 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
  "pin-project-lite",
- "slab",
  "sync_wrapper",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -2913,12 +2732,6 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
-
-[[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"

--- a/email/Cargo.toml
+++ b/email/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.16.0-next.2"
+iii-sdk = "=0.20.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time", "io-util", "net"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/email/src/handlers/accounts.rs
+++ b/email/src/handlers/accounts.rs
@@ -1,4 +1,4 @@
-use iii_sdk::{IIIError, RegisterFunction, III};
+use iii_sdk::{errors::Error, IIIClient, RegisterFunction};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::json;
@@ -7,7 +7,7 @@ use std::sync::Arc;
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct AccountsListReq {}
 
-pub fn register(iii: &Arc<III>, cfg: &Arc<crate::config::WorkerConfig>) {
+pub fn register(iii: &Arc<IIIClient>, cfg: &Arc<crate::config::WorkerConfig>) {
     let cfg = cfg.clone();
     iii.register_function(
         "email::accounts::list",
@@ -31,7 +31,7 @@ pub fn register(iii: &Arc<III>, cfg: &Arc<crate::config::WorkerConfig>) {
                         })
                     })
                     .collect();
-                Ok::<_, IIIError>(json!({ "accounts": accounts }))
+                Ok::<_, Error>(json!({ "accounts": accounts }))
             }
         })
         .description(

--- a/email/src/handlers/attachment.rs
+++ b/email/src/handlers/attachment.rs
@@ -1,5 +1,5 @@
 use iii_sdk::channels::ChannelWriter;
-use iii_sdk::{IIIError, RegisterFunction, III};
+use iii_sdk::{errors::Error, IIIClient, RegisterFunction};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -16,7 +16,7 @@ struct AttachReq {
     response: StreamRef,
 }
 
-pub fn register(iii: &Arc<III>, pool: &Arc<crate::provider::imap::ImapPool>) {
+pub fn register(iii: &Arc<IIIClient>, pool: &Arc<crate::provider::imap::ImapPool>) {
     let pool = pool.clone();
     let iii_inner = iii.clone();
     iii.register_function(
@@ -41,19 +41,19 @@ pub fn register(iii: &Arc<III>, pool: &Arc<crate::provider::imap::ImapPool>) {
                 if let Err(e) = fetch_result {
                     guard.poison();
                     let _ = writer.close().await;
-                    return Err(IIIError::Handler(
+                    return Err(Error::Handler(
                         json!({"code":"E625","message":format!("attachment fetch failed: {e}")})
                             .to_string(),
                     ));
                 }
 
                 writer.close().await.map_err(|e| {
-                    IIIError::Handler(
+                    Error::Handler(
                         json!({"code":"E621","message":format!("channel close failed: {e}")})
                             .to_string(),
                     )
                 })?;
-                Ok::<_, IIIError>(Value::Null)
+                Ok::<_, Error>(Value::Null)
             }
         })
         .description(

--- a/email/src/handlers/flag.rs
+++ b/email/src/handlers/flag.rs
@@ -1,5 +1,5 @@
 use futures_util::StreamExt;
-use iii_sdk::{IIIError, RegisterFunction, III};
+use iii_sdk::{errors::Error, IIIClient, RegisterFunction};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::json;
@@ -18,7 +18,7 @@ fn default_add() -> bool {
     true
 }
 
-pub fn register(iii: &Arc<III>, pool: &Arc<crate::provider::imap::ImapPool>) {
+pub fn register(iii: &Arc<IIIClient>, pool: &Arc<crate::provider::imap::ImapPool>) {
     let pool = pool.clone();
     iii.register_function(
         "email::flag",
@@ -27,7 +27,7 @@ pub fn register(iii: &Arc<III>, pool: &Arc<crate::provider::imap::ImapPool>) {
             async move {
                 let allowed = ["seen", "flagged", "answered", "deleted", "draft"];
                 if !allowed.iter().any(|a| a.eq_ignore_ascii_case(&req.flag)) {
-                    return Err(IIIError::Handler(
+                    return Err(Error::Handler(
                         json!({
                             "code":"E622",
                             "message":format!("flag `{}` not in {{seen, flagged, answered, deleted, draft}}", req.flag)
@@ -55,10 +55,10 @@ pub fn register(iii: &Arc<III>, pool: &Arc<crate::provider::imap::ImapPool>) {
                 .await;
 
                 match outcome {
-                    Ok(()) => Ok::<_, IIIError>(json!({ "ok": true })),
+                    Ok(()) => Ok::<_, Error>(json!({ "ok": true })),
                     Err(e) => {
                         guard.poison();
-                        Err(IIIError::Handler(
+                        Err(Error::Handler(
                             json!({"code":"E623","message":format!("uid_store failed: {e}")})
                                 .to_string(),
                         ))

--- a/email/src/handlers/get.rs
+++ b/email/src/handlers/get.rs
@@ -1,4 +1,4 @@
-use iii_sdk::{IIIError, RegisterFunction, III};
+use iii_sdk::{errors::Error, IIIClient, RegisterFunction};
 use mail_parser::{MessageParser, MimeHeaders};
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -12,7 +12,7 @@ struct GetReq {
     uid: u32,
 }
 
-pub fn register(iii: &Arc<III>, pool: &Arc<crate::provider::imap::ImapPool>) {
+pub fn register(iii: &Arc<IIIClient>, pool: &Arc<crate::provider::imap::ImapPool>) {
     let pool = pool.clone();
     iii.register_function(
         "email::get",
@@ -28,7 +28,7 @@ pub fn register(iii: &Arc<III>, pool: &Arc<crate::provider::imap::ImapPool>) {
                     Ok(b) => b,
                     Err(e) => {
                         guard.poison();
-                        return Err(IIIError::Handler(
+                        return Err(Error::Handler(
                             json!({"code":"E619","message":format!("fetch body failed: {e}")})
                                 .to_string(),
                         ));
@@ -36,7 +36,7 @@ pub fn register(iii: &Arc<III>, pool: &Arc<crate::provider::imap::ImapPool>) {
                 };
 
                 let parsed = MessageParser::default().parse(&body[..]).ok_or_else(|| {
-                    IIIError::Handler(
+                    Error::Handler(
                         json!({"code":"E619","message":"mime parse failed"}).to_string(),
                     )
                 })?;
@@ -51,7 +51,7 @@ pub fn register(iii: &Arc<III>, pool: &Arc<crate::provider::imap::ImapPool>) {
                     }));
                 }
 
-                Ok::<_, IIIError>(json!({
+                Ok::<_, Error>(json!({
                     "uid": req.uid,
                     "message_id": parsed.message_id().unwrap_or(""),
                     "from": parsed.from()

--- a/email/src/handlers/list.rs
+++ b/email/src/handlers/list.rs
@@ -1,4 +1,4 @@
-use iii_sdk::{IIIError, RegisterFunction, III};
+use iii_sdk::{errors::Error, IIIClient, RegisterFunction};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -22,7 +22,7 @@ fn default_limit() -> u32 {
 }
 const MAX_LIMIT: u32 = 1000;
 
-pub fn register(iii: &Arc<III>, pool: &Arc<crate::provider::imap::ImapPool>) {
+pub fn register(iii: &Arc<IIIClient>, pool: &Arc<crate::provider::imap::ImapPool>) {
     let pool = pool.clone();
     iii.register_function(
         "email::list",
@@ -42,7 +42,7 @@ pub fn register(iii: &Arc<III>, pool: &Arc<crate::provider::imap::ImapPool>) {
                     Ok(u) => u,
                     Err(e) => {
                         guard.poison();
-                        return Err(IIIError::Handler(
+                        return Err(Error::Handler(
                             json!({"code":"E612","message":format!("uid_search failed: {e}")})
                                 .to_string(),
                         ));
@@ -65,7 +65,7 @@ pub fn register(iii: &Arc<III>, pool: &Arc<crate::provider::imap::ImapPool>) {
                 }
 
                 let next_cursor = uids.first().copied();
-                Ok::<_, IIIError>(json!({
+                Ok::<_, Error>(json!({
                     "items": items,
                     "next_since_uid": next_cursor,
                 }))

--- a/email/src/handlers/mod.rs
+++ b/email/src/handlers/mod.rs
@@ -1,4 +1,4 @@
-use iii_sdk::III;
+use iii_sdk::IIIClient;
 use std::sync::Arc;
 
 pub mod accounts;
@@ -13,7 +13,7 @@ pub mod send;
 pub const REGISTERED_FN_COUNT: usize = 8;
 
 pub fn register_all(
-    iii: &Arc<III>,
+    iii: &Arc<IIIClient>,
     cfg: &Arc<crate::config::WorkerConfig>,
     pool: &Arc<crate::provider::imap::ImapPool>,
 ) {

--- a/email/src/handlers/move_.rs
+++ b/email/src/handlers/move_.rs
@@ -1,5 +1,5 @@
 use futures_util::StreamExt;
-use iii_sdk::{IIIError, RegisterFunction, III};
+use iii_sdk::{errors::Error, IIIClient, RegisterFunction};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::json;
@@ -27,7 +27,7 @@ enum MoveError {
     PartialCopyStore(async_imap::error::Error),
 }
 
-pub fn register(iii: &Arc<III>, pool: &Arc<crate::provider::imap::ImapPool>) {
+pub fn register(iii: &Arc<IIIClient>, pool: &Arc<crate::provider::imap::ImapPool>) {
     let pool = pool.clone();
     iii.register_function(
         "email::move",
@@ -65,20 +65,20 @@ pub fn register(iii: &Arc<III>, pool: &Arc<crate::provider::imap::ImapPool>) {
                 .await;
 
                 match outcome {
-                    Ok(MoveOutcome::Move) => Ok::<_, IIIError>(json!({ "ok": true, "method": "MOVE" })),
+                    Ok(MoveOutcome::Move) => Ok::<_, Error>(json!({ "ok": true, "method": "MOVE" })),
                     Ok(MoveOutcome::CopyStore) => {
                         Ok(json!({ "ok": true, "method": "COPY+STORE" }))
                     }
                     Err(MoveError::BothFailed(e)) => {
                         guard.poison();
-                        Err(IIIError::Handler(
+                        Err(Error::Handler(
                             json!({"code":"E624","message":format!("imap move failed: {e}")})
                                 .to_string(),
                         ))
                     }
                     Err(MoveError::PartialCopyStore(e)) => {
                         guard.poison();
-                        Err(IIIError::Handler(
+                        Err(Error::Handler(
                             json!({
                                 "code": "E627",
                                 "message": format!(

--- a/email/src/handlers/search.rs
+++ b/email/src/handlers/search.rs
@@ -1,5 +1,5 @@
 use iii_sdk::channels::ChannelWriter;
-use iii_sdk::{IIIError, RegisterFunction, III};
+use iii_sdk::{errors::Error, IIIClient, RegisterFunction};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -19,7 +19,7 @@ fn default_folder() -> String {
     "INBOX".into()
 }
 
-pub fn register(iii: &Arc<III>, pool: &Arc<crate::provider::imap::ImapPool>) {
+pub fn register(iii: &Arc<IIIClient>, pool: &Arc<crate::provider::imap::ImapPool>) {
     let pool = pool.clone();
     let iii_inner = iii.clone();
     iii.register_function(
@@ -40,7 +40,7 @@ pub fn register(iii: &Arc<III>, pool: &Arc<crate::provider::imap::ImapPool>) {
                     Ok(u) => u,
                     Err(e) => {
                         guard.poison();
-                        return Err(IIIError::Handler(
+                        return Err(Error::Handler(
                             json!({"code":"E612","message":format!("uid_search failed: {e}")})
                                 .to_string(),
                         ));
@@ -74,12 +74,12 @@ pub fn register(iii: &Arc<III>, pool: &Arc<crate::provider::imap::ImapPool>) {
                 }
 
                 writer.close().await.map_err(|e| {
-                    IIIError::Handler(
+                    Error::Handler(
                         json!({"code":"E621","message":format!("channel close failed: {e}")})
                             .to_string(),
                     )
                 })?;
-                Ok::<_, IIIError>(Value::Null)
+                Ok::<_, Error>(Value::Null)
             }
         })
         .description(

--- a/email/src/handlers/send.rs
+++ b/email/src/handlers/send.rs
@@ -1,4 +1,4 @@
-use iii_sdk::{protocol::TriggerRequest, IIIError, RegisterFunction, III};
+use iii_sdk::{errors::Error, protocol::TriggerRequest, IIIClient, RegisterFunction};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::json;
@@ -29,7 +29,7 @@ pub struct SendReq {
     pub attachments: Vec<Attachment>,
 }
 
-pub fn register(iii: &Arc<III>, cfg: &Arc<crate::config::WorkerConfig>) {
+pub fn register(iii: &Arc<IIIClient>, cfg: &Arc<crate::config::WorkerConfig>) {
     let cfg = cfg.clone();
     let iii_inner = iii.clone();
     iii.register_function(
@@ -39,20 +39,20 @@ pub fn register(iii: &Arc<III>, cfg: &Arc<crate::config::WorkerConfig>) {
             let iii = iii_inner.clone();
             async move {
                 if req.to.is_empty() {
-                    return Err(IIIError::Handler(
+                    return Err(Error::Handler(
                         json!({"code":"E601","message":"at least one recipient required in `to`"})
                             .to_string(),
                     ));
                 }
                 if req.html.is_none() && req.text.is_none() {
-                    return Err(IIIError::Handler(
+                    return Err(Error::Handler(
                         json!({"code":"E604","message":"provide at least one of `html` or `text`"})
                             .to_string(),
                     ));
                 }
                 let total = req.to.len() + req.cc.len() + req.bcc.len();
                 if total > cfg.limits.max_recipients {
-                    return Err(IIIError::Handler(
+                    return Err(Error::Handler(
                         json!({
                             "code":"E602",
                             "message":format!("recipient count {} exceeds max {}", total, cfg.limits.max_recipients)
@@ -61,13 +61,13 @@ pub fn register(iii: &Arc<III>, cfg: &Arc<crate::config::WorkerConfig>) {
                 }
 
                 let acct = cfg.accounts.get(&req.account).ok_or_else(|| {
-                    IIIError::Handler(
+                    Error::Handler(
                         json!({"code":"E600","message":format!("unknown account `{}`", req.account)})
                             .to_string(),
                     )
                 })?;
                 let smtp_cfg = acct.smtp.as_ref().ok_or_else(|| {
-                    IIIError::Handler(
+                    Error::Handler(
                         json!({"code":"E603","message":format!("account `{}` has no smtp transport configured", req.account)})
                             .to_string(),
                     )
@@ -80,7 +80,7 @@ pub fn register(iii: &Arc<III>, cfg: &Arc<crate::config::WorkerConfig>) {
                     // Base64 inflates by ~4/3 → conservative check on decoded size.
                     let approx = b.len() * 3 / 4;
                     if approx > max_bytes {
-                        return Err(IIIError::Handler(
+                        return Err(Error::Handler(
                             json!({
                                 "code":"E605",
                                 "message":format!("attachment `{}` exceeds max {} bytes", a.filename, max_bytes)
@@ -98,7 +98,7 @@ pub fn register(iii: &Arc<III>, cfg: &Arc<crate::config::WorkerConfig>) {
                     })
                     .await
                     .map_err(|e| {
-                        IIIError::Handler(
+                        Error::Handler(
                             json!({
                                 "code":"E606",
                                 "message":format!("auth::get_token failed for `email::{}`: {e}", req.account)
@@ -106,7 +106,7 @@ pub fn register(iii: &Arc<III>, cfg: &Arc<crate::config::WorkerConfig>) {
                         )
                     })?;
                 if cred.is_null() {
-                    return Err(IIIError::Handler(
+                    return Err(Error::Handler(
                         json!({
                             "code":"E607",
                             "message":format!("no credential stored for `email::{}` — call auth::set_token first", req.account)
@@ -118,7 +118,7 @@ pub fn register(iii: &Arc<III>, cfg: &Arc<crate::config::WorkerConfig>) {
                     &acct.from, smtp_cfg, &cred, req, cfg.limits.send_timeout_ms,
                 ).await?;
 
-                Ok::<_, IIIError>(json!({ "message_id": message_id }))
+                Ok::<_, Error>(json!({ "message_id": message_id }))
             }
         })
         .description(

--- a/email/src/main.rs
+++ b/email/src/main.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use clap::Parser;
 use iii_sdk::{
-    register_worker, IIIError, InitOptions, RegisterTriggerInput, RegisterTriggerType,
-    WorkerMetadata,
+    errors::Error, protocol::RegisterTriggerInput, register_worker, runtime::WorkerMetadata,
+    InitOptions, RegisterTriggerType,
 };
 use std::sync::Arc;
 
@@ -154,4 +154,4 @@ async fn wait_for_shutdown_signal() -> std::io::Result<()> {
 }
 
 #[allow(dead_code)]
-fn _suppress_unused(_: IIIError, _: RegisterTriggerInput) {}
+fn _suppress_unused(_: Error, _: RegisterTriggerInput) {}

--- a/email/src/provider/imap/connection.rs
+++ b/email/src/provider/imap/connection.rs
@@ -3,7 +3,7 @@
 //! pool (`mod.rs::ImapPool`). The two paths must NEVER share a session — IMAP
 //! is half-duplex once a command is in flight.
 
-use iii_sdk::{protocol::TriggerRequest, IIIError, III};
+use iii_sdk::{errors::Error, protocol::TriggerRequest, IIIClient};
 use serde_json::{json, Value};
 use std::sync::Arc;
 use std::time::Duration;
@@ -23,7 +23,7 @@ pub async fn open_and_select(
     folder: &str,
     cfg: &ImapConfig,
     connect_timeout_ms: u64,
-) -> Result<Session, IIIError> {
+) -> Result<Session, Error> {
     let cred = fetch_credential(account).await?;
     open_and_select_with_cred(account, folder, cfg, connect_timeout_ms, &cred).await
 }
@@ -34,7 +34,7 @@ pub async fn open_and_select_with_cred(
     cfg: &ImapConfig,
     connect_timeout_ms: u64,
     cred: &Value,
-) -> Result<Session, IIIError> {
+) -> Result<Session, Error> {
     let user = cred
         .get("username")
         .and_then(|v| v.as_str())
@@ -181,7 +181,7 @@ pub async fn run_until_shutdown(
     }
 }
 
-async fn fetch_credential(account: &str) -> Result<Value, IIIError> {
+async fn fetch_credential(account: &str) -> Result<Value, Error> {
     // The connection module is invoked from contexts that hold an `Arc<III>`
     // upstream. For the supervisor path we re-resolve via the global SDK
     // handle exposed at `connection::iii_handle`. For the pool path the
@@ -215,7 +215,7 @@ async fn fetch_credential(account: &str) -> Result<Value, IIIError> {
     Ok(cred)
 }
 
-fn build_tls_connector() -> Result<TlsConnector, IIIError> {
+fn build_tls_connector() -> Result<TlsConnector, Error> {
     let mut roots = RootCertStore::empty();
     roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     let cfg = ClientConfig::builder()
@@ -224,8 +224,8 @@ fn build_tls_connector() -> Result<TlsConnector, IIIError> {
     Ok(TlsConnector::from(Arc::new(cfg)))
 }
 
-fn handler_err(code: &str, msg: &str) -> IIIError {
-    IIIError::Handler(json!({ "code": code, "message": msg }).to_string())
+fn handler_err(code: &str, msg: &str) -> Error {
+    Error::Handler(json!({ "code": code, "message": msg }).to_string())
 }
 
 // ---- shared III handle for credential lookup from non-handler tasks ----
@@ -235,13 +235,13 @@ fn handler_err(code: &str, msg: &str) -> IIIError {
 // main.rs initializes once after register_worker.
 
 use std::sync::OnceLock;
-static III_HANDLE: OnceLock<Arc<III>> = OnceLock::new();
+static III_HANDLE: OnceLock<Arc<IIIClient>> = OnceLock::new();
 
-pub fn install_iii_handle(iii: Arc<III>) {
+pub fn install_iii_handle(iii: Arc<IIIClient>) {
     let _ = III_HANDLE.set(iii);
 }
 
-fn iii_handle() -> Option<Arc<III>> {
+fn iii_handle() -> Option<Arc<IIIClient>> {
     III_HANDLE.get().cloned()
 }
 

--- a/email/src/provider/imap/mod.rs
+++ b/email/src/provider/imap/mod.rs
@@ -4,7 +4,7 @@ pub mod idle;
 pub mod reconnect;
 
 use dashmap::DashMap;
-use iii_sdk::IIIError;
+use iii_sdk::errors::Error;
 use serde_json::json;
 use std::sync::Arc;
 use tokio::net::TcpStream;
@@ -35,23 +35,23 @@ impl ImapPool {
     /// Acquire (or open) a connection for the given (account, folder). Returns
     /// an owned guard that holds the lock for the duration of the IMAP
     /// exchange. Reconnects transparently on first acquire after a drop.
-    pub async fn acquire(&self, account: &str, folder: &str) -> Result<SessionGuard, IIIError> {
+    pub async fn acquire(&self, account: &str, folder: &str) -> Result<SessionGuard, Error> {
         // Validate FIRST — invalid (account, folder) tuples must never reach
         // the DashMap, otherwise a malformed-payload flood from a hostile
         // caller can balloon `self.sessions` without bound.
         let acct = self.cfg.accounts.get(account).ok_or_else(|| {
-            IIIError::Handler(
+            Error::Handler(
                 json!({"code":"E600","message":format!("unknown account `{account}`")}).to_string(),
             )
         })?;
         let imap_cfg = acct.imap.as_ref().ok_or_else(|| {
-            IIIError::Handler(
+            Error::Handler(
                 json!({"code":"E603","message":format!("account `{account}` has no imap config")})
                     .to_string(),
             )
         })?;
         if !imap_cfg.folders.iter().any(|f| f == folder) {
-            return Err(IIIError::Handler(
+            return Err(Error::Handler(
                 json!({
                     "code":"E613",
                     "message":format!("folder `{folder}` not in account `{account}`.imap.folders")

--- a/email/src/provider/smtp.rs
+++ b/email/src/provider/smtp.rs
@@ -1,5 +1,5 @@
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
-use iii_sdk::IIIError;
+use iii_sdk::errors::Error;
 use lettre::{
     message::{
         header::ContentType, Attachment as LAttach, Mailbox, Message, MultiPart, SinglePart,
@@ -37,12 +37,12 @@ pub async fn send(
     cred: &Value,
     req: SendReq,
     timeout_ms: u64,
-) -> Result<String, IIIError> {
+) -> Result<String, Error> {
     let user = cred
         .get("username")
         .and_then(|v| v.as_str())
         .ok_or_else(|| {
-            IIIError::Handler(
+            Error::Handler(
                 json!({"code":"E608","message":"credential missing `username`"}).to_string(),
             )
         })?;
@@ -50,13 +50,13 @@ pub async fn send(
         .get("password")
         .and_then(|v| v.as_str())
         .ok_or_else(|| {
-            IIIError::Handler(
+            Error::Handler(
                 json!({"code":"E608","message":"credential missing `password`"}).to_string(),
             )
         })?;
 
     let from_mb: Mailbox = from.parse().map_err(|e| {
-        IIIError::Handler(
+        Error::Handler(
             json!({"code":"E609","message":format!("invalid from address `{from}`: {e}")})
                 .to_string(),
         )
@@ -98,16 +98,14 @@ pub async fn send(
     };
 
     let message = builder.multipart(multipart).map_err(|e| {
-        IIIError::Handler(
-            json!({"code":"E609","message":format!("build message: {e}")}).to_string(),
-        )
+        Error::Handler(json!({"code":"E609","message":format!("build message: {e}")}).to_string())
     })?;
 
     let creds = Credentials::new(user.to_string(), pass.to_string());
     let transport: AsyncSmtpTransport<Tokio1Executor> = if cfg.starttls {
         AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&cfg.host)
             .map_err(|e| {
-                IIIError::Handler(json!({"code":"E609","message":e.to_string()}).to_string())
+                Error::Handler(json!({"code":"E609","message":e.to_string()}).to_string())
             })?
             .port(cfg.port)
             .credentials(creds)
@@ -125,7 +123,7 @@ pub async fn send(
     };
 
     let response = transport.send(message).await.map_err(|e| {
-        IIIError::Handler(
+        Error::Handler(
             json!({"code":"E620","message":format!("smtp send failed: {e}")}).to_string(),
         )
     })?;
@@ -141,16 +139,16 @@ pub async fn send(
     Ok(message_id)
 }
 
-fn parse_addr(field: &str, addr: &str) -> Result<Mailbox, IIIError> {
+fn parse_addr(field: &str, addr: &str) -> Result<Mailbox, Error> {
     addr.parse::<Mailbox>().map_err(|e| {
-        IIIError::Handler(
+        Error::Handler(
             json!({"code":"E609","message":format!("invalid {field} address `{addr}`: {e}")})
                 .to_string(),
         )
     })
 }
 
-fn build_body(html: Option<&str>, text: Option<&str>) -> Result<MultiPart, IIIError> {
+fn build_body(html: Option<&str>, text: Option<&str>) -> Result<MultiPart, Error> {
     let mp = match (html, text) {
         (Some(h), Some(t)) => MultiPart::alternative()
             .singlepart(
@@ -182,9 +180,9 @@ fn into_multipart(mp: MultiPart) -> MultiPart {
     mp
 }
 
-fn build_attachment_part(a: Attachment) -> Result<SinglePart, IIIError> {
+fn build_attachment_part(a: Attachment) -> Result<SinglePart, Error> {
     let ct: ContentType = a.content_type.parse().map_err(|e| {
-        IIIError::Handler(
+        Error::Handler(
             json!({
                 "code":"E609",
                 "message":format!("invalid attachment content_type `{}`: {e}", a.content_type)
@@ -196,7 +194,7 @@ fn build_attachment_part(a: Attachment) -> Result<SinglePart, IIIError> {
     // reserved for size-limit violations.
     let bytes = match a.source {
         AttachmentSource::Base64(s) => B64.decode(s.as_bytes()).map_err(|e| {
-            IIIError::Handler(
+            Error::Handler(
                 json!({"code":"E626","message":format!("attachment `{}` base64 decode failed: {e}", a.filename)}).to_string(),
             )
         })?,

--- a/email/src/triggers/dispatcher.rs
+++ b/email/src/triggers/dispatcher.rs
@@ -3,7 +3,7 @@
 
 use async_trait::async_trait;
 use iii_sdk::protocol::TriggerRequest;
-use iii_sdk::III;
+use iii_sdk::IIIClient;
 use serde_json::json;
 use std::sync::Arc;
 use std::time::Duration;
@@ -18,12 +18,12 @@ pub trait EventDispatcher: Send + Sync {
 }
 
 pub struct EngineDispatcher {
-    iii: Arc<III>,
+    iii: Arc<IIIClient>,
     registry: Arc<TriggerRegistry>,
 }
 
 impl EngineDispatcher {
-    pub fn new(iii: Arc<III>, registry: Arc<TriggerRegistry>) -> Self {
+    pub fn new(iii: Arc<IIIClient>, registry: Arc<TriggerRegistry>) -> Self {
         Self { iii, registry }
     }
 }

--- a/email/src/triggers/new_mail.rs
+++ b/email/src/triggers/new_mail.rs
@@ -1,5 +1,8 @@
 use async_trait::async_trait;
-use iii_sdk::{IIIError, TriggerConfig, TriggerHandler};
+use iii_sdk::{
+    errors::Error,
+    trigger::{TriggerConfig, TriggerHandler},
+};
 use serde::Deserialize;
 use serde_json::json;
 use std::sync::Arc;
@@ -27,9 +30,9 @@ pub struct Handler {
 
 #[async_trait]
 impl TriggerHandler for Handler {
-    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn register_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         let cfg: Config = serde_json::from_value(config.config.clone()).map_err(|e| {
-            IIIError::Handler(
+            Error::Handler(
                 json!({
                     "code":"CONFIG_ERROR",
                     "message":format!("email::new-mail config: {e}")
@@ -54,7 +57,7 @@ impl TriggerHandler for Handler {
         Ok(())
     }
 
-    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), IIIError> {
+    async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         self.registry.unregister(&config.id);
         tracing::info!(instance = %config.id, "email::new-mail trigger unregistered");
         Ok(())

--- a/email/tests/common/engine.rs
+++ b/email/tests/common/engine.rs
@@ -1,4 +1,4 @@
-//! Lazily resolve a single shared `iii_sdk::III` handle so `@engine`
+//! Lazily resolve a single shared `iii_sdk::IIIClient` handle so `@engine`
 //! scenarios can run in-process against a live engine. When the engine
 //! isn't reachable (typical contributor laptop), every consumer gets
 //! `None` and `@engine` steps short-circuit without failing the run.
@@ -9,12 +9,12 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use iii_sdk::{register_worker, InitOptions, III};
+use iii_sdk::{register_worker, IIIClient, InitOptions};
 use tokio::sync::OnceCell;
 
-static ENGINE: OnceCell<Option<Arc<III>>> = OnceCell::const_new();
+static ENGINE: OnceCell<Option<Arc<IIIClient>>> = OnceCell::const_new();
 
-pub async fn get_or_init() -> Option<Arc<III>> {
+pub async fn get_or_init() -> Option<Arc<IIIClient>> {
     ENGINE
         .get_or_init(|| async {
             let url = std::env::var("III_ENGINE_WS_URL")

--- a/email/tests/common/world.rs
+++ b/email/tests/common/world.rs
@@ -7,14 +7,14 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use cucumber::World;
-use iii_sdk::III;
+use iii_sdk::IIIClient;
 use serde_json::Value;
 use uuid::Uuid;
 
 #[derive(World)]
 #[world(init = Self::new)]
 pub struct EmailWorld {
-    pub iii: Option<Arc<III>>,
+    pub iii: Option<Arc<IIIClient>>,
     pub unique_id: String,
     pub stash: HashMap<String, Value>,
 }


### PR DESCRIPTION
Bump iii-sdk 0.16.0-next.2 → 0.20.0 per https://iii.dev/docs/upgrading/from-0-19-x.md. IIIError→errors::Error, III→IIIClient, TriggerConfig/TriggerHandler→iii_sdk::trigger; canonical channels/protocol paths kept. Build, fmt, clippy, tests green; surface parity (8 functions + 1 trigger) 1:1. No import aliases. No on-config-change handler.