### PR TITLE
(MOT-3869) fix(console): reconcile session sidebar status

### DIFF
--- a/console/web/src/hooks/use-conversations.test.ts
+++ b/console/web/src/hooks/use-conversations.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import type { SessionMeta } from '@/lib/sessions/types'
+import type { Conversation } from '@/types/chat'
+import {
+  appendMessageToConversation,
+  applyCatalogModelFallback,
+  mergeConversationMeta,
+} from './use-conversations'
+
+function conversation(overrides: Partial<Conversation>): Conversation {
+  return {
+    id: 'console-1',
+    title: 'old session',
+    model: 'provider::removed-model',
+    mode: 'agent',
+    messages: [],
+    status: 'done',
+    hydrated: false,
+    createdAt: 1_000,
+    updatedAt: 2_000,
+    ...overrides,
+  }
+}
+
+function sessionMeta(overrides: Partial<SessionMeta>): SessionMeta {
+  return {
+    session_id: 'console-1',
+    title: 'server title',
+    description: '',
+    status: 'idle',
+    metadata: {},
+    created_at: 1_000,
+    updated_at: 2_000,
+    message_count: 0,
+    ...overrides,
+  }
+}
+
+describe('applyCatalogModelFallback', () => {
+  it('preserves activity timestamps when replacing stale model ids', () => {
+    const fallback = 'provider::current-model'
+    const sessions = [
+      conversation({
+        id: 'stale-model',
+        model: 'provider::removed-model',
+        updatedAt: 2_000,
+      }),
+      conversation({
+        id: 'missing-model',
+        model: null,
+        updatedAt: 3_000,
+      }),
+    ]
+
+    const next = applyCatalogModelFallback(
+      sessions,
+      new Set([fallback]),
+      fallback,
+    )
+
+    expect(next.map((c) => c.model)).toEqual([fallback, fallback])
+    expect(next.map((c) => c.updatedAt)).toEqual([2_000, 3_000])
+  })
+})
+
+describe('mergeConversationMeta', () => {
+  it('repairs a stale idle row from authoritative session metadata', () => {
+    const existing = conversation({
+      status: 'idle',
+      messages: [
+        {
+          id: 'm1',
+          role: 'user',
+          content: 'run it',
+          createdAt: 1_500,
+        },
+      ],
+      hydrated: true,
+      updatedAt: 1_500,
+    })
+
+    const next = mergeConversationMeta(
+      existing,
+      sessionMeta({
+        status: 'working',
+        updated_at: 4_000,
+        metadata: {
+          model: 'provider::current-model',
+          mode: 'agent',
+          parent_session_id: 'console-parent',
+          depth: 1,
+        },
+      }),
+    )
+
+    expect(next.status).toBe('working')
+    expect(next.updatedAt).toBe(4_000)
+    expect(next.parentId).toBe('console-parent')
+    expect(next.messages).toBe(existing.messages)
+    expect(next.hydrated).toBe(true)
+  })
+})
+
+describe('appendMessageToConversation', () => {
+  it('marks a session working as soon as the user send is appended', () => {
+    const next = appendMessageToConversation(
+      conversation({ status: 'idle', messages: [] }),
+      {
+        id: 'm1',
+        role: 'user',
+        content: 'start',
+        createdAt: 3_000,
+      },
+      3_500,
+    )
+
+    expect(next.status).toBe('working')
+    expect(next.statusReason).toBeUndefined()
+    expect(next.updatedAt).toBe(3_500)
+  })
+})

--- a/console/web/src/hooks/use-conversations.ts
+++ b/console/web/src/hooks/use-conversations.ts
@@ -150,6 +150,58 @@ function conversationFromMeta(meta: SessionMeta): Conversation {
   }
 }
 
+export function applyCatalogModelFallback(
+  conversations: Conversation[],
+  validModels: ReadonlySet<string>,
+  fallbackModel: ModelId,
+): Conversation[] {
+  let changed = false
+  const next = conversations.map((c) => {
+    if (c.model && validModels.has(c.model)) return c
+    changed = true
+    return { ...c, model: fallbackModel }
+  })
+  return changed ? next : conversations
+}
+
+export function mergeConversationMeta(
+  existing: Conversation | undefined,
+  meta: SessionMeta,
+): Conversation {
+  const mapped = conversationFromMeta(meta)
+  if (!existing || existing.draft) return mapped
+  return {
+    ...mapped,
+    messages: existing.messages,
+    hydrated: existing.hydrated,
+  }
+}
+
+export function appendMessageToConversation(
+  c: Conversation,
+  message: Message,
+  now = Date.now(),
+): Conversation {
+  const messages = [...c.messages, message]
+  const next: Conversation = {
+    ...c,
+    messages,
+    updatedAt: now,
+  }
+  if (message.role === 'user') {
+    next.status = 'working'
+    next.statusReason = undefined
+  }
+  if (
+    !c.titleManual &&
+    message.role === 'user' &&
+    c.messages.every((m) => m.role !== 'user')
+  ) {
+    next.title = deriveTitle(message.content)
+  }
+  return next
+}
+
 export interface ConversationsApi {
   conversations: Conversation[]
   activeId: string | null
@@ -216,17 +268,9 @@ export function useConversations(
         setConversations((prev) => {
           const drafts = prev.filter((c) => c.draft)
           const byId = new Map(prev.map((c) => [c.id, c]))
-          const listed = metas.map((meta) => {
-            const existing = byId.get(meta.session_id)
-            const mapped = conversationFromMeta(meta)
-            if (!existing || existing.draft) return mapped
-            // Keep already-reconciled transcript state across re-lists.
-            return {
-              ...mapped,
-              messages: existing.messages,
-              hydrated: existing.hydrated,
-            }
-          })
+          const listed = metas.map((meta) =>
+            mergeConversationMeta(byId.get(meta.session_id), meta),
+          )
           const listedIds = new Set(listed.map((c) => c.id))
           return [...drafts.filter((c) => !listedIds.has(c.id)), ...listed]
         })
@@ -284,18 +328,9 @@ export function useConversations(
           void getSession(event.session_id)
             .then((meta) => {
               if (cancelled || !meta) return
-              const md = meta.metadata ?? {}
-              const parentId =
-                typeof md.parent_session_id === 'string'
-                  ? md.parent_session_id
-                  : undefined
-              if (!parentId) return
-              const depth = typeof md.depth === 'number' ? md.depth : undefined
-              patchConversation(event.session_id, (c) => ({
-                ...c,
-                parentId,
-                depth,
-              }))
+              patchConversation(event.session_id, (c) =>
+                mergeConversationMeta(c, meta),
+              )
             })
             .catch(() => {})
         },
@@ -467,13 +502,7 @@ export function useConversations(
     const valid = new Set(keys)
     const fallback = keys[0]
     setConversations((prev) => {
-      let changed = false
-      const next = prev.map((c) => {
-        if (c.model && valid.has(c.model)) return c
-        changed = true
-        return { ...c, model: fallback, updatedAt: Date.now() }
-      })
-      return changed ? next : prev
+      return applyCatalogModelFallback(prev, valid, fallback)
     })
     const lastModel = loadLastModel()
     if (lastModel && !valid.has(lastModel)) {
@@ -595,22 +624,7 @@ export function useConversations(
 
   const appendMessage = useCallback(
     (id: string, message: Message) =>
-      patchConversation(id, (c) => {
-        const messages = [...c.messages, message]
-        const next: Conversation = {
-          ...c,
-          messages,
-          updatedAt: Date.now(),
-        }
-        if (
-          !c.titleManual &&
-          message.role === 'user' &&
-          c.messages.every((m) => m.role !== 'user')
-        ) {
-          next.title = deriveTitle(message.content)
-        }
-        return next
-      }),
+      patchConversation(id, (c) => appendMessageToConversation(c, message)),
     [patchConversation],
   )
 
@@ -646,18 +660,18 @@ export function useConversations(
           ? deriveTitle(titleHint)
           : conv.title
       try {
-        await ensureSessionApi({
+        const resp = await ensureSessionApi({
           session_id: id,
           title,
           metadata: metadataFor(conv),
         })
         patchConversation(id, (c) => ({
-          ...c,
+          ...mergeConversationMeta(
+            { ...c, draft: false, hydrated: true },
+            resp.meta,
+          ),
           draft: false,
           hydrated: true,
-          title,
-          status: 'idle',
-          updatedAt: Date.now(),
         }))
       } catch (err) {
         if (import.meta.env.DEV) {


### PR DESCRIPTION
## Summary
- Reconcile session rows from authoritative `SessionMeta` when listing or fetching session metadata so stale sidebar state does not overwrite working sessions.
- Mark a conversation `working` immediately when a user message is appended, and preserve activity timestamps during model fallback normalization.
- Add regression coverage for stale idle rows, optimistic working state, and timestamp preservation.

Fixes MOT-3869

## Test Plan
- [x] `pnpm --dir console/web exec vitest run src/hooks/use-conversations.test.ts`
- [x] `pnpm --dir console/web test`
- [x] `pnpm --dir console/web typecheck`
- [x] `pnpm --dir console/web exec biome check src/hooks/use-conversations.ts src/hooks/use-conversations.test.ts`
- [x] `pnpm --dir console/web build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation syncing so existing chat details stay aligned with the latest session data.
  * Conversation status now updates immediately when a message is sent.
  * Model selection fallback is handled more consistently when an unavailable model is encountered.

* **Refactor**
  * Centralized conversation update logic to make metadata handling more reliable across the app.

* **Tests**
  * Added coverage for conversation metadata merging, model fallback behavior, and message appending updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
