### PR TITLE
(MOT-3874) feat(harness): worktree-isolated spawns + GPT-family code prompt

### DIFF
--- a/harness/prompts/code-gpt.txt
+++ b/harness/prompts/code-gpt.txt
@@ -10,10 +10,10 @@ An <environment> block in this prompt describes your workspace: the working dire
 
 - Locate before you read: coder::search finds content and paths (literal or regex, with context lines); coder::tree and coder::list-folder map structure. Read only the regions you need — coder::read-file supports line windows (line_from/line_to) and stat probes.
 - Read before you edit. Never edit text you have not seen in this session; a file may have changed since you last read it.
-- Edit with coder::update-file's str_replace op: copy the exact existing text — including whitespace and indentation — as old_str, and supply the replacement as new_str. old_str must match exactly once; when it is ambiguous, include more surrounding lines, or set replace_all only for intentional bulk replacements. Use insert/update_lines for new blocks, and the regex replace op only for pattern rewrites across many sites.
+- Edit with coder::apply-patch: pass the complete patch in the apply_patch format you know — `*** Begin Patch`, one hunk per file (`*** Add File: `, `*** Delete File: `, `*** Update File: ` with optional `*** Move to: `), `@@ ` context markers, ` `/`+`/`-` change lines, `*** End Patch`. Copy context lines exactly from the file; a context mismatch fails the whole patch with nothing written — re-read the file and regenerate. One patch can touch several files.
 - Verify each edit from the echoes the call returns instead of re-reading the file.
 - Make minimal diffs that match the file's existing style: naming, indentation, comment density, idioms. Do not reformat code you are not changing.
-- Renames and moves go through coder::move — never delete-and-recreate a file.
+- Renames go through an Update File hunk with `*** Move to: `, or coder::move — never delete-and-recreate a file.
 
 # Running commands
 

--- a/harness/src/deferred.rs
+++ b/harness/src/deferred.rs
@@ -46,15 +46,33 @@ pub async fn resolve(
         "deliver" => {
             let function_id = checkpoint.function_id.clone().unwrap_or_default();
             let entry_id = ids::function_result_entry_id(&record.turn_id, &req.function_call_id);
+            let mut content = req
+                .content
+                .clone()
+                .unwrap_or_else(|| vec![ContentBlock::text("")]);
+            let mut details = req.details.clone().unwrap_or(Value::Null);
+            // Worktree-isolated child: clean up (clean-only — dirty trees
+            // survive) and tell the parent where the child's work landed.
+            if let Some(wt) = &checkpoint.worktree {
+                let removal = crate::subagent::remove_child_worktree(deps, &cfg, &record, wt).await;
+                content.push(ContentBlock::text(worktree_note(wt, removal.as_ref())));
+                if let Value::Object(map) = &mut details {
+                    map.insert(
+                        "worktree".to_string(),
+                        json!({
+                            "path": wt.path,
+                            "branch": wt.branch,
+                            "removal": removal,
+                        }),
+                    );
+                }
+            }
             let message = AgentMessage::FunctionResult(FunctionResultMessage {
                 role: FunctionResultRoleTag::FunctionResult,
                 function_call_id: req.function_call_id.clone(),
                 function_id,
-                content: req
-                    .content
-                    .clone()
-                    .unwrap_or_else(|| vec![ContentBlock::text("")]),
-                details: req.details.clone().unwrap_or(Value::Null),
+                content,
+                details,
                 is_error: req.is_error.unwrap_or(false),
                 timestamp: AgentMessage::now_ms(),
             });
@@ -264,6 +282,50 @@ async fn find_call_arguments(
 /// Resolve a parked parent call from a finishing child (harness.md §
 /// Sub-agents). `completed` delivers the child's result; `failed`/`cancelled`
 /// deliver an `is_error`.
+/// Human/model-facing summary of a worktree-isolated child's workspace
+/// disposition, appended to the parent's function result.
+fn worktree_note(wt: &crate::types::turn::WorktreeRef, removal: Option<&Value>) -> String {
+    let Some(v) = removal else {
+        return format!(
+            "[worktree] cleanup failed; the child's worktree may remain at \
+             {} (branch {})",
+            wt.path, wt.branch
+        );
+    };
+    let dirty = v.get("dirty").and_then(Value::as_bool).unwrap_or(false);
+    let removed = v.get("removed").and_then(Value::as_bool).unwrap_or(false);
+    let branch_deleted = v
+        .get("branch_deleted")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if dirty {
+        format!(
+            "[worktree] the child left uncommitted changes at {} — inspect \
+             or commit them; the worktree was kept",
+            wt.path
+        )
+    } else if removed && branch_deleted {
+        format!(
+            "[worktree] the child made no unmerged commits; its worktree \
+             and branch {} were cleaned up",
+            wt.branch
+        )
+    } else if removed {
+        format!(
+            "[worktree] the child's commits are on branch {} — merge them \
+             with `git merge {}` at the repository root; the worktree was \
+             removed",
+            wt.branch, wt.branch
+        )
+    } else {
+        format!(
+            "[worktree] the child's worktree at {} was not removed (branch \
+             {})",
+            wt.path, wt.branch
+        )
+    }
+}
+
 pub async fn resolve_parent(
     deps: &Deps,
     parent: &crate::types::turn::ParentLink,
@@ -416,6 +478,7 @@ mod tests {
             } else {
                 None
             },
+            worktree: None,
             held_by: held_by.map(str::to_string),
             pending_timeout_ms: timeout_ms,
             pending_at: Some(pending_at),

--- a/harness/src/functions/spawn.rs
+++ b/harness/src/functions/spawn.rs
@@ -40,6 +40,21 @@ pub struct SpawnOptions {
     /// Parent-side wait guard for this child.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_timeout_ms: Option<u64>,
+    /// Workspace isolation for the child. `worktree` gives it its own git
+    /// worktree (`.worktrees/<name>` on branch `wt/<name>` under the
+    /// parent's filesystem root) so parallel children never edit the same
+    /// tree; the parent merges `wt/<name>` when the child finishes.
+    /// Requires the parent turn to have a filesystem root inside a git
+    /// repository. Dispatch-path spawns only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isolation: Option<Isolation>,
+}
+
+/// Child workspace isolation modes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum Isolation {
+    Worktree,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/harness/src/ids.rs
+++ b/harness/src/ids.rs
@@ -56,7 +56,7 @@ fn short_uuid() -> String {
 }
 
 /// Keep ids filesystem/key safe: replace anything outside `[A-Za-z0-9_-]`.
-fn sanitize(s: &str) -> String {
+pub(crate) fn sanitize(s: &str) -> String {
     s.chars()
         .map(|c| {
             if c.is_ascii_alphanumeric() || c == '_' || c == '-' {

--- a/harness/src/policy.rs
+++ b/harness/src/policy.rs
@@ -115,6 +115,7 @@ pub fn code_mode_policy() -> FunctionPolicy {
             "shell::exec_bg",
             "shell::kill",
             "shell::status",
+            "harness::spawn",
         ]
         .into_iter()
         .map(String::from)
@@ -278,17 +279,20 @@ mod tests {
             "coder::context",
             "coder::read-file",
             "coder::update-file",
+            "coder::apply-patch",
+            "coder::worktree-add",
             "coder::search",
             "shell::exec",
             "shell::exec_bg",
             "shell::kill",
             "shell::status",
+            "harness::spawn",
         ] {
             assert!(c.allows(allowed), "{allowed} must be allowed");
         }
         for denied in [
             "engine::functions::list",
-            "harness::spawn",
+            "harness::send",
             "worker::add",
             "shell::fs::rm",
             "shell::list",

--- a/harness/src/prompt/family.rs
+++ b/harness/src/prompt/family.rs
@@ -15,7 +15,7 @@ pub enum PromptFamily {
 pub fn prompt_family(provider: &str) -> PromptFamily {
     match provider {
         "anthropic" => PromptFamily::Anthropic,
-        "openai" => PromptFamily::Gpt,
+        "openai" | "openai-codex" => PromptFamily::Gpt,
         "kimi" => PromptFamily::Kimi,
         // No routed provider (router unreachable during provisioning): mirror the
         // router's seeded default_provider so the un-routed prompt matches what

--- a/harness/src/prompt/mod.rs
+++ b/harness/src/prompt/mod.rs
@@ -37,7 +37,10 @@ pub struct SystemPromptOpts<'a> {
 /// surface that does not exist under native exposure.
 pub fn build_system_prompt(opts: SystemPromptOpts<'_>) -> String {
     if opts.mode == Some(Mode::Code) {
-        return variants::CODE.to_string();
+        return match prompt_family(opts.provider) {
+            PromptFamily::Gpt => variants::CODE_GPT.to_string(),
+            _ => variants::CODE.to_string(),
+        };
     }
     let identity = select_identity_prompt(opts.provider);
     match opts.mode {

--- a/harness/src/prompt/tests.rs
+++ b/harness/src/prompt/tests.rs
@@ -399,8 +399,20 @@ fn code_mode_replaces_mesh_identity() {
 }
 
 #[test]
-fn code_mode_is_provider_agnostic() {
-    for provider in ["anthropic", "openai", "kimi", "unknown", ""] {
+fn code_mode_selects_identity_by_family() {
+    // GPT family (openai + openai-codex) gets the apply_patch discipline.
+    for provider in ["openai", "openai-codex"] {
+        assert_eq!(
+            build_system_prompt(SystemPromptOpts {
+                mode: Some(Mode::Code),
+                provider,
+            }),
+            variants::CODE_GPT,
+            "provider {provider:?}"
+        );
+    }
+    // Everyone else keeps the str_replace discipline.
+    for provider in ["anthropic", "kimi", "unknown", ""] {
         assert_eq!(
             build_system_prompt(SystemPromptOpts {
                 mode: Some(Mode::Code),
@@ -410,6 +422,16 @@ fn code_mode_is_provider_agnostic() {
             "provider {provider:?}"
         );
     }
+}
+
+#[test]
+fn both_code_identities_carry_the_delegation_section() {
+    for body in [variants::CODE, variants::CODE_GPT] {
+        assert!(body.contains("# Delegating"));
+        assert!(body.contains("isolation: \"worktree\""));
+    }
+    assert!(variants::CODE_GPT.contains("coder::apply-patch"));
+    assert!(variants::CODE.contains("str_replace"));
 }
 
 #[test]

--- a/harness/src/prompt/variants.rs
+++ b/harness/src/prompt/variants.rs
@@ -1,9 +1,12 @@
 //! Per-provider identity prompt bodies (engine-grounded capability ladder).
 
 pub const ANTHROPIC: &str = include_str!("../../prompts/anthropic.txt");
-/// Code-mode identity (provider-agnostic): replaces the mesh identity
-/// entirely — native tool exposure has no `agent_trigger` to document.
+/// Code-mode identity: replaces the mesh identity entirely — native tool
+/// exposure has no `agent_trigger` to document. The GPT/codex variant
+/// swaps the edit discipline to the apply_patch format that family is
+/// trained on.
 pub const CODE: &str = include_str!("../../prompts/code.txt");
+pub const CODE_GPT: &str = include_str!("../../prompts/code-gpt.txt");
 pub const GPT: &str = include_str!("../../prompts/gpt.txt");
 pub const KIMI: &str = include_str!("../../prompts/kimi.txt");
 pub const DEFAULT: &str = include_str!("../../prompts/default.txt");

--- a/harness/src/subagent.rs
+++ b/harness/src/subagent.rs
@@ -72,14 +72,40 @@ pub async fn spawn_pending(
         ));
     }
 
+    // Worktree isolation: create the child's workspace BEFORE seeding it,
+    // so the child's very first step already runs jailed to it.
+    let worktree = match req.options.as_ref().and_then(|o| o.isolation) {
+        Some(crate::functions::spawn::Isolation::Worktree) => {
+            Some(create_child_worktree(deps, &cfg, parent, req.session_id.as_deref()).await?)
+        }
+        None => None,
+    };
+
     let parent_link = ParentLink {
         session_id: parent.session_id.clone(),
         turn_id: parent.turn_id.clone(),
         function_call_id: call_id.to_string(),
     };
-    let child = seed_child(deps, &cfg, &req, Some(&parent_link), Some(parent))
-        .await
-        .map_err(|e| is_error(e.code(), e.to_string()))?;
+    let seeded = seed_child_with_root(
+        deps,
+        &cfg,
+        &req,
+        Some(&parent_link),
+        Some(parent),
+        worktree.as_ref().map(|w| w.path.as_str()),
+    )
+    .await;
+    let child = match seeded {
+        Ok(child) => child,
+        Err(e) => {
+            // Best-effort orphan cleanup: the worktree was created for a
+            // child that never came to exist.
+            if let Some(wt) = &worktree {
+                remove_child_worktree(deps, &cfg, parent, wt).await;
+            }
+            return Err(is_error(e.code(), e.to_string()));
+        }
+    };
 
     let pending_timeout_ms = req
         .options
@@ -92,7 +118,102 @@ pub async fn spawn_pending(
         held_by: None,
         child_session_id: Some(child.session_id),
         child_turn_id: Some(child.turn_id),
+        worktree,
     })
+}
+
+/// Create the isolated worktree for a spawn with `isolation: "worktree"`.
+/// The name derives from the caller-picked child session id (sanitized)
+/// or a fresh slug; the parent's filesystem root is the git repository.
+async fn create_child_worktree(
+    deps: &Deps,
+    cfg: &WorkerConfig,
+    parent: &TurnRecord,
+    child_session_id: Option<&str>,
+) -> Result<crate::types::turn::WorktreeRef, ResultData> {
+    let Some(root) = parent.options.filesystem_root().map(str::to_string) else {
+        return Err(is_error(
+            "harness/worktree_requires_fs_root",
+            "worktree isolation requires this turn to have a filesystem root \
+             (metadata.fs_scope.root) inside a git repository — spawn without \
+             isolation, or run in a session with a working directory"
+                .to_string(),
+        ));
+    };
+    let name = match child_session_id {
+        Some(id) => crate::ids::sanitize(id),
+        None => format!("child-{}", &crate::ids::new_session_id()[2..10]),
+    };
+    let grants =
+        crate::filesystem_grants::roots(&deps.iii, &parent.session_id, cfg.session_timeout_ms)
+            .await
+            .unwrap_or_default();
+    let args = crate::filesystem_scope::inject(
+        "coder::worktree-add",
+        json!({ "name": name }),
+        Some(&root),
+        &grants,
+    );
+    let engine = deps.engine().await;
+    match engine.dispatch("coder::worktree-add", args).await {
+        Ok(value) => {
+            let path = value.get("path").and_then(Value::as_str);
+            let branch = value.get("branch").and_then(Value::as_str);
+            match (path, branch) {
+                (Some(path), Some(branch)) => Ok(crate::types::turn::WorktreeRef {
+                    name,
+                    path: path.to_string(),
+                    branch: branch.to_string(),
+                }),
+                _ => Err(is_error(
+                    "harness/worktree_add_failed",
+                    format!("coder::worktree-add returned an unexpected shape: {value}"),
+                )),
+            }
+        }
+        Err(e) => Err(is_error(
+            "harness/worktree_add_failed",
+            format!(
+                "could not create the child's worktree: {} — spawn without \
+                 isolation, or fix the repository state",
+                e.message
+            ),
+        )),
+    }
+}
+
+/// Best-effort worktree removal (orphan cleanup / child completion).
+/// Failures are logged, never surfaced — the worktree is inert on disk.
+pub(crate) async fn remove_child_worktree(
+    deps: &Deps,
+    cfg: &WorkerConfig,
+    parent: &TurnRecord,
+    worktree: &crate::types::turn::WorktreeRef,
+) -> Option<Value> {
+    let root = parent.options.filesystem_root()?.to_string();
+    let grants =
+        crate::filesystem_grants::roots(&deps.iii, &parent.session_id, cfg.session_timeout_ms)
+            .await
+            .unwrap_or_default();
+    let args = crate::filesystem_scope::inject(
+        "coder::worktree-remove",
+        json!({ "name": worktree.name }),
+        Some(&root),
+        &grants,
+    );
+    let engine = deps.engine().await;
+    match engine.dispatch("coder::worktree-remove", args).await {
+        Ok(value) => Some(value),
+        Err(e) => {
+            tracing::warn!(
+                session_id = %parent.session_id,
+                worktree = %worktree.path,
+                error = %e.message,
+                "worktree cleanup failed; directory may remain"
+            );
+            None
+        }
+    }
 }
 
 /// Direct-call entry (a consumer starting a linked child). No parent linkage or
@@ -115,6 +236,19 @@ async fn seed_child(
     req: &SpawnRequest,
     parent: Option<&ParentLink>,
     parent_record: Option<&TurnRecord>,
+) -> Result<ChildIds, HarnessError> {
+    seed_child_with_root(deps, cfg, req, parent, parent_record, None).await
+}
+
+/// [`seed_child`] with an explicit filesystem root for the child (worktree
+/// isolation): the override replaces the inherited parent scope.
+async fn seed_child_with_root(
+    deps: &Deps,
+    cfg: &WorkerConfig,
+    req: &SpawnRequest,
+    parent: Option<&ParentLink>,
+    parent_record: Option<&TurnRecord>,
+    fs_root_override: Option<&str>,
 ) -> Result<ChildIds, HarnessError> {
     let session = deps.session().await;
 
@@ -237,7 +371,10 @@ async fn seed_child(
                 .and_then(|o| o.output.clone())
                 .unwrap_or_default(),
             functions,
-            metadata: inherit_filesystem_scope(parent_record),
+            metadata: match fs_root_override {
+                Some(root) => Some(json!({ FS_SCOPE_KEY: { FS_SCOPE_ROOT_KEY: root } })),
+                None => inherit_filesystem_scope(parent_record),
+            },
             max_validation_retries: cfg.max_validation_retries,
         },
         calls: Default::default(),

--- a/harness/src/trigger.rs
+++ b/harness/src/trigger.rs
@@ -37,6 +37,8 @@ pub struct PendingInfo {
     pub held_by: Option<String>,
     pub child_session_id: Option<String>,
     pub child_turn_id: Option<String>,
+    /// The child's isolated worktree (spawn `isolation: "worktree"`).
+    pub worktree: Option<crate::types::turn::WorktreeRef>,
 }
 
 /// Run the trigger pipeline for one call. `function_id` is the unwrapped

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -482,6 +482,7 @@ pub async fn run_step(
                         held_by: Some(held_by),
                         child_session_id: None,
                         child_turn_id: None,
+                        worktree: None,
                     };
                     checkpoint_pending(&mut record, &call.id, call, &info);
                     crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
@@ -524,6 +525,7 @@ pub async fn run_step(
                     entry_id: None,
                     child_session_id: None,
                     child_turn_id: None,
+                    worktree: None,
                     held_by: None,
                     pending_timeout_ms: None,
                     pending_at: None,
@@ -569,6 +571,7 @@ pub async fn run_step(
                         held_by: Some(held_by),
                         child_session_id: None,
                         child_turn_id: None,
+                        worktree: None,
                     };
                     checkpoint_pending(&mut record, &call.id, call, &info);
                     crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
@@ -904,6 +907,7 @@ fn checkpoint_pending(
             entry_id: None,
             child_session_id: info.child_session_id.clone(),
             child_turn_id: info.child_turn_id.clone(),
+            worktree: info.worktree.clone(),
             held_by: info.held_by.clone(),
             pending_timeout_ms: info.pending_timeout_ms,
             pending_at: Some(AgentMessage::now_ms()),
@@ -923,6 +927,7 @@ fn mark_done(record: &mut TurnRecord, call_id: &str, entry_id: &str) {
             entry_id: Some(entry_id.to_string()),
             child_session_id: None,
             child_turn_id: None,
+            worktree: None,
             held_by: None,
             pending_timeout_ms: None,
             pending_at: None,

--- a/harness/src/types/turn.rs
+++ b/harness/src/types/turn.rs
@@ -137,6 +137,18 @@ pub enum CallState {
     Done,
 }
 
+/// A worktree-isolated child's workspace, recorded on the parent's call
+/// checkpoint so child completion can clean it up and report it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct WorktreeRef {
+    /// The `.worktrees/<name>` entry under the parent's filesystem root.
+    pub name: String,
+    /// Canonical absolute path of the worktree.
+    pub path: String,
+    /// The worktree's branch (`wt/<name>`).
+    pub branch: String,
+}
+
 /// One call's checkpoint on the turn record. `held_by` marks a `pre_trigger`
 /// hook hold; `child_*` marks a `harness::spawn` pending trigger.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -150,6 +162,10 @@ pub struct CallCheckpoint {
     pub child_session_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub child_turn_id: Option<String>,
+    /// Set when the child runs in an isolated git worktree
+    /// (`spawn options.isolation: "worktree"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree: Option<WorktreeRef>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub held_by: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -305,6 +321,7 @@ mod tests {
             entry_id: None,
             child_session_id: child.map(|s| s.to_string()),
             child_turn_id: child.map(|_| "t_child".to_string()),
+            worktree: None,
             held_by: None,
             pending_timeout_ms: None,
             pending_at: None,

--- a/harness/tests/golden/schemas/harness.spawn.json
+++ b/harness/tests/golden/schemas/harness.spawn.json
@@ -373,6 +373,13 @@
         ],
         "type": "string"
       },
+      "Isolation": {
+        "description": "Child workspace isolation modes.",
+        "enum": [
+          "worktree"
+        ],
+        "type": "string"
+      },
       "MessageInput": {
         "anyOf": [
           {
@@ -440,6 +447,17 @@
               }
             ],
             "description": "Intersected with the parent policy — narrow, never escalate."
+          },
+          "isolation": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Isolation"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Workspace isolation for the child. `worktree` gives it its own git worktree (`.worktrees/<name>` on branch `wt/<name>` under the parent's filesystem root) so parallel children never edit the same tree; the parent merges `wt/<name>` when the child finishes. Requires the parent turn to have a filesystem root inside a git repository. Dispatch-path spawns only."
           },
           "max_children": {
             "description": "Fan-out guard for the child's own spawns.",

--- a/shell/src/code/functions/mod.rs
+++ b/shell/src/code/functions/mod.rs
@@ -22,6 +22,7 @@ pub mod read_window;
 pub mod search;
 pub mod tree;
 pub mod update_file;
+pub mod worktree;
 
 use iii_sdk::errors::Error;
 use iii_sdk::{IIIClient, RegisterFunction};
@@ -136,6 +137,21 @@ const APPLY_PATCH_DESC: &str = "Apply a whole patch in the apply_patch (V4A) for
      root (coder::info lists them); for host paths outside the jail use \
      shell::fs::*.";
 
+const WORKTREE_ADD_ID: &str = "coder::worktree-add";
+const WORKTREE_ADD_DESC: &str = "Create an isolated git worktree at .worktrees/<name> under the \
+     effective root, on a new branch wt/<name> from the current HEAD. \
+     Used to give a sub-agent its own working copy so parallel edits \
+     never collide; the effective root must be inside a git work tree. \
+     Returns the worktree's canonical path and branch.";
+
+const WORKTREE_REMOVE_ID: &str = "coder::worktree-remove";
+const WORKTREE_REMOVE_DESC: &str =
+    "Remove the git worktree at .worktrees/<name> under the effective \
+     root. Clean-only: a worktree with uncommitted changes is left in \
+     place and reported dirty. The wt/<name> branch is deleted only \
+     when fully merged — unmerged work survives for the caller to \
+     merge (e.g. git merge wt/<name> via shell::exec).";
+
 const CREATE_FILE_ID: &str = "coder::create-file";
 const CREATE_FILE_DESC: &str = "Create one or more files. Request shape: {\"files\": [{\"path\": \
      \"...\", \"content\": \"...\"}]}. Per-file `overwrite` and `parents` \
@@ -244,6 +260,14 @@ pub fn catalog() -> Vec<FunctionSpec> {
             APPLY_PATCH_ID,
             APPLY_PATCH_DESC,
         ),
+        spec::<worktree::WorktreeAddInput, worktree::WorktreeAddOutput>(
+            WORKTREE_ADD_ID,
+            WORKTREE_ADD_DESC,
+        ),
+        spec::<worktree::WorktreeRemoveInput, worktree::WorktreeRemoveOutput>(
+            WORKTREE_REMOVE_ID,
+            WORKTREE_REMOVE_DESC,
+        ),
         spec::<create_file::CreateFileInput, create_file::CreateFileOutput>(
             CREATE_FILE_ID,
             CREATE_FILE_DESC,
@@ -279,6 +303,10 @@ pub fn register_all(iii: &IIIClient, cells: CodeCells) {
     register_update_file(iii, cells.clone());
     registered += 1;
     register_apply_patch(iii, cells.clone());
+    registered += 1;
+    register_worktree_add(iii, cells.clone());
+    registered += 1;
+    register_worktree_remove(iii, cells.clone());
     registered += 1;
     register_create_file(iii, cells.clone());
     registered += 1;
@@ -417,6 +445,48 @@ fn register_apply_patch(iii: &IIIClient, cells: CodeCells) {
             }
         })
         .description(APPLY_PATCH_DESC),
+    );
+}
+
+fn register_worktree_add(iii: &IIIClient, cells: CodeCells) {
+    iii.register_function(
+        WORKTREE_ADD_ID,
+        RegisterFunction::new_async(move |req: worktree::WorktreeAddInput| {
+            let cells = cells.clone();
+            async move {
+                let resolver = cells.resolver.read().await.clone();
+                let resolver = resolver.session_scoped(
+                    crate::fs::scope_root(req.fs_scope.as_ref()),
+                    crate::fs::scope_grants(req.fs_scope.as_ref()),
+                );
+                let cfg = cells.config.read().await.clone();
+                worktree::handle_add(resolver, cfg, req)
+                    .await
+                    .map_err(Error::from)
+            }
+        })
+        .description(WORKTREE_ADD_DESC),
+    );
+}
+
+fn register_worktree_remove(iii: &IIIClient, cells: CodeCells) {
+    iii.register_function(
+        WORKTREE_REMOVE_ID,
+        RegisterFunction::new_async(move |req: worktree::WorktreeRemoveInput| {
+            let cells = cells.clone();
+            async move {
+                let resolver = cells.resolver.read().await.clone();
+                let resolver = resolver.session_scoped(
+                    crate::fs::scope_root(req.fs_scope.as_ref()),
+                    crate::fs::scope_grants(req.fs_scope.as_ref()),
+                );
+                let cfg = cells.config.read().await.clone();
+                worktree::handle_remove(resolver, cfg, req)
+                    .await
+                    .map_err(Error::from)
+            }
+        })
+        .description(WORKTREE_REMOVE_DESC),
     );
 }
 

--- a/shell/src/code/functions/worktree.rs
+++ b/shell/src/code/functions/worktree.rs
@@ -1,0 +1,234 @@
+//! `coder::worktree-add` / `coder::worktree-remove` — git worktree
+//! lifecycle for isolated sub-agent workspaces. A worktree lives at
+//! `<root>/.worktrees/<name>` on branch `wt/<name>`, where `<root>` is the
+//! call's effective root (the harness-stamped fs_scope root, else the
+//! primary allowed root). Removal is clean-only: a dirty worktree is left
+//! in place and reported, never force-deleted.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::code::config::CoderConfig;
+use crate::code::error::{err_to_string, CoderError};
+use crate::code::path::PathResolver;
+
+/// Wall-clock budget per git invocation (worktree add checks out files).
+const GIT_TIMEOUT: Duration = Duration::from_secs(30);
+/// Directory (under the effective root) that holds the worktrees.
+const WORKTREES_DIR: &str = ".worktrees";
+/// Branch prefix for worktree branches.
+const BRANCH_PREFIX: &str = "wt/";
+
+// examples are wire-contract; goldens pin them.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[schemars(example = "example_worktree_add_input")]
+pub struct WorktreeAddInput {
+    /// Worktree name — letters, digits, `-` and `_` only. The worktree is
+    /// created at `.worktrees/<name>` under the effective root, on a new
+    /// branch `wt/<name>` from the current HEAD.
+    pub name: String,
+    /// Internal harness filesystem scope; omitted from published schema.
+    #[serde(default)]
+    #[schemars(skip)]
+    pub fs_scope: Option<crate::fs::FsScope>,
+}
+
+// examples are wire-contract; goldens pin them.
+fn example_worktree_add_input() -> serde_json::Value {
+    serde_json::json!({ "name": "fix-auth-bug-k4x2" })
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct WorktreeAddOutput {
+    /// Canonical absolute path of the new worktree.
+    pub path: String,
+    /// The branch the worktree is on (`wt/<name>`), from the root's HEAD.
+    pub branch: String,
+}
+
+// examples are wire-contract; goldens pin them.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[schemars(example = "example_worktree_remove_input")]
+pub struct WorktreeRemoveInput {
+    /// Name of the worktree to remove (the `.worktrees/<name>` entry).
+    pub name: String,
+    /// Internal harness filesystem scope; omitted from published schema.
+    #[serde(default)]
+    #[schemars(skip)]
+    pub fs_scope: Option<crate::fs::FsScope>,
+}
+
+// examples are wire-contract; goldens pin them.
+fn example_worktree_remove_input() -> serde_json::Value {
+    serde_json::json!({ "name": "fix-auth-bug-k4x2" })
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct WorktreeRemoveOutput {
+    /// True when the worktree directory was removed.
+    pub removed: bool,
+    /// True when removal was refused because the worktree has uncommitted
+    /// changes — inspect or commit them, the path is untouched.
+    pub dirty: bool,
+    /// Canonical absolute path of the (former) worktree.
+    pub path: String,
+    /// The worktree's branch (`wt/<name>`). Kept when it holds unmerged
+    /// commits; deleted with the worktree only when fully merged.
+    pub branch: String,
+    /// True when `branch` was deleted along with the worktree.
+    pub branch_deleted: bool,
+}
+
+pub async fn handle_add(
+    resolver: Arc<PathResolver>,
+    _cfg: Arc<CoderConfig>,
+    req: WorktreeAddInput,
+) -> Result<WorktreeAddOutput, String> {
+    let root = effective_root(&resolver, req.fs_scope.as_ref());
+    let name = validate_name(&req.name).map_err(|e| err_to_string(e))?;
+    require_git_worktree(&root).await.map_err(err_to_string)?;
+
+    let rel = format!("{WORKTREES_DIR}/{name}");
+    let branch = format!("{BRANCH_PREFIX}{name}");
+    let out = run_git(&root, &["worktree", "add", "-b", &branch, &rel, "HEAD"])
+        .await
+        .map_err(err_to_string)?;
+    if !out.status.success() {
+        return Err(err_to_string(CoderError::BadInput(format!(
+            "git worktree add failed: {} — a worktree or branch named \
+             {name:?} may already exist; pick a different name",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ))));
+    }
+    let path = root.join(&rel);
+    let path = path.canonicalize().unwrap_or(path);
+    Ok(WorktreeAddOutput {
+        path: path.display().to_string(),
+        branch,
+    })
+}
+
+pub async fn handle_remove(
+    resolver: Arc<PathResolver>,
+    _cfg: Arc<CoderConfig>,
+    req: WorktreeRemoveInput,
+) -> Result<WorktreeRemoveOutput, String> {
+    let root = effective_root(&resolver, req.fs_scope.as_ref());
+    let name = validate_name(&req.name).map_err(|e| err_to_string(e))?;
+    require_git_worktree(&root).await.map_err(err_to_string)?;
+
+    let rel = format!("{WORKTREES_DIR}/{name}");
+    let branch = format!("{BRANCH_PREFIX}{name}");
+    let wt_path = root.join(&rel);
+    let wt_display = wt_path
+        .canonicalize()
+        .unwrap_or_else(|_| wt_path.clone())
+        .display()
+        .to_string();
+    if !wt_path.is_dir() {
+        return Err(err_to_string(CoderError::BadInput(format!(
+            "no worktree at {WORKTREES_DIR}/{name} under the effective root"
+        ))));
+    }
+
+    // Clean-only: uncommitted changes keep the worktree in place.
+    let status = run_git(&wt_path, &["status", "--porcelain"])
+        .await
+        .map_err(err_to_string)?;
+    if !status.status.success() {
+        return Err(err_to_string(CoderError::Io(format!(
+            "git status failed in {wt_display}: {}",
+            String::from_utf8_lossy(&status.stderr).trim()
+        ))));
+    }
+    if !status.stdout.is_empty() {
+        return Ok(WorktreeRemoveOutput {
+            removed: false,
+            dirty: true,
+            path: wt_display,
+            branch,
+            branch_deleted: false,
+        });
+    }
+
+    let rm = run_git(&root, &["worktree", "remove", &rel])
+        .await
+        .map_err(err_to_string)?;
+    if !rm.status.success() {
+        return Err(err_to_string(CoderError::Io(format!(
+            "git worktree remove failed: {}",
+            String::from_utf8_lossy(&rm.stderr).trim()
+        ))));
+    }
+    // `-d` only deletes a fully-merged branch — an unmerged branch (the
+    // child's unlanded work) survives for the parent to merge.
+    let branch_deleted = run_git(&root, &["branch", "-d", &branch])
+        .await
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    Ok(WorktreeRemoveOutput {
+        removed: true,
+        dirty: false,
+        path: wt_display,
+        branch,
+        branch_deleted,
+    })
+}
+
+/// The effective root: the harness-stamped fs_scope root when present
+/// (canonicalized + confined by `session_root`), else the primary root.
+fn effective_root(resolver: &PathResolver, scope: Option<&crate::fs::FsScope>) -> PathBuf {
+    crate::fs::scope_root(scope)
+        .and_then(|r| resolver.session_root(r))
+        .unwrap_or_else(|| resolver.base_root().to_path_buf())
+}
+
+fn validate_name(name: &str) -> Result<&str, CoderError> {
+    if name.is_empty()
+        || name.len() > 128
+        || !name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(CoderError::BadInput(format!(
+            "invalid worktree name {name:?} — use only letters, digits, \
+             '-' and '_' (max 128 chars)"
+        )));
+    }
+    Ok(name)
+}
+
+async fn require_git_worktree(root: &Path) -> Result<(), CoderError> {
+    let out = run_git(root, &["rev-parse", "--is-inside-work-tree"]).await?;
+    if !out.status.success() {
+        return Err(CoderError::BadInput(format!(
+            "{} is not inside a git work tree — worktree isolation needs a \
+             git repository",
+            root.display()
+        )));
+    }
+    Ok(())
+}
+
+async fn run_git(cwd: &Path, args: &[&str]) -> Result<std::process::Output, CoderError> {
+    let fut = tokio::process::Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .stdin(std::process::Stdio::null())
+        .output();
+    match tokio::time::timeout(GIT_TIMEOUT, fut).await {
+        Err(_) => Err(CoderError::Io(format!(
+            "git {} timed out after {}s",
+            args.first().unwrap_or(&""),
+            GIT_TIMEOUT.as_secs()
+        ))),
+        Ok(Err(e)) => Err(CoderError::Io(format!("failed to run git: {e}"))),
+        Ok(Ok(out)) => Ok(out),
+    }
+}

--- a/shell/tests/code_golden_schemas.rs
+++ b/shell/tests/code_golden_schemas.rs
@@ -1,4 +1,4 @@
-//! GOLDEN FAMILY A — wire-schema snapshots for all 11 `coder::*` functions
+//! GOLDEN FAMILY A — wire-schema snapshots for all 13 `coder::*` functions
 //! served by the shell worker.
 //!
 //! `shell::code::functions::catalog()` is the single source of truth for
@@ -35,10 +35,10 @@ fn spec_to_pretty_json(spec: &FunctionSpec) -> String {
     pretty
 }
 
-/// The catalog must cover exactly the 11 registered functions, in
+/// The catalog must cover exactly the 13 registered functions, in
 /// registration order (kept in lockstep with `register_all`).
 #[test]
-fn catalog_lists_all_eleven_functions_in_registration_order() {
+fn catalog_lists_all_thirteen_functions_in_registration_order() {
     let ids: Vec<&str> = catalog().iter().map(|s| s.function_id).collect();
     assert_eq!(
         ids,
@@ -49,6 +49,8 @@ fn catalog_lists_all_eleven_functions_in_registration_order() {
             "coder::search",
             "coder::update-file",
             "coder::apply-patch",
+            "coder::worktree-add",
+            "coder::worktree-remove",
             "coder::create-file",
             "coder::delete-file",
             "coder::list-folder",

--- a/shell/tests/code_worktree.rs
+++ b/shell/tests/code_worktree.rs
@@ -1,0 +1,166 @@
+//! Integration coverage for `coder::worktree-add` / `coder::worktree-remove`
+//! — isolated sub-agent workspaces on real git repos.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+use shell::code::config::CoderConfig;
+use shell::code::functions::worktree::{
+    handle_add, handle_remove, WorktreeAddInput, WorktreeRemoveInput,
+};
+use shell::code::path::PathResolver;
+use tempfile::tempdir;
+
+fn make(base: PathBuf) -> (Arc<PathResolver>, Arc<CoderConfig>) {
+    let cfg = Arc::new(CoderConfig {
+        base_paths: vec![base],
+        ..CoderConfig::default()
+    });
+    let r = Arc::new(PathResolver::new(&cfg).unwrap());
+    (r, cfg)
+}
+
+fn git(root: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["-c", "user.email=t@t", "-c", "user.name=t"])
+        .args(args)
+        .status()
+        .expect("git binary available in test env");
+    assert!(status.success(), "git {args:?} failed");
+}
+
+fn seed_repo(root: &Path) {
+    git(root, &["init", "-b", "main"]);
+    std::fs::write(root.join("f.txt"), "base\n").unwrap();
+    git(root, &["add", "."]);
+    git(root, &["commit", "-m", "seed"]);
+}
+
+fn add_input(name: &str) -> WorktreeAddInput {
+    WorktreeAddInput {
+        name: name.into(),
+        fs_scope: None,
+    }
+}
+
+fn remove_input(name: &str) -> WorktreeRemoveInput {
+    WorktreeRemoveInput {
+        name: name.into(),
+        fs_scope: None,
+    }
+}
+
+#[tokio::test]
+async fn add_creates_isolated_worktree_on_branch() {
+    let tmp = tempdir().unwrap();
+    seed_repo(tmp.path());
+    let (r, c) = make(tmp.path().to_path_buf());
+
+    let out = handle_add(r, c, add_input("child-a1b2")).await.unwrap();
+    assert!(out.path.ends_with(".worktrees/child-a1b2"), "{}", out.path);
+    assert_eq!(out.branch, "wt/child-a1b2");
+    let wt = Path::new(&out.path);
+    assert!(wt.join("f.txt").exists(), "worktree has the checkout");
+
+    // Edits in the worktree do not touch the main tree.
+    std::fs::write(wt.join("f.txt"), "changed\n").unwrap();
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("f.txt")).unwrap(),
+        "base\n"
+    );
+}
+
+#[tokio::test]
+async fn remove_clean_worktree_deletes_dir_and_merged_branch() {
+    let tmp = tempdir().unwrap();
+    seed_repo(tmp.path());
+    let (r, c) = make(tmp.path().to_path_buf());
+    let added = handle_add(r.clone(), c.clone(), add_input("done-x1"))
+        .await
+        .unwrap();
+
+    let out = handle_remove(r, c, remove_input("done-x1")).await.unwrap();
+    assert!(out.removed);
+    assert!(!out.dirty);
+    assert!(
+        out.branch_deleted,
+        "no new commits — wt branch is merged and deletable"
+    );
+    assert!(!Path::new(&added.path).exists());
+}
+
+#[tokio::test]
+async fn remove_dirty_worktree_is_refused_and_left_in_place() {
+    let tmp = tempdir().unwrap();
+    seed_repo(tmp.path());
+    let (r, c) = make(tmp.path().to_path_buf());
+    let added = handle_add(r.clone(), c.clone(), add_input("busy-z9"))
+        .await
+        .unwrap();
+    std::fs::write(Path::new(&added.path).join("wip.txt"), "uncommitted\n").unwrap();
+
+    let out = handle_remove(r, c, remove_input("busy-z9")).await.unwrap();
+    assert!(!out.removed);
+    assert!(out.dirty);
+    assert!(Path::new(&added.path).join("wip.txt").exists());
+}
+
+#[tokio::test]
+async fn remove_keeps_unmerged_branch() {
+    let tmp = tempdir().unwrap();
+    seed_repo(tmp.path());
+    let (r, c) = make(tmp.path().to_path_buf());
+    let added = handle_add(r.clone(), c.clone(), add_input("work-q7"))
+        .await
+        .unwrap();
+    let wt = PathBuf::from(&added.path);
+    std::fs::write(wt.join("new.txt"), "child work\n").unwrap();
+    git(&wt, &["add", "."]);
+    git(&wt, &["commit", "-m", "child work"]);
+
+    let out = handle_remove(r, c, remove_input("work-q7")).await.unwrap();
+    assert!(out.removed, "committed (clean) worktree is removable");
+    assert!(
+        !out.branch_deleted,
+        "unmerged branch must survive for the parent to merge"
+    );
+    // The parent can still merge the child's branch.
+    git(tmp.path(), &["merge", "wt/work-q7"]);
+    assert!(tmp.path().join("new.txt").exists());
+}
+
+#[tokio::test]
+async fn add_outside_a_git_repo_is_rejected() {
+    let tmp = tempdir().unwrap();
+    let (r, c) = make(tmp.path().to_path_buf());
+    let err = handle_add(r, c, add_input("nope")).await.unwrap_err();
+    assert!(err.contains("git work tree"), "{err}");
+}
+
+#[tokio::test]
+async fn invalid_names_are_rejected() {
+    let tmp = tempdir().unwrap();
+    seed_repo(tmp.path());
+    let (r, c) = make(tmp.path().to_path_buf());
+    for bad in ["../escape", "a/b", "", "has space"] {
+        let err = handle_add(r.clone(), c.clone(), add_input(bad))
+            .await
+            .unwrap_err();
+        assert!(err.contains("invalid worktree name"), "{bad:?}: {err}");
+    }
+}
+
+#[tokio::test]
+async fn duplicate_name_is_rejected_with_guidance() {
+    let tmp = tempdir().unwrap();
+    seed_repo(tmp.path());
+    let (r, c) = make(tmp.path().to_path_buf());
+    handle_add(r.clone(), c.clone(), add_input("dup-1"))
+        .await
+        .unwrap();
+    let err = handle_add(r, c, add_input("dup-1")).await.unwrap_err();
+    assert!(err.contains("different name"), "{err}");
+}

--- a/shell/tests/golden/schemas/coder.worktree-add.json
+++ b/shell/tests/golden/schemas/coder.worktree-add.json
@@ -1,0 +1,42 @@
+{
+  "description": "Create an isolated git worktree at .worktrees/<name> under the effective root, on a new branch wt/<name> from the current HEAD. Used to give a sub-agent its own working copy so parallel edits never collide; the effective root must be inside a git work tree. Returns the worktree's canonical path and branch.",
+  "function_id": "coder::worktree-add",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "examples": [
+      {
+        "name": "fix-auth-bug-k4x2"
+      }
+    ],
+    "properties": {
+      "name": {
+        "description": "Worktree name — letters, digits, `-` and `_` only. The worktree is created at `.worktrees/<name>` under the effective root, on a new branch `wt/<name>` from the current HEAD.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "name"
+    ],
+    "title": "WorktreeAddInput",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "branch": {
+        "description": "The branch the worktree is on (`wt/<name>`), from the root's HEAD.",
+        "type": "string"
+      },
+      "path": {
+        "description": "Canonical absolute path of the new worktree.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "branch",
+      "path"
+    ],
+    "title": "WorktreeAddOutput",
+    "type": "object"
+  }
+}

--- a/shell/tests/golden/schemas/coder.worktree-remove.json
+++ b/shell/tests/golden/schemas/coder.worktree-remove.json
@@ -1,0 +1,57 @@
+{
+  "description": "Remove the git worktree at .worktrees/<name> under the effective root. Clean-only: a worktree with uncommitted changes is left in place and reported dirty. The wt/<name> branch is deleted only when fully merged — unmerged work survives for the caller to merge (e.g. git merge wt/<name> via shell::exec).",
+  "function_id": "coder::worktree-remove",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "examples": [
+      {
+        "name": "fix-auth-bug-k4x2"
+      }
+    ],
+    "properties": {
+      "name": {
+        "description": "Name of the worktree to remove (the `.worktrees/<name>` entry).",
+        "type": "string"
+      }
+    },
+    "required": [
+      "name"
+    ],
+    "title": "WorktreeRemoveInput",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "branch": {
+        "description": "The worktree's branch (`wt/<name>`). Kept when it holds unmerged commits; deleted with the worktree only when fully merged.",
+        "type": "string"
+      },
+      "branch_deleted": {
+        "description": "True when `branch` was deleted along with the worktree.",
+        "type": "boolean"
+      },
+      "dirty": {
+        "description": "True when removal was refused because the worktree has uncommitted changes — inspect or commit them, the path is untouched.",
+        "type": "boolean"
+      },
+      "path": {
+        "description": "Canonical absolute path of the (former) worktree.",
+        "type": "string"
+      },
+      "removed": {
+        "description": "True when the worktree directory was removed.",
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "branch",
+      "branch_deleted",
+      "dirty",
+      "path",
+      "removed"
+    ],
+    "title": "WorktreeRemoveOutput",
+    "type": "object"
+  }
+}


### PR DESCRIPTION
### feat(shell): coder::worktree-add / coder::worktree-remove

Git worktree lifecycle for isolated sub-agent workspaces: worktree-add
creates .worktrees/<name> on branch wt/<name> from the effective root's
HEAD (fs_scope-aware, name-validated, requires a git work tree);
worktree-remove is clean-only — uncommitted changes keep the worktree
in place and are reported dirty, and the wt/<name> branch is deleted
only when fully merged so unlanded child work survives for the caller
to merge. Catalog grows to 13.

### feat(harness): worktree-isolated spawns + GPT-family code prompt

- spawn options gain isolation: "worktree" (dispatch path): the child
  gets its own git worktree via coder::worktree-add before seeding, its
  fs_scope root points at it, and the worktree rides the parent's call
  checkpoint. On child completion (including sweep-expired children,
  which route through the same deliver path) the harness removes the
  worktree clean-only and appends a disposition note to the parent's
  result: merge wt/<name>, inspect a dirty tree, or nothing to do.
- code mode selects a per-family identity: openai/openai-codex route to
  prompts/code-gpt.txt (apply_patch edit discipline); openai-codex now
  maps to the Gpt prompt family. Both code prompts gain a delegation
  section (spawn + worktree isolation + merge guidance).
- code_mode_policy adds harness::spawn to the native surface.

Refs MOT-3874
