### PR TITLE
(MOT-3874) feat(shell): coder::apply-patch + worktree add/remove

### DIFF
--- a/shell/src/code/functions/apply_patch.rs
+++ b/shell/src/code/functions/apply_patch.rs
@@ -1,0 +1,281 @@
+//! `coder::apply-patch` — apply a whole patch in the V4A "apply_patch"
+//! format codex-family models are trained on (`*** Begin Patch` …
+//! `*** End Patch`). All-or-nothing: every hunk is resolved, read, and
+//! computed BEFORE anything is written, so a bad context match or a jail
+//! rejection fails the whole call (C210/C211/C215) with the filesystem
+//! byte-identical. Writes then land per-file via sibling-temp + rename.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::code::config::CoderConfig;
+use crate::code::error::{err_to_string, CoderError};
+use crate::code::functions::update_file::atomic_write;
+use crate::code::patch::{self, Hunk};
+use crate::code::path::PathResolver;
+
+/// Lines echoed around the first changed region of a modified file.
+const ECHO_CONTEXT: u64 = 2;
+/// Cap on echoed lines per modified file.
+const ECHO_MAX_LINES: usize = 20;
+
+// examples are wire-contract; goldens pin them.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[schemars(example = "example_apply_patch_input")]
+pub struct ApplyPatchInput {
+    /// The full patch text in the apply_patch format: starts with
+    /// `*** Begin Patch`, ends with `*** End Patch`, with one hunk per
+    /// file (`*** Add File: `, `*** Delete File: `, or `*** Update File: `
+    /// with an optional `*** Move to: `). Paths are relative to the
+    /// primary allowed root, or absolute inside any allowed root.
+    pub patch: String,
+    /// Internal harness filesystem scope; omitted from published schema.
+    #[serde(default)]
+    #[schemars(skip)]
+    pub fs_scope: Option<crate::fs::FsScope>,
+}
+
+// examples are wire-contract; goldens pin them.
+fn example_apply_patch_input() -> serde_json::Value {
+    serde_json::json!({
+        "patch": "*** Begin Patch\n*** Update File: src/calc.py\n@@ def add(a, b):\n-    return a - b\n+    return a + b\n*** End Patch"
+    })
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ApplyPatchOutput {
+    /// One entry per file hunk, in patch order. The whole patch applied —
+    /// a failure anywhere returns an error with nothing written.
+    pub results: Vec<PatchFileResult>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct PatchFileResult {
+    /// Canonical absolute path of the affected file (the destination for
+    /// a moved file).
+    pub path: String,
+    /// What happened: "added" | "modified" | "deleted" | "moved".
+    pub kind: String,
+    /// Line count after applying (absent for deletions).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_line_count: Option<u64>,
+    /// Bounded post-apply snapshot of the first changed region (modified
+    /// files only) — verify from this instead of re-reading the file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub echo: Option<PatchEcho>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct PatchEcho {
+    /// 1-based line number of the first echoed line, post-apply.
+    pub from_line: u64,
+    pub lines: Vec<String>,
+}
+
+/// One fully-planned write, computed before any filesystem mutation.
+enum PlannedWrite {
+    Add {
+        abs: PathBuf,
+        contents: String,
+    },
+    Delete {
+        abs: PathBuf,
+    },
+    Update {
+        abs: PathBuf,
+        move_to: Option<PathBuf>,
+        new_contents: String,
+        first_change: Option<(u64, u64)>,
+    },
+}
+
+pub async fn handle(
+    resolver: Arc<PathResolver>,
+    cfg: Arc<CoderConfig>,
+    req: ApplyPatchInput,
+) -> Result<ApplyPatchOutput, String> {
+    let scope_root = crate::fs::scope_root(req.fs_scope.as_ref()).map(str::to_string);
+    tokio::task::spawn_blocking(move || {
+        inner(&resolver, &cfg, scope_root.as_deref(), &req.patch).map_err(err_to_string)
+    })
+    .await
+    .map_err(|e| format!("apply-patch task join failed: {e}"))?
+}
+
+fn inner(
+    resolver: &PathResolver,
+    cfg: &CoderConfig,
+    scope_root: Option<&str>,
+    patch_text: &str,
+) -> Result<ApplyPatchOutput, CoderError> {
+    let hunks = patch::parse_patch(patch_text)
+        .map_err(|e| CoderError::BadInput(format!("invalid patch: {e}")))?;
+    if hunks.is_empty() {
+        return Err(CoderError::BadInput(
+            "patch contains no hunks — nothing between '*** Begin Patch' and '*** End Patch'"
+                .into(),
+        ));
+    }
+
+    // Plan phase: resolve every path through the jail, read + compute every
+    // update, and validate every precondition BEFORE any write.
+    let mut planned: Vec<PlannedWrite> = Vec::with_capacity(hunks.len());
+    for hunk in &hunks {
+        match hunk {
+            Hunk::AddFile { path, contents } => {
+                let wire = path.display().to_string();
+                let abs = resolver.require_writable_opt(scope_root, &wire)?;
+                if abs.exists() {
+                    return Err(CoderError::BadInput(format!(
+                        "add file target already exists: {wire} — use an \
+                         '*** Update File: ' hunk to modify it"
+                    )));
+                }
+                check_write_size(cfg, &wire, contents.len())?;
+                planned.push(PlannedWrite::Add {
+                    abs,
+                    contents: contents.clone(),
+                });
+            }
+            Hunk::DeleteFile { path } => {
+                let wire = path.display().to_string();
+                let abs = resolver.require_writable_opt(scope_root, &wire)?;
+                let md = std::fs::metadata(&abs).map_err(|e| CoderError::io_for_path(e, &wire))?;
+                if !md.is_file() {
+                    return Err(CoderError::BadInput(format!(
+                        "delete file target is not a regular file: {wire}"
+                    )));
+                }
+                planned.push(PlannedWrite::Delete { abs });
+            }
+            Hunk::UpdateFile {
+                path,
+                move_path,
+                chunks,
+            } => {
+                let wire = path.display().to_string();
+                let abs = resolver.require_writable_opt(scope_root, &wire)?;
+                let bytes = std::fs::read(&abs).map_err(|e| CoderError::io_for_path(e, &wire))?;
+                let original = String::from_utf8_lossy(&bytes);
+                let applied = patch::derive_new_contents_from_chunks(&original, &wire, chunks)
+                    .map_err(|e| CoderError::BadInput(e.0))?;
+                check_write_size(cfg, &wire, applied.new_contents.len())?;
+                let move_to = match move_path {
+                    Some(dest) => {
+                        let dest_wire = dest.display().to_string();
+                        let dest_abs = resolver.require_writable_opt(scope_root, &dest_wire)?;
+                        if dest_abs.exists() {
+                            return Err(CoderError::BadInput(format!(
+                                "move destination already exists: {dest_wire}"
+                            )));
+                        }
+                        Some(dest_abs)
+                    }
+                    None => None,
+                };
+                planned.push(PlannedWrite::Update {
+                    abs,
+                    move_to,
+                    new_contents: applied.new_contents,
+                    first_change: applied.first_change,
+                });
+            }
+        }
+    }
+
+    // Write phase: every plan entry validated — apply in patch order.
+    let mut results = Vec::with_capacity(planned.len());
+    for write in &planned {
+        match write {
+            PlannedWrite::Add { abs, contents } => {
+                if let Some(parent) = abs.parent() {
+                    std::fs::create_dir_all(parent)
+                        .map_err(|e| CoderError::io_for_path(e, &abs.display().to_string()))?;
+                }
+                atomic_write(abs, contents.as_bytes())?;
+                results.push(PatchFileResult {
+                    path: abs.display().to_string(),
+                    kind: "added".into(),
+                    new_line_count: Some(line_count(contents)),
+                    echo: None,
+                });
+            }
+            PlannedWrite::Delete { abs } => {
+                std::fs::remove_file(abs)
+                    .map_err(|e| CoderError::io_for_path(e, &abs.display().to_string()))?;
+                results.push(PatchFileResult {
+                    path: abs.display().to_string(),
+                    kind: "deleted".into(),
+                    new_line_count: None,
+                    echo: None,
+                });
+            }
+            PlannedWrite::Update {
+                abs,
+                move_to,
+                new_contents,
+                first_change,
+            } => {
+                let target: &Path = move_to.as_deref().unwrap_or(abs.as_path());
+                if let Some(parent) = target.parent() {
+                    std::fs::create_dir_all(parent)
+                        .map_err(|e| CoderError::io_for_path(e, &target.display().to_string()))?;
+                }
+                atomic_write(target, new_contents.as_bytes())?;
+                if move_to.is_some() && target != abs {
+                    std::fs::remove_file(abs)
+                        .map_err(|e| CoderError::io_for_path(e, &abs.display().to_string()))?;
+                }
+                results.push(PatchFileResult {
+                    path: target.display().to_string(),
+                    kind: if move_to.is_some() {
+                        "moved"
+                    } else {
+                        "modified"
+                    }
+                    .into(),
+                    new_line_count: Some(line_count(new_contents)),
+                    echo: build_echo(new_contents, *first_change),
+                });
+            }
+        }
+    }
+    Ok(ApplyPatchOutput { results })
+}
+
+fn check_write_size(cfg: &CoderConfig, wire: &str, len: usize) -> Result<(), CoderError> {
+    if (len as u64) > cfg.max_write_bytes {
+        return Err(CoderError::TooLarge(format!(
+            "{wire} new contents are {len} bytes, which exceeds max_write_bytes \
+             ({}). Split the patch or raise max_write_bytes in coder config.",
+            cfg.max_write_bytes
+        )));
+    }
+    Ok(())
+}
+
+fn line_count(contents: &str) -> u64 {
+    contents.lines().count() as u64
+}
+
+/// Bounded snapshot of the first changed region ±2 context lines.
+fn build_echo(new_contents: &str, first_change: Option<(u64, u64)>) -> Option<PatchEcho> {
+    let (line, len) = first_change?;
+    let lines: Vec<&str> = new_contents.lines().collect();
+    let from = line.saturating_sub(1 + ECHO_CONTEXT) as usize; // 0-based
+    let to = ((line - 1 + len + ECHO_CONTEXT) as usize).min(lines.len());
+    let window: Vec<String> = lines
+        .get(from..to)
+        .unwrap_or(&[])
+        .iter()
+        .take(ECHO_MAX_LINES)
+        .map(|s| s.to_string())
+        .collect();
+    Some(PatchEcho {
+        from_line: from as u64 + 1,
+        lines: window,
+    })
+}

--- a/shell/src/code/functions/mod.rs
+++ b/shell/src/code/functions/mod.rs
@@ -10,6 +10,7 @@
 //! `tests/code_golden_schemas.rs` snapshots each entry so ANY change to the
 //! agent-facing wire surface shows up as an explicit, reviewed diff.
 
+pub mod apply_patch;
 pub mod context;
 pub mod create_file;
 pub mod delete_file;
@@ -121,6 +122,20 @@ const UPDATE_FILE_DESC: &str = "Apply batched line-oriented and regex edits acro
      allowed root or absolute inside any allowed root (coder::info \
      lists them); for host paths outside the jail use shell::fs::*.";
 
+const APPLY_PATCH_ID: &str = "coder::apply-patch";
+const APPLY_PATCH_DESC: &str = "Apply a whole patch in the apply_patch (V4A) format: the exact \
+     '*** Begin Patch' … '*** End Patch' format you know, with \
+     '*** Add File: ', '*** Delete File: ', '*** Update File: ' (+ \
+     optional '*** Move to: ') hunks, '@@ ' context markers, and \
+     ' '/'+'/'-' change lines. All-or-nothing: every hunk is validated \
+     and computed before anything is written — a context mismatch fails \
+     the whole call with C210 and the guidance to re-read and regenerate; \
+     on success each file commits atomically and modified files return a \
+     bounded post-apply echo of the first changed region. Paths are \
+     relative to the primary allowed root or absolute inside any allowed \
+     root (coder::info lists them); for host paths outside the jail use \
+     shell::fs::*.";
+
 const CREATE_FILE_ID: &str = "coder::create-file";
 const CREATE_FILE_DESC: &str = "Create one or more files. Request shape: {\"files\": [{\"path\": \
      \"...\", \"content\": \"...\"}]}. Per-file `overwrite` and `parents` \
@@ -225,6 +240,10 @@ pub fn catalog() -> Vec<FunctionSpec> {
             UPDATE_FILE_ID,
             UPDATE_FILE_DESC,
         ),
+        spec::<apply_patch::ApplyPatchInput, apply_patch::ApplyPatchOutput>(
+            APPLY_PATCH_ID,
+            APPLY_PATCH_DESC,
+        ),
         spec::<create_file::CreateFileInput, create_file::CreateFileOutput>(
             CREATE_FILE_ID,
             CREATE_FILE_DESC,
@@ -258,6 +277,8 @@ pub fn register_all(iii: &IIIClient, cells: CodeCells) {
     register_search(iii, cells.clone());
     registered += 1;
     register_update_file(iii, cells.clone());
+    registered += 1;
+    register_apply_patch(iii, cells.clone());
     registered += 1;
     register_create_file(iii, cells.clone());
     registered += 1;
@@ -375,6 +396,27 @@ fn register_update_file(iii: &IIIClient, cells: CodeCells) {
             }
         })
         .description(UPDATE_FILE_DESC),
+    );
+}
+
+fn register_apply_patch(iii: &IIIClient, cells: CodeCells) {
+    iii.register_function(
+        APPLY_PATCH_ID,
+        RegisterFunction::new_async(move |req: apply_patch::ApplyPatchInput| {
+            let cells = cells.clone();
+            async move {
+                let resolver = cells.resolver.read().await.clone();
+                let resolver = resolver.session_scoped(
+                    crate::fs::scope_root(req.fs_scope.as_ref()),
+                    crate::fs::scope_grants(req.fs_scope.as_ref()),
+                );
+                let cfg = cells.config.read().await.clone();
+                apply_patch::handle(resolver, cfg, req)
+                    .await
+                    .map_err(Error::from)
+            }
+        })
+        .description(APPLY_PATCH_DESC),
     );
 }
 

--- a/shell/src/code/functions/update_file.rs
+++ b/shell/src/code/functions/update_file.rs
@@ -1275,7 +1275,7 @@ fn join_lines(lines: &[String], ending: LineEnding, trailing: bool) -> Vec<u8> {
 }
 
 /// Write atomically via sibling temp file + rename.
-fn atomic_write(target: &Path, bytes: &[u8]) -> Result<(), CoderError> {
+pub(crate) fn atomic_write(target: &Path, bytes: &[u8]) -> Result<(), CoderError> {
     let parent = target
         .parent()
         .ok_or_else(|| CoderError::Io(format!("no parent for {}", target.display())))?;

--- a/shell/src/code/mod.rs
+++ b/shell/src/code/mod.rs
@@ -17,6 +17,7 @@
 pub mod config;
 pub mod error;
 pub mod functions;
+pub mod patch;
 pub mod path;
 pub mod state;
 

--- a/shell/src/code/patch.rs
+++ b/shell/src/code/patch.rs
@@ -1,0 +1,691 @@
+//! V4A patch format ("apply_patch"): parser + application engine.
+//!
+//! The format codex-family models are trained to emit:
+//!
+//! ```text
+//! *** Begin Patch
+//! [*** Environment ID: <id>]      (accepted and ignored)
+//! *** Add File: <path>            followed by +<line> content lines
+//! *** Delete File: <path>
+//! *** Update File: <path>         [*** Move to: <path>] then chunks:
+//! @@ <context line>               (or bare @@)
+//!  <context> / -<old> / +<new>    change lines
+//! *** End of File                 (optional, pins the chunk to EOF)
+//! *** End Patch
+//! ```
+//!
+//! `seek_sequence`, `compute_replacements`, and `apply_replacements` are
+//! ported from OpenAI's `codex-rs/apply-patch` crate
+//! (github.com/openai/codex, Apache-2.0) so context matching behaves
+//! exactly like the reference implementation (exact → rstrip → trim →
+//! unicode-normalised passes). The parser is a compact non-streaming
+//! re-implementation of the same grammar, pinned by the reference test
+//! cases in this module.
+
+use std::path::PathBuf;
+
+/// One parsed patch operation.
+#[derive(Debug, PartialEq, Clone)]
+#[allow(clippy::enum_variant_names)] // mirrors the upstream crate
+pub enum Hunk {
+    AddFile {
+        path: PathBuf,
+        contents: String,
+    },
+    DeleteFile {
+        path: PathBuf,
+    },
+    UpdateFile {
+        path: PathBuf,
+        move_path: Option<PathBuf>,
+        chunks: Vec<UpdateFileChunk>,
+    },
+}
+
+#[derive(Debug, PartialEq, Clone, Default)]
+pub struct UpdateFileChunk {
+    /// A single context line (usually a class/fn definition) that narrows
+    /// down where `old_lines` should be searched for.
+    pub change_context: Option<String>,
+    /// Contiguous block of lines to replace with `new_lines`.
+    pub old_lines: Vec<String>,
+    pub new_lines: Vec<String>,
+    /// When true, `old_lines` must match at the end of the file.
+    pub is_end_of_file: bool,
+}
+
+impl UpdateFileChunk {
+    fn is_empty(&self) -> bool {
+        self.change_context.is_none()
+            && self.old_lines.is_empty()
+            && self.new_lines.is_empty()
+            && !self.is_end_of_file
+    }
+}
+
+/// Parse failure with a prescriptive message (line numbers are 1-based
+/// within the patch text).
+#[derive(Debug, PartialEq)]
+pub struct PatchError(pub String);
+
+impl std::fmt::Display for PatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+const BEGIN_MARKER: &str = "*** Begin Patch";
+const END_MARKER: &str = "*** End Patch";
+const ADD_MARKER: &str = "*** Add File: ";
+const DELETE_MARKER: &str = "*** Delete File: ";
+const UPDATE_MARKER: &str = "*** Update File: ";
+const MOVE_MARKER: &str = "*** Move to: ";
+const EOF_MARKER: &str = "*** End of File";
+const ENV_ID_MARKER: &str = "*** Environment ID: ";
+
+/// Parse a full patch text into hunks. Strict boundaries: the first
+/// non-blank line must be `*** Begin Patch` and the last `*** End Patch`.
+pub fn parse_patch(patch: &str) -> Result<Vec<Hunk>, PatchError> {
+    let lines: Vec<&str> = patch.trim().lines().collect();
+    match (lines.first(), lines.last()) {
+        (Some(first), _) if first.trim() != BEGIN_MARKER => {
+            return Err(PatchError(
+                "the first line of the patch must be '*** Begin Patch'".into(),
+            ));
+        }
+        (Some(_), Some(last)) if last.trim() == END_MARKER => {}
+        _ => {
+            return Err(PatchError(
+                "the last line of the patch must be '*** End Patch'".into(),
+            ));
+        }
+    }
+    let body = &lines[1..lines.len() - 1];
+
+    let mut hunks: Vec<Hunk> = Vec::new();
+    let mut i = 0usize;
+    // 1-based line number of body[i] within the full patch text.
+    let line_no = |i: usize| i + 2;
+
+    while i < body.len() {
+        let line = body[i];
+        if let Some(path) = line.strip_prefix(ADD_MARKER) {
+            let (contents, next) = parse_add_lines(body, i + 1);
+            hunks.push(Hunk::AddFile {
+                path: PathBuf::from(path.trim()),
+                contents,
+            });
+            i = next;
+        } else if let Some(path) = line.strip_prefix(DELETE_MARKER) {
+            hunks.push(Hunk::DeleteFile {
+                path: PathBuf::from(path.trim()),
+            });
+            i += 1;
+        } else if let Some(path) = line.strip_prefix(UPDATE_MARKER) {
+            let (hunk, next) = parse_update_hunk(body, i, path.trim())?;
+            hunks.push(hunk);
+            i = next;
+        } else if line.strip_prefix(ENV_ID_MARKER).is_some() && hunks.is_empty() {
+            i += 1; // accepted and ignored
+        } else if line.trim().is_empty() {
+            i += 1; // blank line between hunks
+        } else {
+            return Err(PatchError(format!(
+                "unexpected line {} in patch: {:?} — every hunk starts with \
+                 '*** Add File: ', '*** Delete File: ' or '*** Update File: '",
+                line_no(i),
+                line
+            )));
+        }
+    }
+    Ok(hunks)
+}
+
+/// Consume `+`-prefixed content lines of an Add File hunk.
+fn parse_add_lines(body: &[&str], mut i: usize) -> (String, usize) {
+    let mut contents = String::new();
+    while i < body.len() {
+        let Some(rest) = body[i].strip_prefix('+') else {
+            break;
+        };
+        contents.push_str(rest);
+        contents.push('\n');
+        i += 1;
+    }
+    (contents, i)
+}
+
+/// Parse an Update File hunk starting at `body[start]` (the marker line).
+fn parse_update_hunk(body: &[&str], start: usize, path: &str) -> Result<(Hunk, usize), PatchError> {
+    let mut i = start + 1;
+    let move_path = if i < body.len() {
+        body[i].strip_prefix(MOVE_MARKER).map(|p| {
+            i += 1;
+            PathBuf::from(p.trim())
+        })
+    } else {
+        None
+    };
+
+    let mut chunks: Vec<UpdateFileChunk> = Vec::new();
+    let mut current = UpdateFileChunk::default();
+    let mut current_started = false;
+    let mut flush = |current: &mut UpdateFileChunk, started: &mut bool| -> Result<(), PatchError> {
+        if *started && !current.is_empty() {
+            chunks.push(std::mem::take(current));
+        }
+        *started = false;
+        Ok(())
+    };
+
+    while i < body.len() {
+        let line = body[i];
+        if line == EOF_MARKER {
+            // Per the grammar (`change: (change_context | change_line)+
+            // eof_line?`) the EOF marker terminates the whole update hunk.
+            current.is_end_of_file = true;
+            current_started = true;
+            flush(&mut current, &mut current_started)?;
+            i += 1;
+            break;
+        }
+        if line.starts_with("*** ") {
+            break; // next hunk marker
+        }
+        if line == "@@" || line.starts_with("@@ ") {
+            flush(&mut current, &mut current_started)?;
+            current.change_context = line.strip_prefix("@@ ").map(|c| c.to_string());
+            current_started = true;
+            i += 1;
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix('+') {
+            current.new_lines.push(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix('-') {
+            current.old_lines.push(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix(' ') {
+            current.old_lines.push(rest.to_string());
+            current.new_lines.push(rest.to_string());
+        } else if line.is_empty() {
+            // Models routinely trim the ' ' diff prefix off blank context
+            // lines; treat a fully empty line as empty context.
+            current.old_lines.push(String::new());
+            current.new_lines.push(String::new());
+        } else {
+            return Err(PatchError(format!(
+                "unexpected line {} in update hunk for {:?}: {:?} — change \
+                 lines must start with '+', '-', ' ' or '@@'",
+                i + 2,
+                path,
+                line
+            )));
+        }
+        current_started = true;
+        i += 1;
+    }
+    flush(&mut current, &mut current_started)?;
+
+    if chunks.is_empty() {
+        return Err(PatchError(format!(
+            "update file hunk for path {path:?} is empty"
+        )));
+    }
+    Ok((
+        Hunk::UpdateFile {
+            path: PathBuf::from(path),
+            move_path,
+            chunks,
+        },
+        i,
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Context matching + replacement — ported from codex-rs/apply-patch
+// (github.com/openai/codex, Apache-2.0).
+// ---------------------------------------------------------------------------
+
+/// Find `pattern` within `lines` at or after `start`, with decreasing
+/// strictness: exact, rstrip, trim, then unicode-normalised. When `eof`
+/// is true, try matching at the end of file first.
+pub(crate) fn seek_sequence(
+    lines: &[String],
+    pattern: &[String],
+    start: usize,
+    eof: bool,
+) -> Option<usize> {
+    if pattern.is_empty() {
+        return Some(start);
+    }
+    if pattern.len() > lines.len() {
+        return None;
+    }
+    let search_start = if eof && lines.len() >= pattern.len() {
+        lines.len() - pattern.len()
+    } else {
+        start
+    };
+    for i in search_start..=lines.len().saturating_sub(pattern.len()) {
+        if lines[i..i + pattern.len()] == *pattern {
+            return Some(i);
+        }
+    }
+    for i in search_start..=lines.len().saturating_sub(pattern.len()) {
+        if pattern
+            .iter()
+            .enumerate()
+            .all(|(p, pat)| lines[i + p].trim_end() == pat.trim_end())
+        {
+            return Some(i);
+        }
+    }
+    for i in search_start..=lines.len().saturating_sub(pattern.len()) {
+        if pattern
+            .iter()
+            .enumerate()
+            .all(|(p, pat)| lines[i + p].trim() == pat.trim())
+        {
+            return Some(i);
+        }
+    }
+
+    fn normalise(s: &str) -> String {
+        s.trim()
+            .chars()
+            .map(|c| match c {
+                '\u{2010}' | '\u{2011}' | '\u{2012}' | '\u{2013}' | '\u{2014}' | '\u{2015}'
+                | '\u{2212}' => '-',
+                '\u{2018}' | '\u{2019}' | '\u{201A}' | '\u{201B}' => '\'',
+                '\u{201C}' | '\u{201D}' | '\u{201E}' | '\u{201F}' => '"',
+                '\u{00A0}' | '\u{2002}' | '\u{2003}' | '\u{2004}' | '\u{2005}' | '\u{2006}'
+                | '\u{2007}' | '\u{2008}' | '\u{2009}' | '\u{200A}' | '\u{202F}' | '\u{205F}'
+                | '\u{3000}' => ' ',
+                other => other,
+            })
+            .collect()
+    }
+    (search_start..=lines.len().saturating_sub(pattern.len())).find(|&i| {
+        pattern
+            .iter()
+            .enumerate()
+            .all(|(p, pat)| normalise(&lines[i + p]) == normalise(pat))
+    })
+}
+
+/// Result of applying update chunks to one file's contents.
+#[derive(Debug)]
+pub struct AppliedUpdate {
+    pub new_contents: String,
+    /// 1-based line (in the NEW contents) where the first replacement
+    /// landed, with that replacement's new-line count — enough for a
+    /// bounded verification echo. `None` when the chunks were a no-op.
+    pub first_change: Option<(u64, u64)>,
+}
+
+/// Apply `chunks` to `original_contents`, returning the new contents.
+/// Fails with a prescriptive message when a chunk's context cannot be
+/// located (the caller maps this to C210; nothing is written).
+pub fn derive_new_contents_from_chunks(
+    original_contents: &str,
+    path: &str,
+    chunks: &[UpdateFileChunk],
+) -> Result<AppliedUpdate, PatchError> {
+    let mut original_lines: Vec<String> = original_contents.split('\n').map(String::from).collect();
+    // Drop the trailing empty element from the final newline so line
+    // counts match standard `diff` behaviour.
+    if original_lines.last().is_some_and(String::is_empty) {
+        original_lines.pop();
+    }
+    let replacements = compute_replacements(&original_lines, path, chunks)?;
+    // Replacements apply in DESCENDING order, so the FIRST (lowest-index)
+    // replacement's position is never shifted by the others — its index is
+    // valid in the new contents as-is.
+    let first_change = replacements
+        .first()
+        .map(|(idx, _, new)| (*idx as u64 + 1, new.len() as u64));
+    let mut new_lines = apply_replacements(original_lines, &replacements);
+    if !new_lines.last().is_some_and(String::is_empty) {
+        new_lines.push(String::new());
+    }
+    Ok(AppliedUpdate {
+        new_contents: new_lines.join("\n"),
+        first_change,
+    })
+}
+
+/// `(start_index, old_len, new_lines)` replacements, in ascending order.
+pub(crate) fn compute_replacements(
+    original_lines: &[String],
+    path: &str,
+    chunks: &[UpdateFileChunk],
+) -> Result<Vec<(usize, usize, Vec<String>)>, PatchError> {
+    let mut replacements: Vec<(usize, usize, Vec<String>)> = Vec::new();
+    let mut line_index: usize = 0;
+
+    for chunk in chunks {
+        if let Some(ctx_line) = &chunk.change_context {
+            if let Some(idx) = seek_sequence(
+                original_lines,
+                std::slice::from_ref(ctx_line),
+                line_index,
+                false,
+            ) {
+                line_index = idx + 1;
+            } else {
+                return Err(PatchError(format!(
+                    "failed to find context {ctx_line:?} in {path} — re-read \
+                     the file and regenerate the patch against its current \
+                     contents"
+                )));
+            }
+        }
+
+        if chunk.old_lines.is_empty() {
+            // Pure addition: append at the end of the file.
+            let insertion_idx = if original_lines.last().is_some_and(String::is_empty) {
+                original_lines.len() - 1
+            } else {
+                original_lines.len()
+            };
+            replacements.push((insertion_idx, 0, chunk.new_lines.clone()));
+            continue;
+        }
+
+        // A trailing empty old-line often represents the file's final
+        // newline; retry without it when the direct search fails.
+        let mut pattern: &[String] = &chunk.old_lines;
+        let mut found = seek_sequence(original_lines, pattern, line_index, chunk.is_end_of_file);
+        let mut new_slice: &[String] = &chunk.new_lines;
+        if found.is_none() && pattern.last().is_some_and(String::is_empty) {
+            pattern = &pattern[..pattern.len() - 1];
+            if new_slice.last().is_some_and(String::is_empty) {
+                new_slice = &new_slice[..new_slice.len() - 1];
+            }
+            found = seek_sequence(original_lines, pattern, line_index, chunk.is_end_of_file);
+        }
+
+        if let Some(start_idx) = found {
+            replacements.push((start_idx, pattern.len(), new_slice.to_vec()));
+            line_index = start_idx + pattern.len();
+        } else {
+            return Err(PatchError(format!(
+                "failed to find expected lines in {}:\n{}\n— re-read the file \
+                 and regenerate the patch against its current contents",
+                path,
+                chunk.old_lines.join("\n"),
+            )));
+        }
+    }
+
+    replacements.sort_by_key(|(index, _, _)| *index);
+    Ok(replacements)
+}
+
+/// Apply replacements in descending order so earlier ones don't shift
+/// later positions.
+pub(crate) fn apply_replacements(
+    mut lines: Vec<String>,
+    replacements: &[(usize, usize, Vec<String>)],
+) -> Vec<String> {
+    for (start_idx, old_len, new_segment) in replacements.iter().rev() {
+        let start_idx = *start_idx;
+        for _ in 0..*old_len {
+            if start_idx < lines.len() {
+                lines.remove(start_idx);
+            }
+        }
+        for (offset, new_line) in new_segment.iter().enumerate() {
+            lines.insert(start_idx + offset, new_line.clone());
+        }
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use Hunk::*;
+
+    // -----------------------------------------------------------------
+    // Parser cases pinned against codex-rs/apply-patch's reference tests.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn rejects_missing_boundaries() {
+        assert!(parse_patch("bad").unwrap_err().0.contains("Begin Patch"));
+        assert!(parse_patch("*** Begin Patch\nbad")
+            .unwrap_err()
+            .0
+            .contains("End Patch"));
+    }
+
+    #[test]
+    fn empty_patch_yields_no_hunks() {
+        assert_eq!(
+            parse_patch("*** Begin Patch\n*** End Patch").unwrap(),
+            Vec::new()
+        );
+    }
+
+    #[test]
+    fn parses_all_three_hunk_kinds_with_move() {
+        let hunks = parse_patch(
+            "*** Begin Patch\n\
+             *** Add File: path/add.py\n\
+             +abc\n\
+             +def\n\
+             *** Delete File: path/delete.py\n\
+             *** Update File: path/update.py\n\
+             *** Move to: path/update2.py\n\
+             @@ def f():\n\
+             -    pass\n\
+             +    return 123\n\
+             *** End Patch",
+        )
+        .unwrap();
+        assert_eq!(
+            hunks,
+            vec![
+                AddFile {
+                    path: PathBuf::from("path/add.py"),
+                    contents: "abc\ndef\n".to_string()
+                },
+                DeleteFile {
+                    path: PathBuf::from("path/delete.py")
+                },
+                UpdateFile {
+                    path: PathBuf::from("path/update.py"),
+                    move_path: Some(PathBuf::from("path/update2.py")),
+                    chunks: vec![UpdateFileChunk {
+                        change_context: Some("def f():".to_string()),
+                        old_lines: vec!["    pass".to_string()],
+                        new_lines: vec!["    return 123".to_string()],
+                        is_end_of_file: false
+                    }]
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn update_followed_by_add() {
+        let hunks = parse_patch(
+            "*** Begin Patch\n\
+             *** Update File: file.py\n\
+             @@\n\
+             +line\n\
+             *** Add File: other.py\n\
+             +content\n\
+             *** End Patch",
+        )
+        .unwrap();
+        assert_eq!(
+            hunks,
+            vec![
+                UpdateFile {
+                    path: PathBuf::from("file.py"),
+                    move_path: None,
+                    chunks: vec![UpdateFileChunk {
+                        change_context: None,
+                        old_lines: vec![],
+                        new_lines: vec!["line".to_string()],
+                        is_end_of_file: false
+                    }],
+                },
+                AddFile {
+                    path: PathBuf::from("other.py"),
+                    contents: "content\n".to_string()
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn update_without_context_header_parses() {
+        let hunks = parse_patch(
+            "*** Begin Patch\n*** Update File: file2.py\n import foo\n+bar\n*** End Patch",
+        )
+        .unwrap();
+        assert_eq!(
+            hunks,
+            vec![UpdateFile {
+                path: PathBuf::from("file2.py"),
+                move_path: None,
+                chunks: vec![UpdateFileChunk {
+                    change_context: None,
+                    old_lines: vec!["import foo".to_string()],
+                    new_lines: vec!["import foo".to_string(), "bar".to_string()],
+                    is_end_of_file: false,
+                }],
+            }]
+        );
+    }
+
+    #[test]
+    fn end_of_file_marker_is_preserved() {
+        let hunks = parse_patch(
+            "*** Begin Patch\n*** Update File: file.txt\n@@\n+quux\n*** End of File\n\n*** End Patch",
+        )
+        .unwrap();
+        assert_eq!(
+            hunks,
+            vec![UpdateFile {
+                path: PathBuf::from("file.txt"),
+                move_path: None,
+                chunks: vec![UpdateFileChunk {
+                    change_context: None,
+                    old_lines: Vec::new(),
+                    new_lines: vec!["quux".to_string()],
+                    is_end_of_file: true,
+                }],
+            }]
+        );
+    }
+
+    #[test]
+    fn empty_update_hunk_is_rejected() {
+        let err =
+            parse_patch("*** Begin Patch\n*** Update File: test.py\n*** End Patch").unwrap_err();
+        assert!(err.0.contains("is empty"), "{err}");
+    }
+
+    #[test]
+    fn environment_id_preamble_is_ignored() {
+        let hunks = parse_patch(
+            "*** Begin Patch\n\
+             *** Environment ID: remote\n\
+             *** Add File: hello.txt\n\
+             +hello\n\
+             *** End Patch",
+        )
+        .unwrap();
+        assert_eq!(
+            hunks,
+            vec![AddFile {
+                path: PathBuf::from("hello.txt"),
+                contents: "hello\n".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn multiple_chunks_in_one_update() {
+        let hunks = parse_patch(
+            "*** Begin Patch\n\
+             *** Update File: f.py\n\
+             @@ def a():\n\
+             -    x = 1\n\
+             +    x = 2\n\
+             @@ def b():\n\
+             -    y = 1\n\
+             +    y = 2\n\
+             *** End Patch",
+        )
+        .unwrap();
+        match &hunks[0] {
+            UpdateFile { chunks, .. } => assert_eq!(chunks.len(), 2),
+            other => panic!("expected update, got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Application semantics.
+    // -----------------------------------------------------------------
+
+    fn chunk(ctx: Option<&str>, old: &[&str], new: &[&str]) -> UpdateFileChunk {
+        UpdateFileChunk {
+            change_context: ctx.map(str::to_string),
+            old_lines: old.iter().map(|s| s.to_string()).collect(),
+            new_lines: new.iter().map(|s| s.to_string()).collect(),
+            is_end_of_file: false,
+        }
+    }
+
+    #[test]
+    fn applies_simple_replacement() {
+        let out =
+            derive_new_contents_from_chunks("a\nb\nc\n", "f.txt", &[chunk(None, &["b"], &["B"])])
+                .unwrap()
+                .new_contents;
+        assert_eq!(out, "a\nB\nc\n");
+    }
+
+    #[test]
+    fn applies_with_context_narrowing() {
+        let src = "def a():\n    pass\n\ndef b():\n    pass\n";
+        let out = derive_new_contents_from_chunks(
+            src,
+            "f.py",
+            &[chunk(Some("def b():"), &["    pass"], &["    return 1"])],
+        )
+        .unwrap()
+        .new_contents;
+        assert_eq!(out, "def a():\n    pass\n\ndef b():\n    return 1\n");
+    }
+
+    #[test]
+    fn pure_addition_appends_at_end() {
+        let out =
+            derive_new_contents_from_chunks("a\n", "f.txt", &[chunk(None, &[], &["z"])]).unwrap();
+        assert_eq!(out.new_contents, "a\nz\n");
+    }
+
+    #[test]
+    fn missing_context_fails_with_reread_guidance() {
+        let err =
+            derive_new_contents_from_chunks("a\nb\n", "f.txt", &[chunk(None, &["nope"], &["x"])])
+                .unwrap_err();
+        assert!(err.0.contains("re-read the file"), "{err}");
+    }
+
+    #[test]
+    fn fuzzy_match_tolerates_trailing_whitespace() {
+        let out = derive_new_contents_from_chunks(
+            "keep   \nold\n",
+            "f.txt",
+            &[chunk(None, &["keep", "old"], &["keep", "new"])],
+        )
+        .unwrap();
+        assert_eq!(out.new_contents, "keep\nnew\n");
+    }
+}

--- a/shell/tests/code_apply_patch.rs
+++ b/shell/tests/code_apply_patch.rs
@@ -1,0 +1,182 @@
+//! Integration coverage for `coder::apply-patch` — the V4A whole-patch
+//! applier. Exercises the real handler: multi-hunk success, all-or-nothing
+//! failure atomicity, move semantics, and jail rejection.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use shell::code::config::CoderConfig;
+use shell::code::functions::apply_patch::{handle as apply_handle, ApplyPatchInput};
+use shell::code::path::PathResolver;
+use tempfile::tempdir;
+
+fn make(base: PathBuf) -> (Arc<PathResolver>, Arc<CoderConfig>) {
+    let cfg = Arc::new(CoderConfig {
+        base_paths: vec![base],
+        max_read_bytes: 1024 * 1024,
+        max_write_bytes: 1024 * 1024,
+        ..CoderConfig::default()
+    });
+    let r = Arc::new(PathResolver::new(&cfg).unwrap());
+    (r, cfg)
+}
+
+fn input(patch: &str) -> ApplyPatchInput {
+    ApplyPatchInput {
+        patch: patch.to_string(),
+        fs_scope: None,
+    }
+}
+
+#[tokio::test]
+async fn applies_add_update_delete_in_one_patch() {
+    let tmp = tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("calc.py"),
+        "def add(a, b):\n    return a - b\n",
+    )
+    .unwrap();
+    std::fs::write(tmp.path().join("legacy.py"), "old\n").unwrap();
+    let (r, c) = make(tmp.path().to_path_buf());
+
+    let out = apply_handle(
+        r,
+        c,
+        input(
+            "*** Begin Patch\n\
+             *** Update File: calc.py\n\
+             @@ def add(a, b):\n\
+             -    return a - b\n\
+             +    return a + b\n\
+             *** Add File: util/helpers.py\n\
+             +def helper():\n\
+             +    return 1\n\
+             *** Delete File: legacy.py\n\
+             *** End Patch",
+        ),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(out.results.len(), 3);
+    assert_eq!(out.results[0].kind, "modified");
+    assert_eq!(out.results[1].kind, "added");
+    assert_eq!(out.results[2].kind, "deleted");
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("calc.py")).unwrap(),
+        "def add(a, b):\n    return a + b\n"
+    );
+    // Add created parent dirs automatically.
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("util/helpers.py")).unwrap(),
+        "def helper():\n    return 1\n"
+    );
+    assert!(!tmp.path().join("legacy.py").exists());
+    // Modified files echo the first changed region.
+    let echo = out.results[0].echo.as_ref().expect("modified file echoes");
+    assert!(echo.lines.iter().any(|l| l.contains("return a + b")));
+}
+
+#[tokio::test]
+async fn context_mismatch_fails_whole_patch_with_nothing_written() {
+    let tmp = tempdir().unwrap();
+    std::fs::write(tmp.path().join("a.txt"), "alpha\n").unwrap();
+    std::fs::write(tmp.path().join("b.txt"), "beta\n").unwrap();
+    let (r, c) = make(tmp.path().to_path_buf());
+
+    // First hunk is valid, second has stale context — NOTHING may land.
+    let err = apply_handle(
+        r,
+        c,
+        input(
+            "*** Begin Patch\n\
+             *** Update File: a.txt\n\
+             @@\n\
+             -alpha\n\
+             +ALPHA\n\
+             *** Update File: b.txt\n\
+             @@\n\
+             -does-not-exist\n\
+             +x\n\
+             *** End Patch",
+        ),
+    )
+    .await
+    .unwrap_err();
+
+    assert!(err.contains("C210"), "{err}");
+    assert!(err.contains("re-read the file"), "{err}");
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("a.txt")).unwrap(),
+        "alpha\n",
+        "valid first hunk must not land when a later hunk fails"
+    );
+}
+
+#[tokio::test]
+async fn update_with_move_relocates_the_file() {
+    let tmp = tempdir().unwrap();
+    std::fs::write(tmp.path().join("old_name.py"), "value = 1\n").unwrap();
+    let (r, c) = make(tmp.path().to_path_buf());
+
+    let out = apply_handle(
+        r,
+        c,
+        input(
+            "*** Begin Patch\n\
+             *** Update File: old_name.py\n\
+             *** Move to: new_name.py\n\
+             @@\n\
+             -value = 1\n\
+             +value = 2\n\
+             *** End Patch",
+        ),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(out.results[0].kind, "moved");
+    assert!(!tmp.path().join("old_name.py").exists());
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("new_name.py")).unwrap(),
+        "value = 2\n"
+    );
+}
+
+#[tokio::test]
+async fn jail_escape_is_rejected() {
+    let tmp = tempdir().unwrap();
+    let (r, c) = make(tmp.path().to_path_buf());
+    let err = apply_handle(
+        r,
+        c,
+        input(
+            "*** Begin Patch\n\
+             *** Add File: ../outside.txt\n\
+             +nope\n\
+             *** End Patch",
+        ),
+    )
+    .await
+    .unwrap_err();
+    assert!(err.contains("C215") || err.contains("C211"), "{err}");
+}
+
+#[tokio::test]
+async fn add_existing_file_is_rejected_with_guidance() {
+    let tmp = tempdir().unwrap();
+    std::fs::write(tmp.path().join("x.txt"), "here\n").unwrap();
+    let (r, c) = make(tmp.path().to_path_buf());
+    let err = apply_handle(
+        r,
+        c,
+        input("*** Begin Patch\n*** Add File: x.txt\n+dup\n*** End Patch"),
+    )
+    .await
+    .unwrap_err();
+    assert!(err.contains("Update File"), "{err}");
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("x.txt")).unwrap(),
+        "here\n"
+    );
+}

--- a/shell/tests/code_golden_schemas.rs
+++ b/shell/tests/code_golden_schemas.rs
@@ -1,4 +1,4 @@
-//! GOLDEN FAMILY A — wire-schema snapshots for all 10 `coder::*` functions
+//! GOLDEN FAMILY A — wire-schema snapshots for all 11 `coder::*` functions
 //! served by the shell worker.
 //!
 //! `shell::code::functions::catalog()` is the single source of truth for
@@ -35,10 +35,10 @@ fn spec_to_pretty_json(spec: &FunctionSpec) -> String {
     pretty
 }
 
-/// The catalog must cover exactly the 10 registered functions, in
+/// The catalog must cover exactly the 11 registered functions, in
 /// registration order (kept in lockstep with `register_all`).
 #[test]
-fn catalog_lists_all_ten_functions_in_registration_order() {
+fn catalog_lists_all_eleven_functions_in_registration_order() {
     let ids: Vec<&str> = catalog().iter().map(|s| s.function_id).collect();
     assert_eq!(
         ids,
@@ -48,6 +48,7 @@ fn catalog_lists_all_ten_functions_in_registration_order() {
             "coder::read-file",
             "coder::search",
             "coder::update-file",
+            "coder::apply-patch",
             "coder::create-file",
             "coder::delete-file",
             "coder::list-folder",

--- a/shell/tests/golden/schemas/coder.apply-patch.json
+++ b/shell/tests/golden/schemas/coder.apply-patch.json
@@ -1,0 +1,100 @@
+{
+  "description": "Apply a whole patch in the apply_patch (V4A) format: the exact '*** Begin Patch' … '*** End Patch' format you know, with '*** Add File: ', '*** Delete File: ', '*** Update File: ' (+ optional '*** Move to: ') hunks, '@@ ' context markers, and ' '/'+'/'-' change lines. All-or-nothing: every hunk is validated and computed before anything is written — a context mismatch fails the whole call with C210 and the guidance to re-read and regenerate; on success each file commits atomically and modified files return a bounded post-apply echo of the first changed region. Paths are relative to the primary allowed root or absolute inside any allowed root (coder::info lists them); for host paths outside the jail use shell::fs::*.",
+  "function_id": "coder::apply-patch",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "examples": [
+      {
+        "patch": "*** Begin Patch\n*** Update File: src/calc.py\n@@ def add(a, b):\n-    return a - b\n+    return a + b\n*** End Patch"
+      }
+    ],
+    "properties": {
+      "patch": {
+        "description": "The full patch text in the apply_patch format: starts with `*** Begin Patch`, ends with `*** End Patch`, with one hunk per file (`*** Add File: `, `*** Delete File: `, or `*** Update File: ` with an optional `*** Move to: `). Paths are relative to the primary allowed root, or absolute inside any allowed root.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "patch"
+    ],
+    "title": "ApplyPatchInput",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+      "PatchEcho": {
+        "properties": {
+          "from_line": {
+            "description": "1-based line number of the first echoed line, post-apply.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "lines": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "from_line",
+          "lines"
+        ],
+        "type": "object"
+      },
+      "PatchFileResult": {
+        "properties": {
+          "echo": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/PatchEcho"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Bounded post-apply snapshot of the first changed region (modified files only) — verify from this instead of re-reading the file."
+          },
+          "kind": {
+            "description": "What happened: \"added\" | \"modified\" | \"deleted\" | \"moved\".",
+            "type": "string"
+          },
+          "new_line_count": {
+            "description": "Line count after applying (absent for deletions).",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "path": {
+            "description": "Canonical absolute path of the affected file (the destination for a moved file).",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "path"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "results": {
+        "description": "One entry per file hunk, in patch order. The whole patch applied — a failure anywhere returns an error with nothing written.",
+        "items": {
+          "$ref": "#/definitions/PatchFileResult"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "results"
+    ],
+    "title": "ApplyPatchOutput",
+    "type": "object"
+  }
+}


### PR DESCRIPTION
Adds the apply_patch (V4A) format codex-family models are trained on:
*** Begin/End Patch with Add/Delete/Update File hunks, @@ context
markers, optional Move to, and End of File pinning. seek_sequence and
the replacement engine are ported from OpenAI's codex-rs apply-patch
crate (Apache-2.0) so context matching (exact -> rstrip -> trim ->
unicode-normalised) matches the reference; the parser is a compact
re-implementation pinned by the reference test cases.

All-or-nothing: every hunk resolves through the jail and computes
before anything is written (context mismatch fails C210 with re-read
guidance, filesystem untouched); writes land atomically per file and
modified files return a bounded echo of the first changed region.

Refs MOT-3874
