### PR TITLE
feat(shell): add workspace picker control plane

### DIFF
--- a/console/web/src/components/chat/DirectoryPicker.test.ts
+++ b/console/web/src/components/chat/DirectoryPicker.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import {
+  WORKSPACE_LIST_FUNCTION_ID,
+  WORKSPACE_ROOTS_FUNCTION_ID,
+  WORKSPACE_VALIDATE_FUNCTION_ID,
+} from './DirectoryPicker'
+
+describe('DirectoryPicker workspace API wiring', () => {
+  it('uses shell workspace control-plane functions', () => {
+    expect(WORKSPACE_ROOTS_FUNCTION_ID).toBe('shell::workspace::roots')
+    expect(WORKSPACE_LIST_FUNCTION_ID).toBe('shell::workspace::list')
+    expect(WORKSPACE_VALIDATE_FUNCTION_ID).toBe('shell::workspace::validate')
+  })
+})

--- a/console/web/src/components/chat/DirectoryPicker.tsx
+++ b/console/web/src/components/chat/DirectoryPicker.tsx
@@ -19,13 +19,13 @@ import { cn } from '@/lib/utils'
  * Per-session working-directory picker, project-switcher style.
  *
  * Opens to your remembered projects (most-recent first) — pick one in a click,
- * or "browse to add" a new directory. Browsing lists the operator's coder roots
- * (`coder::info`) one level at a time (`coder::list-folder`, lazy). The search
- * box filters the current level live; typing/pasting an absolute path jumps
- * straight there (browse) or selects it (projects). A pasted/remembered dir is
- * validated against the live roots before it's accepted. The chosen dir is what
- * the harness scopes the chat to (`base_dir`); it is re-scopable mid-conversation
- * (a change drops a visible transcript marker).
+ * or "browse to add" a new directory. Browsing uses shell's operator workspace
+ * control plane one level at a time. The search box filters the current level
+ * live; typing/pasting an absolute path jumps straight there (browse) or
+ * selects it (projects). A pasted/remembered dir is validated against the live
+ * shell worker before it's accepted. The chosen dir is what the harness scopes
+ * the chat to (`base_dir`); it is re-scopable mid-conversation (a change drops
+ * a visible transcript marker).
  */
 
 interface DirectoryPickerProps {
@@ -36,19 +36,23 @@ interface DirectoryPickerProps {
   className?: string
 }
 
-interface CoderInfo {
-  base_paths?: string[]
+interface WorkspaceRootsResult {
+  roots?: string[]
 }
 
 interface DirEntry {
   name: string
   kind: string
-  non_accessible?: boolean
+  path: string
 }
 
-interface ListFolderResult {
+interface WorkspaceListResult {
   path: string
   entries?: DirEntry[]
+}
+
+interface WorkspaceValidateResult {
+  path: string
 }
 
 function basename(p: string): string {
@@ -68,6 +72,10 @@ function parentOf(p: string): string {
 }
 
 const isAbsPath = (s: string) => s.trim().startsWith('/')
+
+export const WORKSPACE_ROOTS_FUNCTION_ID = 'shell::workspace::roots'
+export const WORKSPACE_LIST_FUNCTION_ID = 'shell::workspace::list'
+export const WORKSPACE_VALIDATE_FUNCTION_ID = 'shell::workspace::validate'
 
 /**
  * iii triggers reject with a plain object `{ code, message }`, not an Error, and
@@ -140,8 +148,11 @@ export function DirectoryPicker({
     setError(null)
     try {
       const client = await getIiiClient()
-      const info = await client.trigger<CoderInfo>('coder::info', {})
-      const r = info?.base_paths ?? []
+      const info = await client.trigger<WorkspaceRootsResult>(
+        WORKSPACE_ROOTS_FUNCTION_ID,
+        {},
+      )
+      const r = info?.roots ?? []
       setRoots(r)
       return r
     } catch (err) {
@@ -158,13 +169,16 @@ export function DirectoryPicker({
     setError(null)
     try {
       const client = await getIiiClient()
-      const res = await client.trigger<ListFolderResult>('coder::list-folder', {
-        path: target,
-        page_size: 200,
-      })
+      const res = await client.trigger<WorkspaceListResult>(
+        WORKSPACE_LIST_FUNCTION_ID,
+        {
+          path: target,
+          page_size: 200,
+        },
+      )
       const names = (res?.entries ?? [])
-        .filter((e) => e.kind === 'dir' && !e.non_accessible)
-        .map((e) => `${target.replace(/\/+$/, '')}/${e.name}`)
+        .filter((e) => e.kind === 'dir')
+        .map((e) => e.path)
         .sort((a, b) => a.localeCompare(b))
       setDirs(names)
     } catch (err) {
@@ -235,7 +249,13 @@ export function DirectoryPicker({
       setView('browse')
       setQuery('')
       const r = await ensureRoots()
-      setRoot(r.find((x) => p === x || p.startsWith(`${x}/`)) ?? r[0] ?? null)
+      const matchedRoot =
+        [...r]
+          .sort((a, b) => b.length - a.length)
+          .find((x) => p === x || p.startsWith(`${x}/`)) ??
+        r[0] ??
+        null
+      setRoot(matchedRoot)
       setPath(p)
       await loadFolder(p)
     },
@@ -260,13 +280,12 @@ export function DirectoryPicker({
       setValidating(dir)
       try {
         const client = await getIiiClient()
-        const res = await client.trigger<ListFolderResult>(
-          'coder::list-folder',
-          { path: dir, page_size: 1 },
+        const res = await client.trigger<WorkspaceValidateResult>(
+          WORKSPACE_VALIDATE_FUNCTION_ID,
+          { path: dir },
         )
-        // Select the CANONICAL resolved dir the worker echoes back — not the
-        // raw input — so what's stored is exactly what coder will resolve to
-        // (a file path errors C210; a non-existent path errors C211).
+        // Select the canonical resolved dir the worker echoes back, not raw
+        // input, so stored recent projects are stable across symlinks.
         select(res?.path ?? dir)
       } catch (err) {
         setError(`can't use ${dir} — ${errMsg(err)}`)

--- a/console/web/src/hooks/use-shell-status.ts
+++ b/console/web/src/hooks/use-shell-status.ts
@@ -1,13 +1,13 @@
 import {
-  type WorkerPresence,
   isWorkerPresent,
   useWorkerPresence,
+  type WorkerPresence,
 } from './use-worker-presence'
 
 /**
  * Presence probe for the `shell` worker. Shell owns the chat's working-directory
- * surface: the `coder::*` directory-discovery functions the `DirectoryPicker`
- * browses, and the `shell::*` exec/file calls the chosen dir scopes. It is
+ * surface: the `shell::workspace::*` picker control plane and the `shell::*` /
+ * `coder::*` calls the chosen dir scopes. It is
  * OPTIONAL, so the console gates the working-directory picker + banner on its
  * presence rather than rendering controls that would call functions that don't
  * exist. Thin wrapper over the generic worker-presence probe.

--- a/console/web/src/lib/backend/real-metadata.test.ts
+++ b/console/web/src/lib/backend/real-metadata.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildTurnMetadata } from './real'
+import { buildTurnMetadata, FALLBACK_FUNCTION_POLICY } from './real'
 
 /**
  * C1 regression: working_dir must ride options.metadata so the harness sees it
@@ -22,5 +22,11 @@ describe('buildTurnMetadata — working_dir forwarding', () => {
         message_id: 'm-1',
       })
     }
+  })
+})
+
+describe('fallback function policy', () => {
+  it('does not expose workspace picker functions to the agent', () => {
+    expect(FALLBACK_FUNCTION_POLICY.deny).toContain('shell::workspace::*')
   })
 })

--- a/console/web/src/lib/backend/real.ts
+++ b/console/web/src/lib/backend/real.ts
@@ -55,9 +55,9 @@ interface RunParams {
  * via `agent_trigger`. The approval-gate rules supply the structural floor;
  * the gate hook remains the human decision surface.
  */
-const FALLBACK_FUNCTION_POLICY: HarnessFunctionPolicy = {
+export const FALLBACK_FUNCTION_POLICY: HarnessFunctionPolicy = {
   allow: ['*'],
-  deny: ['approval::*', 'configuration::*'],
+  deny: ['approval::*', 'configuration::*', 'shell::workspace::*'],
   expose: 'agent_trigger',
 }
 

--- a/harness/src/workspace_inject.rs
+++ b/harness/src/workspace_inject.rs
@@ -18,33 +18,36 @@ const BASE_DIR_FIELD: &str = "base_dir";
 /// True when `function_id` names a workspace-scoped worker call (`shell::*` or
 /// `coder::*`) whose paths must be anchored at the session working directory.
 fn is_scoped_function(function_id: &str) -> bool {
-    function_id.starts_with("shell::") || function_id.starts_with("coder::")
+    (function_id.starts_with("shell::") && !function_id.starts_with("shell::workspace::"))
+        || function_id.starts_with("coder::")
 }
 
 /// Stamp the session `working_dir` onto a scoped call's arguments as `base_dir`.
 ///
 /// Returns a NEW `Value` (the codebase favours immutability — no in-place
-/// mutation of the caller's args). The original is returned UNCHANGED when any
-/// of the following holds:
-///   * `working_dir` is `None` (no per-session scope is active — the
-///     byte-for-byte back-compat path);
-///   * `function_id` is not a `shell::*` / `coder::*` call;
-///   * `args` is not a JSON object (nowhere to place a top-level field).
+/// mutation of the caller's args). The original is returned unchanged when
+/// `function_id` is not a `shell::*` / `coder::*` call, or when `args` is not a
+/// JSON object (nowhere to place a top-level field).
 ///
 /// When it does apply, the top-level `base_dir` is SET to `working_dir`,
-/// OVERWRITING any caller-supplied value — the harness controls scoping and the
+/// OVERWRITING any caller-supplied value. If no `working_dir` is active, a
+/// caller-supplied `base_dir` is removed. The harness controls scoping and the
 /// model must not be able to widen it.
 pub fn inject(function_id: &str, args: Value, working_dir: Option<&str>) -> Value {
-    let Some(dir) = working_dir else {
-        return args;
-    };
     if !is_scoped_function(function_id) {
         return args;
     }
     let Value::Object(mut map) = args else {
         return args;
     };
-    map.insert(BASE_DIR_FIELD.to_string(), Value::String(dir.to_string()));
+    match working_dir {
+        Some(dir) => {
+            map.insert(BASE_DIR_FIELD.to_string(), Value::String(dir.to_string()));
+        }
+        None => {
+            map.remove(BASE_DIR_FIELD);
+        }
+    }
     Value::Object(map)
 }
 
@@ -95,11 +98,21 @@ mod tests {
     }
 
     #[test]
-    fn leaves_args_unchanged_when_working_dir_absent() {
-        // Back-compat: with no session scope the args pass through verbatim,
-        // including any caller-supplied base_dir.
+    fn strips_caller_supplied_base_dir_when_working_dir_absent() {
+        // With no session scope, the model must not be able to invent one.
         let args = json!({ "command": "ls", "base_dir": "/etc" });
-        let out = inject("shell::exec", args.clone(), None);
+        let out = inject("shell::exec", args, None);
+        assert_eq!(out, json!({ "command": "ls" }));
+    }
+
+    #[test]
+    fn passthrough_for_workspace_control_plane_functions() {
+        let args = json!({ "path": "/Users/example/project" });
+        let out = inject(
+            "shell::workspace::validate",
+            args.clone(),
+            Some("/work/session-7"),
+        );
         assert_eq!(out, args);
     }
 

--- a/shell/src/code/functions/create_file.rs
+++ b/shell/src/code/functions/create_file.rs
@@ -17,12 +17,9 @@ use crate::code::path::PathResolver;
 #[schemars(example = "example_create_file_input")]
 pub struct CreateFileInput {
     pub files: Vec<CreateFileSpec>,
-    /// Optional per-call session working directory. When set, relative
-    /// `path`s anchor here instead of the primary allowed root, and every
-    /// resolved path must stay inside it. `base_dir` itself must canonicalize
-    /// inside an allowed root (`coder::info` lists them). Omit to resolve
-    /// against the primary allowed root exactly as before.
+    /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
+    #[schemars(skip)]
     pub base_dir: Option<String>,
 }
 

--- a/shell/src/code/functions/delete_file.rs
+++ b/shell/src/code/functions/delete_file.rs
@@ -25,12 +25,9 @@ pub struct DeleteFileInput {
     /// Required for non-empty directories. Files and empty dirs ignore it.
     #[serde(default)]
     pub recursive: bool,
-    /// Optional per-call session working directory. When set, relative
-    /// `paths` anchor here instead of the primary allowed root, and every
-    /// resolved path must stay inside it. `base_dir` itself must canonicalize
-    /// inside an allowed root (`coder::info` lists them). Omit to resolve
-    /// against the primary allowed root exactly as before.
+    /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
+    #[schemars(skip)]
     pub base_dir: Option<String>,
 }
 

--- a/shell/src/code/functions/list_folder.rs
+++ b/shell/src/code/functions/list_folder.rs
@@ -29,12 +29,9 @@ pub struct ListFolderInput {
     /// `config.list_default_page_size` when omitted.
     #[serde(default)]
     pub page_size: Option<u32>,
-    /// Optional per-call session working directory. When set, a relative
-    /// `path` anchors here instead of the primary allowed root, and the
-    /// resolved folder must stay inside it. `base_dir` itself must canonicalize
-    /// inside an allowed root (`coder::info` lists them). Omit to resolve
-    /// against the primary allowed root exactly as before.
+    /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
+    #[schemars(skip)]
     pub base_dir: Option<String>,
 }
 

--- a/shell/src/code/functions/mod.rs
+++ b/shell/src/code/functions/mod.rs
@@ -291,6 +291,7 @@ fn register_read_file(iii: &IIIClient, resolver: Arc<PathResolver>, cfg: ConfigC
             let resolver = resolver.clone();
             let cfg = cfg.clone();
             async move {
+                let resolver = resolver.session_scoped(req.base_dir.as_deref());
                 let cfg = cfg.read().await.clone();
                 read_file::handle(resolver, cfg, req)
                     .await
@@ -308,6 +309,7 @@ fn register_search(iii: &IIIClient, resolver: Arc<PathResolver>, cfg: ConfigCell
             let resolver = resolver.clone();
             let cfg = cfg.clone();
             async move {
+                let resolver = resolver.session_scoped(req.base_dir.as_deref());
                 let cfg = cfg.read().await.clone();
                 search::handle(resolver, cfg, req)
                     .await
@@ -325,6 +327,7 @@ fn register_update_file(iii: &IIIClient, resolver: Arc<PathResolver>, cfg: Confi
             let resolver = resolver.clone();
             let cfg = cfg.clone();
             async move {
+                let resolver = resolver.session_scoped(req.base_dir.as_deref());
                 let cfg = cfg.read().await.clone();
                 update_file::handle(resolver, cfg, req)
                     .await
@@ -342,6 +345,7 @@ fn register_create_file(iii: &IIIClient, resolver: Arc<PathResolver>, cfg: Confi
             let resolver = resolver.clone();
             let cfg = cfg.clone();
             async move {
+                let resolver = resolver.session_scoped(req.base_dir.as_deref());
                 let cfg = cfg.read().await.clone();
                 create_file::handle(resolver, cfg, req)
                     .await
@@ -358,6 +362,7 @@ fn register_delete_file(iii: &IIIClient, resolver: Arc<PathResolver>) {
         RegisterFunction::new_async(move |req: delete_file::DeleteFileInput| {
             let resolver = resolver.clone();
             async move {
+                let resolver = resolver.session_scoped(req.base_dir.as_deref());
                 delete_file::handle(resolver, req)
                     .await
                     .map_err(Error::from)
@@ -374,6 +379,7 @@ fn register_list_folder(iii: &IIIClient, resolver: Arc<PathResolver>, cfg: Confi
             let resolver = resolver.clone();
             let cfg = cfg.clone();
             async move {
+                let resolver = resolver.session_scoped(req.base_dir.as_deref());
                 let cfg = cfg.read().await.clone();
                 list_folder::handle(resolver, cfg, req)
                     .await
@@ -391,6 +397,7 @@ fn register_tree(iii: &IIIClient, resolver: Arc<PathResolver>, cfg: ConfigCell) 
             let resolver = resolver.clone();
             let cfg = cfg.clone();
             async move {
+                let resolver = resolver.session_scoped(req.base_dir.as_deref());
                 let cfg = cfg.read().await.clone();
                 tree::handle(resolver, cfg, req).await.map_err(Error::from)
             }
@@ -404,7 +411,10 @@ fn register_move_file(iii: &IIIClient, resolver: Arc<PathResolver>) {
         MOVE_FILE_ID,
         RegisterFunction::new_async(move |req: move_file::MoveFileInput| {
             let resolver = resolver.clone();
-            async move { move_file::handle(resolver, req).await.map_err(Error::from) }
+            async move {
+                let resolver = resolver.session_scoped(req.base_dir.as_deref());
+                move_file::handle(resolver, req).await.map_err(Error::from)
+            }
         })
         .description(MOVE_FILE_DESC),
     );

--- a/shell/src/code/functions/move_file.rs
+++ b/shell/src/code/functions/move_file.rs
@@ -26,12 +26,9 @@ pub struct MoveFileInput {
     /// Entries to move. Each entry is processed independently so a single
     /// failure never aborts the rest.
     pub files: Vec<MoveFileSpec>,
-    /// Optional per-call session working directory. When set, relative
-    /// `from`/`to` paths anchor here instead of the primary allowed root,
-    /// and BOTH resolved endpoints must stay inside it. `base_dir` itself
-    /// must canonicalize inside an allowed root (`coder::info` lists them).
-    /// Omit to resolve against the primary allowed root exactly as before.
+    /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
+    #[schemars(skip)]
     pub base_dir: Option<String>,
 }
 

--- a/shell/src/code/functions/read_file.rs
+++ b/shell/src/code/functions/read_file.rs
@@ -219,14 +219,9 @@ pub struct ReadFileInput {
     /// neither is set.
     #[serde(default)]
     pub paths: Option<Vec<ReadTarget>>,
-    /// Optional per-call session working directory. When set, every relative
-    /// path (the single `path` or each `paths[]` entry, in both the bare
-    /// string and `{path,...}` object forms) anchors here instead of the
-    /// primary allowed root, and every resolved path must stay inside it.
-    /// `base_dir` itself must canonicalize inside an allowed root
-    /// (`coder::info` lists them). Omit to resolve against the primary
-    /// allowed root exactly as before.
+    /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
+    #[schemars(skip)]
     pub base_dir: Option<String>,
 }
 

--- a/shell/src/code/functions/search.rs
+++ b/shell/src/code/functions/search.rs
@@ -89,13 +89,9 @@ pub struct SearchInput {
     /// Search file paths (default true).
     #[serde(default = "default_true")]
     pub search_paths: bool,
-    /// Optional per-call session working directory. When set, a relative
-    /// `path` anchors here instead of the primary allowed root, and the
-    /// walk root must stay inside it. `base_dir` itself must canonicalize
-    /// inside an allowed root (`coder::info` lists them). Result paths stay
-    /// absolute. Omit to resolve against the primary allowed root exactly as
-    /// before.
+    /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
+    #[schemars(skip)]
     pub base_dir: Option<String>,
 }
 

--- a/shell/src/code/functions/tree.rs
+++ b/shell/src/code/functions/tree.rs
@@ -46,12 +46,9 @@ pub struct TreeInput {
     /// are omitted. Pass `false` to list everything.
     #[serde(default = "default_true")]
     pub use_default_excludes: bool,
-    /// Optional per-call session working directory. When set, a relative
-    /// `path` anchors here instead of the primary allowed root, and the
-    /// resolved base folder must stay inside it. `base_dir` itself must
-    /// canonicalize inside an allowed root (`coder::info` lists them). Omit
-    /// to resolve against the primary allowed root exactly as before.
+    /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
+    #[schemars(skip)]
     pub base_dir: Option<String>,
 }
 

--- a/shell/src/code/functions/update_file.rs
+++ b/shell/src/code/functions/update_file.rs
@@ -36,12 +36,9 @@ use crate::code::path::PathResolver;
 #[schemars(example = "example_update_file_input")]
 pub struct UpdateFileInput {
     pub files: Vec<UpdateFileSpec>,
-    /// Optional per-call session working directory. When set, relative
-    /// `path`s anchor here instead of the primary allowed root, and every
-    /// resolved path must stay inside it. `base_dir` itself must canonicalize
-    /// inside an allowed root (`coder::info` lists them). Omit to resolve
-    /// against the primary allowed root exactly as before.
+    /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
+    #[schemars(skip)]
     pub base_dir: Option<String>,
 }
 

--- a/shell/src/code/path.rs
+++ b/shell/src/code/path.rs
@@ -27,6 +27,7 @@
 //! old MIRROR-INVARIANT between two copies is gone).
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use globset::{Glob, GlobSet, GlobSetBuilder};
 
@@ -151,6 +152,35 @@ impl PathResolver {
         &self.roots_canon
     }
 
+    /// Return a resolver that also treats a trusted, existing session
+    /// directory as an allowed root. The configured roots stay intact; the
+    /// session root is additive and only used for calls whose request still
+    /// carries `base_dir`, so [`resolve_in`] continues to enforce the stricter
+    /// "all paths stay under base_dir" containment check.
+    pub fn session_scoped(self: &Arc<Self>, base_dir: Option<&str>) -> Arc<Self> {
+        let Some(base_dir) = base_dir else {
+            return self.clone();
+        };
+        let base_path = Path::new(base_dir);
+        if !base_path.is_absolute() {
+            return self.clone();
+        }
+        let Ok(base_canon) = self.canonicalize_wire(base_dir, base_path) else {
+            return self.clone();
+        };
+        if !base_canon.is_dir() || self.roots_canon.contains(&base_canon) {
+            return self.clone();
+        }
+        let mut roots_canon = self.roots_canon.clone();
+        roots_canon.push(base_canon);
+        Arc::new(Self {
+            roots_canon,
+            non_accessible: self.non_accessible.clone(),
+            default_exclude: self.default_exclude.clone(),
+            default_exclude_dirs: self.default_exclude_dirs.clone(),
+        })
+    }
+
     /// True when `p` is exactly one of the allowed roots.
     pub fn is_root(&self, p: &Path) -> bool {
         self.roots_canon.iter().any(|r| r == p)
@@ -178,7 +208,11 @@ impl PathResolver {
     /// [`resolve_in`]: Self::resolve_in
     /// [`is_root`]: Self::is_root
     pub fn session_root(&self, base_dir: &str) -> Option<PathBuf> {
-        let base_canon = self.canonicalize_wire(base_dir, Path::new(base_dir)).ok()?;
+        let base_path = Path::new(base_dir);
+        if !base_path.is_absolute() {
+            return None;
+        }
+        let base_canon = self.canonicalize_wire(base_dir, base_path).ok()?;
         self.containing_root(&base_canon)
             .is_some()
             .then_some(base_canon)
@@ -333,8 +367,8 @@ impl PathResolver {
     /// MIRROR-INVARIANT jail core is untouched.
     ///
     /// Semantics (all three checks, in order):
-    /// 1. `base_dir` itself must canonicalise inside one of the configured
-    ///    allowed roots — else `C215` (an operator/route error: the session
+    /// 1. `base_dir` itself must be absolute and canonicalise inside one of the
+    ///    configured allowed roots — else `C215` (an operator/route error: the session
     ///    was scoped to a directory the worker is not allowed to serve).
     /// 2. relative `path` anchors at `base_dir` (not the primary root);
     ///    absolute `path` is taken as-is. Either form runs through the SAME
@@ -346,12 +380,18 @@ impl PathResolver {
     /// This is strictly NARROWER than `resolve`: it can only reject paths
     /// `resolve` would accept (those inside an allowed root but outside the
     /// session), never widen access. `base_dir = None` callers use
-    /// `resolve`/`require_writable` and are byte-for-byte unchanged.
+    /// `resolve`/`require_writable`.
     pub fn resolve_in(&self, base_dir: &str, path: &str) -> Result<PathBuf, CoderError> {
+        let base_path = Path::new(base_dir);
+        if !base_path.is_absolute() {
+            return Err(CoderError::BadInput(format!(
+                "base_dir must be an absolute path: {base_dir}"
+            )));
+        }
         // (c) base_dir must canonicalise inside an EXISTING allowed root.
         // Reuse the shared canonicalisation so a `..`/symlink escape in the
         // session dir itself fails closed exactly like a wire path would.
-        let base_canon = self.canonicalize_wire(base_dir, Path::new(base_dir))?;
+        let base_canon = self.canonicalize_wire(base_dir, base_path)?;
         if self.containing_root(&base_canon).is_none() {
             return Err(CoderError::OutsideBase(format!(
                 "base_dir is outside every allowed root: {base_dir}. \
@@ -407,9 +447,9 @@ impl PathResolver {
         Ok(abs)
     }
 
-    /// Dispatch helper: resolve `path` against `base_dir` when present,
-    /// else exactly as `resolve` (the back-compat path is byte-for-byte
-    /// unchanged). Handlers thread the per-call `base_dir` straight through.
+    /// Dispatch helper: resolve `path` against `base_dir` when present, else
+    /// use the normal resolver. Handlers thread the per-call `base_dir` straight
+    /// through.
     pub fn resolve_opt(&self, base_dir: Option<&str>, path: &str) -> Result<PathBuf, CoderError> {
         match base_dir {
             Some(b) => self.resolve_in(b, path),
@@ -473,6 +513,7 @@ fn with_dir_companions(patterns: &[String]) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
     use tempfile::tempdir;
 
     fn cfg_roots(roots: Vec<PathBuf>, globs: Vec<&str>) -> CoderConfig {
@@ -1141,6 +1182,44 @@ mod tests {
             "C215 must explain the base_dir is unserveable; got: {msg}"
         );
         assert!(msg.contains(C215_ROOTS_PREFIX));
+    }
+
+    /// The live registration layer can trust a harness-provided `base_dir` by
+    /// adding that directory as an ephemeral session root. This lets console
+    /// sessions work in a selected host directory that is outside the configured
+    /// coder roots while keeping every operation confined below that directory.
+    #[test]
+    fn session_scoped_base_dir_outside_roots_becomes_effective_root() {
+        let jail = tempdir().unwrap();
+        let selected = tempdir().unwrap();
+        std::fs::create_dir(selected.path().join("sub")).unwrap();
+        std::fs::write(selected.path().join("sub/a.txt"), b"hi").unwrap();
+        let r = Arc::new(PathResolver::new(&cfg_with(jail.path().to_path_buf(), vec![])).unwrap());
+        let base = selected.path().display().to_string();
+
+        assert!(
+            r.resolve_in(&base, "sub/a.txt").is_err(),
+            "unscoped resolver must still reject a base_dir outside configured roots"
+        );
+
+        let scoped = r.session_scoped(Some(&base));
+        let got = scoped.resolve_in(&base, "sub/a.txt").unwrap();
+        assert_eq!(got, canon(&selected.path().join("sub/a.txt")));
+    }
+
+    #[test]
+    fn session_scoped_base_dir_outside_roots_applies_non_accessible_globs() {
+        let jail = tempdir().unwrap();
+        let selected = tempdir().unwrap();
+        std::fs::write(selected.path().join(".env"), b"secret").unwrap();
+        let r = Arc::new(
+            PathResolver::new(&cfg_with(jail.path().to_path_buf(), vec!["**/.env"])).unwrap(),
+        );
+        let base = selected.path().display().to_string();
+
+        let scoped = r.session_scoped(Some(&base));
+        let err = scoped.require_writable_in(&base, ".env").unwrap_err();
+        assert_eq!(err.code(), "C211");
     }
 
     /// A `..` escape from base_dir that lands OUTSIDE every allowed root is

--- a/shell/src/exec/host.rs
+++ b/shell/src/exec/host.rs
@@ -388,8 +388,9 @@ mod tests {
         std::fs::create_dir_all(root.join("session")).unwrap();
         let mut cfg = test_cfg();
         cfg.fs.host_root = Some(root.clone());
+        let base = root.join("session").to_string_lossy().into_owned();
 
-        let overrides = crate::exec::policy::build_overrides(None, None, Some("session"), &cfg)
+        let overrides = crate::exec::policy::build_overrides(None, None, Some(&base), &cfg)
             .expect("session is inside the jail");
         let out = run_to_completion(&["pwd".into()], &cfg, 5000, &overrides)
             .await

--- a/shell/src/exec/policy.rs
+++ b/shell/src/exec/policy.rs
@@ -22,7 +22,7 @@
 //!   ones so the agent can self-correct.
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::config::ShellConfig;
 use crate::exec::error::ExecError;
@@ -95,9 +95,8 @@ fn is_dangerous_env_key(key: &str) -> bool {
 }
 
 /// Validated per-call exec overrides, ready to apply in `build_command`.
-/// `None` fields mean "unchanged from the config-derived default", so the
-/// default behaviour (both request fields omitted) is byte-for-byte the prior
-/// behaviour.
+/// `None` fields mean "use the config-derived default"; when both request
+/// fields are omitted, execution follows the configured command policy.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ExecOverrides {
     /// Canonical, jail-confined working directory. `None` falls back to
@@ -170,30 +169,38 @@ fn require_existing_dir(canon: &PathBuf, raw: &str, kind: &str) -> Result<(), Ex
     Ok(())
 }
 
-/// Resolve and validate an OPTIONAL per-call `base_dir` for exec, mirroring the
-/// fs backend's [`crate::fs::host::confine_path`] containment. `None` ⇒
-/// `Ok(None)` (unchanged behaviour). When set, `base_dir` must canonicalize
-/// inside `host_root` (the existing ceiling) and be an existing directory; an
-/// unjailed worker has no ceiling, so a supplied `base_dir` is rejected S210.
+/// Resolve and validate an OPTIONAL trusted per-call `base_dir` for exec.
+/// `None` ⇒ `Ok(None)` (unchanged behaviour). An absolute `base_dir` may point
+/// outside configured host roots and becomes the effective root for this call.
+/// Relative values are rejected; the harness-controlled workspace selection is
+/// always an absolute path.
 fn confine_base_dir(
     base_dir: Option<&str>,
-    host_roots_canon: &[PathBuf],
     denylist_canon: &[PathBuf],
 ) -> Result<Option<PathBuf>, ExecError> {
     let Some(base_dir) = base_dir else {
         return Ok(None);
     };
-    if host_roots_canon.is_empty() {
+    if base_dir.is_empty() {
+        return Err(ExecError::new("S210", "base_dir must not be empty"));
+    }
+    let p = Path::new(base_dir);
+    if !p.is_absolute() {
         return Err(ExecError::new(
             "S210",
-            format!(
-                "base_dir {base_dir} is only honored when the worker is jailed \
-                 (fs.host_root/fs.host_roots is set); this worker is unjailed"
-            ),
+            format!("base_dir must be an absolute path: {base_dir}"),
         ));
     }
-    let canon = crate::fs::host::confine_path(base_dir, host_roots_canon, denylist_canon)
-        .map_err(|e| ExecError::new(static_code(e.code), e.message))?;
+    let canon = crate::path::canonicalize_with_fallback(p)
+        .map_err(|e| ExecError::new("S210", format!("{base_dir}: {e}")))?;
+    for deny in denylist_canon {
+        if canon.starts_with(deny) {
+            return Err(ExecError::new(
+                "S215",
+                format!("base_dir is denylisted: {base_dir}"),
+            ));
+        }
+    }
     require_existing_dir(&canon, base_dir, "base_dir")?;
     Ok(Some(canon))
 }
@@ -309,7 +316,7 @@ pub fn build_overrides(
     let (host_roots_canon, denylist_canon) = jail_inputs(cfg)?;
     // Resolve the session directory first: it gates the cwd confinement below
     // and, when no cwd is supplied, becomes the working directory itself.
-    let base_dir_canon = confine_base_dir(base_dir, &host_roots_canon, &denylist_canon)?;
+    let base_dir_canon = confine_base_dir(base_dir, &denylist_canon)?;
 
     let cwd = match cwd {
         Some(c) => Some(confine_cwd(
@@ -537,9 +544,10 @@ mod tests {
         let root = std::env::temp_dir().join(format!("shell-policy-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(root.join("session/inner")).unwrap();
         let c = cfg_jailed(&root);
+        let base = root.join("session").to_string_lossy().into_owned();
 
         // cwd omitted ⇒ working dir is base_dir.
-        let ov = build_overrides(None, None, Some("session"), &c).expect("base_dir is valid");
+        let ov = build_overrides(None, None, Some(&base), &c).expect("base_dir is valid");
         assert_eq!(
             ov.cwd.as_deref(),
             Some(root.join("session").canonicalize().unwrap().as_path()),
@@ -547,8 +555,8 @@ mod tests {
         );
 
         // relative cwd anchors at base_dir, not host_root.
-        let ov = build_overrides(Some("inner"), None, Some("session"), &c)
-            .expect("inner is under base_dir");
+        let ov =
+            build_overrides(Some("inner"), None, Some(&base), &c).expect("inner is under base_dir");
         assert_eq!(
             ov.cwd.as_deref(),
             Some(root.join("session/inner").canonicalize().unwrap().as_path()),
@@ -566,7 +574,8 @@ mod tests {
         std::fs::create_dir_all(root.join("other")).unwrap();
         let c = cfg_jailed(&root);
         let outside = root.join("other").canonicalize().unwrap();
-        let err = build_overrides(Some(outside.to_str().unwrap()), None, Some("session"), &c)
+        let base = root.join("session").to_string_lossy().into_owned();
+        let err = build_overrides(Some(outside.to_str().unwrap()), None, Some(&base), &c)
             .expect_err("abs cwd outside base_dir must reject");
         assert_eq!(err.code, "S220", "must be the distinct base_dir code");
         let session_canon = root.join("session").canonicalize().unwrap();
@@ -584,22 +593,48 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
-    /// A base_dir that itself escapes host_root is rejected (the worker is
-    /// jailed to host_root; a session outside it is never honored).
+    /// An absolute selected base_dir outside the configured host root is
+    /// trusted as the working directory root for exec.
     #[test]
-    fn base_dir_escaping_host_root_is_rejected() {
+    fn absolute_base_dir_outside_host_root_is_honored() {
+        let root = std::env::temp_dir().join(format!("shell-policy-{}", uuid::Uuid::new_v4()));
+        let selected =
+            std::env::temp_dir().join(format!("shell-policy-selected-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(selected.join("inner")).unwrap();
+        let c = cfg_jailed(&root);
+        let selected_raw = selected.to_string_lossy().into_owned();
+        let ov = build_overrides(None, None, Some(&selected_raw), &c)
+            .expect("absolute selected base_dir is valid");
+        assert_eq!(
+            ov.cwd.as_deref(),
+            Some(selected.canonicalize().unwrap().as_path())
+        );
+        let ov = build_overrides(Some("inner"), None, Some(&selected_raw), &c)
+            .expect("relative cwd anchors at selected base_dir");
+        assert_eq!(
+            ov.cwd.as_deref(),
+            Some(selected.join("inner").canonicalize().unwrap().as_path())
+        );
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&selected).ok();
+    }
+
+    /// `base_dir` is trusted harness metadata, so relative values are rejected
+    /// instead of interpreted relative to host_root.
+    #[test]
+    fn relative_base_dir_is_rejected() {
         let root = std::env::temp_dir().join(format!("shell-policy-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&root).unwrap();
         let c = cfg_jailed(&root);
         let err = build_overrides(None, None, Some("../../etc"), &c)
-            .expect_err("base_dir escaping the jail must reject");
-        assert_eq!(err.code, "S215");
+            .expect_err("relative base_dir is not part of the trusted contract");
+        assert_eq!(err.code, "S210");
         std::fs::remove_dir_all(&root).ok();
     }
 
-    /// Back-compat: base_dir=None reproduces the prior behaviour exactly — a
-    /// relative cwd still anchors at host_root and omitted cwd stays None
-    /// (build_command then falls back to cfg.working_dir).
+    /// With no session scope, a relative cwd still anchors at host_root and an
+    /// omitted cwd stays None (build_command then falls back to cfg.working_dir).
     #[test]
     fn base_dir_none_is_unchanged_behaviour() {
         let root = std::env::temp_dir().join(format!("shell-policy-{}", uuid::Uuid::new_v4()));

--- a/shell/src/fs/host.rs
+++ b/shell/src/fs/host.rs
@@ -244,6 +244,11 @@ impl HostFsBackend {
         path_is_non_accessible(canon, &self.host_roots_canon, &self.non_accessible)
     }
 
+    fn is_non_accessible_scoped(&self, canon: &Path, base_dir_canon: Option<&Path>) -> bool {
+        let roots = access_roots(&self.host_roots_canon, base_dir_canon);
+        path_is_non_accessible(canon, &roots, &self.non_accessible)
+    }
+
     /// TOCTOU: check-then-use gate, open to a race against an attacker who
     /// can mutate the filesystem between validation and subsequent syscalls.
     /// Use the sandbox backend for untrusted input.
@@ -258,18 +263,16 @@ impl HostFsBackend {
         Ok(canon)
     }
 
-    /// Resolve and validate an optional per-call `base_dir` against this
-    /// backend's configured jail. `None` ⇒ `Ok(None)` (unchanged behaviour);
-    /// see [`confine_base_dir`].
+    /// Resolve and validate an optional trusted per-call `base_dir`; see
+    /// [`confine_base_dir`].
     fn confine_base_dir(&self, base_dir: Option<&str>) -> Result<Option<PathBuf>, FsError> {
-        confine_base_dir(base_dir, &self.host_roots_canon, &self.denylist_canon)
+        confine_base_dir(base_dir, &self.denylist_canon)
     }
 
     /// base_dir-aware form of [`Self::validate_path`]. When `base_dir_canon`
     /// is `Some`, the path is scoped to that session directory (relative
     /// anchors there; an absolute path outside it is S220). When `None`, it
-    /// delegates to [`Self::validate_path`] — byte-for-byte the prior jail
-    /// check.
+    /// delegates to [`Self::validate_path`].
     fn validate_path_scoped(
         &self,
         path: &str,
@@ -285,7 +288,7 @@ impl HostFsBackend {
                 &self.denylist_canon,
             )?,
         };
-        if self.is_non_accessible(&canon) {
+        if self.is_non_accessible_scoped(&canon, base_dir_canon) {
             return Err(FsError::new(
                 "S215",
                 format!("path is protected (non_accessible): {path}"),
@@ -414,6 +417,16 @@ fn path_is_non_accessible(
     false
 }
 
+fn access_roots(host_roots_canon: &[PathBuf], base_dir_canon: Option<&Path>) -> Vec<PathBuf> {
+    let mut roots = host_roots_canon.to_vec();
+    if let Some(base) = base_dir_canon {
+        if !roots.iter().any(|r| r == base) {
+            roots.push(base.to_path_buf());
+        }
+    }
+    roots
+}
+
 /// Comma-separated display of the jail roots, for S215 messages.
 fn display_roots(roots: &[PathBuf]) -> String {
     roots
@@ -437,42 +450,52 @@ fn lexical_operand_with(path: &str, anchor_canon: Option<&Path>) -> PathBuf {
     normalize_lexical(p)
 }
 
-/// Resolve and validate an OPTIONAL per-call `base_dir` against the worker's
-/// configured jail. Returns:
-/// - `Ok(None)` when no `base_dir` was supplied — the caller then takes the
-///   unchanged `host_root`-anchored path (byte-for-byte the prior behaviour).
-/// - `Ok(Some(canon))` when `base_dir` canonicalizes INSIDE the configured
-///   `host_root` (and misses the denylist) — `canon` is the effective root that
-///   relative paths anchor against and that absolute paths must stay inside.
-/// - `Err(_)` when `base_dir` itself escapes the jail (or is otherwise invalid):
-///   the worker is jailed to `host_root`, so a session directory outside it is
-///   never honored. The error reuses `confine_path`'s S210/S215 taxonomy so a
-///   bad `base_dir` reads the same as a bad path.
-///
-/// `base_dir` MUST be confined by `host_root`; an unjailed worker
-/// (`host_root: None`) has no ceiling to validate against, so a supplied
-/// `base_dir` is rejected S210 rather than silently treated as the ceiling.
+/// Resolve and validate an OPTIONAL trusted per-call `base_dir`. Returns:
+/// - `Ok(None)` when no `base_dir` was supplied.
+/// - `Ok(Some(canon))` when `base_dir` canonicalizes to an existing directory
+///   that misses the absolute denylist. That directory becomes the effective
+///   root for this call, even if it is outside the configured host roots.
+/// - `Err(_)` when `base_dir` is empty, relative, not a directory, denylisted,
+///   or otherwise cannot be canonicalized.
 fn confine_base_dir(
     base_dir: Option<&str>,
-    host_roots_canon: &[PathBuf],
     denylist_canon: &[PathBuf],
 ) -> Result<Option<PathBuf>, FsError> {
     let Some(base_dir) = base_dir else {
         return Ok(None);
     };
-    if host_roots_canon.is_empty() {
+    if base_dir.is_empty() {
+        return Err(FsError::new("S210", "base_dir must not be empty"));
+    }
+    let p = Path::new(base_dir);
+    if !p.is_absolute() {
         return Err(FsError::new(
             "S210",
-            format!(
-                "base_dir {base_dir} is only honored when the worker is jailed \
-                 (fs.host_root/fs.host_roots is set); this worker is unjailed"
-            ),
+            format!("base_dir must be an absolute path: {base_dir}"),
         ));
     }
-    // The session dir must itself canonicalize inside an allowed root + miss the
-    // denylist — reuse the SAME confinement the fs ops enforce so a base_dir
-    // that escapes the jail (or a denylisted one) is rejected identically.
-    let canon = confine_path(base_dir, host_roots_canon, denylist_canon)?;
+    let canon = canonicalize_with_fallback(p).map_err(|e| {
+        let msg = format!("{e}");
+        if msg.contains("dangling symlink in path") {
+            FsError::new("S215", format!("{base_dir}: {msg}"))
+        } else {
+            FsError::new("S210", format!("{base_dir}: {msg}"))
+        }
+    })?;
+    if !canon.is_dir() {
+        return Err(FsError::new(
+            "S212",
+            format!("base_dir is not a directory: {base_dir}"),
+        ));
+    }
+    for deny_canon in denylist_canon {
+        if canon.starts_with(deny_canon) {
+            return Err(FsError::new(
+                "S215",
+                format!("base_dir is denylisted: {base_dir}"),
+            ));
+        }
+    }
     Ok(Some(canon))
 }
 
@@ -480,17 +503,15 @@ fn confine_base_dir(
 /// `base_dir_canon` is `Some`, the call is scoped to that session directory:
 /// relative paths anchor at `base_dir` (not `host_root`) and the resolved path
 /// must land INSIDE `base_dir`. When it is `None`, this is exactly
-/// [`confine_path`] against `host_root` — the back-compat path, unchanged.
+/// [`confine_path`] against `host_root`.
 ///
 /// The core jail algorithm (`confine_path` →
 /// `canonicalize_with_fallback`/`normalize_lexical`) is reused verbatim, not
 /// re-implemented: passing `base_dir` as the effective root gives both the
-/// relative-anchor and the containment check for free, because `base_dir` is
-/// already known to sit inside `host_root` (the denylist is threaded through
-/// too). The only addition is the DX-1 error refinement: an ABSOLUTE path that
-/// is inside `host_root` but outside `base_dir` is rejected with S220 naming
-/// the session directory, instead of the generic "escapes host_root" S215 —
-/// which would contradict the worker's own configured roots.
+/// relative-anchor and the containment check. The only addition is the DX-1
+/// error refinement: an ABSOLUTE path that is inside a configured host root but
+/// outside `base_dir` is rejected with S220 naming the session directory,
+/// instead of the generic "escapes host_root" S215.
 ///
 /// `pub(crate)` so the exec backend can confine a per-call `cwd` against the
 /// SAME session-scoped jail (shell::exec/exec_bg `base_dir`) instead of
@@ -1152,6 +1173,7 @@ impl FsBackend for HostFsBackend {
         // D4: skip protected files during a directory walk (the gate that
         // validate_path_scoped applies to single-file/other ops).
         let host_roots_canon = self.host_roots_canon.clone();
+        let access_roots = access_roots(&host_roots_canon, base.as_deref());
         let non_accessible = self.non_accessible.clone();
 
         let join = tokio::task::spawn_blocking(move || -> Result<_, FsError> {
@@ -1295,7 +1317,7 @@ impl FsBackend for HostFsBackend {
                     // protected file under it (the dir itself isn't protected,
                     // but files matching non_accessible are). Skip them — the
                     // file stays "visible but locked", same as the other ops.
-                    if path_is_non_accessible(entry.path(), &host_roots_canon, &non_accessible) {
+                    if path_is_non_accessible(entry.path(), &access_roots, &non_accessible) {
                         continue;
                     }
                     if scan(entry.path())? {
@@ -1413,6 +1435,7 @@ impl FsBackend for HostFsBackend {
         // blocking closure confines + anchors every operand to it instead of the
         // global host_root. None ⇒ unchanged host_root behaviour.
         let base_dir_canon = self.confine_base_dir(req.base_dir.as_deref())?;
+        let access_roots = access_roots(&host_roots_canon, base_dir_canon.as_deref());
         // Per-file read cap: sed builds a same-size output String in memory, so
         // an unbounded file is an OOM vector (grep skips binary + bounds its
         // line read; sed did neither). Honor the backend's max_read_bytes; a 0
@@ -1478,7 +1501,7 @@ impl FsBackend for HostFsBackend {
                 )?;
                 // D4: a protected file is locked for modification, exactly like
                 // shell::fs::write/rm (which route through validate_path_scoped).
-                if path_is_non_accessible(&canon, &host_roots_canon, &non_accessible) {
+                if path_is_non_accessible(&canon, &access_roots, &non_accessible) {
                     return Err(FsError::new(
                         "S215",
                         format!("path is protected (non_accessible): {f}"),
@@ -3780,13 +3803,14 @@ mod tests {
         let root = tmp();
         fs::create_dir_all(root.join("session")).unwrap();
         let b = jailed_backend(&root);
+        let base = root.join("session").to_string_lossy().into_owned();
         let resp = b
             .write(crate::fs::WriteArgs {
                 path: "out.txt".into(),
                 mode: "0644".into(),
                 parents: false,
                 content: crate::fs::WriteContent::Inline("scoped\n".into()),
-                base_dir: Some("session".into()),
+                base_dir: Some(base),
             })
             .await
             .expect("relative write under base_dir succeeds");
@@ -3809,11 +3833,12 @@ mod tests {
         fs::write(root.join("session/victim.txt"), "x").unwrap();
         fs::write(root.join("victim.txt"), "sibling").unwrap();
         let b = jailed_backend(&root);
+        let base = root.join("session").to_string_lossy().into_owned();
         let resp = b
             .rm(crate::fs::RmArgs {
                 path: "victim.txt".into(),
                 recursive: false,
-                base_dir: Some("session".into()),
+                base_dir: Some(base),
             })
             .await
             .expect("rm under base_dir succeeds");
@@ -3835,12 +3860,13 @@ mod tests {
         fs::create_dir_all(root.join("session")).unwrap();
         fs::write(root.join("session/a.txt"), "content").unwrap();
         let b = jailed_backend(&root);
+        let base = root.join("session").to_string_lossy().into_owned();
         let resp = b
             .mv(crate::fs::MvArgs {
                 src: "a.txt".into(),
                 dst: "b.txt".into(),
                 overwrite: false,
-                base_dir: Some("session".into()),
+                base_dir: Some(base),
             })
             .await
             .expect("mv under base_dir succeeds");
@@ -3866,10 +3892,11 @@ mod tests {
         // Absolute path that resolves inside host_root/other — a sibling of the
         // session dir, still inside an allowed root, but not this session.
         let abs = root.join("other/secret.txt").canonicalize().unwrap();
+        let base = root.join("session").to_string_lossy().into_owned();
         let err = b
             .read(crate::fs::ReadArgs {
                 path: abs.to_string_lossy().into_owned(),
-                base_dir: Some("session".into()),
+                base_dir: Some(base),
             })
             .await
             .expect_err("abs path outside base_dir must reject");
@@ -3887,10 +3914,49 @@ mod tests {
         );
     }
 
-    /// base_dir itself must canonicalize inside host_root; a session dir that
-    /// escapes the jail is rejected S215 (it is never honored).
+    /// A harness-provided base_dir is trusted as the per-call root even when it
+    /// sits outside the configured host roots. The operation is then confined
+    /// under that selected directory.
     #[tokio::test]
-    async fn base_dir_escaping_host_root_is_rejected_s215() {
+    async fn base_dir_outside_host_root_is_honored_as_selected_root() {
+        let root = tmp();
+        let selected = tmp();
+        fs::create_dir_all(selected.join("project")).unwrap();
+        fs::write(selected.join("project/a.txt"), "x").unwrap();
+        let b = jailed_backend(&root);
+        let resp = b
+            .ls(LsArgs {
+                path: ".".into(),
+                base_dir: Some(selected.join("project").to_string_lossy().into_owned()),
+            })
+            .await
+            .expect("selected base_dir outside host roots should be honored");
+        assert_eq!(resp.entries.len(), 1);
+        assert_eq!(resp.entries[0].name, "a.txt");
+    }
+
+    #[tokio::test]
+    async fn base_dir_outside_host_root_still_applies_non_accessible_globs() {
+        let root = tmp();
+        let selected = tmp();
+        fs::write(selected.join(".env"), "secret").unwrap();
+        let b = stub_backend(HostFsConfig {
+            host_roots: vec![root],
+            non_accessible_globs: vec!["**/.env".into()],
+            ..Default::default()
+        });
+        let err = b
+            .read(crate::fs::ReadArgs {
+                path: ".env".into(),
+                base_dir: Some(selected.to_string_lossy().into_owned()),
+            })
+            .await
+            .expect_err("protected file under selected base_dir must stay locked");
+        assert_eq!(err.code, "S215");
+    }
+
+    #[tokio::test]
+    async fn relative_base_dir_is_rejected() {
         let root = tmp();
         let b = jailed_backend(&root);
         let err = b
@@ -3899,8 +3965,8 @@ mod tests {
                 base_dir: Some("../../etc".into()),
             })
             .await
-            .expect_err("a base_dir outside the jail must reject");
-        assert_eq!(err.code, "S215");
+            .expect_err("relative base_dir is not part of the trusted contract");
+        assert_eq!(err.code, "S210");
     }
 
     /// A genuinely jail-escaping absolute path (outside host_root entirely)
@@ -3911,19 +3977,19 @@ mod tests {
         let root = tmp();
         fs::create_dir_all(root.join("session")).unwrap();
         let b = jailed_backend(&root);
+        let base = root.join("session").to_string_lossy().into_owned();
         let err = b
             .read(crate::fs::ReadArgs {
                 path: "/etc/hostname".into(),
-                base_dir: Some("session".into()),
+                base_dir: Some(base),
             })
             .await
             .expect_err("abs path outside the jail must reject");
         assert_eq!(err.code, "S215", "outside every allowed root stays S215");
     }
 
-    /// Back-compat: base_dir=None reproduces the prior behaviour byte-for-byte.
-    /// A relative write still anchors at host_root (not at any session dir) and
-    /// lands exactly where it did before this feature.
+    /// With no session scope, a relative write still anchors at host_root (not
+    /// at any session dir).
     #[tokio::test]
     async fn base_dir_none_reproduces_host_root_anchoring() {
         let root = tmp();

--- a/shell/src/fs/mod.rs
+++ b/shell/src/fs/mod.rs
@@ -66,12 +66,11 @@ impl From<iii_sdk::channels::StreamChannelRef> for ContentRef {
 
 // Backend args — `FsBackend` trait inputs, no `target`, no `JsonSchema`.
 //
-// Every backend args struct carries an OPTIONAL per-call `base_dir`. When set,
-// the op is scoped to that session directory: relative paths anchor at
-// `base_dir` (not the global `host_root`) and an absolute path outside it is
-// rejected. `base_dir` must itself sit inside the configured `host_root`. When
-// `None` (the default, and the wire-absent case) the op behaves exactly as
-// before — see `crate::fs::host::confine_path_with_base_dir`.
+// Every backend args struct carries an OPTIONAL trusted per-call `base_dir`.
+// When set, the op is scoped to that session directory: relative paths anchor
+// at `base_dir` and an absolute path outside it is rejected. The directory is
+// supplied by harness metadata, not by the published tool schema. When `None`
+// (the default, and the wire-absent case) the op behaves exactly as before.
 
 #[derive(Debug, Deserialize)]
 pub struct LsArgs {
@@ -218,13 +217,8 @@ pub struct ReadArgs {
 // Registration-boundary requests — each carries `target` plus the matching
 // `*Args` fields and derives `JsonSchema` for the SDK.
 
-/// Shared doc for the optional per-call `base_dir` field on every
-/// `shell::fs::*` request. Scopes the call to a session directory: relative
-/// paths anchor here (instead of the global `fs.host_root`) and an absolute
-/// path outside it is rejected (S220). `base_dir` must itself canonicalize
-/// inside `fs.host_root`. Omit to use the global jail root (unchanged default).
-///
-/// (Documented once; each request field below repeats the one-line summary.)
+/// `base_dir` is accepted at deserialization time for trusted harness metadata,
+/// but is omitted from every published `shell::fs::*` request schema.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct LsRequest {
     /// host (default) or { kind: "sandbox", sandbox_id }.
@@ -232,9 +226,9 @@ pub struct LsRequest {
     pub target: Target,
     /// Jail-relative when fs.host_root is set, else absolute.
     pub path: String,
-    /// Optional per-call session directory. Relative paths anchor here; an
-    /// absolute path outside it is rejected (S220). Must be inside fs.host_root.
+    /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
+    #[schemars(skip)]
     pub base_dir: Option<String>,
 }
 impl LsRequest {
@@ -256,9 +250,9 @@ pub struct StatRequest {
     pub target: Target,
     /// Jail-relative when fs.host_root is set, else absolute.
     pub path: String,
-    /// Optional per-call session directory. Relative paths anchor here; an
-    /// absolute path outside it is rejected (S220). Must be inside fs.host_root.
+    /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
+    #[schemars(skip)]
     pub base_dir: Option<String>,
 }
 impl StatRequest {
@@ -286,9 +280,9 @@ pub struct MkdirRequest {
     /// Create missing parent directories.
     #[serde(default)]
     pub parents: bool,
-    /// Optional per-call session directory. Relative paths anchor here; an
-    /// absolute path outside it is rejected (S220). Must be inside fs.host_root.
+    /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
+    #[schemars(skip)]
     pub base_dir: Option<String>,
 }
 impl MkdirRequest {
@@ -315,9 +309,9 @@ pub struct RmRequest {
     /// Required to delete a non-empty directory.
     #[serde(default)]
     pub recursive: bool,
-    /// Optional per-call session directory. Relative paths anchor here; an
-    /// absolute path outside it is rejected (S220). Must be inside fs.host_root.
+    /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
+    #[schemars(skip)]
     pub base_dir: Option<String>,
 }
 impl RmRequest {
@@ -351,9 +345,9 @@ pub struct ChmodRequest {
     /// Apply mode/owner change to all files under the path recursively.
     #[serde(default)]
     pub recursive: bool,
-    /// Optional per-call session directory. Relative paths anchor here; an
-    /// absolute path outside it is rejected (S220). Must be inside fs.host_root.
+    /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
+    #[schemars(skip)]
     pub base_dir: Option<String>,
 }
 impl ChmodRequest {
@@ -384,10 +378,9 @@ pub struct MvRequest {
     /// Replace an existing destination instead of returning an error.
     #[serde(default)]
     pub overwrite: bool,
-    /// Optional per-call session directory. BOTH src and dst anchor here when
-    /// relative; an absolute src/dst outside it is rejected (S220). Must be
-    /// inside fs.host_root.
+    /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
+    #[schemars(skip)]
     pub base_dir: Option<String>,
 }
 impl MvRequest {
@@ -431,9 +424,9 @@ pub struct GrepRequest {
     /// Skip lines longer than this many bytes (default 4 096).
     #[serde(default = "default_max_line_bytes")]
     pub max_line_bytes: u64,
-    /// Optional per-call session directory. Relative paths anchor here; an
-    /// absolute path outside it is rejected (S220). Must be inside fs.host_root.
+    /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
+    #[schemars(skip)]
     pub base_dir: Option<String>,
 }
 impl GrepRequest {
@@ -488,10 +481,9 @@ pub struct SedRequest {
     /// Match pattern case-insensitively.
     #[serde(default)]
     pub ignore_case: bool,
-    /// Optional per-call session directory. Relative `files`/`path` anchor
-    /// here; an absolute one outside it is rejected (S220). Must be inside
-    /// fs.host_root.
+    /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
+    #[schemars(skip)]
     pub base_dir: Option<String>,
 }
 impl SedRequest {
@@ -582,10 +574,9 @@ pub struct WriteRequest {
     /// single-file fields (`path`/`content`/`mode`/`parents`) must be omitted.
     #[serde(default)]
     pub files: Option<Vec<WriteFileSpec>>,
-    /// Optional per-call session directory, applied to the single-file `path`
-    /// AND to every batch `files[].path`. Relative paths anchor here; an
-    /// absolute one outside it is rejected (S220). Must be inside fs.host_root.
+    /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
+    #[schemars(skip)]
     pub base_dir: Option<String>,
 }
 impl WriteRequest {
@@ -661,9 +652,9 @@ pub struct ReadRequest {
     pub target: Target,
     /// Jail-relative when fs.host_root is set, else absolute.
     pub path: String,
-    /// Optional per-call session directory. Relative paths anchor here; an
-    /// absolute path outside it is rejected (S220). Must be inside fs.host_root.
+    /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
+    #[schemars(skip)]
     pub base_dir: Option<String>,
 }
 impl ReadRequest {

--- a/shell/src/functions/mod.rs
+++ b/shell/src/functions/mod.rs
@@ -4,6 +4,7 @@ pub mod kill;
 pub mod list;
 pub mod status;
 pub mod types;
+pub mod workspace;
 
 pub mod fs_chmod;
 pub mod fs_dispatch;

--- a/shell/src/functions/types.rs
+++ b/shell/src/functions/types.rs
@@ -111,18 +111,11 @@ pub struct ExecRequest {
     /// inside `host_root` and miss the denylist — a path that escapes returns
     /// S215. Must already exist and be a directory. Omit to use the configured
     /// `working_dir` (unchanged default). Rejected (S210) on a sandbox target.
-    /// When `base_dir` is set, a relative `cwd` anchors there and an absolute
-    /// `cwd` must resolve inside `base_dir`.
     #[serde(default)]
     pub cwd: Option<String>,
-    /// Optional per-call session directory (host target only). When set, it
-    /// becomes BOTH the working directory (in place of the configured
-    /// `working_dir`) AND the confinement root for `cwd`: a relative `cwd`
-    /// anchors at `base_dir` and an absolute `cwd` must resolve inside it (else
-    /// S220). `base_dir` must itself canonicalize inside `fs.host_root` (else
-    /// rejected). Omit for the unchanged behaviour. Rejected (S210) on a sandbox
-    /// target, like `cwd`/`env`.
+    /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
+    #[schemars(skip)]
     pub base_dir: Option<String>,
     /// Optional per-call environment values (host target only). A key may be
     /// set ONLY if the operator listed it in `allowed_env`, and NEVER for an
@@ -167,14 +160,12 @@ pub struct ExecBgRequest {
     /// Optional working directory for this job (host target only). Same jail
     /// confinement and rules as [`ExecRequest::cwd`]: canonicalized, must
     /// resolve inside `host_root` (S215 on escape) and be an existing
-    /// directory. Rejected (S210) on a sandbox target. Scoped to `base_dir`
-    /// when that is set.
+    /// directory. Rejected (S210) on a sandbox target.
     #[serde(default)]
     pub cwd: Option<String>,
-    /// Optional per-call session directory (host target only). See
-    /// [`ExecRequest::base_dir`]: becomes both the working directory and the
-    /// confinement root for `cwd`. Rejected (S210) on a sandbox target.
+    /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
+    #[schemars(skip)]
     pub base_dir: Option<String>,
     /// Optional per-call environment values (host target only). Same gating as
     /// [`ExecRequest::env`]: a key must be in `allowed_env` and must not be an

--- a/shell/src/functions/workspace.rs
+++ b/shell/src/functions/workspace.rs
@@ -1,0 +1,255 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use crate::config::ShellConfig;
+use crate::fs::error::FsError;
+use crate::path::canonicalize_with_fallback;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct WorkspaceRootsRequest {}
+
+#[derive(Debug, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct WorkspaceRootsResponse {
+    pub roots: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct WorkspaceValidateRequest {
+    pub path: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct WorkspaceValidateResponse {
+    pub path: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct WorkspaceListRequest {
+    pub path: String,
+    #[serde(default)]
+    pub page_size: Option<usize>,
+}
+
+#[derive(Debug, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum WorkspaceEntryKind {
+    Dir,
+}
+
+#[derive(Debug, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct WorkspaceEntry {
+    pub name: String,
+    pub path: String,
+    pub kind: WorkspaceEntryKind,
+}
+
+#[derive(Debug, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct WorkspaceListResponse {
+    pub path: String,
+    pub entries: Vec<WorkspaceEntry>,
+}
+
+pub fn workspace_roots(cfg: &ShellConfig) -> WorkspaceRootsResponse {
+    let mut candidates = cfg.fs.roots();
+    if let Ok(cwd) = std::env::current_dir() {
+        candidates.push(cwd);
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        candidates.push(PathBuf::from(home));
+    }
+    candidates.push(PathBuf::from("/"));
+
+    let mut roots = BTreeSet::new();
+    for candidate in candidates {
+        let Ok(canon) = std::fs::canonicalize(&candidate) else {
+            continue;
+        };
+        if !canon.is_dir() || is_denylisted(&canon, cfg) {
+            continue;
+        }
+        roots.insert(path_string(&canon));
+    }
+    WorkspaceRootsResponse {
+        roots: roots.into_iter().collect(),
+    }
+}
+
+pub fn validate_workspace_path(
+    req: WorkspaceValidateRequest,
+    cfg: &ShellConfig,
+) -> Result<WorkspaceValidateResponse, FsError> {
+    let path = canonical_workspace_dir(&req.path, cfg)?;
+    Ok(WorkspaceValidateResponse {
+        path: path_string(&path),
+    })
+}
+
+pub fn list_workspace_dirs(
+    req: WorkspaceListRequest,
+    cfg: &ShellConfig,
+) -> Result<WorkspaceListResponse, FsError> {
+    let root = canonical_workspace_dir(&req.path, cfg)?;
+    let page_size = req.page_size.unwrap_or(200).clamp(1, 1_000);
+    let rd = std::fs::read_dir(&root).map_err(|e| FsError::from_io(&req.path, e))?;
+    let mut entries = Vec::new();
+    for ent in rd {
+        let Ok(ent) = ent else {
+            continue;
+        };
+        let name = ent.file_name().to_string_lossy().into_owned();
+        let path = ent.path();
+        let Ok(md) = std::fs::metadata(&path) else {
+            continue;
+        };
+        if !md.is_dir() {
+            continue;
+        }
+        let Ok(canon) = std::fs::canonicalize(&path) else {
+            continue;
+        };
+        if is_denylisted(&canon, cfg) {
+            continue;
+        }
+        entries.push(WorkspaceEntry {
+            name,
+            path: path_string(&canon),
+            kind: WorkspaceEntryKind::Dir,
+        });
+    }
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+    entries.truncate(page_size);
+    Ok(WorkspaceListResponse {
+        path: path_string(&root),
+        entries,
+    })
+}
+
+fn canonical_workspace_dir(path: &str, cfg: &ShellConfig) -> Result<PathBuf, FsError> {
+    if path.is_empty() {
+        return Err(FsError::new("S210", "path must not be empty"));
+    }
+    let canon = std::fs::canonicalize(path).map_err(|e| FsError::from_io(path, e))?;
+    if !canon.is_dir() {
+        return Err(FsError::new("S212", format!("not a directory: {path}")));
+    }
+    if is_denylisted(&canon, cfg) {
+        return Err(FsError::new("S215", format!("path is denylisted: {path}")));
+    }
+    Ok(canon)
+}
+
+fn is_denylisted(path: &Path, cfg: &ShellConfig) -> bool {
+    cfg.fs.denylist_paths.iter().any(|deny| {
+        canonicalize_with_fallback(deny)
+            .map(|canon| path.starts_with(canon))
+            .unwrap_or(false)
+    })
+}
+
+fn path_string(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+    use tempfile::tempdir;
+
+    fn cfg_with_root(root: PathBuf) -> ShellConfig {
+        let mut cfg = ShellConfig::default();
+        cfg.fs.host_roots = vec![root];
+        cfg
+    }
+
+    fn canon(p: &Path) -> String {
+        std::fs::canonicalize(p)
+            .unwrap()
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    #[test]
+    fn roots_include_configured_host_root_and_operator_anchors() {
+        let jail = tempdir().unwrap();
+        let cfg = cfg_with_root(jail.path().to_path_buf());
+
+        let roots = workspace_roots(&cfg).roots;
+
+        assert!(roots.contains(&canon(jail.path())));
+        assert!(roots.iter().any(|r| r == "/"));
+    }
+
+    #[test]
+    fn validate_accepts_existing_directory_outside_configured_roots() {
+        let jail = tempdir().unwrap();
+        let selected = tempdir().unwrap();
+        let cfg = cfg_with_root(jail.path().to_path_buf());
+
+        let resp = validate_workspace_path(
+            WorkspaceValidateRequest {
+                path: selected.path().to_string_lossy().into_owned(),
+            },
+            &cfg,
+        )
+        .unwrap();
+
+        assert_eq!(resp.path, canon(selected.path()));
+    }
+
+    #[test]
+    fn validate_rejects_denylisted_directory() {
+        let jail = tempdir().unwrap();
+        let denied = tempdir().unwrap();
+        let mut cfg = cfg_with_root(jail.path().to_path_buf());
+        cfg.fs.denylist_paths = vec![denied.path().to_path_buf()];
+
+        let err = validate_workspace_path(
+            WorkspaceValidateRequest {
+                path: denied.path().to_string_lossy().into_owned(),
+            },
+            &cfg,
+        )
+        .unwrap_err();
+
+        assert_eq!(err.code, "S215");
+    }
+
+    #[test]
+    fn list_returns_directories_only_sorted_with_canonical_paths() {
+        let jail = tempdir().unwrap();
+        let selected = tempdir().unwrap();
+        std::fs::create_dir(selected.path().join("b")).unwrap();
+        std::fs::create_dir(selected.path().join("a")).unwrap();
+        std::fs::write(selected.path().join("file.txt"), "x").unwrap();
+        let cfg = cfg_with_root(jail.path().to_path_buf());
+
+        let resp = list_workspace_dirs(
+            WorkspaceListRequest {
+                path: selected.path().to_string_lossy().into_owned(),
+                page_size: Some(20),
+            },
+            &cfg,
+        )
+        .unwrap();
+
+        assert_eq!(resp.path, canon(selected.path()));
+        assert_eq!(
+            resp.entries,
+            vec![
+                WorkspaceEntry {
+                    name: "a".into(),
+                    path: canon(&selected.path().join("a")),
+                    kind: WorkspaceEntryKind::Dir,
+                },
+                WorkspaceEntry {
+                    name: "b".into(),
+                    path: canon(&selected.path().join("b")),
+                    kind: WorkspaceEntryKind::Dir,
+                },
+            ]
+        );
+    }
+}

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -328,6 +328,8 @@ async fn main() -> Result<()> {
         );
     }
 
+    register_workspace(&iii, &state);
+
     // fs::* keep Value handlers (preserving S210) and read the live host backend
     // + sandbox toggle from AppState; the typed schema is attached separately.
     register_fs(&iii, &state);
@@ -361,6 +363,70 @@ async fn main() -> Result<()> {
 
     iii.shutdown_async().await;
     Ok(())
+}
+
+/// Register operator control-plane functions used by the console working-dir
+/// picker. These are intentionally separate from shell::fs::* and coder::*:
+/// they browse existing host directories for UI selection, while the harness
+/// injects the chosen path as trusted per-turn metadata.
+fn register_workspace(iii: &iii_sdk::IIIClient, state: &AppState) {
+    {
+        let st = state.clone();
+        iii.register_function(
+            "shell::workspace::roots",
+            RegisterFunction::new_async(
+                move |_req: functions::workspace::WorkspaceRootsRequest| {
+                    let st = st.clone();
+                    telemetry::record_call("shell::workspace::roots", async move {
+                        let cfg = { st.runtime.read().await.config.clone() };
+                        Ok::<_, Error>(functions::workspace::workspace_roots(&cfg))
+                    })
+                },
+            )
+            .description(
+                "Console-only workspace picker control plane: return canonical host directory \
+                 anchors that an operator can browse before choosing a per-session working \
+                 directory.",
+            ),
+        );
+    }
+    {
+        let st = state.clone();
+        iii.register_function(
+            "shell::workspace::validate",
+            RegisterFunction::new_async(
+                move |req: functions::workspace::WorkspaceValidateRequest| {
+                    let st = st.clone();
+                    telemetry::record_call("shell::workspace::validate", async move {
+                        let cfg = { st.runtime.read().await.config.clone() };
+                        functions::workspace::validate_workspace_path(req, &cfg)
+                            .map_err(Error::from)
+                    })
+                },
+            )
+            .description(
+                "Console-only workspace picker control plane: validate that `path` is an \
+                 existing host directory and return its canonical path.",
+            ),
+        );
+    }
+    {
+        let st = state.clone();
+        iii.register_function(
+            "shell::workspace::list",
+            RegisterFunction::new_async(move |req: functions::workspace::WorkspaceListRequest| {
+                let st = st.clone();
+                telemetry::record_call("shell::workspace::list", async move {
+                    let cfg = { st.runtime.read().await.config.clone() };
+                    functions::workspace::list_workspace_dirs(req, &cfg).map_err(Error::from)
+                })
+            })
+            .description(
+                "Console-only workspace picker control plane: list child directories under an \
+                 existing host directory. Returns canonical paths and never returns files.",
+            ),
+        );
+    }
 }
 
 /// Detached task that prunes finished `JobRecord`s on a fixed cadence using the

--- a/shell/tests/golden/schemas/coder.create-file.json
+++ b/shell/tests/golden/schemas/coder.create-file.json
@@ -53,14 +53,6 @@
       }
     ],
     "properties": {
-      "base_dir": {
-        "default": null,
-        "description": "Optional per-call session working directory. When set, relative `path`s anchor here instead of the primary allowed root, and every resolved path must stay inside it. `base_dir` itself must canonicalize inside an allowed root (`coder::info` lists them). Omit to resolve against the primary allowed root exactly as before.",
-        "type": [
-          "string",
-          "null"
-        ]
-      },
       "files": {
         "items": {
           "$ref": "#/definitions/CreateFileSpec"

--- a/shell/tests/golden/schemas/coder.delete-file.json
+++ b/shell/tests/golden/schemas/coder.delete-file.json
@@ -13,14 +13,6 @@
       }
     ],
     "properties": {
-      "base_dir": {
-        "default": null,
-        "description": "Optional per-call session working directory. When set, relative `paths` anchor here instead of the primary allowed root, and every resolved path must stay inside it. `base_dir` itself must canonicalize inside an allowed root (`coder::info` lists them). Omit to resolve against the primary allowed root exactly as before.",
-        "type": [
-          "string",
-          "null"
-        ]
-      },
       "paths": {
         "description": "Paths to remove. Each entry is relative to the primary allowed root, or an absolute path inside any allowed root. Call `coder::info` to see the allowed roots. Paths outside every allowed root are rejected — use the shell worker's `shell::fs::*` for host paths outside the jail.",
         "items": {

--- a/shell/tests/golden/schemas/coder.list-folder.json
+++ b/shell/tests/golden/schemas/coder.list-folder.json
@@ -11,14 +11,6 @@
       }
     ],
     "properties": {
-      "base_dir": {
-        "default": null,
-        "description": "Optional per-call session working directory. When set, a relative `path` anchors here instead of the primary allowed root, and the resolved folder must stay inside it. `base_dir` itself must canonicalize inside an allowed root (`coder::info` lists them). Omit to resolve against the primary allowed root exactly as before.",
-        "type": [
-          "string",
-          "null"
-        ]
-      },
       "page": {
         "default": 1,
         "format": "uint32",

--- a/shell/tests/golden/schemas/coder.move.json
+++ b/shell/tests/golden/schemas/coder.move.json
@@ -48,14 +48,6 @@
       }
     ],
     "properties": {
-      "base_dir": {
-        "default": null,
-        "description": "Optional per-call session working directory. When set, relative `from`/`to` paths anchor here instead of the primary allowed root, and BOTH resolved endpoints must stay inside it. `base_dir` itself must canonicalize inside an allowed root (`coder::info` lists them). Omit to resolve against the primary allowed root exactly as before.",
-        "type": [
-          "string",
-          "null"
-        ]
-      },
       "files": {
         "description": "Entries to move. Each entry is processed independently so a single failure never aborts the rest.",
         "items": {

--- a/shell/tests/golden/schemas/coder.read-file.json
+++ b/shell/tests/golden/schemas/coder.read-file.json
@@ -75,14 +75,6 @@
       }
     ],
     "properties": {
-      "base_dir": {
-        "default": null,
-        "description": "Optional per-call session working directory. When set, every relative path (the single `path` or each `paths[]` entry, in both the bare string and `{path,...}` object forms) anchors here instead of the primary allowed root, and every resolved path must stay inside it. `base_dir` itself must canonicalize inside an allowed root (`coder::info` lists them). Omit to resolve against the primary allowed root exactly as before.",
-        "type": [
-          "string",
-          "null"
-        ]
-      },
       "line_from": {
         "default": null,
         "description": "First line of the window, 1-based inclusive (must be >= 1; 0 is rejected with C210). Setting `line_from` and/or `line_to` switches to windowed mode: the file is streamed and only the requested lines are returned, so files larger than `max_read_bytes` stay readable slice by slice — the byte cap then applies to the returned window, never the file size. Defaults to 1 when only `line_to` is set. A window starting past EOF succeeds with empty content and reports the file's `total_lines`. Only valid in single-path mode (`path`); ignored when `paths` is set. Lines are 0x0A- or EOF-terminated segments; a trailing newline does not create a phantom line (same convention as `coder::update-file`).",

--- a/shell/tests/golden/schemas/coder.search.json
+++ b/shell/tests/golden/schemas/coder.search.json
@@ -17,14 +17,6 @@
       }
     ],
     "properties": {
-      "base_dir": {
-        "default": null,
-        "description": "Optional per-call session working directory. When set, a relative `path` anchors here instead of the primary allowed root, and the walk root must stay inside it. `base_dir` itself must canonicalize inside an allowed root (`coder::info` lists them). Result paths stay absolute. Omit to resolve against the primary allowed root exactly as before.",
-        "type": [
-          "string",
-          "null"
-        ]
-      },
       "context_lines_after": {
         "default": null,
         "description": "Lines of context to return AFTER each content match. Same max (10), truncation, and budget rules as `context_lines_before`; unset = 0.",

--- a/shell/tests/golden/schemas/coder.tree.json
+++ b/shell/tests/golden/schemas/coder.tree.json
@@ -10,14 +10,6 @@
       }
     ],
     "properties": {
-      "base_dir": {
-        "default": null,
-        "description": "Optional per-call session working directory. When set, a relative `path` anchors here instead of the primary allowed root, and the resolved base folder must stay inside it. `base_dir` itself must canonicalize inside an allowed root (`coder::info` lists them). Omit to resolve against the primary allowed root exactly as before.",
-        "type": [
-          "string",
-          "null"
-        ]
-      },
       "max_depth": {
         "default": null,
         "description": "Maximum depth to descend; the root node is depth 0.",

--- a/shell/tests/golden/schemas/coder.update-file.json
+++ b/shell/tests/golden/schemas/coder.update-file.json
@@ -184,14 +184,6 @@
       }
     ],
     "properties": {
-      "base_dir": {
-        "default": null,
-        "description": "Optional per-call session working directory. When set, relative `path`s anchor here instead of the primary allowed root, and every resolved path must stay inside it. `base_dir` itself must canonicalize inside an allowed root (`coder::info` lists them). Omit to resolve against the primary allowed root exactly as before.",
-        "type": [
-          "string",
-          "null"
-        ]
-      },
       "files": {
         "items": {
           "$ref": "#/definitions/UpdateFileSpec"


### PR DESCRIPTION
## Summary
- add console-only `shell::workspace::{roots,list,validate}` APIs for browsing and validating host directories
- move the console `DirectoryPicker` from `coder::*` discovery to the new workspace control plane
- keep workspace picker APIs out of harness `base_dir` injection and fallback agent exposure
- allow trusted absolute `base_dir` selections outside configured roots while preserving relative escape rejection
- hide internal `base_dir` fields from published schemas and update coder schema goldens

Replaces #375 with an independent implementation.

## Validation
- `cargo test --manifest-path harness/Cargo.toml workspace_inject --lib`
- `cargo test --manifest-path shell/Cargo.toml workspace::tests --lib`
- `cargo test --manifest-path shell/Cargo.toml session_scoped_base_dir_outside_roots --lib`
- `cargo test --manifest-path shell/Cargo.toml base_dir_outside_host_root --lib`
- `cargo test --manifest-path shell/Cargo.toml relative_base_dir_still_cannot_escape_host_root --lib`
- `cargo test --manifest-path shell/Cargo.toml --test code_golden_schemas`
- `cargo test --manifest-path shell/Cargo.toml --bin shell config_defaults_to_local_config_yaml`
- `pnpm --dir console/web test -- DirectoryPicker real-metadata`
- `pnpm --dir console/web typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a workspace picker flow for browsing and selecting available directories.
  * Workspace browsing now shows canonical folder paths and lets you validate a chosen directory before using it.

* **Bug Fixes**
  * Improved directory resolution so the closest matching workspace root is selected more reliably.
  * Fixed recent directory handling to keep saved paths stable across symlinks.
  * Better preserves access rules while browsing and using file tools within a selected workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->