### PR TITLE
(MOT-3863) feat: release process hardening

### DIFF
--- a/.claude/skills/release-sync/SKILL.md
+++ b/.claude/skills/release-sync/SKILL.md
@@ -63,7 +63,11 @@ would be written (typical of a first backfill), show the plan
    `create_issue_label` with `parent: release`; skip if it exists).
 2. Label every verified issue: read the issue's current labels first and
    pass the union to `save_issue` — never drop existing labels.
-3. Document: `save_document` on team iii titled `Release YYYY-MM-DD`
+3. Worker labels: also apply `worker` group child labels (`shell`,
+   `console`, ...) matching the worker commit ranges that referenced the
+   issue — create missing children under the team label group `worker`
+   lazily; same union rule.
+4. Document: `save_document` on team iii titled `Release YYYY-MM-DD`
    (update the existing one if present — look it up via `list_documents`).
    First line: the full tag list (idempotency record — always complete)
    and the wave label name. Body: a `## <worker> vX.Y.Z` section per tag

--- a/.claude/skills/release-sync/SKILL.md
+++ b/.claude/skills/release-sync/SKILL.md
@@ -63,10 +63,11 @@ would be written (typical of a first backfill), show the plan
    `create_issue_label` with `parent: release`; skip if it exists).
 2. Label every verified issue: read the issue's current labels first and
    pass the union to `save_issue` — never drop existing labels.
-3. Worker labels: also apply `worker` group child labels (`shell`,
-   `console`, ...) matching the worker commit ranges that referenced the
-   issue — create missing children under the team label group `worker`
-   lazily; same union rule.
+3. Worker labels: also apply flat `worker:<name>` team labels
+   (`worker:shell`, `worker:console`, ...) matching the worker commit
+   ranges that referenced the issue — create missing ones lazily; same
+   union rule. Flat, NOT a label group: Linear group children are
+   mutually exclusive, and one issue often spans several workers.
 4. Document: `save_document` on team iii titled `Release YYYY-MM-DD`
    (update the existing one if present — look it up via `list_documents`).
    First line: the full tag list (idempotency record — always complete)

--- a/.github/scripts/manifest_version.py
+++ b/.github/scripts/manifest_version.py
@@ -35,7 +35,7 @@ def cmd_bump(args: argparse.Namespace) -> int:
     path = Path(args.manifest)
     try:
         current = _lib.read_version(path)
-        new = _lib.bump(current, args.kind)
+        new = current if args.kind == "none" else _lib.bump(current, args.kind)
         _lib.write_version(path, new)
     except (FileNotFoundError, ValueError) as e:
         print(f"error: {e}", file=sys.stderr)
@@ -130,7 +130,7 @@ def main(argv: list[str] | None = None) -> int:
 
     p_bump = sub.add_parser("bump", help="bump the manifest version in place")
     p_bump.add_argument("manifest")
-    p_bump.add_argument("--kind", choices=["patch", "minor", "major"], required=True)
+    p_bump.add_argument("--kind", choices=["patch", "minor", "major", "none"], required=True)
     p_bump.set_defaults(func=cmd_bump)
 
     p_verify = sub.add_parser("verify", help="assert the manifest version equals --expected")

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -40,13 +40,14 @@ on:
           - storage
           - web
       bump:
-        description: 'Version bump'
+        description: 'Version bump (none = release the manifest version as-is, e.g. when a merged PR already set it)'
         required: true
         type: choice
         options:
           - patch
           - minor
           - major
+          - none
         default: patch
       tag:
         description: 'Registry tag (passed to POST /publish; not part of git tag name)'
@@ -178,9 +179,13 @@ jobs:
           WORKER: ${{ inputs.worker }}
           NEW_VERSION: ${{ steps.versions.outputs.version }}
         run: |
-          git add -A
-          git commit -m "chore(${WORKER}): bump to v${NEW_VERSION}"
-          git push origin main
+          if git diff --quiet; then
+            echo "::notice::manifest unchanged (bump: none); skipping bump commit"
+          else
+            git add -A
+            git commit -m "chore(${WORKER}): bump to v${NEW_VERSION}"
+            git push origin main
+          fi
 
       - name: Create and push annotated tag
         env:

--- a/.github/workflows/pr-linear-check.yml
+++ b/.github/workflows/pr-linear-check.yml
@@ -1,0 +1,40 @@
+# Every PR must reference a Linear ticket: title formatted
+# "(MOT-123) feat: ..." (squash-merge carries it into main history),
+# or an MOT-### reference in the body, or the no-ticket label for
+# bump/typo/CI-only changes.
+name: PR Linear Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, labeled, unlabeled]
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  linear-ticket:
+    name: Linear ticket reference
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Check for Linear ticket reference
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+          BODY: ${{ github.event.pull_request.body }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          set -euo pipefail
+          if [[ ",${LABELS}," == *",no-ticket,"* ]]; then
+            echo "::notice::no-ticket label present; skipping ticket requirement"
+            exit 0
+          fi
+          if [[ "$TITLE" =~ \(MOT-[0-9]+\) ]]; then
+            echo "::notice::Linear ticket found in PR title"
+            exit 0
+          fi
+          if [[ "${BODY:-}" =~ MOT-[0-9]+ ]]; then
+            echo "::notice::Linear ticket found in PR body"
+            exit 0
+          fi
+          echo "::error::No Linear ticket reference. Title the PR '(MOT-123) feat: ...', or add 'Fixes MOT-123' to the body, or apply the 'no-ticket' label for bump/typo/CI-only changes."
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,6 +230,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post to Slack
+        id: post
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           CHANNEL: worker-releases
@@ -243,6 +244,33 @@ jobs:
           if [[ "$IS_PRERELEASE" == "true" ]]; then suffix=" (pre-release)"; fi
           text="🚀 ${WORKER} v${VERSION}${suffix} released — <${RELEASE_URL}|GitHub Release>"
           payload=$(jq -n --arg channel "$CHANNEL" --arg text "$text" '{channel: $channel, text: $text}')
+          resp=$(curl -sf -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            -d "$payload")
+          if ! echo "$resp" | jq -e .ok > /dev/null; then
+            echo "::error::Slack API error: $(echo "$resp" | jq -r .error)"
+            exit 1
+          fi
+          echo "ts=$(echo "$resp" | jq -r .ts)" >> "$GITHUB_OUTPUT"
+
+      - name: Post release notes in thread
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          CHANNEL: worker-releases
+          TAG: ${{ needs.setup.outputs.tag }}
+          THREAD_TS: ${{ steps.post.outputs.ts }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          notes=$(gh release view "$TAG" -R "${{ github.repository }}" --json body --jq .body 2>/dev/null || true)
+          if [[ -z "$notes" ]]; then
+            echo "::notice::no release notes body; skipping thread reply"
+            exit 0
+          fi
+          notes=$(printf '%s' "$notes" | head -c 2900)
+          payload=$(jq -n --arg channel "$CHANNEL" --arg text "$notes" --arg ts "$THREAD_TS" \
+            '{channel: $channel, text: $text, thread_ts: $ts}')
           resp=$(curl -sf -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
             -H "Content-Type: application/json; charset=utf-8" \

--- a/docs/sops/release.md
+++ b/docs/sops/release.md
@@ -162,6 +162,13 @@ VS Code** manually with the existing tag and the failed target:
 Use `publish_target=all` only for the first publish attempt or when all targets
 are known to be safe to run again.
 
+### Pre-bumped manifest
+
+If a merged PR already set the manifest version (e.g. a breaking change
+that names its own release), use Create Tag with **Bump = none**: it
+releases the manifest version as-is, skips the bump commit, and still
+refuses existing tags.
+
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |
@@ -209,7 +216,10 @@ Slack announcement is automatic: the terminal `announce` job in
 `release.yml` posts `🚀 <worker> vX.Y.Z` to `#worker-releases` for every
 successful non-dry-run release. `SLACK_BOT_TOKEN` is org-level (the same
 bot as the iii engine release pipeline); the bot must be invited to
-`#worker-releases`.
+`#worker-releases`. The GitHub release-notes body is posted as a thread
+reply under the announcement. Ticket association rides on PR titles —
+`(MOT-##) type: description` — enforced by the `PR Linear Check` workflow
+(`no-ticket` label for bump/typo/CI-only PRs).
 
 After a release session — any number of tags — run `/release-sync` in Claude
 Code from the repo root. Same-day tags form one **wave** = one Linear


### PR DESCRIPTION
## What

- **`pr-linear-check` workflow** (new): every PR to main must reference a Linear ticket — `(MOT-##)` title prefix (squash-merge carries it into main history), an `MOT-###` reference in the body, or the `no-ticket` label for bump/typo/CI-only changes. Non-blocking red X at rollout; to make it required later, add a ruleset on main requiring this check with a bypass for the III CI app (its version-bump pushes go straight to main).
- **Create Tag `bump: none`**: releases the manifest version as-is (for PRs that already set it, like the shell 0.7.0 case) — skips the bump commit when nothing changed; the existing tag-exists check still rejects re-releases.
- **Slack announce thread**: the announce job now posts the GitHub release-notes body (truncated to 2,900 chars) as a thread reply under the 🚀 message.
- **release-sync skill**: also applies `worker · <name>` team labels derived from the shipped commit ranges, giving area × wave filtering in Linear.
- **SOP**: pre-bumped-manifest variant + ticket-association conventions.

## Verification

- Both workflows parse (yaml.safe_load); `manifest_version.py bump --kind none` prints the current version and leaves the file byte-identical; `--kind patch` unaffected.
- Check exercised on this PR: ticketless title → red X; `no-ticket` label → green; `(MOT-3863)` title → green.
- Thread reply + `bump: none` verify end-to-end on the next worker release.

Fixes MOT-3863