### PR TITLE
feat(harness): use native engine trigger metadata delivery

### DIFF
--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -764,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.20.0"
+version = "0.20.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09daa7c14a9e4c1f7077c4a181918d207e3f05cdfea8b2d7781bbeb80caf4c5d"
+checksum = "5c9e3b39400a92c73f60484580b74b70a86e762580a4780afb6564fdd6857fd5"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -785,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.20.0"
+version = "0.20.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5957568413b9a5178c11bf91b20909e93e568b187e259e941ba6009a7ec3f5c1"
+checksum = "9b8db86bbb94bd65650ab716ef24ab8321062c05b91511a7b5854a862b755b3b"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -15,10 +15,10 @@ name = "harness"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.20.0"
+iii-sdk = "=0.20.0-alpha.1"
 # Re-exports the same `opentelemetry` the SDK uses, so we can carry the active
 # OTel context across `tokio::spawn` boundaries (shared `Context` global).
-iii-helpers = "=0.20.0"
+iii-helpers = "=0.20.0-alpha.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/harness/src/functions/subscribe.rs
+++ b/harness/src/functions/subscribe.rs
@@ -2,8 +2,10 @@
 //! fires, instead of polling (harness.md § Subscriptions). The agent calls
 //! `engine::register_trigger` / `engine::unregister_trigger`; the harness
 //! intercepts those calls (see [`invoke`]) so the trusted owning session,
-//! `harness::notify_agent` target, and engine-proxied subscription metadata are
-//! injected, and teardown stays owner-checked — the agent can never supply those.
+//! `harness::notify_agent` target, and subscription metadata are injected, and
+//! teardown stays owner-checked — the agent can never supply those. The engine
+//! stores this metadata on the `Trigger` and delivers it to `notify_agent` as a
+//! distinct invocation argument at fire time (not folded into the payload).
 
 use iii_sdk::protocol::TriggerRequest;
 use iii_sdk::TriggerAction;

--- a/harness/src/subscriptions/mod.rs
+++ b/harness/src/subscriptions/mod.rs
@@ -15,13 +15,14 @@
 //! `state` on a key and have the signaller call the existing `state::set`.
 //!
 //! Routing: the interceptor registers a trigger (via `engine::register_trigger`)
-//! bound to the ONE shared `harness::notify_agent` function. The engine's
-//! per-subscription proxy round-trips the registration metadata into the fired
-//! payload under [`TRIGGER_META_KEY`] (`__metadata`). That metadata carries the
-//! subscription id, owning session, label, and `once`; the local registry
-//! validates liveness/ownership for cleanup. The owning session is injected by
-//! the harness when it intercepts the agent's `engine::register_trigger` call,
-//! never trusted from model arguments.
+//! bound to the ONE shared `harness::notify_agent` function, with the
+//! registration metadata stored on the engine's `Trigger` and delivered back
+//! to the handler as a distinct invocation argument at fire time (not folded
+//! into the fired payload). That metadata carries the subscription id, owning
+//! session, label, and `once`; the local registry validates liveness/ownership
+//! for cleanup. The owning session is injected by the harness when it
+//! intercepts the agent's `engine::register_trigger` call, never trusted from
+//! model arguments.
 
 pub mod notify_agent;
 pub mod registry;
@@ -38,11 +39,6 @@ pub const NOTIFY_AGENT_ID: &str = "harness::notify_agent";
 pub const NOTIFY_AGENT_DESC: &str =
     "Internal: the shared subscription fire handler — injects a notification into the owning \
      session (resolved from the local subscription registry). Not called directly.";
-
-/// Reserved payload key under which the engine's subscription proxy round-trips a
-/// trigger's registration metadata into the fired payload. MUST match the engine
-/// constant `iii::trigger::TRIGGER_META_KEY`.
-pub const TRIGGER_META_KEY: &str = "__metadata";
 
 /// Internal `session::deleted` cleanup handler id.
 pub const ON_SESSION_DELETED_ID: &str = "harness::on-session-deleted";

--- a/harness/src/subscriptions/notify_agent.rs
+++ b/harness/src/subscriptions/notify_agent.rs
@@ -1,11 +1,11 @@
 //! `harness::notify_agent` — the ONE shared subscription fire handler.
 //!
 //! Every subscription binds (via `engine::register_trigger`) to this single
-//! function. The engine's per-subscription proxy injects the registration
-//! `metadata` into the fired payload under [`TRIGGER_META_KEY`]
-//! (`__metadata`). That trusted metadata carries the subscription id, owning
-//! session, label, and one-shot semantics; the local registry validates liveness
-//! and ownership for cleanup.
+//! function. The engine stores the registration `metadata` on the `Trigger`
+//! and delivers it at fire time as a distinct invocation argument (not folded
+//! into the fired payload). That trusted metadata carries the subscription id,
+//! owning session, label, and one-shot semantics; the local registry validates
+//! liveness and ownership for cleanup.
 
 use std::sync::Arc;
 
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::deps::Deps;
-use crate::subscriptions::{NOTIFY_AGENT_DESC, NOTIFY_AGENT_ID, TRIGGER_META_KEY};
+use crate::subscriptions::{NOTIFY_AGENT_DESC, NOTIFY_AGENT_ID};
 use crate::types::message::AgentMessage;
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -32,10 +32,10 @@ pub fn register(deps: Arc<Deps>) {
     let iii = deps.iii.clone();
     iii.register_function(
         NOTIFY_AGENT_ID,
-        RegisterFunction::new_async(move |event: Value| {
+        RegisterFunction::new_async_with_metadata(move |event: Value, metadata: Option<Value>| {
             let deps = deps.clone();
             async move {
-                on_fire(&deps, event).await;
+                on_fire(&deps, event, metadata).await;
                 Ok::<Value, Error>(json!({ "ok": true }))
             }
         })
@@ -43,11 +43,11 @@ pub fn register(deps: Arc<Deps>) {
     );
 }
 
-async fn on_fire(deps: &Deps, mut event: Value) {
-    let meta = match take_metadata(&mut event) {
+async fn on_fire(deps: &Deps, event: Value, metadata: Option<Value>) {
+    let meta = match parse_metadata(metadata) {
         Ok(meta) => meta,
         Err(MetadataError::Missing) => {
-            tracing::warn!("notify_agent fire without {TRIGGER_META_KEY}; dropping");
+            tracing::warn!("notify_agent fire without trigger metadata; dropping");
             return;
         }
         Err(MetadataError::Invalid(e)) => {
@@ -92,12 +92,8 @@ enum MetadataError {
     Invalid(serde_json::Error),
 }
 
-fn take_metadata(event: &mut Value) -> Result<NotifyMetadata, MetadataError> {
-    let meta = event
-        .as_object_mut()
-        .and_then(|o| o.remove(TRIGGER_META_KEY))
-        .ok_or(MetadataError::Missing)?;
-
+fn parse_metadata(metadata: Option<Value>) -> Result<NotifyMetadata, MetadataError> {
+    let meta = metadata.ok_or(MetadataError::Missing)?;
     serde_json::from_value(meta).map_err(MetadataError::Invalid)
 }
 
@@ -143,37 +139,29 @@ mod tests {
     }
 
     #[test]
-    fn metadata_is_required_valid_and_stripped() {
-        let mut missing = json!({ "event_type": "set" });
-        assert!(matches!(
-            take_metadata(&mut missing),
-            Err(MetadataError::Missing)
-        ));
+    fn metadata_is_required_and_validated() {
+        assert!(matches!(parse_metadata(None), Err(MetadataError::Missing)));
 
-        let mut invalid = json!({ TRIGGER_META_KEY: { "session_id": "s" } });
+        let invalid = Some(json!({ "session_id": "s" }));
         assert!(matches!(
-            take_metadata(&mut invalid),
+            parse_metadata(invalid),
             Err(MetadataError::Invalid(_))
         ));
 
-        let mut event = json!({
-            "event_type": "set",
-            TRIGGER_META_KEY: {
-                "subscription_id": "sub_1",
-                "session_id": "s_secret",
-                "label": "done"
-            }
-        });
-        let meta = take_metadata(&mut event).unwrap();
+        let valid = Some(json!({
+            "subscription_id": "sub_1",
+            "session_id": "s_secret",
+            "label": "done"
+        }));
+        let meta = parse_metadata(valid).unwrap();
 
         assert_eq!(meta.subscription_id, "sub_1");
         assert_eq!(meta.session_id, "s_secret");
         assert_eq!(meta.label.as_deref(), Some("done"));
-        assert!(event.get(TRIGGER_META_KEY).is_none());
     }
 
     #[test]
-    fn notification_message_uses_label_origin_and_stripped_event() {
+    fn notification_message_uses_label_and_origin() {
         let meta = NotifyMetadata {
             subscription_id: "sub_1".to_string(),
             session_id: "s_1".to_string(),

--- a/harness/src/subscriptions/registry.rs
+++ b/harness/src/subscriptions/registry.rs
@@ -1,12 +1,12 @@
 //! In-memory ephemeral subscription index (harness.md § Subscriptions).
 //!
-//! The engine owns each subscription's trigger AND its delivery proxy; the
-//! harness keeps only the small bookkeeping it needs LOCALLY: the owning session
-//! (per-session cap, ownership check, session-deleted cleanup), a fire counter
-//! (for idempotent notification entry ids), and the engine-returned trigger id
-//! (to unregister). Fire context such as label / once is carried by the
-//! engine's registration metadata proxy, not duplicated here. No iii handles are
-//! held here.
+//! The engine owns each subscription's trigger AND its fire-time metadata
+//! delivery; the harness keeps only the small bookkeeping it needs LOCALLY: the
+//! owning session (per-session cap, ownership check, session-deleted cleanup),
+//! a fire counter (for idempotent notification entry ids), and the
+//! engine-returned trigger id (to unregister). Fire context such as label /
+//! once is carried by the engine's `Trigger` metadata, not duplicated here. No
+//! iii handles are held here.
 //!
 //! Subscriptions are intentionally NOT persisted: they live for the harness
 //! process only (the "ephemeral" contract). Lifecycle is covered by explicit


### PR DESCRIPTION
## Why

#333 (agent trigger subscriptions) merged one commit short: `feat(harness): use native engine trigger metadata delivery` was written locally but never pushed before the PR got squash-merged, so `main` still carries the older payload-folding approach for subscription metadata delivery.

## What

Bumps `iii-sdk` / `iii-helpers` to `0.20.0-alpha.1` for `engine::register_trigger`'s first-class per-invocation metadata argument, and refactors `harness::notify_agent` to receive that metadata as a distinct handler argument instead of round-tripping it through a `__metadata` key folded into the fired event payload.

- `notify_agent::register` now uses `RegisterFunction::new_async_with_metadata`, receiving `(event, metadata)` instead of a single mutated `event`.
- `parse_metadata` replaces `take_metadata` — it reads the engine-delivered `metadata` argument directly instead of removing a reserved key from the payload.
- Drops `TRIGGER_META_KEY` (`__metadata`) and the payload round-tripping it required — the engine now stores registration metadata on the `Trigger` and hands it back at fire time as its own argument, so the fired payload can never be mistaken for (or spoof) subscription metadata.
- Doc comments in `subscribe.rs`, `subscriptions/mod.rs`, and `subscriptions/registry.rs` updated to describe the new delivery path.

No behavior change from the agent's perspective — this only changes how the harness receives trusted metadata from the engine at fire time.

## Test plan

- [x] `cargo build --all-targets`
- [x] `cargo test` (115 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription notifications now use fire-time metadata directly, improving reliability and avoiding payload mutation.
  * Missing or invalid subscription metadata is now detected more consistently, preventing malformed notifications from being delivered.

* **Documentation**
  * Clarified how subscription registration, teardown, and notification metadata are handled.

* **Chores**
  * Updated dependency versions to match the pre-release SDK and helper package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->