### PR TITLE
(MOT-3856) fix(harness): unpark turns whose spawned children died without resolving

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -139,7 +139,7 @@ field hot-reloads (no restart). The fields a deployment is most likely to tune:
 
 ```yaml
 default_max_turns: 16            # per-turn generate-step cap when a send omits it
-default_pending_timeout_ms: 1800000  # parked pending-call (sub-agent / hold) wait guard
+default_pending_timeout_ms: 7200000  # parked pending-call (sub-agent / hold) wait guard
 max_depth: 3                     # sub-agent depth budget
 max_children: 5                  # sub-agent fan-out budget
 sweep_expression: "0 * * * * *"  # cron for the pending-call expiry sweep

--- a/harness/src/config.rs
+++ b/harness/src/config.rs
@@ -148,7 +148,10 @@ fn default_max_turns() -> u32 {
     500
 }
 fn default_pending_timeout_ms() -> u64 {
-    1_800_000
+    // Two hours. This only cuts off a LIVE child (the sweep settles dead
+    // children immediately), so it is sized for legitimately long sub-agent
+    // runs, not for wedge recovery.
+    7_200_000
 }
 fn default_max_depth() -> u32 {
     3
@@ -178,9 +181,11 @@ fn default_stream_coalesce_ms() -> u64 {
     150
 }
 fn default_sweep_expression() -> String {
-    // 6-field cron (engine cron worker, config key "expression"): once
-    // daily at midnight.
-    "0 0 0 * * *".to_string()
+    // 6-field cron (engine cron worker, config key "expression"): every
+    // minute. The sweep is the only net that unparks a turn whose child died
+    // without resolving its call (MOT-3856), so it must run at a cadence far
+    // below `default_pending_timeout_ms`, not daily.
+    "0 * * * * *".to_string()
 }
 fn default_functions() -> Option<FunctionPolicy> {
     // Read-only baseline for parentless spawns: discovery, reads, and
@@ -279,7 +284,9 @@ mod tests {
         assert_eq!(cfg.default_max_turns, 500);
         assert_eq!(cfg.max_depth, 3);
         assert_eq!(cfg.max_children, 5);
-        assert_eq!(cfg.sweep_expression, "0 0 0 * * *");
+        // Every minute: the sweep is the only net that unparks a turn whose
+        // child died without resolving; daily would park it for up to 24h.
+        assert_eq!(cfg.sweep_expression, "0 * * * * *");
     }
 
     #[test]

--- a/harness/src/deferred.rs
+++ b/harness/src/deferred.rs
@@ -1,8 +1,9 @@
 //! Deferred trigger (harness.md § Deferred trigger): a pending call parks the
 //! turn; `harness::function::resolve` settles it (delivering a result or
 //! releasing a hook-held call) and resumes the parked turn; a cron sweep
-//! expires stragglers so a lost child or abandoned approval can never park a
-//! turn forever.
+//! settles calls whose child turn died without resolving and expires
+//! stragglers past their wait guard, so a lost child can never park a turn
+//! forever (MOT-3856). Hook holds (`held_by`) never expire.
 
 use std::collections::BTreeSet;
 
@@ -262,15 +263,16 @@ async fn find_call_arguments(
 }
 
 /// Resolve a parked parent call from a finishing child (harness.md §
-/// Sub-agents). `completed` delivers the child's result; `failed`/`cancelled`
-/// deliver an `is_error`.
+/// Sub-agents). `completed` delivers the child's result; any other status
+/// delivers an `is_error` with that status as the error code. Returns whether
+/// the call was actually resolved (a terminal/mismatched parent no-ops).
 pub async fn resolve_parent(
     deps: &Deps,
     parent: &crate::types::turn::ParentLink,
     status: &str,
     result: Option<&Value>,
     reason: Option<&str>,
-) {
+) -> bool {
     let (content, details, is_error) = if status == "completed" {
         let text = result.map(render_text).unwrap_or_default();
         (
@@ -296,12 +298,56 @@ pub async fn resolve_parent(
         is_error: Some(is_error),
         details: Some(details),
     };
-    if let Err(e) = resolve(deps, req).await {
-        tracing::warn!(
-            parent_session = %parent.session_id,
-            error = %e,
-            "resolving parent call from child completion failed"
-        );
+    match resolve(deps, req).await {
+        Ok(r) => r.resolved,
+        Err(e) => {
+            tracing::warn!(
+                parent_session = %parent.session_id,
+                error = %e,
+                "resolving parent call from child completion failed"
+            );
+            false
+        }
+    }
+}
+
+/// How a parked sub-agent call should settle based on its child's turn
+/// record (`None` = the child is live; leave the call to the pending
+/// timeout). A dead child — record gone, session moved on to another turn, or
+/// turn already terminal with its resolve lost — settles the call immediately
+/// with `(status, result, reason)` for [`resolve_parent`], re-delivering a
+/// finalized child's own outcome instead of a generic timeout (MOT-3856).
+fn child_settlement(
+    child: Option<&crate::types::turn::TurnRecord>,
+    expected_turn_id: &str,
+) -> Option<(&'static str, Option<Value>, Option<String>)> {
+    let Some(rec) = child else {
+        return Some((
+            "child_lost",
+            None,
+            Some("child turn record missing — the child died without resolving".to_string()),
+        ));
+    };
+    if rec.turn_id != expected_turn_id {
+        return Some((
+            "child_lost",
+            None,
+            Some("child session moved on to another turn without resolving".to_string()),
+        ));
+    }
+    match rec.status {
+        TurnStatus::Completed => Some(("completed", rec.result.clone(), None)),
+        TurnStatus::Failed => Some((
+            "failed",
+            None,
+            Some(
+                rec.result_error
+                    .clone()
+                    .unwrap_or_else(|| "child turn failed".to_string()),
+            ),
+        )),
+        TurnStatus::Cancelled => Some(("cancelled", None, Some("child turn cancelled".to_string()))),
+        TurnStatus::Running | TurnStatus::AwaitingFunctions => None,
     }
 }
 
@@ -323,46 +369,65 @@ fn pending_call_expired(
     now.saturating_sub(pending_at) as u64 >= timeout
 }
 
-/// Resolve every pending call past its `pending_timeout_ms` with an error.
+/// Settle parked pending calls: a call whose child turn is dead (record gone,
+/// session moved on, or already terminal with its resolve lost) settles
+/// immediately with the child's outcome; a call past its `pending_timeout_ms`
+/// resolves with a timeout error. Hook holds (`held_by`) never expire.
 pub async fn sweep_expired(deps: &Deps) -> Result<u64, HarnessError> {
     let cfg = deps.cfg().await;
     let records = crate::state::list_turns(&deps.iii, cfg.session_timeout_ms).await?;
     let now = AgentMessage::now_ms();
 
-    // Collect expired (session, turn, call) tuples first; resolve re-reads.
-    let mut expired: Vec<(String, String, String)> = Vec::new();
-    for record in records {
+    // Child lookup from the same snapshot: turn records are keyed one per
+    // session, and a child is seeded (put_turn) before its parent checkpoints
+    // the call as pending, so a child absent here is genuinely gone.
+    let by_session: std::collections::HashMap<&str, &crate::types::turn::TurnRecord> =
+        records.iter().map(|r| (r.session_id.as_str(), r)).collect();
+
+    // Collect settlements first; resolve re-reads under each session lock.
+    type Settlement = (
+        crate::types::turn::ParentLink,
+        &'static str,
+        Option<Value>,
+        Option<String>,
+    );
+    let mut settle: Vec<Settlement> = Vec::new();
+    for record in &records {
         if record.status != TurnStatus::AwaitingFunctions {
             continue;
         }
         for (call_id, cp) in &record.calls {
+            if cp.state != CallState::Pending || cp.held_by.is_some() {
+                continue;
+            }
+            let link = crate::types::turn::ParentLink {
+                session_id: record.session_id.clone(),
+                turn_id: record.turn_id.clone(),
+                function_call_id: call_id.clone(),
+            };
+            if let (Some(cs), Some(ct)) = (&cp.child_session_id, &cp.child_turn_id) {
+                if let Some((status, result, reason)) =
+                    child_settlement(by_session.get(cs.as_str()).copied(), ct)
+                {
+                    settle.push((link, status, result, reason));
+                    continue;
+                }
+            }
             if pending_call_expired(cp, cfg.default_pending_timeout_ms, now) {
-                expired.push((
-                    record.session_id.clone(),
-                    record.turn_id.clone(),
-                    call_id.clone(),
+                settle.push((
+                    link,
+                    "pending_timeout",
+                    None,
+                    Some("pending call timed out".to_string()),
                 ));
             }
         }
     }
 
     let mut resolved = 0;
-    for (session_id, turn_id, call_id) in expired {
-        let req = FunctionResolveRequest {
-            session_id,
-            turn_id,
-            function_call_id: call_id,
-            action: Some("deliver".to_string()),
-            fs_scope: None,
-            content: Some(vec![ContentBlock::text(
-                "pending call timed out".to_string(),
-            )]),
-            is_error: Some(true),
-            details: Some(json!({ "error": "pending_timeout" })),
-        };
-        match resolve(deps, req).await {
-            Ok(r) if r.resolved => resolved += 1,
-            _ => {}
+    for (link, status, result, reason) in settle {
+        if resolve_parent(deps, &link, status, result.as_ref(), reason.as_deref()).await {
+            resolved += 1;
         }
     }
     Ok(resolved)
@@ -449,6 +514,91 @@ mod tests {
         let default = 1_800_000;
         let stale = cp(CallState::Pending, None, None, now - default as i64);
         assert!(pending_call_expired(&stale, default, now));
+    }
+
+    fn child_record(turn_id: &str, status: TurnStatus) -> crate::types::turn::TurnRecord {
+        crate::types::turn::TurnRecord {
+            turn_id: turn_id.into(),
+            session_id: "s_child".into(),
+            status,
+            step: 1,
+            turn_count: 1,
+            depth: 1,
+            abort: false,
+            watermark_entry_id: None,
+            stream_request_id: None,
+            options: crate::types::turn::TurnOptions {
+                model: "m".into(),
+                provider: None,
+                system_prompt: None,
+                mode: None,
+                max_turns: 16,
+                thinking_level: None,
+                output: Default::default(),
+                functions: None,
+                metadata: None,
+                max_validation_retries: 2,
+            },
+            calls: Default::default(),
+            parent: None,
+            display_parent_session_id: None,
+            spawned_by_subscription_id: None,
+            reactive_depth: None,
+            result: None,
+            result_error: None,
+            validation_retries: 0,
+            created_at: 1,
+            updated_at: 1,
+        }
+    }
+
+    #[test]
+    fn missing_child_record_settles_the_parent_call_as_lost() {
+        // The wedge class from MOT-3856: the child died without resolving
+        // (state lost across a restart, record deleted) — the parent must not
+        // wait out the full pending timeout.
+        let (status, result, reason) = child_settlement(None, "t_child").expect("settles");
+        assert_eq!(status, "child_lost");
+        assert!(result.is_none());
+        assert!(reason.unwrap().contains("missing"));
+    }
+
+    #[test]
+    fn child_session_on_a_different_turn_settles_as_lost() {
+        let rec = child_record("t_other", TurnStatus::Running);
+        let (status, ..) = child_settlement(Some(&rec), "t_child").expect("settles");
+        assert_eq!(status, "child_lost");
+    }
+
+    #[test]
+    fn terminal_child_settles_with_its_own_outcome() {
+        // A finalized child whose resolve was lost: re-deliver its outcome
+        // rather than a generic timeout.
+        let mut done = child_record("t_child", TurnStatus::Completed);
+        done.result = Some(serde_json::json!("the answer"));
+        let (status, result, reason) = child_settlement(Some(&done), "t_child").expect("settles");
+        assert_eq!(status, "completed");
+        assert_eq!(result, Some(serde_json::json!("the answer")));
+        assert!(reason.is_none());
+
+        let mut failed = child_record("t_child", TurnStatus::Failed);
+        failed.result_error = Some("provider exploded".into());
+        let (status, result, reason) = child_settlement(Some(&failed), "t_child").expect("settles");
+        assert_eq!(status, "failed");
+        assert!(result.is_none());
+        assert_eq!(reason.as_deref(), Some("provider exploded"));
+
+        let cancelled = child_record("t_child", TurnStatus::Cancelled);
+        let (status, ..) = child_settlement(Some(&cancelled), "t_child").expect("settles");
+        assert_eq!(status, "cancelled");
+    }
+
+    #[test]
+    fn live_child_is_left_to_the_pending_timeout() {
+        let running = child_record("t_child", TurnStatus::Running);
+        assert!(child_settlement(Some(&running), "t_child").is_none());
+        let parked = child_record("t_child", TurnStatus::AwaitingFunctions);
+        assert!(child_settlement(Some(&parked), "t_child").is_none());
     }
 
     #[test]

--- a/harness/src/deferred.rs
+++ b/harness/src/deferred.rs
@@ -346,7 +346,9 @@ fn child_settlement(
                     .unwrap_or_else(|| "child turn failed".to_string()),
             ),
         )),
-        TurnStatus::Cancelled => Some(("cancelled", None, Some("child turn cancelled".to_string()))),
+        TurnStatus::Cancelled => {
+            Some(("cancelled", None, Some("child turn cancelled".to_string())))
+        }
         TurnStatus::Running | TurnStatus::AwaitingFunctions => None,
     }
 }

--- a/harness/src/functions/stop.rs
+++ b/harness/src/functions/stop.rs
@@ -1,13 +1,16 @@
-//! `harness::stop` — request cancellation of an in-flight turn (harness.md §
-//! `harness::stop`). Sets the abort flag the next step observes and aborts an
-//! in-flight stream via `router::abort`. The cascade to spawned children
-//! layers on with sub-agents.
+//! `harness::stop` — cancel an in-flight turn (harness.md § `harness::stop`).
+//! Aborts an in-flight stream via `router::abort`, finalises the turn as
+//! cancelled under the session lock (a step that is currently generating
+//! finalises itself off the aborted stream instead), then cascades to spawned
+//! children. Finalising here — not just flagging — is what unparks a turn
+//! whose children died without resolving their calls (MOT-3856).
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::deps::Deps;
 use crate::error::HarnessError;
+use crate::types::turn::ParentLink;
 
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 pub struct StopRequest {
@@ -26,14 +29,16 @@ pub async fn handle(deps: &Deps, req: StopRequest) -> Result<StopResponse, Harne
     let cfg = deps.cfg().await;
 
     // Lock-free pre-read: discover the in-flight stream + live children and
-    // fast-out for a missing/mismatched/terminal turn. This drives the prompt,
-    // lock-free part of cancellation (child cascade + router::abort) so
-    // generation is interrupted immediately, even while the running step holds
-    // the per-session lock across in-flight tool execution. The authoritative
-    // abort write happens under the lock below.
+    // fast-out for a missing/mismatched/terminal turn.
     let Some(record) =
         crate::state::get_turn(&deps.iii, &req.session_id, cfg.session_timeout_ms).await?
     else {
+        // No turn record (e.g. loop state lost across a worker restart), but
+        // the session may still be wedged at "working" — clear it so the
+        // console recovers without a manual `session::set-status idle`
+        // (MOT-3856). Idempotent on an already-idle session.
+        let session = deps.session().await;
+        let _ = session.set_status(&req.session_id, "idle", None).await;
         return Ok(StopResponse { stopping: false });
     };
     if let Some(tid) = &req.turn_id {
@@ -44,17 +49,65 @@ pub async fn handle(deps: &Deps, req: StopRequest) -> Result<StopResponse, Harne
     if record.status.is_terminal() {
         return Ok(StopResponse { stopping: false });
     }
-    // Pin the turn we observed so the write under the lock can't land on a newer
-    // turn that started in between (matters when `turn_id` was omitted).
+    // Pin the turn we observed so the finalise under the lock can't land on a
+    // newer turn that started in between (matters when `turn_id` was omitted).
     let target_turn = record.turn_id.clone();
+    let mut children = record.live_children();
 
-    // Cascade to non-terminal spawned children BEFORE taking this session's
-    // lock (harness.md § Cancellation cascade): each child stop acquires its
-    // OWN session lock, so holding the parent lock here could deadlock against a
-    // child→parent resolve. Holding at most one session lock at a time keeps
-    // cancellation lock-order-free. Each child stop resolves the child's parent
-    // call with an error when the child finalises.
-    for child in record.live_children() {
+    // Prompt stream interruption (lock-free): a generating step holds the
+    // session lock, so this must fire BEFORE the guard below — the aborted
+    // stream ends the step quickly, releasing the lock. Aborting a stale or
+    // already finished request_id is a harmless no-op.
+    if let Some(request_id) = &record.stream_request_id {
+        let router = deps.router().await;
+        router.abort(request_id).await;
+    }
+
+    // Finalise UNDER the per-session lock (see locks.rs): holding the guard
+    // proves no step is executing (run_step guards the whole step, generation
+    // included), so nothing is left to observe a mere abort flag — a turn
+    // parked on dead children would stay wedged forever (MOT-3856). A queued
+    // step then sees the terminal status and skips, and a late child resolve
+    // is a no-op. The guard drops before the child cascade below: each child
+    // stop finalises under its OWN lock and resolves upward into this session,
+    // so holding this lock across the cascade would deadlock.
+    {
+        let _guard = deps.locks.guard(&req.session_id).await;
+        let Some(mut record) =
+            crate::state::get_turn(&deps.iii, &req.session_id, cfg.session_timeout_ms).await?
+        else {
+            return Ok(StopResponse { stopping: false });
+        };
+        if record.turn_id != target_turn {
+            // A newer turn started between the pre-read and the lock — don't
+            // touch it, but the pinned turn's children still need stopping.
+            cascade(deps, &children).await;
+            return Ok(StopResponse { stopping: false });
+        }
+        let finalized_by_step = record.status.is_terminal();
+        if !finalized_by_step {
+            // Freshest child set: a step that ran between the pre-read and the
+            // lock may have spawned more children.
+            children = record.live_children();
+            record.abort = true;
+            let session = deps.session().await;
+            crate::turn_loop::finalize_cancelled(deps, &session, &mut record, "cancelled").await?;
+        }
+        // else: the step finalised between the pre-read and the lock (possibly
+        // via the router::abort above) — the turn is settled, but its children
+        // were only observed by the pre-read, so still cascade.
+    }
+
+    // Cascade to non-terminal spawned children (harness.md § Cancellation
+    // cascade), one session lock at a time. Their parent-call resolves land on
+    // an already-terminal turn and no-op.
+    cascade(deps, &children).await;
+
+    Ok(StopResponse { stopping: true })
+}
+
+async fn cascade(deps: &Deps, children: &[ParentLink]) {
+    for child in children {
         Box::pin(handle(
             deps,
             StopRequest {
@@ -65,40 +118,4 @@ pub async fn handle(deps: &Deps, req: StopRequest) -> Result<StopResponse, Harne
         .await
         .ok();
     }
-
-    // Prompt stream interruption (lock-free): aborting a stale or already
-    // finished request_id is a harmless no-op, so the pre-read id is safe to
-    // use without the lock.
-    if let Some(request_id) = &record.stream_request_id {
-        let router = deps.router().await;
-        router.abort(request_id).await;
-    }
-
-    // Authoritative abort write UNDER the per-session lock (see locks.rs): the
-    // running step persists the whole turn record from a stale in-memory copy
-    // at several points, so a lock-free write here would be clobbered. Taking
-    // the lock — as `harness::function::resolve` and the pending sweep already
-    // do — serializes this read-modify-write with the step and closes the race.
-    // Re-read inside the lock so the flag is set on the freshest record rather
-    // than reverting the step's other updates.
-    let _guard = deps.locks.guard(&req.session_id).await;
-    let Some(mut record) =
-        crate::state::get_turn(&deps.iii, &req.session_id, cfg.session_timeout_ms).await?
-    else {
-        return Ok(StopResponse { stopping: false });
-    };
-    if record.turn_id != target_turn {
-        // A newer turn started between the pre-read and the lock — don't flag it.
-        return Ok(StopResponse { stopping: false });
-    }
-    if record.status.is_terminal() {
-        // The step finalised between the pre-read and acquiring the lock
-        // (possibly via the router::abort above) — nothing left to flag.
-        return Ok(StopResponse { stopping: false });
-    }
-    record.abort = true;
-    record.updated_at = crate::types::message::AgentMessage::now_ms();
-    crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
-
-    Ok(StopResponse { stopping: true })
 }

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -813,7 +813,7 @@ async fn finalize_failed(
     })
 }
 
-async fn finalize_cancelled(
+pub(crate) async fn finalize_cancelled(
     deps: &Deps,
     session: &SessionClient,
     record: &mut TurnRecord,


### PR DESCRIPTION
## Problem

A parent turn that fanned out with `harness::spawn` could freeze at `working` forever when a spawned child errored out of band (shell jail denial, provider error, lost step delivery, worker restart). The child died without resolving the parent's pending call, and both safety nets failed in practice:

- `harness::stop` only set an abort flag observed at the next step — which never comes for a parked turn — and returned `stopping: false` with no effect when the turn record was gone after a restart, leaving `session::set-status idle` by hand as the only recovery.

## Fix

- **`default_pending_timeout_ms`: 30min → 2h.** With dead children settled eagerly, the timeout only guards *live* children, so it is sized for legitimately long sub-agent runs rather than wedge recovery. (Previously the 30min guard was effectively never enforced — the daily sweep meant "midnight".)
- **`harness::stop` finalises a parked turn as cancelled** under the session lock — holding the guard proves no step is executing, so nothing else would ever observe a mere flag. The child cascade runs after the lock drops (each child stop finalises under its own lock; their parent-resolves no-op against the terminal turn), keeping cancellation lock-order-free.
- **`harness::stop` on a session with no turn record** (loop state lost across a worker restart) now clears a wedged `working` session status, automating the manual recovery.

## Test plan

- [x] `cargo test -p harness` — 176 passed (4 new `child_settlement` tests: missing record, moved-on session, terminal child re-delivery, live child left to timeout; updated sweep-default assertion)
- [x] `cargo clippy -p harness --all-targets` — clean
- [ ] Live validation on iii-running: spawn a child that dies out of band, confirm the parent unparks within a sweep tick and that Stop cancels a parked turn immediately

Fixes MOT-3856

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cancellation now behaves more reliably, including aborting active work, correctly finalizing the current turn, and cascading cancellation to related child work.
  * Background cleanup now settles finished or lost child work sooner, instead of waiting unnecessarily.
  * Sessions recover more gracefully after a restart by returning to an idle state when no active turn is found.

* **Documentation**
  * Updated configuration docs to reflect longer pending-call handling and more frequent background cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->