### PR TITLE
feat(web): content pipeline for web::fetch (static crawl parity, Phase 1)

### DIFF
--- a/web/Cargo.lock
+++ b/web/Cargo.lock
@@ -1367,6 +1367,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "web"
-version = "1.1.2"
+version = "1.1.4"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2208,6 +2218,7 @@ dependencies = [
  "iii-sdk",
  "ipnet",
  "reqwest",
+ "rust-stemmers",
  "schemars",
  "serde",
  "serde_json",
@@ -2217,6 +2228,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
  "wiremock",
 ]
 

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -35,6 +35,8 @@ tl = { package = "astral-tl", version = "0.7" }
 ipnet = "2"
 base64 = "0.22"
 bytes = "1"
+rust-stemmers = "1"
+url = "2"
 
 [dev-dependencies]
 serde_json = "1"

--- a/web/README.md
+++ b/web/README.md
@@ -156,7 +156,7 @@ ignored.
 - **`format: "text"`** — `text/html` → plain text.
 - **`format: "html"`** — raw HTML.
 
-When `content_filter` is set, `body` is the filtered output (there is no separate field) — feed it straight to a model.
+When `content_filter` is set, `body` is the filtered output (there is no separate field) — feed it straight to a model. (If filtering would empty the page, or the page is too large or deeply nested to transform, `body` falls back to the unfiltered content.)
 
 In page-reading mode the request goes out with a browser User-Agent +
 format-matched `Accept` header, and retries once with the honest UA on a

--- a/web/README.md
+++ b/web/README.md
@@ -79,6 +79,11 @@ default:
 | `body` | — | raw string body; ignored on GET/HEAD |
 | `response_format` | `"text"` | `"text"` \| `"base64"` (binary) \| `"json"` (also parses into `json`) |
 | `format` | — | page-reading mode: `"markdown"` \| `"text"` \| `"html"` (see below) |
+| `content_filter` | — | `{ type: "pruning"\|"bm25", query?, threshold?, threshold_type?, min_word_threshold? }`. Page mode only. When set, `body` holds the **filtered** content (pruning default threshold 0.48; bm25 default 1.0; `query` falls back to page metadata). |
+| `target_elements` | — | CSS selectors (tl subset: tag/`.class`/`#id`); restrict rendered content to these regions |
+| `excluded_tags` | — | tag/selectors to drop before rendering (e.g. `nav`, `footer`) |
+| `include_links` | `false` | adds `links: { internal, external }` (absolute URLs, classified by host) |
+| `include_media` | `false` | adds `media: { images, videos, audios }` (absolute URLs) |
 | `timeout_ms` | `default_timeout_ms` | clamped DOWN to `max_timeout_ms` |
 | `max_bytes` | `max_response_bytes` (`default_response_bytes` in `format` mode) | over-cap body is truncated, not errored |
 | `follow_redirects` | `true` | each hop re-checked against the SSRF blocklist |
@@ -100,7 +105,9 @@ default:
   "bytes_truncated": false,   // true when body hit max_bytes (NOT an error)
   "redirect_chain": ["https://…/a"],  // omitted when no redirects
   "content_type": "text/html",  // page-reading mode only
-  "transformed": "markdown"     // only when an HTML transform actually ran
+  "transformed": "markdown",    // only when an HTML transform actually ran
+  "links": { "internal": [{ "href": "…", "text": "…" }], "external": [ … ] },  // include_links
+  "media": { "images": [{ "src": "…", "alt": "…" }], "videos": [ … ], "audios": [ … ] },  // include_media
 }
 ```
 
@@ -148,6 +155,8 @@ ignored.
 - **`format: "markdown"`** — `text/html` → Markdown (the right default for reading pages; far fewer tokens than raw HTML).
 - **`format: "text"`** — `text/html` → plain text.
 - **`format: "html"`** — raw HTML.
+
+When `content_filter` is set, `body` is the filtered output (there is no separate field) — feed it straight to a model.
 
 In page-reading mode the request goes out with a browser User-Agent +
 format-matched `Accept` header, and retries once with the honest UA on a

--- a/web/skills/index.md
+++ b/web/skills/index.md
@@ -61,6 +61,20 @@ One exception: in page-reading mode (`format` set), an `image/*` response return
 | `max_bytes` | 5 MiB (256 KiB in `format` mode) | raw fetches default to the 5 MiB ceiling; page-reading mode (`format` set) uses a context-safe 256 KiB. Pass an explicit value to override (up to the 5 MiB ceiling). Over-cap body is truncated, not errored |
 | `follow_redirects` | `true` | each hop re-checked against the SSRF blocklist |
 
+# Content pipeline
+
+Four request controls for page-reading mode (`format` set):
+
+| Field | Effect |
+|---|---|
+| `content_filter` | `{ type: "pruning"\|"bm25", query?, threshold?, threshold_type?, min_word_threshold? }` — filters `body` to signal content. Pruning default threshold 0.48; BM25 default 1.0. `query` falls back to page `<title>`/`<meta description>` if omitted. |
+| `target_elements` | Restrict body to matching regions. Selector subset: tag, `.class`, `#id` — other forms are silently ignored. |
+| `excluded_tags` | Drop matching elements before rendering (e.g. `["nav", "footer"]`). |
+| `include_links` | `true` → adds `links: { internal, external }` arrays (absolute URLs, classified by host). |
+| `include_media` | `true` → adds `media: { images, videos, audios }` arrays (absolute URLs). |
+
+When `content_filter` is set, `body` **is** the filtered output — no separate field. Feed it straight to a model.
+
 # Response
 
 **Success** (`ok: true`) — returned for *any* completed response, 2xx through 5xx:

--- a/web/src/content/filter.rs
+++ b/web/src/content/filter.rs
@@ -1,0 +1,492 @@
+//! Content filters → filtered HTML (surviving blocks' source, concatenated).
+//! Pruning scores block elements by tag weight, text/link density, and
+//! boilerplate class/id penalties. BM25 ranks blocks against a query. Scoring
+//! runs on `inner_text`, which recurses; the caller's depth guard
+//! (`content::process`) prevents pathological nesting.
+
+use std::collections::HashMap;
+
+use rust_stemmers::{Algorithm, Stemmer};
+use tl::{parse, ParserOptions};
+
+use crate::schemas::{ContentFilter, FilterType, ThresholdType};
+
+const BLOCK_TAGS: [&str; 19] = [
+    "p",
+    "div",
+    "article",
+    "section",
+    "main",
+    "li",
+    "blockquote",
+    "pre",
+    "td",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "nav",
+    "footer",
+    "header",
+    "aside",
+];
+
+// Matched against whole tokens of an element's class/id (split on non-alphanumeric),
+// NOT as substrings — otherwise "ad" matches "mw-heading"/"header"/"thread" and
+// short hints silently flag real content. Include full-word variants ("navigation",
+// "navbox") so token-equality keeps the coverage substring matching used to give.
+const BOILERPLATE_HINTS: [&str; 17] = [
+    "nav",
+    "navigation",
+    "navbox",
+    "footer",
+    "sidebar",
+    "comment",
+    "comments",
+    "menu",
+    "ad",
+    "ads",
+    "promo",
+    "social",
+    "share",
+    "related",
+    "cookie",
+    "banner",
+    "breadcrumb",
+];
+
+pub struct Block {
+    pub start: usize,
+    pub end: usize,
+    pub text: String,
+    pub words: usize,
+    pub link_density: f64,
+    pub tag: String,
+    pub boilerplate: bool,
+}
+
+fn tag_weight(t: &str) -> f64 {
+    match t {
+        "article" | "main" | "section" | "p" => 1.0,
+        "blockquote" | "pre" | "li" | "td" => 0.8,
+        "div" => 0.7,
+        "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => 0.6,
+        "nav" | "footer" | "header" | "aside" => 0.5,
+        _ => 0.5,
+    }
+}
+
+/// Build the good-block set — `is_content_good` per block, OR a rescued content
+/// heading (a heading that is not boilerplate and not inside a boilerplate
+/// region) — then splice out every block whose span contains no good block.
+/// Shared by pruning and BM25; they differ only in what counts as content-good.
+fn keep_good(
+    html: &str,
+    blocks: &[Block],
+    rescue_headings: bool,
+    is_content_good: impl Fn(usize, &Block) -> bool,
+) -> String {
+    // Boilerplate spans, sorted by start, with a prefix-max of end → O(log n)
+    // "is [start,end] inside any boilerplate block?" test (for heading rescue).
+    let mut bp: Vec<(usize, usize)> = blocks
+        .iter()
+        .filter(|b| b.boilerplate)
+        .map(|b| (b.start, b.end))
+        .collect();
+    bp.sort_unstable_by_key(|&(s, _)| s);
+    let bp_starts: Vec<usize> = bp.iter().map(|&(s, _)| s).collect();
+    let mut bp_max_end = vec![0usize; bp.len() + 1];
+    for (i, &(_, e)) in bp.iter().enumerate() {
+        bp_max_end[i + 1] = bp_max_end[i].max(e);
+    }
+    let inside_boilerplate = |start: usize, end: usize| -> bool {
+        let k = bp_starts.partition_point(|&s| s <= start);
+        k > 0 && bp_max_end[k] >= end
+    };
+    let is_heading = |t: &str| matches!(t, "h1" | "h2" | "h3" | "h4" | "h5" | "h6");
+
+    let mut good_starts: Vec<usize> = Vec::new();
+    for (i, b) in blocks.iter().enumerate() {
+        let heading_good = rescue_headings
+            && is_heading(&b.tag)
+            && !b.boilerplate
+            && !inside_boilerplate(b.start, b.end);
+        if is_content_good(i, b) || heading_good {
+            good_starts.push(b.start);
+        }
+    }
+    good_starts.sort_unstable();
+
+    let mut removable: Vec<(usize, usize)> = Vec::new();
+    for b in blocks {
+        let lo = good_starts.partition_point(|&s| s < b.start);
+        let hi = good_starts.partition_point(|&s| s <= b.end);
+        if lo == hi {
+            removable.push((b.start, b.end));
+        }
+    }
+    crate::content::select::splice_out_ranges(html, removable)
+}
+
+/// Collect candidate block elements with the metrics needed for scoring.
+/// Anchor text length is precomputed once and attributed to a block by source
+/// containment, giving each block's link density.
+pub fn collect_blocks(html: &str) -> Vec<Block> {
+    let Ok(dom) = parse(html, ParserOptions::default()) else {
+        return Vec::new();
+    };
+    let parser = dom.parser();
+
+    // Precompute anchors sorted by start for O(n log n) binary-search attribution.
+    // ponytail: prefix-sum over sorted anchors; well-nested HTML guarantees start containment is sufficient.
+    let mut anchors: Vec<(usize, usize)> = Vec::new(); // (start, text_len)
+    for node in dom.nodes() {
+        if let Some(tag) = node.as_tag() {
+            if tag.name().as_utf8_str().eq_ignore_ascii_case("a") {
+                let (s, _) = tag.boundaries(parser);
+                anchors.push((s, tag.inner_text(parser).chars().count()));
+            }
+        }
+    }
+    anchors.sort_unstable_by_key(|&(s, _)| s);
+    let starts: Vec<usize> = anchors.iter().map(|&(s, _)| s).collect();
+    let mut prefix = vec![0usize; anchors.len() + 1];
+    for (i, &(_, len)) in anchors.iter().enumerate() {
+        prefix[i + 1] = prefix[i] + len;
+    }
+
+    let mut blocks = Vec::new();
+    for node in dom.nodes() {
+        let Some(tag) = node.as_tag() else { continue };
+        let name = tag.name().as_utf8_str().to_lowercase();
+        if !BLOCK_TAGS.contains(&name.as_str()) {
+            continue;
+        }
+        let (start, end) = tag.boundaries(parser);
+        let text = tag.inner_text(parser);
+        let text_chars = text.chars().count().max(1);
+        let words = text.split_whitespace().count();
+        let lo = starts.partition_point(|&s| s < start);
+        let hi = starts.partition_point(|&s| s <= end);
+        let link_chars = prefix[hi] - prefix[lo];
+        let link_density = (link_chars as f64 / text_chars as f64).min(1.0);
+        let attrs = tag.attributes();
+        let class_id = format!(
+            "{} {}",
+            attrs.id().map(|b| b.as_utf8_str()).unwrap_or_default(),
+            attrs.class().map(|b| b.as_utf8_str()).unwrap_or_default()
+        )
+        .to_lowercase();
+        let boilerplate = matches!(name.as_str(), "nav" | "footer" | "aside")
+            || class_id
+                .split(|c: char| !c.is_alphanumeric())
+                .any(|tok| BOILERPLATE_HINTS.contains(&tok));
+        blocks.push(Block {
+            start,
+            end,
+            text: text.into_owned(),
+            words,
+            link_density,
+            tag: name,
+            boilerplate,
+        });
+    }
+    blocks
+}
+
+fn score(b: &Block) -> f64 {
+    let penalty = if b.boilerplate { 0.5 } else { 1.0 };
+    // Saturating density: rewards word-rich blocks, half-saturates at 15 words.
+    let density = b.words as f64 / (b.words as f64 + 15.0);
+    tag_weight(&b.tag) * penalty * (1.0 - b.link_density) * density
+}
+
+/// Remove boilerplate blocks from `html` in-place: score every block element,
+/// mark low-scorers as removable (unless they contain a good block), splice
+/// them out of the source. `dynamic` lowers the bar for high-weight tags.
+pub fn prune(html: &str, threshold: f64, dynamic: bool, min_words: Option<u32>) -> String {
+    let blocks = collect_blocks(html);
+    // rescue_headings = true: pruning keeps document structure (section titles).
+    keep_good(html, &blocks, true, |_, b| {
+        let passes_words = min_words.is_none_or(|m| b.words as u32 >= m);
+        let eff = if dynamic {
+            threshold * (1.0 - 0.3 * (tag_weight(&b.tag) - 0.5))
+        } else {
+            threshold
+        };
+        passes_words && score(b) >= eff
+    })
+}
+
+fn tokenize(text: &str, stemmer: &Stemmer) -> Vec<String> {
+    text.to_lowercase()
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|t| t.len() > 1)
+        .map(|t| stemmer.stem(t).into_owned())
+        .collect()
+}
+
+/// Keep query-relevant content: score each block by BM25 (k1=1.2, b=0.75), treat
+/// non-boilerplate blocks scoring >= `threshold` as good, and splice out subtrees
+/// with no relevant block. Chrome (nav/footer/sidebar) is dropped even if it
+/// matches the query. Empty query: no-op (returns `html`).
+pub fn bm25(html: &str, query: &str, threshold: f64) -> String {
+    if query.trim().is_empty() {
+        return html.to_string();
+    }
+    let stemmer = Stemmer::create(Algorithm::English);
+    let q = tokenize(query, &stemmer);
+    if q.is_empty() {
+        return html.to_string();
+    }
+    let blocks = collect_blocks(html);
+    if blocks.is_empty() {
+        return html.to_string();
+    }
+
+    let docs: Vec<Vec<String>> = blocks.iter().map(|b| tokenize(&b.text, &stemmer)).collect();
+    let n = docs.len() as f64;
+    let avgdl = docs.iter().map(|d| d.len()).sum::<usize>() as f64 / n;
+    let (k1, b) = (1.2_f64, 0.75_f64);
+
+    // Precompute tf and df once — O(D×T) instead of O(D²×Q×avgdl).
+    let tf: Vec<HashMap<&str, usize>> = docs
+        .iter()
+        .map(|d| {
+            let mut m: HashMap<&str, usize> = HashMap::new();
+            for t in d {
+                *m.entry(t.as_str()).or_insert(0) += 1;
+            }
+            m
+        })
+        .collect();
+    let mut df: HashMap<&str, usize> = HashMap::new();
+    for m in &tf {
+        for &term in m.keys() {
+            *df.entry(term).or_insert(0) += 1;
+        }
+    }
+
+    let scores: Vec<f64> = docs
+        .iter()
+        .enumerate()
+        .map(|(idx, doc)| {
+            let dl = doc.len() as f64;
+            let mut s = 0.0;
+            for term in &q {
+                let f = *tf[idx].get(term.as_str()).unwrap_or(&0) as f64;
+                if f == 0.0 {
+                    continue;
+                }
+                let d_f = *df.get(term.as_str()).unwrap_or(&0) as f64;
+                let idf = (1.0 + (n - d_f + 0.5) / (d_f + 0.5)).ln();
+                s += idf * (f * (k1 + 1.0)) / (f + k1 * (1.0 - b + b * dl / avgdl.max(1.0)));
+            }
+            s
+        })
+        .collect();
+
+    // Removal-based: keep query-relevant PROSE, splice out everything else. A block
+    // is relevant only if it scores >= threshold AND is not boilerplate AND is not
+    // link-dominated (link_density < 0.5) — so a nav/sidebar that merely mentions a
+    // query term (e.g. "Tools") is still dropped. Headings are NOT rescued here
+    // (relevance, not structure). Old keep-outermost returned the whole wrapper.
+    keep_good(html, &blocks, false, |i, b| {
+        scores[i] >= threshold && !b.boilerplate && b.link_density < 0.5
+    })
+}
+
+/// Dispatch to the configured filter, applying default thresholds.
+/// `fallback_query` (page metadata) is used when the caller omits `query`.
+pub fn apply(html: &str, cf: &ContentFilter, fallback_query: &str) -> String {
+    let query = cf
+        .query
+        .as_deref()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or(fallback_query);
+    match cf.kind {
+        FilterType::Pruning => {
+            let threshold = cf.threshold.unwrap_or(0.48);
+            let dynamic = matches!(cf.threshold_type, Some(ThresholdType::Dynamic));
+            prune(html, threshold, dynamic, cf.min_word_threshold)
+        }
+        FilterType::Bm25 => {
+            let threshold = cf.threshold.unwrap_or(1.0);
+            bm25(html, query, threshold)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PAGE: &str = r#"<body>
+        <div class="nav"><a href="/a">Home</a> <a href="/b">About</a> <a href="/c">Blog</a></div>
+        <article><p>The quick brown fox jumps over the lazy dog and keeps running through a long
+        descriptive paragraph with plenty of real words and almost no links at all here.</p></article>
+        <div class="footer">© 2026 <a href="/x">terms</a></div>
+    </body>"#;
+
+    const DOCS: &str = r#"<body>
+        <p>Rust ownership and the borrow checker prevent data races at compile time.</p>
+        <p>Bananas are a good source of potassium and make a tasty snack.</p>
+        <p>The borrow checker enforces lifetimes so references never dangle in Rust.</p>
+    </body>"#;
+
+    #[test]
+    fn bm25_keeps_query_relevant_blocks() {
+        let out = bm25(DOCS, "rust borrow checker", 0.5);
+        assert!(out.contains("borrow checker"));
+        assert!(!out.contains("Bananas"));
+    }
+
+    #[test]
+    fn bm25_scores_visible_text_not_markup() {
+        // Query terms appear ONLY in markup (the href path), never in visible prose.
+        // Scoring on inner_text must NOT rescue this block; scoring on raw HTML would.
+        let html = r#"<body>
+            <p><a href="/rust-borrow-checker-guide">read more</a> Bananas are a tasty snack rich
+            in potassium enjoyed worldwide in smoothies and desserts by many people every day.</p>
+            <p>Ownership and the borrow checker in Rust prevent data races at compile time via
+            affine types and lifetimes the compiler verifies statically for every reference.</p>
+        </body>"#;
+        let out = bm25(html, "rust borrow checker", 0.5);
+        assert!(out.contains("Ownership and the borrow checker")); // real prose kept
+        assert!(!out.contains("Bananas")); // markup-only match dropped
+    }
+
+    #[test]
+    fn bm25_empty_query_is_noop() {
+        let out = bm25(DOCS, "", 1.0);
+        assert!(out.contains("Bananas")); // nothing filtered
+    }
+
+    #[test]
+    fn bm25_removes_irrelevant_and_boilerplate() {
+        // Nested page: relevant section + irrelevant section + boilerplate nav/footer.
+        // bm25 must drop nav/footer AND the irrelevant prose, keep the relevant prose.
+        // Regression: old keep-outermost returned the whole query-matching wrapper.
+        let html = r#"<body>
+            <nav class="nav"><a href="/a">Home</a></nav>
+            <div id="main">
+                <p>Rust ownership and the borrow checker prevent data races at compile time
+                through affine types and lifetimes the compiler verifies statically at build.</p>
+                <p>Bananas are an excellent source of potassium and make a tasty snack in many
+                smoothies and desserts enjoyed by people all around the world every single day.</p>
+            </div>
+            <footer class="footer">Privacy policy and cookie notice apply</footer>
+        </body>"#;
+        let out = bm25(html, "rust ownership borrow checker", 0.5);
+        assert!(out.contains("borrow checker")); // relevant prose kept
+        assert!(!out.contains("potassium")); // irrelevant prose removed
+        assert!(!out.contains("Home")); // boilerplate nav removed
+        assert!(!out.contains("Privacy policy")); // boilerplate footer removed
+        assert!(out.len() < html.len());
+    }
+
+    #[test]
+    fn apply_dispatches_pruning_and_bm25() {
+        let pruned = apply(
+            PAGE,
+            &crate::schemas::ContentFilter {
+                kind: crate::schemas::FilterType::Pruning,
+                query: None,
+                threshold: None,
+                threshold_type: None,
+                min_word_threshold: None,
+            },
+            "",
+        );
+        assert!(pruned.contains("quick brown fox"));
+
+        let ranked = apply(
+            DOCS,
+            &crate::schemas::ContentFilter {
+                kind: crate::schemas::FilterType::Bm25,
+                query: Some("potassium snack".to_string()),
+                threshold: None,
+                threshold_type: None,
+                min_word_threshold: None,
+            },
+            "",
+        );
+        assert!(ranked.contains("Bananas"));
+        assert!(!ranked.contains("borrow checker"));
+    }
+
+    #[test]
+    fn prune_keeps_article_drops_boilerplate() {
+        let out = prune(PAGE, 0.48, false, None);
+        assert!(out.contains("quick brown fox"));
+        assert!(!out.contains("Home"));
+        assert!(!out.contains("terms"));
+        // Threshold genuinely matters: at 0.0 the nav block survives,
+        // proving it was score-dropped at 0.48, not structurally excluded.
+        assert!(prune(PAGE, 0.0, false, None).contains("Home"));
+    }
+
+    #[test]
+    fn prune_respects_min_word_threshold() {
+        let html = "<article><p>too short</p></article>";
+        let out = prune(html, 0.0, false, Some(50));
+        assert!(out.trim().is_empty());
+    }
+
+    #[test]
+    fn prune_keeps_article_heading() {
+        let html = r#"<article><h1>Pruning in Rust</h1>
+        <p>The quick brown fox jumps over the lazy dog through a long and genuinely substantive
+        paragraph of real prose with many ordinary words and very few links at all.</p></article>"#;
+        let out = prune(html, 0.48, false, None);
+        assert!(out.contains("Pruning in Rust")); // title rescued
+        assert!(out.contains("quick brown fox"));
+    }
+
+    #[test]
+    fn prune_keeps_heading_in_heading_classed_wrapper() {
+        // Wikipedia wraps section headings as <div class="mw-heading"><h2>..</h2></div>.
+        // Hint "ad" must NOT substring-match "heading" and flag the wrapper boilerplate,
+        // which would drop every section heading. Regression for the substring bug.
+        let html = r#"<article>
+            <div class="mw-heading mw-heading2"><h2>History</h2></div>
+            <p>The quick brown fox jumps over the lazy dog in a long substantive paragraph
+            of genuine prose with many ordinary words and almost no links here at all.</p>
+        </article>"#;
+        let out = prune(html, 0.48, false, None);
+        assert!(out.contains("History")); // section heading kept, not flagged via "ad"
+        assert!(out.contains("quick brown fox"));
+    }
+
+    #[test]
+    fn prune_drops_heading_inside_boilerplate() {
+        let html = r#"<body>
+        <footer class="footer"><h2>Quick Links</h2><a href="/a">A</a> <a href="/b">B</a></footer>
+        <article><p>The quick brown fox jumps over the lazy dog through a long substantive paragraph
+        of genuine article prose with many ordinary words and very few links here.</p></article>
+    </body>"#;
+        let out = prune(html, 0.48, false, None);
+        assert!(out.contains("quick brown fox")); // content kept
+        assert!(!out.contains("Quick Links")); // heading inside footer dropped
+        assert!(!out.contains(">A<") && !out.contains("href=\"/a\"")); // footer links dropped
+    }
+
+    #[test]
+    fn prune_drops_nested_boilerplate_in_wrapper() {
+        let html = r#"<body><div id="page">
+        <nav class="nav"><a href="/a">Home</a> <a href="/b">About</a> <a href="/c">Docs</a> <a href="/d">Blog</a></nav>
+        <div id="main"><article><p>The quick brown fox jumps over the lazy dog while a long and
+        genuinely substantive paragraph of real article prose continues with many ordinary words and
+        very few links so that it reads as primary content rather than navigation chrome.</p></article></div>
+        <footer class="footer">© 2026 Example Inc. <a href="/x">Terms</a> <a href="/y">Privacy</a></footer>
+    </div></body>"#;
+        let out = prune(html, 0.48, false, None);
+        assert!(out.contains("quick brown fox")); // article kept
+        assert!(!out.contains("Home")); // nested nav removed
+        assert!(!out.contains("Terms")); // nested footer removed
+                                         // and meaningfully shorter than the input
+        assert!(out.len() < html.len());
+    }
+}

--- a/web/src/content/filter.rs
+++ b/web/src/content/filter.rs
@@ -139,22 +139,26 @@ pub fn collect_blocks(html: &str) -> Vec<Block> {
     };
     let parser = dom.parser();
 
-    // Precompute anchors sorted by start for O(n log n) binary-search attribution.
-    // ponytail: prefix-sum over sorted anchors; well-nested HTML guarantees start containment is sufficient.
-    let mut anchors: Vec<(usize, usize)> = Vec::new(); // (start, text_len)
+    // Anchors sorted by start for O(log n) attribution. `prefix` sums descendant
+    // anchor text (anchor start inside the block); `end_max` (prefix-max of end)
+    // detects an ancestor anchor wrapping the block. ponytail: well-nested HTML
+    // lets start/end offsets alone decide descendant vs. ancestor containment.
+    let mut anchors: Vec<(usize, usize, usize)> = Vec::new(); // (start, end, text_len)
     for node in dom.nodes() {
         if let Some(tag) = node.as_tag() {
             if tag.name().as_utf8_str().eq_ignore_ascii_case("a") {
-                let (s, _) = tag.boundaries(parser);
-                anchors.push((s, tag.inner_text(parser).chars().count()));
+                let (s, e) = tag.boundaries(parser);
+                anchors.push((s, e, tag.inner_text(parser).chars().count()));
             }
         }
     }
-    anchors.sort_unstable_by_key(|&(s, _)| s);
-    let starts: Vec<usize> = anchors.iter().map(|&(s, _)| s).collect();
+    anchors.sort_unstable_by_key(|&(s, _, _)| s);
+    let starts: Vec<usize> = anchors.iter().map(|&(s, _, _)| s).collect();
     let mut prefix = vec![0usize; anchors.len() + 1];
-    for (i, &(_, len)) in anchors.iter().enumerate() {
+    let mut end_max = vec![0usize; anchors.len() + 1];
+    for (i, &(_, e, len)) in anchors.iter().enumerate() {
         prefix[i + 1] = prefix[i] + len;
+        end_max[i + 1] = end_max[i].max(e);
     }
 
     let mut blocks = Vec::new();
@@ -170,8 +174,15 @@ pub fn collect_blocks(html: &str) -> Vec<Block> {
         let words = text.split_whitespace().count();
         let lo = starts.partition_point(|&s| s < start);
         let hi = starts.partition_point(|&s| s <= end);
-        let link_chars = prefix[hi] - prefix[lo];
-        let link_density = (link_chars as f64 / text_chars as f64).min(1.0);
+        // A block fully enclosed by an ancestor <a> (valid HTML5) is entirely link
+        // text, so score it as fully linked; otherwise attribute descendant anchors.
+        let enclosing = starts.partition_point(|&s| s <= start);
+        let link_density = if enclosing > 0 && end_max[enclosing] >= end {
+            1.0
+        } else {
+            let link_chars = prefix[hi] - prefix[lo];
+            (link_chars as f64 / text_chars as f64).min(1.0)
+        };
         let attrs = tag.attributes();
         let class_id = format!(
             "{} {}",
@@ -488,5 +499,21 @@ mod tests {
         assert!(!out.contains("Terms")); // nested footer removed
                                          // and meaningfully shorter than the input
         assert!(out.len() < html.len());
+    }
+
+    #[test]
+    fn prune_drops_block_wrapped_in_ancestor_anchor() {
+        // Valid HTML5: <a> wrapping block content (a fully-linked "card"). The block
+        // starts after the <a>, so start-based attribution alone sees zero link text
+        // and scores the card as prose; the ancestor anchor must make it fully linked.
+        let html = r#"<body>
+            <a href="/card"><div class="card"><p>Read this featured teaser blurb that is long
+            and wordy enough to look like genuine prose to the density scorer right here.</p></div></a>
+            <article><p>The quick brown fox jumps over the lazy dog through a long substantive
+            paragraph of genuine article prose with many ordinary words and very few links.</p></article>
+        </body>"#;
+        let out = prune(html, 0.48, false, None);
+        assert!(out.contains("quick brown fox")); // real article kept
+        assert!(!out.contains("featured teaser")); // fully-linked card dropped
     }
 }

--- a/web/src/content/links.rs
+++ b/web/src/content/links.rs
@@ -1,0 +1,240 @@
+//! Link & media extraction from the full document. Relative URLs resolve
+//! against the document's `<base href>` when present (per the HTML spec),
+//! otherwise the final (post-redirect) fetch URL. Links are classified
+//! internal/external by comparing against the fetch host.
+
+use tl::{parse, ParserOptions};
+use url::Url;
+
+use crate::content::{Link, Links, Media, MediaItem};
+
+fn resolve(base: &Option<Url>, raw: &str) -> String {
+    match base {
+        Some(b) => b
+            .join(raw)
+            .map(|u| u.to_string())
+            .unwrap_or_else(|_| raw.to_string()),
+        None => raw.to_string(),
+    }
+}
+
+/// Effective base URL for resolving relative references: the first `<base href>`
+/// in the document (itself resolved against the fetch URL, since it may be
+/// relative), falling back to the fetch URL.
+fn effective_base(dom: &tl::VDom, fetch_url: &str) -> Option<Url> {
+    let fetch = Url::parse(fetch_url).ok();
+    let parser = dom.parser();
+    if let Some(iter) = dom.query_selector("base") {
+        for handle in iter {
+            let Some(tag) = handle.get(parser).and_then(|n| n.as_tag()) else {
+                continue;
+            };
+            if let Some(href) = tag.attributes().get("href").flatten() {
+                let href = href.as_utf8_str();
+                let href = href.trim();
+                if !href.is_empty() {
+                    return match &fetch {
+                        Some(f) => f.join(href).ok().or_else(|| fetch.clone()),
+                        None => Url::parse(href).ok(),
+                    };
+                }
+            }
+        }
+    }
+    fetch
+}
+
+/// `src` of the first `<source>` child of a `<video>`/`<audio>` element — the
+/// standard `<video><source src=…></video>` markup where the element itself has
+/// no `src`.
+fn source_child_src(tag: &tl::HTMLTag, parser: &tl::Parser) -> Option<String> {
+    for child in tag.children().top().as_slice() {
+        let Some(ct) = child.get(parser).and_then(|n| n.as_tag()) else {
+            continue;
+        };
+        if ct.name().as_utf8_str().eq_ignore_ascii_case("source") {
+            if let Some(src) = ct.attributes().get("src").flatten() {
+                let s = src.as_utf8_str();
+                if !s.trim().is_empty() {
+                    return Some(s.into_owned());
+                }
+            }
+        }
+    }
+    None
+}
+
+pub fn extract_links(html: &str, base: &str) -> Links {
+    let mut links = Links {
+        internal: Vec::new(),
+        external: Vec::new(),
+    };
+    let Ok(dom) = parse(html, ParserOptions::default()) else {
+        return links;
+    };
+    let parser = dom.parser();
+    let resolve_base = effective_base(&dom, base);
+    // Classify against the FETCH host (not the <base> host): a <base> pointing
+    // off-site still yields links external to the page we actually fetched.
+    let fetch_host = Url::parse(base)
+        .ok()
+        .and_then(|u| u.host_str().map(str::to_string));
+
+    if let Some(iter) = dom.query_selector("a") {
+        for handle in iter {
+            let Some(tag) = handle.get(parser).and_then(|n| n.as_tag()) else {
+                continue;
+            };
+            let Some(href) = tag.attributes().get("href").flatten() else {
+                continue;
+            };
+            let href = href.as_utf8_str();
+            if href.trim().is_empty() {
+                continue;
+            }
+            let abs = resolve(&resolve_base, &href);
+            let host = Url::parse(&abs)
+                .ok()
+                .and_then(|u| u.host_str().map(str::to_string));
+            let is_internal = match (&fetch_host, &host) {
+                (Some(b), Some(h)) => b == h,
+                // No comparable host (mailto:/tel:/data:, or an unresolvable ref) is
+                // not a same-origin page → external, never silently internal.
+                _ => false,
+            };
+            let link = Link {
+                href: abs,
+                text: tag.inner_text(parser).trim().to_string(),
+                title: tag
+                    .attributes()
+                    .get("title")
+                    .flatten()
+                    .map(|b| b.as_utf8_str().trim().to_string()),
+            };
+            if is_internal {
+                links.internal.push(link);
+            } else {
+                links.external.push(link);
+            }
+        }
+    }
+    links
+}
+
+pub fn extract_media(html: &str, base: &str) -> Media {
+    let mut media = Media {
+        images: Vec::new(),
+        videos: Vec::new(),
+        audios: Vec::new(),
+    };
+    let Ok(dom) = parse(html, ParserOptions::default()) else {
+        return media;
+    };
+    let parser = dom.parser();
+    let resolve_base = effective_base(&dom, base);
+
+    if let Some(iter) = dom.query_selector("img") {
+        for handle in iter {
+            let Some(tag) = handle.get(parser).and_then(|n| n.as_tag()) else {
+                continue;
+            };
+            if let Some(src) = tag.attributes().get("src").flatten() {
+                if src.as_utf8_str().trim().is_empty() {
+                    continue;
+                }
+                media.images.push(MediaItem {
+                    src: resolve(&resolve_base, &src.as_utf8_str()),
+                    alt: tag
+                        .attributes()
+                        .get("alt")
+                        .flatten()
+                        .map(|b| b.as_utf8_str().trim().to_string()),
+                });
+            }
+        }
+    }
+    for (sel, bucket) in [("video", &mut media.videos), ("audio", &mut media.audios)] {
+        if let Some(iter) = dom.query_selector(sel) {
+            for handle in iter {
+                let Some(tag) = handle.get(parser).and_then(|n| n.as_tag()) else {
+                    continue;
+                };
+                // src may be on the element directly or (the common case) on a child
+                // <source src=…>; prefer the direct attribute, then the first source.
+                let direct = tag
+                    .attributes()
+                    .get("src")
+                    .flatten()
+                    .map(|b| b.as_utf8_str().into_owned())
+                    .filter(|s| !s.trim().is_empty());
+                if let Some(src) = direct.or_else(|| source_child_src(tag, parser)) {
+                    bucket.push(MediaItem {
+                        src: resolve(&resolve_base, &src),
+                        alt: None,
+                    });
+                }
+            }
+        }
+    }
+    media
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_and_classifies_links() {
+        let html = r#"<a href="/about">About</a><a href="https://other.test/x">Ext</a>"#;
+        let links = extract_links(html, "https://site.test/page");
+        assert_eq!(links.internal.len(), 1);
+        assert_eq!(links.internal[0].href, "https://site.test/about");
+        assert_eq!(links.internal[0].text, "About");
+        assert_eq!(links.external.len(), 1);
+        assert_eq!(links.external[0].href, "https://other.test/x");
+    }
+
+    #[test]
+    fn extracts_images_with_alt() {
+        let html = r#"<img src="/img/a.png" alt="logo"><img src="b.jpg">"#;
+        let media = extract_media(html, "https://site.test/dir/page");
+        assert_eq!(media.images[0].src, "https://site.test/img/a.png");
+        assert_eq!(media.images[0].alt.as_deref(), Some("logo"));
+        assert_eq!(media.images[1].src, "https://site.test/dir/b.jpg");
+        assert!(media.images[1].alt.is_none());
+    }
+
+    #[test]
+    fn resolves_against_base_href_and_classifies_by_fetch_host() {
+        // <base href> off-site: relative URLs resolve against it (per spec) and,
+        // being off the fetch host, are external — not internal.
+        let html = r#"<head><base href="https://cdn.other.test/app/"></head>
+            <body><a href="x">rel</a><a href="/root">root</a></body>"#;
+        let links = extract_links(html, "https://site.test/docs/page");
+        assert!(links.internal.is_empty());
+        let ext: Vec<&str> = links.external.iter().map(|l| l.href.as_str()).collect();
+        assert!(ext.contains(&"https://cdn.other.test/app/x"));
+        assert!(ext.contains(&"https://cdn.other.test/root"));
+    }
+
+    #[test]
+    fn mailto_is_external_not_internal() {
+        let html = r#"<a href="mailto:a@b.com">mail</a><a href="/x">x</a>"#;
+        let links = extract_links(html, "https://site.test/");
+        assert_eq!(links.internal.len(), 1);
+        assert_eq!(links.internal[0].href, "https://site.test/x");
+        assert!(links.external.iter().any(|l| l.href == "mailto:a@b.com"));
+    }
+
+    #[test]
+    fn video_audio_source_children_extracted() {
+        let html = r#"<video><source src="/clip.mp4"></video>
+            <audio><source src="/a.mp3"></audio>
+            <video src="/direct.webm"></video>"#;
+        let media = extract_media(html, "https://site.test/");
+        let vids: Vec<&str> = media.videos.iter().map(|m| m.src.as_str()).collect();
+        assert!(vids.contains(&"https://site.test/clip.mp4")); // via <source> child
+        assert!(vids.contains(&"https://site.test/direct.webm")); // direct src still works
+        assert_eq!(media.audios[0].src, "https://site.test/a.mp3"); // audio <source>
+    }
+}

--- a/web/src/content/meta.rs
+++ b/web/src/content/meta.rs
@@ -1,0 +1,61 @@
+//! Page-metadata extraction. Used as the BM25 query fallback when the caller
+//! omits `query`.
+
+/// Build a query string from `<title>` + `<meta name=description|keywords>`.
+/// Returns "" when none are present or the HTML fails to parse.
+pub fn extract_metadata_query(html: &str) -> String {
+    let dom = match tl::parse(html, tl::ParserOptions::default()) {
+        Ok(d) => d,
+        Err(_) => return String::new(),
+    };
+    let parser = dom.parser();
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(tag) = dom
+        .query_selector("title")
+        .and_then(|mut it| it.next())
+        .and_then(|h| h.get(parser))
+        .and_then(|n| n.as_tag())
+    {
+        parts.push(tag.inner_text(parser).trim().to_string());
+    }
+    if let Some(iter) = dom.query_selector("meta") {
+        for handle in iter {
+            let Some(tag) = handle.get(parser).and_then(|n| n.as_tag()) else {
+                continue;
+            };
+            let name = tag
+                .attributes()
+                .get("name")
+                .flatten()
+                .map(|b| b.as_utf8_str().to_lowercase());
+            if matches!(name.as_deref(), Some("description") | Some("keywords")) {
+                if let Some(content) = tag.attributes().get("content").flatten() {
+                    parts.push(content.as_utf8_str().trim().to_string());
+                }
+            }
+        }
+    }
+    parts.retain(|p| !p.is_empty());
+    parts.join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pulls_title_and_meta() {
+        let html = r#"<html><head><title>Rust Guide</title>
+            <meta name="description" content="learn ownership">
+            <meta name="keywords" content="borrow checker"></head><body>x</body></html>"#;
+        let q = extract_metadata_query(html);
+        assert!(q.contains("Rust Guide"));
+        assert!(q.contains("ownership"));
+        assert!(q.contains("borrow checker"));
+    }
+
+    #[test]
+    fn empty_when_no_metadata() {
+        assert_eq!(extract_metadata_query("<p>hi</p>"), "");
+    }
+}

--- a/web/src/content/mod.rs
+++ b/web/src/content/mod.rs
@@ -1,0 +1,221 @@
+//! Single-page content pipeline for `web::fetch`: content selection, content
+//! filtering (pruning/BM25), and link/media extraction. Pure + synchronous;
+//! the caller runs `process` inside `spawn_blocking`. Reused by later phases
+//! (`web::extract`, `web::crawl`).
+
+use serde::Serialize;
+
+use crate::convert;
+use crate::schemas::{ContentFilter, PageFormat};
+
+pub mod filter;
+pub mod links;
+pub mod meta;
+pub mod select;
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Link {
+    pub href: String,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Links {
+    pub internal: Vec<Link>,
+    pub external: Vec<Link>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct MediaItem {
+    pub src: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alt: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Media {
+    pub images: Vec<MediaItem>,
+    pub videos: Vec<MediaItem>,
+    pub audios: Vec<MediaItem>,
+}
+
+/// Owned so the whole struct can move into `spawn_blocking`.
+pub struct ContentOpts {
+    pub format: PageFormat,
+    pub content_filter: Option<ContentFilter>,
+    pub target_elements: Vec<String>,
+    pub excluded_tags: Vec<String>,
+    pub include_links: bool,
+    pub include_media: bool,
+}
+
+impl ContentOpts {
+    /// True when any field activates the pipeline. When false, the caller must
+    /// use the existing (backward-compatible) render path.
+    pub fn is_enriched(&self) -> bool {
+        self.content_filter.is_some()
+            || !self.target_elements.is_empty()
+            || !self.excluded_tags.is_empty()
+            || self.include_links
+            || self.include_media
+    }
+}
+
+pub struct PageContent {
+    /// `None` => caller keeps the raw body (size cap or over-depth; no transform ran).
+    pub rendered: Option<String>,
+    pub filtered: bool,
+    pub links: Option<Links>,
+    pub media: Option<Media>,
+}
+
+/// Run the single-page pipeline: exclude → scope → filter → render, plus
+/// link/media extraction from the full document. Pure + synchronous; run under
+/// `spawn_blocking`.
+///
+/// Link/media extraction is a flat, non-recursive scan, so it runs on every
+/// input. The recursive transforms (markdown/text) and filtering run only when
+/// `allow_transform` (the caller's within-size-cap decision) is true AND the
+/// document isn't pathologically nested; otherwise `rendered` is `None` and the
+/// caller keeps the raw body.
+pub fn process(
+    html: &str,
+    base_url: &str,
+    opts: &ContentOpts,
+    allow_transform: bool,
+) -> PageContent {
+    // Flat, non-recursive (tl + query_selector); safe on any size/depth.
+    let links = opts
+        .include_links
+        .then(|| links::extract_links(html, base_url));
+    let media = opts
+        .include_media
+        .then(|| links::extract_media(html, base_url));
+
+    if !allow_transform || convert::max_tag_depth(html) > convert::MAX_NESTING_DEPTH {
+        return PageContent {
+            rendered: None,
+            filtered: false,
+            links,
+            media,
+        };
+    }
+
+    let mut working = select::remove_excluded(html, &opts.excluded_tags);
+    if let Some(scoped) = select::scope_to_targets(&working, &opts.target_elements) {
+        working = scoped;
+    }
+    let mut filtered = false;
+    if let Some(cf) = &opts.content_filter {
+        let fallback = meta::extract_metadata_query(html);
+        let f = filter::apply(&working, cf, &fallback);
+        if !f.trim().is_empty() {
+            working = f;
+            filtered = true;
+        }
+    }
+
+    let rendered = match opts.format {
+        // On markdown failure, fall back to text of the PROCESSED html — never the
+        // caller's unfiltered raw body, which would resurrect the removed boilerplate.
+        PageFormat::Markdown => Some(
+            convert::html_to_markdown(&working).unwrap_or_else(|_| convert::extract_text(&working)),
+        ),
+        PageFormat::Text => Some(convert::extract_text(&working)),
+        PageFormat::Html => Some(working),
+    };
+
+    PageContent {
+        rendered,
+        filtered,
+        links,
+        media,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schemas::{ContentFilter, FilterType, PageFormat};
+
+    fn opts() -> ContentOpts {
+        ContentOpts {
+            format: PageFormat::Markdown,
+            content_filter: None,
+            target_elements: Vec::new(),
+            excluded_tags: Vec::new(),
+            include_links: false,
+            include_media: false,
+        }
+    }
+
+    const PAGE: &str = r#"<body><nav class="nav"><a href="/h">Home</a></nav>
+        <article><p>The quick brown fox jumps over the lazy dog through a long real paragraph.</p>
+        <img src="/p.png" alt="pic"></article></body>"#;
+
+    #[test]
+    fn filter_replaces_rendered_with_fit_content() {
+        let o = ContentOpts {
+            content_filter: Some(ContentFilter {
+                kind: FilterType::Pruning,
+                query: None,
+                threshold: None,
+                threshold_type: None,
+                min_word_threshold: None,
+            }),
+            ..opts()
+        };
+        let pc = process(PAGE, "https://s.test/", &o, true);
+        let md = pc.rendered.unwrap();
+        assert!(md.contains("quick brown fox"));
+        assert!(!md.contains("Home"));
+        assert!(pc.filtered);
+    }
+
+    #[test]
+    fn links_and_media_extracted_when_requested() {
+        let o = ContentOpts {
+            include_links: true,
+            include_media: true,
+            ..opts()
+        };
+        let pc = process(PAGE, "https://s.test/", &o, true);
+        assert_eq!(pc.links.unwrap().internal[0].href, "https://s.test/h");
+        assert_eq!(pc.media.unwrap().images[0].src, "https://s.test/p.png");
+    }
+
+    #[test]
+    fn extraction_runs_without_transform() {
+        // Oversized body (allow_transform=false): no transform, but links/media
+        // extraction still runs — the flat scan isn't gated by the size cap.
+        let o = ContentOpts {
+            include_links: true,
+            include_media: true,
+            ..opts()
+        };
+        let pc = process(PAGE, "https://s.test/", &o, false);
+        assert!(pc.rendered.is_none());
+        assert_eq!(pc.links.unwrap().internal[0].href, "https://s.test/h");
+        assert_eq!(pc.media.unwrap().images[0].src, "https://s.test/p.png");
+    }
+
+    #[test]
+    fn over_depth_skips_transform_but_still_extracts_links() {
+        let deep = format!(
+            "{}<a href=\"/deep\">D</a>{}",
+            "<div>".repeat(300),
+            "</div>".repeat(300)
+        );
+        let o = ContentOpts {
+            include_links: true,
+            include_media: true,
+            ..opts()
+        };
+        let pc = process(&deep, "https://s.test/", &o, true);
+        assert!(pc.rendered.is_none()); // recursive transform skipped on over-depth
+        assert_eq!(pc.links.unwrap().internal[0].href, "https://s.test/deep"); // flat scan still runs
+        assert!(pc.media.is_some());
+    }
+}

--- a/web/src/content/select.rs
+++ b/web/src/content/select.rs
@@ -1,0 +1,137 @@
+//! Content selection via source-offset splicing. `remove_excluded` deletes the
+//! source ranges of excluded subtrees; `scope_to_targets` keeps only matched
+//! regions. Selectors use the tl subset (tag/.class/#id). tag boundaries fall
+//! on ASCII `<`/`>`, so byte-offset slicing is always on char boundaries.
+
+use tl::{parse, ParserOptions};
+
+/// Splice out the given byte ranges (inclusive start, end) from `html`.
+/// Ranges are sorted and merged before removal.
+pub(crate) fn splice_out_ranges(html: &str, mut ranges: Vec<(usize, usize)>) -> String {
+    if ranges.is_empty() {
+        return html.to_string();
+    }
+    ranges.sort_by_key(|r| r.0);
+    let mut merged: Vec<(usize, usize)> = Vec::new();
+    for (s, e) in ranges {
+        match merged.last_mut() {
+            Some(last) if s <= last.1.saturating_add(1) => last.1 = last.1.max(e),
+            _ => merged.push((s, e)),
+        }
+    }
+    let mut out = String::with_capacity(html.len());
+    let mut cursor = 0usize;
+    for (s, e) in merged {
+        if s > cursor {
+            out.push_str(&html[cursor..s]);
+        }
+        cursor = e + 1; // end is inclusive
+    }
+    if cursor < html.len() {
+        out.push_str(&html[cursor..]);
+    }
+    out
+}
+
+/// Delete every subtree matching any `excluded` selector. Returns `html`
+/// unchanged when `excluded` is empty, parsing fails, or nothing matches.
+pub fn remove_excluded(html: &str, excluded: &[String]) -> String {
+    if excluded.is_empty() {
+        return html.to_string();
+    }
+    let Ok(dom) = parse(html, ParserOptions::default()) else {
+        return html.to_string();
+    };
+    let parser = dom.parser();
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    for sel in excluded {
+        if let Some(iter) = dom.query_selector(sel.trim()) {
+            for handle in iter {
+                if let Some(tag) = handle.get(parser).and_then(|n| n.as_tag()) {
+                    ranges.push(tag.boundaries(parser)); // (start, end) inclusive
+                }
+            }
+        }
+    }
+    if ranges.is_empty() {
+        return html.to_string();
+    }
+    splice_out_ranges(html, ranges)
+}
+
+/// Keep only the source of elements matching any `targets` selector (outermost
+/// match wins; nested matches are dropped). `None` when `targets` is empty or
+/// nothing matches — the caller then keeps the unscoped HTML.
+pub fn scope_to_targets(html: &str, targets: &[String]) -> Option<String> {
+    if targets.is_empty() {
+        return None;
+    }
+    let dom = parse(html, ParserOptions::default()).ok()?;
+    let parser = dom.parser();
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    for sel in targets {
+        if let Some(iter) = dom.query_selector(sel.trim()) {
+            for handle in iter {
+                if let Some(tag) = handle.get(parser).and_then(|n| n.as_tag()) {
+                    ranges.push(tag.boundaries(parser));
+                }
+            }
+        }
+    }
+    if ranges.is_empty() {
+        return None;
+    }
+    ranges.sort_by_key(|r| r.0);
+    let mut kept: Vec<(usize, usize)> = Vec::new();
+    for (s, e) in ranges {
+        if let Some(last) = kept.last() {
+            if s <= last.1 {
+                continue; // contained in / overlapping a kept outer range
+            }
+        }
+        kept.push((s, e));
+    }
+    let mut out = String::new();
+    for (s, e) in kept {
+        out.push_str(&html[s..=e]);
+        out.push('\n');
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(v: &[&str]) -> Vec<String> {
+        v.iter().map(|x| x.to_string()).collect()
+    }
+
+    #[test]
+    fn removes_excluded_tag() {
+        let html = "<body><nav>menu</nav><p>keep me</p><footer>foot</footer></body>";
+        let out = remove_excluded(html, &s(&["nav", "footer"]));
+        assert!(out.contains("keep me"));
+        assert!(!out.contains("menu"));
+        assert!(!out.contains("foot"));
+    }
+
+    #[test]
+    fn remove_excluded_noop_when_empty() {
+        let html = "<p>x</p>";
+        assert_eq!(remove_excluded(html, &[]), html);
+    }
+
+    #[test]
+    fn scopes_to_target() {
+        let html = "<body><nav>menu</nav><article>real content</article></body>";
+        let out = scope_to_targets(html, &s(&["article"])).unwrap();
+        assert!(out.contains("real content"));
+        assert!(!out.contains("menu"));
+    }
+
+    #[test]
+    fn scope_none_when_no_match() {
+        assert!(scope_to_targets("<p>x</p>", &s(&["article"])).is_none());
+    }
+}

--- a/web/src/fetch.rs
+++ b/web/src/fetch.rs
@@ -12,6 +12,7 @@ use futures::StreamExt;
 use serde_json::{json, Value};
 
 use crate::config::WebConfig;
+use crate::content::{self, ContentOpts};
 use crate::convert::{
     accept_header_for, extract_text, html_to_markdown, is_image_mime, is_viewable_image_mime,
     max_tag_depth, ACCEPT_LANGUAGE, BROWSER_USER_AGENT, MAX_NESTING_DEPTH,
@@ -37,6 +38,18 @@ pub fn resolve_max_bytes(p: &FetchPayload, cfg: &WebConfig) -> u64 {
         cfg.max_response_bytes
     };
     p.max_bytes.unwrap_or(fallback).min(cfg.max_response_bytes)
+}
+
+/// Build the content-pipeline options from the payload for a given page format.
+pub fn build_content_opts(p: &FetchPayload, format: PageFormat) -> ContentOpts {
+    ContentOpts {
+        format,
+        content_filter: p.content_filter.clone(),
+        target_elements: p.target_elements.clone().unwrap_or_default(),
+        excluded_tags: p.excluded_tags.clone().unwrap_or_default(),
+        include_links: p.include_links.unwrap_or(false),
+        include_media: p.include_media.unwrap_or(false),
+    }
 }
 
 /// If `json` is set, stringify it into the body and set content-type to
@@ -357,7 +370,17 @@ pub async fn execute_fetch(payload: FetchPayload, cfg: &WebConfig) -> Value {
             // 3xx without Location: fall through and return the response.
         }
 
-        return shape_response(resp, page_format, response_format, &redirect_chain, cfg).await;
+        let content_opts = page_format.map(|f| build_content_opts(&payload, f));
+        return shape_response(
+            resp,
+            page_format,
+            response_format,
+            &redirect_chain,
+            cfg,
+            content_opts.as_ref(),
+            &current_url,
+        )
+        .await;
     }
 
     error_envelope(
@@ -372,6 +395,8 @@ async fn shape_response(
     response_format: ResponseFormat,
     redirect_chain: &[String],
     cfg: &WebConfig,
+    content_opts: Option<&ContentOpts>,
+    final_url: &str,
 ) -> Value {
     if let Some(pf) = page_format {
         let content_type = resp
@@ -429,11 +454,55 @@ async fn shape_response(
 
         let raw = String::from_utf8_lossy(&resp.bytes).into_owned();
         let is_html = mime == "text/html" || mime == "application/xhtml+xml";
+        let within_cap = (resp.bytes.len() as u64) <= cfg.max_transform_bytes;
+        let enriched = content_opts.map(|o| o.is_enriched()).unwrap_or(false);
+
         let mut body = raw.clone();
         let mut transformed: Option<&str> = None;
-        let within_cap = (resp.bytes.len() as u64) <= cfg.max_transform_bytes;
+        let mut links_val: Option<Value> = None;
+        let mut media_val: Option<Value> = None;
 
-        if is_html && within_cap && matches!(pf, PageFormat::Markdown | PageFormat::Text) {
+        let format_label = |pf: PageFormat| match pf {
+            PageFormat::Markdown => "markdown",
+            PageFormat::Text => "text",
+            PageFormat::Html => "html",
+        };
+
+        if is_html && enriched {
+            // Enriched path: flat link/media extraction always runs; the recursive
+            // transform + filtering run only within the size cap (`within_cap`).
+            let raw_clone = raw.clone();
+            let base = final_url.to_string();
+            let o = content_opts.expect("enriched implies opts");
+            let opts_owned = ContentOpts {
+                format: pf,
+                content_filter: o.content_filter.clone(),
+                target_elements: o.target_elements.clone(),
+                excluded_tags: o.excluded_tags.clone(),
+                include_links: o.include_links,
+                include_media: o.include_media,
+            };
+            let pc: content::PageContent = tokio::task::spawn_blocking(move || {
+                content::process(&raw_clone, &base, &opts_owned, within_cap)
+            })
+            .await
+            .unwrap_or(content::PageContent {
+                rendered: None,
+                filtered: false,
+                links: None,
+                media: None,
+            });
+            if let Some(r) = pc.rendered {
+                body = r;
+                transformed = Some(format_label(pf));
+                if resp.truncated {
+                    body.push_str("\n\n[Content truncated at max_bytes — the page continues beyond this point]");
+                }
+            }
+            links_val = pc.links.as_ref().map(|l| serde_json::to_value(l).unwrap());
+            media_val = pc.media.as_ref().map(|m| serde_json::to_value(m).unwrap());
+        } else if is_html && within_cap && matches!(pf, PageFormat::Markdown | PageFormat::Text) {
+            // Backward-compatible path: unchanged from before enrichment existed.
             let raw_clone = raw.clone();
             let maybe_text: Option<String> = tokio::task::spawn_blocking(move || {
                 if max_tag_depth(&raw_clone) > MAX_NESTING_DEPTH {
@@ -447,19 +516,13 @@ async fn shape_response(
             })
             .await
             .unwrap_or(None);
-
             if let Some(text) = maybe_text {
                 body = text;
-                transformed = Some(match pf {
-                    PageFormat::Markdown => "markdown",
-                    PageFormat::Text => "text",
-                    PageFormat::Html => "html",
-                });
+                transformed = Some(format_label(pf));
                 if resp.truncated {
                     body.push_str("\n\n[Content truncated at max_bytes — the page continues beyond this point]");
                 }
             }
-            // On transform failure / over-depth / panic: keep raw body, leave transformed unset.
         }
 
         let mut out = json!({
@@ -474,6 +537,12 @@ async fn shape_response(
         });
         if let Some(t) = transformed {
             out["transformed"] = json!(t);
+        }
+        if let Some(l) = links_val {
+            out["links"] = l;
+        }
+        if let Some(m) = media_val {
+            out["media"] = m;
         }
         if !redirect_chain.is_empty() {
             out["redirect_chain"] = json!(redirect_chain);
@@ -517,6 +586,28 @@ mod tests {
 
     fn p(j: serde_json::Value) -> FetchPayload {
         serde_json::from_value(j).unwrap()
+    }
+
+    #[test]
+    fn content_opts_built_from_payload() {
+        let pl = p(serde_json::json!({
+            "url": "https://x.test/",
+            "format": "markdown",
+            "excluded_tags": ["nav"],
+            "include_links": true
+        }));
+        let opts = build_content_opts(&pl, crate::schemas::PageFormat::Markdown);
+        assert!(opts.is_enriched());
+        assert_eq!(opts.excluded_tags, vec!["nav".to_string()]);
+        assert!(opts.include_links);
+        assert!(!opts.include_media);
+    }
+
+    #[test]
+    fn content_opts_empty_is_not_enriched() {
+        let pl = p(serde_json::json!({ "url": "https://x.test/", "format": "markdown" }));
+        let opts = build_content_opts(&pl, crate::schemas::PageFormat::Markdown);
+        assert!(!opts.is_enriched());
     }
 
     #[test]

--- a/web/src/fetch.rs
+++ b/web/src/fetch.rs
@@ -495,7 +495,9 @@ async fn shape_response(
             if let Some(r) = pc.rendered {
                 body = r;
                 transformed = Some(format_label(pf));
-                if resp.truncated {
+                // Don't inject a plain-text note into HTML output; `bytes_truncated`
+                // already signals truncation for every format.
+                if resp.truncated && !matches!(pf, PageFormat::Html) {
                     body.push_str("\n\n[Content truncated at max_bytes — the page continues beyond this point]");
                 }
             }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod config;
 pub mod configuration;
+pub mod content;
 pub mod convert;
 pub mod fetch;
 pub mod functions;

--- a/web/src/schemas.rs
+++ b/web/src/schemas.rs
@@ -154,6 +154,8 @@ impl FetchPayload {
         if let Some(cf) = &self.content_filter {
             if let Some(t) = cf.threshold {
                 match cf.kind {
+                    // Pruning scores are normalized to [0,1] (a product of factors each
+                    // <= 1): 0 keeps everything, 1 is strictest; outside is degenerate.
                     FilterType::Pruning => {
                         if !(0.0..=1.0).contains(&t) {
                             return Err(

--- a/web/src/schemas.rs
+++ b/web/src/schemas.rs
@@ -27,6 +27,37 @@ pub enum PageFormat {
     Html,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum FilterType {
+    Pruning,
+    Bm25,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ThresholdType {
+    Fixed,
+    Dynamic,
+}
+
+/// Content-filter request block. `query`, `threshold`, `threshold_type`, and
+/// `min_word_threshold` are optional; their default values are applied when
+/// the filter runs (see the content pipeline), not at deserialization.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct ContentFilter {
+    #[serde(rename = "type")]
+    pub kind: FilterType,
+    #[serde(default)]
+    pub query: Option<String>,
+    #[serde(default)]
+    pub threshold: Option<f64>,
+    #[serde(default)]
+    pub threshold_type: Option<ThresholdType>,
+    #[serde(default)]
+    pub min_word_threshold: Option<u32>,
+}
+
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct FetchPayload {
     /// Absolute http(s):// URL to fetch.
@@ -63,6 +94,23 @@ pub struct FetchPayload {
     /// response_format is ignored (treated as "text").
     #[serde(default)]
     pub format: Option<PageFormat>,
+    /// Content filter: prunes boilerplate. When set, `body` holds the filtered
+    /// output in the requested `format` (page-reading mode only).
+    #[serde(default)]
+    pub content_filter: Option<ContentFilter>,
+    /// CSS selectors (tl subset: tag/.class/#id). Restrict rendered content to
+    /// these regions. Unmatched selectors are ignored.
+    #[serde(default)]
+    pub target_elements: Option<Vec<String>>,
+    /// Tag names / selectors to drop before rendering (e.g. "nav", "footer").
+    #[serde(default)]
+    pub excluded_tags: Option<Vec<String>>,
+    /// Add `links: { internal, external }` to the envelope.
+    #[serde(default)]
+    pub include_links: Option<bool>,
+    /// Add `media: { images, videos, audios }` to the envelope.
+    #[serde(default)]
+    pub include_media: Option<bool>,
 }
 
 impl FetchPayload {
@@ -89,6 +137,50 @@ impl FetchPayload {
         }
         if matches!(self.max_bytes, Some(0)) {
             return Err("max_bytes: must be a positive integer".to_string());
+        }
+        // Enrichment (filtering, scoping, link/media extraction) is page-reading
+        // mode only; without `format` it would be silently ignored, so reject it.
+        let wants_enrichment = self.content_filter.is_some()
+            || self.target_elements.as_ref().is_some_and(|v| !v.is_empty())
+            || self.excluded_tags.as_ref().is_some_and(|v| !v.is_empty())
+            || self.include_links == Some(true)
+            || self.include_media == Some(true);
+        if wants_enrichment && self.format.is_none() {
+            return Err(
+                "format: required with content_filter/target_elements/excluded_tags/include_links/include_media"
+                    .to_string(),
+            );
+        }
+        if let Some(cf) = &self.content_filter {
+            if let Some(t) = cf.threshold {
+                match cf.kind {
+                    FilterType::Pruning => {
+                        if !(0.0..=1.0).contains(&t) {
+                            return Err(
+                                "content_filter.threshold: pruning threshold must be in [0,1]"
+                                    .to_string(),
+                            );
+                        }
+                    }
+                    FilterType::Bm25 => {
+                        if t < 0.0 {
+                            return Err(
+                                "content_filter.threshold: bm25 threshold must be >= 0".to_string()
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        for (field, list) in [
+            ("target_elements", &self.target_elements),
+            ("excluded_tags", &self.excluded_tags),
+        ] {
+            if let Some(v) = list {
+                if v.iter().any(|s| s.trim().is_empty()) {
+                    return Err(format!("{field}: selectors must be non-empty strings"));
+                }
+            }
         }
         Ok(())
     }
@@ -124,6 +216,8 @@ pub struct FetchResponse {
     pub redirect_chain: Option<Vec<String>>,
     pub content: Option<serde_json::Value>,
     pub details: Option<serde_json::Value>,
+    pub links: Option<serde_json::Value>,
+    pub media: Option<serde_json::Value>,
 }
 
 pub fn response_schema() -> serde_json::Value {
@@ -221,5 +315,113 @@ mod tests {
         assert_eq!(s["type"], "object");
         assert!(s["properties"].get("ok").is_some());
         assert!(s["properties"].get("error").is_some());
+    }
+
+    #[test]
+    fn parses_content_filter_pruning() {
+        let p = payload(serde_json::json!({
+            "url": "https://x.test/",
+            "content_filter": { "type": "pruning", "threshold": 0.5 }
+        }))
+        .unwrap();
+        let cf = p.content_filter.unwrap();
+        assert_eq!(cf.kind, FilterType::Pruning);
+        assert_eq!(cf.threshold, Some(0.5));
+    }
+
+    #[test]
+    fn parses_selection_and_extraction_flags() {
+        let p = payload(serde_json::json!({
+            "url": "https://x.test/",
+            "target_elements": ["article", ".main"],
+            "excluded_tags": ["nav", "footer"],
+            "include_links": true,
+            "include_media": true
+        }))
+        .unwrap();
+        assert_eq!(p.target_elements.unwrap(), vec!["article", ".main"]);
+        assert_eq!(p.excluded_tags.unwrap(), vec!["nav", "footer"]);
+        assert_eq!(p.include_links, Some(true));
+        assert_eq!(p.include_media, Some(true));
+    }
+
+    #[test]
+    fn rejects_pruning_threshold_out_of_range() {
+        let p = payload(serde_json::json!({
+            "url": "https://x.test/",
+            "format": "markdown",
+            "content_filter": { "type": "pruning", "threshold": 1.5 }
+        }))
+        .unwrap();
+        assert!(p.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_enrichment_without_format() {
+        // Page-mode-only fields without `format` must error, not be silently dropped.
+        for field in [
+            serde_json::json!({ "include_links": true }),
+            serde_json::json!({ "include_media": true }),
+            serde_json::json!({ "excluded_tags": ["nav"] }),
+            serde_json::json!({ "target_elements": ["article"] }),
+            serde_json::json!({ "content_filter": { "type": "pruning" } }),
+        ] {
+            let mut obj = serde_json::json!({ "url": "https://x.test/" });
+            obj.as_object_mut()
+                .unwrap()
+                .extend(field.as_object().unwrap().clone());
+            assert!(payload(obj).unwrap().validate().is_err());
+        }
+        // Same fields WITH format validate fine.
+        assert!(payload(serde_json::json!({
+            "url": "https://x.test/",
+            "format": "markdown",
+            "include_links": true
+        }))
+        .unwrap()
+        .validate()
+        .is_ok());
+    }
+
+    #[test]
+    fn bm25_threshold_above_one_is_allowed() {
+        let p = payload(serde_json::json!({
+            "url": "https://x.test/",
+            "format": "markdown",
+            "content_filter": { "type": "bm25", "threshold": 2.5, "query": "rust" }
+        }))
+        .unwrap();
+        p.validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_empty_selector() {
+        let p = payload(serde_json::json!({
+            "url": "https://x.test/",
+            "format": "markdown",
+            "target_elements": ["article", "  "]
+        }))
+        .unwrap();
+        assert!(p.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_empty_excluded_tag() {
+        let p = payload(serde_json::json!({
+            "url": "https://x.test/",
+            "format": "markdown",
+            "excluded_tags": ["nav", "  "]
+        }))
+        .unwrap();
+        assert!(p.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_filter_type() {
+        assert!(payload(serde_json::json!({
+            "url": "https://x.test/",
+            "content_filter": { "type": "magic" }
+        }))
+        .is_err());
     }
 }

--- a/web/tests/content_pipeline.rs
+++ b/web/tests/content_pipeline.rs
@@ -1,0 +1,147 @@
+use serde_json::json;
+use web::config::WebConfig;
+use web::fetch::execute_fetch;
+use web::schemas::FetchPayload;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn payload(j: serde_json::Value) -> FetchPayload {
+    serde_json::from_value(j).unwrap()
+}
+
+const PAGE: &str = r#"<html><head><title>T</title></head><body>
+<nav class="nav"><a href="/home">Home</a></nav>
+<article><p>The quick brown fox jumps over the lazy dog in a long real paragraph of content.</p>
+<img src="/pic.png" alt="pic"></article>
+<footer class="footer">footer junk</footer></body></html>"#;
+
+async fn serve(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/p"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(PAGE, "text/html; charset=utf-8"))
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn content_filter_prunes_boilerplate_into_body() {
+    let server = MockServer::start().await;
+    serve(&server).await;
+    let out = execute_fetch(
+        payload(json!({
+            "url": format!("{}/p", server.uri()),
+            "format": "markdown",
+            "content_filter": { "type": "pruning" }
+        })),
+        &WebConfig::default(),
+    )
+    .await;
+    let body = out["body"].as_str().unwrap();
+    assert!(body.contains("quick brown fox"));
+    assert!(!body.contains("Home"));
+    assert!(!body.contains("footer junk"));
+    assert_eq!(out["transformed"], "markdown");
+}
+
+#[tokio::test]
+async fn include_links_and_media_populate_envelope() {
+    let server = MockServer::start().await;
+    serve(&server).await;
+    let base = server.uri();
+    let out = execute_fetch(
+        payload(json!({
+            "url": format!("{}/p", base),
+            "format": "markdown",
+            "include_links": true,
+            "include_media": true
+        })),
+        &WebConfig::default(),
+    )
+    .await;
+    assert_eq!(
+        out["links"]["internal"][0]["href"],
+        format!("{}/home", base)
+    );
+    assert_eq!(
+        out["media"]["images"][0]["src"],
+        format!("{}/pic.png", base)
+    );
+    assert_eq!(out["media"]["images"][0]["alt"], "pic");
+}
+
+#[tokio::test]
+async fn excluded_tags_and_target_elements_scope_body() {
+    let server = MockServer::start().await;
+    serve(&server).await;
+    let out = execute_fetch(
+        payload(json!({
+            "url": format!("{}/p", server.uri()),
+            "format": "markdown",
+            "target_elements": ["article"],
+            "excluded_tags": ["nav", "footer"]
+        })),
+        &WebConfig::default(),
+    )
+    .await;
+    let body = out["body"].as_str().unwrap();
+    assert!(body.contains("quick brown fox"));
+    assert!(!body.contains("Home"));
+    assert!(!body.contains("footer junk"));
+}
+
+#[tokio::test]
+async fn target_elements_alone_scopes_body() {
+    let server = MockServer::start().await;
+    serve(&server).await;
+    let out = execute_fetch(
+        payload(json!({
+            "url": format!("{}/p", server.uri()),
+            "format": "markdown",
+            "target_elements": ["article"]
+        })),
+        &WebConfig::default(),
+    )
+    .await;
+    let body = out["body"].as_str().unwrap();
+    assert!(body.contains("quick brown fox"));
+    assert!(!body.contains("Home")); // nav is outside <article>
+    assert!(!body.contains("footer junk")); // footer is outside <article>
+    assert!(out.get("links").is_none()); // not requested
+}
+
+#[tokio::test]
+async fn excluded_tags_alone_drops_boilerplate() {
+    let server = MockServer::start().await;
+    serve(&server).await;
+    let out = execute_fetch(
+        payload(json!({
+            "url": format!("{}/p", server.uri()),
+            "format": "markdown",
+            "excluded_tags": ["nav", "footer"]
+        })),
+        &WebConfig::default(),
+    )
+    .await;
+    let body = out["body"].as_str().unwrap();
+    assert!(body.contains("quick brown fox"));
+    assert!(!body.contains("Home"));
+    assert!(!body.contains("footer junk"));
+}
+
+#[tokio::test]
+async fn backward_compat_no_new_fields_unchanged() {
+    let server = MockServer::start().await;
+    serve(&server).await;
+    let out = execute_fetch(
+        payload(json!({ "url": format!("{}/p", server.uri()), "format": "markdown" })),
+        &WebConfig::default(),
+    )
+    .await;
+    let body = out["body"].as_str().unwrap();
+    // full page rendered (boilerplate retained), no links/media keys
+    assert!(body.contains("quick brown fox"));
+    assert!(body.contains("Home"));
+    assert!(out.get("links").is_none());
+    assert!(out.get("media").is_none());
+    assert_eq!(out["transformed"], "markdown");
+}


### PR DESCRIPTION
## Phase 1: static-crawl content pipeline for the `web` worker

Enriches the existing `web::fetch` bus function with a single-page **content pipeline**, the first phase of reaching full static-HTTP crawl parity. No browser, no JS — pure static HTTP + DOM.

### What's added
- **Content filters** — `pruning` (boilerplate scoring, `threshold=0.48`) and `bm25` (query relevance, `threshold=1.0`). Filtered output **replaces** `body` (the JSON envelope *is* the LLM context, so we don't return both raw + fit).
- **Content selection** — `target_elements` (restrict to CSS regions) and `excluded_tags` (drop subtrees like `nav`/`footer`/`aside`) before rendering.
- **Link & media extraction** — opt-in `include_links` / `include_media`, with URL resolution.
- **Page-metadata extraction** — feeds the filter `query` fallback when no explicit query is given.
- Pipeline orchestrator (`content/mod.rs::process`) wired into `fetch.rs::shape_response`.

### Backward compatibility
Hard requirement, preserved: **all new request fields are optional**. When none are set, `web::fetch` output is byte-identical to today via short-circuit. Existing callers and the harness consumer are unaffected.

### Design
Pure, synchronous, side-effect-free functions (matches existing `convert.rs` style); only the existing fetch does I/O.

### Tests
Integration coverage in `web/tests/content_pipeline.rs` plus per-module unit tests (pruning scoring/threshold, BM25 relevance, selection scoping, boilerplate hints).

Roadmap (later, separate PRs): `web::extract` (structured/table), `web::crawl` (deep crawl), `web::seed` (URL discovery).
