### PR TITLE
(MOT-3875) feat(harness): harness::todo session checklist

### DIFF
--- a/console/web/src/components/chat/Message.tsx
+++ b/console/web/src/components/chat/Message.tsx
@@ -89,6 +89,8 @@ export function Message({
     case 'system':
       return message.kind === 'compaction' ? (
         <CompactionMarker message={message} />
+      ) : message.kind === 'todo' ? (
+        <TodoCard message={message} />
       ) : (
         <SystemNotice message={message} />
       )
@@ -111,6 +113,60 @@ function SystemNotice({ message }: { message: SystemMessageType }) {
       )}
     >
       {message.content}
+    </article>
+  )
+}
+
+/** The harness::todo checklist — the latest todo entry is the live list. */
+function TodoCard({ message }: { message: SystemMessageType }) {
+  const items = message.todoItems ?? []
+  if (items.length === 0) return null
+  const done = items.filter((i) => i.status === 'completed').length
+  return (
+    <article className="my-2 border border-rule rounded-md px-3 py-2">
+      <div className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-faint mb-1.5 flex items-center gap-2">
+        <span>tasks</span>
+        <span className="text-ink-ghost">·</span>
+        <span className="tabular-nums">
+          {done}/{items.length}
+        </span>
+      </div>
+      <ul className="space-y-1">
+        {items.map((item) => (
+          <li
+            key={`${item.status}:${item.text}`}
+            className="flex items-start gap-2 text-[13px] leading-snug"
+          >
+            <span
+              aria-hidden="true"
+              className={
+                item.status === 'completed'
+                  ? 'text-ok'
+                  : item.status === 'in_progress'
+                    ? 'text-warn'
+                    : 'text-ink-ghost'
+              }
+            >
+              {item.status === 'completed'
+                ? '◼'
+                : item.status === 'in_progress'
+                  ? '▸'
+                  : '◻'}
+            </span>
+            <span
+              className={
+                item.status === 'completed'
+                  ? 'text-ink-faint line-through'
+                  : item.status === 'in_progress'
+                    ? 'text-ink'
+                    : 'text-ink-faint'
+              }
+            >
+              {item.text}
+            </span>
+          </li>
+        ))}
+      </ul>
     </article>
   )
 }

--- a/console/web/src/lib/sessions/entry-mapper.ts
+++ b/console/web/src/lib/sessions/entry-mapper.ts
@@ -131,6 +131,9 @@ export function entrySegments(
     if (item.custom.custom_type === COMPACTION_CUSTOM_TYPE) {
       return [compactionMarker(item.entry_id, item.custom.data, Date.now())]
     }
+    if (item.custom.custom_type === 'todo') {
+      return [todoCard(item.entry_id, item.custom.data)]
+    }
     return []
   }
   const message = item.message
@@ -169,6 +172,26 @@ export function entrySegments(
       }
       return [msg]
     }
+  }
+}
+
+/** `custom_type: "todo"` — the harness::todo checklist (latest wins). */
+function todoCard(entryId: string, data: unknown): Message {
+  const items = Array.isArray((data as { items?: unknown })?.items)
+    ? ((data as { items: unknown[] }).items.filter(
+        (i): i is { text: string; status: string } =>
+          typeof (i as { text?: unknown })?.text === 'string' &&
+          typeof (i as { status?: unknown })?.status === 'string',
+      ) as { text: string; status: 'pending' | 'in_progress' | 'completed' }[])
+    : []
+  return {
+    id: entryId,
+    role: 'system',
+    kind: 'todo',
+    content: `todo: ${items.length} items`,
+    tone: 'info',
+    todoItems: items,
+    createdAt: Date.now(),
   }
 }
 

--- a/console/web/src/types/chat.ts
+++ b/console/web/src/types/chat.ts
@@ -112,9 +112,17 @@ export interface SystemMessage extends BaseMessage {
   role: 'system'
   content: string
   tone?: 'info' | 'warn' | 'error'
-  kind?: 'notice' | 'compaction'
+  kind?: 'notice' | 'compaction' | 'todo'
   summaryText?: string
   tokensBefore?: number
+  /** `kind: 'todo'` — the session task list (latest entry wins). */
+  todoItems?: TodoItem[]
+}
+
+/** One `harness::todo` checklist item. */
+export interface TodoItem {
+  text: string
+  status: 'pending' | 'in_progress' | 'completed'
 }
 
 export type Message =

--- a/harness/prompts/code-gpt.txt
+++ b/harness/prompts/code-gpt.txt
@@ -26,6 +26,10 @@ An <environment> block in this prompt describes your workspace: the working dire
 
 For genuinely parallel, independent subtasks, spawn sub-agents with harness::spawn: pass `task` (the child's goal) and `options: { mode: "code", isolation: "worktree" }` so each child works in its own git worktree — never let two agents edit the same tree. Independent spawns go in ONE message so the children run concurrently; your turn parks until they finish. Each child's result notes where its work landed: merge a finished branch with `git merge wt/<name>` via shell::exec at the repository root, and inspect any worktree reported dirty. Do not spawn for work you can do directly in a few calls.
 
+# Tracking multi-step work
+
+For any task with more than a couple of steps, maintain the session todo list with harness::todo: send the COMPLETE list on every update (full-replace, not a delta), keep exactly one item in_progress while you work, and mark items completed as you finish them. The user watches this checklist live — update it when you start an item, not just at the end.
+
 # Verifying your work
 
 Before declaring a task done, run the project's build or tests through shell::exec and read the output. Report results honestly: if a test fails, say so and show the failure — never claim a success you have not observed. When you mention code in prose, reference it as path:line so the user can jump to it.

--- a/harness/prompts/code.txt
+++ b/harness/prompts/code.txt
@@ -26,6 +26,10 @@ An <environment> block in this prompt describes your workspace: the working dire
 
 For genuinely parallel, independent subtasks, spawn sub-agents with harness::spawn: pass `task` (the child's goal) and `options: { mode: "code", isolation: "worktree" }` so each child works in its own git worktree — never let two agents edit the same tree. Independent spawns go in ONE message so the children run concurrently; your turn parks until they finish. Each child's result notes where its work landed: merge a finished branch with `git merge wt/<name>` via shell::exec at the repository root, and inspect any worktree reported dirty. Do not spawn for work you can do directly in a few calls.
 
+# Tracking multi-step work
+
+For any task with more than a couple of steps, maintain the session todo list with harness::todo: send the COMPLETE list on every update (full-replace, not a delta), keep exactly one item in_progress while you work, and mark items completed as you finish them. The user watches this checklist live — update it when you start an item, not just at the end.
+
 # Verifying your work
 
 Before declaring a task done, run the project's build or tests through shell::exec and read the output. Report results honestly: if a test fails, say so and show the failure — never claim a success you have not observed. When you mention code in prose, reference it as path:line so the user can jump to it.

--- a/harness/src/clients/router.rs
+++ b/harness/src/clients/router.rs
@@ -286,6 +286,29 @@ impl RouterClient {
         serde_json::from_value::<Model>(model).ok()
     }
 
+    /// The provider owning `id`, scanned from the router's full catalog —
+    /// `router::models::get` needs a provider hint, so a provider-less
+    /// lookup goes through `router::models::list`. `None` when the router
+    /// is absent or no catalog entry matches.
+    pub async fn models_find_provider(&self, id: &str) -> Option<String> {
+        let resp = self
+            .iii
+            .trigger(TriggerRequest {
+                function_id: "router::models::list".into(),
+                payload: json!({}),
+                action: None,
+                timeout_ms: Some(self.timeout_ms),
+            })
+            .await
+            .ok()?;
+        resp.get("models")?
+            .as_array()?
+            .iter()
+            .find(|m| m.get("id").and_then(Value::as_str) == Some(id))
+            .and_then(|m| m.get("provider").and_then(Value::as_str))
+            .map(str::to_string)
+    }
+
     /// Whether `model` supports a capability (false when the router is absent
     /// or the model is unknown — the caller falls back).
     pub async fn models_supports(&self, provider: &str, id: &str, capability: &str) -> bool {

--- a/harness/src/functions/mod.rs
+++ b/harness/src/functions/mod.rs
@@ -14,6 +14,7 @@ pub mod status;
 pub mod stop;
 pub mod subscribe;
 pub mod sweep_pending;
+pub mod todo;
 pub mod turn;
 
 use std::future::Future;
@@ -156,6 +157,13 @@ pub fn register_all(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
     register(iii, deps, STATUS_ID, STATUS_DESC, |d, r| async move {
         status::handle(&d, r).await
     });
+    register(
+        iii,
+        deps,
+        todo::TODO_ID,
+        todo::TODO_DESC,
+        |d, r| async move { todo::handle(&d, r).await },
+    );
 
     // Internal filesystem grant controls — registered for trusted callers, kept
     // off the model-facing catalog.

--- a/harness/src/functions/send.rs
+++ b/harness/src/functions/send.rs
@@ -246,12 +246,7 @@ pub(crate) fn normalize_message(input: MessageInput) -> Result<AgentMessage, Har
 /// router is unreachable or the model is unknown (the prompt family then
 /// falls back to the seeded default, mirroring the un-routed mesh prompt).
 pub(crate) async fn resolve_provider(deps: &Deps, model: &str) -> Option<String> {
-    let provider = deps
-        .router()
-        .await
-        .models_get(None, model)
-        .await
-        .map(|m| m.provider);
+    let provider = deps.router().await.models_find_provider(model).await;
     if provider.is_none() {
         tracing::warn!(
             model,

--- a/harness/src/functions/subscribe.rs
+++ b/harness/src/functions/subscribe.rs
@@ -140,6 +140,18 @@ pub async fn invoke(
     match function_id {
         REGISTER_TRIGGER_ID => intercept_register(deps, arguments, session_id).await,
         UNREGISTER_TRIGGER_ID => intercept_unregister(deps, arguments, session_id).await,
+        // The todo list is per-session state: the CALLING session is
+        // authoritative, never a model-supplied id.
+        crate::functions::todo::TODO_ID => {
+            let mut args = arguments.clone();
+            if let Value::Object(map) = &mut args {
+                map.insert(
+                    "session_id".to_string(),
+                    Value::String(session_id.to_string()),
+                );
+            }
+            trigger::invoke_target(engine, policy, crate::functions::todo::TODO_ID, &args).await
+        }
         _ => trigger::invoke_target(engine, policy, function_id, arguments).await,
     }
 }

--- a/harness/src/functions/todo.rs
+++ b/harness/src/functions/todo.rs
@@ -1,0 +1,183 @@
+//! `harness::todo` — the session's structured task list (full-list replace,
+//! TodoWrite semantics): the model maintains it during multi-step work so
+//! the user can watch progress. Persists to the `harness_todo` state scope
+//! and mirrors each update into a `custom` session entry (type "todo") the
+//! console renders as a checklist (latest entry wins — `session::append`
+//! is a no-op on repeated entry ids, so every update gets a fresh id).
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::deps::Deps;
+use crate::error::HarnessError;
+
+pub const TODO_ID: &str = "harness::todo";
+pub const TODO_DESC: &str = "Replace this session's structured todo list (full-list semantics — \
+     send the COMPLETE list every time, not a delta). Use it for \
+     multi-step tasks so progress is visible: at most 50 items, 500 \
+     chars each, statuses pending | in_progress | completed, and keep \
+     exactly ONE item in_progress while working. The list persists on \
+     the session and renders as a live checklist in the console.";
+
+/// State scope holding each session's current list.
+pub const TODO_SCOPE: &str = "harness_todo";
+
+const MAX_ITEMS: usize = 50;
+const MAX_ITEM_CHARS: usize = 500;
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum TodoStatus {
+    Pending,
+    InProgress,
+    Completed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TodoItem {
+    /// The task, imperative and specific (≤ 500 chars).
+    pub text: String,
+    pub status: TodoStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TodoRequest {
+    /// The session whose list to replace. Callers inside a turn omit it —
+    /// the harness injects the calling session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    /// The complete list (replaces the previous one; empty clears it).
+    pub items: Vec<TodoItem>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TodoResponse {
+    pub ok: bool,
+    /// Items stored (after validation).
+    pub count: u32,
+}
+
+pub async fn handle(deps: &Deps, req: TodoRequest) -> Result<TodoResponse, HarnessError> {
+    let Some(session_id) = req.session_id.clone() else {
+        return Err(HarnessError::InvalidRequest(
+            "harness::todo requires a session_id (injected automatically for in-turn calls)".into(),
+        ));
+    };
+    validate(&req.items)?;
+
+    let cfg = deps.cfg().await;
+    let value =
+        json!({ "items": req.items, "updated_at": crate::types::message::AgentMessage::now_ms() });
+    crate::state::put_scoped(
+        &deps.iii,
+        TODO_SCOPE,
+        &session_id,
+        &value,
+        cfg.session_timeout_ms,
+    )
+    .await?;
+
+    // Mirror into the transcript for console rendering (the console shows
+    // the LATEST todo entry; older ones are history). Best-effort: a
+    // session-manager hiccup must not fail the todo write.
+    let session = deps.session().await;
+    let turn_id = crate::state::get_turn(&deps.iii, &session_id, cfg.session_timeout_ms)
+        .await
+        .ok()
+        .flatten()
+        .map(|r| r.turn_id)
+        .unwrap_or_else(|| "manual".to_string());
+    let _ = session
+        .append_custom(
+            &session_id,
+            "todo",
+            value,
+            &format!("e_todo_{}", crate::types::message::AgentMessage::now_ms()),
+            Some(&json!({ "turn_id": turn_id })),
+        )
+        .await;
+
+    Ok(TodoResponse {
+        ok: true,
+        count: req.items.len() as u32,
+    })
+}
+
+fn validate(items: &[TodoItem]) -> Result<(), HarnessError> {
+    if items.len() > MAX_ITEMS {
+        return Err(HarnessError::InvalidRequest(format!(
+            "todo list has {} items; the cap is {MAX_ITEMS} — collapse finished work",
+            items.len()
+        )));
+    }
+    for (i, item) in items.iter().enumerate() {
+        if item.text.trim().is_empty() {
+            return Err(HarnessError::InvalidRequest(format!(
+                "todo item {i} is empty"
+            )));
+        }
+        if item.text.chars().count() > MAX_ITEM_CHARS {
+            return Err(HarnessError::InvalidRequest(format!(
+                "todo item {i} exceeds {MAX_ITEM_CHARS} chars"
+            )));
+        }
+    }
+    let in_progress = items
+        .iter()
+        .filter(|i| i.status == TodoStatus::InProgress)
+        .count();
+    if in_progress > 1 {
+        return Err(HarnessError::InvalidRequest(format!(
+            "{in_progress} items are in_progress; keep exactly one active task"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(text: &str, status: TodoStatus) -> TodoItem {
+        TodoItem {
+            text: text.into(),
+            status,
+        }
+    }
+
+    #[test]
+    fn accepts_a_reasonable_list() {
+        let items = vec![
+            item("read the failing test", TodoStatus::Completed),
+            item("fix the bug", TodoStatus::InProgress),
+            item("run the suite", TodoStatus::Pending),
+        ];
+        assert!(validate(&items).is_ok());
+    }
+
+    #[test]
+    fn rejects_multiple_in_progress() {
+        let items = vec![
+            item("a", TodoStatus::InProgress),
+            item("b", TodoStatus::InProgress),
+        ];
+        let err = validate(&items).unwrap_err().to_string();
+        assert!(err.contains("exactly one"), "{err}");
+    }
+
+    #[test]
+    fn rejects_oversized_and_empty_items() {
+        assert!(validate(&[item("", TodoStatus::Pending)]).is_err());
+        assert!(validate(&[item(&"x".repeat(501), TodoStatus::Pending)]).is_err());
+        let too_many: Vec<TodoItem> = (0..51)
+            .map(|i| item(&format!("t{i}"), TodoStatus::Pending))
+            .collect();
+        assert!(validate(&too_many).is_err());
+    }
+
+    #[test]
+    fn empty_list_clears_without_error() {
+        assert!(validate(&[]).is_ok());
+    }
+}

--- a/harness/src/functions/todo.rs
+++ b/harness/src/functions/todo.rs
@@ -36,7 +36,10 @@ pub enum TodoStatus {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct TodoItem {
-    /// The task, imperative and specific (≤ 500 chars).
+    /// The task, imperative and specific (≤ 500 chars). `content` is
+    /// accepted as an alias — models trained on TodoWrite-shaped tools
+    /// send it.
+    #[serde(alias = "content")]
     pub text: String,
     pub status: TodoStatus,
 }
@@ -48,6 +51,8 @@ pub struct TodoRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
     /// The complete list (replaces the previous one; empty clears it).
+    /// `todos` is accepted as an alias for the same reason as `content`.
+    #[serde(alias = "todos")]
     pub items: Vec<TodoItem>,
 }
 
@@ -179,5 +184,19 @@ mod tests {
     #[test]
     fn empty_list_clears_without_error() {
         assert!(validate(&[]).is_ok());
+    }
+
+    #[test]
+    fn todowrite_shaped_payload_deserializes() {
+        // gpt-5.4 emits the TodoWrite field names it was trained on.
+        let req: TodoRequest = serde_json::from_value(serde_json::json!({
+            "todos": [
+                { "content": "fix the bug", "status": "in_progress", "activeForm": "Fixing" }
+            ]
+        }))
+        .unwrap();
+        assert_eq!(req.items.len(), 1);
+        assert_eq!(req.items[0].text, "fix the bug");
+        assert_eq!(req.items[0].status, TodoStatus::InProgress);
     }
 }

--- a/harness/src/policy.rs
+++ b/harness/src/policy.rs
@@ -116,6 +116,7 @@ pub fn code_mode_policy() -> FunctionPolicy {
             "shell::kill",
             "shell::status",
             "harness::spawn",
+            "harness::todo",
         ]
         .into_iter()
         .map(String::from)
@@ -287,6 +288,7 @@ mod tests {
             "shell::kill",
             "shell::status",
             "harness::spawn",
+            "harness::todo",
         ] {
             assert!(c.allows(allowed), "{allowed} must be allowed");
         }

--- a/harness/src/state.rs
+++ b/harness/src/state.rs
@@ -94,6 +94,18 @@ pub async fn put_turn(
     state_set(iii, TURN_SCOPE, &record.session_id, value, timeout_ms).await
 }
 
+/// Persist an arbitrary value under a harness-owned scope (e.g. the
+/// session todo list).
+pub async fn put_scoped(
+    iii: &IIIClient,
+    scope: &str,
+    key: &str,
+    value: &serde_json::Value,
+    timeout_ms: u64,
+) -> Result<(), HarnessError> {
+    state_set(iii, scope, key, value.clone(), timeout_ms).await
+}
+
 pub async fn delete_turn(
     iii: &IIIClient,
     session_id: &str,

--- a/harness/src/surface.rs
+++ b/harness/src/surface.rs
@@ -7,6 +7,7 @@
 //! of the agent-facing surface.
 
 use crate::functions::react::REACT_ID;
+use crate::functions::todo::{TodoRequest, TodoResponse, TODO_ID};
 use crate::functions::{
     function_resolve::{FunctionResolveRequest, FunctionResolveResponse},
     function_trigger::{FunctionTriggerRequest, FunctionTriggerResponse},
@@ -64,6 +65,7 @@ pub fn catalog() -> Vec<FunctionSpec> {
         spec::<FunctionResolveRequest, FunctionResolveResponse>(FUNCTION_RESOLVE_ID),
         spec::<StopRequest, StopResponse>(STOP_ID),
         spec::<StatusRequest, Option<StatusReport>>(STATUS_ID),
+        spec::<TodoRequest, TodoResponse>(TODO_ID),
         spec::<ReactEvent, ReactResult>(REACT_ID),
     ]
 }

--- a/harness/tests/golden/schemas/harness.todo.json
+++ b/harness/tests/golden/schemas/harness.todo.json
@@ -9,7 +9,7 @@
             "$ref": "#/definitions/TodoStatus"
           },
           "text": {
-            "description": "The task, imperative and specific (≤ 500 chars).",
+            "description": "The task, imperative and specific (≤ 500 chars). `content` is accepted as an alias — models trained on TodoWrite-shaped tools send it.",
             "type": "string"
           }
         },
@@ -30,7 +30,7 @@
     },
     "properties": {
       "items": {
-        "description": "The complete list (replaces the previous one; empty clears it).",
+        "description": "The complete list (replaces the previous one; empty clears it). `todos` is accepted as an alias for the same reason as `content`.",
         "items": {
           "$ref": "#/definitions/TodoItem"
         },

--- a/harness/tests/golden/schemas/harness.todo.json
+++ b/harness/tests/golden/schemas/harness.todo.json
@@ -1,0 +1,73 @@
+{
+  "function_id": "harness::todo",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+      "TodoItem": {
+        "properties": {
+          "status": {
+            "$ref": "#/definitions/TodoStatus"
+          },
+          "text": {
+            "description": "The task, imperative and specific (≤ 500 chars).",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "text"
+        ],
+        "type": "object"
+      },
+      "TodoStatus": {
+        "enum": [
+          "pending",
+          "in_progress",
+          "completed"
+        ],
+        "type": "string"
+      }
+    },
+    "properties": {
+      "items": {
+        "description": "The complete list (replaces the previous one; empty clears it).",
+        "items": {
+          "$ref": "#/definitions/TodoItem"
+        },
+        "type": "array"
+      },
+      "session_id": {
+        "description": "The session whose list to replace. Callers inside a turn omit it — the harness injects the calling session.",
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "required": [
+      "items"
+    ],
+    "title": "TodoRequest",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "count": {
+        "description": "Items stored (after validation).",
+        "format": "uint32",
+        "minimum": 0.0,
+        "type": "integer"
+      },
+      "ok": {
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "count",
+      "ok"
+    ],
+    "title": "TodoResponse",
+    "type": "object"
+  }
+}

--- a/harness/tests/schemas.rs
+++ b/harness/tests/schemas.rs
@@ -40,6 +40,7 @@ fn catalog_lists_all_functions_in_registration_order() {
             "harness::function::resolve",
             "harness::stop",
             "harness::status",
+            "harness::todo",
             "harness::react",
         ]
     );


### PR DESCRIPTION
### feat(harness): harness::todo — the session's live task checklist

Full-list-replace todo semantics for multi-step coding runs: at most 50
items / 500 chars, exactly one in_progress, persisted to the
harness_todo state scope and mirrored into custom session entries
(type "todo", fresh entry id per update — session::append is a no-op
on repeated ids). In-turn calls get the CALLING session injected at the
invocation chokepoint, so a model can never write another session's
list. code_mode_policy gains harness::todo and both code prompts teach
the discipline; the console renders the latest todo entry as a live
checklist card (done-count header, status glyphs).

### fix(harness): provider resolution scans the router catalog

router::models::get requires a provider hint, so a provider-less send
resolved to None (default prompt family) — scan router::models::list
by model id instead.

### fix(harness): harness::todo accepts TodoWrite-shaped payloads

Models trained on TodoWrite-shaped todo tools send { todos: [{ content,
status }] }; serde aliases (todos->items, content->text) accept both
spellings, extra fields like activeForm are ignored as before.

Fixes MOT-3875
