### PR TITLE
fix(email): publish typed schemas

### DIFF
--- a/email/Cargo.lock
+++ b/email/Cargo.lock
@@ -572,7 +572,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "email"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-imap",

--- a/email/src/handlers/accounts.rs
+++ b/email/src/handlers/accounts.rs
@@ -1,11 +1,25 @@
 use iii_sdk::{errors::Error, IIIClient, RegisterFunction};
 use schemars::JsonSchema;
-use serde::Deserialize;
-use serde_json::json;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct AccountsListReq {}
+
+#[derive(Debug, Serialize, JsonSchema)]
+struct AccountsListResp {
+    accounts: Vec<AccountInfo>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+struct AccountInfo {
+    name: String,
+    provider: String,
+    from: String,
+    can_send: bool,
+    can_read: bool,
+    folders: Vec<String>,
+}
 
 pub fn register(iii: &Arc<IIIClient>, cfg: &Arc<crate::config::WorkerConfig>) {
     let cfg = cfg.clone();
@@ -17,21 +31,23 @@ pub fn register(iii: &Arc<IIIClient>, cfg: &Arc<crate::config::WorkerConfig>) {
                 let accounts: Vec<_> = cfg
                     .accounts
                     .iter()
-                    .map(|(k, v)| {
-                        json!({
-                            "name": k,
-                            "provider": match v.provider {
-                                crate::config::Provider::Smtp => "smtp",
-                                crate::config::Provider::Imap => "imap",
-                            },
-                            "from": v.from,
-                            "can_send": v.smtp.is_some(),
-                            "can_read": v.imap.is_some(),
-                            "folders": v.imap.as_ref().map(|i| i.folders.clone()).unwrap_or_default(),
-                        })
+                    .map(|(name, account)| AccountInfo {
+                        name: name.clone(),
+                        provider: match account.provider {
+                            crate::config::Provider::Smtp => "smtp".to_string(),
+                            crate::config::Provider::Imap => "imap".to_string(),
+                        },
+                        from: account.from.clone(),
+                        can_send: account.smtp.is_some(),
+                        can_read: account.imap.is_some(),
+                        folders: account
+                            .imap
+                            .as_ref()
+                            .map(|imap| imap.folders.clone())
+                            .unwrap_or_default(),
                     })
                     .collect();
-                Ok::<_, Error>(json!({ "accounts": accounts }))
+                Ok::<_, Error>(AccountsListResp { accounts })
             }
         })
         .description(

--- a/email/src/handlers/attachment.rs
+++ b/email/src/handlers/attachment.rs
@@ -1,8 +1,8 @@
 use iii_sdk::channels::ChannelWriter;
 use iii_sdk::{errors::Error, IIIClient, RegisterFunction};
 use schemars::JsonSchema;
-use serde::Deserialize;
-use serde_json::{json, Value};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
 use std::sync::Arc;
 
 use crate::provider::StreamRef;
@@ -14,6 +14,11 @@ struct AttachReq {
     uid: u32,
     part_id: String,
     response: StreamRef,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+struct AttachmentGetResp {
+    ok: bool,
 }
 
 pub fn register(iii: &Arc<IIIClient>, pool: &Arc<crate::provider::imap::ImapPool>) {
@@ -53,7 +58,7 @@ pub fn register(iii: &Arc<IIIClient>, pool: &Arc<crate::provider::imap::ImapPool
                             .to_string(),
                     )
                 })?;
-                Ok::<_, Error>(Value::Null)
+                Ok::<_, Error>(AttachmentGetResp { ok: true })
             }
         })
         .description(

--- a/email/src/handlers/flag.rs
+++ b/email/src/handlers/flag.rs
@@ -1,7 +1,7 @@
 use futures_util::StreamExt;
 use iii_sdk::{errors::Error, IIIClient, RegisterFunction};
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
 
@@ -16,6 +16,11 @@ struct FlagReq {
 }
 fn default_add() -> bool {
     true
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+struct FlagResp {
+    ok: bool,
 }
 
 pub fn register(iii: &Arc<IIIClient>, pool: &Arc<crate::provider::imap::ImapPool>) {
@@ -55,7 +60,7 @@ pub fn register(iii: &Arc<IIIClient>, pool: &Arc<crate::provider::imap::ImapPool
                 .await;
 
                 match outcome {
-                    Ok(()) => Ok::<_, Error>(json!({ "ok": true })),
+                    Ok(()) => Ok::<_, Error>(FlagResp { ok: true }),
                     Err(e) => {
                         guard.poison();
                         Err(Error::Handler(

--- a/email/src/handlers/get.rs
+++ b/email/src/handlers/get.rs
@@ -1,7 +1,7 @@
 use iii_sdk::{errors::Error, IIIClient, RegisterFunction};
 use mail_parser::{MessageParser, MimeHeaders};
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
 
@@ -10,6 +10,27 @@ struct GetReq {
     account: String,
     folder: String,
     uid: u32,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+struct GetResp {
+    uid: u32,
+    message_id: String,
+    from: Option<String>,
+    to: Vec<String>,
+    subject: String,
+    date: Option<String>,
+    html: Option<String>,
+    text: Option<String>,
+    attachments: Vec<AttachmentInfo>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+struct AttachmentInfo {
+    part_id: String,
+    filename: String,
+    content_type: String,
+    size: usize,
 }
 
 pub fn register(iii: &Arc<IIIClient>, pool: &Arc<crate::provider::imap::ImapPool>) {
@@ -36,38 +57,43 @@ pub fn register(iii: &Arc<IIIClient>, pool: &Arc<crate::provider::imap::ImapPool
                 };
 
                 let parsed = MessageParser::default().parse(&body[..]).ok_or_else(|| {
-                    Error::Handler(
-                        json!({"code":"E619","message":"mime parse failed"}).to_string(),
-                    )
+                    Error::Handler(json!({"code":"E619","message":"mime parse failed"}).to_string())
                 })?;
 
                 let mut attachments = Vec::new();
                 for (idx, part) in parsed.attachments().enumerate() {
-                    attachments.push(json!({
-                        "part_id": format!("{}", idx + 1),
-                        "filename": part.attachment_name().unwrap_or(""),
-                        "content_type": part.content_type().map(|c| c.c_type.to_string()).unwrap_or_default(),
-                        "size": part.contents().len(),
-                    }));
+                    attachments.push(AttachmentInfo {
+                        part_id: format!("{}", idx + 1),
+                        filename: part.attachment_name().unwrap_or("").to_string(),
+                        content_type: part
+                            .content_type()
+                            .map(|content_type| content_type.c_type.to_string())
+                            .unwrap_or_default(),
+                        size: part.contents().len(),
+                    });
                 }
 
-                Ok::<_, Error>(json!({
-                    "uid": req.uid,
-                    "message_id": parsed.message_id().unwrap_or(""),
-                    "from": parsed.from()
+                Ok::<_, Error>(GetResp {
+                    uid: req.uid,
+                    message_id: parsed.message_id().unwrap_or("").to_string(),
+                    from: parsed
+                        .from()
                         .and_then(|a| a.first())
                         .and_then(|a| a.address.as_ref().map(|s| s.to_string())),
-                    "to": parsed.to()
-                        .map(|tos| tos.iter()
-                            .filter_map(|a| a.address.as_ref().map(|s| s.to_string()))
-                            .collect::<Vec<_>>())
+                    to: parsed
+                        .to()
+                        .map(|tos| {
+                            tos.iter()
+                                .filter_map(|a| a.address.as_ref().map(|s| s.to_string()))
+                                .collect::<Vec<_>>()
+                        })
                         .unwrap_or_default(),
-                    "subject": parsed.subject().unwrap_or(""),
-                    "date": parsed.date().map(|d| d.to_rfc3339()),
-                    "html": parsed.body_html(0).map(|s| s.to_string()),
-                    "text": parsed.body_text(0).map(|s| s.to_string()),
-                    "attachments": attachments,
-                }))
+                    subject: parsed.subject().unwrap_or("").to_string(),
+                    date: parsed.date().map(|d| d.to_rfc3339()),
+                    html: parsed.body_html(0).map(|s| s.to_string()),
+                    text: parsed.body_text(0).map(|s| s.to_string()),
+                    attachments,
+                })
             }
         })
         .description(

--- a/email/src/handlers/list.rs
+++ b/email/src/handlers/list.rs
@@ -1,7 +1,7 @@
 use iii_sdk::{errors::Error, IIIClient, RegisterFunction};
 use schemars::JsonSchema;
-use serde::Deserialize;
-use serde_json::{json, Value};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
 use std::sync::Arc;
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -21,6 +21,12 @@ fn default_limit() -> u32 {
     50
 }
 const MAX_LIMIT: u32 = 1000;
+
+#[derive(Debug, Serialize, JsonSchema)]
+struct ListResp {
+    items: Vec<crate::provider::imap::fetch::HeaderSummary>,
+    next_since_uid: Option<u32>,
+}
 
 pub fn register(iii: &Arc<IIIClient>, pool: &Arc<crate::provider::imap::ImapPool>) {
     let pool = pool.clone();
@@ -57,7 +63,7 @@ pub fn register(iii: &Arc<IIIClient>, pool: &Arc<crate::provider::imap::ImapPool
                 let mut items = Vec::with_capacity(uids.len());
                 for uid in &uids {
                     match crate::provider::imap::fetch::header_summary(session, *uid).await {
-                        Ok(s) => items.push(serde_json::to_value(&s).unwrap_or(Value::Null)),
+                        Ok(summary) => items.push(summary),
                         Err(e) => {
                             tracing::warn!(uid, error = %e, "header_summary skipped");
                         }
@@ -65,10 +71,10 @@ pub fn register(iii: &Arc<IIIClient>, pool: &Arc<crate::provider::imap::ImapPool
                 }
 
                 let next_cursor = uids.first().copied();
-                Ok::<_, Error>(json!({
-                    "items": items,
-                    "next_since_uid": next_cursor,
-                }))
+                Ok::<_, Error>(ListResp {
+                    items,
+                    next_since_uid: next_cursor,
+                })
             }
         })
         .description(

--- a/email/src/handlers/move_.rs
+++ b/email/src/handlers/move_.rs
@@ -1,7 +1,7 @@
 use futures_util::StreamExt;
 use iii_sdk::{errors::Error, IIIClient, RegisterFunction};
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
 
@@ -11,6 +11,12 @@ struct MoveReq {
     folder: String,
     uid: u32,
     dst_folder: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+struct MoveResp {
+    ok: bool,
+    method: String,
 }
 
 enum MoveOutcome {
@@ -65,10 +71,14 @@ pub fn register(iii: &Arc<IIIClient>, pool: &Arc<crate::provider::imap::ImapPool
                 .await;
 
                 match outcome {
-                    Ok(MoveOutcome::Move) => Ok::<_, Error>(json!({ "ok": true, "method": "MOVE" })),
-                    Ok(MoveOutcome::CopyStore) => {
-                        Ok(json!({ "ok": true, "method": "COPY+STORE" }))
-                    }
+                    Ok(MoveOutcome::Move) => Ok::<_, Error>(MoveResp {
+                        ok: true,
+                        method: "MOVE".to_string(),
+                    }),
+                    Ok(MoveOutcome::CopyStore) => Ok(MoveResp {
+                        ok: true,
+                        method: "COPY+STORE".to_string(),
+                    }),
                     Err(MoveError::BothFailed(e)) => {
                         guard.poison();
                         Err(Error::Handler(

--- a/email/src/handlers/search.rs
+++ b/email/src/handlers/search.rs
@@ -1,8 +1,8 @@
 use iii_sdk::channels::ChannelWriter;
 use iii_sdk::{errors::Error, IIIClient, RegisterFunction};
 use schemars::JsonSchema;
-use serde::Deserialize;
-use serde_json::{json, Value};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
 use std::sync::Arc;
 
 use crate::provider::StreamRef;
@@ -17,6 +17,11 @@ struct SearchReq {
 }
 fn default_folder() -> String {
     "INBOX".into()
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+struct SearchResp {
+    ok: bool,
 }
 
 pub fn register(iii: &Arc<IIIClient>, pool: &Arc<crate::provider::imap::ImapPool>) {
@@ -79,7 +84,7 @@ pub fn register(iii: &Arc<IIIClient>, pool: &Arc<crate::provider::imap::ImapPool
                             .to_string(),
                     )
                 })?;
-                Ok::<_, Error>(Value::Null)
+                Ok::<_, Error>(SearchResp { ok: true })
             }
         })
         .description(

--- a/email/src/handlers/send.rs
+++ b/email/src/handlers/send.rs
@@ -1,6 +1,6 @@
 use iii_sdk::{errors::Error, protocol::TriggerRequest, IIIClient, RegisterFunction};
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
 
@@ -27,6 +27,11 @@ pub struct SendReq {
     pub references: Vec<String>,
     #[serde(default)]
     pub attachments: Vec<Attachment>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+struct SendResp {
+    message_id: String,
 }
 
 pub fn register(iii: &Arc<IIIClient>, cfg: &Arc<crate::config::WorkerConfig>) {
@@ -118,7 +123,7 @@ pub fn register(iii: &Arc<IIIClient>, cfg: &Arc<crate::config::WorkerConfig>) {
                     &acct.from, smtp_cfg, &cred, req, cfg.limits.send_timeout_ms,
                 ).await?;
 
-                Ok::<_, Error>(json!({ "message_id": message_id }))
+                Ok::<_, Error>(SendResp { message_id })
             }
         })
         .description(

--- a/email/src/main.rs
+++ b/email/src/main.rs
@@ -87,15 +87,18 @@ async fn main() -> Result<()> {
 
     email::handlers::register_all(&iii, &cfg, &imap_pool);
 
-    let _new_mail_ref = iii.register_trigger_type(RegisterTriggerType::new(
-        "email::new-mail",
-        "Fires when IMAP IDLE pushes a new message to a configured (account, folder). \
+    let _new_mail_ref = iii.register_trigger_type(
+        RegisterTriggerType::new(
+            "email::new-mail",
+            "Fires when IMAP IDLE pushes a new message to a configured (account, folder). \
          Payload: { account, folder, uid, message_id, from, subject, snippet, ts }. \
          If the IMAP server lacks the IDLE capability, the account fails at startup (E610).",
-        email::triggers::new_mail::Handler {
-            registry: trig_registry.clone(),
-        },
-    ));
+            email::triggers::new_mail::Handler {
+                registry: trig_registry.clone(),
+            },
+        )
+        .trigger_request_format::<email::triggers::new_mail::NewMailBindingConfig>(),
+    );
 
     // Spawn one persistent IMAP+IDLE connection per (account, folder).
     // E610 here is fatal — we refuse to silently degrade to polling.

--- a/email/src/provider/imap/fetch.rs
+++ b/email/src/provider/imap/fetch.rs
@@ -8,11 +8,12 @@ use chrono::{DateTime, Utc};
 use futures_util::StreamExt;
 use iii_sdk::channels::ChannelWriter;
 use mail_parser::MessageParser;
+use schemars::JsonSchema;
 use serde::Serialize;
 
 use super::Session;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct HeaderSummary {
     pub uid: u32,
     pub message_id: Option<String>,

--- a/email/src/triggers/new_mail.rs
+++ b/email/src/triggers/new_mail.rs
@@ -3,14 +3,15 @@ use iii_sdk::{
     errors::Error,
     trigger::{TriggerConfig, TriggerHandler},
 };
-use serde::Deserialize;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
 
 use super::registry::TriggerRegistry;
 
-#[derive(Deserialize)]
-struct Config {
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct NewMailBindingConfig {
     account: String,
     #[serde(default = "default_folder")]
     folder: String,
@@ -31,15 +32,16 @@ pub struct Handler {
 #[async_trait]
 impl TriggerHandler for Handler {
     async fn register_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
-        let cfg: Config = serde_json::from_value(config.config.clone()).map_err(|e| {
-            Error::Handler(
-                json!({
-                    "code":"CONFIG_ERROR",
-                    "message":format!("email::new-mail config: {e}")
-                })
-                .to_string(),
-            )
-        })?;
+        let cfg: NewMailBindingConfig =
+            serde_json::from_value(config.config.clone()).map_err(|e| {
+                Error::Handler(
+                    json!({
+                        "code":"CONFIG_ERROR",
+                        "message":format!("email::new-mail config: {e}")
+                    })
+                    .to_string(),
+                )
+            })?;
         self.registry.register(
             cfg.account.clone(),
             cfg.folder.clone(),


### PR DESCRIPTION
## Summary
- replace serde_json::Value/json response returns in email handlers with concrete Serialize + JsonSchema response structs
- add JsonSchema to IMAP HeaderSummary so email::list response is typed
- add a typed binding schema for email::new-mail trigger config
- sync email/Cargo.lock package version to 0.1.2

## Validation
- cargo build
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features
- collect_worker_interface.py --worker email --assert-non-empty --assert-typed-schemas
- smoke: iii trigger email::accounts::list --json '{}'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized several email API responses, making returned data more consistent across listing, reading, sending, searching, moving, flagging, attachments, and account info.
  * Added clearer structured output for message details, attachments, and account listings.
  * Enabled explicit configuration handling for new mail triggers.

* **Bug Fixes**
  * Improved default handling for missing message and account fields so responses are more reliable.
  * Search and attachment actions now return clearer success responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->