### PR TITLE
fix(slack): match live engine dep ranges so the worker installs (v0.1.3)

### DIFF
--- a/slack/Cargo.lock
+++ b/slack/Cargo.lock
@@ -1414,7 +1414,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slack"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/slack/Cargo.toml
+++ b/slack/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "slack"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 publish = false
 

--- a/slack/iii.worker.yaml
+++ b/slack/iii.worker.yaml
@@ -7,7 +7,7 @@ bin: slack
 description: Slack as an iii worker — exposes the Slack Web API as slack::* functions, plus a harness bridge (inbound events → harness::send, native streaming, approvals). Configurable from the console.
 
 dependencies:
-  configuration: "^0.20.0"
-  iii-state: "^0.20.0"
+  configuration: "^0.19.0"
+  iii-state: "^0.19.0"
   harness: "^1.0.0"
   session-manager: "^1.0.0"


### PR DESCRIPTION
## Summary

`iii worker add harness console slack` fails at the slack step:

```
version_conflict  slack -> harness -> iii-state
No version of 'iii-state' satisfies ^0.20.0 and ^0.19.0
requested: ["^0.20.0","^0.19.0"]
```

slack pins `configuration`/`iii-state` at `^0.20.0`, but the live ecosystem (the `harness` graph) still pins `^0.19.0`. `^0.20.0 ∩ ^0.19.0 = ∅`, so the resolver rejects the install.

The `^0.20.0` convention only arrives with the open dependency sweep (#347); until that publishes, slack must match the live ecosystem — same as `telegram-bot` (`^0.19.0`).

## Change

- `iii.worker.yaml`: `configuration`/`iii-state` → `^0.19.0` (`harness`/`session-manager` unchanged at `^1.0.0`).
- Patch bump `0.1.2` → `0.1.3` so the registry republishes the fixed manifest.

No code change. When #347 lands and sweeps the ecosystem to 0.20, slack moves with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Slack package version to `0.1.3`.
  * Adjusted internal dependency version ranges for the Slack worker configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->