### PR TITLE
fix: guarantee the picked working directory reaches every shell/coder call

### DIFF
--- a/console/web/src/components/chat/DirectoryPicker.tsx
+++ b/console/web/src/components/chat/DirectoryPicker.tsx
@@ -22,10 +22,11 @@ import { cn } from '@/lib/utils'
  * or "browse to add" a new directory. Browsing uses shell's operator workspace
  * control plane one level at a time. The search box filters the current level
  * live; typing/pasting an absolute path jumps straight there (browse) or
- * selects it (projects). A pasted/remembered dir is validated against the live
- * shell worker before it's accepted. The chosen dir is what the harness scopes
- * the chat to (`base_dir`); it is re-scopable mid-conversation (a change drops
- * a visible transcript marker).
+ * selects it (projects). Every selection — pasted, remembered, or browsed — is
+ * validated against the live shell worker before it's accepted, and the
+ * worker-echoed canonical path is what gets stored. The chosen dir is what the
+ * harness scopes the chat to (`base_dir`); it is re-scopable mid-conversation
+ * (a change drops a visible transcript marker).
  */
 
 interface DirectoryPickerProps {
@@ -270,9 +271,11 @@ export function DirectoryPicker({
     [onChange],
   )
 
-  // Validate a pasted/remembered dir against the LIVE worker roots before
-  // accepting it — a remembered project may be deleted, on another machine, or
-  // outside the configured roots. Browsed dirs are already known-valid.
+  // Validate a dir against the LIVE worker before accepting it — a
+  // remembered project may be deleted, on another machine, or denylisted, and
+  // even a just-browsed dir can vanish between listing and clicking. Every
+  // selection path goes through here so the worker-echoed canonical path is
+  // what gets stored.
   const validateAndSelect = useCallback(
     async (raw: string) => {
       const dir = raw.trim().replace(/\/+$/, '') || '/'
@@ -503,8 +506,9 @@ export function DirectoryPicker({
                 {path ? (
                   <button
                     type="button"
-                    onClick={() => select(path)}
-                    className="inline-flex items-center gap-1 whitespace-nowrap text-[11px] lowercase text-accent hover:underline"
+                    disabled={validating !== null}
+                    onClick={() => void validateAndSelect(path)}
+                    className="inline-flex items-center gap-1 whitespace-nowrap text-[11px] lowercase text-accent hover:underline disabled:opacity-50"
                   >
                     <Check size={12} aria-hidden /> use this folder
                   </button>

--- a/harness/src/deferred.rs
+++ b/harness/src/deferred.rs
@@ -90,6 +90,16 @@ pub async fn resolve(
             let arguments = find_call_arguments(deps, &record, &req.function_call_id)
                 .await
                 .unwrap_or(Value::Null);
+            // The release path runs OUTSIDE the turn loop, so re-apply the
+            // workspace stamp the loop would have added: without it an
+            // approved shell/coder call runs un-scoped (the session's picked
+            // directory becomes unreachable) and a model-supplied base_dir
+            // recovered from the transcript would survive un-stripped.
+            let arguments = crate::workspace_inject::inject(
+                &function_id,
+                arguments,
+                record.options.working_dir(),
+            );
             if let Some(cp) = record.calls.get_mut(&req.function_call_id) {
                 cp.state = CallState::Triggered;
             }

--- a/harness/src/functions/function_trigger.rs
+++ b/harness/src/functions/function_trigger.rs
@@ -92,7 +92,17 @@ pub async fn handle(
         ));
     }
 
-    let mut arguments = req.call.arguments.clone();
+    // Stamp the turn's workspace scope onto scoped shell/coder args BEFORE the
+    // hook chain (an approver must see the base_dir the call will run under)
+    // and re-apply it before invocation so neither a direct caller nor a hook
+    // rewrite can widen the session scope. No turn record → no scope: any
+    // caller-supplied base_dir is stripped.
+    let working_dir = record.as_ref().and_then(|r| r.options.working_dir());
+    let mut arguments = crate::workspace_inject::inject(
+        &req.call.function_id,
+        req.call.arguments.clone(),
+        working_dir,
+    );
     if let Some(rec) = &record {
         match deps
             .hooks
@@ -129,6 +139,10 @@ pub async fn handle(
             }
         }
     }
+
+    // Re-stamp after the hook chain (idempotent) — a hook rewrite must not
+    // widen or drop the session scope.
+    let arguments = crate::workspace_inject::inject(&req.call.function_id, arguments, working_dir);
 
     // Single invocation chokepoint: subscription control calls are intercepted
     // (trusted session injected); everything else invokes the target.

--- a/harness/src/subagent.rs
+++ b/harness/src/subagent.rs
@@ -196,7 +196,7 @@ async fn seed_child(
                 .and_then(|o| o.output.clone())
                 .unwrap_or_default(),
             functions,
-            metadata: None,
+            metadata: inherit_workspace(parent_record),
             max_validation_retries: cfg.max_validation_retries,
         },
         calls: Default::default(),
@@ -216,10 +216,83 @@ async fn seed_child(
     })
 }
 
+/// A child inherits ONLY the parent's workspace scope (`working_dir`), so the
+/// session's picked directory stays reachable from sub-agent shell/coder
+/// calls. The rest of the parent metadata (message ids, tracing passthrough)
+/// belongs to the parent's turn and must not leak onto the child.
+fn inherit_workspace(parent: Option<&TurnRecord>) -> Option<Value> {
+    let dir = parent.and_then(|p| p.options.working_dir())?;
+    Some(json!({ "working_dir": dir }))
+}
+
 fn is_error(code: &str, message: String) -> ResultData {
     ResultData {
         content: vec![ContentBlock::text(message.clone())],
         is_error: true,
         details: json!({ "error": code, "message": message }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::output::OutputContract;
+
+    fn parent_record(metadata: Option<Value>) -> TurnRecord {
+        TurnRecord {
+            turn_id: "t_parent".into(),
+            session_id: "s_parent".into(),
+            status: TurnStatus::AwaitingFunctions,
+            step: 1,
+            turn_count: 1,
+            depth: 0,
+            abort: false,
+            watermark_entry_id: None,
+            stream_request_id: None,
+            options: TurnOptions {
+                model: "m".into(),
+                provider: None,
+                system_prompt: None,
+                mode: None,
+                max_turns: 16,
+                thinking_level: None,
+                output: OutputContract::Text,
+                functions: None,
+                metadata,
+                max_validation_retries: 2,
+            },
+            calls: Default::default(),
+            parent: None,
+            result: None,
+            result_error: None,
+            validation_retries: 0,
+            created_at: 1,
+            updated_at: 1,
+        }
+    }
+
+    #[test]
+    fn child_inherits_the_parent_working_dir() {
+        let parent = parent_record(Some(json!({
+            "working_dir": "/work/project",
+            "message_id": "m_1",
+            "session_id": "s_console",
+        })));
+        assert_eq!(
+            inherit_workspace(Some(&parent)),
+            Some(json!({ "working_dir": "/work/project" }))
+        );
+    }
+
+    #[test]
+    fn child_metadata_stays_none_without_a_parent_working_dir() {
+        // Direct spawns have no parent record; parents without a picked
+        // directory must not fabricate one. Other metadata keys are per-turn
+        // tracing and never leak onto the child.
+        assert_eq!(inherit_workspace(None), None);
+        let unscoped = parent_record(Some(json!({ "message_id": "m_1" })));
+        assert_eq!(inherit_workspace(Some(&unscoped)), None);
+        let bare = parent_record(None);
+        assert_eq!(inherit_workspace(Some(&bare)), None);
     }
 }

--- a/harness/src/subagent.rs
+++ b/harness/src/subagent.rs
@@ -16,7 +16,7 @@ use crate::prompt;
 use crate::trigger::{PendingInfo, ResultData};
 use crate::types::content::ContentBlock;
 use crate::types::message::AgentMessage;
-use crate::types::turn::{ParentLink, TurnOptions, TurnRecord, TurnStatus};
+use crate::types::turn::{ParentLink, TurnOptions, TurnRecord, TurnStatus, WORKING_DIR_KEY};
 
 /// The ids of a freshly-seeded child turn.
 pub struct ChildIds {
@@ -222,7 +222,7 @@ async fn seed_child(
 /// belongs to the parent's turn and must not leak onto the child.
 fn inherit_workspace(parent: Option<&TurnRecord>) -> Option<Value> {
     let dir = parent.and_then(|p| p.options.working_dir())?;
-    Some(json!({ "working_dir": dir }))
+    Some(json!({ WORKING_DIR_KEY: dir }))
 }
 
 fn is_error(code: &str, message: String) -> ResultData {

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -370,7 +370,15 @@ pub async fn run_step(
                 continue;
             }
 
-            // pre_trigger chain: deny / hold / rewrite arguments.
+            // pre_trigger chain: deny / hold / rewrite arguments. Hooks see
+            // args ALREADY carrying the workspace stamp so an approver reviews
+            // the base_dir the call will actually run under; the stamp is
+            // re-applied after the chain so a hook rewrite can never widen it.
+            let staged_args = crate::workspace_inject::inject(
+                &call.function_id,
+                call.arguments.clone(),
+                record.options.working_dir(),
+            );
             let (eff_args, pre_ann) = match deps
                 .hooks
                 .run_pre_trigger(
@@ -378,7 +386,7 @@ pub async fn run_step(
                     payload.step,
                     &call.id,
                     &call.function_id,
-                    &call.arguments,
+                    &staged_args,
                 )
                 .await
             {
@@ -466,14 +474,11 @@ pub async fn run_step(
             // this overwrites any model-supplied base_dir so the model cannot
             // widen its own workspace. A None working_dir is a no-op (the args
             // pass through byte-for-byte unchanged).
-            let working_dir = record
-                .options
-                .metadata
-                .as_ref()
-                .and_then(|m| m.get("working_dir"))
-                .and_then(Value::as_str);
-            let scoped_args =
-                crate::workspace_inject::inject(&call.function_id, eff_args, working_dir);
+            let scoped_args = crate::workspace_inject::inject(
+                &call.function_id,
+                eff_args,
+                record.options.working_dir(),
+            );
 
             // Single invocation chokepoint: subscription control calls are
             // intercepted (trusted session injected); everything else invokes the
@@ -1039,13 +1044,7 @@ async fn assemble_context(
 /// (`workspace_inject::inject`); this line just tells the model where it is so
 /// it reasons about relative paths sensibly.
 fn with_working_dir_aid(system_prompt: Option<String>, record: &TurnRecord) -> Option<String> {
-    let working_dir = record
-        .options
-        .metadata
-        .as_ref()
-        .and_then(|m| m.get("working_dir"))
-        .and_then(Value::as_str);
-    let Some(dir) = working_dir else {
+    let Some(dir) = record.options.working_dir() else {
         return system_prompt;
     };
     let line = format!("Your working directory is {dir}.");

--- a/harness/src/types/turn.rs
+++ b/harness/src/types/turn.rs
@@ -12,6 +12,13 @@ use crate::prompt::Mode;
 use crate::types::model::ThinkingLevel;
 use crate::types::output::OutputContract;
 
+/// The options-metadata key that carries the session working directory. The
+/// read side (`TurnOptions::working_dir`) and the sub-agent write side
+/// (`subagent::inherit_workspace`) share this constant so a rename can't
+/// silently desync the two and drop child scope. Mirrors
+/// `workspace_inject::BASE_DIR_FIELD`.
+pub const WORKING_DIR_KEY: &str = "working_dir";
+
 /// The coarse, harness-internal turn lifecycle (harness.md § API Reference).
 /// Finer-grained than the session's `status`, which the loop derives from it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -89,12 +96,13 @@ impl TurnOptions {
     /// The session working directory this turn is scoped to: the
     /// `working_dir` key of the frozen options metadata. Every path that
     /// invokes a scoped `shell::*` / `coder::*` call (turn loop, deferred
-    /// release) must stamp this via `workspace_inject::inject` so the
-    /// console-picked directory stays reachable.
+    /// release, `function::trigger`) must stamp this via
+    /// `workspace_inject::inject` so the console-picked directory stays
+    /// reachable.
     pub fn working_dir(&self) -> Option<&str> {
         self.metadata
             .as_ref()
-            .and_then(|m| m.get("working_dir"))
+            .and_then(|m| m.get(WORKING_DIR_KEY))
             .and_then(Value::as_str)
     }
 }

--- a/harness/src/types/turn.rs
+++ b/harness/src/types/turn.rs
@@ -85,6 +85,20 @@ fn default_max_validation_retries() -> u32 {
     2
 }
 
+impl TurnOptions {
+    /// The session working directory this turn is scoped to: the
+    /// `working_dir` key of the frozen options metadata. Every path that
+    /// invokes a scoped `shell::*` / `coder::*` call (turn loop, deferred
+    /// release) must stamp this via `workspace_inject::inject` so the
+    /// console-picked directory stays reachable.
+    pub fn working_dir(&self) -> Option<&str> {
+        self.metadata
+            .as_ref()
+            .and_then(|m| m.get("working_dir"))
+            .and_then(Value::as_str)
+    }
+}
+
 /// Lifecycle of one function call within a turn (harness.md § Per-call
 /// checkpoints).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -245,6 +259,23 @@ mod tests {
             pending_timeout_ms: None,
             pending_at: None,
         }
+    }
+
+    #[test]
+    fn working_dir_reads_the_metadata_key() {
+        let mut r = record();
+        r.options.metadata = Some(json!({ "working_dir": "/work/p", "message_id": "m_1" }));
+        assert_eq!(r.options.working_dir(), Some("/work/p"));
+    }
+
+    #[test]
+    fn working_dir_is_none_without_metadata_or_key_or_string() {
+        let mut r = record();
+        assert_eq!(r.options.working_dir(), None);
+        r.options.metadata = Some(json!({ "message_id": "m_1" }));
+        assert_eq!(r.options.working_dir(), None);
+        r.options.metadata = Some(json!({ "working_dir": 7 }));
+        assert_eq!(r.options.working_dir(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When a working directory is picked in the chat console, it must be reachable from every `shell::*`/`coder::*` call the session makes. The mechanism for that guarantee already exists — the harness stamps the turn's `working_dir` onto each scoped call as `base_dir`, and the shell worker adopts an operator-picked `base_dir` as an effective jail root per call — but three invocation paths skipped the stamp, silently breaking the guarantee:

- **Approval-release path** (`deferred.rs` `execute`): a hook-held call, once approved, was invoked with the transcript-original arguments and no stamp — the approved shell/coder call ran outside the session scope, and a model-supplied `base_dir` recovered from the transcript survived un-stripped (a scope-widening hole).
- **Sub-agents** (`subagent.rs`): child turns were seeded with `metadata: None`, so the picked directory was unreachable from every child (and grandchild) turn. Children now inherit exactly the parent's `working_dir` — never its per-turn tracing metadata.
- **`harness::function::trigger`** (`function_trigger.rs`): the direct-invoke entry point never stamped, with the same un-scoped/escape consequences. With no turn record, a caller-supplied `base_dir` on a scoped call is now stripped.

Two related hardenings ride along:

- `pre_trigger` hooks now receive the **stamped** arguments, so an approval gate reviews the `base_dir` the call will actually run under (previously it saw the call without its scope, or with a bogus model-supplied one). The stamp is re-applied after the hook chain, so a hook rewrite can never widen or drop the scope.
- The console picker's browsed **"use this folder"** selection now round-trips through `shell::workspace::validate` like pasted/remembered picks — every selection path is validated against the live worker and stores the worker-echoed canonical path.

`TurnOptions::working_dir()` is the new shared accessor; the turn loop, deferred release, `function::trigger`, and the system-prompt working-dir aid all read the same source.

## Known gaps left out (deliberate contracts, follow-up decisions)

- A send merged into a running turn keeps the old `working_dir` until the next turn (turn options are frozen by design).
- Sandbox-targeted exec/fs drops `base_dir` by design (it is a host path).
- `coder::info` has no `base_dir` field and describes the unscoped jail to a scoped model.

## Test plan

- [x] `cargo test` in `harness/` — 119 passed, including new unit tests for `TurnOptions::working_dir()` and sub-agent `working_dir` inheritance (only-inherit-the-scope, no-parent, unscoped-parent cases)
- [x] `cargo clippy --all-targets` and `cargo fmt --check` clean
- [x] `console/web`: `tsc -b --noEmit`, `vitest run` (803 tests, 52 files), `biome check` on the changed file — all clean
- [x] Adversarial review of each change (turn-loop ordering parity, hook-envelope consumers, grandchild inheritance, picker error surfacing and root-path edge cases) found no regressions
- [ ] Live smoke on the running stack: pick a directory outside the static jail, trigger an approval-gated `shell::exec` and a sub-agent spawn, confirm both operate in the picked directory


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Child sessions now inherit the active working folder more consistently.
  * Folder selection in the chat directory picker now validates consistently across browse, paste, and remembered paths, and stores the canonical path from validation.

* **Bug Fixes**
  * Improved consistency for tool and command actions so they reliably remain scoped to the active workspace, including during function calls and hook processing.
  * Prevented folder selection from being confirmed while validation is still running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->