### PR TITLE
feat(shell)!: consolidate env/fs config into nested blocks; hard-reject every removed 0.6.x key

### DIFF
--- a/shell/ARCHITECTURE.md
+++ b/shell/ARCHITECTURE.md
@@ -17,7 +17,7 @@ cargo build --release --bin iii-shell
 mkdir -p ~/.iii/workers
 ln -sfn $(pwd)/target/release/iii-shell ~/.iii/workers/shell
 
-# 4. Start the engine (it spawns the worker). Pin a host_root or set
+# 4. Start the engine (it spawns the worker). Pin fs.host_roots or set
 #    fs.allow_unjailed: true in config.yaml first — the worker refuses to
 #    start unjailed by default.
 iii -c ./config.yaml
@@ -43,8 +43,8 @@ The shell worker integrates with the central `configuration` worker rather than 
 2. It immediately fetches the live value over RPC and activates the security policy and fs backend from that response.
 3. It then registers the `configuration:updated` trigger and runs a **fail-closed** boot reconcile before exposing any public function. The reconcile re-fetches the authoritative value (closing the race where an update lands between the initial fetch and trigger registration, leaving no listener). If that re-fetch fails the worker aborts startup — it exits rather than serve a possibly stale security policy, and no `shell::*` / `shell::fs::*` function is ever exposed.
 4. It subscribes to `configuration:updated` events. When the config for schema id `shell` changes, the worker hot-reloads the security policy and fs backend atomically.
-5. If the incoming config is invalid or unsafe (e.g. schema validation passes but the worker cannot build it — bad denylist regex, unreachable `host_root`), the worker keeps the last-good runtime and logs an error — it does **not** crash, and it does **not** retry (re-fetching returns the same bad value, so a retry would storm). The rejection is recorded and surfaced by `shell::config-status` (a `rejected` outcome with a non-zero `rejected_reloads` count) so the divergence between the central store and the enforced policy is detectable instead of silent.
-6. A reload that widens the jail (clearing `host_root`) succeeds, but is logged as a privilege change.
+5. If the incoming config is invalid or unsafe (e.g. schema validation passes but the worker cannot build it — bad denylist regex, unreachable jail root), the worker keeps the last-good runtime and logs an error — it does **not** crash, and it does **not** retry (re-fetching returns the same bad value, so a retry would storm). The rejection is recorded and surfaced by `shell::config-status` (a `rejected` outcome with a non-zero `rejected_reloads` count) so the divergence between the central store and the enforced policy is detectable instead of silent.
+6. A reload that widens the jail (clearing `host_roots`) succeeds, but is logged as a privilege change.
 
 ## Full YAML defaults
 
@@ -66,8 +66,8 @@ deliberately more permissive for dev use: `env.inherit true`, jailed to `/tmp`,
 | `denylist_patterns` | `[]` | advisory regex tripwire on `argv.join(" ")` |
 | `max_concurrent_jobs` | `16` | rejects new `exec_bg` past the cap |
 | `job_retention_secs` | `3600` | finished jobs evicted by a background reaper (interval `min(30s, retention/2)`) — the primary prune path; prune-on-`shell::list` remains as a harmless secondary trigger |
-| `fs.host_root` | `null` | jail root; required unless `fs.allow_unjailed: true` |
-| `fs.allow_unjailed` | `false` | explicit opt-in to running with `host_root: null` |
+| `fs.host_roots` | `[]` | jail roots; first = primary; required non-empty unless `fs.allow_unjailed: true` |
+| `fs.allow_unjailed` | `false` | explicit opt-in to running with an empty `host_roots` |
 | `fs.max_read_bytes` | `0` (unlimited) | pre-flight cap via `fs::metadata` (`S218`) |
 | `fs.max_write_bytes` | `0` (unlimited) | mid-stream cap during write (`S218`) |
 | `fs.denylist_paths` | `[]` | absolute-prefix denylist; rejected with `S215` |
@@ -76,7 +76,7 @@ deliberately more permissive for dev use: `env.inherit true`, jailed to `/tmp`,
 
 ## Threat model
 
-The host backend's path-validation gate is check-then-use: there is a TOCTOU window between validation and the `std::fs::*` call. Validation walks to the longest existing ancestor, canonicalizes that (resolving symlinks in the existing portion), and lexically collapses the non-existent tail before the `starts_with(host_root)` check — so a symlink whose target escapes the jail cannot slip through the lexical fallback. The worker is intended for trusted caller pipelines; for untrusted input, use the sandbox backend.
+The host backend's path-validation gate is check-then-use: there is a TOCTOU window between validation and the `std::fs::*` call. Validation walks to the longest existing ancestor, canonicalizes that (resolving symlinks in the existing portion), and lexically collapses the non-existent tail before the jail-root containment check — so a symlink whose target escapes the jail cannot slip through the lexical fallback. The worker is intended for trusted caller pipelines; for untrusted input, use the sandbox backend.
 
 Host-targeted calls run with the shell worker's OS permissions. The denylist is regex over `argv.join(" ")` and only catches honest typos — a caller invoking an allowlisted shell or interpreter (`sh`, `node`, `python`, …) can bypass it by construction. The actual security boundary is `target: { kind: "sandbox", sandbox_id }`.
 
@@ -146,11 +146,11 @@ let bytes = reader.read_all().await?;
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `fs.host_root is unset and fs.allow_unjailed is false — refusing to start unjailed` | Default config no longer permits running unjailed. | Set `fs.host_root` to a directory, OR set `fs.allow_unjailed: true`. |
+| `fs.host_roots is empty and fs.allow_unjailed is false — refusing to start unjailed` | Default config no longer permits running unjailed. | Set `fs.host_roots` to at least one directory, OR set `fs.allow_unjailed: true`. |
 | `command 'xyz' not in allowlist` | `allowlist` is non-empty and doesn't include the binary's basename. | Add it to `allowlist`, or empty the list to allow anything. |
 | Worker never connects to engine | Engine isn't running or isn't bound on the URL the worker is configured for. | Start the engine first; check `--url` matches. The default WS port is 49134. |
 | Engine started but doesn't see the worker | Binary isn't symlinked at `~/.iii/workers/shell`. | `ln -sfn $(pwd)/target/release/iii-shell ~/.iii/workers/shell` |
-| `S215 path escapes host_root` on a path inside the jail | A symlink in the path resolves outside the jail. | Resolve the symlink yourself, or move the target inside `host_root`. |
+| `S215 path escapes the fs jail roots` on a path inside the jail | A symlink in the path resolves outside the jail. | Resolve the symlink yourself, or move the target inside a jail root. |
 
 ## Tests
 

--- a/shell/ARCHITECTURE.md
+++ b/shell/ARCHITECTURE.md
@@ -30,7 +30,10 @@ iii -c ./config.yaml
 | flag | default | purpose |
 |------|---------|---------|
 | `--config <path>` | `./config.yaml` | Optional seed config: the YAML is passed as `initial_value` when registering the schema with the `configuration` worker on first boot. It is **not** the live source of truth — the live value is fetched over RPC after registration. When the file is absent and nothing is stored yet, the worker seeds a built-in zero-config default (`ShellConfig::seed_default()`, jailed to `/tmp`) instead. |
-| `--url <ws-url>` | `ws://127.0.0.1:49134` | iii engine WebSocket |
+| `--url <ws-url>` | `ws://127.0.0.1:49134` | iii engine WebSocket. Also read from the `III_URL` env var (the flag wins). A pre-connect probe logs one ERROR with a fix hint when the engine is unreachable; the SDK then retries forever with a 2s backoff. |
+| `--version` | — | print the worker version |
+
+Logging is controlled by the `RUST_LOG` env var (tracing `EnvFilter` syntax; default `info`).
 
 ## Configuration
 
@@ -45,6 +48,11 @@ The shell worker integrates with the central `configuration` worker rather than 
 
 ## Full YAML defaults
 
+These are the CODE defaults (`ShellConfig::default()` — fail-closed: `env.inherit
+false`, unjailed refused). The shipped seed `config.yaml` / `seed_default()` is
+deliberately more permissive for dev use: `env.inherit true`, jailed to `/tmp`,
+`max_timeout_ms 120000`, catastrophic-only denylist.
+
 | key | default | enforced where |
 |-----|---------|----------------|
 | `max_timeout_ms` | `30000` | foreground `exec` hard cap; per-call `timeout_ms` clamped to this |
@@ -52,8 +60,8 @@ The shell worker integrates with the central `configuration` worker rather than 
 | `default_timeout_ms` | `10000` | applied when caller omits `timeout_ms` |
 | `max_output_bytes` | `1048576` (1 MiB) | stdout/stderr truncated; `*_truncated` flagged |
 | `working_dir` | `null` | pins cwd for spawned commands when set |
-| `inherit_env` | `false` | when `false`, only `allowed_env` keys are forwarded |
-| `allowed_env` | `[PATH, HOME, LANG, LC_ALL, TERM]` | env passthrough allowlist |
+| `env.inherit` | `false` | forward the worker's FULL env to children; when `false`, only `env.allow` keys are forwarded |
+| `env.allow` | `[PATH, HOME, LANG, LC_ALL, TERM]` | dual role: forwarding allowlist when `env.inherit` is false, AND the per-call `env` settable gate (minus the hardcoded dangerous keys, which are never settable) |
 | `allowlist` | `[]` (open) | command basename allowlist; empty = open |
 | `denylist_patterns` | `[]` | advisory regex tripwire on `argv.join(" ")` |
 | `max_concurrent_jobs` | `16` | rejects new `exec_bg` past the cap |

--- a/shell/CHANGELOG.md
+++ b/shell/CHANGELOG.md
@@ -28,8 +28,10 @@ binary itself.
   the `shell` value at boot, and boot no longer probes `configuration::get`
   for a `coder` entry — which also removes the boot-time
   "configuration 'coder' not found" WARN retries. Stored values still
-  carrying the marker parse fine (it is ignored). Stacks that still need the
-  fold should boot 0.6.x once before upgrading.
+  carrying the marker parse fine (it is ignored). **Skipping this on a
+  standalone-`coder`-only install silently seeds the generic permissive
+  `/tmp` dev default for `shell` instead of the old coder roots/globs** —
+  stacks that still need the fold should boot 0.6.x once before upgrading.
 
 ### Added
 - `--version` prints the worker version.
@@ -53,8 +55,8 @@ binary itself.
   rewrite their stored value by hand should adopt the anchored forms too.
 - The denylist rejection message now says it is an advisory tripwire and to
   rephrase the command, so agents stop retrying verbatim.
-- The seed uses the preferred multi-root jail form (`fs.host_roots: [/tmp]`)
-  instead of the legacy `fs.host_root`.
+- The seed uses the multi-root jail form (`fs.host_roots: [/tmp]`) — the
+  singular `fs.host_root` was then removed outright (see Breaking).
 - Seed `default_timeout_ms` raised 10s → 30s: the seed raises
   `max_timeout_ms` to 120s so real builds survive; callers omitting
   `timeout_ms` shouldn't be reaped at 10s on the same workload. The CODE
@@ -65,6 +67,55 @@ binary itself.
   `fs.denylist_paths` is defense in depth (unreachable anyway while jailed).
 - Every `code.*` (CoderConfig) budget field now carries a schema description;
   the schema test covers all nested definitions, not just the top level.
+
+### Fixed (pre-landing review)
+- **Seed-file parse failures now fail closed.** A `--config` file that EXISTS
+  but fails to parse (e.g. still carries the removed 0.6.x keys) aborts boot
+  instead of warning and silently seeding the permissive built-in default in
+  its place — that fallback would have handed a fresh registration an open
+  allowlist and full env forwarding instead of the operator's intended
+  policy. A genuinely MISSING file still falls through gracefully.
+- **Hot-reload no longer retry-storms on an unparseable stored value.**
+  Previously, a stored config carrying removed keys failed inside the fetch
+  step and was misclassified as a *transient* error (dispatcher retries
+  forever against bytes that can never parse). It is now classified as
+  `Rejected` — the same treatment as an unbuildable-but-parseable config:
+  keep last-good, ack (no storm), and record the rejection for
+  `shell::config-status`.
+- **`env.allow` half-migration is rejected.** `EnvConfig` now denies unknown
+  fields, so nesting the OLD key names under the new block (e.g.
+  `env: { inherit_env: true }`) fails closed instead of silently falling back
+  to the wider default `allow` list.
+- **Command-shaped denylist patterns tolerate a wrapper prefix**
+  (`sudo`, `doas`, `nohup`, `env`, `timeout [duration]`, optionally
+  path-qualified): `sudo shutdown -h now` trips the tripwire again — the
+  argv[0]-anchoring in the first pass of this release had dropped that case,
+  arguably the most likely accidental invocation for commands that normally
+  require root.
+- **The removed-key check found and fixed its own bug during consolidation**:
+  merging the top-level and nested-`fs` checks into one function surfaced
+  that the original used `.any()`, which short-circuits — a config carrying
+  BOTH `inherit_env` and `allowed_env` only ever named the first in its error.
+  Every removed key present is now named in one pass.
+- **The boot-time reachability probe runs detached** so its DNS resolution
+  (unbounded — system resolver) and 2s-per-address TCP connect attempts can
+  never delay startup, and it logs host:port rather than the raw URL (a
+  `wss://user:pass@host` URL could otherwise leak credentials to the log).
+- **A half-migrated `env` block now gets the same migration hint as every
+  other removed key.** Nesting the OLD field names under the NEW `env:`
+  block (e.g. `env: { inherit_env: true }`) previously hit `EnvConfig`'s
+  generic `deny_unknown_fields` serde error with no guidance; it now names
+  the key and points at `env.inherit`/`env.allow` like the other rejections.
+- **The anchored denylist wrapper tolerance is now case-insensitive and
+  handles `env`'s idiomatic `KEY=VALUE...` form.** `SUDO shutdown -h now`
+  and `env FOO=bar shutdown -h now` (env's actual common usage — bare
+  `env cmd` was covered, `env KEY=VAL cmd` was not) now trip the tripwire;
+  previously both silently bypassed it, undermining the wrapper-tolerance
+  feature's own stated purpose for its most-used wrapper.
+- **Fixed a flaky test**: two tests that mutate process-wide environment
+  state (`std::env::set_var`) could race on separate `cargo test` threads
+  within the same binary, producing an intermittent, environment-dependent
+  failure. Both now serialize on a shared test-only mutex.
 
 ### Migration
 ```yaml

--- a/shell/CHANGELOG.md
+++ b/shell/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## 0.7.0
+
+Environment-variable DX overhaul: one consolidated `env` config block, a
+self-documenting config schema, and a discoverable operator surface for the
+binary itself.
+
+### Breaking
+- **`inherit_env` and `allowed_env` are replaced by a nested `env` block**
+  (`env.inherit`, `env.allow`) — no legacy aliases. The old top-level keys are
+  **rejected at parse** with a migration hint naming the new keys. This is
+  deliberate fail-closed behavior: serde ignores unknown fields, so accepting
+  the old shape would silently boot with `env.inherit false` and stop
+  forwarding the worker's environment to children.
+
+### Added
+- `--version` prints the worker version.
+- `--url` is documented in `--help`, including the `III_URL` env var binding.
+- Pre-connect reachability probe: when the engine is unreachable at boot, one
+  ERROR names the URL and the fix (`is the iii engine running? Set --url or
+  III_URL...`) before the SDK's silent 2s-backoff retry loop takes over. The
+  worker still never exits.
+- Every operator-visible config field (including the nested `env`, `fs`, and
+  `sandbox` blocks) now carries a schema description, so the console
+  configuration UI documents each knob inline. Pinned by a unit test.
+- A `## Running` README section documents the binary's full operator surface
+  (`--config`, `--url`/`III_URL`, `--version`, `RUST_LOG`).
+
+### Migration
+```yaml
+# 0.6.x                                # 0.7.0
+inherit_env: true                      env:
+allowed_env: [PATH, HOME, LANG]          inherit: true
+                                         allow: [PATH, HOME, LANG]
+```
+- A stored configuration value (id `shell`) still carrying the old keys makes
+  the worker fail closed at boot with the hint above. Rewrite it via
+  `configuration::set` with the nested shape.
+- **Order matters**: deploy the 0.7.0 binary FIRST, then rewrite the stored
+  value. Writing the new shape while 0.6.x is still running makes the old
+  worker hot-reload it, ignore the unknown `env` block, and silently stop
+  forwarding env until restart.
+
 ## 0.6.0
 
 The standalone `coder` worker is folded into `shell`. There is now ONE worker,

--- a/shell/CHANGELOG.md
+++ b/shell/CHANGELOG.md
@@ -13,6 +13,23 @@ binary itself.
   deliberate fail-closed behavior: serde ignores unknown fields, so accepting
   the old shape would silently boot with `env.inherit false` and stop
   forwarding the worker's environment to children.
+- **`fs.host_root` (the 0.6.x single-root alias) is removed** — use
+  `fs.host_roots` (one-entry list). Like the env keys it is **rejected at
+  parse** with a migration hint (`fs.host_root` -> `fs.host_roots`); serde
+  would otherwise ignore the stale key and the worker would see no jail
+  configured at all.
+- **`code.base_path` and `code.base_paths` are removed from the schema.**
+  They were inert: the code resolver has always taken its roots from
+  `fs.host_roots` (one jail config), so stored values still carrying them are
+  silently **ignored** (no reject — they never had an effect).
+- **The one-shot coder→shell config migration is removed**
+  (`migrate_legacy_coder` and the hidden `migrated_from_coder` marker field).
+  0.7.0 no longer folds a legacy standalone-`coder` configuration entry into
+  the `shell` value at boot, and boot no longer probes `configuration::get`
+  for a `coder` entry — which also removes the boot-time
+  "configuration 'coder' not found" WARN retries. Stored values still
+  carrying the marker parse fine (it is ignored). Stacks that still need the
+  fold should boot 0.6.x once before upgrading.
 
 ### Added
 - `--version` prints the worker version.

--- a/shell/CHANGELOG.md
+++ b/shell/CHANGELOG.md
@@ -18,20 +18,29 @@ binary itself.
   parse** with a migration hint (`fs.host_root` -> `fs.host_roots`); serde
   would otherwise ignore the stale key and the worker would see no jail
   configured at all.
-- **`code.base_path` and `code.base_paths` are removed from the schema.**
-  They were inert: the code resolver has always taken its roots from
-  `fs.host_roots` (one jail config), so stored values still carrying them are
-  silently **ignored** (no reject — they never had an effect).
+- **`code.base_path` and `code.base_paths` are removed from the schema and
+  REJECTED at parse.** They were inert even before removal — the code
+  resolver has always taken its roots from `fs.host_roots` (one jail
+  config) — but this is a hard migration: "never had an effect" is not an
+  exception. A stored value still carrying either fails closed with a hint
+  naming both keys, same as every other removed key.
 - **The one-shot coder→shell config migration is removed**
-  (`migrate_legacy_coder` and the hidden `migrated_from_coder` marker field).
-  0.7.0 no longer folds a legacy standalone-`coder` configuration entry into
-  the `shell` value at boot, and boot no longer probes `configuration::get`
-  for a `coder` entry — which also removes the boot-time
-  "configuration 'coder' not found" WARN retries. Stored values still
-  carrying the marker parse fine (it is ignored). **Skipping this on a
-  standalone-`coder`-only install silently seeds the generic permissive
-  `/tmp` dev default for `shell` instead of the old coder roots/globs** —
-  stacks that still need the fold should boot 0.6.x once before upgrading.
+  (`migrate_legacy_coder`), and the hidden `migrated_from_coder` marker
+  field is REJECTED at parse, not silently tolerated. 0.7.0 no longer folds
+  a legacy standalone-`coder` configuration entry into the `shell` value at
+  boot, and boot no longer probes `configuration::get` for a `coder` entry
+  — which also removes the boot-time "configuration 'coder' not found" WARN
+  retries. Two distinct upgrade scenarios:
+  - An install that ALREADY has a `shell` entry (it went through the fold
+    under 0.6.x, so that entry carries `migrated_from_coder: true`) now
+    fails closed at 0.7.0 boot with a migration hint, instead of silently
+    parsing past the marker.
+  - An install with ONLY a standalone `coder` entry and NO `shell` entry at
+    all has nothing to reject — `register_config` still seeds the generic
+    permissive `/tmp` dev default for `shell`, silently, because there is no
+    stored `shell` value to fail closed on. Boot 0.6.x once first (it
+    performs the fold and writes the `shell` entry) before upgrading to
+    0.7.0 to avoid this.
 
 ### Added
 - `--version` prints the worker version.

--- a/shell/CHANGELOG.md
+++ b/shell/CHANGELOG.md
@@ -27,6 +27,28 @@ binary itself.
 - A `## Running` README section documents the binary's full operator surface
   (`--config`, `--url`/`III_URL`, `--version`, `RUST_LOG`).
 
+### Changed (shipped seed / defaults review)
+- **Command-shaped denylist patterns are anchored to argv[0]**
+  (`^(\S*/)?mkfs|dd|shutdown|reboot`): they fire when the tool IS the command,
+  not when the word appears in an argument — `grep -rn shutdown src/` and
+  `rg "dd if=" docs/` are no longer rejected. Argument-shaped patterns
+  (`rm -rf /`, the fork bomb, `/etc/shadow`) stay unanchored. Stacks that
+  rewrite their stored value by hand should adopt the anchored forms too.
+- The denylist rejection message now says it is an advisory tripwire and to
+  rephrase the command, so agents stop retrying verbatim.
+- The seed uses the preferred multi-root jail form (`fs.host_roots: [/tmp]`)
+  instead of the legacy `fs.host_root`.
+- Seed `default_timeout_ms` raised 10s → 30s: the seed raises
+  `max_timeout_ms` to 120s so real builds survive; callers omitting
+  `timeout_ms` shouldn't be reaped at 10s on the same workload. The CODE
+  default is unchanged (10s).
+- `fs.max_read_bytes`/`fs.max_write_bytes` descriptions now explain why the
+  code default is unlimited (reads/writes stream in chunks; the cap bounds
+  caller cost, not worker memory), and the seed comments say
+  `fs.denylist_paths` is defense in depth (unreachable anyway while jailed).
+- Every `code.*` (CoderConfig) budget field now carries a schema description;
+  the schema test covers all nested definitions, not just the top level.
+
 ### Migration
 ```yaml
 # 0.6.x                                # 0.7.0

--- a/shell/Cargo.lock
+++ b/shell/Cargo.lock
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "shell"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1798,6 +1798,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
  "walkdir",
 ]

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "shell"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 publish = false
 
@@ -29,6 +29,7 @@ once_cell = "1"
 regex = "1"
 shell-words = "1"
 async-trait = "0.1"
+url = "2"
 base64 = "0.22"
 walkdir = "2"
 globset = "0.4"

--- a/shell/README.md
+++ b/shell/README.md
@@ -248,24 +248,31 @@ Sandbox-forwarded `fs::*`/`exec` errors can also surface engine codes verbatim i
 
   Same fail-closed rationale as the env keys: serde would otherwise ignore
   the stale key and the worker would see no jail configured at all.
-- **BREAKING: `code.base_path`/`code.base_paths` removed from the schema.**
-  They were inert — the code resolver has taken its roots from
-  `fs.host_roots` since the coder merge — so stored values still carrying
-  them are silently **ignored** (no reject; they never had an effect). Set
-  the jail once via `fs.host_roots`.
+- **BREAKING: `code.base_path`/`code.base_paths` removed from the schema and
+  REJECTED at parse.** They were inert even before removal — the code
+  resolver has taken its roots from `fs.host_roots` since the coder merge —
+  but this is a hard migration: "never had an effect" is not an exception. A
+  stored value still carrying either fails closed with a hint naming both
+  keys, same as every other removed key. Set the jail once via
+  `fs.host_roots`.
 - **The one-shot coder→shell config migration is removed.** 0.7.0 no longer
   folds a legacy standalone-`coder` configuration entry into the `shell`
-  value at boot (the `migrated_from_coder` marker field is gone too; stored
-  values still carrying it parse fine and the marker is ignored). Boot also
-  no longer probes `configuration::get` for the `coder` entry, so the
+  value at boot, and the hidden `migrated_from_coder` marker field is
+  REJECTED at parse rather than silently tolerated. Boot also no longer
+  probes `configuration::get` for the `coder` entry, so the
   "configuration 'coder' not found" WARN retries at startup are gone.
-  **Consequence if you skip the escape hatch below**: an install with only a
-  standalone `coder` entry and no `shell` entry boots 0.7.0 with the generic
-  permissive `/tmp` dev seed for `shell` — the old `coder` roots and
-  protected globs are NOT carried over, silently. If you are upgrading a
-  pre-0.6 stack that still relies on the fold, boot 0.6.x once first (it
-  performs the migration and writes the `shell` entry), THEN upgrade to
-  0.7.0.
+  **Two distinct upgrade scenarios**:
+  - An install that ALREADY has a `shell` entry (it went through the fold
+    under 0.6.x, so the entry carries `migrated_from_coder: true`) now fails
+    closed at 0.7.0 boot with a migration hint, instead of silently parsing
+    past the marker.
+  - An install with ONLY a standalone `coder` entry and NO `shell` entry at
+    all has nothing to reject — it still boots 0.7.0 with the generic
+    permissive `/tmp` dev seed for `shell`, silently, because there is no
+    stored `shell` value to fail closed on. The old `coder` roots and
+    protected globs are NOT carried over. Boot 0.6.x once first (it performs
+    the migration and writes the `shell` entry) before upgrading to 0.7.0 to
+    avoid this.
 - **`--version` added**, and `--url`/`III_URL` and `RUST_LOG` are now
   documented (see [Running](#running)).
 - **Unreachable-engine boot is loud**: one ERROR naming the host/port and the

--- a/shell/README.md
+++ b/shell/README.md
@@ -51,14 +51,14 @@ it never exits, so supervised deployments recover as soon as the engine is up.
 
 Settings are managed through the central `configuration` worker. On boot, the shell worker registers its schema (id `shell`) and fetches the live value over RPC — that live value is the authoritative config, not a local file. The optional `--config <path>` flag (default `./config.yaml`) provides the `initial_value` sent on first registration only; once registered, subsequent boots pull the stored value from the `configuration` worker. When the config changes, the worker hot-reloads the security policy and fs backend automatically (see [Hot-reload](#hot-reload)).
 
-The worker refuses to start unless `fs.host_root` is set, or `fs.allow_unjailed: true` is explicitly opted in, because an unset root exposes the whole host filesystem behind only the advisory denylist.
+The worker refuses to start unless `fs.host_roots` is set (or the legacy one-entry `fs.host_root`), or `fs.allow_unjailed: true` is explicitly opted in, because an unset root exposes the whole host filesystem behind only the advisory denylist.
 
 By default, `mkdir`/`chmod`/`write` reject modes carrying setuid/setgid/sticky bits (the top octal digit, e.g. `4755`) with `S210`, since they are a privilege-escalation primitive when the worker runs as root inside the jail. Set `fs.allow_special_bits: true` only if your workload genuinely needs them.
 
 ```yaml
 max_timeout_ms: 120000       # foreground exec hard cap; per-call timeout_ms is clamped to this
 max_bg_timeout_ms: 0         # host bg job hard cap in ms; 0 = unbounded (foreground uses max_timeout_ms)
-default_timeout_ms: 10000    # applied when the caller omits timeout_ms
+default_timeout_ms: 30000    # applied when the caller omits timeout_ms (code default 10000)
 max_output_bytes: 1048576    # 1 MiB; stdout/stderr past this set *_truncated
 env:
   inherit: true              # forward the worker's env to children; per-call dangerous keys still blocked
@@ -67,22 +67,24 @@ env:
 # exec gate. argv[0] is matched by basename or exact path; an empty
 # allowlist means OPEN — the shipped default, so any command runs.
 # denylist_patterns are advisory regex over argv.join(" "), a tripwire for
-# catastrophic mistakes only, NOT a security boundary.
+# catastrophic mistakes only, NOT a security boundary. Command-shaped
+# patterns are anchored to argv[0] so `grep -rn shutdown src/` is not
+# rejected; argument-shaped ones (rm -rf /) stay unanchored.
 allowlist: []
 denylist_patterns:
   - "rm\\s+-rf\\s+/"
-  - "mkfs"
-  - "dd\\s+if="
+  - "^(\\S*/)?mkfs"
+  - "^(\\S*/)?dd\\s+if="
 
 max_concurrent_jobs: 16      # exec_bg past this is rejected
 job_retention_secs: 3600     # finished jobs pruned after this
 
 fs:
-  host_root: /tmp            # jail root for shell::fs::*; required (see above)
-  allow_unjailed: false      # opt-in to running with host_root unset
-  max_read_bytes: 16777216   # 0 = unlimited
+  host_roots: [/tmp]         # jail roots for shell::fs::*; first = primary (legacy alias: host_root)
+  allow_unjailed: false      # opt-in to running with no jail root
+  max_read_bytes: 16777216   # 0 = unlimited (reads stream; cap bounds caller cost)
   max_write_bytes: 16777216  # 0 = unlimited
-  denylist_paths: [/etc/passwd, /etc/shadow]
+  denylist_paths: [/etc/passwd, /etc/shadow]  # defense in depth; unreachable anyway while jailed
   allow_special_bits: false  # permit setuid/setgid/sticky bits in mode (default false)
 
 sandbox:

--- a/shell/README.md
+++ b/shell/README.md
@@ -51,7 +51,7 @@ it never exits, so supervised deployments recover as soon as the engine is up.
 
 Settings are managed through the central `configuration` worker. On boot, the shell worker registers its schema (id `shell`) and fetches the live value over RPC — that live value is the authoritative config, not a local file. The optional `--config <path>` flag (default `./config.yaml`) provides the `initial_value` sent on first registration only; once registered, subsequent boots pull the stored value from the `configuration` worker. When the config changes, the worker hot-reloads the security policy and fs backend automatically (see [Hot-reload](#hot-reload)).
 
-The worker refuses to start unless `fs.host_roots` is set (or the legacy one-entry `fs.host_root`), or `fs.allow_unjailed: true` is explicitly opted in, because an unset root exposes the whole host filesystem behind only the advisory denylist.
+The worker refuses to start unless `fs.host_roots` is set, or `fs.allow_unjailed: true` is explicitly opted in, because an unset root exposes the whole host filesystem behind only the advisory denylist.
 
 By default, `mkdir`/`chmod`/`write` reject modes carrying setuid/setgid/sticky bits (the top octal digit, e.g. `4755`) with `S210`, since they are a privilege-escalation primitive when the worker runs as root inside the jail. Set `fs.allow_special_bits: true` only if your workload genuinely needs them.
 
@@ -80,7 +80,7 @@ max_concurrent_jobs: 16      # exec_bg past this is rejected
 job_retention_secs: 3600     # finished jobs pruned after this
 
 fs:
-  host_roots: [/tmp]         # jail roots for shell::fs::*; first = primary (legacy alias: host_root)
+  host_roots: [/tmp]         # jail roots for shell::fs::*; first = primary
   allow_unjailed: false      # opt-in to running with no jail root
   max_read_bytes: 16777216   # 0 = unlimited (reads stream; cap bounds caller cost)
   max_write_bytes: 16777216  # 0 = unlimited
@@ -93,7 +93,7 @@ sandbox:
 
 ### Zero-config default
 
-With no `--config` file and no value stored in the `configuration` worker, the worker seeds a built-in default on first registration — so it boots with nothing configured (database-style). That built-in default is the shipped [`config.yaml`](config.yaml): jailed to `/tmp`, env forwarded, open exec with a catastrophic-only denylist (kept in sync by a unit test). If the stored value is later nulled, the worker does not silently fall back to this seed: boot fails closed and a hot-reload keeps the last-good config. A config that is *present* but leaves `fs.host_root` unset (without `fs.allow_unjailed: true`) also fails closed.
+With no `--config` file and no value stored in the `configuration` worker, the worker seeds a built-in default on first registration — so it boots with nothing configured (database-style). That built-in default is the shipped [`config.yaml`](config.yaml): jailed to `/tmp`, env forwarded, open exec with a catastrophic-only denylist (kept in sync by a unit test). If the stored value is later nulled, the worker does not silently fall back to this seed: boot fails closed and a hot-reload keeps the last-good config. A config that is *present* but leaves `fs.host_roots` unset (without `fs.allow_unjailed: true`) also fails closed.
 
 Host `shell::exec` is not a security boundary: any allowlisted interpreter (`sh`, `node`, `python3`) can construct a denylisted token at runtime and bypass the regex. Run untrusted input with `target: { kind: "sandbox", sandbox_id }`, which forwards through the `iii-sandbox` microVM. The allowlist and denylist still apply on top of either backend.
 
@@ -101,7 +101,7 @@ Host `shell::exec` is not a security boundary: any allowlisted interpreter (`sh`
 
 `shell::exec` and `shell::exec_bg` each accept optional fields so an agent can scope a single command to a directory, set specific env values, and feed it standard input without wrapping everything in `sh -lc` (which would defeat the argv allowlist):
 
-- **`cwd`** (string): the working directory for this one call. It is confined to the fs jail **exactly** like `shell::fs::*` paths — jail-relative when `fs.host_root` is set (else absolute), canonicalized, and required to resolve inside `host_root` and miss `denylist_paths`. A `cwd` that escapes the jail returns `S215`; one that doesn't exist or isn't a directory returns `S211`/`S210`. Omit it to use the configured `working_dir` (unchanged default).
+- **`cwd`** (string): the working directory for this one call. It is confined to the fs jail **exactly** like `shell::fs::*` paths — jail-relative when `fs.host_roots` is set (else absolute), canonicalized, and required to resolve inside a jail root and miss `denylist_paths`. A `cwd` that escapes the jail returns `S215`; one that doesn't exist or isn't a directory returns `S211`/`S210`. Omit it to use the configured `working_dir` (unchanged default).
 - **`env`** (object of string→string): per-call environment values. A key may be set **only** if the operator already listed it in `env.allow`, and **never** for an exec-hijacking key — `PATH`, `IFS`, `HOME`, every `LD_*`/`DYLD_*` variant, and other loader/lookup-path and interpreter startup-file keys (`GCONV_PATH`, `BASH_ENV`, `ENV`, `PYTHONSTARTUP`, `PERL5OPT`, `RUBYOPT`, `NODE_OPTIONS`, …) are on a hardcoded denylist that **wins over** `env.allow`. Note that `HOME` ships in the default `env.allow` for the worker's own forwarded env but is **not** settable per-call. Supplying a key that is not in `env.allow`, or any dangerous key, rejects the **whole call** with `S210` (the offending key is named and the permitted keys are listed); the env is never silently dropped. A permitted per-call value overrides the value that would otherwise be forwarded for that key. So an agent can do `NODE_ENV=test` only if the operator put `NODE_ENV` in `env.allow`, and can never inject `PATH`, `HOME`, or `LD_PRELOAD`.
 - **`stdin`** (string): written to the program's standard input, which is then closed (EOF). Use it to feed `tee`, `patch`, `cat`, or any stdin filter instead of a shell heredoc. Omit it and stdin is `/dev/null`.
 
@@ -174,7 +174,7 @@ When the `configuration` worker pushes an updated config, the shell worker swaps
 
 - Each call executes against one consistent runtime snapshot; there is no mid-call config change.
 - Already-running background jobs are **not** retroactively re-checked when the policy tightens — they continue under the policy that was active when they were spawned.
-- A reload that widens the jail (for example, clearing `host_root`) succeeds but is logged as a privilege change.
+- A reload that widens the jail (for example, clearing `host_roots`) succeeds but is logged as a privilege change.
 - If the incoming config is invalid or unsafe, the worker keeps the last-good runtime and logs an error. The rejection is also surfaced through `shell::config-status` (a `rejected` outcome with a non-zero `rejected_reloads` count), so the divergence between the central store and the policy shell is actually enforcing is detectable instead of silent. Rejections are kept last-good and not retried (re-fetching returns the same bad value), so they will not retry-storm.
 - At boot the reconcile against the configuration worker is **fail-closed**: the worker refuses to start (and exposes no functions) if it cannot confirm the authoritative config, so it never serves a possibly stale security policy.
 
@@ -190,7 +190,7 @@ Returned error bodies carry a stable `code` field. Allowlist and denylist reject
 | `S212` | Wrong file type for the operation (for example, a file where a directory was expected). |
 | `S213` | Path already exists. |
 | `S214` | Directory not empty (non-recursive `rm`). |
-| `S215` | Path (or a per-call `cwd`) escapes `host_root`, hits `fs.denylist_paths`, or permission denied. |
+| `S215` | Path (or a per-call `cwd`) escapes the `fs.host_roots` jail, hits `fs.denylist_paths`, or permission denied. |
 | `S216` | Generic shell-internal failure: host spawn error, channel error, or a bad engine response. |
 | `S217` | Invalid regex passed to `grep`/`sed`. |
 | `S218` | `fs.max_read_bytes` / `fs.max_write_bytes` cap exceeded. |
@@ -219,6 +219,32 @@ Sandbox-forwarded `fs::*`/`exec` errors can also surface engine codes verbatim i
   value — writing the new shape while 0.6.x is still running makes the old
   worker hot-reload it, ignore the unknown `env` block, and silently stop
   forwarding env until restart.
+- **BREAKING: `fs.host_root` (single-root alias) removed.** The 0.6.x
+  one-entry alias for the jail root is **rejected at parse** with a migration
+  hint ("config key removed in 0.7.0: `fs.host_root` -> `fs.host_roots`
+  (one-entry list)"). Replace it with the list form:
+
+  ```yaml
+  # 0.6.x                                # 0.7.0
+  fs:                                    fs:
+    host_root: /srv/app                    host_roots: [/srv/app]
+  ```
+
+  Same fail-closed rationale as the env keys: serde would otherwise ignore
+  the stale key and the worker would see no jail configured at all.
+- **BREAKING: `code.base_path`/`code.base_paths` removed from the schema.**
+  They were inert — the code resolver has taken its roots from
+  `fs.host_roots` since the coder merge — so stored values still carrying
+  them are silently **ignored** (no reject; they never had an effect). Set
+  the jail once via `fs.host_roots`.
+- **The one-shot coder→shell config migration is removed.** 0.7.0 no longer
+  folds a legacy standalone-`coder` configuration entry into the `shell`
+  value at boot (the `migrated_from_coder` marker field is gone too; stored
+  values still carrying it parse fine and the marker is ignored). Boot also
+  no longer probes `configuration::get` for the `coder` entry, so the
+  "configuration 'coder' not found" WARN retries at startup are gone. If you
+  are upgrading a pre-0.6 stack that still relies on the fold, boot 0.6.x
+  once first (it performs the migration), then upgrade to 0.7.0.
 - **`--version` added**, and `--url`/`III_URL` and `RUST_LOG` are now
   documented (see [Running](#running)).
 - **Unreachable-engine boot is loud**: one ERROR with the URL and the fix
@@ -241,12 +267,12 @@ Sandbox-forwarded `fs::*`/`exec` errors can also surface engine codes verbatim i
 
 ## Troubleshooting
 
-- **`fs.host_root is unset ... refusing to start unjailed`**: set `fs.host_root` to a directory, or set `fs.allow_unjailed: true`.
+- **`fs.host_roots is empty ... refusing to start unjailed`**: set `fs.host_roots` to at least one directory, or set `fs.allow_unjailed: true`.
 - **`command '<x>' not in allowlist`**: the basename of `argv[0]` is not in a non-empty `allowlist`. Add it, or empty the list to allow anything.
-- **`S215 path escapes host_root` on a path inside the jail**: a symlink in the path resolves outside the jail. Resolve it yourself, or move the target inside `host_root`.
+- **`S215 path escapes the fs jail roots` on a path inside the jail**: a symlink in the path resolves outside the jail. Resolve it yourself, or move the target inside a jail root.
 - **`S300` on a sandbox target**: the host cannot boot microVMs. Sandbox execution requires Apple Silicon or `/dev/kvm`.
 - **Worker never connects**: the engine is not running or not bound on the configured `--url`. Start the engine first; the default WebSocket port is 49134.
-- **`config keys removed in 0.7.0: ...` at boot or on reload**: the seed file or the stored configuration value still uses the 0.6.x `inherit_env`/`allowed_env` keys. Nest them under `env:` (`inherit`/`allow`) — see [Upgrading to 0.7.0](#upgrading-to-070).
+- **`config keys removed in 0.7.0: ...` at boot or on reload**: the seed file or the stored configuration value still uses the 0.6.x `inherit_env`/`allowed_env` keys (nest them under `env:` as `inherit`/`allow`) or the single-root `fs.host_root` alias (use `fs.host_roots: [<path>]`) — see [Upgrading to 0.7.0](#upgrading-to-070).
 
 For the threat model, streaming wire shapes, and contributor build steps, see [ARCHITECTURE.md](ARCHITECTURE.md).
 

--- a/shell/README.md
+++ b/shell/README.md
@@ -30,6 +30,23 @@ npx skills add iii-hq/workers --list
 npx skills add iii-hq/workers --all
 ```
 
+## Running
+
+The binary needs no required environment variables — it boots against a local
+engine with pure defaults. The full operator surface:
+
+| Knob | Default | What it does |
+|---|---|---|
+| `--url <URL>` / `III_URL` env var | `ws://127.0.0.1:49134` | WebSocket URL of the iii engine. The CLI flag wins over the env var. |
+| `--config <path>` | `./config.yaml` | Seed config sent as `initial_value` on FIRST registration only; the stored value wins afterwards (see [Configure](#configure)). |
+| `--version` | — | Print the worker version (also registered with the engine as worker metadata). |
+| `RUST_LOG` env var | `info` | Log filter (tracing `EnvFilter` syntax, e.g. `RUST_LOG=shell=debug,info`). |
+
+If the engine is unreachable at boot, a pre-connect probe logs one ERROR
+("engine unreachable at <url> — is the iii engine running? Set --url or the
+III_URL env var...") and the worker keeps retrying in the background every 2s —
+it never exits, so supervised deployments recover as soon as the engine is up.
+
 ## Configure
 
 Settings are managed through the central `configuration` worker. On boot, the shell worker registers its schema (id `shell`) and fetches the live value over RPC — that live value is the authoritative config, not a local file. The optional `--config <path>` flag (default `./config.yaml`) provides the `initial_value` sent on first registration only; once registered, subsequent boots pull the stored value from the `configuration` worker. When the config changes, the worker hot-reloads the security policy and fs backend automatically (see [Hot-reload](#hot-reload)).
@@ -43,8 +60,9 @@ max_timeout_ms: 120000       # foreground exec hard cap; per-call timeout_ms is 
 max_bg_timeout_ms: 0         # host bg job hard cap in ms; 0 = unbounded (foreground uses max_timeout_ms)
 default_timeout_ms: 10000    # applied when the caller omits timeout_ms
 max_output_bytes: 1048576    # 1 MiB; stdout/stderr past this set *_truncated
-inherit_env: true            # forward the worker's env to children; per-call dangerous keys still blocked
-allowed_env: [PATH, HOME, LANG, LC_ALL, TERM]  # gates per-call `env` (dangerous keys never settable)
+env:
+  inherit: true              # forward the worker's env to children; per-call dangerous keys still blocked
+  allow: [PATH, HOME, LANG, LC_ALL, TERM]  # forwarded when inherit is false; gates per-call `env` (dangerous keys never settable)
 
 # exec gate. argv[0] is matched by basename or exact path; an empty
 # allowlist means OPEN — the shipped default, so any command runs.
@@ -82,7 +100,7 @@ Host `shell::exec` is not a security boundary: any allowlisted interpreter (`sh`
 `shell::exec` and `shell::exec_bg` each accept optional fields so an agent can scope a single command to a directory, set specific env values, and feed it standard input without wrapping everything in `sh -lc` (which would defeat the argv allowlist):
 
 - **`cwd`** (string): the working directory for this one call. It is confined to the fs jail **exactly** like `shell::fs::*` paths — jail-relative when `fs.host_root` is set (else absolute), canonicalized, and required to resolve inside `host_root` and miss `denylist_paths`. A `cwd` that escapes the jail returns `S215`; one that doesn't exist or isn't a directory returns `S211`/`S210`. Omit it to use the configured `working_dir` (unchanged default).
-- **`env`** (object of string→string): per-call environment values. A key may be set **only** if the operator already listed it in `allowed_env`, and **never** for an exec-hijacking key — `PATH`, `IFS`, `HOME`, every `LD_*`/`DYLD_*` variant, and other loader/lookup-path and interpreter startup-file keys (`GCONV_PATH`, `BASH_ENV`, `ENV`, `PYTHONSTARTUP`, `PERL5OPT`, `RUBYOPT`, `NODE_OPTIONS`, …) are on a hardcoded denylist that **wins over** `allowed_env`. Note that `HOME` ships in the default `allowed_env` for the worker's own forwarded env but is **not** settable per-call. Supplying a key that is not in `allowed_env`, or any dangerous key, rejects the **whole call** with `S210` (the offending key is named and the permitted keys are listed); the env is never silently dropped. A permitted per-call value overrides the value that would otherwise be forwarded for that key. So an agent can do `NODE_ENV=test` only if the operator put `NODE_ENV` in `allowed_env`, and can never inject `PATH`, `HOME`, or `LD_PRELOAD`.
+- **`env`** (object of string→string): per-call environment values. A key may be set **only** if the operator already listed it in `env.allow`, and **never** for an exec-hijacking key — `PATH`, `IFS`, `HOME`, every `LD_*`/`DYLD_*` variant, and other loader/lookup-path and interpreter startup-file keys (`GCONV_PATH`, `BASH_ENV`, `ENV`, `PYTHONSTARTUP`, `PERL5OPT`, `RUBYOPT`, `NODE_OPTIONS`, …) are on a hardcoded denylist that **wins over** `env.allow`. Note that `HOME` ships in the default `env.allow` for the worker's own forwarded env but is **not** settable per-call. Supplying a key that is not in `env.allow`, or any dangerous key, rejects the **whole call** with `S210` (the offending key is named and the permitted keys are listed); the env is never silently dropped. A permitted per-call value overrides the value that would otherwise be forwarded for that key. So an agent can do `NODE_ENV=test` only if the operator put `NODE_ENV` in `env.allow`, and can never inject `PATH`, `HOME`, or `LD_PRELOAD`.
 - **`stdin`** (string): written to the program's standard input, which is then closed (EOF). Use it to feed `tee`, `patch`, `cat`, or any stdin filter instead of a shell heredoc. Omit it and stdin is `/dev/null`.
 
 All three fields are **host-only**. The `sandbox::exec` protocol does not forward `cwd`/`env`/`stdin`, so a sandbox-targeted call that supplies any of them is rejected with `S210` rather than silently ignoring it. Omit them and behaviour is identical to prior versions.
@@ -108,7 +126,7 @@ The example runs on the host. The same payload retargets at a microVM with `targ
 
 | Function | Purpose |
 |---|---|
-| `shell::exec` | Run an allowlisted command in the foreground; returns stdout, stderr, exit code, and timing. Blocks until exit or timeout. Accepts optional host-only `cwd` (jail-confined), `env` (gated by `allowed_env` + a dangerous-key denylist), and `stdin` (string piped to the program's stdin, then EOF) — see [Per-call `cwd`, `env`, and `stdin`](#per-call-cwd-env-and-stdin-host-target). |
+| `shell::exec` | Run an allowlisted command in the foreground; returns stdout, stderr, exit code, and timing. Blocks until exit or timeout. Accepts optional host-only `cwd` (jail-confined), `env` (gated by `env.allow` + a dangerous-key denylist), and `stdin` (string piped to the program's stdin, then EOF) — see [Per-call `cwd`, `env`, and `stdin`](#per-call-cwd-env-and-stdin-host-target). |
 | `shell::exec_bg` | Spawn an allowlisted command as a background job; returns `{ job_id, argv }` immediately. Host-targeted jobs run until they exit or `shell::kill` terminates them — unbounded by default, and capped only when the operator sets a positive `max_bg_timeout_ms` (default `0` = unbounded), after which a runaway job is killed and its status becomes `killed`. Sandbox jobs honor `timeout_ms`. Same optional host-only `cwd`/`env`/`stdin` as `shell::exec`. |
 | `shell::status` | Fetch one job's full record: state, exit code, and captured stdout/stderr. A missing id — one that never existed or aged out past `job_retention_secs` — returns an `S211` ("no such job") error. |
 | `shell::list` | Enumerate current jobs as lightweight summaries; argv, stdout, and stderr are redacted. |
@@ -165,7 +183,7 @@ Returned error bodies carry a stable `code` field. Allowlist and denylist reject
 | Code | Meaning |
 |---|---|
 | `S200` | In-VM execution failure on a sandbox target. |
-| `S210` | Invalid request: non-absolute path, empty command or pattern, bad octal mode, malformed payload, `sandbox.enabled: false` on a sandbox-targeted call, a `cwd` that is not a directory, an `env` key outside `allowed_env` or in the dangerous-key denylist, `cwd`/`env`/`stdin` supplied on a sandbox target (host-only), an inline string `content` on a sandbox-targeted `shell::fs::write`, or both single `path`/`content` and `files` on `shell::fs::write`. |
+| `S210` | Invalid request: non-absolute path, empty command or pattern, bad octal mode, malformed payload, `sandbox.enabled: false` on a sandbox-targeted call, a `cwd` that is not a directory, an `env` key outside `env.allow` or in the dangerous-key denylist, `cwd`/`env`/`stdin` supplied on a sandbox target (host-only), an inline string `content` on a sandbox-targeted `shell::fs::write`, or both single `path`/`content` and `files` on `shell::fs::write`. |
 | `S211` | Path not found (including a `cwd` that does not exist). |
 | `S212` | Wrong file type for the operation (for example, a file where a directory was expected). |
 | `S213` | Path already exists. |
@@ -177,6 +195,34 @@ Returned error bodies carry a stable `code` field. Allowlist and denylist reject
 | `S300` | Sandbox VM boot failed (needs a virtualization host: Apple Silicon or `/dev/kvm`). |
 
 Sandbox-forwarded `fs::*`/`exec` errors can also surface engine codes verbatim instead of collapsing to `S216`: `S001`–`S004` (sandbox lifecycle), `S100`–`S102` (image/VM/resource), `S300`, and `S400`. Branch on the specific code where relevant; only an unrecognized engine code falls back to `S216`.
+
+## Upgrading to 0.7.0
+
+- **BREAKING: env config keys renamed and nested.** The top-level `inherit_env`
+  and `allowed_env` keys are replaced by one `env` block — no legacy aliases:
+
+  ```yaml
+  # 0.6.x                                # 0.7.0
+  inherit_env: true                      env:
+  allowed_env: [PATH, HOME, LANG]          inherit: true
+                                           allow: [PATH, HOME, LANG]
+  ```
+
+  The old keys are **rejected at parse** with a migration hint ("config keys
+  removed in 0.7.0: `inherit_env` -> `env.inherit` ..."), because serde would
+  otherwise ignore them silently and boot with env forwarding OFF. A stored
+  configuration value still carrying the old keys makes the worker fail closed
+  at boot; rewrite it via `configuration::set` (id `shell`) with the nested
+  shape. **Sequencing matters**: update the binary FIRST, then the stored
+  value — writing the new shape while 0.6.x is still running makes the old
+  worker hot-reload it, ignore the unknown `env` block, and silently stop
+  forwarding env until restart.
+- **`--version` added**, and `--url`/`III_URL` and `RUST_LOG` are now
+  documented (see [Running](#running)).
+- **Unreachable-engine boot is loud**: one ERROR with the URL and the fix
+  hint, instead of only the SDK's silent retry WARNs.
+- **Every config field now carries a schema description**, so the console
+  configuration UI documents each knob inline.
 
 ## Upgrading to 0.4.0
 
@@ -198,6 +244,7 @@ Sandbox-forwarded `fs::*`/`exec` errors can also surface engine codes verbatim i
 - **`S215 path escapes host_root` on a path inside the jail**: a symlink in the path resolves outside the jail. Resolve it yourself, or move the target inside `host_root`.
 - **`S300` on a sandbox target**: the host cannot boot microVMs. Sandbox execution requires Apple Silicon or `/dev/kvm`.
 - **Worker never connects**: the engine is not running or not bound on the configured `--url`. Start the engine first; the default WebSocket port is 49134.
+- **`config keys removed in 0.7.0: ...` at boot or on reload**: the seed file or the stored configuration value still uses the 0.6.x `inherit_env`/`allowed_env` keys. Nest them under `env:` (`inherit`/`allow`) — see [Upgrading to 0.7.0](#upgrading-to-070).
 
 For the threat model, streaming wire shapes, and contributor build steps, see [ARCHITECTURE.md](ARCHITECTURE.md).
 

--- a/shell/README.md
+++ b/shell/README.md
@@ -42,10 +42,18 @@ engine with pure defaults. The full operator surface:
 | `--version` | — | Print the worker version (also registered with the engine as worker metadata). |
 | `RUST_LOG` env var | `info` | Log filter (tracing `EnvFilter` syntax, e.g. `RUST_LOG=shell=debug,info`). |
 
-If the engine is unreachable at boot, a pre-connect probe logs one ERROR
-("engine unreachable at <url> — is the iii engine running? Set --url or the
-III_URL env var...") and the worker keeps retrying in the background every 2s —
-it never exits, so supervised deployments recover as soon as the engine is up.
+If the engine is unreachable at boot, a pre-connect probe (run detached, so it
+never delays startup) logs one ERROR ("engine unreachable at <host>:<port> —
+is the iii engine running? Set --url or the III_URL env var...", logging the
+resolved host/port rather than the raw URL) and the worker keeps retrying in
+the background every 2s — it never exits, so supervised deployments recover
+as soon as the engine is up.
+
+A `--config` seed file that exists but fails to parse (for example, one still
+carrying 0.6.x keys) aborts boot rather than silently falling back to the
+permissive built-in default — see [Upgrading to 0.7.0](#upgrading-to-070). A
+genuinely missing file still falls through gracefully to the stored value or
+the built-in zero-config default.
 
 ## Configure
 
@@ -68,8 +76,10 @@ env:
 # allowlist means OPEN — the shipped default, so any command runs.
 # denylist_patterns are advisory regex over argv.join(" "), a tripwire for
 # catastrophic mistakes only, NOT a security boundary. Command-shaped
-# patterns are anchored to argv[0] so `grep -rn shutdown src/` is not
-# rejected; argument-shaped ones (rm -rf /) stay unanchored.
+# patterns are anchored to argv[0] (tolerating a sudo/doas/nohup/env/timeout
+# wrapper) so `grep -rn shutdown src/` is not rejected but `sudo shutdown -h
+# now` still is; argument-shaped ones (rm -rf /) stay unanchored. See the
+# shipped config.yaml for the full patterns.
 allowlist: []
 denylist_patterns:
   - "rm\\s+-rf\\s+/"
@@ -218,7 +228,13 @@ Sandbox-forwarded `fs::*`/`exec` errors can also surface engine codes verbatim i
   shape. **Sequencing matters**: update the binary FIRST, then the stored
   value — writing the new shape while 0.6.x is still running makes the old
   worker hot-reload it, ignore the unknown `env` block, and silently stop
-  forwarding env until restart.
+  forwarding env until restart. A **half-migration** (nesting the OLD key
+  names under the new block, e.g. `env: { inherit_env: true }`) is also
+  rejected — `env` denies unknown fields — rather than silently falling back
+  to the wider default `allow` list.
+  A `--config` seed file carrying any of these removed keys now **aborts
+  boot** rather than warning and falling back to the permissive built-in
+  seed; only a genuinely missing seed file falls through gracefully.
 - **BREAKING: `fs.host_root` (single-root alias) removed.** The 0.6.x
   one-entry alias for the jail root is **rejected at parse** with a migration
   hint ("config key removed in 0.7.0: `fs.host_root` -> `fs.host_roots`
@@ -242,15 +258,24 @@ Sandbox-forwarded `fs::*`/`exec` errors can also surface engine codes verbatim i
   value at boot (the `migrated_from_coder` marker field is gone too; stored
   values still carrying it parse fine and the marker is ignored). Boot also
   no longer probes `configuration::get` for the `coder` entry, so the
-  "configuration 'coder' not found" WARN retries at startup are gone. If you
-  are upgrading a pre-0.6 stack that still relies on the fold, boot 0.6.x
-  once first (it performs the migration), then upgrade to 0.7.0.
+  "configuration 'coder' not found" WARN retries at startup are gone.
+  **Consequence if you skip the escape hatch below**: an install with only a
+  standalone `coder` entry and no `shell` entry boots 0.7.0 with the generic
+  permissive `/tmp` dev seed for `shell` — the old `coder` roots and
+  protected globs are NOT carried over, silently. If you are upgrading a
+  pre-0.6 stack that still relies on the fold, boot 0.6.x once first (it
+  performs the migration and writes the `shell` entry), THEN upgrade to
+  0.7.0.
 - **`--version` added**, and `--url`/`III_URL` and `RUST_LOG` are now
   documented (see [Running](#running)).
-- **Unreachable-engine boot is loud**: one ERROR with the URL and the fix
-  hint, instead of only the SDK's silent retry WARNs.
+- **Unreachable-engine boot is loud**: one ERROR naming the host/port and the
+  fix hint, instead of only the SDK's silent retry WARNs. The probe runs
+  detached so it never delays boot.
 - **Every config field now carries a schema description**, so the console
   configuration UI documents each knob inline.
+- **Command-shaped denylist patterns tolerate a wrapper prefix**
+  (`sudo`/`doas`/`nohup`/`env`/`timeout [duration]`, optionally
+  path-qualified): `sudo shutdown -h now` trips the tripwire again.
 
 ## Upgrading to 0.4.0
 

--- a/shell/config.collect.yaml
+++ b/shell/config.collect.yaml
@@ -4,7 +4,7 @@
 # copy of this worker purely to read back the functions it registers with the
 # engine — the published "interface". The shell worker refuses to start unless
 # the fs jail is configured. Interface collection runs no fs operations, so we
-# boot UNJAILED (allow_unjailed: true, no host_root) — this needs no pre-created
+# boot UNJAILED (allow_unjailed: true, no host_roots) — this needs no pre-created
 # directory, so it works on a clean CI runner with just `--config config.collect.yaml`.
 max_bg_timeout_ms: 0  # host bg job hard cap in ms; 0 = unbounded (foreground uses max_timeout_ms)
 fs:

--- a/shell/config.yaml
+++ b/shell/config.yaml
@@ -6,19 +6,24 @@ max_bg_timeout_ms: 0  # host bg job hard cap in ms; 0 = unbounded (foreground us
 default_timeout_ms: 10000
 max_output_bytes: 1048576
 working_dir: null
-# Forward the worker's full environment to children so toolchains (cargo,
-# rustup, git, node) find their PATH/HOME/CARGO_HOME/etc. Per-call `env`
-# overrides are still gated: PATH/HOME/LD_*/DYLD_* and interpreter startup
-# keys can never be set per call (see exec/policy.rs DANGEROUS_ENV_KEYS).
-# NOTE: this also forwards any secrets in the worker's env to every command;
-# run the worker with a clean environment if that matters to you.
-inherit_env: true
-allowed_env:
-  - PATH
-  - HOME
-  - LANG
-  - LC_ALL
-  - TERM
+# Environment policy for spawned commands.
+env:
+  # Forward the worker's full environment to children so toolchains (cargo,
+  # rustup, git, node) find their PATH/HOME/CARGO_HOME/etc. Per-call `env`
+  # overrides are still gated: PATH/HOME/LD_*/DYLD_* and interpreter startup
+  # keys can never be set per call (see exec/policy.rs DANGEROUS_ENV_KEYS).
+  # NOTE: this also forwards any secrets in the worker's env to every command;
+  # run the worker with a clean environment if that matters to you.
+  inherit: true
+  # Dual role: (1) when `inherit` is false, ONLY these keys are forwarded to
+  # children; (2) per-call `env` may set a key only if it is listed here —
+  # minus the hardcoded dangerous keys above, which are never settable.
+  allow:
+    - PATH
+    - HOME
+    - LANG
+    - LC_ALL
+    - TERM
 # PERMISSIVE DEFAULT: an EMPTY allowlist means every command is allowed
 # (cargo, git, bash, make, node, python3, …). This is deliberate — a coding
 # agent needs arbitrary build/test/VCS tooling, and a half-open list is

--- a/shell/config.yaml
+++ b/shell/config.yaml
@@ -3,7 +3,10 @@
 # still go through shell::exec_bg (unbounded by default).
 max_timeout_ms: 120000
 max_bg_timeout_ms: 0  # host bg job hard cap in ms; 0 = unbounded (foreground uses max_timeout_ms)
-default_timeout_ms: 10000
+# 30s (not the 10s code default): callers that omit timeout_ms shouldn't have
+# their first `cargo build` reaped while max_timeout_ms was raised for exactly
+# that workload.
+default_timeout_ms: 30000
 max_output_bytes: 1048576
 working_dir: null
 # Environment policy for spawned commands.
@@ -37,30 +40,44 @@ allowlist: []
 # sub-execution escapes (find -exec, sed -i, node/python -c, npm run, env <cmd>)
 # are pure dev friction with no security value, so they were dropped; only
 # catastrophic, host-wrecking patterns are kept to catch honest mistakes.
+#
+# Command-SHAPED patterns (mkfs/dd/shutdown/reboot) are anchored to argv[0]
+# (`^(\S*/)?name`) so they fire only when the tool IS the command — a coding
+# agent running `grep -rn shutdown src/` or `rg "dd if=" docs/` is not
+# rejected. Argument-shaped patterns (rm -rf /, the fork bomb, /etc/shadow)
+# stay unanchored: their dangerous form lives in the arguments.
 denylist_patterns:
   - "rm\\s+-rf\\s+/"
   - ":\\(\\)\\s*\\{\\s*:\\|"   # fork bomb
-  - "mkfs"
-  - "dd\\s+if="
-  - "shutdown"
-  - "reboot"
+  - "^(\\S*/)?mkfs"
+  - "^(\\S*/)?dd\\s+if="
+  - "^(\\S*/)?shutdown\\b"
+  - "^(\\S*/)?reboot\\b"
   - "/etc/shadow"
 max_concurrent_jobs: 16
 job_retention_secs: 3600
 
 fs:
-  # SET host_root to a directory you intend to expose to shell::fs::*.
-  # When unset, the worker refuses to start unless allow_unjailed is true
+  # SET host_roots to the directories you intend to expose to shell::fs::*.
+  # The FIRST entry is the primary root (relative paths resolve against it).
+  # When empty, the worker refuses to start unless allow_unjailed is true
   # (because the alternative is "the entire filesystem is reachable
   # behind only the advisory denylist", which is rarely intended).
+  # `host_root` (singular) is a legacy one-entry alias; prefer this list.
   #
   # Default is /tmp: exists on every Unix host, is writable, and contains
-  # only ephemeral data. Operators should point this at the workspace
+  # only ephemeral data. Operators should point this at the workspace(s)
   # they intend the shell worker to manage.
-  host_root: /tmp
+  host_roots: [/tmp]
   allow_unjailed: false
   max_read_bytes: 16777216
   max_write_bytes: 16777216
+  # Defense in depth: while the jail is /tmp these paths are unreachable
+  # through shell::fs::* anyway (the jail rejects them first, S215); they
+  # exist so widening the jail — or going unjailed — never exposes them.
+  # The exec side can't be fs-jailed (children read the host freely), which
+  # is why /etc/shadow ALSO appears in denylist_patterns above; /etc/passwd
+  # is world-readable by design and gets no exec tripwire.
   denylist_paths:
     - /etc/passwd
     - /etc/shadow

--- a/shell/config.yaml
+++ b/shell/config.yaml
@@ -31,7 +31,7 @@ env:
 # (cargo, git, bash, make, node, python3, …). This is deliberate — a coding
 # agent needs arbitrary build/test/VCS tooling, and a half-open list is
 # defeated the moment any shell/interpreter is on it. This worker is NOT a
-# sandbox: the security boundary is the fs jail (fs.host_root) plus the
+# sandbox: the security boundary is the fs jail (fs.host_roots) plus the
 # optional sandbox backend, NOT this list. To re-scope exec to deny-by-default,
 # list the permitted argv[0] basenames here (a non-empty list flips the gate).
 allowlist: []
@@ -63,7 +63,7 @@ fs:
   # When empty, the worker refuses to start unless allow_unjailed is true
   # (because the alternative is "the entire filesystem is reachable
   # behind only the advisory denylist", which is rarely intended).
-  # `host_root` (singular) is a legacy one-entry alias; prefer this list.
+  # (the 0.6.x `host_root` single-root form was removed in 0.7.0)
   #
   # Default is /tmp: exists on every Unix host, is writable, and contains
   # only ephemeral data. Operators should point this at the workspace(s)

--- a/shell/config.yaml
+++ b/shell/config.yaml
@@ -41,18 +41,24 @@ allowlist: []
 # are pure dev friction with no security value, so they were dropped; only
 # catastrophic, host-wrecking patterns are kept to catch honest mistakes.
 #
-# Command-SHAPED patterns (mkfs/dd/shutdown/reboot) are anchored to argv[0]
-# (`^(\S*/)?name`) so they fire only when the tool IS the command — a coding
-# agent running `grep -rn shutdown src/` or `rg "dd if=" docs/` is not
-# rejected. Argument-shaped patterns (rm -rf /, the fork bomb, /etc/shadow)
-# stay unanchored: their dangerous form lives in the arguments.
+# Command-SHAPED patterns (mkfs/dd/shutdown/reboot) are anchored to argv[0],
+# case-insensitive, tolerating an optional sudo/doas/nohup/timeout wrapper (or
+# `env`, with its idiomatic `KEY=VALUE...` assignments) — mkfs/dd-to-device/
+# shutdown/reboot normally require root, so `sudo shutdown -h now` is
+# arguably the MOST likely accidental invocation. They fire only when the
+# tool IS the command (wrapped or not) — a coding agent running
+# `grep -rn shutdown src/` or `rg "dd if=" docs/` is not rejected.
+# Argument-shaped patterns (rm -rf /, the fork bomb, /etc/shadow) stay
+# unanchored: their dangerous form lives in the arguments. Still advisory
+# only: a wrapper not named here, flags BEFORE the wrapped command
+# (`sudo -u root shutdown`), or spawning via `sh -c`, still evade it.
 denylist_patterns:
   - "rm\\s+-rf\\s+/"
   - ":\\(\\)\\s*\\{\\s*:\\|"   # fork bomb
-  - "^(\\S*/)?mkfs"
-  - "^(\\S*/)?dd\\s+if="
-  - "^(\\S*/)?shutdown\\b"
-  - "^(\\S*/)?reboot\\b"
+  - "(?i)^(?:(?:\\S*/)?env(?:\\s+\\S+=\\S*)*\\s+|(?:\\S*/)?(?:sudo|doas|nohup)\\s+|(?:\\S*/)?timeout(?:\\s+\\S+)?\\s+)*(\\S*/)?mkfs"
+  - "(?i)^(?:(?:\\S*/)?env(?:\\s+\\S+=\\S*)*\\s+|(?:\\S*/)?(?:sudo|doas|nohup)\\s+|(?:\\S*/)?timeout(?:\\s+\\S+)?\\s+)*(\\S*/)?dd\\s+if="
+  - "(?i)^(?:(?:\\S*/)?env(?:\\s+\\S+=\\S*)*\\s+|(?:\\S*/)?(?:sudo|doas|nohup)\\s+|(?:\\S*/)?timeout(?:\\s+\\S+)?\\s+)*(\\S*/)?shutdown\\b"
+  - "(?i)^(?:(?:\\S*/)?env(?:\\s+\\S+=\\S*)*\\s+|(?:\\S*/)?(?:sudo|doas|nohup)\\s+|(?:\\S*/)?timeout(?:\\s+\\S+)?\\s+)*(\\S*/)?reboot\\b"
   - "/etc/shadow"
 max_concurrent_jobs: 16
 job_retention_secs: 3600

--- a/shell/skills/SKILL.md
+++ b/shell/skills/SKILL.md
@@ -48,7 +48,7 @@ agents, pair with the `skills` worker.
 - Host `shell::exec` is not a security sandbox: the denylist is bypassable by
   any allowlisted interpreter. Run untrusted commands with `target: sandbox`
   (needs `iii-sandbox`).
-- `shell::fs::*` is jailed to `cfg.fs.host_root` and refuses denylisted paths;
+- `shell::fs::*` is jailed to `cfg.fs.host_roots` and refuses denylisted paths;
   paths must be absolute and symlinks are never followed.
 - Sandbox-backed background jobs cannot be hard-killed: `shell::kill` flips the
   record but the in-VM process runs until its `timeout_ms` (or `sandbox::stop`).

--- a/shell/src/code/config.rs
+++ b/shell/src/code/config.rs
@@ -347,17 +347,6 @@ mod tests {
     }
 
     #[test]
-    fn stored_base_path_and_base_paths_are_ignored() {
-        // Removed in 0.7.0 WITHOUT a reject: these keys never had a runtime
-        // effect (code_resolver_config always overwrote the roots from
-        // fs.host_roots), so an old stored value carrying them parses fine
-        // and the roots stay runtime-filled (empty here).
-        let cfg: CoderConfig =
-            serde_yaml::from_str("base_path: /tmp/legacy\nbase_paths: [/tmp/x]\n").unwrap();
-        assert!(cfg.base_paths.is_empty());
-    }
-
-    #[test]
     fn custom_yaml_overrides_each_field() {
         let yaml = r#"
 non_accessible_globs:

--- a/shell/src/code/config.rs
+++ b/shell/src/code/config.rs
@@ -452,6 +452,12 @@ search_response_budget_bytes: 11
 
     #[test]
     fn from_yaml_expands_env_var() {
+        // Serialized against every other process-env-mutating test in the
+        // crate (see ENV_TEST_MUTEX) — set_var/var race across threads
+        // otherwise.
+        let _env_lock = crate::config::ENV_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         std::env::set_var("CODER_TEST_ROOT", "/tmp/expanded-glob");
         let yaml = "non_accessible_globs:\n  - \"${CODER_TEST_ROOT}\"\n";
         let cfg = CoderConfig::from_yaml(yaml).unwrap();

--- a/shell/src/code/config.rs
+++ b/shell/src/code/config.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+#[cfg(test)]
 use serde_json::Value;
 
 /// Configuration for the folded `coder::*` code surface: protected/noise
@@ -15,19 +16,18 @@ use serde_json::Value;
 /// here at runtime — the resolver uses `fs.host_roots` (one jail config).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct CoderConfig {
-    /// Legacy single-root form. Honored as a one-entry `base_paths` list.
-    /// Setting BOTH `base_path` and `base_paths` is a startup error
-    /// (checked at `PathResolver` construction).
-    #[serde(default)]
-    pub base_path: Option<PathBuf>,
-
-    /// Root directories the worker operates inside. The FIRST entry is
-    /// the primary root: relative wire paths resolve against it. Absolute
-    /// wire paths are accepted when they canonicalize inside ANY listed
-    /// root. When neither this nor `base_path` is set, the effective
+    /// Runtime plumbing, NEVER read from config: the resolver's roots are
+    /// copied here from `fs.host_roots` by
+    /// `ShellConfig::code_resolver_config`, so there is a single jail
+    /// config. The FIRST entry is the primary root: relative wire paths
+    /// resolve against it; absolute wire paths are accepted when they
+    /// canonicalize inside ANY listed root. When empty, the effective
     /// default is `["./", "/tmp"]` (resolved at `PathResolver`
-    /// construction).
-    #[serde(default)]
+    /// construction). The 0.6.x `code.base_path`/`base_paths` config keys
+    /// were removed from the schema in 0.7.0; stored values still carrying
+    /// them are silently ignored — deliberate, they never had an effect.
+    #[serde(skip)]
+    #[schemars(skip)]
     pub base_paths: Vec<PathBuf>,
 
     /// Glob patterns matched against the path *relative to its containing
@@ -178,9 +178,6 @@ fn default_search_response_budget_bytes() -> u64 {
 #[cfg(test)]
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct JailSignature {
-    /// Legacy single-root form. A change re-roots the jail — restart-required
-    /// (`PathResolver` compiles the effective root set from this + `base_paths`).
-    pub base_path: Option<PathBuf>,
     /// The root directories the jail confines all access to. A change to the
     /// set (or order — the first entry is the primary root) moves the security
     /// boundary, so it is restart-required: the `PathResolver` canonicalizes
@@ -201,7 +198,6 @@ pub struct JailSignature {
 impl Default for CoderConfig {
     fn default() -> Self {
         Self {
-            base_path: None,
             base_paths: Vec::new(),
             non_accessible_globs: Vec::new(),
             default_exclude_globs: default_default_exclude_globs(),
@@ -222,9 +218,9 @@ impl Default for CoderConfig {
 
 impl CoderConfig {
     /// Test helper: parse a config from a YAML string, expanding `${NAME}`
-    /// against the process environment first. Production loads the `code` block
-    /// as JSON via [`from_json`]; this YAML path is exercised only by unit
-    /// tests.
+    /// against the process environment first. Production deserializes the
+    /// `code` block as part of `ShellConfig` (serde derive); this YAML path
+    /// is exercised only by unit tests.
     #[cfg(test)]
     pub fn from_yaml(yaml: &str) -> Result<Self, String> {
         let expanded = expand_env(yaml);
@@ -233,9 +229,12 @@ impl CoderConfig {
         Ok(cfg)
     }
 
-    /// Parse a config from a JSON value already env-expanded by the
-    /// configuration worker. Does NOT run `expand_env` — double-expansion would
-    /// be a bug — and tolerates a zero-field object (serde defaults fill in).
+    /// Parse a config from a standalone JSON value. Does NOT run `expand_env`
+    /// — double-expansion would be a bug — and tolerates a zero-field object
+    /// (serde defaults fill in). Production deserializes the `code` block as
+    /// part of `ShellConfig`; this was the coder-migration entry point and is
+    /// now exercised only by unit tests.
+    #[cfg(test)]
     pub fn from_json(value: &Value) -> Result<Self, String> {
         let cfg: CoderConfig =
             serde_json::from_value(value.clone()).map_err(|e| format!("json parse: {e}"))?;
@@ -247,9 +246,9 @@ impl CoderConfig {
         serde_json::to_value(self).expect("CoderConfig serializes")
     }
 
-    /// Build the restart-required jail signature. These four fields are
-    /// EVERYTHING the `PathResolver` compiles: the root set (`base_path` +
-    /// `base_paths`) that bounds the security jail, the access-deny globs
+    /// Build the restart-required jail signature. These three fields are
+    /// EVERYTHING the `PathResolver` compiles: the root set (`base_paths`)
+    /// that bounds the security jail, the access-deny globs
     /// (`non_accessible_globs`), and the resolver-compiled noise filter
     /// (`default_exclude_globs`). A live config update that changes ANY of them
     /// is refused on hot-reload (logged "restart coder to apply", previous
@@ -259,7 +258,6 @@ impl CoderConfig {
     #[cfg(test)]
     pub fn jail_signature(&self) -> JailSignature {
         JailSignature {
-            base_path: self.base_path.clone(),
             base_paths: self.base_paths.clone(),
             non_accessible_globs: self.non_accessible_globs.clone(),
             default_exclude_globs: self.default_exclude_globs.clone(),
@@ -310,7 +308,6 @@ mod tests {
     #[test]
     fn empty_yaml_parses_to_defaults() {
         let cfg: CoderConfig = serde_yaml::from_str("{}").expect("empty yaml parses");
-        assert_eq!(cfg.base_path, None);
         assert!(cfg.base_paths.is_empty());
         assert!(cfg.non_accessible_globs.is_empty());
         assert_eq!(
@@ -348,18 +345,19 @@ mod tests {
     }
 
     #[test]
-    fn legacy_base_path_parses_as_option() {
-        let cfg: CoderConfig = serde_yaml::from_str("base_path: /tmp/legacy").unwrap();
-        assert_eq!(cfg.base_path, Some(PathBuf::from("/tmp/legacy")));
+    fn stored_base_path_and_base_paths_are_ignored() {
+        // Removed in 0.7.0 WITHOUT a reject: these keys never had a runtime
+        // effect (code_resolver_config always overwrote the roots from
+        // fs.host_roots), so an old stored value carrying them parses fine
+        // and the roots stay runtime-filled (empty here).
+        let cfg: CoderConfig =
+            serde_yaml::from_str("base_path: /tmp/legacy\nbase_paths: [/tmp/x]\n").unwrap();
         assert!(cfg.base_paths.is_empty());
     }
 
     #[test]
     fn custom_yaml_overrides_each_field() {
         let yaml = r#"
-base_paths:
-  - /tmp/c
-  - /tmp/d
 non_accessible_globs:
   - "**/.env"
 default_exclude_globs:
@@ -377,11 +375,6 @@ max_output_bytes: 31
 search_response_budget_bytes: 29
 "#;
         let cfg: CoderConfig = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(cfg.base_path, None);
-        assert_eq!(
-            cfg.base_paths,
-            vec![PathBuf::from("/tmp/c"), PathBuf::from("/tmp/d")]
-        );
         assert_eq!(cfg.non_accessible_globs, vec!["**/.env".to_string()]);
         assert_eq!(cfg.default_exclude_globs, vec!["**/build/**".to_string()]);
         assert_eq!(cfg.max_read_bytes, 42);
@@ -414,13 +407,11 @@ search_response_budget_bytes: 29
     #[test]
     fn from_json_round_trips_custom_values() {
         let json = serde_json::json!({
-            "base_paths": ["/tmp/x"],
             "non_accessible_globs": ["**/.env"],
             "max_read_bytes": 99,
             "tree_default_depth": 2,
         });
         let cfg = CoderConfig::from_json(&json).unwrap();
-        assert_eq!(cfg.base_paths, vec![PathBuf::from("/tmp/x")]);
         assert_eq!(cfg.non_accessible_globs, vec!["**/.env".to_string()]);
         assert_eq!(cfg.max_read_bytes, 99);
         assert_eq!(cfg.tree_default_depth, 2);
@@ -450,24 +441,24 @@ search_response_budget_bytes: 29
     #[test]
     fn to_json_round_trips_through_from_json() {
         let yaml = r#"
-base_paths:
-  - /tmp/a
 max_output_bytes: 7
 search_response_budget_bytes: 11
 "#;
         let cfg = CoderConfig::from_yaml(yaml).unwrap();
         let back = CoderConfig::from_json(&cfg.to_json()).unwrap();
-        assert_eq!(back.base_paths, vec![PathBuf::from("/tmp/a")]);
         assert_eq!(back.max_output_bytes, 7);
         assert_eq!(back.search_response_budget_bytes, 11);
     }
 
     #[test]
     fn from_yaml_expands_env_var() {
-        std::env::set_var("CODER_TEST_ROOT", "/tmp/expanded-root");
-        let yaml = "base_paths:\n  - \"${CODER_TEST_ROOT}\"\n";
+        std::env::set_var("CODER_TEST_ROOT", "/tmp/expanded-glob");
+        let yaml = "non_accessible_globs:\n  - \"${CODER_TEST_ROOT}\"\n";
         let cfg = CoderConfig::from_yaml(yaml).unwrap();
-        assert_eq!(cfg.base_paths, vec![PathBuf::from("/tmp/expanded-root")]);
+        assert_eq!(
+            cfg.non_accessible_globs,
+            vec!["/tmp/expanded-glob".to_string()]
+        );
         std::env::remove_var("CODER_TEST_ROOT");
     }
 
@@ -505,16 +496,6 @@ search_response_budget_bytes: 11
             ..base.clone()
         };
         assert_eq!(base.jail_signature(), tuned.jail_signature());
-    }
-
-    #[test]
-    fn jail_signature_differs_when_base_path_changes() {
-        let a = CoderConfig::default();
-        let b = CoderConfig {
-            base_path: Some(PathBuf::from("/tmp/legacy")),
-            ..CoderConfig::default()
-        };
-        assert_ne!(a.jail_signature(), b.jail_signature());
     }
 
     #[test]

--- a/shell/src/code/config.rs
+++ b/shell/src/code/config.rs
@@ -10,6 +10,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+/// Configuration for the folded `coder::*` code surface: protected/noise
+/// globs plus per-call read/search/tree budgets. Roots are NOT taken from
+/// here at runtime — the resolver uses `fs.host_roots` (one jail config).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct CoderConfig {
     /// Legacy single-root form. Honored as a one-entry `base_paths` list.
@@ -42,27 +45,45 @@ pub struct CoderConfig {
     #[serde(default = "default_default_exclude_globs")]
     pub default_exclude_globs: Vec<String>,
 
+    /// Per-file IO ceiling, in bytes, for `coder::read-file` in every mode
+    /// (full, windowed, batch). A larger file fails with C213 naming the
+    /// size. Default 10485760 (10 MiB).
     #[serde(default = "default_max_read_bytes")]
     pub max_read_bytes: u64,
 
+    /// Cap, in bytes, on the content of a single `coder::create-file` /
+    /// `coder::update-file` call (C213 when exceeded). Default 10485760
+    /// (10 MiB).
     #[serde(default = "default_max_write_bytes")]
     pub max_write_bytes: u64,
 
+    /// Directory depth `coder::tree` descends when the caller omits `depth`.
+    /// Default 4.
     #[serde(default = "default_tree_default_depth")]
     pub tree_default_depth: u32,
 
+    /// Maximum entries `coder::tree` lists per folder before eliding the
+    /// rest (flagged in the response). Default 50.
     #[serde(default = "default_tree_per_folder_limit")]
     pub tree_per_folder_limit: u32,
 
+    /// Page size `coder::list-folder` uses when the caller omits one.
+    /// Default 100.
     #[serde(default = "default_list_default_page_size")]
     pub list_default_page_size: u32,
 
+    /// Hard cap on a `coder::list-folder` page; a larger requested page size
+    /// is clamped to this. Default 1000.
     #[serde(default = "default_list_max_page_size")]
     pub list_max_page_size: u32,
 
+    /// Maximum matches one `coder::search` call returns when the caller
+    /// omits `max_matches`. Default 1000.
     #[serde(default = "default_search_max_matches")]
     pub search_default_max_matches: u32,
 
+    /// Per-line byte cap for `coder::search` results; longer matched lines
+    /// are truncated for the response. Default 4096.
     #[serde(default = "default_search_max_line_bytes")]
     pub search_default_max_line_bytes: u32,
 

--- a/shell/src/code/config.rs
+++ b/shell/src/code/config.rs
@@ -24,8 +24,10 @@ pub struct CoderConfig {
     /// canonicalize inside ANY listed root. When empty, the effective
     /// default is `["./", "/tmp"]` (resolved at `PathResolver`
     /// construction). The 0.6.x `code.base_path`/`base_paths` config keys
-    /// were removed from the schema in 0.7.0; stored values still carrying
-    /// them are silently ignored — deliberate, they never had an effect.
+    /// were removed from the schema in 0.7.0; a stored value still carrying
+    /// either is REJECTED at parse (`config::check_removed_keys`) — hard
+    /// migration, no silent tolerance even though they were already inert
+    /// before removal.
     #[serde(skip)]
     #[schemars(skip)]
     pub base_paths: Vec<PathBuf>,

--- a/shell/src/code/functions/info.rs
+++ b/shell/src/code/functions/info.rs
@@ -219,7 +219,6 @@ mod tests {
             search_response_budget_bytes: 29,
             batch_read_budget_bytes: 23,
             max_output_bytes: 31,
-            ..CoderConfig::default()
         });
         let resolver = Arc::new(PathResolver::new(&cfg).unwrap());
 

--- a/shell/src/code/path.rs
+++ b/shell/src/code/path.rs
@@ -1,7 +1,7 @@
 //! Path resolution and access control.
 //!
-//! The worker is jailed to a set of allowed roots (`base_paths`; the
-//! legacy `base_path` is honored as a one-entry list). Relative wire
+//! The worker is jailed to a set of allowed roots (`base_paths`, filled at
+//! runtime from `fs.host_roots`). Relative wire
 //! paths resolve against the FIRST root (the "primary"); absolute wire
 //! paths are accepted when they canonicalise inside ANY allowed root.
 //! `PathResolver` canonicalises inputs (symlink-aware) and verifies
@@ -54,9 +54,8 @@ pub struct PathResolver {
     default_exclude_dirs: GlobSet,
 }
 
-/// Effective roots when neither `base_paths` nor legacy `base_path` is
-/// configured: the engine workspace cwd plus `/tmp` (a deliberate,
-/// user-approved default).
+/// Effective roots when `base_paths` is empty: the engine workspace cwd
+/// plus `/tmp` (a deliberate, user-approved default).
 fn default_roots() -> Vec<PathBuf> {
     vec![PathBuf::from("./"), PathBuf::from("/tmp")]
 }
@@ -83,19 +82,10 @@ fn display_paths(paths: &[PathBuf]) -> String {
 
 impl PathResolver {
     pub fn new(cfg: &CoderConfig) -> Result<Self, CoderError> {
-        let configured: Vec<PathBuf> = match (&cfg.base_path, cfg.base_paths.as_slice()) {
-            (Some(_), [_, ..]) => {
-                return Err(CoderError::BadInput(
-                    "both `base_path` and `base_paths` are set; set either \
-                     `base_path` or `base_paths` in config.yaml, not both. \
-                     Remove `base_path` and keep only `base_paths` \
-                     (legacy `base_path` is honored as a one-entry list)."
-                        .into(),
-                ))
-            }
-            (Some(single), []) => vec![single.clone()],
-            (None, []) => default_roots(),
-            (None, many) => many.to_vec(),
+        let configured: Vec<PathBuf> = if cfg.base_paths.is_empty() {
+            default_roots()
+        } else {
+            cfg.base_paths.clone()
         };
 
         let mut roots_canon: Vec<PathBuf> = Vec::with_capacity(configured.len());
@@ -115,12 +105,12 @@ impl PathResolver {
             }
         }
         if roots_canon.is_empty() {
-            // C210 like the both-set case above: an operator config error
-            // detected at construction time, not a runtime I/O failure.
+            // C210: an operator config error detected at construction time,
+            // not a runtime I/O failure.
             return Err(CoderError::BadInput(format!(
                 "no reachable roots: none of [{}] could be canonicalized. \
                  Ensure the directories exist and are accessible, then set \
-                 `base_paths` in config.yaml to at least one reachable path.",
+                 `fs.host_roots` to at least one reachable path.",
                 display_paths(&configured)
             )));
         }
@@ -686,19 +676,6 @@ mod tests {
     }
 
     #[test]
-    fn both_base_path_and_base_paths_set_is_construction_error() {
-        let a = tempdir().unwrap();
-        let b = tempdir().unwrap();
-        let cfg = CoderConfig {
-            base_path: Some(a.path().to_path_buf()),
-            base_paths: vec![b.path().to_path_buf()],
-            ..CoderConfig::default()
-        };
-        let err = PathResolver::new(&cfg).unwrap_err();
-        assert_eq!(err.code(), "C210");
-    }
-
-    #[test]
     fn zero_reachable_roots_is_construction_error() {
         let cfg = cfg_roots(
             vec![
@@ -708,7 +685,19 @@ mod tests {
             vec![],
         );
         let err = PathResolver::new(&cfg).unwrap_err();
-        // C210: operator config error, same class as the both-set case.
+        // C210: operator config error detected at construction time.
+        assert_eq!(err.code(), "C210");
+    }
+
+    #[test]
+    fn single_unreachable_root_is_construction_error() {
+        // One-entry form of the case above (the shape a single-root
+        // fs.host_roots produces): still an operator config error.
+        let cfg = cfg_roots(
+            vec![PathBuf::from("/this/does/not/exist/probably/xyz123")],
+            vec![],
+        );
+        let err = PathResolver::new(&cfg).unwrap_err();
         assert_eq!(err.code(), "C210");
     }
 
@@ -776,12 +765,9 @@ mod tests {
     }
 
     #[test]
-    fn legacy_base_path_honored_as_single_root() {
+    fn single_base_path_entry_jails_to_that_root() {
         let tmp = tempdir().unwrap();
-        let cfg = CoderConfig {
-            base_path: Some(tmp.path().to_path_buf()),
-            ..CoderConfig::default()
-        };
+        let cfg = cfg_roots(vec![tmp.path().to_path_buf()], vec![]);
         let r = PathResolver::new(&cfg).unwrap();
         assert_eq!(r.roots().len(), 1);
         assert_eq!(r.resolve(".").unwrap(), canon(tmp.path()));
@@ -941,17 +927,6 @@ mod tests {
         let dir = r.resolve("node_modules").unwrap();
         assert!(!r.is_non_accessible(&dir));
         assert!(r.require_writable("node_modules/x.txt").is_ok());
-    }
-
-    #[test]
-    fn legacy_missing_base_path_is_construction_error() {
-        let cfg = CoderConfig {
-            base_path: Some(PathBuf::from("/this/does/not/exist/probably/xyz123")),
-            ..CoderConfig::default()
-        };
-        let err = PathResolver::new(&cfg).unwrap_err();
-        // C210: operator config error, same class as the both-set case.
-        assert_eq!(err.code(), "C210");
     }
 
     // RECOVERY-PAIR TEST: parse the first allowed root out of the C215 error

--- a/shell/src/config.rs
+++ b/shell/src/config.rs
@@ -1092,6 +1092,32 @@ sandbox:
         assert!(!props.contains_key("compiled_denylist"));
     }
 
+    /// The resolver-roots wiring hop: `code_resolver_config` must copy
+    /// `fs.roots()` into `code.base_paths` while preserving the rest of the
+    /// `code` block. Since 0.7.0 `code.base_paths` is serde-skipped, this
+    /// copy is the ONLY source of coder roots — a regression dropping it
+    /// would hand `PathResolver` an empty root set, which falls back to the
+    /// default `["./", "/tmp"]` jail: coder::* silently jailed WIDER than
+    /// the operator's fs jail. (Same wiring class as the D4 glob test in
+    /// tests/code_unified_protection.rs.)
+    #[test]
+    fn code_resolver_config_fills_roots_from_fs_jail() {
+        let mut c = ShellConfig::default();
+        c.fs.host_roots = vec!["/tmp/a".into(), "/tmp/b".into()];
+        c.code.non_accessible_globs = vec!["**/.env".into()];
+        let resolved = c.code_resolver_config();
+        assert_eq!(
+            resolved.base_paths,
+            c.fs.roots(),
+            "coder roots must come from the unified fs jail"
+        );
+        assert_eq!(
+            resolved.non_accessible_globs,
+            vec!["**/.env".to_string()],
+            "the rest of the code block is preserved"
+        );
+    }
+
     #[test]
     fn to_json_from_json_round_trips() {
         let mut c = ShellConfig::default();

--- a/shell/src/config.rs
+++ b/shell/src/config.rs
@@ -105,8 +105,7 @@ pub struct ShellConfig {
     /// per-file/response budgets. The code resolver's ROOTS are NOT taken from
     /// here — it uses `fs.host_roots` so there is a single jail config
     /// (`code.base_path`/`base_paths` were removed from the schema in 0.7.0;
-    /// stored values still carrying them are ignored — they never had an
-    /// effect).
+    /// stored values still carrying them are rejected at parse).
     #[serde(default)]
     pub code: crate::code::config::CoderConfig,
 

--- a/shell/src/config.rs
+++ b/shell/src/config.rs
@@ -223,12 +223,17 @@ pub struct FsConfig {
     /// harnesses, sandbox-only deployments).
     #[serde(default)]
     pub allow_unjailed: bool,
-    /// Cap, in bytes, on a single `shell::fs::read`. `0` (the default) means
-    /// unlimited. The shipped seed sets 16777216 (16 MiB).
+    /// Cap, in bytes, on a single `shell::fs::read` (S218 when exceeded).
+    /// `0` (the default) means unlimited — safe because reads stream over a
+    /// channel in 64 KiB chunks rather than buffering the file in memory; the
+    /// cap exists to bound CALLER cost, not worker memory. The shipped seed
+    /// sets 16777216 (16 MiB).
     #[serde(default = "default_max_read_bytes")]
     pub max_read_bytes: usize,
-    /// Cap, in bytes, on a single `shell::fs::write`. `0` (the default) means
-    /// unlimited. The shipped seed sets 16777216 (16 MiB).
+    /// Cap, in bytes, on a single `shell::fs::write` (S218 mid-stream when
+    /// exceeded). `0` (the default) means unlimited — writes stream like
+    /// reads, so the cap bounds caller cost, not worker memory. The shipped
+    /// seed sets 16777216 (16 MiB).
     #[serde(default = "default_max_write_bytes")]
     pub max_write_bytes: usize,
     /// Absolute path prefixes that are hard-rejected (S215) by every fs
@@ -342,21 +347,31 @@ impl ShellConfig {
     pub fn seed_default() -> Self {
         Self {
             max_timeout_ms: 120_000,
+            // 30s (not the 10s code default): the dev seed raises max_timeout_ms
+            // to 120s so real builds survive — a 10s default for callers that
+            // omit timeout_ms would undercut that on the first `cargo build`.
+            default_timeout_ms: 30_000,
             env: EnvConfig {
                 inherit: true,
                 ..EnvConfig::default()
             },
+            // Command-SHAPED patterns (mkfs/shutdown/reboot/dd) are anchored to
+            // argv[0] — `^(\S*/)?name` fires when the tool IS the command, not
+            // when the word appears in an argument, so `grep -rn shutdown src/`
+            // or `rg "dd if=" docs/` are not rejected. Argument-shaped patterns
+            // (rm -rf /, the fork bomb, /etc/shadow) stay full-line: their
+            // dangerous form lives in the arguments.
             denylist_patterns: vec![
                 r"rm\s+-rf\s+/".into(),
                 r":\(\)\s*\{\s*:\|".into(),
-                "mkfs".into(),
-                r"dd\s+if=".into(),
-                "shutdown".into(),
-                "reboot".into(),
+                r"^(\S*/)?mkfs".into(),
+                r"^(\S*/)?dd\s+if=".into(),
+                r"^(\S*/)?shutdown\b".into(),
+                r"^(\S*/)?reboot\b".into(),
                 "/etc/shadow".into(),
             ],
             fs: FsConfig {
-                host_root: Some(PathBuf::from("/tmp")),
+                host_roots: vec![PathBuf::from("/tmp")],
                 max_read_bytes: 16_777_216,
                 max_write_bytes: 16_777_216,
                 denylist_paths: vec![PathBuf::from("/etc/passwd"), PathBuf::from("/etc/shadow")],
@@ -449,7 +464,12 @@ impl ShellConfig {
         let joined = argv.join(" ");
         for re in &self.compiled_denylist {
             if re.is_match(&joined) {
-                return Err(format!("command matches denylist: {}", re.as_str()));
+                return Err(format!(
+                    "command matches denylist pattern '{}' — an advisory tripwire for \
+                     catastrophic mistakes, not a security boundary; rephrase the command \
+                     to avoid the pattern",
+                    re.as_str()
+                ));
             }
         }
 
@@ -698,6 +718,34 @@ mod tests {
             .is_command_allowed(&["rm".into(), "-rf".into(), "/".into()])
             .expect_err("rm -rf / must still trip the denylist");
         assert!(err.contains("denylist"), "got: {err}");
+
+        // Command-shaped patterns are anchored to argv[0]: they fire when the
+        // tool IS the command (bare or path-qualified)...
+        for argv in [
+            vec!["shutdown".to_string(), "-h".into(), "now".into()],
+            vec!["/sbin/shutdown".to_string(), "-r".into()],
+            vec!["reboot".to_string()],
+            vec!["mkfs.ext4".to_string(), "/dev/sda1".into()],
+            vec!["dd".to_string(), "if=/dev/zero".into(), "of=/dev/sda".into()],
+        ] {
+            assert!(
+                c.is_command_allowed(&argv).is_err(),
+                "{argv:?} must trip the anchored denylist"
+            );
+        }
+        // ...but NOT when the word merely appears in an argument — a coding
+        // agent grepping a codebase for "shutdown" is not a mistake.
+        for argv in [
+            vec!["grep".to_string(), "-rn".into(), "shutdown".into(), "src/".into()],
+            vec!["cargo".to_string(), "test".into(), "reboot".into()],
+            vec!["rg".to_string(), "dd if=".into(), "docs/".into()],
+            vec!["git".to_string(), "log".into(), "--grep".into(), "mkfs".into()],
+        ] {
+            assert!(
+                c.is_command_allowed(&argv).is_ok(),
+                "{argv:?} must NOT trip the denylist (argument, not command)"
+            );
+        }
     }
 
     /// `seed_default()` is the in-code twin of the shipped `config.yaml` — the
@@ -803,16 +851,28 @@ mod tests {
                 "config field `{name}` has no schema description (console UI shows it bare)"
             );
         }
-        let env_props = &schema["definitions"]["EnvConfig"]["properties"];
-        for key in ["inherit", "allow"] {
-            assert!(
-                env_props[key]["description"]
-                    .as_str()
-                    .is_some_and(|s| !s.is_empty()),
-                "EnvConfig.{key} has no schema description"
-            );
+        // Same rule for every nested definition (EnvConfig, FsConfig,
+        // SandboxConfig, CoderConfig, and anything added later): the console
+        // renders their fields too.
+        let defs = schema["definitions"]
+            .as_object()
+            .expect("nested definitions");
+        for (def_name, def) in defs {
+            let Some(props) = def["properties"].as_object() else {
+                continue; // non-object definitions (enums etc.) have no fields
+            };
+            for (name, prop) in props {
+                assert!(
+                    prop.get("description")
+                        .and_then(|d| d.as_str())
+                        .is_some_and(|s| !s.is_empty()),
+                    "{def_name}.{name} has no schema description (console UI shows it bare)"
+                );
+            }
         }
-        let allow_desc = env_props["allow"]["description"].as_str().unwrap();
+        let allow_desc = schema["definitions"]["EnvConfig"]["properties"]["allow"]["description"]
+            .as_str()
+            .expect("env.allow described");
         assert!(
             allow_desc.contains("Forwarding") && allow_desc.contains("Per-call"),
             "env.allow description must explain both roles: {allow_desc}"

--- a/shell/src/config.rs
+++ b/shell/src/config.rs
@@ -4,8 +4,16 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+/// Root configuration for the shell worker: exec policy (timeouts, output
+/// caps, allow/denylist, env forwarding), the fs jail, the sandbox toggle,
+/// and the folded `coder::*` code surface. Stored in the `configuration`
+/// worker under id `shell` and hot-reloaded on change.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ShellConfig {
+    /// Hard cap, in milliseconds, on a foreground `shell::exec` call. A
+    /// per-call `timeout_ms` above this is clamped down to it. Default 30000
+    /// (30s); the shipped dev seed raises it to 120000 so real builds/tests
+    /// are not reaped.
     #[serde(default = "default_max_timeout_ms")]
     pub max_timeout_ms: u64,
 
@@ -19,21 +27,35 @@ pub struct ShellConfig {
     #[serde(default = "default_max_bg_timeout_ms")]
     pub max_bg_timeout_ms: u64,
 
+    /// Timeout, in milliseconds, applied to a foreground `shell::exec` call
+    /// when the caller omits `timeout_ms`. Always clamped to `max_timeout_ms`.
+    /// Default 10000 (10s).
     #[serde(default = "default_default_timeout_ms")]
     pub default_timeout_ms: u64,
 
+    /// Per-stream cap, in bytes, on captured stdout and stderr. Output beyond
+    /// the cap is dropped and the response flags `stdout_truncated` /
+    /// `stderr_truncated`. Default 1048576 (1 MiB).
     #[serde(default = "default_max_output_bytes")]
     pub max_output_bytes: usize,
 
+    /// Default working directory for spawned commands. `null` (the default)
+    /// runs children in the worker's own cwd. A per-call `cwd` or a
+    /// harness-stamped session `base_dir` overrides it for that one call.
     #[serde(default)]
     pub working_dir: Option<PathBuf>,
 
+    /// Environment policy for spawned commands (host target): whether the
+    /// worker's env is forwarded to children, and which keys are
+    /// forwardable/settable. See the field docs on `EnvConfig`.
     #[serde(default)]
-    pub inherit_env: bool,
+    pub env: EnvConfig,
 
-    #[serde(default = "default_allowed_env")]
-    pub allowed_env: Vec<String>,
-
+    /// Command allowlist by argv[0] basename. EMPTY (the default) means every
+    /// command is allowed — deliberate for coding agents that need arbitrary
+    /// build/test/VCS tooling; the security boundary is the fs jail and the
+    /// sandbox backend, not this list. A non-empty list flips exec to
+    /// deny-by-default: only the listed basenames run.
     #[serde(default)]
     pub allowlist: Vec<String>,
 
@@ -45,15 +67,23 @@ pub struct ShellConfig {
     #[serde(default)]
     pub denylist_patterns: Vec<String>,
 
+    /// Maximum number of live background jobs (`shell::exec_bg`). A spawn past
+    /// the cap is rejected until a job finishes or is killed. Default 16.
     #[serde(default = "default_max_concurrent_jobs")]
     pub max_concurrent_jobs: usize,
 
+    /// How long, in seconds, a FINISHED job record (status, exit code,
+    /// captured output) stays queryable via `shell::status` before a
+    /// background reaper evicts it. Default 3600 (1h).
     #[serde(default = "default_job_retention_secs")]
     pub job_retention_secs: u64,
 
+    /// The filesystem jail shared by `shell::fs::*`, `coder::*`, and per-call
+    /// exec `cwd` confinement. See the field docs on `FsConfig`.
     #[serde(default)]
     pub fs: FsConfig,
 
+    /// The `iii-sandbox` microVM backend toggle for sandbox-targeted calls.
     #[serde(default)]
     pub sandbox: SandboxConfig,
 
@@ -94,12 +124,6 @@ fn default_default_timeout_ms() -> u64 {
 fn default_max_output_bytes() -> usize {
     1_048_576
 }
-fn default_allowed_env() -> Vec<String> {
-    vec!["PATH", "HOME", "LANG", "LC_ALL", "TERM"]
-        .into_iter()
-        .map(String::from)
-        .collect()
-}
 fn default_max_concurrent_jobs() -> usize {
     16
 }
@@ -107,6 +131,76 @@ fn default_job_retention_secs() -> u64 {
     3600
 }
 
+/// Top-level keys removed in 0.7.0 and where they moved. serde ignores
+/// unknown fields, so a 0.6.x config carrying `inherit_env: true` would
+/// otherwise parse into `env.inherit = false` — silently disabling env
+/// forwarding. Fail closed with a migration hint instead.
+const REMOVED_TOP_LEVEL_KEYS: &[(&str, &str)] =
+    &[("inherit_env", "env.inherit"), ("allowed_env", "env.allow")];
+
+fn check_removed_keys<'a>(keys: impl Iterator<Item = &'a str>) -> Result<(), String> {
+    let hits: Vec<String> = keys
+        .filter_map(|k| {
+            REMOVED_TOP_LEVEL_KEYS
+                .iter()
+                .find(|(old, _)| *old == k)
+                .map(|(old, new)| format!("`{old}` -> `{new}`"))
+        })
+        .collect();
+    if hits.is_empty() {
+        return Ok(());
+    }
+    Err(format!(
+        "config keys removed in 0.7.0: {}. Nest them under `env:` (e.g. env: {{ inherit: true, \
+         allow: [PATH, HOME] }}). If this is the stored value, rewrite it via \
+         configuration::set (id: shell).",
+        hits.join(", ")
+    ))
+}
+
+/// Environment policy for spawned commands (host target). Replaces the
+/// 0.6.x top-level `inherit_env` / `allowed_env` keys (renamed in 0.7.0;
+/// the old keys are rejected at parse with a migration hint).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct EnvConfig {
+    /// Forward the worker's ENTIRE environment to child processes. Toolchains
+    /// (cargo, rustup, git, node) need this to find PATH/HOME/CARGO_HOME.
+    /// WARNING: it also forwards any secrets in the worker's env to every
+    /// command — run the worker with a clean environment if that matters.
+    /// When false (the default), children start from a clean env containing
+    /// only the keys listed in `allow`.
+    #[serde(default)]
+    pub inherit: bool,
+    /// Env keys with a dual role. (1) Forwarding allowlist: when `inherit` is
+    /// false, ONLY these keys are copied from the worker's env into the child.
+    /// (2) Per-call gate: a `shell::exec`/`shell::exec_bg` request may set an
+    /// `env` value only for a key listed here — MINUS the hardcoded dangerous
+    /// keys (PATH, IFS, HOME, LD_*/DYLD_*, GCONV_PATH, BASH_ENV,
+    /// PYTHONSTARTUP, NODE_OPTIONS, ...), which are never settable per call
+    /// even if listed. Default: [PATH, HOME, LANG, LC_ALL, TERM].
+    #[serde(default = "default_env_allow")]
+    pub allow: Vec<String>,
+}
+
+fn default_env_allow() -> Vec<String> {
+    vec!["PATH", "HOME", "LANG", "LC_ALL", "TERM"]
+        .into_iter()
+        .map(String::from)
+        .collect()
+}
+
+impl Default for EnvConfig {
+    fn default() -> Self {
+        Self {
+            inherit: false,
+            allow: default_env_allow(),
+        }
+    }
+}
+
+/// The filesystem jail: which host roots are reachable through
+/// `shell::fs::*`, `coder::*`, and per-call exec `cwd`, plus read/write
+/// budgets and hard-denied paths.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct FsConfig {
     /// Legacy single jail root. Honored as a one-entry `host_roots` list.
@@ -129,10 +223,17 @@ pub struct FsConfig {
     /// harnesses, sandbox-only deployments).
     #[serde(default)]
     pub allow_unjailed: bool,
+    /// Cap, in bytes, on a single `shell::fs::read`. `0` (the default) means
+    /// unlimited. The shipped seed sets 16777216 (16 MiB).
     #[serde(default = "default_max_read_bytes")]
     pub max_read_bytes: usize,
+    /// Cap, in bytes, on a single `shell::fs::write`. `0` (the default) means
+    /// unlimited. The shipped seed sets 16777216 (16 MiB).
     #[serde(default = "default_max_write_bytes")]
     pub max_write_bytes: usize,
+    /// Absolute path prefixes that are hard-rejected (S215) by every fs
+    /// operation and per-call exec `cwd`, even inside a jail root. A separate
+    /// layer from `code.non_accessible_globs` (glob-based, show-but-lock).
     #[serde(default)]
     pub denylist_paths: Vec<PathBuf>,
     /// Permit setuid/setgid/sticky bits (the top octal digit, `mode & 0o7000`)
@@ -144,8 +245,12 @@ pub struct FsConfig {
     pub allow_special_bits: bool,
 }
 
+/// Toggle for the `iii-sandbox` microVM exec backend.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct SandboxConfig {
+    /// Accept `target: { kind: "sandbox", sandbox_id }` calls and forward
+    /// them to the `iii-sandbox` worker. When false, sandbox-targeted calls
+    /// are rejected with S210. Default true.
     #[serde(default = "default_sandbox_enabled")]
     pub enabled: bool,
 }
@@ -211,8 +316,7 @@ impl Default for ShellConfig {
             default_timeout_ms: default_default_timeout_ms(),
             max_output_bytes: default_max_output_bytes(),
             working_dir: None,
-            inherit_env: false,
-            allowed_env: default_allowed_env(),
+            env: EnvConfig::default(),
             allowlist: Vec::new(),
             denylist_patterns: Vec::new(),
             max_concurrent_jobs: default_max_concurrent_jobs(),
@@ -238,7 +342,10 @@ impl ShellConfig {
     pub fn seed_default() -> Self {
         Self {
             max_timeout_ms: 120_000,
-            inherit_env: true,
+            env: EnvConfig {
+                inherit: true,
+                ..EnvConfig::default()
+            },
             denylist_patterns: vec![
                 r"rm\s+-rf\s+/".into(),
                 r":\(\)\s*\{\s*:\|".into(),
@@ -407,7 +514,18 @@ impl ShellConfig {
 
     /// Parse a YAML seed (no denylist compile, no jail validation — those run
     /// in `configuration::build_runtime`).
+    ///
+    /// The removed-key check parses to a `Value` first, but the config itself
+    /// deserializes from the TEXT again: `serde_yaml::from_value` self-tags
+    /// plain scalars (an unquoted `false` in `allowlist` becomes `Bool` and can
+    /// no longer deserialize into `String`), while `from_str` drives parsing by
+    /// the target type. Double-parsing a config-sized string is free.
     pub fn from_yaml(yaml: &str) -> Result<Self, String> {
+        let raw: serde_yaml::Value =
+            serde_yaml::from_str(yaml).map_err(|e| format!("yaml parse: {e}"))?;
+        if let Some(map) = raw.as_mapping() {
+            check_removed_keys(map.keys().filter_map(|k| k.as_str()))?;
+        }
         serde_yaml::from_str(yaml).map_err(|e| format!("yaml parse: {e}"))
     }
 
@@ -419,6 +537,9 @@ impl ShellConfig {
 
     /// Deserialize the live value fetched from the configuration worker.
     pub fn from_json(value: &serde_json::Value) -> Result<Self, String> {
+        if let Some(obj) = value.as_object() {
+            check_removed_keys(obj.keys().map(String::as_str))?;
+        }
         serde_json::from_value(value.clone()).map_err(|e| format!("json parse: {e}"))
     }
 
@@ -454,7 +575,8 @@ mod tests {
         let c = ShellConfig::default();
         assert_eq!(c.max_timeout_ms, 30_000);
         assert_eq!(c.default_timeout_ms, 10_000);
-        assert!(!c.inherit_env);
+        assert!(!c.env.inherit);
+        assert_eq!(c.env.allow, default_env_allow());
         assert_eq!(c.max_concurrent_jobs, 16);
     }
 
@@ -581,15 +703,119 @@ mod tests {
     /// `seed_default()` is the in-code twin of the shipped `config.yaml` — the
     /// file the registry publishes and that `cargo run` loads. If they drift, a
     /// zero-config boot and a `config.yaml` boot would diverge silently.
+    /// Routed through `from_yaml` so the shipped seed also passes the
+    /// removed-key check production uses.
     #[test]
     fn seed_default_matches_shipped_config_yaml() {
         let path = concat!(env!("CARGO_MANIFEST_DIR"), "/config.yaml");
         let content = std::fs::read_to_string(path).expect("read config.yaml");
-        let from_file: ShellConfig = serde_yaml::from_str(&content).expect("config.yaml parses");
+        let from_file = ShellConfig::from_yaml(&content).expect("config.yaml parses");
         assert_eq!(
             from_file.to_json(),
             ShellConfig::seed_default().to_json(),
             "config.yaml and ShellConfig::seed_default() must stay in sync"
+        );
+    }
+
+    /// A 0.6.x seed carrying the removed top-level `inherit_env` must be
+    /// rejected with a hint naming the new key — serde would otherwise ignore
+    /// it and silently boot with env forwarding OFF.
+    #[test]
+    fn from_yaml_rejects_removed_inherit_env_with_hint() {
+        let err = ShellConfig::from_yaml("inherit_env: true\n").expect_err("removed key rejects");
+        assert!(err.contains("removed in 0.7.0"), "{err}");
+        assert!(err.contains("`inherit_env` -> `env.inherit`"), "{err}");
+    }
+
+    /// Same for `allowed_env` through the live-value (JSON) funnel, which is
+    /// what an un-migrated stored configuration hits at boot and hot-reload.
+    #[test]
+    fn from_json_rejects_removed_allowed_env_with_hint() {
+        let v = serde_json::json!({"allowed_env": ["PATH"], "fs": {"allow_unjailed": true}});
+        let err = ShellConfig::from_json(&v).expect_err("removed key rejects");
+        assert!(err.contains("`allowed_env` -> `env.allow`"), "{err}");
+        assert!(err.contains("configuration::set"), "{err}");
+    }
+
+    /// Both removed keys present → both mappings named, so an operator fixes
+    /// the config in one pass instead of playing whack-a-mole.
+    #[test]
+    fn removed_keys_error_names_both_mappings() {
+        let err = ShellConfig::from_yaml("inherit_env: true\nallowed_env: [PATH]\n")
+            .expect_err("removed keys reject");
+        assert!(err.contains("`inherit_env` -> `env.inherit`"), "{err}");
+        assert!(err.contains("`allowed_env` -> `env.allow`"), "{err}");
+    }
+
+    /// Round-trip realism: exactly what a live 0.6.x STORED value looks like —
+    /// the old seed serialized with top-level `inherit_env`/`allowed_env` and
+    /// no `env` block — must fail closed through `from_json`.
+    #[test]
+    fn stored_060_shape_fails_closed_with_hint() {
+        let mut v = ShellConfig::seed_default().to_json();
+        let obj = v.as_object_mut().unwrap();
+        obj.remove("env");
+        obj.insert("inherit_env".into(), serde_json::Value::Bool(true));
+        obj.insert("allowed_env".into(), serde_json::json!(["PATH", "HOME"]));
+        let err = ShellConfig::from_json(&v).expect_err("0.6.x shape fails closed");
+        assert!(err.contains("removed in 0.7.0"), "{err}");
+    }
+
+    /// Regression: the removed-key pre-parse must NOT change how scalars
+    /// deserialize. An unquoted `false` in a string list (the e2e fixture
+    /// allowlists the `false` binary) self-tags as Bool through
+    /// `serde_yaml::from_value`, so `from_yaml` must re-deserialize from the
+    /// text, where the target type drives parsing.
+    #[test]
+    fn from_yaml_keeps_unquoted_boolean_like_strings() {
+        let c = ShellConfig::from_yaml("allowlist: [echo, false, \"true\"]\n")
+            .expect("boolean-looking allowlist entries parse as strings");
+        assert_eq!(c.allowlist, vec!["echo", "false", "true"]);
+    }
+
+    /// The nested block parses, and every omitted field takes the EnvConfig
+    /// default (inherit false, standard allow list).
+    #[test]
+    fn env_block_parses_and_defaults() {
+        let c = ShellConfig::from_yaml("env:\n  inherit: true\n").expect("nested env parses");
+        assert!(c.env.inherit);
+        assert_eq!(c.env.allow, default_env_allow());
+
+        let d = ShellConfig::from_yaml("{}").expect("empty config parses");
+        assert!(!d.env.inherit);
+        assert_eq!(d.env.allow, default_env_allow());
+    }
+
+    /// Every operator-visible config field must carry a schema description —
+    /// the console configuration UI renders them, and a bare field name is
+    /// exactly the DX gap this schema exists to close. Also pins that the
+    /// nested `EnvConfig` definition documents the dual role of `allow`.
+    #[test]
+    fn json_schema_every_field_has_description() {
+        let schema = ShellConfig::json_schema();
+        let props = schema["properties"].as_object().expect("top-level properties");
+        assert!(!props.is_empty());
+        for (name, prop) in props {
+            assert!(
+                prop.get("description")
+                    .and_then(|d| d.as_str())
+                    .is_some_and(|s| !s.is_empty()),
+                "config field `{name}` has no schema description (console UI shows it bare)"
+            );
+        }
+        let env_props = &schema["definitions"]["EnvConfig"]["properties"];
+        for key in ["inherit", "allow"] {
+            assert!(
+                env_props[key]["description"]
+                    .as_str()
+                    .is_some_and(|s| !s.is_empty()),
+                "EnvConfig.{key} has no schema description"
+            );
+        }
+        let allow_desc = env_props["allow"]["description"].as_str().unwrap();
+        assert!(
+            allow_desc.contains("Forwarding") && allow_desc.contains("Per-call"),
+            "env.allow description must explain both roles: {allow_desc}"
         );
     }
 

--- a/shell/src/config.rs
+++ b/shell/src/config.rs
@@ -137,12 +137,37 @@ fn default_job_retention_secs() -> u64 {
     3600
 }
 
-/// Top-level keys removed in 0.7.0 and where they moved.
-const REMOVED_TOP_LEVEL_KEYS: &[(&str, &str)] =
-    &[("inherit_env", "env.inherit"), ("allowed_env", "env.allow")];
+/// A removed config key: `old` is gone; `new` is where it moved (`Some`), or
+/// `None` if it has NO replacement (a pure removal — nothing to migrate to,
+/// the value should simply be deleted). This crate does a HARD migration:
+/// every 0.6.x key that no longer exists is rejected at parse, never
+/// silently ignored or tolerated — there is no soft/gradual transition path.
+struct RemovedKey {
+    old: &'static str,
+    new: Option<&'static str>,
+}
+const fn renamed(old: &'static str, new: &'static str) -> RemovedKey {
+    RemovedKey {
+        old,
+        new: Some(new),
+    }
+}
+const fn deleted(old: &'static str) -> RemovedKey {
+    RemovedKey { old, new: None }
+}
 
-/// Keys removed from the nested `fs` block in 0.7.0 and where they moved.
-const REMOVED_FS_KEYS: &[(&str, &str)] = &[("host_root", "fs.host_roots")];
+/// Top-level keys removed in 0.7.0.
+const REMOVED_TOP_LEVEL_KEYS: &[RemovedKey] = &[
+    renamed("inherit_env", "env.inherit"),
+    renamed("allowed_env", "env.allow"),
+    // The one-shot coder->shell migration marker: pure internal bookkeeping
+    // an operator never set, but still no exception — a hard migration means
+    // EVERY 0.6.x artifact is rejected, not just the operator-facing ones.
+    deleted("migrated_from_coder"),
+];
+
+/// Keys removed from the nested `fs` block in 0.7.0.
+const REMOVED_FS_KEYS: &[RemovedKey] = &[renamed("host_root", "fs.host_roots")];
 
 /// Keys removed from the nested `env` block in 0.7.0: an operator
 /// half-migrating by nesting the OLD field names under the new block (e.g.
@@ -150,75 +175,81 @@ const REMOVED_FS_KEYS: &[(&str, &str)] = &[("host_root", "fs.host_roots")];
 /// `deny_unknown_fields` with a generic serde "unknown field" error and no
 /// migration guidance. Give it the same friendly hint as every other
 /// removed-key case.
-const REMOVED_ENV_KEYS: &[(&str, &str)] =
-    &[("inherit_env", "env.inherit"), ("allowed_env", "env.allow")];
+const REMOVED_ENV_KEYS: &[RemovedKey] = &[
+    renamed("inherit_env", "env.inherit"),
+    renamed("allowed_env", "env.allow"),
+];
+
+/// Keys removed from the nested `code` block in 0.7.0. Both were already
+/// inert before removal — the code resolver has always taken its roots from
+/// `fs.host_roots` — but "never had an effect" is not an exception to a hard
+/// migration: a 0.6.x stored value carrying them must still be cleaned up,
+/// not silently tolerated forever.
+const REMOVED_CODE_KEYS: &[RemovedKey] = &[deleted("base_path"), deleted("base_paths")];
 
 const CONFIGURATION_SET_HINT: &str =
     "If this is the stored value, rewrite it via configuration::set (id: shell).";
 
+/// Check one nested object (or the top-level document, via `prefix == ""`)
+/// against a table of removed keys, pushing a hint for every hit into `hits`.
+/// Returns whether anything in `table` matched, so the caller can decide
+/// which remedy sentence(s) to attach. Iterates the WHOLE table — never
+/// short-circuits — so a value carrying multiple removed keys under the same
+/// object gets every one named, not just the first.
+fn scan_removed(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    prefix: &str,
+    table: &[RemovedKey],
+    hits: &mut Vec<String>,
+) -> bool {
+    let mut hit = false;
+    for key in table {
+        if obj.contains_key(key.old) {
+            hit = true;
+            match key.new {
+                Some(new) => hits.push(format!("`{prefix}{}` -> `{new}`", key.old)),
+                None => hits.push(format!("`{prefix}{}` (removed, no replacement)", key.old)),
+            }
+        }
+    }
+    hit
+}
+
 /// Fail closed on any 0.7.0-removed key, wherever serde would otherwise
-/// silently ignore it and boot with a narrower (env forwarding) or absent
-/// (fs jail) policy than the operator intended. One traversal over the
-/// top-level document and the nested `fs`/`env` objects, shared by
-/// `from_yaml` (via a text->Value bridge, see its doc comment) and
-/// `from_json` — a future removed key is wired into ONE place, not
-/// duplicated per funnel. Reports every hit in a single error so an operator
-/// who left MULTIPLE removed keys unmigrated fixes everything in one pass.
+/// silently ignore it and boot with a narrower (env forwarding), absent (fs
+/// jail), or merely STALE (coder migration marker, inert code roots) state
+/// than the operator intended. One traversal over the top-level document and
+/// the nested `fs`/`env`/`code` objects, shared by `from_yaml` (via a
+/// text->Value bridge, see its doc comment) and `from_json` — a future
+/// removed key is wired into ONE place, not duplicated per funnel. Reports
+/// every hit in a single error so an operator who left MULTIPLE removed keys
+/// unmigrated fixes everything in one pass. This is a HARD migration: there
+/// is no silent-ignore path for ANY removed key, including ones (like
+/// `code.base_path`/`migrated_from_coder`) that were already inert before
+/// removal — "harmless to keep" is not the same as "supported."
 fn check_removed_keys(value: &serde_json::Value) -> Result<(), String> {
     let Some(obj) = value.as_object() else {
         return Ok(());
     };
 
-    // NOTE: `.filter()` + `.count()`, NOT `.any()` — `.any()` short-circuits
-    // on the first match, so a config carrying BOTH removed env keys would
-    // only ever name the first in its error.
     let mut hits = Vec::new();
-    let env_hit = REMOVED_TOP_LEVEL_KEYS
-        .iter()
-        .filter(|(old, new)| {
-            let present = obj.contains_key(*old);
-            if present {
-                hits.push(format!("`{old}` -> `{new}`"));
-            }
-            present
-        })
-        .count()
-        > 0;
+    let env_hit = scan_removed(obj, "", REMOVED_TOP_LEVEL_KEYS, &mut hits);
 
     let fs_hit = obj
         .get("fs")
         .and_then(serde_json::Value::as_object)
-        .is_some_and(|fs| {
-            REMOVED_FS_KEYS
-                .iter()
-                .filter(|(old, new)| {
-                    let present = fs.contains_key(*old);
-                    if present {
-                        hits.push(format!("`fs.{old}` -> `{new}` (one-entry list)"));
-                    }
-                    present
-                })
-                .count()
-                > 0
-        });
+        .is_some_and(|fs| scan_removed(fs, "fs.", REMOVED_FS_KEYS, &mut hits));
 
     // Half-migration: the OLD key names nested under the NEW `env:` block.
     let env_nested_hit = obj
         .get("env")
         .and_then(serde_json::Value::as_object)
-        .is_some_and(|env| {
-            REMOVED_ENV_KEYS
-                .iter()
-                .filter(|(old, new)| {
-                    let present = env.contains_key(*old);
-                    if present {
-                        hits.push(format!("`env.{old}` -> `{new}`"));
-                    }
-                    present
-                })
-                .count()
-                > 0
-        });
+        .is_some_and(|env| scan_removed(env, "env.", REMOVED_ENV_KEYS, &mut hits));
+
+    let code_hit = obj
+        .get("code")
+        .and_then(serde_json::Value::as_object)
+        .is_some_and(|code| scan_removed(code, "code.", REMOVED_CODE_KEYS, &mut hits));
 
     if hits.is_empty() {
         return Ok(());
@@ -231,6 +262,9 @@ fn check_removed_keys(value: &serde_json::Value) -> Result<(), String> {
     }
     if fs_hit {
         remedies.push("Set the fs jail under `fs: { host_roots: [<path>] }`.");
+    }
+    if code_hit {
+        remedies.push("Delete `code.base_path`/`code.base_paths` — the code resolver's roots always come from `fs.host_roots`.");
     }
 
     Err(format!(
@@ -986,13 +1020,65 @@ mod tests {
     /// no `env` block — must fail closed through `from_json`.
     #[test]
     fn stored_060_shape_fails_closed_with_hint() {
+        // Realistic: a real 0.6.x stored value that went through the
+        // coder->shell fold also carries `migrated_from_coder: true` — the
+        // hard-migration check must reject this shape wholesale, not just
+        // the env keys.
         let mut v = ShellConfig::seed_default().to_json();
         let obj = v.as_object_mut().unwrap();
         obj.remove("env");
         obj.insert("inherit_env".into(), serde_json::Value::Bool(true));
         obj.insert("allowed_env".into(), serde_json::json!(["PATH", "HOME"]));
+        obj.insert("migrated_from_coder".into(), serde_json::Value::Bool(true));
         let err = ShellConfig::from_json(&v).expect_err("0.6.x shape fails closed");
         assert!(err.contains("removed in 0.7.0"), "{err}");
+        assert!(err.contains("`inherit_env` -> `env.inherit`"), "{err}");
+        assert!(
+            err.contains("`migrated_from_coder` (removed, no replacement)"),
+            "{err}"
+        );
+    }
+
+    /// Hard migration: `migrated_from_coder` is pure internal bookkeeping an
+    /// operator never set, but a hard migration has NO exception for
+    /// "harmless" removed keys — every 0.6.x artifact is rejected, not just
+    /// the operator-facing ones.
+    #[test]
+    fn from_json_rejects_migrated_from_coder_marker() {
+        let v = serde_json::json!({
+            "migrated_from_coder": true,
+            "fs": {"allow_unjailed": true},
+        });
+        let err = ShellConfig::from_json(&v).expect_err("removed marker rejects");
+        assert!(err.contains("removed in 0.7.0"), "{err}");
+        assert!(
+            err.contains("`migrated_from_coder` (removed, no replacement)"),
+            "{err}"
+        );
+        assert!(err.contains("configuration::set"), "{err}");
+    }
+
+    /// Hard migration: `code.base_path`/`code.base_paths` were already
+    /// inert before removal (the resolver always used `fs.host_roots`), but
+    /// "never had an effect" is not an exception — a stored value still
+    /// carrying either is rejected, not silently tolerated.
+    #[test]
+    fn from_json_rejects_removed_code_base_path_keys() {
+        let v = serde_json::json!({
+            "code": {"base_path": "/tmp", "base_paths": ["/tmp/a"]},
+            "fs": {"allow_unjailed": true},
+        });
+        let err = ShellConfig::from_json(&v).expect_err("removed code keys reject");
+        assert!(err.contains("removed in 0.7.0"), "{err}");
+        assert!(
+            err.contains("`code.base_path` (removed, no replacement)"),
+            "{err}"
+        );
+        assert!(
+            err.contains("`code.base_paths` (removed, no replacement)"),
+            "{err}"
+        );
+        assert!(err.contains("configuration::set"), "{err}");
     }
 
     /// Regression: the removed-key pre-parse must NOT change how scalars

--- a/shell/src/config.rs
+++ b/shell/src/config.rs
@@ -4,6 +4,19 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+/// Serializes every test in the crate that mutates PROCESS-WIDE environment
+/// state (`std::env::set_var`/`remove_var`). `cargo test` runs tests within
+/// one binary on multiple threads by default; `set_var`/`var` on different
+/// threads race at the libc level regardless of Rust-side `Mutex` discipline
+/// around any ONE test's own state, so every such test — here and in
+/// `code/config.rs`'s `from_yaml_expands_env_var` — must hold this lock for
+/// its full set→use→unset span. `.unwrap_or_else(...)` recovers from
+/// poisoning: an earlier test panicking mid-mutation still leaves the
+/// environment consistent (its own RAII guard/explicit cleanup already ran),
+/// so a poisoned lock is not a reason to fail later tests too.
+#[cfg(test)]
+pub(crate) static ENV_TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Root configuration for the shell worker: exec policy (timeouts, output
 /// caps, allow/denylist, env forwarding), the fs jail, the sandbox toggle,
 /// and the folded `coder::*` code surface. Stored in the `configuration`
@@ -124,54 +137,121 @@ fn default_job_retention_secs() -> u64 {
     3600
 }
 
-/// Top-level keys removed in 0.7.0 and where they moved. serde ignores
-/// unknown fields, so a 0.6.x config carrying `inherit_env: true` would
-/// otherwise parse into `env.inherit = false` — silently disabling env
-/// forwarding. Fail closed with a migration hint instead.
+/// Top-level keys removed in 0.7.0 and where they moved.
 const REMOVED_TOP_LEVEL_KEYS: &[(&str, &str)] =
     &[("inherit_env", "env.inherit"), ("allowed_env", "env.allow")];
 
-fn check_removed_keys<'a>(keys: impl Iterator<Item = &'a str>) -> Result<(), String> {
-    let hits: Vec<String> = keys
-        .filter_map(|k| {
-            REMOVED_TOP_LEVEL_KEYS
-                .iter()
-                .find(|(old, _)| *old == k)
-                .map(|(old, new)| format!("`{old}` -> `{new}`"))
+/// Keys removed from the nested `fs` block in 0.7.0 and where they moved.
+const REMOVED_FS_KEYS: &[(&str, &str)] = &[("host_root", "fs.host_roots")];
+
+/// Keys removed from the nested `env` block in 0.7.0: an operator
+/// half-migrating by nesting the OLD field names under the new block (e.g.
+/// `env: { inherit_env: true }`) would otherwise hit `EnvConfig`'s
+/// `deny_unknown_fields` with a generic serde "unknown field" error and no
+/// migration guidance. Give it the same friendly hint as every other
+/// removed-key case.
+const REMOVED_ENV_KEYS: &[(&str, &str)] =
+    &[("inherit_env", "env.inherit"), ("allowed_env", "env.allow")];
+
+const CONFIGURATION_SET_HINT: &str =
+    "If this is the stored value, rewrite it via configuration::set (id: shell).";
+
+/// Fail closed on any 0.7.0-removed key, wherever serde would otherwise
+/// silently ignore it and boot with a narrower (env forwarding) or absent
+/// (fs jail) policy than the operator intended. One traversal over the
+/// top-level document and the nested `fs`/`env` objects, shared by
+/// `from_yaml` (via a text->Value bridge, see its doc comment) and
+/// `from_json` — a future removed key is wired into ONE place, not
+/// duplicated per funnel. Reports every hit in a single error so an operator
+/// who left MULTIPLE removed keys unmigrated fixes everything in one pass.
+fn check_removed_keys(value: &serde_json::Value) -> Result<(), String> {
+    let Some(obj) = value.as_object() else {
+        return Ok(());
+    };
+
+    // NOTE: `.filter()` + `.count()`, NOT `.any()` — `.any()` short-circuits
+    // on the first match, so a config carrying BOTH removed env keys would
+    // only ever name the first in its error.
+    let mut hits = Vec::new();
+    let env_hit = REMOVED_TOP_LEVEL_KEYS
+        .iter()
+        .filter(|(old, new)| {
+            let present = obj.contains_key(*old);
+            if present {
+                hits.push(format!("`{old}` -> `{new}`"));
+            }
+            present
         })
-        .collect();
+        .count()
+        > 0;
+
+    let fs_hit = obj
+        .get("fs")
+        .and_then(serde_json::Value::as_object)
+        .is_some_and(|fs| {
+            REMOVED_FS_KEYS
+                .iter()
+                .filter(|(old, new)| {
+                    let present = fs.contains_key(*old);
+                    if present {
+                        hits.push(format!("`fs.{old}` -> `{new}` (one-entry list)"));
+                    }
+                    present
+                })
+                .count()
+                > 0
+        });
+
+    // Half-migration: the OLD key names nested under the NEW `env:` block.
+    let env_nested_hit = obj
+        .get("env")
+        .and_then(serde_json::Value::as_object)
+        .is_some_and(|env| {
+            REMOVED_ENV_KEYS
+                .iter()
+                .filter(|(old, new)| {
+                    let present = env.contains_key(*old);
+                    if present {
+                        hits.push(format!("`env.{old}` -> `{new}`"));
+                    }
+                    present
+                })
+                .count()
+                > 0
+        });
+
     if hits.is_empty() {
         return Ok(());
     }
-    Err(format!(
-        "config keys removed in 0.7.0: {}. Nest them under `env:` (e.g. env: {{ inherit: true, \
-         allow: [PATH, HOME] }}). If this is the stored value, rewrite it via \
-         configuration::set (id: shell).",
-        hits.join(", ")
-    ))
-}
 
-/// Nested `fs` key removed in 0.7.0: `host_root`, the 0.6.x single-root
-/// alias. serde ignores unknown fields, so a config still carrying it would
-/// otherwise parse with NO jail configured — and either fail the jail check
-/// with a message that never names the stale key, or (with `allow_unjailed`)
-/// silently boot unjailed. Same fail-closed treatment as the top-level keys.
-fn check_removed_fs_keys<'a>(mut keys: impl Iterator<Item = &'a str>) -> Result<(), String> {
-    if keys.any(|k| k == "host_root") {
-        return Err(
-            "config key removed in 0.7.0: `fs.host_root` -> `fs.host_roots` (one-entry list). \
-             Set fs: { host_roots: [<path>] }. If this is the stored value, rewrite it via \
-             configuration::set (id: shell)."
-                .to_string(),
-        );
+    let mut remedies = Vec::new();
+    if env_hit || env_nested_hit {
+        remedies
+            .push("Nest env keys under `env:` (e.g. env: { inherit: true, allow: [PATH, HOME] }).");
     }
-    Ok(())
+    if fs_hit {
+        remedies.push("Set the fs jail under `fs: { host_roots: [<path>] }`.");
+    }
+
+    Err(format!(
+        "config keys removed in 0.7.0: {}. {} {CONFIGURATION_SET_HINT}",
+        hits.join(", "),
+        remedies.join(" "),
+    ))
 }
 
 /// Environment policy for spawned commands (host target). Replaces the
 /// 0.6.x top-level `inherit_env` / `allowed_env` keys (renamed in 0.7.0;
 /// the old keys are rejected at parse with a migration hint).
+///
+/// `deny_unknown_fields`: unlike the request types (which deliberately
+/// tolerate unknown fields the engine may inject), this struct has no such
+/// fields and no forward-compat need to ignore extras. `check_removed_keys`
+/// catches the anticipated half-migration (old names nested under `env:`)
+/// with a friendly hint BEFORE deserialization; this attribute is the
+/// backstop for anything that check doesn't know about (e.g. a typo).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct EnvConfig {
     /// Forward the worker's ENTIRE environment to child processes. Toolchains
     /// (cargo, rustup, git, node) need this to find PATH/HOME/CARGO_HOME.
@@ -204,6 +284,19 @@ impl Default for EnvConfig {
         Self {
             inherit: false,
             allow: default_env_allow(),
+        }
+    }
+}
+
+#[cfg(test)]
+impl EnvConfig {
+    /// Test fixture: forward the worker's full env, like the shipped dev
+    /// seed. Several unrelated test modules need an open exec env and would
+    /// otherwise repeat `EnvConfig { inherit: true, ..Default::default() }`.
+    pub fn inherit_all() -> Self {
+        Self {
+            inherit: true,
+            ..Default::default()
         }
     }
 }
@@ -332,6 +425,33 @@ impl Default for ShellConfig {
     }
 }
 
+/// Optional wrapper-invocation chain (`sudo`, `doas`, `nohup`, `env`
+/// — optionally with `KEY=VALUE` assignments, its idiomatic form — or
+/// `timeout [duration]`, each optionally path-qualified) a command-shaped
+/// denylist pattern tolerates before the real command name. mkfs/dd-to-device/
+/// shutdown/reboot normally require root, so `sudo shutdown -h now` is
+/// arguably the MOST likely accidental invocation — anchoring bare argv[0]
+/// without this silently drops the exact case the tripwire exists to catch.
+///
+/// Still advisory-only, deliberately so (see the crate-level threat model:
+/// the fs jail and sandbox backend are the actual security boundary, not
+/// this list). Known gaps this tolerance does NOT close: a wrapper not named
+/// here; flags interposed before the wrapped command (`sudo -u root
+/// shutdown`); or the command spawned indirectly via `sh -c`. Closing those
+/// would need per-argv-token wrapper-skipping instead of a joined-string
+/// regex — a bigger design change than a tripwire warrants.
+const DENYLIST_WRAPPER_PREFIX: &str = r"(?:(?:\S*/)?env(?:\s+\S+=\S*)*\s+|(?:\S*/)?(?:sudo|doas|nohup)\s+|(?:\S*/)?timeout(?:\s+\S+)?\s+)*";
+
+/// Build a command-shaped denylist pattern: anchored to the start of the
+/// joined argv line, tolerant of [`DENYLIST_WRAPPER_PREFIX`], tolerant of a
+/// path-qualified command name, then `cmd_pattern` verbatim. Case-insensitive
+/// (`(?i)`): the wrapper names and dangerous commands are conventionally
+/// lowercase, but the tripwire should still fire on `SUDO shutdown` — this
+/// pattern exists to catch mistakes, not to reward exact casing.
+fn command_shaped_denylist_pattern(cmd_pattern: &str) -> String {
+    format!("(?i)^{DENYLIST_WRAPPER_PREFIX}(\\S*/)?{cmd_pattern}")
+}
+
 impl ShellConfig {
     /// The bootable, zero-config default: seeded as `initial_value` on first
     /// registration and used as the runtime fallback when the stored value is
@@ -353,18 +473,20 @@ impl ShellConfig {
                 ..EnvConfig::default()
             },
             // Command-SHAPED patterns (mkfs/shutdown/reboot/dd) are anchored to
-            // argv[0] — `^(\S*/)?name` fires when the tool IS the command, not
-            // when the word appears in an argument, so `grep -rn shutdown src/`
-            // or `rg "dd if=" docs/` are not rejected. Argument-shaped patterns
-            // (rm -rf /, the fork bomb, /etc/shadow) stay full-line: their
-            // dangerous form lives in the arguments.
+            // argv[0] (tolerating a sudo/doas/nohup/env/timeout wrapper — see
+            // DENYLIST_WRAPPER_PREFIX) — they fire when the tool IS the
+            // command, not when the word appears in an argument, so
+            // `grep -rn shutdown src/` or `rg "dd if=" docs/` are not
+            // rejected. Argument-shaped patterns (rm -rf /, the fork bomb,
+            // /etc/shadow) stay full-line: their dangerous form lives in the
+            // arguments.
             denylist_patterns: vec![
                 r"rm\s+-rf\s+/".into(),
                 r":\(\)\s*\{\s*:\|".into(),
-                r"^(\S*/)?mkfs".into(),
-                r"^(\S*/)?dd\s+if=".into(),
-                r"^(\S*/)?shutdown\b".into(),
-                r"^(\S*/)?reboot\b".into(),
+                command_shaped_denylist_pattern("mkfs"),
+                command_shaped_denylist_pattern(r"dd\s+if="),
+                command_shaped_denylist_pattern(r"shutdown\b"),
+                command_shaped_denylist_pattern(r"reboot\b"),
                 "/etc/shadow".into(),
             ],
             fs: FsConfig {
@@ -526,20 +648,21 @@ impl ShellConfig {
     /// Parse a YAML seed (no denylist compile, no jail validation — those run
     /// in `configuration::build_runtime`).
     ///
-    /// The removed-key check parses to a `Value` first, but the config itself
-    /// deserializes from the TEXT again: `serde_yaml::from_value` self-tags
-    /// plain scalars (an unquoted `false` in `allowlist` becomes `Bool` and can
-    /// no longer deserialize into `String`), while `from_str` drives parsing by
-    /// the target type. Double-parsing a config-sized string is free.
+    /// The removed-key check runs over a `serde_json::Value` bridged from the
+    /// parsed YAML (`serde_yaml::Value` implements `Serialize`, so
+    /// `serde_json::to_value` round-trips it) so `from_yaml`/`from_json` share
+    /// ONE traversal (`check_removed_keys`) instead of duplicating the
+    /// top-level/`fs`/`env` walk per funnel. The config itself still
+    /// deserializes from the ORIGINAL TEXT, not the bridged Value:
+    /// `serde_yaml::from_value` self-tags plain scalars (an unquoted `false`
+    /// in `allowlist` becomes `Bool` and can no longer deserialize into
+    /// `String`), while `from_str` drives parsing by the target type.
+    /// Double-parsing a config-sized string is free.
     pub fn from_yaml(yaml: &str) -> Result<Self, String> {
         let raw: serde_yaml::Value =
             serde_yaml::from_str(yaml).map_err(|e| format!("yaml parse: {e}"))?;
-        if let Some(map) = raw.as_mapping() {
-            check_removed_keys(map.keys().filter_map(|k| k.as_str()))?;
-            if let Some(fs) = map.get("fs").and_then(|v| v.as_mapping()) {
-                check_removed_fs_keys(fs.keys().filter_map(|k| k.as_str()))?;
-            }
-        }
+        let bridged = serde_json::to_value(&raw).map_err(|e| format!("yaml->json bridge: {e}"))?;
+        check_removed_keys(&bridged)?;
         serde_yaml::from_str(yaml).map_err(|e| format!("yaml parse: {e}"))
     }
 
@@ -551,12 +674,7 @@ impl ShellConfig {
 
     /// Deserialize the live value fetched from the configuration worker.
     pub fn from_json(value: &serde_json::Value) -> Result<Self, String> {
-        if let Some(obj) = value.as_object() {
-            check_removed_keys(obj.keys().map(String::as_str))?;
-            if let Some(fs) = obj.get("fs").and_then(serde_json::Value::as_object) {
-                check_removed_fs_keys(fs.keys().map(String::as_str))?;
-            }
-        }
+        check_removed_keys(value)?;
         serde_json::from_value(value.clone()).map_err(|e| format!("json parse: {e}"))
     }
 
@@ -723,20 +841,91 @@ mod tests {
             vec!["/sbin/shutdown".to_string(), "-r".into()],
             vec!["reboot".to_string()],
             vec!["mkfs.ext4".to_string(), "/dev/sda1".into()],
-            vec!["dd".to_string(), "if=/dev/zero".into(), "of=/dev/sda".into()],
+            vec![
+                "dd".to_string(),
+                "if=/dev/zero".into(),
+                "of=/dev/sda".into(),
+            ],
         ] {
             assert!(
                 c.is_command_allowed(&argv).is_err(),
                 "{argv:?} must trip the anchored denylist"
             );
         }
+        // ...and a bounded set of wrapper prefixes are tolerated too: mkfs/
+        // dd-to-device/shutdown/reboot normally require root, so `sudo
+        // shutdown -h now` is arguably the MOST likely accidental invocation
+        // — anchoring bare argv[0] alone would silently drop exactly this
+        // case (a real regression caught in review).
+        for argv in [
+            vec![
+                "sudo".to_string(),
+                "shutdown".into(),
+                "-h".into(),
+                "now".into(),
+            ],
+            vec!["/usr/bin/sudo".to_string(), "reboot".into()],
+            vec!["doas".to_string(), "reboot".into()],
+            vec!["nohup".to_string(), "shutdown".into(), "-r".into()],
+            vec![
+                "sudo".to_string(),
+                "dd".to_string(),
+                "if=/dev/zero".into(),
+                "of=/dev/sda".into(),
+            ],
+            vec![
+                "timeout".to_string(),
+                "10".into(),
+                "shutdown".into(),
+                "now".into(),
+            ],
+            // env's idiomatic form: KEY=VALUE assignments before the command
+            // — a bare `env cmd` check alone would miss the common case.
+            vec![
+                "env".to_string(),
+                "FOO=bar".into(),
+                "shutdown".into(),
+                "-h".into(),
+                "now".into(),
+            ],
+            vec![
+                "env".to_string(),
+                "A=1".into(),
+                "B=2".into(),
+                "reboot".into(),
+            ],
+            // Case-insensitive: the tripwire exists to catch mistakes, not
+            // to reward exact casing.
+            vec![
+                "SUDO".to_string(),
+                "shutdown".into(),
+                "-h".into(),
+                "now".into(),
+            ],
+            vec!["Sudo".to_string(), "Shutdown".into()],
+        ] {
+            assert!(
+                c.is_command_allowed(&argv).is_err(),
+                "{argv:?} (wrapped) must trip the anchored denylist"
+            );
+        }
         // ...but NOT when the word merely appears in an argument — a coding
         // agent grepping a codebase for "shutdown" is not a mistake.
         for argv in [
-            vec!["grep".to_string(), "-rn".into(), "shutdown".into(), "src/".into()],
+            vec![
+                "grep".to_string(),
+                "-rn".into(),
+                "shutdown".into(),
+                "src/".into(),
+            ],
             vec!["cargo".to_string(), "test".into(), "reboot".into()],
             vec!["rg".to_string(), "dd if=".into(), "docs/".into()],
-            vec!["git".to_string(), "log".into(), "--grep".into(), "mkfs".into()],
+            vec![
+                "git".to_string(),
+                "log".into(),
+                "--grep".into(),
+                "mkfs".into(),
+            ],
         ] {
             assert!(
                 c.is_command_allowed(&argv).is_ok(),
@@ -838,7 +1027,9 @@ mod tests {
     #[test]
     fn json_schema_every_field_has_description() {
         let schema = ShellConfig::json_schema();
-        let props = schema["properties"].as_object().expect("top-level properties");
+        let props = schema["properties"]
+            .as_object()
+            .expect("top-level properties");
         assert!(!props.is_empty());
         for (name, prop) in props {
             assert!(
@@ -1022,7 +1213,8 @@ sandbox:
     fn validate_fs_jail_accepts_single_host_root() {
         let mut c = ShellConfig::default();
         c.fs.host_roots = vec![std::path::PathBuf::from("/tmp/something")];
-        c.validate_fs_jail().expect("a one-entry host_roots is valid");
+        c.validate_fs_jail()
+            .expect("a one-entry host_roots is valid");
     }
 
     #[test]
@@ -1141,7 +1333,8 @@ sandbox:
     /// ignore it and parse a config with NO jail configured.
     #[test]
     fn from_yaml_rejects_removed_fs_host_root_with_hint() {
-        let err = ShellConfig::from_yaml("fs:\n  host_root: /tmp\n").expect_err("removed key rejects");
+        let err =
+            ShellConfig::from_yaml("fs:\n  host_root: /tmp\n").expect_err("removed key rejects");
         assert!(err.contains("removed in 0.7.0"), "{err}");
         assert!(err.contains("fs.host_roots"), "{err}");
     }
@@ -1154,6 +1347,39 @@ sandbox:
         let err = ShellConfig::from_json(&v).expect_err("removed key rejects");
         assert!(err.contains("removed in 0.7.0"), "{err}");
         assert!(err.contains("fs.host_roots"), "{err}");
+        assert!(err.contains("configuration::set"), "{err}");
+    }
+
+    /// Both a top-level removed env key AND the nested `fs.host_root` present
+    /// at once must name BOTH in one error — the unified `check_removed_keys`
+    /// walks the top-level, `fs`, and `env` objects together, not as two
+    /// independent checks that could each report only their own hit.
+    #[test]
+    fn removed_keys_error_names_both_env_and_fs_hits() {
+        let v = serde_json::json!({
+            "inherit_env": true,
+            "fs": {"host_root": "/tmp"},
+        });
+        let err = ShellConfig::from_json(&v).expect_err("removed keys reject");
+        assert!(err.contains("`inherit_env` -> `env.inherit`"), "{err}");
+        assert!(err.contains("fs.host_roots"), "{err}");
+    }
+
+    /// Half-migration: nesting the OLD field names under the NEW `env:`
+    /// block (e.g. an operator who read "nest it under env:" too literally)
+    /// must get the SAME friendly migration hint as every other removed-key
+    /// case, not `EnvConfig`'s generic `deny_unknown_fields` serde error —
+    /// found during pre-landing review as a DX regression the unified
+    /// checker introduced.
+    #[test]
+    fn from_json_rejects_half_migrated_env_block_with_hint() {
+        let v = serde_json::json!({
+            "env": {"inherit_env": true},
+            "fs": {"allow_unjailed": true},
+        });
+        let err = ShellConfig::from_json(&v).expect_err("half-migrated env block rejects");
+        assert!(err.contains("removed in 0.7.0"), "{err}");
+        assert!(err.contains("`env.inherit_env` -> `env.inherit`"), "{err}");
         assert!(err.contains("configuration::set"), "{err}");
     }
 }

--- a/shell/src/config.rs
+++ b/shell/src/config.rs
@@ -90,19 +90,12 @@ pub struct ShellConfig {
     /// The folded `code` surface (`coder::*`) config: glob protection
     /// (`non_accessible_globs`), noise excludes (`default_exclude_globs`), and
     /// per-file/response budgets. The code resolver's ROOTS are NOT taken from
-    /// here — it uses `fs.host_roots` so there is a single jail config; any
-    /// `base_path`/`base_paths` set under `code` is ignored.
+    /// here — it uses `fs.host_roots` so there is a single jail config
+    /// (`code.base_path`/`base_paths` were removed from the schema in 0.7.0;
+    /// stored values still carrying them are ignored — they never had an
+    /// effect).
     #[serde(default)]
     pub code: crate::code::config::CoderConfig,
-
-    /// One-shot migration marker (D4/T5): set true once the legacy `coder`
-    /// config entry has been folded into this value at boot. Persisted in the
-    /// stored value so the fold runs exactly once, but hidden from the operator
-    /// schema (not a knob anyone edits). PERSISTS (no `skip`) — that is the
-    /// whole point of an idempotency marker.
-    #[serde(default)]
-    #[schemars(skip)]
-    pub migrated_from_coder: bool,
 
     #[serde(default, skip)]
     #[schemars(skip)]
@@ -158,6 +151,23 @@ fn check_removed_keys<'a>(keys: impl Iterator<Item = &'a str>) -> Result<(), Str
     ))
 }
 
+/// Nested `fs` key removed in 0.7.0: `host_root`, the 0.6.x single-root
+/// alias. serde ignores unknown fields, so a config still carrying it would
+/// otherwise parse with NO jail configured — and either fail the jail check
+/// with a message that never names the stale key, or (with `allow_unjailed`)
+/// silently boot unjailed. Same fail-closed treatment as the top-level keys.
+fn check_removed_fs_keys<'a>(mut keys: impl Iterator<Item = &'a str>) -> Result<(), String> {
+    if keys.any(|k| k == "host_root") {
+        return Err(
+            "config key removed in 0.7.0: `fs.host_root` -> `fs.host_roots` (one-entry list). \
+             Set fs: { host_roots: [<path>] }. If this is the stored value, rewrite it via \
+             configuration::set (id: shell)."
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
 /// Environment policy for spawned commands (host target). Replaces the
 /// 0.6.x top-level `inherit_env` / `allowed_env` keys (renamed in 0.7.0;
 /// the old keys are rejected at parse with a migration hint).
@@ -203,20 +213,16 @@ impl Default for EnvConfig {
 /// budgets and hard-denied paths.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct FsConfig {
-    /// Legacy single jail root. Honored as a one-entry `host_roots` list.
-    /// Setting BOTH `host_root` and `host_roots` is a config error
-    /// (`validate_fs_jail`). Prefer `host_roots`.
-    #[serde(default)]
-    pub host_root: Option<PathBuf>,
     /// Allowed jail roots. The FIRST entry is the PRIMARY root: relative wire
     /// paths and a relative per-call `cwd`/`base_dir` resolve against it.
     /// Absolute paths are accepted when they canonicalize inside ANY listed
-    /// root. Empty (and `host_root` unset) means unjailed — refused at boot
-    /// unless `allow_unjailed` is true.
+    /// root. Empty means unjailed — refused at boot unless `allow_unjailed`
+    /// is true. (The 0.6.x single-root `host_root` alias was removed in
+    /// 0.7.0 and is rejected at parse with a migration hint.)
     #[serde(default)]
     pub host_roots: Vec<PathBuf>,
-    /// Operator opt-in for running with `host_root: null`. When false (the
-    /// default) the worker refuses to start unjailed — the entire host
+    /// Operator opt-in for running with an empty `host_roots`. When false
+    /// (the default) the worker refuses to start unjailed — the entire host
     /// filesystem is reachable through `shell::fs::*` aside from the small
     /// denylist, which is rarely what the operator actually wants. Setting
     /// this to true is equivalent to acknowledging that fact (test
@@ -271,30 +277,22 @@ fn default_sandbox_enabled() -> bool {
 }
 
 impl FsConfig {
-    /// Effective jail roots, in priority order (index 0 = primary). Returns
-    /// `host_roots` when set, else the legacy `host_root` as a one-entry list,
-    /// else empty (unjailed). Does NOT canonicalize — that happens once at
-    /// backend construction. `validate_fs_jail` rejects setting both keys.
+    /// Effective jail roots, in priority order (index 0 = primary). Empty
+    /// means unjailed. Does NOT canonicalize — that happens once at backend
+    /// construction.
     pub fn roots(&self) -> Vec<PathBuf> {
-        if !self.host_roots.is_empty() {
-            self.host_roots.clone()
-        } else if let Some(r) = &self.host_root {
-            vec![r.clone()]
-        } else {
-            Vec::new()
-        }
+        self.host_roots.clone()
     }
 
     /// True when a jail boundary is configured (at least one root).
     pub fn is_jailed(&self) -> bool {
-        !self.host_roots.is_empty() || self.host_root.is_some()
+        !self.host_roots.is_empty()
     }
 }
 
 impl Default for FsConfig {
     fn default() -> Self {
         Self {
-            host_root: None,
             host_roots: Vec::new(),
             allow_unjailed: false,
             max_read_bytes: default_max_read_bytes(),
@@ -329,7 +327,6 @@ impl Default for ShellConfig {
             fs: FsConfig::default(),
             sandbox: SandboxConfig::default(),
             code: crate::code::config::CoderConfig::default(),
-            migrated_from_coder: false,
             compiled_denylist: Vec::new(),
         }
     }
@@ -340,7 +337,7 @@ impl ShellConfig {
     /// registration and used as the runtime fallback when the stored value is
     /// null, so the worker boots with no config file at all (database-style
     /// zero-config). This is deliberately NOT `Default::default()` — that is
-    /// unjailed (`host_root: None`) so an operator config that omits the jail
+    /// unjailed (empty `host_roots`) so an operator config that omits the jail
     /// fails closed. This seed is the shipped permissive dev default: jailed to
     /// `/tmp`, env forwarded, open exec with a catastrophic-only denylist. It is
     /// kept in sync with `config.yaml` by a unit test.
@@ -395,12 +392,12 @@ impl ShellConfig {
     }
 
     /// Assemble the `CoderConfig` the code `PathResolver` is built from: the
-    /// glob/budget settings from the `code` block, but with ROOTS taken from
-    /// `fs.host_roots` (the unified jail) — never from `code.base_paths`. This
-    /// is what keeps the merge's promise that the operator sets the root once.
+    /// glob/budget settings from the `code` block, with ROOTS taken from
+    /// `fs.host_roots` (the unified jail) — `code.base_paths` is runtime
+    /// plumbing filled here, never read from config. This is what keeps the
+    /// merge's promise that the operator sets the root once.
     pub fn code_resolver_config(&self) -> crate::code::config::CoderConfig {
         let mut c = self.code.clone();
-        c.base_path = None;
         c.base_paths = self.fs.roots();
         c
     }
@@ -417,18 +414,12 @@ impl ShellConfig {
     }
 
     /// Refuse to start with the host backend exposing the entire filesystem
-    /// behind only the (advisory) denylist — the operator must either pin a
-    /// host_root jail or explicitly opt in via `fs.allow_unjailed: true`.
+    /// behind only the (advisory) denylist — the operator must either pin
+    /// `fs.host_roots` or explicitly opt in via `fs.allow_unjailed: true`.
     pub fn validate_fs_jail(&self) -> Result<()> {
-        if self.fs.host_root.is_some() && !self.fs.host_roots.is_empty() {
-            anyhow::bail!(
-                "both fs.host_root and fs.host_roots are set — set either fs.host_root (legacy \
-                 single root) or fs.host_roots (the list form), not both. Keep only fs.host_roots."
-            );
-        }
         if !self.fs.is_jailed() && !self.fs.allow_unjailed {
             anyhow::bail!(
-                "fs.host_root/fs.host_roots are unset and fs.allow_unjailed is false — refusing \
+                "fs.host_roots is empty and fs.allow_unjailed is false — refusing \
                  to start unjailed. Set fs.host_roots to the directories you intend to expose, or \
                  set fs.allow_unjailed: true to accept that the entire host filesystem is \
                  reachable through shell::fs::* (subject only to the advisory denylist)."
@@ -475,9 +466,9 @@ impl ShellConfig {
 
         // Confinement guard: a command given as a PATH (contains a '/') that
         // canonicalizes to a location INSIDE the writable fs jail is rejected.
-        // `shell::fs::write` can plant an executable (0755) under `fs.host_root`,
+        // `shell::fs::write` can plant an executable (0755) under a jail root,
         // and the basename allowlist check above matches by file_name — so
-        // `command: "<host_root>/ls"` would otherwise pass the allowlist and be
+        // `command: "<jail root>/ls"` would otherwise pass the allowlist and be
         // executed verbatim, a host RCE that bypasses the read-only allowlist.
         // Bare program names (no '/') are PATH-resolved by the OS and stay
         // allowed; legitimate absolute paths OUTSIDE the jail (e.g. /usr/bin/ls)
@@ -485,18 +476,18 @@ impl ShellConfig {
         // fails to canonicalize (does not exist) is NOT rejected here — the
         // normal exec spawn surfaces its own not-found error.
         if cmd.contains('/') {
-            // Unjailed mode (host_root: null) has NO writable boundary — the
+            // Unjailed mode (empty host_roots) has NO writable boundary — the
             // whole host filesystem is reachable via shell::fs::write, so an
             // agent can plant `/tmp/ls` and run `command: "/tmp/ls"` (basename
             // `ls` is allowlisted), bypassing the read-only allowlist entirely.
             // There is no path that distinguishes "agent-planted" from "system
             // binary" here, so reject ALL command paths and require a bare,
             // PATH-resolved name. (In jailed mode the check below is precise:
-            // only paths inside host_root are rejected.)
+            // only paths inside the jail roots are rejected.)
             if !self.fs.is_jailed() {
                 return Err(format!(
                     "command path '{}' is not allowed when fs is unjailed \
-                     (no fs.host_root/fs.host_roots): any host path is writable via \
+                     (fs.host_roots is empty): any host path is writable via \
                      shell::fs::write, so a command path could execute \
                      agent-planted bytes and bypass the allowlist. Use a bare \
                      command name (PATH-resolved).",
@@ -545,6 +536,9 @@ impl ShellConfig {
             serde_yaml::from_str(yaml).map_err(|e| format!("yaml parse: {e}"))?;
         if let Some(map) = raw.as_mapping() {
             check_removed_keys(map.keys().filter_map(|k| k.as_str()))?;
+            if let Some(fs) = map.get("fs").and_then(|v| v.as_mapping()) {
+                check_removed_fs_keys(fs.keys().filter_map(|k| k.as_str()))?;
+            }
         }
         serde_yaml::from_str(yaml).map_err(|e| format!("yaml parse: {e}"))
     }
@@ -559,6 +553,9 @@ impl ShellConfig {
     pub fn from_json(value: &serde_json::Value) -> Result<Self, String> {
         if let Some(obj) = value.as_object() {
             check_removed_keys(obj.keys().map(String::as_str))?;
+            if let Some(fs) = obj.get("fs").and_then(serde_json::Value::as_object) {
+                check_removed_fs_keys(fs.keys().map(String::as_str))?;
+            }
         }
         serde_json::from_value(value.clone()).map_err(|e| format!("json parse: {e}"))
     }
@@ -639,16 +636,16 @@ mod tests {
         // Basename matching for an absolute command path is only meaningful in
         // JAILED mode: an out-of-jail path (not writable via shell::fs::write)
         // is permitted by basename. Unjailed mode rejects all paths outright
-        // (see exec_command_path_rejected_when_unjailed), so set a host_root
+        // (see exec_command_path_rejected_when_unjailed), so set a jail root
         // that does NOT contain /usr/bin/ls to exercise the basename contract.
         let mut c = cfg_with(vec!["ls"], vec![]);
-        c.fs.host_root =
-            Some(std::env::temp_dir().join(format!("shell-basename-{}", uuid::Uuid::new_v4())));
-        std::fs::create_dir_all(c.fs.host_root.as_ref().unwrap()).unwrap();
+        c.fs.host_roots =
+            vec![std::env::temp_dir().join(format!("shell-basename-{}", uuid::Uuid::new_v4()))];
+        std::fs::create_dir_all(&c.fs.host_roots[0]).unwrap();
         assert!(c
             .is_command_allowed(&["/usr/bin/ls".into(), "-la".into()])
             .is_ok());
-        std::fs::remove_dir_all(c.fs.host_root.as_ref().unwrap()).ok();
+        std::fs::remove_dir_all(&c.fs.host_roots[0]).ok();
     }
 
     #[test]
@@ -881,9 +878,9 @@ mod tests {
 
     #[test]
     fn exec_command_path_inside_jail_is_rejected() {
-        // An agent can plant `<host_root>/ls` (0755) via shell::fs::write; the
+        // An agent can plant `<jail root>/ls` (0755) via shell::fs::write; the
         // basename allowlist matches "ls", so without the confinement guard
-        // `command: "<host_root>/ls"` would execute that jail-planted file —
+        // `command: "<jail root>/ls"` would execute that jail-planted file —
         // host RCE. The guard must reject a command path that canonicalizes
         // inside the jail while still permitting bare PATH-resolved names and
         // out-of-jail absolute paths.
@@ -895,7 +892,7 @@ mod tests {
             allowlist: vec!["ls".into()],
             ..Default::default()
         };
-        c.fs.host_root = Some(root.clone());
+        c.fs.host_roots = vec![root.clone()];
         c.compile_denylist().unwrap();
 
         // The jail-planted path is rejected with a jail-mentioning error.
@@ -920,7 +917,7 @@ mod tests {
                         .to_string()],
                     ..Default::default()
                 };
-                c2.fs.host_root = Some(root.clone());
+                c2.fs.host_roots = vec![root.clone()];
                 c2.compile_denylist().unwrap();
                 assert!(
                     c2.is_command_allowed(&[candidate.to_string()]).is_ok(),
@@ -934,7 +931,7 @@ mod tests {
 
     #[test]
     fn exec_command_path_rejected_when_unjailed() {
-        // Unjailed mode (host_root: null) has no writable boundary: the whole
+        // Unjailed mode (empty host_roots) has no writable boundary: the whole
         // host FS is reachable via shell::fs::write, so ANY command path could
         // execute agent-planted bytes and bypass the allowlist. Reject every
         // path; only bare PATH-resolved names are permitted.
@@ -942,7 +939,7 @@ mod tests {
             allowlist: vec!["ls".into()],
             ..Default::default()
         };
-        c.fs.host_root = None;
+        c.fs.host_roots = Vec::new();
         c.fs.allow_unjailed = true;
         c.compile_denylist().unwrap();
 
@@ -971,7 +968,7 @@ mod tests {
         assert_eq!(c.fs.max_read_bytes, 0);
         assert_eq!(c.fs.max_write_bytes, 0);
         assert!(c.sandbox.enabled);
-        assert!(c.fs.host_root.is_none());
+        assert!(c.fs.host_roots.is_empty());
     }
 
     #[test]
@@ -979,7 +976,7 @@ mod tests {
         let yaml = r#"
 allowlist: []
 fs:
-  host_root: /tmp/shell
+  host_roots: [/tmp/shell]
   max_read_bytes: 1024
   denylist_paths:
     - /etc
@@ -988,8 +985,8 @@ sandbox:
 "#;
         let c: ShellConfig = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(
-            c.fs.host_root.as_deref(),
-            Some(std::path::Path::new("/tmp/shell"))
+            c.fs.host_roots,
+            vec![std::path::PathBuf::from("/tmp/shell")]
         );
         assert_eq!(c.fs.max_read_bytes, 1024);
         assert!(!c.sandbox.enabled);
@@ -1010,7 +1007,7 @@ sandbox:
         let c = ShellConfig::default();
         let err = c.validate_fs_jail().expect_err("must reject default");
         let msg = format!("{err}");
-        assert!(msg.contains("host_root"));
+        assert!(msg.contains("host_roots"));
         assert!(msg.contains("allow_unjailed"));
     }
 
@@ -1022,10 +1019,10 @@ sandbox:
     }
 
     #[test]
-    fn validate_fs_jail_accepts_pinned_host_root() {
+    fn validate_fs_jail_accepts_single_host_root() {
         let mut c = ShellConfig::default();
-        c.fs.host_root = Some(std::path::PathBuf::from("/tmp/something"));
-        c.validate_fs_jail().expect("pinned host_root is valid");
+        c.fs.host_roots = vec![std::path::PathBuf::from("/tmp/something")];
+        c.validate_fs_jail().expect("a one-entry host_roots is valid");
     }
 
     #[test]
@@ -1036,29 +1033,11 @@ sandbox:
     }
 
     #[test]
-    fn validate_fs_jail_rejects_both_host_root_and_host_roots() {
-        let mut c = ShellConfig::default();
-        c.fs.host_root = Some("/tmp/a".into());
-        c.fs.host_roots = vec!["/tmp/b".into()];
-        let err = c.validate_fs_jail().expect_err("both set must be rejected");
-        let msg = format!("{err}");
-        assert!(
-            msg.contains("both fs.host_root and fs.host_roots"),
-            "got: {msg}"
-        );
-    }
-
-    #[test]
-    fn roots_prefers_host_roots_then_legacy_host_root() {
+    fn roots_returns_host_roots_and_empty_means_unjailed() {
         let mut c = FsConfig::default();
         assert!(c.roots().is_empty(), "unset = unjailed");
         assert!(!c.is_jailed());
-        c.host_root = Some("/tmp/legacy".into());
-        assert_eq!(c.roots(), vec![std::path::PathBuf::from("/tmp/legacy")]);
-        assert!(c.is_jailed());
         c.host_roots = vec!["/tmp/a".into(), "/tmp/b".into()];
-        // host_roots wins when both are present (validate_fs_jail rejects that
-        // combo at boot, but roots() stays deterministic).
         assert_eq!(
             c.roots(),
             vec![
@@ -1066,6 +1045,7 @@ sandbox:
                 std::path::PathBuf::from("/tmp/b")
             ]
         );
+        assert!(c.is_jailed());
     }
 
     #[test]
@@ -1115,18 +1095,39 @@ sandbox:
     #[test]
     fn to_json_from_json_round_trips() {
         let mut c = ShellConfig::default();
-        c.fs.host_root = Some(std::path::PathBuf::from("/tmp/shell"));
+        c.fs.host_roots = vec![std::path::PathBuf::from("/tmp/shell")];
         c.allowlist = vec!["ls".into(), "cat".into()];
         let v = c.to_json();
         let back = ShellConfig::from_json(&v).expect("from_json round-trips");
         assert_eq!(back.allowlist, c.allowlist);
-        assert_eq!(back.fs.host_root, c.fs.host_root);
+        assert_eq!(back.fs.host_roots, c.fs.host_roots);
     }
 
     #[test]
     fn from_yaml_parses_seed() {
-        let c = ShellConfig::from_yaml("allowlist: [ls]\nfs:\n  host_root: /tmp/x\n")
+        let c = ShellConfig::from_yaml("allowlist: [ls]\nfs:\n  host_roots: [/tmp/x]\n")
             .expect("seed yaml parses");
         assert_eq!(c.allowlist, vec!["ls".to_string()]);
+    }
+
+    /// A 0.6.x seed still carrying the removed single-root alias must be
+    /// rejected with a hint naming the list form — serde would otherwise
+    /// ignore it and parse a config with NO jail configured.
+    #[test]
+    fn from_yaml_rejects_removed_fs_host_root_with_hint() {
+        let err = ShellConfig::from_yaml("fs:\n  host_root: /tmp\n").expect_err("removed key rejects");
+        assert!(err.contains("removed in 0.7.0"), "{err}");
+        assert!(err.contains("fs.host_roots"), "{err}");
+    }
+
+    /// Same through the live-value (JSON) funnel — what an un-migrated stored
+    /// configuration hits at boot and hot-reload.
+    #[test]
+    fn from_json_rejects_removed_fs_host_root_with_hint() {
+        let v = serde_json::json!({"fs": {"host_root": "/tmp"}});
+        let err = ShellConfig::from_json(&v).expect_err("removed key rejects");
+        assert!(err.contains("removed in 0.7.0"), "{err}");
+        assert!(err.contains("fs.host_roots"), "{err}");
+        assert!(err.contains("configuration::set"), "{err}");
     }
 }

--- a/shell/src/configuration.rs
+++ b/shell/src/configuration.rs
@@ -186,6 +186,16 @@ async fn should_seed_default_value(iii: &IIIClient) -> Result<bool, String> {
 /// Read the live `shell` configuration (env-expanded by the configuration worker).
 pub async fn fetch_config(iii: &IIIClient) -> Result<ShellConfig, String> {
     let value = get_config_value(iii).await?;
+    parse_fetched_value(value)
+}
+
+/// Parse a successfully fetched raw configuration value. Split from
+/// [`fetch_config`] so `reload_serialized` can classify a PARSE failure of a
+/// fetched value as `Rejected` (permanent — re-fetching returns the same
+/// value) rather than a transient fetch error (retryable). Conflating the two
+/// turns every un-migrated stored value into a retry storm and hides the
+/// divergence from `shell::config-status`.
+fn parse_fetched_value(value: Value) -> Result<ShellConfig, String> {
     if value.is_null() {
         // Null means register_config did not seed (its seed_default failed
         // validation) or the stored value was nulled at runtime. Fall back to
@@ -296,14 +306,21 @@ pub fn register_config_trigger(iii: &IIIClient, state: AppState) -> Result<(), E
 /// awaited INSIDE the lock, so overlapping `configuration:updated` events are
 /// applied one at a time and each observes the latest authoritative value — a
 /// slow build from an older event can never overwrite a newer applied config.
+///
+/// Three-way classification: a TRANSPORT failure (fetch Err) is transient —
+/// surface Err so the dispatcher retries. A PARSE failure of the fetched value
+/// (removed 0.7.0 keys, malformed JSON shape) is permanent — re-fetching
+/// returns the same bytes — so it is `Rejected`: keep last-good, record for
+/// `shell::config-status`, ack (no retry storm). An unbuildable parsed config
+/// is likewise `Rejected` via `apply_config`.
 async fn reload_serialized<F, Fut>(state: &AppState, fetch: F) -> Result<ReloadOutcome, String>
 where
     F: FnOnce() -> Fut,
-    Fut: std::future::Future<Output = Result<ShellConfig, String>>,
+    Fut: std::future::Future<Output = Result<Value, String>>,
 {
     let _reload = state.reload_lock.lock().await;
-    let cfg = match fetch().await {
-        Ok(cfg) => cfg,
+    let raw = match fetch().await {
+        Ok(raw) => raw,
         Err(e) => {
             // Transient fetch failure (e.g. configuration::get timed out): the
             // authoritative value is unknown. Keep the previous runtime AND
@@ -313,6 +330,20 @@ where
                 "failed to fetch configuration on change; keeping previous runtime, signaling retry"
             );
             return Err(e);
+        }
+    };
+    let cfg = match parse_fetched_value(raw) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            // The value WAS fetched; it just doesn't parse (e.g. an
+            // un-migrated 0.6.x shape carrying removed keys). Same class as
+            // unbuildable below: permanent until the store changes.
+            tracing::error!(
+                error = %e,
+                "rejected configuration change; keeping previous runtime (not retrying — value does not parse)"
+            );
+            state.reload_status.write().await.record_rejected(e);
+            return Ok(ReloadOutcome::Rejected);
         }
     };
     match apply_config(state, cfg).await {
@@ -353,7 +384,7 @@ async fn on_config_change(state: &AppState) -> Result<(), String> {
     // and a slow build from an older event cannot roll back a newer policy.
     // Steady-state: an invalid config keeps last-good (Rejected is not an error
     // here), only a transient fetch failure propagates Err for the dispatcher.
-    reload_serialized(state, || fetch_config(&state.iii))
+    reload_serialized(state, || get_config_value(&state.iii))
         .await
         .map(|_| ())
 }
@@ -366,7 +397,7 @@ async fn on_config_change(state: &AppState) -> Result<(), String> {
 /// (unbuildable) authoritative config aborts startup rather than serving the
 /// stale last-good runtime, and a transient fetch failure also aborts.
 pub async fn reconcile(state: &AppState) -> Result<(), String> {
-    reconcile_with(state, || fetch_config(&state.iii)).await
+    reconcile_with(state, || get_config_value(&state.iii)).await
 }
 
 /// Boot reconcile core, split from `fetch_config` so the fail-closed mapping is
@@ -374,7 +405,7 @@ pub async fn reconcile(state: &AppState) -> Result<(), String> {
 async fn reconcile_with<F, Fut>(state: &AppState, fetch: F) -> Result<(), String>
 where
     F: FnOnce() -> Fut,
-    Fut: std::future::Future<Output = Result<ShellConfig, String>>,
+    Fut: std::future::Future<Output = Result<Value, String>>,
 {
     match reload_serialized(state, fetch).await? {
         ReloadOutcome::Applied => Ok(()),
@@ -528,7 +559,7 @@ mod tests {
         let h1 = tokio::spawn(async move {
             let _ = reload_serialized(&s1, || async move {
                 tokio::time::sleep(std::time::Duration::from_millis(150)).await;
-                Ok::<_, String>(old)
+                Ok::<_, String>(old.to_json())
             })
             .await;
         });
@@ -541,7 +572,7 @@ mod tests {
         let s2 = state.clone();
         let new = cfg_new.clone();
         let h2 = tokio::spawn(async move {
-            let _ = reload_serialized(&s2, || async move { Ok::<_, String>(new) }).await;
+            let _ = reload_serialized(&s2, || async move { Ok::<_, String>(new.to_json()) }).await;
         });
 
         h1.await.unwrap();
@@ -571,7 +602,7 @@ mod tests {
             reload_status: Arc::new(RwLock::new(ReloadStatus::default())),
         };
         let res = reload_serialized(&state, || async {
-            Err::<ShellConfig, String>("get timed out".into())
+            Err::<Value, String>("get timed out".into())
         })
         .await;
         assert!(
@@ -608,8 +639,10 @@ mod tests {
             reload_status: Arc::new(RwLock::new(ReloadStatus::default())),
         };
         // ShellConfig::default() is unjailed (empty host_roots, allow_unjailed false) → rejected by prepare_config.
-        let res =
-            reload_serialized(&state, || async { Ok::<_, String>(ShellConfig::default()) }).await;
+        let res = reload_serialized(&state, || async {
+            Ok::<_, String>(ShellConfig::default().to_json())
+        })
+        .await;
         assert!(
             matches!(res, Ok(ReloadOutcome::Rejected)),
             "invalid config must be acked as Rejected (no retry storm), not Err"
@@ -619,6 +652,55 @@ mod tests {
             vec![dir],
             "runtime keeps last-good on invalid config"
         );
+    }
+
+    /// A stored value that FAILS TO PARSE (e.g. a 0.6.x shape carrying the
+    /// removed `inherit_env`/`allowed_env` keys) must classify the same as an
+    /// unbuildable-but-parseable config: `Rejected`, keep last-good, ack (no
+    /// retry storm), and record the rejection for `shell::config-status`.
+    /// Before the fix this hit the transient-fetch-failure branch instead —
+    /// re-fetching returns the identical bytes, so the dispatcher would retry
+    /// forever against a value that can never parse.
+    #[tokio::test]
+    async fn reload_rejects_and_records_unparseable_stored_value() {
+        let dir = std::env::temp_dir().join("shell-reload-unparseable-9b3c");
+        std::fs::create_dir_all(&dir).unwrap();
+        let iii = iii_sdk::register_worker("ws://127.0.0.1:59593", iii_sdk::InitOptions::default());
+        let mut good = ShellConfig::default();
+        good.fs.host_roots = vec![dir.clone()];
+        let state = AppState {
+            runtime: Arc::new(RwLock::new(build_runtime(&good, &iii).expect("initial"))),
+            iii: iii.clone(),
+            reload_lock: Arc::new(Mutex::new(())),
+            reload_status: Arc::new(RwLock::new(ReloadStatus::default())),
+        };
+        // A literal 0.6.x stored shape: top-level inherit_env/allowed_env,
+        // no `env` block — fails check_removed_keys inside parse_fetched_value.
+        let stale_060_shape = serde_json::json!({
+            "inherit_env": true,
+            "allowed_env": ["PATH", "HOME"],
+        });
+        let res =
+            reload_serialized(&state, || async move { Ok::<_, String>(stale_060_shape) }).await;
+        assert!(
+            matches!(res, Ok(ReloadOutcome::Rejected)),
+            "unparseable stored value must be Rejected (permanent), not Err (transient): {res:?}"
+        );
+        assert_eq!(
+            state.runtime.read().await.config.fs.host_roots,
+            vec![dir],
+            "runtime keeps last-good on an unparseable stored value"
+        );
+        let s = state.reload_status.read().await;
+        assert_eq!(s.last_outcome, ReloadOutcome::Rejected);
+        assert!(
+            s.last_error
+                .as_deref()
+                .is_some_and(|e| e.contains("removed in 0.7.0")),
+            "config-status must surface the migration hint: {:?}",
+            s.last_error
+        );
+        assert_eq!(s.rejected_reloads, 1);
     }
 
     #[tokio::test]
@@ -641,7 +723,7 @@ mod tests {
         };
         let res = reload_serialized(&state, {
             let b = b.clone();
-            move || async move { Ok::<_, String>(b) }
+            move || async move { Ok::<_, String>(b.to_json()) }
         })
         .await;
         assert!(matches!(res, Ok(ReloadOutcome::Applied)));
@@ -677,8 +759,10 @@ mod tests {
         }
 
         // A rejected (invalid: unjailed default) reload keeps last-good AND records it.
-        let res =
-            reload_serialized(&state, || async { Ok::<_, String>(ShellConfig::default()) }).await;
+        let res = reload_serialized(&state, || async {
+            Ok::<_, String>(ShellConfig::default().to_json())
+        })
+        .await;
         assert!(res.is_ok(), "invalid config is acked (no storm)");
         {
             let s = state.reload_status.read().await;
@@ -697,7 +781,7 @@ mod tests {
         good2.fs.host_roots = vec![dir.clone()];
         let res = reload_serialized(&state, {
             let g = good2.clone();
-            move || async move { Ok::<_, String>(g) }
+            move || async move { Ok::<_, String>(g.to_json()) }
         })
         .await;
         assert!(res.is_ok());
@@ -748,8 +832,10 @@ mod tests {
         };
 
         // Invalid (unjailed default) authoritative config → fail closed.
-        let res =
-            reconcile_with(&state, || async { Ok::<_, String>(ShellConfig::default()) }).await;
+        let res = reconcile_with(&state, || async {
+            Ok::<_, String>(ShellConfig::default().to_json())
+        })
+        .await;
         assert!(
             res.is_err(),
             "boot reconcile must fail closed on an invalid stored config"
@@ -757,7 +843,7 @@ mod tests {
 
         // Transient fetch failure → fail closed too.
         let res = reconcile_with(&state, || async {
-            Err::<ShellConfig, String>("get timed out".into())
+            Err::<Value, String>("get timed out".into())
         })
         .await;
         assert!(
@@ -770,7 +856,7 @@ mod tests {
         good2.fs.host_roots = vec![dir.clone()];
         let res = reconcile_with(&state, {
             let g = good2.clone();
-            move || async move { Ok::<_, String>(g) }
+            move || async move { Ok::<_, String>(g.to_json()) }
         })
         .await;
         assert!(res.is_ok(), "boot reconcile applies a valid config");

--- a/shell/src/configuration.rs
+++ b/shell/src/configuration.rs
@@ -108,7 +108,7 @@ pub fn build_runtime(cfg: &ShellConfig, iii: &IIIClient) -> Result<ShellRuntime,
     let config = prepare_config(cfg)?;
     if !config.fs.is_jailed() {
         tracing::warn!(
-            "fs.host_root/fs.host_roots are unset — host backend is unjailed; every absolute \
+            "fs.host_roots is empty — host backend is unjailed; every absolute \
              path is reachable by shell::fs::* (denylist still applies)"
         );
     }
@@ -131,144 +131,6 @@ pub fn build_runtime(cfg: &ShellConfig, iii: &IIIClient) -> Result<ShellRuntime,
         config,
         host_backend,
     })
-}
-
-/// Fold a legacy `coder` config value into the `shell` config value, ONCE.
-///
-/// Returns `Some(merged)` when the stored `shell` value should be rewritten
-/// (gaps filled and/or the one-shot marker set), or `None` when the fold has
-/// already run (`migrated_from_coder` is set) — making it idempotent across
-/// reboots even while the inert `coder` entry still exists.
-///
-/// SECURITY — NEVER WIDEN. The fold only FILLS gaps; it never broadens access:
-///   * Roots: coder's roots are adopted ONLY when `shell` has no jail at all.
-///     If `shell` is already jailed its roots are kept untouched — adopting
-///     coder's would silently widen the jail. coder's *implicit* default
-///     (no `base_path`/`base_paths`) is never migrated.
-///   * Protected globs / code tuning: adopted only into an UNTOUCHED `code`
-///     block; a `shell` value that already tuned `code` keeps its values, and
-///     a non-empty `non_accessible_globs` is never dropped.
-///
-/// The roots that land in the merged value go to `fs.host_roots` (the unified
-/// jail), never to `code.base_paths`.
-pub fn fold_coder_into_shell(
-    mut shell: ShellConfig,
-    coder: &crate::code::config::CoderConfig,
-) -> Option<ShellConfig> {
-    if shell.migrated_from_coder {
-        return None;
-    }
-
-    // Roots — NEVER WIDEN. Only when shell has no jail do we adopt coder's
-    // EXPLICIT roots (its implicit ["./","/tmp"] default is not migrated).
-    if !shell.fs.is_jailed() {
-        let coder_roots: Vec<std::path::PathBuf> = if !coder.base_paths.is_empty() {
-            coder.base_paths.clone()
-        } else if let Some(p) = &coder.base_path {
-            vec![p.clone()]
-        } else {
-            Vec::new()
-        };
-        if !coder_roots.is_empty() {
-            shell.fs.host_roots = coder_roots;
-        }
-    }
-
-    // Code block — fill an UNTOUCHED block wholesale (globs + excludes +
-    // budgets), minus the roots (which live in fs.host_roots). A tuned block
-    // keeps its values; only an empty protected-glob list is back-filled.
-    let default_code = crate::code::config::CoderConfig::default();
-    // "Untouched" means the ENTIRE code block is still at its defaults (roots
-    // excluded — they live in fs and are cleared on both sides). Comparing the
-    // whole struct, not just the glob lists, prevents the fold from silently
-    // overwriting a tuned numeric knob (e.g. max_read_bytes) that the operator
-    // set while leaving the default globs.
-    let code_untouched = {
-        let mut probe = shell.code.clone();
-        probe.base_path = None;
-        probe.base_paths = Vec::new();
-        probe == default_code
-    };
-    if code_untouched {
-        let mut adopted = coder.clone();
-        adopted.base_path = None;
-        adopted.base_paths = Vec::new();
-        shell.code = adopted;
-    } else if shell.code.non_accessible_globs.is_empty() {
-        shell.code.non_accessible_globs = coder.non_accessible_globs.clone();
-    }
-
-    shell.migrated_from_coder = true;
-    Some(shell)
-}
-
-/// Fetch the stored value for an arbitrary configuration id (`Ok(None)` when
-/// the entry does not exist). Generalises [`try_get_config_value`] so the
-/// migration can read both `coder` and `shell`.
-async fn try_get_value_for(iii: &IIIClient, id: &str) -> Result<Option<Value>, String> {
-    match trigger_with_retry(iii, "configuration::get", json!({ "id": id })).await {
-        Ok(resp) => Ok(resp.get("value").cloned()),
-        Err(e) if e.to_ascii_uppercase().contains("NOT_FOUND") => Ok(None),
-        Err(e) => Err(e),
-    }
-}
-
-/// One-shot boot migration: fold a legacy `coder` config entry into the `shell`
-/// value (see [`fold_coder_into_shell`]). MUST run AFTER schema registration
-/// and BEFORE the initial fetch so `build_runtime` sees the merged value.
-///
-/// BEST-EFFORT / NON-FATAL: a missing `coder` entry, an unparseable value, or a
-/// write failure logs and returns without aborting boot — the worker proceeds
-/// with the existing `shell` config. The legacy `coder` entry is left intact
-/// (inert) as the rollback artifact; the console annotates it (T8).
-pub async fn migrate_legacy_coder(iii: &IIIClient) {
-    let coder_value = match try_get_value_for(iii, "coder").await {
-        Ok(Some(v)) if !v.is_null() => v,
-        Ok(_) => return, // no legacy entry — fresh install or already gone
-        Err(e) => {
-            tracing::warn!(error = %e, "could not read legacy coder config; skipping migration");
-            return;
-        }
-    };
-    let coder = match crate::code::config::CoderConfig::from_json(&coder_value) {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::warn!(error = %e, "legacy coder config unparseable; skipping migration");
-            return;
-        }
-    };
-    // Current shell value, or the (invalid, unjailed) default when none is
-    // stored yet — the latter is the "only coder was configured" upgrade path,
-    // where the fold derives a valid jailed shell config from coder's roots.
-    let shell = match try_get_value_for(iii, CONFIG_ID).await {
-        Ok(Some(v)) if !v.is_null() => match ShellConfig::from_json(&v) {
-            Ok(c) => c,
-            // A stored-but-unparseable shell value must NOT be silently
-            // overwritten by a default+coder fold — that would clobber a
-            // possibly-recoverable config. Skip; the subsequent fetch_config
-            // surfaces the parse error and boot fails closed cleanly.
-            Err(e) => {
-                tracing::warn!(error = %e, "stored shell config is unparseable; skipping coder migration");
-                return;
-            }
-        },
-        _ => ShellConfig::default(),
-    };
-    match fold_coder_into_shell(shell, &coder) {
-        None => tracing::debug!("coder→shell migration already applied; skipping"),
-        Some(merged) => {
-            let payload = json!({ "id": CONFIG_ID, "value": merged.to_json() });
-            match trigger_with_retry(iii, "configuration::set", payload).await {
-                Ok(_) => tracing::info!(
-                    "folded the legacy coder config into the shell config (one-shot)"
-                ),
-                Err(e) => tracing::warn!(
-                    error = %e,
-                    "failed to persist coder→shell migration; continuing with the existing shell config"
-                ),
-            }
-        }
-    }
 }
 
 /// Register the `shell` configuration schema with the configuration worker.
@@ -294,7 +156,7 @@ pub async fn register_config(iii: &IIIClient, seed: Option<&ShellConfig>) -> Res
     };
     if let Some(cfg) = &candidate {
         // Validate with the SAME checks build_runtime uses (denylist regex
-        // compile, fs-jail rule, host_root/denylist reachability) BEFORE
+        // compile, fs-jail rule, host_roots/denylist reachability) BEFORE
         // persisting. configuration::register preserves the value after first
         // registration, so a one-line typo in --config — or an unbootable
         // built-in seed — would become a persistent outage. If invalid, register
@@ -377,7 +239,7 @@ async fn apply_config(state: &AppState, cfg: ShellConfig) -> Result<(), String> 
     let now_jailed = new_runtime.config.fs.is_jailed();
     if was_jailed && !now_jailed {
         tracing::warn!(
-            "configuration change WIDENED the fs jail (host_root cleared); the entire \
+            "configuration change WIDENED the fs jail (host_roots cleared); the entire \
              host filesystem is now reachable through shell::fs::* (denylist still applies)"
         );
     }
@@ -463,7 +325,7 @@ where
         }
         Err(e) => {
             // Config was fetched but is unbuildable (bad denylist regex, unreachable
-            // host_root, …). Re-fetching returns the SAME rejected value, so ack +
+            // jail root, …). Re-fetching returns the SAME rejected value, so ack +
             // keep last-good to avoid a retry storm; the loud error log is the signal.
             // Record the rejection so `shell::config-status` makes the divergence
             // (active policy older than the central store) operator-visible.
@@ -568,7 +430,7 @@ mod tests {
         // that silently retries but never panics or blocks this thread.
         let iii = iii_sdk::register_worker("ws://127.0.0.1:59599", iii_sdk::InitOptions::default());
         let mut cfg = ShellConfig::default();
-        cfg.fs.host_root = Some(std::path::PathBuf::from("/nonexistent/shell-jail-xyz"));
+        cfg.fs.host_roots = vec![std::path::PathBuf::from("/nonexistent/shell-jail-xyz")];
         cfg.fs.allow_unjailed = false;
         let res = build_runtime(&cfg, &iii);
         assert!(res.is_err(), "build_runtime must return Err, not panic");
@@ -588,150 +450,25 @@ mod tests {
     }
 
     #[test]
-    fn prepare_config_accepts_pinned_host_root() {
+    fn prepare_config_accepts_pinned_host_roots() {
         let mut c = ShellConfig::default();
-        c.fs.host_root = Some(std::path::PathBuf::from("/tmp/shell"));
-        prepare_config(&c).expect("pinned host_root is valid");
+        c.fs.host_roots = vec![std::path::PathBuf::from("/tmp/shell")];
+        prepare_config(&c).expect("pinned host_roots is valid");
     }
 
     #[test]
-    fn legacy_host_root_only_config_boots_jailed_to_that_root() {
-        // REGRESSION (T6, CRITICAL): a pre-merge shell config — a single
-        // fs.host_root, NO fs.host_roots, NO `code:` block — must still
-        // deserialize via serde defaults, boot, and jail shell::fs to that one
-        // root. This guards every existing shell deployment across the coder
-        // merge. (Byte-identical fs *behaviour* is additionally proven by the
-        // unchanged shell::fs test suite continuing to pass.)
-        let dir = std::env::temp_dir().join("shell-t6-legacy-regression");
-        std::fs::create_dir_all(&dir).unwrap();
-        // Exactly the pre-merge config shape — nothing the merge added.
-        let yaml = format!("allowlist: []\nfs:\n  host_root: {}\n", dir.display());
-        let cfg = ShellConfig::from_yaml(&yaml).expect("legacy yaml parses via serde defaults");
-        assert!(
-            cfg.fs.host_roots.is_empty(),
-            "a legacy config carries no host_roots"
-        );
-        assert_eq!(cfg.fs.host_root.as_deref(), Some(dir.as_path()));
-        // The added `code` block defaulted (empty), and the effective jail is
-        // the single legacy root via the compatibility alias.
-        assert_eq!(cfg.fs.roots(), vec![dir.clone()]);
-        assert!(cfg.code.non_accessible_globs.is_empty());
-
-        let iii = iii_sdk::register_worker("ws://127.0.0.1:59571", iii_sdk::InitOptions::default());
-        let runtime = build_runtime(&cfg, &iii).expect("legacy config still builds a runtime");
-        assert!(runtime.config.fs.is_jailed());
-        assert_eq!(runtime.config.fs.roots(), vec![dir.clone()]);
-    }
-
-    #[test]
-    fn fold_never_widens_an_already_jailed_shell() {
-        // SECURITY: shell already has a jail root; coder declares DIFFERENT
-        // roots. The fold must KEEP shell's roots (adopting coder's would widen
-        // the jail) and only fill the empty code protected-globs.
-        let mut shell = ShellConfig::default();
-        shell.fs.host_root = Some("/srv/app".into());
-        let coder = crate::code::config::CoderConfig {
-            base_paths: vec!["/etc".into(), "/var".into()],
-            non_accessible_globs: vec!["**/.env".into()],
-            ..Default::default()
-        };
-        let merged = fold_coder_into_shell(shell, &coder).expect("a change (marker + globs)");
-        assert_eq!(
-            merged.fs.host_root.as_deref(),
-            Some(std::path::Path::new("/srv/app"))
-        );
-        assert!(
-            merged.fs.host_roots.is_empty(),
-            "coder roots must NOT be adopted into an already-jailed shell (no widening)"
-        );
-        assert_eq!(
-            merged.fs.roots(),
-            vec![std::path::PathBuf::from("/srv/app")]
-        );
-        assert_eq!(
-            merged.code.non_accessible_globs,
-            vec!["**/.env".to_string()]
-        );
-        assert!(merged.migrated_from_coder);
-    }
-
-    #[test]
-    fn fold_adopts_coder_roots_only_when_shell_unjailed() {
-        // The "only coder was configured" upgrade path: shell has no jail, coder
-        // does — derive shell's jail from coder's roots + tuning.
-        let shell = ShellConfig::default();
-        assert!(!shell.fs.is_jailed());
-        let coder = crate::code::config::CoderConfig {
-            base_paths: vec!["/work/project".into()],
-            non_accessible_globs: vec!["**/*.pem".into()],
-            ..Default::default()
-        };
-        let merged = fold_coder_into_shell(shell, &coder).expect("a change");
-        assert_eq!(
-            merged.fs.host_roots,
-            vec![std::path::PathBuf::from("/work/project")]
-        );
-        assert!(merged.fs.is_jailed());
-        assert_eq!(
-            merged.code.non_accessible_globs,
-            vec!["**/*.pem".to_string()]
-        );
-        assert!(merged.migrated_from_coder);
-    }
-
-    #[test]
-    fn fold_is_idempotent_once_marked() {
-        let shell = ShellConfig {
-            migrated_from_coder: true,
-            ..Default::default()
-        };
-        let coder = crate::code::config::CoderConfig::default();
-        assert!(
-            fold_coder_into_shell(shell, &coder).is_none(),
-            "an already-migrated shell value is a no-op"
-        );
-    }
-
-    #[test]
-    fn fold_never_drops_existing_shell_protected_globs() {
-        // shell already tuned its protected globs; the fold must not overwrite.
-        let mut shell = ShellConfig::default();
-        shell.fs.host_root = Some("/srv".into());
-        shell.code.non_accessible_globs = vec!["**/secret.key".into()];
-        let coder = crate::code::config::CoderConfig {
-            non_accessible_globs: vec!["**/.env".into()],
-            ..Default::default()
-        };
-        let merged = fold_coder_into_shell(shell, &coder).expect("marker set");
-        assert_eq!(
-            merged.code.non_accessible_globs,
-            vec!["**/secret.key".to_string()],
-            "shell's own protected globs must be preserved"
-        );
-    }
-
-    #[test]
-    fn fold_preserves_a_tuned_code_knob_with_default_globs() {
-        // Regression: a shell that tuned a numeric knob (max_read_bytes) but
-        // left default globs is NOT "untouched" — the fold must keep the knob,
-        // not overwrite the whole code block with coder's defaults.
-        let mut shell = ShellConfig::default();
-        shell.fs.host_root = Some("/srv".into());
-        shell.code.max_read_bytes = 5_000_000;
-        let coder = crate::code::config::CoderConfig {
-            non_accessible_globs: vec!["**/.env".into()],
-            ..Default::default()
-        };
-        let merged = fold_coder_into_shell(shell, &coder).expect("a change");
-        assert_eq!(
-            merged.code.max_read_bytes, 5_000_000,
-            "a tuned numeric knob must survive the fold"
-        );
-        // The empty protected globs are still back-filled from coder.
-        assert_eq!(
-            merged.code.non_accessible_globs,
-            vec!["**/.env".to_string()]
-        );
+    fn legacy_host_root_config_is_rejected_with_hint() {
+        // INVERSION of the old T6 regression test: through 0.6.x a single
+        // fs.host_root was honored as a one-entry jail, and this test proved
+        // that pre-merge shape still booted. 0.7.0 removes the alias outright,
+        // so the SAME config shape must now FAIL CLOSED at parse with a hint
+        // naming fs.host_roots — serde would otherwise ignore the stale key
+        // and the worker would refuse to start with a message that never
+        // names the actual mistake.
+        let yaml = "allowlist: []\nfs:\n  host_root: /tmp/legacy-root\n";
+        let err = ShellConfig::from_yaml(yaml).expect_err("the 0.6.x alias must be rejected");
+        assert!(err.contains("removed in 0.7.0"), "{err}");
+        assert!(err.contains("fs.host_roots"), "{err}");
     }
 
     #[test]
@@ -770,7 +507,7 @@ mod tests {
 
         let iii = iii_sdk::register_worker("ws://127.0.0.1:59597", iii_sdk::InitOptions::default());
         let mut base = ShellConfig::default();
-        base.fs.host_root = Some(dir_old.clone());
+        base.fs.host_roots = vec![dir_old.clone()];
         let initial = build_runtime(&base, &iii).expect("initial runtime");
         let state = AppState {
             runtime: Arc::new(RwLock::new(initial)),
@@ -780,9 +517,9 @@ mod tests {
         };
 
         let mut cfg_old = ShellConfig::default();
-        cfg_old.fs.host_root = Some(dir_old.clone());
+        cfg_old.fs.host_roots = vec![dir_old.clone()];
         let mut cfg_new = ShellConfig::default();
-        cfg_new.fs.host_root = Some(dir_new.clone());
+        cfg_new.fs.host_roots = vec![dir_new.clone()];
 
         // OLDER reload: acquires the reload lock first, then stalls inside the
         // (lock-held) fetch — simulating a slow build for an older event.
@@ -810,10 +547,10 @@ mod tests {
         h1.await.unwrap();
         h2.await.unwrap();
 
-        let final_root = state.runtime.read().await.config.fs.host_root.clone();
+        let final_root = state.runtime.read().await.config.fs.host_roots.clone();
         assert_eq!(
             final_root,
-            Some(dir_new),
+            vec![dir_new],
             "newest config must win; a stale older build must not clobber it"
         );
     }
@@ -826,7 +563,7 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let iii = iii_sdk::register_worker("ws://127.0.0.1:59596", iii_sdk::InitOptions::default());
         let mut base = ShellConfig::default();
-        base.fs.host_root = Some(dir.clone());
+        base.fs.host_roots = vec![dir.clone()];
         let state = AppState {
             runtime: Arc::new(RwLock::new(build_runtime(&base, &iii).expect("initial"))),
             iii: iii.clone(),
@@ -842,8 +579,8 @@ mod tests {
             "transient fetch failure must surface as Err, not ack success"
         );
         assert_eq!(
-            state.runtime.read().await.config.fs.host_root,
-            Some(dir),
+            state.runtime.read().await.config.fs.host_roots,
+            vec![dir],
             "runtime unchanged on fetch failure"
         );
         // A transient fetch failure is NOT a config rejection: status untouched.
@@ -863,14 +600,14 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let iii = iii_sdk::register_worker("ws://127.0.0.1:59595", iii_sdk::InitOptions::default());
         let mut good = ShellConfig::default();
-        good.fs.host_root = Some(dir.clone());
+        good.fs.host_roots = vec![dir.clone()];
         let state = AppState {
             runtime: Arc::new(RwLock::new(build_runtime(&good, &iii).expect("initial"))),
             iii: iii.clone(),
             reload_lock: Arc::new(Mutex::new(())),
             reload_status: Arc::new(RwLock::new(ReloadStatus::default())),
         };
-        // ShellConfig::default() is unjailed (host_root None, allow_unjailed false) → rejected by prepare_config.
+        // ShellConfig::default() is unjailed (empty host_roots, allow_unjailed false) → rejected by prepare_config.
         let res =
             reload_serialized(&state, || async { Ok::<_, String>(ShellConfig::default()) }).await;
         assert!(
@@ -878,8 +615,8 @@ mod tests {
             "invalid config must be acked as Rejected (no retry storm), not Err"
         );
         assert_eq!(
-            state.runtime.read().await.config.fs.host_root,
-            Some(dir),
+            state.runtime.read().await.config.fs.host_roots,
+            vec![dir],
             "runtime keeps last-good on invalid config"
         );
     }
@@ -893,9 +630,9 @@ mod tests {
         std::fs::create_dir_all(&dir_b).unwrap();
         let iii = iii_sdk::register_worker("ws://127.0.0.1:59594", iii_sdk::InitOptions::default());
         let mut a = ShellConfig::default();
-        a.fs.host_root = Some(dir_a.clone());
+        a.fs.host_roots = vec![dir_a.clone()];
         let mut b = ShellConfig::default();
-        b.fs.host_root = Some(dir_b.clone());
+        b.fs.host_roots = vec![dir_b.clone()];
         let state = AppState {
             runtime: Arc::new(RwLock::new(build_runtime(&a, &iii).expect("initial"))),
             iii: iii.clone(),
@@ -909,8 +646,8 @@ mod tests {
         .await;
         assert!(matches!(res, Ok(ReloadOutcome::Applied)));
         assert_eq!(
-            state.runtime.read().await.config.fs.host_root,
-            Some(dir_b),
+            state.runtime.read().await.config.fs.host_roots,
+            vec![dir_b],
             "reconcile/reload applies the freshly fetched config"
         );
     }
@@ -924,7 +661,7 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let iii = iii_sdk::register_worker("ws://127.0.0.1:59592", iii_sdk::InitOptions::default());
         let mut good = ShellConfig::default();
-        good.fs.host_root = Some(dir.clone());
+        good.fs.host_roots = vec![dir.clone()];
         let state = AppState {
             runtime: Arc::new(RwLock::new(build_runtime(&good, &iii).expect("initial"))),
             iii: iii.clone(),
@@ -951,13 +688,13 @@ mod tests {
         }
         // Runtime kept the previous (valid) policy.
         assert_eq!(
-            state.runtime.read().await.config.fs.host_root,
-            Some(dir.clone())
+            state.runtime.read().await.config.fs.host_roots,
+            vec![dir.clone()]
         );
 
         // A subsequent valid reload flips back to Applied but preserves the count.
         let mut good2 = ShellConfig::default();
-        good2.fs.host_root = Some(dir.clone());
+        good2.fs.host_roots = vec![dir.clone()];
         let res = reload_serialized(&state, {
             let g = good2.clone();
             move || async move { Ok::<_, String>(g) }
@@ -1002,7 +739,7 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let iii = iii_sdk::register_worker("ws://127.0.0.1:59591", iii_sdk::InitOptions::default());
         let mut good = ShellConfig::default();
-        good.fs.host_root = Some(dir.clone());
+        good.fs.host_roots = vec![dir.clone()];
         let state = AppState {
             runtime: Arc::new(RwLock::new(build_runtime(&good, &iii).expect("initial"))),
             iii: iii.clone(),
@@ -1030,7 +767,7 @@ mod tests {
 
         // A valid config reconciles cleanly.
         let mut good2 = ShellConfig::default();
-        good2.fs.host_root = Some(dir.clone());
+        good2.fs.host_roots = vec![dir.clone()];
         let res = reconcile_with(&state, {
             let g = good2.clone();
             move || async move { Ok::<_, String>(g) }

--- a/shell/src/exec/host.rs
+++ b/shell/src/exec/host.rs
@@ -40,9 +40,9 @@ pub fn build_command(
     if argv.len() > 1 {
         cmd.args(&argv[1..]);
     }
-    if !cfg.inherit_env {
+    if !cfg.env.inherit {
         cmd.env_clear();
-        for k in &cfg.allowed_env {
+        for k in &cfg.env.allow {
             if let Ok(v) = std::env::var(k) {
                 cmd.env(k, v);
             }
@@ -50,8 +50,8 @@ pub fn build_command(
     }
     // Per-call env overrides are applied LAST so a permitted key's per-call
     // value wins over the config-forwarded value. Keys were already gated
-    // against allowed_env + DANGEROUS_ENV_KEYS in the handler, so this loop
-    // trusts the validated map. Note: when inherit_env is true the child
+    // against env.allow + DANGEROUS_ENV_KEYS in the handler, so this loop
+    // trusts the validated map. Note: when env.inherit is true the child
     // already inherits the worker's full env; the override still sets these
     // keys explicitly on top.
     if let Some(env) = &overrides.env {
@@ -252,7 +252,10 @@ mod tests {
 
     fn test_cfg() -> ShellConfig {
         let mut c = ShellConfig {
-            inherit_env: true,
+            env: crate::config::EnvConfig {
+                inherit: true,
+                ..Default::default()
+            },
             max_output_bytes: 4096,
             ..Default::default()
         };
@@ -401,13 +404,49 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
+    /// With `env.inherit: false`, the child env is scrubbed to exactly the
+    /// `env.allow` keys: an allowed worker var round-trips, a non-allowed one
+    /// never reaches the child. (Unit twin of the e2e scrub/passthrough cases.)
+    #[tokio::test]
+    async fn inherit_false_forwards_only_allow_keys() {
+        // Unique names so parallel tests can't collide on process env state.
+        std::env::set_var("SHELL_DX_ALLOWED_9F3A", "allowed-value");
+        std::env::set_var("SHELL_DX_BLOCKED_9F3A", "blocked-value");
+
+        let mut cfg = test_cfg();
+        cfg.env.inherit = false;
+        cfg.env.allow = vec!["PATH".into(), "SHELL_DX_ALLOWED_9F3A".into()];
+
+        let out = run_to_completion(
+            &["env".into()],
+            &cfg,
+            5000,
+            &crate::exec::policy::ExecOverrides::default(),
+        )
+        .await
+        .unwrap();
+        assert!(
+            out.stdout.contains("SHELL_DX_ALLOWED_9F3A=allowed-value"),
+            "allowed key forwarded: {}",
+            out.stdout
+        );
+        assert!(
+            !out.stdout.contains("SHELL_DX_BLOCKED_9F3A"),
+            "non-allowed key scrubbed: {}",
+            out.stdout
+        );
+
+        std::env::remove_var("SHELL_DX_ALLOWED_9F3A");
+        std::env::remove_var("SHELL_DX_BLOCKED_9F3A");
+    }
+
     /// A permitted `env` key is visible to the child process. We forward
-    /// `printenv NODE_ENV`; with NODE_ENV in allowed_env and a per-call value,
+    /// `printenv NODE_ENV`; with NODE_ENV in env.allow and a per-call value,
     /// the child sees it.
     #[tokio::test]
     async fn env_override_is_visible_to_child() {
         let mut cfg = test_cfg();
-        cfg.allowed_env = vec!["NODE_ENV".into()];
+        cfg.env.allow = vec!["NODE_ENV".into()];
 
         let mut env = std::collections::BTreeMap::new();
         env.insert("NODE_ENV".to_string(), "from-override".to_string());
@@ -425,12 +464,12 @@ mod tests {
         assert_eq!(out.stdout.trim(), "from-override");
     }
 
-    /// An env key NOT in allowed_env is rejected (S210) before any spawn,
+    /// An env key NOT in env.allow is rejected (S210) before any spawn,
     /// naming the offending key — the call never reaches the child.
     #[tokio::test]
-    async fn env_key_outside_allowed_env_is_rejected_s210() {
+    async fn env_key_outside_allow_list_is_rejected_s210() {
         let mut cfg = test_cfg();
-        cfg.allowed_env = vec!["NODE_ENV".into()];
+        cfg.env.allow = vec!["NODE_ENV".into()];
         let mut env = std::collections::BTreeMap::new();
         env.insert("SECRET_TOKEN".to_string(), "x".to_string());
         let err = crate::exec::policy::build_overrides(None, Some(&env), None, &cfg)
@@ -444,12 +483,12 @@ mod tests {
     }
 
     /// LD_PRELOAD is rejected (S210) even when the test also adds it to
-    /// allowed_env — proof that the dangerous-key denylist wins over the
+    /// env.allow — proof that the dangerous-key denylist wins over the
     /// operator's allowlist.
     #[tokio::test]
     async fn dangerous_env_key_rejected_even_if_allowlisted_on_host_path() {
         let mut cfg = test_cfg();
-        cfg.allowed_env = vec!["LD_PRELOAD".into(), "NODE_ENV".into()];
+        cfg.env.allow = vec!["LD_PRELOAD".into(), "NODE_ENV".into()];
         let mut env = std::collections::BTreeMap::new();
         env.insert("LD_PRELOAD".to_string(), "/tmp/evil.so".to_string());
         let err = crate::exec::policy::build_overrides(None, Some(&env), None, &cfg)

--- a/shell/src/exec/host.rs
+++ b/shell/src/exec/host.rs
@@ -368,7 +368,7 @@ mod tests {
         let root = std::env::temp_dir().join(format!("shell-cwd-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(root.join("workdir")).unwrap();
         let mut cfg = test_cfg();
-        cfg.fs.host_root = Some(root.clone());
+        cfg.fs.host_roots = vec![root.clone()];
 
         let overrides = crate::exec::policy::build_overrides(Some("workdir"), None, None, &cfg)
             .expect("workdir is inside the jail");
@@ -390,7 +390,7 @@ mod tests {
         let root = std::env::temp_dir().join(format!("shell-cwd-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(root.join("session")).unwrap();
         let mut cfg = test_cfg();
-        cfg.fs.host_root = Some(root.clone());
+        cfg.fs.host_roots = vec![root.clone()];
         let base = root.join("session").to_string_lossy().into_owned();
 
         let overrides = crate::exec::policy::build_overrides(None, None, Some(&base), &cfg)
@@ -503,7 +503,7 @@ mod tests {
         let root = std::env::temp_dir().join(format!("shell-cwd-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&root).unwrap();
         let mut cfg = test_cfg();
-        cfg.fs.host_root = Some(root.clone());
+        cfg.fs.host_roots = vec![root.clone()];
         let err = crate::exec::policy::build_overrides(Some("../../etc"), None, None, &cfg)
             .expect_err("escape must reject");
         assert_eq!(err.code, "S215");

--- a/shell/src/exec/host.rs
+++ b/shell/src/exec/host.rs
@@ -252,10 +252,7 @@ mod tests {
 
     fn test_cfg() -> ShellConfig {
         let mut c = ShellConfig {
-            env: crate::config::EnvConfig {
-                inherit: true,
-                ..Default::default()
-            },
+            env: crate::config::EnvConfig::inherit_all(),
             max_output_bytes: 4096,
             ..Default::default()
         };
@@ -404,18 +401,59 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
+    /// Removes the named process env vars on drop, even if the test body
+    /// panics between `set_var` and where a plain cleanup call would have
+    /// run — an assertion failure without this leaks the var into every
+    /// later test in the binary. Unique per-test var names (see the caller)
+    /// keep the residual risk to a logical leak, not a data race: full
+    /// concurrent-mutation safety would need a process-wide env mutex shared
+    /// with `code/config.rs`'s `CODER_TEST_ROOT` test, a larger change than
+    /// this test warrants on its own.
+    /// Holds [`crate::config::ENV_TEST_MUTEX`] for its whole lifetime AND
+    /// removes the named process env vars on drop, even if the test body
+    /// panics between `set_var` and where a plain cleanup call would have
+    /// run. The mutex serializes against every other test in the crate that
+    /// touches process env (see that constant's doc comment for why); the
+    /// Drop cleanup handles the panic case the mutex alone doesn't cover.
+    /// Held across `.await` below — fine under the default `#[tokio::test]`
+    /// current-thread flavor, where the outer test future need not be
+    /// `Send`.
+    struct EnvVarGuard {
+        keys: &'static [&'static str],
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+    impl EnvVarGuard {
+        fn new(keys: &'static [&'static str]) -> Self {
+            let lock = crate::config::ENV_TEST_MUTEX
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            Self { keys, _lock: lock }
+        }
+    }
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            for k in self.keys {
+                std::env::remove_var(k);
+            }
+        }
+    }
+
     /// With `env.inherit: false`, the child env is scrubbed to exactly the
     /// `env.allow` keys: an allowed worker var round-trips, a non-allowed one
     /// never reaches the child. (Unit twin of the e2e scrub/passthrough cases.)
     #[tokio::test]
     async fn inherit_false_forwards_only_allow_keys() {
-        // Unique names so parallel tests can't collide on process env state.
-        std::env::set_var("SHELL_DX_ALLOWED_9F3A", "allowed-value");
-        std::env::set_var("SHELL_DX_BLOCKED_9F3A", "blocked-value");
+        const ALLOWED: &str = "SHELL_DX_ALLOWED_9F3A";
+        const BLOCKED: &str = "SHELL_DX_BLOCKED_9F3A";
+        // Guard acquired BEFORE set_var: it holds the cross-test env mutex,
+        // so the sets below can't race with another test's env mutation.
+        let _guard = EnvVarGuard::new(&[ALLOWED, BLOCKED]);
+        std::env::set_var(ALLOWED, "allowed-value");
+        std::env::set_var(BLOCKED, "blocked-value");
 
         let mut cfg = test_cfg();
         cfg.env.inherit = false;
-        cfg.env.allow = vec!["PATH".into(), "SHELL_DX_ALLOWED_9F3A".into()];
+        cfg.env.allow = vec!["PATH".into(), ALLOWED.into()];
 
         let out = run_to_completion(
             &["env".into()],
@@ -435,9 +473,6 @@ mod tests {
             "non-allowed key scrubbed: {}",
             out.stdout
         );
-
-        std::env::remove_var("SHELL_DX_ALLOWED_9F3A");
-        std::env::remove_var("SHELL_DX_BLOCKED_9F3A");
     }
 
     /// A permitted `env` key is visible to the child process. We forward

--- a/shell/src/exec/policy.rs
+++ b/shell/src/exec/policy.rs
@@ -14,9 +14,9 @@
 //!   `allow_unjailed`), the same code path runs with no root to confine to,
 //!   matching the fs backend's unjailed behaviour.
 //! - `env` may set a VALUE only for a key the operator already put in
-//!   `cfg.allowed_env`, and NEVER for an exec-hijacking key (see
+//!   `cfg.env.allow`, and NEVER for an exec-hijacking key (see
 //!   [`DANGEROUS_ENV_KEYS`]) — those are rejected even if an operator
-//!   mistakenly lists them in `allowed_env`. Any offending key rejects the
+//!   mistakenly lists them in `env.allow`. Any offending key rejects the
 //!   WHOLE call `S210` (we never silently drop a key — the agent must learn its
 //!   env was not applied), naming the offending key and listing the permitted
 //!   ones so the agent can self-correct.
@@ -29,10 +29,10 @@ use crate::exec::error::ExecError;
 use crate::target::Target;
 
 /// Environment keys that an agent may NEVER set per-call, regardless of
-/// `allowed_env`. Setting any of these can hijack which binary the child
+/// `env.allow`. Setting any of these can hijack which binary the child
 /// actually executes or which shared libraries it loads — turning a benign
 /// allowlisted `command` into arbitrary code execution. The denylist is a
-/// HARD boundary: it wins over `allowed_env` so an operator's typo can't open
+/// HARD boundary: it wins over `env.allow` so an operator's typo can't open
 /// a privesc hole.
 ///
 /// - `PATH` / `IFS`: change which binary an allowlisted name resolves to / how
@@ -86,7 +86,7 @@ pub const DANGEROUS_ENV_KEYS: &[&str] = &[
 /// the dynamic-loader variables (`LD_*` on glibc, `DYLD_*` on macOS) — the set
 /// of these is open-ended across libc/OS versions, so an exact-name list would
 /// silently let a future `LD_SOMETHING` through if an operator widened
-/// `allowed_env`; (2) the explicit [`DANGEROUS_ENV_KEYS`] denylist for the
+/// `env.allow`; (2) the explicit [`DANGEROUS_ENV_KEYS`] denylist for the
 /// non-family names (PATH/IFS/HOME, glibc lookup paths, interpreter startup
 /// keys). Case-sensitive: env var names are case-sensitive on Unix and the
 /// dangerous names are upper-case.
@@ -102,7 +102,7 @@ pub struct ExecOverrides {
     /// Canonical, jail-confined working directory. `None` falls back to
     /// `cfg.working_dir` in `build_command`.
     pub cwd: Option<PathBuf>,
-    /// Per-call env values, already gated against `allowed_env` +
+    /// Per-call env values, already gated against `env.allow` +
     /// [`DANGEROUS_ENV_KEYS`]. Applied on top of the config-forwarded env.
     pub env: Option<BTreeMap<String, String>>,
     /// Bytes fed to the child's stdin (then EOF). `None` leaves stdin closed
@@ -249,7 +249,7 @@ fn static_code(code: &str) -> &'static str {
 }
 
 /// Validate a per-call `env` map: every key must be present in
-/// `cfg.allowed_env` AND absent from [`DANGEROUS_ENV_KEYS`]. The dangerous
+/// `cfg.env.allow` AND absent from [`DANGEROUS_ENV_KEYS`]. The dangerous
 /// check runs FIRST so a key that is both dangerous and (mistakenly)
 /// allowlisted is still rejected. On any violation the WHOLE call fails S210 —
 /// we never partially apply env, so the agent always knows whether its env took
@@ -258,12 +258,13 @@ fn validate_env(
     env: &BTreeMap<String, String>,
     cfg: &ShellConfig,
 ) -> Result<BTreeMap<String, String>, ExecError> {
-    // The keys an agent can actually set per call: in allowed_env AND not in the
-    // dangerous denylist. Listing the raw allowed_env would name HOME/PATH (both
+    // The keys an agent can actually set per call: in env.allow AND not in the
+    // dangerous denylist. Listing the raw env.allow would name HOME/PATH (both
     // default-allowed but always-rejected) as "settable", contradicting the very
     // error that rejected them and sending the agent into a retry loop.
     let settable = cfg
-        .allowed_env
+        .env
+        .allow
         .iter()
         .filter(|k| !is_dangerous_env_key(k))
         .cloned()
@@ -275,16 +276,16 @@ fn validate_env(
                 "S210",
                 format!(
                     "env key '{key}' is never settable per-call (exec-hijacking key); \
-                     remove it. Settable keys (in allowed_env, minus exec-hijacking keys): [{settable}]"
+                     remove it. Settable keys (env.allow minus exec-hijacking keys): [{settable}]"
                 ),
             ));
         }
-        if !cfg.allowed_env.iter().any(|a| a == key) {
+        if !cfg.env.allow.iter().any(|a| a == key) {
             return Err(ExecError::new(
                 "S210",
                 format!(
-                    "env key '{key}' is not in allowed_env; the operator must permit it. \
-                     Settable keys: [{settable}]"
+                    "env key '{key}' is not in the operator's env.allow list; the operator must \
+                     permit it. Settable keys: [{settable}]"
                 ),
             ));
         }
@@ -367,7 +368,10 @@ mod tests {
 
     fn cfg_jailed(root: &std::path::Path) -> ShellConfig {
         let mut c = ShellConfig {
-            allowed_env: vec!["NODE_ENV".into(), "MY_VAR".into()],
+            env: crate::config::EnvConfig {
+                allow: vec!["NODE_ENV".into(), "MY_VAR".into()],
+                ..Default::default()
+            },
             ..Default::default()
         };
         c.fs.host_root = Some(root.to_path_buf());
@@ -422,7 +426,10 @@ mod tests {
     #[test]
     fn env_in_allowed_is_accepted() {
         let c = ShellConfig {
-            allowed_env: vec!["NODE_ENV".into()],
+            env: crate::config::EnvConfig {
+                allow: vec!["NODE_ENV".into()],
+                ..Default::default()
+            },
             ..Default::default()
         };
         let mut env = BTreeMap::new();
@@ -434,7 +441,10 @@ mod tests {
     #[test]
     fn env_not_in_allowed_is_rejected_naming_key_and_listing_permitted() {
         let c = ShellConfig {
-            allowed_env: vec!["NODE_ENV".into(), "MY_VAR".into()],
+            env: crate::config::EnvConfig {
+                allow: vec!["NODE_ENV".into(), "MY_VAR".into()],
+                ..Default::default()
+            },
             ..Default::default()
         };
         let mut env = BTreeMap::new();
@@ -460,10 +470,13 @@ mod tests {
 
     #[test]
     fn dangerous_key_rejected_even_when_allowlisted() {
-        // The denylist must WIN over allowed_env: an operator typo listing
+        // The denylist must WIN over env.allow: an operator typo listing
         // LD_PRELOAD must not open a code-injection hole.
         let c = ShellConfig {
-            allowed_env: vec!["LD_PRELOAD".into()],
+            env: crate::config::EnvConfig {
+                allow: vec!["LD_PRELOAD".into()],
+                ..Default::default()
+            },
             ..Default::default()
         };
         let mut env = BTreeMap::new();

--- a/shell/src/exec/policy.rs
+++ b/shell/src/exec/policy.rs
@@ -8,11 +8,11 @@
 //!
 //! Gating rules (mandatory, not best-effort):
 //! - `cwd` is confined to the SAME jail the fs backend enforces — it is
-//!   canonicalized and must `starts_with(host_root)` and miss the denylist,
-//!   exactly like `shell::fs::*` paths. A `cwd` resolving outside the jail is
-//!   rejected `S215`. When `fs.host_root` is unset (operator opted into
-//!   `allow_unjailed`), the same code path runs with no root to confine to,
-//!   matching the fs backend's unjailed behaviour.
+//!   canonicalized and must resolve inside a jail root (`fs.host_roots`) and
+//!   miss the denylist, exactly like `shell::fs::*` paths. A `cwd` resolving
+//!   outside the jail is rejected `S215`. When `fs.host_roots` is empty
+//!   (operator opted into `allow_unjailed`), the same code path runs with no
+//!   root to confine to, matching the fs backend's unjailed behaviour.
 //! - `env` may set a VALUE only for a key the operator already put in
 //!   `cfg.env.allow`, and NEVER for an exec-hijacking key (see
 //!   [`DANGEROUS_ENV_KEYS`]) — those are rejected even if an operator
@@ -121,7 +121,7 @@ impl ExecOverrides {
     }
 }
 
-/// Canonicalize `host_root` + every `denylist_paths` entry the same way
+/// Canonicalize every jail root + every `denylist_paths` entry the same way
 /// `HostFsBackend::try_new` does, so the confinement helpers see the identical
 /// inputs. An unreachable root is an operator config error (surfaced S216); a
 /// non-existent denylist entry can't be escaped through, so it is kept as-is.
@@ -131,7 +131,7 @@ fn jail_inputs(cfg: &ShellConfig) -> Result<(Vec<PathBuf>, Vec<PathBuf>), ExecEr
         let canon = std::fs::canonicalize(&root).map_err(|e| {
             ExecError::new(
                 "S216",
-                format!("host_root unreachable ({}): {e}", root.display()),
+                format!("jail root unreachable ({}): {e}", root.display()),
             )
         })?;
         if !host_roots_canon.contains(&canon) {
@@ -211,8 +211,9 @@ fn confine_base_dir(
 /// same one `shell::fs::*` enforces: canonicalize → `starts_with(root)` →
 /// denylist. When `base_dir_canon` is set the confinement root is the session
 /// directory (relative `cwd` anchors there; an absolute `cwd` outside it is
-/// S220); otherwise it is `host_root` (unchanged). Per-call (not cached like
-/// the fs backend) because the exec handler reads the live config snapshot.
+/// S220); otherwise it is the jail roots (unchanged). Per-call (not cached
+/// like the fs backend) because the exec handler reads the live config
+/// snapshot.
 fn confine_cwd(
     cwd: &str,
     host_roots_canon: &[PathBuf],
@@ -302,8 +303,9 @@ fn validate_env(
 /// BOTH the confinement root for `cwd` AND the effective working directory when
 /// no `cwd` is given.
 ///
-/// - `base_dir=None`: today's behaviour — `cwd` is confined to `host_root` and
-///   an omitted `cwd` leaves the working dir to fall back to `cfg.working_dir`.
+/// - `base_dir=None`: today's behaviour — `cwd` is confined to the jail roots
+///   and an omitted `cwd` leaves the working dir to fall back to
+///   `cfg.working_dir`.
 /// - `base_dir=Some`, `cwd=None`: the child runs in `base_dir`.
 /// - `base_dir=Some`, `cwd=Some`: the child runs in `cwd`, which must resolve
 ///   inside `base_dir` (relative anchors there; an absolute cwd outside it is
@@ -374,7 +376,7 @@ mod tests {
             },
             ..Default::default()
         };
-        c.fs.host_root = Some(root.to_path_buf());
+        c.fs.host_roots = vec![root.to_path_buf()];
         c
     }
 
@@ -488,7 +490,7 @@ mod tests {
     }
 
     /// Test shim: derive the canonical jail inputs from `cfg` and confine `cwd`
-    /// against `host_root` with NO session base_dir, so the existing
+    /// against the jail roots with NO session base_dir, so the existing
     /// no-base_dir cwd tests keep asserting the same contract against the new
     /// four-arg `confine_cwd`.
     fn confine_cwd_via_cfg(cwd: &str, cfg: &ShellConfig) -> Result<PathBuf, ExecError> {
@@ -550,7 +552,7 @@ mod tests {
 
     // --- per-call base_dir (session scope) ---
 
-    /// With base_dir set, a relative cwd anchors at base_dir (not host_root),
+    /// With base_dir set, a relative cwd anchors at base_dir (not the jail root),
     /// and an OMITTED cwd makes base_dir itself the working directory.
     #[test]
     fn base_dir_anchors_relative_cwd_and_becomes_default_cwd() {
@@ -567,7 +569,7 @@ mod tests {
             "omitted cwd defaults to base_dir"
         );
 
-        // relative cwd anchors at base_dir, not host_root.
+// relative cwd anchors at base_dir, not the jail root.
         let ov =
             build_overrides(Some("inner"), None, Some(&base), &c).expect("inner is under base_dir");
         assert_eq!(
@@ -578,10 +580,10 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
-    /// DX-1: an ABSOLUTE cwd that is inside host_root but OUTSIDE base_dir is
+    /// DX-1: an ABSOLUTE cwd that is inside the jail but OUTSIDE base_dir is
     /// rejected with the new S220 code, and the message names the session dir.
     #[test]
-    fn abs_cwd_inside_host_root_but_outside_base_dir_is_s220_naming_session() {
+    fn abs_cwd_inside_jail_but_outside_base_dir_is_s220_naming_session() {
         let root = std::env::temp_dir().join(format!("shell-policy-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(root.join("session")).unwrap();
         std::fs::create_dir_all(root.join("other")).unwrap();
@@ -599,17 +601,17 @@ mod tests {
         );
         // It must NOT reuse the generic 'outside every allowed root' S215 wording.
         assert!(
-            !err.message.contains("escapes host_root"),
+            !err.message.contains("escapes the fs jail"),
             "must not contradict the tool's own roots, got: {}",
             err.message
         );
         std::fs::remove_dir_all(&root).ok();
     }
 
-    /// An absolute selected base_dir outside the configured host root is
+    /// An absolute selected base_dir outside the configured jail roots is
     /// trusted as the working directory root for exec.
     #[test]
-    fn absolute_base_dir_outside_host_root_is_honored() {
+    fn absolute_base_dir_outside_jail_roots_is_honored() {
         let root = std::env::temp_dir().join(format!("shell-policy-{}", uuid::Uuid::new_v4()));
         let selected =
             std::env::temp_dir().join(format!("shell-policy-selected-{}", uuid::Uuid::new_v4()));
@@ -634,7 +636,7 @@ mod tests {
     }
 
     /// `base_dir` is trusted harness metadata, so relative values are rejected
-    /// instead of interpreted relative to host_root.
+    /// instead of interpreted relative to the jail root.
     #[test]
     fn relative_base_dir_is_rejected() {
         let root = std::env::temp_dir().join(format!("shell-policy-{}", uuid::Uuid::new_v4()));
@@ -646,7 +648,7 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
-    /// With no session scope, a relative cwd still anchors at host_root and an
+    /// With no session scope, a relative cwd still anchors at the primary jail root and an
     /// omitted cwd stays None (build_command then falls back to cfg.working_dir).
     #[test]
     fn base_dir_none_is_unchanged_behaviour() {
@@ -661,12 +663,12 @@ mod tests {
             "no base_dir, no cwd ⇒ None (prior behaviour)"
         );
 
-        // Relative cwd still anchors at host_root when base_dir is absent.
+// Relative cwd still anchors at the primary jail root when base_dir is absent.
         let ov = build_overrides(Some("sub"), None, None, &c).expect("ok");
         assert_eq!(
             ov.cwd.as_deref(),
             Some(root.join("sub").canonicalize().unwrap().as_path()),
-            "relative cwd anchors at host_root when base_dir is absent"
+            "relative cwd anchors at the primary jail root when base_dir is absent"
         );
         std::fs::remove_dir_all(&root).ok();
     }

--- a/shell/src/exec/policy.rs
+++ b/shell/src/exec/policy.rs
@@ -569,7 +569,7 @@ mod tests {
             "omitted cwd defaults to base_dir"
         );
 
-// relative cwd anchors at base_dir, not the jail root.
+        // relative cwd anchors at base_dir, not the jail root.
         let ov =
             build_overrides(Some("inner"), None, Some(&base), &c).expect("inner is under base_dir");
         assert_eq!(
@@ -663,7 +663,7 @@ mod tests {
             "no base_dir, no cwd ⇒ None (prior behaviour)"
         );
 
-// Relative cwd still anchors at the primary jail root when base_dir is absent.
+        // Relative cwd still anchors at the primary jail root when base_dir is absent.
         let ov = build_overrides(Some("sub"), None, None, &c).expect("ok");
         assert_eq!(
             ov.cwd.as_deref(),

--- a/shell/src/fs/host.rs
+++ b/shell/src/fs/host.rs
@@ -73,8 +73,7 @@ impl ChannelMaker for IiiChannelMaker {
 #[derive(Debug, Clone, Default)]
 pub struct HostFsConfig {
     /// Effective jail roots (index 0 = primary; empty = unjailed). Built from
-    /// `FsConfig::roots()` so the legacy single `host_root` and the
-    /// `host_roots` list both land here as one canonical list.
+    /// `FsConfig::roots()` (the `fs.host_roots` list) as one canonical list.
     pub host_roots: Vec<PathBuf>,
     pub max_read_bytes: usize,
     pub max_write_bytes: usize,
@@ -182,7 +181,7 @@ impl HostFsBackend {
         }
     }
 
-    /// Resolve `host_root` and every `denylist_paths` entry to canonical form
+    /// Resolve every jail root and `denylist_paths` entry to canonical form
     /// once at startup. Errors here are operator config bugs (path doesn't
     /// exist, can't be canonicalized, etc.) and the worker should refuse to
     /// start instead of degrading to lexical fallback per-call.
@@ -192,7 +191,7 @@ impl HostFsBackend {
             let canon = std::fs::canonicalize(root).map_err(|e| {
                 FsError::new(
                     "S216",
-                    format!("host_root unreachable ({}): {e}", root.display()),
+                    format!("jail root unreachable ({}): {e}", root.display()),
                 )
             })?;
             // Dedup after canonicalization (a root listed twice, or once
@@ -310,7 +309,7 @@ impl HostFsBackend {
     /// `base_dir` is in effect, a relative operand must anchor at `base_dir`
     /// (the directory `validate_path_scoped` validated against) so the
     /// validated and operated-on paths cannot diverge. `None` ⇒ delegates to
-    /// [`Self::lexical_operand`] (the unchanged `host_root`-anchored operand).
+    /// [`Self::lexical_operand`] (the unchanged primary-root-anchored operand).
     fn lexical_operand_scoped(&self, path: &str, base_dir_canon: Option<&Path>) -> PathBuf {
         match base_dir_canon {
             None => self.lexical_operand(path),
@@ -329,7 +328,7 @@ impl HostFsBackend {
 ///
 /// `pub(crate)` so the exec backend can confine a per-call `cwd` against the
 /// SAME jail the fs backend enforces (shell::exec/exec_bg `cwd`) instead of
-/// duplicating the canonicalize / starts_with(host_root) / denylist logic.
+/// duplicating the canonicalize / jail-root containment / denylist logic.
 pub(crate) fn confine_path(
     path: &str,
     host_roots_canon: &[PathBuf],
@@ -501,9 +500,9 @@ fn confine_base_dir(
 
 /// base_dir-aware jail confinement, LAYERED on top of [`confine_path`]. When
 /// `base_dir_canon` is `Some`, the call is scoped to that session directory:
-/// relative paths anchor at `base_dir` (not `host_root`) and the resolved path
+/// relative paths anchor at `base_dir` (not the primary jail root) and the resolved path
 /// must land INSIDE `base_dir`. When it is `None`, this is exactly
-/// [`confine_path`] against `host_root`.
+/// [`confine_path`] against the jail roots.
 ///
 /// The core jail algorithm (`confine_path` →
 /// `canonicalize_with_fallback`/`normalize_lexical`) is reused verbatim, not
@@ -511,7 +510,7 @@ fn confine_base_dir(
 /// relative-anchor and the containment check. The only addition is the DX-1
 /// error refinement: an ABSOLUTE path that is inside a configured host root but
 /// outside `base_dir` is rejected with S220 naming the session directory,
-/// instead of the generic "escapes host_root" S215.
+/// instead of the generic "escapes the fs jail roots" S215.
 ///
 /// `pub(crate)` so the exec backend can confine a per-call `cwd` against the
 /// SAME session-scoped jail (shell::exec/exec_bg `base_dir`) instead of
@@ -542,9 +541,9 @@ pub(crate) fn confine_path_with_base_dir(
             // path under the session directory rather than guessing roots.
             if e.code == "S215" && Path::new(path).is_absolute() {
                 if let Ok(canon) = canonicalize_with_fallback(Path::new(path)) {
-                    let inside_host_root = host_roots_canon.iter().any(|hr| canon.starts_with(hr));
+                    let inside_jail_root = host_roots_canon.iter().any(|hr| canon.starts_with(hr));
                     let denied = denylist_canon.iter().any(|d| canon.starts_with(d));
-                    if inside_host_root && !canon.starts_with(base) && !denied {
+                    if inside_jail_root && !canon.starts_with(base) && !denied {
                         return Err(FsError::new(
                             "S220",
                             format!(
@@ -857,7 +856,7 @@ impl FsBackend for HostFsBackend {
         // Jail validation runs here, on the async fn, BEFORE the blocking work.
         // A per-call base_dir (when set) scopes both the relative anchor and the
         // containment ceiling to the session directory; None ⇒ the unchanged
-        // host_root jail.
+        // configured jail.
         let base = self.confine_base_dir(req.base_dir.as_deref())?;
         let p = self.validate_path_scoped(&req.path, base.as_deref())?;
         // The symlink_metadata stat, read_dir, and the per-entry
@@ -1415,7 +1414,7 @@ impl FsBackend for HostFsBackend {
         // a `sed --path=large-dir --recursive` stalled the executor for the
         // entire traversal — exactly what spawn_blocking was meant to prevent.
         // We move it all into the closure. The per-file jail confinement
-        // (confine_path: starts_with(host_root) + denylist) still runs for
+        // (confine_path: jail-root containment + denylist) still runs for
         // EVERY file — it just runs on the blocking thread now, with owned
         // copies of the precomputed canonical root + denylist (compiled
         // regexes are Send+Sync and move in too). Streaming read/write paths
@@ -1433,7 +1432,7 @@ impl FsBackend for HostFsBackend {
         let non_accessible = self.non_accessible.clone();
         // Resolve the optional session base_dir up front (on the async fn) so the
         // blocking closure confines + anchors every operand to it instead of the
-        // global host_root. None ⇒ unchanged host_root behaviour.
+        // global jail roots. None ⇒ unchanged jail behaviour.
         let base_dir_canon = self.confine_base_dir(req.base_dir.as_deref())?;
         let access_roots = access_roots(&host_roots_canon, base_dir_canon.as_deref());
         // Per-file read cap: sed builds a same-size output String in memory, so
@@ -1913,7 +1912,7 @@ mod tests {
     }
 
     #[test]
-    fn try_new_returns_err_on_unreachable_host_root() {
+    fn try_new_returns_err_on_unreachable_jail_root() {
         let cfg = Arc::new(HostFsConfig {
             host_roots: vec![PathBuf::from("/nonexistent/shell-jail-xyz")],
             ..HostFsConfig::default()
@@ -2031,7 +2030,7 @@ mod tests {
     }
 
     #[test]
-    fn relative_path_resolves_under_host_root() {
+    fn relative_path_resolves_under_jail_root() {
         // Regression: agents commonly probe with `.` or bare names; under a
         // jail there is exactly one sensible base, so resolve instead of
         // erroring with S210.
@@ -2049,7 +2048,7 @@ mod tests {
     }
 
     #[test]
-    fn relative_dotdot_cannot_escape_host_root() {
+    fn relative_dotdot_cannot_escape_jail_root() {
         let root = tmp();
         let cfg = HostFsConfig {
             host_roots: vec![root.clone()],
@@ -2061,7 +2060,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_path_rejected_even_under_host_root() {
+    fn empty_path_rejected_even_under_jail_root() {
         let root = tmp();
         let cfg = HostFsConfig {
             host_roots: vec![root],
@@ -2073,10 +2072,10 @@ mod tests {
     }
 
     #[test]
-    fn escape_error_names_the_host_root() {
-        // Regression: "path escapes host_root: <path>" gave the caller no way
-        // to recover — the agent burned turns guessing. The message must name
-        // the jail root.
+    fn escape_error_names_the_jail_root() {
+        // Regression: the pre-fix S215 wording named no root at all ("path
+        // escapes the jail: <path>"), giving the caller no way to recover —
+        // the agent burned turns guessing. The message must name the jail root.
         let root = tmp();
         let cfg = HostFsConfig {
             host_roots: vec![root.clone()],
@@ -2088,13 +2087,13 @@ mod tests {
         let root_canon = root.canonicalize().unwrap();
         assert!(
             err.message.contains(&root_canon.display().to_string()),
-            "S215 message must name host_root, got: {}",
+            "S215 message must name the jail root, got: {}",
             err.message
         );
     }
 
     #[test]
-    fn empty_path_rejected_without_host_root() {
+    fn empty_path_rejected_when_unjailed() {
         let h = stub_backend(HostFsConfig::default());
         let err = h.validate_path("").unwrap_err();
         assert_eq!(err.code, "S210");
@@ -2102,7 +2101,7 @@ mod tests {
 
     #[tokio::test]
     async fn rm_relative_path_operates_on_jail_file_not_cwd() {
-        // Regression: rm validated host_root/<rel> but removed <cwd>/<rel>
+        // Regression: rm validated <jail root>/<rel> but removed <cwd>/<rel>
         // (the operand was rebuilt from the raw request string). The operand
         // must be the SAME jail-anchored path validate_path saw.
         let root = tmp();
@@ -2326,7 +2325,7 @@ mod tests {
         let root_canon = root.canonicalize().unwrap();
         assert!(
             err.message.contains(&root_canon.display().to_string()),
-            "S215 message must name host_root, got: {}",
+            "S215 message must name the jail root, got: {}",
             err.message
         );
     }
@@ -2338,7 +2337,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_path_outside_host_root() {
+    fn rejects_path_outside_jail_root() {
         let root = tmp();
         let cfg = HostFsConfig {
             host_roots: vec![root.clone()],
@@ -2350,7 +2349,7 @@ mod tests {
     }
 
     #[test]
-    fn allows_descendant_of_host_root() {
+    fn allows_descendant_of_jail_root() {
         let root = tmp();
         fs::create_dir(root.join("sub")).unwrap();
         let cfg = HostFsConfig {
@@ -2915,7 +2914,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn write_rejects_path_outside_host_root_with_s215() {
+    async fn write_rejects_path_outside_jail_root_with_s215() {
         let root = tmp();
         let cfg = HostFsConfig {
             host_roots: vec![root.clone()],
@@ -3101,7 +3100,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn read_rejects_path_outside_host_root_with_s215() {
+    async fn read_rejects_path_outside_jail_root_with_s215() {
         let root = tmp();
         let cfg = HostFsConfig {
             host_roots: vec![root.clone()],
@@ -3739,9 +3738,9 @@ mod tests {
     }
 
     // --- jail escape via a LIVE (non-dangling) symlink whose target is
-    // outside the jail. The canonicalize + starts_with(host_root) gate in
+    // outside the jail. The canonicalize + jail-root containment gate in
     // validate_path is the core security control; this exact vector was
-    // untested. We point host_root/escape at a real existing dir outside the
+    // untested. We point <jail root>/escape at a real existing dir outside the
     // jail and assert read/stat/ls all reject with S215.
 
     #[tokio::test]
@@ -3795,8 +3794,8 @@ mod tests {
         })
     }
 
-    /// A write with a relative path anchors at base_dir, not at host_root: the
-    /// file lands under <host_root>/session/, proving base_dir re-anchors the
+    /// A write with a relative path anchors at base_dir, not at the jail root: the
+    /// file lands under <jail root>/session/, proving base_dir re-anchors the
     /// relative path.
     #[tokio::test]
     async fn write_relative_path_anchors_at_base_dir() {
@@ -3819,13 +3818,13 @@ mod tests {
             fs::read_to_string(root.join("session/out.txt")).unwrap(),
             "scoped\n"
         );
-        // It must NOT have landed at the host_root level.
+        // It must NOT have landed at the jail-root level.
         assert!(!root.join("out.txt").exists());
     }
 
     /// rm with a relative path is confined to base_dir: the victim under
-    /// <host_root>/session is removed, while an identically-named file at the
-    /// host_root level is untouched.
+    /// <jail root>/session is removed, while an identically-named file at the
+    /// jail-root level is untouched.
     #[tokio::test]
     async fn rm_relative_path_is_confined_to_base_dir() {
         let root = tmp();
@@ -3849,7 +3848,7 @@ mod tests {
         );
         assert!(
             root.join("victim.txt").exists(),
-            "host_root sibling untouched — rm was confined to base_dir"
+            "jail-root sibling untouched — rm was confined to base_dir"
         );
     }
 
@@ -3878,18 +3877,18 @@ mod tests {
         );
     }
 
-    /// DX-1: an ABSOLUTE path that is inside host_root but OUTSIDE base_dir is
+    /// DX-1: an ABSOLUTE path that is inside the jail root but OUTSIDE base_dir is
     /// rejected with the new S220 code, and the message NAMES the session dir
-    /// (not the generic "escapes host_root" S215, which would contradict the
+    /// (not the generic "escapes the fs jail" S215, which would contradict the
     /// tool's own configured roots).
     #[tokio::test]
-    async fn abs_path_inside_host_root_outside_base_dir_is_s220_naming_session() {
+    async fn abs_path_inside_jail_root_outside_base_dir_is_s220_naming_session() {
         let root = tmp();
         fs::create_dir_all(root.join("session")).unwrap();
         fs::create_dir_all(root.join("other")).unwrap();
         fs::write(root.join("other/secret.txt"), "x").unwrap();
         let b = jailed_backend(&root);
-        // Absolute path that resolves inside host_root/other — a sibling of the
+        // Absolute path that resolves inside <jail root>/other — a sibling of the
         // session dir, still inside an allowed root, but not this session.
         let abs = root.join("other/secret.txt").canonicalize().unwrap();
         let base = root.join("session").to_string_lossy().into_owned();
@@ -3908,7 +3907,7 @@ mod tests {
             err.message
         );
         assert!(
-            !err.message.contains("escapes host_root"),
+            !err.message.contains("escapes the fs jail"),
             "must not reuse the generic jail-escape wording, got: {}",
             err.message
         );
@@ -3918,7 +3917,7 @@ mod tests {
     /// sits outside the configured host roots. The operation is then confined
     /// under that selected directory.
     #[tokio::test]
-    async fn base_dir_outside_host_root_is_honored_as_selected_root() {
+    async fn base_dir_outside_jail_root_is_honored_as_selected_root() {
         let root = tmp();
         let selected = tmp();
         fs::create_dir_all(selected.join("project")).unwrap();
@@ -3936,7 +3935,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn base_dir_outside_host_root_still_applies_non_accessible_globs() {
+    async fn base_dir_outside_jail_root_still_applies_non_accessible_globs() {
         let root = tmp();
         let selected = tmp();
         fs::write(selected.join(".env"), "secret").unwrap();
@@ -3969,11 +3968,11 @@ mod tests {
         assert_eq!(err.code, "S210");
     }
 
-    /// A genuinely jail-escaping absolute path (outside host_root entirely)
+    /// A genuinely jail-escaping absolute path (outside the jail root entirely)
     /// under a base_dir still rejects S215 — the DX-1 refinement only applies
     /// to paths that ARE inside an allowed root.
     #[tokio::test]
-    async fn abs_path_outside_host_root_under_base_dir_still_s215() {
+    async fn abs_path_outside_jail_root_under_base_dir_still_s215() {
         let root = tmp();
         fs::create_dir_all(root.join("session")).unwrap();
         let b = jailed_backend(&root);
@@ -3988,10 +3987,10 @@ mod tests {
         assert_eq!(err.code, "S215", "outside every allowed root stays S215");
     }
 
-    /// With no session scope, a relative write still anchors at host_root (not
+    /// With no session scope, a relative write still anchors at the jail root (not
     /// at any session dir).
     #[tokio::test]
-    async fn base_dir_none_reproduces_host_root_anchoring() {
+    async fn base_dir_none_reproduces_jail_root_anchoring() {
         let root = tmp();
         let b = jailed_backend(&root);
         let resp = b
@@ -4003,12 +4002,12 @@ mod tests {
                 base_dir: None,
             })
             .await
-            .expect("relative write with base_dir=None anchors at host_root");
+            .expect("relative write with base_dir=None anchors at the jail root");
         assert_eq!(resp.bytes_written, 7);
         assert_eq!(
             fs::read_to_string(root.join("top.txt")).unwrap(),
             "legacy\n",
-            "base_dir=None ⇒ anchors at host_root exactly as before"
+            "base_dir=None ⇒ anchors at the jail root exactly as before"
         );
     }
 }

--- a/shell/src/fs/mod.rs
+++ b/shell/src/fs/mod.rs
@@ -224,7 +224,7 @@ pub struct LsRequest {
     /// host (default) or { kind: "sandbox", sandbox_id }.
     #[serde(default)]
     pub target: Target,
-    /// Jail-relative when fs.host_root is set, else absolute.
+    /// Jail-relative when fs.host_roots is set, else absolute.
     pub path: String,
     /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
@@ -248,7 +248,7 @@ pub struct StatRequest {
     /// host (default) or { kind: "sandbox", sandbox_id }.
     #[serde(default)]
     pub target: Target,
-    /// Jail-relative when fs.host_root is set, else absolute.
+    /// Jail-relative when fs.host_roots is set, else absolute.
     pub path: String,
     /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]
@@ -272,7 +272,7 @@ pub struct MkdirRequest {
     /// host (default) or { kind: "sandbox", sandbox_id }.
     #[serde(default)]
     pub target: Target,
-    /// Jail-relative when fs.host_root is set, else absolute.
+    /// Jail-relative when fs.host_roots is set, else absolute.
     pub path: String,
     /// Octal permission string, e.g. "0755".
     #[serde(default = "default_mkdir_mode")]
@@ -304,7 +304,7 @@ pub struct RmRequest {
     /// host (default) or { kind: "sandbox", sandbox_id }.
     #[serde(default)]
     pub target: Target,
-    /// Jail-relative when fs.host_root is set, else absolute.
+    /// Jail-relative when fs.host_roots is set, else absolute.
     pub path: String,
     /// Required to delete a non-empty directory.
     #[serde(default)]
@@ -332,7 +332,7 @@ pub struct ChmodRequest {
     /// host (default) or { kind: "sandbox", sandbox_id }.
     #[serde(default)]
     pub target: Target,
-    /// Jail-relative when fs.host_root is set, else absolute.
+    /// Jail-relative when fs.host_roots is set, else absolute.
     pub path: String,
     /// Octal permission string, e.g. "0755".
     pub mode: String,
@@ -371,9 +371,9 @@ pub struct MvRequest {
     /// host (default) or { kind: "sandbox", sandbox_id }.
     #[serde(default)]
     pub target: Target,
-    /// Source path; jail-relative when fs.host_root is set, else absolute.
+    /// Source path; jail-relative when fs.host_roots is set, else absolute.
     pub src: String,
-    /// Destination path; jail-relative when fs.host_root is set, else absolute.
+    /// Destination path; jail-relative when fs.host_roots is set, else absolute.
     pub dst: String,
     /// Replace an existing destination instead of returning an error.
     #[serde(default)]
@@ -402,7 +402,7 @@ pub struct GrepRequest {
     /// host (default) or { kind: "sandbox", sandbox_id }.
     #[serde(default)]
     pub target: Target,
-    /// Jail-relative when fs.host_root is set, else absolute.
+    /// Jail-relative when fs.host_roots is set, else absolute.
     pub path: String,
     /// Rust regex (RE2-like) matched against each line.
     pub pattern: String,
@@ -532,7 +532,7 @@ impl From<WriteContentWire> for WriteContent {
 /// One file in a batch `shell::fs::write` (`files: [...]`).
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct WriteFileSpec {
-    /// Jail-relative when fs.host_root is set, else absolute.
+    /// Jail-relative when fs.host_roots is set, else absolute.
     pub path: String,
     /// Inline string (recommended) or a streaming ContentRef.
     pub content: WriteContentWire,
@@ -549,7 +549,7 @@ pub struct WriteRequest {
     /// host (default) or { kind: "sandbox", sandbox_id }.
     #[serde(default)]
     pub target: Target,
-    /// Single-file form: the path to write. Jail-relative when fs.host_root is
+    /// Single-file form: the path to write. Jail-relative when fs.host_roots is
     /// set, else absolute. Omit when using `files`.
     #[serde(default)]
     pub path: Option<String>,
@@ -650,7 +650,7 @@ pub struct ReadRequest {
     /// host (default) or { kind: "sandbox", sandbox_id }.
     #[serde(default)]
     pub target: Target,
-    /// Jail-relative when fs.host_root is set, else absolute.
+    /// Jail-relative when fs.host_roots is set, else absolute.
     pub path: String,
     /// Internal harness-scoped working directory; omitted from published schema.
     #[serde(default)]

--- a/shell/src/functions/exec.rs
+++ b/shell/src/functions/exec.rs
@@ -31,7 +31,7 @@ pub async fn handle(
     cfg.is_command_allowed(&argv)?;
 
     // Gate the per-call cwd/env BEFORE picking a backend. A jail-escaping cwd
-    // (S215) or an env key outside allowed_env / in DANGEROUS_ENV_KEYS (S210)
+    // (S215) or an env key outside env.allow / in DANGEROUS_ENV_KEYS (S210)
     // rejects here, carrying the S-code to the wire via From<ExecError>. The
     // sandbox backend additionally rejects any populated override (host-only).
     // `base_dir` only scopes the host working directory: drop it for a sandbox

--- a/shell/src/functions/exec_bg.rs
+++ b/shell/src/functions/exec_bg.rs
@@ -502,10 +502,7 @@ mod host_path_tests {
     // (0 → unbounded bg job.)
     fn cfg(bg_cap_ms: u64, max_concurrent_jobs: usize) -> Arc<ShellConfig> {
         let mut c = ShellConfig {
-            env: crate::config::EnvConfig {
-                inherit: true,
-                ..Default::default()
-            },
+            env: crate::config::EnvConfig::inherit_all(),
             max_output_bytes: 4096,
             max_timeout_ms: bg_cap_ms,
             max_bg_timeout_ms: bg_cap_ms,
@@ -793,10 +790,7 @@ mod sandbox_path_tests {
 
     fn cfg_open() -> Arc<ShellConfig> {
         let mut c = ShellConfig {
-            env: crate::config::EnvConfig {
-                inherit: true,
-                ..Default::default()
-            },
+            env: crate::config::EnvConfig::inherit_all(),
             max_output_bytes: 4096,
             ..Default::default()
         };

--- a/shell/src/functions/exec_bg.rs
+++ b/shell/src/functions/exec_bg.rs
@@ -40,7 +40,7 @@ pub async fn handle(
     cfg.is_command_allowed(&argv)?;
 
     // Gate the per-call cwd/env up front, BEFORE branching on target. Same
-    // rules as shell::exec (jail-confined cwd, allowed_env + dangerous-key env
+    // rules as shell::exec (jail-confined cwd, env.allow + dangerous-key env
     // gating). exec_bg returns its spawn-time failures as plain strings (its
     // documented contract), so we stringify the S-code into the message — the
     // agent still sees the code (e.g. "S215") and the self-correcting text.
@@ -502,7 +502,10 @@ mod host_path_tests {
     // (0 → unbounded bg job.)
     fn cfg(bg_cap_ms: u64, max_concurrent_jobs: usize) -> Arc<ShellConfig> {
         let mut c = ShellConfig {
-            inherit_env: true,
+            env: crate::config::EnvConfig {
+                inherit: true,
+                ..Default::default()
+            },
             max_output_bytes: 4096,
             max_timeout_ms: bg_cap_ms,
             max_bg_timeout_ms: bg_cap_ms,
@@ -790,7 +793,10 @@ mod sandbox_path_tests {
 
     fn cfg_open() -> Arc<ShellConfig> {
         let mut c = ShellConfig {
-            inherit_env: true,
+            env: crate::config::EnvConfig {
+                inherit: true,
+                ..Default::default()
+            },
             max_output_bytes: 4096,
             ..Default::default()
         };

--- a/shell/src/functions/kill.rs
+++ b/shell/src/functions/kill.rs
@@ -189,7 +189,10 @@ mod host_kill_tests {
 
     fn open_cfg() -> ShellConfig {
         let mut c = ShellConfig {
-            inherit_env: true,
+            env: crate::config::EnvConfig {
+                inherit: true,
+                ..Default::default()
+            },
             max_output_bytes: 4096,
             ..Default::default()
         };

--- a/shell/src/functions/kill.rs
+++ b/shell/src/functions/kill.rs
@@ -189,10 +189,7 @@ mod host_kill_tests {
 
     fn open_cfg() -> ShellConfig {
         let mut c = ShellConfig {
-            env: crate::config::EnvConfig {
-                inherit: true,
-                ..Default::default()
-            },
+            env: crate::config::EnvConfig::inherit_all(),
             max_output_bytes: 4096,
             ..Default::default()
         };

--- a/shell/src/functions/types.rs
+++ b/shell/src/functions/types.rs
@@ -118,10 +118,10 @@ pub struct ExecRequest {
     #[schemars(skip)]
     pub base_dir: Option<String>,
     /// Optional per-call environment values (host target only). A key may be
-    /// set ONLY if the operator listed it in `allowed_env`, and NEVER for an
+    /// set ONLY if the operator listed it in `env.allow`, and NEVER for an
     /// exec-hijacking key (PATH, IFS, HOME, LD_*/DYLD_*, and other loader/lookup
     /// and interpreter-startup keys — see DANGEROUS_ENV_KEYS) — those are
-    /// rejected even if allowlisted. Supplying a key that is not in `allowed_env`,
+    /// rejected even if allowlisted. Supplying a key that is not in `env.allow`,
     /// or any dangerous key, rejects the WHOLE call (S210) naming the offending
     /// key; the env is never silently dropped. Permitted values override what
     /// would otherwise be forwarded for that key. Rejected (S210) on a sandbox target.
@@ -168,7 +168,7 @@ pub struct ExecBgRequest {
     #[schemars(skip)]
     pub base_dir: Option<String>,
     /// Optional per-call environment values (host target only). Same gating as
-    /// [`ExecRequest::env`]: a key must be in `allowed_env` and must not be an
+    /// [`ExecRequest::env`]: a key must be in `env.allow` and must not be an
     /// exec-hijacking key (PATH, IFS, HOME, LD_*/DYLD_*, and other loader/lookup
     /// and interpreter-startup keys — see DANGEROUS_ENV_KEYS); any violation
     /// rejects the whole call (S210). Rejected (S210) on a sandbox target.

--- a/shell/src/functions/types.rs
+++ b/shell/src/functions/types.rs
@@ -107,8 +107,8 @@ pub struct ExecRequest {
     pub timeout_ms: Option<u64>,
     /// Optional working directory for this call (host target only). Confined to
     /// the fs jail exactly like `shell::fs::*` paths: jail-relative when
-    /// `fs.host_root` is set (else absolute), canonicalized, and must resolve
-    /// inside `host_root` and miss the denylist — a path that escapes returns
+    /// `fs.host_roots` is set (else absolute), canonicalized, and must resolve
+    /// inside a jail root and miss the denylist — a path that escapes returns
     /// S215. Must already exist and be a directory. Omit to use the configured
     /// `working_dir` (unchanged default). Rejected (S210) on a sandbox target.
     #[serde(default)]
@@ -159,7 +159,7 @@ pub struct ExecBgRequest {
     pub timeout_ms: Option<u64>,
     /// Optional working directory for this job (host target only). Same jail
     /// confinement and rules as [`ExecRequest::cwd`]: canonicalized, must
-    /// resolve inside `host_root` (S215 on escape) and be an existing
+    /// resolve inside a jail root (S215 on escape) and be an existing
     /// directory. Rejected (S210) on a sandbox target.
     #[serde(default)]
     pub cwd: Option<String>,

--- a/shell/src/functions/workspace.rs
+++ b/shell/src/functions/workspace.rs
@@ -172,7 +172,7 @@ mod tests {
     }
 
     #[test]
-    fn roots_include_configured_host_root_and_operator_anchors() {
+    fn roots_include_configured_jail_root_and_operator_anchors() {
         let jail = tempdir().unwrap();
         let cfg = cfg_with_root(jail.path().to_path_buf());
 

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -155,11 +155,6 @@ async fn main() -> Result<()> {
         .map_err(anyhow::Error::msg)
         .context("registering shell configuration schema")?;
 
-    // One-shot, best-effort fold of a legacy `coder` config entry into the
-    // `shell` value (never-widen; idempotent). Runs after schema registration
-    // and before the fetch below so the merged value is what we boot from.
-    configuration::migrate_legacy_coder(&iii).await;
-
     let cfg = configuration::fetch_config(&iii)
         .await
         .map_err(anyhow::Error::msg)
@@ -225,7 +220,7 @@ async fn main() -> Result<()> {
         tracing::info!("code surface (coder::*) registered over the unified fs jail");
     } else {
         tracing::warn!(
-            "fs is unjailed (no fs.host_root/fs.host_roots) — code surface (coder::*) NOT \
+            "fs is unjailed (fs.host_roots is empty) — code surface (coder::*) NOT \
              registered; coder file functions require a jail root"
         );
     }
@@ -538,12 +533,13 @@ fn register_fs(iii: &iii_sdk::IIIClient, state: &AppState) {
     }
 
     fs_fn!("shell::fs::ls", fs_ls, fs::LsRequest, fs::LsResponse,
-        "List directory contents. `path` is relative to the configured fs jail root (fs.host_root) \
-         when set, otherwise absolute. `target` defaults to host; pass { kind: \"sandbox\", sandbox_id } \
+        "List directory contents. `path` is relative to the primary fs jail root (the first \
+         fs.host_roots entry) when set, otherwise absolute. `target` defaults to host; pass \
+         { kind: \"sandbox\", sandbox_id } \
          to run in a microVM. Errors return { code, message }; common: S210 bad path, S211 not found, \
          S212 not a directory, S215 jail/denylist.");
     fs_fn!("shell::fs::stat", fs_stat, fs::StatRequest, fs::StatResponse,
-        "Stat a single path (jail-relative when fs.host_root is set). Returns the entry's type, size, \
+        "Stat a single path (jail-relative when fs.host_roots is set). Returns the entry's type, size, \
          mode, and mtime. Errors return { code, message }; common: S211 not found, S215 jail/denylist.");
     fs_fn!("shell::fs::mkdir", fs_mkdir, fs::MkdirRequest, fs::MkdirResponse,
         "Create a directory. `mode` is an octal string like \"0755\". `parents: true` creates missing \

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -24,7 +24,11 @@ use configuration::AppState;
 use functions::types::{KillRequest, StatusRequest};
 
 #[derive(Parser, Debug)]
-#[command(name = "shell", about = "Unix shell execution worker for iii agents")]
+#[command(
+    name = "shell",
+    version,
+    about = "Unix shell execution worker for iii agents"
+)]
 struct Cli {
     /// Seed config registered as `initial_value` with the `configuration` worker
     /// on first registration. Defaults to ./config.yaml. The live value from the
@@ -32,8 +36,56 @@ struct Cli {
     #[arg(long, default_value = "./config.yaml")]
     config: String,
 
+    /// WebSocket URL of the iii engine. Also read from the III_URL env var.
+    /// The worker retries the connection forever (2s backoff); when the engine
+    /// is unreachable at boot, a single loud error from the pre-connect probe
+    /// says so.
     #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
+}
+
+/// Host/port of a ws(s):// engine URL, for the pre-connect probe. `None` when
+/// the URL does not parse or has no host; `port_or_known_default` maps
+/// ws→80 / wss→443 when no explicit port is given.
+fn ws_host_port(url_str: &str) -> Option<(String, u16)> {
+    let u = url::Url::parse(url_str).ok()?;
+    // host_str keeps IPv6 brackets ("[::1]"), which ToSocketAddrs rejects.
+    let host = u.host_str()?.trim_matches(['[', ']']).to_string();
+    let port = u.port_or_known_default()?;
+    Some((host, port))
+}
+
+/// One loud, actionable ERROR when the engine is unreachable, BEFORE handing
+/// off to the SDK's silent infinite 2s-backoff reconnect loop (which only
+/// WARNs). Never fails fast — supervised deployments rely on the SDK retry —
+/// and never blocks boot for more than ~4s (2s connect timeout, at most two
+/// resolved addresses tried). Parse/resolve failures just skip the probe: the
+/// SDK is the authority on what URLs it accepts.
+fn probe_engine_reachable(url_str: &str) {
+    use std::net::{TcpStream, ToSocketAddrs};
+    let Some((host, port)) = ws_host_port(url_str) else {
+        tracing::warn!(url = %url_str, "could not parse engine URL; skipping reachability probe");
+        return;
+    };
+    let addrs = match (host.as_str(), port).to_socket_addrs() {
+        Ok(a) => a.collect::<Vec<_>>(),
+        Err(e) => {
+            tracing::warn!(url = %url_str, error = %e, "engine host did not resolve");
+            return;
+        }
+    };
+    let reachable = addrs
+        .iter()
+        .take(2)
+        .any(|a| TcpStream::connect_timeout(a, std::time::Duration::from_secs(2)).is_ok());
+    if !reachable {
+        tracing::error!(
+            url = %url_str,
+            "engine unreachable at {url_str} — is the iii engine running? Set --url or the \
+             III_URL env var if it listens elsewhere. Continuing to retry in the background \
+             every 2s."
+        );
+    }
 }
 
 /// Identify this worker to the engine as `shell` (name, runtime, version, pid)
@@ -71,6 +123,7 @@ async fn main() -> Result<()> {
 
     let cli = Cli::parse();
     tracing::info!(url = %cli.url, seed_config = %cli.config, "connecting to IIIClient engine");
+    probe_engine_reachable(&cli.url);
 
     let iii = register_worker(
         &cli.url,
@@ -210,7 +263,7 @@ async fn main() -> Result<()> {
                  defaults to the host; pass { kind: \"sandbox\", sandbox_id } to run in a microVM. \
                  Optional host-only `cwd` scopes this call to a directory (jail-confined exactly \
                  like shell::fs::* paths; escaping it is S215), optional `env` (object) sets \
-                 per-call values — but only for keys already in allowed_env and never for \
+                 per-call values — but only for keys already in the operator's env.allow list and never for \
                  PATH/IFS/HOME/LD_*/DYLD_* or other loader/lookup and interpreter-startup keys \
                  (those reject S210) — and optional host-only `stdin` (string) is written to the \
                  program's standard input (use it for `tee`, `patch`, or any stdin filter instead \
@@ -238,7 +291,7 @@ async fn main() -> Result<()> {
                 "Spawn an allowlisted command as a background job; returns { job_id, argv } \
                  immediately. Same payload as shell::exec (command + args, do NOT pass argv as an \
                  array), including the optional host-only `cwd` (jail-confined; escape is S215), \
-                 `env` (only allowed_env keys, never PATH/IFS/HOME/LD_*/DYLD_* or other loader/lookup \
+                 `env` (only keys in the operator's env.allow list, never PATH/IFS/HOME/LD_*/DYLD_* or other loader/lookup \
                  and interpreter-startup keys), and `stdin` (string written to the job's stdin); \
                  violations and cwd/env/stdin on a sandbox target reject with an S210 message. Poll \
                  with shell::status, terminate with shell::kill, list with shell::list. \
@@ -574,12 +627,72 @@ async fn wait_for_shutdown_signal() -> std::io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::Cli;
+    use super::{ws_host_port, Cli};
     use clap::Parser;
 
     #[test]
     fn config_defaults_to_local_config_yaml() {
         let cli = Cli::parse_from(["shell"]);
         assert_eq!(cli.config, "./config.yaml");
+    }
+
+    /// `--version` must exist and report the crate version — operators use it
+    /// to check what a deployed binary actually is.
+    #[test]
+    fn version_flag_reports_crate_version() {
+        let err = Cli::try_parse_from(["shell", "--version"])
+            .expect_err("--version short-circuits parsing");
+        assert_eq!(err.kind(), clap::error::ErrorKind::DisplayVersion);
+        assert!(
+            err.to_string().contains(env!("CARGO_PKG_VERSION")),
+            "renders the crate version: {err}"
+        );
+    }
+
+    /// The long help must surface the III_URL env var and the default engine
+    /// URL — this is the only self-documenting place for the binary's env vars.
+    #[test]
+    fn help_documents_url_env_and_default() {
+        use clap::CommandFactory;
+        let help = Cli::command().render_long_help().to_string();
+        assert!(help.contains("III_URL"), "help names III_URL: {help}");
+        assert!(
+            help.contains("ws://127.0.0.1:49134"),
+            "help shows the default URL: {help}"
+        );
+        assert!(
+            help.contains("iii engine"),
+            "help describes what the URL points at: {help}"
+        );
+    }
+
+    #[test]
+    fn ws_host_port_parses_explicit_port() {
+        assert_eq!(
+            ws_host_port("ws://127.0.0.1:49134"),
+            Some(("127.0.0.1".to_string(), 49134))
+        );
+    }
+
+    #[test]
+    fn ws_host_port_parses_ipv6_without_brackets() {
+        assert_eq!(
+            ws_host_port("ws://[::1]:1234"),
+            Some(("::1".to_string(), 1234))
+        );
+    }
+
+    #[test]
+    fn ws_host_port_uses_known_default_ports() {
+        assert_eq!(ws_host_port("ws://localhost"), Some(("localhost".to_string(), 80)));
+        assert_eq!(
+            ws_host_port("wss://engine.example"),
+            Some(("engine.example".to_string(), 443))
+        );
+    }
+
+    #[test]
+    fn ws_host_port_rejects_garbage() {
+        assert_eq!(ws_host_port("not a url"), None);
     }
 }

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -55,37 +55,42 @@ fn ws_host_port(url_str: &str) -> Option<(String, u16)> {
     Some((host, port))
 }
 
-/// One loud, actionable ERROR when the engine is unreachable, BEFORE handing
-/// off to the SDK's silent infinite 2s-backoff reconnect loop (which only
-/// WARNs). Never fails fast — supervised deployments rely on the SDK retry —
-/// and never blocks boot for more than ~4s (2s connect timeout, at most two
-/// resolved addresses tried). Parse/resolve failures just skip the probe: the
-/// SDK is the authority on what URLs it accepts.
+/// One loud, actionable ERROR when the engine is unreachable, BEFORE the SDK's
+/// silent infinite 2s-backoff reconnect loop makes the failure look quiet.
+/// Runs DETACHED (spawned thread): it only logs, never gates boot, so neither
+/// the synchronous DNS lookup (unbounded — system resolver) nor the 2s TCP
+/// connect attempts can delay startup. Never fails fast — supervised
+/// deployments rely on the SDK retry. Parse/resolve failures just skip the
+/// probe: the SDK is the authority on what URLs it accepts. Log lines carry
+/// host:port, not the raw URL — a wss:// URL can embed credentials.
 fn probe_engine_reachable(url_str: &str) {
-    use std::net::{TcpStream, ToSocketAddrs};
     let Some((host, port)) = ws_host_port(url_str) else {
-        tracing::warn!(url = %url_str, "could not parse engine URL; skipping reachability probe");
+        tracing::warn!("could not parse engine URL; skipping reachability probe");
         return;
     };
-    let addrs = match (host.as_str(), port).to_socket_addrs() {
-        Ok(a) => a.collect::<Vec<_>>(),
-        Err(e) => {
-            tracing::warn!(url = %url_str, error = %e, "engine host did not resolve");
-            return;
+    std::thread::spawn(move || {
+        use std::net::{TcpStream, ToSocketAddrs};
+        let addrs = match (host.as_str(), port).to_socket_addrs() {
+            Ok(a) => a.collect::<Vec<_>>(),
+            Err(e) => {
+                tracing::warn!(host = %host, port, error = %e, "engine host did not resolve");
+                return;
+            }
+        };
+        let reachable = addrs
+            .iter()
+            .take(2)
+            .any(|a| TcpStream::connect_timeout(a, std::time::Duration::from_secs(2)).is_ok());
+        if !reachable {
+            tracing::error!(
+                host = %host,
+                port,
+                "engine unreachable at {host}:{port} — is the iii engine running? Set --url \
+                 or the III_URL env var if it listens elsewhere. Continuing to retry in the \
+                 background every 2s."
+            );
         }
-    };
-    let reachable = addrs
-        .iter()
-        .take(2)
-        .any(|a| TcpStream::connect_timeout(a, std::time::Duration::from_secs(2)).is_ok());
-    if !reachable {
-        tracing::error!(
-            url = %url_str,
-            "engine unreachable at {url_str} — is the iii engine running? Set --url or the \
-             III_URL env var if it listens elsewhere. Continuing to retry in the background \
-             every 2s."
-        );
-    }
+    });
 }
 
 /// Identify this worker to the engine as `shell` (name, runtime, version, pid)
@@ -139,14 +144,30 @@ async fn main() -> Result<()> {
     // installed. Idempotent and a silent no-op when no collector is attached.
     telemetry::init();
 
+    // Seed policy: a MISSING file is the zero-config path (warn + fall through
+    // to the stored value or built-in seed). A file that EXISTS but fails to
+    // parse aborts boot: on first registration the fallback would silently
+    // replace the operator's intended policy with the permissive dev seed —
+    // fail-open — and with 0.7.0's removed-key rejection every un-migrated
+    // 0.6.x config file hits exactly this path. Mirrors the stored-value
+    // story: reject loudly, never degrade to a wider policy.
     let seed = match config::ShellConfig::from_file(&cli.config) {
         Ok(cfg) => {
             tracing::info!(path = %cli.config, "loaded seed config for initial registration");
             Some(cfg)
         }
-        Err(e) => {
-            tracing::warn!(path = %cli.config, error = %e, "could not load --config seed; using the stored configuration value if present, else the built-in zero-config default");
+        Err(e) if !std::path::Path::new(&cli.config).exists() => {
+            tracing::warn!(path = %cli.config, error = %e, "no --config seed file; using the stored configuration value if present, else the built-in zero-config default");
             None
+        }
+        Err(e) => {
+            anyhow::bail!(
+                "--config seed {} exists but failed to parse: {e}. Refusing to boot: falling \
+                 back would seed the permissive built-in default in place of the intended \
+                 policy. Fix the file (see the migration hint above) or remove it to opt \
+                 into the zero-config default.",
+                cli.config
+            );
         }
     };
 
@@ -680,7 +701,10 @@ mod tests {
 
     #[test]
     fn ws_host_port_uses_known_default_ports() {
-        assert_eq!(ws_host_port("ws://localhost"), Some(("localhost".to_string(), 80)));
+        assert_eq!(
+            ws_host_port("ws://localhost"),
+            Some(("localhost".to_string(), 80))
+        );
         assert_eq!(
             ws_host_port("wss://engine.example"),
             Some(("engine.example".to_string(), 443))

--- a/shell/src/path/mod.rs
+++ b/shell/src/path/mod.rs
@@ -20,13 +20,13 @@ use std::path::{Component, Path, PathBuf};
 /// ancestor, even when `p` itself doesn't yet exist. The naive fallback —
 /// "canonicalize, on ENOENT use the lexical path" — is a jail-escape vector
 /// when the path traverses a symlink whose target is outside the jail: the
-/// lexical form still `starts_with(host_root)`, but the kernel will follow
+/// lexical form still `starts_with(<jail root>)`, but the kernel will follow
 /// the link on the subsequent syscall. Walking up to the longest existing
 /// ancestor and canonicalizing *that* forces every symlink in the existing
 /// portion to be resolved; the non-existent tail can't itself contain
 /// symlinks (it doesn't exist) but can still contain `..`/`.`, which we
 /// then collapse lexically against the canonical prefix so the
-/// `starts_with(host_root)` check is sound.
+/// jail-root containment check is sound.
 pub(crate) fn canonicalize_with_fallback(p: &Path) -> std::io::Result<PathBuf> {
     if let Ok(c) = std::fs::canonicalize(p) {
         return Ok(c);
@@ -37,7 +37,7 @@ pub(crate) fn canonicalize_with_fallback(p: &Path) -> std::io::Result<PathBuf> {
     // forward through each tail component and reject if any of them is a
     // *dangling* symlink: canonicalize fails on dangling symlinks (target
     // doesn't exist), so they'd otherwise survive into the lexical tail
-    // and let `starts_with(host_root)` succeed against a path the kernel
+    // and let the jail-root containment check succeed against a path the kernel
     // would resolve outside the jail. Existing-but-resolvable symlinks
     // are caught by the top-of-function canonicalize.
     for anc in p.ancestors().skip(1) {

--- a/shell/tests/code_golden_errors.rs
+++ b/shell/tests/code_golden_errors.rs
@@ -177,16 +177,18 @@ async fn error_message_formats_match_golden() {
         );
     };
 
-    // --- C210: operator config error — both root forms set -------------
+    // --- C210: operator config error — no reachable roots ---------------
+    // (Replaces the retired both-root-forms case: `base_path` was removed in
+    // 0.7.0, so the remaining construction-time config error is a root set
+    // where nothing canonicalizes.)
     {
         let cfg = CoderConfig {
-            base_path: Some(jail.root0.clone()),
-            base_paths: vec![jail.root1.clone()],
+            base_paths: vec![PathBuf::from("/this/does/not/exist/golden-xyz")],
             ..CoderConfig::default()
         };
-        let err = PathResolver::new(&cfg).expect_err("both-set must fail");
+        let err = PathResolver::new(&cfg).expect_err("unreachable roots must fail");
         put(
-            "C210_config_both_root_forms_set",
+            "C210_config_no_reachable_roots",
             from_coder_error(&err),
             &jail,
         );

--- a/shell/tests/e2e/.gitignore
+++ b/shell/tests/e2e/.gitignore
@@ -2,6 +2,11 @@ data/*
 !data/.gitkeep
 reports/*
 !reports/.gitkeep
+# Engine-externalized worker config (runtime state): newer engines move the
+# `workers[].config` blocks from config.yaml into ./config/*.yaml on boot and
+# stamp the block with a pointer comment. The tracked config.yaml stays
+# self-contained; delete ./config/ to re-derive from it.
+config/
 node_modules/
 dist/
 *.log

--- a/shell/tests/e2e/README.md
+++ b/shell/tests/e2e/README.md
@@ -116,16 +116,16 @@ so they're easy to grep.
 | Finding | Where | Suite |
 |---|---|---|
 | S-H1 (`chmod -R` follows symlinks) | `cases-vuln-repro.ts` | default |
-| S-H2 (`host_root: null` is unjailed) | `cases-vuln-repro.ts` | default |
+| S-H2 (no `host_roots` is unjailed) | `cases-vuln-repro.ts` | default |
 | S-H3 (denylist regex bypass via shell vars) | `cases-vuln-repro.ts` | default |
 | S-H4 (`shell::list` cross-call argv/stdout leak) | `cases-vuln-repro.ts` | default |
 | S-C1 (symlink-parent jail escape on writes) | `cases-vuln-repro-jailed.ts` | jailed |
 
 The default suite (`./run-tests.sh`) runs the unjailed four alongside
 the rest. The jailed suite (`./run-tests-jailed.sh`) boots the engine
-with `config-jailed.yaml` (`host_root: /private/tmp/iii-shell-jailed-root`)
+with `config-jailed.yaml` (`host_roots: [/private/tmp/iii-shell-jailed-root]`)
 and runs only the C1 repro — the rest of the suite assumes
-`host_root: null` and would mis-fail with a jail set.
+no jail (`host_roots` unset) and would mis-fail with a jail set.
 
 ## Coder BDD coverage
 

--- a/shell/tests/e2e/config-jailed.yaml
+++ b/shell/tests/e2e/config-jailed.yaml
@@ -31,8 +31,9 @@ workers:
       default_timeout_ms: 1500
       max_output_bytes: 4096
       working_dir: ./data
-      inherit_env: false
-      allowed_env: [PATH, HOME, LANG, HARNESS_TEST_VAR]
+      env:
+        inherit: false
+        allow: [PATH, HOME, LANG, HARNESS_TEST_VAR]
       allowlist: [echo, ls, cat, sleep, pwd, printf, sh, false, "true", env]
       denylist_patterns:
         - "rm\\s+-rf\\s+/"

--- a/shell/tests/e2e/config-jailed.yaml
+++ b/shell/tests/e2e/config-jailed.yaml
@@ -1,7 +1,7 @@
 # Variant of config.yaml used by run-tests-jailed.sh to reproduce
 # S-C1 (symlink-parent jail escape) — see
 # `cases-vuln-repro-jailed.ts`. Only difference from the default
-# config is `fs.host_root` being set to a fixed absolute path; the
+# config is `fs.host_roots` being set to a fixed absolute path; the
 # jailed suite creates the directory and a symlink inside it that
 # points at /private/tmp/<uuid>. The vuln is that
 # `validate_path` falls back to lexical normalization on ENOENT
@@ -40,7 +40,7 @@ workers:
       max_concurrent_jobs: 2
       job_retention_secs: 2
       fs:
-        host_root: /private/tmp/iii-shell-jailed-root
+        host_roots: [/private/tmp/iii-shell-jailed-root]
         max_read_bytes: 1048576
         max_write_bytes: 1048576
         denylist_paths:

--- a/shell/tests/e2e/config.yaml
+++ b/shell/tests/e2e/config.yaml
@@ -45,8 +45,9 @@ workers:
       default_timeout_ms: 1500
       max_output_bytes: 4096
       working_dir: ./data
-      inherit_env: false
-      allowed_env: [PATH, HOME, LANG, HARNESS_TEST_VAR]
+      env:
+        inherit: false
+        allow: [PATH, HOME, LANG, HARNESS_TEST_VAR]
       allowlist: [echo, ls, cat, sleep, pwd, printf, sh, false, "true", env]
       denylist_patterns:
         - "rm\\s+-rf\\s+/"

--- a/shell/tests/e2e/config.yaml
+++ b/shell/tests/e2e/config.yaml
@@ -56,10 +56,10 @@ workers:
       max_concurrent_jobs: 2
       job_retention_secs: 2
       fs:
-        host_root: null
         # Test harness needs to write to OS tmpdirs scattered across the
-        # filesystem, so the jail is intentionally off here. Production
-        # operators should leave this false (default) and pin host_root.
+        # filesystem, so the jail is intentionally off here (no host_roots).
+        # Production operators should leave this false (default) and pin
+        # host_roots.
         allow_unjailed: true
         # Caps deliberately set to 1 MiB so size-cap-boundary tests
         # in cases-fs-protocol-break.ts can trip S218 cheaply. Streaming

--- a/shell/tests/e2e/run-tests-jailed.sh
+++ b/shell/tests/e2e/run-tests-jailed.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Variant of run-tests.sh that boots the engine against
-# `config-jailed.yaml` (with `fs.host_root` set) and runs the
+# `config-jailed.yaml` (with `fs.host_roots` set) and runs the
 # jailed-only vuln-repro suite (S-C1). Reuses the same engine startup
 # logic; the differences are: (1) a different config, (2) HARNESS_SUITE=jailed
 # so runner.ts picks the matching case set, (3) a separate report path
@@ -94,7 +94,7 @@ fi
 
 export HARNESS_TEST_VAR="harness-allowed-value"
 
-echo "[run-tests-jailed] starting iii engine (jailed config: host_root=$JAIL_ROOT)"
+echo "[run-tests-jailed] starting iii engine (jailed config: host_roots=[$JAIL_ROOT])"
 : > "$ENGINE_LOG"
 : > "$HARNESS_LOG"
 

--- a/shell/tests/e2e/run-tests.sh
+++ b/shell/tests/e2e/run-tests.sh
@@ -131,7 +131,7 @@ if [[ ! -d "$ROOT_DIR/workers/harness/node_modules" ]]; then
 fi
 
 # 5. Set env vars used by the env-scrubbing/passthrough cases. HARNESS_TEST_VAR
-# is in allowed_env — should round-trip. HARNESS_NOT_ALLOWED is not — should be
+# is in env.allow — should round-trip. HARNESS_NOT_ALLOWED is not — should be
 # scrubbed before reaching the spawned `env` command.
 export HARNESS_TEST_VAR="harness-allowed-value"
 export HARNESS_NOT_ALLOWED="harness-blocked-value"

--- a/shell/tests/e2e/workers/harness/src/cases-safety.ts
+++ b/shell/tests/e2e/workers/harness/src/cases-safety.ts
@@ -12,11 +12,11 @@ export const SAFETY_CASES: TestCase[] = [
     },
   },
   {
-    // This suite runs UNJAILED (config.yaml host_root: null). In that mode a
+    // This suite runs UNJAILED (config.yaml sets no host_roots). In that mode a
     // command path (anything with '/') is rejected outright: the whole host FS
     // is writable via shell::fs::write, so a path could execute agent-planted
     // bytes and bypass the read-only allowlist. Bare PATH-resolved names work.
-    // (In jailed mode an absolute path OUTSIDE host_root is still permitted by
+    // (In jailed mode an absolute path OUTSIDE the jail roots is still permitted by
     // basename — exercised by the jailed suite / Rust unit tests.)
     name: 'unjailed mode rejects command paths (RCE guard)',
     async run({ call, expectError }) {

--- a/shell/tests/e2e/workers/harness/src/cases-vuln-repro-jailed.ts
+++ b/shell/tests/e2e/workers/harness/src/cases-vuln-repro-jailed.ts
@@ -1,6 +1,6 @@
 // Regression test for S-C1 (symlink-parent jail escape). Originally
 // this case demonstrated the vuln by writing through a symlink whose
-// target was outside host_root and observing the bytes land outside;
+// target was outside the jail root and observing the bytes land outside;
 // after the fix in `shell/src/fs/host.rs` (canonicalize_with_fallback
 // + lexical normalization of the non-existent tail), the same
 // invocation must reject with S215. Runs only against
@@ -39,8 +39,8 @@ export const VULN_REPRO_JAILED_CASES: TestCase[] = [
 
       // FIX: validate_path now canonicalizes the longest existing
       // ancestor (which resolves the symlink to externalDir, outside
-      // host_root) and lexically appends the non-existent tail. The
-      // resulting path no longer starts_with(host_root) — engine
+      // the jail root) and lexically appends the non-existent tail. The
+      // resulting path no longer resolves inside the jail root — engine
       // rejects with S215.
       let rejected = false;
       let observed = '';
@@ -81,7 +81,7 @@ export const VULN_REPRO_JAILED_CASES: TestCase[] = [
     // The original lexical-fallback flaw existed both in validate_path
     // and in the parents:true defense-in-depth re-check. The fix to
     // validate_path closes the upstream side; the defense-in-depth now
-    // uses host_root_canon (precomputed at HostFsBackend::new()) to
+    // uses host_roots_canon (precomputed at HostFsBackend::new()) to
     // re-check the parent. This case exercises the parents:true path
     // explicitly: the external escape directory does NOT pre-exist, so
     // create_dir_all has to walk through the symlink, and the

--- a/shell/tests/e2e/workers/harness/src/cases-vuln-repro.ts
+++ b/shell/tests/e2e/workers/harness/src/cases-vuln-repro.ts
@@ -4,7 +4,7 @@
 // post-fix behavior (error code, redaction, opt-in flag). Names start
 // with `vuln_repro_` for grep continuity.
 //
-// Coverage in this file (default config = host_root: null,
+// Coverage in this file (default config = no host_roots,
 // allow_unjailed: true):
 //   - S-H1: chmod -R no longer rewrites symlink targets
 //   - S-H2: unjailed mode requires explicit allow_unjailed: true (the
@@ -16,7 +16,7 @@
 //     reachable only via shell::status <job_id> (the UUID is the cap).
 //
 // S-C1 (symlink-parent escape) is tested in `cases-vuln-repro-jailed.ts`
-// against `config-jailed.yaml` (host_root set).
+// against `config-jailed.yaml` (host_roots set).
 
 import { mkdtempSync, mkdirSync, writeFileSync, statSync, symlinkSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -116,7 +116,7 @@ export const VULN_REPRO_CASES: TestCase[] = [
   },
   {
     // S-H2: shell/src/config.rs (validate_fs_jail).
-    // Fix: the worker refuses to start when host_root is null AND
+    // Fix: the worker refuses to start when host_roots is empty AND
     // fs.allow_unjailed is false. The test config sets allow_unjailed:
     // true (test harness writes to OS tmpdirs scattered across the
     // FS), so the writes-anywhere behavior is preserved as the

--- a/shell/tests/e2e/workers/harness/src/runner.ts
+++ b/shell/tests/e2e/workers/harness/src/runner.ts
@@ -127,7 +127,7 @@ export class Runner {
     // set) is the full unjailed suite + the unjailed vuln repros.
     // `jailed` runs ONLY the symlink-jail-escape repro against an
     // engine started with config-jailed.yaml — the rest of the suite
-    // assumes host_root: null and would mis-fail there.
+    // assumes no host_roots and would mis-fail there.
     const suite = process.env.HARNESS_SUITE ?? 'default';
     const allCases: TestCase[] =
       suite === 'jailed'

--- a/shell/tests/golden/errors.json
+++ b/shell/tests/golden/errors.json
@@ -1,7 +1,7 @@
 {
-  "C210_config_both_root_forms_set": {
+  "C210_config_no_reachable_roots": {
     "code": "C210",
-    "message": "both `base_path` and `base_paths` are set; set either `base_path` or `base_paths` in config.yaml, not both. Remove `base_path` and keep only `base_paths` (legacy `base_path` is honored as a one-entry list)."
+    "message": "no reachable roots: none of [/this/does/not/exist/golden-xyz] could be canonicalized. Ensure the directories exist and are accessible, then set `fs.host_roots` to at least one reachable path."
   },
   "C210_create_bad_mode": {
     "code": "C210",


### PR DESCRIPTION
## Summary

Consolidates the shell worker's environment-variable config into a nested `env` block, and turns every removed 0.6.x key into a hard, parse-time rejection — no legacy aliases, no silent tolerance, no soft transition period anywhere in the schema.

**Breaking, all with a migration hint at parse time:**
- `inherit_env`/`allowed_env` → `env.inherit`/`env.allow`. A half-migration (old names nested under the new `env:` block) is caught too — `EnvConfig` denies unknown fields.
- `fs.host_root` (single-root alias) → `fs.host_roots` (list).
- `code.base_path`/`code.base_paths` removed from the schema entirely. These never had a runtime effect (the code resolver has always taken its roots from `fs.host_roots`), but "harmless to keep" isn't an exception — a stored value carrying either now fails closed like everything else.
- The one-shot coder→shell config migration (`migrate_legacy_coder`) is gone, including the hidden `migrated_from_coder` marker field, which is now rejected at parse rather than silently ignored. An install that already has a `shell` entry (went through the 0.6.x fold) fails closed at boot with a hint. An install with *only* a standalone `coder` entry has nothing to reject and will still seed the generic `/tmp` dev default — boot 0.6.x once first to avoid that.

All four removed-key checks are driven by one table-scanning function (`check_removed_keys`) instead of ad hoc per-case logic, so adding a future removed key means one new table entry, not a new code path.

**Hardening riding along:**
- The advisory, argv[0]-anchored denylist patterns (`mkfs`, `dd`, `shutdown`, `reboot`) now tolerate a bounded wrapper prefix (`sudo`, `doas`, `nohup`, `timeout [duration]`, or `env` with its idiomatic `KEY=VALUE...` form) and are case-insensitive — `sudo shutdown -h now` and `env FOO=bar shutdown -h now` trip the tripwire; `grep -rn shutdown src/` still doesn't. Known remaining gap, documented rather than "fixed": flags interposed before the wrapped command (`sudo -u root shutdown`) still evade it — closing that needs per-argv-token wrapper-skipping, not a joined-string regex.
- A seed (`--config`) file that exists but fails to parse now aborts boot instead of silently falling back to the permissive built-in default in place of the operator's intended policy.
- Hot-reload no longer misclassifies a fetched-but-unparseable stored config as a transient fetch error (which would retry forever against bytes that can never parse); it's now `Rejected` — same treatment as an unbuildable config, recorded for `shell::config-status`.
- The boot-time engine-reachability probe runs on a detached thread (its DNS resolution is unbounded, so it can no longer delay startup) and logs host:port instead of the raw URL, since a `wss://user:pass@host` URL can embed credentials.
- `--version`, and `--url`/`III_URL`/`RUST_LOG` documented in `--help`/README.
- Every operator-visible config field, including the nested blocks, now carries a schema description for the console configuration UI.

## Known gaps (deliberate, not fixed here)

- `coder::*` keeps its `PathResolver` across a hot-reload that changes `fs.host_roots` — this is pre-existing, restart-required-by-design architecture (`ARCHITECTURE.md`, `jail_signature`), unrelated to and not worsened by this branch. Worth its own follow-up.
- Live rollout on the `iii-running` and `harness` dev stacks is deferred until this merges — both have stored configs carrying the removed keys and need a `configuration::set` rewrite in the correct order (deploy binary first, then rewrite the value — see README "Upgrading to 0.7.0" for the exact sequencing trap).

## Test plan

- [x] `cargo test` in `shell/` — 1282 passed
- [x] `cargo fmt --check` / `cargo clippy --all-targets` — clean
- [x] `tests/e2e/run-tests.sh` — 171/171
- [x] `tests/e2e/run-tests-jailed.sh` — 2/2
- [x] Multiple independent adversarial review passes (specialist dispatch + red-team + cross-model) — every confirmed finding applied and re-verified
- [ ] Live rollout on `iii-running` + `harness` dev stacks (deferred until merge, see README)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--version` and improved CLI URL handling with a pre-boot reachability probe.
  * Updated config schema support for `env` policies and jail setup via `fs.host_roots`.
* **Bug Fixes**
  * Fail-closed behavior for invalid/unsafe stored configs now stops startup or marks reloads as rejected (avoids retry storms).
  * Hardened per-call `cwd`/`env` validation and denylist matching, including wrapper/case-tolerant command patterns.
* **Documentation**
  * Revised upgrade/troubleshooting guidance, removed-key migration hints, and examples.
* **Chores**
  * Updated default timeout and sample configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->