### PR TITLE
fix(pi): use managed worker engine url

### DIFF
--- a/pi/src/index.ts
+++ b/pi/src/index.ts
@@ -27,23 +27,28 @@ const { values } = parseArgs({
 });
 
 const seed = await loadConfig(String(values.config));
-const url = values.url ? String(values.url) : seed.engine_url;
+const url = values.url
+  ? String(values.url)
+  : (process.env.III_URL ?? process.env.III_ENGINE_URL ?? seed.engine_url);
+const bootConfig: Config = { ...seed, engine_url: url };
 
 const iii = registerWorker(url, { workerName: 'pi' });
 
 // Best-effort: a configuration-worker hiccup at boot must not stop the worker
 // from registering pi::*; it falls back to the seed via fetchRuntime.
 try {
-  await registerPiConfig(iii, seed);
+  await registerPiConfig(iii, bootConfig);
 } catch (err) {
   console.warn(`configuration::register failed; continuing with the seed: ${String(err)}`);
 }
 
 // Live snapshot: start from the seed, then refresh from the configuration worker.
-const holder: ConfigHolder = { current: seed };
+const holder: ConfigHolder = { current: bootConfig };
 const refresh = async () => {
   const runtime = (await fetchRuntime(iii)) ?? undefined;
-  const merged: Config = runtime ? { engine_url: seed.engine_url, ...runtime } : { ...seed };
+  const merged: Config = runtime
+    ? { engine_url: bootConfig.engine_url, ...runtime }
+    : { ...bootConfig };
   holder.current = merged;
 };
 


### PR DESCRIPTION
Fix pi bundle startup under the managed worker VM by honoring III_URL / III_ENGINE_URL before falling back to config.yaml.\n\nEvidence:\n- pnpm install --frozen-lockfile\n- pnpm run build\n- pnpm run typecheck\n- pnpm run lint\n- pnpm test\n- pnpm run build:bundle\n- Local minimal bundle smoke: pi registered 9 functions and pi::sessions::list returned { sessions: [] }.