### PR TITLE
chore(pi): bump iii-sdk to 0.20.0

### DIFF
--- a/pi/package.json
+++ b/pi/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@earendil-works/pi-coding-agent": "^0.79.0",
-    "iii-sdk": "^0.19.2",
+    "iii-sdk": "^0.20.0",
     "yaml": "^2.6.0",
     "zod": "^4.0.0"
   },

--- a/pi/src/configuration.ts
+++ b/pi/src/configuration.ts
@@ -8,7 +8,7 @@
  * workers refuse a topology change. Every other field hot-reloads.
  */
 
-import type { ISdk } from 'iii-sdk';
+import type { IIIClient } from 'iii-sdk';
 import {
   type Config,
   type RuntimeConfig,
@@ -24,7 +24,7 @@ const TIMEOUT_MS = 5_000;
 /** Live snapshot shared with the handlers; `current` is whole-replaced on reload. */
 export type ConfigHolder = { current: Config };
 
-export async function registerPiConfig(iii: ISdk, seed: Config): Promise<void> {
+export async function registerPiConfig(iii: IIIClient, seed: Config): Promise<void> {
   await iii.trigger({
     function_id: 'configuration::register',
     payload: {
@@ -40,7 +40,7 @@ export async function registerPiConfig(iii: ISdk, seed: Config): Promise<void> {
 }
 
 /** Fetch the live runtime config; null when unset/unreachable. */
-export async function fetchRuntime(iii: ISdk): Promise<RuntimeConfig | null> {
+export async function fetchRuntime(iii: IIIClient): Promise<RuntimeConfig | null> {
   try {
     const res = await iii.trigger<unknown, { value?: unknown }>({
       function_id: 'configuration::get',
@@ -60,7 +60,10 @@ export async function fetchRuntime(iii: ISdk): Promise<RuntimeConfig | null> {
  * Register the change handler + bind the `configuration` trigger. `onChange` is
  * called once now (reconcile) and on every `configuration:updated`.
  */
-export async function bindConfigTrigger(iii: ISdk, onChange: () => Promise<void>): Promise<void> {
+export async function bindConfigTrigger(
+  iii: IIIClient,
+  onChange: () => Promise<void>,
+): Promise<void> {
   await onChange();
   iii.registerFunction(
     CONFIG_FN_ID,

--- a/pi/src/events.ts
+++ b/pi/src/events.ts
@@ -5,11 +5,11 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import type { ISdk } from 'iii-sdk';
+import type { IIIClient } from 'iii-sdk';
 const PROCESS_EPOCH = randomUUID();
 const seqBySession = new Map<string, number>();
 
-export function makeEmitter(iii: ISdk, streamName: string) {
+export function makeEmitter(iii: IIIClient, streamName: string) {
   return async function emit(session_id: string, event: unknown): Promise<void> {
     const seq = seqBySession.get(session_id) ?? 0;
     seqBySession.set(session_id, seq + 1);

--- a/pi/src/run.ts
+++ b/pi/src/run.ts
@@ -13,7 +13,7 @@
 
 import { randomUUID } from 'node:crypto';
 import type { AgentSession } from '@earendil-works/pi-coding-agent';
-import type { ISdk } from 'iii-sdk';
+import type { IIIClient } from 'iii-sdk';
 import { z } from 'zod';
 import type { Config } from './config.js';
 import type { Emit } from './events.js';
@@ -171,7 +171,7 @@ const live = new Map<string, LiveRun>();
 
 /** Best-effort: flip a session record to `error` so a failed background run
  *  never leaves it stuck in `working`. Swallows its own failure. */
-async function markSessionError(iii: ISdk, session_id: string): Promise<void> {
+async function markSessionError(iii: IIIClient, session_id: string): Promise<void> {
   try {
     const record = await loadSession(iii, session_id);
     if (record && record.status === 'working') {
@@ -197,7 +197,7 @@ export function extractPrompt(payload: RunPayload): string {
 }
 
 export async function executeRun(
-  iii: ISdk,
+  iii: IIIClient,
   cfg: Config,
   emit: Emit,
   emitRaw: Emit,
@@ -223,7 +223,7 @@ export async function executeRun(
 }
 
 async function runReserved(
-  iii: ISdk,
+  iii: IIIClient,
   cfg: Config,
   emit: Emit,
   emitRaw: Emit,
@@ -387,7 +387,7 @@ async function runReserved(
   };
 }
 
-export function register(iii: ISdk, getCfg: () => Config, emit: Emit, emitRaw: Emit): void {
+export function register(iii: IIIClient, getCfg: () => Config, emit: Emit, emitRaw: Emit): void {
   iii.registerFunction(
     'pi::run',
     async (payload: unknown) =>

--- a/pi/src/state.ts
+++ b/pi/src/state.ts
@@ -4,12 +4,15 @@
  * resumes the underlying Pi conversation.
  */
 
-import type { ISdk } from 'iii-sdk';
+import type { IIIClient } from 'iii-sdk';
 import type { SessionRecord } from './types.js';
 
 const SCOPE = 'pi_sessions';
 
-export async function loadSession(iii: ISdk, session_id: string): Promise<SessionRecord | null> {
+export async function loadSession(
+  iii: IIIClient,
+  session_id: string,
+): Promise<SessionRecord | null> {
   const res = await iii.trigger<unknown, SessionRecord | null>({
     function_id: 'state::get',
     payload: { scope: SCOPE, key: session_id },
@@ -17,14 +20,14 @@ export async function loadSession(iii: ISdk, session_id: string): Promise<Sessio
   return res && typeof res === 'object' && 'session_id' in res ? res : null;
 }
 
-export async function saveSession(iii: ISdk, record: SessionRecord): Promise<void> {
+export async function saveSession(iii: IIIClient, record: SessionRecord): Promise<void> {
   await iii.trigger({
     function_id: 'state::set',
     payload: { scope: SCOPE, key: record.session_id, value: record },
   });
 }
 
-export async function listSessions(iii: ISdk): Promise<SessionRecord[]> {
+export async function listSessions(iii: IIIClient): Promise<SessionRecord[]> {
   const res = await iii.trigger<unknown, SessionRecord[] | null>({
     function_id: 'state::list',
     payload: { scope: SCOPE },


### PR DESCRIPTION
Bump iii-sdk ^0.19.2 → ^0.20.0. ISdk → IIIClient (only renamed symbol used). No @iii-dev/helpers needed. Build, typecheck, biome lint, 69 vitest tests green; surface parity (9 functions) 1:1; --assert-typed-schemas exits 0.