### PR TITLE
chore(coder): bump iii-sdk to 0.20.0

### DIFF
--- a/coder/Cargo.lock
+++ b/coder/Cargo.lock
@@ -85,12 +85,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "autocfg"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,18 +236,6 @@ dependencies = [
  "libc",
  "unicode-width",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "const-hex"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "proptest",
- "serde_core",
 ]
 
 [[package]]
@@ -479,12 +461,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,25 +655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,7 +741,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -809,19 +765,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -973,23 +916,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-observability"
-version = "0.16.0-next.2"
+name = "iii-helpers"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ee84dacaf7e14750ebdc229523e52029441c4ae1f72d25972bf1f2e1edeb99"
+checksum = "09daa7c14a9e4c1f7077c4a181918d207e3f05cdfea8b2d7781bbeb80caf4c5d"
 dependencies = [
- "async-trait",
  "futures-util",
  "opentelemetry",
  "opentelemetry-http",
- "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
  "reqwest",
+ "schemars",
  "serde",
  "serde_json",
  "sysinfo",
- "thiserror",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -998,14 +938,14 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.16.0-next.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c18b68b2aa09e18c68fb023c78316fe7ccf42181874eab584d66f40119b47e"
+checksum = "5957568413b9a5178c11bf91b20909e93e568b187e259e941ba6009a7ec3f5c1"
 dependencies = [
  "async-trait",
  "futures-util",
  "hostname",
- "iii-observability",
+ "iii-helpers",
  "reqwest",
  "schemars",
  "serde",
@@ -1196,15 +1136,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,23 +1197,6 @@ dependencies = [
  "http",
  "opentelemetry",
  "reqwest",
-]
-
-[[package]]
-name = "opentelemetry-proto"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
-dependencies = [
- "base64",
- "const-hex",
- "opentelemetry",
- "opentelemetry_sdk",
- "prost",
- "serde",
- "serde_json",
- "tonic",
- "tonic-prost",
 ]
 
 [[package]]
@@ -1399,44 +1313,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
-dependencies = [
- "bitflags",
- "num-traits",
- "rand",
- "rand_chacha",
- "rand_xorshift",
- "regex-syntax",
- "unarray",
-]
-
-[[package]]
-name = "prost"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,15 +1415,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -2223,56 +2090,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tonic"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
-dependencies = [
- "async-trait",
- "base64",
- "bytes",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "sync_wrapper",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic-prost"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
-dependencies = [
- "bytes",
- "prost",
- "tonic",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2280,15 +2097,11 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
  "pin-project-lite",
- "slab",
  "sync_wrapper",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -2432,12 +2245,6 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
-
-[[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"

--- a/coder/Cargo.toml
+++ b/coder/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.16.0-next.2"
+iii-sdk = "=0.20.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time", "fs", "io-util"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/coder/src/configuration.rs
+++ b/coder/src/configuration.rs
@@ -17,7 +17,9 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use iii_sdk::{IIIError, RegisterFunction, RegisterTriggerInput, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::{json, Value};
 use tokio::sync::RwLock;
 
@@ -39,7 +41,7 @@ const CONFIG_RETRIES: u32 = 3;
 /// Register the `coder` configuration schema with the configuration worker.
 /// When `seed` is present, its value is installed as `initial_value`. Otherwise,
 /// the built-in default is seeded only when no stored value exists yet.
-pub async fn register_config(iii: &III, seed: Option<&CoderConfig>) -> Result<(), String> {
+pub async fn register_config(iii: &IIIClient, seed: Option<&CoderConfig>) -> Result<(), String> {
     let mut payload = json!({
         "id": CONFIG_ID,
         "name": "Coder",
@@ -57,7 +59,7 @@ pub async fn register_config(iii: &III, seed: Option<&CoderConfig>) -> Result<()
 
 /// Read the live `coder` configuration (env-expanded by the configuration
 /// worker — `from_json` does NOT re-expand).
-pub async fn fetch_config(iii: &III) -> Result<CoderConfig, String> {
+pub async fn fetch_config(iii: &IIIClient) -> Result<CoderConfig, String> {
     let value = get_config_value(iii).await?;
     if value.is_null() {
         tracing::info!("no configuration value found; using built-in default configuration");
@@ -66,7 +68,7 @@ pub async fn fetch_config(iii: &III) -> Result<CoderConfig, String> {
     CoderConfig::from_json(&value)
 }
 
-async fn should_seed_default_value(iii: &III) -> Result<bool, String> {
+async fn should_seed_default_value(iii: &IIIClient) -> Result<bool, String> {
     match try_get_config_value(iii).await? {
         None => Ok(true),
         Some(value) if value.is_null() => Ok(true),
@@ -74,14 +76,14 @@ async fn should_seed_default_value(iii: &III) -> Result<bool, String> {
     }
 }
 
-async fn get_config_value(iii: &III) -> Result<Value, String> {
+async fn get_config_value(iii: &IIIClient) -> Result<Value, String> {
     try_get_config_value(iii)
         .await?
         .ok_or_else(|| format!("configuration `{CONFIG_ID}` not found"))
 }
 
 /// Returns `Ok(None)` when the entry does not exist (`NOT_FOUND`).
-async fn try_get_config_value(iii: &III) -> Result<Option<Value>, String> {
+async fn try_get_config_value(iii: &IIIClient) -> Result<Option<Value>, String> {
     match trigger_with_retry(iii, "configuration::get", json!({ "id": CONFIG_ID })).await {
         Ok(resp) => Ok(resp.get("value").cloned()),
         Err(e) if e.contains("NOT_FOUND") => Ok(None),
@@ -135,10 +137,10 @@ pub struct OnConfigChangeResponse {
 /// change it is refused (those require a worker restart because the
 /// `PathResolver` is never rebuilt).
 pub fn register_config_trigger(
-    iii: &III,
+    iii: &IIIClient,
     cell: ConfigCell,
     boot_sig: JailSignature,
-) -> Result<(), IIIError> {
+) -> Result<(), Error> {
     let cell_for_fn = cell.clone();
     let engine = iii.clone();
     iii.register_function(
@@ -149,7 +151,7 @@ pub fn register_config_trigger(
             let boot_sig = boot_sig.clone();
             async move {
                 on_config_change(&engine, &cell, &boot_sig).await;
-                Ok::<OnConfigChangeResponse, IIIError>(OnConfigChangeResponse { ok: true })
+                Ok::<OnConfigChangeResponse, Error>(OnConfigChangeResponse { ok: true })
             }
         })
         .description(
@@ -179,7 +181,7 @@ pub fn register_config_trigger(
 /// the stored value via `configuration::get` instead. A jail-changing update is
 /// refused (it requires a restart); the previous snapshot is always kept on any
 /// failure path.
-async fn on_config_change(iii: &III, cell: &ConfigCell, boot_sig: &JailSignature) {
+async fn on_config_change(iii: &IIIClient, cell: &ConfigCell, boot_sig: &JailSignature) {
     let cfg = match fetch_config(iii).await {
         Ok(cfg) => cfg,
         Err(e) => {
@@ -204,7 +206,11 @@ async fn on_config_change(iii: &III, cell: &ConfigCell, boot_sig: &JailSignature
     tracing::info!("coder tuning limits reloaded (jail unchanged)");
 }
 
-async fn trigger_with_retry(iii: &III, function_id: &str, payload: Value) -> Result<Value, String> {
+async fn trigger_with_retry(
+    iii: &IIIClient,
+    function_id: &str,
+    payload: Value,
+) -> Result<Value, String> {
     let mut last_err = String::new();
     for attempt in 1..=CONFIG_RETRIES {
         match iii

--- a/coder/src/functions/mod.rs
+++ b/coder/src/functions/mod.rs
@@ -23,7 +23,8 @@ pub mod update_file;
 
 use std::sync::Arc;
 
-use iii_sdk::{IIIError, RegisterFunction, III};
+use iii_sdk::errors::Error;
+use iii_sdk::{IIIClient, RegisterFunction};
 
 use crate::configuration::ConfigCell;
 use crate::path::PathResolver;
@@ -226,7 +227,7 @@ pub fn catalog() -> Vec<FunctionSpec> {
     ]
 }
 
-pub fn register_all(iii: &III, resolver: Arc<PathResolver>, cfg: ConfigCell) {
+pub fn register_all(iii: &IIIClient, resolver: Arc<PathResolver>, cfg: ConfigCell) {
     // DRIFT GUARD: the register_* calls below and the entries in
     // `catalog()` must stay 1:1 — catalog() feeds the wire-schema goldens
     // (tests/golden_schemas.rs). Adding a function to one list but not
@@ -261,7 +262,7 @@ pub fn register_all(iii: &III, resolver: Arc<PathResolver>, cfg: ConfigCell) {
     tracing::info!(count = registered, "coder registered functions");
 }
 
-fn register_info(iii: &III, resolver: Arc<PathResolver>, cfg: ConfigCell) {
+fn register_info(iii: &IIIClient, resolver: Arc<PathResolver>, cfg: ConfigCell) {
     iii.register_function(
         INFO_ID,
         RegisterFunction::new_async(move |_req: info::InfoInput| {
@@ -269,14 +270,14 @@ fn register_info(iii: &III, resolver: Arc<PathResolver>, cfg: ConfigCell) {
             let cfg = cfg.clone();
             async move {
                 let cfg = cfg.read().await.clone();
-                info::handle(resolver, cfg).await.map_err(IIIError::from)
+                info::handle(resolver, cfg).await.map_err(Error::from)
             }
         })
         .description(INFO_DESC),
     );
 }
 
-fn register_read_file(iii: &III, resolver: Arc<PathResolver>, cfg: ConfigCell) {
+fn register_read_file(iii: &IIIClient, resolver: Arc<PathResolver>, cfg: ConfigCell) {
     iii.register_function(
         READ_FILE_ID,
         RegisterFunction::new_async(move |req: read_file::ReadFileInput| {
@@ -286,14 +287,14 @@ fn register_read_file(iii: &III, resolver: Arc<PathResolver>, cfg: ConfigCell) {
                 let cfg = cfg.read().await.clone();
                 read_file::handle(resolver, cfg, req)
                     .await
-                    .map_err(IIIError::from)
+                    .map_err(Error::from)
             }
         })
         .description(READ_FILE_DESC),
     );
 }
 
-fn register_search(iii: &III, resolver: Arc<PathResolver>, cfg: ConfigCell) {
+fn register_search(iii: &IIIClient, resolver: Arc<PathResolver>, cfg: ConfigCell) {
     iii.register_function(
         SEARCH_ID,
         RegisterFunction::new_async(move |req: search::SearchInput| {
@@ -303,14 +304,14 @@ fn register_search(iii: &III, resolver: Arc<PathResolver>, cfg: ConfigCell) {
                 let cfg = cfg.read().await.clone();
                 search::handle(resolver, cfg, req)
                     .await
-                    .map_err(IIIError::from)
+                    .map_err(Error::from)
             }
         })
         .description(SEARCH_DESC),
     );
 }
 
-fn register_update_file(iii: &III, resolver: Arc<PathResolver>, cfg: ConfigCell) {
+fn register_update_file(iii: &IIIClient, resolver: Arc<PathResolver>, cfg: ConfigCell) {
     iii.register_function(
         UPDATE_FILE_ID,
         RegisterFunction::new_async(move |req: update_file::UpdateFileInput| {
@@ -320,14 +321,14 @@ fn register_update_file(iii: &III, resolver: Arc<PathResolver>, cfg: ConfigCell)
                 let cfg = cfg.read().await.clone();
                 update_file::handle(resolver, cfg, req)
                     .await
-                    .map_err(IIIError::from)
+                    .map_err(Error::from)
             }
         })
         .description(UPDATE_FILE_DESC),
     );
 }
 
-fn register_create_file(iii: &III, resolver: Arc<PathResolver>, cfg: ConfigCell) {
+fn register_create_file(iii: &IIIClient, resolver: Arc<PathResolver>, cfg: ConfigCell) {
     iii.register_function(
         CREATE_FILE_ID,
         RegisterFunction::new_async(move |req: create_file::CreateFileInput| {
@@ -337,14 +338,14 @@ fn register_create_file(iii: &III, resolver: Arc<PathResolver>, cfg: ConfigCell)
                 let cfg = cfg.read().await.clone();
                 create_file::handle(resolver, cfg, req)
                     .await
-                    .map_err(IIIError::from)
+                    .map_err(Error::from)
             }
         })
         .description(CREATE_FILE_DESC),
     );
 }
 
-fn register_delete_file(iii: &III, resolver: Arc<PathResolver>) {
+fn register_delete_file(iii: &IIIClient, resolver: Arc<PathResolver>) {
     iii.register_function(
         DELETE_FILE_ID,
         RegisterFunction::new_async(move |req: delete_file::DeleteFileInput| {
@@ -352,14 +353,14 @@ fn register_delete_file(iii: &III, resolver: Arc<PathResolver>) {
             async move {
                 delete_file::handle(resolver, req)
                     .await
-                    .map_err(IIIError::from)
+                    .map_err(Error::from)
             }
         })
         .description(DELETE_FILE_DESC),
     );
 }
 
-fn register_list_folder(iii: &III, resolver: Arc<PathResolver>, cfg: ConfigCell) {
+fn register_list_folder(iii: &IIIClient, resolver: Arc<PathResolver>, cfg: ConfigCell) {
     iii.register_function(
         LIST_FOLDER_ID,
         RegisterFunction::new_async(move |req: list_folder::ListFolderInput| {
@@ -369,14 +370,14 @@ fn register_list_folder(iii: &III, resolver: Arc<PathResolver>, cfg: ConfigCell)
                 let cfg = cfg.read().await.clone();
                 list_folder::handle(resolver, cfg, req)
                     .await
-                    .map_err(IIIError::from)
+                    .map_err(Error::from)
             }
         })
         .description(LIST_FOLDER_DESC),
     );
 }
 
-fn register_tree(iii: &III, resolver: Arc<PathResolver>, cfg: ConfigCell) {
+fn register_tree(iii: &IIIClient, resolver: Arc<PathResolver>, cfg: ConfigCell) {
     iii.register_function(
         TREE_ID,
         RegisterFunction::new_async(move |req: tree::TreeInput| {
@@ -384,25 +385,19 @@ fn register_tree(iii: &III, resolver: Arc<PathResolver>, cfg: ConfigCell) {
             let cfg = cfg.clone();
             async move {
                 let cfg = cfg.read().await.clone();
-                tree::handle(resolver, cfg, req)
-                    .await
-                    .map_err(IIIError::from)
+                tree::handle(resolver, cfg, req).await.map_err(Error::from)
             }
         })
         .description(TREE_DESC),
     );
 }
 
-fn register_move_file(iii: &III, resolver: Arc<PathResolver>) {
+fn register_move_file(iii: &IIIClient, resolver: Arc<PathResolver>) {
     iii.register_function(
         MOVE_FILE_ID,
         RegisterFunction::new_async(move |req: move_file::MoveFileInput| {
             let resolver = resolver.clone();
-            async move {
-                move_file::handle(resolver, req)
-                    .await
-                    .map_err(IIIError::from)
-            }
+            async move { move_file::handle(resolver, req).await.map_err(Error::from) }
         })
         .description(MOVE_FILE_DESC),
     );
@@ -412,7 +407,7 @@ fn register_move_file(iii: &III, resolver: Arc<PathResolver>) {
 mod tests {
     use super::*;
 
-    /// DRIFT GUARD execution: `III::new` only buffers registrations into a
+    /// DRIFT GUARD execution: `IIIClient::new` only buffers registrations into a
     /// channel (no connection, no runtime needed), so `register_all` runs
     /// engine-free here and its debug_assert fires in `cargo test` when
     /// the register_* calls and `catalog()` fall out of 1:1.
@@ -420,7 +415,7 @@ mod tests {
     fn register_all_count_matches_catalog() {
         use crate::config::CoderConfig;
         use tokio::sync::RwLock;
-        let iii = III::new("ws://127.0.0.1:1");
+        let iii = IIIClient::new("ws://127.0.0.1:1");
         let cfg = CoderConfig::default();
         let resolver = Arc::new(PathResolver::new(&cfg).unwrap());
         let cell: ConfigCell = Arc::new(RwLock::new(Arc::new(cfg)));

--- a/coder/src/main.rs
+++ b/coder/src/main.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use iii_sdk::{register_worker, InitOptions, WorkerMetadata};
+use iii_sdk::runtime::WorkerMetadata;
+use iii_sdk::{register_worker, InitOptions};
 use tokio::sync::RwLock;
 
 use coder::config::CoderConfig;

--- a/coder/tests/common/engine.rs
+++ b/coder/tests/common/engine.rs
@@ -8,19 +8,21 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use iii_sdk::{register_worker, IIIError, InitOptions, TriggerRequest, III};
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::{register_worker, IIIClient, InitOptions};
 use serde_json::json;
 use tokio::sync::OnceCell;
 
 const DEFAULT_WS_URL: &str = "ws://127.0.0.1:49134";
 
-static ENGINE: OnceCell<Option<Arc<III>>> = OnceCell::const_new();
+static ENGINE: OnceCell<Option<Arc<IIIClient>>> = OnceCell::const_new();
 
 pub fn ws_url() -> String {
     std::env::var("III_ENGINE_WS_URL").unwrap_or_else(|_| DEFAULT_WS_URL.to_string())
 }
 
-pub async fn try_connect_raw() -> Option<Arc<III>> {
+pub async fn try_connect_raw() -> Option<Arc<IIIClient>> {
     let url = ws_url();
     let iii = Arc::new(register_worker(&url, InitOptions::default()));
 
@@ -36,7 +38,7 @@ pub async fn try_connect_raw() -> Option<Arc<III>> {
             .await;
         match probe {
             Ok(_) => return Some(iii),
-            Err(IIIError::NotConnected) => continue,
+            Err(Error::NotConnected) => continue,
             Err(_) => continue,
         }
     }
@@ -52,7 +54,7 @@ pub async fn try_connect_raw() -> Option<Arc<III>> {
 /// Get-or-init the shared engine handle. Registers coder's own function
 /// surface in-process so BDD scenarios drive the same code paths the
 /// production binary would.
-pub async fn get_or_init() -> Option<Arc<III>> {
+pub async fn get_or_init() -> Option<Arc<IIIClient>> {
     ENGINE
         .get_or_init(|| async {
             let iii = try_connect_raw().await?;

--- a/coder/tests/common/helpers.rs
+++ b/coder/tests/common/helpers.rs
@@ -3,7 +3,7 @@
 //! out for `Then` assertions.
 
 use cucumber::gherkin::Step;
-use iii_sdk::TriggerRequest;
+use iii_sdk::protocol::TriggerRequest;
 use serde_json::Value;
 
 use crate::common::world::CoderWorld;

--- a/coder/tests/common/workers.rs
+++ b/coder/tests/common/workers.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Result;
-use iii_sdk::III;
+use iii_sdk::IIIClient;
 use tokio::sync::OnceCell;
 
 use coder::config::CoderConfig;
@@ -40,7 +40,7 @@ pub struct Shared {
 static SHARED: OnceCell<Arc<Shared>> = OnceCell::const_new();
 
 /// Idempotent: the first caller registers; subsequent callers reuse.
-pub async fn register_all(iii: &Arc<III>) -> Result<Arc<Shared>> {
+pub async fn register_all(iii: &Arc<IIIClient>) -> Result<Arc<Shared>> {
     if let Some(s) = SHARED.get() {
         return Ok(s.clone());
     }

--- a/coder/tests/common/world.rs
+++ b/coder/tests/common/world.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use cucumber::World;
-use iii_sdk::III;
+use iii_sdk::IIIClient;
 use serde_json::Value;
 
 use coder::config::CoderConfig;
@@ -23,7 +23,7 @@ use coder::config::CoderConfig;
 #[derive(World)]
 #[world(init = Self::new)]
 pub struct CoderWorld {
-    pub iii: Option<Arc<III>>,
+    pub iii: Option<Arc<IIIClient>>,
     pub cfg: Arc<CoderConfig>,
     pub stash: HashMap<String, Value>,
     pub base_path: Option<PathBuf>,

--- a/coder/tests/integration.rs
+++ b/coder/tests/integration.rs
@@ -9,7 +9,8 @@
 use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
-use iii_sdk::{register_worker, InitOptions, TriggerRequest};
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::{register_worker, InitOptions};
 use serde_json::json;
 use tempfile::TempDir;
 use tokio::time::{sleep, timeout};
@@ -78,7 +79,7 @@ async fn boot() -> Option<Harness> {
 /// Poll `function_id` with `payload` until the worker has registered, or
 /// give up. Returns the response (or panics with the last error).
 async fn call_when_ready(
-    client: &iii_sdk::III,
+    client: &iii_sdk::IIIClient,
     function_id: &str,
     payload: serde_json::Value,
 ) -> serde_json::Value {


### PR DESCRIPTION
Bump iii-sdk 0.16.0-next.2 → 0.20.0 per https://iii.dev/docs/upgrading/from-0-19-x.md. IIIError→errors::Error, III→IIIClient, protocol/runtime submodules. Build, fmt, clippy, tests green (324 tests); 10-function surface (coder::*) intact, all schemas typed (--assert-typed-schemas exits 0; on-config-change already typed). No import aliases.

Note: PR #340 proposes merging coder into shell — if that lands, this becomes moot; until then coder is kept current with 0.20.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the app to work with a newer supported SDK version, improving compatibility and reducing the risk of runtime issues.
  * Adjusted background configuration and integration flows to use the updated client interface, keeping setup and sync behavior reliable.
  * Refreshed test coverage and helpers to match the new SDK behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->