### PR TITLE
chore(acp): bump iii-sdk to 0.20.0

### DIFF
--- a/acp/Cargo.lock
+++ b/acp/Cargo.lock
@@ -85,12 +85,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,18 +186,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "const-hex"
-version = "1.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "proptest",
- "serde_core",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,12 +274,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,12 +294,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -454,25 +424,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,7 +510,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -584,19 +534,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -747,23 +684,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-observability"
-version = "0.16.0-next.2"
+name = "iii-helpers"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ee84dacaf7e14750ebdc229523e52029441c4ae1f72d25972bf1f2e1edeb99"
+checksum = "09daa7c14a9e4c1f7077c4a181918d207e3f05cdfea8b2d7781bbeb80caf4c5d"
 dependencies = [
- "async-trait",
  "futures-util",
  "opentelemetry",
  "opentelemetry-http",
- "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
  "reqwest",
+ "schemars",
  "serde",
  "serde_json",
  "sysinfo",
- "thiserror",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -772,14 +706,14 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.16.0-next.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c18b68b2aa09e18c68fb023c78316fe7ccf42181874eab584d66f40119b47e"
+checksum = "5957568413b9a5178c11bf91b20909e93e568b187e259e941ba6009a7ec3f5c1"
 dependencies = [
  "async-trait",
  "futures-util",
  "hostname",
- "iii-observability",
+ "iii-helpers",
  "reqwest",
  "schemars",
  "serde",
@@ -824,15 +758,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itoa"
@@ -942,15 +867,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,23 +931,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-proto"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
-dependencies = [
- "base64",
- "const-hex",
- "opentelemetry",
- "opentelemetry_sdk",
- "prost",
- "serde",
- "serde_json",
- "tonic",
- "tonic-prost",
-]
-
-[[package]]
 name = "opentelemetry_sdk"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,26 +965,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pin-project"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -1128,44 +1007,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proptest"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
-dependencies = [
- "bitflags",
- "num-traits",
- "rand",
- "rand_chacha",
- "rand_xorshift",
- "regex-syntax",
- "unarray",
-]
-
-[[package]]
-name = "prost"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1271,15 +1112,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -1799,56 +1631,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tonic"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
-dependencies = [
- "async-trait",
- "base64",
- "bytes",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "sync_wrapper",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic-prost"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
-dependencies = [
- "bytes",
- "prost",
- "tonic",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,15 +1638,11 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
  "pin-project-lite",
- "slab",
  "sync_wrapper",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1988,12 +1766,6 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
-
-[[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"

--- a/acp/Cargo.toml
+++ b/acp/Cargo.toml
@@ -23,7 +23,7 @@ name = "iii-acp"
 path = "src/main.rs"
 
 [dependencies]
-iii-sdk = "=0.16.0-next.2"
+iii-sdk = "=0.20.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util", "sync", "time", "signal"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/acp/iii.worker.yaml
+++ b/acp/iii.worker.yaml
@@ -5,3 +5,7 @@ deploy: binary
 manifest: Cargo.toml
 bin: iii-acp
 description: Agent Client Protocol surface — stdio JSON-RPC, exposes iii agents as ACP sessions
+# Opt out of the interface boot smoke: acp is a stdio JSON-RPC worker that exits
+# on stdin EOF and registers only dynamic per-connection functions, so there is
+# no static interface to collect (mirrors lsp).
+interface_smoke: false

--- a/acp/src/handler.rs
+++ b/acp/src/handler.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use dashmap::{DashMap, DashSet};
-use iii_sdk::{FunctionRef, III, RegisterFunction, RegisterTriggerInput};
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::runtime::FunctionRef;
+use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::{Value, json};
 use uuid::Uuid;
 
@@ -52,7 +54,7 @@ impl CancelHandle {
 }
 
 pub struct AcpHandler {
-    iii: III,
+    iii: IIIClient,
     conn_id: String,
     initialized: AtomicBool,
     // Cancel handle per active session: AtomicBool gates the abort state for
@@ -77,7 +79,7 @@ pub struct AcpHandler {
     owned_sessions: Arc<DashSet<String>>,
     // Trigger + function guards. Dropping them tears the registration
     // down on the engine, so they live for the lifetime of the handler.
-    _event_subscriber: Option<iii_sdk::Trigger>,
+    _event_subscriber: Option<iii_sdk::trigger::Trigger>,
     _event_function: Option<FunctionRef>,
     // True iff agent::events stream subscriber registered cleanly. When an
     // external brain is configured but this is false, session/prompt fails
@@ -94,7 +96,7 @@ pub struct BrainConfig {
 }
 
 impl AcpHandler {
-    pub fn new(iii: III, outbound: Arc<Outbound>, brain: BrainConfig) -> Self {
+    pub fn new(iii: IIIClient, outbound: Arc<Outbound>, brain: BrainConfig) -> Self {
         let conn_id = Uuid::new_v4().to_string();
         let update_seq = Arc::new(AtomicU64::new(0));
         let owned_sessions: Arc<DashSet<String>> = Arc::new(DashSet::new());
@@ -575,7 +577,7 @@ impl AcpHandler {
             payload["system_prompt"] = json!(sys);
         }
 
-        let req = iii_sdk::TriggerRequest {
+        let req = TriggerRequest {
             function_id: fn_id.to_string(),
             payload,
             action: None,
@@ -667,13 +669,13 @@ async fn write_notification(outbound: &Outbound, seq: &AtomicU64, method: &str, 
 // session_id) against the per-process owned_sessions set so multiple
 // iii-acp subprocesses don't fight over the same events.
 fn register_event_subscriber(
-    iii: &III,
+    iii: &IIIClient,
     conn_id: &str,
     outbound: &Arc<Outbound>,
     update_seq: &Arc<AtomicU64>,
     owned_sessions: &Arc<DashSet<String>>,
     history_locks: &Arc<DashMap<String, Arc<tokio::sync::Mutex<()>>>>,
-) -> (Option<iii_sdk::Trigger>, Option<FunctionRef>) {
+) -> (Option<iii_sdk::trigger::Trigger>, Option<FunctionRef>) {
     let fn_id = format!("acp::__on_event::{}", conn_id);
 
     let outbound_inner = outbound.clone();
@@ -720,7 +722,7 @@ fn register_event_subscriber(
 // and writes it to stdout. Frames for sessions we don't own (another
 // connection's editor, or sessions closed mid-flight) are skipped.
 async fn forward_agent_event(
-    iii: &III,
+    iii: &IIIClient,
     outbound: &Outbound,
     seq: &AtomicU64,
     owned: &DashSet<String>,

--- a/acp/src/session.rs
+++ b/acp/src/session.rs
@@ -1,4 +1,6 @@
-use iii_sdk::{III, IIIError, TriggerRequest};
+use iii_sdk::IIIClient;
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
@@ -53,7 +55,7 @@ pub struct SessionRecord {
     pub config_options: serde_json::Map<String, Value>,
 }
 
-pub async fn state_get(iii: &III, scope: &str, key: &str) -> Result<Option<Value>, IIIError> {
+pub async fn state_get(iii: &IIIClient, scope: &str, key: &str) -> Result<Option<Value>, Error> {
     let result = iii
         .trigger(TriggerRequest {
             function_id: "state::get".to_string(),
@@ -75,7 +77,7 @@ pub async fn state_get(iii: &III, scope: &str, key: &str) -> Result<Option<Value
     }
 }
 
-pub async fn state_set(iii: &III, scope: &str, key: &str, value: Value) -> Result<(), IIIError> {
+pub async fn state_set(iii: &IIIClient, scope: &str, key: &str, value: Value) -> Result<(), Error> {
     iii.trigger(TriggerRequest {
         function_id: "state::set".to_string(),
         payload: json!({ "scope": scope, "key": key, "value": value }),
@@ -86,7 +88,7 @@ pub async fn state_set(iii: &III, scope: &str, key: &str, value: Value) -> Resul
     Ok(())
 }
 
-pub async fn state_delete(iii: &III, scope: &str, key: &str) -> Result<(), IIIError> {
+pub async fn state_delete(iii: &IIIClient, scope: &str, key: &str) -> Result<(), Error> {
     iii.trigger(TriggerRequest {
         function_id: "state::delete".to_string(),
         payload: json!({ "scope": scope, "key": key }),
@@ -97,7 +99,7 @@ pub async fn state_delete(iii: &III, scope: &str, key: &str) -> Result<(), IIIEr
     Ok(())
 }
 
-pub async fn durable_publish(iii: &III, topic: &str, data: Value) -> Result<(), IIIError> {
+pub async fn durable_publish(iii: &IIIClient, topic: &str, data: Value) -> Result<(), Error> {
     iii.trigger(TriggerRequest {
         function_id: "iii::durable::publish".to_string(),
         payload: json!({ "topic": topic, "data": data }),
@@ -132,7 +134,7 @@ fn unwrap_value(v: Value) -> Option<Value> {
 // same session race here. Caller (handler.rs) serializes via a per-session
 // in-process mutex to close the window for the common case (multiple
 // agent::events arriving in parallel from one stream subscriber).
-pub async fn append_history(iii: &III, session_id: &str, entry: Value) -> Result<(), IIIError> {
+pub async fn append_history(iii: &IIIClient, session_id: &str, entry: Value) -> Result<(), Error> {
     let scope = scope();
     let key = session_history_key(session_id);
     let mut hist = state_get(iii, &scope, &key)
@@ -143,7 +145,7 @@ pub async fn append_history(iii: &III, session_id: &str, entry: Value) -> Result
     state_set(iii, &scope, &key, Value::Array(hist)).await
 }
 
-pub async fn read_history(iii: &III, session_id: &str) -> Result<Vec<Value>, IIIError> {
+pub async fn read_history(iii: &IIIClient, session_id: &str) -> Result<Vec<Value>, Error> {
     let scope = scope();
     let key = session_history_key(session_id);
     Ok(state_get(iii, &scope, &key)
@@ -152,7 +154,7 @@ pub async fn read_history(iii: &III, session_id: &str) -> Result<Vec<Value>, III
         .unwrap_or_default())
 }
 
-pub async fn append_session_to_index(iii: &III, session_id: &str) -> Result<(), IIIError> {
+pub async fn append_session_to_index(iii: &IIIClient, session_id: &str) -> Result<(), Error> {
     // Read-modify-write under in-process index mutex (caller-owned).
     let scope = scope();
     let key = session_index_key();
@@ -168,7 +170,7 @@ pub async fn append_session_to_index(iii: &III, session_id: &str) -> Result<(), 
     Ok(())
 }
 
-pub async fn remove_session_from_index(iii: &III, session_id: &str) -> Result<(), IIIError> {
+pub async fn remove_session_from_index(iii: &IIIClient, session_id: &str) -> Result<(), Error> {
     // state::update has no array-element-by-value remove op, so this stays
     // a read-modify-write. Race window: a concurrent append from
     // session/new for a different id can be lost. Acceptable in practice
@@ -185,7 +187,7 @@ pub async fn remove_session_from_index(iii: &III, session_id: &str) -> Result<()
     state_set(iii, &scope, key, Value::Array(next)).await
 }
 
-pub async fn read_session_index(iii: &III) -> Result<Vec<String>, IIIError> {
+pub async fn read_session_index(iii: &IIIClient) -> Result<Vec<String>, Error> {
     let scope = scope();
     let key = session_index_key();
     let mut seen = std::collections::HashSet::new();


### PR DESCRIPTION
Bump iii-sdk 0.16.0-next.2 → 0.20.0 per https://iii.dev/docs/upgrading/from-0-19-x.md. IIIError→errors::Error, III→IIIClient, FunctionRef→runtime, protocol/trigger submodules. Build, fmt, clippy, tests green (27 tests). No import aliases. Added interface_smoke:false — acp is a stdio worker (exits on stdin EOF, dynamic per-connection functions only), so there is no static surface to collect (mirrors lsp).