### PR TITLE
feat(console): #file mentions attach working-dir files to chat messages

### DIFF
--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -19,6 +19,7 @@ import type { ChatBackend } from '@/lib/backend'
 import { predictedUserEntryId } from '@/lib/backend/harness-send'
 import type { CompactResult } from '@/lib/backend/types'
 import { useConversationsCtxOptional } from '@/lib/conversations-context'
+import { expandFileMentions, parseFileMentions } from '@/lib/file-mentions'
 import { formatStopReason } from '@/lib/format-stop-reason'
 import { newMessageId } from '@/lib/session-id'
 import { cn } from '@/lib/utils'
@@ -357,6 +358,42 @@ export function ChatView({
         return
       }
 
+      // Expand `#file(...)` mentions into attachment blocks (real backend
+      // with a working dir only). Failures never block the send — a failed
+      // mention becomes a placeholder block plus a warn notice.
+      let attachedBlocks: string[] | undefined
+      const workingDir = conversation.workingDir
+      const mentionPaths =
+        backend.id === 'real' && workingDir
+          ? parseFileMentions(payload.text)
+          : []
+      if (workingDir && mentionPaths.length > 0) {
+        const expanded = await expandFileMentions(workingDir, mentionPaths)
+        attachedBlocks = expanded.blocks
+        if (expanded.attachments.length > 0) {
+          onPatchMessage(conversationId, userMsg.id, {
+            attachments: [
+              ...(userMsg.attachments ?? []),
+              ...expanded.attachments.map((a) => ({
+                id: `mention-${a.path}`,
+                name: a.path,
+                size: a.size,
+                type: 'text/x-file-mention',
+              })),
+            ],
+          })
+        }
+        for (const failure of expanded.failures) {
+          onAppendMessage(
+            conversationId,
+            makeSystemNotice(
+              `could not attach ${failure.path} — ${failure.reason}`,
+              'warn',
+            ),
+          )
+        }
+      }
+
       const controller = new AbortController()
       abortRef.current = controller
       setIsStreaming(true)
@@ -380,6 +417,9 @@ export function ChatView({
             thinkingLevel,
             workingDir: conversation.workingDir,
             approvalGateAvailable: approvalEnabled,
+            ...(attachedBlocks && attachedBlocks.length > 0
+              ? { attachedBlocks }
+              : {}),
           },
         )) {
           switch (event.kind) {

--- a/console/web/src/components/chat/Composer.tsx
+++ b/console/web/src/components/chat/Composer.tsx
@@ -156,6 +156,7 @@ export function Composer({
           disabled={inputDisabled}
           initialContent={initialContent}
           functionEntries={functionEntries}
+          workingDir={workingDir}
         />
       </div>
 

--- a/console/web/src/components/chat/LexicalShell.tsx
+++ b/console/web/src/components/chat/LexicalShell.tsx
@@ -15,6 +15,9 @@ import {
 } from 'lexical'
 import { useEffect, useMemo, useRef } from 'react'
 import type { FunctionEntry } from '@/lib/functions'
+import { FileMentionNode } from './lexical/FileMentionNode'
+import { FileMentionsPlugin } from './lexical/FileMentionsPlugin'
+import { FileMentionTransformPlugin } from './lexical/FileMentionTransformPlugin'
 import { FunctionMentionNode } from './lexical/FunctionMentionNode'
 import { FunctionMentionTransformPlugin } from './lexical/FunctionMentionTransformPlugin'
 import { MentionsPlugin } from './lexical/MentionsPlugin'
@@ -32,7 +35,7 @@ const baseConfig = {
   /* no theme classes — surface inherits Chivo Mono from <body> */
   theme: {},
   /* Decorator nodes must be registered up-front so importJSON/restore work. */
-  nodes: [FunctionMentionNode],
+  nodes: [FunctionMentionNode, FileMentionNode],
   onError(error: Error) {
     console.error(error)
   },
@@ -126,6 +129,8 @@ interface LexicalShellExtendedProps extends LexicalShellProps {
   /** Optional one-shot initializer that runs once on mount inside the editor. */
   initialContent?: (editor: LexicalEditor) => void
   functionEntries?: FunctionEntry[]
+  /** Enables the `#` file-mention typeahead, scoped to this directory. */
+  workingDir?: string | null
 }
 
 export function LexicalShell({
@@ -136,6 +141,7 @@ export function LexicalShell({
   clearToken,
   initialContent,
   functionEntries,
+  workingDir,
 }: LexicalShellExtendedProps) {
   /* LexicalComposer reads initialConfig once on mount; lock it behind useMemo
      so the initializer callback identity doesn't trigger a remount on re-render. */
@@ -178,8 +184,12 @@ export function LexicalShell({
         menuOpenRef={menuOpenRef}
         functionEntries={functionEntries}
       />
+      {workingDir ? (
+        <FileMentionsPlugin menuOpenRef={menuOpenRef} workingDir={workingDir} />
+      ) : null}
       <SlashCommandsPlugin menuOpenRef={menuOpenRef} />
       <FunctionMentionTransformPlugin />
+      <FileMentionTransformPlugin />
     </LexicalComposer>
   )
 }

--- a/console/web/src/components/chat/lexical/FileMentionNode.tsx
+++ b/console/web/src/components/chat/lexical/FileMentionNode.tsx
@@ -1,0 +1,261 @@
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import { useLexicalNodeSelection } from '@lexical/react/useLexicalNodeSelection'
+import {
+  $getNodeByKey,
+  CLICK_COMMAND,
+  COMMAND_PRIORITY_LOW,
+  DecoratorNode,
+  type DOMConversion,
+  type DOMConversionMap,
+  type DOMConversionOutput,
+  type DOMExportOutput,
+  type EditorConfig,
+  KEY_BACKSPACE_COMMAND,
+  KEY_DELETE_COMMAND,
+  type LexicalNode,
+  mergeRegister,
+  type NodeKey,
+  type SerializedLexicalNode,
+  type Spread,
+} from 'lexical'
+import { type JSX, type RefObject, useEffect, useRef } from 'react'
+import { cn } from '@/lib/utils'
+
+export type SerializedFileMentionNode = Spread<
+  { path: string },
+  SerializedLexicalNode
+>
+
+/**
+ * An inline pill representing a `#file(<path>)` mention. Rendered through
+ * Lexical's `decorate()` so React owns the visuals (file glyph + relative
+ * path + panel background), while `getTextContent()` returns the plain-text
+ * `#file(<path>)` form so the existing OnChange lift in LexicalShell keeps
+ * working. The markdown renderer detects the same `#file(<path>)` token and
+ * reuses the presentational pill (`FileMentionPill`) below.
+ */
+export class FileMentionNode extends DecoratorNode<JSX.Element> {
+  __path: string
+
+  static getType(): string {
+    return 'file-mention'
+  }
+
+  static clone(node: FileMentionNode): FileMentionNode {
+    return new FileMentionNode(node.__path, node.__key)
+  }
+
+  static importJSON(serialized: SerializedFileMentionNode): FileMentionNode {
+    return $createFileMentionNode(serialized.path)
+  }
+
+  /* Recreate the pill on HTML paste (cross-editor or external apps).
+     `exportDOM` already stamps the `data-lexical-file-mention` flag and
+     a `data-file-path` attribute, so the round-trip is symmetrical. */
+  static importDOM(): DOMConversionMap | null {
+    return {
+      span: (el: HTMLElement): DOMConversion<HTMLElement> | null => {
+        if (el.getAttribute('data-lexical-file-mention') !== 'true') {
+          return null
+        }
+        return {
+          conversion: convertFileMentionElement,
+          priority: 1,
+        }
+      },
+    }
+  }
+
+  constructor(path: string, key?: NodeKey) {
+    super(key)
+    this.__path = path
+  }
+
+  exportJSON(): SerializedFileMentionNode {
+    return {
+      type: FileMentionNode.getType(),
+      version: 1,
+      path: this.__path,
+    }
+  }
+
+  exportDOM(): DOMExportOutput {
+    const element = document.createElement('span')
+    element.setAttribute('data-lexical-file-mention', 'true')
+    element.setAttribute('data-file-path', this.__path)
+    element.textContent = this.getTextContent()
+    return { element }
+  }
+
+  createDOM(_config: EditorConfig): HTMLElement {
+    /* Lexical needs a host DOM node; React's decorate() output mounts inside. */
+    const span = document.createElement('span')
+    span.style.display = 'inline-block'
+    span.style.verticalAlign = 'middle'
+    return span
+  }
+
+  updateDOM(): false {
+    return false
+  }
+
+  isInline(): true {
+    return true
+  }
+
+  isKeyboardSelectable(): true {
+    return true
+  }
+
+  getTextContent(): string {
+    return `#file(${this.__path})`
+  }
+
+  getPath(): string {
+    return this.__path
+  }
+
+  decorate(): JSX.Element {
+    return <EditableFileMentionPill path={this.__path} nodeKey={this.__key} />
+  }
+}
+
+function convertFileMentionElement(el: HTMLElement): DOMConversionOutput {
+  const path = el.getAttribute('data-file-path') ?? ''
+  if (!path) return { node: null }
+  return { node: $createFileMentionNode(path) }
+}
+
+interface PillProps {
+  path: string
+  /** Visible-selected state. Defaults to false; only the Lexical decorator
+      wrapper passes a real value. Markdown renders never set this. */
+  selected?: boolean
+  /** Click-target ref; only the Lexical wrapper supplies one (so its
+      `CLICK_COMMAND` handler can scope hit-tests to the pill). Markdown
+      renders leave this unset and the pill behaves as pure decoration. */
+  pillRef?: RefObject<HTMLSpanElement | null>
+}
+
+/**
+ * The inserted-token visual. Hairline file glyph in accent, relative path in
+ * ink, on a panel background. Rectilinear; no rounded corners; monospace;
+ * tight inline-block sizing so it flows with text. When `selected` is true
+ * the border swaps to accent and the surface lifts one step to `paper-2` —
+ * same 1px footprint, no layout shift. No DOM-level click handler lives
+ * here; the Lexical wrapper drives selection via `CLICK_COMMAND` so the pill
+ * stays a static, accessible inline element in both editor and markdown.
+ */
+export function FileMentionPill({ path, selected, pillRef }: PillProps) {
+  return (
+    <span
+      ref={pillRef}
+      contentEditable={false}
+      data-file-path={path}
+      className={cn(
+        'inline-flex items-center gap-1 px-1.5 h-[20px] -mt-[2px] border align-middle font-mono text-[13px] text-ink select-none transition-colors',
+        selected
+          ? 'bg-paper-2 border-accent cursor-pointer'
+          : 'bg-panel border-rule',
+        pillRef && 'cursor-pointer',
+      )}
+    >
+      <span aria-hidden className="text-accent leading-none shrink-0">
+        {/* tiny "file" glyph: hairline rectangle with a corner fold */}
+        <svg
+          width="9"
+          height="11"
+          viewBox="0 0 10 12"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1"
+          aria-hidden="true"
+        >
+          <path d="M1 1H6L9 4V11H1V1Z" />
+          <path d="M6 1V4H9" />
+        </svg>
+      </span>
+      <span className="leading-none truncate max-w-[280px]">{path}</span>
+    </span>
+  )
+}
+
+interface EditablePillProps {
+  path: string
+  nodeKey: NodeKey
+}
+
+/**
+ * Lexical-decorator wrapper: tracks selection via `useLexicalNodeSelection`
+ * and listens for `CLICK_COMMAND` / `KEY_BACKSPACE_COMMAND` /
+ * `KEY_DELETE_COMMAND` so the user can select the pill, then cut/copy/paste
+ * or delete it. Click-with-shift toggles the selection; plain click replaces
+ * the current selection.
+ */
+function EditableFileMentionPill({ path, nodeKey }: EditablePillProps) {
+  const [editor] = useLexicalComposerContext()
+  const [isSelected, setSelected, clearSelection] =
+    useLexicalNodeSelection(nodeKey)
+  const pillRef = useRef<HTMLSpanElement | null>(null)
+
+  useEffect(() => {
+    const removeIfSelected = (event: KeyboardEvent): boolean => {
+      if (!isSelected) return false
+      event.preventDefault()
+      editor.update(() => {
+        const node = $getNodeByKey(nodeKey)
+        if (node) node.remove()
+      })
+      return true
+    }
+    return mergeRegister(
+      editor.registerCommand(
+        CLICK_COMMAND,
+        (event: MouseEvent) => {
+          const target = event.target as Node | null
+          if (
+            !pillRef.current ||
+            !target ||
+            !pillRef.current.contains(target)
+          ) {
+            return false
+          }
+          /* preventDefault keeps the caret from landing inside the decorator
+             host; Lexical would otherwise place selection just before/after
+             the pill and fight our node selection. */
+          event.preventDefault()
+          if (event.shiftKey) {
+            setSelected(!isSelected)
+          } else {
+            clearSelection()
+            setSelected(true)
+          }
+          return true
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+      editor.registerCommand(
+        KEY_BACKSPACE_COMMAND,
+        removeIfSelected,
+        COMMAND_PRIORITY_LOW,
+      ),
+      editor.registerCommand(
+        KEY_DELETE_COMMAND,
+        removeIfSelected,
+        COMMAND_PRIORITY_LOW,
+      ),
+    )
+  }, [editor, nodeKey, isSelected, setSelected, clearSelection])
+
+  return <FileMentionPill path={path} selected={isSelected} pillRef={pillRef} />
+}
+
+export function $createFileMentionNode(path: string): FileMentionNode {
+  return new FileMentionNode(path)
+}
+
+export function $isFileMentionNode(
+  node: LexicalNode | null | undefined,
+): node is FileMentionNode {
+  return node instanceof FileMentionNode
+}

--- a/console/web/src/components/chat/lexical/FileMentionTransformPlugin.tsx
+++ b/console/web/src/components/chat/lexical/FileMentionTransformPlugin.tsx
@@ -1,0 +1,57 @@
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import { TextNode } from 'lexical'
+import { useEffect } from 'react'
+import { $createFileMentionNode } from './FileMentionNode'
+
+/* Matches a single `#file(<path>)` token where `<path>` contains no closing
+   paren (spaces are fine — file names can carry them). Intentionally
+   non-global so the transform processes one match per pass — Lexical will
+   re-run it on the resulting nodes until the text stops matching, which
+   keeps the conversion incremental and safe. */
+const FILE_PATTERN = /#file\(([^)]+)\)/
+
+/**
+ * Auto-converts plain `#file(<path>)` text into the decorator pill. Fires
+ * whenever a `TextNode` is mutated — paste, drop, typing, or programmatic
+ * insertion — so the user can drop a literal mention into the composer and
+ * see it render exactly the same as one inserted through the typeahead menu.
+ *
+ * The transform splits the matched substring out as its own TextNode (using
+ * `splitText`) and replaces it in place with a `FileMentionNode`. Leading
+ * and trailing text around the match is preserved.
+ */
+export function FileMentionTransformPlugin() {
+  const [editor] = useLexicalComposerContext()
+
+  useEffect(() => {
+    return editor.registerNodeTransform(TextNode, (node) => {
+      if (!node.isSimpleText()) return
+      const text = node.getTextContent()
+      const match = text.match(FILE_PATTERN)
+      if (!match || match.index === undefined) return
+
+      const start = match.index
+      const end = start + match[0].length
+      const path = match[1]
+
+      /* `splitText` returns the chunks in order; the original node is mutated
+         to hold the first chunk and any tail chunks are returned as new nodes.
+         We pick whichever chunk is the matched substring as `target`. */
+      let target: TextNode
+      if (start === 0 && end === text.length) {
+        target = node
+      } else if (start === 0) {
+        target = node.splitText(end)[0]
+      } else if (end === text.length) {
+        target = node.splitText(start)[1]
+      } else {
+        target = node.splitText(start, end)[1]
+      }
+
+      const mention = $createFileMentionNode(path)
+      target.replace(mention)
+    })
+  }, [editor])
+
+  return null
+}

--- a/console/web/src/components/chat/lexical/FileMentionsPlugin.tsx
+++ b/console/web/src/components/chat/lexical/FileMentionsPlugin.tsx
@@ -1,0 +1,146 @@
+import {
+  LexicalTypeaheadMenuPlugin,
+  MenuOption,
+  useBasicTypeaheadTriggerMatch,
+} from '@lexical/react/LexicalTypeaheadMenuPlugin'
+import {
+  $createTextNode,
+  COMMAND_PRIORITY_NORMAL,
+  type TextNode,
+} from 'lexical'
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { fetchFileIndex, fuzzyFilterFiles } from '@/lib/file-index'
+import { $createFileMentionNode } from './FileMentionNode'
+import { FlipMenu } from './FlipMenu'
+
+class FileMentionOption extends MenuOption {
+  path: string
+  constructor(path: string) {
+    super(path)
+    this.path = path
+  }
+}
+
+interface FileMentionsPluginProps {
+  /** When set, this ref is flipped to true while the typeahead is visible
+      so a sibling SubmitOnEnter plugin can skip its Enter handler. */
+  menuOpenRef?: React.MutableRefObject<boolean>
+  /** Jail anchor for the file index; the menu is inert without one. */
+  workingDir: string
+}
+
+/**
+ * `#` typeahead over the working directory's files. The index is fetched
+ * lazily on first open (and re-used through file-index's TTL cache), so a
+ * conversation that never mentions files never walks the repo. `minLength: 1`
+ * keeps markdown headings (`# foo` — the space ends the match) from flashing
+ * the menu.
+ */
+export function FileMentionsPlugin({
+  menuOpenRef,
+  workingDir,
+}: FileMentionsPluginProps) {
+  const [query, setQuery] = useState<string | null>(null)
+  const [index, setIndex] = useState<string[]>([])
+  /* Guards a slow fetch resolving after the working dir changed. */
+  const workingDirRef = useRef(workingDir)
+  workingDirRef.current = workingDir
+
+  const triggerFn = useBasicTypeaheadTriggerMatch('#', { minLength: 1 })
+
+  const options = useMemo(
+    () =>
+      fuzzyFilterFiles(index, query ?? '').map(
+        (path) => new FileMentionOption(path),
+      ),
+    [index, query],
+  )
+
+  const loadIndex = useCallback(() => {
+    const dir = workingDir
+    fetchFileIndex(dir)
+      .then((paths) => {
+        if (workingDirRef.current === dir) setIndex(paths)
+      })
+      .catch(() => {
+        /* Worker away or dir invalid: the menu simply stays empty. */
+      })
+  }, [workingDir])
+
+  const onSelectOption = useCallback(
+    (
+      option: FileMentionOption,
+      textNodeContainingQuery: TextNode | null,
+      closeMenu: () => void,
+    ) => {
+      if (textNodeContainingQuery) {
+        const mention = $createFileMentionNode(option.path)
+        const trailing = $createTextNode(' ')
+        textNodeContainingQuery.replace(mention)
+        mention.insertAfter(trailing)
+        trailing.selectEnd()
+      }
+      closeMenu()
+    },
+    [],
+  )
+
+  return (
+    <LexicalTypeaheadMenuPlugin<FileMentionOption>
+      options={options}
+      onQueryChange={setQuery}
+      onSelectOption={onSelectOption}
+      onOpen={() => {
+        if (menuOpenRef) menuOpenRef.current = true
+        loadIndex()
+      }}
+      onClose={() => {
+        if (menuOpenRef) menuOpenRef.current = false
+      }}
+      triggerFn={triggerFn}
+      /* Run the typeahead's KEY_ENTER_COMMAND (and arrows/tab/escape) at NORMAL
+         so it consumes Enter before our SubmitOnEnter handler at LOW. */
+      commandPriority={COMMAND_PRIORITY_NORMAL}
+      menuRenderFn={(anchorElementRef, props) => {
+        if (!anchorElementRef.current || options.length === 0) return null
+        return createPortal(
+          <FlipMenu
+            anchorEl={anchorElementRef.current}
+            header="files"
+            options={options}
+            selectedIndex={props.selectedIndex}
+            selectOptionAndCleanUp={props.selectOptionAndCleanUp}
+            setHighlightedIndex={props.setHighlightedIndex}
+            getOptionKey={(opt) => opt.path}
+            renderOption={(opt) => (
+              <>
+                <span
+                  aria-hidden="true"
+                  className="text-accent leading-none w-3 flex justify-center shrink-0"
+                >
+                  <svg
+                    width="9"
+                    height="11"
+                    viewBox="0 0 10 12"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1"
+                    aria-hidden="true"
+                  >
+                    <path d="M1 1H6L9 4V11H1V1Z" />
+                    <path d="M6 1V4H9" />
+                  </svg>
+                </span>
+                <span className="min-w-0 font-mono text-[13px] text-ink truncate">
+                  {opt.path}
+                </span>
+              </>
+            )}
+          />,
+          anchorElementRef.current,
+        )
+      }}
+    />
+  )
+}

--- a/console/web/src/components/chat/lexical/FlipMenu.tsx
+++ b/console/web/src/components/chat/lexical/FlipMenu.tsx
@@ -1,0 +1,124 @@
+import type { MenuOption } from '@lexical/react/LexicalTypeaheadMenuPlugin'
+import { type ReactNode, useLayoutEffect, useRef } from 'react'
+import { cn } from '@/lib/utils'
+
+/**
+ * Shared typeahead dropdown chrome for the composer's `/`, `@`, and `#`
+ * menus: the bordered listbox, the section header, row selection styling,
+ * and the flip-up positioning fix.
+ *
+ * Lexical positions the anchor div just below the caret. When the composer
+ * sits near the viewport bottom the menu would hang off the page (and grow
+ * body height, scrolling the page) because Lexical's flip-up branch only
+ * triggers when there's room above WITHIN the editor's root element — which
+ * our short composer never satisfies. We layer a `transform: translateY(...)`
+ * on top of Lexical's `style.top` so Lexical's repositioning keeps working
+ * while we override the placement when needed.
+ */
+
+interface FlipMenuProps<T extends MenuOption> {
+  anchorEl: HTMLElement
+  /** Uppercased section label, e.g. "commands" / "functions" / "files". */
+  header: string
+  options: T[]
+  selectedIndex: number | null
+  selectOptionAndCleanUp: (option: T) => void
+  setHighlightedIndex: (index: number) => void
+  getOptionKey: (option: T) => string
+  /** Inner row content (glyph + labels); the row shell is shared. */
+  renderOption: (option: T) => ReactNode
+}
+
+export function FlipMenu<T extends MenuOption>({
+  anchorEl,
+  header,
+  options,
+  selectedIndex,
+  selectOptionAndCleanUp,
+  setHighlightedIndex,
+  getOptionKey,
+  renderOption,
+}: FlipMenuProps<T>) {
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  /* Re-run on options.length so the menu repositions when the option count
+     changes (the menu's height shifts and the flip-up threshold may cross). */
+  // biome-ignore lint/correctness/useExhaustiveDependencies: options.length is a trigger, not read in the effect body.
+  useLayoutEffect(() => {
+    const adjust = () => {
+      const menu = menuRef.current
+      if (!menu) return
+      /* IMPORTANT: read layout (offsetTop/offsetHeight), not visual
+         (getBoundingClientRect). The anchor's bounding rect reflects the
+         transform we apply here, so using it would make the overflow check
+         flip true/false on every MutationObserver fire and lock the UI. */
+      const viewportTop = anchorEl.offsetTop - window.scrollY
+      const menuHeight = menu.getBoundingClientRect().height
+      const anchorHeight = anchorEl.offsetHeight
+      const SAFE = 12
+      const next =
+        viewportTop + menuHeight > window.innerHeight - SAFE
+          ? `translateY(-${menuHeight + anchorHeight + 8}px)`
+          : ''
+      /* Guard against the MutationObserver → setter → MutationObserver loop. */
+      if (anchorEl.style.transform !== next) anchorEl.style.transform = next
+    }
+    adjust()
+    const mo = new MutationObserver(adjust)
+    mo.observe(anchorEl, { attributes: true, attributeFilter: ['style'] })
+    const ro = new ResizeObserver(adjust)
+    if (menuRef.current) ro.observe(menuRef.current)
+    window.addEventListener('resize', adjust)
+    document.addEventListener('scroll', adjust, true)
+    return () => {
+      mo.disconnect()
+      ro.disconnect()
+      window.removeEventListener('resize', adjust)
+      document.removeEventListener('scroll', adjust, true)
+      anchorEl.style.transform = ''
+    }
+  }, [anchorEl, options.length])
+
+  return (
+    <div
+      ref={menuRef}
+      className="border border-rule bg-bg w-[300px] max-h-[280px] overflow-y-auto shadow-none"
+    >
+      <div className="px-3 py-1.5 border-b border-rule-2 bg-panel font-mono text-[11px] uppercase tracking-[0.18em] text-ink-faint">
+        {header}
+      </div>
+      {/* div+role over ul/li because keyboard navigation is driven by Lexical's
+          typeahead controller (arrow keys, enter, escape), not by Tab. The
+          listbox/option roles preserve the screen-reader semantics without
+          dragging in semantic <ul>/<li> structure that Biome's a11y rules
+          (correctly) treat as non-interactive. */}
+      <div role="listbox" className="divide-y divide-rule-2">
+        {options.map((opt, i) => {
+          const active = i === selectedIndex
+          return (
+            <div
+              key={getOptionKey(opt)}
+              role="option"
+              tabIndex={-1}
+              aria-selected={active}
+              ref={(el) => opt.setRefElement(el)}
+              onMouseEnter={() => setHighlightedIndex(i)}
+              onMouseDown={(e) => {
+                e.preventDefault()
+                selectOptionAndCleanUp(opt)
+              }}
+              className={cn(
+                'flex items-center gap-2 px-3 py-2 cursor-pointer transition-colors',
+                active
+                  ? 'bg-panel border-l-2 border-l-accent pl-[10px]'
+                  : 'border-l-2 border-l-transparent hover:bg-paper-2',
+              )}
+            >
+              {renderOption(opt)}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/console/web/src/components/chat/lexical/MentionsPlugin.tsx
+++ b/console/web/src/components/chat/lexical/MentionsPlugin.tsx
@@ -8,10 +8,10 @@ import {
   COMMAND_PRIORITY_NORMAL,
   type TextNode,
 } from 'lexical'
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { type FunctionEntry, fuzzyFilter } from '@/lib/functions'
-import { cn } from '@/lib/utils'
+import { FlipMenu } from './FlipMenu'
 import { $createFunctionMentionNode } from './FunctionMentionNode'
 
 class FunctionMentionOption extends MenuOption {
@@ -27,125 +27,6 @@ interface MentionsPluginProps {
       so a sibling SubmitOnEnter plugin can skip its Enter handler. */
   menuOpenRef?: React.MutableRefObject<boolean>
   functionEntries?: FunctionEntry[]
-}
-
-interface FlipMenuProps {
-  anchorEl: HTMLElement
-  options: FunctionMentionOption[]
-  selectedIndex: number | null
-  selectOptionAndCleanUp: (option: FunctionMentionOption) => void
-  setHighlightedIndex: (index: number) => void
-}
-
-/* Lexical positions the anchor div just below the caret. When the composer sits
-   near the viewport bottom the menu would hang off the page (and grow body
-   height, scrolling the page) because Lexical's flip-up branch only triggers
-   when there's room above WITHIN the editor's root element — which our short
-   composer never satisfies. We layer a `transform: translateY(...)` on top of
-   Lexical's `style.top` so Lexical's repositioning keeps working while we
-   override the placement when needed. */
-function FlipMenu({
-  anchorEl,
-  options,
-  selectedIndex,
-  selectOptionAndCleanUp,
-  setHighlightedIndex,
-}: FlipMenuProps) {
-  const menuRef = useRef<HTMLDivElement>(null)
-
-  /* Re-run on options.length so the menu repositions when the option count
-     changes (the menu's height shifts and the flip-up threshold may cross). */
-  // biome-ignore lint/correctness/useExhaustiveDependencies: options.length is a trigger, not read in the effect body.
-  useLayoutEffect(() => {
-    const adjust = () => {
-      const menu = menuRef.current
-      if (!menu) return
-      /* IMPORTANT: read layout (offsetTop/offsetHeight), not visual
-         (getBoundingClientRect). The anchor's bounding rect reflects the
-         transform we apply here, so using it would make the overflow check
-         flip true/false on every MutationObserver fire and lock the UI. */
-      const viewportTop = anchorEl.offsetTop - window.scrollY
-      const menuHeight = menu.getBoundingClientRect().height
-      const anchorHeight = anchorEl.offsetHeight
-      const SAFE = 12
-      const next =
-        viewportTop + menuHeight > window.innerHeight - SAFE
-          ? `translateY(-${menuHeight + anchorHeight + 8}px)`
-          : ''
-      /* Guard against the MutationObserver → setter → MutationObserver loop. */
-      if (anchorEl.style.transform !== next) anchorEl.style.transform = next
-    }
-    adjust()
-    const mo = new MutationObserver(adjust)
-    mo.observe(anchorEl, { attributes: true, attributeFilter: ['style'] })
-    const ro = new ResizeObserver(adjust)
-    if (menuRef.current) ro.observe(menuRef.current)
-    window.addEventListener('resize', adjust)
-    document.addEventListener('scroll', adjust, true)
-    return () => {
-      mo.disconnect()
-      ro.disconnect()
-      window.removeEventListener('resize', adjust)
-      document.removeEventListener('scroll', adjust, true)
-      anchorEl.style.transform = ''
-    }
-  }, [anchorEl, options.length])
-
-  return (
-    <div
-      ref={menuRef}
-      className="border border-rule bg-bg w-[300px] max-h-[280px] overflow-y-auto shadow-none"
-    >
-      <div className="px-3 py-1.5 border-b border-rule-2 bg-panel font-mono text-[11px] uppercase tracking-[0.18em] text-ink-faint">
-        functions
-      </div>
-      {/* div+role over ul/li because keyboard navigation is driven by Lexical's
-          typeahead controller (arrow keys, enter, escape), not by Tab. The
-          listbox/option roles preserve the screen-reader semantics without
-          dragging in semantic <ul>/<li> structure that Biome's a11y rules
-          (correctly) treat as non-interactive. */}
-      <div role="listbox" className="divide-y divide-rule-2">
-        {options.map((opt, i) => {
-          const active = i === selectedIndex
-          return (
-            <div
-              key={opt.entry.id}
-              role="option"
-              tabIndex={-1}
-              aria-selected={active}
-              ref={(el) => opt.setRefElement(el)}
-              onMouseEnter={() => setHighlightedIndex(i)}
-              onMouseDown={(e) => {
-                e.preventDefault()
-                selectOptionAndCleanUp(opt)
-              }}
-              className={cn(
-                'flex items-center gap-2 px-3 py-2 cursor-pointer transition-colors',
-                active
-                  ? 'bg-panel border-l-2 border-l-accent pl-[10px]'
-                  : 'border-l-2 border-l-transparent hover:bg-paper-2',
-              )}
-            >
-              <span
-                aria-hidden="true"
-                className="text-accent font-semibold italic leading-none w-3 text-center shrink-0"
-              >
-                ƒ
-              </span>
-              <div className="min-w-0 flex flex-col">
-                <span className="font-mono text-[13px] text-ink truncate">
-                  {opt.entry.id}
-                </span>
-                <span className="font-mono text-[11px] text-ink-faint truncate lowercase">
-                  {opt.entry.description}
-                </span>
-              </div>
-            </div>
-          )
-        })}
-      </div>
-    </div>
-  )
 }
 
 export function MentionsPlugin({
@@ -206,10 +87,30 @@ export function MentionsPlugin({
         return createPortal(
           <FlipMenu
             anchorEl={anchorElementRef.current}
+            header="functions"
             options={options}
             selectedIndex={props.selectedIndex}
             selectOptionAndCleanUp={props.selectOptionAndCleanUp}
             setHighlightedIndex={props.setHighlightedIndex}
+            getOptionKey={(opt) => opt.entry.id}
+            renderOption={(opt) => (
+              <>
+                <span
+                  aria-hidden="true"
+                  className="text-accent font-semibold italic leading-none w-3 text-center shrink-0"
+                >
+                  ƒ
+                </span>
+                <div className="min-w-0 flex flex-col">
+                  <span className="font-mono text-[13px] text-ink truncate">
+                    {opt.entry.id}
+                  </span>
+                  <span className="font-mono text-[11px] text-ink-faint truncate lowercase">
+                    {opt.entry.description}
+                  </span>
+                </div>
+              </>
+            )}
           />,
           anchorElementRef.current,
         )

--- a/console/web/src/components/chat/lexical/SlashCommandsPlugin.tsx
+++ b/console/web/src/components/chat/lexical/SlashCommandsPlugin.tsx
@@ -8,10 +8,10 @@ import {
   type LexicalEditor,
   type TextNode,
 } from 'lexical'
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { fuzzyFilterSlash, type SlashCommand } from '@/lib/slash-commands'
-import { cn } from '@/lib/utils'
+import { FlipMenu } from './FlipMenu'
 
 class SlashCommandOption extends MenuOption {
   entry: SlashCommand
@@ -24,106 +24,6 @@ class SlashCommandOption extends MenuOption {
 interface SlashCommandsPluginProps {
   /** True while the menu is open so SubmitOnEnter yields Enter to the typeahead. */
   menuOpenRef?: React.RefObject<boolean>
-}
-
-interface FlipMenuProps {
-  anchorEl: HTMLElement
-  options: SlashCommandOption[]
-  selectedIndex: number | null
-  selectOptionAndCleanUp: (option: SlashCommandOption) => void
-  setHighlightedIndex: (index: number) => void
-}
-
-function FlipMenu({
-  anchorEl,
-  options,
-  selectedIndex,
-  selectOptionAndCleanUp,
-  setHighlightedIndex,
-}: FlipMenuProps) {
-  const menuRef = useRef<HTMLDivElement>(null)
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: options.length is a trigger, not read in the effect body.
-  useLayoutEffect(() => {
-    const adjust = () => {
-      const menu = menuRef.current
-      if (!menu) return
-      const viewportTop = anchorEl.offsetTop - window.scrollY
-      const menuHeight = menu.getBoundingClientRect().height
-      const anchorHeight = anchorEl.offsetHeight
-      const SAFE = 12
-      const next =
-        viewportTop + menuHeight > window.innerHeight - SAFE
-          ? `translateY(-${menuHeight + anchorHeight + 8}px)`
-          : ''
-      if (anchorEl.style.transform !== next) anchorEl.style.transform = next
-    }
-    adjust()
-    const mo = new MutationObserver(adjust)
-    mo.observe(anchorEl, { attributes: true, attributeFilter: ['style'] })
-    const ro = new ResizeObserver(adjust)
-    if (menuRef.current) ro.observe(menuRef.current)
-    window.addEventListener('resize', adjust)
-    document.addEventListener('scroll', adjust, true)
-    return () => {
-      mo.disconnect()
-      ro.disconnect()
-      window.removeEventListener('resize', adjust)
-      document.removeEventListener('scroll', adjust, true)
-      anchorEl.style.transform = ''
-    }
-  }, [anchorEl, options.length])
-
-  return (
-    <div
-      ref={menuRef}
-      className="border border-rule bg-bg w-[300px] max-h-[280px] overflow-y-auto shadow-none"
-    >
-      <div className="px-3 py-1.5 border-b border-rule-2 bg-panel font-mono text-[11px] uppercase tracking-[0.18em] text-ink-faint">
-        commands
-      </div>
-      <div role="listbox" className="divide-y divide-rule-2">
-        {options.map((opt, i) => {
-          const active = i === selectedIndex
-          return (
-            <div
-              key={opt.entry.command}
-              role="option"
-              tabIndex={-1}
-              aria-selected={active}
-              ref={(el) => opt.setRefElement(el)}
-              onMouseEnter={() => setHighlightedIndex(i)}
-              onMouseDown={(e) => {
-                e.preventDefault()
-                selectOptionAndCleanUp(opt)
-              }}
-              className={cn(
-                'flex items-center gap-2 px-3 py-2 cursor-pointer transition-colors',
-                active
-                  ? 'bg-panel border-l-2 border-l-accent pl-[10px]'
-                  : 'border-l-2 border-l-transparent hover:bg-paper-2',
-              )}
-            >
-              <span
-                aria-hidden="true"
-                className="text-accent font-semibold leading-none w-3 text-center shrink-0"
-              >
-                /
-              </span>
-              <div className="min-w-0 flex flex-col">
-                <span className="font-mono text-[13px] text-ink truncate">
-                  {opt.entry.command}
-                </span>
-                <span className="font-mono text-[11px] text-ink-faint truncate lowercase">
-                  {opt.entry.description}
-                </span>
-              </div>
-            </div>
-          )
-        })}
-      </div>
-    </div>
-  )
 }
 
 // Anchored at column 0 so `/` mid-sentence ("either/or") doesn't fire.
@@ -187,10 +87,30 @@ export function SlashCommandsPlugin({
         return createPortal(
           <FlipMenu
             anchorEl={anchorElementRef.current}
+            header="commands"
             options={options}
             selectedIndex={props.selectedIndex}
             selectOptionAndCleanUp={props.selectOptionAndCleanUp}
             setHighlightedIndex={props.setHighlightedIndex}
+            getOptionKey={(opt) => opt.entry.command}
+            renderOption={(opt) => (
+              <>
+                <span
+                  aria-hidden="true"
+                  className="text-accent font-semibold leading-none w-3 text-center shrink-0"
+                >
+                  /
+                </span>
+                <div className="min-w-0 flex flex-col">
+                  <span className="font-mono text-[13px] text-ink truncate">
+                    {opt.entry.command}
+                  </span>
+                  <span className="font-mono text-[11px] text-ink-faint truncate lowercase">
+                    {opt.entry.description}
+                  </span>
+                </div>
+              </>
+            )}
           />,
           anchorElementRef.current,
         )

--- a/console/web/src/lib/backend/harness-send.ts
+++ b/console/web/src/lib/backend/harness-send.ts
@@ -59,11 +59,28 @@ export interface HarnessSessionInit {
   metadata?: Record<string, unknown>
 }
 
+/** A text content block on a structured user message. */
+export interface HarnessTextBlock {
+  type: 'text'
+  text: string
+}
+
+/**
+ * The structured form of `harness::send`'s `message` (MessageInput::Message
+ * with `role: user`). The console uses it when a send carries `#file(...)`
+ * attachment blocks; plain sends keep the string-sugar form.
+ */
+export interface HarnessUserMessage {
+  role: 'user'
+  content: HarnessTextBlock[]
+  timestamp: number
+}
+
 export interface HarnessSendRequest {
   /** Omit to create a new session. */
   session_id?: string
   /** A string is sugar for a user text message. */
-  message: string
+  message: string | HarnessUserMessage
   model: string
   provider?: string
   /** Webhook dedupe: a repeated key returns the original `{session_id, turn_id}`. */

--- a/console/web/src/lib/backend/real.ts
+++ b/console/web/src/lib/backend/real.ts
@@ -184,11 +184,27 @@ async function* realStream(
       }
     }
 
+    // Attachment blocks (file-mention expansions) upgrade the message to the
+    // structured MessageInput form; plain sends keep the string sugar so the
+    // wire payload stays byte-identical for the common case.
+    const attachedBlocks = opts?.attachedBlocks ?? []
+    const message =
+      attachedBlocks.length > 0
+        ? {
+            role: 'user' as const,
+            content: [prompt, ...attachedBlocks].map((text) => ({
+              type: 'text' as const,
+              text,
+            })),
+            timestamp: Date.now(),
+          }
+        : prompt
+
     // Kick off (or steer) the turn. A turn already running for this session
     // folds the message in (merge) rather than rejecting — no busy error.
     void sendTurn(client, {
       session_id: sessionId,
-      message: prompt,
+      message,
       model: modelId,
       provider,
       idempotency_key: messageId,

--- a/console/web/src/lib/backend/types.ts
+++ b/console/web/src/lib/backend/types.ts
@@ -106,6 +106,14 @@ export interface ChatStreamOptions {
    * `harness::send` `options.metadata.fs_scope.root`.
    */
   workingDir?: string | null
+  /**
+   * Extra text content blocks appended after the prompt on the outgoing
+   * user message — `#file(...)` mention expansions (`<attached-file …>`
+   * blocks). When present the real backend sends a structured
+   * `harness::send` message instead of the string-sugar form. Mock
+   * backends ignore this.
+   */
+  attachedBlocks?: string[]
   /** mean delay between assistant tokens, in ms */
   meanDelayMs?: number
   /**

--- a/console/web/src/lib/file-index.test.ts
+++ b/console/web/src/lib/file-index.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  __resetFileIndexCacheForTests,
+  fetchFileIndex,
+  flattenTree,
+  fuzzyFilterFiles,
+  TREE_FUNCTION_ID,
+  type TreeNodeWire,
+} from './file-index'
+
+const tree: TreeNodeWire = {
+  name: 'repo',
+  kind: 'dir',
+  children: [
+    { name: 'README.md', kind: 'file' },
+    {
+      name: 'src',
+      kind: 'dir',
+      children: [
+        { name: 'main.rs', kind: 'file' },
+        { name: 'weird (copy).rs', kind: 'file' },
+        { name: 'link', kind: 'symlink' },
+        {
+          name: 'nested',
+          kind: 'dir',
+          children: [{ name: 'deep.ts', kind: 'file' }],
+        },
+      ],
+    },
+    { name: 'empty', kind: 'dir', children: [] },
+    { name: 'no-children-dir', kind: 'dir' },
+  ],
+}
+
+describe('flattenTree', () => {
+  it('collects relative file paths, skipping dirs/symlinks and paren paths', () => {
+    expect(flattenTree(tree)).toEqual([
+      'README.md',
+      'src/main.rs',
+      'src/nested/deep.ts',
+    ])
+  })
+
+  it('returns [] for a childless root', () => {
+    expect(flattenTree({ name: 'x', kind: 'dir' })).toEqual([])
+  })
+})
+
+describe('fuzzyFilterFiles', () => {
+  const index = [
+    'src/lib/config.ts',
+    'src/components/ConfigPanel.tsx',
+    'harness/config.rs',
+    'docs/notes.md',
+  ]
+
+  it('returns head of index for an empty query', () => {
+    expect(fuzzyFilterFiles(index, '', 2)).toEqual(index.slice(0, 2))
+  })
+
+  it('ranks basename-prefix matches before substring matches', () => {
+    const out = fuzzyFilterFiles(index, 'config')
+    expect(out.slice(0, 2)).toEqual(['harness/config.rs', 'src/lib/config.ts'])
+    expect(out).toContain('src/components/ConfigPanel.tsx')
+  })
+
+  it('matches subsequences as a last resort', () => {
+    expect(fuzzyFilterFiles(index, 'dnm')).toEqual(['docs/notes.md'])
+  })
+
+  it('excludes non-matches', () => {
+    expect(fuzzyFilterFiles(index, 'zzz')).toEqual([])
+  })
+})
+
+describe('fetchFileIndex', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    __resetFileIndexCacheForTests()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  const treeResponse = { path: '/w', root: tree }
+
+  it('fetches through coder::tree with the working dir as base_dir', async () => {
+    const trigger = vi.fn().mockResolvedValue(treeResponse)
+    const index = await fetchFileIndex('/w', trigger)
+    expect(index).toEqual(['README.md', 'src/main.rs', 'src/nested/deep.ts'])
+    expect(trigger).toHaveBeenCalledWith(
+      TREE_FUNCTION_ID,
+      expect.objectContaining({
+        fs_scope: { root: '/w' },
+        use_default_excludes: true,
+      }),
+    )
+  })
+
+  it('serves from cache within the TTL and refetches after it', async () => {
+    const trigger = vi.fn().mockResolvedValue(treeResponse)
+    await fetchFileIndex('/w', trigger)
+    await fetchFileIndex('/w', trigger)
+    expect(trigger).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(31_000)
+    await fetchFileIndex('/w', trigger)
+    expect(trigger).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns the last good index when a refetch fails', async () => {
+    const trigger = vi
+      .fn()
+      .mockResolvedValueOnce(treeResponse)
+      .mockRejectedValueOnce(new Error('worker away'))
+    const first = await fetchFileIndex('/w', trigger)
+    vi.advanceTimersByTime(31_000)
+    const second = await fetchFileIndex('/w', trigger)
+    expect(second).toEqual(first)
+  })
+
+  it('propagates the error when there is no cached index', async () => {
+    const trigger = vi.fn().mockRejectedValue(new Error('worker away'))
+    await expect(fetchFileIndex('/w', trigger)).rejects.toThrow('worker away')
+  })
+})

--- a/console/web/src/lib/file-index.ts
+++ b/console/web/src/lib/file-index.ts
@@ -1,0 +1,171 @@
+/**
+ * Working-directory file index for `#` file mentions in the composer.
+ *
+ * Fetches a bounded `coder::tree` snapshot scoped to the conversation's
+ * working directory (`fs_scope.root`), flattens it to relative file paths,
+ * and caches per working dir with a short TTL so reopening the typeahead
+ * doesn't re-walk the repo. The shell worker jail-validates the scope on
+ * every call, so this surface carries the same trust as the DirectoryPicker
+ * flow.
+ */
+
+import { getIiiClient } from '@/lib/iii-client'
+
+export const TREE_FUNCTION_ID = 'coder::tree'
+
+/** Bounds for the snapshot walk; noise dirs are excluded server-side. */
+const TREE_MAX_DEPTH = 8
+const TREE_PER_FOLDER_LIMIT = 500
+const CACHE_TTL_MS = 30_000
+
+/** Subset of `coder::tree`'s `TreeNode` the index consumes. */
+export interface TreeNodeWire {
+  name: string
+  kind: 'file' | 'dir' | 'symlink' | 'other'
+  children?: TreeNodeWire[]
+}
+
+export interface TreeOutputWire {
+  path: string
+  root: TreeNodeWire
+}
+
+type TriggerFn = (
+  functionId: string,
+  payload: Record<string, unknown>,
+) => Promise<unknown>
+
+interface CacheEntry {
+  at: number
+  index: string[]
+}
+
+const cache = new Map<string, CacheEntry>()
+const inFlight = new Map<string, Promise<string[]>>()
+
+/**
+ * Flatten a tree snapshot to sorted RELATIVE file paths (the root itself is
+ * `''` and never listed). Paths containing `)` are dropped — the
+ * `#file(<path>)` token cannot carry them (documented limitation).
+ */
+export function flattenTree(root: TreeNodeWire): string[] {
+  const out: string[] = []
+  const walk = (node: TreeNodeWire, prefix: string) => {
+    for (const child of node.children ?? []) {
+      const path = prefix ? `${prefix}/${child.name}` : child.name
+      if (child.kind === 'file') {
+        if (!path.includes(')')) out.push(path)
+      } else if (child.kind === 'dir') {
+        walk(child, path)
+      }
+    }
+  }
+  walk(root, '')
+  return out.sort((a, b) => a.localeCompare(b))
+}
+
+/**
+ * Case-insensitive subsequence filter over relative paths. Ranks (1) basename
+ * prefix matches, then (2) substring matches anywhere, then (3) subsequence
+ * matches; ties break on shorter path then lexicographic.
+ */
+export function fuzzyFilterFiles(
+  index: string[],
+  query: string,
+  limit = 8,
+): string[] {
+  const q = query.trim().toLowerCase()
+  if (!q) return index.slice(0, limit)
+
+  const ranked: Array<{ path: string; rank: number }> = []
+  for (const path of index) {
+    const lower = path.toLowerCase()
+    const base = lower.slice(lower.lastIndexOf('/') + 1)
+    let rank: number
+    if (base.startsWith(q)) rank = 0
+    else if (lower.includes(q)) rank = 1
+    else if (isSubsequence(q, lower)) rank = 2
+    else continue
+    ranked.push({ path, rank })
+  }
+  return ranked
+    .sort(
+      (a, b) =>
+        a.rank - b.rank ||
+        a.path.length - b.path.length ||
+        a.path.localeCompare(b.path),
+    )
+    .slice(0, limit)
+    .map((r) => r.path)
+}
+
+function isSubsequence(needle: string, haystack: string): boolean {
+  let i = 0
+  for (const ch of haystack) {
+    if (ch === needle[i]) i++
+    if (i === needle.length) return true
+  }
+  return false
+}
+
+/**
+ * Fetch (or reuse) the file index for a working directory. Returns the cached
+ * index while fresh; on fetch failure the last good index is returned when one
+ * exists, otherwise the error propagates. Concurrent callers share one fetch.
+ */
+export async function fetchFileIndex(
+  workingDir: string,
+  trigger?: TriggerFn,
+): Promise<string[]> {
+  const cached = cache.get(workingDir)
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
+    return cached.index
+  }
+  const pending = inFlight.get(workingDir)
+  if (pending) return pending
+
+  const fetchPromise = doFetch(workingDir, trigger)
+    .then((index) => {
+      cache.set(workingDir, { at: Date.now(), index })
+      return index
+    })
+    .catch((err) => {
+      const lastGood = cache.get(workingDir)
+      if (lastGood) return lastGood.index
+      throw err
+    })
+    .finally(() => {
+      inFlight.delete(workingDir)
+    })
+  inFlight.set(workingDir, fetchPromise)
+  return fetchPromise
+}
+
+async function doFetch(
+  workingDir: string,
+  trigger?: TriggerFn,
+): Promise<string[]> {
+  const call =
+    trigger ??
+    (async (functionId: string, payload: Record<string, unknown>) => {
+      const client = await getIiiClient()
+      return client.trigger(functionId, payload)
+    })
+  const res = (await call(TREE_FUNCTION_ID, {
+    path: '.',
+    fs_scope: { root: workingDir },
+    max_depth: TREE_MAX_DEPTH,
+    per_folder_limit: TREE_PER_FOLDER_LIMIT,
+    use_default_excludes: true,
+  })) as TreeOutputWire
+  if (!res || typeof res !== 'object' || !res.root) {
+    throw new Error('coder::tree returned an unexpected shape')
+  }
+  return flattenTree(res.root)
+}
+
+/** Test seam: drop all cached indexes. */
+export function __resetFileIndexCacheForTests(): void {
+  cache.clear()
+  inFlight.clear()
+}

--- a/console/web/src/lib/file-mentions.test.ts
+++ b/console/web/src/lib/file-mentions.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  expandFileMentions,
+  isAttachedFileBlock,
+  MAX_MENTIONS_PER_SEND,
+  parseAttachedFileHeader,
+  parseFileMentions,
+  READ_FILE_FUNCTION_ID,
+} from './file-mentions'
+
+describe('parseFileMentions', () => {
+  it('extracts unique paths in first-appearance order', () => {
+    const text =
+      'see #file(src/a.rs) and #file(docs/x y.md) then #file(src/a.rs) again'
+    expect(parseFileMentions(text)).toEqual(['src/a.rs', 'docs/x y.md'])
+  })
+
+  it('returns [] when there are no mentions', () => {
+    expect(parseFileMentions('plain text @fn(engine::echo) # heading')).toEqual(
+      [],
+    )
+  })
+
+  it('caps at MAX_MENTIONS_PER_SEND unique paths', () => {
+    const text = Array.from(
+      { length: MAX_MENTIONS_PER_SEND + 5 },
+      (_, i) => `#file(f${i}.txt)`,
+    ).join(' ')
+    expect(parseFileMentions(text)).toHaveLength(MAX_MENTIONS_PER_SEND)
+  })
+})
+
+describe('expandFileMentions', () => {
+  it('formats content blocks and chip attachments from a batch read', async () => {
+    const trigger = vi.fn().mockResolvedValue({
+      results: [
+        {
+          path: '/w/src/a.rs',
+          success: true,
+          content: 'fn main() {}',
+          is_utf8: true,
+          total_lines: 1,
+          more_lines: false,
+          size: 12,
+        },
+      ],
+    })
+    const out = await expandFileMentions('/w', ['src/a.rs'], trigger)
+    expect(trigger).toHaveBeenCalledWith(READ_FILE_FUNCTION_ID, {
+      paths: ['src/a.rs'],
+      fs_scope: { root: '/w' },
+    })
+    expect(out.blocks).toEqual([
+      '<attached-file path="src/a.rs" size="12" total-lines="1">\nfn main() {}\n</attached-file>',
+    ])
+    expect(out.attachments).toEqual([{ path: 'src/a.rs', size: 12 }])
+    expect(out.failures).toEqual([])
+  })
+
+  it('marks truncated reads and keeps them as attachments', async () => {
+    const trigger = vi.fn().mockResolvedValue({
+      results: [
+        {
+          path: '/w/big.log',
+          success: true,
+          content: 'first lines',
+          is_utf8: true,
+          more_lines: true,
+          size: 999_999,
+        },
+      ],
+    })
+    const out = await expandFileMentions('/w', ['big.log'], trigger)
+    expect(out.blocks[0]).toContain('truncated="true"')
+    expect(out.failures).toEqual([])
+  })
+
+  it('turns per-entry failures and binary files into placeholder blocks', async () => {
+    const trigger = vi.fn().mockResolvedValue({
+      results: [
+        {
+          path: 'gone.txt',
+          success: false,
+          error: { code: 'C211', message: 'not found: gone.txt' },
+        },
+        { path: '/w/pic.png', success: true, content: '�', is_utf8: false },
+      ],
+    })
+    const out = await expandFileMentions('/w', ['gone.txt', 'pic.png'], trigger)
+    expect(out.blocks[0]).toBe(
+      '<attached-file path="gone.txt" error="not found: gone.txt" />',
+    )
+    expect(out.blocks[1]).toBe(
+      '<attached-file path="pic.png" error="binary file" />',
+    )
+    expect(out.failures).toEqual([
+      { path: 'gone.txt', reason: 'not found: gone.txt' },
+      { path: 'pic.png', reason: 'binary file' },
+    ])
+    expect(out.attachments).toEqual([])
+  })
+
+  it('degrades every mention to a failure when the batch call throws', async () => {
+    const trigger = vi.fn().mockRejectedValue(new Error('shell worker away'))
+    const out = await expandFileMentions('/w', ['a.txt', 'b.txt'], trigger)
+    expect(out.blocks).toHaveLength(2)
+    expect(out.failures.map((f) => f.reason)).toEqual([
+      'shell worker away',
+      'shell worker away',
+    ])
+  })
+})
+
+describe('attached-file block helpers', () => {
+  it('round-trips header attributes, including escaped quotes', () => {
+    const block =
+      '<attached-file path="a &quot;b&quot;.txt" size="7" total-lines="3" truncated="true">\nx\n</attached-file>'
+    expect(isAttachedFileBlock(block)).toBe(true)
+    expect(parseAttachedFileHeader(block)).toEqual({
+      path: 'a "b".txt',
+      size: 7,
+      totalLines: 3,
+      truncated: true,
+    })
+  })
+
+  it('parses failure placeholders', () => {
+    const block = '<attached-file path="gone.txt" error="not found" />'
+    expect(parseAttachedFileHeader(block)).toEqual({
+      path: 'gone.txt',
+      error: 'not found',
+    })
+  })
+
+  it('rejects non-attachment text', () => {
+    expect(isAttachedFileBlock('hello')).toBe(false)
+    expect(parseAttachedFileHeader('hello')).toBeNull()
+    expect(parseAttachedFileHeader('<attached-file broken')).toBeNull()
+  })
+})

--- a/console/web/src/lib/file-mentions.ts
+++ b/console/web/src/lib/file-mentions.ts
@@ -1,0 +1,199 @@
+/**
+ * `#file(<path>)` mention expansion for the composer send path.
+ *
+ * The composer inserts `#file(<relpath>)` tokens (FileMentionNode pills). At
+ * send time the console reads every mentioned file through one
+ * `coder::read-file` batch call scoped to the conversation's working
+ * directory, and appends one `<attached-file …>` text block per mention to
+ * the outgoing user message. Failures never block the send: the failed
+ * mention becomes a self-closing placeholder block the model can see, plus a
+ * `failures` entry the caller surfaces as a chat notice.
+ */
+
+import { getIiiClient } from '@/lib/iii-client'
+
+export const READ_FILE_FUNCTION_ID = 'coder::read-file'
+
+/** Path may contain spaces but not `)` — see file-index (paren paths dropped). */
+const FILE_MENTION_RE = /#file\(([^)]+)\)/g
+
+/** Max unique mentions expanded per send; extras are ignored. */
+export const MAX_MENTIONS_PER_SEND = 20
+
+const ATTACHED_FILE_PREFIX = '<attached-file '
+
+export interface FileMentionFailure {
+  path: string
+  reason: string
+}
+
+export interface ExpandedMentions {
+  /** One `<attached-file …>` text block per requested path, request order. */
+  blocks: string[]
+  /** Chip data for the optimistic user row: bytes actually attached. */
+  attachments: Array<{ path: string; size: number }>
+  failures: FileMentionFailure[]
+}
+
+/** Header fields parsed back out of an `<attached-file …>` block. */
+export interface AttachedFileHeader {
+  path: string
+  size?: number
+  totalLines?: number
+  truncated?: boolean
+  error?: string
+}
+
+/** Unique `#file(...)` paths in first-appearance order, capped. */
+export function parseFileMentions(text: string): string[] {
+  const seen = new Set<string>()
+  for (const m of text.matchAll(FILE_MENTION_RE)) {
+    const path = m[1].trim()
+    if (path.length > 0) seen.add(path)
+    if (seen.size >= MAX_MENTIONS_PER_SEND) break
+  }
+  return [...seen]
+}
+
+// --- wire subset of coder::read-file batch mode ---------------------------
+
+interface ReadEntryResultWire {
+  path: string
+  success: boolean
+  content?: string | null
+  is_utf8?: boolean | null
+  total_lines?: number | null
+  more_lines?: boolean | null
+  size?: number | null
+  error?: { code?: string; message?: string } | null
+}
+
+interface ReadFileBatchWire {
+  results?: ReadEntryResultWire[]
+}
+
+type TriggerFn = (
+  functionId: string,
+  payload: Record<string, unknown>,
+) => Promise<unknown>
+
+/**
+ * Read every mentioned file in one jail-validated batch call and format the
+ * attachment blocks. Batch results come back in request order (the wire
+ * contract), so blocks are labeled with the caller's relative paths.
+ */
+export async function expandFileMentions(
+  workingDir: string,
+  paths: string[],
+  trigger?: TriggerFn,
+): Promise<ExpandedMentions> {
+  if (paths.length === 0) return { blocks: [], attachments: [], failures: [] }
+
+  const call =
+    trigger ??
+    (async (functionId: string, payload: Record<string, unknown>) => {
+      const client = await getIiiClient()
+      return client.trigger(functionId, payload)
+    })
+
+  let results: ReadEntryResultWire[]
+  try {
+    const res = (await call(READ_FILE_FUNCTION_ID, {
+      paths,
+      fs_scope: { root: workingDir },
+    })) as ReadFileBatchWire
+    results = res?.results ?? []
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err)
+    return {
+      blocks: paths.map((path) => failureBlock(path, reason)),
+      attachments: [],
+      failures: paths.map((path) => ({ path, reason })),
+    }
+  }
+
+  const blocks: string[] = []
+  const attachments: Array<{ path: string; size: number }> = []
+  const failures: FileMentionFailure[] = []
+
+  for (const [i, path] of paths.entries()) {
+    const entry = results[i]
+    if (!entry?.success || typeof entry.content !== 'string') {
+      const reason = shortReason(entry?.error?.message) ?? 'read failed'
+      blocks.push(failureBlock(path, reason))
+      failures.push({ path, reason })
+      continue
+    }
+    if (entry.is_utf8 === false) {
+      const reason = 'binary file'
+      blocks.push(failureBlock(path, reason))
+      failures.push({ path, reason })
+      continue
+    }
+    blocks.push(contentBlock(path, entry))
+    attachments.push({ path, size: entry.size ?? entry.content.length })
+  }
+  return { blocks, attachments, failures }
+}
+
+function contentBlock(path: string, entry: ReadEntryResultWire): string {
+  const attrs = [`path="${escapeAttr(path)}"`]
+  if (typeof entry.size === 'number') attrs.push(`size="${entry.size}"`)
+  if (typeof entry.total_lines === 'number') {
+    attrs.push(`total-lines="${entry.total_lines}"`)
+  }
+  if (entry.more_lines === true) attrs.push('truncated="true"')
+  return `${ATTACHED_FILE_PREFIX}${attrs.join(' ')}>\n${entry.content}\n</attached-file>`
+}
+
+function failureBlock(path: string, reason: string): string {
+  return `${ATTACHED_FILE_PREFIX}path="${escapeAttr(path)}" error="${escapeAttr(reason)}" />`
+}
+
+function shortReason(message: string | undefined | null): string | undefined {
+  if (!message) return undefined
+  return message.length > 120 ? `${message.slice(0, 117)}…` : message
+}
+
+/** Whether a text content block is a console-authored file attachment. */
+export function isAttachedFileBlock(text: string): boolean {
+  return text.startsWith(ATTACHED_FILE_PREFIX)
+}
+
+/**
+ * Parse the header of an `<attached-file …>` block. Returns null when the
+ * text is not an attachment block or the header has no path.
+ */
+export function parseAttachedFileHeader(
+  text: string,
+): AttachedFileHeader | null {
+  if (!isAttachedFileBlock(text)) return null
+  const headerEnd = text.indexOf('>')
+  if (headerEnd < 0) return null
+  const header = text.slice(ATTACHED_FILE_PREFIX.length, headerEnd)
+
+  const attr = (name: string): string | undefined => {
+    const m = header.match(new RegExp(`${name}="([^"]*)"`))
+    return m ? unescapeAttr(m[1]) : undefined
+  }
+  const path = attr('path')
+  if (!path) return null
+
+  const size = attr('size')
+  const totalLines = attr('total-lines')
+  return {
+    path,
+    ...(size !== undefined ? { size: Number(size) } : {}),
+    ...(totalLines !== undefined ? { totalLines: Number(totalLines) } : {}),
+    ...(attr('truncated') === 'true' ? { truncated: true } : {}),
+    ...(attr('error') !== undefined ? { error: attr('error') } : {}),
+  }
+}
+
+function escapeAttr(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('"', '&quot;')
+}
+
+function unescapeAttr(value: string): string {
+  return value.replaceAll('&quot;', '"').replaceAll('&amp;', '&')
+}

--- a/console/web/src/lib/markdown.tsx
+++ b/console/web/src/lib/markdown.tsx
@@ -1,6 +1,7 @@
 import type { Element, Root, RootContent, Text } from 'hast'
 import ReactMarkdown, { type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { FileMentionPill } from '@/components/chat/lexical/FileMentionNode'
 import { FunctionMentionPill } from '@/components/chat/lexical/FunctionMentionNode'
 import { JsonHighlight } from '@/lib/syntax'
 import { cn } from '@/lib/utils'
@@ -10,17 +11,19 @@ interface MarkdownProps {
   className?: string
 }
 
-/* Matches `@fn(<id>)` where `<id>` excludes whitespace and `)`. Tolerates
-   trailing punctuation outside the parens. The pattern is intentionally
-   defensive: we never accept arbitrary content inside the parens, so the
-   pill can't be smuggled into otherwise-safe markdown. */
-const FN_MENTION_RE = /@fn\(([^)\s]+)\)/g
+/* Matches `@fn(<id>)` (id excludes whitespace and `)`) or `#file(<path>)`
+   (path excludes `)` — file names may carry spaces). Tolerates trailing
+   punctuation outside the parens. The pattern is intentionally defensive:
+   we never accept arbitrary content inside the parens, so the pill can't
+   be smuggled into otherwise-safe markdown. */
+const MENTION_RE = /@fn\(([^)\s]+)\)|#file\(([^)]+)\)/g
 
 /* Inline rehype plugin: walks the hast tree and splits any `text` node that
-   contains `@fn(<id>)` into a mix of leftover text + a marker `span` element
-   carrying the function id. The actual pill rendering happens in the `span`
-   component override below. Code / pre subtrees are skipped so literal
-   mentions inside fenced blocks stay verbatim. */
+   contains `@fn(<id>)` or `#file(<path>)` into a mix of leftover text + a
+   marker `span` element carrying the mention payload. The actual pill
+   rendering happens in the `span` component override below. Code / pre
+   subtrees are skipped so literal mentions inside fenced blocks stay
+   verbatim. */
 function rehypeFnMention() {
   return (tree: Root) => walk(tree)
 }
@@ -57,21 +60,25 @@ function hasLanguageJson(node: Element): boolean {
 }
 
 function splitMention(value: string): Array<Text | Element> {
-  if (!value.includes('@fn(')) return []
+  if (!value.includes('@fn(') && !value.includes('#file(')) return []
   const out: Array<Text | Element> = []
   let last = 0
   /* matchAll iterates with stateless semantics on a /g regex, so we don't
-     have to babysit FN_MENTION_RE.lastIndex between calls. */
-  for (const m of value.matchAll(FN_MENTION_RE)) {
+     have to babysit MENTION_RE.lastIndex between calls. */
+  for (const m of value.matchAll(MENTION_RE)) {
     const index = m.index ?? 0
     if (index > last) {
       out.push({ type: 'text', value: value.slice(last, index) })
     }
+    /* Group 1 = `@fn` id, group 2 = `#file` path (the alternation makes
+       exactly one of them defined per match). */
     out.push({
       type: 'element',
       tagName: 'span',
-      properties: { className: ['fn-mention'] },
-      children: [{ type: 'text', value: m[1] }],
+      properties: {
+        className: [m[1] !== undefined ? 'fn-mention' : 'file-mention'],
+      },
+      children: [{ type: 'text', value: m[1] ?? m[2] }],
     })
     last = index + m[0].length
   }
@@ -240,14 +247,19 @@ const components: Components = {
   },
   span: ({ className, children, ...rest }) => {
     const cls = typeof className === 'string' ? className : ''
-    if (cls.split(/\s+/).includes('fn-mention')) {
-      const id =
+    const classes = cls.split(/\s+/)
+    if (classes.includes('fn-mention') || classes.includes('file-mention')) {
+      const payload =
         typeof children === 'string'
           ? children
           : Array.isArray(children) && typeof children[0] === 'string'
             ? children[0]
             : ''
-      return <FunctionMentionPill functionId={id} />
+      return classes.includes('fn-mention') ? (
+        <FunctionMentionPill functionId={payload} />
+      ) : (
+        <FileMentionPill path={payload} />
+      )
     }
     return (
       <span className={className} {...rest}>

--- a/console/web/src/lib/sessions/entry-mapper.test.ts
+++ b/console/web/src/lib/sessions/entry-mapper.test.ts
@@ -68,6 +68,47 @@ describe('entrySegments', () => {
     })
   })
 
+  it('collapses attached-file blocks into chips instead of dumping content', () => {
+    const item: TranscriptItem = {
+      entry_id: 'msg-2-user-0',
+      message: {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'review #file(src/a.rs) please' },
+          {
+            type: 'text',
+            text: '<attached-file path="src/a.rs" size="12" total-lines="1">\nfn main() {}\n</attached-file>',
+          },
+          {
+            type: 'text',
+            text: '<attached-file path="gone.txt" error="not found" />',
+          },
+        ],
+        timestamp: 1,
+      },
+    }
+    const [msg] = entrySegments(item)
+    expect(msg).toMatchObject({
+      role: 'user',
+      content: 'review #file(src/a.rs) please',
+      attachments: [
+        {
+          id: 'mention-src/a.rs',
+          name: 'src/a.rs',
+          size: 12,
+          type: 'text/x-file-mention',
+        },
+        {
+          id: 'mention-gone.txt',
+          name: 'gone.txt (not found)',
+          size: 0,
+          type: 'text/x-file-mention',
+        },
+      ],
+    })
+    expect((msg as { content: string }).content).not.toContain('fn main')
+  })
+
   it('marks only trusted notification user entries', () => {
     expect(
       entrySegments(userItem('e-1', 'normal', { notification: false }))[0],

--- a/console/web/src/lib/sessions/entry-mapper.ts
+++ b/console/web/src/lib/sessions/entry-mapper.ts
@@ -22,7 +22,9 @@
  * read-backs as the source of truth.
  */
 
+import { parseAttachedFileHeader } from '@/lib/file-mentions'
 import type {
+  Attachment,
   FunctionCallMessage,
   Message,
   SystemMessage,
@@ -58,6 +60,36 @@ function textOf(blocks: ContentBlock[]): string {
     if (block.type === 'text') out += block.text
   }
   return out
+}
+
+/**
+ * Split a user message's blocks into visible text and attachment chips.
+ * `<attached-file …>` blocks are console-authored `#file(...)` mention
+ * expansions — rendering their full content in the user bubble would dump
+ * whole files into the chat, so they collapse to chips instead (failure
+ * placeholders keep the error visible in the chip name).
+ */
+function splitUserContent(blocks: ContentBlock[]): {
+  text: string
+  attachments: Attachment[]
+} {
+  let text = ''
+  const attachments: Attachment[] = []
+  for (const block of blocks) {
+    if (block.type !== 'text') continue
+    const header = parseAttachedFileHeader(block.text)
+    if (header) {
+      attachments.push({
+        id: `mention-${header.path}`,
+        name: header.error ? `${header.path} (${header.error})` : header.path,
+        size: header.size ?? 0,
+        type: 'text/x-file-mention',
+      })
+    } else {
+      text += block.text
+    }
+  }
+  return { text, attachments }
 }
 
 function compactionMarker(
@@ -109,11 +141,13 @@ export function entrySegments(
       const notif = (item.origin as { notification?: unknown } | undefined)
         ?.notification
       const isNotif = notif === true || item.entry_id.startsWith('e_notify_')
+      const { text, attachments } = splitUserContent(message.content)
       const msg: UserMessage = {
         id: item.entry_id,
         role: 'user',
-        content: textOf(message.content),
+        content: text,
         createdAt: message.timestamp,
+        ...(attachments.length > 0 ? { attachments } : {}),
         ...(isNotif ? { notification: true } : {}),
       }
       return [msg]
@@ -309,8 +343,11 @@ export function applyEntryUpsert(
   })
 
   // Preserve optimistic-only fields when replacing a user message in place.
+  // Snapshot-derived attachments (collapsed `<attached-file>` blocks) win —
+  // they are the durable truth; optimistic chips only fill the gap.
   segments = segments.map((segment) => {
     if (segment.role !== 'user') return segment
+    if (segment.attachments) return segment
     const existing = messages.find(
       (m): m is UserMessage => m.role === 'user' && m.id === segment.id,
     )


### PR DESCRIPTION
Closes MOT-3860

## Summary

Adds file mentions to the console chat composer: type `#`, fuzzy-pick a file from the session working directory, and its content is attached to the message the model receives.

- `#` opens a files-only typeahead (bounded `coder::tree` snapshot, fuzzy-filtered, 30s TTL cache) and inserts a `#file(<path>)` pill; `@` function mentions are unchanged. `minLength: 1` on the trigger keeps markdown headings (`# foo`) from opening the menu.
- On send, mentioned files are read in one `coder::read-file` batch scoped by `fs_scope: { root: workingDir }` and attached as `<attached-file …>` text blocks on a structured `harness::send` user message. Plain sends keep the string-sugar wire form.
- Failures never block the send: a missing/binary/over-budget file becomes an error placeholder block plus a warning notice. Caps: 20 unique mentions per send; the server byte budget flags truncated reads on the block.
- Transcript rendering collapses attachment blocks into size-labeled chips and renders mention tokens as pills, both live and on reload from the server transcript.
- Extracts the shared `FlipMenu` dropdown from the mentions/slash typeahead menus instead of copying it a third time.

Zero harness/shell changes — client-side expansion over existing jail-validated functions; the transcript stores the content snapshot, so replays are deterministic and compaction-safe.

## Test plan

- [x] Unit: 866/866 web tests pass (23 new — index flattening/filtering/TTL, expansion formatting and failure paths, header round-trip, entry-mapper chip collapse)
- [x] `tsc -b`, vite build, and biome clean on all touched files
- [x] E2E on a live stack: `#READM` lists repo files (default excludes honored) → pill inserts → send fires `coder::read-file` then structured `harness::send` (verified in traces) → model reply summarizes the attached README
- [x] Reload: reopened conversation renders text + pill + `README.md 11kb` chip purely from the server transcript, no raw `<attached-file` leakage
- [x] Regressions: `@fn` menu, `/compact` interception, and plain string-sugar sends unchanged; `# heading ` opens no menu
- [ ] Follow-ups (out of scope): directory mentions, image attachments as image blocks, wiring the upload button to real sends

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now type `#file(...)` mentions in chat to attach files from the current working directory.
  * File mentions appear as inline pills in the editor and in rendered messages.
  * Long menus now flip upward automatically to stay visible.

* **Bug Fixes**
  * File mention expansion now continues even if some files fail to load, while showing warnings.
  * Attached file content is now handled correctly in message history and optimistic sends.
  * Mention menus and file lookups now respect the active working directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->