### PR TITLE
feat(console): register-trigger + state tool views; fix duplicated request pane

### DIFF
--- a/console/web/src/components/chat/FunctionCallMessage.stories.tsx
+++ b/console/web/src/components/chat/FunctionCallMessage.stories.tsx
@@ -6,6 +6,7 @@ import { harnessFixtures } from '@/stories/fixtures/harness-fixtures'
 import { routerFixtures } from '@/stories/fixtures/router-fixtures'
 import { sandboxFixtures } from '@/stories/fixtures/sandbox-fixtures'
 import { shellFixtures } from '@/stories/fixtures/shell-fixtures'
+import { stateFixtures } from '@/stories/fixtures/state-fixtures'
 import { webFixtures } from '@/stories/fixtures/web-fixtures'
 import { workerFixtures } from '@/stories/fixtures/worker-fixtures'
 import { workflowFixtures } from '@/stories/fixtures/workflow-fixtures'
@@ -172,4 +173,9 @@ export const RouterFamily: Story = {
 export const HarnessFamily: Story = {
   name: 'harness family',
   render: () => <FamilyGallery fixtures={harnessFixtures} />,
+}
+
+export const StateFamily: Story = {
+  name: 'state family',
+  render: () => <FamilyGallery fixtures={stateFixtures} />,
 }

--- a/console/web/src/components/chat/FunctionCallMessage.tsx
+++ b/console/web/src/components/chat/FunctionCallMessage.tsx
@@ -15,6 +15,7 @@ import {
   SandboxToolView,
 } from '@/components/chat/sandbox'
 import { ShellFunctionIdLabel, ShellToolView } from '@/components/chat/shell'
+import { StateFunctionIdLabel, StateToolView } from '@/components/chat/state'
 import { WebFunctionIdLabel, WebToolView } from '@/components/chat/web'
 import { WorkerFunctionIdLabel, WorkerToolView } from '@/components/chat/worker'
 import {
@@ -140,6 +141,9 @@ function FunctionIdLabel({ functionId }: { functionId: string }) {
   if (HarnessToolView.isHarnessFunction(functionId)) {
     return <HarnessFunctionIdLabel functionId={functionId} />
   }
+  if (StateToolView.isStateFunction(functionId)) {
+    return <StateFunctionIdLabel functionId={functionId} />
+  }
   return <span className="text-ink">{functionId}</span>
 }
 
@@ -170,7 +174,8 @@ export function FunctionCallMessage({
     ShellToolView.tryRenderPreview(message) ??
     WorkflowToolView.tryRenderPreview(message) ??
     RouterToolView.tryRenderPreview(message) ??
-    HarnessToolView.tryRenderPreview(message)
+    HarnessToolView.tryRenderPreview(message) ??
+    StateToolView.tryRenderPreview(message)
   const customTerminal = !pending
     ? (SandboxToolView.tryRender(message) ??
       EngineToolView.tryRender(message) ??
@@ -181,13 +186,14 @@ export function FunctionCallMessage({
       ShellToolView.tryRender(message) ??
       WorkflowToolView.tryRender(message) ??
       RouterToolView.tryRender(message) ??
-      HarnessToolView.tryRender(message))
+      HarnessToolView.tryRender(message) ??
+      StateToolView.tryRender(message))
     : null
   const hasCustomTerminal = customTerminal != null
   const showRequestPaneAbove =
     !(pending && customPreview) &&
     !(running && hasCustomTerminal) &&
-    !(!pending && !running && hasCustomTerminal)
+    !(!pending && !running)
 
   const runResolve = async (kind: 'approve' | 'deny' | 'always_allow') => {
     const handler =

--- a/console/web/src/components/chat/engine/RegisterTriggerView.tsx
+++ b/console/web/src/components/chat/engine/RegisterTriggerView.tsx
@@ -125,7 +125,7 @@ export function RegisterTriggerView({
           <div className="px-3 py-1.5 border-b border-rule-2 bg-paper-2 flex flex-wrap items-center gap-1.5">
             <FilterChip label="model" value={react.model} />
             {allow?.length
-              ? allow.map((fn) => (
+              ? Array.from(new Set(allow)).map((fn) => (
                   <Chip key={fn}>
                     <span className="text-ink">{fn}</span>
                   </Chip>

--- a/console/web/src/components/chat/engine/RegisterTriggerView.tsx
+++ b/console/web/src/components/chat/engine/RegisterTriggerView.tsx
@@ -1,0 +1,208 @@
+import type { ReactNode } from 'react'
+import { Chip, MetaRow, StatusPill } from '@/components/chat/sandbox/shared'
+import { JsonHighlight } from '@/lib/syntax'
+import {
+  type ReactOptions,
+  type ReactSpec,
+  type RegisterTriggerRequest,
+  type RegisterTriggerResponse,
+  reactOptionsSchema,
+  reactSpecSchema,
+  registerTriggerRequestSchema,
+  registerTriggerResponseSchema,
+  type StateTriggerConfig,
+  safeParseRequest,
+  safeParseResponse,
+  stateTriggerConfigSchema,
+} from './parsers'
+import { FilterChip } from './shared'
+
+interface RegisterTriggerViewProps {
+  input: unknown
+  output: unknown
+  running?: boolean
+}
+
+export function RegisterTriggerView({
+  input,
+  output,
+  running,
+}: RegisterTriggerViewProps) {
+  const req = safeParseRequest<RegisterTriggerRequest>(
+    registerTriggerRequestSchema,
+    input,
+  )
+  // Never render blank: an unrecognized payload falls back to raw JSON rather
+  // than an empty terminal pane (the switch always mounts this component).
+  if (!req) return <LabeledJson label="request" value={input} />
+
+  const stateCfg =
+    req.trigger_type === 'state'
+      ? safeParseRequest<StateTriggerConfig>(
+          stateTriggerConfigSchema,
+          req.config,
+        )
+      : null
+  const react =
+    req.function_id === 'harness::react'
+      ? safeParseRequest<ReactSpec>(reactSpecSchema, req.metadata)
+      : null
+  const allow = react
+    ? safeParseRequest<ReactOptions>(reactOptionsSchema, react.options)
+        ?.functions?.allow
+    : undefined
+
+  const resp = running
+    ? null
+    : safeParseResponse<RegisterTriggerResponse>(
+        registerTriggerResponseSchema,
+        output,
+      )
+  const regId = resp?.id ?? resp?.subscription_id
+  const once = resp?.once ?? req.once
+
+  const hasStateChips =
+    !!stateCfg &&
+    (!!stateCfg.scope || !!stateCfg.key || !!stateCfg.condition_function_id)
+
+  return (
+    <div className="border-t border-rule-2 bg-bg">
+      <MetaRow>
+        <StatusPill
+          label={running ? 'registering trigger…' : 'trigger registered'}
+          variant={running ? 'default' : 'accent'}
+        />
+        {req.label ? <FilterChip label="label" value={req.label} /> : null}
+        {typeof once === 'boolean' ? (
+          <FilterChip label="mode" value={once ? 'one-shot' : 'persistent'} />
+        ) : null}
+        {regId ? (
+          <Chip>
+            <span className="text-ink-faint uppercase tracking-[0.06em]">
+              id
+            </span>
+            <span className="ml-1 text-ink" title={regId}>
+              {shortenId(regId)}
+            </span>
+          </Chip>
+        ) : null}
+      </MetaRow>
+
+      <div className="px-3 py-2 border-b border-rule-2 bg-bg flex items-baseline gap-2 flex-wrap">
+        <span className="font-mono text-[11px] uppercase tracking-[0.06em] text-ink-faint">
+          {req.trigger_type}
+        </span>
+        <span className="font-mono text-[11px] text-ink-faint">→</span>
+        {req.function_id ? (
+          <span className="font-mono text-[12.5px] text-accent break-all">
+            {req.function_id}
+          </span>
+        ) : (
+          <span className="font-mono text-[12.5px] text-ink-faint italic">
+            notify session
+          </span>
+        )}
+      </div>
+
+      {hasStateChips ? (
+        <div className="px-3 py-1.5 border-b border-rule-2 bg-paper-2 flex flex-wrap items-center gap-1.5">
+          {stateCfg?.scope ? (
+            <FilterChip label="scope" value={stateCfg.scope} />
+          ) : null}
+          {stateCfg?.key ? (
+            <FilterChip label="key" value={stateCfg.key} />
+          ) : null}
+          {stateCfg?.condition_function_id ? (
+            <FilterChip label="if" value={stateCfg.condition_function_id} />
+          ) : null}
+        </div>
+      ) : req.config !== undefined && !isEmpty(req.config) ? (
+        <LabeledJson label="config" value={req.config} />
+      ) : null}
+
+      {react ? (
+        <>
+          <div className="px-3 py-1.5 border-b border-rule-2 bg-paper-2 flex flex-wrap items-center gap-1.5">
+            <FilterChip label="model" value={react.model} />
+            {allow?.length
+              ? allow.map((fn) => (
+                  <Chip key={fn}>
+                    <span className="text-ink">{fn}</span>
+                  </Chip>
+                ))
+              : null}
+          </div>
+          {react.join ? (
+            <div className="px-3 py-2 border-b border-rule-2 bg-bg font-mono text-[12px] text-ink flex flex-wrap items-center gap-x-2 gap-y-1">
+              <span className="text-ink-faint uppercase tracking-[0.06em] text-[10px]">
+                join
+              </span>
+              <span className="text-accent break-all">{react.join.id}</span>
+              <span className="text-ink-ghost">·</span>
+              <span>
+                key <span className="text-ink-faint">{react.join.key}</span>
+              </span>
+              <span className="text-ink-ghost">·</span>
+              <span>
+                expect{' '}
+                <span className="text-ink-faint">
+                  [{react.join.expect.join(', ')}]
+                </span>
+              </span>
+              {react.join.rearm ? (
+                <>
+                  <span className="text-ink-ghost">·</span>
+                  <span className="text-accent">rearm</span>
+                </>
+              ) : null}
+            </div>
+          ) : null}
+          <LabeledText label="task" text={react.task} />
+        </>
+      ) : req.metadata !== undefined ? (
+        <LabeledJson label="metadata" value={req.metadata} />
+      ) : null}
+    </div>
+  )
+}
+
+function isEmpty(v: unknown): boolean {
+  if (v === null || v === undefined) return true
+  if (typeof v === 'object') {
+    return Object.keys(v as Record<string, unknown>).length === 0
+  }
+  return false
+}
+
+function shortenId(id: string): string {
+  if (id.length <= 14) return id
+  return `${id.slice(0, 8)}…${id.slice(-4)}`
+}
+
+function PaneLabel({ children }: { children: ReactNode }) {
+  return (
+    <div className="bg-paper-2 px-3 py-1.5 border-b border-rule-2 font-mono text-[11px] uppercase tracking-[0.06em] text-ink-faint">
+      {children}
+    </div>
+  )
+}
+
+function LabeledJson({ label, value }: { label: string; value: unknown }) {
+  return (
+    <div>
+      <PaneLabel>{label}</PaneLabel>
+      <JsonHighlight code={JSON.stringify(value ?? null, null, 2)} />
+    </div>
+  )
+}
+
+function LabeledText({ label, text }: { label: string; text: string }) {
+  return (
+    <div>
+      <PaneLabel>{label}</PaneLabel>
+      <pre className="bg-bg overflow-x-auto px-3 py-2 font-mono text-[12.5px] leading-[1.55] text-ink whitespace-pre-wrap break-words">
+        <code>{text}</code>
+      </pre>
+    </div>
+  )
+}

--- a/console/web/src/components/chat/engine/__tests__/parsers.test.ts
+++ b/console/web/src/components/chat/engine/__tests__/parsers.test.ts
@@ -6,8 +6,11 @@ import {
   functionsListRequestSchema,
   functionsListResponseSchema,
   isEngineListFunction,
+  reactSpecSchema,
   registeredTriggersListRequestSchema,
   registeredTriggersListResponseSchema,
+  registerTriggerRequestSchema,
+  registerTriggerResponseSchema,
   safeParseRequest,
   safeParseResponse,
   triggersListRequestSchema,
@@ -358,6 +361,82 @@ describe('engine::workers::register', () => {
     expect(
       safeParseResponse(workersRegisterResponseSchema, wrap({ success: true })),
     ).toEqual({ success: true })
+  })
+})
+
+describe('engine::register_trigger', () => {
+  it('is included in the engine function id set', () => {
+    expect(ENGINE_FUNCTION_IDS).toContain('engine::register_trigger')
+    expect(isEngineListFunction('engine::register_trigger')).toBe(true)
+  })
+
+  it('parses a state-trigger → harness::react registration', () => {
+    const req = safeParseRequest(registerTriggerRequestSchema, {
+      trigger_type: 'state',
+      function_id: 'harness::react',
+      config: { key: 'build', scope: 'ops' },
+      metadata: {
+        model: 'claude-sonnet-5',
+        task: 'You are the GATE REVIEWER',
+        options: { functions: { allow: ['state::get'] } },
+        join: {
+          id: 'gate-decision-join',
+          key: 'build',
+          expect: ['build', 'tests'],
+          rearm: true,
+        },
+      },
+    })
+    expect(req?.trigger_type).toBe('state')
+    expect(req?.function_id).toBe('harness::react')
+    const react = safeParseRequest(reactSpecSchema, req?.metadata)
+    expect(react?.model).toBe('claude-sonnet-5')
+    expect(react?.join?.expect).toEqual(['build', 'tests'])
+    expect(react?.join?.rearm).toBe(true)
+  })
+
+  it('rejects a react spec whose join.expect is a count, not an array', () => {
+    expect(
+      safeParseRequest(reactSpecSchema, {
+        model: 'm',
+        task: 't',
+        join: { id: 'j', key: 'build', expect: 2 },
+      }),
+    ).toBeNull()
+  })
+
+  it('parses the harness subscribe variant (no function_id, has label/once)', () => {
+    const req = safeParseRequest(registerTriggerRequestSchema, {
+      trigger_type: 'state',
+      config: { key: 'progress', scope: 'research' },
+      label: 'research-progress-watch',
+      once: false,
+    })
+    expect(req?.trigger_type).toBe('state')
+    expect(req?.function_id).toBeUndefined()
+    expect(req?.label).toBe('research-progress-watch')
+    expect(req?.once).toBe(false)
+  })
+
+  it('rejects a request missing the required trigger_type', () => {
+    expect(
+      safeParseRequest(registerTriggerRequestSchema, { config: {} }),
+    ).toBeNull()
+  })
+
+  it('parses the engine response { id }', () => {
+    expect(
+      safeParseResponse(registerTriggerResponseSchema, wrap({ id: 'trg-1' })),
+    ).toEqual({ id: 'trg-1' })
+  })
+
+  it('parses the harness-intercepted response { subscription_id, once }', () => {
+    expect(
+      safeParseResponse(registerTriggerResponseSchema, {
+        subscription_id: 'sub-1',
+        once: false,
+      }),
+    ).toEqual({ subscription_id: 'sub-1', once: false })
   })
 })
 

--- a/console/web/src/components/chat/engine/index.tsx
+++ b/console/web/src/components/chat/engine/index.tsx
@@ -5,6 +5,7 @@ import { FunctionInfoView } from './FunctionInfoView'
 import { FunctionsListView } from './FunctionsListView'
 import { isEngineListFunction, unwrapEnvelope } from './parsers'
 import { RegisteredTriggersListView } from './RegisteredTriggersListView'
+import { RegisterTriggerView } from './RegisterTriggerView'
 import { TriggersListView } from './TriggersListView'
 import { WorkerInfoView } from './WorkerInfoView'
 import { WorkersListView } from './WorkersListView'
@@ -72,6 +73,10 @@ function tryRender(message: FunctionCallMessage): React.ReactNode | null {
     case 'engine::workers::register':
       return (
         <WorkersRegisterView input={input} output={output} running={running} />
+      )
+    case 'engine::register_trigger':
+      return (
+        <RegisterTriggerView input={input} output={output} running={running} />
       )
     default:
       return null

--- a/console/web/src/components/chat/engine/parsers.ts
+++ b/console/web/src/components/chat/engine/parsers.ts
@@ -23,6 +23,7 @@ export const ENGINE_FUNCTION_IDS = [
   'engine::workers::list',
   'engine::workers::info',
   'engine::workers::register',
+  'engine::register_trigger',
 ] as const
 
 export type EngineFunctionId = (typeof ENGINE_FUNCTION_IDS)[number]
@@ -239,6 +240,81 @@ export const workersRegisterResponseSchema = z.object({
 })
 export type WorkersRegisterResponse = z.infer<
   typeof workersRegisterResponseSchema
+>
+
+/* ---------------- engine::register_trigger ---------------- */
+
+/**
+ * Registration request. Covers both wire shapes seen under this id:
+ *  - engine `RegisterTriggerInput` (iii-sdk `protocol.rs`): `{ trigger_type,
+ *    function_id, config, metadata? }`.
+ *  - harness `SubscribeArgs` (`harness/src/functions/subscribe.rs`):
+ *    `{ trigger_type, config?, label?, once?, function_id?, metadata? }` —
+ *    `function_id` omitted means "notify this session".
+ * Only `trigger_type` is guaranteed; everything else is optional so the view
+ * always renders. `config`/`metadata` are opaque JSON parsed per-provider.
+ */
+export const registerTriggerRequestSchema = z.object({
+  trigger_type: z.string(),
+  function_id: z.string().optional(),
+  config: z.unknown().optional(),
+  metadata: z.unknown().optional(),
+  label: z.string().optional(),
+  once: z.boolean().optional(),
+})
+export type RegisterTriggerRequest = z.infer<
+  typeof registerTriggerRequestSchema
+>
+
+/** `config` shape for `trigger_type: "state"` (all fields optional filters). */
+export const stateTriggerConfigSchema = z.object({
+  scope: z.string().optional(),
+  key: z.string().optional(),
+  condition_function_id: z.string().optional(),
+})
+export type StateTriggerConfig = z.infer<typeof stateTriggerConfigSchema>
+
+/**
+ * `metadata` shape for `function_id: "harness::react"` — the reactive bridge.
+ * Wire source: `harness/src/functions/react.rs` (`ReactSpec` / `JoinSpec`).
+ * `options` is free-form (mirrors `harness::spawn` SpawnOptions); the common
+ * `options.functions.allow: string[]` is surfaced by the view.
+ */
+export const joinSpecSchema = z.object({
+  id: z.string(),
+  expect: z.array(z.string()),
+  key: z.string(),
+  rearm: z.boolean().optional(),
+})
+export type JoinSpec = z.infer<typeof joinSpecSchema>
+
+export const reactSpecSchema = z.object({
+  model: z.string(),
+  task: z.string(),
+  session_id: z.string().optional(),
+  provider: z.string().optional(),
+  options: z.unknown().optional(),
+  parent_session_id: z.string().optional(),
+  join: joinSpecSchema.optional(),
+})
+export type ReactSpec = z.infer<typeof reactSpecSchema>
+
+/** `options.functions.allow` — the only bit of the free-form `options` the
+ * view reads. Non-strict so unknown option keys pass through. */
+export const reactOptionsSchema = z.object({
+  functions: z.object({ allow: z.array(z.string()).optional() }).optional(),
+})
+export type ReactOptions = z.infer<typeof reactOptionsSchema>
+
+/** Engine returns `{ id }`; the harness-intercepted path returns
+ * `{ subscription_id, once }`. Model both loosely. */
+export const registerTriggerResponseSchema = z.object({
+  id: z.string().optional(),
+  subscription_id: z.string().optional(),
+  once: z.boolean().optional(),
+})
+export type RegisterTriggerResponse = z.infer<
+  typeof registerTriggerResponseSchema
 >
 
 /* ---------------- generic helpers ---------------- */

--- a/console/web/src/components/chat/state/StateView.tsx
+++ b/console/web/src/components/chat/state/StateView.tsx
@@ -1,0 +1,59 @@
+import { FilterChip } from '@/components/chat/engine/shared'
+import { MetaRow, StatusPill } from '@/components/chat/sandbox/shared'
+import { JsonHighlight } from '@/lib/syntax'
+import { safeParseRequest, stateRequestSchema, unwrapEnvelope } from './parsers'
+
+interface StateViewProps {
+  functionId: string
+  input: unknown
+  output: unknown
+  running?: boolean
+}
+
+/** `null`, `undefined`, `""`, `[]`, `{}` render as a compact "empty" note
+ * rather than a noisy JSON block. Mirrors `ValuePane`'s `isEmptyValue`. */
+function isEmptyValue(v: unknown): boolean {
+  if (v === null || v === undefined) return true
+  if (typeof v === 'string') return v.length === 0
+  if (Array.isArray(v)) return v.length === 0
+  if (typeof v === 'object') {
+    return Object.keys(v as Record<string, unknown>).length === 0
+  }
+  return false
+}
+
+export function StateView({
+  functionId,
+  input,
+  output,
+  running,
+}: StateViewProps) {
+  const req = safeParseRequest(stateRequestSchema, input)
+  const op = functionId.startsWith('state::')
+    ? functionId.slice('state::'.length)
+    : functionId
+
+  const value = running ? undefined : unwrapEnvelope(output)
+  const empty = !running && isEmptyValue(value)
+
+  return (
+    <div className="border-t border-rule-2 bg-bg">
+      <MetaRow>
+        <StatusPill label={op} variant={running ? 'default' : 'accent'} />
+        {req?.scope ? <FilterChip label="scope" value={req.scope} /> : null}
+        {req?.key ? <FilterChip label="key" value={req.key} /> : null}
+      </MetaRow>
+      {running ? (
+        <div className="px-3 py-3 font-mono text-[12.5px] text-ink-ghost animate-pulse">
+          · running…
+        </div>
+      ) : empty ? (
+        <div className="px-3 py-3 font-mono text-[12.5px] text-ink-ghost">
+          · empty
+        </div>
+      ) : (
+        <JsonHighlight code={JSON.stringify(value ?? null, null, 2)} />
+      )}
+    </div>
+  )
+}

--- a/console/web/src/components/chat/state/__tests__/parsers.test.ts
+++ b/console/web/src/components/chat/state/__tests__/parsers.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isStateFunction,
+  safeParseRequest,
+  stateRequestSchema,
+  unwrapEnvelope,
+} from '../parsers'
+
+function wrap<T>(details: T) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(details) }],
+    details,
+    terminate: false,
+  }
+}
+
+describe('isStateFunction', () => {
+  it('matches every state:: op via prefix', () => {
+    for (const id of [
+      'state::get',
+      'state::set',
+      'state::delete',
+      'state::update',
+      'state::list',
+      'state::list_groups',
+    ]) {
+      expect(isStateFunction(id)).toBe(true)
+    }
+  })
+
+  it('rejects non-state ids', () => {
+    expect(isStateFunction('stateful::x')).toBe(false)
+    expect(isStateFunction('engine::register_trigger')).toBe(false)
+    expect(isStateFunction('state')).toBe(false)
+  })
+})
+
+describe('stateRequestSchema', () => {
+  it('parses scope + key', () => {
+    expect(
+      safeParseRequest(stateRequestSchema, { scope: 'ops', key: 'build' }),
+    ).toEqual({ scope: 'ops', key: 'build' })
+  })
+
+  it('tolerates missing fields (list_groups)', () => {
+    expect(safeParseRequest(stateRequestSchema, {})).toEqual({})
+    expect(safeParseRequest(stateRequestSchema, undefined)).toEqual({})
+  })
+
+  it('ignores extra request fields (value / ops)', () => {
+    expect(
+      safeParseRequest(stateRequestSchema, {
+        scope: 'ops',
+        key: 'build',
+        value: { status: 'green' },
+      }),
+    ).toEqual({ scope: 'ops', key: 'build' })
+  })
+})
+
+describe('unwrapEnvelope re-export', () => {
+  it('peels the harness envelope to the stored value', () => {
+    const value = { commit: 'abc123', status: 'green' }
+    expect(unwrapEnvelope(wrap(value))).toEqual(value)
+  })
+
+  it('returns primitives unchanged', () => {
+    expect(unwrapEnvelope(null)).toBeNull()
+    expect(unwrapEnvelope(42)).toBe(42)
+  })
+})

--- a/console/web/src/components/chat/state/__tests__/view.test.tsx
+++ b/console/web/src/components/chat/state/__tests__/view.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { SandboxErrorView } from '@/components/chat/sandbox/ErrorView'
+import type { FunctionCallMessage } from '@/types/chat'
+import { StateToolView } from '../index'
+import { StateView } from '../StateView'
+
+function wrap<T>(details: T) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(details) }],
+    details,
+    terminate: false,
+  }
+}
+
+function msg(output: unknown): FunctionCallMessage {
+  return {
+    id: 'state-view-test',
+    role: 'function-call',
+    functionId: 'state::get',
+    input: { scope: 'ops', key: 'gate' },
+    output,
+    durationMs: 1,
+    createdAt: 0,
+  }
+}
+
+/** Regression: state values are arbitrary JSON, so a *successful* get whose
+ *  stored value merely looks like a denial (`{ status: 'denied' }`) must render
+ *  as the value view — not the red error view — while a genuine
+ *  `function_error` envelope still surfaces as the error view. */
+describe('StateToolView.tryRender error discrimination', () => {
+  it('renders a denial-shaped stored value as the value view, not an error', () => {
+    const node = StateToolView.tryRender(
+      msg(wrap({ status: 'denied', reason: 'gate closed' })),
+    )
+    expect(node).not.toBeNull()
+    expect((node as { type: unknown }).type).toBe(StateView)
+  })
+
+  it('renders a { denied_by } stored value as the value view, not an error', () => {
+    const node = StateToolView.tryRender(msg(wrap({ denied_by: 'user' })))
+    expect((node as { type: unknown }).type).toBe(StateView)
+  })
+
+  it('still renders a real function_error envelope as the error view', () => {
+    const node = StateToolView.tryRender(
+      msg({
+        error: {
+          kind: 'function_error',
+          message: 'boom',
+          details: { status: 'denied', denied_by: 'gate_unavailable' },
+        },
+      }),
+    )
+    expect(node).not.toBeNull()
+    expect((node as { type: unknown }).type).toBe(SandboxErrorView)
+  })
+})

--- a/console/web/src/components/chat/state/index.tsx
+++ b/console/web/src/components/chat/state/index.tsx
@@ -1,0 +1,61 @@
+import { SandboxErrorView } from '@/components/chat/sandbox/ErrorView'
+import { parseSandboxErrorDisplay } from '@/components/chat/sandbox/parsers'
+import type { FunctionCallMessage } from '@/types/chat'
+import { isStateFunction } from './parsers'
+import { StateView } from './StateView'
+
+/**
+ * Header label for `state::*` ids — dims the namespace prefix so the op
+ * (`get`, `set`, …) reads clearly. Mirrors `EngineFunctionIdLabel`.
+ */
+export function StateFunctionIdLabel({ functionId }: { functionId: string }) {
+  if (!functionId.startsWith('state::')) {
+    return <span className="text-ink">{functionId}</span>
+  }
+  const tail = functionId.slice('state::'.length)
+  return (
+    <>
+      <span className="text-ink-faint">state::</span>
+      <span className="text-ink font-medium">{tail}</span>
+    </>
+  )
+}
+
+function tryRender(message: FunctionCallMessage): React.ReactNode | null {
+  if (!isStateFunction(message.functionId)) return null
+  if (message.pendingApproval) return null
+
+  const running = !!message.running
+  const rawOutput = message.output
+
+  // Reuse the shared error parser for gate/transport-level errors — the
+  // `function_error` envelope is shared infra, not sandbox-specific.
+  const errorDisplay =
+    !running && rawOutput != null ? parseSandboxErrorDisplay(rawOutput) : null
+  if (errorDisplay) {
+    return <SandboxErrorView display={errorDisplay} />
+  }
+
+  return (
+    <StateView
+      functionId={message.functionId}
+      input={message.input}
+      output={rawOutput}
+      running={running}
+    />
+  )
+}
+
+/** `state::*` calls have no bespoke pending preview. */
+function tryRenderPreview(
+  _message: FunctionCallMessage,
+): React.ReactNode | null {
+  return null
+}
+
+export const StateToolView = {
+  isStateFunction,
+  tryRender,
+  tryRenderRunning: tryRender,
+  tryRenderPreview,
+}

--- a/console/web/src/components/chat/state/index.tsx
+++ b/console/web/src/components/chat/state/index.tsx
@@ -29,9 +29,23 @@ function tryRender(message: FunctionCallMessage): React.ReactNode | null {
   const rawOutput = message.output
 
   // Reuse the shared error parser for gate/transport-level errors — the
-  // `function_error` envelope is shared infra, not sandbox-specific.
+  // `function_error` envelope is shared infra, not sandbox-specific. But state
+  // values are arbitrary JSON, and a *successful* result whose stored value
+  // looks like a denial (e.g. `{ status: 'denied' }`, `{ denied_by: … }`) would
+  // otherwise be misread as an error. A real error is `{ error: { kind:
+  // 'function_error', … } }`; a success is a `{ content, details }` harness
+  // envelope. Skip the parser for success envelopes so only genuine errors —
+  // which are never `{ content, details }` shaped — reach it.
+  const isSuccessEnvelope =
+    !!rawOutput &&
+    typeof rawOutput === 'object' &&
+    !Array.isArray(rawOutput) &&
+    Array.isArray((rawOutput as Record<string, unknown>).content) &&
+    'details' in (rawOutput as Record<string, unknown>)
   const errorDisplay =
-    !running && rawOutput != null ? parseSandboxErrorDisplay(rawOutput) : null
+    !running && rawOutput != null && !isSuccessEnvelope
+      ? parseSandboxErrorDisplay(rawOutput)
+      : null
   if (errorDisplay) {
     return <SandboxErrorView display={errorDisplay} />
   }

--- a/console/web/src/components/chat/state/parsers.ts
+++ b/console/web/src/components/chat/state/parsers.ts
@@ -1,0 +1,32 @@
+/**
+ * Parsers for the `state::*` family (`state::get|set|delete|update|list|
+ * list_groups`). All ops are keyed by `scope` (+ `key`, except `list` /
+ * `list_groups`); stored values are arbitrary JSON. The minimal view only
+ * surfaces `scope`/`key` from the request and renders the unwrapped result
+ * as JSON, so the request schema stays deliberately loose.
+ *
+ * Wire source: engine state worker (`state::*` are engine built-ins).
+ */
+import { z } from 'zod'
+import { unwrapEnvelope } from '@/components/chat/sandbox/parsers'
+
+export { unwrapEnvelope }
+
+/** Every `state::` id is handled by this family (prefix match). */
+export function isStateFunction(id: string): boolean {
+  return id.startsWith('state::')
+}
+
+export const stateRequestSchema = z.object({
+  scope: z.string().optional(),
+  key: z.string().optional(),
+})
+export type StateRequest = z.infer<typeof stateRequestSchema>
+
+export function safeParseRequest<T>(
+  schema: z.ZodType<T>,
+  value: unknown,
+): T | null {
+  const parsed = schema.safeParse(value ?? {})
+  return parsed.success ? parsed.data : null
+}

--- a/console/web/src/stories/fixtures/engine-fixtures.ts
+++ b/console/web/src/stories/fixtures/engine-fixtures.ts
@@ -559,6 +559,70 @@ export const engineWorkerRegisterRunning = base(
   { running: true },
 )
 
+/* ---------------- engine::register_trigger ---------------- */
+
+export const engineRegisterTriggerReact = base(
+  'engine-register-trigger-react',
+  'engine::register_trigger',
+  {
+    trigger_type: 'state',
+    function_id: 'harness::react',
+    config: { key: 'build', scope: 'ops' },
+    metadata: {
+      model: 'claude-sonnet-5',
+      session_id: 'console-f0aac029-62a3-43f8-953b-45d0d903a866',
+      task: 'You are the GATE REVIEWER for a deploy pipeline. Both state records ops/build and ops/tests must be green before you approve.',
+      options: { functions: { allow: ['state::get'] } },
+      join: {
+        id: 'gate-decision-join',
+        key: 'build',
+        expect: ['build', 'tests'],
+        rearm: true,
+      },
+    },
+  },
+  wrapHarness({ id: 'trg-abc123def456' }),
+)
+
+export const engineRegisterTriggerCron = base(
+  'engine-register-trigger-cron',
+  'engine::register_trigger',
+  {
+    trigger_type: 'cron',
+    function_id: 'ops::nightly-sweep',
+    config: { expression: '0 0 3 * * *' },
+  },
+  wrapHarness({ id: 'trg-cron-01' }),
+)
+
+export const engineRegisterTriggerSubscribe = base(
+  'engine-register-trigger-subscribe',
+  'engine::register_trigger',
+  {
+    trigger_type: 'state',
+    config: { key: 'progress', scope: 'research' },
+    label: 'research-progress-watch',
+    once: false,
+  },
+  wrapHarness({
+    once: false,
+    subscription_id: 'sub_6c9c9f043f5f449dab6569d2f27a8c05',
+  }),
+)
+
+export const engineRegisterTriggerRunning = base(
+  'engine-register-trigger-running',
+  'engine::register_trigger',
+  {
+    trigger_type: 'state',
+    function_id: 'harness::react',
+    config: { scope: 'ops' },
+    metadata: { model: 'claude-sonnet-5', task: 'watch for changes' },
+  },
+  undefined,
+  { running: true },
+)
+
 export const engineFixtures = [
   engineFunctionsListDone,
   engineFunctionsListRaw,
@@ -578,6 +642,10 @@ export const engineFixtures = [
   engineWorkerInfoNotFound,
   engineWorkerRegisterDone,
   engineWorkerRegisterRunning,
+  engineRegisterTriggerReact,
+  engineRegisterTriggerCron,
+  engineRegisterTriggerSubscribe,
+  engineRegisterTriggerRunning,
   engineRunning,
   engineFunctionsListGateError,
 ] as const

--- a/console/web/src/stories/fixtures/state-fixtures.ts
+++ b/console/web/src/stories/fixtures/state-fixtures.ts
@@ -1,0 +1,81 @@
+import type { FunctionCallMessage } from '@/types/chat'
+import { wrapHarness } from './sandbox-fixtures'
+
+const now = Date.now()
+
+function base(
+  id: string,
+  functionId: string,
+  input: unknown,
+  output?: unknown,
+  extra?: Partial<FunctionCallMessage>,
+): FunctionCallMessage {
+  return {
+    id,
+    role: 'function-call',
+    functionId,
+    input,
+    output,
+    durationMs: 2,
+    createdAt: now,
+    ...extra,
+  }
+}
+
+/* ---------------- state::get ---------------- */
+
+export const stateGetValue = base(
+  'state-get-value',
+  'state::get',
+  { scope: 'ops', key: 'build' },
+  wrapHarness({ commit: 'abc123', status: 'green' }),
+)
+
+export const stateGetMissing = base(
+  'state-get-missing',
+  'state::get',
+  { scope: 'ops', key: 'nonexistent' },
+  wrapHarness(null),
+)
+
+export const stateGetRunning = base(
+  'state-get-running',
+  'state::get',
+  { scope: 'ops', key: 'build' },
+  undefined,
+  { running: true },
+)
+
+/* ---------------- state::set / delete ---------------- */
+
+export const stateSet = base(
+  'state-set',
+  'state::set',
+  { scope: 'ops', key: 'build', value: { status: 'green' } },
+  wrapHarness({ old_value: { status: 'red' }, new_value: { status: 'green' } }),
+)
+
+export const stateDelete = base(
+  'state-delete',
+  'state::delete',
+  { scope: 'ops', key: 'build' },
+  wrapHarness({ status: 'green' }),
+)
+
+/* ---------------- state::list_groups ---------------- */
+
+export const stateListGroups = base(
+  'state-list-groups',
+  'state::list_groups',
+  {},
+  wrapHarness({ groups: ['ops', 'build', 'sessions'] }),
+)
+
+export const stateFixtures = [
+  stateGetValue,
+  stateGetMissing,
+  stateGetRunning,
+  stateSet,
+  stateDelete,
+  stateListGroups,
+] as const


### PR DESCRIPTION
## What

Adds two custom tool-views to the console chat transcript and fixes a rendering bug.

### 1. Fix duplicated `REQUEST` pane
For any **completed, generic** tool call (one without a custom view), the request JSON pane rendered **twice**. `showRequestPaneAbove` only excluded the completed-*with*-custom-view case, so the top pane and the generic completed branch both emitted `REQUEST`. Now it's suppressed for every completed state — a one-line root-cause fix that repairs every generic tool card.

### 2. `engine::register_trigger` view (rich, react-aware)
Legible view for trigger registration. Handles both wire shapes seen under this id:
- engine `RegisterTriggerInput` — `{ trigger_type, function_id, config, metadata }`
- harness `SubscribeArgs` — `{ trigger_type, config?, label?, once?, function_id? }` (no `function_id` ⇒ "notify session")

Surfaces `trigger_type → function_id`, config chips for `state` triggers, `label`/`once` (one-shot vs persistent), the registration/subscription `id`, and for `harness::react` the `model`, `options.functions.allow`, join summary (`id · key · expect[] · rearm`), and `task`. Falls back to raw request JSON so the terminal pane is never blank.

### 3. `state::*` view (new family)
Minimal, uniform view for `get / set / delete / update / list / list_groups`: scope/key chips + the unwrapped result rendered as one highlighted JSON block.

## Tests / verification
- `pnpm typecheck` clean · `pnpm test` **817 pass** (new engine + state parser tests) · biome lint clean · `storybook build` succeeds.
- Storybook: `RegisterTriggerView` under **EngineFamily** (react/cron/subscribe/running fixtures); `StateView` under the new **StateFamily** gallery.

https://claude.ai/code/session_01SB8sknFhJLojcaBdQazmPH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for viewing state-related chat actions, including request details, running status, and formatted output.
  * Added a new trigger registration view with clearer status, IDs, modes, and configuration details.
  * Expanded Storybook coverage with new state and trigger examples.

* **Bug Fixes**
  * Improved how request and response details are shown for state and trigger messages.
  * Better handling of empty, missing, or running outputs in the chat UI.

* **Tests**
  * Added parser coverage for state and trigger message formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Post-review hardening (follow-up commit `8e76e77d`)

Ran `/review` + `/ship` on the branch. Two informational findings, both fixed:

- **State view no longer misreports success as error.** `state::*` results are arbitrary JSON, but the view ran every result through the shared sandbox error parser — so a successful `state::get` returning `{ status: "denied" }` / `{ denied_by: … }` rendered as a red "Denied" error. Now error-parsing is skipped for success envelopes (`{ content, details }`); genuine errors (`{ error: { kind: "function_error" } }`, wire/denial shapes) still surface. Matters for this feature's gate/deploy domain, where denial-shaped state values are realistic. Added `state/__tests__/view.test.tsx` (3 tests) locking both directions.
- **`harness::react` allow-list chips** now dedupe so the React key stays unique on repeated function ids.

Verified: `pnpm test` **840 pass**, `tsc -b` clean, biome clean on changed files.

> Heads-up (not this PR): after merging `main`, `biome check src` reports **15 pre-existing errors** in `pages/Workers/**` and `Configuration/tabs/WorkersTab/schema-form/**` (inherited from `main`, not gated by console CI). Worth a separate cleanup pass.