### PR TITLE
(MOT-3874) feat(shell): post-write checks on coder writes

### DIFF
--- a/harness/prompts/code-gpt.txt
+++ b/harness/prompts/code-gpt.txt
@@ -12,6 +12,7 @@ An <environment> block in this prompt describes your workspace: the working dire
 - Read before you edit. Never edit text you have not seen in this session; a file may have changed since you last read it.
 - Edit with coder::apply-patch: pass the complete patch in the apply_patch format you know — `*** Begin Patch`, one hunk per file (`*** Add File: `, `*** Delete File: `, `*** Update File: ` with optional `*** Move to: `), `@@ ` context markers, ` `/`+`/`-` change lines, `*** End Patch`. Copy context lines exactly from the file; a context mismatch fails the whole patch with nothing written — re-read the file and regenerate. One patch can touch several files.
 - Verify each edit from the echoes the call returns instead of re-reading the file.
+- Configured project checks may run automatically after each edit and land in the response's `checks` array — read their output and fix what they flag before moving on.
 - Make minimal diffs that match the file's existing style: naming, indentation, comment density, idioms. Do not reformat code you are not changing.
 - Renames go through an Update File hunk with `*** Move to: `, or coder::move — never delete-and-recreate a file.
 

--- a/harness/prompts/code.txt
+++ b/harness/prompts/code.txt
@@ -12,6 +12,7 @@ An <environment> block in this prompt describes your workspace: the working dire
 - Read before you edit. Never edit text you have not seen in this session; a file may have changed since you last read it.
 - Edit with coder::update-file's str_replace op: copy the exact existing text — including whitespace and indentation — as old_str, and supply the replacement as new_str. old_str must match exactly once; when it is ambiguous, include more surrounding lines, or set replace_all only for intentional bulk replacements. Use insert/update_lines for new blocks, and the regex replace op only for pattern rewrites across many sites.
 - Verify each edit from the echoes the call returns instead of re-reading the file.
+- Configured project checks may run automatically after each edit and land in the response's `checks` array — read their output and fix what they flag before moving on.
 - Make minimal diffs that match the file's existing style: naming, indentation, comment density, idioms. Do not reformat code you are not changing.
 - Renames and moves go through coder::move — never delete-and-recreate a file.
 

--- a/harness/src/subagent.rs
+++ b/harness/src/subagent.rs
@@ -332,8 +332,24 @@ async fn seed_child_with_root(
         None => session.create(None, linkage.as_ref()).await?,
     };
 
-    // The task is the child's opening user message.
-    let task = normalize_message(req.task.clone())?;
+    // The task is the child's opening user message. A worktree-isolated
+    // child gets an explicit commit instruction: its code prompt forbids
+    // commits, but committing to the worktree branch is exactly how its
+    // work reaches the parent (clean-only removal + `git merge wt/<name>`).
+    let mut task = normalize_message(req.task.clone())?;
+    if fs_root_override.is_some() {
+        if let AgentMessage::User(user) = &mut task {
+            user.content.push(ContentBlock::text(
+                "[isolation] You are working in a git worktree dedicated to \
+                 this task, on its own branch. When your work is complete and \
+                 verified, COMMIT it (git add -A && git commit -m \"<what you \
+                 did>\" via shell::exec) — this is the sanctioned exception to \
+                 the no-commit rule: your branch is how the work reaches the \
+                 agent that spawned you, and an uncommitted worktree cannot be \
+                 merged. Do not push.",
+            ));
+        }
+    }
     session
         .append(&child_session_id, &task, None, None, None)
         .await?;

--- a/shell/src/code/checks.rs
+++ b/shell/src/code/checks.rs
@@ -1,0 +1,125 @@
+//! Post-write checks: report-only diagnostics run after coder writes
+//! (`post_write_checks` in `CoderConfig`). Each configured check whose
+//! glob matches a written file runs ONCE per call (deduplicated by
+//! command) with the effective root as cwd; output is bounded and
+//! attached to the write response. A check can fail, time out, or be
+//! unrunnable — none of that fails the edit that triggered it.
+
+use std::path::Path;
+use std::time::Duration;
+
+use schemars::JsonSchema;
+use serde::Serialize;
+
+use crate::code::config::{CoderConfig, PostWriteCheck};
+use crate::code::path::PathResolver;
+
+/// Byte cap on a check's captured output (stdout + stderr merged).
+const CHECK_OUTPUT_MAX_BYTES: usize = 4 * 1024;
+
+/// One executed check's outcome, attached to the write response.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct CheckOutcome {
+    /// The configured command, verbatim.
+    pub command: String,
+    /// Process exit code; absent when the check timed out or failed to
+    /// spawn (see `error`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    /// Merged stdout + stderr, capped at 4 KiB (char-boundary safe).
+    pub output: String,
+    /// True when `output` was capped.
+    pub truncated: bool,
+    /// Timeout / spawn failure note; the edit itself already succeeded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Run every configured check matching one of `written` (canonical
+/// absolute paths of files this call wrote/deleted). Never errors.
+pub async fn run_post_write_checks(
+    cfg: &CoderConfig,
+    resolver: &PathResolver,
+    root: &Path,
+    written: &[String],
+) -> Vec<CheckOutcome> {
+    if cfg.post_write_checks.is_empty() || written.is_empty() {
+        return Vec::new();
+    }
+    let rels: Vec<String> = written
+        .iter()
+        .filter_map(|p| resolver.relative(Path::new(p)))
+        .collect();
+
+    let mut seen_commands: Vec<&str> = Vec::new();
+    let mut outcomes = Vec::new();
+    for check in &cfg.post_write_checks {
+        if seen_commands.contains(&check.command.as_str()) {
+            continue;
+        }
+        if !matches_any(&check.match_glob, &rels) {
+            continue;
+        }
+        seen_commands.push(&check.command);
+        outcomes.push(run_one(check, root).await);
+    }
+    outcomes
+}
+
+fn matches_any(glob: &str, rels: &[String]) -> bool {
+    let Ok(compiled) = globset::Glob::new(glob).map(|g| g.compile_matcher()) else {
+        tracing::warn!(glob = %glob, "ignoring invalid post_write_checks glob");
+        return false;
+    };
+    rels.iter().any(|r| compiled.is_match(r))
+}
+
+async fn run_one(check: &PostWriteCheck, root: &Path) -> CheckOutcome {
+    let fut = tokio::process::Command::new("/bin/sh")
+        .arg("-c")
+        .arg(&check.command)
+        .current_dir(root)
+        .stdin(std::process::Stdio::null())
+        .output();
+    match tokio::time::timeout(Duration::from_millis(check.timeout_ms), fut).await {
+        Err(_) => CheckOutcome {
+            command: check.command.clone(),
+            exit_code: None,
+            output: String::new(),
+            truncated: false,
+            error: Some(format!("check timed out after {}ms", check.timeout_ms)),
+        },
+        Ok(Err(e)) => CheckOutcome {
+            command: check.command.clone(),
+            exit_code: None,
+            output: String::new(),
+            truncated: false,
+            error: Some(format!("check failed to run: {e}")),
+        },
+        Ok(Ok(out)) => {
+            let mut merged = String::from_utf8_lossy(&out.stdout).into_owned();
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            if !stderr.trim().is_empty() {
+                if !merged.is_empty() {
+                    merged.push('\n');
+                }
+                merged.push_str(&stderr);
+            }
+            let truncated = merged.len() > CHECK_OUTPUT_MAX_BYTES;
+            if truncated {
+                let mut end = CHECK_OUTPUT_MAX_BYTES;
+                while !merged.is_char_boundary(end) {
+                    end -= 1;
+                }
+                merged.truncate(end);
+            }
+            CheckOutcome {
+                command: check.command.clone(),
+                exit_code: out.status.code(),
+                output: merged,
+                truncated,
+                error: None,
+            }
+        }
+    }
+}

--- a/shell/src/code/config.rs
+++ b/shell/src/code/config.rs
@@ -123,6 +123,39 @@ pub struct CoderConfig {
     /// `truncated: true` — it degrades, it never errors.
     #[serde(default = "default_search_response_budget_bytes")]
     pub search_response_budget_bytes: u64,
+
+    /// Report-only checks run after successful `coder::update-file` /
+    /// `coder::create-file` / `coder::apply-patch` writes. Each entry
+    /// whose glob matches a written file's root-relative path runs ONCE
+    /// per call (deduplicated by command), with the effective root as
+    /// cwd; the bounded output is attached to the response's `checks`
+    /// array for the caller to read. A failing check NEVER fails the
+    /// edit. Commands are operator-configured (this configuration entry,
+    /// not workspace files — a hostile repo must not choose them) and
+    /// should be read-only checks (lint/typecheck/test), not mutating
+    /// formatters: they run after the response echoes are built. Default
+    /// empty (no checks).
+    #[serde(default)]
+    pub post_write_checks: Vec<PostWriteCheck>,
+}
+
+/// One post-write check rule (see `post_write_checks`).
+#[derive(Debug, Clone, PartialEq, serde::Serialize, Deserialize, JsonSchema)]
+pub struct PostWriteCheck {
+    /// Glob matched against the written file's root-relative path
+    /// (same convention as `default_exclude_globs`), e.g. `**/*.py`.
+    pub match_glob: String,
+    /// Command run via `/bin/sh -c` with the effective root as cwd,
+    /// e.g. `python3 -m py_compile $(git ls-files '*.py')` or
+    /// `cargo check --quiet`.
+    pub command: String,
+    /// Wall-clock cap in milliseconds. Default 30000.
+    #[serde(default = "default_check_timeout_ms")]
+    pub timeout_ms: u64,
+}
+
+fn default_check_timeout_ms() -> u64 {
+    30_000
 }
 
 fn default_default_exclude_globs() -> Vec<String> {
@@ -214,6 +247,7 @@ impl Default for CoderConfig {
             batch_read_budget_bytes: default_batch_read_budget_bytes(),
             max_output_bytes: default_max_output_bytes(),
             search_response_budget_bytes: default_search_response_budget_bytes(),
+            post_write_checks: Vec::new(),
         }
     }
 }

--- a/shell/src/code/functions/apply_patch.rs
+++ b/shell/src/code/functions/apply_patch.rs
@@ -50,6 +50,12 @@ pub struct ApplyPatchOutput {
     /// One entry per file hunk, in patch order. The whole patch applied —
     /// a failure anywhere returns an error with nothing written.
     pub results: Vec<PatchFileResult>,
+    /// Post-write check outcomes (configured `post_write_checks` whose
+    /// glob matched an affected file; each command runs once per call).
+    /// Read them — a failing check means the patch landed but broke
+    /// something. Empty when no checks are configured or matched.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub checks: Vec<crate::code::checks::CheckOutcome>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -98,11 +104,18 @@ pub async fn handle(
     req: ApplyPatchInput,
 ) -> Result<ApplyPatchOutput, String> {
     let scope_root = crate::fs::scope_root(req.fs_scope.as_ref()).map(str::to_string);
-    tokio::task::spawn_blocking(move || {
-        inner(&resolver, &cfg, scope_root.as_deref(), &req.patch).map_err(err_to_string)
+    let blocking_resolver = resolver.clone();
+    let blocking_cfg = cfg.clone();
+    let sr = scope_root.clone();
+    let mut out = tokio::task::spawn_blocking(move || {
+        inner(&blocking_resolver, &blocking_cfg, sr.as_deref(), &req.patch).map_err(err_to_string)
     })
     .await
-    .map_err(|e| format!("apply-patch task join failed: {e}"))?
+    .map_err(|e| format!("apply-patch task join failed: {e}"))??;
+    let written: Vec<String> = out.results.iter().map(|r| r.path.clone()).collect();
+    let root = resolver.effective_root(scope_root.as_deref());
+    out.checks = crate::code::checks::run_post_write_checks(&cfg, &resolver, &root, &written).await;
+    Ok(out)
 }
 
 fn inner(
@@ -243,7 +256,10 @@ fn inner(
             }
         }
     }
-    Ok(ApplyPatchOutput { results })
+    Ok(ApplyPatchOutput {
+        results,
+        checks: Vec::new(),
+    })
 }
 
 fn check_write_size(cfg: &CoderConfig, wire: &str, len: usize) -> Result<(), CoderError> {

--- a/shell/src/code/functions/context.rs
+++ b/shell/src/code/functions/context.rs
@@ -97,15 +97,8 @@ pub async fn handle(
     _cfg: Arc<CoderConfig>,
     req: ContextInput,
 ) -> Result<ContextOutput, String> {
-    // The effective root is the call's fs_scope root when the harness
-    // stamped one (the turn's working directory) — the configured primary
-    // only when the call is unscoped. session_root canonicalizes and
-    // confines it to the allowed roots, exactly like resolve_in.
     let scope_root = crate::fs::scope_root(req.fs_scope.as_ref()).map(str::to_string);
-    let primary = scope_root
-        .as_deref()
-        .and_then(|r| resolver.session_root(r))
-        .unwrap_or_else(|| resolver.base_root().to_path_buf());
+    let primary = resolver.effective_root(scope_root.as_deref());
     let git = git_context(&primary).await;
     let resolver_for_files = resolver.clone();
     let files_scope = scope_root.clone();

--- a/shell/src/code/functions/create_file.rs
+++ b/shell/src/code/functions/create_file.rs
@@ -71,6 +71,12 @@ fn example_create_file_input() -> serde_json::Value {
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct CreateFileOutput {
     pub results: Vec<CreateFileResult>,
+    /// Post-write check outcomes (configured `post_write_checks` whose
+    /// glob matched a successfully created file; each command runs once
+    /// per call). Read them — a failing check means the file landed but
+    /// broke something. Empty when no checks are configured or matched.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub checks: Vec<crate::code::checks::CheckOutcome>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -107,11 +113,18 @@ pub async fn handle(
             Err(e) => entries.push((spec, Err(e))),
         }
     }
-    let results = entries
+    let results: Vec<CreateFileResult> = entries
         .into_iter()
         .map(|(spec, resolved)| create_one(&cfg, spec, resolved))
         .collect();
-    Ok(CreateFileOutput { results })
+    let written: Vec<String> = results
+        .iter()
+        .filter(|r| r.success)
+        .map(|r| r.path.clone())
+        .collect();
+    let root = resolver.effective_root(scope_root);
+    let checks = crate::code::checks::run_post_write_checks(&cfg, &resolver, &root, &written).await;
+    Ok(CreateFileOutput { results, checks })
 }
 
 fn create_one(

--- a/shell/src/code/functions/info.rs
+++ b/shell/src/code/functions/info.rs
@@ -219,6 +219,7 @@ mod tests {
             search_response_budget_bytes: 29,
             batch_read_budget_bytes: 23,
             max_output_bytes: 31,
+            post_write_checks: Vec::new(),
         });
         let resolver = Arc::new(PathResolver::new(&cfg).unwrap());
 

--- a/shell/src/code/functions/update_file.rs
+++ b/shell/src/code/functions/update_file.rs
@@ -184,6 +184,12 @@ pub struct OpEcho {
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct UpdateFileOutput {
     pub results: Vec<UpdateFileResult>,
+    /// Post-write check outcomes (configured `post_write_checks` whose
+    /// glob matched a successfully written file; each command runs once
+    /// per call). Read them — a failing check means the edit landed but
+    /// broke something. Empty when no checks are configured or matched.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub checks: Vec<crate::code::checks::CheckOutcome>,
 }
 
 /// Maximum lines echoed per op before elision kicks in (first 8 + last 8).
@@ -246,11 +252,18 @@ pub async fn handle(
             Err(e) => entries.push((spec, Err(e))),
         }
     }
-    let results = entries
+    let results: Vec<UpdateFileResult> = entries
         .into_iter()
         .map(|(spec, resolved)| update_one(&cfg, spec, resolved))
         .collect();
-    Ok(UpdateFileOutput { results })
+    let written: Vec<String> = results
+        .iter()
+        .filter(|r| r.success)
+        .map(|r| r.path.clone())
+        .collect();
+    let root = resolver.effective_root(scope_root);
+    let checks = crate::code::checks::run_post_write_checks(&cfg, &resolver, &root, &written).await;
+    Ok(UpdateFileOutput { results, checks })
 }
 
 fn update_one(

--- a/shell/src/code/functions/worktree.rs
+++ b/shell/src/code/functions/worktree.rs
@@ -89,7 +89,7 @@ pub async fn handle_add(
     req: WorktreeAddInput,
 ) -> Result<WorktreeAddOutput, String> {
     let root = resolver.effective_root(crate::fs::scope_root(req.fs_scope.as_ref()));
-    let name = validate_name(&req.name).map_err(|e| err_to_string(e))?;
+    let name = validate_name(&req.name).map_err(err_to_string)?;
     require_git_worktree(&root).await.map_err(err_to_string)?;
 
     let rel = format!("{WORKTREES_DIR}/{name}");
@@ -118,7 +118,7 @@ pub async fn handle_remove(
     req: WorktreeRemoveInput,
 ) -> Result<WorktreeRemoveOutput, String> {
     let root = resolver.effective_root(crate::fs::scope_root(req.fs_scope.as_ref()));
-    let name = validate_name(&req.name).map_err(|e| err_to_string(e))?;
+    let name = validate_name(&req.name).map_err(err_to_string)?;
     require_git_worktree(&root).await.map_err(err_to_string)?;
 
     let rel = format!("{WORKTREES_DIR}/{name}");

--- a/shell/src/code/functions/worktree.rs
+++ b/shell/src/code/functions/worktree.rs
@@ -5,7 +5,7 @@
 //! primary allowed root). Removal is clean-only: a dirty worktree is left
 //! in place and reported, never force-deleted.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -88,7 +88,7 @@ pub async fn handle_add(
     _cfg: Arc<CoderConfig>,
     req: WorktreeAddInput,
 ) -> Result<WorktreeAddOutput, String> {
-    let root = effective_root(&resolver, req.fs_scope.as_ref());
+    let root = resolver.effective_root(crate::fs::scope_root(req.fs_scope.as_ref()));
     let name = validate_name(&req.name).map_err(|e| err_to_string(e))?;
     require_git_worktree(&root).await.map_err(err_to_string)?;
 
@@ -117,7 +117,7 @@ pub async fn handle_remove(
     _cfg: Arc<CoderConfig>,
     req: WorktreeRemoveInput,
 ) -> Result<WorktreeRemoveOutput, String> {
-    let root = effective_root(&resolver, req.fs_scope.as_ref());
+    let root = resolver.effective_root(crate::fs::scope_root(req.fs_scope.as_ref()));
     let name = validate_name(&req.name).map_err(|e| err_to_string(e))?;
     require_git_worktree(&root).await.map_err(err_to_string)?;
 
@@ -178,14 +178,6 @@ pub async fn handle_remove(
         branch,
         branch_deleted,
     })
-}
-
-/// The effective root: the harness-stamped fs_scope root when present
-/// (canonicalized + confined by `session_root`), else the primary root.
-fn effective_root(resolver: &PathResolver, scope: Option<&crate::fs::FsScope>) -> PathBuf {
-    crate::fs::scope_root(scope)
-        .and_then(|r| resolver.session_root(r))
-        .unwrap_or_else(|| resolver.base_root().to_path_buf())
 }
 
 fn validate_name(name: &str) -> Result<&str, CoderError> {

--- a/shell/src/code/mod.rs
+++ b/shell/src/code/mod.rs
@@ -14,6 +14,7 @@
 //! offloaded via `spawn_blocking` so a large traversal cannot stall the shared
 //! tokio runtime that also dispatches `shell::exec`/jobs/config-reload.
 
+pub mod checks;
 pub mod config;
 pub mod error;
 pub mod functions;

--- a/shell/src/code/path.rs
+++ b/shell/src/code/path.rs
@@ -139,6 +139,16 @@ impl PathResolver {
         &self.roots_canon[0]
     }
 
+    /// The effective root for a call: the harness-stamped `scope_root`
+    /// (canonicalized + confined via [`Self::session_root`]) when present,
+    /// else the primary root. The shared convention for every call that
+    /// operates "at the workspace root" (context, worktrees, checks).
+    pub fn effective_root(&self, scope_root: Option<&str>) -> PathBuf {
+        scope_root
+            .and_then(|r| self.session_root(r))
+            .unwrap_or_else(|| self.base_root().to_path_buf())
+    }
+
     /// All canonical allowed roots, in configuration order.
     pub fn roots(&self) -> &[PathBuf] {
         &self.roots_canon

--- a/shell/tests/code_post_write_checks.rs
+++ b/shell/tests/code_post_write_checks.rs
@@ -1,0 +1,143 @@
+//! Integration coverage for `post_write_checks` — report-only diagnostics
+//! attached to coder write responses.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use shell::code::config::{CoderConfig, PostWriteCheck};
+use shell::code::functions::update_file::{
+    handle as update_handle, UpdateFileInput, UpdateFileSpec, UpdateOp,
+};
+use shell::code::path::PathResolver;
+use tempfile::tempdir;
+
+fn make_with_checks(
+    base: PathBuf,
+    checks: Vec<PostWriteCheck>,
+) -> (Arc<PathResolver>, Arc<CoderConfig>) {
+    let cfg = Arc::new(CoderConfig {
+        base_paths: vec![base],
+        post_write_checks: checks,
+        ..CoderConfig::default()
+    });
+    let r = Arc::new(PathResolver::new(&cfg).unwrap());
+    (r, cfg)
+}
+
+fn check(glob: &str, command: &str) -> PostWriteCheck {
+    PostWriteCheck {
+        match_glob: glob.into(),
+        command: command.into(),
+        timeout_ms: 10_000,
+    }
+}
+
+fn str_replace_input(path: &str, old: &str, new: &str) -> UpdateFileInput {
+    UpdateFileInput {
+        files: vec![UpdateFileSpec {
+            path: path.into(),
+            ops: vec![UpdateOp::StrReplace {
+                old_str: old.into(),
+                new_str: new.into(),
+                replace_all: false,
+            }],
+        }],
+        fs_scope: None,
+    }
+}
+
+#[tokio::test]
+async fn matching_check_runs_and_reports_failure_without_failing_the_edit() {
+    let tmp = tempdir().unwrap();
+    std::fs::write(tmp.path().join("app.py"), "x = (1\n").unwrap();
+    let (r, c) = make_with_checks(
+        tmp.path().to_path_buf(),
+        vec![check("**/*.py", "python3 -m py_compile app.py")],
+    );
+
+    // The edit keeps the file syntactically broken — the check must flag
+    // it while the edit itself still succeeds.
+    let out = update_handle(r, c, str_replace_input("app.py", "x = (1", "y = (2"))
+        .await
+        .unwrap();
+    assert!(out.results[0].success, "edit succeeds regardless of checks");
+    assert_eq!(out.checks.len(), 1);
+    let outcome = &out.checks[0];
+    assert_ne!(outcome.exit_code, Some(0), "py_compile must fail");
+    assert!(
+        outcome.output.contains("SyntaxError") || !outcome.output.is_empty(),
+        "check output is surfaced: {outcome:?}"
+    );
+}
+
+#[tokio::test]
+async fn non_matching_glob_runs_nothing() {
+    let tmp = tempdir().unwrap();
+    std::fs::write(tmp.path().join("notes.txt"), "hello\n").unwrap();
+    let (r, c) = make_with_checks(
+        tmp.path().to_path_buf(),
+        vec![check("**/*.py", "echo should-not-run")],
+    );
+    let out = update_handle(r, c, str_replace_input("notes.txt", "hello", "hi"))
+        .await
+        .unwrap();
+    assert!(out.results[0].success);
+    assert!(out.checks.is_empty());
+}
+
+#[tokio::test]
+async fn duplicate_commands_run_once_and_output_is_bounded() {
+    let tmp = tempdir().unwrap();
+    std::fs::write(tmp.path().join("a.py"), "a = 1\n").unwrap();
+    let (r, c) = make_with_checks(
+        tmp.path().to_path_buf(),
+        vec![
+            // Same command via two globs — must run once.
+            check("**/*.py", "yes x | head -c 10000"),
+            check("a.*", "yes x | head -c 10000"),
+        ],
+    );
+    let out = update_handle(r, c, str_replace_input("a.py", "a = 1", "a = 2"))
+        .await
+        .unwrap();
+    assert_eq!(out.checks.len(), 1, "deduplicated by command");
+    assert!(out.checks[0].truncated);
+    assert!(out.checks[0].output.len() <= 4 * 1024);
+}
+
+#[tokio::test]
+async fn failed_file_does_not_trigger_checks() {
+    let tmp = tempdir().unwrap();
+    std::fs::write(tmp.path().join("a.py"), "a = 1\n").unwrap();
+    let (r, c) = make_with_checks(tmp.path().to_path_buf(), vec![check("**/*.py", "echo ran")]);
+    // Ambiguity failure: nothing written, so no check runs.
+    let out = update_handle(r, c, str_replace_input("a.py", "does-not-exist", "x"))
+        .await
+        .unwrap();
+    assert!(!out.results[0].success);
+    assert!(out.checks.is_empty());
+}
+
+#[tokio::test]
+async fn timeout_is_reported_not_fatal() {
+    let tmp = tempdir().unwrap();
+    std::fs::write(tmp.path().join("a.py"), "a = 1\n").unwrap();
+    let (r, c) = make_with_checks(
+        tmp.path().to_path_buf(),
+        vec![PostWriteCheck {
+            match_glob: "**/*.py".into(),
+            command: "sleep 5".into(),
+            timeout_ms: 200,
+        }],
+    );
+    let out = update_handle(r, c, str_replace_input("a.py", "a = 1", "a = 3"))
+        .await
+        .unwrap();
+    assert!(out.results[0].success);
+    assert_eq!(out.checks.len(), 1);
+    assert!(out.checks[0]
+        .error
+        .as_deref()
+        .unwrap()
+        .contains("timed out"));
+}

--- a/shell/tests/golden/schemas/coder.apply-patch.json
+++ b/shell/tests/golden/schemas/coder.apply-patch.json
@@ -23,6 +23,44 @@
   "response_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
+      "CheckOutcome": {
+        "description": "One executed check's outcome, attached to the write response.",
+        "properties": {
+          "command": {
+            "description": "The configured command, verbatim.",
+            "type": "string"
+          },
+          "error": {
+            "description": "Timeout / spawn failure note; the edit itself already succeeded.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "exit_code": {
+            "description": "Process exit code; absent when the check timed out or failed to spawn (see `error`).",
+            "format": "int32",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "output": {
+            "description": "Merged stdout + stderr, capped at 4 KiB (char-boundary safe).",
+            "type": "string"
+          },
+          "truncated": {
+            "description": "True when `output` was capped.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "command",
+          "output",
+          "truncated"
+        ],
+        "type": "object"
+      },
       "PatchEcho": {
         "properties": {
           "from_line": {
@@ -83,6 +121,13 @@
       }
     },
     "properties": {
+      "checks": {
+        "description": "Post-write check outcomes (configured `post_write_checks` whose glob matched an affected file; each command runs once per call). Read them — a failing check means the patch landed but broke something. Empty when no checks are configured or matched.",
+        "items": {
+          "$ref": "#/definitions/CheckOutcome"
+        },
+        "type": "array"
+      },
       "results": {
         "description": "One entry per file hunk, in patch order. The whole patch applied — a failure anywhere returns an error with nothing written.",
         "items": {

--- a/shell/tests/golden/schemas/coder.create-file.json
+++ b/shell/tests/golden/schemas/coder.create-file.json
@@ -69,6 +69,44 @@
   "response_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
+      "CheckOutcome": {
+        "description": "One executed check's outcome, attached to the write response.",
+        "properties": {
+          "command": {
+            "description": "The configured command, verbatim.",
+            "type": "string"
+          },
+          "error": {
+            "description": "Timeout / spawn failure note; the edit itself already succeeded.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "exit_code": {
+            "description": "Process exit code; absent when the check timed out or failed to spawn (see `error`).",
+            "format": "int32",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "output": {
+            "description": "Merged stdout + stderr, capped at 4 KiB (char-boundary safe).",
+            "type": "string"
+          },
+          "truncated": {
+            "description": "True when `output` was capped.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "command",
+          "output",
+          "truncated"
+        ],
+        "type": "object"
+      },
       "CreateFileResult": {
         "properties": {
           "bytes_written": {
@@ -122,6 +160,13 @@
       }
     },
     "properties": {
+      "checks": {
+        "description": "Post-write check outcomes (configured `post_write_checks` whose glob matched a successfully created file; each command runs once per call). Read them — a failing check means the file landed but broke something. Empty when no checks are configured or matched.",
+        "items": {
+          "$ref": "#/definitions/CheckOutcome"
+        },
+        "type": "array"
+      },
       "results": {
         "items": {
           "$ref": "#/definitions/CreateFileResult"

--- a/shell/tests/golden/schemas/coder.update-file.json
+++ b/shell/tests/golden/schemas/coder.update-file.json
@@ -235,6 +235,44 @@
   "response_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
+      "CheckOutcome": {
+        "description": "One executed check's outcome, attached to the write response.",
+        "properties": {
+          "command": {
+            "description": "The configured command, verbatim.",
+            "type": "string"
+          },
+          "error": {
+            "description": "Timeout / spawn failure note; the edit itself already succeeded.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "exit_code": {
+            "description": "Process exit code; absent when the check timed out or failed to spawn (see `error`).",
+            "format": "int32",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "output": {
+            "description": "Merged stdout + stderr, capped at 4 KiB (char-boundary safe).",
+            "type": "string"
+          },
+          "truncated": {
+            "description": "True when `output` was capped.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "command",
+          "output",
+          "truncated"
+        ],
+        "type": "object"
+      },
       "OpEcho": {
         "description": "Post-apply snapshot of the region affected by one op. Line ops echo the affected region with ±2 context lines; regex `replace` ops emit one echo per match site (up to 5, no context): the FIRST and LAST line of the post-replace region, with `elided` set to the inner line count when the region spans more than 2 lines (single-line replacements echo just that line). Each site carries `total_replacements`. Provides just enough context to verify the edit landed in the right place without flooding the LLM context with the full file body.",
         "properties": {
@@ -357,6 +395,13 @@
       }
     },
     "properties": {
+      "checks": {
+        "description": "Post-write check outcomes (configured `post_write_checks` whose glob matched a successfully written file; each command runs once per call). Read them — a failing check means the edit landed but broke something. Empty when no checks are configured or matched.",
+        "items": {
+          "$ref": "#/definitions/CheckOutcome"
+        },
+        "type": "array"
+      },
       "results": {
         "items": {
           "$ref": "#/definitions/UpdateFileResult"


### PR DESCRIPTION
### feat(shell): post_write_checks — report-only diagnostics after coder writes

CoderConfig gains post_write_checks ({match_glob, command, timeout_ms},
default empty, hot-reloads like every coder knob): after a successful
coder::update-file / create-file / apply-patch write, each configured
check whose glob matches a written file's root-relative path runs ONCE
per call (deduplicated by command) via /bin/sh -c with the effective
root as cwd, and its bounded (4 KiB) output lands in the response's
top-level checks array. A failing, timing-out, or unrunnable check
never fails the edit — it is feedback for the caller to act on.
Config-sourced on purpose: workspace files must not choose commands.

Also promotes the fs_scope effective-root convention into
PathResolver::effective_root (context/worktree/checks now share it),
and both harness code prompts tell the model to read the checks array.

### chore(shell): clippy — redundant closures in worktree handlers

### fix(harness): worktree-isolated children are told to commit their work

The code prompt's no-commit rule left isolated children's worktrees
dirty, so clean-only removal kept them and the parent had nothing on
wt/<name> to merge. A worktree spawn now appends an explicit commit
instruction to the child's task — the sanctioned exception that makes
the branch the handoff artifact.

Fixes MOT-3874
