### PR TITLE
(MOT-3877) feat(console): checkpoints dialog with per-turn undo + medium thinking default

### DIFF
--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -38,6 +38,7 @@ import {
   type ThoughtMessage,
   type UserMessage,
 } from '@/types/chat'
+import { CheckpointsDialog } from './CheckpointsDialog'
 import { Composer, type ComposerSubmitPayload } from './Composer'
 import { ContextUsage } from './ContextUsage'
 import { ExportSessionButton } from './ExportSessionButton'
@@ -196,6 +197,7 @@ export function ChatView({
 
   const filesystemGrants = useFilesystemGrants(sessionId)
   const [filesystemDialogOpen, setFilesystemDialogOpen] = useState(false)
+  const [checkpointsDialogOpen, setCheckpointsDialogOpen] = useState(false)
   const handleManageFilesystemAccess = useCallback(() => {
     setFilesystemDialogOpen(true)
   }, [])
@@ -841,16 +843,31 @@ export function ChatView({
                   no working directory — using default workspace
                 </span>
               )}
-              <button
-                type="button"
-                onClick={handleManageFilesystemAccess}
-                className="ml-auto shrink-0 lowercase text-ink-ghost hover:text-ink transition-colors"
-              >
-                filesystem access
-                {filesystemGrants.grants.length > 0
-                  ? ` · ${filesystemGrants.grants.length}`
-                  : ''}
-              </button>
+              <div className="ml-auto flex shrink-0 items-center gap-3">
+                <button
+                  type="button"
+                  disabled={!conversation.workingDir}
+                  title={
+                    conversation.workingDir
+                      ? undefined
+                      : 'set a working directory first'
+                  }
+                  onClick={() => setCheckpointsDialogOpen(true)}
+                  className="lowercase text-ink-ghost transition-colors hover:text-ink disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:text-ink-ghost"
+                >
+                  checkpoints
+                </button>
+                <button
+                  type="button"
+                  onClick={handleManageFilesystemAccess}
+                  className="lowercase text-ink-ghost hover:text-ink transition-colors"
+                >
+                  filesystem access
+                  {filesystemGrants.grants.length > 0
+                    ? ` · ${filesystemGrants.grants.length}`
+                    : ''}
+                </button>
+              </div>
             </div>
           ) : null}
           <Composer
@@ -887,16 +904,24 @@ export function ChatView({
       </footer>
 
       {workingDirEnabled ? (
-        <FilesystemAccessDialog
-          open={filesystemDialogOpen}
-          onOpenChange={setFilesystemDialogOpen}
-          workingDir={conversation.workingDir ?? null}
-          grants={filesystemGrants.grants}
-          grantsSupported={filesystemGrants.supported}
-          onRevoke={filesystemGrants.revoke}
-          onRefreshGrants={filesystemGrants.refresh}
-          sessionBusy={streamingIndicator}
-        />
+        <>
+          <FilesystemAccessDialog
+            open={filesystemDialogOpen}
+            onOpenChange={setFilesystemDialogOpen}
+            workingDir={conversation.workingDir ?? null}
+            grants={filesystemGrants.grants}
+            grantsSupported={filesystemGrants.supported}
+            onRevoke={filesystemGrants.revoke}
+            onRefreshGrants={filesystemGrants.refresh}
+            sessionBusy={streamingIndicator}
+          />
+          <CheckpointsDialog
+            open={checkpointsDialogOpen}
+            onOpenChange={setCheckpointsDialogOpen}
+            workingDir={conversation.workingDir ?? null}
+            sessionBusy={streamingIndicator}
+          />
+        </>
       ) : null}
     </section>
   )

--- a/console/web/src/components/chat/CheckpointsDialog.test.tsx
+++ b/console/web/src/components/chat/CheckpointsDialog.test.tsx
@@ -1,0 +1,90 @@
+import type { ReactElement } from 'react'
+import { describe, expect, it } from 'vitest'
+import type { CheckpointGroup } from '@/lib/backend/coder-checkpoints'
+import { GroupRow, renderBody } from './CheckpointsDialog'
+
+const group = (over: Partial<CheckpointGroup>): CheckpointGroup => ({
+  key: 't1',
+  turnId: 't1',
+  ts: 1000,
+  functionIds: ['coder::update-file'],
+  files: ['/w/src/a.rs'],
+  isRevert: false,
+  records: [],
+  ...over,
+})
+
+/** GroupRow renders <section><div>[meta, button]</div></section>. */
+function buttonOf(el: ReactElement): {
+  disabled?: boolean
+  title?: string
+  children: unknown
+} {
+  const inner = (el.props as { children: ReactElement }).children
+  const kids = (inner.props as { children: ReactElement[] }).children
+  return kids[1].props as {
+    disabled?: boolean
+    title?: string
+    children: unknown
+  }
+}
+
+describe('GroupRow', () => {
+  it('labels a normal group "undo"', () => {
+    const el = GroupRow({
+      group: group({}),
+      canUndo: true,
+      busy: false,
+      inFlight: false,
+      onUndo: () => {},
+    })
+    expect(buttonOf(el).children).toBe('undo')
+  })
+
+  it('labels a revert group "redo"', () => {
+    const el = GroupRow({
+      group: group({ isRevert: true }),
+      canUndo: true,
+      busy: false,
+      inFlight: false,
+      onUndo: () => {},
+    })
+    expect(buttonOf(el).children).toBe('redo')
+  })
+
+  it('disables with a hint when the group is not undoable', () => {
+    const el = GroupRow({
+      group: group({ turnId: undefined, key: 'seq-4' }),
+      canUndo: false,
+      busy: false,
+      inFlight: false,
+      onUndo: () => {},
+    })
+    const btn = buttonOf(el)
+    expect(btn.disabled).toBe(true)
+    expect(btn.title).toMatch(/turn id/)
+  })
+})
+
+describe('renderBody', () => {
+  const handlers = {
+    undoingKey: null,
+    onUndo: () => {},
+    onRetry: () => {},
+  }
+
+  it('prompts for a working directory when none is set', () => {
+    const el = renderBody({ status: 'idle' }, { ...handlers, workingDir: null })
+    expect((el.props as { text: string }).text).toBe(
+      'set a working directory first.',
+    )
+  })
+
+  it('shows the empty state when there are no checkpoints', () => {
+    const el = renderBody(
+      { status: 'ready', groups: [], truncated: false },
+      { ...handlers, workingDir: '/w' },
+    )
+    expect((el.props as { text: string }).text).toBe('no checkpoints yet.')
+  })
+})

--- a/console/web/src/components/chat/CheckpointsDialog.tsx
+++ b/console/web/src/components/chat/CheckpointsDialog.tsx
@@ -1,0 +1,262 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/components/ui/Dialog'
+import {
+  type CheckpointGroup,
+  groupCheckpoints,
+  listCheckpoints,
+  type UndoRecord,
+  undoCheckpoint,
+} from '@/lib/backend/coder-checkpoints'
+
+interface CheckpointsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** The conversation's session workspace — journal root for `coder::*`. */
+  workingDir?: string | null
+  /** Warns that undoing while a turn runs may fight the agent's writes. */
+  sessionBusy?: boolean
+}
+
+type LoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'ready'; groups: CheckpointGroup[]; truncated: boolean }
+
+const basename = (p: string): string => p.split('/').pop() || p
+
+function formatUndoSummary(undone: UndoRecord[], wasRevert: boolean): string {
+  if (undone.length === 0) return 'nothing to undo.'
+  const restored = undone.reduce((n, u) => n + u.restored.length, 0)
+  const removed = undone.reduce((n, u) => n + u.removed.length, 0)
+  const skipped = undone.reduce((n, u) => n + u.skipped.length, 0)
+  const parts = [`${restored} restored`, `${removed} removed`]
+  if (skipped > 0) parts.push(`${skipped} skipped`)
+  return `${wasRevert ? 'redone' : 'undone'} — ${parts.join(', ')}.`
+}
+
+/**
+ * File-history / undo surface: lists the shell's journal records (newest-first,
+ * grouped per turn) and reverses a group with one `coder::undo` call. Opened
+ * from the ChatView working-dir footer row; mirrors FilesystemAccessDialog.
+ */
+export function CheckpointsDialog({
+  open,
+  onOpenChange,
+  workingDir,
+  sessionBusy,
+}: CheckpointsDialogProps) {
+  const [state, setState] = useState<LoadState>({ status: 'idle' })
+  const [undoingKey, setUndoingKey] = useState<string | null>(null)
+  const [summary, setSummary] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    if (!workingDir) return
+    setState({ status: 'loading' })
+    try {
+      const res = await listCheckpoints(workingDir)
+      setState({
+        status: 'ready',
+        groups: groupCheckpoints(res.records),
+        truncated: res.truncated,
+      })
+    } catch (err) {
+      setState({
+        status: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }, [workingDir])
+
+  useEffect(() => {
+    if (!open) return
+    setSummary(null)
+    void load()
+  }, [open, load])
+
+  const handleUndo = useCallback(
+    async (group: CheckpointGroup) => {
+      if (!workingDir) return
+      setUndoingKey(group.key)
+      setSummary(null)
+      try {
+        const undone = await undoCheckpoint(
+          workingDir,
+          // Turn-less records can only be targeted by count, and only the
+          // newest is offered (steps: 1) — see canUndo in render.
+          group.turnId ? { turnId: group.turnId } : { steps: 1 },
+        )
+        setSummary(formatUndoSummary(undone, group.isRevert))
+        await load()
+      } catch (err) {
+        setSummary(
+          `undo failed — ${err instanceof Error ? err.message : String(err)}`,
+        )
+      } finally {
+        setUndoingKey(null)
+      }
+    },
+    [workingDir, load],
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogTitle className="text-[14px]">checkpoints</DialogTitle>
+        <DialogDescription className="mt-1">
+          undo file changes the agent made in this conversation.
+        </DialogDescription>
+
+        {sessionBusy ? (
+          <p className="mt-3 font-mono text-[11px] text-ink-faint">
+            the agent is running — undoing files it's editing may make it redo
+            work.
+          </p>
+        ) : null}
+
+        {summary ? (
+          <div className="mt-3 border border-rule-2 bg-bg px-2 py-1.5 font-mono text-[11px] text-ink">
+            {summary}
+          </div>
+        ) : null}
+
+        <div className="mt-4 flex flex-col gap-2">
+          {renderBody(state, {
+            workingDir,
+            undoingKey,
+            onUndo: handleUndo,
+            onRetry: load,
+          })}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+interface BodyHandlers {
+  workingDir?: string | null
+  undoingKey: string | null
+  onUndo: (group: CheckpointGroup) => void
+  onRetry: () => void
+}
+
+// Exported for unit tests (no DOM harness in this project — tests inspect the
+// returned element tree, mirroring the state-view tests).
+export function renderBody(state: LoadState, h: BodyHandlers) {
+  if (!h.workingDir) return <Empty text="set a working directory first." />
+  if (state.status === 'loading' || state.status === 'idle')
+    return <Empty text="loading…" />
+  if (state.status === 'error')
+    return (
+      <div className="px-2 py-3 font-mono text-[11px] text-alert">
+        {state.message}{' '}
+        <button
+          type="button"
+          onClick={h.onRetry}
+          className="lowercase text-accent hover:underline"
+        >
+          retry
+        </button>
+      </div>
+    )
+  if (state.groups.length === 0) return <Empty text="no checkpoints yet." />
+
+  return (
+    <>
+      {state.groups.map((group, index) => (
+        <GroupRow
+          key={group.key}
+          group={group}
+          // Turn-less records are only reversible when newest (steps: 1).
+          canUndo={Boolean(group.turnId) || index === 0}
+          busy={h.undoingKey !== null}
+          inFlight={h.undoingKey === group.key}
+          onUndo={h.onUndo}
+        />
+      ))}
+      {state.truncated ? (
+        <p className="px-2 pt-1 font-mono text-[10px] lowercase text-ink-ghost">
+          showing the most recent changes only.
+        </p>
+      ) : null}
+    </>
+  )
+}
+
+export function GroupRow({
+  group,
+  canUndo,
+  busy,
+  inFlight,
+  onUndo,
+}: {
+  group: CheckpointGroup
+  canUndo: boolean
+  busy: boolean
+  inFlight: boolean
+  onUndo: (group: CheckpointGroup) => void
+}) {
+  return (
+    <section className="border border-rule-2 bg-bg">
+      <div className="flex items-start gap-2 px-2 py-1.5">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span
+              className="font-mono text-[11px] text-ink"
+              title={new Date(group.ts).toLocaleString()}
+            >
+              {new Date(group.ts).toLocaleTimeString()}
+            </span>
+            {group.isRevert ? (
+              <span className="font-mono text-[10px] uppercase tracking-[0.06em] text-accent">
+                revert
+              </span>
+            ) : null}
+          </div>
+          <div className="mt-0.5 font-mono text-[10px] lowercase text-ink-ghost">
+            {group.functionIds.join(', ')}
+          </div>
+          {group.files.length > 0 ? (
+            <div className="mt-1 flex flex-wrap gap-x-2 gap-y-0.5">
+              {group.files.map((f) => (
+                <span
+                  key={f}
+                  title={f}
+                  className="font-mono text-[10px] text-ink-faint"
+                >
+                  {basename(f)}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          disabled={!canUndo || busy}
+          title={
+            canUndo
+              ? undefined
+              : 'only the most recent change can be undone without a turn id'
+          }
+          onClick={() => onUndo(group)}
+          className="shrink-0 lowercase text-ink-faint transition-colors hover:text-ink disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {inFlight ? '…' : group.isRevert ? 'redo' : 'undo'}
+        </button>
+      </div>
+    </section>
+  )
+}
+
+function Empty({ text }: { text: string }) {
+  return (
+    <div className="px-2 py-6 text-center font-mono text-[11px] lowercase text-ink-ghost">
+      {text}
+    </div>
+  )
+}

--- a/console/web/src/lib/backend/coder-checkpoints.test.ts
+++ b/console/web/src/lib/backend/coder-checkpoints.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  CHECKPOINTS_FUNCTION_ID,
+  type CheckpointRecord,
+  groupCheckpoints,
+  listCheckpoints,
+  UNDO_FUNCTION_ID,
+  undoCheckpoint,
+} from './coder-checkpoints'
+
+const rec = (over: Partial<CheckpointRecord>): CheckpointRecord => ({
+  seq: 1,
+  ts: 1000,
+  functionId: 'coder::update-file',
+  files: [],
+  ...over,
+})
+
+describe('listCheckpoints', () => {
+  it('sends the full fs_scope shape and coerces snake_case records', async () => {
+    const trigger = vi.fn().mockResolvedValue({
+      records: [
+        {
+          seq: 7,
+          ts: 42,
+          session_id: 's1',
+          turn_id: 't1',
+          function_id: 'coder::update-file',
+          files: ['/w/a.rs', 3],
+        },
+        { seq: 'bad' }, // dropped: no numeric seq / function_id
+      ],
+      truncated: true,
+    })
+    const out = await listCheckpoints('/w', { limit: 50, trigger })
+    expect(trigger).toHaveBeenCalledWith(CHECKPOINTS_FUNCTION_ID, {
+      fs_scope: { root: '/w', grants: [] },
+      limit: 50,
+    })
+    expect(out.truncated).toBe(true)
+    expect(out.records).toEqual([
+      {
+        seq: 7,
+        ts: 42,
+        sessionId: 's1',
+        turnId: 't1',
+        functionId: 'coder::update-file',
+        files: ['/w/a.rs'],
+      },
+    ])
+  })
+
+  it('tolerates a missing records array', async () => {
+    const trigger = vi.fn().mockResolvedValue({})
+    const out = await listCheckpoints('/w', { trigger })
+    expect(out).toEqual({ records: [], truncated: false })
+  })
+})
+
+describe('undoCheckpoint', () => {
+  it('reverses a turn by turn_id (no steps)', async () => {
+    const trigger = vi.fn().mockResolvedValue({
+      undone: [
+        {
+          seq: 3,
+          function_id: 'coder::update-file',
+          restored: ['/w/a.rs'],
+          removed: [],
+          skipped: [],
+        },
+      ],
+    })
+    const out = await undoCheckpoint('/w', { turnId: 't1', trigger })
+    expect(trigger).toHaveBeenCalledWith(UNDO_FUNCTION_ID, {
+      turn_id: 't1',
+      fs_scope: { root: '/w', grants: [] },
+    })
+    expect(out).toHaveLength(1)
+    expect(out[0].restored).toEqual(['/w/a.rs'])
+  })
+
+  it('reverses by step count when no turn_id (no turn_id key sent)', async () => {
+    const trigger = vi.fn().mockResolvedValue({ undone: [] })
+    await undoCheckpoint('/w', { steps: 1, trigger })
+    expect(trigger).toHaveBeenCalledWith(UNDO_FUNCTION_ID, {
+      steps: 1,
+      fs_scope: { root: '/w', grants: [] },
+    })
+  })
+})
+
+describe('groupCheckpoints', () => {
+  it('merges contiguous records of the same turn and unions their files', () => {
+    const groups = groupCheckpoints([
+      rec({
+        seq: 9,
+        turnId: 't2',
+        functionId: 'coder::update-file',
+        files: ['/w/b.rs'],
+      }),
+      rec({
+        seq: 8,
+        turnId: 't2',
+        functionId: 'coder::create-file',
+        files: ['/w/c.rs'],
+      }),
+      rec({
+        seq: 7,
+        turnId: 't1',
+        functionId: 'coder::update-file',
+        files: ['/w/a.rs'],
+      }),
+    ])
+    expect(groups).toHaveLength(2)
+    expect(groups[0].turnId).toBe('t2')
+    expect(groups[0].functionIds).toEqual([
+      'coder::update-file',
+      'coder::create-file',
+    ])
+    expect(groups[0].files).toEqual(['/w/b.rs', '/w/c.rs'])
+    expect(groups[1].turnId).toBe('t1')
+  })
+
+  it('keeps turn-less records as their own group with a stable key', () => {
+    const groups = groupCheckpoints([
+      rec({ seq: 5, turnId: undefined }),
+      rec({ seq: 4, turnId: undefined }),
+    ])
+    expect(groups).toHaveLength(2)
+    expect(groups.map((g) => g.key)).toEqual(['seq-5', 'seq-4'])
+  })
+
+  it('flags a coder::undo record as a revert (redo target)', () => {
+    const [group] = groupCheckpoints([
+      rec({
+        seq: 6,
+        turnId: 't3',
+        functionId: UNDO_FUNCTION_ID,
+        files: ['/w/a.rs'],
+      }),
+    ])
+    expect(group.isRevert).toBe(true)
+  })
+})

--- a/console/web/src/lib/backend/coder-checkpoints.ts
+++ b/console/web/src/lib/backend/coder-checkpoints.ts
@@ -1,0 +1,166 @@
+/**
+ * RPC adapters for the shell worker's undo journal
+ * (`coder::checkpoints` / `coder::undo`). The shell journals every file
+ * mutation; these read the log and reverse it, scoped to the conversation's
+ * working directory (`fs_scope.root`). Mirrors the `filesystem-grants` adapter
+ * shape: a thin wire layer plus an injectable `trigger` for tests.
+ *
+ * Undoing an `coder::undo` record is a redo — the journal treats the undo as
+ * just another mutation, so replaying it restores the reverted files.
+ */
+
+import { getIiiClient } from '@/lib/iii-client'
+
+export const CHECKPOINTS_FUNCTION_ID = 'coder::checkpoints'
+export const UNDO_FUNCTION_ID = 'coder::undo'
+
+export interface CheckpointRecord {
+  seq: number
+  ts: number
+  sessionId?: string
+  turnId?: string
+  functionId: string
+  files: string[]
+}
+
+export interface CheckpointsResult {
+  records: CheckpointRecord[]
+  truncated: boolean
+}
+
+export interface UndoRecord {
+  seq: number
+  functionId: string
+  restored: string[]
+  removed: string[]
+  skipped: string[]
+}
+
+type TriggerFn = (
+  functionId: string,
+  payload: Record<string, unknown>,
+) => Promise<unknown>
+
+function defaultTrigger(): TriggerFn {
+  return async (functionId, payload) => {
+    const client = await getIiiClient()
+    return client.trigger(functionId, payload)
+  }
+}
+
+/** The coder undo/checkpoint functions take the full fs_scope shape. */
+function fsScope(root: string): { root: string; grants: string[] } {
+  return { root, grants: [] }
+}
+
+const strArray = (v: unknown): string[] =>
+  Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : []
+
+function coerceRecord(raw: unknown): CheckpointRecord | null {
+  if (!raw || typeof raw !== 'object') return null
+  const r = raw as Record<string, unknown>
+  if (typeof r.seq !== 'number' || typeof r.function_id !== 'string')
+    return null
+  return {
+    seq: r.seq,
+    ts: typeof r.ts === 'number' ? r.ts : 0,
+    ...(typeof r.session_id === 'string' ? { sessionId: r.session_id } : {}),
+    ...(typeof r.turn_id === 'string' ? { turnId: r.turn_id } : {}),
+    functionId: r.function_id,
+    files: strArray(r.files),
+  }
+}
+
+function coerceUndo(raw: unknown): UndoRecord | null {
+  if (!raw || typeof raw !== 'object') return null
+  const r = raw as Record<string, unknown>
+  if (typeof r.seq !== 'number' || typeof r.function_id !== 'string')
+    return null
+  return {
+    seq: r.seq,
+    functionId: r.function_id,
+    restored: strArray(r.restored),
+    removed: strArray(r.removed),
+    skipped: strArray(r.skipped),
+  }
+}
+
+/** Journal records for `root`, newest-first (the wire contract). */
+export async function listCheckpoints(
+  root: string,
+  opts?: { limit?: number; trigger?: TriggerFn },
+): Promise<CheckpointsResult> {
+  const call = opts?.trigger ?? defaultTrigger()
+  const raw = (await call(CHECKPOINTS_FUNCTION_ID, {
+    fs_scope: fsScope(root),
+    ...(opts?.limit ? { limit: opts.limit } : {}),
+  })) as { records?: unknown[]; truncated?: unknown } | null
+  const records = Array.isArray(raw?.records)
+    ? raw.records
+        .map(coerceRecord)
+        .filter((r): r is CheckpointRecord => r !== null)
+    : []
+  return { records, truncated: raw?.truncated === true }
+}
+
+/**
+ * Reverse a turn (`turnId`) or the newest `steps` records. The two are mutually
+ * exclusive; the shell rejects passing both.
+ */
+export async function undoCheckpoint(
+  root: string,
+  opts: { turnId?: string; steps?: number; trigger?: TriggerFn },
+): Promise<UndoRecord[]> {
+  const call = opts.trigger ?? defaultTrigger()
+  const raw = (await call(UNDO_FUNCTION_ID, {
+    ...(opts.turnId ? { turn_id: opts.turnId } : {}),
+    ...(opts.steps ? { steps: opts.steps } : {}),
+    fs_scope: fsScope(root),
+  })) as { undone?: unknown[] } | null
+  return Array.isArray(raw?.undone)
+    ? raw.undone.map(coerceUndo).filter((r): r is UndoRecord => r !== null)
+    : []
+}
+
+export interface CheckpointGroup {
+  /** Stable react key: the turn id, or `seq-<n>` for turn-less records. */
+  key: string
+  turnId?: string
+  /** Newest record's timestamp (records arrive newest-first). */
+  ts: number
+  functionIds: string[]
+  /** Union of every file touched across the group's records. */
+  files: string[]
+  /** True when the group reverts a prior change (`coder::undo`) — shows "redo". */
+  isRevert: boolean
+  records: CheckpointRecord[]
+}
+
+const uniq = (values: string[]): string[] => [...new Set(values)]
+
+/**
+ * Fold newest-first records into per-turn groups. Records without a turn id
+ * each stand alone; contiguous records sharing a turn id merge into one group.
+ */
+export function groupCheckpoints(
+  records: CheckpointRecord[],
+): CheckpointGroup[] {
+  const buckets: CheckpointRecord[][] = []
+  for (const rec of records) {
+    const last = buckets[buckets.length - 1]
+    if (rec.turnId && last && last[0].turnId === rec.turnId) {
+      buckets[buckets.length - 1] = [...last, rec]
+    } else {
+      buckets.push([rec])
+    }
+  }
+  return buckets.map((recs) => ({
+    key: recs[0].turnId ?? `seq-${recs[0].seq}`,
+    turnId: recs[0].turnId,
+    ts: recs[0].ts,
+    functionIds: uniq(recs.map((r) => r.functionId)),
+    files: uniq(recs.flatMap((r) => r.files)),
+    isRevert: recs.some((r) => r.functionId === UNDO_FUNCTION_ID),
+    records: recs,
+  }))
+}

--- a/console/web/src/types/chat.ts
+++ b/console/web/src/types/chat.ts
@@ -38,7 +38,7 @@ export const THINKING_LEVELS: ThinkingLevel[] = [
   'xhigh',
 ]
 
-export const DEFAULT_THINKING_LEVEL: ThinkingLevel = 'off'
+export const DEFAULT_THINKING_LEVEL: ThinkingLevel = 'medium'
 
 export type Role = 'user' | 'assistant' | 'thought' | 'function-call'
 


### PR DESCRIPTION
Add a checkpoints dialog to the chat working-dir footer that lists the
shell's file-mutation journal newest-first, grouped per turn, and reverses
a group with one coder::undo call. Records authored by coder::undo are
labeled "revert" and offer "redo". The trigger is disabled until a working
directory is set. Also default the composer's thinking level to medium.

Fixes MOT-3877
