### PR TITLE
chore(hermes): bump iii-sdk to 0.20.0

### DIFF
--- a/hermes/pyproject.toml
+++ b/hermes/pyproject.toml
@@ -10,7 +10,8 @@ authors = [{ name = "iii" }]
 license = "Apache-2.0"
 requires-python = ">=3.11"
 dependencies = [
-    "iii-sdk==0.19.6",
+    "iii-sdk==0.20.0",
+    "iii-helpers==0.20.0",
     "opentelemetry-api",
     "opentelemetry-sdk",
     "pyyaml",

--- a/hermes/src/handlers.py
+++ b/hermes/src/handlers.py
@@ -16,7 +16,8 @@ import time
 import uuid
 from typing import Any
 
-from iii import ApiRequest, ApiResponse, IIIClient
+from iii import IIIClient
+from iii_helpers.http import HttpRequest, HttpResponse
 
 from . import hermes_cli
 from .iii_prompt import III_CONTEXT_PROMPT
@@ -187,7 +188,7 @@ def create_handlers(iii: IIIClient, get_cfg, logger: logging.Logger) -> dict[str
         # depends on a long-running gateway run (live-integration item).
         return {"session_id": session_id, "stopped": False, "reason": "hermes one-shot turns are not interruptible"}
 
-    async def inbound(req: ApiRequest[Any], log: logging.Logger) -> ApiResponse[Any]:
+    async def inbound(req: HttpRequest[Any], log: logging.Logger) -> HttpResponse[Any]:
         cfg = get_cfg()
         body = req.body or {}
         # Republish the inbound platform/webhook delivery so iii workers can
@@ -197,7 +198,7 @@ def create_handlers(iii: IIIClient, get_cfg, logger: logging.Logger) -> dict[str
         gid = str(body.get("session_id") or body.get("chat_id") or uuid.uuid4())
         await _emit(iii, cfg["raw_events_stream"], gid, {"type": "inbound", "body": body})
         log.info("hermes inbound delivery: group_id=%s", gid)
-        return ApiResponse(statusCode=200, body={"ok": True}, headers=JSON_HEADERS)
+        return HttpResponse(statusCode=200, body={"ok": True}, headers=JSON_HEADERS)
 
     return {
         "run": run,

--- a/hermes/src/hooks.py
+++ b/hermes/src/hooks.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import logging
 from typing import Any, Awaitable, Callable
 
-from iii import ApiRequest, ApiResponse, IIIClient
+from iii import IIIClient
+from iii_helpers.http import HttpRequest, HttpResponse
 
 
 def use_api(
     iii: IIIClient,
     config: dict[str, Any],
-    handler: Callable[[ApiRequest[Any], logging.Logger], Awaitable[ApiResponse[Any]]],
+    handler: Callable[[HttpRequest[Any], logging.Logger], Awaitable[HttpResponse[Any]]],
 ) -> None:
     api_path = config["api_path"]
     http_method = config["http_method"]
@@ -21,8 +22,8 @@ def use_api(
     )
     logger = logging.getLogger(function_id)
 
-    async def wrapped(data: ApiRequest[Any] | dict[str, Any]) -> dict[str, Any]:
-        req = ApiRequest(**data) if isinstance(data, dict) else data
+    async def wrapped(data: HttpRequest[Any] | dict[str, Any]) -> dict[str, Any]:
+        req = HttpRequest(**data) if isinstance(data, dict) else data
         result = await handler(req, logger)
         return result.model_dump(by_alias=True)
 


### PR DESCRIPTION
Bump iii-sdk 0.19.6 → 0.20.0 + add iii-helpers 0.20.0 per https://iii.dev/docs/upgrading/from-0-19-x.md. ApiRequest/ApiResponse → HttpRequest/HttpResponse from iii_helpers.http (identical constructor: statusCode/body/headers). IIIClient unchanged. ruff clean, 46 pytest green; surface parity (8 functions) 1:1; --assert-typed-schemas exits 0.