### PR TITLE
(MOT-3855) fix(provider-openai-codex): surface stream-fatal error events instead of empty responses

### DIFF
--- a/provider-openai-codex/src/sse.rs
+++ b/provider-openai-codex/src/sse.rs
@@ -54,6 +54,12 @@ impl PartialState {
     pub fn stop_reason(&self) -> StopReason {
         self.stop_reason
     }
+
+    /// Whether any output accumulated (text, thinking, or tool calls) —
+    /// distinguishes legitimate close-framing from a truncated/empty stream.
+    pub fn has_content(&self) -> bool {
+        !self.text.is_empty() || !self.thinking.is_empty() || !self.tool_calls.is_empty()
+    }
 }
 
 pub fn empty_assistant(model: &str) -> AssistantMessage {
@@ -336,7 +342,12 @@ pub fn handle_chunk(
                 message: build_final(state, model),
             });
         }
-        n if n.contains("failed")
+        // `error` is the Responses API's stream-fatal event: the message sits
+        // at TOP level (`{"type":"error","code":…,"message":…}`), unlike
+        // `response.failed`'s nested `response.error`. The body's message
+        // lookup covers both shapes.
+        n if n == "error"
+            || n.contains("failed")
             || n.contains("incomplete")
             || (n.contains(".error") && !n.contains("delta")) =>
         {
@@ -441,5 +452,28 @@ mod tests {
             }
             other => panic!("want error, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn top_level_error_event_is_terminal_error() {
+        // The Responses API's stream-fatal signal: `{"type":"error"}` with the
+        // message at TOP level (no nested `error` object, no `response.`
+        // prefix). Swallowing it ends the run as an empty `done` or a
+        // ping-until-timeout "ended without a terminal frame" (MOT-3855).
+        let (_, events) = run(&[
+            json!({ "type": "response.output_text.delta", "delta": "par" }),
+            json!({ "type": "error", "code": "server_error", "message": "The model produced no output", "sequence_number": 7 }),
+        ]);
+        match events.last().unwrap() {
+            AssistantMessageEvent::Error { error } => {
+                assert_eq!(
+                    error.error_message.as_deref(),
+                    Some("The model produced no output")
+                );
+                assert_eq!(error.stop_reason, StopReason::Error);
+            }
+            other => panic!("want error, got {other:?}"),
+        }
+        assert_eq!(events.iter().filter(|e| e.is_terminal()).count(), 1);
     }
 }

--- a/provider-openai-codex/src/upstream.rs
+++ b/provider-openai-codex/src/upstream.rs
@@ -155,12 +155,26 @@ async fn run_upstream(
             }
         }
     }
-    // Stream ended without [DONE] (connection close framing): still terminal.
-    let _ = tx
-        .send(AssistantMessageEvent::Done {
-            message: build_final(&state, &args.model),
-        })
-        .await;
+    // Stream ended without [DONE]. With output accumulated this is
+    // legitimate connection-close framing: still terminal. With NOTHING
+    // accumulated the stream was truncated (or spoke only unrecognized
+    // events) — an empty `done` would end the run with an empty "successful"
+    // response, so surface a retryable error instead (MOT-3855).
+    if state.has_content() {
+        let _ = tx
+            .send(AssistantMessageEvent::Done {
+                message: build_final(&state, &args.model),
+            })
+            .await;
+    } else {
+        let _ = tx
+            .send(synthetic_error_event(
+                "codex stream ended without output or a completion event",
+                &args.model,
+                ErrorKind::Transient,
+            ))
+            .await;
+    }
 }
 
 #[cfg(test)]
@@ -303,6 +317,26 @@ mod tests {
             }
             other => panic!("want done, got {other:?}"),
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_stream_end_yields_transient_error_not_empty_done() {
+        // The backend cut the stream (or sent only unrecognized events) before
+        // any output arrived: an empty `done` would end the agent run with an
+        // empty "successful" response and nothing for the router to retry
+        // (MOT-3855).
+        let url = stub(
+            "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\n",
+        )
+        .await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        match events.last() {
+            Some(AssistantMessageEvent::Error { error }) => {
+                assert_eq!(error.error_kind, Some(ErrorKind::Transient));
+            }
+            other => panic!("want error, got {other:?}"),
+        }
+        assert_eq!(events.iter().filter(|e| e.is_terminal()).count(), 1);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/provider-openai-codex/src/upstream.rs
+++ b/provider-openai-codex/src/upstream.rs
@@ -325,10 +325,9 @@ mod tests {
         // any output arrived: an empty `done` would end the agent run with an
         // empty "successful" response and nothing for the router to retry
         // (MOT-3855).
-        let url = stub(
-            "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\n",
-        )
-        .await;
+        let url =
+            stub("HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\n")
+                .await;
         let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
         match events.last() {
             Some(AssistantMessageEvent::Error { error }) => {


### PR DESCRIPTION
## Problem

GPT-5.5 (Codex) agent runs sometimes ended with an empty response, with the router reporting `provider codex stream ended without a terminal frame` (`llm-router/src/chat/chat.rs:433`).

Root cause: the Responses API signals a stream-fatal failure with a **top-level** `{"type":"error","code":…,"message":…}` event — no nested `error` object, no `response.` prefix. `handle_chunk` recognized neither:
- the bare-error branch only runs when the event has no `type` field (`sse.rs`),
- the terminal-error arm matched `*failed*` / `*incomplete*` / `*.error`, none of which match `error`,

so the event fell through to the forward-compat ignore arm. The run then ended one of two ways:
- backend closes after the error → the EOF fallback emitted an **empty `done`** — an empty "successful" response, no error surfaced, nothing to retry;
- backend doesn't close cleanly → no terminal frame, and the provider's 30s pings kept resetting the router's idle budget until the outer stream timeout tore the trigger down → the exact "ended without a terminal frame" error.

The Chat-Completions siblings (openai/anthropic/kimi/xai) all handle their error envelope unconditionally at the top of their SSE state machines — Codex's Responses adaptation missed this event shape (present since the provider's introduction in `e571ef24`).

## Fix

- `handle_chunk`: widen the terminal-error arm to also match `type == "error"`; the arm's body already falls back to the top-level `message`. The error now surfaces immediately as a terminal `Error` frame with a classified `error_kind`, so the router can retry retryable failures.
- EOF-without-`[DONE]` fallback: with output accumulated this stays legitimate close-framing (`done`); with **nothing** accumulated it now emits a retryable transient error instead of an empty `done`, so a truncated stream can't masquerade as an empty successful response.

## Test plan

- [x] `cargo test` — 52 passed; new: `top_level_error_event_is_terminal_error` (sse), `empty_stream_end_yields_transient_error_not_empty_done` (upstream); existing close-framing-with-content test still green
- [x] `cargo clippy --all-targets` — clean
- [ ] Live validation against the ChatGPT backend on a long GPT-5.5 agent run

Fixes MOT-3855

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream completion handling so empty or truncated responses no longer appear as successful finishes.
  * Expanded error detection to recognize additional terminal error responses and surface them correctly.
  * Streams with real content now complete normally even when a final end marker is missing, while empty streams now return an error state.
* **Tests**
  * Added coverage for top-level error events and empty-stream termination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->