### PR TITLE
feat(provider-xai): xAI Agent Tools (live X/web) with console toggle

### DIFF
--- a/provider-xai/src/config.rs
+++ b/provider-xai/src/config.rs
@@ -11,6 +11,30 @@ use serde_json::Value;
 pub const DEFAULT_API_URL: &str = "https://api.x.ai/v1/chat/completions";
 pub const DEFAULT_MAX_TOKENS: u64 = 8192;
 
+/// The xAI server-side tools we support on the `/v1/responses` path. An enum
+/// so the config schema (and thus the console + deserialize path) rejects an
+/// unknown tool name before it can be stored or forwarded to the API.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolSource {
+    XSearch,
+    WebSearch,
+    CodeInterpreter,
+    CollectionsSearch,
+}
+
+impl ToolSource {
+    /// The `type` string sent in the `/v1/responses` `tools` array.
+    pub fn as_type(self) -> &'static str {
+        match self {
+            ToolSource::XSearch => "x_search",
+            ToolSource::WebSearch => "web_search",
+            ToolSource::CodeInterpreter => "code_interpreter",
+            ToolSource::CollectionsSearch => "collections_search",
+        }
+    }
+}
+
 /// Operator-tunable worker config, registered with the `configuration` worker
 /// so it renders as an editable item in the console configuration sidebar.
 /// Distinct from the per-request `XaiConfig` (credentials/url/max_tokens come
@@ -22,16 +46,15 @@ pub struct WorkerConfig {
     /// Enable xAI Agent Tools (live X / web search via the /v1/responses API).
     /// Off = the provider is a plain Chat Completions inference wrapper.
     pub tools_enabled: bool,
-    /// Server-side tools offered when enabled: x_search, web_search,
-    /// code_interpreter, collections_search.
-    pub tool_sources: Vec<String>,
+    /// Server-side tools offered when enabled.
+    pub tool_sources: Vec<ToolSource>,
 }
 
 impl Default for WorkerConfig {
     fn default() -> Self {
         Self {
             tools_enabled: false,
-            tool_sources: vec!["x_search".to_string(), "web_search".to_string()],
+            tool_sources: vec![ToolSource::XSearch, ToolSource::WebSearch],
         }
     }
 }
@@ -133,6 +156,22 @@ pub fn config_from_resolve(
 mod tests {
     use super::*;
     use llm_router::types::router::CredentialSource;
+
+    #[test]
+    fn worker_config_rejects_unknown_tool_and_maps_types() {
+        // valid enum values round-trip and carry the right API type strings
+        let cfg = WorkerConfig::from_json(&serde_json::json!({ "tools_enabled": true,
+                "tool_sources": ["x_search", "code_interpreter"] }))
+        .unwrap();
+        assert!(cfg.tools_enabled);
+        assert_eq!(cfg.tool_sources[0].as_type(), "x_search");
+        assert_eq!(cfg.tool_sources[1].as_type(), "code_interpreter");
+        // an unknown tool name is rejected at the deserialize boundary
+        assert!(
+            WorkerConfig::from_json(&serde_json::json!({ "tool_sources": ["not_a_tool"] }))
+                .is_err()
+        );
+    }
 
     fn resolved(
         credential: Option<Credential>,

--- a/provider-xai/src/config.rs
+++ b/provider-xai/src/config.rs
@@ -4,9 +4,50 @@
 //! `max_tokens` (from resolve) → the worker default.
 use llm_router::types::credential::Credential;
 use llm_router::types::router::ProviderResolveResponse;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 pub const DEFAULT_API_URL: &str = "https://api.x.ai/v1/chat/completions";
 pub const DEFAULT_MAX_TOKENS: u64 = 8192;
+
+/// Operator-tunable worker config, registered with the `configuration` worker
+/// so it renders as an editable item in the console configuration sidebar.
+/// Distinct from the per-request `XaiConfig` (credentials/url/max_tokens come
+/// from the llm-router resolve step); this only governs xAI's Agent Tools
+/// (server-side `x_search` / `web_search` on the `/v1/responses` API).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
+pub struct WorkerConfig {
+    /// Enable xAI Agent Tools (live X / web search via the /v1/responses API).
+    /// Off = the provider is a plain Chat Completions inference wrapper.
+    pub tools_enabled: bool,
+    /// Server-side tools offered when enabled: x_search, web_search,
+    /// code_interpreter, collections_search.
+    pub tool_sources: Vec<String>,
+}
+
+impl Default for WorkerConfig {
+    fn default() -> Self {
+        Self {
+            tools_enabled: false,
+            tool_sources: vec!["x_search".to_string(), "web_search".to_string()],
+        }
+    }
+}
+
+impl WorkerConfig {
+    pub fn json_schema() -> Value {
+        let root = schemars::gen::SchemaGenerator::default().into_root_schema_for::<WorkerConfig>();
+        serde_json::to_value(root).expect("config schema serializes")
+    }
+    pub fn to_json(&self) -> Value {
+        serde_json::to_value(self).expect("config serializes")
+    }
+    pub fn from_json(value: &Value) -> Result<WorkerConfig, serde_json::Error> {
+        serde_json::from_value(value.clone())
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct XaiConfig {

--- a/provider-xai/src/configuration.rs
+++ b/provider-xai/src/configuration.rs
@@ -1,0 +1,154 @@
+//! Integration with the `configuration` worker — register the provider-xai
+//! worker-config schema (Agent Tools toggle), fetch the live value, and
+//! hot-reload it on change so an operator can flip tools on/off in the console
+//! configuration sidebar without a restart. Unlike credentials (router-owned),
+//! this is provider behaviour, so it lives in the worker's own config entry.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::{IIIClient, RegisterFunction};
+use serde_json::{json, Value};
+use tokio::sync::RwLock;
+
+use crate::config::WorkerConfig;
+
+/// Hot-swappable config snapshot shared with the stream handler.
+pub type ConfigCell = Arc<RwLock<Arc<WorkerConfig>>>;
+
+pub const CONFIG_ID: &str = "provider-xai";
+const CONFIG_FN_ID: &str = "provider::xai::on-config-change";
+const CONFIG_TIMEOUT_MS: u64 = 5_000;
+const CONFIG_RETRIES: u32 = 3;
+
+pub fn new_cell() -> ConfigCell {
+    Arc::new(RwLock::new(Arc::new(WorkerConfig::default())))
+}
+
+/// Register the `provider-xai` configuration schema, seeding the default only
+/// when no stored value exists yet.
+pub async fn register_config(iii: &IIIClient) -> Result<(), String> {
+    let mut payload = json!({
+        "id": CONFIG_ID,
+        "name": "xAI Provider",
+        "description": "xAI provider behaviour: enable Agent Tools (live X / web search via the /v1/responses API) and pick which server-side tools to offer. Credentials and endpoints are managed by the llm-router configuration entry, not here.",
+        "schema": WorkerConfig::json_schema(),
+    });
+    if should_seed_default(iii).await? {
+        payload["initial_value"] = WorkerConfig::default().to_json();
+    }
+    trigger_with_retry(iii, "configuration::register", payload).await?;
+    Ok(())
+}
+
+pub async fn fetch_config(iii: &IIIClient) -> Result<WorkerConfig, String> {
+    match try_get_value(iii).await? {
+        Some(v) if !v.is_null() => WorkerConfig::from_json(&v).map_err(|e| e.to_string()),
+        _ => Ok(WorkerConfig::default()),
+    }
+}
+
+async fn should_seed_default(iii: &IIIClient) -> Result<bool, String> {
+    Ok(matches!(
+        try_get_value(iii).await?,
+        None | Some(Value::Null)
+    ))
+}
+
+/// `Ok(None)` when the entry does not exist (`NOT_FOUND`).
+async fn try_get_value(iii: &IIIClient) -> Result<Option<Value>, String> {
+    match trigger_with_retry(iii, "configuration::get", json!({ "id": CONFIG_ID })).await {
+        Ok(resp) => Ok(resp.get("value").cloned()),
+        Err(e) if e.contains("NOT_FOUND") => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+pub async fn apply_config(cell: &ConfigCell, cfg: WorkerConfig) {
+    *cell.write().await = Arc::new(cfg);
+}
+
+/// Register the internal config-change handler and bind the `configuration`
+/// trigger that wakes it.
+pub fn register_config_trigger(iii: &IIIClient, cell: ConfigCell) -> Result<(), Error> {
+    let engine = iii.clone();
+    iii.register_function(
+        CONFIG_FN_ID,
+        RegisterFunction::new_async(move |_payload: Value| {
+            let cell = cell.clone();
+            let engine = engine.clone();
+            async move {
+                on_config_change(&engine, &cell).await;
+                Ok::<Value, Error>(json!({ "ok": true }))
+            }
+        })
+        .request_format(json!({ "type": "object", "properties": {} }))
+        .response_format(json!({
+            "type": "object",
+            "properties": { "ok": { "type": "boolean" } },
+        }))
+        .description("Internal: reload provider-xai configuration when it changes."),
+    );
+
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: "configuration".to_string(),
+        function_id: CONFIG_FN_ID.to_string(),
+        config: json!({
+            "configuration_id": CONFIG_ID,
+            "event_types": ["configuration:updated"],
+        }),
+        metadata: None,
+    })?;
+    Ok(())
+}
+
+/// Re-fetch the authoritative value after trigger registration to close the
+/// boot race.
+pub async fn reconcile(iii: &IIIClient, cell: &ConfigCell) {
+    on_config_change(iii, cell).await;
+}
+
+async fn on_config_change(iii: &IIIClient, cell: &ConfigCell) {
+    match fetch_config(iii).await {
+        Ok(cfg) => {
+            apply_config(cell, cfg).await;
+            tracing::info!("provider-xai configuration reloaded");
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "config-change: fetch failed; keeping previous config");
+        }
+    }
+}
+
+async fn trigger_with_retry(
+    iii: &IIIClient,
+    function_id: &str,
+    payload: Value,
+) -> Result<Value, String> {
+    let mut last_err = String::new();
+    for attempt in 1..=CONFIG_RETRIES {
+        match iii
+            .trigger(TriggerRequest {
+                function_id: function_id.to_string(),
+                payload: payload.clone(),
+                action: None,
+                timeout_ms: Some(CONFIG_TIMEOUT_MS),
+            })
+            .await
+        {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                last_err = e.to_string();
+                if attempt < CONFIG_RETRIES {
+                    let backoff = 250u64 << (attempt - 1);
+                    tokio::time::sleep(Duration::from_millis(backoff)).await;
+                }
+            }
+        }
+    }
+    Err(format!(
+        "{function_id} failed after {CONFIG_RETRIES} attempts: {last_err}"
+    ))
+}

--- a/provider-xai/src/lib.rs
+++ b/provider-xai/src/lib.rs
@@ -2,6 +2,7 @@
 //! Spec: tech-specs/2026-06-agentic/llm-router.md § The provider protocol.
 
 pub mod config;
+pub mod configuration;
 pub mod curated;
 pub mod discovery;
 pub mod errors;

--- a/provider-xai/src/lib.rs
+++ b/provider-xai/src/lib.rs
@@ -9,6 +9,7 @@ pub mod manifest;
 pub mod reasoning;
 pub mod register;
 pub mod request;
+pub mod responses;
 pub mod router_client;
 pub mod sse;
 pub mod state;

--- a/provider-xai/src/register.rs
+++ b/provider-xai/src/register.rs
@@ -116,14 +116,31 @@ pub async fn register_provider(iii: IIIClient) -> Result<(), Error> {
     // schema register + first fetch run off the boot path (the configuration
     // worker may not be up yet).
     let cell = crate::configuration::new_cell();
-    let _ = crate::configuration::register_config_trigger(&iii, cell.clone());
+    if let Err(e) = crate::configuration::register_config_trigger(&iii, cell.clone()) {
+        eprintln!("[provider-xai] config-change trigger registration failed ({e})");
+    }
     {
         let (iii_cfg, cell_cfg) = (iii.clone(), cell.clone());
         tokio::spawn(async move {
-            if let Err(e) = crate::configuration::register_config(&iii_cfg).await {
-                eprintln!("[provider-xai] register_config failed ({e})");
+            // Retry until the configuration worker is reachable, so the console
+            // config is eventually loaded and `make_stream` never serves the
+            // default snapshot forever when the config bus was down at boot.
+            let mut delay = Duration::from_millis(500);
+            loop {
+                match crate::configuration::register_config(&iii_cfg).await {
+                    Ok(()) => {
+                        crate::configuration::reconcile(&iii_cfg, &cell_cfg).await;
+                        return;
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "[provider-xai] config bootstrap failed ({e}); retrying in {delay:?}"
+                        );
+                        tokio::time::sleep(delay).await;
+                        delay = (delay * 2).min(Duration::from_secs(10));
+                    }
+                }
             }
-            crate::configuration::reconcile(&iii_cfg, &cell_cfg).await;
         });
     }
 

--- a/provider-xai/src/register.rs
+++ b/provider-xai/src/register.rs
@@ -111,10 +111,26 @@ pub async fn register_provider(iii: IIIClient) -> Result<(), Error> {
         .build()
         .expect("reqwest client");
 
+    // Worker-config cell (Agent Tools toggle): register its schema + hot-reload
+    // trigger so operators flip live X/web tools in the console sidebar. The
+    // schema register + first fetch run off the boot path (the configuration
+    // worker may not be up yet).
+    let cell = crate::configuration::new_cell();
+    let _ = crate::configuration::register_config_trigger(&iii, cell.clone());
+    {
+        let (iii_cfg, cell_cfg) = (iii.clone(), cell.clone());
+        tokio::spawn(async move {
+            if let Err(e) = crate::configuration::register_config(&iii_cfg).await {
+                eprintln!("[provider-xai] register_config failed ({e})");
+            }
+            crate::configuration::reconcile(&iii_cfg, &cell_cfg).await;
+        });
+    }
+
     iii.register_function(
         surface::STREAM_ID,
         RegisterFunction::new_async_with_bad_request(
-            make_stream(iii.clone(), http.clone()),
+            make_stream(iii.clone(), http.clone(), cell.clone()),
             invalid_request_from_serde,
         )
         .description(surface::STREAM_DESC),

--- a/provider-xai/src/responses.rs
+++ b/provider-xai/src/responses.rs
@@ -1,0 +1,385 @@
+//! xAI Agent Tools path: the `/v1/responses` API (server-side tools like
+//! `x_search` / `web_search`), distinct from the OpenAI-compatible
+//! `/v1/chat/completions` path in `request.rs` + `sse.rs`.
+//!
+//! xAI deprecated the old `search_parameters` "Live Search"; real-time X/web
+//! now comes from server-side tools on `/v1/responses`. This module builds the
+//! request body and translates the Responses streaming events into the shared
+//! `AssistantMessageEvent` sequence. Event shapes captured live from
+//! api.x.ai (2026-07): `response.reasoning_summary_text.delta`,
+//! `response.output_text.delta`, `response.output_text.annotation.added`
+//! (`url_citation`), `response.custom_tool_call_input.*` (the searches), and
+//! `response.completed` (final, with usage).
+
+use crate::wire::messages::to_wire_messages;
+use crate::wire::names::decode_tool_name;
+use crate::{now_ms, PROVIDER_ID};
+use llm_router::types::content::ContentBlock;
+use llm_router::types::events::{AssistantMessageEvent, StopReason, Usage};
+use llm_router::types::messages::{AgentMessage, AssistantMessage, AssistantRoleTag};
+use serde_json::{json, Value};
+
+/// Derive the `/v1/responses` endpoint from the configured completions URL
+/// (`…/v1/chat/completions` → `…/v1/responses`).
+pub fn responses_url(api_url: &str) -> String {
+    match api_url.strip_suffix("/chat/completions") {
+        Some(base) => format!("{base}/responses"),
+        None => "https://api.x.ai/v1/responses".to_string(),
+    }
+}
+
+/// Build the `/v1/responses` request body. `tools` are xAI server-side tool
+/// type strings (`x_search`, `web_search`, `code_interpreter`, …). The
+/// `input` array reuses the shared chat-wire message shape (`{role, content}`),
+/// which the Responses API accepts verbatim.
+pub fn build_responses_body(
+    model: &str,
+    system_prompt: &str,
+    messages: &[AgentMessage],
+    tools: &[String],
+    max_tokens: u64,
+) -> Value {
+    let input = to_wire_messages(messages, system_prompt);
+    let tool_specs: Vec<Value> = tools.iter().map(|t| json!({ "type": t })).collect();
+    json!({
+        "model": model,
+        "input": input,
+        "tools": tool_specs,
+        "max_output_tokens": max_tokens,
+        "stream": true,
+    })
+}
+
+/// Accumulated Responses-stream state; folded into the terminal message.
+pub struct ResponsesState {
+    thinking: String,
+    text: String,
+    /// `url_citation` targets gathered from annotations, in arrival order.
+    citations: Vec<String>,
+    /// Server-side tool calls seen (e.g. `x_search`), for a report line.
+    tool_calls: Vec<String>,
+    open_thinking: bool,
+    open_text: bool,
+    usage: Usage,
+    usage_seen: bool,
+    stop_reason: StopReason,
+    warnings: Vec<String>,
+}
+
+impl ResponsesState {
+    pub fn new(warnings: Vec<String>) -> Self {
+        ResponsesState {
+            thinking: String::new(),
+            text: String::new(),
+            citations: Vec::new(),
+            tool_calls: Vec::new(),
+            open_thinking: false,
+            open_text: false,
+            usage: Usage::default(),
+            usage_seen: false,
+            stop_reason: StopReason::End,
+            warnings,
+        }
+    }
+    pub fn stop_reason(&self) -> StopReason {
+        self.stop_reason
+    }
+}
+
+fn content(state: &ResponsesState) -> Vec<ContentBlock> {
+    let mut out = Vec::new();
+    if !state.thinking.is_empty() {
+        out.push(ContentBlock::Thinking {
+            text: state.thinking.clone(),
+            signature: None,
+        });
+    }
+    if !state.text.is_empty() {
+        out.push(ContentBlock::Text {
+            text: state.text.clone(),
+        });
+    }
+    out
+}
+
+fn partial(state: &ResponsesState, model: &str) -> AssistantMessage {
+    // Citations ride the warnings channel (report-and-continue): the shared
+    // AssistantMessage has no dedicated citation field, and warnings already
+    // surface non-fatal side-band info to the console.
+    let mut warnings = state.warnings.clone();
+    if !state.citations.is_empty() {
+        warnings.push(format!("citations: {}", state.citations.join(", ")));
+    }
+    AssistantMessage {
+        role: AssistantRoleTag::Assistant,
+        content: content(state),
+        stop_reason: state.stop_reason,
+        native_stop_reason: None,
+        error_message: None,
+        error_kind: None,
+        warnings: (!warnings.is_empty()).then_some(warnings),
+        usage: state.usage_seen.then(|| state.usage.clone()),
+        model: model.to_string(),
+        provider: PROVIDER_ID.to_string(),
+        timestamp: now_ms(),
+    }
+}
+
+pub fn build_final(state: &ResponsesState, model: &str) -> AssistantMessage {
+    partial(state, model)
+}
+
+fn close_thinking(state: &mut ResponsesState, model: &str, out: &mut Vec<AssistantMessageEvent>) {
+    if state.open_thinking {
+        state.open_thinking = false;
+        out.push(AssistantMessageEvent::ThinkingEnd {
+            partial: partial(state, model),
+        });
+    }
+}
+
+/// Process one parsed Responses SSE event into 0+ AssistantMessageEvents.
+/// `event_type` is the SSE `event:` name; `data` its JSON payload.
+pub fn handle_event(
+    event_type: &str,
+    data: &Value,
+    state: &mut ResponsesState,
+    model: &str,
+) -> Vec<AssistantMessageEvent> {
+    let mut out = Vec::new();
+    match event_type {
+        "response.reasoning_summary_text.delta" => {
+            let delta = data.get("delta").and_then(Value::as_str).unwrap_or("");
+            if !delta.is_empty() {
+                if !state.open_thinking {
+                    state.open_thinking = true;
+                    out.push(AssistantMessageEvent::ThinkingStart {
+                        partial: partial(state, model),
+                    });
+                }
+                state.thinking.push_str(delta);
+                out.push(AssistantMessageEvent::ThinkingDelta {
+                    partial: partial(state, model),
+                    delta: delta.to_string(),
+                });
+            }
+        }
+        "response.custom_tool_call_input.done" => {
+            // Record which server-side tool ran (name may carry the search).
+            if let Some(name) = data.get("name").and_then(Value::as_str) {
+                state.tool_calls.push(decode_tool_name(name));
+            }
+        }
+        "response.output_text.delta" => {
+            let delta = data.get("delta").and_then(Value::as_str).unwrap_or("");
+            if !delta.is_empty() {
+                close_thinking(state, model, &mut out);
+                if !state.open_text {
+                    state.open_text = true;
+                    out.push(AssistantMessageEvent::TextStart {
+                        partial: partial(state, model),
+                    });
+                }
+                state.text.push_str(delta);
+                out.push(AssistantMessageEvent::TextDelta {
+                    partial: partial(state, model),
+                    delta: delta.to_string(),
+                });
+            }
+        }
+        "response.output_text.annotation.added" => {
+            if let Some(url) = data.pointer("/annotation/url").and_then(Value::as_str) {
+                state.citations.push(url.to_string());
+            }
+        }
+        "response.output_text.done" => {
+            if state.open_text {
+                state.open_text = false;
+                out.push(AssistantMessageEvent::TextEnd {
+                    partial: partial(state, model),
+                });
+            }
+        }
+        "response.completed" => {
+            close_thinking(state, model, &mut out);
+            if let Some(u) = data.pointer("/response/usage").filter(|u| u.is_object()) {
+                merge_usage(u, &mut state.usage);
+                state.usage_seen = true;
+                out.push(AssistantMessageEvent::Usage {
+                    usage: state.usage.clone(),
+                });
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
+/// Map the Responses usage object onto the shared `Usage`.
+fn merge_usage(raw: &Value, into: &mut Usage) {
+    let num = |k: &str| raw.get(k).and_then(Value::as_u64);
+    if let Some(v) = num("input_tokens") {
+        into.input = Some(v);
+    }
+    if let Some(v) = num("output_tokens") {
+        into.output = Some(v);
+    }
+    if let Some(v) = raw
+        .pointer("/input_tokens_details/cached_tokens")
+        .and_then(Value::as_u64)
+    {
+        into.cache_read = Some(v);
+    }
+    if let Some(v) = raw
+        .pointer("/output_tokens_details/reasoning_tokens")
+        .and_then(Value::as_u64)
+    {
+        into.reasoning = Some(v);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn user(text: &str) -> AgentMessage {
+        AgentMessage::User(llm_router::types::messages::UserMessage {
+            role: llm_router::types::messages::UserRoleTag::User,
+            content: vec![ContentBlock::Text { text: text.into() }],
+            timestamp: 0,
+        })
+    }
+
+    #[test]
+    fn responses_url_derives_from_completions() {
+        assert_eq!(
+            responses_url("https://api.x.ai/v1/chat/completions"),
+            "https://api.x.ai/v1/responses"
+        );
+        assert_eq!(
+            responses_url("http://127.0.0.1:9/v1/chat/completions"),
+            "http://127.0.0.1:9/v1/responses"
+        );
+        assert_eq!(
+            responses_url("https://p/custom"),
+            "https://api.x.ai/v1/responses"
+        );
+    }
+
+    #[test]
+    fn body_carries_input_and_tools() {
+        let b = build_responses_body(
+            "grok-4.3",
+            "be brief",
+            &[user("hi")],
+            &["x_search".into(), "web_search".into()],
+            8192,
+        );
+        assert_eq!(b["model"], "grok-4.3");
+        assert_eq!(b["stream"], true);
+        assert_eq!(b["input"][0]["role"], "system");
+        assert_eq!(b["input"][1]["role"], "user");
+        assert_eq!(b["input"][1]["content"], "hi");
+        assert_eq!(b["tools"][0]["type"], "x_search");
+        assert_eq!(b["tools"][1]["type"], "web_search");
+    }
+
+    fn run(events: &[(&str, Value)]) -> (ResponsesState, Vec<AssistantMessageEvent>) {
+        let mut st = ResponsesState::new(vec![]);
+        let mut evs = Vec::new();
+        for (t, d) in events {
+            evs.extend(handle_event(t, d, &mut st, "grok-4.3"));
+        }
+        (st, evs)
+    }
+
+    fn tags(evs: &[AssistantMessageEvent]) -> Vec<&'static str> {
+        evs.iter()
+            .map(|e| match e {
+                AssistantMessageEvent::ThinkingStart { .. } => "thinking_start",
+                AssistantMessageEvent::ThinkingDelta { .. } => "thinking_delta",
+                AssistantMessageEvent::ThinkingEnd { .. } => "thinking_end",
+                AssistantMessageEvent::TextStart { .. } => "text_start",
+                AssistantMessageEvent::TextDelta { .. } => "text_delta",
+                AssistantMessageEvent::TextEnd { .. } => "text_end",
+                AssistantMessageEvent::Usage { .. } => "usage",
+                _ => "other",
+            })
+            .collect()
+    }
+
+    #[test]
+    fn reasoning_then_text_with_citation_and_usage() {
+        let (state, evs) = run(&[
+            (
+                "response.reasoning_summary_text.delta",
+                json!({"delta":"think"}),
+            ),
+            (
+                "response.custom_tool_call_input.done",
+                json!({"name":"x_search"}),
+            ),
+            ("response.output_text.delta", json!({"delta":"World Cup"})),
+            (
+                "response.output_text.annotation.added",
+                json!({"annotation":{"type":"url_citation","url":"https://x.com/i/status/1"}}),
+            ),
+            ("response.output_text.done", json!({})),
+            (
+                "response.completed",
+                json!({"response":{"usage":{"input_tokens":10,"output_tokens":4,
+                    "output_tokens_details":{"reasoning_tokens":2}}}}),
+            ),
+        ]);
+        assert_eq!(
+            tags(&evs),
+            vec![
+                "thinking_start",
+                "thinking_delta",
+                "thinking_end",
+                "text_start",
+                "text_delta",
+                "text_end",
+                "usage",
+            ]
+        );
+        let f = build_final(&state, "grok-4.3");
+        assert_eq!(
+            f.content,
+            vec![
+                ContentBlock::Thinking {
+                    text: "think".into(),
+                    signature: None
+                },
+                ContentBlock::Text {
+                    text: "World Cup".into()
+                },
+            ]
+        );
+        // citation surfaced on warnings
+        assert!(f
+            .warnings
+            .unwrap()
+            .iter()
+            .any(|w| w.contains("https://x.com/i/status/1")));
+        let u = f.usage.unwrap();
+        assert_eq!(u.input, Some(10));
+        assert_eq!(u.output, Some(4));
+        assert_eq!(u.reasoning, Some(2));
+        assert_eq!(state.tool_calls, vec!["x_search"]);
+    }
+
+    #[test]
+    fn unknown_events_are_ignored() {
+        let (_s, evs) = run(&[
+            ("response.created", json!({})),
+            ("response.in_progress", json!({})),
+            (
+                "response.output_item.added",
+                json!({"item":{"type":"reasoning"}}),
+            ),
+        ]);
+        assert!(evs.is_empty());
+    }
+}

--- a/provider-xai/src/responses.rs
+++ b/provider-xai/src/responses.rs
@@ -11,13 +11,17 @@
 //! (`url_citation`), `response.custom_tool_call_input.*` (the searches), and
 //! `response.completed` (final, with usage).
 
+use crate::errors::classify;
+use crate::sse::synthetic_error_event;
 use crate::wire::messages::to_wire_messages;
 use crate::wire::names::decode_tool_name;
 use crate::{now_ms, PROVIDER_ID};
+use futures::StreamExt;
 use llm_router::types::content::ContentBlock;
-use llm_router::types::events::{AssistantMessageEvent, StopReason, Usage};
+use llm_router::types::events::{AssistantMessageEvent, ErrorKind, StopReason, Usage};
 use llm_router::types::messages::{AgentMessage, AssistantMessage, AssistantRoleTag};
 use serde_json::{json, Value};
+use tokio::sync::mpsc;
 
 /// Derive the `/v1/responses` endpoint from the configured completions URL
 /// (`…/v1/chat/completions` → `…/v1/responses`).
@@ -192,13 +196,11 @@ pub fn handle_event(
                 state.citations.push(url.to_string());
             }
         }
-        "response.output_text.done" => {
-            if state.open_text {
-                state.open_text = false;
-                out.push(AssistantMessageEvent::TextEnd {
-                    partial: partial(state, model),
-                });
-            }
+        "response.output_text.done" if state.open_text => {
+            state.open_text = false;
+            out.push(AssistantMessageEvent::TextEnd {
+                partial: partial(state, model),
+            });
         }
         "response.completed" => {
             close_thinking(state, model, &mut out);
@@ -236,6 +238,148 @@ fn merge_usage(raw: &Value, into: &mut Usage) {
     {
         into.reasoning = Some(v);
     }
+}
+
+/// Parse an SSE block into `(event_name, data_json_str)`. Responses events are
+/// `event: <name>\ndata: <json>`.
+fn event_and_data(block: &str) -> Option<(&str, &str)> {
+    let mut ev = None;
+    let mut data = None;
+    for line in block.lines() {
+        if let Some(v) = line.strip_prefix("event: ") {
+            ev = Some(v.trim());
+        } else if let Some(v) = line.strip_prefix("data: ") {
+            data = Some(v);
+        }
+    }
+    match (ev, data) {
+        (Some(e), Some(d)) => Some((e, d)),
+        _ => None,
+    }
+}
+
+pub struct ResponsesUpstreamArgs {
+    pub api_url: String,
+    pub model: String,
+    pub body: Value,
+    pub headers: Vec<(&'static str, String)>,
+    pub warnings: Vec<String>,
+}
+
+/// POST `/v1/responses` (stream) → SSE → mpsc<AssistantMessageEvent>. Mirrors
+/// `upstream::spawn_upstream` but parses the Responses `event:`/`data:` frames.
+pub fn spawn_responses_upstream(
+    client: reqwest::Client,
+    args: ResponsesUpstreamArgs,
+) -> mpsc::Receiver<AssistantMessageEvent> {
+    let (tx, rx) = mpsc::channel(64);
+    tokio::spawn(async move {
+        run_responses_upstream(client, args, tx).await;
+    });
+    rx
+}
+
+async fn run_responses_upstream(
+    client: reqwest::Client,
+    args: ResponsesUpstreamArgs,
+    tx: mpsc::Sender<AssistantMessageEvent>,
+) {
+    let mut req = client.post(&args.api_url);
+    for (name, value) in &args.headers {
+        req = req.header(*name, value);
+    }
+    let resp = match req.json(&args.body).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            let _ = tx
+                .send(synthetic_error_event(
+                    &format!("xai responses fetch failed: {e}"),
+                    &args.model,
+                    ErrorKind::Transient,
+                ))
+                .await;
+            return;
+        }
+    };
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        let kind = classify(Some(status.as_u16()), &text);
+        let msg = if text.is_empty() {
+            format!("xai responses http {status}")
+        } else {
+            text
+        };
+        let _ = tx
+            .send(synthetic_error_event(&msg, &args.model, kind))
+            .await;
+        return;
+    }
+
+    let mut state = ResponsesState::new(args.warnings);
+    if tx
+        .send(AssistantMessageEvent::Start {
+            partial: partial(&state, &args.model),
+        })
+        .await
+        .is_err()
+    {
+        return;
+    }
+
+    let mut stream = resp.bytes_stream();
+    let mut buf = String::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = match chunk {
+            Ok(c) => c,
+            Err(e) => {
+                let _ = tx
+                    .send(synthetic_error_event(
+                        &format!("stream read failed: {e}"),
+                        &args.model,
+                        ErrorKind::Transient,
+                    ))
+                    .await;
+                return;
+            }
+        };
+        buf.push_str(&String::from_utf8_lossy(&chunk));
+        while let Some(idx) = buf.find("\n\n") {
+            let block: String = buf.drain(..idx + 2).collect();
+            let Some((event_type, data)) = event_and_data(&block) else {
+                continue;
+            };
+            let Ok(parsed) = serde_json::from_str::<Value>(data) else {
+                continue;
+            };
+            for ev in handle_event(event_type, &parsed, &mut state, &args.model) {
+                if tx.send(ev).await.is_err() {
+                    return;
+                }
+            }
+            if event_type == "response.completed" {
+                let _ = tx
+                    .send(AssistantMessageEvent::Stop {
+                        stop_reason: state.stop_reason(),
+                        error_message: None,
+                        error_kind: None,
+                    })
+                    .await;
+                let _ = tx
+                    .send(AssistantMessageEvent::Done {
+                        message: build_final(&state, &args.model),
+                    })
+                    .await;
+                return;
+            }
+        }
+    }
+    // Stream ended without response.completed: still terminal.
+    let _ = tx
+        .send(AssistantMessageEvent::Done {
+            message: build_final(&state, &args.model),
+        })
+        .await;
 }
 
 #[cfg(test)]

--- a/provider-xai/src/responses.rs
+++ b/provider-xai/src/responses.rs
@@ -24,11 +24,17 @@ use serde_json::{json, Value};
 use tokio::sync::mpsc;
 
 /// Derive the `/v1/responses` endpoint from the configured completions URL
-/// (`…/v1/chat/completions` → `…/v1/responses`).
+/// (`…/v1/chat/completions` → `…/v1/responses`). When the configured URL does
+/// not have the expected `/chat/completions` suffix (a custom origin), keep
+/// that origin and swap the trailing path segment to `responses` rather than
+/// silently jumping to the public xAI endpoint.
 pub fn responses_url(api_url: &str) -> String {
-    match api_url.strip_suffix("/chat/completions") {
-        Some(base) => format!("{base}/responses"),
-        None => "https://api.x.ai/v1/responses".to_string(),
+    if let Some(base) = api_url.strip_suffix("/chat/completions") {
+        return format!("{base}/responses");
+    }
+    match api_url.rsplit_once('/') {
+        Some((base, _last)) if !base.is_empty() => format!("{base}/responses"),
+        _ => "https://api.x.ai/v1/responses".to_string(),
     }
 }
 
@@ -111,6 +117,9 @@ fn partial(state: &ResponsesState, model: &str) -> AssistantMessage {
     // AssistantMessage has no dedicated citation field, and warnings already
     // surface non-fatal side-band info to the console.
     let mut warnings = state.warnings.clone();
+    if !state.tool_calls.is_empty() {
+        warnings.push(format!("tools used: {}", state.tool_calls.join(", ")));
+    }
     if !state.citations.is_empty() {
         warnings.push(format!("citations: {}", state.citations.join(", ")));
     }
@@ -240,6 +249,11 @@ fn merge_usage(raw: &Value, into: &mut Usage) {
     }
 }
 
+/// Byte offset of the first `\n\n` SSE frame terminator, if present.
+fn find_frame_boundary(buf: &[u8]) -> Option<usize> {
+    buf.windows(2).position(|w| w == b"\n\n")
+}
+
 /// Parse an SSE block into `(event_name, data_json_str)`. Responses events are
 /// `event: <name>\ndata: <json>`.
 fn event_and_data(block: &str) -> Option<(&str, &str)> {
@@ -328,7 +342,10 @@ async fn run_responses_upstream(
     }
 
     let mut stream = resp.bytes_stream();
-    let mut buf = String::new();
+    // Accumulate raw bytes and only decode a complete SSE frame (up to the
+    // `\n\n` boundary) as UTF-8, so a multi-byte character split across two
+    // network chunks is never corrupted — X content is unicode-heavy.
+    let mut buf: Vec<u8> = Vec::new();
     while let Some(chunk) = stream.next().await {
         let chunk = match chunk {
             Ok(c) => c,
@@ -343,9 +360,10 @@ async fn run_responses_upstream(
                 return;
             }
         };
-        buf.push_str(&String::from_utf8_lossy(&chunk));
-        while let Some(idx) = buf.find("\n\n") {
-            let block: String = buf.drain(..idx + 2).collect();
+        buf.extend_from_slice(&chunk);
+        while let Some(idx) = find_frame_boundary(&buf) {
+            let frame: Vec<u8> = buf.drain(..idx + 2).collect();
+            let block = String::from_utf8_lossy(&frame);
             let Some((event_type, data)) = event_and_data(&block) else {
                 continue;
             };
@@ -374,11 +392,15 @@ async fn run_responses_upstream(
             }
         }
     }
-    // Stream ended without response.completed: still terminal.
+    // Stream ended without `response.completed`: the turn was truncated, not
+    // completed. Surface a transient error so callers can distinguish this from
+    // a real terminal completion (and retry).
     let _ = tx
-        .send(AssistantMessageEvent::Done {
-            message: build_final(&state, &args.model),
-        })
+        .send(synthetic_error_event(
+            "xai responses stream ended before completion",
+            &args.model,
+            ErrorKind::Transient,
+        ))
         .await;
 }
 
@@ -405,9 +427,11 @@ mod tests {
             responses_url("http://127.0.0.1:9/v1/chat/completions"),
             "http://127.0.0.1:9/v1/responses"
         );
+        // custom origin without the chat/completions suffix: keep the origin,
+        // swap the trailing segment — never silently jump to public xAI.
         assert_eq!(
-            responses_url("https://p/custom"),
-            "https://api.x.ai/v1/responses"
+            responses_url("https://proxy.internal/v1/foo"),
+            "https://proxy.internal/v1/responses"
         );
     }
 

--- a/provider-xai/src/stream_fn.rs
+++ b/provider-xai/src/stream_fn.rs
@@ -2,9 +2,13 @@
 //! contract): write AssistantMessageEvent frames as JSON text messages into
 //! the router-owned channel, terminal done/error last, then close.
 use crate::config::config_from_resolve;
+use crate::configuration::ConfigCell;
 use crate::errors::classify_bus_error;
 use crate::reasoning::{is_reasoning_model, reasoning_effort_for};
 use crate::request::{build_body, build_headers, BodyArgs};
+use crate::responses::{
+    build_responses_body, responses_url, spawn_responses_upstream, ResponsesUpstreamArgs,
+};
 use crate::sse::synthetic_error_event;
 use crate::upstream::{spawn_upstream, UpstreamArgs};
 use crate::{router_client, state};
@@ -24,15 +28,17 @@ pub const PING_INTERVAL: Duration = Duration::from_secs(30);
 pub fn make_stream(
     iii: IIIClient,
     http: reqwest::Client,
+    cell: ConfigCell,
 ) -> impl Fn(ProviderStreamInput) -> BoxFuture<'static, Result<ProviderStreamOutput, Error>>
        + Send
        + Sync
        + 'static {
     move |input: ProviderStreamInput| {
-        let (iii, http) = (iii.clone(), http.clone());
+        let (iii, http, cell) = (iii.clone(), http.clone(), cell.clone());
         Box::pin(async move {
             let sink = open_sink(&iii, &input.writer_ref).await?;
-            run_stream_call(&iii, http, input, sink.as_ref()).await;
+            let wc = { cell.read().await.clone() };
+            run_stream_call(&iii, http, &wc, input, sink.as_ref()).await;
             sink.close();
             // ProviderStreamOutput (spec § stream contract)
             Ok(ProviderStreamOutput { ok: true })
@@ -48,6 +54,7 @@ fn send_event(sink: &dyn FrameSink, ev: &AssistantMessageEvent) -> Result<(), ()
 async fn run_stream_call(
     iii: &IIIClient,
     http: reqwest::Client,
+    wc: &crate::config::WorkerConfig,
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
@@ -79,6 +86,34 @@ async fn run_stream_call(
             return;
         }
     };
+
+    // Agent Tools path (opt-in via the console config): when enabled, route to
+    // the /v1/responses API with server-side tools (x_search / web_search) so
+    // the model can pull live X / web data. Otherwise fall through to the plain
+    // Chat Completions path below.
+    if wc.tools_enabled && !wc.tool_sources.is_empty() {
+        let system_prompt = input.system_prompt.clone().unwrap_or_default();
+        let body = build_responses_body(
+            &cfg.model,
+            &system_prompt,
+            &input.messages,
+            &wc.tool_sources,
+            cfg.max_tokens,
+        );
+        let headers = build_headers(&cfg);
+        let rx = spawn_responses_upstream(
+            http,
+            ResponsesUpstreamArgs {
+                api_url: responses_url(&cfg.api_url),
+                model,
+                body,
+                headers,
+                warnings,
+            },
+        );
+        pump(rx, sink, PING_INTERVAL).await;
+        return;
+    }
 
     // model_meta is a hint, never source of truth (spec): absent → the
     // catalog is authoritative → curated snapshot as a last resort.

--- a/provider-xai/src/stream_fn.rs
+++ b/provider-xai/src/stream_fn.rs
@@ -92,12 +92,33 @@ async fn run_stream_call(
     // the model can pull live X / web data. Otherwise fall through to the plain
     // Chat Completions path below.
     if wc.tools_enabled && !wc.tool_sources.is_empty() {
+        // Report-and-continue: the Responses path carries the conversation +
+        // server-side tools, but not the chat-path per-request controls, so
+        // name each dropped one instead of silently ignoring it.
+        if input.tools.as_ref().is_some_and(|t| !t.is_empty()) {
+            warnings.push(
+                "client function tools are not sent on the xAI Agent Tools path; \
+                 disable provider-xai tools to use function calling"
+                    .to_string(),
+            );
+        }
+        if input.response_format.is_some() {
+            warnings.push("response_format is not applied on the xAI Agent Tools path".to_string());
+        }
+        if input.thinking_level.is_some() {
+            warnings.push("thinking_level is not applied on the xAI Agent Tools path".to_string());
+        }
         let system_prompt = input.system_prompt.clone().unwrap_or_default();
+        let tool_types: Vec<String> = wc
+            .tool_sources
+            .iter()
+            .map(|t| t.as_type().to_string())
+            .collect();
         let body = build_responses_body(
             &cfg.model,
             &system_prompt,
             &input.messages,
-            &wc.tool_sources,
+            &tool_types,
             cfg.max_tokens,
         );
         let headers = build_headers(&cfg);


### PR DESCRIPTION
## What

Completes **MOT-3789**. Adds opt-in support for xAI's **Agent Tools API** (`/v1/responses` with server-side `x_search` / `web_search`) to `provider-xai`, so grok models can pull **real-time X / web data with citations** instead of running as a plain LLM. Configurable from the console.

Background: xAI deprecated the old `search_parameters` "Live Search"; the current surface is the Agent Tools API on `/v1/responses` (verified live).

## How

- **`config.rs`** — `WorkerConfig { tools_enabled, tool_sources }` with labelled `JsonSchema` fields.
- **`configuration.rs`** — Path B per [`docs/sops/configuration.md`](docs/sops/configuration.md): registers a `provider-xai` config entry ("xAI Provider") + `ConfigCell` hot-reload trigger, so operators flip tools on/off in the **console configuration sidebar** with no restart. Credentials/endpoints stay router-managed as before.
- **`responses.rs`** — `/v1/responses` request builder (`input` + server-side `tools`) + a Responses-SSE upstream loop parsing `event:`/`data:` frames into the shared `AssistantMessageEvent` sequence: `reasoning_summary_text.delta` → thinking, `output_text.delta` → text, `output_text.annotation.added` (`url_citation`) → citations, `custom_tool_call` recorded, `response.completed` → usage.
- **`stream_fn.rs`** — opt-in branch: `tools_enabled` → responses path; otherwise the existing chat-completions path is untouched. **Default OFF**, so the provider stays a clean inference wrapper.

## Verified end-to-end

Against the live engine + api.x.ai:
- The `provider-xai` config entry shows in the console sidebar with the labelled `tools_enabled` / `tool_sources` fields.
- Flipping `tools_enabled` hot-reloaded the worker (log: `provider-xai configuration reloaded`).
- A "trending on X" query through the harness returned **live X data with a citation** — the chat path can't produce that, proving the `/v1/responses` path ran.

## Checks

`cargo fmt --all -- --check` clean · `cargo clippy --all-targets --all-features -- -D warnings` clean · **81 tests** (request builder + Responses-SSE → frames golden + config).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for server-side Agent Tools in streaming responses.
  * Enabled a new responses-based path for compatible requests, including reasoning, citations, and usage reporting.
  * Added configurable tool settings so operators can turn tools on or off and control allowed tool types.

* **Bug Fixes**
  * Improved handling of streamed response events to better preserve output and complete the message flow even when streams end unexpectedly.

* **Chores**
  * Updated configuration handling so changes can be applied dynamically without restarting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->