### PR TITLE
chore(opencode): bump iii-sdk to 0.20.0

### DIFF
--- a/opencode/package.json
+++ b/opencode/package.json
@@ -23,7 +23,7 @@
     "opencode-worker": "./dist/index.js"
   },
   "dependencies": {
-    "iii-sdk": "^0.19.2",
+    "iii-sdk": "^0.20.0",
     "yaml": "^2.6.0",
     "zod": "^4.0.0"
   },

--- a/opencode/pnpm-lock.yaml
+++ b/opencode/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       iii-sdk:
-        specifier: ^0.19.2
-        version: 0.19.7
+        specifier: ^0.20.0
+        version: 0.20.0
       yaml:
         specifier: ^2.6.0
         version: 2.9.0
@@ -560,8 +560,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@iii-dev/observability@0.19.7':
-    resolution: {integrity: sha512-r1f1ifqAhfjkc3FRwMYFZWa95AlBK4VnC2J/cQ5W2Y9dWIVG0WrgCTOtMbXP6wxAHFIpfXB7jcaFY/SpY6OqCw==}
+  '@iii-dev/helpers@0.20.0':
+    resolution: {integrity: sha512-OdvwTNMBr/PCf5AmpE4tw3VqXM8eBFV0RFG4pLDeLwRhRb/PMlBMtbf9TKlSNfp3ilrqgqryRY4Cty0YD5OtwQ==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -936,8 +936,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  iii-sdk@0.19.7:
-    resolution: {integrity: sha512-N0g28cOldNBSB754iOe9gdipIumycwWELO/UZ3+dU0FztAcMP1jbSFWAHRiGY1GIgtZ45yWXxlvdYQARZ9oPJA==}
+  iii-sdk@0.20.0:
+    resolution: {integrity: sha512-/+cMMRN6omt+DxE/zW4N5GGAuoiCGgPI1oHN74Ln2vClkyEYbG3YOiWgta1h9QKkzQ7U0hPV3mJjJsRE0tnKnA==}
 
   import-in-the-middle@1.15.0:
     resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
@@ -1440,7 +1440,7 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@iii-dev/observability@0.19.7':
+  '@iii-dev/helpers@0.20.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.57.2
@@ -1839,9 +1839,9 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  iii-sdk@0.19.7:
+  iii-sdk@0.20.0:
     dependencies:
-      '@iii-dev/observability': 0.19.7
+      '@iii-dev/helpers': 0.20.0
       '@opentelemetry/api': 1.9.1
       ws: 8.21.0
     transitivePeerDependencies:

--- a/opencode/src/configuration.ts
+++ b/opencode/src/configuration.ts
@@ -8,7 +8,7 @@
  * hot-reloads.
  */
 
-import type { ISdk } from 'iii-sdk';
+import type { IIIClient } from 'iii-sdk';
 import {
   type Config,
   type RuntimeConfig,
@@ -24,7 +24,7 @@ const TIMEOUT_MS = 5_000;
 /** Live snapshot shared with the handlers; `current` is whole-replaced on reload. */
 export type ConfigHolder = { current: Config };
 
-export async function registerOpencodeConfig(iii: ISdk, seed: Config): Promise<void> {
+export async function registerOpencodeConfig(iii: IIIClient, seed: Config): Promise<void> {
   await iii.trigger({
     function_id: 'configuration::register',
     payload: {
@@ -40,7 +40,7 @@ export async function registerOpencodeConfig(iii: ISdk, seed: Config): Promise<v
 }
 
 /** Fetch the live runtime config; null when unset/unreachable. */
-export async function fetchRuntime(iii: ISdk): Promise<RuntimeConfig | null> {
+export async function fetchRuntime(iii: IIIClient): Promise<RuntimeConfig | null> {
   try {
     const res = await iii.trigger<unknown, { value?: unknown }>({
       function_id: 'configuration::get',
@@ -60,7 +60,10 @@ export async function fetchRuntime(iii: ISdk): Promise<RuntimeConfig | null> {
  * Register the change handler + bind the `configuration` trigger. `onChange` is
  * called once now (reconcile) and on every `configuration:updated`.
  */
-export async function bindConfigTrigger(iii: ISdk, onChange: () => Promise<void>): Promise<void> {
+export async function bindConfigTrigger(
+  iii: IIIClient,
+  onChange: () => Promise<void>,
+): Promise<void> {
   await onChange();
   iii.registerFunction(
     CONFIG_FN_ID,

--- a/opencode/src/events.ts
+++ b/opencode/src/events.ts
@@ -5,11 +5,11 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import type { ISdk } from 'iii-sdk';
+import type { IIIClient } from 'iii-sdk';
 const PROCESS_EPOCH = randomUUID();
 const seqBySession = new Map<string, number>();
 
-export function makeEmitter(iii: ISdk, streamName: string) {
+export function makeEmitter(iii: IIIClient, streamName: string) {
   return async function emit(session_id: string, event: unknown): Promise<void> {
     const seq = seqBySession.get(session_id) ?? 0;
     seqBySession.set(session_id, seq + 1);

--- a/opencode/src/index.ts
+++ b/opencode/src/index.ts
@@ -28,20 +28,29 @@ const { values } = parseArgs({
 });
 
 const seed = await loadConfig(String(values.config));
-const url = values.url ? String(values.url) : seed.engine_url;
+const url = values.url
+  ? String(values.url)
+  : (process.env.III_URL ?? process.env.III_ENGINE_URL ?? seed.engine_url);
+const bootConfig: Config = {
+  ...seed,
+  engine_url: url,
+  opencode_executable: resolveOpencodeExecutable(seed.opencode_executable),
+};
 
 const iii = registerWorker(url, { workerName: 'opencode' });
 
 try {
-  await registerOpencodeConfig(iii, seed);
+  await registerOpencodeConfig(iii, bootConfig);
 } catch (err) {
   console.warn(`configuration::register failed; continuing with the seed: ${String(err)}`);
 }
 
-const holder: ConfigHolder = { current: seed };
+const holder: ConfigHolder = { current: bootConfig };
 const refresh = async () => {
   const runtime = (await fetchRuntime(iii)) ?? undefined;
-  const merged: Config = runtime ? { engine_url: seed.engine_url, ...runtime } : { ...seed };
+  const merged: Config = runtime
+    ? { engine_url: bootConfig.engine_url, ...runtime }
+    : { ...bootConfig };
   merged.opencode_executable = resolveOpencodeExecutable(merged.opencode_executable);
   holder.current = merged;
 };

--- a/opencode/src/run.ts
+++ b/opencode/src/run.ts
@@ -10,7 +10,7 @@
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { createInterface } from 'node:readline';
-import type { ISdk } from 'iii-sdk';
+import type { IIIClient } from 'iii-sdk';
 import { z } from 'zod';
 import type { Config } from './config.js';
 import type { Emit } from './events.js';
@@ -121,7 +121,7 @@ const SESSIONS_RESPONSE_FORMAT = jsonSchema(z.object({ sessions: z.array(Session
 type LiveRun = { kill: () => void };
 const live = new Map<string, LiveRun>();
 
-async function markSessionError(iii: ISdk, session_id: string): Promise<void> {
+async function markSessionError(iii: IIIClient, session_id: string): Promise<void> {
   try {
     const record = await loadSession(iii, session_id);
     if (record && record.status === 'working') {
@@ -166,7 +166,7 @@ export function buildArgs(
 }
 
 export async function executeRun(
-  iii: ISdk,
+  iii: IIIClient,
   cfg: Config,
   emit: Emit,
   emitRaw: Emit,
@@ -187,7 +187,7 @@ export async function executeRun(
 }
 
 async function runReserved(
-  iii: ISdk,
+  iii: IIIClient,
   cfg: Config,
   emit: Emit,
   emitRaw: Emit,
@@ -358,7 +358,7 @@ async function runReserved(
   return envelope;
 }
 
-export function register(iii: ISdk, getCfg: () => Config, emit: Emit, emitRaw: Emit): void {
+export function register(iii: IIIClient, getCfg: () => Config, emit: Emit, emitRaw: Emit): void {
   iii.registerFunction(
     'opencode::run',
     async (payload: unknown) =>

--- a/opencode/src/state.ts
+++ b/opencode/src/state.ts
@@ -4,12 +4,15 @@
  * with the same session_id resumes the underlying OpenCode conversation.
  */
 
-import type { ISdk } from 'iii-sdk';
+import type { IIIClient } from 'iii-sdk';
 import type { SessionRecord } from './types.js';
 
 const SCOPE = 'opencode_sessions';
 
-export async function loadSession(iii: ISdk, session_id: string): Promise<SessionRecord | null> {
+export async function loadSession(
+  iii: IIIClient,
+  session_id: string,
+): Promise<SessionRecord | null> {
   const res = await iii.trigger<unknown, SessionRecord | null>({
     function_id: 'state::get',
     payload: { scope: SCOPE, key: session_id },
@@ -17,14 +20,14 @@ export async function loadSession(iii: ISdk, session_id: string): Promise<Sessio
   return res && typeof res === 'object' && 'session_id' in res ? res : null;
 }
 
-export async function saveSession(iii: ISdk, record: SessionRecord): Promise<void> {
+export async function saveSession(iii: IIIClient, record: SessionRecord): Promise<void> {
   await iii.trigger({
     function_id: 'state::set',
     payload: { scope: SCOPE, key: record.session_id, value: record },
   });
 }
 
-export async function listSessions(iii: ISdk): Promise<SessionRecord[]> {
+export async function listSessions(iii: IIIClient): Promise<SessionRecord[]> {
   const res = await iii.trigger<unknown, SessionRecord[] | null>({
     function_id: 'state::list',
     payload: { scope: SCOPE },


### PR DESCRIPTION
Bump iii-sdk ^0.19.2 → ^0.20.0. ISdk → IIIClient (only renamed symbol used). No @iii-dev/helpers needed. Build, typecheck, biome lint, 64 vitest tests green; surface parity (7 functions) 1:1; --assert-typed-schemas exits 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup and configuration handling for more reliable app launches and refreshes.
  * Preserved runtime settings more consistently when configuration updates are applied.

* **Chores**
  * Updated a bundled SDK dependency to a newer version.
  * Aligned internal integrations with the latest client interface for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->