### PR TITLE
ci(slack): wire release pipeline for the slack worker

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -31,6 +31,7 @@ on:
           - provider-anthropic
           - provider-openai
           - session-manager
+          - slack
           - telegram-bot
           - shell
           - storage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ on:
       - 'provider-anthropic/v*'
       - 'provider-openai/v*'
       - 'session-manager/v*'
+      - 'slack/v*'
       - 'telegram-bot/v*'
       - 'shell/v*'
       - 'storage/v*'


### PR DESCRIPTION
## Summary

Release wiring for the `slack` worker (merged in #348). Without this, `slack` doesn't appear in the **Run workflow → Worker module to release** dropdown and `slack/v*` tags don't trigger Release.

- `create-tag.yml`: add `slack` to `inputs.worker.options`.
- `release.yml`: add `'slack/v*'` to `on.push.tags`.

Follows `docs/sops/new-worker.md` §6. Skills publish via the normal registry release at tag time; `slack` is intentionally **not** added to `parse_publish_workers_input.ALLOWED_WORKERS` (the separate out-of-band skills-publish workflow) — matching `telegram-bot`, which is not in that list either.

No code changes; CI/release config only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the tag creation workflow to include a new `slack` worker option.
  * Updated release automation to also run for tags matching `slack/v*`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->