### PR TITLE
(MOT-3876) perf(harness): concurrent read-only dispatch + fewer model round trips

### DIFF
--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -375,12 +375,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -399,6 +414,12 @@ dependencies = [
  "futures-task",
  "futures-util",
 ]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
@@ -507,6 +528,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
+ "futures",
  "globset",
  "iii-helpers",
  "iii-sdk",

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -29,6 +29,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 clap = { version = "4", features = ["derive"] }
 async-trait = "0.1"
+# join_all for the concurrent read-only dispatch runs in turn_loop.
+futures = { version = "0.3", default-features = false, features = ["alloc"] }
 # Must stay on the same schemars major as iii-sdk so the derived
 # `JsonSchema` impls satisfy `RegisterFunction::new_async`.
 schemars = "0.8"

--- a/harness/prompts/code-gpt.txt
+++ b/harness/prompts/code-gpt.txt
@@ -28,7 +28,11 @@ For genuinely parallel, independent subtasks, spawn sub-agents with harness::spa
 
 # Tracking multi-step work
 
-For any task with more than a couple of steps, maintain the session todo list with harness::todo: send the COMPLETE list on every update (full-replace, not a delta), keep exactly one item in_progress while you work, and mark items completed as you finish them. The user watches this checklist live — update it when you start an item, not just at the end.
+For any task with more than a couple of steps, maintain the session todo list with harness::todo: send the COMPLETE list on every update (full-replace, not a delta), keep exactly one item in_progress while you work, and mark items completed as you finish them. The user watches this checklist live — update it when you start an item, not just at the end. Fold every todo update into the SAME message as your next action calls; never spend a message on a todo update alone.
+
+# Batching independent calls
+
+When the next step needs several independent function calls — reading multiple files, running several searches — emit them all in ONE message. Independent calls execute concurrently, and each extra round trip you avoid saves seconds. Only sequence calls when one truly depends on another's result.
 
 # Verifying your work
 

--- a/harness/prompts/code.txt
+++ b/harness/prompts/code.txt
@@ -28,7 +28,11 @@ For genuinely parallel, independent subtasks, spawn sub-agents with harness::spa
 
 # Tracking multi-step work
 
-For any task with more than a couple of steps, maintain the session todo list with harness::todo: send the COMPLETE list on every update (full-replace, not a delta), keep exactly one item in_progress while you work, and mark items completed as you finish them. The user watches this checklist live — update it when you start an item, not just at the end.
+For any task with more than a couple of steps, maintain the session todo list with harness::todo: send the COMPLETE list on every update (full-replace, not a delta), keep exactly one item in_progress while you work, and mark items completed as you finish them. The user watches this checklist live — update it when you start an item, not just at the end. Fold every todo update into the SAME message as your next action calls; never spend a message on a todo update alone.
+
+# Batching independent calls
+
+When the next step needs several independent function calls — reading multiple files, running several searches — emit them all in ONE message. Independent calls execute concurrently, and each extra round trip you avoid saves seconds. Only sequence calls when one truly depends on another's result.
 
 # Verifying your work
 

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -64,6 +64,24 @@ pub async fn enqueue_step(
     .map_err(|e| HarnessError::Dependency(format!("enqueue harness::turn: {e}")))
 }
 
+/// Batch-mates that may execute concurrently: the read-only coder surface
+/// plus harness bookkeeping. Mutations, shell execution, and everything
+/// unknown stay sequential so an order-dependent batch keeps its order.
+const PARALLEL_SAFE: &[&str] = &[
+    "coder::read-file",
+    "coder::search",
+    "coder::tree",
+    "coder::list-folder",
+    "coder::context",
+    "coder::checkpoints",
+    "harness::todo",
+    "harness::status",
+];
+
+fn parallel_safe(function_id: &str) -> bool {
+    PARALLEL_SAFE.contains(&function_id)
+}
+
 fn origin(turn_id: &str) -> Value {
     json!({ "turn_id": turn_id })
 }
@@ -389,6 +407,9 @@ pub async fn run_step(
             crate::filesystem_grants::roots(&deps.iii, &record.session_id, cfg.session_timeout_ms)
                 .await?;
         let filesystem_root = record.options.filesystem_root().map(str::to_string);
+        // (call, effective args, pre-hook annotations) for calls that passed
+        // policy + pre_trigger and will actually invoke.
+        let mut ready: Vec<(&policy::PlannedCall, serde_json::Value, _)> = Vec::new();
         for call in trigger_calls.iter().copied() {
             // Per-call checkpoint: skip done/pending, recover an interrupted
             // trigger.
@@ -518,7 +539,9 @@ pub async fn run_step(
                 continue;
             }
 
-            // Checkpoint triggered before invoking the (at-most-once) target.
+            // Checkpoint triggered before invoking the (at-most-once) target;
+            // the ready list defers the actual invoke so a run of read-only
+            // calls can execute concurrently (phase 2 below).
             record.calls.insert(
                 call.id.clone(),
                 CallCheckpoint {
@@ -533,20 +556,44 @@ pub async fn run_step(
                     pending_at: None,
                 },
             );
-            crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
+            ready.push((call, eff_args, pre_ann));
+        }
 
-            // Single invocation chokepoint: subscription control calls are
-            // intercepted (trusted session injected); everything else invokes the
-            // target. Then the post_trigger chain runs over the result.
-            let raw = crate::functions::subscribe::invoke(
-                deps,
-                &engine,
-                &policy,
-                &call.function_id,
-                &eff_args,
-                &record.session_id,
-            )
-            .await;
+        // One durable write covers every Triggered checkpoint — all of them
+        // land before ANY invoke, so at-most-once recovery still holds.
+        if !ready.is_empty() {
+            crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
+        }
+
+        // Phase 2 — invoke. Consecutive parallel-safe calls (read-only surface
+        // + bookkeeping) run concurrently; everything else runs sequentially in
+        // content order, so a batch like [build, test] keeps its order.
+        let mut raws = Vec::with_capacity(ready.len());
+        let mut i = 0;
+        while i < ready.len() {
+            let mut j = i + 1;
+            if parallel_safe(&ready[i].0.function_id) {
+                while j < ready.len() && parallel_safe(&ready[j].0.function_id) {
+                    j += 1;
+                }
+            }
+            let futs = ready[i..j].iter().map(|(call, eff_args, _)| {
+                crate::functions::subscribe::invoke(
+                    deps,
+                    &engine,
+                    &policy,
+                    &call.function_id,
+                    eff_args,
+                    &record.session_id,
+                )
+            });
+            raws.extend(futures::future::join_all(futs).await);
+            i = j;
+        }
+
+        // Phase 3 — results, in content order: post_trigger chain, transcript
+        // append, done checkpoint. Unchanged semantics from the sequential loop.
+        for ((call, eff_args, pre_ann), raw) in ready.into_iter().zip(raws) {
             let post_outcome = deps
                 .hooks
                 .run_post_trigger(


### PR DESCRIPTION
A live code-mode session spent ~30 of 66 minutes on standalone
harness::todo round trips (40 updates x ~45s of reasoning each) and
most call batches carried a single call. Function execution itself
measured milliseconds; the cost is round trips.

- Both code prompts now require todo updates to ride along with the
  next action calls (never a standalone message) and push the model to
  batch independent calls into one message.
- The dispatch loop runs in three phases: sequential policy/pre-hook/
  checkpoint pass, concurrent invoke for consecutive parallel-safe
  calls (read-only coder surface + bookkeeping via join_all), then
  in-order post-hook/append/done. Mutations and shell::exec stay
  strictly sequential. All Triggered checkpoints land in ONE durable
  write before any invoke, preserving at-most-once recovery.

Fixes MOT-3876
