### PR TITLE
ci: add http to the create-tag worker dropdown

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -20,6 +20,7 @@ on:
           - email
           - harness
           - hermes
+          - http
           - iii-directory
           - lsp
           - lsp-vscode


### PR DESCRIPTION
The `http` worker was merged and `release.yml` already accepts `http/v*` tags, but the `create-tag` workflow's `worker` choice input was missing `http` — so it couldn't be selected to cut a release. Adds `http` to the list (alphabetical, between `hermes` and `iii-directory`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded an available workflow selection option to include HTTP alongside the existing choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->