### PR TITLE
fix(providers): trim+validate config and surface builder-error cause (openai + anthropic)

### DIFF
--- a/provider-anthropic/src/config.rs
+++ b/provider-anthropic/src/config.rs
@@ -23,9 +23,33 @@ pub struct AnthropicConfig {
     pub api_url: String,
 }
 
-/// No usable credential — the caller turns this into a permanent error frame.
+/// Why an effective config could not be built — the caller turns each into a
+/// permanent error frame with a message that names the actual problem.
 #[derive(Debug, PartialEq, Eq)]
-pub struct NotConfigured;
+pub enum ConfigError {
+    /// No usable credential resolved.
+    NotConfigured,
+    /// `api_url` is set but is not an absolute http(s) URL. Carries the
+    /// offending value so the error frame can show it (a reqwest "builder
+    /// error" otherwise hides which value was bad).
+    InvalidApiUrl(String),
+}
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConfigError::NotConfigured => f.write_str(
+                "provider anthropic not configured (no api_key in the llm-router entry \
+                 and ANTHROPIC_API_KEY unset)",
+            ),
+            ConfigError::InvalidApiUrl(u) => write!(
+                f,
+                "provider anthropic has an invalid endpoint url: {u:?} \
+                 (must be an absolute http(s) URL)"
+            ),
+        }
+    }
+}
 
 /// The single Credential → (secret, auth mode) mapping; streaming and
 /// discovery must agree on it.
@@ -40,12 +64,27 @@ pub fn config_from_resolve(
     model: &str,
     effective_max_tokens: Option<u64>,
     resolved: &ProviderResolveResponse,
-) -> Result<AnthropicConfig, NotConfigured> {
+) -> Result<AnthropicConfig, ConfigError> {
+    // Trim both config-sourced values: a credential pasted with a trailing
+    // newline makes an invalid auth header value, and a stray space breaks URL
+    // parsing — both surface only as an opaque reqwest "builder error" at send.
     let (credential_value, auth_mode) = match &resolved.credential {
         Some(credential) => credential_parts(credential),
-        None => return Err(NotConfigured),
+        None => return Err(ConfigError::NotConfigured),
     };
-    let credential_value = credential_value.to_string();
+    let credential_value = credential_value.trim().to_string();
+    if credential_value.is_empty() {
+        return Err(ConfigError::NotConfigured);
+    }
+    let api_url = match resolved.api_url.as_deref().map(str::trim) {
+        Some(u) if !u.is_empty() => u.to_string(),
+        _ => DEFAULT_API_URL.to_string(),
+    };
+    // Reject anything reqwest can't build a request from, with a clear message.
+    match reqwest::Url::parse(&api_url) {
+        Ok(u) if matches!(u.scheme(), "http" | "https") => {}
+        _ => return Err(ConfigError::InvalidApiUrl(api_url)),
+    }
     Ok(AnthropicConfig {
         credential_value,
         auth_mode,
@@ -53,10 +92,7 @@ pub fn config_from_resolve(
         max_tokens: effective_max_tokens
             .or(resolved.max_tokens)
             .unwrap_or(DEFAULT_MAX_TOKENS),
-        api_url: resolved
-            .api_url
-            .clone()
-            .unwrap_or_else(|| DEFAULT_API_URL.to_string()),
+        api_url,
     })
 }
 
@@ -78,12 +114,73 @@ mod tests {
         }
     }
 
+    fn resolved_with_url(
+        credential: Option<Credential>,
+        api_url: Option<&str>,
+    ) -> ProviderResolveResponse {
+        ProviderResolveResponse {
+            api_url: api_url.map(str::to_string),
+            ..resolved(credential, None)
+        }
+    }
+
+    fn some_key() -> Option<Credential> {
+        Some(Credential::ApiKey { key: "sk".into() })
+    }
+
     #[test]
     fn missing_credential_is_not_configured() {
         assert_eq!(
             config_from_resolve("m", None, &resolved(None, None)).unwrap_err(),
-            NotConfigured
+            ConfigError::NotConfigured
         );
+    }
+
+    #[test]
+    fn credential_is_trimmed() {
+        let cred = Some(Credential::ApiKey {
+            key: "sk-abc\n".into(),
+        });
+        let cfg = config_from_resolve("m", None, &resolved(cred, None)).unwrap();
+        assert_eq!(cfg.credential_value, "sk-abc");
+    }
+
+    #[test]
+    fn whitespace_only_credential_is_not_configured() {
+        let cred = Some(Credential::ApiKey { key: "  \n".into() });
+        assert_eq!(
+            config_from_resolve("m", None, &resolved(cred, None)).unwrap_err(),
+            ConfigError::NotConfigured
+        );
+    }
+
+    #[test]
+    fn api_url_is_trimmed_and_kept() {
+        let cfg = config_from_resolve(
+            "m",
+            None,
+            &resolved_with_url(some_key(), Some(" https://h/v1/messages ")),
+        )
+        .unwrap();
+        assert_eq!(cfg.api_url, "https://h/v1/messages");
+    }
+
+    #[test]
+    fn blank_api_url_override_falls_back_to_default() {
+        let cfg =
+            config_from_resolve("m", None, &resolved_with_url(some_key(), Some("   "))).unwrap();
+        assert_eq!(cfg.api_url, DEFAULT_API_URL);
+    }
+
+    #[test]
+    fn non_http_api_url_is_rejected() {
+        let err = config_from_resolve(
+            "m",
+            None,
+            &resolved_with_url(some_key(), Some("localhost:1234")),
+        )
+        .unwrap_err();
+        assert_eq!(err, ConfigError::InvalidApiUrl("localhost:1234".into()));
     }
 
     #[test]

--- a/provider-anthropic/src/stream_fn.rs
+++ b/provider-anthropic/src/stream_fn.rs
@@ -80,14 +80,10 @@ async fn run_stream_call(
     };
     let cfg = match config_from_resolve(&model, input.max_output_tokens, &resolved) {
         Ok(c) => c,
-        Err(_) => {
+        Err(e) => {
             let _ = send_event(
                 sink,
-                &synthetic_error_event(
-                    "provider anthropic not configured (no api_key in the llm-router entry and ANTHROPIC_API_KEY unset)",
-                    &model,
-                    ErrorKind::Permanent,
-                ),
+                &synthetic_error_event(&e.to_string(), &model, ErrorKind::Permanent),
             );
             return;
         }

--- a/provider-anthropic/src/upstream.rs
+++ b/provider-anthropic/src/upstream.rs
@@ -31,6 +31,24 @@ pub fn spawn_upstream(
     rx
 }
 
+/// Flatten an error and its `source()` chain into one string. reqwest's
+/// top-level Display for a builder error is just "builder error"; the real
+/// cause (invalid header value, bad URL) lives in the source chain, so without
+/// this the message is undiagnosable.
+fn error_chain(e: &dyn std::error::Error) -> String {
+    let mut msg = e.to_string();
+    let mut src = e.source();
+    while let Some(s) = src {
+        let next = s.to_string();
+        if !msg.ends_with(&next) {
+            msg.push_str(": ");
+            msg.push_str(&next);
+        }
+        src = s.source();
+    }
+    msg
+}
+
 /// Append chunk bytes to `text`, retaining any trailing incomplete UTF-8 sequence.
 fn append_utf8_chunk(byte_buf: &mut Vec<u8>, text: &mut String, chunk: &[u8]) {
     byte_buf.extend_from_slice(chunk);
@@ -113,7 +131,7 @@ async fn run_upstream(
         Err(e) => {
             let _ = tx
                 .send(synthetic_error_event(
-                    &format!("anthropic fetch failed: {e}"),
+                    &format!("anthropic fetch failed: {}", error_chain(&e)),
                     &args.model,
                     ErrorKind::Transient,
                 ))
@@ -241,6 +259,29 @@ mod tests {
     const HAPPY: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\nevent: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":12}}}\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":2}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
 
     const TRUNCATED: &str = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\nevent: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":3}}}\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"partial\"}}\n\n";
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn builder_error_surfaces_its_source_not_just_builder_error() {
+        // A header value with a newline is an invalid HeaderValue → reqwest
+        // raises a builder error before connecting. The frame must name the
+        // cause, not stop at the opaque "builder error".
+        let mut a = args("http://127.0.0.1:1/v1/messages".into());
+        a.headers = vec![("x-api-key", "sk-bad\ninjected".into())];
+        let events = drain(spawn_upstream(reqwest::Client::new(), a)).await;
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AssistantMessageEvent::Error { error } => {
+                let msg = error.error_message.as_deref().unwrap_or_default();
+                assert!(msg.starts_with("anthropic fetch failed: "), "got {msg:?}");
+                assert_ne!(
+                    msg, "anthropic fetch failed: builder error",
+                    "source dropped"
+                );
+                assert!(msg.matches(':').count() >= 2, "no source segment: {msg:?}");
+            }
+            other => panic!("want error, got {other:?}"),
+        }
+    }
 
     #[test]
     fn utf8_split_across_chunks_is_preserved() {

--- a/provider-openai/src/config.rs
+++ b/provider-openai/src/config.rs
@@ -16,9 +16,33 @@ pub struct OpenaiConfig {
     pub api_url: String,
 }
 
-/// No usable credential — the caller turns this into a permanent error frame.
+/// Why an effective config could not be built — the caller turns each into a
+/// permanent error frame with a message that names the actual problem.
 #[derive(Debug, PartialEq, Eq)]
-pub struct NotConfigured;
+pub enum ConfigError {
+    /// No usable credential resolved.
+    NotConfigured,
+    /// `api_url` is set but is not an absolute http(s) URL. Carries the
+    /// offending value so the error frame can show it (a reqwest "builder
+    /// error" otherwise hides which value was bad).
+    InvalidApiUrl(String),
+}
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConfigError::NotConfigured => f.write_str(
+                "provider openai not configured (no api_key in the llm-router entry \
+                 and OPENAI_API_KEY unset)",
+            ),
+            ConfigError::InvalidApiUrl(u) => write!(
+                f,
+                "provider openai has an invalid endpoint url: {u:?} \
+                 (must be an absolute http(s) URL)"
+            ),
+        }
+    }
+}
 
 /// The single Credential → bearer secret mapping; streaming and discovery
 /// must agree on it. OpenAI takes `Authorization: Bearer` for both shapes.
@@ -33,21 +57,34 @@ pub fn config_from_resolve(
     model: &str,
     effective_max_tokens: Option<u64>,
     resolved: &ProviderResolveResponse,
-) -> Result<OpenaiConfig, NotConfigured> {
+) -> Result<OpenaiConfig, ConfigError> {
+    // Trim both config-sourced values: a credential pasted with a trailing
+    // newline makes an invalid `Authorization` header value, and a stray space
+    // breaks URL parsing — both surface only as an opaque reqwest "builder
+    // error" at send time.
     let credential_value = match &resolved.credential {
-        Some(credential) => credential_parts(credential).to_string(),
-        None => return Err(NotConfigured),
+        Some(credential) => credential_parts(credential).trim().to_string(),
+        None => return Err(ConfigError::NotConfigured),
     };
+    if credential_value.is_empty() {
+        return Err(ConfigError::NotConfigured);
+    }
+    let api_url = match resolved.api_url.as_deref().map(str::trim) {
+        Some(u) if !u.is_empty() => u.to_string(),
+        _ => DEFAULT_API_URL.to_string(),
+    };
+    // Reject anything reqwest can't build a request from, with a clear message.
+    match reqwest::Url::parse(&api_url) {
+        Ok(u) if matches!(u.scheme(), "http" | "https") => {}
+        _ => return Err(ConfigError::InvalidApiUrl(api_url)),
+    }
     Ok(OpenaiConfig {
         credential_value,
         model: model.to_string(),
         max_tokens: effective_max_tokens
             .or(resolved.max_tokens)
             .unwrap_or(DEFAULT_MAX_TOKENS),
-        api_url: resolved
-            .api_url
-            .clone()
-            .unwrap_or_else(|| DEFAULT_API_URL.to_string()),
+        api_url,
     })
 }
 
@@ -69,12 +106,77 @@ mod tests {
         }
     }
 
+    /// Build a resolve response with an explicit api_url override.
+    fn resolved_with_url(
+        credential: Option<Credential>,
+        api_url: Option<&str>,
+    ) -> ProviderResolveResponse {
+        ProviderResolveResponse {
+            api_url: api_url.map(str::to_string),
+            ..resolved(credential, None)
+        }
+    }
+
+    fn some_key() -> Option<Credential> {
+        Some(Credential::ApiKey { key: "sk".into() })
+    }
+
     #[test]
     fn missing_credential_is_not_configured() {
         assert_eq!(
             config_from_resolve("m", None, &resolved(None, None)).unwrap_err(),
-            NotConfigured
+            ConfigError::NotConfigured
         );
+    }
+
+    #[test]
+    fn credential_is_trimmed() {
+        // A key pasted with a trailing newline must not poison the auth header.
+        let cred = Some(Credential::ApiKey {
+            key: "sk-abc\n".into(),
+        });
+        let cfg = config_from_resolve("m", None, &resolved(cred, None)).unwrap();
+        assert_eq!(cfg.credential_value, "sk-abc");
+    }
+
+    #[test]
+    fn whitespace_only_credential_is_not_configured() {
+        let cred = Some(Credential::ApiKey { key: "  \n".into() });
+        assert_eq!(
+            config_from_resolve("m", None, &resolved(cred, None)).unwrap_err(),
+            ConfigError::NotConfigured
+        );
+    }
+
+    #[test]
+    fn api_url_is_trimmed_and_kept() {
+        let cfg = config_from_resolve(
+            "m",
+            None,
+            &resolved_with_url(some_key(), Some(" https://h/v1 ")),
+        )
+        .unwrap();
+        assert_eq!(cfg.api_url, "https://h/v1");
+    }
+
+    #[test]
+    fn blank_api_url_override_falls_back_to_default() {
+        let cfg =
+            config_from_resolve("m", None, &resolved_with_url(some_key(), Some("   "))).unwrap();
+        assert_eq!(cfg.api_url, DEFAULT_API_URL);
+    }
+
+    #[test]
+    fn non_http_api_url_is_rejected() {
+        // No scheme: reqwest would fail with an opaque "builder error" at send;
+        // we reject up front with the offending value.
+        let err = config_from_resolve(
+            "m",
+            None,
+            &resolved_with_url(some_key(), Some("localhost:1234")),
+        )
+        .unwrap_err();
+        assert_eq!(err, ConfigError::InvalidApiUrl("localhost:1234".into()));
     }
 
     #[test]

--- a/provider-openai/src/stream_fn.rs
+++ b/provider-openai/src/stream_fn.rs
@@ -71,14 +71,10 @@ async fn run_stream_call(
     };
     let cfg = match config_from_resolve(&model, input.max_output_tokens, &resolved) {
         Ok(c) => c,
-        Err(_) => {
+        Err(e) => {
             let _ = send_event(
                 sink,
-                &synthetic_error_event(
-                    "provider openai not configured (no api_key in the llm-router entry and OPENAI_API_KEY unset)",
-                    &model,
-                    ErrorKind::Permanent,
-                ),
+                &synthetic_error_event(&e.to_string(), &model, ErrorKind::Permanent),
             );
             return;
         }

--- a/provider-openai/src/upstream.rs
+++ b/provider-openai/src/upstream.rs
@@ -28,6 +28,25 @@ pub fn spawn_upstream(
     rx
 }
 
+/// Flatten an error and its `source()` chain into one string. reqwest's
+/// top-level Display for a builder error is just "builder error"; the real
+/// cause (invalid header value, bad URL) lives in the source chain, so without
+/// this the message is undiagnosable.
+fn error_chain(e: &dyn std::error::Error) -> String {
+    let mut msg = e.to_string();
+    let mut src = e.source();
+    while let Some(s) = src {
+        let next = s.to_string();
+        // reqwest sometimes nests the same text; skip exact repeats.
+        if !msg.ends_with(&next) {
+            msg.push_str(": ");
+            msg.push_str(&next);
+        }
+        src = s.source();
+    }
+    msg
+}
+
 /// Last `data: ` payload in an SSE block, if any.
 fn data_line(block: &str) -> Option<&str> {
     block
@@ -50,7 +69,7 @@ async fn run_upstream(
         Err(e) => {
             let _ = tx
                 .send(synthetic_error_event(
-                    &format!("openai fetch failed: {e}"),
+                    &format!("openai fetch failed: {}", error_chain(&e)),
                     &args.model,
                     ErrorKind::Transient,
                 ))
@@ -227,6 +246,27 @@ mod tests {
         match &events[0] {
             AssistantMessageEvent::Error { error } => {
                 assert_eq!(error.error_kind, Some(ErrorKind::AuthExpired));
+            }
+            other => panic!("want error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn builder_error_surfaces_its_source_not_just_builder_error() {
+        // A header value with a newline is an invalid HeaderValue → reqwest
+        // raises a builder error before connecting. The frame must name the
+        // cause, not stop at the opaque "builder error".
+        let mut a = args("http://127.0.0.1:1/v1/chat/completions".into());
+        a.headers = vec![("authorization", "Bearer sk-bad\ninjected".into())];
+        let events = drain(spawn_upstream(reqwest::Client::new(), a)).await;
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AssistantMessageEvent::Error { error } => {
+                let msg = error.error_message.as_deref().unwrap_or_default();
+                assert!(msg.starts_with("openai fetch failed: "), "got {msg:?}");
+                // The source chain was appended past the bare "builder error".
+                assert_ne!(msg, "openai fetch failed: builder error", "source dropped");
+                assert!(msg.matches(':').count() >= 2, "no source segment: {msg:?}");
             }
             other => panic!("want error, got {other:?}"),
         }


### PR DESCRIPTION
## Problem

Chat requests fail immediately with an opaque, undiagnosable error — on **both** providers:

- `openai fetch failed: builder error`
- `anthropic fetch failed: builder error`

A reqwest "builder error" is raised when the request is *constructed*, before any network call. In both providers it has exactly two triggers, both fed by config values that were never trimmed or validated:

1. **Invalid auth header** — a credential pasted with a trailing newline makes an invalid header value (`Authorization: Bearer …` / `x-api-key`).
2. **Unparseable api_url** — a custom endpoint without a scheme (`localhost:1234`) or with stray whitespace fails URL parsing.

Both surfaced only as reqwest's top-level Display `"builder error"`; the real cause lives in the dropped `source()` chain, so the message couldn't say which value was bad. Both providers failing identically is the tell that it's one shared code pattern, not a per-provider typo.

## Fix (mirrored in both providers)

- `config_from_resolve` **trims** the credential and `api_url`, **rejects** an empty credential, and **validates** `api_url` is an absolute http(s) URL up front via `ConfigError::InvalidApiUrl` (carrying the offending value).
- The send-error frame **walks the error `source()` chain**, so `builder error` becomes e.g. `builder error: invalid HTTP header value` — actionable.
- The config-error consumer emits the real message instead of a fixed "not configured" string.

## Effect

The trim alone fixes the trailing-newline case outright. A bad endpoint now produces `provider … has an invalid endpoint url: "…"` instead of `builder error`. Any remaining builder error now names its cause.

## Tests

Per provider: credential/url trimming, blank-url fallback, non-http URL rejection, and a builder-error frame that proves the source is appended (with a negative proof that it fails on the bare "builder error" without the fix). **openai 75 passed, anthropic 89 passed, clippy clean.**

## Scope

6 files, two crates (`provider-openai`, `provider-anthropic`), source only — no lockfile/manifest changes.

https://claude.ai/code/session_01XpRGok9auKNuhwzrQKNibU


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider setup errors to show clearer messages for missing credentials and invalid API endpoint URLs.
  * Validates and trims credentials and endpoint URLs more reliably, including better handling of blank values and non-HTTP(S) URLs.
  * Stream and upstream failures now surface more helpful error details, including underlying causes instead of generic messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->