### PR TITLE
fix(console): implement client-side configuration validation and temp…

### DIFF
--- a/console/web/src/pages/Configuration/tabs/WorkersTab/WorkerEditor.tsx
+++ b/console/web/src/pages/Configuration/tabs/WorkersTab/WorkerEditor.tsx
@@ -9,6 +9,7 @@ import { useConfigurationValue, useSetConfiguration } from './hooks'
 import { SaveBar, type SaveStatus } from './SaveBar'
 import { isObjectSchema } from './schema-form/guard'
 import { SchemaForm } from './schema-form/SchemaForm'
+import { validateConfig } from './schema-form/validate'
 import { wt } from './typography'
 
 interface WorkerEditorProps {
@@ -59,6 +60,30 @@ export function WorkerEditor({ entry, onDirtyChange }: WorkerEditorProps) {
     [valueQuery.data, draft],
   )
 
+  // Client-side schema validation that mirrors the engine: env templates are
+  // resolved/coerced before type-checking (so `${PORT:3111}` validates as an
+  // integer), while a defaultless `${VAR}` is left for the runtime to resolve.
+  // Derived from the live draft, so it can never go stale — unlike the server
+  // `errors` below, which are cleared on edit.
+  const clientErrors = useMemo(
+    () =>
+      draft === undefined || !isObjectSchema(entry.schema)
+        ? new Map<string, string>()
+        : validateConfig(draft, entry.schema),
+    [draft, entry.schema],
+  )
+
+  // Client errors layer on top of any server error (client is always fresh).
+  const displayErrors = useMemo(() => {
+    const merged = new Map(errors)
+    for (const [pointer, message] of clientErrors) merged.set(pointer, message)
+    return merged
+  }, [errors, clientErrors])
+
+  // A root-level ('') validation error can't attach to any field; surface it
+  // near the save bar so a disabled Save button always has a visible reason.
+  const rootError = displayErrors.get('')
+
   // Bubble dirty changes up so the page shell can gate navigation.
   useEffect(() => {
     onDirtyChange(dirty)
@@ -91,6 +116,16 @@ export function WorkerEditor({ entry, onDirtyChange }: WorkerEditorProps) {
 
   const handleSave = useCallback(() => {
     if (draft === undefined) return
+    // Defensive: the Save button is disabled while client errors exist, but
+    // guard here too in case a draft change races the click.
+    if (clientErrors.size > 0) {
+      setStatus({
+        kind: 'error',
+        message:
+          clientErrors.get('') ?? 'fix the validation errors before saving',
+      })
+      return
+    }
     setStatus({ kind: 'saving' })
     setErrors(new Map())
     setMutation.mutate(
@@ -111,7 +146,7 @@ export function WorkerEditor({ entry, onDirtyChange }: WorkerEditorProps) {
         },
       },
     )
-  }, [draft, entry.id, setMutation])
+  }, [draft, entry.id, setMutation, clientErrors])
 
   return (
     <section
@@ -136,14 +171,20 @@ export function WorkerEditor({ entry, onDirtyChange }: WorkerEditorProps) {
                   schema={entry.schema}
                   value={draft}
                   onChange={handleDraftChange}
-                  errors={errors}
+                  errors={displayErrors}
                 />
+                {rootError ? (
+                  <p className={cn(wt.bodySm, 'text-alert mt-4')} role="alert">
+                    {rootError}
+                  </p>
+                ) : null}
               </div>
               <SaveBar
                 dirty={dirty}
                 status={status}
                 onSave={handleSave}
                 onReset={handleReset}
+                saveDisabled={clientErrors.size > 0}
               />
             </>
           ) : (

--- a/console/web/src/pages/Configuration/tabs/WorkersTab/schema-form/BooleanField.tsx
+++ b/console/web/src/pages/Configuration/tabs/WorkersTab/schema-form/BooleanField.tsx
@@ -1,7 +1,7 @@
 import { ModeToggle } from '@/components/ui/ModeToggle'
 import { wt } from '../typography'
 import type { FieldProps } from './FieldDispatch'
-import { errorForField, FieldShell } from './FieldShell'
+import { TemplatableField } from './TemplatableField'
 
 type BoolKey = 'true' | 'false'
 
@@ -15,22 +15,20 @@ const BOOL_OPTIONS: { value: BoolKey; label: string }[] = [
  * in `radio` mode so the visual matches the theme picker on the console
  * settings tab — boolean preferences read consistently across the whole
  * page instead of inventing a one-off toggle widget.
+ *
+ * A `${VAR}` env template can also live in a boolean field; `TemplatableField`
+ * swaps in the pill editor when the value is a string and offers a toggle
+ * between a literal value and an env template.
  */
 export function BooleanField(props: FieldProps) {
-  const { label, schema, value, onChange, required, hideLabel } = props
-  const description =
-    typeof schema.description === 'string' ? schema.description : undefined
+  const { label, value, onChange } = props
   const current: BoolKey = value === true ? 'true' : 'false'
 
   return (
-    <FieldShell
-      label={label}
-      description={description}
-      required={required}
-      errorMessage={errorForField(props)}
-      hideLabel={hideLabel}
-    >
-      {() => (
+    <TemplatableField
+      props={props}
+      scalarDefault={false}
+      renderScalar={() => (
         <ModeToggle<BoolKey>
           value={current}
           onChange={(next) => onChange(next === 'true')}
@@ -40,6 +38,6 @@ export function BooleanField(props: FieldProps) {
           className={wt.toggle}
         />
       )}
-    </FieldShell>
+    />
   )
 }

--- a/console/web/src/pages/Configuration/tabs/WorkersTab/schema-form/NumberField.tsx
+++ b/console/web/src/pages/Configuration/tabs/WorkersTab/schema-form/NumberField.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@/lib/utils'
 import { wt } from '../typography'
 import type { FieldProps } from './FieldDispatch'
-import { errorForField, FieldShell } from './FieldShell'
+import { TemplatableField } from './TemplatableField'
 
 /**
  * Numeric field for `type: integer` and `type: number`. Stores `null`
@@ -13,11 +13,13 @@ import { errorForField, FieldShell } from './FieldShell'
  * `min` / `max` are surfaced as HTML attributes for browser-level UX
  * affordances; full validation runs on the server. `step` defaults to
  * 1 for integers and `any` for numbers so spinner arrows feel right.
+ *
+ * A `${VAR}` env template can also live in a numeric field; `TemplatableField`
+ * swaps in the pill editor when the value is a string and offers a toggle
+ * between a literal value and an env template.
  */
 export function NumberField(props: FieldProps) {
-  const { label, schema, value, onChange, required, hideLabel } = props
-  const description =
-    typeof schema.description === 'string' ? schema.description : undefined
+  const { label, schema, value, onChange } = props
   const isInteger = schema.type === 'integer'
 
   const current =
@@ -42,14 +44,10 @@ export function NumberField(props: FieldProps) {
   }
 
   return (
-    <FieldShell
-      label={label}
-      description={description}
-      required={required}
-      errorMessage={errorForField(props)}
-      hideLabel={hideLabel}
-    >
-      {(controlId) => (
+    <TemplatableField
+      props={props}
+      scalarDefault={null}
+      renderScalar={(controlId) => (
         <input
           id={controlId}
           name={label}
@@ -74,6 +72,6 @@ export function NumberField(props: FieldProps) {
           )}
         />
       )}
-    </FieldShell>
+    />
   )
 }

--- a/console/web/src/pages/Configuration/tabs/WorkersTab/schema-form/TemplatableField.tsx
+++ b/console/web/src/pages/Configuration/tabs/WorkersTab/schema-form/TemplatableField.tsx
@@ -1,0 +1,80 @@
+/**
+ * Shared scalar ⇄ env-template wrapper for typed leaf fields (number, boolean).
+ *
+ * `FieldDispatch` routes by *schema* type, so a number/boolean field can be
+ * handed a string value — a `${VAR}` template a human (or another editor) put
+ * in the config. The native numeric/boolean controls can't represent that, so
+ * without this wrapper the template renders blank and the first edit silently
+ * discards it. This wrapper lets the same field hold either form:
+ *
+ *   - value is a string → TEMPLATE mode → the `${VAR}` pill editor
+ *     (`EnvLexicalInput`), identical to how `StringField` handles templates;
+ *   - otherwise → SCALAR mode → the field's native control (`renderScalar`).
+ *
+ * Mode is derived purely from the value type (no local state that could
+ * desync from a re-seeded draft). Switching modes just rewrites the value:
+ * "use an env variable" sets `''` (a string ⇒ template mode); "use a value"
+ * sets `scalarDefault` (a non-string ⇒ scalar mode).
+ */
+
+import type { ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+import type { JsonValue } from '../api'
+import { wt } from '../typography'
+import { EnvLexicalInput } from './env-lexical/EnvLexicalInput'
+import type { FieldProps } from './FieldDispatch'
+import { errorForField, FieldShell } from './FieldShell'
+
+interface TemplatableFieldProps {
+  props: FieldProps
+  /** Value installed when leaving template mode (e.g. `null`, `false`). */
+  scalarDefault: JsonValue
+  /** Renders the native scalar control, given the FieldShell control id. */
+  renderScalar: (controlId: string) => ReactNode
+}
+
+export function TemplatableField({
+  props,
+  scalarDefault,
+  renderScalar,
+}: TemplatableFieldProps) {
+  const { label, schema, value, onChange, required, hideLabel } = props
+  const description =
+    typeof schema.description === 'string' ? schema.description : undefined
+  const isTemplate = typeof value === 'string'
+
+  return (
+    <FieldShell
+      label={label}
+      description={description}
+      required={required}
+      errorMessage={errorForField(props)}
+      hideLabel={hideLabel}
+    >
+      {(controlId) => (
+        <div className="space-y-1.5">
+          {isTemplate ? (
+            <EnvLexicalInput
+              id={controlId}
+              value={value}
+              onChange={onChange}
+              aria-label={label}
+            />
+          ) : (
+            renderScalar(controlId)
+          )}
+          <button
+            type="button"
+            onClick={() => onChange(isTemplate ? scalarDefault : '')}
+            className={cn(
+              wt.micro,
+              'text-ink-ghost hover:text-ink transition-colors lowercase',
+            )}
+          >
+            {isTemplate ? 'use a literal value' : 'use an env variable'}
+          </button>
+        </div>
+      )}
+    </FieldShell>
+  )
+}

--- a/console/web/src/pages/Configuration/tabs/WorkersTab/schema-form/validate.test.ts
+++ b/console/web/src/pages/Configuration/tabs/WorkersTab/schema-form/validate.test.ts
@@ -1,0 +1,231 @@
+// biome-ignore-all lint/suspicious/noTemplateCurlyInString: this file's whole point is exercising the literal `${VAR}` env-template syntax — backticks would change what we're testing.
+import { describe, expect, it } from 'vitest'
+import type { JsonSchema } from '../api'
+import {
+  coerceScalar,
+  resolveLeafForValidation,
+  validateConfig,
+} from './validate'
+
+describe('coerceScalar', () => {
+  it('coerces integers, floats, bools, and null like the engine', () => {
+    expect(coerceScalar('8080')).toBe(8080)
+    expect(Number.isInteger(coerceScalar('8080') as number)).toBe(true)
+    expect(coerceScalar('3.5')).toBe(3.5)
+    expect(coerceScalar('true')).toBe(true)
+    expect(coerceScalar('false')).toBe(false)
+    expect(coerceScalar('null')).toBe(null)
+  })
+
+  it('keeps non-scalar-looking text as a string', () => {
+    expect(coerceScalar('localhost')).toBe('localhost')
+    expect(coerceScalar('127.0.0.1')).toBe('127.0.0.1')
+    expect(coerceScalar('on')).toBe('on')
+    expect(coerceScalar('')).toBe('')
+  })
+})
+
+describe('resolveLeafForValidation', () => {
+  it('passes through non-strings and plain literals', () => {
+    expect(resolveLeafForValidation(42)).toEqual({
+      kind: 'value',
+      resolved: 42,
+    })
+    expect(resolveLeafForValidation('hello')).toEqual({
+      kind: 'value',
+      resolved: 'hello',
+    })
+  })
+
+  it('coerces the default of a lone placeholder', () => {
+    expect(resolveLeafForValidation('${PORT:3111}')).toEqual({
+      kind: 'value',
+      resolved: 3111,
+    })
+    expect(resolveLeafForValidation('${FLAG:true}')).toEqual({
+      kind: 'value',
+      resolved: true,
+    })
+    expect(resolveLeafForValidation('${NAME:}')).toEqual({
+      kind: 'value',
+      resolved: '',
+    })
+  })
+
+  it('reports a defaultless lone placeholder as unresolved', () => {
+    expect(resolveLeafForValidation('${PORT}')).toEqual({ kind: 'unresolved' })
+  })
+
+  it('keeps embedded templates as strings', () => {
+    expect(resolveLeafForValidation('redis://${HOST:h}:6379')).toEqual({
+      kind: 'value',
+      resolved: 'redis://${HOST:h}:6379',
+    })
+  })
+})
+
+describe('validateConfig — #1916 typed env placeholders', () => {
+  const portSchema: JsonSchema = {
+    type: 'object',
+    required: ['port'],
+    properties: {
+      port: { type: 'integer', minimum: 1, maximum: 65535 },
+    },
+  }
+
+  it('accepts a templated integer whose coerced default is valid', () => {
+    expect(validateConfig({ port: '${HTTP_PORT:3111}' }, portSchema).size).toBe(
+      0,
+    )
+  })
+
+  it('rejects a templated default out of range', () => {
+    const errs = validateConfig({ port: '${HTTP_PORT:70000}' }, portSchema)
+    expect(errs.get('/port')).toMatch(/65535/)
+  })
+
+  it('rejects a templated default of the wrong type', () => {
+    const errs = validateConfig({ port: '${HTTP_PORT:notaport}' }, portSchema)
+    expect(errs.get('/port')).toMatch(/integer/)
+  })
+
+  it('rejects an out-of-range literal', () => {
+    expect(validateConfig({ port: 99999 }, portSchema).get('/port')).toMatch(
+      /65535/,
+    )
+  })
+
+  it('rejects a wrong-typed literal', () => {
+    expect(validateConfig({ port: 'nope' }, portSchema).get('/port')).toMatch(
+      /integer/,
+    )
+  })
+
+  it('does not block a defaultless placeholder (resolved at runtime)', () => {
+    expect(validateConfig({ port: '${HTTP_PORT}' }, portSchema).size).toBe(0)
+  })
+
+  it('flags a missing required property', () => {
+    expect(validateConfig({}, portSchema).get('/port')).toMatch(/required/)
+  })
+})
+
+describe('validateConfig — strings, enums, nullable, dictionaries', () => {
+  it('skips pattern on a defaultless templated string but enforces it on a literal', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { url: { type: 'string', pattern: '^https://' } },
+    }
+    expect(validateConfig({ url: '${API_URL}' }, schema).size).toBe(0)
+    expect(validateConfig({ url: 'ftp://x' }, schema).get('/url')).toMatch(
+      /pattern/,
+    )
+  })
+
+  it('validates enums, allowing coerced template defaults', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: { mode: { enum: ['fs', 'bridge'] } },
+    }
+    expect(validateConfig({ mode: 'fs' }, schema).size).toBe(0)
+    expect(validateConfig({ mode: 'nfs' }, schema).get('/mode')).toMatch(
+      /one of/,
+    )
+    expect(validateConfig({ mode: '${ADAPTER:fs}' }, schema).size).toBe(0)
+    expect(validateConfig({ mode: '${ADAPTER}' }, schema).size).toBe(0)
+  })
+
+  it('handles Option<T> nullable unions', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        limit: { anyOf: [{ type: 'integer' }, { type: 'null' }] },
+      },
+    }
+    expect(validateConfig({ limit: null }, schema).size).toBe(0)
+    expect(validateConfig({ limit: 5 }, schema).size).toBe(0)
+    expect(validateConfig({ limit: 'x' }, schema).get('/limit')).toMatch(
+      /integer/,
+    )
+  })
+
+  it('validates dictionary (additionalProperties) values', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        env: { type: 'object', additionalProperties: { type: 'string' } },
+      },
+    }
+    expect(validateConfig({ env: { A: 'x', B: 'y' } }, schema).size).toBe(0)
+    expect(validateConfig({ env: { A: 5 } }, schema).get('/env/A')).toMatch(
+      /string/,
+    )
+  })
+
+  it('points errors at the pointer the form renders (nested + escaped keys)', () => {
+    const schema: JsonSchema = {
+      type: 'object',
+      properties: {
+        items: { type: 'array', items: { type: 'integer' } },
+        env: { type: 'object', additionalProperties: { type: 'integer' } },
+      },
+    }
+    const errs = validateConfig(
+      { items: [1, 'bad'], env: { 'weird/key': 'no' } },
+      schema,
+    )
+    expect(errs.get('/items/1')).toMatch(/integer/)
+    expect(errs.get('/env/weird~1key')).toMatch(/integer/)
+  })
+})
+
+describe('validateConfig — discriminated oneOf (adapter shape)', () => {
+  const ROOT: JsonSchema = {
+    type: 'object',
+    properties: {
+      adapter: {
+        oneOf: [
+          {
+            type: 'object',
+            properties: {
+              name: { enum: ['fs'] },
+              config: {
+                type: 'object',
+                properties: { data_dir: { type: 'string' } },
+              },
+            },
+          },
+          {
+            type: 'object',
+            required: ['config'],
+            properties: {
+              name: { enum: ['bridge'] },
+              config: {
+                type: 'object',
+                required: ['url'],
+                properties: { url: { type: 'string' } },
+              },
+            },
+          },
+        ],
+      },
+    },
+  }
+
+  it('validates only the active branch and flags its missing field', () => {
+    const errs = validateConfig(
+      { adapter: { name: 'bridge', config: {} } },
+      ROOT,
+    )
+    expect(errs.get('/adapter/config/url')).toMatch(/required/)
+  })
+
+  it('accepts a valid active branch with a templated leaf', () => {
+    expect(
+      validateConfig(
+        { adapter: { name: 'fs', config: { data_dir: '${DIR:/tmp}' } } },
+        ROOT,
+      ).size,
+    ).toBe(0)
+  })
+})

--- a/console/web/src/pages/Configuration/tabs/WorkersTab/schema-form/validate.ts
+++ b/console/web/src/pages/Configuration/tabs/WorkersTab/schema-form/validate.ts
@@ -1,0 +1,427 @@
+/**
+ * Client-side configuration validation that mirrors the engine's
+ * configuration worker, so the console can block an invalid save and show the
+ * error inline instead of round-tripping to the server.
+ *
+ * The hard part is NOT the JSON Schema keywords — it's env templates. The
+ * engine validates the APPLIED (env-expanded + type-coerced) value, not the raw
+ * `${VAR}` template: it substitutes a lone placeholder and re-parses the result
+ * as a YAML scalar, so `port: ${HTTP_PORT:3111}` validates as the integer 3111.
+ * This module reproduces that contract:
+ *
+ *   - a lone `${VAR:default}` placeholder → its coerced default is validated
+ *     (the browser has no process env, so the default is the best we can do);
+ *   - a lone `${VAR}` with no default → unresolvable here → that leaf is left
+ *     unvalidated (the engine resolves it from env at runtime — we must not
+ *     falsely reject it, and key-presence still satisfies `required`);
+ *   - a mixed/embedded template (`redis://${HOST}`) → stays a string; only its
+ *     type is checked, not pattern/length (the runtime value differs).
+ *
+ * IMPORTANT — keep `coerceScalar` in lock-step with the engine's
+ * `expand_string` in
+ * `iii/engine/src/workers/configuration/store.rs`. Both re-parse a substituted
+ * lone placeholder as a YAML 1.2 scalar; if they drift, the console and engine
+ * will disagree about which env-driven values are valid.
+ *
+ * This is a deliberately conservative subset of JSON Schema — it covers the
+ * keywords schemars emits and these configs use (type, required, enum, const,
+ * minimum/maximum/exclusive*, minLength/maxLength, pattern, minItems/maxItems,
+ * properties, additionalProperties, items, oneOf/anyOf, $ref/allOf-wrapper).
+ * Out of scope (the server stays the final authority): format assertions,
+ * multipleOf, uniqueItems, dependencies, if/then/else. For oneOf/anyOf we
+ * validate only the *active* branch (the one the form renders), to keep errors
+ * attributable to what the operator can see, rather than scattering them across
+ * branches they never chose.
+ */
+
+import type { JsonSchema, JsonValue } from '../api'
+import { parseTemplate } from './env-lexical/env-template'
+import { discriminator, nullableUnionInner } from './oneof-shape'
+import { type Path, pathToPointer } from './path'
+import {
+  isNullable,
+  resolveSchema,
+  schemaTypes,
+  withoutNull,
+} from './ref-resolver'
+import { matchVariantIndex } from './variant-match'
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+const BOOL_TRUE = new Set(['true', 'True', 'TRUE'])
+const BOOL_FALSE = new Set(['false', 'False', 'FALSE'])
+const NULL_TOKENS = new Set(['null', 'Null', 'NULL', '~'])
+// Plain base-10 number (YAML 1.2 core scalar). Mirrors what serde_yaml resolves
+// a substituted scalar to: integers, decimals, and scientific notation. Bare
+// words, IPs (`127.0.0.1`), `on`/`off`, hex, etc. fall through to string.
+const NUMBER_RE = /^[-+]?(\d+\.?\d*|\.\d+)([eE][-+]?\d+)?$/
+
+/**
+ * Coerce the substituted text of a lone placeholder to the scalar the engine
+ * would produce (`"8080"` → `8080`, `"true"` → `true`, `"localhost"` →
+ * `"localhost"`). Keep in lock-step with `store.rs::expand_string`.
+ */
+export function coerceScalar(text: string): JsonValue {
+  if (text.length === 0) return text
+  if (BOOL_TRUE.has(text)) return true
+  if (BOOL_FALSE.has(text)) return false
+  if (NULL_TOKENS.has(text)) return null
+  if (NUMBER_RE.test(text)) {
+    const n = Number(text)
+    if (Number.isFinite(n)) return n
+  }
+  return text
+}
+
+type LeafResolution =
+  | { kind: 'value'; resolved: JsonValue }
+  | { kind: 'unresolved' }
+
+/**
+ * Resolve a leaf to the value the engine would validate. See the module
+ * header for the rules. Non-strings pass through unchanged.
+ */
+export function resolveLeafForValidation(value: JsonValue): LeafResolution {
+  if (typeof value !== 'string') return { kind: 'value', resolved: value }
+  const segments = parseTemplate(value)
+  const placeholders = segments.filter((s) => s.kind === 'placeholder')
+  if (placeholders.length === 0) {
+    // A plain literal string.
+    return { kind: 'value', resolved: value }
+  }
+  if (segments.length === 1 && segments[0].kind === 'placeholder') {
+    // A lone `${...}` placeholder.
+    const { defaultValue } = segments[0]
+    if (defaultValue === null) return { kind: 'unresolved' }
+    if (defaultValue === '') return { kind: 'value', resolved: '' }
+    return { kind: 'value', resolved: coerceScalar(defaultValue) }
+  }
+  // Mixed / embedded template — stays a string at runtime.
+  return { kind: 'value', resolved: value }
+}
+
+/** True when a (resolved) value is still a string carrying `${...}` segments. */
+function stillTemplated(value: JsonValue): boolean {
+  return (
+    typeof value === 'string' &&
+    parseTemplate(value).some((s) => s.kind === 'placeholder')
+  )
+}
+
+type JsonTypeName =
+  | 'null'
+  | 'boolean'
+  | 'integer'
+  | 'number'
+  | 'string'
+  | 'array'
+  | 'object'
+
+function jsonTypeOf(value: JsonValue): JsonTypeName {
+  if (value === null) return 'null'
+  if (Array.isArray(value)) return 'array'
+  const t = typeof value
+  if (t === 'number') return Number.isInteger(value) ? 'integer' : 'number'
+  if (t === 'boolean') return 'boolean'
+  if (t === 'object') return 'object'
+  return 'string'
+}
+
+function typeAllowed(value: JsonValue, types: string[]): boolean {
+  if (types.length === 0) return true // no `type` constraint to enforce
+  const actual = jsonTypeOf(value)
+  if (types.includes(actual)) return true
+  // An integer satisfies a `number` schema.
+  if (actual === 'integer' && types.includes('number')) return true
+  return false
+}
+
+function typeMessage(types: string[]): string {
+  if (types.length === 1) {
+    switch (types[0]) {
+      case 'integer':
+        return 'must be an integer'
+      case 'number':
+        return 'must be a number'
+      case 'boolean':
+        return 'must be a boolean'
+      case 'string':
+        return 'must be a string'
+      case 'object':
+        return 'must be an object'
+      case 'array':
+        return 'must be an array'
+    }
+  }
+  return `must be of type: ${types.join(', ')}`
+}
+
+interface Ctx {
+  root: JsonSchema
+  out: Map<string, string>
+}
+
+/** Record the first error seen for a pointer (later ones are usually noise). */
+function emit(ctx: Ctx, path: Path, message: string): void {
+  const ptr = pathToPointer(path)
+  if (!ctx.out.has(ptr)) ctx.out.set(ptr, message)
+}
+
+/**
+ * Validate `value` against `schema`, returning a map of JSON Pointer → message
+ * keyed exactly like `errorForField` (`FieldShell.tsx`) reads it, so errors
+ * render inline on the owning field. An empty map means "valid".
+ */
+export function validateConfig(
+  value: JsonValue,
+  schema: JsonSchema,
+): Map<string, string> {
+  const ctx: Ctx = { root: schema, out: new Map() }
+  validateNode(schema, value, [], ctx)
+  return ctx.out
+}
+
+function validateNode(
+  schemaIn: JsonSchema,
+  value: JsonValue | undefined,
+  path: Path,
+  ctx: Ctx,
+): void {
+  if (value === undefined) return // absent; `required` is enforced by the parent
+  const schema = resolveSchema(schemaIn, { root: ctx.root })
+
+  if (Array.isArray(schema.enum)) {
+    validateEnum(schema, value, path, ctx)
+    return
+  }
+  if ('const' in schema) {
+    validateConst(schema, value, path, ctx)
+    return
+  }
+
+  const variants = (schema.oneOf ?? schema.anyOf) as JsonSchema[] | undefined
+  if (Array.isArray(variants)) {
+    validateUnion(variants, value, path, ctx)
+    return
+  }
+
+  if (isNullable(schema)) {
+    if (value === null) return // the `null` branch is satisfied
+    validateNode(withoutNull(schema), value, path, ctx)
+    return
+  }
+
+  const types = schemaTypes(schema)
+  const primary = types[0]
+
+  if (
+    primary === 'object' ||
+    (types.length === 0 && isObject(schema.properties))
+  ) {
+    validateObject(schema, value, path, ctx)
+    return
+  }
+  if (primary === 'array') {
+    validateArray(schema, value, path, ctx)
+    return
+  }
+  if (
+    primary === 'string' ||
+    primary === 'number' ||
+    primary === 'integer' ||
+    primary === 'boolean'
+  ) {
+    validateLeaf(schema, value, path, ctx, types)
+    return
+  }
+  // Unknown / untyped schema — nothing to assert (server stays authoritative).
+}
+
+function validateEnum(
+  schema: JsonSchema,
+  value: JsonValue,
+  path: Path,
+  ctx: Ctx,
+): void {
+  const res = resolveLeafForValidation(value)
+  if (res.kind === 'unresolved') return
+  if (stillTemplated(res.resolved)) return
+  const allowed = schema.enum as JsonValue[]
+  if (!allowed.some((a) => a === res.resolved)) {
+    emit(
+      ctx,
+      path,
+      `must be one of: ${allowed.map((a) => String(a)).join(', ')}`,
+    )
+  }
+}
+
+function validateConst(
+  schema: JsonSchema,
+  value: JsonValue,
+  path: Path,
+  ctx: Ctx,
+): void {
+  const res = resolveLeafForValidation(value)
+  if (res.kind === 'unresolved') return
+  if (stillTemplated(res.resolved)) return
+  if (res.resolved !== (schema.const as JsonValue)) {
+    emit(ctx, path, `must be ${JSON.stringify(schema.const)}`)
+  }
+}
+
+function validateUnion(
+  variants: JsonSchema[],
+  value: JsonValue,
+  path: Path,
+  ctx: Ctx,
+): void {
+  // `Option<T>` → `[T, null]`: validate the inner branch unless the value is null.
+  const inner = nullableUnionInner(variants)
+  if (inner) {
+    if (value === null) return
+    validateNode(inner, value, path, ctx)
+    return
+  }
+  // Discriminated union (adjacently-tagged enum): pick by the tag the value
+  // carries, so we validate the branch the form actually renders.
+  const disc = discriminator(variants)
+  if (disc && isObject(value)) {
+    const tag = (value as Record<string, JsonValue>)[disc.key]
+    const idx = typeof tag === 'string' ? disc.values.indexOf(tag) : -1
+    if (idx === -1) {
+      emit(ctx, path, `must be one of: ${disc.values.join(', ')}`)
+      return
+    }
+    validateNode(variants[idx], value, path, ctx)
+    return
+  }
+  // Heterogeneous union — validate the structurally-matched branch.
+  validateNode(variants[matchVariantIndex(variants, value)], value, path, ctx)
+}
+
+function validateObject(
+  schema: JsonSchema,
+  value: JsonValue,
+  path: Path,
+  ctx: Ctx,
+): void {
+  if (!isObject(value)) {
+    emit(ctx, path, 'must be an object')
+    return
+  }
+  const obj = value as Record<string, JsonValue>
+
+  // `required` is satisfied by key presence on the raw draft — an unresolved
+  // `${VAR}` leaf is still present, so it counts.
+  if (Array.isArray(schema.required)) {
+    for (const key of schema.required as string[]) {
+      if (obj[key] === undefined) {
+        emit(ctx, [...path, key], `"${key}" is a required property`)
+      }
+    }
+  }
+
+  if (isObject(schema.properties)) {
+    const props = schema.properties as Record<string, JsonSchema>
+    for (const [key, propSchema] of Object.entries(props)) {
+      if (!isObject(propSchema)) continue
+      validateNode(propSchema as JsonSchema, obj[key], [...path, key], ctx)
+    }
+    return
+  }
+
+  // Dictionary: `additionalProperties` is a schema applied to every value.
+  const ap = schema.additionalProperties
+  if (isObject(ap)) {
+    for (const [key, child] of Object.entries(obj)) {
+      validateNode(ap as JsonSchema, child, [...path, key], ctx)
+    }
+  }
+}
+
+function validateArray(
+  schema: JsonSchema,
+  value: JsonValue,
+  path: Path,
+  ctx: Ctx,
+): void {
+  if (!Array.isArray(value)) {
+    emit(ctx, path, 'must be an array')
+    return
+  }
+  if (typeof schema.minItems === 'number' && value.length < schema.minItems) {
+    emit(ctx, path, `must have at least ${schema.minItems} item(s)`)
+  }
+  if (typeof schema.maxItems === 'number' && value.length > schema.maxItems) {
+    emit(ctx, path, `must have at most ${schema.maxItems} item(s)`)
+  }
+  if (isObject(schema.items)) {
+    const items = schema.items as JsonSchema
+    value.forEach((el, i) => {
+      validateNode(items, el, [...path, i], ctx)
+    })
+  }
+}
+
+function validateLeaf(
+  schema: JsonSchema,
+  value: JsonValue,
+  path: Path,
+  ctx: Ctx,
+  types: string[],
+): void {
+  const res = resolveLeafForValidation(value)
+  if (res.kind === 'unresolved') return
+  const v = res.resolved
+
+  if (!typeAllowed(v, types)) {
+    emit(ctx, path, typeMessage(types))
+    return
+  }
+
+  // An embedded/mixed template stays a string at runtime; only its type is
+  // knowable client-side, so skip value-shape constraints below.
+  if (stillTemplated(v)) return
+
+  if (typeof v === 'number') {
+    if (typeof schema.minimum === 'number' && v < schema.minimum) {
+      emit(ctx, path, `must be >= ${schema.minimum}`)
+    }
+    if (typeof schema.maximum === 'number' && v > schema.maximum) {
+      emit(ctx, path, `must be <= ${schema.maximum}`)
+    }
+    if (
+      typeof schema.exclusiveMinimum === 'number' &&
+      v <= schema.exclusiveMinimum
+    ) {
+      emit(ctx, path, `must be > ${schema.exclusiveMinimum}`)
+    }
+    if (
+      typeof schema.exclusiveMaximum === 'number' &&
+      v >= schema.exclusiveMaximum
+    ) {
+      emit(ctx, path, `must be < ${schema.exclusiveMaximum}`)
+    }
+  }
+
+  if (typeof v === 'string') {
+    if (typeof schema.minLength === 'number' && v.length < schema.minLength) {
+      emit(ctx, path, `must be at least ${schema.minLength} character(s)`)
+    }
+    if (typeof schema.maxLength === 'number' && v.length > schema.maxLength) {
+      emit(ctx, path, `must be at most ${schema.maxLength} character(s)`)
+    }
+    if (typeof schema.pattern === 'string') {
+      try {
+        if (!new RegExp(schema.pattern).test(v)) {
+          emit(ctx, path, `must match pattern ${schema.pattern}`)
+        }
+      } catch {
+        // Invalid regex in the schema — let the server be the authority.
+      }
+    }
+  }
+}


### PR DESCRIPTION
…latable fields

- Added client-side validation for configuration using `validateConfig` to ensure user inputs are valid before saving.
- Introduced `TemplatableField` to handle both scalar values and environment templates for boolean and numeric fields.
- Updated `WorkerEditor` to display validation errors, including root-level errors, and prevent saving when errors exist.
- Refactored `BooleanField` and `NumberField` to utilize `TemplatableField`, enhancing their functionality with template support.
- Added comprehensive tests for the new validation logic to ensure correctness and reliability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client-side JSON Schema validation to the Workers editor with inline field error display and a root-level error message; save is blocked when client validation fails.
  * Introduced an env-template mode toggle for scalar inputs (boolean and number) via a shared templatable field renderer.
* **Bug Fixes**
  * Validation now reports errors at the exact JSON field path, including correctly escaped nested keys, matching engine expectations for typed templates, enums/unions, nullable values, and dictionaries.
* **Tests**
  * Added a comprehensive test suite covering scalar coercion, placeholder resolution rules, enum/union behavior, nested pointer paths, and discriminated `oneOf` validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->