### PR TITLE
fix(ci): sync Cargo.lock self-version on release bump

### DIFF
--- a/.github/scripts/_lib.py
+++ b/.github/scripts/_lib.py
@@ -144,6 +144,62 @@ def write_version(manifest_path: Path, new_version: str) -> None:
     raise ValueError(f"unhandled manifest kind: {kind}")
 
 
+def read_cargo_package_name(manifest_path: Path) -> str:
+    """Reads `name = "X"` from a Cargo.toml `[package]` section."""
+    in_section = False
+    for line in manifest_path.read_text().splitlines():
+        s = line.strip()
+        if s.startswith("["):
+            in_section = (s == "[package]")
+            continue
+        if in_section:
+            m = re.match(r'^name\s*=\s*"([^"]+)"', s)
+            if m:
+                return m.group(1)
+    raise ValueError(f"no name field in [package] section of {manifest_path}")
+
+
+def sync_cargo_lock_self_version(lock_path: Path, name: str, new_version: str) -> bool:
+    """Update a worker's own `[[package]]` version in its Cargo.lock to match
+    its bumped Cargo.toml.
+
+    Bumping only rewrites Cargo.toml, so the crate's own entry in Cargo.lock
+    keeps the old version until the next local `cargo build` rewrites it —
+    leaving every developer with a dirty lockfile. Rewriting the matching block
+    here, at tag time, keeps the committed lock in sync. Only the crate's own
+    version line changes; the dependency graph is untouched (a bump never alters
+    resolution).
+
+    Returns True if the version was changed, False if it already matched.
+    Raises ValueError if no `[[package]]` block named `name` exists.
+    """
+    text = lock_path.read_text()
+    out: list[str] = []
+    in_target = False
+    found = replaced = False
+    for line in text.splitlines():
+        s = line.strip()
+        if s == "[[package]]":
+            in_target = False
+        else:
+            m = re.match(r'^name = "([^"]+)"$', s)
+            if m:
+                in_target = (m.group(1) == name)
+                found = found or in_target
+            elif in_target and re.match(r'^version = "[^"]+"$', s):
+                new_line = f'version = "{new_version}"'
+                replaced = replaced or (new_line != s)
+                line = new_line
+                in_target = False
+        out.append(line)
+    if not found:
+        raise ValueError(f"package {name!r} not found in {lock_path}")
+    if replaced:
+        trailing = "\n" if text.endswith("\n") else ""
+        lock_path.write_text("\n".join(out) + trailing)
+    return replaced
+
+
 @dataclass(frozen=True)
 class WorkerManifest:
     """Parsed view of a `<worker>/iii.worker.yaml` file."""

--- a/.github/scripts/manifest_version.py
+++ b/.github/scripts/manifest_version.py
@@ -97,6 +97,29 @@ def cmd_deploy_mode(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_sync_lock(args: argparse.Namespace) -> int:
+    """Sync a Rust worker's own version in Cargo.lock to its bumped Cargo.toml.
+
+    No-op (exit 0) when the manifest is not a Cargo.toml or the worker has no
+    committed Cargo.lock — non-Rust workers and lockless crates need nothing.
+    """
+    manifest = Path(args.manifest)
+    if manifest.name != "Cargo.toml":
+        return 0
+    lock = manifest.with_name("Cargo.lock")
+    if not lock.exists():
+        return 0
+    try:
+        name = _lib.read_cargo_package_name(manifest)
+        version = _lib.read_version(manifest)
+        changed = _lib.sync_cargo_lock_self_version(lock, name, version)
+    except (FileNotFoundError, ValueError) as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+    print(f"{name} {version}" + ("" if changed else " (already in sync)"))
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(prog="manifest_version.py")
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -118,6 +141,10 @@ def main(argv: list[str] | None = None) -> int:
     p_dm = sub.add_parser("deploy-mode", help="print the interface-collection mode")
     p_dm.add_argument("worker_dir")
     p_dm.set_defaults(func=cmd_deploy_mode)
+
+    p_sl = sub.add_parser("sync-lock", help="sync Cargo.lock self-version to Cargo.toml")
+    p_sl.add_argument("manifest", help="path to the bumped Cargo.toml")
+    p_sl.set_defaults(func=cmd_sync_lock)
 
     args = p.parse_args(argv)
     return args.func(args)

--- a/.github/scripts/tests/test_lib.py
+++ b/.github/scripts/tests/test_lib.py
@@ -225,3 +225,53 @@ class TestReadTagAnnotation:
         monkeypatch.chdir(tmp_path)
         ann = _lib.read_tag_annotation("v0")
         assert ann == {"key": "val", "other": "more"}
+
+
+class TestCargoLockSelfVersion:
+    LOCK = (
+        'version = 3\n\n'
+        '[[package]]\n'
+        'name = "dep"\n'
+        'version = "2.0.0"\n\n'
+        '[[package]]\n'
+        'name = "harness"\n'
+        'version = "1.0.4"\n'
+        'dependencies = [\n'
+        ' "dep",\n'
+        ']\n'
+    )
+
+    def test_read_cargo_package_name(self, tmp_path):
+        m = tmp_path / "Cargo.toml"
+        m.write_text('[package]\nname = "harness"\nversion = "1.0.6"\n')
+        assert _lib.read_cargo_package_name(m) == "harness"
+
+    def test_read_name_ignores_dependency_sections(self, tmp_path):
+        m = tmp_path / "Cargo.toml"
+        m.write_text(
+            '[package]\nname = "harness"\nversion = "1.0.6"\n\n'
+            '[dependencies]\nname = "not-this"\n'
+        )
+        assert _lib.read_cargo_package_name(m) == "harness"
+
+    def test_sync_updates_only_self_entry(self, tmp_path):
+        lock = tmp_path / "Cargo.lock"
+        lock.write_text(self.LOCK)
+        changed = _lib.sync_cargo_lock_self_version(lock, "harness", "1.0.6")
+        assert changed is True
+        body = lock.read_text()
+        assert 'name = "harness"\nversion = "1.0.6"' in body
+        assert 'name = "dep"\nversion = "2.0.0"' in body  # untouched
+
+    def test_sync_is_idempotent(self, tmp_path):
+        lock = tmp_path / "Cargo.lock"
+        lock.write_text(self.LOCK.replace('"1.0.4"', '"1.0.6"'))
+        before = lock.read_text()
+        assert _lib.sync_cargo_lock_self_version(lock, "harness", "1.0.6") is False
+        assert lock.read_text() == before
+
+    def test_sync_raises_when_package_absent(self, tmp_path):
+        lock = tmp_path / "Cargo.lock"
+        lock.write_text(self.LOCK)
+        with pytest.raises(ValueError, match="not found"):
+            _lib.sync_cargo_lock_self_version(lock, "ghost", "9.9.9")

--- a/.github/scripts/tests/test_manifest_version.py
+++ b/.github/scripts/tests/test_manifest_version.py
@@ -81,6 +81,50 @@ class TestVerifySubcommand:
         assert "9.9.9" in (r.stderr + r.stdout)
 
 
+class TestSyncLockSubcommand:
+    def _lock(self, dir_path: Path, name: str, version: str) -> Path:
+        p = dir_path / "Cargo.lock"
+        p.write_text(
+            'version = 3\n\n'
+            '[[package]]\n'
+            'name = "leftpad"\n'
+            'version = "1.0.0"\n\n'
+            '[[package]]\n'
+            f'name = "{name}"\n'
+            f'version = "{version}"\n'
+            'dependencies = [\n'
+            ' "leftpad",\n'
+            ']\n'
+        )
+        return p
+
+    def test_syncs_stale_self_version(self, cargo_manifest):
+        # cargo_manifest is name="smoke" version="0.1.0"; lock is stale at 0.0.9.
+        lock = self._lock(cargo_manifest.parent, "smoke", "0.0.9")
+        r = run_script("sync-lock", str(cargo_manifest))
+        assert r.returncode == 0, r.stderr
+        body = lock.read_text()
+        assert 'name = "smoke"\nversion = "0.1.0"' in body
+        # The unrelated dependency entry is untouched.
+        assert 'name = "leftpad"\nversion = "1.0.0"' in body
+
+    def test_idempotent_when_already_synced(self, cargo_manifest):
+        lock = self._lock(cargo_manifest.parent, "smoke", "0.1.0")
+        before = lock.read_text()
+        r = run_script("sync-lock", str(cargo_manifest))
+        assert r.returncode == 0
+        assert "already in sync" in r.stdout
+        assert lock.read_text() == before
+
+    def test_noop_without_lockfile(self, cargo_manifest):
+        r = run_script("sync-lock", str(cargo_manifest))
+        assert r.returncode == 0  # no Cargo.lock present -> nothing to do
+
+    def test_noop_for_non_cargo_manifest(self, package_json_manifest):
+        r = run_script("sync-lock", str(package_json_manifest))
+        assert r.returncode == 0
+
+
 class TestDeployModeSubcommand:
     def test_binary_yields_release_binary(self, tmp_path):
         (tmp_path / "iii.worker.yaml").write_text(

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -144,6 +144,19 @@ jobs:
             "$WORKER/$MANIFEST" --expected "$NEW_VERSION"
           echo "Validated $WORKER/$MANIFEST = $NEW_VERSION"
 
+      # The bump only rewrites Cargo.toml. Without this, the crate's own entry
+      # in Cargo.lock keeps the old version until someone's local `cargo build`
+      # rewrites it, so every developer pulls a dirty lockfile. Sync it here so
+      # `git add -A` below commits the lockfile alongside the manifest. No-op
+      # for non-Rust workers and crates without a committed Cargo.lock.
+      - name: Sync Cargo.lock to bumped version
+        env:
+          WORKER: ${{ inputs.worker }}
+          MANIFEST: ${{ steps.meta.outputs.manifest }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/manifest_version.py sync-lock "$WORKER/$MANIFEST"
+
       - name: Check tag does not exist
         env:
           TAG: ${{ steps.versions.outputs.tag }}


### PR DESCRIPTION
## Problem

`create-tag.yml` bumps a worker's version by editing **only `Cargo.toml`** (`manifest_version.py bump` → `_lib.write_version`), then commits with `git add -A`. Nothing ever regenerates `Cargo.lock`, so the worker's own `[[package]]` entry keeps the **old** version in the committed lockfile.

The next local `cargo build` / `cargo run` sees `Cargo.toml` ≠ `Cargo.lock` and rewrites the lockfile self-version — leaving **every developer with a dirty `Cargo.lock`** after every release, across all 25 worker workspaces.

It's not that the lockfile fails to commit — `git add -A` would stage it. There's simply nothing changed to stage, because no cargo step runs in the tag job.

### Evidence

```
git show HEAD:harness/Cargo.lock  →  name = "harness"  version = "1.0.4"
harness/Cargo.toml                →  version = "1.0.6"
```

The committed lockfile on `main` is already stale.

## Fix

A toolchain-free `manifest_version.py sync-lock <Cargo.toml>` subcommand rewrites the crate's own version line in its `Cargo.lock` to match the bumped manifest. It's wired into `create-tag.yml` as a step **between the bump and `git add -A`**, so the lockfile lands in the same release commit.

- No-op for non-Rust workers and crates without a committed `Cargo.lock`.
- Only the crate's own version line changes; the dependency graph is untouched (a version bump never alters resolution).
- Chosen over `cargo update` because the tag job has no Rust toolchain or registry cache — installing one to sync a single line is more infrastructure than a small parser.

## Why not cargo

The `create-tag` job is a lightweight bump/tag runner with no `dtolnay/rust-toolchain` setup and no warm registry cache, so `cargo update --offline` can't resolve and a non-offline run would need a toolchain install + index fetch just to rewrite one version line. The Python edit is deterministic, hermetic, and fast.

## Tests

9 new tests (5 unit on `_lib`, 4 on the `sync-lock` CLI): stale-sync, idempotency, dependency-entry untouched, missing-package error, no-op paths. Full `test_lib` + `test_manifest_version` suites pass (63 tests). Verified end-to-end against the real `harness` lockfile.

## Follow-up (not in this PR)

`main` already has stale committed lockfiles from past releases. This stops future drift but doesn't heal existing ones — a one-time `sync-lock` backfill across all workers would clear the recurring local churn. Kept separate since it touches 20+ lockfiles.

https://claude.ai/code/session_01XpRGok9auKNuhwzrQKNibU


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic Cargo.lock synchronization when a Rust package version changes.
  * Introduced a new command to align lockfile versions with the updated manifest.
* **Bug Fixes**
  * Ensured only the matching package entry is updated in Cargo.lock.
  * Kept the process safe for non-Rust manifests and when no lockfile is present.
* **Tests**
  * Added coverage for lockfile syncing, idempotent updates, and missing-package handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->