### PR TITLE
(MOT-3875) feat(shell): write journal + coder::undo / coder::checkpoints

### DIFF
--- a/harness/src/deferred.rs
+++ b/harness/src/deferred.rs
@@ -134,6 +134,7 @@ pub async fn resolve(
                 arguments,
                 filesystem_root.as_deref(),
                 &trusted_roots,
+                Some((&record.session_id, &record.turn_id)),
             );
             if let Some(cp) = record.calls.get_mut(&req.function_call_id) {
                 cp.state = CallState::Triggered;

--- a/harness/src/filesystem_scope.rs
+++ b/harness/src/filesystem_scope.rs
@@ -18,7 +18,15 @@ fn is_scoped_function(function_id: &str) -> bool {
 }
 
 /// Stamp the trusted filesystem scope onto a scoped call's arguments.
-pub fn inject(function_id: &str, args: Value, root: Option<&str>, grants: &[String]) -> Value {
+/// `origin` carries the issuing (session_id, turn_id) so the shell's write
+/// journal can attribute mutations and support undo-by-turn.
+pub fn inject(
+    function_id: &str,
+    args: Value,
+    root: Option<&str>,
+    grants: &[String],
+    origin: Option<(&str, &str)>,
+) -> Value {
     if !is_scoped_function(function_id) {
         return args;
     }
@@ -27,13 +35,15 @@ pub fn inject(function_id: &str, args: Value, root: Option<&str>, grants: &[Stri
     };
 
     if let Some(root) = root {
-        map.insert(
-            FS_SCOPE_FIELD.to_string(),
-            json!({
-                "root": root,
-                "grants": grants,
-            }),
-        );
+        let mut scope = json!({
+            "root": root,
+            "grants": grants,
+        });
+        if let Some((session_id, turn_id)) = origin {
+            scope["session_id"] = json!(session_id);
+            scope["turn_id"] = json!(turn_id);
+        }
+        map.insert(FS_SCOPE_FIELD.to_string(), scope);
     } else {
         map.remove(FS_SCOPE_FIELD);
     }
@@ -53,6 +63,7 @@ mod tests {
             json!({ "command": "ls" }),
             Some("/work/session-7"),
             &[],
+            None,
         );
         assert_eq!(
             out,
@@ -67,6 +78,7 @@ mod tests {
             json!({ "path": "src/main.rs" }),
             Some("/work/session-7"),
             &[],
+            None,
         );
         assert_eq!(
             out,
@@ -81,6 +93,7 @@ mod tests {
             json!({ "command": "ls", "fs_scope": { "root": "/etc", "grants": ["/model"] } }),
             Some("/work/session-7"),
             &[],
+            None,
         );
         assert_eq!(
             out,
@@ -96,6 +109,7 @@ mod tests {
             json!({ "command": "ls", "fs_scope": { "root": "/etc", "grants": ["/model"] } }),
             Some("/work/session-7"),
             &grants,
+            None,
         );
         assert_eq!(
             out,
@@ -106,7 +120,7 @@ mod tests {
     #[test]
     fn strips_caller_supplied_fs_scope_when_root_absent() {
         let args = json!({ "command": "ls", "fs_scope": { "root": "/etc", "grants": ["/model"] } });
-        let out = inject("shell::exec", args, None, &[]);
+        let out = inject("shell::exec", args, None, &[], None);
         assert_eq!(out, json!({ "command": "ls" }));
     }
 
@@ -118,6 +132,7 @@ mod tests {
             args.clone(),
             Some("/work/session-7"),
             &["/approved".to_string()],
+            None,
         );
         assert_eq!(out, args);
     }
@@ -130,6 +145,7 @@ mod tests {
             args.clone(),
             Some("/work/session-7"),
             &["/approved".to_string()],
+            None,
         );
         assert_eq!(out, args);
     }
@@ -137,7 +153,13 @@ mod tests {
     #[test]
     fn passthrough_when_args_not_an_object() {
         let args = json!(["ls", "-la"]);
-        let out = inject("shell::exec", args.clone(), Some("/work/session-7"), &[]);
+        let out = inject(
+            "shell::exec",
+            args.clone(),
+            Some("/work/session-7"),
+            &[],
+            None,
+        );
         assert_eq!(out, args);
 
         let scalar = json!("raw");
@@ -146,6 +168,7 @@ mod tests {
             scalar.clone(),
             Some("/work/session-7"),
             &[],
+            None,
         );
         assert_eq!(out, scalar);
     }

--- a/harness/src/functions/function_trigger.rs
+++ b/harness/src/functions/function_trigger.rs
@@ -106,11 +106,15 @@ pub async fn handle(
         .as_ref()
         .and_then(|rec| rec.options.filesystem_root())
         .map(str::to_string);
+    let origin = record
+        .as_ref()
+        .map(|rec| (rec.session_id.clone(), rec.turn_id.clone()));
     let mut arguments = crate::filesystem_scope::inject(
         &req.call.function_id,
         req.call.arguments.clone(),
         filesystem_root.as_deref(),
         &session_grants,
+        origin.as_ref().map(|(s, t)| (s.as_str(), t.as_str())),
     );
     if let Some(rec) = &record {
         match deps
@@ -130,6 +134,7 @@ pub async fn handle(
                     a,
                     filesystem_root.as_deref(),
                     &session_grants,
+                    origin.as_ref().map(|(s, t)| (s.as_str(), t.as_str())),
                 );
             }
             PreTriggerOutcome::Deny(reason) => {
@@ -163,6 +168,7 @@ pub async fn handle(
         arguments,
         filesystem_root.as_deref(),
         &session_grants,
+        origin.as_ref().map(|(s, t)| (s.as_str(), t.as_str())),
     );
 
     // Single invocation chokepoint: subscription control calls are intercepted

--- a/harness/src/subagent.rs
+++ b/harness/src/subagent.rs
@@ -153,6 +153,7 @@ async fn create_child_worktree(
         json!({ "name": name }),
         Some(&root),
         &grants,
+        Some((&parent.session_id, &parent.turn_id)),
     );
     let engine = deps.engine().await;
     match engine.dispatch("coder::worktree-add", args).await {
@@ -200,6 +201,7 @@ pub(crate) async fn remove_child_worktree(
         json!({ "name": worktree.name }),
         Some(&root),
         &grants,
+        Some((&parent.session_id, &parent.turn_id)),
     );
     let engine = deps.engine().await;
     match engine.dispatch("coder::worktree-remove", args).await {

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -432,6 +432,7 @@ pub async fn run_step(
                 call.arguments.clone(),
                 filesystem_root.as_deref(),
                 &session_grants,
+                Some((&record.session_id, &record.turn_id)),
             );
             let (eff_args, pre_ann) = match deps
                 .hooks
@@ -453,6 +454,7 @@ pub async fn run_step(
                         arguments,
                         filesystem_root.as_deref(),
                         &session_grants,
+                        Some((&record.session_id, &record.turn_id)),
                     );
                     (arguments, annotations)
                 }
@@ -1068,6 +1070,7 @@ async fn fetch_env_context(
         json!({}),
         record.options.filesystem_root(),
         &grants,
+        Some((&record.session_id, &record.turn_id)),
     );
     let engine = deps.engine().await;
     match engine.dispatch("coder::context", args).await {

--- a/shell/src/code/config.rs
+++ b/shell/src/code/config.rs
@@ -124,6 +124,13 @@ pub struct CoderConfig {
     #[serde(default = "default_search_response_budget_bytes")]
     pub search_response_budget_bytes: u64,
 
+    /// Write-journal settings for `coder::undo` / `coder::checkpoints`:
+    /// every mutating coder call records bounded before-images keyed by
+    /// the effective root, enabling per-step and per-turn revert. Set
+    /// `max_records: 0` to disable journaling entirely.
+    #[serde(default)]
+    pub journal: JournalConfig,
+
     /// Report-only checks run after successful `coder::update-file` /
     /// `coder::create-file` / `coder::apply-patch` writes. Each entry
     /// whose glob matches a written file's root-relative path runs ONCE
@@ -137,6 +144,43 @@ pub struct CoderConfig {
     /// empty (no checks).
     #[serde(default)]
     pub post_write_checks: Vec<PostWriteCheck>,
+}
+
+/// Write-journal knobs (see `journal`).
+#[derive(Debug, Clone, PartialEq, serde::Serialize, Deserialize, JsonSchema)]
+pub struct JournalConfig {
+    /// Journal directory (per-root subdirectories are created inside it).
+    /// Relative paths resolve against the worker's working directory.
+    #[serde(default = "default_journal_dir")]
+    pub dir: String,
+    /// Total on-disk budget per root before oldest-first eviction.
+    /// Default 64 MiB.
+    #[serde(default = "default_journal_max_bytes")]
+    pub max_bytes: u64,
+    /// Record-count budget per root before oldest-first eviction.
+    /// Default 500; 0 disables journaling.
+    #[serde(default = "default_journal_max_records")]
+    pub max_records: u32,
+}
+
+impl Default for JournalConfig {
+    fn default() -> Self {
+        Self {
+            dir: default_journal_dir(),
+            max_bytes: default_journal_max_bytes(),
+            max_records: default_journal_max_records(),
+        }
+    }
+}
+
+fn default_journal_dir() -> String {
+    "./data/coder-journal".to_string()
+}
+fn default_journal_max_bytes() -> u64 {
+    64 * 1024 * 1024
+}
+fn default_journal_max_records() -> u32 {
+    500
 }
 
 /// One post-write check rule (see `post_write_checks`).
@@ -248,6 +292,7 @@ impl Default for CoderConfig {
             max_output_bytes: default_max_output_bytes(),
             search_response_budget_bytes: default_search_response_budget_bytes(),
             post_write_checks: Vec::new(),
+            journal: JournalConfig::default(),
         }
     }
 }

--- a/shell/src/code/functions/apply_patch.rs
+++ b/shell/src/code/functions/apply_patch.rs
@@ -89,12 +89,14 @@ enum PlannedWrite {
     },
     Delete {
         abs: PathBuf,
+        before: Vec<u8>,
     },
     Update {
         abs: PathBuf,
         move_to: Option<PathBuf>,
         new_contents: String,
         first_change: Option<(u64, u64)>,
+        before: Vec<u8>,
     },
 }
 
@@ -107,23 +109,33 @@ pub async fn handle(
     let blocking_resolver = resolver.clone();
     let blocking_cfg = cfg.clone();
     let sr = scope_root.clone();
-    let mut out = tokio::task::spawn_blocking(move || {
+    let fs_scope = req.fs_scope.clone();
+    let (mut out, journal) = tokio::task::spawn_blocking(move || {
         inner(&blocking_resolver, &blocking_cfg, sr.as_deref(), &req.patch).map_err(err_to_string)
     })
     .await
     .map_err(|e| format!("apply-patch task join failed: {e}"))??;
-    let written: Vec<String> = out.results.iter().map(|r| r.path.clone()).collect();
     let root = resolver.effective_root(scope_root.as_deref());
+    crate::code::journal::record(
+        &cfg,
+        &root,
+        fs_scope.as_ref(),
+        "coder::apply-patch",
+        journal,
+    );
+    let written: Vec<String> = out.results.iter().map(|r| r.path.clone()).collect();
     out.checks = crate::code::checks::run_post_write_checks(&cfg, &resolver, &root, &written).await;
     Ok(out)
 }
+
+type JournalInputs = Vec<crate::code::journal::EntryInput>;
 
 fn inner(
     resolver: &PathResolver,
     cfg: &CoderConfig,
     scope_root: Option<&str>,
     patch_text: &str,
-) -> Result<ApplyPatchOutput, CoderError> {
+) -> Result<(ApplyPatchOutput, JournalInputs), CoderError> {
     let hunks = patch::parse_patch(patch_text)
         .map_err(|e| CoderError::BadInput(format!("invalid patch: {e}")))?;
     if hunks.is_empty() {
@@ -162,7 +174,8 @@ fn inner(
                         "delete file target is not a regular file: {wire}"
                     )));
                 }
-                planned.push(PlannedWrite::Delete { abs });
+                let before = std::fs::read(&abs).map_err(|e| CoderError::io_for_path(e, &wire))?;
+                planned.push(PlannedWrite::Delete { abs, before });
             }
             Hunk::UpdateFile {
                 path,
@@ -172,7 +185,7 @@ fn inner(
                 let wire = path.display().to_string();
                 let abs = resolver.require_writable_opt(scope_root, &wire)?;
                 let bytes = std::fs::read(&abs).map_err(|e| CoderError::io_for_path(e, &wire))?;
-                let original = String::from_utf8_lossy(&bytes);
+                let original = String::from_utf8_lossy(&bytes).into_owned();
                 let applied = patch::derive_new_contents_from_chunks(&original, &wire, chunks)
                     .map_err(|e| CoderError::BadInput(e.0))?;
                 check_write_size(cfg, &wire, applied.new_contents.len())?;
@@ -194,6 +207,7 @@ fn inner(
                     move_to,
                     new_contents: applied.new_contents,
                     first_change: applied.first_change,
+                    before: bytes,
                 });
             }
         }
@@ -201,9 +215,15 @@ fn inner(
 
     // Write phase: every plan entry validated — apply in patch order.
     let mut results = Vec::with_capacity(planned.len());
+    let mut journal: JournalInputs = Vec::new();
     for write in &planned {
         match write {
             PlannedWrite::Add { abs, contents } => {
+                journal.push(crate::code::journal::EntryInput {
+                    path: abs.clone(),
+                    before: None,
+                    skipped: false,
+                });
                 if let Some(parent) = abs.parent() {
                     std::fs::create_dir_all(parent)
                         .map_err(|e| CoderError::io_for_path(e, &abs.display().to_string()))?;
@@ -216,7 +236,12 @@ fn inner(
                     echo: None,
                 });
             }
-            PlannedWrite::Delete { abs } => {
+            PlannedWrite::Delete { abs, before } => {
+                journal.push(crate::code::journal::EntryInput {
+                    path: abs.clone(),
+                    before: Some(before.clone()),
+                    skipped: false,
+                });
                 std::fs::remove_file(abs)
                     .map_err(|e| CoderError::io_for_path(e, &abs.display().to_string()))?;
                 results.push(PatchFileResult {
@@ -231,7 +256,22 @@ fn inner(
                 move_to,
                 new_contents,
                 first_change,
+                before,
             } => {
+                journal.push(crate::code::journal::EntryInput {
+                    path: abs.clone(),
+                    before: Some(before.clone()),
+                    skipped: false,
+                });
+                if move_to.is_some() {
+                    // Destination existence was rejected at plan time, so
+                    // its before-state is always absent.
+                    journal.push(crate::code::journal::EntryInput {
+                        path: move_to.clone().expect("move_to checked above"),
+                        before: None,
+                        skipped: false,
+                    });
+                }
                 let target: &Path = move_to.as_deref().unwrap_or(abs.as_path());
                 if let Some(parent) = target.parent() {
                     std::fs::create_dir_all(parent)
@@ -256,10 +296,13 @@ fn inner(
             }
         }
     }
-    Ok(ApplyPatchOutput {
-        results,
-        checks: Vec::new(),
-    })
+    Ok((
+        ApplyPatchOutput {
+            results,
+            checks: Vec::new(),
+        },
+        journal,
+    ))
 }
 
 fn check_write_size(cfg: &CoderConfig, wire: &str, len: usize) -> Result<(), CoderError> {

--- a/shell/src/code/functions/checkpoints.rs
+++ b/shell/src/code/functions/checkpoints.rs
@@ -1,0 +1,90 @@
+//! `coder::checkpoints` — bounded listing of the workspace write journal
+//! (newest first) so a caller can pick an undo target: by recency
+//! (`coder::undo { steps }`) or by turn (`coder::undo { turn_id }`).
+
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::code::config::CoderConfig;
+use crate::code::journal;
+use crate::code::path::PathResolver;
+
+/// Default listing cap.
+const DEFAULT_LIMIT: u32 = 50;
+
+// examples are wire-contract; goldens pin them.
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[schemars(example = "example_checkpoints_input")]
+pub struct CheckpointsInput {
+    /// Maximum records returned (newest first). Default 50.
+    #[serde(default)]
+    pub limit: Option<u32>,
+    /// Internal harness filesystem scope; omitted from published schema.
+    #[serde(default)]
+    #[schemars(skip)]
+    pub fs_scope: Option<crate::fs::FsScope>,
+}
+
+// examples are wire-contract; goldens pin them.
+fn example_checkpoints_input() -> serde_json::Value {
+    serde_json::json!({})
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct CheckpointsOutput {
+    /// Journal records, newest first.
+    pub records: Vec<CheckpointMeta>,
+    /// True when older records exist beyond `limit`.
+    pub truncated: bool,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct CheckpointMeta {
+    pub seq: u64,
+    /// Unix millis when the mutation was journaled.
+    pub ts: i64,
+    /// The mutation (e.g. "coder::apply-patch", "coder::undo").
+    pub function_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    /// Affected file paths.
+    pub files: Vec<String>,
+    /// Count of unrecoverable entries in this record (oversized images,
+    /// directory operations).
+    pub skipped: u32,
+}
+
+pub async fn handle(
+    resolver: Arc<PathResolver>,
+    cfg: Arc<CoderConfig>,
+    req: CheckpointsInput,
+) -> Result<CheckpointsOutput, String> {
+    let scope_root = crate::fs::scope_root(req.fs_scope.as_ref()).map(str::to_string);
+    tokio::task::spawn_blocking(move || {
+        let root = resolver.effective_root(scope_root.as_deref());
+        let mut records = journal::list(&cfg, &root);
+        records.reverse(); // newest first
+        let limit = req.limit.unwrap_or(DEFAULT_LIMIT).max(1) as usize;
+        let truncated = records.len() > limit;
+        let records = records
+            .into_iter()
+            .take(limit)
+            .map(|r| CheckpointMeta {
+                seq: r.seq,
+                ts: r.ts,
+                function_id: r.function_id,
+                session_id: r.session_id,
+                turn_id: r.turn_id,
+                files: r.entries.iter().map(|e| e.path.clone()).collect(),
+                skipped: r.entries.iter().filter(|e| e.skipped).count() as u32,
+            })
+            .collect();
+        Ok(CheckpointsOutput { records, truncated })
+    })
+    .await
+    .map_err(|e| format!("checkpoints task join failed: {e}"))?
+}

--- a/shell/src/code/functions/create_file.rs
+++ b/shell/src/code/functions/create_file.rs
@@ -113,16 +113,28 @@ pub async fn handle(
             Err(e) => entries.push((spec, Err(e))),
         }
     }
+    let mut journal_entries = Vec::new();
     let results: Vec<CreateFileResult> = entries
         .into_iter()
-        .map(|(spec, resolved)| create_one(&cfg, spec, resolved))
+        .map(|(spec, resolved)| {
+            let (result, journal) = create_one(&cfg, spec, resolved);
+            journal_entries.extend(journal);
+            result
+        })
         .collect();
+    let root = resolver.effective_root(scope_root);
+    crate::code::journal::record(
+        &cfg,
+        &root,
+        req.fs_scope.as_ref(),
+        "coder::create-file",
+        journal_entries,
+    );
     let written: Vec<String> = results
         .iter()
         .filter(|r| r.success)
         .map(|r| r.path.clone())
         .collect();
-    let root = resolver.effective_root(scope_root);
     let checks = crate::code::checks::run_post_write_checks(&cfg, &resolver, &root, &written).await;
     Ok(CreateFileOutput { results, checks })
 }
@@ -131,7 +143,7 @@ fn create_one(
     cfg: &CoderConfig,
     spec: CreateFileSpec,
     resolved: Result<std::path::PathBuf, CoderError>,
-) -> CreateFileResult {
+) -> (CreateFileResult, Option<crate::code::journal::EntryInput>) {
     // Resolve up front: from here on every filesystem operation uses ONLY
     // the resolver-returned path (never re-derived from the raw request),
     // and the result echoes that canonical absolute path. When resolution
@@ -139,28 +151,48 @@ fn create_one(
     let abs = match resolved {
         Ok(abs) => abs,
         Err(e) => {
-            return CreateFileResult {
-                path: spec.path,
-                success: false,
-                bytes_written: 0,
-                error: Some((&e).into()),
-            }
+            return (
+                CreateFileResult {
+                    path: spec.path,
+                    success: false,
+                    bytes_written: 0,
+                    error: Some((&e).into()),
+                },
+                None,
+            )
         }
     };
     let wire_path = abs.display().to_string();
+    // Before-image for the journal: the overwritten content, or None for a
+    // brand-new file (undo then deletes it). Captured before the write.
+    let before = if abs.exists() {
+        std::fs::read(&abs).ok()
+    } else {
+        None
+    };
     match try_create_one(cfg, &abs, spec) {
-        Ok(bytes) => CreateFileResult {
-            path: wire_path,
-            success: true,
-            bytes_written: bytes,
-            error: None,
-        },
-        Err(e) => CreateFileResult {
-            path: wire_path,
-            success: false,
-            bytes_written: 0,
-            error: Some((&e).into()),
-        },
+        Ok(bytes) => (
+            CreateFileResult {
+                path: wire_path,
+                success: true,
+                bytes_written: bytes,
+                error: None,
+            },
+            Some(crate::code::journal::EntryInput {
+                path: abs,
+                before,
+                skipped: false,
+            }),
+        ),
+        Err(e) => (
+            CreateFileResult {
+                path: wire_path,
+                success: false,
+                bytes_written: 0,
+                error: Some((&e).into()),
+            },
+            None,
+        ),
     }
 }
 

--- a/shell/src/code/functions/delete_file.rs
+++ b/shell/src/code/functions/delete_file.rs
@@ -61,6 +61,7 @@ pub struct DeleteFileResult {
 
 pub async fn handle(
     resolver: Arc<PathResolver>,
+    cfg: Arc<crate::code::config::CoderConfig>,
     req: DeleteFileInput,
 ) -> Result<DeleteFileOutput, String> {
     if req.paths.is_empty() {
@@ -77,10 +78,23 @@ pub async fn handle(
             Err(e) => entries.push((p, Err(e))),
         }
     }
+    let mut journal_entries = Vec::new();
     let results = entries
         .into_iter()
-        .map(|(p, resolved)| delete_one(&resolver, scope_root, &p, req.recursive, resolved))
+        .map(|(p, resolved)| {
+            let (result, journal) = delete_one(&resolver, scope_root, &p, req.recursive, resolved);
+            journal_entries.extend(journal);
+            result
+        })
         .collect();
+    let root = resolver.effective_root(scope_root);
+    crate::code::journal::record(
+        &cfg,
+        &root,
+        req.fs_scope.as_ref(),
+        "coder::delete-file",
+        journal_entries,
+    );
     Ok(DeleteFileOutput { results })
 }
 
@@ -90,7 +104,7 @@ fn delete_one(
     rel: &str,
     recursive: bool,
     resolved: Result<std::path::PathBuf, CoderError>,
-) -> DeleteFileResult {
+) -> (DeleteFileResult, Option<crate::code::journal::EntryInput>) {
     // Resolve up front: deletion operates ONLY on the resolver-returned
     // path, and the result echoes that canonical absolute path. When
     // resolution fails there is no canonical path, so the caller's input
@@ -98,28 +112,52 @@ fn delete_one(
     let abs = match resolved {
         Ok(abs) => abs,
         Err(e) => {
-            return DeleteFileResult {
-                path: rel.to_string(),
-                success: false,
-                removed: false,
-                error: Some((&e).into()),
-            }
+            return (
+                DeleteFileResult {
+                    path: rel.to_string(),
+                    success: false,
+                    removed: false,
+                    error: Some((&e).into()),
+                },
+                None,
+            )
         }
     };
     let wire_path = abs.display().to_string();
+    // Journal before-image: file contents pre-delete; a directory tree
+    // cannot be snapshotted — journal it as a skipped (unrecoverable) gap.
+    let journal_input = match std::fs::symlink_metadata(&abs) {
+        Ok(md) if md.is_file() => Some(crate::code::journal::EntryInput {
+            path: abs.clone(),
+            before: std::fs::read(&abs).ok(),
+            skipped: false,
+        }),
+        Ok(md) if md.is_dir() => Some(crate::code::journal::EntryInput {
+            path: abs.clone(),
+            before: None,
+            skipped: true,
+        }),
+        _ => None,
+    };
     match try_delete_one(resolver, scope_root, &abs, recursive) {
-        Ok(removed) => DeleteFileResult {
-            path: wire_path,
-            success: true,
-            removed,
-            error: None,
-        },
-        Err(e) => DeleteFileResult {
-            path: wire_path,
-            success: false,
-            removed: false,
-            error: Some((&e).into()),
-        },
+        Ok(removed) => (
+            DeleteFileResult {
+                path: wire_path,
+                success: true,
+                removed,
+                error: None,
+            },
+            if removed { journal_input } else { None },
+        ),
+        Err(e) => (
+            DeleteFileResult {
+                path: wire_path,
+                success: false,
+                removed: false,
+                error: Some((&e).into()),
+            },
+            None,
+        ),
     }
 }
 
@@ -201,7 +239,11 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
-    fn setup() -> (tempfile::TempDir, Arc<PathResolver>) {
+    fn setup() -> (
+        tempfile::TempDir,
+        Arc<PathResolver>,
+        Arc<crate::code::config::CoderConfig>,
+    ) {
         let tmp = tempdir().unwrap();
         let cfg = Arc::new(crate::code::config::CoderConfig {
             base_paths: vec![tmp.path().to_path_buf()],
@@ -209,15 +251,16 @@ mod tests {
             ..crate::code::config::CoderConfig::default()
         });
         let resolver = Arc::new(PathResolver::new(&cfg).unwrap());
-        (tmp, resolver)
+        (tmp, resolver, cfg)
     }
 
     #[tokio::test]
     async fn deletes_file() {
-        let (tmp, r) = setup();
+        let (tmp, r, c) = setup();
         std::fs::write(tmp.path().join("a.txt"), "x").unwrap();
         let out = handle(
             r,
+            c.clone(),
             DeleteFileInput {
                 paths: vec!["a.txt".into()],
                 recursive: false,
@@ -233,9 +276,10 @@ mod tests {
 
     #[tokio::test]
     async fn missing_path_is_idempotent_success() {
-        let (_tmp, r) = setup();
+        let (_tmp, r, c) = setup();
         let out = handle(
             r,
+            c.clone(),
             DeleteFileInput {
                 paths: vec!["nope.txt".into()],
                 recursive: false,
@@ -250,10 +294,11 @@ mod tests {
 
     #[tokio::test]
     async fn refuses_non_accessible() {
-        let (tmp, r) = setup();
+        let (tmp, r, c) = setup();
         std::fs::write(tmp.path().join(".env"), "x").unwrap();
         let out = handle(
             r,
+            c.clone(),
             DeleteFileInput {
                 paths: vec![".env".into()],
                 recursive: false,
@@ -269,11 +314,12 @@ mod tests {
 
     #[tokio::test]
     async fn directory_without_recursive_rejected() {
-        let (tmp, r) = setup();
+        let (tmp, r, c) = setup();
         std::fs::create_dir(tmp.path().join("d")).unwrap();
         std::fs::write(tmp.path().join("d/x"), "x").unwrap();
         let out = handle(
             r,
+            c.clone(),
             DeleteFileInput {
                 paths: vec!["d".into()],
                 recursive: false,
@@ -287,11 +333,12 @@ mod tests {
 
     #[tokio::test]
     async fn directory_with_recursive_succeeds() {
-        let (tmp, r) = setup();
+        let (tmp, r, c) = setup();
         std::fs::create_dir(tmp.path().join("d")).unwrap();
         std::fs::write(tmp.path().join("d/x"), "x").unwrap();
         let out = handle(
             r,
+            c.clone(),
             DeleteFileInput {
                 paths: vec!["d".into()],
                 recursive: true,
@@ -306,11 +353,12 @@ mod tests {
 
     #[tokio::test]
     async fn recursive_refuses_when_subtree_has_non_accessible() {
-        let (tmp, r) = setup();
+        let (tmp, r, c) = setup();
         std::fs::create_dir(tmp.path().join("d")).unwrap();
         std::fs::write(tmp.path().join("d/.env"), "secret").unwrap();
         let out = handle(
             r,
+            c.clone(),
             DeleteFileInput {
                 paths: vec!["d".into()],
                 recursive: true,
@@ -330,11 +378,12 @@ mod tests {
     // appear — the child ".env" must be invisible to the caller.
     #[tokio::test]
     async fn recursive_blocked_error_does_not_leak_child_path() {
-        let (tmp, r) = setup();
+        let (tmp, r, c) = setup();
         std::fs::create_dir(tmp.path().join("secrets")).unwrap();
         std::fs::write(tmp.path().join("secrets/.env"), "API_KEY=secret").unwrap();
         let out = handle(
             r,
+            c.clone(),
             DeleteFileInput {
                 paths: vec!["secrets".into()],
                 recursive: true,
@@ -364,9 +413,10 @@ mod tests {
 
     #[tokio::test]
     async fn refuses_to_delete_base_root() {
-        let (_tmp, r) = setup();
+        let (_tmp, r, c) = setup();
         let out = handle(
             r,
+            c.clone(),
             DeleteFileInput {
                 paths: vec![".".into()],
                 recursive: true,
@@ -384,18 +434,21 @@ mod tests {
     // refused (C210) — otherwise a recursive delete wipes the active project.
     #[tokio::test]
     async fn refuses_to_delete_session_dir_via_dot() {
-        let (tmp, r) = setup();
+        let (tmp, r, c) = setup();
         let session = tmp.path().join("project");
         std::fs::create_dir(&session).unwrap();
         std::fs::write(session.join("keep.txt"), "x").unwrap();
         let out = handle(
             r,
+            c.clone(),
             DeleteFileInput {
                 paths: vec![".".into()],
                 recursive: true,
                 fs_scope: Some(crate::fs::FsScope {
                     root: session.to_string_lossy().into_owned(),
                     grants: Vec::new(),
+                    session_id: None,
+                    turn_id: None,
                 }),
             },
         )
@@ -411,18 +464,21 @@ mod tests {
     // absolute path rather than ".".
     #[tokio::test]
     async fn refuses_to_delete_session_dir_via_absolute_path() {
-        let (tmp, r) = setup();
+        let (tmp, r, c) = setup();
         let session = tmp.path().join("project");
         std::fs::create_dir(&session).unwrap();
         let abs = session.to_string_lossy().into_owned();
         let out = handle(
             r,
+            c.clone(),
             DeleteFileInput {
                 paths: vec![abs.clone()],
                 recursive: true,
                 fs_scope: Some(crate::fs::FsScope {
                     root: abs,
                     grants: Vec::new(),
+                    session_id: None,
+                    turn_id: None,
                 }),
             },
         )
@@ -437,18 +493,21 @@ mod tests {
     // still deletes normally.
     #[tokio::test]
     async fn deletes_file_inside_session_dir() {
-        let (tmp, r) = setup();
+        let (tmp, r, c) = setup();
         let session = tmp.path().join("project");
         std::fs::create_dir(&session).unwrap();
         std::fs::write(session.join("a.txt"), "x").unwrap();
         let out = handle(
             r,
+            c.clone(),
             DeleteFileInput {
                 paths: vec!["a.txt".into()],
                 recursive: false,
                 fs_scope: Some(crate::fs::FsScope {
                     root: session.to_string_lossy().into_owned(),
                     grants: Vec::new(),
+                    session_id: None,
+                    turn_id: None,
                 }),
             },
         )

--- a/shell/src/code/functions/info.rs
+++ b/shell/src/code/functions/info.rs
@@ -220,6 +220,7 @@ mod tests {
             batch_read_budget_bytes: 23,
             max_output_bytes: 31,
             post_write_checks: Vec::new(),
+            journal: Default::default(),
         });
         let resolver = Arc::new(PathResolver::new(&cfg).unwrap());
 

--- a/shell/src/code/functions/mod.rs
+++ b/shell/src/code/functions/mod.rs
@@ -11,6 +11,7 @@
 //! agent-facing wire surface shows up as an explicit, reviewed diff.
 
 pub mod apply_patch;
+pub mod checkpoints;
 pub mod context;
 pub mod create_file;
 pub mod delete_file;
@@ -21,6 +22,7 @@ pub mod read_file;
 pub mod read_window;
 pub mod search;
 pub mod tree;
+pub mod undo;
 pub mod update_file;
 pub mod worktree;
 
@@ -136,6 +138,23 @@ const APPLY_PATCH_DESC: &str = "Apply a whole patch in the apply_patch (V4A) for
      relative to the primary allowed root or absolute inside any allowed \
      root (coder::info lists them); for host paths outside the jail use \
      shell::fs::*.";
+
+const UNDO_ID: &str = "coder::undo";
+const UNDO_DESC: &str = "Revert journaled coder writes in this workspace: the last N records \
+     ({ steps }, default 1) or everything a specific turn changed \
+     ({ turn_id } — coder::checkpoints lists them). Restores run newest \
+     first through the live jail; files that did not exist before a \
+     write are removed, others are rewritten to their before-image. \
+     The undo journals its own pre-undo state first, so running \
+     coder::undo again REDOES the change. Unrecoverable gaps (oversized \
+     before-images, directory deletes/moves) are reported in `skipped`, \
+     never silently ignored.";
+
+const CHECKPOINTS_ID: &str = "coder::checkpoints";
+const CHECKPOINTS_DESC: &str = "List this workspace's write-journal records (newest first, \
+     default 50): seq, timestamp, mutating function, the session/turn \
+     that issued it, and the affected files — the picker surface for \
+     coder::undo ({ steps } by recency, { turn_id } by turn).";
 
 const WORKTREE_ADD_ID: &str = "coder::worktree-add";
 const WORKTREE_ADD_DESC: &str = "Create an isolated git worktree at .worktrees/<name> under the \
@@ -268,6 +287,11 @@ pub fn catalog() -> Vec<FunctionSpec> {
             WORKTREE_REMOVE_ID,
             WORKTREE_REMOVE_DESC,
         ),
+        spec::<undo::UndoInput, undo::UndoOutput>(UNDO_ID, UNDO_DESC),
+        spec::<checkpoints::CheckpointsInput, checkpoints::CheckpointsOutput>(
+            CHECKPOINTS_ID,
+            CHECKPOINTS_DESC,
+        ),
         spec::<create_file::CreateFileInput, create_file::CreateFileOutput>(
             CREATE_FILE_ID,
             CREATE_FILE_DESC,
@@ -307,6 +331,10 @@ pub fn register_all(iii: &IIIClient, cells: CodeCells) {
     register_worktree_add(iii, cells.clone());
     registered += 1;
     register_worktree_remove(iii, cells.clone());
+    registered += 1;
+    register_undo(iii, cells.clone());
+    registered += 1;
+    register_checkpoints(iii, cells.clone());
     registered += 1;
     register_create_file(iii, cells.clone());
     registered += 1;
@@ -490,6 +518,46 @@ fn register_worktree_remove(iii: &IIIClient, cells: CodeCells) {
     );
 }
 
+fn register_undo(iii: &IIIClient, cells: CodeCells) {
+    iii.register_function(
+        UNDO_ID,
+        RegisterFunction::new_async(move |req: undo::UndoInput| {
+            let cells = cells.clone();
+            async move {
+                let resolver = cells.resolver.read().await.clone();
+                let resolver = resolver.session_scoped(
+                    crate::fs::scope_root(req.fs_scope.as_ref()),
+                    crate::fs::scope_grants(req.fs_scope.as_ref()),
+                );
+                let cfg = cells.config.read().await.clone();
+                undo::handle(resolver, cfg, req).await.map_err(Error::from)
+            }
+        })
+        .description(UNDO_DESC),
+    );
+}
+
+fn register_checkpoints(iii: &IIIClient, cells: CodeCells) {
+    iii.register_function(
+        CHECKPOINTS_ID,
+        RegisterFunction::new_async(move |req: checkpoints::CheckpointsInput| {
+            let cells = cells.clone();
+            async move {
+                let resolver = cells.resolver.read().await.clone();
+                let resolver = resolver.session_scoped(
+                    crate::fs::scope_root(req.fs_scope.as_ref()),
+                    crate::fs::scope_grants(req.fs_scope.as_ref()),
+                );
+                let cfg = cells.config.read().await.clone();
+                checkpoints::handle(resolver, cfg, req)
+                    .await
+                    .map_err(Error::from)
+            }
+        })
+        .description(CHECKPOINTS_DESC),
+    );
+}
+
 fn register_create_file(iii: &IIIClient, cells: CodeCells) {
     iii.register_function(
         CREATE_FILE_ID,
@@ -522,7 +590,8 @@ fn register_delete_file(iii: &IIIClient, cells: CodeCells) {
                     crate::fs::scope_root(req.fs_scope.as_ref()),
                     crate::fs::scope_grants(req.fs_scope.as_ref()),
                 );
-                delete_file::handle(resolver, req)
+                let cfg = cells.config.read().await.clone();
+                delete_file::handle(resolver, cfg, req)
                     .await
                     .map_err(Error::from)
             }
@@ -582,7 +651,10 @@ fn register_move_file(iii: &IIIClient, cells: CodeCells) {
                     crate::fs::scope_root(req.fs_scope.as_ref()),
                     crate::fs::scope_grants(req.fs_scope.as_ref()),
                 );
-                move_file::handle(resolver, req).await.map_err(Error::from)
+                let cfg = cells.config.read().await.clone();
+                move_file::handle(resolver, cfg, req)
+                    .await
+                    .map_err(Error::from)
             }
         })
         .description(MOVE_FILE_DESC),

--- a/shell/src/code/functions/move_file.rs
+++ b/shell/src/code/functions/move_file.rs
@@ -110,6 +110,7 @@ pub struct MoveFileResult {
 
 pub async fn handle(
     resolver: Arc<PathResolver>,
+    cfg: Arc<crate::code::config::CoderConfig>,
     req: MoveFileInput,
 ) -> Result<MoveFileOutput, String> {
     if req.files.is_empty() {
@@ -128,9 +129,20 @@ pub async fn handle(
         }
     }
     let mut results = Vec::with_capacity(req.files.len());
+    let mut journal_entries = Vec::new();
     for spec in req.files {
-        results.push(move_one(&resolver, scope_root, spec));
+        let (result, journal) = move_one(&resolver, scope_root, spec);
+        journal_entries.extend(journal);
+        results.push(result);
     }
+    let root = resolver.effective_root(scope_root);
+    crate::code::journal::record(
+        &cfg,
+        &root,
+        req.fs_scope.as_ref(),
+        "coder::move",
+        journal_entries,
+    );
     Ok(MoveFileOutput { results })
 }
 
@@ -149,18 +161,21 @@ fn move_one(
     resolver: &PathResolver,
     scope_root: Option<&str>,
     spec: MoveFileSpec,
-) -> MoveFileResult {
+) -> (MoveFileResult, Vec<crate::code::journal::EntryInput>) {
     // Resolve source.
     let abs_from = match resolver.require_writable_opt(scope_root, &spec.from) {
         Ok(p) => p,
         Err(e) => {
-            return MoveFileResult {
-                from: spec.from,
-                to: spec.to,
-                success: false,
-                moved: false,
-                error: Some((&e).into()),
-            }
+            return (
+                MoveFileResult {
+                    from: spec.from,
+                    to: spec.to,
+                    success: false,
+                    moved: false,
+                    error: Some((&e).into()),
+                },
+                Vec::new(),
+            )
         }
     };
 
@@ -168,13 +183,16 @@ fn move_one(
     let abs_to = match resolver.require_writable_opt(scope_root, &spec.to) {
         Ok(p) => p,
         Err(e) => {
-            return MoveFileResult {
-                from: abs_from.display().to_string(),
-                to: spec.to,
-                success: false,
-                moved: false,
-                error: Some((&e).into()),
-            }
+            return (
+                MoveFileResult {
+                    from: abs_from.display().to_string(),
+                    to: spec.to,
+                    success: false,
+                    moved: false,
+                    error: Some((&e).into()),
+                },
+                Vec::new(),
+            )
         }
     };
 
@@ -187,18 +205,55 @@ fn move_one(
     // is a no-op success: moved=false, no error.
     if abs_from == abs_to {
         let wire = abs_from.display().to_string();
-        return MoveFileResult {
-            from: wire.clone(),
-            to: wire,
-            success: true,
-            moved: false,
-            error: None,
-        };
+        return (
+            MoveFileResult {
+                from: wire.clone(),
+                to: wire,
+                success: true,
+                moved: false,
+                error: None,
+            },
+            Vec::new(),
+        );
     }
 
     let wire_from = abs_from.display().to_string();
     let wire_to = abs_to.display().to_string();
 
+    // Journal before-images pre-move: a moved FILE restores fully (source
+    // rewritten, destination reverted/removed); a moved DIRECTORY cannot be
+    // snapshotted — both sides journal as skipped gaps.
+    let journal = match std::fs::symlink_metadata(&abs_from) {
+        Ok(md) if md.is_file() => vec![
+            crate::code::journal::EntryInput {
+                path: abs_from.clone(),
+                before: std::fs::read(&abs_from).ok(),
+                skipped: false,
+            },
+            crate::code::journal::EntryInput {
+                path: abs_to.clone(),
+                before: if abs_to.exists() {
+                    std::fs::read(&abs_to).ok()
+                } else {
+                    None
+                },
+                skipped: false,
+            },
+        ],
+        Ok(md) if md.is_dir() => vec![
+            crate::code::journal::EntryInput {
+                path: abs_from.clone(),
+                before: None,
+                skipped: true,
+            },
+            crate::code::journal::EntryInput {
+                path: abs_to.clone(),
+                before: None,
+                skipped: true,
+            },
+        ],
+        _ => Vec::new(),
+    };
     match try_move_one(
         resolver,
         &abs_from,
@@ -208,20 +263,26 @@ fn move_one(
         spec.overwrite,
         spec.parents,
     ) {
-        Ok(()) => MoveFileResult {
-            from: wire_from,
-            to: wire_to,
-            success: true,
-            moved: true,
-            error: None,
-        },
-        Err(e) => MoveFileResult {
-            from: wire_from,
-            to: wire_to,
-            success: false,
-            moved: false,
-            error: Some((&e).into()),
-        },
+        Ok(()) => (
+            MoveFileResult {
+                from: wire_from,
+                to: wire_to,
+                success: true,
+                moved: true,
+                error: None,
+            },
+            journal,
+        ),
+        Err(e) => (
+            MoveFileResult {
+                from: wire_from,
+                to: wire_to,
+                success: false,
+                moved: false,
+                error: Some((&e).into()),
+            },
+            Vec::new(),
+        ),
     }
 }
 
@@ -396,7 +457,11 @@ mod tests {
     use std::sync::Arc;
     use tempfile::tempdir;
 
-    fn setup_single() -> (tempfile::TempDir, Arc<PathResolver>) {
+    fn setup_single() -> (
+        tempfile::TempDir,
+        Arc<PathResolver>,
+        Arc<crate::code::config::CoderConfig>,
+    ) {
         let tmp = tempdir().unwrap();
         let cfg = Arc::new(crate::code::config::CoderConfig {
             base_paths: vec![tmp.path().to_path_buf()],
@@ -404,10 +469,15 @@ mod tests {
             ..crate::code::config::CoderConfig::default()
         });
         let resolver = Arc::new(PathResolver::new(&cfg).unwrap());
-        (tmp, resolver)
+        (tmp, resolver, cfg)
     }
 
-    fn setup_two_roots() -> (tempfile::TempDir, tempfile::TempDir, Arc<PathResolver>) {
+    fn setup_two_roots() -> (
+        tempfile::TempDir,
+        tempfile::TempDir,
+        Arc<PathResolver>,
+        Arc<crate::code::config::CoderConfig>,
+    ) {
         let tmp0 = tempdir().unwrap();
         let tmp1 = tempdir().unwrap();
         let cfg = Arc::new(crate::code::config::CoderConfig {
@@ -416,7 +486,7 @@ mod tests {
             ..crate::code::config::CoderConfig::default()
         });
         let resolver = Arc::new(PathResolver::new(&cfg).unwrap());
-        (tmp0, tmp1, resolver)
+        (tmp0, tmp1, resolver, cfg)
     }
 
     // ------------------------------------------------------------------
@@ -424,10 +494,11 @@ mod tests {
     // ------------------------------------------------------------------
     #[tokio::test]
     async fn same_root_rename_file() {
-        let (tmp, r) = setup_single();
+        let (tmp, r, c) = setup_single();
         std::fs::write(tmp.path().join("a.txt"), "hello").unwrap();
         let out = handle(
             r,
+            c.clone(),
             MoveFileInput {
                 files: vec![MoveFileSpec {
                     from: "a.txt".into(),
@@ -461,11 +532,12 @@ mod tests {
     // ------------------------------------------------------------------
     #[tokio::test]
     async fn same_root_rename_directory() {
-        let (tmp, r) = setup_single();
+        let (tmp, r, c) = setup_single();
         std::fs::create_dir(tmp.path().join("src_dir")).unwrap();
         std::fs::write(tmp.path().join("src_dir/file.txt"), "content").unwrap();
         let out = handle(
             r,
+            c.clone(),
             MoveFileInput {
                 files: vec![MoveFileSpec {
                     from: "src_dir".into(),
@@ -490,11 +562,12 @@ mod tests {
     // ------------------------------------------------------------------
     #[tokio::test]
     async fn self_move_is_noop_success_with_content_intact() {
-        let (tmp, r) = setup_single();
+        let (tmp, r, c) = setup_single();
         std::fs::write(tmp.path().join("a.txt"), "precious").unwrap();
         for overwrite in [false, true] {
             let out = handle(
                 r.clone(),
+                c.clone(),
                 MoveFileInput {
                     files: vec![MoveFileSpec {
                         from: "a.txt".into(),
@@ -545,6 +618,7 @@ mod tests {
         let to_abs = std::fs::canonicalize(&nested).unwrap().join("file.txt");
         let out = handle(
             r,
+            cfg.clone(),
             MoveFileInput {
                 files: vec![MoveFileSpec {
                     from: "sub/file.txt".into(),
@@ -572,11 +646,12 @@ mod tests {
     // ------------------------------------------------------------------
     #[tokio::test]
     async fn cross_root_file_copy_and_delete() {
-        let (tmp0, tmp1, r) = setup_two_roots();
+        let (tmp0, tmp1, r, c) = setup_two_roots();
         std::fs::write(tmp0.path().join("src.txt"), "cross-root content").unwrap();
         let dst_abs = tmp1.path().join("dst.txt");
         let out = handle(
             r,
+            c.clone(),
             MoveFileInput {
                 files: vec![MoveFileSpec {
                     from: "src.txt".into(),
@@ -620,7 +695,7 @@ mod tests {
             return;
         }
 
-        let (tmp0, tmp1, r) = setup_two_roots();
+        let (tmp0, tmp1, r, c) = setup_two_roots();
         // Write source file under a parent directory we can make read-only.
         std::fs::create_dir(tmp0.path().join("locked")).unwrap();
         std::fs::write(tmp0.path().join("locked/src.txt"), "rollback test").unwrap();
@@ -638,6 +713,7 @@ mod tests {
 
         let out = handle(
             r,
+            c.clone(),
             MoveFileInput {
                 files: vec![MoveFileSpec {
                     from: src_abs.display().to_string(),
@@ -677,11 +753,12 @@ mod tests {
     // ------------------------------------------------------------------
     #[tokio::test]
     async fn overwrite_false_dst_exists_c217() {
-        let (tmp, r) = setup_single();
+        let (tmp, r, c) = setup_single();
         std::fs::write(tmp.path().join("src.txt"), "new").unwrap();
         std::fs::write(tmp.path().join("dst.txt"), "old").unwrap();
         let out = handle(
             r,
+            c.clone(),
             MoveFileInput {
                 files: vec![MoveFileSpec {
                     from: "src.txt".into(),
@@ -715,11 +792,12 @@ mod tests {
     // ------------------------------------------------------------------
     #[tokio::test]
     async fn overwrite_true_replaces_existing() {
-        let (tmp, r) = setup_single();
+        let (tmp, r, c) = setup_single();
         std::fs::write(tmp.path().join("src.txt"), "new-content").unwrap();
         std::fs::write(tmp.path().join("dst.txt"), "old-content").unwrap();
         let out = handle(
             r,
+            c.clone(),
             MoveFileInput {
                 files: vec![MoveFileSpec {
                     from: "src.txt".into(),
@@ -745,9 +823,10 @@ mod tests {
     // ------------------------------------------------------------------
     #[tokio::test]
     async fn missing_src_c211() {
-        let (_tmp, r) = setup_single();
+        let (_tmp, r, c) = setup_single();
         let out = handle(
             r,
+            c.clone(),
             MoveFileInput {
                 files: vec![MoveFileSpec {
                     from: "no-such-file.txt".into(),
@@ -781,11 +860,12 @@ mod tests {
     // ------------------------------------------------------------------
     #[tokio::test]
     async fn glob_denied_src_c211_identical_suffix_to_missing() {
-        let (tmp, r) = setup_single();
+        let (tmp, r, c) = setup_single();
         std::fs::write(tmp.path().join(".env"), "secret").unwrap();
         // Both resolve + deny and stat failure yield C211; suffix must match.
         let out_denied = handle(
             r.clone(),
+            c.clone(),
             MoveFileInput {
                 files: vec![MoveFileSpec {
                     from: ".env".into(),
@@ -800,6 +880,7 @@ mod tests {
         .unwrap();
         let out_missing = handle(
             r,
+            c.clone(),
             MoveFileInput {
                 files: vec![MoveFileSpec {
                     from: "definitely-missing.txt".into(),
@@ -840,10 +921,11 @@ mod tests {
     // ------------------------------------------------------------------
     #[tokio::test]
     async fn glob_denied_dst_c211() {
-        let (tmp, r) = setup_single();
+        let (tmp, r, c) = setup_single();
         std::fs::write(tmp.path().join("src.txt"), "x").unwrap();
         let out = handle(
             r,
+            c.clone(),
             MoveFileInput {
                 files: vec![MoveFileSpec {
                     from: "src.txt".into(),
@@ -867,9 +949,10 @@ mod tests {
     // ------------------------------------------------------------------
     #[tokio::test]
     async fn move_root_rejected_c210() {
-        let (_tmp, r) = setup_single();
+        let (_tmp, r, c) = setup_single();
         let out = handle(
             r,
+            c.clone(),
             MoveFileInput {
                 files: vec![MoveFileSpec {
                     from: ".".into(),
@@ -891,12 +974,13 @@ mod tests {
     // ------------------------------------------------------------------
     #[tokio::test]
     async fn cross_root_dir_rejected_c210() {
-        let (tmp0, tmp1, r) = setup_two_roots();
+        let (tmp0, tmp1, r, c) = setup_two_roots();
         std::fs::create_dir(tmp0.path().join("mydir")).unwrap();
         std::fs::write(tmp0.path().join("mydir/f.txt"), "x").unwrap();
         let dst_abs = tmp1.path().join("mydir");
         let out = handle(
             r,
+            c.clone(),
             MoveFileInput {
                 files: vec![MoveFileSpec {
                     from: "mydir".into(),
@@ -927,13 +1011,14 @@ mod tests {
     // ------------------------------------------------------------------
     #[tokio::test]
     async fn rejected_cross_root_dir_move_leaves_dst_tree_absent() {
-        let (tmp0, tmp1, r) = setup_two_roots();
+        let (tmp0, tmp1, r, c) = setup_two_roots();
         std::fs::create_dir(tmp0.path().join("mydir")).unwrap();
         std::fs::write(tmp0.path().join("mydir/f.txt"), "x").unwrap();
         // Destination nested under parents that don't exist yet.
         let dst_abs = tmp1.path().join("a/b/mydir");
         let out = handle(
             r,
+            c.clone(),
             MoveFileInput {
                 files: vec![MoveFileSpec {
                     from: "mydir".into(),
@@ -963,7 +1048,7 @@ mod tests {
     // ------------------------------------------------------------------
     #[tokio::test]
     async fn dst_is_directory_src_is_file_prescriptive_c210() {
-        let (tmp, r) = setup_single();
+        let (tmp, r, c) = setup_single();
         std::fs::write(tmp.path().join("src.txt"), "x").unwrap();
         std::fs::create_dir(tmp.path().join("destdir")).unwrap();
         // Both overwrite=false AND overwrite=true must get the same
@@ -971,6 +1056,7 @@ mod tests {
         for overwrite in [false, true] {
             let out = handle(
                 r.clone(),
+                c.clone(),
                 MoveFileInput {
                     files: vec![MoveFileSpec {
                         from: "src.txt".into(),
@@ -1008,10 +1094,11 @@ mod tests {
     // ------------------------------------------------------------------
     #[tokio::test]
     async fn parents_false_missing_parent_errors() {
-        let (tmp, r) = setup_single();
+        let (tmp, r, c) = setup_single();
         std::fs::write(tmp.path().join("src.txt"), "x").unwrap();
         let out = handle(
             r,
+            c.clone(),
             MoveFileInput {
                 files: vec![MoveFileSpec {
                     from: "src.txt".into(),
@@ -1037,11 +1124,12 @@ mod tests {
     // ------------------------------------------------------------------
     #[tokio::test]
     async fn batch_order_preserved() {
-        let (tmp, r) = setup_single();
+        let (tmp, r, c) = setup_single();
         std::fs::write(tmp.path().join("a.txt"), "A").unwrap();
         std::fs::write(tmp.path().join("b.txt"), "B").unwrap();
         let out = handle(
             r,
+            c.clone(),
             MoveFileInput {
                 files: vec![
                     MoveFileSpec {
@@ -1075,10 +1163,11 @@ mod tests {
     // ------------------------------------------------------------------
     #[tokio::test]
     async fn jail_escape_aborts_batch_with_top_level_c215() {
-        let (_tmp, r) = setup_single();
+        let (_tmp, r, c) = setup_single();
         // A path that escapes the jail will fail resolution (C215).
         let err = handle(
             r,
+            c.clone(),
             MoveFileInput {
                 files: vec![MoveFileSpec {
                     from: "/etc/passwd".into(),
@@ -1102,10 +1191,11 @@ mod tests {
     // ------------------------------------------------------------------
     #[tokio::test]
     async fn batch_continues_after_failure() {
-        let (tmp, r) = setup_single();
+        let (tmp, r, c) = setup_single();
         std::fs::write(tmp.path().join("good.txt"), "ok").unwrap();
         let out = handle(
             r,
+            c.clone(),
             MoveFileInput {
                 files: vec![
                     // First entry: missing source → C211.

--- a/shell/src/code/functions/undo.rs
+++ b/shell/src/code/functions/undo.rs
@@ -1,0 +1,196 @@
+//! `coder::undo` — revert journaled coder writes: the last N records or
+//! every record a specific turn produced. Restores run newest-first; every
+//! restored path re-validates through the LIVE jail (journal data is never
+//! trusted as authority to write). The undo journals its own pre-undo state
+//! as an ordinary record first, so undoing an undo redoes the change.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::code::config::CoderConfig;
+use crate::code::error::{err_to_string, CoderError};
+use crate::code::functions::update_file::atomic_write;
+use crate::code::journal::{self, JournalRecord};
+use crate::code::path::PathResolver;
+
+// examples are wire-contract; goldens pin them.
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[schemars(example = "example_undo_input")]
+pub struct UndoInput {
+    /// Undo the last N journaled records (default 1). Mutually exclusive
+    /// with `turn_id`.
+    #[serde(default)]
+    pub steps: Option<u32>,
+    /// Undo every journaled record this turn produced (see
+    /// `coder::checkpoints` for turn ids). Mutually exclusive with `steps`.
+    #[serde(default)]
+    pub turn_id: Option<String>,
+    /// Internal harness filesystem scope; omitted from published schema.
+    #[serde(default)]
+    #[schemars(skip)]
+    pub fs_scope: Option<crate::fs::FsScope>,
+}
+
+// examples are wire-contract; goldens pin them.
+fn example_undo_input() -> serde_json::Value {
+    serde_json::json!({ "steps": 1 })
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct UndoOutput {
+    /// Undone records, newest first. The undo itself was journaled before
+    /// any restore, so `coder::undo { steps: 1 }` again redoes the change.
+    pub undone: Vec<UndoneRecord>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct UndoneRecord {
+    pub seq: u64,
+    /// The mutation this record captured (e.g. "coder::update-file").
+    pub function_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    /// Files rewritten to their journaled before-image.
+    pub restored: Vec<String>,
+    /// Files removed (they did not exist before the journaled write).
+    pub removed: Vec<String>,
+    /// Unrecoverable gaps: oversized before-images, directory operations,
+    /// or paths the live jail rejected — inspect these manually.
+    pub skipped: Vec<String>,
+}
+
+pub async fn handle(
+    resolver: Arc<PathResolver>,
+    cfg: Arc<CoderConfig>,
+    req: UndoInput,
+) -> Result<UndoOutput, String> {
+    if req.steps.is_some() && req.turn_id.is_some() {
+        return Err(err_to_string(CoderError::BadInput(
+            "pass either `steps` or `turn_id`, not both".into(),
+        )));
+    }
+    if !journal::enabled(&cfg) {
+        return Err(err_to_string(CoderError::BadInput(
+            "the coder write journal is disabled (journal.max_records = 0)".into(),
+        )));
+    }
+    let scope_root = crate::fs::scope_root(req.fs_scope.as_ref()).map(str::to_string);
+    tokio::task::spawn_blocking(move || {
+        inner(&resolver, &cfg, scope_root.as_deref(), &req).map_err(err_to_string)
+    })
+    .await
+    .map_err(|e| format!("undo task join failed: {e}"))?
+}
+
+fn inner(
+    resolver: &PathResolver,
+    cfg: &CoderConfig,
+    scope_root: Option<&str>,
+    req: &UndoInput,
+) -> Result<UndoOutput, CoderError> {
+    let root = resolver.effective_root(scope_root);
+    let mut records = journal::list(cfg, &root);
+    // Newest first.
+    records.reverse();
+
+    let selected: Vec<JournalRecord> = match (&req.steps, &req.turn_id) {
+        (_, Some(turn)) => records
+            .into_iter()
+            .filter(|r| r.turn_id.as_deref() == Some(turn.as_str()))
+            .collect(),
+        (steps, None) => {
+            let n = steps.unwrap_or(1).max(1) as usize;
+            records.into_iter().take(n).collect()
+        }
+    };
+    if selected.is_empty() {
+        return Err(CoderError::BadInput(
+            "nothing to undo — no matching journal records for this \
+             workspace (see coder::checkpoints)"
+                .into(),
+        ));
+    }
+
+    let mut undone = Vec::with_capacity(selected.len());
+    for record in &selected {
+        undone.push(undo_record(resolver, cfg, scope_root, &root, record)?);
+        journal::remove_record(cfg, &root, record);
+    }
+    Ok(UndoOutput { undone })
+}
+
+fn undo_record(
+    resolver: &PathResolver,
+    cfg: &CoderConfig,
+    scope_root: Option<&str>,
+    root: &Path,
+    record: &JournalRecord,
+) -> Result<UndoneRecord, CoderError> {
+    // Journal the PRE-undo state first (redo path). Skipped entries stay
+    // skipped — there is nothing to restore either way.
+    let mut redo_entries = Vec::new();
+    for entry in &record.entries {
+        if entry.skipped {
+            continue;
+        }
+        let path = std::path::PathBuf::from(&entry.path);
+        redo_entries.push(journal::EntryInput {
+            before: std::fs::read(&path).ok(),
+            path,
+            skipped: false,
+        });
+    }
+    journal::record(cfg, root, None, "coder::undo", redo_entries);
+
+    let mut restored = Vec::new();
+    let mut removed = Vec::new();
+    let mut skipped = Vec::new();
+    for entry in &record.entries {
+        if entry.skipped {
+            skipped.push(entry.path.clone());
+            continue;
+        }
+        // Re-jail: the LIVE resolver decides whether this path is writable
+        // now; a stale or tampered record must not write outside the jail.
+        let abs = match resolver.require_writable_opt(scope_root, &entry.path) {
+            Ok(abs) => abs,
+            Err(_) => {
+                skipped.push(entry.path.clone());
+                continue;
+            }
+        };
+        match &entry.blob {
+            Some(blob) => {
+                let bytes = journal::read_blob(cfg, root, blob)
+                    .map_err(|e| CoderError::Io(format!("journal blob unreadable: {e}")))?;
+                if let Some(parent) = abs.parent() {
+                    std::fs::create_dir_all(parent)
+                        .map_err(|e| CoderError::io_for_path(e, &entry.path))?;
+                }
+                atomic_write(&abs, &bytes)?;
+                restored.push(entry.path.clone());
+            }
+            None => {
+                // The file did not exist before the journaled write.
+                match std::fs::remove_file(&abs) {
+                    Ok(()) => removed.push(entry.path.clone()),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        removed.push(entry.path.clone())
+                    }
+                    Err(e) => return Err(CoderError::io_for_path(e, &entry.path)),
+                }
+            }
+        }
+    }
+    Ok(UndoneRecord {
+        seq: record.seq,
+        function_id: record.function_id.clone(),
+        turn_id: record.turn_id.clone(),
+        restored,
+        removed,
+        skipped,
+    })
+}

--- a/shell/src/code/functions/update_file.rs
+++ b/shell/src/code/functions/update_file.rs
@@ -252,16 +252,28 @@ pub async fn handle(
             Err(e) => entries.push((spec, Err(e))),
         }
     }
+    let mut journal_entries = Vec::new();
     let results: Vec<UpdateFileResult> = entries
         .into_iter()
-        .map(|(spec, resolved)| update_one(&cfg, spec, resolved))
+        .map(|(spec, resolved)| {
+            let (result, journal) = update_one(&cfg, spec, resolved);
+            journal_entries.extend(journal);
+            result
+        })
         .collect();
+    let root = resolver.effective_root(scope_root);
+    crate::code::journal::record(
+        &cfg,
+        &root,
+        req.fs_scope.as_ref(),
+        "coder::update-file",
+        journal_entries,
+    );
     let written: Vec<String> = results
         .iter()
         .filter(|r| r.success)
         .map(|r| r.path.clone())
         .collect();
-    let root = resolver.effective_root(scope_root);
     let checks = crate::code::checks::run_post_write_checks(&cfg, &resolver, &root, &written).await;
     Ok(UpdateFileOutput { results, checks })
 }
@@ -270,7 +282,7 @@ fn update_one(
     cfg: &CoderConfig,
     spec: UpdateFileSpec,
     resolved: Result<std::path::PathBuf, CoderError>,
-) -> UpdateFileResult {
+) -> (UpdateFileResult, Option<crate::code::journal::EntryInput>) {
     // Resolve up front: the edit pipeline operates ONLY on the
     // resolver-returned path, and the result echoes that canonical
     // absolute path. When resolution fails there is no canonical path,
@@ -278,37 +290,50 @@ fn update_one(
     let abs = match resolved {
         Ok(abs) => abs,
         Err(e) => {
-            return UpdateFileResult {
-                path: spec.path,
+            return (
+                UpdateFileResult {
+                    path: spec.path,
+                    success: false,
+                    applied: 0,
+                    new_line_count: 0,
+                    echoes: vec![],
+                    echoes_truncated: false,
+                    error: Some((&e).into()),
+                },
+                None,
+            )
+        }
+    };
+    let wire_path = abs.display().to_string();
+    match try_update_one(cfg, &abs, spec) {
+        Ok((applied, new_line_count, echoes, echoes_truncated, before)) => (
+            UpdateFileResult {
+                path: wire_path,
+                success: true,
+                applied,
+                new_line_count,
+                echoes,
+                echoes_truncated,
+                error: None,
+            },
+            Some(crate::code::journal::EntryInput {
+                path: abs,
+                before: Some(before),
+                skipped: false,
+            }),
+        ),
+        Err(e) => (
+            UpdateFileResult {
+                path: wire_path,
                 success: false,
                 applied: 0,
                 new_line_count: 0,
                 echoes: vec![],
                 echoes_truncated: false,
                 error: Some((&e).into()),
-            }
-        }
-    };
-    let wire_path = abs.display().to_string();
-    match try_update_one(cfg, &abs, spec) {
-        Ok((applied, new_line_count, echoes, echoes_truncated)) => UpdateFileResult {
-            path: wire_path,
-            success: true,
-            applied,
-            new_line_count,
-            echoes,
-            echoes_truncated,
-            error: None,
-        },
-        Err(e) => UpdateFileResult {
-            path: wire_path,
-            success: false,
-            applied: 0,
-            new_line_count: 0,
-            echoes: vec![],
-            echoes_truncated: false,
-            error: Some((&e).into()),
-        },
+            },
+            None,
+        ),
     }
 }
 
@@ -323,7 +348,7 @@ fn try_update_one(
     cfg: &CoderConfig,
     abs: &Path,
     spec: UpdateFileSpec,
-) -> Result<(u32, u64, Vec<OpEcho>, bool), CoderError> {
+) -> Result<(u32, u64, Vec<OpEcho>, bool, Vec<u8>), CoderError> {
     // NotFound is intercepted with the wire path in scope so the C211
     // message names the path the caller supplied (standardized wording —
     // REDACTION INVARIANT: identical to the glob-denied message).
@@ -388,6 +413,7 @@ fn try_update_one(
         final_lines.len() as u64,
         echoes,
         echoes_truncated,
+        bytes,
     ))
 }
 

--- a/shell/src/code/journal.rs
+++ b/shell/src/code/journal.rs
@@ -1,0 +1,436 @@
+//! The coder write journal: bounded before-images of every mutating coder
+//! call, keyed by effective root — the substrate for `coder::undo` and
+//! `coder::checkpoints`. Recording is best-effort and NEVER fails the write
+//! that triggered it (a journal error logs and the edit proceeds); restoring
+//! re-validates every path through the live jail, never trusting stored
+//! paths.
+//!
+//! Layout: `<journal.dir>/<root_key>/<seq>.json` with `<seq>-<i>.blob`
+//! sidecars for before-images (raw bytes — no encoding, binary-safe).
+//! `root_key` is an FNV-1a hash of the canonical root plus its last path
+//! component for human readability. Oldest-first eviction keeps each root
+//! under `journal.max_bytes` / `journal.max_records`.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use serde::{Deserialize, Serialize};
+
+use crate::code::config::CoderConfig;
+use crate::fs::FsScope;
+
+/// One file's before-state inside a record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JournalEntry {
+    /// Canonical absolute path at record time.
+    pub path: String,
+    /// Sidecar blob file name holding the before-image; `None` when the
+    /// file did not exist before the write (undo removes it).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blob: Option<String>,
+    /// Before-image byte length (0 for absent files).
+    pub before_bytes: u64,
+    /// True when the before-image was too large to journal — undo cannot
+    /// restore this file and reports the gap.
+    #[serde(default)]
+    pub skipped: bool,
+}
+
+/// One journaled mutation (a single coder call's write set).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JournalRecord {
+    pub seq: u64,
+    pub ts: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    pub function_id: String,
+    pub entries: Vec<JournalEntry>,
+}
+
+/// Input to [`record`]: a file about to be (or just) mutated and its
+/// pre-write content (`None` = did not exist).
+pub struct EntryInput {
+    pub path: PathBuf,
+    pub before: Option<Vec<u8>>,
+    /// Force-mark unrecoverable (e.g. a directory delete/move whose tree
+    /// cannot be snapshotted) — undo reports it as a gap.
+    pub skipped: bool,
+}
+
+/// Journaling disabled?
+pub fn enabled(cfg: &CoderConfig) -> bool {
+    cfg.journal.max_records > 0
+}
+
+/// Record one mutation's before-images. Best-effort: any failure logs a
+/// warning and returns — the caller's write is never blocked.
+pub fn record(
+    cfg: &CoderConfig,
+    root: &Path,
+    scope: Option<&FsScope>,
+    function_id: &str,
+    inputs: Vec<EntryInput>,
+) {
+    if !enabled(cfg) || inputs.is_empty() {
+        return;
+    }
+    if let Err(e) = record_inner(cfg, root, scope, function_id, inputs) {
+        tracing::warn!(function_id, error = %e, "coder journal record failed (write unaffected)");
+    }
+}
+
+fn record_inner(
+    cfg: &CoderConfig,
+    root: &Path,
+    scope: Option<&FsScope>,
+    function_id: &str,
+    inputs: Vec<EntryInput>,
+) -> std::io::Result<()> {
+    let dir = root_dir(cfg, root);
+    std::fs::create_dir_all(&dir)?;
+    let seq = next_seq(&dir);
+
+    let mut entries = Vec::with_capacity(inputs.len());
+    for (i, input) in inputs.into_iter().enumerate() {
+        let (blob, before_bytes, skipped) = match (input.skipped, input.before) {
+            (true, before) => (None, before.map(|b| b.len() as u64).unwrap_or(0), true),
+            (false, None) => (None, 0, false),
+            (false, Some(bytes)) if (bytes.len() as u64) > cfg.max_write_bytes => {
+                (None, bytes.len() as u64, true)
+            }
+            (false, Some(bytes)) => {
+                let name = format!("{seq:08}-{i}.blob");
+                std::fs::write(dir.join(&name), &bytes)?;
+                (Some(name), bytes.len() as u64, false)
+            }
+        };
+        entries.push(JournalEntry {
+            path: input.path.display().to_string(),
+            blob,
+            before_bytes,
+            skipped,
+        });
+    }
+
+    let record = JournalRecord {
+        seq,
+        ts: now_ms(),
+        session_id: scope.and_then(|s| s.session_id.clone()),
+        turn_id: scope.and_then(|s| s.turn_id.clone()),
+        function_id: function_id.to_string(),
+        entries,
+    };
+    let json = serde_json::to_vec(&record)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    std::fs::write(dir.join(format!("{seq:08}.json")), json)?;
+    evict(cfg, &dir);
+    Ok(())
+}
+
+/// All records for a root, ascending seq. Unreadable records are skipped.
+pub fn list(cfg: &CoderConfig, root: &Path) -> Vec<JournalRecord> {
+    let dir = root_dir(cfg, root);
+    let Ok(rd) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    let mut out: Vec<JournalRecord> = rd
+        .flatten()
+        .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .filter_map(|e| {
+            std::fs::read(e.path())
+                .ok()
+                .and_then(|b| serde_json::from_slice(&b).ok())
+        })
+        .collect();
+    out.sort_by_key(|r: &JournalRecord| r.seq);
+    out
+}
+
+/// Read one entry's before-image blob.
+pub fn read_blob(cfg: &CoderConfig, root: &Path, blob: &str) -> std::io::Result<Vec<u8>> {
+    // Blob names are journal-generated (`{seq}-{i}.blob`); reject anything
+    // path-like so a tampered record cannot read outside the journal dir.
+    if blob.contains('/') || blob.contains('\\') || blob.contains("..") {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "invalid blob name",
+        ));
+    }
+    std::fs::read(root_dir(cfg, root).join(blob))
+}
+
+/// Delete a record and its blobs (after a successful undo of it, the undo
+/// itself having journaled the pre-undo state as a NEW record).
+pub fn remove_record(cfg: &CoderConfig, root: &Path, record: &JournalRecord) {
+    let dir = root_dir(cfg, root);
+    for e in &record.entries {
+        if let Some(blob) = &e.blob {
+            let _ = std::fs::remove_file(dir.join(blob));
+        }
+    }
+    let _ = std::fs::remove_file(dir.join(format!("{:08}.json", record.seq)));
+}
+
+fn evict(cfg: &CoderConfig, dir: &Path) {
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut json_files: Vec<(u64, PathBuf, u64)> = Vec::new(); // (seq, path, bytes incl. blobs)
+    let mut blob_sizes: HashMap<u64, u64> = HashMap::new();
+    let mut blob_paths: HashMap<u64, Vec<PathBuf>> = HashMap::new();
+    for e in rd.flatten() {
+        let p = e.path();
+        let size = e.metadata().map(|m| m.len()).unwrap_or(0);
+        let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if let Some(stem) = name.strip_suffix(".json") {
+            if let Ok(seq) = stem.parse::<u64>() {
+                json_files.push((seq, p.clone(), size));
+            }
+        } else if let Some(stem) = name.strip_suffix(".blob") {
+            if let Some((seq_part, _)) = stem.split_once('-') {
+                if let Ok(seq) = seq_part.parse::<u64>() {
+                    *blob_sizes.entry(seq).or_default() += size;
+                    blob_paths.entry(seq).or_default().push(p.clone());
+                }
+            }
+        }
+    }
+    json_files.sort_by_key(|(seq, _, _)| *seq);
+    let mut total: u64 = json_files
+        .iter()
+        .map(|(seq, _, sz)| sz + blob_sizes.get(seq).copied().unwrap_or(0))
+        .sum();
+    let mut count = json_files.len() as u32;
+    for (seq, path, sz) in &json_files {
+        let over_bytes = total > cfg.journal.max_bytes;
+        let over_count = count > cfg.journal.max_records;
+        if !over_bytes && !over_count {
+            break;
+        }
+        let _ = std::fs::remove_file(path);
+        for bp in blob_paths.get(seq).into_iter().flatten() {
+            let _ = std::fs::remove_file(bp);
+        }
+        total = total.saturating_sub(sz + blob_sizes.get(seq).copied().unwrap_or(0));
+        count -= 1;
+    }
+}
+
+/// Per-root journal directory: `<dir>/<fnv(root)>-<last component>`.
+fn root_dir(cfg: &CoderConfig, root: &Path) -> PathBuf {
+    let canon = root.to_string_lossy();
+    let tail: String = root
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default()
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .take(32)
+        .collect();
+    PathBuf::from(&cfg.journal.dir).join(format!("{:016x}-{tail}", fnv1a(canon.as_bytes())))
+}
+
+/// Stable across processes and Rust versions (unlike DefaultHasher).
+fn fnv1a(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf29ce484222325;
+    for b in bytes {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    h
+}
+
+/// Next sequence number for a root dir: max on disk + 1 at first use, then
+/// a process-local counter (the shell worker is the only writer).
+fn next_seq(dir: &Path) -> u64 {
+    static COUNTERS: OnceLock<Mutex<HashMap<PathBuf, u64>>> = OnceLock::new();
+    let counters = COUNTERS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut map = counters.lock().unwrap_or_else(|p| p.into_inner());
+    let next = map
+        .entry(dir.to_path_buf())
+        .or_insert_with(|| max_seq_on_disk(dir));
+    *next += 1;
+    *next
+}
+
+fn max_seq_on_disk(dir: &Path) -> u64 {
+    std::fs::read_dir(dir)
+        .map(|rd| {
+            rd.flatten()
+                .filter_map(|e| {
+                    e.path()
+                        .file_name()?
+                        .to_str()?
+                        .strip_suffix(".json")?
+                        .parse::<u64>()
+                        .ok()
+                })
+                .max()
+                .unwrap_or(0)
+        })
+        .unwrap_or(0)
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn cfg_with(dir: &Path, max_records: u32, max_bytes: u64) -> CoderConfig {
+        let mut c = CoderConfig::default();
+        c.journal.dir = dir.display().to_string();
+        c.journal.max_records = max_records;
+        c.journal.max_bytes = max_bytes;
+        c
+    }
+
+    fn entry(path: &str, before: Option<&[u8]>) -> EntryInput {
+        EntryInput {
+            path: PathBuf::from(path),
+            before: before.map(|b| b.to_vec()),
+            skipped: false,
+        }
+    }
+
+    #[test]
+    fn record_and_list_round_trip() {
+        let jd = tempdir().unwrap();
+        let root = tempdir().unwrap();
+        let cfg = cfg_with(jd.path(), 100, 1 << 20);
+        record(
+            &cfg,
+            root.path(),
+            None,
+            "coder::update-file",
+            vec![entry("/w/a.rs", Some(b"old contents"))],
+        );
+        record(
+            &cfg,
+            root.path(),
+            None,
+            "coder::create-file",
+            vec![entry("/w/new.rs", None)],
+        );
+        let records = list(&cfg, root.path());
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].function_id, "coder::update-file");
+        assert!(records[0].seq < records[1].seq);
+        let blob = records[0].entries[0].blob.as_ref().unwrap();
+        assert_eq!(read_blob(&cfg, root.path(), blob).unwrap(), b"old contents");
+        assert!(
+            records[1].entries[0].blob.is_none(),
+            "absent before = no blob"
+        );
+    }
+
+    #[test]
+    fn scope_stamps_ride_the_record() {
+        let jd = tempdir().unwrap();
+        let root = tempdir().unwrap();
+        let cfg = cfg_with(jd.path(), 100, 1 << 20);
+        let scope = FsScope {
+            root: root.path().display().to_string(),
+            grants: vec![],
+            session_id: Some("s-1".into()),
+            turn_id: Some("t-1".into()),
+        };
+        record(
+            &cfg,
+            root.path(),
+            Some(&scope),
+            "coder::apply-patch",
+            vec![entry("/w/a.rs", Some(b"x"))],
+        );
+        let r = &list(&cfg, root.path())[0];
+        assert_eq!(r.session_id.as_deref(), Some("s-1"));
+        assert_eq!(r.turn_id.as_deref(), Some("t-1"));
+    }
+
+    #[test]
+    fn oversized_before_image_is_skipped_honestly() {
+        let jd = tempdir().unwrap();
+        let root = tempdir().unwrap();
+        let mut cfg = cfg_with(jd.path(), 100, 1 << 20);
+        cfg.max_write_bytes = 4;
+        record(
+            &cfg,
+            root.path(),
+            None,
+            "coder::delete-file",
+            vec![entry("/w/big.bin", Some(b"way too large"))],
+        );
+        let r = &list(&cfg, root.path())[0];
+        assert!(r.entries[0].skipped);
+        assert!(r.entries[0].blob.is_none());
+        assert_eq!(r.entries[0].before_bytes, 13);
+    }
+
+    #[test]
+    fn record_count_eviction_drops_oldest() {
+        let jd = tempdir().unwrap();
+        let root = tempdir().unwrap();
+        let cfg = cfg_with(jd.path(), 3, 1 << 20);
+        for i in 0..5u8 {
+            record(
+                &cfg,
+                root.path(),
+                None,
+                "coder::update-file",
+                vec![entry(&format!("/w/{i}.rs"), Some(&[i]))],
+            );
+        }
+        let records = list(&cfg, root.path());
+        assert_eq!(records.len(), 3, "oldest evicted");
+        assert!(records[0].entries[0].path.ends_with("2.rs"));
+    }
+
+    #[test]
+    fn zero_max_records_disables_journaling() {
+        let jd = tempdir().unwrap();
+        let root = tempdir().unwrap();
+        let cfg = cfg_with(jd.path(), 0, 1 << 20);
+        record(
+            &cfg,
+            root.path(),
+            None,
+            "coder::update-file",
+            vec![entry("/w/a.rs", Some(b"x"))],
+        );
+        assert!(list(&cfg, root.path()).is_empty());
+    }
+
+    #[test]
+    fn blob_names_reject_path_traversal() {
+        let jd = tempdir().unwrap();
+        let root = tempdir().unwrap();
+        let cfg = cfg_with(jd.path(), 100, 1 << 20);
+        assert!(read_blob(&cfg, root.path(), "../../etc/passwd").is_err());
+    }
+
+    #[test]
+    fn distinct_roots_do_not_share_journals() {
+        let jd = tempdir().unwrap();
+        let root_a = tempdir().unwrap();
+        let root_b = tempdir().unwrap();
+        let cfg = cfg_with(jd.path(), 100, 1 << 20);
+        record(
+            &cfg,
+            root_a.path(),
+            None,
+            "coder::update-file",
+            vec![entry("/w/a.rs", Some(b"a"))],
+        );
+        assert_eq!(list(&cfg, root_a.path()).len(), 1);
+        assert!(list(&cfg, root_b.path()).is_empty());
+    }
+}

--- a/shell/src/code/mod.rs
+++ b/shell/src/code/mod.rs
@@ -18,6 +18,7 @@ pub mod checks;
 pub mod config;
 pub mod error;
 pub mod functions;
+pub mod journal;
 pub mod patch;
 pub mod path;
 pub mod state;

--- a/shell/src/fs/host.rs
+++ b/shell/src/fs/host.rs
@@ -2252,6 +2252,8 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: session.display().to_string(),
                     grants: Vec::new(),
+                    session_id: None,
+                    turn_id: None,
                 }),
             })
             .await
@@ -2264,6 +2266,8 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: session.display().to_string(),
                     grants: vec![granted.display().to_string()],
+                    session_id: None,
+                    turn_id: None,
                 }),
             })
             .await
@@ -3991,6 +3995,8 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: base,
                     grants: Vec::new(),
+                    session_id: None,
+                    turn_id: None,
                 }),
             })
             .await
@@ -4022,6 +4028,8 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: base,
                     grants: Vec::new(),
+                    session_id: None,
+                    turn_id: None,
                 }),
             })
             .await
@@ -4053,6 +4061,8 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: base,
                     grants: Vec::new(),
+                    session_id: None,
+                    turn_id: None,
                 }),
             })
             .await
@@ -4086,6 +4096,8 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: base,
                     grants: Vec::new(),
+                    session_id: None,
+                    turn_id: None,
                 }),
             })
             .await
@@ -4120,6 +4132,8 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: selected.join("project").to_string_lossy().into_owned(),
                     grants: Vec::new(),
+                    session_id: None,
+                    turn_id: None,
                 }),
             })
             .await
@@ -4144,6 +4158,8 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: selected.to_string_lossy().into_owned(),
                     grants: Vec::new(),
+                    session_id: None,
+                    turn_id: None,
                 }),
             })
             .await
@@ -4161,6 +4177,8 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: "../../etc".into(),
                     grants: Vec::new(),
+                    session_id: None,
+                    turn_id: None,
                 }),
             })
             .await
@@ -4183,6 +4201,8 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: base,
                     grants: Vec::new(),
+                    session_id: None,
+                    turn_id: None,
                 }),
             })
             .await

--- a/shell/src/fs/mod.rs
+++ b/shell/src/fs/mod.rs
@@ -21,6 +21,12 @@ pub struct FsScope {
     pub root: String,
     #[serde(default)]
     pub grants: Vec<String>,
+    /// Session that issued the call (harness-stamped; journal attribution).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    /// Turn that issued the call (harness-stamped; enables undo-by-turn).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
 }
 
 impl FsScope {

--- a/shell/tests/code_context.rs
+++ b/shell/tests/code_context.rs
@@ -111,6 +111,8 @@ async fn context_honors_fs_scope_root() {
             fs_scope: Some(shell::fs::FsScope {
                 root: scope,
                 grants: vec![],
+                session_id: None,
+                turn_id: None,
             }),
         },
     )

--- a/shell/tests/code_golden_errors.rs
+++ b/shell/tests/code_golden_errors.rs
@@ -264,6 +264,7 @@ async fn error_message_formats_match_golden() {
         std::fs::write(jail.root0.join("blocked-dir/nested/.env"), "s").unwrap();
         let out = delete_file::handle(
             jail.resolver.clone(),
+            jail.cfg.clone(),
             delete_file::DeleteFileInput {
                 paths: vec!["blocked-dir".into()],
                 recursive: true,
@@ -438,6 +439,7 @@ async fn error_message_formats_match_golden() {
         std::fs::write(jail.root0.join("move-dst.txt"), "dst").unwrap();
         let out = move_file::handle(
             jail.resolver.clone(),
+            jail.cfg.clone(),
             move_file::MoveFileInput {
                 files: vec![move_file::MoveFileSpec {
                     from: "move-src.txt".into(),
@@ -468,6 +470,7 @@ async fn error_message_formats_match_golden() {
         let dst_abs = jail.root1.join("cross-dir");
         let out = move_file::handle(
             jail.resolver.clone(),
+            jail.cfg.clone(),
             move_file::MoveFileInput {
                 files: vec![move_file::MoveFileSpec {
                     from: "cross-dir".into(),
@@ -497,6 +500,7 @@ async fn error_message_formats_match_golden() {
         std::fs::create_dir_all(jail.root0.join("move-dst-dir")).unwrap();
         let out = move_file::handle(
             jail.resolver.clone(),
+            jail.cfg.clone(),
             move_file::MoveFileInput {
                 files: vec![move_file::MoveFileSpec {
                     from: "move-dir-src.txt".into(),
@@ -569,6 +573,7 @@ async fn error_message_formats_match_golden() {
     {
         let out = move_file::handle(
             jail.resolver.clone(),
+            jail.cfg.clone(),
             move_file::MoveFileInput {
                 files: vec![move_file::MoveFileSpec {
                     from: "no-such-move-src.txt".into(),

--- a/shell/tests/code_golden_schemas.rs
+++ b/shell/tests/code_golden_schemas.rs
@@ -1,4 +1,4 @@
-//! GOLDEN FAMILY A — wire-schema snapshots for all 13 `coder::*` functions
+//! GOLDEN FAMILY A — wire-schema snapshots for all 15 `coder::*` functions
 //! served by the shell worker.
 //!
 //! `shell::code::functions::catalog()` is the single source of truth for
@@ -35,10 +35,10 @@ fn spec_to_pretty_json(spec: &FunctionSpec) -> String {
     pretty
 }
 
-/// The catalog must cover exactly the 13 registered functions, in
+/// The catalog must cover exactly the 15 registered functions, in
 /// registration order (kept in lockstep with `register_all`).
 #[test]
-fn catalog_lists_all_thirteen_functions_in_registration_order() {
+fn catalog_lists_all_fifteen_functions_in_registration_order() {
     let ids: Vec<&str> = catalog().iter().map(|s| s.function_id).collect();
     assert_eq!(
         ids,
@@ -51,6 +51,8 @@ fn catalog_lists_all_thirteen_functions_in_registration_order() {
             "coder::apply-patch",
             "coder::worktree-add",
             "coder::worktree-remove",
+            "coder::undo",
+            "coder::checkpoints",
             "coder::create-file",
             "coder::delete-file",
             "coder::list-folder",

--- a/shell/tests/code_lifecycle.rs
+++ b/shell/tests/code_lifecycle.rs
@@ -216,9 +216,13 @@ async fn full_lifecycle_via_handlers() {
 
     // 8. delete-file removes the file.
     let del = wire(
-        delete_file::handle(s.resolver.clone(), input(json!({ "paths": ["hello.txt"] })))
-            .await
-            .expect("delete-file"),
+        delete_file::handle(
+            s.resolver.clone(),
+            s.cfg.clone(),
+            input(json!({ "paths": ["hello.txt"] })),
+        )
+        .await
+        .expect("delete-file"),
     );
     assert_eq!(del["results"][0]["success"], true);
     assert_eq!(del["results"][0]["removed"], true);

--- a/shell/tests/code_path_jail.rs
+++ b/shell/tests/code_path_jail.rs
@@ -169,6 +169,8 @@ async fn scoped_scope_root_blocks_sibling_escape_across_handlers() {
             fs_scope: Some(shell::fs::FsScope {
                 root: scope_root.clone(),
                 grants: Vec::new(),
+                session_id: None,
+                turn_id: None,
             }),
             ..ReadFileInput::default()
         },
@@ -179,7 +181,7 @@ async fn scoped_scope_root_blocks_sibling_escape_across_handlers() {
 
     let create_err = create_handle(
         r.clone(),
-        c,
+        c.clone(),
         CreateFileInput {
             files: vec![CreateFileSpec {
                 path: "../created-outside.txt".into(),
@@ -191,6 +193,8 @@ async fn scoped_scope_root_blocks_sibling_escape_across_handlers() {
             fs_scope: Some(shell::fs::FsScope {
                 root: scope_root.clone(),
                 grants: Vec::new(),
+                session_id: None,
+                turn_id: None,
             }),
         },
     )
@@ -204,12 +208,15 @@ async fn scoped_scope_root_blocks_sibling_escape_across_handlers() {
 
     let delete_err = delete_handle(
         r,
+        c.clone(),
         DeleteFileInput {
             paths: vec!["../sibling.txt".into()],
             recursive: false,
             fs_scope: Some(shell::fs::FsScope {
                 root: scope_root,
                 grants: Vec::new(),
+                session_id: None,
+                turn_id: None,
             }),
         },
     )

--- a/shell/tests/code_undo.rs
+++ b/shell/tests/code_undo.rs
@@ -1,0 +1,256 @@
+//! Integration coverage for the write journal + `coder::undo` /
+//! `coder::checkpoints`: full pipeline through the real handlers.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use shell::code::config::CoderConfig;
+use shell::code::functions::apply_patch::{handle as apply_handle, ApplyPatchInput};
+use shell::code::functions::checkpoints::{handle as checkpoints_handle, CheckpointsInput};
+use shell::code::functions::delete_file::{handle as delete_handle, DeleteFileInput};
+use shell::code::functions::undo::{handle as undo_handle, UndoInput};
+use shell::code::functions::update_file::{
+    handle as update_handle, UpdateFileInput, UpdateFileSpec, UpdateOp,
+};
+use shell::code::path::PathResolver;
+use shell::fs::FsScope;
+use tempfile::tempdir;
+
+fn make(base: PathBuf, journal_dir: PathBuf) -> (Arc<PathResolver>, Arc<CoderConfig>) {
+    let mut cfg = CoderConfig {
+        base_paths: vec![base],
+        ..CoderConfig::default()
+    };
+    cfg.journal.dir = journal_dir.display().to_string();
+    let cfg = Arc::new(cfg);
+    let r = Arc::new(PathResolver::new(&cfg).unwrap());
+    (r, cfg)
+}
+
+fn scope(root: &std::path::Path, turn: &str) -> Option<FsScope> {
+    Some(FsScope {
+        root: root.display().to_string(),
+        grants: vec![],
+        session_id: Some("s-e2e".into()),
+        turn_id: Some(turn.into()),
+    })
+}
+
+fn str_replace(path: &str, old: &str, new: &str, fs_scope: Option<FsScope>) -> UpdateFileInput {
+    UpdateFileInput {
+        files: vec![UpdateFileSpec {
+            path: path.into(),
+            ops: vec![UpdateOp::StrReplace {
+                old_str: old.into(),
+                new_str: new.into(),
+                replace_all: false,
+            }],
+        }],
+        fs_scope,
+    }
+}
+
+#[tokio::test]
+async fn undo_restores_an_update_byte_identical_and_redo_works() {
+    let tmp = tempdir().unwrap();
+    let jd = tempdir().unwrap();
+    std::fs::write(tmp.path().join("a.txt"), "original\n").unwrap();
+    let (r, c) = make(tmp.path().to_path_buf(), jd.path().to_path_buf());
+
+    update_handle(
+        r.clone(),
+        c.clone(),
+        str_replace("a.txt", "original", "changed", None),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("a.txt")).unwrap(),
+        "changed\n"
+    );
+
+    // Undo restores the before-image.
+    let out = undo_handle(r.clone(), c.clone(), UndoInput::default())
+        .await
+        .unwrap();
+    assert_eq!(out.undone.len(), 1);
+    assert_eq!(out.undone[0].function_id, "coder::update-file");
+    assert_eq!(out.undone[0].restored.len(), 1);
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("a.txt")).unwrap(),
+        "original\n"
+    );
+
+    // Undo of the undo = redo.
+    let out = undo_handle(r, c, UndoInput::default()).await.unwrap();
+    assert_eq!(out.undone[0].function_id, "coder::undo");
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("a.txt")).unwrap(),
+        "changed\n"
+    );
+}
+
+#[tokio::test]
+async fn undo_by_turn_reverts_everything_that_turn_did() {
+    let tmp = tempdir().unwrap();
+    let jd = tempdir().unwrap();
+    std::fs::write(tmp.path().join("a.txt"), "a0\n").unwrap();
+    std::fs::write(tmp.path().join("b.txt"), "b0\n").unwrap();
+    let (r, c) = make(tmp.path().to_path_buf(), jd.path().to_path_buf());
+
+    // Turn t-1 edits a.txt and deletes b.txt; turn t-2 edits a.txt again.
+    update_handle(
+        r.clone(),
+        c.clone(),
+        str_replace("a.txt", "a0", "a1", scope(tmp.path(), "t-1")),
+    )
+    .await
+    .unwrap();
+    delete_handle(
+        r.clone(),
+        c.clone(),
+        DeleteFileInput {
+            paths: vec!["b.txt".into()],
+            recursive: false,
+            fs_scope: scope(tmp.path(), "t-1"),
+        },
+    )
+    .await
+    .unwrap();
+    update_handle(
+        r.clone(),
+        c.clone(),
+        str_replace("a.txt", "a1", "a2", scope(tmp.path(), "t-2")),
+    )
+    .await
+    .unwrap();
+
+    // Undo ONLY t-1: b.txt comes back; a.txt reverts to its t-1 before-image
+    // (a0) because t-1's record is the oldest layer — t-2's record remains
+    // journaled for its own undo.
+    let out = undo_handle(
+        r.clone(),
+        c.clone(),
+        UndoInput {
+            steps: None,
+            turn_id: Some("t-1".into()),
+            fs_scope: scope(tmp.path(), "t-3"),
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(out.undone.len(), 2, "both t-1 records undone");
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("b.txt")).unwrap(),
+        "b0\n",
+        "deleted file restored"
+    );
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("a.txt")).unwrap(),
+        "a0\n"
+    );
+}
+
+#[tokio::test]
+async fn undo_removes_files_created_by_the_journaled_write() {
+    let tmp = tempdir().unwrap();
+    let jd = tempdir().unwrap();
+    let (r, c) = make(tmp.path().to_path_buf(), jd.path().to_path_buf());
+
+    apply_handle(
+        r.clone(),
+        c.clone(),
+        ApplyPatchInput {
+            patch: "*** Begin Patch\n*** Add File: fresh.py\n+x = 1\n*** End Patch".into(),
+            fs_scope: None,
+        },
+    )
+    .await
+    .unwrap();
+    assert!(tmp.path().join("fresh.py").exists());
+
+    let out = undo_handle(r, c, UndoInput::default()).await.unwrap();
+    assert_eq!(out.undone[0].function_id, "coder::apply-patch");
+    assert_eq!(
+        out.undone[0].removed,
+        vec![tmp
+            .path()
+            .canonicalize()
+            .unwrap()
+            .join("fresh.py")
+            .display()
+            .to_string()]
+    );
+    assert!(!tmp.path().join("fresh.py").exists());
+}
+
+#[tokio::test]
+async fn checkpoints_lists_newest_first_with_turn_attribution() {
+    let tmp = tempdir().unwrap();
+    let jd = tempdir().unwrap();
+    std::fs::write(tmp.path().join("a.txt"), "0\n").unwrap();
+    let (r, c) = make(tmp.path().to_path_buf(), jd.path().to_path_buf());
+
+    update_handle(
+        r.clone(),
+        c.clone(),
+        str_replace("a.txt", "0", "1", scope(tmp.path(), "t-early")),
+    )
+    .await
+    .unwrap();
+    update_handle(
+        r.clone(),
+        c.clone(),
+        str_replace("a.txt", "1", "2", scope(tmp.path(), "t-late")),
+    )
+    .await
+    .unwrap();
+
+    let out = checkpoints_handle(r, c, CheckpointsInput::default())
+        .await
+        .unwrap();
+    assert_eq!(out.records.len(), 2);
+    assert!(!out.truncated);
+    assert_eq!(out.records[0].turn_id.as_deref(), Some("t-late"));
+    assert_eq!(out.records[1].turn_id.as_deref(), Some("t-early"));
+    assert_eq!(out.records[0].session_id.as_deref(), Some("s-e2e"));
+    assert!(out.records[0].files[0].ends_with("a.txt"));
+}
+
+#[tokio::test]
+async fn undo_reports_directory_delete_as_skipped_gap() {
+    let tmp = tempdir().unwrap();
+    let jd = tempdir().unwrap();
+    std::fs::create_dir(tmp.path().join("dir")).unwrap();
+    std::fs::write(tmp.path().join("dir/x.txt"), "x\n").unwrap();
+    let (r, c) = make(tmp.path().to_path_buf(), jd.path().to_path_buf());
+
+    delete_handle(
+        r.clone(),
+        c.clone(),
+        DeleteFileInput {
+            paths: vec!["dir".into()],
+            recursive: true,
+            fs_scope: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let out = undo_handle(r, c, UndoInput::default()).await.unwrap();
+    assert_eq!(out.undone[0].skipped.len(), 1, "dir delete is a gap");
+    assert!(out.undone[0].restored.is_empty());
+    assert!(
+        !tmp.path().join("dir").exists(),
+        "gaps are reported, not silently resurrected"
+    );
+}
+
+#[tokio::test]
+async fn undo_with_nothing_journaled_is_a_clear_error() {
+    let tmp = tempdir().unwrap();
+    let jd = tempdir().unwrap();
+    let (r, c) = make(tmp.path().to_path_buf(), jd.path().to_path_buf());
+    let err = undo_handle(r, c, UndoInput::default()).await.unwrap_err();
+    assert!(err.contains("nothing to undo"), "{err}");
+}

--- a/shell/tests/common/world.rs
+++ b/shell/tests/common/world.rs
@@ -281,11 +281,15 @@ async fn call_direct(
         }
         "coder::delete-file" => {
             let input = decode_payload(payload)?;
-            serialize_result(delete_file::handle(surface.resolver.clone(), input).await)
+            serialize_result(
+                delete_file::handle(surface.resolver.clone(), surface.cfg.clone(), input).await,
+            )
         }
         "coder::move" => {
             let input = decode_payload(payload)?;
-            serialize_result(move_file::handle(surface.resolver.clone(), input).await)
+            serialize_result(
+                move_file::handle(surface.resolver.clone(), surface.cfg.clone(), input).await,
+            )
         }
         "coder::list-folder" => {
             let input = decode_payload(payload)?;

--- a/shell/tests/golden/schemas/coder.checkpoints.json
+++ b/shell/tests/golden/schemas/coder.checkpoints.json
@@ -1,0 +1,99 @@
+{
+  "description": "List this workspace's write-journal records (newest first, default 50): seq, timestamp, mutating function, the session/turn that issued it, and the affected files — the picker surface for coder::undo ({ steps } by recency, { turn_id } by turn).",
+  "function_id": "coder::checkpoints",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "examples": [
+      {}
+    ],
+    "properties": {
+      "limit": {
+        "default": null,
+        "description": "Maximum records returned (newest first). Default 50.",
+        "format": "uint32",
+        "minimum": 0.0,
+        "type": [
+          "integer",
+          "null"
+        ]
+      }
+    },
+    "title": "CheckpointsInput",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+      "CheckpointMeta": {
+        "properties": {
+          "files": {
+            "description": "Affected file paths.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "function_id": {
+            "description": "The mutation (e.g. \"coder::apply-patch\", \"coder::undo\").",
+            "type": "string"
+          },
+          "seq": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "session_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "skipped": {
+            "description": "Count of unrecoverable entries in this record (oversized images, directory operations).",
+            "format": "uint32",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "ts": {
+            "description": "Unix millis when the mutation was journaled.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "turn_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "files",
+          "function_id",
+          "seq",
+          "skipped",
+          "ts"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "records": {
+        "description": "Journal records, newest first.",
+        "items": {
+          "$ref": "#/definitions/CheckpointMeta"
+        },
+        "type": "array"
+      },
+      "truncated": {
+        "description": "True when older records exist beyond `limit`.",
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "records",
+      "truncated"
+    ],
+    "title": "CheckpointsOutput",
+    "type": "object"
+  }
+}

--- a/shell/tests/golden/schemas/coder.undo.json
+++ b/shell/tests/golden/schemas/coder.undo.json
@@ -1,0 +1,101 @@
+{
+  "description": "Revert journaled coder writes in this workspace: the last N records ({ steps }, default 1) or everything a specific turn changed ({ turn_id } — coder::checkpoints lists them). Restores run newest first through the live jail; files that did not exist before a write are removed, others are rewritten to their before-image. The undo journals its own pre-undo state first, so running coder::undo again REDOES the change. Unrecoverable gaps (oversized before-images, directory deletes/moves) are reported in `skipped`, never silently ignored.",
+  "function_id": "coder::undo",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "examples": [
+      {
+        "steps": 1
+      }
+    ],
+    "properties": {
+      "steps": {
+        "default": null,
+        "description": "Undo the last N journaled records (default 1). Mutually exclusive with `turn_id`.",
+        "format": "uint32",
+        "minimum": 0.0,
+        "type": [
+          "integer",
+          "null"
+        ]
+      },
+      "turn_id": {
+        "default": null,
+        "description": "Undo every journaled record this turn produced (see `coder::checkpoints` for turn ids). Mutually exclusive with `steps`.",
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "title": "UndoInput",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+      "UndoneRecord": {
+        "properties": {
+          "function_id": {
+            "description": "The mutation this record captured (e.g. \"coder::update-file\").",
+            "type": "string"
+          },
+          "removed": {
+            "description": "Files removed (they did not exist before the journaled write).",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "restored": {
+            "description": "Files rewritten to their journaled before-image.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "seq": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "skipped": {
+            "description": "Unrecoverable gaps: oversized before-images, directory operations, or paths the live jail rejected — inspect these manually.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "turn_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "function_id",
+          "removed",
+          "restored",
+          "seq",
+          "skipped"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "undone": {
+        "description": "Undone records, newest first. The undo itself was journaled before any restore, so `coder::undo { steps: 1 }` again redoes the change.",
+        "items": {
+          "$ref": "#/definitions/UndoneRecord"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "undone"
+    ],
+    "title": "UndoOutput",
+    "type": "object"
+  }
+}


### PR DESCRIPTION
Every mutating coder call (update-file, create-file, delete-file, move,
apply-patch) records bounded before-images into a per-root journal
(journal.dir / max_bytes 64MiB / max_records 500, hot-reloading,
oldest-first eviction, raw-byte blob sidecars — binary-safe). The
harness fs_scope stamp gains session_id/turn_id so records attribute to
the turn that wrote them.

coder::undo reverts the last N records or everything a turn changed:
restores run newest-first, every path re-validates through the LIVE
jail, files that did not pre-exist are removed, and the undo journals
its own pre-undo state first — undoing an undo redoes the change.
Unrecoverable gaps (oversized images, directory deletes/moves) are
reported in skipped, never silently ignored. coder::checkpoints lists
the journal (newest first) as the undo picker. Catalog grows to 15.

Refs MOT-3875
