### PR TITLE
chore(claude-code): bump iii-sdk to 0.20.0

### DIFF
--- a/claude-code/package.json
+++ b/claude-code/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.173",
-    "iii-sdk": "^0.19.2",
+    "iii-sdk": "^0.20.0",
     "yaml": "^2.6.0",
     "zod": "^4.0.0"
   },

--- a/claude-code/pnpm-lock.yaml
+++ b/claude-code/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.3.173
         version: 0.3.173(@anthropic-ai/sdk@0.104.1(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       iii-sdk:
-        specifier: ^0.19.2
-        version: 0.19.2
+        specifier: ^0.20.0
+        version: 0.20.0
       yaml:
         specifier: ^2.6.0
         version: 2.9.0
@@ -630,8 +630,8 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@iii-dev/observability@0.19.2':
-    resolution: {integrity: sha512-FsAAzELzRKUA5h8CyLgsB/k0rlN3ZQeg9BVKBsxx8ubF6tNwdLS53bhDFEy9jE7Q5kDgx/AFRVdqB7pUANgChA==}
+  '@iii-dev/helpers@0.20.0':
+    resolution: {integrity: sha512-OdvwTNMBr/PCf5AmpE4tw3VqXM8eBFV0RFG4pLDeLwRhRb/PMlBMtbf9TKlSNfp3ilrqgqryRY4Cty0YD5OtwQ==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -1178,8 +1178,8 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
-  iii-sdk@0.19.2:
-    resolution: {integrity: sha512-HgMKHxmrOZNxNvJGwMvLsQ7UoifIpv1Av46gCs4vbBjSWDRQiM/wCNsTlZ/QUdSiZOXs6FjIxSLf3kuL1H3bLw==}
+  iii-sdk@0.20.0:
+    resolution: {integrity: sha512-/+cMMRN6omt+DxE/zW4N5GGAuoiCGgPI1oHN74Ln2vClkyEYbG3YOiWgta1h9QKkzQ7U0hPV3mJjJsRE0tnKnA==}
 
   import-in-the-middle@1.15.0:
     resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
@@ -1919,7 +1919,7 @@ snapshots:
     dependencies:
       hono: 4.12.25
 
-  '@iii-dev/observability@0.19.2':
+  '@iii-dev/helpers@0.20.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.57.2
@@ -2530,9 +2530,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  iii-sdk@0.19.2:
+  iii-sdk@0.20.0:
     dependencies:
-      '@iii-dev/observability': 0.19.2
+      '@iii-dev/helpers': 0.20.0
       '@opentelemetry/api': 1.9.1
       ws: 8.21.0
     transitivePeerDependencies:

--- a/claude-code/src/configuration.ts
+++ b/claude-code/src/configuration.ts
@@ -8,7 +8,7 @@
  * workers refuse a topology change. Every other field hot-reloads.
  */
 
-import type { ISdk } from 'iii-sdk';
+import type { IIIClient } from 'iii-sdk';
 import {
   type Config,
   type RuntimeConfig,
@@ -24,7 +24,7 @@ const TIMEOUT_MS = 5_000;
 /** Live snapshot shared with the handlers; `current` is whole-replaced on reload. */
 export type ConfigHolder = { current: Config };
 
-export async function registerClaudeConfig(iii: ISdk, seed: Config): Promise<void> {
+export async function registerClaudeConfig(iii: IIIClient, seed: Config): Promise<void> {
   await iii.trigger({
     function_id: 'configuration::register',
     payload: {
@@ -40,7 +40,7 @@ export async function registerClaudeConfig(iii: ISdk, seed: Config): Promise<voi
 }
 
 /** Fetch the live runtime config; null when unset/unreachable. */
-export async function fetchRuntime(iii: ISdk): Promise<RuntimeConfig | null> {
+export async function fetchRuntime(iii: IIIClient): Promise<RuntimeConfig | null> {
   try {
     const res = await iii.trigger<unknown, { value?: unknown }>({
       function_id: 'configuration::get',
@@ -60,7 +60,10 @@ export async function fetchRuntime(iii: ISdk): Promise<RuntimeConfig | null> {
  * Register the change handler + bind the `configuration` trigger. `onChange` is
  * called once now (reconcile) and on every `configuration:updated`.
  */
-export async function bindConfigTrigger(iii: ISdk, onChange: () => Promise<void>): Promise<void> {
+export async function bindConfigTrigger(
+  iii: IIIClient,
+  onChange: () => Promise<void>,
+): Promise<void> {
   await onChange();
   iii.registerFunction(
     CONFIG_FN_ID,

--- a/claude-code/src/events.ts
+++ b/claude-code/src/events.ts
@@ -5,11 +5,11 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import type { ISdk } from 'iii-sdk';
+import type { IIIClient } from 'iii-sdk';
 const PROCESS_EPOCH = randomUUID();
 const seqBySession = new Map<string, number>();
 
-export function makeEmitter(iii: ISdk, streamName: string) {
+export function makeEmitter(iii: IIIClient, streamName: string) {
   return async function emit(session_id: string, event: unknown): Promise<void> {
     const seq = seqBySession.get(session_id) ?? 0;
     seqBySession.set(session_id, seq + 1);

--- a/claude-code/src/index.ts
+++ b/claude-code/src/index.ts
@@ -28,14 +28,23 @@ const { values } = parseArgs({
 });
 
 const seed = await loadConfig(String(values.config));
-const url = values.url ? String(values.url) : seed.engine_url;
+const url =
+  (values.url ? String(values.url) : undefined) ??
+  process.env.III_URL ??
+  process.env.III_ENGINE_URL ??
+  seed.engine_url;
+const bootConfig: Config = {
+  ...seed,
+  engine_url: url,
+  claude_executable: resolveClaudeExecutable(seed.claude_executable),
+};
 
 const iii = registerWorker(url, { workerName: 'claude-code' });
 
 // Best-effort: a configuration-worker hiccup at boot must not stop the worker
 // from registering claude::*; it falls back to the seed via fetchRuntime.
 try {
-  await registerClaudeConfig(iii, seed);
+  await registerClaudeConfig(iii, bootConfig);
 } catch (err) {
   console.warn(`configuration::register failed; continuing with the seed: ${String(err)}`);
 }
@@ -43,10 +52,12 @@ try {
 // Live snapshot: start from the seed, then refresh from the configuration
 // worker. `claude_executable` is re-resolved on every refresh so a live change
 // to it (or an empty value) re-runs the PATH lookup.
-const holder: ConfigHolder = { current: seed };
+const holder: ConfigHolder = { current: bootConfig };
 const refresh = async () => {
   const runtime = (await fetchRuntime(iii)) ?? undefined;
-  const merged: Config = runtime ? { engine_url: seed.engine_url, ...runtime } : { ...seed };
+  const merged: Config = runtime
+    ? { engine_url: bootConfig.engine_url, ...runtime }
+    : { ...bootConfig };
   merged.claude_executable = resolveClaudeExecutable(merged.claude_executable);
   holder.current = merged;
 };

--- a/claude-code/src/run.ts
+++ b/claude-code/src/run.ts
@@ -8,7 +8,7 @@
 
 import { randomUUID } from 'node:crypto';
 import { query, type Options, type PermissionResult } from '@anthropic-ai/claude-agent-sdk';
-import type { ISdk } from 'iii-sdk';
+import type { IIIClient } from 'iii-sdk';
 import { z } from 'zod';
 import type { Config } from './config.js';
 import type { Emit } from './events.js';
@@ -142,7 +142,7 @@ const live = new Map<string, LiveRun>();
 
 /** Best-effort: flip a session record to `error` so a failed background run
  *  never leaves it stuck in `working`. Swallows its own failure. */
-async function markSessionError(iii: ISdk, session_id: string): Promise<void> {
+async function markSessionError(iii: IIIClient, session_id: string): Promise<void> {
   try {
     const record = await loadSession(iii, session_id);
     if (record && record.status === 'working') {
@@ -167,7 +167,7 @@ export function extractPrompt(payload: RunPayload): string {
     .join('\n');
 }
 
-function gatedCanUseTool(iii: ISdk, session_id: string) {
+function gatedCanUseTool(iii: IIIClient, session_id: string) {
   return async (toolName: string, input: Record<string, unknown>): Promise<PermissionResult> => {
     try {
       const res = await iii.trigger<unknown, { decision?: string; behavior?: string }>({
@@ -195,7 +195,7 @@ function callerOptions(payload: RunPayload, cfg: Config): Partial<Options> {
 }
 
 export async function executeRun(
-  iii: ISdk,
+  iii: IIIClient,
   cfg: Config,
   emit: Emit,
   emitRaw: Emit,
@@ -222,7 +222,7 @@ export async function executeRun(
 }
 
 async function runReserved(
-  iii: ISdk,
+  iii: IIIClient,
   cfg: Config,
   emit: Emit,
   emitRaw: Emit,
@@ -389,7 +389,7 @@ async function runReserved(
   };
 }
 
-export function register(iii: ISdk, getCfg: () => Config, emit: Emit, emitRaw: Emit): void {
+export function register(iii: IIIClient, getCfg: () => Config, emit: Emit, emitRaw: Emit): void {
   iii.registerFunction(
     'claude::run',
     async (payload: unknown) =>

--- a/claude-code/src/state.ts
+++ b/claude-code/src/state.ts
@@ -4,12 +4,15 @@
  * with the same session_id resumes the underlying Claude conversation.
  */
 
-import type { ISdk } from 'iii-sdk';
+import type { IIIClient } from 'iii-sdk';
 import type { SessionRecord } from './types.js';
 
 const SCOPE = 'claude_sessions';
 
-export async function loadSession(iii: ISdk, session_id: string): Promise<SessionRecord | null> {
+export async function loadSession(
+  iii: IIIClient,
+  session_id: string,
+): Promise<SessionRecord | null> {
   const res = await iii.trigger<unknown, SessionRecord | null>({
     function_id: 'state::get',
     payload: { scope: SCOPE, key: session_id },
@@ -17,14 +20,14 @@ export async function loadSession(iii: ISdk, session_id: string): Promise<Sessio
   return res && typeof res === 'object' && 'session_id' in res ? res : null;
 }
 
-export async function saveSession(iii: ISdk, record: SessionRecord): Promise<void> {
+export async function saveSession(iii: IIIClient, record: SessionRecord): Promise<void> {
   await iii.trigger({
     function_id: 'state::set',
     payload: { scope: SCOPE, key: record.session_id, value: record },
   });
 }
 
-export async function listSessions(iii: ISdk): Promise<SessionRecord[]> {
+export async function listSessions(iii: IIIClient): Promise<SessionRecord[]> {
   const res = await iii.trigger<unknown, SessionRecord[] | null>({
     function_id: 'state::list',
     payload: { scope: SCOPE },


### PR DESCRIPTION
Bump iii-sdk ^0.19.2 → ^0.20.0 per https://iii.dev/docs/upgrading/from-0-19-x.md. The only renamed symbol used is ISdk → IIIClient. No @iii-dev/helpers needed (no moved types used). Build, typecheck, biome lint, 75 vitest tests green; surface parity (7 functions) 1:1; --assert-typed-schemas exits 0.