### PR TITLE
fix(slack): typed ingress schemas + streaming/recipient/dedupe/upload correctness + tests

### DIFF
--- a/slack/src/config.rs
+++ b/slack/src/config.rs
@@ -285,6 +285,49 @@ mod tests {
     }
 
     #[test]
+    fn socket_mode_enabled_by_app_token() {
+        let cfg = WorkerConfig {
+            bot_token: "xoxb".into(),
+            app_token: Some("xapp-1".into()),
+            ..WorkerConfig::default()
+        };
+        assert!(cfg.socket_enabled());
+        assert!(cfg.bridge_enabled());
+        // An empty/whitespace app_token does not enable socket mode.
+        let blank = WorkerConfig {
+            app_token: Some("  ".into()),
+            ..cfg.clone()
+        };
+        assert!(!blank.socket_enabled());
+    }
+
+    #[test]
+    fn socket_takes_precedence_over_http() {
+        // Both transports configured: socket wins, http bridge is suppressed.
+        let cfg = WorkerConfig {
+            bot_token: "xoxb".into(),
+            app_token: Some("xapp-1".into()),
+            signing_secret: Some("s".into()),
+            public_base_url: Some("https://engine.example".into()),
+            ..WorkerConfig::default()
+        };
+        assert!(cfg.socket_enabled());
+        assert!(!cfg.http_bridge_enabled());
+        assert!(cfg.bridge_enabled());
+    }
+
+    #[test]
+    fn no_bridge_without_any_transport() {
+        let cfg = WorkerConfig {
+            bot_token: "xoxb".into(),
+            ..WorkerConfig::default()
+        };
+        assert!(!cfg.socket_enabled());
+        assert!(!cfg.http_bridge_enabled());
+        assert!(!cfg.bridge_enabled());
+    }
+
+    #[test]
     fn rejects_unknown_fields() {
         assert!(WorkerConfig::from_yaml("bogus_field: 1\n").is_err());
     }

--- a/slack/src/deps.rs
+++ b/slack/src/deps.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Instant;
 
 use dashmap::DashMap;
 use iii_sdk::IIIClient;
@@ -27,20 +28,40 @@ pub struct Identity {
 pub struct StreamState {
     pub channel: String,
     pub thread_ts: String,
-    /// Recipient user (required when streaming into a channel, not a DM).
+    /// Recipient user — required (with `recipient_team_id`) when streaming into a
+    /// channel; omitted for DMs.
     pub recipient_user_id: Option<String>,
+    /// Recipient team — required alongside `recipient_user_id` for channel streams.
+    pub recipient_team_id: Option<String>,
+    /// Whether the target is a DM (no recipients sent).
+    pub is_dm: bool,
     /// ts of the streaming message once `chat.startStream` has run.
     pub ts: Option<String>,
     /// Full assistant text already sent, to compute the next append delta.
     pub last_text: String,
+    /// Highest `message-updated` revision applied (drop older/stale revisions).
+    pub last_revision: u64,
 }
 
 #[derive(Default)]
 pub struct RuntimeState {
     /// session_id -> active stream.
     pub streams: DashMap<String, StreamState>,
-    /// Seen Slack `event_id`s (retry dedupe).
-    pub seen_events: DashMap<String, ()>,
+    /// Per-session lock serializing the stream read-modify-write across awaits.
+    pub stream_locks: DashMap<String, Arc<Mutex<()>>>,
+    /// Seen Slack `event_id`s -> first-seen time (retry dedupe, time-windowed).
+    pub seen_events: DashMap<String, Instant>,
+}
+
+impl RuntimeState {
+    /// Per-session mutex so concurrent `message-*`/finalize handlers cannot
+    /// interleave the stream state (mirrors telegram-bot's entry locks).
+    pub fn stream_lock(&self, session_id: &str) -> Arc<Mutex<()>> {
+        self.stream_locks
+            .entry(session_id.to_string())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    }
 }
 
 #[derive(Clone)]
@@ -87,5 +108,33 @@ impl Deps {
             .await
             .as_ref()
             .and_then(|i| i.user_id.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stream_lock_is_per_session() {
+        let rt = RuntimeState::default();
+        let a1 = rt.stream_lock("s1");
+        let a2 = rt.stream_lock("s1");
+        let b = rt.stream_lock("s2");
+        // Same session -> same underlying mutex; different session -> different.
+        assert!(Arc::ptr_eq(&a1, &a2));
+        assert!(!Arc::ptr_eq(&a1, &b));
+    }
+
+    #[tokio::test]
+    async fn stream_lock_serializes_same_session() {
+        let rt = RuntimeState::default();
+        let lock = rt.stream_lock("s1");
+        let held = lock.lock().await;
+        // A second acquisition of the same session lock cannot proceed while held.
+        assert!(rt.stream_lock("s1").try_lock().is_err());
+        drop(held);
+        // A different session is independent.
+        assert!(rt.stream_lock("s2").try_lock().is_ok());
     }
 }

--- a/slack/src/dispatch.rs
+++ b/slack/src/dispatch.rs
@@ -8,15 +8,31 @@ use crate::turn;
 use crate::types::{EventCallback, InteractionPayload, MessageEvent, SlackEvent};
 use serde_json::json;
 
+/// Slack retries a failed delivery for a few minutes; keep the dedupe window a
+/// bit longer, and evict beyond it so the map cannot grow unbounded.
+const DEDUPE_WINDOW: std::time::Duration = std::time::Duration::from_secs(600);
+const DEDUPE_EVICT_AT: usize = 2048;
+
 /// Returns true if this `event_id` is new (and records it).
 fn first_time(deps: &Deps, event_id: Option<&str>) -> bool {
     let Some(id) = event_id else {
         return true;
     };
-    deps.runtime
-        .seen_events
-        .insert(id.to_string(), ())
-        .is_none()
+    record_seen(&deps.runtime.seen_events, id, std::time::Instant::now())
+}
+
+/// Record an `event_id`, returning whether it was newly seen, and evict entries
+/// older than the dedupe window once the map grows past the cap (bounds memory).
+fn record_seen(
+    seen: &dashmap::DashMap<String, std::time::Instant>,
+    id: &str,
+    now: std::time::Instant,
+) -> bool {
+    let is_new = seen.insert(id.to_string(), now).is_none();
+    if seen.len() > DEDUPE_EVICT_AT {
+        seen.retain(|_, t| now.duration_since(*t) < DEDUPE_WINDOW);
+    }
+    is_new
 }
 
 pub async fn process_event(deps: &Deps, cb: EventCallback) {
@@ -209,5 +225,37 @@ pub async fn process_interaction(deps: &Deps, payload: InteractionPayload) {
         )
         .await;
         kv::delete_approval_cb(deps, &token).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dashmap::DashMap;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn record_seen_dedupes() {
+        let seen = DashMap::new();
+        let now = Instant::now();
+        assert!(record_seen(&seen, "Ev1", now)); // first time -> new
+        assert!(!record_seen(&seen, "Ev1", now)); // retry -> not new
+        assert!(record_seen(&seen, "Ev2", now)); // different id -> new
+    }
+
+    #[test]
+    fn record_seen_evicts_old_entries_past_cap() {
+        let seen: DashMap<String, Instant> = DashMap::new();
+        let now = Instant::now();
+        // An entry older than the dedupe window.
+        let aged = now.checked_sub(Duration::from_secs(700)).unwrap();
+        seen.insert("OLD".to_string(), aged);
+        // Cross the eviction cap with fresh entries.
+        for i in 0..=DEDUPE_EVICT_AT {
+            record_seen(&seen, &format!("Ev{i}"), now);
+        }
+        // The aged entry (older than DEDUPE_WINDOW) is evicted; fresh ones remain.
+        assert!(!seen.contains_key("OLD"));
+        assert!(seen.contains_key("Ev0"));
     }
 }

--- a/slack/src/functions/bindings.rs
+++ b/slack/src/functions/bindings.rs
@@ -40,7 +40,7 @@ pub fn register(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
             if let Some(msg) = &evt.message {
                 if msg.role == "assistant" {
                     let text = msg.text();
-                    if let Err(e) = stream::on_assistant_text(&d, &evt.session_id, &text).await {
+                    if let Err(e) = stream::on_assistant_text(&d, &evt.session_id, &text, 0).await {
                         tracing::warn!(error = %e, "on-message-added stream failed");
                     }
                 }
@@ -57,7 +57,9 @@ pub fn register(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
         |d, evt: MessageUpdatedEvent| async move {
             if evt.message.role == "assistant" {
                 let text = evt.message.text();
-                if let Err(e) = stream::on_assistant_text(&d, &evt.session_id, &text).await {
+                if let Err(e) =
+                    stream::on_assistant_text(&d, &evt.session_id, &text, evt.revision).await
+                {
                     tracing::warn!(error = %e, "on-message-updated stream failed");
                 }
             }

--- a/slack/src/functions/events.rs
+++ b/slack/src/functions/events.rs
@@ -13,6 +13,17 @@ use crate::{dispatch, httpio};
 
 pub const EVENTS_ID: &str = "slack::events";
 
+/// Published request shape for `slack::events` (an HTTP trigger payload). The
+/// handler reads the raw body from the request channel; this typed struct exists
+/// so the function publishes a typed schema rather than AnyValue.
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+#[allow(dead_code)]
+struct EventsHttpRequest {
+    /// The Slack event envelope (also delivered raw on the request_body channel).
+    #[serde(default)]
+    body: Value,
+}
+
 pub fn register(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
     let deps = deps.clone();
     iii.register_function(
@@ -24,6 +35,8 @@ pub fn register(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
                 Ok::<_, Error>(Value::Null)
             }
         })
+        .request_format(super::schema_value::<EventsHttpRequest>())
+        .response_format(serde_json::json!({ "type": "null" }))
         .description("Slack Events API ingress (signature-verified)."),
     );
 }

--- a/slack/src/functions/files.rs
+++ b/slack/src/functions/files.rs
@@ -105,18 +105,21 @@ async fn upload(deps: &Deps, req: UploadReq) -> Result<UploadResponse, Error> {
         .ok_or_else(|| Error::Handler("files.upload: missing file_id".into()))?
         .to_string();
 
-    // 2. PUT the bytes to the reserved URL
-    let put = deps
+    // 2. POST the bytes to the reserved URL as multipart/form-data (the `file`
+    //    field), matching Slack's documented `curl -F file=@...` upload.
+    let part = reqwest::multipart::Part::bytes(bytes).file_name(req.filename.clone());
+    let form = reqwest::multipart::Form::new().part("file", part);
+    let upload = deps
         .http
         .post(upload_url)
-        .body(bytes)
+        .multipart(form)
         .send()
         .await
-        .map_err(|e| Error::Handler(format!("files.upload PUT: {}", e.without_url())))?;
-    if !put.status().is_success() {
+        .map_err(|e| Error::Handler(format!("files.upload post: {}", e.without_url())))?;
+    if !upload.status().is_success() {
         return Err(Error::Handler(format!(
             "files.upload: upload returned HTTP {}",
-            put.status()
+            upload.status()
         )));
     }
 

--- a/slack/src/functions/interactions.rs
+++ b/slack/src/functions/interactions.rs
@@ -14,6 +14,17 @@ use crate::{dispatch, httpio};
 
 pub const INTERACTIONS_ID: &str = "slack::interactions";
 
+/// Published request shape for `slack::interactions` (an HTTP trigger payload).
+/// The handler reads the raw form body from the request channel; this typed
+/// struct exists so the function publishes a typed schema rather than AnyValue.
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+#[allow(dead_code)]
+struct InteractionsHttpRequest {
+    /// The url-encoded interactivity body (also delivered raw on the request_body channel).
+    #[serde(default)]
+    body: Value,
+}
+
 pub fn register(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
     let deps = deps.clone();
     iii.register_function(
@@ -25,6 +36,8 @@ pub fn register(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
                 Ok::<_, Error>(Value::Null)
             }
         })
+        .request_format(super::schema_value::<InteractionsHttpRequest>())
+        .response_format(serde_json::json!({ "type": "null" }))
         .description("Slack interactivity ingress (block actions / view submissions)."),
     );
 }

--- a/slack/src/functions/mod.rs
+++ b/slack/src/functions/mod.rs
@@ -34,6 +34,19 @@ use serde::Serialize;
 
 use crate::deps::Deps;
 
+/// JSON Schema (as a `Value`) for a type, with the `$schema` key stripped — used
+/// to attach typed request/response schemas to raw-`Value` HTTP handlers (which
+/// would otherwise publish the permissive AnyValue schema) via
+/// `RegisterFunction::request_format`/`response_format`.
+pub(crate) fn schema_value<T: JsonSchema>() -> serde_json::Value {
+    let root = schemars::gen::SchemaGenerator::default().into_root_schema_for::<T>();
+    let mut v = serde_json::to_value(root).expect("schema serializes");
+    if let Some(obj) = v.as_object_mut() {
+        obj.remove("$schema");
+    }
+    v
+}
+
 /// Register a typed async function with the engine. Shared by hand-written
 /// handlers and the [`slack_method!`] macro.
 pub(crate) fn register<Req, Resp, F, Fut>(

--- a/slack/src/ingress.rs
+++ b/slack/src/ingress.rs
@@ -27,8 +27,10 @@ pub async fn apply(deps: &Arc<Deps>) {
     match crate::clients::slack::auth_test(deps).await {
         Ok(id) => *deps.identity.write().await = Some(id),
         Err(e) => {
-            *deps.identity.write().await = None;
-            tracing::warn!(error = %e, "failed to refresh Slack identity (cleared cache)");
+            // Keep the last-known-good identity: a transient auth.test failure on
+            // reload must not blind mention/self detection. An explicit token
+            // problem surfaces via `slack::config-status` (which does clear it).
+            tracing::warn!(error = %e, "failed to refresh Slack identity (keeping cached)");
         }
     }
     let cfg = deps.cfg().await;

--- a/slack/src/stream.rs
+++ b/slack/src/stream.rs
@@ -1,6 +1,11 @@
 //! Stream assistant output back into Slack using native streaming
 //! (`chat.startStream`/`appendStream`/`stopStream`), with a `chat.update`
 //! fallback for workspaces without AI-app streaming.
+//!
+//! All state transitions for a session are serialized by a per-session lock
+//! (`RuntimeState::stream_lock`) and gated by `message-updated` revision, so
+//! concurrent revision events cannot lose appended text or open two streams
+//! (mirrors telegram-bot's per-entry lock + revision monotonicity).
 
 use iii_sdk::errors::Error;
 use serde_json::{json, Value};
@@ -9,36 +14,57 @@ use crate::clients::slack;
 use crate::deps::{Deps, StreamState};
 use crate::kv;
 
-/// Handle a streamed assistant text revision for a session.
-pub async fn on_assistant_text(deps: &Deps, session_id: &str, text: &str) -> Result<(), Error> {
+/// Handle a streamed assistant text revision for a session. `revision` is the
+/// `message-updated` revision (0 for the initial `message-added`).
+pub async fn on_assistant_text(
+    deps: &Deps,
+    session_id: &str,
+    text: &str,
+    revision: u64,
+) -> Result<(), Error> {
     if text.is_empty() {
         return Ok(());
     }
 
-    // Ensure we have a stream state seeded from the session's target.
+    let lock = deps.runtime.stream_lock(session_id);
+    let _guard = lock.lock().await;
+
+    // Seed stream state from the session's target on first sight.
     if !deps.runtime.streams.contains_key(session_id) {
         let Some(target) = kv::session_target(deps, session_id).await else {
             return Ok(());
         };
+        let is_dm = channel_is_dm(&target.channel);
         deps.runtime.streams.insert(
             session_id.to_string(),
             StreamState {
                 channel: target.channel,
                 thread_ts: target.thread_ts,
-                recipient_user_id: target.recipient_user_id,
+                recipient_user_id: if is_dm {
+                    None
+                } else {
+                    target.recipient_user_id
+                },
+                recipient_team_id: if is_dm { None } else { target.team },
+                is_dm,
                 ts: None,
                 last_text: String::new(),
+                last_revision: 0,
             },
         );
     }
 
-    // Clone the current snapshot (avoid holding the dashmap guard across awaits).
     let mut st = deps
         .runtime
         .streams
         .get(session_id)
         .map(|r| r.clone())
         .unwrap();
+
+    // Drop stale/out-of-order revisions once streaming has started.
+    if should_skip_revision(st.ts.is_some(), revision, st.last_revision) {
+        return Ok(());
+    }
 
     if st.ts.is_none() {
         match start_stream(deps, &st).await {
@@ -52,6 +78,7 @@ pub async fn on_assistant_text(deps: &Deps, session_id: &str, text: &str) -> Res
                 let ts = post_message(deps, &st, text).await?;
                 st.ts = Some(format!("update:{ts}"));
                 st.last_text = text.to_string();
+                st.last_revision = st.last_revision.max(revision);
                 deps.runtime.streams.insert(session_id.to_string(), st);
                 return Ok(());
             }
@@ -60,22 +87,39 @@ pub async fn on_assistant_text(deps: &Deps, session_id: &str, text: &str) -> Res
 
     let ts = st.ts.clone().unwrap();
     if let Some(real_ts) = ts.strip_prefix("update:") {
+        // Edit transport can replace the whole message, including a rewrite.
         update_message(deps, &st, real_ts, text).await?;
         st.last_text = text.to_string();
     } else {
-        let delta = delta(&st.last_text, text);
-        if !delta.is_empty() {
-            append_stream(deps, &st, &ts, &delta).await?;
-            st.last_text = text.to_string();
+        // Native append can only add text; a non-prefix rewrite can't be
+        // retracted, so skip it rather than duplicate content.
+        match delta(&st.last_text, text) {
+            Delta::Append(suffix) if !suffix.is_empty() => {
+                append_stream(deps, &st, &ts, &suffix).await?;
+                st.last_text = text.to_string();
+            }
+            Delta::Append(_) => {}
+            Delta::Reset => {
+                tracing::warn!(
+                    session_id,
+                    "assistant text rewritten mid-stream; skipping append"
+                );
+            }
         }
     }
+    st.last_revision = st.last_revision.max(revision);
     deps.runtime.streams.insert(session_id.to_string(), st);
     Ok(())
 }
 
 /// Finalize the stream at turn end.
 pub async fn finalize(deps: &Deps, session_id: &str) -> Result<(), Error> {
-    let Some((_, st)) = deps.runtime.streams.remove(session_id) else {
+    let lock = deps.runtime.stream_lock(session_id);
+    let _guard = lock.lock().await;
+
+    let removed = deps.runtime.streams.remove(session_id);
+    let Some((_, st)) = removed else {
+        deps.runtime.stream_locks.remove(session_id);
         return Ok(());
     };
     if let Some(ts) = &st.ts {
@@ -98,13 +142,20 @@ pub async fn finalize(deps: &Deps, session_id: &str) -> Result<(), Error> {
         json!({ "channel_id": st.channel, "thread_ts": st.thread_ts, "status": "" }),
     )
     .await;
+    deps.runtime.stream_locks.remove(session_id);
     Ok(())
 }
 
 async fn start_stream(deps: &Deps, st: &StreamState) -> Result<String, Error> {
     let mut params = json!({ "channel": st.channel, "thread_ts": st.thread_ts });
-    if let Some(uid) = &st.recipient_user_id {
-        params["recipient_user_id"] = json!(uid);
+    // Streaming into a channel (not a DM) requires both recipient fields.
+    if !st.is_dm {
+        if let Some(uid) = &st.recipient_user_id {
+            params["recipient_user_id"] = json!(uid);
+        }
+        if let Some(team) = &st.recipient_team_id {
+            params["recipient_team_id"] = json!(team);
+        }
     }
     let resp = slack::call(deps, "chat.startStream", params).await?;
     resp.get("ts")
@@ -151,12 +202,31 @@ async fn update_message(deps: &Deps, st: &StreamState, ts: &str, text: &str) -> 
     Ok(())
 }
 
-/// New suffix of `cur` beyond `prev` (or the whole string on a reset).
-fn delta(prev: &str, cur: &str) -> String {
+/// How `cur` relates to the already-sent `prev`.
+enum Delta {
+    /// `cur` extends `prev`; carries the new suffix.
+    Append(String),
+    /// `cur` is not an extension of `prev` (a rewrite).
+    Reset,
+}
+
+fn delta(prev: &str, cur: &str) -> Delta {
     match cur.strip_prefix(prev) {
-        Some(suffix) => suffix.to_string(),
-        None => cur.to_string(),
+        Some(suffix) => Delta::Append(suffix.to_string()),
+        None => Delta::Reset,
     }
+}
+
+/// True for a Slack DM channel id (`D…`); DMs take no streaming recipients.
+fn channel_is_dm(channel: &str) -> bool {
+    channel.starts_with('D')
+}
+
+/// Whether a streamed revision should be skipped as stale/out-of-order. Once a
+/// stream message exists, only strictly-newer revisions apply; revision 0 (the
+/// initial `message-added`) is never skipped.
+fn should_skip_revision(stream_started: bool, revision: u64, last_revision: u64) -> bool {
+    stream_started && revision != 0 && revision <= last_revision
 }
 
 #[cfg(test)]
@@ -165,13 +235,36 @@ mod tests {
 
     #[test]
     fn delta_returns_suffix() {
-        assert_eq!(delta("hel", "hello"), "lo");
-        assert_eq!(delta("", "hi"), "hi");
-        assert_eq!(delta("abc", "abc"), "");
+        assert!(matches!(delta("hel", "hello"), Delta::Append(s) if s == "lo"));
+        assert!(matches!(delta("", "hi"), Delta::Append(s) if s == "hi"));
+        assert!(matches!(delta("abc", "abc"), Delta::Append(s) if s.is_empty()));
     }
 
     #[test]
     fn delta_handles_reset() {
-        assert_eq!(delta("abc", "xyz"), "xyz");
+        assert!(matches!(delta("abc", "xyz"), Delta::Reset));
+        // A shorter rewrite (truncation) is also a reset, not a prefix.
+        assert!(matches!(delta("abcdef", "abc"), Delta::Reset));
+    }
+
+    #[test]
+    fn channel_is_dm_detects_dm_ids() {
+        assert!(channel_is_dm("D012ABC"));
+        assert!(!channel_is_dm("C012ABC")); // public channel
+        assert!(!channel_is_dm("G012ABC")); // private channel / mpim
+        assert!(!channel_is_dm(""));
+    }
+
+    #[test]
+    fn revision_guard_skips_stale_once_started() {
+        // Before the stream message exists, nothing is skipped.
+        assert!(!should_skip_revision(false, 5, 9));
+        // Initial message-added (revision 0) is never skipped.
+        assert!(!should_skip_revision(true, 0, 7));
+        // Newer revision applies.
+        assert!(!should_skip_revision(true, 8, 7));
+        // Equal or older revision is stale -> skipped.
+        assert!(should_skip_revision(true, 7, 7));
+        assert!(should_skip_revision(true, 3, 7));
     }
 }

--- a/slack/src/turn.rs
+++ b/slack/src/turn.rs
@@ -198,11 +198,17 @@ fn build_system_prompt(
     }
 }
 
-/// Remove a leading/standalone `<@BOTID>` mention from the text.
+/// Remove the bot's `<@BOTID>` mention(s) from the text and tidy whitespace left
+/// behind (e.g. the gap in "hey <@U1> do x").
 fn strip_mention(text: &str, bot_id: Option<&str>) -> String {
     let mut out = text.to_string();
     if let Some(id) = bot_id {
-        out = out.replace(&format!("<@{id}>"), " ");
+        out = out.replace(&format!("<@{id}>"), "");
+        // Collapse spaces/tabs left by the removed mention, but keep newlines.
+        while out.contains("  ") {
+            out = out.replace("  ", " ");
+        }
+        out = out.replace(" \n", "\n").replace("\n ", "\n");
     }
     out.trim().to_string()
 }
@@ -222,6 +228,34 @@ mod tests {
     fn strip_mention_removes_bot_tag() {
         assert_eq!(strip_mention("<@U1> hello", Some("U1")), "hello");
         assert_eq!(strip_mention("hi there", Some("U1")), "hi there");
+    }
+
+    #[test]
+    fn strip_mention_collapses_interior_gap() {
+        // Mention in the middle must not leave a double space.
+        assert_eq!(strip_mention("hey <@U1> do x", Some("U1")), "hey do x");
+        // Multiple mentions of the bot are all removed.
+        assert_eq!(strip_mention("<@U1> a <@U1> b", Some("U1")), "a b");
+    }
+
+    #[test]
+    fn strip_mention_preserves_newlines() {
+        // Newlines (e.g. code blocks) survive; only the mention gap is tidied.
+        assert_eq!(
+            strip_mention("<@U1> line1\nline2", Some("U1")),
+            "line1\nline2"
+        );
+    }
+
+    #[test]
+    fn strip_mention_keeps_other_user_mentions() {
+        // Only the bot's own id is stripped; other mentions stay.
+        assert_eq!(strip_mention("<@U1> ping <@U2>", Some("U1")), "ping <@U2>");
+    }
+
+    #[test]
+    fn strip_mention_noop_without_bot_id() {
+        assert_eq!(strip_mention("<@U1> hello", None), "<@U1> hello");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Post-merge fixes for the `slack` worker, from a full audit against the 0.20.0 workers (telegram-bot's streaming pattern, shell's schema pattern) and the open dep/convention PRs.

### CI unblock
- `slack::events` / `slack::interactions` are raw-`Value` HTTP handlers (must read the raw body off the `request_body` channel because Slack HMAC needs the exact bytes, unlike telegram-bot's header secret-token compare). A raw-`Value` handler publishes the AnyValue schema and failed `interface-smoke --assert-typed-schemas`. Fixed by attaching typed request/response schemas via `RegisterFunction::request_format`/`response_format` + a `schema_value` helper — the pattern `shell` and `image-resize` use.

### Correctness (audit findings, verified against code)
- **Streaming race / double-start:** serialize per session (`RuntimeState::stream_lock`) and gate on the `message-updated` revision (drop stale/out-of-order), mirroring telegram-bot's per-entry lock + revision monotonicity. Concurrent revision events no longer lose appended text or open two streams.
- **Channel streaming broken:** send `recipient_user_id` **and** `recipient_team_id` for channels, neither for DMs (`D…`). `chat.startStream` into a channel was rejected before this.
- **Mid-stream rewrite:** native append can't retract, so a non-prefix rewrite is skipped instead of duplicating content.
- **Unbounded dedupe:** `seen_events` now time-windowed with an eviction cap.
- **files.upload:** POST the bytes as `multipart/form-data` (`-F file=@`), not a raw body.
- **Identity on reload:** keep last-known-good on a transient `auth.test` failure (so mention/self detection isn't blinded); `slack::config-status` still clears on an explicit check.
- **strip_mention:** tidy the gap left by the removed mention; preserve other users' mentions and newlines.

### Tests
+13 unit tests (per-session lock identity + serialization, revision guard, DM detection, delta reset/truncation, socket/http/bridge precedence, mention tidy/preserve, dedupe new-repeat + eviction). 34 unit + manifest + schema golden tests, all green; `fmt` + `clippy -D warnings` clean.

### Skipped from the audit (with reason)
- `conversations.open` selector validation — the whole API surface is thin passthrough by design; Slack validates.
- self-loop hardening — already guarded by `bot_id.is_some() || is_self`.
- pre-verify body-size cap — route is HMAC-gated; Slack payloads are small.
