### PR TITLE
feat(harness): support workspace folder grants

### DIFF
--- a/harness/src/clients/engine.rs
+++ b/harness/src/clients/engine.rs
@@ -9,8 +9,6 @@ use iii_sdk::protocol::TriggerRequest;
 use iii_sdk::IIIClient;
 use serde_json::{json, Value};
 
-use crate::error::HarnessError;
-
 /// A registry function descriptor (id + optional schemas/description). Only
 /// the fields the harness reads are typed; the rest pass through as `extra`.
 #[derive(Debug, Clone)]
@@ -18,6 +16,12 @@ pub struct FunctionDescriptor {
     pub function_id: String,
     pub description: Option<String>,
     pub parameters: Option<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DispatchError {
+    pub code: Option<String>,
+    pub message: String,
 }
 
 #[derive(Clone)]
@@ -33,7 +37,11 @@ impl EngineClient {
 
     /// Dispatch an arbitrary iii function and return its raw result. This is
     /// the target invocation of an unwrapped `agent_trigger` call.
-    pub async fn dispatch(&self, function_id: &str, payload: Value) -> Result<Value, HarnessError> {
+    pub async fn dispatch(
+        &self,
+        function_id: &str,
+        payload: Value,
+    ) -> Result<Value, DispatchError> {
         self.iii
             .trigger(TriggerRequest {
                 function_id: function_id.to_string(),
@@ -42,7 +50,12 @@ impl EngineClient {
                 timeout_ms: Some(self.timeout_ms),
             })
             .await
-            .map_err(|e| HarnessError::Dependency(format!("{function_id}: {e}")))
+            .map_err(|e| {
+                let raw = e.to_string();
+                let mut parsed = parse_dispatch_error_message(&raw);
+                parsed.message = format!("{function_id}: {}", parsed.message);
+                parsed
+            })
     }
 
     /// List registry function descriptors (best-effort; empty on failure).
@@ -84,6 +97,60 @@ impl EngineClient {
     }
 }
 
+fn parse_dispatch_error_message(raw: &str) -> DispatchError {
+    if let Some(parsed) = parse_dispatch_error_value(raw) {
+        return parsed;
+    }
+
+    for index in raw.char_indices().map(|(index, _)| index) {
+        let suffix = &raw[index..];
+        if let Some(parsed) = parse_dispatch_error_value(suffix) {
+            return parsed;
+        }
+    }
+
+    DispatchError {
+        code: None,
+        message: raw.to_string(),
+    }
+}
+
+fn parse_dispatch_error_value(input: &str) -> Option<DispatchError> {
+    let value: Value = serde_json::from_str(input).ok()?;
+    parse_dispatch_error_json(&value)
+}
+
+fn parse_dispatch_error_json(value: &Value) -> Option<DispatchError> {
+    match value {
+        Value::Object(map) => {
+            let code = map.get("code").and_then(Value::as_str).map(str::to_string);
+            let message = map
+                .get("message")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            match (code, message) {
+                (Some(code), Some(message)) => Some(DispatchError {
+                    code: Some(code),
+                    message,
+                }),
+                (None, Some(message)) => {
+                    if let Ok(inner) = serde_json::from_str::<Value>(&message) {
+                        parse_dispatch_error_json(&inner)
+                    } else {
+                        Some(DispatchError {
+                            code: None,
+                            message,
+                        })
+                    }
+                }
+                _ => None,
+            }
+        }
+        Value::String(s) => parse_dispatch_error_value(s),
+        _ => None,
+    }
+}
+
 fn parse_descriptor_list(v: &Value) -> Vec<FunctionDescriptor> {
     let items: Vec<&Value> = match v {
         Value::Array(items) => items.iter().collect(),
@@ -122,4 +189,27 @@ fn descriptor_of(v: &Value) -> Option<FunctionDescriptor> {
         description,
         parameters,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dispatch_error_parser_extracts_plain_json_code_and_message() {
+        let err = parse_dispatch_error_message(
+            "remote error: {\"code\":\"C215\",\"message\":\"outside jail\"}",
+        );
+        assert_eq!(err.code.as_deref(), Some("C215"));
+        assert_eq!(err.message, "outside jail");
+    }
+
+    #[test]
+    fn dispatch_error_parser_extracts_coder_string_error_json() {
+        let err = parse_dispatch_error_message(
+            "handler error: \"{\\\"code\\\":\\\"C218\\\",\\\"message\\\":\\\"outside session\\\"}\"",
+        );
+        assert_eq!(err.code.as_deref(), Some("C218"));
+        assert_eq!(err.message, "outside session");
+    }
 }

--- a/harness/src/deferred.rs
+++ b/harness/src/deferred.rs
@@ -4,6 +4,8 @@
 //! expires stragglers so a lost child or abandoned approval can never park a
 //! turn forever.
 
+use std::collections::BTreeSet;
+
 use serde_json::{json, Value};
 
 use crate::deps::Deps;
@@ -95,10 +97,20 @@ pub async fn resolve(
             // approved shell/coder call runs un-scoped (the session's picked
             // directory becomes unreachable) and a model-supplied base_dir
             // recovered from the transcript would survive un-stripped.
+            let session_grants = crate::workspace_grants::roots(
+                &deps.iii,
+                &record.session_id,
+                cfg.session_timeout_ms,
+            )
+            .await?;
+            let trusted_roots =
+                union_roots(session_grants, req.extra_roots.clone().unwrap_or_default());
+            let working_dir = record.options.working_dir().map(str::to_string);
             let arguments = crate::workspace_inject::inject(
                 &function_id,
                 arguments,
-                record.options.working_dir(),
+                working_dir.as_deref(),
+                &trusted_roots,
             );
             if let Some(cp) = record.calls.get_mut(&req.function_call_id) {
                 cp.state = CallState::Triggered;
@@ -119,16 +131,40 @@ pub async fn resolve(
                 &record.session_id,
             )
             .await;
-            let (data, annotations) = deps
+            let post_outcome = deps
                 .hooks
                 .run_post_trigger(
                     &record,
                     record.step,
                     &req.function_call_id,
                     &function_id,
+                    &arguments,
                     raw,
                 )
                 .await;
+            let (data, annotations) = match post_outcome {
+                crate::hooks::runner::PostTriggerOutcome::Result {
+                    result,
+                    annotations,
+                } => (result, annotations),
+                crate::hooks::runner::PostTriggerOutcome::Hold {
+                    held_by,
+                    annotations: _,
+                } => {
+                    if let Some(cp) = record.calls.get_mut(&req.function_call_id) {
+                        cp.state = CallState::Pending;
+                        cp.held_by = Some(held_by);
+                        cp.pending_at = Some(AgentMessage::now_ms());
+                    }
+                    record.status = TurnStatus::AwaitingFunctions;
+                    record.updated_at = AgentMessage::now_ms();
+                    crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
+                    return Ok(FunctionResolveResponse {
+                        resolved: true,
+                        turn_resumed: false,
+                    });
+                }
+            };
 
             let entry_id = ids::function_result_entry_id(&record.turn_id, &req.function_call_id);
             let mut origin = serde_json::Map::new();
@@ -250,6 +286,7 @@ pub async fn resolve_parent(
         turn_id: parent.turn_id.clone(),
         function_call_id: parent.function_call_id.clone(),
         action: Some("deliver".to_string()),
+        extra_roots: None,
         content: Some(content),
         is_error: Some(is_error),
         details: Some(details),
@@ -311,6 +348,7 @@ pub async fn sweep_expired(deps: &Deps) -> Result<u64, HarnessError> {
             turn_id,
             function_call_id: call_id,
             action: Some("deliver".to_string()),
+            extra_roots: None,
             content: Some(vec![ContentBlock::text(
                 "pending call timed out".to_string(),
             )]),
@@ -337,6 +375,15 @@ fn render_text(value: &Value) -> String {
         Value::String(s) => s.clone(),
         other => serde_json::to_string(other).unwrap_or_default(),
     }
+}
+
+fn union_roots(session_roots: Vec<String>, extra_roots: Vec<String>) -> Vec<String> {
+    session_roots
+        .into_iter()
+        .chain(extra_roots)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
 }
 
 #[cfg(test)]
@@ -397,5 +444,20 @@ mod tests {
         let default = 1_800_000;
         let stale = cp(CallState::Pending, None, None, now - default as i64);
         assert!(pending_call_expired(&stale, default, now));
+    }
+
+    #[test]
+    fn union_roots_dedupes_session_and_one_shot_roots() {
+        assert_eq!(
+            union_roots(
+                vec!["/session".to_string(), "/shared".to_string()],
+                vec!["/once".to_string(), "/shared".to_string()],
+            ),
+            vec![
+                "/once".to_string(),
+                "/session".to_string(),
+                "/shared".to_string()
+            ]
+        );
     }
 }

--- a/harness/src/functions/function_resolve.rs
+++ b/harness/src/functions/function_resolve.rs
@@ -20,6 +20,10 @@ pub struct FunctionResolveRequest {
     /// hook-held call through the remaining trigger pipeline.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub action: Option<String>,
+    /// execute only: one-shot additional roots trusted by the caller and
+    /// unioned with the session's durable workspace grants.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra_roots: Option<Vec<String>>,
     // deliver only:
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content: Option<Vec<ContentBlock>>,

--- a/harness/src/functions/function_trigger.rs
+++ b/harness/src/functions/function_trigger.rs
@@ -97,11 +97,20 @@ pub async fn handle(
     // and re-apply it before invocation so neither a direct caller nor a hook
     // rewrite can widen the session scope. No turn record → no scope: any
     // caller-supplied base_dir is stripped.
-    let working_dir = record.as_ref().and_then(|r| r.options.working_dir());
+    let session_grants = if record.is_some() {
+        crate::workspace_grants::roots(&deps.iii, &req.session_id, cfg.session_timeout_ms).await?
+    } else {
+        Vec::new()
+    };
+    let working_dir = record
+        .as_ref()
+        .and_then(|rec| rec.options.working_dir())
+        .map(str::to_string);
     let mut arguments = crate::workspace_inject::inject(
         &req.call.function_id,
         req.call.arguments.clone(),
-        working_dir,
+        working_dir.as_deref(),
+        &session_grants,
     );
     if let Some(rec) = &record {
         match deps
@@ -115,7 +124,14 @@ pub async fn handle(
             )
             .await
         {
-            PreTriggerOutcome::Continue { arguments: a, .. } => arguments = a,
+            PreTriggerOutcome::Continue { arguments: a, .. } => {
+                arguments = crate::workspace_inject::inject(
+                    &req.call.function_id,
+                    a,
+                    working_dir.as_deref(),
+                    &session_grants,
+                );
+            }
             PreTriggerOutcome::Deny(reason) => {
                 let data = trigger::ResultData {
                     content: vec![ContentBlock::text(reason.clone())],
@@ -142,7 +158,12 @@ pub async fn handle(
 
     // Re-stamp after the hook chain (idempotent) — a hook rewrite must not
     // widen or drop the session scope.
-    let arguments = crate::workspace_inject::inject(&req.call.function_id, arguments, working_dir);
+    let arguments = crate::workspace_inject::inject(
+        &req.call.function_id,
+        arguments,
+        working_dir.as_deref(),
+        &session_grants,
+    );
 
     // Single invocation chokepoint: subscription control calls are intercepted
     // (trusted session injected); everything else invokes the target.
@@ -156,10 +177,28 @@ pub async fn handle(
     )
     .await;
     let data = if let Some(rec) = &record {
-        deps.hooks
-            .run_post_trigger(rec, rec.step, &req.call.id, &req.call.function_id, raw)
+        match deps
+            .hooks
+            .run_post_trigger(
+                rec,
+                rec.step,
+                &req.call.id,
+                &req.call.function_id,
+                &arguments,
+                raw,
+            )
             .await
-            .0
+        {
+            crate::hooks::runner::PostTriggerOutcome::Result { result, .. } => result,
+            crate::hooks::runner::PostTriggerOutcome::Hold { .. } => {
+                return Ok(FunctionTriggerResponse::Pending(TriggerPendingResponse {
+                    function_call_id: req.call.id,
+                    function_id: req.call.function_id,
+                    pending: true,
+                    pending_timeout_ms: None,
+                }));
+            }
+        }
     } else {
         raw
     };

--- a/harness/src/functions/mod.rs
+++ b/harness/src/functions/mod.rs
@@ -13,6 +13,7 @@ pub mod stop;
 pub mod subscribe;
 pub mod sweep_pending;
 pub mod turn;
+pub mod workspace;
 
 use std::future::Future;
 use std::sync::Arc;
@@ -54,6 +55,18 @@ pub const STOP_DESC: &str =
 
 pub const STATUS_ID: &str = "harness::status";
 pub const STATUS_DESC: &str = "Read the current turn status for a session.";
+
+pub const WORKSPACE_GRANT_ID: &str = "harness::workspace::grant";
+pub const WORKSPACE_GRANT_DESC: &str =
+    "Internal control-plane: grant a session access to an additional workspace root.";
+
+pub const WORKSPACE_GRANTS_ID: &str = "harness::workspace::grants";
+pub const WORKSPACE_GRANTS_DESC: &str =
+    "Internal control-plane: list additional workspace roots granted to a session.";
+
+pub const WORKSPACE_REVOKE_ID: &str = "harness::workspace::revoke";
+pub const WORKSPACE_REVOKE_DESC: &str =
+    "Internal control-plane: revoke a session's access to an additional workspace root.";
 
 /// Register one typed handler under `id`, mapping `HarnessError` into the bus
 /// error shape (`code: message`).
@@ -111,6 +124,30 @@ pub fn register_all(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
     register(iii, deps, STATUS_ID, STATUS_DESC, |d, r| async move {
         status::handle(&d, r).await
     });
+
+    // Internal workspace grant controls — registered for trusted callers, kept
+    // off the model-facing catalog.
+    register(
+        iii,
+        deps,
+        WORKSPACE_GRANT_ID,
+        WORKSPACE_GRANT_DESC,
+        |d, r| async move { workspace::grant(&d, r).await },
+    );
+    register(
+        iii,
+        deps,
+        WORKSPACE_GRANTS_ID,
+        WORKSPACE_GRANTS_DESC,
+        |d, r| async move { workspace::grants(&d, r).await },
+    );
+    register(
+        iii,
+        deps,
+        WORKSPACE_REVOKE_ID,
+        WORKSPACE_REVOKE_DESC,
+        |d, r| async move { workspace::revoke(&d, r).await },
+    );
 
     // Internal cron target — registered, but kept off the public catalog.
     register(

--- a/harness/src/functions/on_session_deleted.rs
+++ b/harness/src/functions/on_session_deleted.rs
@@ -37,5 +37,7 @@ pub async fn handle(
             "session deleted: ephemeral subscriptions dropped"
         );
     }
+    let cfg = deps.cfg().await;
+    crate::workspace_grants::purge(&deps.iii, &event.session_id, cfg.session_timeout_ms).await?;
     Ok(SessionDeletedAck { ok: true, removed })
 }

--- a/harness/src/functions/send.rs
+++ b/harness/src/functions/send.rs
@@ -272,12 +272,18 @@ async fn seed_or_merge(
             let recheck =
                 crate::state::get_turn(&deps.iii, session_id, cfg.session_timeout_ms).await?;
             match recheck {
-                Some(r) if !r.status.is_terminal() => Ok(StartOutcome {
-                    session_id: session_id.to_string(),
-                    turn_id: r.turn_id,
-                    merged: true,
-                    deduplicated: false,
-                }),
+                Some(mut r) if !r.status.is_terminal() => {
+                    if r.options.refresh_working_dir_from(&options) {
+                        r.updated_at = AgentMessage::now_ms();
+                        crate::state::put_turn(&deps.iii, &r, cfg.session_timeout_ms).await?;
+                    }
+                    Ok(StartOutcome {
+                        session_id: session_id.to_string(),
+                        turn_id: r.turn_id,
+                        merged: true,
+                        deduplicated: false,
+                    })
+                }
                 _ => seed_new(deps, cfg, session_id, options).await,
             }
         }

--- a/harness/src/functions/workspace.rs
+++ b/harness/src/functions/workspace.rs
@@ -1,0 +1,75 @@
+//! Trusted workspace grant controls. These are registered harness functions for
+//! orchestration code, but intentionally excluded from the model-facing catalog.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::deps::Deps;
+use crate::error::HarnessError;
+
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct WorkspaceGrantRequest {
+    pub session_id: String,
+    pub root: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct WorkspaceGrantsRequest {
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct WorkspaceRevokeRequest {
+    pub session_id: String,
+    pub root: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct WorkspaceGrantsResponse {
+    pub session_id: String,
+    pub roots: Vec<String>,
+}
+
+pub async fn grant(
+    deps: &Deps,
+    req: WorkspaceGrantRequest,
+) -> Result<WorkspaceGrantsResponse, HarnessError> {
+    let cfg = deps.cfg().await;
+    let roots = crate::workspace_grants::grant(
+        &deps.iii,
+        &req.session_id,
+        req.root,
+        cfg.session_timeout_ms,
+    )
+    .await?;
+    Ok(response(req.session_id, roots))
+}
+
+pub async fn grants(
+    deps: &Deps,
+    req: WorkspaceGrantsRequest,
+) -> Result<WorkspaceGrantsResponse, HarnessError> {
+    let cfg = deps.cfg().await;
+    let roots =
+        crate::workspace_grants::roots(&deps.iii, &req.session_id, cfg.session_timeout_ms).await?;
+    Ok(response(req.session_id, roots))
+}
+
+pub async fn revoke(
+    deps: &Deps,
+    req: WorkspaceRevokeRequest,
+) -> Result<WorkspaceGrantsResponse, HarnessError> {
+    let cfg = deps.cfg().await;
+    let roots = crate::workspace_grants::revoke(
+        &deps.iii,
+        &req.session_id,
+        &req.root,
+        cfg.session_timeout_ms,
+    )
+    .await?;
+    Ok(response(req.session_id, roots))
+}
+
+fn response(session_id: String, roots: Vec<String>) -> WorkspaceGrantsResponse {
+    WorkspaceGrantsResponse { session_id, roots }
+}

--- a/harness/src/hooks/runner.rs
+++ b/harness/src/hooks/runner.rs
@@ -55,6 +55,17 @@ pub enum PreTriggerOutcome {
     },
 }
 
+pub enum PostTriggerOutcome {
+    Result {
+        result: crate::trigger::ResultData,
+        annotations: Map<String, Value>,
+    },
+    Hold {
+        held_by: String,
+        annotations: Map<String, Value>,
+    },
+}
+
 impl HookRegistry {
     fn envelope(&self, point: HookPoint, record: &TurnRecord, step: u64) -> Value {
         let mut v = serde_json::json!({
@@ -185,14 +196,20 @@ impl HookRegistry {
         step: u64,
         call_id: &str,
         function_id: &str,
+        arguments: &Value,
         mut result: crate::trigger::ResultData,
-    ) -> (crate::trigger::ResultData, Map<String, Value>) {
+    ) -> PostTriggerOutcome {
         let mut annotations = Map::new();
         for binding in self.post_trigger.ordered() {
             if !functions_match(&binding, function_id) {
                 continue;
             }
             let mut input = self.envelope(HookPoint::PostTrigger, record, step);
+            input["call"] = serde_json::json!({
+                "id": call_id,
+                "function_id": function_id,
+                "arguments": arguments,
+            });
             input["result"] = serde_json::json!({
                 "function_call_id": call_id,
                 "function_id": function_id,
@@ -200,21 +217,34 @@ impl HookRegistry {
                 "is_error": result.is_error,
                 "details": result.details,
             });
-            // deny/hold are not valid at post_trigger — treat as continue.
-            if let HookOutcome::Continue(m) = self.invoke(&binding, input).await {
-                if let Some(c) = m.content {
-                    result.content = c;
+            match self.invoke(&binding, input).await {
+                HookOutcome::Continue(m) => {
+                    if let Some(c) = m.content {
+                        result.content = c;
+                    }
+                    if let Some(d) = m.details {
+                        result.details = d;
+                    }
+                    if let Some(e) = m.is_error {
+                        result.is_error = e;
+                    }
+                    merge(&mut annotations, m.annotations);
                 }
-                if let Some(d) = m.details {
-                    result.details = d;
+                // Deny is not valid at post_trigger; fail-open like existing
+                // post-trigger error handling.
+                HookOutcome::Deny(_) => {}
+                HookOutcome::Hold => {
+                    return PostTriggerOutcome::Hold {
+                        held_by: binding.function_id.clone(),
+                        annotations,
+                    };
                 }
-                if let Some(e) = m.is_error {
-                    result.is_error = e;
-                }
-                merge(&mut annotations, m.annotations);
             }
         }
-        (result, annotations)
+        PostTriggerOutcome::Result {
+            result,
+            annotations,
+        }
     }
 
     /// Invoke one bound hook function, bounded by `timeout_ms` and resolved by

--- a/harness/src/lib.rs
+++ b/harness/src/lib.rs
@@ -30,4 +30,5 @@ pub mod surface;
 pub mod trigger;
 pub mod turn_loop;
 pub mod types;
+pub mod workspace_grants;
 pub mod workspace_inject;

--- a/harness/src/state.rs
+++ b/harness/src/state.rs
@@ -16,7 +16,7 @@ use crate::types::turn::{IdemRecord, TurnRecord};
 pub const TURN_SCOPE: &str = "harness_turn";
 pub const IDEM_SCOPE: &str = "harness_idem";
 
-async fn state_get(
+pub(crate) async fn state_get(
     iii: &IIIClient,
     scope: &str,
     key: &str,
@@ -32,7 +32,7 @@ async fn state_get(
     .map_err(|e| HarnessError::State(format!("state::get {scope}/{key}: {e}")))
 }
 
-async fn state_set(
+pub(crate) async fn state_set(
     iii: &IIIClient,
     scope: &str,
     key: &str,
@@ -50,7 +50,7 @@ async fn state_set(
     .map_err(|e| HarnessError::State(format!("state::set {scope}/{key}: {e}")))
 }
 
-async fn state_delete(
+pub(crate) async fn state_delete(
     iii: &IIIClient,
     scope: &str,
     key: &str,

--- a/harness/src/trigger.rs
+++ b/harness/src/trigger.rs
@@ -78,11 +78,14 @@ pub async fn invoke_target(
                 details: value,
             }
         }
-        Err(e) => ResultData {
-            content: vec![ContentBlock::text(e.to_string())],
-            is_error: true,
-            details: json!({ "error": e.to_string() }),
-        },
+        Err(e) => {
+            let message = e.message.clone();
+            ResultData {
+                content: vec![ContentBlock::text(message.clone())],
+                is_error: true,
+                details: json!({ "error": { "code": e.code, "message": message } }),
+            }
+        }
     }
 }
 

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -336,6 +336,10 @@ pub async fn run_step(
     if !trigger_calls.is_empty() {
         let policy = CompiledPolicy::from(record.options.functions.as_ref());
         let engine = deps.engine().await;
+        let session_grants =
+            crate::workspace_grants::roots(&deps.iii, &record.session_id, cfg.session_timeout_ms)
+                .await?;
+        let working_dir = record.options.working_dir().map(str::to_string);
         for call in trigger_calls.iter().copied() {
             // Per-call checkpoint: skip done/pending, recover an interrupted
             // trigger.
@@ -374,10 +378,11 @@ pub async fn run_step(
             // args ALREADY carrying the workspace stamp so an approver reviews
             // the base_dir the call will actually run under; the stamp is
             // re-applied after the chain so a hook rewrite can never widen it.
-            let staged_args = crate::workspace_inject::inject(
+            let trusted_call_args = crate::workspace_inject::inject(
                 &call.function_id,
                 call.arguments.clone(),
-                record.options.working_dir(),
+                working_dir.as_deref(),
+                &session_grants,
             );
             let (eff_args, pre_ann) = match deps
                 .hooks
@@ -386,14 +391,22 @@ pub async fn run_step(
                     payload.step,
                     &call.id,
                     &call.function_id,
-                    &staged_args,
+                    &trusted_call_args,
                 )
                 .await
             {
                 crate::hooks::runner::PreTriggerOutcome::Continue {
                     arguments,
                     annotations,
-                } => (arguments, annotations),
+                } => {
+                    let arguments = crate::workspace_inject::inject(
+                        &call.function_id,
+                        arguments,
+                        working_dir.as_deref(),
+                        &session_grants,
+                    );
+                    (arguments, annotations)
+                }
                 crate::hooks::runner::PreTriggerOutcome::Deny(reason) => {
                     let data = trigger::ResultData {
                         content: vec![ContentBlock::text(reason.clone())],
@@ -469,17 +482,6 @@ pub async fn run_step(
             );
             crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
 
-            // Stamp the per-session working directory onto scoped shell/coder
-            // calls as `base_dir` BEFORE invocation. The harness owns scoping:
-            // this overwrites any model-supplied base_dir so the model cannot
-            // widen its own workspace. A None working_dir is a no-op (the args
-            // pass through byte-for-byte unchanged).
-            let scoped_args = crate::workspace_inject::inject(
-                &call.function_id,
-                eff_args,
-                record.options.working_dir(),
-            );
-
             // Single invocation chokepoint: subscription control calls are
             // intercepted (trusted session injected); everything else invokes the
             // target. Then the post_trigger chain runs over the result.
@@ -488,15 +490,42 @@ pub async fn run_step(
                 &engine,
                 &policy,
                 &call.function_id,
-                &scoped_args,
+                &eff_args,
                 &record.session_id,
             )
             .await;
-            let (data, post_ann) = deps
+            let post_outcome = deps
                 .hooks
-                .run_post_trigger(&record, payload.step, &call.id, &call.function_id, raw)
+                .run_post_trigger(
+                    &record,
+                    payload.step,
+                    &call.id,
+                    &call.function_id,
+                    &eff_args,
+                    raw,
+                )
                 .await;
             let mut annotations = pre_ann;
+            let (data, post_ann) = match post_outcome {
+                crate::hooks::runner::PostTriggerOutcome::Result {
+                    result,
+                    annotations,
+                } => (result, annotations),
+                crate::hooks::runner::PostTriggerOutcome::Hold {
+                    held_by,
+                    annotations: _,
+                } => {
+                    let info = trigger::PendingInfo {
+                        pending_timeout_ms: None,
+                        held_by: Some(held_by),
+                        child_session_id: None,
+                        child_turn_id: None,
+                    };
+                    checkpoint_pending(&mut record, &call.id, call, &info);
+                    crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
+                    continue;
+                }
+            };
             for (k, v) in post_ann {
                 annotations.insert(k, v);
             }

--- a/harness/src/types/turn.rs
+++ b/harness/src/types/turn.rs
@@ -105,6 +105,29 @@ impl TurnOptions {
             .and_then(|m| m.get(WORKING_DIR_KEY))
             .and_then(Value::as_str)
     }
+
+    pub fn refresh_working_dir_from(&mut self, incoming: &TurnOptions) -> bool {
+        let Some(working_dir) = incoming.working_dir() else {
+            return false;
+        };
+        if self.working_dir() == Some(working_dir) {
+            return false;
+        }
+
+        let metadata = self
+            .metadata
+            .get_or_insert_with(|| Value::Object(Default::default()));
+        if !metadata.is_object() {
+            *metadata = Value::Object(Default::default());
+        }
+        if let Some(map) = metadata.as_object_mut() {
+            map.insert(
+                WORKING_DIR_KEY.to_string(),
+                Value::String(working_dir.to_string()),
+            );
+        }
+        true
+    }
 }
 
 /// Lifecycle of one function call within a turn (harness.md § Per-call
@@ -334,5 +357,30 @@ mod tests {
         assert!(r.calls.is_empty());
         assert_eq!(r.options.max_validation_retries, 2);
         assert_eq!(r.options.output, OutputContract::Text);
+    }
+
+    #[test]
+    fn refresh_working_dir_updates_only_when_incoming_has_scope() {
+        let mut existing = record().options;
+        existing.metadata = Some(json!({ "trace": "keep", "working_dir": "/old" }));
+
+        let mut incoming = existing.clone();
+        incoming.metadata = Some(json!({ "working_dir": "/new", "ignored": true }));
+
+        assert!(existing.refresh_working_dir_from(&incoming));
+        assert_eq!(existing.working_dir(), Some("/new"));
+        assert_eq!(
+            existing
+                .metadata
+                .as_ref()
+                .and_then(|m| m.get("trace"))
+                .and_then(Value::as_str),
+            Some("keep")
+        );
+
+        let mut no_scope = incoming;
+        no_scope.metadata = Some(json!({ "other": "/ignored" }));
+        assert!(!existing.refresh_working_dir_from(&no_scope));
+        assert_eq!(existing.working_dir(), Some("/new"));
     }
 }

--- a/harness/src/workspace_grants.rs
+++ b/harness/src/workspace_grants.rs
@@ -1,0 +1,110 @@
+use std::collections::BTreeSet;
+
+use iii_sdk::IIIClient;
+use serde::{Deserialize, Serialize};
+
+use crate::error::HarnessError;
+
+pub const WORKSPACE_GRANTS_SCOPE: &str = "harness_workspace_grants";
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GrantSet {
+    #[serde(default)]
+    roots: BTreeSet<String>,
+}
+
+impl GrantSet {
+    pub fn grant(&mut self, root: String) -> bool {
+        self.roots.insert(root)
+    }
+
+    pub fn revoke(&mut self, root: &str) -> bool {
+        self.roots.remove(root)
+    }
+
+    pub fn roots(&self) -> Vec<String> {
+        self.roots.iter().cloned().collect()
+    }
+}
+
+pub async fn roots(
+    iii: &IIIClient,
+    session_id: &str,
+    timeout_ms: u64,
+) -> Result<Vec<String>, HarnessError> {
+    Ok(read(iii, session_id, timeout_ms).await?.roots())
+}
+
+pub async fn grant(
+    iii: &IIIClient,
+    session_id: &str,
+    root: String,
+    timeout_ms: u64,
+) -> Result<Vec<String>, HarnessError> {
+    let mut grants = read(iii, session_id, timeout_ms).await?;
+    grants.grant(root);
+    write(iii, session_id, &grants, timeout_ms).await?;
+    Ok(grants.roots())
+}
+
+pub async fn revoke(
+    iii: &IIIClient,
+    session_id: &str,
+    root: &str,
+    timeout_ms: u64,
+) -> Result<Vec<String>, HarnessError> {
+    let mut grants = read(iii, session_id, timeout_ms).await?;
+    grants.revoke(root);
+    write(iii, session_id, &grants, timeout_ms).await?;
+    Ok(grants.roots())
+}
+
+pub async fn purge(iii: &IIIClient, session_id: &str, timeout_ms: u64) -> Result<(), HarnessError> {
+    crate::state::state_delete(iii, WORKSPACE_GRANTS_SCOPE, session_id, timeout_ms).await
+}
+
+async fn read(
+    iii: &IIIClient,
+    session_id: &str,
+    timeout_ms: u64,
+) -> Result<GrantSet, HarnessError> {
+    let value =
+        crate::state::state_get(iii, WORKSPACE_GRANTS_SCOPE, session_id, timeout_ms).await?;
+    if value.is_null() {
+        return Ok(GrantSet::default());
+    }
+    serde_json::from_value(value)
+        .map_err(|e| HarnessError::State(format!("workspace grants parse: {e}")))
+}
+
+async fn write(
+    iii: &IIIClient,
+    session_id: &str,
+    grants: &GrantSet,
+    timeout_ms: u64,
+) -> Result<(), HarnessError> {
+    let value = serde_json::to_value(grants)
+        .map_err(|e| HarnessError::State(format!("workspace grants serialize: {e}")))?;
+    crate::state::state_set(iii, WORKSPACE_GRANTS_SCOPE, session_id, value, timeout_ms).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grant_set_dedupes_lists_and_revokes_session_roots() {
+        let mut grants = GrantSet::default();
+        grants.grant("/tmp/z".to_string());
+        grants.grant("/tmp/a".to_string());
+        grants.grant("/tmp/z".to_string());
+
+        assert_eq!(
+            grants.roots(),
+            vec!["/tmp/a".to_string(), "/tmp/z".to_string()]
+        );
+        assert!(grants.revoke("/tmp/z"));
+        assert!(!grants.revoke("/tmp/missing"));
+        assert_eq!(grants.roots(), vec!["/tmp/a".to_string()]);
+    }
+}

--- a/harness/src/workspace_inject.rs
+++ b/harness/src/workspace_inject.rs
@@ -14,6 +14,7 @@ use serde_json::Value;
 /// The per-call field the harness stamps onto scoped function arguments.
 /// `snake_case` on the wire — the shell/coder workers read it verbatim.
 const BASE_DIR_FIELD: &str = "base_dir";
+const EXTRA_ROOTS_FIELD: &str = "extra_roots";
 
 /// True when `function_id` names a workspace-scoped worker call (`shell::*` or
 /// `coder::*`) whose paths must be anchored at the session working directory.
@@ -31,9 +32,15 @@ fn is_scoped_function(function_id: &str) -> bool {
 ///
 /// When it does apply, the top-level `base_dir` is SET to `working_dir`,
 /// OVERWRITING any caller-supplied value. If no `working_dir` is active, a
-/// caller-supplied `base_dir` is removed. The harness controls scoping and the
-/// model must not be able to widen it.
-pub fn inject(function_id: &str, args: Value, working_dir: Option<&str>) -> Value {
+/// caller-supplied `base_dir` is removed. `extra_roots` is always replaced with
+/// the trusted grant list, or stripped when that list is empty. The harness
+/// controls scoping and the model must not be able to widen it.
+pub fn inject(
+    function_id: &str,
+    args: Value,
+    working_dir: Option<&str>,
+    extra_roots: &[String],
+) -> Value {
     if !is_scoped_function(function_id) {
         return args;
     }
@@ -47,6 +54,19 @@ pub fn inject(function_id: &str, args: Value, working_dir: Option<&str>) -> Valu
         None => {
             map.remove(BASE_DIR_FIELD);
         }
+    }
+    if extra_roots.is_empty() {
+        map.remove(EXTRA_ROOTS_FIELD);
+    } else {
+        map.insert(
+            EXTRA_ROOTS_FIELD.to_string(),
+            Value::Array(
+                extra_roots
+                    .iter()
+                    .map(|root| Value::String(root.clone()))
+                    .collect(),
+            ),
+        );
     }
     Value::Object(map)
 }
@@ -62,6 +82,7 @@ mod tests {
             "shell::exec",
             json!({ "command": "ls" }),
             Some("/work/session-7"),
+            &[],
         );
         assert_eq!(
             out,
@@ -75,6 +96,7 @@ mod tests {
             "coder::fs::read",
             json!({ "path": "src/main.rs" }),
             Some("/work/session-7"),
+            &[],
         );
         assert_eq!(
             out,
@@ -90,6 +112,7 @@ mod tests {
             "shell::exec",
             json!({ "command": "ls", "base_dir": "/etc" }),
             Some("/work/session-7"),
+            &[],
         );
         assert_eq!(
             out,
@@ -98,10 +121,25 @@ mod tests {
     }
 
     #[test]
+    fn overwrites_caller_supplied_extra_roots_with_trusted_grants() {
+        let grants = vec!["/approved".to_string()];
+        let out = inject(
+            "shell::exec",
+            json!({ "command": "ls", "base_dir": "/etc", "extra_roots": ["/model"] }),
+            Some("/work/session-7"),
+            &grants,
+        );
+        assert_eq!(
+            out,
+            json!({ "command": "ls", "base_dir": "/work/session-7", "extra_roots": ["/approved"] })
+        );
+    }
+
+    #[test]
     fn strips_caller_supplied_base_dir_when_working_dir_absent() {
         // With no session scope, the model must not be able to invent one.
-        let args = json!({ "command": "ls", "base_dir": "/etc" });
-        let out = inject("shell::exec", args, None);
+        let args = json!({ "command": "ls", "base_dir": "/etc", "extra_roots": ["/model"] });
+        let out = inject("shell::exec", args, None, &[]);
         assert_eq!(out, json!({ "command": "ls" }));
     }
 
@@ -112,6 +150,7 @@ mod tests {
             "shell::workspace::validate",
             args.clone(),
             Some("/work/session-7"),
+            &["/approved".to_string()],
         );
         assert_eq!(out, args);
     }
@@ -119,7 +158,12 @@ mod tests {
     #[test]
     fn passthrough_for_non_scoped_function() {
         let args = json!({ "to": "user", "text": "hi" });
-        let out = inject("telegram::send", args.clone(), Some("/work/session-7"));
+        let out = inject(
+            "telegram::send",
+            args.clone(),
+            Some("/work/session-7"),
+            &["/approved".to_string()],
+        );
         assert_eq!(out, args);
     }
 
@@ -128,11 +172,16 @@ mod tests {
         // A non-object payload has no top-level slot for base_dir; return it as
         // received rather than reshaping it.
         let args = json!(["ls", "-la"]);
-        let out = inject("shell::exec", args.clone(), Some("/work/session-7"));
+        let out = inject("shell::exec", args.clone(), Some("/work/session-7"), &[]);
         assert_eq!(out, args);
 
         let scalar = json!("raw");
-        let out = inject("coder::fs::read", scalar.clone(), Some("/work/session-7"));
+        let out = inject(
+            "coder::fs::read",
+            scalar.clone(),
+            Some("/work/session-7"),
+            &[],
+        );
         assert_eq!(out, scalar);
     }
 }

--- a/harness/tests/golden/schemas/harness.function.resolve.json
+++ b/harness/tests/golden/schemas/harness.function.resolve.json
@@ -164,6 +164,16 @@
         ]
       },
       "details": true,
+      "extra_roots": {
+        "description": "execute only: one-shot additional roots trusted by the caller and unioned with the session's durable workspace grants.",
+        "items": {
+          "type": "string"
+        },
+        "type": [
+          "array",
+          "null"
+        ]
+      },
       "function_call_id": {
         "type": "string"
       },


### PR DESCRIPTION
## Summary
- add durable per-session workspace grants and trusted harness workspace grant controls
- stamp trusted extra_roots across turn loop, direct trigger, and deferred execute paths
- surface structured target errors and support post-trigger holds/re-parking

## Test plan
- cargo test --manifest-path harness/Cargo.toml
- git diff --check