### PR TITLE
refactor(harness): adopt iii-sdk 0.20.0-alpha.2 metadata API

### DIFF
--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -764,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.20.0-alpha.1"
+version = "0.20.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c9e3b39400a92c73f60484580b74b70a86e762580a4780afb6564fdd6857fd5"
+checksum = "6063cce635b273b4623598b95329d3feeb7f41b9ab5e4ed6168df62f819c6724"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -785,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.20.0-alpha.1"
+version = "0.20.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b8db86bbb94bd65650ab716ef24ab8321062c05b91511a7b5854a862b755b3b"
+checksum = "0afbb588ec77a3f99e2ea534453c3e564d509500f82c9ed46d733dd69871abfa"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -15,10 +15,10 @@ name = "harness"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.20.0-alpha.1"
+iii-sdk = "=0.20.0-alpha.2"
 # Re-exports the same `opentelemetry` the SDK uses, so we can carry the active
 # OTel context across `tokio::spawn` boundaries (shared `Context` global).
-iii-helpers = "=0.20.0-alpha.1"
+iii-helpers = "=0.20.0-alpha.2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/harness/src/subscriptions/notify_agent.rs
+++ b/harness/src/subscriptions/notify_agent.rs
@@ -32,7 +32,7 @@ pub fn register(deps: Arc<Deps>) {
     let iii = deps.iii.clone();
     iii.register_function(
         NOTIFY_AGENT_ID,
-        RegisterFunction::new_async_with_metadata(move |event: Value, metadata: Option<Value>| {
+        RegisterFunction::new_async(move |event: Value, metadata: Option<Value>| {
             let deps = deps.clone();
             async move {
                 on_fire(&deps, event, metadata).await;


### PR DESCRIPTION
## Summary

Bumps the harness worker from `iii-sdk` / `iii-helpers` `=0.20.0-alpha.1` to `=0.20.0-alpha.2` and adapts to the reworked metadata API.

alpha.2 reworked the SDK's metadata surface for backward compatibility (no parallel `*_with_metadata` registration functions; metadata flows through existing constructors via trait overloading and builders). For the harness that means exactly one call-site change:

- `notify_agent.rs`: `RegisterFunction::new_async_with_metadata(|event, metadata| …)` → `RegisterFunction::new_async(|event, metadata| …)` — the dedicated constructor is gone; `new_async` accepts the two-argument closure directly. Metadata sidecar delivery semantics are unchanged.

Everything else compiled as-is on alpha.2, including the subscription registry's `engine::register_trigger` metadata payloads and the `.metadata(…)` registration builder in `discovery.rs`.

Other workers in the monorepo pin `iii-sdk = "=0.20.0"` (stable line) and don't use the metadata APIs, so they are intentionally left untouched.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt --check` — clean
- [x] `cargo test` — 112 passed, 0 failed
- [ ] Live check: subscription fire delivers trigger metadata to `harness::notify-agent` against an engine running the matching build

https://claude.ai/code/session_01FoC1t52yPmFQFTFPHr8kkT