### PR TITLE
feat(worktree): operator gates, integration detection, and lifecycle hardening

### DIFF
--- a/console/PRODUCT.md
+++ b/console/PRODUCT.md
@@ -15,9 +15,9 @@ Both use the same binary on one port. Context is usually a desk with a large mon
 
 ## Product Purpose
 
-Console is the local control panel for the [iii](https://github.com/iii-hq) engine: agentic chat, trace exploration, and provider configuration in a single embedded SPA served by one Rust binary.
+Console is the local control panel for the [iii](https://github.com/iii-hq) engine: agentic chat, trace exploration, worktree oversight for parallel agents, and provider configuration in a single embedded SPA served by one Rust binary. Surfaces backed by optional workers (like the worktree graph) appear only while their worker is connected, so the UI never advertises functions the engine does not have.
 
-Success looks like an operator who can steer an agent, watch function calls resolve, jump from a conversation session into the trace explorer, and configure AI providers without leaving the browser or fighting CORS. The product exists to make the engine legible: what ran, why it failed, and what to do next.
+Success looks like an operator who can steer an agent, watch function calls resolve, jump from a conversation session into the trace explorer, see which agent owns which checkout and whether its branch landed, and configure AI providers without leaving the browser or fighting CORS. The product exists to make the engine legible: what ran, why it failed, and what to do next.
 
 ## Brand Personality
 

--- a/console/README.md
+++ b/console/README.md
@@ -57,6 +57,15 @@ Full-fledged OpenTelemetry explorer over `engine::traces::*` and `engine::logs::
 - **Resizable panels** — drag to resize, double-click to reset
 - **Critical-path breadcrumb** with cross-trace parent jump
 
+### Worktrees
+
+The human window into the [`worktree`](../worktree) worker: parallel agent checkouts, ownership, and land outcomes. Lives in [`web/src/pages/Worktrees/`](web/src/pages/Worktrees) and [`web/src/components/chat/`](web/src/components/chat). The whole surface is presence-gated: it appears only while the worktree worker is connected to the engine (the nav entry and picker tab hide; a direct `#/worktrees` hit lands on an install notice).
+
+- **Graph page** (`#/worktrees`) — repo, worktree, and owning-session nodes from `worktree::list { include_status: true }`, refreshed live off all six `worktree::*` lifecycle trigger types (poll fallback while bindings are unavailable), with a per-worktree detail panel: branch, base, advisory dev port, clean / ahead / behind, diffstat, and the integrated marker for squash- or rebase-landed branches
+- **Picker tab** — the chat working-directory picker grows a **worktrees** tab next to directory browsing: picking a managed worktree validates the path and claims it for the conversation's session; the console-made claim auto-releases when the conversation points elsewhere (best-effort; the worker's prune sweep is the durable backstop). Worktrees with a land in progress are listed but not retargetable
+- **Working-dir badge** — a conversation rooted in a managed worktree shows branch, short id, dirty `*` / ahead `+n` indicators, and a lifecycle dot instead of the plain path chip; the raw path stays reachable as the tooltip
+- **Live land notices** — `worktree::landed` / `worktree::land-blocked` events surface in the chat as notices (target branch and merged sha, or the block reason and conflicted files) and refresh the badge
+
 ### Live catalogs
 
 The composer's `@`-mentions and the model picker pull from the engine in real time.

--- a/console/web/README.md
+++ b/console/web/README.md
@@ -67,6 +67,13 @@ Then open the printed `Local:` URL (Vite picks the first free port from
   localStorage keeps only UI affordances (active id, last model).
   Double-click a row to rename inline (writes through `session::set-meta`);
   hover to reveal the delete affordance (`session::delete`).
+- **Worktree surface** backed by the optional
+  [worktree](../../worktree) worker: a worktrees tab in the
+  working-directory picker (picking validates the path and claims the
+  worktree for the session, released when the conversation points
+  elsewhere), a working-dir badge with branch / dirty / ahead / lifecycle,
+  live landed and land-blocked notices in chat, and the `#/worktrees`
+  graph page. Every piece is gated on worker presence.
 - **Light / dark theme** toggle, persisted under `iii-theme` and applied
   pre-paint to avoid a flash.
 
@@ -75,12 +82,14 @@ Then open the printed `Local:` URL (Vite picks the first free port from
 ```
 src/
   main.tsx
-  App.tsx                # routing (traces + configuration) + always-on chat dock
+  App.tsx                # routing (traces + configuration + worktrees) + always-on chat dock
   index.css              # Tailwind v4 + iii Schematic tokens + utilities
   lib/
     utils.ts             # cn = twMerge(clsx(...))
     storage.ts           # localStorage for UI affordances (active id, last model)
     markdown.tsx         # iii-styled react-markdown wrapper
+    worktrees.ts         # worktree worker wire types, calls, labels
+    worktree-claims.ts   # console-made claims + auto-release decision
     sessions/            # session-manager integration
       api.ts             #     session::* calls (list/ensure/set_meta/delete/messages)
       events.ts          #     bindings for the six session::* trigger types
@@ -97,7 +106,10 @@ src/
   types/chat.ts          # Conversation, Message, Mode, ModelId, Attachment
   hooks/
     use-conversations.ts # server-backed conversation store (session-manager)
-    use-hash-route.ts    # #/traces #/configuration
+    use-hash-route.ts    # #/traces #/configuration #/worktrees
+    use-worktree-status.ts   # worker presence probe (gates the surface)
+    use-worktree-binding.ts  # working dir -> managed worktree for the badge
+    use-worktree-events.ts   # landed / land-blocked trigger bindings
     use-theme.ts         # theme + persistence
   components/
     ui/                  # iii Schematic primitives (+ co-located *.stories.tsx)
@@ -106,6 +118,7 @@ src/
   pages/
     Configuration/       # console + workers config surfaces
     Traces/              # trace explorer
+    Worktrees/           # live worktree graph (repo -> worktree -> session)
   stories/               # Storybook-only assets (never in the app bundle)
     decorators.tsx       # shared decorators (.workers-tab scope, padding)
     fixtures/            # mock data for the component stories

--- a/console/web/src/lib/worktrees.test.ts
+++ b/console/web/src/lib/worktrees.test.ts
@@ -93,6 +93,28 @@ describe('parseWorktreeInfo', () => {
     expect(info?.branch).toBe('iii/wt_1f2e3d4c')
     expect(info?.lifecycle).toBe('claimed')
     expect(info?.status?.ahead).toBe(2)
+    // v0.1 workers do not send the v0.2 fields; they stay undefined.
+    expect(info?.dev_port).toBeUndefined()
+    expect(info?.status?.integrated).toBeUndefined()
+  })
+
+  it('parses the v0.2 fields when a newer worker sends them', () => {
+    const info = parseWorktreeInfo({
+      worktree_id: 'wt_1f2e3d4c',
+      repo_path: '/home/dev/app',
+      path: '/home/dev/.iii/worktrees/app/wt_1f2e3d4c',
+      branch: 'iii/wt_1f2e3d4c',
+      lifecycle: 'active',
+      dev_port: 14_231,
+      status: {
+        ...status,
+        integrated: true,
+        integration_reason: 'patch_id_match',
+      },
+    })
+    expect(info?.dev_port).toBe(14_231)
+    expect(info?.status?.integrated).toBe(true)
+    expect(info?.status?.integration_reason).toBe('patch_id_match')
   })
 
   it('rejects unknown lifecycles and missing fields', () => {

--- a/console/web/src/lib/worktrees.ts
+++ b/console/web/src/lib/worktrees.ts
@@ -57,6 +57,9 @@ const worktreeStatusSchema = z.object({
   in_rebase: z.boolean(),
   diffstat: z.string().optional(),
   head_sha: z.string().optional(),
+  // v0.2 workers; optional so older workers keep parsing.
+  integrated: z.boolean().optional(),
+  integration_reason: z.string().nullable().optional(),
 })
 export type WorktreeStatusInfo = z.infer<typeof worktreeStatusSchema>
 
@@ -70,6 +73,8 @@ const worktreeInfoSchema = z.object({
   base_sha: z.string().optional(),
   lifecycle: lifecycleSchema,
   session_id: z.string().nullable().optional(),
+  // v0.2 workers; optional so older workers keep parsing.
+  dev_port: z.number().optional(),
   created_at: z.number().optional(),
   updated_at: z.number().optional(),
   status: worktreeStatusSchema.nullable().optional(),

--- a/console/web/src/lib/worktrees.ts
+++ b/console/web/src/lib/worktrees.ts
@@ -63,6 +63,16 @@ const worktreeStatusSchema = z.object({
 })
 export type WorktreeStatusInfo = z.infer<typeof worktreeStatusSchema>
 
+/**
+ * Label for an integrated worktree: "merged upstream", with the worker's
+ * detection reason appended when it reports one.
+ */
+export function integrationLabel(status: WorktreeStatusInfo): string {
+  return status.integration_reason
+    ? `merged upstream (${status.integration_reason})`
+    : 'merged upstream'
+}
+
 const worktreeInfoSchema = z.object({
   worktree_id: z.string(),
   repo_path: z.string(),

--- a/console/web/src/pages/Worktrees/components/WorktreeDetailPanel.tsx
+++ b/console/web/src/pages/Worktrees/components/WorktreeDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { Check, Copy, X } from 'lucide-react'
+import { Check, Copy, GitMerge, X } from 'lucide-react'
 import { useCallback, useState } from 'react'
 import { StatusDot } from '@/components/ui/StatusDot'
 import { cn } from '@/lib/utils'
@@ -136,6 +136,27 @@ export function WorktreeDetailPanel({
         ) : null}
         {worktree.session_id ? (
           <Row label="claimed by">{worktree.session_id}</Row>
+        ) : null}
+        {worktree.dev_port != null ? (
+          <Row label="dev port">
+            <span className="tabular-nums">{worktree.dev_port}</span>
+            <span className="ml-2 text-[11px] lowercase text-ink-ghost">
+              advisory, derived from the id
+            </span>
+          </Row>
+        ) : null}
+        {status?.integrated ? (
+          <Row label="integrated">
+            <span className="inline-flex items-center gap-1.5 text-ink">
+              <GitMerge size={12} className="text-ink-faint" aria-hidden />
+              merged upstream
+              {status.integration_reason ? (
+                <span className="text-[11px] lowercase text-ink-ghost">
+                  {status.integration_reason}
+                </span>
+              ) : null}
+            </span>
+          </Row>
         ) : null}
         {created ? <Row label="created">{created}</Row> : null}
         {updated ? <Row label="updated">{updated}</Row> : null}

--- a/console/web/src/pages/Worktrees/components/WorktreeDetailPanel.tsx
+++ b/console/web/src/pages/Worktrees/components/WorktreeDetailPanel.tsx
@@ -3,6 +3,7 @@ import { useCallback, useState } from 'react'
 import { StatusDot } from '@/components/ui/StatusDot'
 import { cn } from '@/lib/utils'
 import {
+  integrationLabel,
   lifecycleTone,
   lifecycleToneClass,
   shortWorktreeId,
@@ -149,12 +150,7 @@ export function WorktreeDetailPanel({
           <Row label="integrated">
             <span className="inline-flex items-center gap-1.5 text-ink">
               <GitMerge size={12} className="text-ink-faint" aria-hidden />
-              merged upstream
-              {status.integration_reason ? (
-                <span className="text-[11px] lowercase text-ink-ghost">
-                  {status.integration_reason}
-                </span>
-              ) : null}
+              {integrationLabel(status)}
             </span>
           </Row>
         ) : null}

--- a/console/web/src/pages/Worktrees/components/WorktreeGraph.tsx
+++ b/console/web/src/pages/Worktrees/components/WorktreeGraph.tsx
@@ -1,4 +1,4 @@
-import { FolderGit2, GitBranch } from 'lucide-react'
+import { FolderGit2, GitBranch, GitMerge } from 'lucide-react'
 import { useMemo } from 'react'
 import { StatusDot } from '@/components/ui/StatusDot'
 import { cn } from '@/lib/utils'
@@ -139,6 +139,18 @@ export function WorktreeGraph({
                   title={`${ahead} commit(s) ahead of base`}
                 >
                   +{ahead}
+                </span>
+              ) : null}
+              {wt.status?.integrated ? (
+                <span
+                  className="shrink-0 text-ink-ghost"
+                  title={`merged upstream${
+                    wt.status.integration_reason
+                      ? ` (${wt.status.integration_reason})`
+                      : ''
+                  }`}
+                >
+                  <GitMerge size={11} aria-hidden />
                 </span>
               ) : null}
             </span>

--- a/console/web/src/pages/Worktrees/components/WorktreeGraph.tsx
+++ b/console/web/src/pages/Worktrees/components/WorktreeGraph.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react'
 import { StatusDot } from '@/components/ui/StatusDot'
 import { cn } from '@/lib/utils'
 import {
+  integrationLabel,
   lifecycleTone,
   lifecycleToneClass,
   shortWorktreeId,
@@ -144,11 +145,7 @@ export function WorktreeGraph({
               {wt.status?.integrated ? (
                 <span
                   className="shrink-0 text-ink-ghost"
-                  title={`merged upstream${
-                    wt.status.integration_reason
-                      ? ` (${wt.status.integration_reason})`
-                      : ''
-                  }`}
+                  title={integrationLabel(wt.status)}
                 >
                   <GitMerge size={11} aria-hidden />
                 </span>

--- a/console/web/src/stories/fixtures/worktree-fixtures.ts
+++ b/console/web/src/stories/fixtures/worktree-fixtures.ts
@@ -187,6 +187,7 @@ function graphWt(
     base_sha: '8fbe7a1c9d0e2f3a4b5c6d7e8f9a0b1c2d3e4f5a',
     lifecycle,
     session_id: null,
+    dev_port: 10_000 + (Number.parseInt(id.slice(3, 7), 16) % 10_000),
     created_at: createdAt,
     updated_at: createdAt + 30_000,
     status: cleanStatus,
@@ -209,7 +210,13 @@ export const worktreeGraphFixtures: WorktreeInfo[] = [
   }),
   graphWt('wt_33cc44dd', '/home/dev/app', 'landing', now - 300_000, {
     session_id: 'console-5e6f7a8b',
-    status: { ...cleanStatus, ahead: 1, unpushed: 1 },
+    status: {
+      ...cleanStatus,
+      ahead: 1,
+      unpushed: 1,
+      integrated: true,
+      integration_reason: 'merge_adds_nothing',
+    },
   }),
   graphWt('wt_55ee66ff', '/home/dev/api', 'land-blocked', now - 200_000, {
     base_ref: 'release/1.2',

--- a/console/web/src/stories/fixtures/worktree-fixtures.ts
+++ b/console/web/src/stories/fixtures/worktree-fixtures.ts
@@ -187,7 +187,7 @@ function graphWt(
     base_sha: '8fbe7a1c9d0e2f3a4b5c6d7e8f9a0b1c2d3e4f5a',
     lifecycle,
     session_id: null,
-    dev_port: 10_000 + (Number.parseInt(id.slice(3, 7), 16) % 10_000),
+    dev_port: 14_310,
     created_at: createdAt,
     updated_at: createdAt + 30_000,
     status: cleanStatus,
@@ -198,6 +198,7 @@ function graphWt(
 export const worktreeGraphFixtures: WorktreeInfo[] = [
   graphWt('wt_11aa22bb', '/home/dev/app', 'active', now - 500_000),
   graphWt('wt_9f8e7d6c', '/home/dev/app', 'claimed', now - 400_000, {
+    dev_port: 11_204,
     session_id: 'console-1a2b3c4d',
     status: {
       ...cleanStatus,
@@ -209,6 +210,7 @@ export const worktreeGraphFixtures: WorktreeInfo[] = [
     },
   }),
   graphWt('wt_33cc44dd', '/home/dev/app', 'landing', now - 300_000, {
+    dev_port: 15_877,
     session_id: 'console-5e6f7a8b',
     status: {
       ...cleanStatus,
@@ -219,11 +221,13 @@ export const worktreeGraphFixtures: WorktreeInfo[] = [
     },
   }),
   graphWt('wt_55ee66ff', '/home/dev/api', 'land-blocked', now - 200_000, {
+    dev_port: 12_642,
     base_ref: 'release/1.2',
     session_id: 'console-9c0d1e2f',
     status: { ...cleanStatus, conflicted: 2, in_rebase: true, ahead: 3 },
   }),
   graphWt('wt_7700aa11', '/home/dev/api', 'orphaned', now - 100_000, {
+    dev_port: 13_098,
     status: null,
   }),
 ]

--- a/worktree/Cargo.lock
+++ b/worktree/Cargo.lock
@@ -2300,7 +2300,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "worktree"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/worktree/Cargo.lock
+++ b/worktree/Cargo.lock
@@ -106,6 +106,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +430,19 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2306,6 +2329,7 @@ dependencies = [
  "async-trait",
  "clap",
  "dirs",
+ "globset",
  "iii-sdk",
  "schemars",
  "serde",

--- a/worktree/Cargo.toml
+++ b/worktree/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "worktree"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/worktree/Cargo.toml
+++ b/worktree/Cargo.toml
@@ -26,6 +26,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 clap = { version = "4", features = ["derive"] }
 async-trait = "0.1"
+globset = "0.4"
 # Must stay on the same schemars major as iii-sdk so the derived
 # `JsonSchema` impls satisfy `RegisterFunction::new_async` /
 # `RegisterTriggerType::trigger_request_format`.

--- a/worktree/Cargo.toml
+++ b/worktree/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 
 [dependencies]
 iii-sdk = "=0.20.0"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time", "process"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time", "process", "fs"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
@@ -37,4 +37,4 @@ dirs = "5"
 serde_json = "1"
 tempfile = "3"
 which = "8"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time", "process", "test-util"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time", "process", "fs", "test-util"] }

--- a/worktree/README.md
+++ b/worktree/README.md
@@ -80,7 +80,29 @@ land_queue: "worktree-land"         # engine queue name for land jobs
 max_land_retries: 3                 # rebase retries when the target branch moves mid-land
 git_timeout_ms: 60000               # per-git-subprocess bound
 test_timeout_ms: 600000             # land test gate bound
+gates:
+  allow_remove: true                # worktree::remove
+  allow_force: false                # remove force, claim/release force, land force_restart
+  allow_branch_delete: true         # remove delete_branch and the land finalize cleanup
+  allow_land: true                  # worktree::land
+  allow_prune: true                 # worktree::prune (including the cron sweep)
+  land_targets: ["*"]               # globs; pin to ["main"] to allow only mainline lands
 ```
+
+### Gates
+
+Every mutating handler checks its gate before anything else, so an operator
+can turn off whole classes of destruction with one config flip and the
+change hot-reloads. Denials are structured: `W500` (operation disabled),
+`W501` (force paths disabled), `W502` (land target not allowed), and every
+message names the exact key to flip, e.g. `worktree::remove is disabled by
+configuration; set gates.allow_remove: true to enable`. Force is the one
+gate that ships closed: takeovers, forced removals, and land restarts are
+opt-in.
+
+Gates constrain this worker's own surface only. Restricting what an agent
+can run in a shell (`rm`, `git branch -D`, ...) is the shell worker's
+allowlist/denylist job; pair both for defense in depth.
 
 ### Filesystem scope interplay
 

--- a/worktree/README.md
+++ b/worktree/README.md
@@ -93,6 +93,8 @@ gates:
   allow_land: true                  # worktree::land
   allow_prune: true                 # worktree::prune (including the cron sweep)
   land_targets: ["*"]               # globs; pin to ["main"] to allow only mainline lands
+  repos: ["*"]                      # globs over canonical repo paths worktrees may branch from
+  max_worktrees_per_repo: 0         # live-worktree budget per repo at create time; 0 = unlimited
 ```
 
 ### Copy-ignored provisioning
@@ -130,6 +132,12 @@ message names the exact key to flip, e.g. `worktree::remove is disabled by
 configuration; set gates.allow_remove: true to enable`. Force is the one
 gate that ships closed: takeovers, forced removals, and land restarts are
 opt-in.
+
+Creation is gated too: `gates.repos` pins which repositories worktrees may
+branch from (globs over the canonicalized path, `W503` otherwise), and
+`gates.max_worktrees_per_repo` caps live worktrees per repository at create
+time (`W504` names the current count; orphaned records do not count, and
+narrowing either gate later never breaks existing worktrees).
 
 Gates constrain this worker's own surface only. Restricting what an agent
 can run in a shell (`rm`, `git branch -D`, ...) is the shell worker's

--- a/worktree/README.md
+++ b/worktree/README.md
@@ -81,6 +81,11 @@ land_queue: "worktree-land"         # engine queue name for land jobs
 max_land_retries: 3                 # rebase retries when the target branch moves mid-land
 git_timeout_ms: 60000               # per-git-subprocess bound
 test_timeout_ms: 600000             # land test gate bound
+provision:
+  copy_ignored: false               # replicate gitignored files into new worktrees
+  include: []                       # globs; empty = every ignored path
+  exclude: []                       # globs subtracted from the copy
+  max_copy_bytes: 2147483648        # total budget; entries beyond it are skipped
 gates:
   allow_remove: true                # worktree::remove
   allow_force: false                # remove force, claim/release force, land force_restart
@@ -89,6 +94,17 @@ gates:
   allow_prune: true                 # worktree::prune (including the cron sweep)
   land_targets: ["*"]               # globs; pin to ["main"] to allow only mainline lands
 ```
+
+### Copy-ignored provisioning
+
+With `provision.copy_ignored: true`, every create spawns a background task
+that replicates the source repo's gitignored files (.env files, caches,
+local settings) into the new worktree: cheapest copy per platform (APFS
+clones via `cp -c` with a plain fallback on macOS, `--reflink=auto` on
+Linux), VCS metadata directories and the managed worktree root always
+excluded, bounded by `max_copy_bytes`. Provisioning is best-effort by
+design: the create response never waits on it, failures only log, and a
+retried copy skips files that already landed.
 
 ### Pull request checkouts, dev ports, integration
 

--- a/worktree/README.md
+++ b/worktree/README.md
@@ -74,6 +74,7 @@ hot-reload on change (a `prune_schedule` change re-binds the cron live).
 ```yaml
 worktree_root: "~/.iii/worktrees"   # where managed worktrees are created
 branch_prefix: "iii/"               # auto-minted branch names
+branch_naming: "id"                 # or "codename" for <adjective>-<noun>-<4hex> names
 prune_schedule: "0 0 * * * *"       # six-field cron for the reconcile sweep
 prune_expire_hours: 72              # idle hours before a clean, unclaimed worktree is prunable
 land_queue: "worktree-land"         # engine queue name for land jobs
@@ -88,6 +89,20 @@ gates:
   allow_prune: true                 # worktree::prune (including the cron sweep)
   land_targets: ["*"]               # globs; pin to ["main"] to allow only mainline lands
 ```
+
+### Pull request checkouts, dev ports, integration
+
+`worktree::create` also takes `pr: <number>`: it fetches
+`refs/pull/<n>/head` from `origin` (GitHub layout) and branches
+`<prefix>pr-<n>` at it, so reviewing a PR gets its own isolated checkout.
+Every worktree carries an advisory `dev_port` (10000 + hash of the id mod
+10000): deterministic, collision-improbable across parallel worktrees, and
+never reserved anywhere; point dev servers at it to avoid port fights.
+`worktree::status` reports `integrated` with an `integration_reason`
+(`same_commit`, `ancestor`, `no_added_changes`, `trees_match`,
+`merge_adds_nothing`, `patch_id_match`) so squash- or rebase-landed branches
+read as merged, and `worktree::prune` removes integrated-but-ahead worktrees
+instead of holding them forever.
 
 ### Gates
 

--- a/worktree/README.md
+++ b/worktree/README.md
@@ -122,6 +122,19 @@ never reserved anywhere; point dev servers at it to avoid port fights.
 read as merged, and `worktree::prune` removes integrated-but-ahead worktrees
 instead of holding them forever.
 
+### Removal and trash
+
+`worktree::remove` never blocks on a large directory delete: the worktree
+is renamed into a `.trash` staging area under `worktree_root` (instant),
+the git admin entry is pruned, and a detached task deletes the staged
+directory in the background; if the rename fails the removal falls back to
+a synchronous `git worktree remove`. Entries stranded by a crash are
+cleared by the next prune's trash sweep, which runs even when
+`gates.allow_prune` is off (it is remove's crash recovery, not part of
+prune's destructive surface). Unforced removals also probe for processes
+holding files open under the worktree and refuse with `W222` rather than
+deleting a directory out from under a running dev server.
+
 ### Gates
 
 Every mutating handler checks its gate before anything else, so an operator
@@ -190,8 +203,9 @@ instance.
   takeover and `W210`/`W211` mismatch errors.
 - `worktree::status` — clean, ahead/behind, staged/unstaged/untracked,
   diffstat, rebase-in-progress.
-- `worktree::remove` — guarded removal (`W220` dirty, `W221` unmerged),
-  optional branch deletion.
+- `worktree::remove` — guarded removal (`W220` dirty, `W221` unmerged,
+  `W222` busy), instant trash staging with background delete, optional
+  branch deletion.
 - `worktree::prune` — reconcile sweep, cron-bound; `{}` payload works.
 - `worktree::land` — queue a land job; returns `{ job_id, queued }`.
 - `worktree::land-step` — internal queue consumer; not agent-callable.

--- a/worktree/skills/SKILL.md
+++ b/worktree/skills/SKILL.md
@@ -23,6 +23,14 @@ The land test gate delegates to `shell::exec`, so the shell worker must be
 installed and `worktree_root` must sit inside its `fs.host_roots` jail.
 Landing never pushes to remotes; it moves local branches only.
 
+Destructive surfaces are gated by configuration: every mutating function
+checks its gate first, the force paths (claim takeover, forced removal,
+land `force_restart`) ship closed, and a denial names the exact config key
+to flip. The path `worktree::create` returns doubles as the turn's
+filesystem scope root (`metadata.fs_scope.root`), so file access inside the
+worktree is fenced by the shell worker while the gates cover the lifecycle
+door the scope cannot see (remove, prune, branch deletion, landing).
+
 ## When to Use
 
 - A task should run in isolation from the primary checkout or from other
@@ -31,6 +39,9 @@ Landing never pushes to remotes; it moves local branches only.
 - You need to see which worktrees exist, who owns them, and whether they
   carry uncommitted or unlanded work (`worktree::list`,
   `worktree::status`).
+- A GitHub pull request should be reviewed or exercised in isolation
+  (`worktree::create` with `pr: <number>` fetches `refs/pull/<n>/head`
+  from `origin` and branches at it).
 - A finished branch should merge back into `main` (or any target) with
   tests enforced first (`worktree::land` with `test_cmd`).
 - A land was blocked on conflicts and the agent resolved them in place:
@@ -56,8 +67,10 @@ Landing never pushes to remotes; it moves local branches only.
 
 ## Functions
 
-- `worktree::create` — mint a locked, isolated worktree off a base ref;
-  auto-claims for `session_id` when given.
+- `worktree::create` — mint a locked, isolated worktree off a base ref or
+  a pull request head (`pr`); auto-claims for `session_id` when given,
+  names the branch by id or deterministic codename per config, and returns
+  an advisory `dev_port` derived from the id (never reserved anywhere).
 - `worktree::list` — registry view, filterable by repo or session, with
   optional git status per worktree.
 - `worktree::get` — one worktree with status.
@@ -66,21 +79,36 @@ Landing never pushes to remotes; it moves local branches only.
 - `worktree::claim` — take session ownership (`force` to take over).
 - `worktree::release` — release ownership (`force` to override).
 - `worktree::status` — clean flag, ahead/behind, staged/unstaged/untracked
-  counts, diffstat, rebase-in-progress.
+  counts, diffstat, rebase-in-progress, and `integrated` with an
+  `integration_reason`, so squash- or rebase-landed branches read as
+  merged even while ahead of their base.
 - `worktree::remove` — remove a worktree; refuses dirty or unlanded work
-  unless forced; can delete the branch.
+  unless forced, and refuses while running processes hold files open under
+  it (`W222`); the directory leaves its path instantly (staged into a
+  trash area, deleted in the background); can delete the branch.
 - `worktree::prune` — sweep: drop records whose directories are gone and
-  remove clean, unclaimed, expired worktrees (cron-bound, `{}` payload).
+  remove clean, unclaimed, expired worktrees, including integrated ones
+  whose work already landed (cron-bound, `{}` payload).
 - `worktree::land` — queue the rebase / test / fast-forward / cleanup
   pipeline; returns a `job_id` immediately.
 - `worktree::land-step` — internal queue consumer that executes land
   phases; never call it directly (denied to agents).
 
+With `provision.copy_ignored` enabled in config, every create also
+replicates the source repo's gitignored files (.env files, caches) into
+the new worktree in the background; the create response never waits on it.
+
 Errors carry stable `W###` codes; the ones worth branching on are `W210`
-(already claimed), `W220` (dirty), `W221` (unmerged work), `W401` (land
-already queued), `W402` (unresolved rebase from a previous land), and the
-land-block reasons carried on events (`W410` conflict, `W411` tests,
-`W412` target kept moving, `W413` target checked out dirty).
+(already claimed), `W220` (dirty), `W221` (unmerged work), `W222` (files
+held open by running processes), `W401` (land already queued), `W402`
+(unresolved rebase from a previous land), and the land-block reasons
+carried on events (`W410` conflict, `W411` tests, `W412` target kept
+moving, `W413` target checked out dirty). `W5xx` means configuration
+denied the operation, not that it failed: `W500` gate off, `W501` force
+disabled, `W502` land target not in `gates.land_targets`, `W503`
+repository not in `gates.repos`, `W504` per-repo worktree budget hit. The
+message names the exact key; do not retry, surface that key to the
+operator (or drop the force flag) instead.
 
 ## Reactive triggers
 

--- a/worktree/src/config.rs
+++ b/worktree/src/config.rs
@@ -125,6 +125,15 @@ pub struct GatesConfig {
     /// characters); pin to `["main"]` to allow only mainline lands.
     #[serde(default = "default_land_targets")]
     pub land_targets: Vec<String>,
+    /// Repositories `worktree::create` may branch from. Glob list over the
+    /// canonicalized repository path; checked at create only, so existing
+    /// worktrees keep working when the list narrows later.
+    #[serde(default = "default_match_all")]
+    pub repos: Vec<String>,
+    /// Live (non-orphaned) worktrees allowed per repository at create time;
+    /// 0 = unlimited.
+    #[serde(default)]
+    pub max_worktrees_per_repo: u32,
 }
 
 fn default_true() -> bool {
@@ -132,6 +141,10 @@ fn default_true() -> bool {
 }
 
 fn default_land_targets() -> Vec<String> {
+    default_match_all()
+}
+
+fn default_match_all() -> Vec<String> {
     vec!["*".to_string()]
 }
 
@@ -144,6 +157,8 @@ impl Default for GatesConfig {
             allow_land: true,
             allow_prune: true,
             land_targets: default_land_targets(),
+            repos: default_match_all(),
+            max_worktrees_per_repo: 0,
         }
     }
 }
@@ -152,6 +167,12 @@ impl GatesConfig {
     /// True when `target` matches any of the `land_targets` globs.
     pub fn land_target_allowed(&self, target: &str) -> bool {
         self.land_targets.iter().any(|g| glob_match(g, target))
+    }
+
+    /// True when the canonicalized repository path matches any of the
+    /// `repos` globs.
+    pub fn repo_allowed(&self, repo_path: &str) -> bool {
+        self.repos.iter().any(|g| glob_match(g, repo_path))
     }
 }
 

--- a/worktree/src/config.rs
+++ b/worktree/src/config.rs
@@ -21,6 +21,10 @@ pub struct WorkerConfig {
     /// Prefix for auto-minted branches (`<prefix><worktree_id>`).
     #[serde(default = "default_branch_prefix")]
     pub branch_prefix: String,
+    /// Default branch naming: `id` uses the worktree id; `codename` mints a
+    /// deterministic friendly `<adjective>-<noun>-<4hex>` name from it.
+    #[serde(default)]
+    pub branch_naming: BranchNaming,
     /// Six-field cron schedule for the automatic prune sweep.
     #[serde(default = "default_prune_schedule")]
     pub prune_schedule: String,
@@ -43,6 +47,17 @@ pub struct WorkerConfig {
     /// hot-reloads; denials name the exact key to flip.
     #[serde(default)]
     pub gates: GatesConfig,
+}
+
+/// How default branch names are minted at create time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum BranchNaming {
+    /// `<branch_prefix><worktree_id>`.
+    #[default]
+    Id,
+    /// `<branch_prefix><adjective>-<noun>-<4hex>`, deterministic per id.
+    Codename,
 }
 
 /// Deny-by-config gates over the mutating surface. Checked FIRST by every
@@ -152,6 +167,7 @@ impl Default for WorkerConfig {
         Self {
             worktree_root: default_worktree_root(),
             branch_prefix: default_branch_prefix(),
+            branch_naming: BranchNaming::default(),
             prune_schedule: default_prune_schedule(),
             prune_expire_hours: default_prune_expire_hours(),
             land_queue: default_land_queue(),

--- a/worktree/src/config.rs
+++ b/worktree/src/config.rs
@@ -47,6 +47,45 @@ pub struct WorkerConfig {
     /// hot-reloads; denials name the exact key to flip.
     #[serde(default)]
     pub gates: GatesConfig,
+    /// Best-effort provisioning of gitignored files into fresh worktrees.
+    #[serde(default)]
+    pub provision: ProvisionConfig,
+}
+
+/// Copy-ignored provisioning: replicate gitignored files (.env, caches)
+/// from the source repository into each new worktree, in the background,
+/// after `worktree::create` returns.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ProvisionConfig {
+    /// Enable the background copy of gitignored files on create.
+    #[serde(default)]
+    pub copy_ignored: bool,
+    /// Globs selecting which ignored paths to copy (empty = all ignored).
+    #[serde(default)]
+    pub include: Vec<String>,
+    /// Globs excluding ignored paths from the copy.
+    #[serde(default)]
+    pub exclude: Vec<String>,
+    /// Total copy budget in bytes; entries beyond it are skipped with a
+    /// warning.
+    #[serde(default = "default_max_copy_bytes")]
+    pub max_copy_bytes: u64,
+}
+
+fn default_max_copy_bytes() -> u64 {
+    2 * 1024 * 1024 * 1024
+}
+
+impl Default for ProvisionConfig {
+    fn default() -> Self {
+        Self {
+            copy_ignored: false,
+            include: Vec::new(),
+            exclude: Vec::new(),
+            max_copy_bytes: default_max_copy_bytes(),
+        }
+    }
 }
 
 /// How default branch names are minted at create time.
@@ -175,6 +214,7 @@ impl Default for WorkerConfig {
             git_timeout_ms: default_git_timeout_ms(),
             test_timeout_ms: default_test_timeout_ms(),
             gates: GatesConfig::default(),
+            provision: ProvisionConfig::default(),
         }
     }
 }

--- a/worktree/src/config.rs
+++ b/worktree/src/config.rs
@@ -5,10 +5,12 @@
 //! (`boot_signature`) re-binds the prune cron trigger.
 
 use anyhow::Result;
+use globset::{Glob, GlobSet, GlobSetBuilder};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -101,7 +103,7 @@ pub enum BranchNaming {
 
 /// Deny-by-config gates over the mutating surface. Checked FIRST by every
 /// mutating handler; a denial returns a `W5xx` error naming the key.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct GatesConfig {
     /// Allow `worktree::remove`.
@@ -123,7 +125,7 @@ pub struct GatesConfig {
     pub allow_prune: bool,
     /// Branches `worktree::land` may target. Glob list (`*` matches any
     /// characters); pin to `["main"]` to allow only mainline lands.
-    #[serde(default = "default_land_targets")]
+    #[serde(default = "default_match_all")]
     pub land_targets: Vec<String>,
     /// Repositories `worktree::create` may branch from. Glob list over the
     /// canonicalized repository path; checked at create only, so existing
@@ -134,14 +136,18 @@ pub struct GatesConfig {
     /// 0 = unlimited.
     #[serde(default)]
     pub max_worktrees_per_repo: u32,
+    /// Compiled `land_targets`, built once per config snapshot.
+    #[serde(skip)]
+    #[schemars(skip)]
+    land_targets_set: OnceLock<GlobSet>,
+    /// Compiled `repos`, built once per config snapshot.
+    #[serde(skip)]
+    #[schemars(skip)]
+    repos_set: OnceLock<GlobSet>,
 }
 
 fn default_true() -> bool {
     true
-}
-
-fn default_land_targets() -> Vec<String> {
-    default_match_all()
 }
 
 fn default_match_all() -> Vec<String> {
@@ -151,43 +157,70 @@ fn default_match_all() -> Vec<String> {
 impl Default for GatesConfig {
     fn default() -> Self {
         Self {
-            allow_remove: true,
+            allow_remove: default_true(),
             allow_force: false,
-            allow_branch_delete: true,
-            allow_land: true,
-            allow_prune: true,
-            land_targets: default_land_targets(),
+            allow_branch_delete: default_true(),
+            allow_land: default_true(),
+            allow_prune: default_true(),
+            land_targets: default_match_all(),
             repos: default_match_all(),
             max_worktrees_per_repo: 0,
+            land_targets_set: OnceLock::new(),
+            repos_set: OnceLock::new(),
         }
+    }
+}
+
+impl PartialEq for GatesConfig {
+    fn eq(&self, other: &Self) -> bool {
+        // Compiled glob caches are derived data; only the source lists count.
+        self.allow_remove == other.allow_remove
+            && self.allow_force == other.allow_force
+            && self.allow_branch_delete == other.allow_branch_delete
+            && self.allow_land == other.allow_land
+            && self.allow_prune == other.allow_prune
+            && self.land_targets == other.land_targets
+            && self.repos == other.repos
+            && self.max_worktrees_per_repo == other.max_worktrees_per_repo
     }
 }
 
 impl GatesConfig {
     /// True when `target` matches any of the `land_targets` globs.
     pub fn land_target_allowed(&self, target: &str) -> bool {
-        self.land_targets.iter().any(|g| glob_match(g, target))
+        self.land_targets_set
+            .get_or_init(|| compile_globs(&self.land_targets))
+            .is_match(target)
     }
 
     /// True when the canonicalized repository path matches any of the
     /// `repos` globs.
     pub fn repo_allowed(&self, repo_path: &str) -> bool {
-        self.repos.iter().any(|g| glob_match(g, repo_path))
+        self.repos_set
+            .get_or_init(|| compile_globs(&self.repos))
+            .is_match(repo_path)
     }
 }
 
-/// Minimal glob: `*` matches any run of characters (including `/`); every
-/// other character matches literally.
-pub fn glob_match(pattern: &str, value: &str) -> bool {
-    fn inner(p: &[u8], v: &[u8]) -> bool {
-        match (p.first(), v.first()) {
-            (None, None) => true,
-            (Some(b'*'), _) => inner(&p[1..], v) || (!v.is_empty() && inner(p, &v[1..])),
-            (Some(pc), Some(vc)) if pc == vc => inner(&p[1..], &v[1..]),
-            _ => false,
+/// Compile a glob list with the default settings (`*` crosses `/`, matching
+/// the documented gate semantics). Invalid patterns are logged and skipped;
+/// they can only narrow, never widen, an allowlist.
+pub(crate) fn compile_globs(patterns: &[String]) -> GlobSet {
+    let mut builder = GlobSetBuilder::new();
+    for pattern in patterns {
+        match Glob::new(pattern) {
+            Ok(glob) => {
+                builder.add(glob);
+            }
+            Err(e) => {
+                tracing::warn!(pattern, error = %e, "invalid glob in config; pattern ignored")
+            }
         }
     }
-    inner(pattern.as_bytes(), value.as_bytes())
+    builder.build().unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "glob set failed to build; nothing will match");
+        GlobSet::empty()
+    })
 }
 
 fn default_worktree_root() -> String {
@@ -258,6 +291,15 @@ impl WorkerConfig {
     /// `worktree_root` with a leading `~/` expanded.
     pub fn expanded_worktree_root(&self) -> PathBuf {
         expand_home(&self.worktree_root)
+    }
+
+    /// Default branch name for a new worktree under the configured naming
+    /// scheme.
+    pub fn default_branch(&self, worktree_id: &str) -> String {
+        match self.branch_naming {
+            BranchNaming::Id => format!("{}{}", self.branch_prefix, worktree_id),
+            BranchNaming::Codename => crate::ids::codename_branch(&self.branch_prefix, worktree_id),
+        }
     }
 
     /// Schema registered with the `configuration` worker; shipped defaults
@@ -377,14 +419,17 @@ mod tests {
 
     #[test]
     fn glob_match_star_and_literals() {
-        assert!(glob_match("*", "anything/at/all"));
-        assert!(glob_match("main", "main"));
-        assert!(!glob_match("main", "main2"));
-        assert!(glob_match("release/*", "release/1.2"));
-        assert!(!glob_match("release/*", "release"));
-        assert!(glob_match("*-wip", "feature-wip"));
-        assert!(!glob_match("", "x"));
-        assert!(glob_match("", ""));
+        let gates = |patterns: &[&str]| GatesConfig {
+            land_targets: patterns.iter().map(|s| s.to_string()).collect(),
+            ..GatesConfig::default()
+        };
+        assert!(gates(&["*"]).land_target_allowed("anything/at/all"));
+        assert!(gates(&["main"]).land_target_allowed("main"));
+        assert!(!gates(&["main"]).land_target_allowed("main2"));
+        assert!(gates(&["release/*"]).land_target_allowed("release/1.2"));
+        assert!(!gates(&["release/*"]).land_target_allowed("release"));
+        assert!(gates(&["*-wip"]).land_target_allowed("feature-wip"));
+        assert!(!gates(&[]).land_target_allowed("anything"));
     }
 
     #[test]

--- a/worktree/src/config.rs
+++ b/worktree/src/config.rs
@@ -39,6 +39,80 @@ pub struct WorkerConfig {
     /// Land test gate timeout, milliseconds.
     #[serde(default = "default_test_timeout_ms")]
     pub test_timeout_ms: u64,
+    /// Operation gates: deny-by-config for destructive surfaces. Every gate
+    /// hot-reloads; denials name the exact key to flip.
+    #[serde(default)]
+    pub gates: GatesConfig,
+}
+
+/// Deny-by-config gates over the mutating surface. Checked FIRST by every
+/// mutating handler; a denial returns a `W5xx` error naming the key.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct GatesConfig {
+    /// Allow `worktree::remove`.
+    #[serde(default = "default_true")]
+    pub allow_remove: bool,
+    /// Allow the force paths: remove force, claim force takeover, release
+    /// force, and land force_restart. Disabled out of the box.
+    #[serde(default)]
+    pub allow_force: bool,
+    /// Allow branch deletion (remove delete_branch and the land finalize
+    /// branch cleanup).
+    #[serde(default = "default_true")]
+    pub allow_branch_delete: bool,
+    /// Allow `worktree::land`.
+    #[serde(default = "default_true")]
+    pub allow_land: bool,
+    /// Allow `worktree::prune` (including the cron sweep).
+    #[serde(default = "default_true")]
+    pub allow_prune: bool,
+    /// Branches `worktree::land` may target. Glob list (`*` matches any
+    /// characters); pin to `["main"]` to allow only mainline lands.
+    #[serde(default = "default_land_targets")]
+    pub land_targets: Vec<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_land_targets() -> Vec<String> {
+    vec!["*".to_string()]
+}
+
+impl Default for GatesConfig {
+    fn default() -> Self {
+        Self {
+            allow_remove: true,
+            allow_force: false,
+            allow_branch_delete: true,
+            allow_land: true,
+            allow_prune: true,
+            land_targets: default_land_targets(),
+        }
+    }
+}
+
+impl GatesConfig {
+    /// True when `target` matches any of the `land_targets` globs.
+    pub fn land_target_allowed(&self, target: &str) -> bool {
+        self.land_targets.iter().any(|g| glob_match(g, target))
+    }
+}
+
+/// Minimal glob: `*` matches any run of characters (including `/`); every
+/// other character matches literally.
+pub fn glob_match(pattern: &str, value: &str) -> bool {
+    fn inner(p: &[u8], v: &[u8]) -> bool {
+        match (p.first(), v.first()) {
+            (None, None) => true,
+            (Some(b'*'), _) => inner(&p[1..], v) || (!v.is_empty() && inner(p, &v[1..])),
+            (Some(pc), Some(vc)) if pc == vc => inner(&p[1..], &v[1..]),
+            _ => false,
+        }
+    }
+    inner(pattern.as_bytes(), value.as_bytes())
 }
 
 fn default_worktree_root() -> String {
@@ -84,6 +158,7 @@ impl Default for WorkerConfig {
             max_land_retries: default_max_land_retries(),
             git_timeout_ms: default_git_timeout_ms(),
             test_timeout_ms: default_test_timeout_ms(),
+            gates: GatesConfig::default(),
         }
     }
 }
@@ -189,6 +264,50 @@ mod tests {
         assert_eq!(cfg, WorkerConfig::default());
         assert_eq!(cfg.land_queue, "worktree-land");
         assert_eq!(cfg.prune_expire_hours, 72);
+    }
+
+    #[test]
+    fn gates_default_open_except_force() {
+        let gates = WorkerConfig::default().gates;
+        assert!(gates.allow_remove);
+        assert!(
+            !gates.allow_force,
+            "force paths are disabled out of the box"
+        );
+        assert!(gates.allow_branch_delete);
+        assert!(gates.allow_land);
+        assert!(gates.allow_prune);
+        assert_eq!(gates.land_targets, vec!["*".to_string()]);
+        assert!(gates.land_target_allowed("anything"));
+    }
+
+    #[test]
+    fn gates_yaml_overrides() {
+        let cfg = WorkerConfig::from_yaml(
+            "gates:\n\
+             \x20 allow_remove: false\n\
+             \x20 allow_force: true\n\
+             \x20 land_targets: [\"main\", \"release/*\"]\n",
+        )
+        .unwrap();
+        assert!(!cfg.gates.allow_remove);
+        assert!(cfg.gates.allow_force);
+        assert!(cfg.gates.allow_land, "unset keys keep their defaults");
+        assert!(cfg.gates.land_target_allowed("main"));
+        assert!(cfg.gates.land_target_allowed("release/1.2"));
+        assert!(!cfg.gates.land_target_allowed("trunk"));
+    }
+
+    #[test]
+    fn glob_match_star_and_literals() {
+        assert!(glob_match("*", "anything/at/all"));
+        assert!(glob_match("main", "main"));
+        assert!(!glob_match("main", "main2"));
+        assert!(glob_match("release/*", "release/1.2"));
+        assert!(!glob_match("release/*", "release"));
+        assert!(glob_match("*-wip", "feature-wip"));
+        assert!(!glob_match("", "x"));
+        assert!(glob_match("", ""));
     }
 
     #[test]

--- a/worktree/src/error.rs
+++ b/worktree/src/error.rs
@@ -54,6 +54,12 @@ pub mod codes {
     pub const TARGET_MOVED_EXHAUSTED: &str = "W412";
     /// The target branch is checked out in a dirty checkout.
     pub const TARGET_CHECKED_OUT_DIRTY: &str = "W413";
+    /// The operation is disabled by configuration (gates).
+    pub const OP_DISABLED: &str = "W500";
+    /// Force paths are disabled by configuration (gates.allow_force).
+    pub const FORCE_DISABLED: &str = "W501";
+    /// The land target branch is not allowed by gates.land_targets.
+    pub const LAND_TARGET_NOT_ALLOWED: &str = "W502";
 }
 
 /// One structured worker error: stable code + human-readable message.

--- a/worktree/src/error.rs
+++ b/worktree/src/error.rs
@@ -62,6 +62,10 @@ pub mod codes {
     pub const FORCE_DISABLED: &str = "W501";
     /// The land target branch is not allowed by gates.land_targets.
     pub const LAND_TARGET_NOT_ALLOWED: &str = "W502";
+    /// The repository is not allowed by gates.repos.
+    pub const REPO_NOT_ALLOWED: &str = "W503";
+    /// The repository already holds gates.max_worktrees_per_repo live worktrees.
+    pub const WORKTREE_BUDGET_EXCEEDED: &str = "W504";
 }
 
 /// One structured worker error: stable code + human-readable message.

--- a/worktree/src/error.rs
+++ b/worktree/src/error.rs
@@ -36,6 +36,8 @@ pub mod codes {
     pub const DIRTY: &str = "W220";
     /// The worktree has commits not merged anywhere.
     pub const UNMERGED_WORK: &str = "W221";
+    /// Running processes hold files open under the worktree.
+    pub const WORKTREE_BUSY: &str = "W222";
     /// The iii state store could not be reached (retryable).
     pub const STATE_UNAVAILABLE: &str = "W300";
     /// Persisted state deserialized into an unexpected shape (corrupt record/job).

--- a/worktree/src/functions/claim.rs
+++ b/worktree/src/functions/claim.rs
@@ -34,6 +34,11 @@ pub struct Response {
 }
 
 pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
+    if req.force && !deps.cfg().await.gates.allow_force {
+        return Err(crate::functions::force_denied(
+            "worktree::claim force takeover",
+        ));
+    }
     if req.session_id.trim().is_empty() {
         return Err(WError::new(
             codes::INVALID_REQUEST,

--- a/worktree/src/functions/create.rs
+++ b/worktree/src/functions/create.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::{codes, WError};
 use crate::events::{CreatedEvent, EventCtx, EventKind};
 use crate::functions::Deps;
-use crate::git::{ops, validate_abs_path, validate_ref_name};
+use crate::git::{canonical_or_self, ops, validate_abs_path, validate_ref_name};
 use crate::ids;
 use crate::state;
 use crate::types::{now_ms, Lifecycle, WorktreeRecord};
@@ -55,6 +55,13 @@ pub struct Response {
 }
 
 pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
+    if req.pr.is_some() && (req.base_ref.is_some() || req.branch.is_some()) {
+        return Err(WError::new(
+            codes::INVALID_REQUEST,
+            "pr is mutually exclusive with base_ref and branch",
+        ));
+    }
+
     let cfg = deps.cfg().await;
     let t = cfg.git_timeout_ms;
 
@@ -68,15 +75,12 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
     // Gate on the canonicalized path so symlink spellings cannot dodge the
     // allowlist. Checked at create only: narrowing the list later never
     // breaks existing worktrees.
-    let canonical_repo = std::fs::canonicalize(&repo).unwrap_or_else(|_| repo.clone());
+    let canonical_repo = canonical_or_self(&repo);
     if !cfg.gates.repo_allowed(&canonical_repo.to_string_lossy()) {
-        return Err(WError::new(
+        return Err(crate::functions::allowlist_denied(
             codes::REPO_NOT_ALLOWED,
-            format!(
-                "repository {} is not allowed by configuration; add it to \
-                 gates.repos to enable",
-                canonical_repo.display()
-            ),
+            &format!("repository {}", canonical_repo.display()),
+            "gates.repos",
         ));
     }
 
@@ -86,61 +90,41 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
     // Budget check under the repo lock so concurrent creates serialize
     // against the same count. Orphaned records are not live worktrees.
     if cfg.gates.max_worktrees_per_repo > 0 {
-        let live = state::list_records(deps.state.as_ref())
+        let live = state::collect_records(deps.state.as_ref())
             .await?
             .iter()
             .filter(|r| r.repo_key == repo_key && r.lifecycle != Lifecycle::Orphaned)
             .count() as u32;
         if live >= cfg.gates.max_worktrees_per_repo {
-            return Err(WError::new(
-                codes::WORKTREE_BUDGET_EXCEEDED,
-                format!(
-                    "repository {} already has {live} live worktree(s), the \
-                     configured budget; raise gates.max_worktrees_per_repo to \
-                     allow more",
-                    canonical_repo.display()
-                ),
-            ));
+            return Err(crate::functions::budget_denied(&canonical_repo, live));
         }
     }
 
-    if req.pr.is_some() && (req.base_ref.is_some() || req.branch.is_some()) {
-        return Err(WError::new(
-            codes::INVALID_REQUEST,
-            "pr is mutually exclusive with base_ref and branch",
-        ));
-    }
-
     let worktree_id = ids::mint_worktree_id();
-    let (base_ref, base_sha, branch) = match req.pr {
+    let (base_ref, base_sha, branch, branch_taken) = match req.pr {
         Some(n) => {
+            let branch = format!("{}pr-{n}", cfg.branch_prefix);
+            validate_ref_name("branch", &branch)?;
             let sha = ops::fetch_pr_head(&repo, n, t).await?;
-            (
-                format!("refs/pull/{n}/head"),
-                sha,
-                format!("{}pr-{n}", cfg.branch_prefix),
-            )
+            let taken = ops::branch_exists(&repo, &branch, t).await?;
+            (format!("refs/pull/{n}/head"), sha, branch, taken)
         }
         None => {
             let base_ref = req.base_ref.unwrap_or_else(|| "HEAD".to_string());
             validate_ref_name("base_ref", &base_ref)?;
-            let sha = ops::rev_parse(&repo, &base_ref, t).await?;
-            let branch = match req.branch {
-                Some(branch) => branch,
-                None => match cfg.branch_naming {
-                    crate::config::BranchNaming::Id => {
-                        format!("{}{}", cfg.branch_prefix, worktree_id)
-                    }
-                    crate::config::BranchNaming::Codename => {
-                        ids::codename_branch(&cfg.branch_prefix, &worktree_id)
-                    }
-                },
-            };
-            (base_ref, sha, branch)
+            let branch = req
+                .branch
+                .unwrap_or_else(|| cfg.default_branch(&worktree_id));
+            validate_ref_name("branch", &branch)?;
+            // Independent read-only lookups; run them concurrently.
+            let (sha, taken) = tokio::join!(
+                ops::rev_parse(&repo, &base_ref, t),
+                ops::branch_exists(&repo, &branch, t),
+            );
+            (base_ref, sha?, branch, taken?)
         }
     };
-    validate_ref_name("branch", &branch)?;
-    if ops::branch_exists(&repo, &branch, t).await? {
+    if branch_taken {
         return Err(WError::new(
             codes::BRANCH_EXISTS,
             format!("branch {branch:?} already exists"),
@@ -160,9 +144,8 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
 
     ops::worktree_add(&repo, &dir, &branch, &base_sha, &worktree_id, t).await?;
     // Store the canonical path so comparisons against git's own worktree
-    // listing (which resolves symlinks, e.g. /var vs /private/var on macOS)
-    // match exactly.
-    let dir = std::fs::canonicalize(&dir).unwrap_or(dir);
+    // listing match exactly.
+    let dir = canonical_or_self(&dir);
 
     let now = now_ms();
     let record = WorktreeRecord {
@@ -179,7 +162,6 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
             Lifecycle::Active
         },
         session_id: req.session_id.clone(),
-        dev_port: ids::dev_port(&worktree_id),
         created_at: now,
         updated_at: now,
     };
@@ -228,7 +210,7 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
     }
 
     Ok(Response {
-        dev_port: record.dev_port,
+        dev_port: ids::dev_port(&worktree_id),
         worktree_id,
         path: record.path,
         branch,

--- a/worktree/src/functions/create.rs
+++ b/worktree/src/functions/create.rs
@@ -65,8 +65,44 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
             format!("repo_path is not a directory: {}", repo.display()),
         ));
     }
+    // Gate on the canonicalized path so symlink spellings cannot dodge the
+    // allowlist. Checked at create only: narrowing the list later never
+    // breaks existing worktrees.
+    let canonical_repo = std::fs::canonicalize(&repo).unwrap_or_else(|_| repo.clone());
+    if !cfg.gates.repo_allowed(&canonical_repo.to_string_lossy()) {
+        return Err(WError::new(
+            codes::REPO_NOT_ALLOWED,
+            format!(
+                "repository {} is not allowed by configuration; add it to \
+                 gates.repos to enable",
+                canonical_repo.display()
+            ),
+        ));
+    }
+
     let repo_key = ops::git_common_dir(&repo, t).await?;
     let _guard = deps.locks.guard(&repo_key).await;
+
+    // Budget check under the repo lock so concurrent creates serialize
+    // against the same count. Orphaned records are not live worktrees.
+    if cfg.gates.max_worktrees_per_repo > 0 {
+        let live = state::list_records(deps.state.as_ref())
+            .await?
+            .iter()
+            .filter(|r| r.repo_key == repo_key && r.lifecycle != Lifecycle::Orphaned)
+            .count() as u32;
+        if live >= cfg.gates.max_worktrees_per_repo {
+            return Err(WError::new(
+                codes::WORKTREE_BUDGET_EXCEEDED,
+                format!(
+                    "repository {} already has {live} live worktree(s), the \
+                     configured budget; raise gates.max_worktrees_per_repo to \
+                     allow more",
+                    canonical_repo.display()
+                ),
+            ));
+        }
+    }
 
     if req.pr.is_some() && (req.base_ref.is_some() || req.branch.is_some()) {
         return Err(WError::new(

--- a/worktree/src/functions/create.rs
+++ b/worktree/src/functions/create.rs
@@ -20,9 +20,15 @@ pub struct Request {
     /// Ref to base the worktree on. Defaults to `HEAD`.
     #[serde(default)]
     pub base_ref: Option<String>,
-    /// Branch to create. Defaults to `<branch_prefix><worktree_id>`.
+    /// Branch to create. Defaults to `<branch_prefix><worktree_id>` (or a
+    /// codename when `branch_naming: codename`).
     #[serde(default)]
     pub branch: Option<String>,
+    /// Create the worktree at a GitHub pull request head: fetches
+    /// `refs/pull/<n>/head` from `origin` and branches `<prefix>pr-<n>` at
+    /// it. Mutually exclusive with `base_ref` and `branch`.
+    #[serde(default)]
+    pub pr: Option<u64>,
     /// Session to auto-claim the worktree for.
     #[serde(default)]
     pub session_id: Option<String>,
@@ -42,6 +48,8 @@ pub struct Response {
     pub base_sha: String,
     /// Canonical per-repo key (FIFO group for lands).
     pub repo_key: String,
+    /// Advisory dev-server port derived from the worktree id.
+    pub dev_port: u16,
     /// Creation time, ms since epoch.
     pub created_at: i64,
 }
@@ -60,14 +68,40 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
     let repo_key = ops::git_common_dir(&repo, t).await?;
     let _guard = deps.locks.guard(&repo_key).await;
 
-    let base_ref = req.base_ref.unwrap_or_else(|| "HEAD".to_string());
-    validate_ref_name("base_ref", &base_ref)?;
-    let base_sha = ops::rev_parse(&repo, &base_ref, t).await?;
+    if req.pr.is_some() && (req.base_ref.is_some() || req.branch.is_some()) {
+        return Err(WError::new(
+            codes::INVALID_REQUEST,
+            "pr is mutually exclusive with base_ref and branch",
+        ));
+    }
 
     let worktree_id = ids::mint_worktree_id();
-    let branch = match req.branch {
-        Some(branch) => branch,
-        None => format!("{}{}", cfg.branch_prefix, worktree_id),
+    let (base_ref, base_sha, branch) = match req.pr {
+        Some(n) => {
+            let sha = ops::fetch_pr_head(&repo, n, t).await?;
+            (
+                format!("refs/pull/{n}/head"),
+                sha,
+                format!("{}pr-{n}", cfg.branch_prefix),
+            )
+        }
+        None => {
+            let base_ref = req.base_ref.unwrap_or_else(|| "HEAD".to_string());
+            validate_ref_name("base_ref", &base_ref)?;
+            let sha = ops::rev_parse(&repo, &base_ref, t).await?;
+            let branch = match req.branch {
+                Some(branch) => branch,
+                None => match cfg.branch_naming {
+                    crate::config::BranchNaming::Id => {
+                        format!("{}{}", cfg.branch_prefix, worktree_id)
+                    }
+                    crate::config::BranchNaming::Codename => {
+                        ids::codename_branch(&cfg.branch_prefix, &worktree_id)
+                    }
+                },
+            };
+            (base_ref, sha, branch)
+        }
     };
     validate_ref_name("branch", &branch)?;
     if ops::branch_exists(&repo, &branch, t).await? {
@@ -109,6 +143,7 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
             Lifecycle::Active
         },
         session_id: req.session_id.clone(),
+        dev_port: ids::dev_port(&worktree_id),
         created_at: now,
         updated_at: now,
     };
@@ -145,6 +180,7 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
         .await;
 
     Ok(Response {
+        dev_port: record.dev_port,
         worktree_id,
         path: record.path,
         branch,

--- a/worktree/src/functions/create.rs
+++ b/worktree/src/functions/create.rs
@@ -179,6 +179,18 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
         )
         .await;
 
+    if cfg.provision.copy_ignored {
+        // Best-effort background provisioning; the create response never
+        // waits on it and nothing new is emitted.
+        crate::provision::spawn_copy_ignored(
+            repo.clone(),
+            std::path::PathBuf::from(&record.path),
+            cfg.provision.clone(),
+            root,
+            t,
+        );
+    }
+
     Ok(Response {
         dev_port: record.dev_port,
         worktree_id,

--- a/worktree/src/functions/create.rs
+++ b/worktree/src/functions/create.rs
@@ -88,13 +88,10 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
     let _guard = deps.locks.guard(&repo_key).await;
 
     // Budget check under the repo lock so concurrent creates serialize
-    // against the same count. Orphaned records are not live worktrees.
+    // against the same count. Orphaned records are not live worktrees;
+    // corrupt records count (they may still be live).
     if cfg.gates.max_worktrees_per_repo > 0 {
-        let live = state::collect_records(deps.state.as_ref())
-            .await?
-            .iter()
-            .filter(|r| r.repo_key == repo_key && r.lifecycle != Lifecycle::Orphaned)
-            .count() as u32;
+        let live = state::count_live_records(deps.state.as_ref(), &repo_key).await?;
         if live >= cfg.gates.max_worktrees_per_repo {
             return Err(crate::functions::budget_denied(&canonical_repo, live));
         }

--- a/worktree/src/functions/get.rs
+++ b/worktree/src/functions/get.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 
 use crate::error::WError;
 use crate::functions::create::require_record;
-use crate::functions::status::build_status;
+use crate::functions::status::{build_status, TargetCache};
 use crate::functions::Deps;
 use crate::types::{Lifecycle, WorktreeInfo};
 
@@ -30,7 +30,7 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
     };
     let mut info = WorktreeInfo::from_record(&record, lifecycle);
     if dir_exists {
-        match build_status(&record, cfg.git_timeout_ms).await {
+        match build_status(&record, cfg.git_timeout_ms, &mut TargetCache::new()).await {
             Ok(status) => info.status = Some(status),
             Err(e) => {
                 tracing::warn!(worktree_id = %record.worktree_id, error = %e, "status failed")

--- a/worktree/src/functions/land.rs
+++ b/worktree/src/functions/land.rs
@@ -57,13 +57,10 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
         ));
     }
     if !cfg.gates.land_target_allowed(&req.target_branch) {
-        return Err(WError::new(
+        return Err(crate::functions::allowlist_denied(
             codes::LAND_TARGET_NOT_ALLOWED,
-            format!(
-                "target branch {:?} is not allowed by configuration; add it to \
-                 gates.land_targets to enable",
-                req.target_branch
-            ),
+            &format!("target branch {:?}", req.target_branch),
+            "gates.land_targets",
         ));
     }
     let t = cfg.git_timeout_ms;

--- a/worktree/src/functions/land.rs
+++ b/worktree/src/functions/land.rs
@@ -45,6 +45,27 @@ pub struct Response {
 
 pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
     let cfg = deps.cfg().await;
+    if !cfg.gates.allow_land {
+        return Err(crate::functions::gate_denied(
+            "worktree::land",
+            "gates.allow_land",
+        ));
+    }
+    if req.force_restart && !cfg.gates.allow_force {
+        return Err(crate::functions::force_denied(
+            "worktree::land force_restart",
+        ));
+    }
+    if !cfg.gates.land_target_allowed(&req.target_branch) {
+        return Err(WError::new(
+            codes::LAND_TARGET_NOT_ALLOWED,
+            format!(
+                "target branch {:?} is not allowed by configuration; add it to \
+                 gates.land_targets to enable",
+                req.target_branch
+            ),
+        ));
+    }
     let t = cfg.git_timeout_ms;
     validate_ref_name("target_branch", &req.target_branch)?;
 

--- a/worktree/src/functions/list.rs
+++ b/worktree/src/functions/list.rs
@@ -7,7 +7,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::error::WError;
-use crate::functions::status::build_status;
+use crate::functions::status::{build_status, TargetCache};
 use crate::functions::Deps;
 use crate::git::{ops, validate_abs_path};
 use crate::state;
@@ -57,6 +57,7 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
     };
 
     let mut worktrees = Vec::new();
+    let mut targets = TargetCache::new();
     for record in state::list_records(deps.state.as_ref()).await? {
         if let Some((_, repo_key)) = &repo_filter {
             if &record.repo_key != repo_key {
@@ -76,7 +77,7 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
         };
         let mut info = WorktreeInfo::from_record(&record, lifecycle);
         if req.include_status && dir_exists {
-            match build_status(&record, t).await {
+            match build_status(&record, t, &mut targets).await {
                 Ok(status) => info.status = Some(status),
                 Err(e) => {
                     tracing::warn!(worktree_id = %record.worktree_id, error = %e, "status failed")

--- a/worktree/src/functions/mod.rs
+++ b/worktree/src/functions/mod.rs
@@ -75,6 +75,32 @@ pub(crate) fn force_denied(op: &str) -> crate::error::WError {
     )
 }
 
+/// Allowlist denial (`W502`/`W503`) naming the rejected subject and the
+/// glob-list config key to extend.
+pub(crate) fn allowlist_denied(
+    code: &'static str,
+    subject: &str,
+    key: &str,
+) -> crate::error::WError {
+    crate::error::WError::new(
+        code,
+        format!("{subject} is not allowed by configuration; add it to {key} to enable"),
+    )
+}
+
+/// `W504` denial carrying the live count that hit the per-repo budget.
+pub(crate) fn budget_denied(repo: &std::path::Path, live: u32) -> crate::error::WError {
+    crate::error::WError::new(
+        crate::error::codes::WORKTREE_BUDGET_EXCEEDED,
+        format!(
+            "repository {} already has {live} live worktree(s), the \
+             configured budget; raise gates.max_worktrees_per_repo to \
+             allow more",
+            repo.display()
+        ),
+    )
+}
+
 macro_rules! register {
     ($iii:expr, $deps:expr, $id:expr, $module:ident, $desc:expr) => {{
         let deps = $deps.clone();

--- a/worktree/src/functions/mod.rs
+++ b/worktree/src/functions/mod.rs
@@ -54,8 +54,25 @@ impl Deps {
             git_timeout_ms: cfg.git_timeout_ms,
             test_timeout_ms: cfg.test_timeout_ms,
             max_land_retries: cfg.max_land_retries,
+            allow_branch_delete: cfg.gates.allow_branch_delete,
         }
     }
+}
+
+/// `W500` denial naming the exact config key to flip.
+pub(crate) fn gate_denied(op: &str, key: &str) -> crate::error::WError {
+    crate::error::WError::new(
+        crate::error::codes::OP_DISABLED,
+        format!("{op} is disabled by configuration; set {key}: true to enable"),
+    )
+}
+
+/// `W501` denial for the force paths, all behind one key.
+pub(crate) fn force_denied(op: &str) -> crate::error::WError {
+    crate::error::WError::new(
+        crate::error::codes::FORCE_DISABLED,
+        format!("{op} is disabled by configuration; set gates.allow_force: true to enable"),
+    )
 }
 
 macro_rules! register {

--- a/worktree/src/functions/prune.rs
+++ b/worktree/src/functions/prune.rs
@@ -193,6 +193,14 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
         ops::worktree_prune(Path::new(&repo_path), t).await;
     }
 
+    // Backstop for detached trash deletes interrupted by a crash/restart.
+    if !req.dry_run {
+        let cleared = crate::trash::sweep(&cfg.expanded_worktree_root(), now).await;
+        if cleared > 0 {
+            tracing::info!(cleared, "trash sweep cleared stale entries");
+        }
+    }
+
     Ok(Response { pruned, skipped })
 }
 

--- a/worktree/src/functions/prune.rs
+++ b/worktree/src/functions/prune.rs
@@ -43,6 +43,18 @@ pub struct Response {
 
 pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
     let cfg = deps.cfg().await;
+    let now = now_ms();
+
+    // The trash sweep is remove's crash recovery (detached deletes that were
+    // interrupted), not part of prune's destructive surface, so it runs even
+    // when the prune gate is closed.
+    if !req.dry_run {
+        let cleared = crate::trash::sweep(&cfg.expanded_worktree_root(), now).await;
+        if cleared > 0 {
+            tracing::info!(cleared, "trash sweep cleared stale entries");
+        }
+    }
+
     if !cfg.gates.allow_prune {
         return Err(crate::functions::gate_denied(
             "worktree::prune",
@@ -60,10 +72,10 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
         None => None,
     };
 
-    let now = now_ms();
     let mut pruned = Vec::new();
     let mut skipped = Vec::new();
     let mut touched_repos: BTreeSet<String> = BTreeSet::new();
+    let mut targets = crate::functions::status::TargetCache::new();
 
     for record in state::list_records(deps.state.as_ref()).await? {
         if let Some(repo_key) = &repo_key_filter {
@@ -155,14 +167,14 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
         if ahead > 0 {
             // Ahead of base is not unmerged work when the target already
             // absorbed it (squash merge, rebase): integrated worktrees are
-            // prunable.
-            let integrated = match ops::rev_parse(wt, "HEAD", t).await {
-                Ok(head_sha) => {
-                    crate::functions::status::integration_of(&record, &head_sha, t)
+            // prunable. HEAD comes from the porcelain status already read.
+            let integrated = match &st.oid {
+                Some(head_sha) => {
+                    crate::functions::status::integration_of(&record, head_sha, t, &mut targets)
                         .await
                         .integrated
                 }
-                Err(_) => false,
+                None => false,
             };
             if !integrated {
                 skipped.push(PruneSkip {
@@ -191,14 +203,6 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
 
     for repo_path in touched_repos {
         ops::worktree_prune(Path::new(&repo_path), t).await;
-    }
-
-    // Backstop for detached trash deletes interrupted by a crash/restart.
-    if !req.dry_run {
-        let cleared = crate::trash::sweep(&cfg.expanded_worktree_root(), now).await;
-        if cleared > 0 {
-            tracing::info!(cleared, "trash sweep cleared stale entries");
-        }
     }
 
     Ok(Response { pruned, skipped })

--- a/worktree/src/functions/prune.rs
+++ b/worktree/src/functions/prune.rs
@@ -43,6 +43,12 @@ pub struct Response {
 
 pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
     let cfg = deps.cfg().await;
+    if !cfg.gates.allow_prune {
+        return Err(crate::functions::gate_denied(
+            "worktree::prune",
+            "gates.allow_prune",
+        ));
+    }
     let t = cfg.git_timeout_ms;
     let expire_ms = (cfg.prune_expire_hours as i64).saturating_mul(3_600_000);
 

--- a/worktree/src/functions/prune.rs
+++ b/worktree/src/functions/prune.rs
@@ -153,11 +153,24 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
             }
         };
         if ahead > 0 {
-            skipped.push(PruneSkip {
-                id: record.worktree_id,
-                reason: "unmerged work".into(),
-            });
-            continue;
+            // Ahead of base is not unmerged work when the target already
+            // absorbed it (squash merge, rebase): integrated worktrees are
+            // prunable.
+            let integrated = match ops::rev_parse(wt, "HEAD", t).await {
+                Ok(head_sha) => {
+                    crate::functions::status::integration_of(&record, &head_sha, t)
+                        .await
+                        .integrated
+                }
+                Err(_) => false,
+            };
+            if !integrated {
+                skipped.push(PruneSkip {
+                    id: record.worktree_id,
+                    reason: "unmerged work".into(),
+                });
+                continue;
+            }
         }
 
         if !req.dry_run {

--- a/worktree/src/functions/release.rs
+++ b/worktree/src/functions/release.rs
@@ -30,6 +30,9 @@ pub struct Response {
 }
 
 pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
+    if req.force && !deps.cfg().await.gates.allow_force {
+        return Err(crate::functions::force_denied("worktree::release force"));
+    }
     if req.session_id.trim().is_empty() {
         return Err(WError::new(
             codes::INVALID_REQUEST,

--- a/worktree/src/functions/remove.rs
+++ b/worktree/src/functions/remove.rs
@@ -83,8 +83,13 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
 
     if wt.is_dir() && repo_available {
         if !req.force {
-            let st = ops::status(wt, t).await?;
-            if !st.clean() {
+            // All three probes are read-only, so they run concurrently.
+            let (st, ahead_behind, busy) = tokio::join!(
+                ops::status(wt, t),
+                ops::ahead_behind(wt, &record.base_sha, t),
+                crate::trash::dir_in_use(wt),
+            );
+            if !st?.clean() {
                 return Err(WError::new(
                     codes::DIRTY,
                     format!(
@@ -93,7 +98,7 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
                     ),
                 ));
             }
-            let (_, ahead) = ops::ahead_behind(wt, &record.base_sha, t).await?;
+            let (_, ahead) = ahead_behind?;
             if ahead > 0 {
                 return Err(WError::new(
                     codes::UNMERGED_WORK,
@@ -104,7 +109,7 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
                     ),
                 ));
             }
-            if crate::trash::dir_in_use(wt).await == Some(true) {
+            if busy == Some(true) {
                 return Err(WError::new(
                     codes::WORKTREE_BUSY,
                     format!(

--- a/worktree/src/functions/remove.rs
+++ b/worktree/src/functions/remove.rs
@@ -36,6 +36,21 @@ pub struct Response {
 
 pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
     let cfg = deps.cfg().await;
+    if !cfg.gates.allow_remove {
+        return Err(crate::functions::gate_denied(
+            "worktree::remove",
+            "gates.allow_remove",
+        ));
+    }
+    if req.force && !cfg.gates.allow_force {
+        return Err(crate::functions::force_denied("worktree::remove force"));
+    }
+    if req.delete_branch && !cfg.gates.allow_branch_delete {
+        return Err(crate::functions::gate_denied(
+            "branch deletion",
+            "gates.allow_branch_delete",
+        ));
+    }
     let t = cfg.git_timeout_ms;
     let record = require_record(deps, &req.worktree_id).await?;
     let _guard = deps.locks.guard(&record.repo_key).await;

--- a/worktree/src/functions/remove.rs
+++ b/worktree/src/functions/remove.rs
@@ -104,9 +104,31 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
                     ),
                 ));
             }
+            if crate::trash::dir_in_use(wt).await == Some(true) {
+                return Err(WError::new(
+                    codes::WORKTREE_BUSY,
+                    format!(
+                        "worktree {} has files open by running processes; stop them \
+                         or pass force to remove anyway",
+                        record.worktree_id
+                    ),
+                ));
+            }
         }
         ops::worktree_unlock(repo, wt, t).await;
-        ops::worktree_remove(repo, wt, true, t).await?;
+        // Rename into the trash (instant) and delete in the background; a
+        // failed rename falls back to the synchronous git removal.
+        let root = cfg.expanded_worktree_root();
+        match crate::trash::stage(wt, &root, &record.worktree_id) {
+            Ok(staged) => {
+                ops::worktree_prune(repo, t).await;
+                crate::trash::spawn_delete(staged);
+            }
+            Err(e) => {
+                tracing::debug!(error = %e, "trash staging failed; removing synchronously");
+                ops::worktree_remove(repo, wt, true, t).await?;
+            }
+        }
     } else if repo_available {
         // Directory already gone: clean up stale admin metadata.
         ops::worktree_prune(repo, t).await;

--- a/worktree/src/functions/status.rs
+++ b/worktree/src/functions/status.rs
@@ -1,6 +1,7 @@
 //! `worktree::status` — git status for one managed worktree, plus the
 //! shared status builder used by `get` and `list`.
 
+use std::collections::HashMap;
 use std::path::Path;
 
 use schemars::JsonSchema;
@@ -11,6 +12,11 @@ use crate::functions::create::{require_dir, require_record};
 use crate::functions::Deps;
 use crate::git::ops;
 use crate::types::{Lifecycle, WorktreeRecord, WorktreeStatus};
+
+/// Handler-local memo of resolved integration targets, keyed by
+/// `(repo_path, base_ref)`. Lives for one handler invocation only, so a
+/// list over many worktrees of one repo resolves the target once.
+pub type TargetCache = HashMap<(String, String), Option<(String, String)>>;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct Request {
@@ -37,9 +43,9 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
     let cfg = deps.cfg().await;
     let record = require_record(deps, &req.worktree_id).await?;
     require_dir(&record)?;
-    let status = build_status(&record, cfg.git_timeout_ms).await?;
+    let status = build_status(&record, cfg.git_timeout_ms, &mut TargetCache::new()).await?;
     Ok(Response {
-        dev_port: crate::types::effective_dev_port(&record),
+        dev_port: crate::ids::dev_port(&record.worktree_id),
         worktree_id: record.worktree_id,
         branch: record.branch,
         lifecycle: record.lifecycle,
@@ -52,12 +58,16 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
 pub async fn build_status(
     record: &WorktreeRecord,
     git_timeout_ms: u64,
+    targets: &mut TargetCache,
 ) -> Result<WorktreeStatus, WError> {
     let wt = Path::new(&record.path);
     let t = git_timeout_ms;
     let st = ops::status(wt, t).await?;
     let in_rebase = ops::is_rebase_in_progress(wt, t).await?;
-    let head_sha = ops::rev_parse(wt, "HEAD", t).await?;
+    let head_sha = match st.oid.clone() {
+        Some(oid) => oid,
+        None => ops::rev_parse(wt, "HEAD", t).await?,
+    };
     let (behind_base, ahead_base) = ops::ahead_behind(wt, &record.base_sha, t).await?;
     let (ahead, behind, unpushed) = if st.has_upstream {
         (st.ahead, st.behind, st.ahead)
@@ -65,7 +75,7 @@ pub async fn build_status(
         (ahead_base, behind_base, ahead_base)
     };
     let diffstat = ops::diffstat(wt, &record.base_sha, t).await?;
-    let integration = integration_of(record, &head_sha, t).await;
+    let integration = integration_of(record, &head_sha, t, targets).await;
     Ok(WorktreeStatus {
         clean: st.clean(),
         ahead,
@@ -84,38 +94,38 @@ pub async fn build_status(
 }
 
 /// Best-effort integration probe; a failed check degrades to not-integrated
-/// rather than failing the whole status read.
+/// rather than failing the whole status read. Target resolution is memoized
+/// in `targets` for the duration of one handler invocation.
 pub async fn integration_of(
     record: &WorktreeRecord,
     head_sha: &str,
     git_timeout_ms: u64,
+    targets: &mut TargetCache,
 ) -> ops::Integration {
     let wt = Path::new(&record.path);
     let repo = Path::new(&record.repo_path);
-    let target = match ops::integration_target(repo, &record.base_ref, git_timeout_ms).await {
-        Ok(Some(target)) if target != record.branch => target,
-        Ok(_) => {
-            return ops::Integration {
-                integrated: false,
-                reason: None,
+    let key = (record.repo_path.clone(), record.base_ref.clone());
+    if !targets.contains_key(&key) {
+        let resolved = match ops::integration_target(repo, &record.base_ref, git_timeout_ms).await {
+            Ok(resolved) => resolved,
+            Err(e) => {
+                tracing::debug!(error = %e, "integration target resolution failed");
+                None
             }
-        }
-        Err(e) => {
-            tracing::debug!(error = %e, "integration target resolution failed");
-            return ops::Integration {
-                integrated: false,
-                reason: None,
-            };
-        }
+        };
+        targets.insert(key.clone(), resolved);
+    }
+    let Some((target_name, target_sha)) = targets.get(&key).and_then(Clone::clone) else {
+        return ops::Integration::no();
     };
-    match ops::check_integration(wt, head_sha, &target, git_timeout_ms).await {
+    if target_name == record.branch {
+        return ops::Integration::no();
+    }
+    match ops::check_integration(wt, head_sha, &target_sha, git_timeout_ms).await {
         Ok(integration) => integration,
         Err(e) => {
             tracing::debug!(error = %e, "integration check failed");
-            ops::Integration {
-                integrated: false,
-                reason: None,
-            }
+            ops::Integration::no()
         }
     }
 }

--- a/worktree/src/functions/status.rs
+++ b/worktree/src/functions/status.rs
@@ -62,6 +62,7 @@ pub async fn build_status(
         (ahead_base, behind_base, ahead_base)
     };
     let diffstat = ops::diffstat(wt, &record.base_sha, t).await?;
+    let integration = integration_of(record, &head_sha, t).await;
     Ok(WorktreeStatus {
         clean: st.clean(),
         ahead,
@@ -74,5 +75,44 @@ pub async fn build_status(
         unpushed,
         in_rebase,
         head_sha,
+        integrated: integration.integrated,
+        integration_reason: integration.reason.map(str::to_string),
     })
+}
+
+/// Best-effort integration probe; a failed check degrades to not-integrated
+/// rather than failing the whole status read.
+pub async fn integration_of(
+    record: &WorktreeRecord,
+    head_sha: &str,
+    git_timeout_ms: u64,
+) -> ops::Integration {
+    let wt = Path::new(&record.path);
+    let repo = Path::new(&record.repo_path);
+    let target = match ops::integration_target(repo, &record.base_ref, git_timeout_ms).await {
+        Ok(Some(target)) if target != record.branch => target,
+        Ok(_) => {
+            return ops::Integration {
+                integrated: false,
+                reason: None,
+            }
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, "integration target resolution failed");
+            return ops::Integration {
+                integrated: false,
+                reason: None,
+            };
+        }
+    };
+    match ops::check_integration(wt, head_sha, &target, git_timeout_ms).await {
+        Ok(integration) => integration,
+        Err(e) => {
+            tracing::debug!(error = %e, "integration check failed");
+            ops::Integration {
+                integrated: false,
+                reason: None,
+            }
+        }
+    }
 }

--- a/worktree/src/functions/status.rs
+++ b/worktree/src/functions/status.rs
@@ -26,6 +26,8 @@ pub struct Response {
     pub branch: String,
     /// Current lifecycle.
     pub lifecycle: Lifecycle,
+    /// Advisory dev-server port derived from the worktree id.
+    pub dev_port: u16,
     /// Git status details.
     #[serde(flatten)]
     pub status: WorktreeStatus,
@@ -37,6 +39,7 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
     require_dir(&record)?;
     let status = build_status(&record, cfg.git_timeout_ms).await?;
     Ok(Response {
+        dev_port: crate::types::effective_dev_port(&record),
         worktree_id: record.worktree_id,
         branch: record.branch,
         lifecycle: record.lifecycle,

--- a/worktree/src/functions/validate.rs
+++ b/worktree/src/functions/validate.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::WError;
 use crate::functions::Deps;
-use crate::git::{ops, validate_abs_path};
+use crate::git::{canonical_or_self, ops, validate_abs_path};
 use crate::state;
 use crate::types::{now_ms, Lifecycle};
 
@@ -35,16 +35,14 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
     let cfg = deps.cfg().await;
     let t = cfg.git_timeout_ms;
     let path = validate_abs_path("path", &req.path)?;
-    let canonical = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+    let canonical = canonical_or_self(&path);
 
     let records = state::list_records(deps.state.as_ref()).await?;
     let matched = records.into_iter().find(|r| {
         let record_path = Path::new(&r.path);
         record_path == path
             || record_path == canonical
-            || std::fs::canonicalize(record_path)
-                .map(|c| c == canonical)
-                .unwrap_or(false)
+            || canonical_or_self(record_path) == canonical
     });
 
     if let Some(mut record) = matched {

--- a/worktree/src/git/mod.rs
+++ b/worktree/src/git/mod.rs
@@ -61,6 +61,59 @@ pub async fn run_git(dir: &Path, args: &[&str], timeout_ms: u64) -> Result<GitOu
     })
 }
 
+/// Like [`run_git`], but feeds `stdin_data` to the child (used for the
+/// `diff-tree --stdin` / `patch-id` plumbing pipelines).
+pub async fn run_git_with_stdin(
+    dir: &Path,
+    args: &[&str],
+    stdin_data: &[u8],
+    timeout_ms: u64,
+) -> Result<GitOutput, WError> {
+    let mut cmd = Command::new("git");
+    cmd.arg("-c")
+        .arg("protocol.ext.allow=never")
+        .args(args)
+        .current_dir(dir)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_PROTOCOL_FROM_USER", "0")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    let run = async {
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| WError::new(codes::GIT_SPAWN, format!("spawn git: {e}")))?;
+        if let Some(mut stdin) = child.stdin.take() {
+            use tokio::io::AsyncWriteExt;
+            stdin
+                .write_all(stdin_data)
+                .await
+                .map_err(|e| WError::new(codes::GIT_SPAWN, format!("write git stdin: {e}")))?;
+            drop(stdin);
+        }
+        child
+            .wait_with_output()
+            .await
+            .map_err(|e| WError::new(codes::GIT_SPAWN, format!("await git: {e}")))
+    };
+    let output = timeout(Duration::from_millis(timeout_ms), run)
+        .await
+        .map_err(|_| {
+            WError::new(
+                codes::GIT_TIMEOUT,
+                format!("git {} timed out after {timeout_ms} ms", args.join(" ")),
+            )
+        })??;
+
+    Ok(GitOutput {
+        exit_code: output.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    })
+}
+
 /// Like [`run_git`], but a nonzero exit is a `W102` error carrying the
 /// trimmed stderr.
 pub async fn run_git_ok(dir: &Path, args: &[&str], timeout_ms: u64) -> Result<GitOutput, WError> {

--- a/worktree/src/git/mod.rs
+++ b/worktree/src/git/mod.rs
@@ -28,45 +28,12 @@ impl GitOutput {
     }
 }
 
-/// Run `git <args>` in `dir` with hardening and a timeout. Returns the
-/// captured output regardless of exit code; use [`run_git_ok`] when nonzero
-/// is an error.
-pub async fn run_git(dir: &Path, args: &[&str], timeout_ms: u64) -> Result<GitOutput, WError> {
-    let mut cmd = Command::new("git");
-    cmd.arg("-c")
-        .arg("protocol.ext.allow=never")
-        .args(args)
-        .current_dir(dir)
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .env("GIT_PROTOCOL_FROM_USER", "0")
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true);
-
-    let output = timeout(Duration::from_millis(timeout_ms), cmd.output())
-        .await
-        .map_err(|_| {
-            WError::new(
-                codes::GIT_TIMEOUT,
-                format!("git {} timed out after {timeout_ms} ms", args.join(" ")),
-            )
-        })?
-        .map_err(|e| WError::new(codes::GIT_SPAWN, format!("spawn git: {e}")))?;
-
-    Ok(GitOutput {
-        exit_code: output.status.code().unwrap_or(-1),
-        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-    })
-}
-
-/// Like [`run_git`], but feeds `stdin_data` to the child (used for the
-/// `diff-tree --stdin` / `patch-id` plumbing pipelines).
-pub async fn run_git_with_stdin(
+/// The single hardened spawn point: prompts disabled, ext transport never
+/// allowed, bounded by one timeout, output captured whatever the exit code.
+async fn run_git_inner(
     dir: &Path,
     args: &[&str],
-    stdin_data: &[u8],
+    stdin_data: Option<&[u8]>,
     timeout_ms: u64,
 ) -> Result<GitOutput, WError> {
     let mut cmd = Command::new("git");
@@ -76,7 +43,11 @@ pub async fn run_git_with_stdin(
         .current_dir(dir)
         .env("GIT_TERMINAL_PROMPT", "0")
         .env("GIT_PROTOCOL_FROM_USER", "0")
-        .stdin(Stdio::piped())
+        .stdin(if stdin_data.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
@@ -85,13 +56,15 @@ pub async fn run_git_with_stdin(
         let mut child = cmd
             .spawn()
             .map_err(|e| WError::new(codes::GIT_SPAWN, format!("spawn git: {e}")))?;
-        if let Some(mut stdin) = child.stdin.take() {
-            use tokio::io::AsyncWriteExt;
-            stdin
-                .write_all(stdin_data)
-                .await
-                .map_err(|e| WError::new(codes::GIT_SPAWN, format!("write git stdin: {e}")))?;
-            drop(stdin);
+        if let Some(data) = stdin_data {
+            if let Some(mut stdin) = child.stdin.take() {
+                use tokio::io::AsyncWriteExt;
+                stdin
+                    .write_all(data)
+                    .await
+                    .map_err(|e| WError::new(codes::GIT_SPAWN, format!("write git stdin: {e}")))?;
+                drop(stdin);
+            }
         }
         child
             .wait_with_output()
@@ -114,6 +87,24 @@ pub async fn run_git_with_stdin(
     })
 }
 
+/// Run `git <args>` in `dir` with hardening and a timeout. Returns the
+/// captured output regardless of exit code; use [`run_git_ok`] when nonzero
+/// is an error.
+pub async fn run_git(dir: &Path, args: &[&str], timeout_ms: u64) -> Result<GitOutput, WError> {
+    run_git_inner(dir, args, None, timeout_ms).await
+}
+
+/// Like [`run_git`], but feeds `stdin_data` to the child (used for the
+/// `diff-tree --stdin` / `patch-id` plumbing pipelines).
+pub async fn run_git_with_stdin(
+    dir: &Path,
+    args: &[&str],
+    stdin_data: &[u8],
+    timeout_ms: u64,
+) -> Result<GitOutput, WError> {
+    run_git_inner(dir, args, Some(stdin_data), timeout_ms).await
+}
+
 /// Like [`run_git`], but a nonzero exit is a `W102` error carrying the
 /// trimmed stderr.
 pub async fn run_git_ok(dir: &Path, args: &[&str], timeout_ms: u64) -> Result<GitOutput, WError> {
@@ -130,6 +121,14 @@ pub async fn run_git_ok(dir: &Path, args: &[&str], timeout_ms: u64) -> Result<Gi
         ));
     }
     Ok(out)
+}
+
+/// Canonicalize a path, falling back to the path itself when resolution
+/// fails (missing entry, permissions). Canonical spellings keep comparisons
+/// against git's own output honest: git reports resolved paths while
+/// callers may use a symlinked spelling (macOS /var vs /private/var).
+pub fn canonical_or_self(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 /// Reject values that would be parsed as git options.

--- a/worktree/src/git/ops.rs
+++ b/worktree/src/git/ops.rs
@@ -393,6 +393,40 @@ pub async fn diffstat(dir: &Path, base: &str, timeout_ms: u64) -> Result<String,
     Ok(out.stdout_trimmed())
 }
 
+/// Fetch a GitHub pull request head from `origin` into `refs/iii/pr/<n>`
+/// and return the commit it points at. `W112` with a clean message when
+/// origin publishes no such ref (non-GitHub layout, wrong number).
+pub async fn fetch_pr_head(repo: &Path, pr: u64, timeout_ms: u64) -> Result<String, WError> {
+    let refspec = format!("+refs/pull/{pr}/head:refs/iii/pr/{pr}");
+    // The runner's GIT_PROTOCOL_FROM_USER=0 also blocks file:// remotes;
+    // re-allow them here only. The remote URL is operator configuration
+    // (origin), never caller input — the PR number is the only variable.
+    let out = run_git(
+        repo,
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "fetch",
+            "--no-tags",
+            "origin",
+            &refspec,
+        ],
+        timeout_ms,
+    )
+    .await?;
+    if out.exit_code != 0 {
+        return Err(WError::new(
+            codes::REF_NOT_FOUND,
+            format!(
+                "refs/pull/{pr}/head not found on origin (GitHub pull request layout \
+                 required): {}",
+                out.stderr.trim()
+            ),
+        ));
+    }
+    rev_parse(repo, &format!("refs/iii/pr/{pr}"), timeout_ms).await
+}
+
 // ---------------------------------------------------------------------------
 // Integration detection
 // ---------------------------------------------------------------------------

--- a/worktree/src/git/ops.rs
+++ b/worktree/src/git/ops.rs
@@ -12,7 +12,13 @@ pub async fn rev_parse(dir: &Path, reference: &str, timeout_ms: u64) -> Result<S
     let spec = format!("{reference}^{{commit}}");
     let out = run_git(
         dir,
-        &["rev-parse", "--verify", "--quiet", &spec],
+        &[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            "--end-of-options",
+            &spec,
+        ],
         timeout_ms,
     )
     .await?;
@@ -117,7 +123,7 @@ pub async fn branch_exists(repo: &Path, branch: &str, timeout_ms: u64) -> Result
     let full = format!("refs/heads/{branch}");
     let out = run_git(
         repo,
-        &["show-ref", "--verify", "--quiet", &full],
+        &["show-ref", "--verify", "--quiet", "--end-of-options", &full],
         timeout_ms,
     )
     .await?;
@@ -127,7 +133,13 @@ pub async fn branch_exists(repo: &Path, branch: &str, timeout_ms: u64) -> Result
 /// Best-effort branch delete; `-d` unless `force`. A missing branch is a no-op.
 pub async fn branch_delete(repo: &Path, branch: &str, force: bool, timeout_ms: u64) -> bool {
     let flag = if force { "-D" } else { "-d" };
-    match run_git(repo, &["branch", flag, branch], timeout_ms).await {
+    match run_git(
+        repo,
+        &["branch", flag, "--end-of-options", branch],
+        timeout_ms,
+    )
+    .await
+    {
         Ok(out) if out.exit_code == 0 => true,
         Ok(out) => {
             tracing::debug!(branch, stderr = %out.stderr.trim(), "branch delete skipped");
@@ -149,7 +161,13 @@ pub async fn is_ancestor(
 ) -> Result<bool, WError> {
     let out = run_git(
         repo,
-        &["merge-base", "--is-ancestor", ancestor, descendant],
+        &[
+            "merge-base",
+            "--is-ancestor",
+            "--end-of-options",
+            ancestor,
+            descendant,
+        ],
         timeout_ms,
     )
     .await?;
@@ -239,7 +257,12 @@ pub async fn cas_update_ref(
     timeout_ms: u64,
 ) -> Result<bool, WError> {
     let full = format!("refs/heads/{target_branch}");
-    let out = run_git(repo, &["update-ref", &full, new_sha, old_sha], timeout_ms).await?;
+    let out = run_git(
+        repo,
+        &["update-ref", "--end-of-options", &full, new_sha, old_sha],
+        timeout_ms,
+    )
+    .await?;
     if out.exit_code == 0 {
         return Ok(true);
     }
@@ -255,6 +278,69 @@ pub async fn cas_update_ref(
         codes::GIT_NONZERO,
         format!("update-ref {full} failed in {}: {stderr}", repo.display()),
     ))
+}
+
+/// CAS branch delete: remove `refs/heads/<branch>` only while it still
+/// points at `expected_sha`. `Ok(false)` when the branch moved (or is
+/// already gone) — the branch is retained rather than dropped blind.
+pub async fn cas_branch_delete(
+    repo: &Path,
+    branch: &str,
+    expected_sha: &str,
+    timeout_ms: u64,
+) -> Result<bool, WError> {
+    let full = format!("refs/heads/{branch}");
+    let out = run_git(
+        repo,
+        &["update-ref", "-d", "--end-of-options", &full, expected_sha],
+        timeout_ms,
+    )
+    .await?;
+    if out.exit_code != 0 {
+        tracing::debug!(branch, stderr = %out.stderr.trim(), "CAS branch delete refused");
+        return Ok(false);
+    }
+    Ok(true)
+}
+
+/// Data-safety anchor for a land in flight: `refs/iii/wt-backup/<id>`
+/// pins the branch head from before the rebase until finalize succeeds.
+pub fn backup_ref(worktree_id: &str) -> String {
+    format!("refs/iii/wt-backup/{worktree_id}")
+}
+
+pub async fn set_backup_ref(
+    repo: &Path,
+    worktree_id: &str,
+    sha: &str,
+    timeout_ms: u64,
+) -> Result<(), WError> {
+    let full = backup_ref(worktree_id);
+    run_git_ok(
+        repo,
+        &["update-ref", "--end-of-options", &full, sha],
+        timeout_ms,
+    )
+    .await
+    .map(|_| ())
+}
+
+/// Best-effort backup-ref cleanup after a successful land.
+pub async fn delete_backup_ref(repo: &Path, worktree_id: &str, timeout_ms: u64) {
+    let full = backup_ref(worktree_id);
+    match run_git(
+        repo,
+        &["update-ref", "-d", "--end-of-options", &full],
+        timeout_ms,
+    )
+    .await
+    {
+        Ok(out) if out.exit_code != 0 => {
+            tracing::debug!(stderr = %out.stderr.trim(), "backup ref delete skipped");
+        }
+        Err(e) => tracing::debug!(error = %e, "backup ref delete failed"),
+        _ => {}
+    }
 }
 
 /// Fast-forward merge inside a live checkout. `Ok(false)` when not
@@ -283,7 +369,13 @@ pub async fn ahead_behind(dir: &Path, base: &str, timeout_ms: u64) -> Result<(u6
     let spec = format!("{base}...HEAD");
     let out = run_git_ok(
         dir,
-        &["rev-list", "--left-right", "--count", &spec],
+        &[
+            "rev-list",
+            "--left-right",
+            "--count",
+            "--end-of-options",
+            &spec,
+        ],
         timeout_ms,
     )
     .await?;

--- a/worktree/src/git/ops.rs
+++ b/worktree/src/git/ops.rs
@@ -300,3 +300,254 @@ pub async fn diffstat(dir: &Path, base: &str, timeout_ms: u64) -> Result<String,
     let out = run_git_ok(dir, &["diff", "--shortstat", &spec], timeout_ms).await?;
     Ok(out.stdout_trimmed())
 }
+
+// ---------------------------------------------------------------------------
+// Integration detection
+// ---------------------------------------------------------------------------
+
+/// Cap on the target-branch commit walk during the patch-id fallback. A
+/// squash merge lands as one target commit, so scanning the most recent
+/// window is enough; beyond it the check conservatively reports
+/// not-integrated instead of walking unbounded history.
+pub const PATCH_ID_WALK_CAP: u64 = 500;
+
+/// Outcome of the integration check chain.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Integration {
+    pub integrated: bool,
+    /// Which check matched: `same_commit`, `ancestor`, `no_added_changes`,
+    /// `trees_match`, `merge_adds_nothing`, or `patch_id_match`.
+    pub reason: Option<&'static str>,
+}
+
+impl Integration {
+    fn no() -> Self {
+        Self {
+            integrated: false,
+            reason: None,
+        }
+    }
+
+    fn yes(reason: &'static str) -> Self {
+        Self {
+            integrated: true,
+            reason: Some(reason),
+        }
+    }
+}
+
+/// The branch a worktree's work is expected to merge into: its recorded
+/// base ref when that is a real ref, else the primary checkout's current
+/// branch. `None` when neither resolves (detached primary, deleted base).
+pub async fn integration_target(
+    repo: &Path,
+    base_ref: &str,
+    timeout_ms: u64,
+) -> Result<Option<String>, WError> {
+    if base_ref != "HEAD" {
+        let out = run_git(
+            repo,
+            &[
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                "--end-of-options",
+                base_ref,
+            ],
+            timeout_ms,
+        )
+        .await?;
+        if out.exit_code == 0 {
+            return Ok(Some(base_ref.to_string()));
+        }
+        return Ok(None);
+    }
+    let out = run_git(repo, &["symbolic-ref", "--short", "HEAD"], timeout_ms).await?;
+    if out.exit_code == 0 {
+        let name = out.stdout_trimmed();
+        if !name.is_empty() {
+            return Ok(Some(name));
+        }
+    }
+    Ok(None)
+}
+
+async fn tree_of(dir: &Path, commitish: &str, timeout_ms: u64) -> Result<String, WError> {
+    let spec = format!("{commitish}^{{tree}}");
+    let out = run_git_ok(
+        dir,
+        &["rev-parse", "--verify", "--quiet", &spec],
+        timeout_ms,
+    )
+    .await?;
+    Ok(out.stdout_trimmed())
+}
+
+/// Cheapest-first integration chain: is every change on `branch_sha` already
+/// contained in `target`? Catches fast-forwards and true merges (ancestor),
+/// rebases (matching trees), squash merges (merge adds nothing, or the
+/// patch-id fallback when the squashed files were touched again), and
+/// no-op branches. A diverged branch with real unmerged work reports
+/// not-integrated. Runs inside the worktree; objects are shared repo-wide.
+pub async fn check_integration(
+    dir: &Path,
+    branch_sha: &str,
+    target: &str,
+    timeout_ms: u64,
+) -> Result<Integration, WError> {
+    let spec = format!("{target}^{{commit}}");
+    let resolved = run_git(
+        dir,
+        &[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            "--end-of-options",
+            &spec,
+        ],
+        timeout_ms,
+    )
+    .await?;
+    if resolved.exit_code != 0 {
+        return Ok(Integration::no());
+    }
+    let target_sha = resolved.stdout_trimmed();
+
+    if branch_sha == target_sha {
+        return Ok(Integration::yes("same_commit"));
+    }
+
+    if is_ancestor(dir, branch_sha, &target_sha, timeout_ms).await? {
+        return Ok(Integration::yes("ancestor"));
+    }
+
+    // Everything past here needs a merge base; unrelated histories are
+    // never integrated.
+    let based = run_git(dir, &["merge-base", branch_sha, &target_sha], timeout_ms).await?;
+    if based.exit_code != 0 {
+        return Ok(Integration::no());
+    }
+    let merge_base = based.stdout_trimmed();
+
+    let added = run_git_ok(
+        dir,
+        &[
+            "diff",
+            "--name-only",
+            &format!("{merge_base}..{branch_sha}"),
+        ],
+        timeout_ms,
+    )
+    .await?;
+    if added.stdout.trim().is_empty() {
+        return Ok(Integration::yes("no_added_changes"));
+    }
+
+    let branch_tree = tree_of(dir, branch_sha, timeout_ms).await?;
+    let target_tree = tree_of(dir, &target_sha, timeout_ms).await?;
+    if branch_tree == target_tree {
+        return Ok(Integration::yes("trees_match"));
+    }
+
+    // In-memory merge: exit 0 = clean (first line is the resulting tree);
+    // exit 1 = conflict (fall through to patch-ids); anything else (e.g.
+    // git without the merge-tree write-tree plumbing) also falls through.
+    let merged = run_git(
+        dir,
+        &["merge-tree", "--write-tree", &target_sha, branch_sha],
+        timeout_ms,
+    )
+    .await?;
+    if merged.exit_code == 0 {
+        let merged_tree = merged.stdout.lines().next().unwrap_or("").trim();
+        if merged_tree == target_tree {
+            return Ok(Integration::yes("merge_adds_nothing"));
+        }
+        return Ok(Integration::no());
+    }
+
+    patch_id_match(dir, branch_sha, &target_sha, &merge_base, timeout_ms).await
+}
+
+/// Squash-merge fallback: the branch's combined diff (merge base to head)
+/// carries the same patch-id as some commit already on the target. Uses
+/// diff-tree plumbing so user diff config never skews the ids, and caps the
+/// target walk at [`PATCH_ID_WALK_CAP`].
+async fn patch_id_match(
+    dir: &Path,
+    branch_sha: &str,
+    target_sha: &str,
+    merge_base: &str,
+    timeout_ms: u64,
+) -> Result<Integration, WError> {
+    let count = run_git_ok(
+        dir,
+        &[
+            "rev-list",
+            "--count",
+            "--end-of-options",
+            &format!("{merge_base}..{target_sha}"),
+        ],
+        timeout_ms,
+    )
+    .await?
+    .stdout_trimmed()
+    .parse::<u64>()
+    .unwrap_or(u64::MAX);
+    if count == 0 || count > PATCH_ID_WALK_CAP {
+        return Ok(Integration::no());
+    }
+
+    let branch_diff = run_git_ok(
+        dir,
+        &["diff-tree", "-p", merge_base, branch_sha],
+        timeout_ms,
+    )
+    .await?;
+    let branch_patch = crate::git::run_git_with_stdin(
+        dir,
+        &["patch-id", "--verbatim"],
+        branch_diff.stdout.as_bytes(),
+        timeout_ms,
+    )
+    .await?;
+    let Some(branch_id) = branch_patch.stdout.split_whitespace().next() else {
+        return Ok(Integration::no());
+    };
+    let branch_id = branch_id.to_string();
+
+    let target_commits = run_git_ok(
+        dir,
+        &[
+            "rev-list",
+            "--end-of-options",
+            &format!("{merge_base}..{target_sha}"),
+        ],
+        timeout_ms,
+    )
+    .await?;
+    let target_diffs = crate::git::run_git_with_stdin(
+        dir,
+        &["diff-tree", "--stdin", "-p"],
+        target_commits.stdout.as_bytes(),
+        timeout_ms,
+    )
+    .await?;
+    let target_ids = crate::git::run_git_with_stdin(
+        dir,
+        &["patch-id", "--verbatim"],
+        target_diffs.stdout.as_bytes(),
+        timeout_ms,
+    )
+    .await?;
+    let matched = target_ids
+        .stdout
+        .lines()
+        .filter_map(|l| l.split_whitespace().next())
+        .any(|id| id == branch_id);
+    Ok(if matched {
+        Integration::yes("patch_id_match")
+    } else {
+        Integration::no()
+    })
+}

--- a/worktree/src/git/ops.rs
+++ b/worktree/src/git/ops.rs
@@ -55,8 +55,9 @@ pub async fn git_common_dir(dir: &Path, timeout_ms: u64) -> Result<String, WErro
     } else {
         dir.join(path)
     };
-    let canonical = std::fs::canonicalize(&absolute).unwrap_or(absolute);
-    Ok(canonical.to_string_lossy().into_owned())
+    Ok(crate::git::canonical_or_self(&absolute)
+        .to_string_lossy()
+        .into_owned())
 }
 
 pub async fn worktree_add(
@@ -149,41 +150,6 @@ pub async fn branch_delete(repo: &Path, branch: &str, force: bool, timeout_ms: u
             tracing::debug!(branch, error = %e, "branch delete failed");
             false
         }
-    }
-}
-
-/// True when `ancestor` is reachable from `descendant`.
-pub async fn is_ancestor(
-    repo: &Path,
-    ancestor: &str,
-    descendant: &str,
-    timeout_ms: u64,
-) -> Result<bool, WError> {
-    let out = run_git(
-        repo,
-        &[
-            "merge-base",
-            "--is-ancestor",
-            "--end-of-options",
-            ancestor,
-            descendant,
-        ],
-        timeout_ms,
-    )
-    .await?;
-    // git reports the ancestry answer as exit 0 (yes) / 1 (no); any other
-    // nonzero exit is a real failure (invalid ref, IO) and must propagate.
-    match out.exit_code {
-        0 => Ok(true),
-        1 => Ok(false),
-        _ => Err(WError::new(
-            codes::GIT_NONZERO,
-            format!(
-                "merge-base --is-ancestor failed in {}: {}",
-                repo.display(),
-                out.stderr.trim()
-            ),
-        )),
     }
 }
 
@@ -447,14 +413,14 @@ pub struct Integration {
 }
 
 impl Integration {
-    fn no() -> Self {
+    pub(crate) fn no() -> Self {
         Self {
             integrated: false,
             reason: None,
         }
     }
 
-    fn yes(reason: &'static str) -> Self {
+    pub(crate) fn yes(reason: &'static str) -> Self {
         Self {
             integrated: true,
             reason: Some(reason),
@@ -464,96 +430,84 @@ impl Integration {
 
 /// The branch a worktree's work is expected to merge into: its recorded
 /// base ref when that is a real ref, else the primary checkout's current
-/// branch. `None` when neither resolves (detached primary, deleted base).
+/// branch. Returns `(name, sha)`; `None` when neither resolves (detached
+/// primary, deleted base).
 pub async fn integration_target(
     repo: &Path,
     base_ref: &str,
     timeout_ms: u64,
-) -> Result<Option<String>, WError> {
-    if base_ref != "HEAD" {
-        let out = run_git(
-            repo,
-            &[
-                "rev-parse",
-                "--verify",
-                "--quiet",
-                "--end-of-options",
-                base_ref,
-            ],
-            timeout_ms,
-        )
-        .await?;
-        if out.exit_code == 0 {
-            return Ok(Some(base_ref.to_string()));
+) -> Result<Option<(String, String)>, WError> {
+    let name = if base_ref != "HEAD" {
+        base_ref.to_string()
+    } else {
+        let out = run_git(repo, &["symbolic-ref", "--short", "HEAD"], timeout_ms).await?;
+        if out.exit_code != 0 {
+            return Ok(None);
         }
-        return Ok(None);
-    }
-    let out = run_git(repo, &["symbolic-ref", "--short", "HEAD"], timeout_ms).await?;
-    if out.exit_code == 0 {
         let name = out.stdout_trimmed();
-        if !name.is_empty() {
-            return Ok(Some(name));
+        if name.is_empty() {
+            return Ok(None);
         }
+        name
+    };
+    match rev_parse(repo, &name, timeout_ms).await {
+        Ok(sha) => Ok(Some((name, sha))),
+        Err(e) if e.code == codes::REF_NOT_FOUND => Ok(None),
+        Err(e) => Err(e),
     }
-    Ok(None)
 }
 
-async fn tree_of(dir: &Path, commitish: &str, timeout_ms: u64) -> Result<String, WError> {
-    let spec = format!("{commitish}^{{tree}}");
-    let out = run_git_ok(
-        dir,
-        &["rev-parse", "--verify", "--quiet", &spec],
-        timeout_ms,
-    )
-    .await?;
-    Ok(out.stdout_trimmed())
+/// Both commits' tree ids in one spawn (one output line per commit). No
+/// `--end-of-options` here: in list mode rev-parse echoes it into stdout,
+/// and both arguments are engine-resolved commit shas, never caller input.
+async fn trees_of(
+    dir: &Path,
+    a: &str,
+    b: &str,
+    timeout_ms: u64,
+) -> Result<(String, String), WError> {
+    let spec_a = format!("{a}^{{tree}}");
+    let spec_b = format!("{b}^{{tree}}");
+    let out = run_git_ok(dir, &["rev-parse", &spec_a, &spec_b], timeout_ms).await?;
+    let mut lines = out.stdout.lines();
+    let tree_a = lines.next().unwrap_or("").trim().to_string();
+    let tree_b = lines.next().unwrap_or("").trim().to_string();
+    Ok((tree_a, tree_b))
 }
 
 /// Cheapest-first integration chain: is every change on `branch_sha` already
-/// contained in `target`? Catches fast-forwards and true merges (ancestor),
-/// rebases (matching trees), squash merges (merge adds nothing, or the
-/// patch-id fallback when the squashed files were touched again), and
-/// no-op branches. A diverged branch with real unmerged work reports
-/// not-integrated. Runs inside the worktree; objects are shared repo-wide.
+/// contained in the commit `target_sha`? Catches fast-forwards and true
+/// merges (ancestor), rebases (matching trees), squash merges (merge adds
+/// nothing, or the patch-id fallback when the squashed files were touched
+/// again), and no-op branches. A diverged branch with real unmerged work
+/// reports not-integrated. Runs inside the worktree; objects are shared
+/// repo-wide.
 pub async fn check_integration(
     dir: &Path,
     branch_sha: &str,
-    target: &str,
+    target_sha: &str,
     timeout_ms: u64,
 ) -> Result<Integration, WError> {
-    let spec = format!("{target}^{{commit}}");
-    let resolved = run_git(
-        dir,
-        &[
-            "rev-parse",
-            "--verify",
-            "--quiet",
-            "--end-of-options",
-            &spec,
-        ],
-        timeout_ms,
-    )
-    .await?;
-    if resolved.exit_code != 0 {
-        return Ok(Integration::no());
-    }
-    let target_sha = resolved.stdout_trimmed();
-
     if branch_sha == target_sha {
         return Ok(Integration::yes("same_commit"));
     }
 
-    if is_ancestor(dir, branch_sha, &target_sha, timeout_ms).await? {
-        return Ok(Integration::yes("ancestor"));
-    }
-
-    // Everything past here needs a merge base; unrelated histories are
-    // never integrated.
-    let based = run_git(dir, &["merge-base", branch_sha, &target_sha], timeout_ms).await?;
+    // One merge-base spawn answers both questions: unrelated histories are
+    // never integrated, and a merge base equal to the branch head means the
+    // branch is an ancestor of the target.
+    let based = run_git(
+        dir,
+        &["merge-base", "--end-of-options", branch_sha, target_sha],
+        timeout_ms,
+    )
+    .await?;
     if based.exit_code != 0 {
         return Ok(Integration::no());
     }
     let merge_base = based.stdout_trimmed();
+    if merge_base == branch_sha {
+        return Ok(Integration::yes("ancestor"));
+    }
 
     let added = run_git_ok(
         dir,
@@ -569,8 +523,7 @@ pub async fn check_integration(
         return Ok(Integration::yes("no_added_changes"));
     }
 
-    let branch_tree = tree_of(dir, branch_sha, timeout_ms).await?;
-    let target_tree = tree_of(dir, &target_sha, timeout_ms).await?;
+    let (branch_tree, target_tree) = trees_of(dir, branch_sha, target_sha, timeout_ms).await?;
     if branch_tree == target_tree {
         return Ok(Integration::yes("trees_match"));
     }
@@ -580,7 +533,7 @@ pub async fn check_integration(
     // git without the merge-tree write-tree plumbing) also falls through.
     let merged = run_git(
         dir,
-        &["merge-tree", "--write-tree", &target_sha, branch_sha],
+        &["merge-tree", "--write-tree", target_sha, branch_sha],
         timeout_ms,
     )
     .await?;
@@ -592,7 +545,7 @@ pub async fn check_integration(
         return Ok(Integration::no());
     }
 
-    patch_id_match(dir, branch_sha, &target_sha, &merge_base, timeout_ms).await
+    patch_id_match(dir, branch_sha, target_sha, &merge_base, timeout_ms).await
 }
 
 /// Squash-merge fallback: the branch's combined diff (merge base to head)
@@ -606,20 +559,21 @@ async fn patch_id_match(
     merge_base: &str,
     timeout_ms: u64,
 ) -> Result<Integration, WError> {
-    let count = run_git_ok(
+    // One walk, capped at one past the limit: line count doubles as the
+    // commit count, and the same stdout feeds `diff-tree --stdin` below.
+    let max_count = format!("--max-count={}", PATCH_ID_WALK_CAP + 1);
+    let target_commits = run_git_ok(
         dir,
         &[
             "rev-list",
-            "--count",
+            &max_count,
             "--end-of-options",
             &format!("{merge_base}..{target_sha}"),
         ],
         timeout_ms,
     )
-    .await?
-    .stdout_trimmed()
-    .parse::<u64>()
-    .unwrap_or(u64::MAX);
+    .await?;
+    let count = target_commits.stdout.lines().count() as u64;
     if count == 0 || count > PATCH_ID_WALK_CAP {
         return Ok(Integration::no());
     }
@@ -642,16 +596,6 @@ async fn patch_id_match(
     };
     let branch_id = branch_id.to_string();
 
-    let target_commits = run_git_ok(
-        dir,
-        &[
-            "rev-list",
-            "--end-of-options",
-            &format!("{merge_base}..{target_sha}"),
-        ],
-        timeout_ms,
-    )
-    .await?;
     let target_diffs = crate::git::run_git_with_stdin(
         dir,
         &["diff-tree", "--stdin", "-p"],

--- a/worktree/src/git/porcelain.rs
+++ b/worktree/src/git/porcelain.rs
@@ -12,6 +12,8 @@ pub struct StatusV2 {
     pub ahead: u64,
     pub behind: u64,
     pub has_upstream: bool,
+    /// HEAD commit from `# branch.oid`; `None` on an unborn branch.
+    pub oid: Option<String>,
 }
 
 impl StatusV2 {
@@ -23,7 +25,11 @@ impl StatusV2 {
 pub fn parse_status_v2(input: &str) -> StatusV2 {
     let mut st = StatusV2::default();
     for line in input.lines() {
-        if let Some(ab) = line.strip_prefix("# branch.ab ") {
+        if let Some(oid) = line.strip_prefix("# branch.oid ") {
+            if oid != "(initial)" {
+                st.oid = Some(oid.to_string());
+            }
+        } else if let Some(ab) = line.strip_prefix("# branch.ab ") {
             st.has_upstream = true;
             for token in ab.split_whitespace() {
                 if let Some(n) = token.strip_prefix('+') {
@@ -129,6 +135,7 @@ u UU N... 100644 100644 100644 100644 a a a conflict.txt
         assert_eq!(st.ahead, 2);
         assert_eq!(st.behind, 1);
         assert!(st.has_upstream);
+        assert_eq!(st.oid.as_deref(), Some("abc"));
         assert!(!st.clean());
     }
 
@@ -138,6 +145,8 @@ u UU N... 100644 100644 100644 100644 a a a conflict.txt
         assert!(st.clean());
         assert!(!st.has_upstream);
         assert_eq!(st.ahead, 0);
+        assert_eq!(st.oid.as_deref(), Some("abc"));
+        assert_eq!(parse_status_v2("# branch.oid (initial)\n").oid, None);
     }
 
     #[test]

--- a/worktree/src/ids.rs
+++ b/worktree/src/ids.rs
@@ -50,6 +50,53 @@ pub fn worktree_dir(root: &Path, repo_key: &str, worktree_id: &str) -> PathBuf {
     root.join(repo_slug(repo_key)).join(worktree_id)
 }
 
+fn stable_hash(value: &str) -> u64 {
+    // DefaultHasher::new() uses fixed keys, so results are stable across
+    // runs and hosts.
+    let mut hasher = std::hash::DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Advisory dev-server port for a worktree: `10000 + hash(id) % 10000`.
+/// Deterministic per id, collision-improbable across a handful of parallel
+/// worktrees; nothing reserves the port.
+pub fn dev_port(worktree_id: &str) -> u16 {
+    10_000 + (stable_hash(worktree_id) % 10_000) as u16
+}
+
+const CODENAME_ADJECTIVES: [&str; 48] = [
+    "amber", "bold", "brisk", "calm", "cedar", "civic", "clear", "cobalt", "copper", "coral",
+    "crisp", "dapper", "deft", "dusky", "eager", "early", "ember", "fabled", "fleet", "gentle",
+    "gilded", "hardy", "hazel", "keen", "limber", "lively", "lucid", "mellow", "misty", "nimble",
+    "noble", "opal", "placid", "plucky", "prime", "quiet", "rapid", "rustic", "sable", "sage",
+    "solid", "sunny", "swift", "tidal", "umber", "vivid", "wry", "zesty",
+];
+
+const CODENAME_NOUNS: [&str; 48] = [
+    "anchor", "aspen", "badger", "basin", "beacon", "birch", "bison", "bluff", "brook", "canyon",
+    "cliff", "comet", "crane", "creek", "delta", "dune", "falcon", "fern", "fjord", "gale",
+    "glade", "grove", "harbor", "heron", "inlet", "jetty", "knoll", "lagoon", "larch", "lark",
+    "ledge", "lynx", "marsh", "mesa", "otter", "pine", "plateau", "prairie", "quarry", "raven",
+    "reef", "ridge", "shoal", "spruce", "summit", "tarn", "thicket", "wren",
+];
+
+/// Deterministic two-word friendly branch name derived from the worktree
+/// id: `<prefix><adjective>-<noun>-<4hex>`, where the hex tail is the id's
+/// own hash prefix (the collision guard).
+pub fn codename_branch(branch_prefix: &str, worktree_id: &str) -> String {
+    let h = stable_hash(worktree_id);
+    let adjective = CODENAME_ADJECTIVES[(h % CODENAME_ADJECTIVES.len() as u64) as usize];
+    let noun = CODENAME_NOUNS[((h >> 8) % CODENAME_NOUNS.len() as u64) as usize];
+    let hex = worktree_id
+        .strip_prefix("wt_")
+        .unwrap_or(worktree_id)
+        .chars()
+        .take(4)
+        .collect::<String>();
+    format!("{branch_prefix}{adjective}-{noun}-{hex}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -78,5 +125,34 @@ mod tests {
         let s = dir.to_string_lossy();
         assert!(s.starts_with("/root/proj-"));
         assert!(s.ends_with("/wt_abc12345"));
+    }
+
+    #[test]
+    fn dev_port_is_deterministic_and_in_range() {
+        let a = dev_port("wt_abc12345");
+        let b = dev_port("wt_abc12345");
+        assert_eq!(a, b);
+        for id in ["wt_abc12345", "wt_00000000", "wt_ffffffff", "wt_1f2e3d4c"] {
+            let port = dev_port(id);
+            assert!((10_000..20_000).contains(&port), "{id} -> {port}");
+        }
+        assert_ne!(dev_port("wt_abc12345"), dev_port("wt_abc12346"));
+    }
+
+    #[test]
+    fn codename_is_deterministic_with_id_hash_suffix() {
+        let a = codename_branch("iii/", "wt_abc12345");
+        let b = codename_branch("iii/", "wt_abc12345");
+        assert_eq!(a, b);
+        assert!(a.starts_with("iii/"));
+        // <prefix><adjective>-<noun>-<4hex of the id>
+        let tail = a.strip_prefix("iii/").unwrap();
+        let parts: Vec<&str> = tail.split('-').collect();
+        assert_eq!(parts.len(), 3, "{a}");
+        assert_eq!(parts[2], "abc1", "collision suffix comes from the id");
+        assert_ne!(
+            codename_branch("iii/", "wt_abc12345"),
+            codename_branch("iii/", "wt_deadbeef"),
+        );
     }
 }

--- a/worktree/src/ids.rs
+++ b/worktree/src/ids.rs
@@ -39,10 +39,7 @@ pub fn repo_slug(repo_key: &str) -> String {
             }
         })
         .collect();
-    // DefaultHasher::new() uses fixed keys, so the slug is stable across runs.
-    let mut hasher = std::hash::DefaultHasher::new();
-    repo_key.hash(&mut hasher);
-    format!("{sanitized}-{:06x}", hasher.finish() & 0xff_ffff)
+    format!("{sanitized}-{:06x}", stable_hash(repo_key) & 0xff_ffff)
 }
 
 /// `<worktree_root>/<repo_slug>/<wt_id>`.
@@ -107,6 +104,15 @@ mod tests {
         assert!(id.starts_with("wt_"));
         assert_eq!(id.len(), 15);
         assert_ne!(mint_worktree_id(), mint_worktree_id());
+    }
+
+    #[test]
+    fn stable_hash_matches_inline_default_hasher() {
+        for input in ["/home/u/My Repo/.git", "/x/.git", "", "wt_abc12345"] {
+            let mut hasher = std::hash::DefaultHasher::new();
+            input.hash(&mut hasher);
+            assert_eq!(stable_hash(input), hasher.finish(), "{input}");
+        }
     }
 
     #[test]

--- a/worktree/src/land/mod.rs
+++ b/worktree/src/land/mod.rs
@@ -79,6 +79,9 @@ pub struct LandDeps {
     pub git_timeout_ms: u64,
     pub test_timeout_ms: u64,
     pub max_land_retries: u32,
+    /// gates.allow_branch_delete snapshot: when false, finalize keeps the
+    /// landed branch instead of deleting it.
+    pub allow_branch_delete: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -354,23 +357,30 @@ pub async fn run_step(deps: &LandDeps, job_id: &str) -> Result<StepResult, WErro
                         // once the directory is gone.
                         ops::worktree_remove(repo, wt, true, git_t).await?;
                     }
-                    // `git branch -d` checks mergedness against HEAD, not the
-                    // land target, so verify the ancestry explicitly and then
-                    // force-delete: the target already contains every commit
-                    // of the landed branch.
-                    let target_ref = format!("refs/heads/{}", job.target_branch);
-                    let branch_ref = format!("refs/heads/{}", job.branch);
-                    match ops::is_ancestor(repo, &branch_ref, &target_ref, git_t).await {
-                        Ok(true) => {
-                            ops::branch_delete(repo, &job.branch, true, git_t).await;
+                    if deps.allow_branch_delete {
+                        // `git branch -d` checks mergedness against HEAD, not
+                        // the land target, so verify the ancestry explicitly
+                        // and then force-delete: the target already contains
+                        // every commit of the landed branch.
+                        let target_ref = format!("refs/heads/{}", job.target_branch);
+                        let branch_ref = format!("refs/heads/{}", job.branch);
+                        match ops::is_ancestor(repo, &branch_ref, &target_ref, git_t).await {
+                            Ok(true) => {
+                                ops::branch_delete(repo, &job.branch, true, git_t).await;
+                            }
+                            Ok(false) => tracing::warn!(
+                                branch = %job.branch,
+                                "finalize: branch is not contained in the target; keeping it"
+                            ),
+                            Err(e) => {
+                                tracing::debug!(error = %e, "finalize: ancestry check failed")
+                            }
                         }
-                        Ok(false) => tracing::warn!(
+                    } else {
+                        tracing::info!(
                             branch = %job.branch,
-                            "finalize: branch is not contained in the target; keeping it"
-                        ),
-                        Err(e) => {
-                            tracing::debug!(error = %e, "finalize: ancestry check failed")
-                        }
+                            "finalize: branch deletion disabled by gates.allow_branch_delete"
+                        );
                     }
                     state::delete_record(deps.state.as_ref(), &job.worktree_id).await?;
                 }

--- a/worktree/src/land/mod.rs
+++ b/worktree/src/land/mod.rs
@@ -148,6 +148,10 @@ pub async fn run_step(deps: &LandDeps, job_id: &str) -> Result<StepResult, WErro
                     return block(deps, &mut job, codes::DIRTY, "dirty", None, None).await;
                 }
                 let repo = Path::new(&job.repo_path);
+                // Data-safety anchor: pin the pre-rebase head until finalize
+                // succeeds; a blocked land keeps the ref for recovery.
+                let head = ops::rev_parse(wt, "HEAD", git_t).await?;
+                ops::set_backup_ref(repo, &job.worktree_id, &head, git_t).await?;
                 match ops::rev_parse(repo, &job.target_branch, git_t).await {
                     Ok(sha) => job.recorded_target_sha = Some(sha),
                     Err(e) if e.code == codes::REF_NOT_FOUND => {
@@ -358,22 +362,17 @@ pub async fn run_step(deps: &LandDeps, job_id: &str) -> Result<StepResult, WErro
                         ops::worktree_remove(repo, wt, true, git_t).await?;
                     }
                     if deps.allow_branch_delete {
-                        // `git branch -d` checks mergedness against HEAD, not
-                        // the land target, so verify the ancestry explicitly
-                        // and then force-delete: the target already contains
-                        // every commit of the landed branch.
-                        let target_ref = format!("refs/heads/{}", job.target_branch);
-                        let branch_ref = format!("refs/heads/{}", job.branch);
-                        match ops::is_ancestor(repo, &branch_ref, &target_ref, git_t).await {
-                            Ok(true) => {
-                                ops::branch_delete(repo, &job.branch, true, git_t).await;
-                            }
+                        // CAS delete: drop the branch only while it still
+                        // points at the exact commit the land merged. A branch
+                        // that moved since is retained, never dropped blind.
+                        match ops::cas_branch_delete(repo, &job.branch, &merged_sha, git_t).await {
+                            Ok(true) => {}
                             Ok(false) => tracing::warn!(
                                 branch = %job.branch,
-                                "finalize: branch is not contained in the target; keeping it"
+                                "finalize: branch moved since the land; keeping it"
                             ),
                             Err(e) => {
-                                tracing::debug!(error = %e, "finalize: ancestry check failed")
+                                tracing::debug!(error = %e, "finalize: CAS branch delete failed")
                             }
                         }
                     } else {
@@ -385,6 +384,8 @@ pub async fn run_step(deps: &LandDeps, job_id: &str) -> Result<StepResult, WErro
                     state::delete_record(deps.state.as_ref(), &job.worktree_id).await?;
                 }
 
+                // The land is durable: release the data-safety anchor.
+                ops::delete_backup_ref(repo, &job.worktree_id, git_t).await;
                 state::clear_active_job_id(deps.state.as_ref(), &job.worktree_id).await?;
                 deps.emitter
                     .emit(

--- a/worktree/src/lib.rs
+++ b/worktree/src/lib.rs
@@ -13,4 +13,5 @@ pub mod locks;
 pub mod manifest;
 pub mod state;
 pub mod surface;
+pub mod trash;
 pub mod types;

--- a/worktree/src/lib.rs
+++ b/worktree/src/lib.rs
@@ -11,6 +11,7 @@ pub mod ids;
 pub mod land;
 pub mod locks;
 pub mod manifest;
+pub mod provision;
 pub mod state;
 pub mod surface;
 pub mod trash;

--- a/worktree/src/provision.rs
+++ b/worktree/src/provision.rs
@@ -94,7 +94,12 @@ pub fn filter_entries(
             if absolute.starts_with(worktree_root) {
                 return false;
             }
-            let abs_str = absolute.to_string_lossy();
+            // Canonicalize before comparing against the registered list:
+            // git reports canonical worktree paths while `repo` may be a
+            // symlinked spelling (macOS /var vs /private/var), and a miss
+            // here silently disables the nested-worktree exclusion.
+            let canonical = std::fs::canonicalize(&absolute).unwrap_or(absolute);
+            let abs_str = canonical.to_string_lossy();
             if registered_worktrees
                 .iter()
                 .any(|wt| wt.starts_with(abs_str.as_ref()) || abs_str.starts_with(wt.as_str()))
@@ -232,8 +237,18 @@ pub fn spawn_copy_ignored(
     timeout_ms: u64,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
+        // The listing includes the primary checkout itself; excluding it
+        // would exclude every repository entry, so drop it (canonical
+        // compare: git reports canonical paths, callers may not).
+        let repo_canon = tokio::fs::canonicalize(&repo)
+            .await
+            .unwrap_or_else(|_| repo.clone());
         let registered = match crate::git::ops::worktree_list(&repo, timeout_ms).await {
-            Ok(entries) => entries.into_iter().map(|e| e.path).collect::<Vec<_>>(),
+            Ok(entries) => entries
+                .into_iter()
+                .map(|e| e.path)
+                .filter(|p| Path::new(p) != repo_canon)
+                .collect::<Vec<_>>(),
             Err(_) => Vec::new(),
         };
         match copy_ignored(

--- a/worktree/src/provision.rs
+++ b/worktree/src/provision.rs
@@ -1,0 +1,262 @@
+//! Copy-ignored provisioning: after `worktree::create` returns, a spawned
+//! background task replicates the source repo's gitignored files (.env,
+//! caches, local settings) into the fresh worktree. Best-effort by design:
+//! failures log and never affect the create; nothing new is emitted.
+//!
+//! Enumeration collapses fully-ignored directories (`git ls-files
+//! --directory`), filters through the operator's include/exclude globs,
+//! always drops VCS metadata dirs and anything under the managed worktree
+//! root, and copies with the platform's cheapest mechanism: APFS clones on
+//! macOS (`cp -c`, plain fallback), `--reflink=auto` on Linux.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use crate::config::{glob_match, ProvisionConfig};
+use crate::error::WError;
+use crate::git::run_git_ok;
+
+/// Directory components never copied, whatever the globs say.
+const VCS_DIRS: [&str; 5] = [".git", ".bzr", ".hg", ".jj", ".svn"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CopyMode {
+    /// macOS `cp -c` (APFS clonefile), plain fallback per entry.
+    MacClone,
+    /// Linux `cp -R --reflink=auto` (degrades to a plain copy by itself).
+    LinuxReflink,
+    /// Plain `cp -R`.
+    Plain,
+}
+
+/// Platform copy mode, probed once per process.
+pub fn platform_copy_mode() -> CopyMode {
+    static MODE: OnceLock<CopyMode> = OnceLock::new();
+    *MODE.get_or_init(|| {
+        if cfg!(target_os = "macos") {
+            CopyMode::MacClone
+        } else if cfg!(target_os = "linux") {
+            CopyMode::LinuxReflink
+        } else {
+            CopyMode::Plain
+        }
+    })
+}
+
+/// Repo-relative gitignored entries, fully-ignored directories collapsed
+/// to one `dir/` entry.
+pub async fn enumerate_ignored(repo: &Path, timeout_ms: u64) -> Result<Vec<String>, WError> {
+    let out = run_git_ok(
+        repo,
+        &[
+            "ls-files",
+            "--others",
+            "--ignored",
+            "--exclude-standard",
+            "--directory",
+            "-z",
+        ],
+        timeout_ms,
+    )
+    .await?;
+    Ok(out
+        .stdout
+        .split('\0')
+        .filter(|entry| !entry.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+/// Apply include/exclude globs plus the always-on exclusions: VCS metadata
+/// dirs, the managed worktree root, and registered worktree paths (a
+/// worktree nested under an ignored dir is never copied).
+pub fn filter_entries(
+    entries: Vec<String>,
+    cfg: &ProvisionConfig,
+    repo: &Path,
+    worktree_root: &Path,
+    registered_worktrees: &[String],
+) -> Vec<String> {
+    entries
+        .into_iter()
+        .filter(|entry| {
+            let rel = entry.trim_end_matches('/');
+            if rel.is_empty() {
+                return false;
+            }
+            if Path::new(rel)
+                .components()
+                .any(|c| VCS_DIRS.contains(&c.as_os_str().to_string_lossy().as_ref()))
+            {
+                return false;
+            }
+            let absolute = repo.join(rel);
+            if absolute.starts_with(worktree_root) {
+                return false;
+            }
+            let abs_str = absolute.to_string_lossy();
+            if registered_worktrees
+                .iter()
+                .any(|wt| wt.starts_with(abs_str.as_ref()) || abs_str.starts_with(wt.as_str()))
+            {
+                return false;
+            }
+            if !cfg.include.is_empty() && !cfg.include.iter().any(|g| glob_match(g, rel)) {
+                return false;
+            }
+            if cfg.exclude.iter().any(|g| glob_match(g, rel)) {
+                return false;
+            }
+            true
+        })
+        .collect()
+}
+
+/// Recursive size of an entry, stopping early once `budget` is exceeded.
+fn entry_size(path: &Path, budget: u64) -> u64 {
+    let Ok(meta) = std::fs::symlink_metadata(path) else {
+        return 0;
+    };
+    if !meta.is_dir() {
+        return meta.len();
+    }
+    let mut total = 0u64;
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return total;
+    };
+    for entry in entries.filter_map(Result::ok) {
+        total = total.saturating_add(entry_size(&entry.path(), budget));
+        if total > budget {
+            return total;
+        }
+    }
+    total
+}
+
+async fn run_cp(program: &str, args: &[&str]) -> bool {
+    let out = tokio::process::Command::new(program)
+        .args(args)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .kill_on_drop(true)
+        .output()
+        .await;
+    matches!(out, Ok(o) if o.status.success())
+}
+
+/// Copy one entry with the mode's cheapest flags, degrading to a plain
+/// `cp -R` when the clone-capable invocation fails (non-APFS volume, older
+/// coreutils). `program` is injectable for tests.
+pub async fn copy_entry_with(program: &str, mode: CopyMode, src: &Path, dst: &Path) -> bool {
+    let src_s = src.to_string_lossy();
+    let dst_s = dst.to_string_lossy();
+    let first: &[&str] = match mode {
+        CopyMode::MacClone => &["-c", "-R", &src_s, &dst_s],
+        CopyMode::LinuxReflink => &["-R", "--reflink=auto", &src_s, &dst_s],
+        CopyMode::Plain => &["-R", &src_s, &dst_s],
+    };
+    if run_cp(program, first).await {
+        return true;
+    }
+    if mode == CopyMode::Plain {
+        return false;
+    }
+    run_cp(program, &["-R", &src_s, &dst_s]).await
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct CopySummary {
+    pub copied: usize,
+    pub bytes: u64,
+    pub over_budget: bool,
+}
+
+/// Replicate the filtered gitignored entries from `repo` into `worktree`,
+/// bounded by `max_copy_bytes`. Entries already present in the worktree are
+/// left alone (idempotent under retries).
+pub async fn copy_ignored(
+    repo: &Path,
+    worktree: &Path,
+    cfg: &ProvisionConfig,
+    registered_worktrees: &[String],
+    worktree_root: &Path,
+    mode: CopyMode,
+    timeout_ms: u64,
+) -> Result<CopySummary, WError> {
+    let raw = enumerate_ignored(repo, timeout_ms).await?;
+    let entries = filter_entries(raw, cfg, repo, worktree_root, registered_worktrees);
+
+    let cp = "cp";
+    let mut summary = CopySummary::default();
+    for entry in entries {
+        let rel = entry.trim_end_matches('/');
+        let src = repo.join(rel);
+        let dst = worktree.join(rel);
+        if !src.exists() || dst.exists() {
+            continue;
+        }
+        let size = entry_size(&src, cfg.max_copy_bytes);
+        if summary.bytes.saturating_add(size) > cfg.max_copy_bytes {
+            summary.over_budget = true;
+            tracing::warn!(
+                entry = rel,
+                max_copy_bytes = cfg.max_copy_bytes,
+                "provision copy budget exceeded; skipping the remaining entries"
+            );
+            break;
+        }
+        if let Some(parent) = dst.parent() {
+            if std::fs::create_dir_all(parent).is_err() {
+                continue;
+            }
+        }
+        if copy_entry_with(cp, mode, &src, &dst).await {
+            summary.copied += 1;
+            summary.bytes = summary.bytes.saturating_add(size);
+        } else {
+            tracing::warn!(entry = rel, "provision copy entry failed");
+        }
+    }
+    Ok(summary)
+}
+
+/// Detached best-effort provisioning task, spawned after the create
+/// response is already on the wire.
+#[allow(clippy::too_many_arguments)]
+pub fn spawn_copy_ignored(
+    repo: PathBuf,
+    worktree: PathBuf,
+    cfg: ProvisionConfig,
+    worktree_root: PathBuf,
+    timeout_ms: u64,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let registered = match crate::git::ops::worktree_list(&repo, timeout_ms).await {
+            Ok(entries) => entries.into_iter().map(|e| e.path).collect::<Vec<_>>(),
+            Err(_) => Vec::new(),
+        };
+        match copy_ignored(
+            &repo,
+            &worktree,
+            &cfg,
+            &registered,
+            &worktree_root,
+            platform_copy_mode(),
+            timeout_ms,
+        )
+        .await
+        {
+            Ok(summary) => tracing::info!(
+                copied = summary.copied,
+                bytes = summary.bytes,
+                over_budget = summary.over_budget,
+                worktree = %worktree.display(),
+                "provisioned gitignored files"
+            ),
+            Err(e) => {
+                tracing::warn!(error = %e, worktree = %worktree.display(), "provisioning failed")
+            }
+        }
+    })
+}

--- a/worktree/src/provision.rs
+++ b/worktree/src/provision.rs
@@ -78,6 +78,7 @@ pub fn filter_entries(
 ) -> Vec<String> {
     let include = compile_globs(&cfg.include);
     let exclude = compile_globs(&cfg.exclude);
+    let worktree_root = crate::git::canonical_or_self(worktree_root);
     entries
         .into_iter()
         .filter(|entry| {
@@ -92,14 +93,15 @@ pub fn filter_entries(
                 return false;
             }
             let absolute = repo_canon.join(rel);
-            if absolute.starts_with(worktree_root) {
+            if absolute.starts_with(&worktree_root) {
                 return false;
             }
-            let abs_str = absolute.to_string_lossy();
-            if registered_worktrees
-                .iter()
-                .any(|wt| wt.starts_with(abs_str.as_ref()) || abs_str.starts_with(wt.as_str()))
-            {
+            // Component-wise on both sides so `/repo/node_modules2` never
+            // reads as nested under a registered `/repo/node_modules`.
+            if registered_worktrees.iter().any(|wt| {
+                let wt = Path::new(wt);
+                wt.starts_with(&absolute) || absolute.starts_with(wt)
+            }) {
                 return false;
             }
             if !cfg.include.is_empty() && !include.is_match(rel) {
@@ -196,6 +198,18 @@ pub async fn copy_ignored(
     let summary = tokio::task::spawn_blocking(move || {
         let mut summary = CopySummary::default();
         for entry in entries {
+            // Liveness guard: `worktree::remove` renames the directory away
+            // instantly (trash staging), so a vanished root means the
+            // worktree is being torn down and copying on would recreate its
+            // parents. The record lives in async state and this loop is
+            // blocking, so the cheap per-entry probe is the right signal.
+            if !worktree.is_dir() {
+                tracing::debug!(
+                    worktree = %worktree.display(),
+                    "worktree gone mid-provision; aborting the remaining entries"
+                );
+                break;
+            }
             let rel = entry.trim_end_matches('/');
             let src = repo.join(rel);
             let dst = worktree.join(rel);

--- a/worktree/src/provision.rs
+++ b/worktree/src/provision.rs
@@ -10,9 +10,8 @@
 //! macOS (`cp -c`, plain fallback), `--reflink=auto` on Linux.
 
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
 
-use crate::config::{glob_match, ProvisionConfig};
+use crate::config::{compile_globs, ProvisionConfig};
 use crate::error::WError;
 use crate::git::run_git_ok;
 
@@ -29,18 +28,15 @@ pub enum CopyMode {
     Plain,
 }
 
-/// Platform copy mode, probed once per process.
+/// Platform copy mode: a compile-time choice, no runtime probing.
 pub fn platform_copy_mode() -> CopyMode {
-    static MODE: OnceLock<CopyMode> = OnceLock::new();
-    *MODE.get_or_init(|| {
-        if cfg!(target_os = "macos") {
-            CopyMode::MacClone
-        } else if cfg!(target_os = "linux") {
-            CopyMode::LinuxReflink
-        } else {
-            CopyMode::Plain
-        }
-    })
+    if cfg!(target_os = "macos") {
+        CopyMode::MacClone
+    } else if cfg!(target_os = "linux") {
+        CopyMode::LinuxReflink
+    } else {
+        CopyMode::Plain
+    }
 }
 
 /// Repo-relative gitignored entries, fully-ignored directories collapsed
@@ -69,14 +65,19 @@ pub async fn enumerate_ignored(repo: &Path, timeout_ms: u64) -> Result<Vec<Strin
 
 /// Apply include/exclude globs plus the always-on exclusions: VCS metadata
 /// dirs, the managed worktree root, and registered worktree paths (a
-/// worktree nested under an ignored dir is never copied).
+/// worktree nested under an ignored dir is never copied). `repo_canon` must
+/// be the canonicalized repository path: git reports canonical worktree
+/// paths, and a symlinked spelling here (macOS /var vs /private/var) would
+/// silently disable the nested-worktree exclusion.
 pub fn filter_entries(
     entries: Vec<String>,
     cfg: &ProvisionConfig,
-    repo: &Path,
+    repo_canon: &Path,
     worktree_root: &Path,
     registered_worktrees: &[String],
 ) -> Vec<String> {
+    let include = compile_globs(&cfg.include);
+    let exclude = compile_globs(&cfg.exclude);
     entries
         .into_iter()
         .filter(|entry| {
@@ -90,26 +91,21 @@ pub fn filter_entries(
             {
                 return false;
             }
-            let absolute = repo.join(rel);
+            let absolute = repo_canon.join(rel);
             if absolute.starts_with(worktree_root) {
                 return false;
             }
-            // Canonicalize before comparing against the registered list:
-            // git reports canonical worktree paths while `repo` may be a
-            // symlinked spelling (macOS /var vs /private/var), and a miss
-            // here silently disables the nested-worktree exclusion.
-            let canonical = std::fs::canonicalize(&absolute).unwrap_or(absolute);
-            let abs_str = canonical.to_string_lossy();
+            let abs_str = absolute.to_string_lossy();
             if registered_worktrees
                 .iter()
                 .any(|wt| wt.starts_with(abs_str.as_ref()) || abs_str.starts_with(wt.as_str()))
             {
                 return false;
             }
-            if !cfg.include.is_empty() && !cfg.include.iter().any(|g| glob_match(g, rel)) {
+            if !cfg.include.is_empty() && !include.is_match(rel) {
                 return false;
             }
-            if cfg.exclude.iter().any(|g| glob_match(g, rel)) {
+            if exclude.is_match(rel) {
                 return false;
             }
             true
@@ -138,22 +134,22 @@ fn entry_size(path: &Path, budget: u64) -> u64 {
     total
 }
 
-async fn run_cp(program: &str, args: &[&str]) -> bool {
-    let out = tokio::process::Command::new(program)
+fn run_cp(program: &str, args: &[&str]) -> bool {
+    std::process::Command::new(program)
         .args(args)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
-        .kill_on_drop(true)
-        .output()
-        .await;
-    matches!(out, Ok(o) if o.status.success())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
 }
 
 /// Copy one entry with the mode's cheapest flags, degrading to a plain
 /// `cp -R` when the clone-capable invocation fails (non-APFS volume, older
-/// coreutils). `program` is injectable for tests.
-pub async fn copy_entry_with(program: &str, mode: CopyMode, src: &Path, dst: &Path) -> bool {
+/// coreutils). Blocking by design: it runs on the copy loop's blocking
+/// thread. `program` is injectable for tests.
+pub fn copy_entry_with(program: &str, mode: CopyMode, src: &Path, dst: &Path) -> bool {
     let src_s = src.to_string_lossy();
     let dst_s = dst.to_string_lossy();
     let first: &[&str] = match mode {
@@ -161,13 +157,13 @@ pub async fn copy_entry_with(program: &str, mode: CopyMode, src: &Path, dst: &Pa
         CopyMode::LinuxReflink => &["-R", "--reflink=auto", &src_s, &dst_s],
         CopyMode::Plain => &["-R", &src_s, &dst_s],
     };
-    if run_cp(program, first).await {
+    if run_cp(program, first) {
         return true;
     }
     if mode == CopyMode::Plain {
         return false;
     }
-    run_cp(program, &["-R", &src_s, &dst_s]).await
+    run_cp(program, &["-R", &src_s, &dst_s])
 }
 
 #[derive(Debug, Default, Clone, PartialEq)]
@@ -177,9 +173,11 @@ pub struct CopySummary {
     pub over_budget: bool,
 }
 
-/// Replicate the filtered gitignored entries from `repo` into `worktree`,
-/// bounded by `max_copy_bytes`. Entries already present in the worktree are
-/// left alone (idempotent under retries).
+/// Replicate the filtered gitignored entries from `repo` (canonicalized by
+/// the caller) into `worktree`, bounded by `max_copy_bytes`. Entries already
+/// present in the worktree are left alone (idempotent under retries). The
+/// size scans and copies are blocking filesystem work and run on a blocking
+/// thread, off the async runtime.
 pub async fn copy_ignored(
     repo: &Path,
     worktree: &Path,
@@ -192,43 +190,54 @@ pub async fn copy_ignored(
     let raw = enumerate_ignored(repo, timeout_ms).await?;
     let entries = filter_entries(raw, cfg, repo, worktree_root, registered_worktrees);
 
-    let cp = "cp";
-    let mut summary = CopySummary::default();
-    for entry in entries {
-        let rel = entry.trim_end_matches('/');
-        let src = repo.join(rel);
-        let dst = worktree.join(rel);
-        if !src.exists() || dst.exists() {
-            continue;
-        }
-        let size = entry_size(&src, cfg.max_copy_bytes);
-        if summary.bytes.saturating_add(size) > cfg.max_copy_bytes {
-            summary.over_budget = true;
-            tracing::warn!(
-                entry = rel,
-                max_copy_bytes = cfg.max_copy_bytes,
-                "provision copy budget exceeded; skipping the remaining entries"
-            );
-            break;
-        }
-        if let Some(parent) = dst.parent() {
-            if std::fs::create_dir_all(parent).is_err() {
+    let repo = repo.to_path_buf();
+    let worktree = worktree.to_path_buf();
+    let max_copy_bytes = cfg.max_copy_bytes;
+    let summary = tokio::task::spawn_blocking(move || {
+        let mut summary = CopySummary::default();
+        for entry in entries {
+            let rel = entry.trim_end_matches('/');
+            let src = repo.join(rel);
+            let dst = worktree.join(rel);
+            if !src.exists() || dst.exists() {
                 continue;
             }
+            let size = entry_size(&src, max_copy_bytes);
+            if summary.bytes.saturating_add(size) > max_copy_bytes {
+                summary.over_budget = true;
+                tracing::warn!(
+                    entry = rel,
+                    max_copy_bytes,
+                    "provision copy budget exceeded; skipping the remaining entries"
+                );
+                break;
+            }
+            if let Some(parent) = dst.parent() {
+                if std::fs::create_dir_all(parent).is_err() {
+                    continue;
+                }
+            }
+            if copy_entry_with("cp", mode, &src, &dst) {
+                summary.copied += 1;
+                summary.bytes = summary.bytes.saturating_add(size);
+            } else {
+                tracing::warn!(entry = rel, "provision copy entry failed");
+            }
         }
-        if copy_entry_with(cp, mode, &src, &dst).await {
-            summary.copied += 1;
-            summary.bytes = summary.bytes.saturating_add(size);
-        } else {
-            tracing::warn!(entry = rel, "provision copy entry failed");
-        }
-    }
+        summary
+    })
+    .await
+    .unwrap_or_else(|e| {
+        // Best-effort contract: a lost copy task degrades to an empty
+        // summary rather than failing the caller.
+        tracing::warn!(error = %e, "provision copy task did not finish");
+        CopySummary::default()
+    });
     Ok(summary)
 }
 
 /// Detached best-effort provisioning task, spawned after the create
 /// response is already on the wire.
-#[allow(clippy::too_many_arguments)]
 pub fn spawn_copy_ignored(
     repo: PathBuf,
     worktree: PathBuf,
@@ -240,9 +249,7 @@ pub fn spawn_copy_ignored(
         // The listing includes the primary checkout itself; excluding it
         // would exclude every repository entry, so drop it (canonical
         // compare: git reports canonical paths, callers may not).
-        let repo_canon = tokio::fs::canonicalize(&repo)
-            .await
-            .unwrap_or_else(|_| repo.clone());
+        let repo_canon = crate::git::canonical_or_self(&repo);
         let registered = match crate::git::ops::worktree_list(&repo, timeout_ms).await {
             Ok(entries) => entries
                 .into_iter()
@@ -252,7 +259,7 @@ pub fn spawn_copy_ignored(
             Err(_) => Vec::new(),
         };
         match copy_ignored(
-            &repo,
+            &repo_canon,
             &worktree,
             &cfg,
             &registered,

--- a/worktree/src/state.rs
+++ b/worktree/src/state.rs
@@ -15,7 +15,7 @@ use iii_sdk::IIIClient;
 use serde_json::{json, Value};
 
 use crate::error::{codes, WError};
-use crate::types::{LandJob, WorktreeRecord};
+use crate::types::{LandJob, Lifecycle, WorktreeRecord};
 
 pub const SCOPE_RECORD: &str = "worktree";
 pub const SCOPE_JOB: &str = "worktree_land_job";
@@ -252,6 +252,39 @@ pub async fn list_records(store: &dyn StateStore) -> Result<Vec<WorktreeRecord>,
     let mut records = collect_records(store).await?;
     records.sort_by_key(|r| r.created_at);
     Ok(records)
+}
+
+/// Live-worktree count for one repo, for the create budget. Parseable
+/// records count when their `repo_key` matches and they are not orphaned.
+/// A corrupt record may still be a live worktree, so it consumes budget
+/// too when its `repo_key` matches or cannot be read (conservative:
+/// skipping it would let creates sail past the operator's cap).
+pub async fn count_live_records(store: &dyn StateStore, repo_key: &str) -> Result<u32, WError> {
+    let mut live: u32 = 0;
+    for value in store.list(SCOPE_RECORD).await? {
+        match serde_json::from_value::<WorktreeRecord>(value.clone()) {
+            Ok(record) => {
+                if record.repo_key == repo_key && record.lifecycle != Lifecycle::Orphaned {
+                    live += 1;
+                }
+            }
+            Err(e) => {
+                let in_scope = value
+                    .get("repo_key")
+                    .and_then(|k| k.as_str())
+                    .is_none_or(|k| k == repo_key);
+                if in_scope {
+                    tracing::warn!(
+                        code = codes::STATE_CORRUPT,
+                        error = %e,
+                        "corrupt worktree record counts against the create budget"
+                    );
+                    live += 1;
+                }
+            }
+        }
+    }
+    Ok(live)
 }
 
 pub async fn get_job(store: &dyn StateStore, job_id: &str) -> Result<Option<LandJob>, WError> {

--- a/worktree/src/state.rs
+++ b/worktree/src/state.rs
@@ -220,8 +220,10 @@ pub async fn delete_record(store: &dyn StateStore, worktree_id: &str) -> Result<
     store.delete(SCOPE_RECORD, worktree_id).await
 }
 
-pub async fn list_records(store: &dyn StateStore) -> Result<Vec<WorktreeRecord>, WError> {
-    let mut records: Vec<WorktreeRecord> = store
+/// All parseable records, in store order. For pure counts/filters where the
+/// oldest-first ordering of [`list_records`] would be wasted work.
+pub async fn collect_records(store: &dyn StateStore) -> Result<Vec<WorktreeRecord>, WError> {
+    Ok(store
         .list(SCOPE_RECORD)
         .await?
         .into_iter()
@@ -243,7 +245,11 @@ pub async fn list_records(store: &dyn StateStore) -> Result<Vec<WorktreeRecord>,
                 }
             }
         })
-        .collect();
+        .collect())
+}
+
+pub async fn list_records(store: &dyn StateStore) -> Result<Vec<WorktreeRecord>, WError> {
+    let mut records = collect_records(store).await?;
     records.sort_by_key(|r| r.created_at);
     Ok(records)
 }

--- a/worktree/src/trash.rs
+++ b/worktree/src/trash.rs
@@ -1,0 +1,167 @@
+//! Async worktree removal: rename the directory into
+//! `<worktree_root>/.trash/<worktree_id>-<epoch-secs>` (instant on the same
+//! filesystem), return immediately, and let a detached task do the real
+//! delete. The cron prune sweep clears trash entries older than 24 hours as
+//! the backstop for deletes interrupted by a crash or restart.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::{codes, WError};
+use crate::types::now_ms;
+
+pub const TRASH_DIR_NAME: &str = ".trash";
+
+/// Backstop age before the prune sweep clears a trash entry whose detached
+/// delete never finished.
+pub const TRASH_MAX_AGE_MS: i64 = 24 * 60 * 60 * 1000;
+
+/// How long the best-effort busy probe may hold up a removal.
+const BUSY_PROBE_TIMEOUT_MS: u64 = 2_000;
+
+pub fn trash_dir(worktree_root: &Path) -> PathBuf {
+    worktree_root.join(TRASH_DIR_NAME)
+}
+
+/// `<worktree_id>-<epoch-secs>`; the suffix drives the sweep's age check.
+fn trash_entry_name(worktree_id: &str, now: i64) -> String {
+    format!("{worktree_id}-{}", now / 1000)
+}
+
+/// Rename the worktree directory into the trash. Same-filesystem rename by
+/// construction (the trash lives under the same worktree root), so this is
+/// a metadata operation; the caller falls back to a direct removal when it
+/// fails (permissions, exotic mounts).
+pub fn stage(
+    worktree_path: &Path,
+    worktree_root: &Path,
+    worktree_id: &str,
+) -> Result<PathBuf, WError> {
+    let dir = trash_dir(worktree_root);
+    std::fs::create_dir_all(&dir).map_err(|e| {
+        WError::new(
+            codes::BAD_PATH,
+            format!("create trash dir {}: {e}", dir.display()),
+        )
+    })?;
+    let staged = dir.join(trash_entry_name(worktree_id, now_ms()));
+    std::fs::rename(worktree_path, &staged).map_err(|e| {
+        WError::new(
+            codes::BAD_PATH,
+            format!("stage {} into trash: {e}", worktree_path.display()),
+        )
+    })?;
+    Ok(staged)
+}
+
+/// Detached delete of a staged trash entry. Failures are logged; the sweep
+/// retries anything left behind.
+pub fn spawn_delete(staged: PathBuf) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        if let Err(e) = tokio::fs::remove_dir_all(&staged).await {
+            tracing::warn!(
+                path = %staged.display(),
+                error = %e,
+                "trash delete failed; the prune sweep will retry"
+            );
+        }
+    })
+}
+
+/// Parse the `-<epoch-secs>` suffix of a trash entry name. Entries without
+/// one were not created by this worker and are never touched.
+pub fn parse_trash_timestamp(name: &str) -> Option<i64> {
+    let (_, ts) = name.rsplit_once('-')?;
+    ts.parse::<i64>().ok().map(|secs| secs * 1000)
+}
+
+/// Trash entries older than [`TRASH_MAX_AGE_MS`] as of `now`.
+pub fn stale_entries(worktree_root: &Path, now: i64) -> Vec<PathBuf> {
+    let dir = trash_dir(worktree_root);
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let staged_at = parse_trash_timestamp(&name)?;
+            (now.saturating_sub(staged_at) >= TRASH_MAX_AGE_MS).then(|| entry.path())
+        })
+        .collect()
+}
+
+/// Remove stale trash entries; returns how many were cleared.
+pub async fn sweep(worktree_root: &Path, now: i64) -> usize {
+    let mut cleared = 0;
+    for path in stale_entries(worktree_root, now) {
+        match tokio::fs::remove_dir_all(&path).await {
+            Ok(()) => cleared += 1,
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "trash sweep entry failed")
+            }
+        }
+    }
+    cleared
+}
+
+/// Best-effort busy probe: does any running process hold something open
+/// under `dir`? Uses `lsof -t +D` with a short timeout; `None` when the
+/// probe is unavailable (no lsof, timeout) so removal proceeds. Never
+/// signals or kills anything.
+pub async fn dir_in_use(dir: &Path) -> Option<bool> {
+    let mut cmd = tokio::process::Command::new("lsof");
+    cmd.arg("-t")
+        .arg("+D")
+        .arg(dir)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .kill_on_drop(true);
+    let out = tokio::time::timeout(
+        std::time::Duration::from_millis(BUSY_PROBE_TIMEOUT_MS),
+        cmd.output(),
+    )
+    .await
+    .ok()?
+    .ok()?;
+    // lsof exits 0 with pids on matches, 1 with empty output on none.
+    Some(!out.stdout.trim_ascii().is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trash_entry_names_carry_epoch_seconds() {
+        let name = trash_entry_name("wt_ab12cd34", 1_700_000_123_456);
+        assert_eq!(name, "wt_ab12cd34-1700000123");
+        assert_eq!(parse_trash_timestamp(&name), Some(1_700_000_123_000));
+    }
+
+    #[test]
+    fn unparseable_entries_are_ignored() {
+        assert_eq!(parse_trash_timestamp("no-suffix-here"), None);
+        assert_eq!(parse_trash_timestamp("plain"), None);
+    }
+
+    #[test]
+    fn stale_entries_honor_the_age_threshold() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let dir = trash_dir(root);
+        std::fs::create_dir_all(&dir).unwrap();
+        let now = now_ms();
+        let fresh = dir.join(trash_entry_name("wt_fresh000", now));
+        let stale = dir.join(trash_entry_name(
+            "wt_stale000",
+            now - TRASH_MAX_AGE_MS - 60_000,
+        ));
+        std::fs::create_dir_all(&fresh).unwrap();
+        std::fs::create_dir_all(&stale).unwrap();
+        std::fs::create_dir_all(dir.join("manual-junk")).unwrap();
+
+        let found = stale_entries(root, now);
+        assert_eq!(found, vec![stale]);
+    }
+}

--- a/worktree/src/trash.rs
+++ b/worktree/src/trash.rs
@@ -68,10 +68,13 @@ pub fn spawn_delete(staged: PathBuf) -> tokio::task::JoinHandle<()> {
 }
 
 /// Parse the `-<epoch-secs>` suffix of a trash entry name. Entries without
-/// one were not created by this worker and are never touched.
+/// one (or with a suffix that does not survive the seconds-to-millis
+/// conversion) were not created by this worker and are never touched.
 pub fn parse_trash_timestamp(name: &str) -> Option<i64> {
     let (_, ts) = name.rsplit_once('-')?;
-    ts.parse::<i64>().ok().map(|secs| secs * 1000)
+    ts.parse::<i64>()
+        .ok()
+        .and_then(|secs| secs.checked_mul(1000))
 }
 
 /// Trash entries older than [`TRASH_MAX_AGE_MS`] as of `now`.
@@ -143,6 +146,11 @@ mod tests {
     fn unparseable_entries_are_ignored() {
         assert_eq!(parse_trash_timestamp("no-suffix-here"), None);
         assert_eq!(parse_trash_timestamp("plain"), None);
+        assert_eq!(
+            parse_trash_timestamp("wt_x-9223372036854775807"),
+            None,
+            "seconds that overflow the millis conversion are rejected"
+        );
     }
 
     #[test]

--- a/worktree/src/types.rs
+++ b/worktree/src/types.rs
@@ -81,6 +81,16 @@ pub struct WorktreeStatus {
     pub in_rebase: bool,
     /// Current HEAD commit.
     pub head_sha: String,
+    /// True when the branch's work is already contained in its integration
+    /// target (fast-forward, merge, rebase, or squash merge). Integrated
+    /// worktrees are prunable even when ahead of their base.
+    #[serde(default)]
+    pub integrated: bool,
+    /// Which check detected the integration: `same_commit`, `ancestor`,
+    /// `no_added_changes`, `trees_match`, `merge_adds_nothing`, or
+    /// `patch_id_match`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub integration_reason: Option<String>,
 }
 
 /// One worktree as reported by `worktree::list` / `worktree::get`.

--- a/worktree/src/types.rs
+++ b/worktree/src/types.rs
@@ -50,10 +50,6 @@ pub struct WorktreeRecord {
     pub lifecycle: Lifecycle,
     /// Owning session, when claimed.
     pub session_id: Option<String>,
-    /// Advisory dev-server port derived from the id (0 on records written
-    /// before ports existed; re-derived on read).
-    #[serde(default)]
-    pub dev_port: u16,
     /// Creation time, ms since epoch.
     pub created_at: i64,
     /// Last mutation time, ms since epoch.
@@ -141,21 +137,11 @@ impl WorktreeInfo {
             base_sha: record.base_sha.clone(),
             lifecycle,
             session_id: record.session_id.clone(),
-            dev_port: effective_dev_port(record),
+            dev_port: crate::ids::dev_port(&record.worktree_id),
             created_at: record.created_at,
             updated_at: record.updated_at,
             status: None,
         }
-    }
-}
-
-/// The record's stored port, re-derived for records written before ports
-/// existed (the derivation is deterministic, so both agree).
-pub fn effective_dev_port(record: &WorktreeRecord) -> u16 {
-    if record.dev_port != 0 {
-        record.dev_port
-    } else {
-        crate::ids::dev_port(&record.worktree_id)
     }
 }
 

--- a/worktree/src/types.rs
+++ b/worktree/src/types.rs
@@ -50,6 +50,10 @@ pub struct WorktreeRecord {
     pub lifecycle: Lifecycle,
     /// Owning session, when claimed.
     pub session_id: Option<String>,
+    /// Advisory dev-server port derived from the id (0 on records written
+    /// before ports existed; re-derived on read).
+    #[serde(default)]
+    pub dev_port: u16,
     /// Creation time, ms since epoch.
     pub created_at: i64,
     /// Last mutation time, ms since epoch.
@@ -114,6 +118,9 @@ pub struct WorktreeInfo {
     pub lifecycle: Lifecycle,
     /// Owning session, when claimed.
     pub session_id: Option<String>,
+    /// Advisory dev-server port derived from the worktree id: deterministic,
+    /// collision-improbable, never reserved anywhere.
+    pub dev_port: u16,
     /// Creation time, ms since epoch.
     pub created_at: i64,
     /// Last mutation time, ms since epoch.
@@ -134,10 +141,21 @@ impl WorktreeInfo {
             base_sha: record.base_sha.clone(),
             lifecycle,
             session_id: record.session_id.clone(),
+            dev_port: effective_dev_port(record),
             created_at: record.created_at,
             updated_at: record.updated_at,
             status: None,
         }
+    }
+}
+
+/// The record's stored port, re-derived for records written before ports
+/// existed (the derivation is deterministic, so both agree).
+pub fn effective_dev_port(record: &WorktreeRecord) -> u16 {
+    if record.dev_port != 0 {
+        record.dev_port
+    } else {
+        crate::ids::dev_port(&record.worktree_id)
     }
 }
 

--- a/worktree/tests/create_sources.rs
+++ b/worktree/tests/create_sources.rs
@@ -6,7 +6,7 @@ mod support;
 
 use std::path::Path;
 
-use support::{commit_file, git, init_repo, make_env, test_config};
+use support::{commit_file, create_request, git, init_repo, make_env, test_config};
 use worktree::config::BranchNaming;
 use worktree::functions::create;
 use worktree::ids;
@@ -34,18 +34,9 @@ async fn create_from_pr_head_branches_at_the_fetched_ref() {
     let (repo, pr_sha) = setup_pr_fixture(tmp.path());
     let env = make_env(tmp.path(), test_config(tmp.path()));
 
-    let created = create::handle(
-        &env.deps,
-        create::Request {
-            repo_path: repo.to_string_lossy().into_owned(),
-            base_ref: None,
-            branch: None,
-            pr: Some(7),
-            session_id: None,
-        },
-    )
-    .await
-    .unwrap();
+    let mut req = create_request(&repo);
+    req.pr = Some(7);
+    let created = create::handle(&env.deps, req).await.unwrap();
 
     assert_eq!(created.branch, "iii/pr-7");
     assert_eq!(created.base_ref, "refs/pull/7/head");
@@ -60,34 +51,16 @@ async fn create_pr_is_mutually_exclusive_and_fails_cleanly_when_missing() {
     let tmp = tempfile::tempdir().unwrap();
     let (repo, _) = setup_pr_fixture(tmp.path());
     let env = make_env(tmp.path(), test_config(tmp.path()));
-    let repo_path = repo.to_string_lossy().into_owned();
 
-    let err = create::handle(
-        &env.deps,
-        create::Request {
-            repo_path: repo_path.clone(),
-            base_ref: Some("main".into()),
-            branch: None,
-            pr: Some(7),
-            session_id: None,
-        },
-    )
-    .await
-    .unwrap_err();
+    let mut req = create_request(&repo);
+    req.base_ref = Some("main".into());
+    req.pr = Some(7);
+    let err = create::handle(&env.deps, req).await.unwrap_err();
     assert_eq!(err.code, "W001");
 
-    let err = create::handle(
-        &env.deps,
-        create::Request {
-            repo_path,
-            base_ref: None,
-            branch: None,
-            pr: Some(999),
-            session_id: None,
-        },
-    )
-    .await
-    .unwrap_err();
+    let mut req = create_request(&repo);
+    req.pr = Some(999);
+    let err = create::handle(&env.deps, req).await.unwrap_err();
     assert_eq!(err.code, "W112");
     assert!(
         err.message.contains("refs/pull/999/head"),
@@ -105,18 +78,9 @@ async fn codename_naming_mints_the_deterministic_friendly_branch() {
     cfg.branch_naming = BranchNaming::Codename;
     let env = make_env(tmp.path(), cfg);
 
-    let created = create::handle(
-        &env.deps,
-        create::Request {
-            repo_path: repo.to_string_lossy().into_owned(),
-            base_ref: None,
-            branch: None,
-            pr: None,
-            session_id: None,
-        },
-    )
-    .await
-    .unwrap();
+    let created = create::handle(&env.deps, create_request(&repo))
+        .await
+        .unwrap();
 
     assert_eq!(
         created.branch,
@@ -135,18 +99,9 @@ async fn dev_port_rides_the_create_response() {
     init_repo(&repo);
     let env = make_env(tmp.path(), test_config(tmp.path()));
 
-    let created = create::handle(
-        &env.deps,
-        create::Request {
-            repo_path: repo.to_string_lossy().into_owned(),
-            base_ref: None,
-            branch: None,
-            pr: None,
-            session_id: None,
-        },
-    )
-    .await
-    .unwrap();
+    let created = create::handle(&env.deps, create_request(&repo))
+        .await
+        .unwrap();
     assert_eq!(created.dev_port, ids::dev_port(&created.worktree_id));
     assert!((10_000..20_000).contains(&created.dev_port));
 }

--- a/worktree/tests/create_sources.rs
+++ b/worktree/tests/create_sources.rs
@@ -1,0 +1,152 @@
+//! Create sources beyond a local ref: the GitHub pull-request head path
+//! (against a file:// origin fixture), codename branch naming, and the
+//! advisory dev port on the wire.
+
+mod support;
+
+use std::path::Path;
+
+use support::{commit_file, git, init_repo, make_env, test_config};
+use worktree::config::BranchNaming;
+use worktree::functions::create;
+use worktree::ids;
+
+/// An origin repo publishing `refs/pull/7/head`, and a consumer clone with
+/// it configured as `origin` over file://.
+fn setup_pr_fixture(tmp: &Path) -> (std::path::PathBuf, String) {
+    let origin = tmp.join("origin");
+    init_repo(&origin);
+    let pr_sha = commit_file(&origin, "pr.txt", "pr work\n", "pr work");
+    git(&origin, &["update-ref", "refs/pull/7/head", &pr_sha]);
+    // Rewind main so the PR ref is the only place the commit lives.
+    git(&origin, &["reset", "--hard", "HEAD~1"]);
+
+    let repo = tmp.join("repo");
+    init_repo(&repo);
+    let url = format!("file://{}", origin.display());
+    git(&repo, &["remote", "add", "origin", &url]);
+    (repo, pr_sha)
+}
+
+#[tokio::test]
+async fn create_from_pr_head_branches_at_the_fetched_ref() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (repo, pr_sha) = setup_pr_fixture(tmp.path());
+    let env = make_env(tmp.path(), test_config(tmp.path()));
+
+    let created = create::handle(
+        &env.deps,
+        create::Request {
+            repo_path: repo.to_string_lossy().into_owned(),
+            base_ref: None,
+            branch: None,
+            pr: Some(7),
+            session_id: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(created.branch, "iii/pr-7");
+    assert_eq!(created.base_ref, "refs/pull/7/head");
+    assert_eq!(created.base_sha, pr_sha);
+    let head = git(Path::new(&created.path), &["rev-parse", "HEAD"]);
+    assert_eq!(head, pr_sha);
+    assert!(Path::new(&created.path).join("pr.txt").is_file());
+}
+
+#[tokio::test]
+async fn create_pr_is_mutually_exclusive_and_fails_cleanly_when_missing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (repo, _) = setup_pr_fixture(tmp.path());
+    let env = make_env(tmp.path(), test_config(tmp.path()));
+    let repo_path = repo.to_string_lossy().into_owned();
+
+    let err = create::handle(
+        &env.deps,
+        create::Request {
+            repo_path: repo_path.clone(),
+            base_ref: Some("main".into()),
+            branch: None,
+            pr: Some(7),
+            session_id: None,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, "W001");
+
+    let err = create::handle(
+        &env.deps,
+        create::Request {
+            repo_path,
+            base_ref: None,
+            branch: None,
+            pr: Some(999),
+            session_id: None,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, "W112");
+    assert!(
+        err.message.contains("refs/pull/999/head"),
+        "{}",
+        err.message
+    );
+}
+
+#[tokio::test]
+async fn codename_naming_mints_the_deterministic_friendly_branch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    init_repo(&repo);
+    let mut cfg = test_config(tmp.path());
+    cfg.branch_naming = BranchNaming::Codename;
+    let env = make_env(tmp.path(), cfg);
+
+    let created = create::handle(
+        &env.deps,
+        create::Request {
+            repo_path: repo.to_string_lossy().into_owned(),
+            base_ref: None,
+            branch: None,
+            pr: None,
+            session_id: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        created.branch,
+        ids::codename_branch("iii/", &created.worktree_id)
+    );
+    let tail = created.branch.strip_prefix("iii/").unwrap();
+    assert_eq!(tail.split('-').count(), 3, "{}", created.branch);
+    let branches = git(&repo, &["branch", "--list", &created.branch]);
+    assert!(branches.contains(tail));
+}
+
+#[tokio::test]
+async fn dev_port_rides_the_create_response() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    init_repo(&repo);
+    let env = make_env(tmp.path(), test_config(tmp.path()));
+
+    let created = create::handle(
+        &env.deps,
+        create::Request {
+            repo_path: repo.to_string_lossy().into_owned(),
+            base_ref: None,
+            branch: None,
+            pr: None,
+            session_id: None,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(created.dev_port, ids::dev_port(&created.worktree_id));
+    assert!((10_000..20_000).contains(&created.dev_port));
+}

--- a/worktree/tests/gates.rs
+++ b/worktree/tests/gates.rs
@@ -4,7 +4,7 @@
 
 mod support;
 
-use support::{init_repo, make_env, test_config, TestEnv};
+use support::{create_request, init_repo, make_env, test_config, TestEnv};
 use worktree::config::WorkerConfig;
 use worktree::functions::{claim, create, land, prune, release, remove, validate};
 
@@ -200,16 +200,6 @@ async fn land_targets_glob_pins_the_target() {
     assert_eq!(err.code, "W200");
 }
 
-fn create_req(repo: &std::path::Path) -> create::Request {
-    create::Request {
-        repo_path: repo.to_string_lossy().into_owned(),
-        base_ref: None,
-        branch: None,
-        pr: None,
-        session_id: None,
-    }
-}
-
 #[tokio::test]
 async fn repos_glob_gates_create_by_canonical_path() {
     let tmp = tempfile::tempdir().unwrap();
@@ -219,7 +209,7 @@ async fn repos_glob_gates_create_by_canonical_path() {
 
     // Denied: the allowlist points elsewhere; the message names the key.
     let env = env_with(tmp.path(), |c| c.gates.repos = vec!["/nowhere/*".into()]);
-    let err = create::handle(&env.deps, create_req(&repo))
+    let err = create::handle(&env.deps, create_request(&repo))
         .await
         .unwrap_err();
     assert_eq!(err.code, "W503");
@@ -228,7 +218,9 @@ async fn repos_glob_gates_create_by_canonical_path() {
     // Allowed: a glob over the canonicalized path admits the create.
     let allow = format!("{}*", canonical.parent().unwrap().to_string_lossy());
     let env = env_with(tmp.path(), |c| c.gates.repos = vec![allow]);
-    let created = create::handle(&env.deps, create_req(&repo)).await.unwrap();
+    let created = create::handle(&env.deps, create_request(&repo))
+        .await
+        .unwrap();
     assert!(created.worktree_id.starts_with("wt_"));
 }
 
@@ -240,11 +232,15 @@ async fn worktree_budget_bounds_live_worktrees_per_repo() {
     let env = env_with(tmp.path(), |c| c.gates.max_worktrees_per_repo = 2);
 
     // N-1 under the budget: both creates succeed.
-    let first = create::handle(&env.deps, create_req(&repo)).await.unwrap();
-    create::handle(&env.deps, create_req(&repo)).await.unwrap();
+    let first = create::handle(&env.deps, create_request(&repo))
+        .await
+        .unwrap();
+    create::handle(&env.deps, create_request(&repo))
+        .await
+        .unwrap();
 
     // At the budget: the third create refuses, naming the key and count.
-    let err = create::handle(&env.deps, create_req(&repo))
+    let err = create::handle(&env.deps, create_request(&repo))
         .await
         .unwrap_err();
     assert_eq!(err.code, "W504");
@@ -267,6 +263,8 @@ async fn worktree_budget_bounds_live_worktrees_per_repo() {
     .await
     .unwrap();
     assert!(!checked.valid);
-    let created = create::handle(&env.deps, create_req(&repo)).await.unwrap();
+    let created = create::handle(&env.deps, create_request(&repo))
+        .await
+        .unwrap();
     assert!(created.worktree_id.starts_with("wt_"));
 }

--- a/worktree/tests/gates.rs
+++ b/worktree/tests/gates.rs
@@ -7,6 +7,7 @@ mod support;
 use support::{create_request, init_repo, make_env, test_config, TestEnv};
 use worktree::config::WorkerConfig;
 use worktree::functions::{claim, create, land, prune, release, remove, validate};
+use worktree::state::{StateStore, SCOPE_RECORD};
 
 fn env_with(tmp: &std::path::Path, mutate: impl FnOnce(&mut WorkerConfig)) -> TestEnv {
     let mut cfg = test_config(tmp);
@@ -267,4 +268,29 @@ async fn worktree_budget_bounds_live_worktrees_per_repo() {
         .await
         .unwrap();
     assert!(created.worktree_id.starts_with("wt_"));
+}
+
+#[tokio::test]
+async fn corrupt_records_consume_the_budget() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    init_repo(&repo);
+    let env = env_with(tmp.path(), |c| c.gates.max_worktrees_per_repo = 1);
+
+    // A corrupt record without a readable repo_key counts against every
+    // repo's budget: it may still be a live worktree.
+    env.state
+        .set(
+            SCOPE_RECORD,
+            "wt_corrupt00000",
+            serde_json::json!({ "garbage": true }),
+        )
+        .await
+        .unwrap();
+
+    let err = create::handle(&env.deps, create_request(&repo))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, "W504");
+    assert!(err.message.contains("1 live worktree"), "{}", err.message);
 }

--- a/worktree/tests/gates.rs
+++ b/worktree/tests/gates.rs
@@ -4,9 +4,9 @@
 
 mod support;
 
-use support::{make_env, test_config, TestEnv};
+use support::{init_repo, make_env, test_config, TestEnv};
 use worktree::config::WorkerConfig;
-use worktree::functions::{claim, land, prune, release, remove};
+use worktree::functions::{claim, create, land, prune, release, remove, validate};
 
 fn env_with(tmp: &std::path::Path, mutate: impl FnOnce(&mut WorkerConfig)) -> TestEnv {
     let mut cfg = test_config(tmp);
@@ -198,4 +198,75 @@ async fn land_targets_glob_pins_the_target() {
     .await
     .unwrap_err();
     assert_eq!(err.code, "W200");
+}
+
+fn create_req(repo: &std::path::Path) -> create::Request {
+    create::Request {
+        repo_path: repo.to_string_lossy().into_owned(),
+        base_ref: None,
+        branch: None,
+        pr: None,
+        session_id: None,
+    }
+}
+
+#[tokio::test]
+async fn repos_glob_gates_create_by_canonical_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    init_repo(&repo);
+    let canonical = std::fs::canonicalize(&repo).unwrap();
+
+    // Denied: the allowlist points elsewhere; the message names the key.
+    let env = env_with(tmp.path(), |c| c.gates.repos = vec!["/nowhere/*".into()]);
+    let err = create::handle(&env.deps, create_req(&repo))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, "W503");
+    assert!(err.message.contains("gates.repos"), "{}", err.message);
+
+    // Allowed: a glob over the canonicalized path admits the create.
+    let allow = format!("{}*", canonical.parent().unwrap().to_string_lossy());
+    let env = env_with(tmp.path(), |c| c.gates.repos = vec![allow]);
+    let created = create::handle(&env.deps, create_req(&repo)).await.unwrap();
+    assert!(created.worktree_id.starts_with("wt_"));
+}
+
+#[tokio::test]
+async fn worktree_budget_bounds_live_worktrees_per_repo() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    init_repo(&repo);
+    let env = env_with(tmp.path(), |c| c.gates.max_worktrees_per_repo = 2);
+
+    // N-1 under the budget: both creates succeed.
+    let first = create::handle(&env.deps, create_req(&repo)).await.unwrap();
+    create::handle(&env.deps, create_req(&repo)).await.unwrap();
+
+    // At the budget: the third create refuses, naming the key and count.
+    let err = create::handle(&env.deps, create_req(&repo))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, "W504");
+    assert!(
+        err.message.contains("gates.max_worktrees_per_repo"),
+        "{}",
+        err.message
+    );
+    assert!(err.message.contains("2 live worktree"), "{}", err.message);
+
+    // Orphaned records do not count against the budget: orphan one (dir
+    // removed out of band, reconciled by validate) and create again.
+    std::fs::remove_dir_all(&first.path).unwrap();
+    let checked = validate::handle(
+        &env.deps,
+        validate::Request {
+            path: first.path.clone(),
+        },
+    )
+    .await
+    .unwrap();
+    assert!(!checked.valid);
+    let created = create::handle(&env.deps, create_req(&repo)).await.unwrap();
+    assert!(created.worktree_id.starts_with("wt_"));
 }

--- a/worktree/tests/gates.rs
+++ b/worktree/tests/gates.rs
@@ -1,0 +1,201 @@
+//! Configuration gates: every mutating handler checks its gate FIRST, so
+//! denials need no repository or record — the error must carry the exact
+//! config key to flip.
+
+mod support;
+
+use support::{make_env, test_config, TestEnv};
+use worktree::config::WorkerConfig;
+use worktree::functions::{claim, land, prune, release, remove};
+
+fn env_with(tmp: &std::path::Path, mutate: impl FnOnce(&mut WorkerConfig)) -> TestEnv {
+    let mut cfg = test_config(tmp);
+    // test_config opens the force gate for behavioral suites; this suite
+    // starts from the shipped defaults.
+    cfg.gates = Default::default();
+    mutate(&mut cfg);
+    make_env(tmp, cfg)
+}
+
+#[tokio::test]
+async fn remove_denied_when_gate_closed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env = env_with(tmp.path(), |c| c.gates.allow_remove = false);
+    let err = remove::handle(
+        &env.deps,
+        remove::Request {
+            worktree_id: "wt_whatever".into(),
+            force: false,
+            delete_branch: false,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, "W500");
+    assert!(
+        err.message.contains("gates.allow_remove"),
+        "{}",
+        err.message
+    );
+}
+
+#[tokio::test]
+async fn branch_delete_denied_when_gate_closed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env = env_with(tmp.path(), |c| c.gates.allow_branch_delete = false);
+    let err = remove::handle(
+        &env.deps,
+        remove::Request {
+            worktree_id: "wt_whatever".into(),
+            force: false,
+            delete_branch: true,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, "W500");
+    assert!(
+        err.message.contains("gates.allow_branch_delete"),
+        "{}",
+        err.message
+    );
+}
+
+#[tokio::test]
+async fn default_force_gate_blocks_all_four_force_paths() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Shipped defaults: allow_force = false.
+    let env = env_with(tmp.path(), |_| {});
+
+    let err = remove::handle(
+        &env.deps,
+        remove::Request {
+            worktree_id: "wt_x".into(),
+            force: true,
+            delete_branch: false,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, "W501");
+    assert!(err.message.contains("gates.allow_force"), "{}", err.message);
+
+    let err = claim::handle(
+        &env.deps,
+        claim::Request {
+            worktree_id: "wt_x".into(),
+            session_id: "s_1".into(),
+            force: true,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, "W501");
+
+    let err = release::handle(
+        &env.deps,
+        release::Request {
+            worktree_id: "wt_x".into(),
+            session_id: "s_1".into(),
+            force: true,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, "W501");
+
+    let err = land::handle(
+        &env.deps,
+        land::Request {
+            worktree_id: "wt_x".into(),
+            target_branch: "main".into(),
+            test_cmd: None,
+            force_restart: true,
+            keep: false,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, "W501");
+    assert!(err.message.contains("gates.allow_force"), "{}", err.message);
+}
+
+#[tokio::test]
+async fn land_denied_when_gate_closed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env = env_with(tmp.path(), |c| c.gates.allow_land = false);
+    let err = land::handle(
+        &env.deps,
+        land::Request {
+            worktree_id: "wt_x".into(),
+            target_branch: "main".into(),
+            test_cmd: None,
+            force_restart: false,
+            keep: false,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, "W500");
+    assert!(err.message.contains("gates.allow_land"), "{}", err.message);
+}
+
+#[tokio::test]
+async fn prune_denied_when_gate_closed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env = env_with(tmp.path(), |c| c.gates.allow_prune = false);
+    let err = prune::handle(
+        &env.deps,
+        prune::Request {
+            repo_path: None,
+            dry_run: false,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, "W500");
+    assert!(err.message.contains("gates.allow_prune"), "{}", err.message);
+}
+
+#[tokio::test]
+async fn land_targets_glob_pins_the_target() {
+    let tmp = tempfile::tempdir().unwrap();
+    let env = env_with(tmp.path(), |c| {
+        c.gates.land_targets = vec!["main".into(), "release/*".into()];
+    });
+
+    let err = land::handle(
+        &env.deps,
+        land::Request {
+            worktree_id: "wt_x".into(),
+            target_branch: "trunk".into(),
+            test_cmd: None,
+            force_restart: false,
+            keep: false,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, "W502");
+    assert!(
+        err.message.contains("gates.land_targets"),
+        "{}",
+        err.message
+    );
+
+    // An allowed target passes the gate and fails later on the missing
+    // record instead — proof the gate itself admitted it.
+    let err = land::handle(
+        &env.deps,
+        land::Request {
+            worktree_id: "wt_x".into(),
+            target_branch: "release/1.2".into(),
+            test_cmd: None,
+            force_restart: false,
+            keep: false,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, "W200");
+}

--- a/worktree/tests/git_ops.rs
+++ b/worktree/tests/git_ops.rs
@@ -7,25 +7,20 @@ mod support;
 use std::path::Path;
 
 use serde_json::json;
-use support::{commit_file, git, head_sha, init_repo, make_env, test_config, TestEnv};
+use support::{
+    commit_file, create_request, git, head_sha, init_repo, make_env, test_config, TestEnv,
+};
 use worktree::error::codes;
 use worktree::functions::{claim, create, list, prune, release, remove, status, validate};
 use worktree::state;
 use worktree::types::Lifecycle;
 
 async fn create_wt(env: &TestEnv, repo: &Path, session: Option<&str>) -> create::Response {
-    create::handle(
-        &env.deps,
-        create::Request {
-            repo_path: repo.to_string_lossy().into_owned(),
-            base_ref: None,
-            branch: None,
-            pr: None,
-            session_id: session.map(str::to_string),
-        },
-    )
-    .await
-    .expect("create worktree")
+    let mut req = create_request(repo);
+    req.session_id = session.map(str::to_string);
+    create::handle(&env.deps, req)
+        .await
+        .expect("create worktree")
 }
 
 #[tokio::test]
@@ -68,48 +63,21 @@ async fn create_rejects_existing_branch_and_bad_paths() {
     git(&repo, &["branch", "taken"]);
     let env = make_env(tmp.path(), test_config(tmp.path()));
 
-    let err = create::handle(
-        &env.deps,
-        create::Request {
-            repo_path: repo.to_string_lossy().into_owned(),
-            base_ref: None,
-            branch: Some("taken".into()),
-            pr: None,
-            session_id: None,
-        },
-    )
-    .await
-    .unwrap_err();
+    let mut req = create_request(&repo);
+    req.branch = Some("taken".into());
+    let err = create::handle(&env.deps, req).await.unwrap_err();
     assert_eq!(err.code, codes::BRANCH_EXISTS);
 
-    let err = create::handle(
-        &env.deps,
-        create::Request {
-            repo_path: "relative/repo".into(),
-            base_ref: None,
-            branch: None,
-            pr: None,
-            session_id: None,
-        },
-    )
-    .await
-    .unwrap_err();
+    let err = create::handle(&env.deps, create_request(Path::new("relative/repo")))
+        .await
+        .unwrap_err();
     assert_eq!(err.code, codes::BAD_PATH);
 
     let not_repo = tmp.path().join("not-a-repo");
     std::fs::create_dir_all(&not_repo).unwrap();
-    let err = create::handle(
-        &env.deps,
-        create::Request {
-            repo_path: not_repo.to_string_lossy().into_owned(),
-            base_ref: None,
-            branch: None,
-            pr: None,
-            session_id: None,
-        },
-    )
-    .await
-    .unwrap_err();
+    let err = create::handle(&env.deps, create_request(&not_repo))
+        .await
+        .unwrap_err();
     assert_eq!(err.code, codes::NOT_A_REPO);
 }
 

--- a/worktree/tests/git_ops.rs
+++ b/worktree/tests/git_ops.rs
@@ -485,3 +485,29 @@ fn prune_request_accepts_empty_cron_payload() {
     assert!(req.repo_path.is_none());
     assert!(!req.dry_run);
 }
+
+#[tokio::test]
+async fn cas_branch_delete_refuses_when_the_branch_moved() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    init_repo(&repo);
+    let first = head_sha(&repo);
+    git(&repo, &["branch", "victim"]);
+    // The branch moves past the sha the caller expects.
+    let moved = commit_file(&repo, "move.txt", "m\n", "moves victim");
+    git(&repo, &["update-ref", "refs/heads/victim", &moved]);
+
+    let refused = worktree::git::ops::cas_branch_delete(&repo, "victim", &first, 30_000)
+        .await
+        .unwrap();
+    assert!(!refused, "delete must refuse when the branch moved");
+    let branches = git(&repo, &["branch", "--list", "victim"]);
+    assert!(branches.contains("victim"), "branch retained");
+
+    let deleted = worktree::git::ops::cas_branch_delete(&repo, "victim", &moved, 30_000)
+        .await
+        .unwrap();
+    assert!(deleted);
+    let branches = git(&repo, &["branch", "--list", "victim"]);
+    assert!(!branches.contains("victim"));
+}

--- a/worktree/tests/git_ops.rs
+++ b/worktree/tests/git_ops.rs
@@ -469,10 +469,10 @@ async fn cas_branch_delete_refuses_when_the_branch_moved() {
     let moved = commit_file(&repo, "move.txt", "m\n", "moves victim");
     git(&repo, &["update-ref", "refs/heads/victim", &moved]);
 
-    let refused = worktree::git::ops::cas_branch_delete(&repo, "victim", &first, 30_000)
+    let deleted = worktree::git::ops::cas_branch_delete(&repo, "victim", &first, 30_000)
         .await
         .unwrap();
-    assert!(!refused, "delete must refuse when the branch moved");
+    assert!(!deleted, "delete must refuse when the branch moved");
     let branches = git(&repo, &["branch", "--list", "victim"]);
     assert!(branches.contains("victim"), "branch retained");
 

--- a/worktree/tests/git_ops.rs
+++ b/worktree/tests/git_ops.rs
@@ -20,6 +20,7 @@ async fn create_wt(env: &TestEnv, repo: &Path, session: Option<&str>) -> create:
             repo_path: repo.to_string_lossy().into_owned(),
             base_ref: None,
             branch: None,
+            pr: None,
             session_id: session.map(str::to_string),
         },
     )
@@ -73,6 +74,7 @@ async fn create_rejects_existing_branch_and_bad_paths() {
             repo_path: repo.to_string_lossy().into_owned(),
             base_ref: None,
             branch: Some("taken".into()),
+            pr: None,
             session_id: None,
         },
     )
@@ -86,6 +88,7 @@ async fn create_rejects_existing_branch_and_bad_paths() {
             repo_path: "relative/repo".into(),
             base_ref: None,
             branch: None,
+            pr: None,
             session_id: None,
         },
     )
@@ -101,6 +104,7 @@ async fn create_rejects_existing_branch_and_bad_paths() {
             repo_path: not_repo.to_string_lossy().into_owned(),
             base_ref: None,
             branch: None,
+            pr: None,
             session_id: None,
         },
     )

--- a/worktree/tests/golden/schemas/worktree.create.json
+++ b/worktree/tests/golden/schemas/worktree.create.json
@@ -13,9 +13,19 @@
       },
       "branch": {
         "default": null,
-        "description": "Branch to create. Defaults to `<branch_prefix><worktree_id>`.",
+        "description": "Branch to create. Defaults to `<branch_prefix><worktree_id>` (or a codename when `branch_naming: codename`).",
         "type": [
           "string",
+          "null"
+        ]
+      },
+      "pr": {
+        "default": null,
+        "description": "Create the worktree at a GitHub pull request head: fetches `refs/pull/<n>/head` from `origin` and branches `<prefix>pr-<n>` at it. Mutually exclusive with `base_ref` and `branch`.",
+        "format": "uint64",
+        "minimum": 0.0,
+        "type": [
+          "integer",
           "null"
         ]
       },
@@ -58,6 +68,12 @@
         "format": "int64",
         "type": "integer"
       },
+      "dev_port": {
+        "description": "Advisory dev-server port derived from the worktree id.",
+        "format": "uint16",
+        "minimum": 0.0,
+        "type": "integer"
+      },
       "path": {
         "description": "Absolute path of the new worktree; hand this to an agent as its working directory.",
         "type": "string"
@@ -76,6 +92,7 @@
       "base_sha",
       "branch",
       "created_at",
+      "dev_port",
       "path",
       "repo_key",
       "worktree_id"

--- a/worktree/tests/golden/schemas/worktree.get.json
+++ b/worktree/tests/golden/schemas/worktree.get.json
@@ -166,6 +166,12 @@
         "format": "int64",
         "type": "integer"
       },
+      "dev_port": {
+        "description": "Advisory dev-server port derived from the worktree id: deterministic, collision-improbable, never reserved anywhere.",
+        "format": "uint16",
+        "minimum": 0.0,
+        "type": "integer"
+      },
       "lifecycle": {
         "allOf": [
           {
@@ -219,6 +225,7 @@
       "base_sha",
       "branch",
       "created_at",
+      "dev_port",
       "lifecycle",
       "path",
       "repo_key",

--- a/worktree/tests/golden/schemas/worktree.get.json
+++ b/worktree/tests/golden/schemas/worktree.get.json
@@ -94,6 +94,18 @@
             "description": "True while a rebase is in progress in this worktree.",
             "type": "boolean"
           },
+          "integrated": {
+            "default": false,
+            "description": "True when the branch's work is already contained in its integration target (fast-forward, merge, rebase, or squash merge). Integrated worktrees are prunable even when ahead of their base.",
+            "type": "boolean"
+          },
+          "integration_reason": {
+            "description": "Which check detected the integration: `same_commit`, `ancestor`, `no_added_changes`, `trees_match`, `merge_adds_nothing`, or `patch_id_match`.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "staged": {
             "description": "Staged entry count.",
             "format": "uint64",

--- a/worktree/tests/golden/schemas/worktree.list.json
+++ b/worktree/tests/golden/schemas/worktree.list.json
@@ -210,6 +210,18 @@
             "description": "True while a rebase is in progress in this worktree.",
             "type": "boolean"
           },
+          "integrated": {
+            "default": false,
+            "description": "True when the branch's work is already contained in its integration target (fast-forward, merge, rebase, or squash merge). Integrated worktrees are prunable even when ahead of their base.",
+            "type": "boolean"
+          },
+          "integration_reason": {
+            "description": "Which check detected the integration: `same_commit`, `ancestor`, `no_added_changes`, `trees_match`, `merge_adds_nothing`, or `patch_id_match`.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "staged": {
             "description": "Staged entry count.",
             "format": "uint64",

--- a/worktree/tests/golden/schemas/worktree.list.json
+++ b/worktree/tests/golden/schemas/worktree.list.json
@@ -111,6 +111,12 @@
             "format": "int64",
             "type": "integer"
           },
+          "dev_port": {
+            "description": "Advisory dev-server port derived from the worktree id: deterministic, collision-improbable, never reserved anywhere.",
+            "format": "uint16",
+            "minimum": 0.0,
+            "type": "integer"
+          },
           "lifecycle": {
             "allOf": [
               {
@@ -164,6 +170,7 @@
           "base_sha",
           "branch",
           "created_at",
+          "dev_port",
           "lifecycle",
           "path",
           "repo_key",

--- a/worktree/tests/golden/schemas/worktree.status.json
+++ b/worktree/tests/golden/schemas/worktree.status.json
@@ -86,6 +86,12 @@
         "minimum": 0.0,
         "type": "integer"
       },
+      "dev_port": {
+        "description": "Advisory dev-server port derived from the worktree id.",
+        "format": "uint16",
+        "minimum": 0.0,
+        "type": "integer"
+      },
       "diffstat": {
         "description": "`git diff --shortstat` of committed work since `base_sha`.",
         "type": "string"
@@ -153,6 +159,7 @@
       "branch",
       "clean",
       "conflicted",
+      "dev_port",
       "diffstat",
       "head_sha",
       "in_rebase",

--- a/worktree/tests/golden/schemas/worktree.status.json
+++ b/worktree/tests/golden/schemas/worktree.status.json
@@ -98,6 +98,18 @@
         "description": "True while a rebase is in progress in this worktree.",
         "type": "boolean"
       },
+      "integrated": {
+        "default": false,
+        "description": "True when the branch's work is already contained in its integration target (fast-forward, merge, rebase, or squash merge). Integrated worktrees are prunable even when ahead of their base.",
+        "type": "boolean"
+      },
+      "integration_reason": {
+        "description": "Which check detected the integration: `same_commit`, `ancestor`, `no_added_changes`, `trees_match`, `merge_adds_nothing`, or `patch_id_match`.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
       "lifecycle": {
         "allOf": [
           {

--- a/worktree/tests/integration_detection.rs
+++ b/worktree/tests/integration_detection.rs
@@ -29,6 +29,7 @@ async fn setup(tmp: &Path) -> Setup {
             repo_path: repo.to_string_lossy().into_owned(),
             base_ref: Some("main".into()),
             branch: None,
+            pr: None,
             session_id: None,
         },
     )
@@ -172,6 +173,7 @@ async fn prune_removes_integrated_but_ahead_and_keeps_diverged() {
         repo_path: repo.to_string_lossy().into_owned(),
         base_ref: Some("main".into()),
         branch,
+        pr: None,
         session_id: None,
     };
     let landed = create::handle(&env.deps, mk(None)).await.unwrap();

--- a/worktree/tests/integration_detection.rs
+++ b/worktree/tests/integration_detection.rs
@@ -1,0 +1,213 @@
+//! The integration check chain against real repositories: every detection
+//! path (ancestor, no-added-changes, trees-match, merge-adds-nothing,
+//! patch-id squash fallback) plus the diverged branch that must never read
+//! integrated, and the prune behavior change for integrated-but-ahead
+//! worktrees.
+
+mod support;
+
+use std::path::Path;
+
+use support::{commit_file, git, init_repo, make_env, test_config, TestEnv};
+use worktree::functions::{create, prune, status};
+
+struct Setup {
+    env: TestEnv,
+    repo: std::path::PathBuf,
+    worktree_id: String,
+    wt_path: std::path::PathBuf,
+}
+
+/// Repo on `main` with one managed worktree based on it.
+async fn setup(tmp: &Path) -> Setup {
+    let repo = tmp.join("repo");
+    init_repo(&repo);
+    let env = make_env(tmp, test_config(tmp));
+    let created = create::handle(
+        &env.deps,
+        create::Request {
+            repo_path: repo.to_string_lossy().into_owned(),
+            base_ref: Some("main".into()),
+            branch: None,
+            session_id: None,
+        },
+    )
+    .await
+    .unwrap();
+    Setup {
+        env,
+        repo,
+        worktree_id: created.worktree_id,
+        wt_path: std::path::PathBuf::from(created.path),
+    }
+}
+
+async fn integration(s: &Setup) -> (bool, Option<String>) {
+    let st = status::handle(
+        &s.env.deps,
+        status::Request {
+            worktree_id: s.worktree_id.clone(),
+        },
+    )
+    .await
+    .unwrap();
+    (st.status.integrated, st.status.integration_reason)
+}
+
+#[tokio::test]
+async fn fresh_worktree_reads_same_commit() {
+    let tmp = tempfile::tempdir().unwrap();
+    let s = setup(tmp.path()).await;
+    let (integrated, reason) = integration(&s).await;
+    assert!(integrated);
+    assert_eq!(reason.as_deref(), Some("same_commit"));
+}
+
+#[tokio::test]
+async fn merged_branch_reads_ancestor() {
+    let tmp = tempfile::tempdir().unwrap();
+    let s = setup(tmp.path()).await;
+    commit_file(&s.wt_path, "feature.txt", "feature\n", "feature");
+    // True merge into main, then main moves on.
+    git(
+        &s.repo,
+        &[
+            "merge",
+            "--no-ff",
+            "-m",
+            "merge feature",
+            &format!("iii/{}", s.worktree_id),
+        ],
+    );
+    commit_file(&s.repo, "after.txt", "after\n", "after merge");
+    let (integrated, reason) = integration(&s).await;
+    assert!(integrated);
+    assert_eq!(reason.as_deref(), Some("ancestor"));
+}
+
+#[tokio::test]
+async fn reverted_branch_reads_no_added_changes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let s = setup(tmp.path()).await;
+    commit_file(&s.wt_path, "scratch.txt", "x\n", "add scratch");
+    git(&s.wt_path, &["revert", "--no-edit", "HEAD"]);
+    // Main moves so the branch is not an ancestor-equal.
+    commit_file(&s.repo, "after.txt", "after\n", "main moves");
+    let (integrated, reason) = integration(&s).await;
+    assert!(integrated);
+    assert_eq!(reason.as_deref(), Some("no_added_changes"));
+}
+
+#[tokio::test]
+async fn cherry_picked_branch_reads_trees_match() {
+    let tmp = tempfile::tempdir().unwrap();
+    let s = setup(tmp.path()).await;
+    let feature_sha = commit_file(&s.wt_path, "feature.txt", "feature\n", "feature");
+    // Rebase-style landing: same change replayed onto main as a new commit
+    // (-x alters the message so the replay never reproduces the same id).
+    git(&s.repo, &["cherry-pick", "-x", &feature_sha]);
+    let (integrated, reason) = integration(&s).await;
+    assert!(integrated);
+    assert_eq!(reason.as_deref(), Some("trees_match"));
+}
+
+#[tokio::test]
+async fn squash_merge_reads_merge_adds_nothing_after_target_moves() {
+    let tmp = tempfile::tempdir().unwrap();
+    let s = setup(tmp.path()).await;
+    commit_file(&s.wt_path, "feature.txt", "feature\n", "feature a");
+    commit_file(&s.wt_path, "feature2.txt", "more\n", "feature b");
+    git(
+        &s.repo,
+        &["merge", "--squash", &format!("iii/{}", s.worktree_id)],
+    );
+    git(&s.repo, &["commit", "-m", "squash: feature"]);
+    // Target moves on OTHER files: trees differ, but merging the branch
+    // adds nothing.
+    commit_file(&s.repo, "unrelated.txt", "u\n", "unrelated");
+    let (integrated, reason) = integration(&s).await;
+    assert!(integrated);
+    assert_eq!(reason.as_deref(), Some("merge_adds_nothing"));
+}
+
+#[tokio::test]
+async fn squash_merge_with_retouched_files_reads_patch_id_match() {
+    let tmp = tempfile::tempdir().unwrap();
+    let s = setup(tmp.path()).await;
+    commit_file(&s.wt_path, "feature.txt", "feature\n", "feature");
+    git(
+        &s.repo,
+        &["merge", "--squash", &format!("iii/{}", s.worktree_id)],
+    );
+    git(&s.repo, &["commit", "-m", "squash: feature"]);
+    // The squashed file is touched AGAIN on main: the in-memory merge now
+    // conflicts, so only the patch-id fallback can prove integration.
+    commit_file(&s.repo, "feature.txt", "feature v2\n", "retouch feature");
+    let (integrated, reason) = integration(&s).await;
+    assert!(integrated);
+    assert_eq!(reason.as_deref(), Some("patch_id_match"));
+}
+
+#[tokio::test]
+async fn diverged_branch_is_not_integrated() {
+    let tmp = tempfile::tempdir().unwrap();
+    let s = setup(tmp.path()).await;
+    commit_file(&s.wt_path, "feature.txt", "feature\n", "unlanded feature");
+    commit_file(&s.repo, "other.txt", "other\n", "main diverges");
+    let (integrated, reason) = integration(&s).await;
+    assert!(!integrated, "diverged branch must not read integrated");
+    assert_eq!(reason, None);
+}
+
+#[tokio::test]
+async fn prune_removes_integrated_but_ahead_and_keeps_diverged() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut cfg = test_config(tmp.path());
+    cfg.prune_expire_hours = 0;
+    let repo = tmp.path().join("repo");
+    init_repo(&repo);
+    let env = make_env(tmp.path(), cfg);
+
+    let mk = |branch: Option<String>| create::Request {
+        repo_path: repo.to_string_lossy().into_owned(),
+        base_ref: Some("main".into()),
+        branch,
+        session_id: None,
+    };
+    let landed = create::handle(&env.deps, mk(None)).await.unwrap();
+    let diverged = create::handle(&env.deps, mk(None)).await.unwrap();
+
+    // `landed` is squash-merged into main (ahead of base, yet integrated).
+    commit_file(
+        Path::new(&landed.path),
+        "landed.txt",
+        "landed\n",
+        "landed work",
+    );
+    git(&repo, &["merge", "--squash", &landed.branch]);
+    git(&repo, &["commit", "-m", "squash: landed work"]);
+
+    // `diverged` carries genuinely unmerged work.
+    commit_file(
+        Path::new(&diverged.path),
+        "diverged.txt",
+        "d\n",
+        "unmerged work",
+    );
+
+    let out = prune::handle(
+        &env.deps,
+        prune::Request {
+            repo_path: None,
+            dry_run: false,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(out.pruned, vec![landed.worktree_id.clone()]);
+    assert!(!Path::new(&landed.path).exists());
+    assert!(Path::new(&diverged.path).is_dir());
+    let reasons: Vec<(String, String)> =
+        out.skipped.into_iter().map(|s| (s.id, s.reason)).collect();
+    assert!(reasons.contains(&(diverged.worktree_id.clone(), "unmerged work".into())));
+}

--- a/worktree/tests/integration_detection.rs
+++ b/worktree/tests/integration_detection.rs
@@ -8,7 +8,7 @@ mod support;
 
 use std::path::Path;
 
-use support::{commit_file, git, init_repo, make_env, test_config, TestEnv};
+use support::{commit_file, create_request, git, init_repo, make_env, test_config, TestEnv};
 use worktree::functions::{create, prune, status};
 
 struct Setup {
@@ -23,18 +23,9 @@ async fn setup(tmp: &Path) -> Setup {
     let repo = tmp.join("repo");
     init_repo(&repo);
     let env = make_env(tmp, test_config(tmp));
-    let created = create::handle(
-        &env.deps,
-        create::Request {
-            repo_path: repo.to_string_lossy().into_owned(),
-            base_ref: Some("main".into()),
-            branch: None,
-            pr: None,
-            session_id: None,
-        },
-    )
-    .await
-    .unwrap();
+    let mut req = create_request(&repo);
+    req.base_ref = Some("main".into());
+    let created = create::handle(&env.deps, req).await.unwrap();
     Setup {
         env,
         repo,
@@ -169,15 +160,13 @@ async fn prune_removes_integrated_but_ahead_and_keeps_diverged() {
     init_repo(&repo);
     let env = make_env(tmp.path(), cfg);
 
-    let mk = |branch: Option<String>| create::Request {
-        repo_path: repo.to_string_lossy().into_owned(),
-        base_ref: Some("main".into()),
-        branch,
-        pr: None,
-        session_id: None,
+    let mk = || {
+        let mut req = create_request(&repo);
+        req.base_ref = Some("main".into());
+        req
     };
-    let landed = create::handle(&env.deps, mk(None)).await.unwrap();
-    let diverged = create::handle(&env.deps, mk(None)).await.unwrap();
+    let landed = create::handle(&env.deps, mk()).await.unwrap();
+    let diverged = create::handle(&env.deps, mk()).await.unwrap();
 
     // `landed` is squash-merged into main (ahead of base, yet integrated).
     commit_file(

--- a/worktree/tests/land_machine.rs
+++ b/worktree/tests/land_machine.rs
@@ -469,6 +469,50 @@ async fn redelivery_at_every_phase_boundary_converges() {
 }
 
 #[tokio::test]
+async fn backup_ref_survives_a_blocked_land_and_clears_on_success() {
+    let tmp = tempfile::tempdir().unwrap();
+    let s = setup(make_env(tmp.path(), test_config(tmp.path())), tmp.path()).await;
+    // Conflicting edits so the first land blocks in the rebase phase.
+    commit_file(&s.wt_path, "README.md", "worktree version\n", "wt edit");
+    commit_file(&s.repo, "README.md", "main version\n", "main edit");
+    let blocked_head = head_sha(&s.wt_path);
+
+    let job_id = enqueue_land(&s, "main", LandOverrides::default()).await;
+    let deps = land_deps(&s.env).await;
+    run_step(&deps, &job_id).await.unwrap();
+
+    let backup = format!("refs/iii/wt-backup/{}", s.worktree_id);
+    let pinned = git(&s.repo, &["rev-parse", &backup]);
+    assert_eq!(pinned, blocked_head, "blocked land keeps the backup ref");
+
+    // Resolve by force-restarting against trunk (no conflict there); the
+    // successful finalize releases the anchor.
+    let retry = land::handle(
+        &s.env.deps,
+        land::Request {
+            worktree_id: s.worktree_id.clone(),
+            target_branch: "trunk".into(),
+            test_cmd: None,
+            force_restart: true,
+            keep: false,
+        },
+    )
+    .await
+    .unwrap();
+    run_step(&deps, &retry.job_id).await.unwrap();
+
+    let out = std::process::Command::new("git")
+        .args(["rev-parse", "--verify", "--quiet", &backup])
+        .current_dir(&s.repo)
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "successful finalize deletes the backup ref"
+    );
+}
+
+#[tokio::test]
 async fn second_land_while_job_live_is_w401_and_unknown_job_is_noop() {
     let tmp = tempfile::tempdir().unwrap();
     let s = setup(make_env(tmp.path(), test_config(tmp.path())), tmp.path()).await;

--- a/worktree/tests/land_machine.rs
+++ b/worktree/tests/land_machine.rs
@@ -37,6 +37,7 @@ async fn setup(env: TestEnv, tmp: &Path) -> Scenario {
             repo_path: repo.to_string_lossy().into_owned(),
             base_ref: None,
             branch: None,
+            pr: None,
             session_id: None,
         },
     )

--- a/worktree/tests/land_machine.rs
+++ b/worktree/tests/land_machine.rs
@@ -10,8 +10,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use support::{
-    branch_sha, commit_file, git, head_sha, init_repo, make_env, make_env_with_runner, test_config,
-    FailingStore, ScriptedTestRunner, TestEnv,
+    branch_sha, commit_file, create_request, git, head_sha, init_repo, make_env,
+    make_env_with_runner, test_config, FailingStore, ScriptedTestRunner, TestEnv,
 };
 use worktree::functions::{create, land};
 use worktree::land::{run_step, LandDeps};
@@ -31,18 +31,9 @@ async fn setup(env: TestEnv, tmp: &Path) -> Scenario {
     let repo = tmp.join("repo");
     init_repo(&repo);
     git(&repo, &["branch", "trunk"]);
-    let created = create::handle(
-        &env.deps,
-        create::Request {
-            repo_path: repo.to_string_lossy().into_owned(),
-            base_ref: None,
-            branch: None,
-            pr: None,
-            session_id: None,
-        },
-    )
-    .await
-    .unwrap();
+    let created = create::handle(&env.deps, create_request(&repo))
+        .await
+        .unwrap();
     let wt_path = PathBuf::from(&created.path);
     commit_file(&wt_path, "feature.txt", "feature\n", "add feature");
     Scenario {

--- a/worktree/tests/provisioning.rs
+++ b/worktree/tests/provisioning.rs
@@ -9,7 +9,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::time::Duration;
 
-use support::{git, init_repo, make_env, test_config};
+use support::{create_request, git, init_repo, make_env, test_config};
 use worktree::config::ProvisionConfig;
 use worktree::functions::create;
 use worktree::provision::{copy_entry_with, copy_ignored, filter_entries, CopyMode};
@@ -139,8 +139,8 @@ async fn copy_budget_stops_the_copy_with_a_warning() {
     assert!(!wt.join(".env").exists());
 }
 
-#[tokio::test]
-async fn clone_flag_falls_back_to_a_plain_copy() {
+#[test]
+fn clone_flag_falls_back_to_a_plain_copy() {
     let tmp = tempfile::tempdir().unwrap();
     // A cp shim that refuses the macOS clone flag and otherwise delegates,
     // simulating a filesystem without clone support.
@@ -161,8 +161,7 @@ async fn clone_flag_falls_back_to_a_plain_copy() {
         CopyMode::MacClone,
         &src,
         &dst,
-    )
-    .await;
+    );
     assert!(ok, "fallback plain copy must succeed");
     assert_eq!(std::fs::read_to_string(&dst).unwrap(), "payload\n");
 }
@@ -175,18 +174,9 @@ async fn create_spawns_the_background_provisioning() {
     cfg.provision.copy_ignored = true;
     let env = make_env(tmp.path(), cfg);
 
-    let created = create::handle(
-        &env.deps,
-        create::Request {
-            repo_path: repo.to_string_lossy().into_owned(),
-            base_ref: None,
-            branch: None,
-            pr: None,
-            session_id: None,
-        },
-    )
-    .await
-    .unwrap();
+    let created = create::handle(&env.deps, create_request(&repo))
+        .await
+        .unwrap();
 
     // The response returns before the copy; poll for the background task
     // with a generous deadline (cold CI runners need well over a second).

--- a/worktree/tests/provisioning.rs
+++ b/worktree/tests/provisioning.rs
@@ -188,9 +188,10 @@ async fn create_spawns_the_background_provisioning() {
     .await
     .unwrap();
 
-    // The response returns before the copy; poll for the background task.
+    // The response returns before the copy; poll for the background task
+    // with a generous deadline (cold CI runners need well over a second).
     let env_file = Path::new(&created.path).join(".env");
-    for _ in 0..100 {
+    for _ in 0..600 {
         if env_file.exists() {
             break;
         }

--- a/worktree/tests/provisioning.rs
+++ b/worktree/tests/provisioning.rs
@@ -116,6 +116,52 @@ async fn copy_ignored_replicates_into_the_worktree() {
     assert!(!wt.join(".git").exists());
 }
 
+#[test]
+fn sibling_prefix_paths_are_not_excluded() {
+    let repo = Path::new("/repo");
+    let root = Path::new("/repo/.wts");
+    let entries = vec!["node_modules/".to_string(), "node_modules2/".to_string()];
+    let kept = filter_entries(
+        entries,
+        &pcfg(|_| {}),
+        repo,
+        root,
+        &["/repo/node_modules".to_string()],
+    );
+    assert_eq!(
+        kept,
+        vec!["node_modules2/"],
+        "prefix-sibling paths must not read as nested worktrees"
+    );
+}
+
+#[tokio::test]
+async fn copy_aborts_when_the_worktree_vanishes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = ignored_fixture(tmp.path());
+    // Never created: simulates worktree::remove staging the directory away
+    // between enumeration and the copy loop.
+    let wt = tmp.path().join("wt-gone");
+
+    let summary = copy_ignored(
+        &repo,
+        &wt,
+        &pcfg(|_| {}),
+        &[],
+        &tmp.path().join("wts"),
+        CopyMode::Plain,
+        30_000,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(summary.copied, 0);
+    assert!(
+        !wt.exists(),
+        "copy loop must not recreate a removed worktree"
+    );
+}
+
 #[tokio::test]
 async fn copy_budget_stops_the_copy_with_a_warning() {
     let tmp = tempfile::tempdir().unwrap();

--- a/worktree/tests/provisioning.rs
+++ b/worktree/tests/provisioning.rs
@@ -1,0 +1,200 @@
+//! Copy-ignored provisioning: filter matrix (include / exclude /
+//! always-excluded VCS dirs and worktree roots), the byte budget, the
+//! macOS clone-flag fallback (via an injected cp shim), and the spawned
+//! background wiring on create.
+
+mod support;
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::time::Duration;
+
+use support::{git, init_repo, make_env, test_config};
+use worktree::config::ProvisionConfig;
+use worktree::functions::create;
+use worktree::provision::{copy_entry_with, copy_ignored, filter_entries, CopyMode};
+
+fn pcfg(mutate: impl FnOnce(&mut ProvisionConfig)) -> ProvisionConfig {
+    let mut cfg = ProvisionConfig {
+        copy_ignored: true,
+        ..Default::default()
+    };
+    mutate(&mut cfg);
+    cfg
+}
+
+/// Repo with tracked + gitignored content.
+fn ignored_fixture(tmp: &Path) -> std::path::PathBuf {
+    let repo = tmp.join("repo");
+    init_repo(&repo);
+    std::fs::write(repo.join(".gitignore"), ".env\nnode_modules/\n*.log\n").unwrap();
+    git(&repo, &["add", ".gitignore"]);
+    git(&repo, &["commit", "-m", "ignore rules"]);
+    std::fs::write(repo.join(".env"), "SECRET=1\n").unwrap();
+    std::fs::create_dir_all(repo.join("node_modules/pkg")).unwrap();
+    std::fs::write(repo.join("node_modules/pkg/a.js"), "js\n").unwrap();
+    std::fs::write(repo.join("debug.log"), "log\n").unwrap();
+    repo
+}
+
+#[test]
+fn filter_matrix_applies_include_exclude_and_always_excludes() {
+    let repo = Path::new("/repo");
+    let root = Path::new("/repo/.wts");
+    let entries = vec![
+        ".env".to_string(),
+        "node_modules/".to_string(),
+        "debug.log".to_string(),
+        ".hg/store".to_string(),
+        ".jj/state".to_string(),
+        ".wts/wt_x/junk".to_string(),
+        "vendor/.svn/props".to_string(),
+    ];
+
+    // Empty include keeps everything not always-excluded.
+    let all = filter_entries(entries.clone(), &pcfg(|_| {}), repo, root, &[]);
+    assert_eq!(all, vec![".env", "node_modules/", "debug.log"]);
+
+    // Include narrows.
+    let only_env = filter_entries(
+        entries.clone(),
+        &pcfg(|c| c.include = vec![".env".into()]),
+        repo,
+        root,
+        &[],
+    );
+    assert_eq!(only_env, vec![".env"]);
+
+    // Exclude subtracts from the included set.
+    let no_logs = filter_entries(
+        entries.clone(),
+        &pcfg(|c| c.exclude = vec!["*.log".into()]),
+        repo,
+        root,
+        &[],
+    );
+    assert_eq!(no_logs, vec![".env", "node_modules/"]);
+
+    // Registered worktree paths are never copied.
+    let skip_nested = filter_entries(
+        entries,
+        &pcfg(|_| {}),
+        repo,
+        root,
+        &["/repo/node_modules".to_string()],
+    );
+    assert_eq!(skip_nested, vec![".env", "debug.log"]);
+}
+
+#[tokio::test]
+async fn copy_ignored_replicates_into_the_worktree() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = ignored_fixture(tmp.path());
+    let wt = tmp.path().join("wt");
+    std::fs::create_dir_all(&wt).unwrap();
+
+    let summary = copy_ignored(
+        &repo,
+        &wt,
+        &pcfg(|_| {}),
+        &[],
+        &tmp.path().join("wts"),
+        CopyMode::Plain,
+        30_000,
+    )
+    .await
+    .unwrap();
+
+    assert!(summary.copied >= 3, "copied {}", summary.copied);
+    assert!(!summary.over_budget);
+    assert_eq!(
+        std::fs::read_to_string(wt.join(".env")).unwrap(),
+        "SECRET=1\n"
+    );
+    assert!(wt.join("node_modules/pkg/a.js").is_file());
+    assert!(wt.join("debug.log").is_file());
+    assert!(!wt.join(".git").exists());
+}
+
+#[tokio::test]
+async fn copy_budget_stops_the_copy_with_a_warning() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = ignored_fixture(tmp.path());
+    let wt = tmp.path().join("wt");
+    std::fs::create_dir_all(&wt).unwrap();
+
+    let summary = copy_ignored(
+        &repo,
+        &wt,
+        &pcfg(|c| c.max_copy_bytes = 1),
+        &[],
+        &tmp.path().join("wts"),
+        CopyMode::Plain,
+        30_000,
+    )
+    .await
+    .unwrap();
+    assert!(summary.over_budget);
+    assert_eq!(summary.copied, 0);
+    assert!(!wt.join(".env").exists());
+}
+
+#[tokio::test]
+async fn clone_flag_falls_back_to_a_plain_copy() {
+    let tmp = tempfile::tempdir().unwrap();
+    // A cp shim that refuses the macOS clone flag and otherwise delegates,
+    // simulating a filesystem without clone support.
+    let shim = tmp.path().join("cp-shim");
+    std::fs::write(
+        &shim,
+        "#!/bin/sh\nfor a in \"$@\"; do [ \"$a\" = \"-c\" ] && exit 1; done\nexec cp \"$@\"\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let src = tmp.path().join("src.txt");
+    std::fs::write(&src, "payload\n").unwrap();
+    let dst = tmp.path().join("dst.txt");
+
+    let ok = copy_entry_with(
+        shim.to_string_lossy().as_ref(),
+        CopyMode::MacClone,
+        &src,
+        &dst,
+    )
+    .await;
+    assert!(ok, "fallback plain copy must succeed");
+    assert_eq!(std::fs::read_to_string(&dst).unwrap(), "payload\n");
+}
+
+#[tokio::test]
+async fn create_spawns_the_background_provisioning() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = ignored_fixture(tmp.path());
+    let mut cfg = test_config(tmp.path());
+    cfg.provision.copy_ignored = true;
+    let env = make_env(tmp.path(), cfg);
+
+    let created = create::handle(
+        &env.deps,
+        create::Request {
+            repo_path: repo.to_string_lossy().into_owned(),
+            base_ref: None,
+            branch: None,
+            pr: None,
+            session_id: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    // The response returns before the copy; poll for the background task.
+    let env_file = Path::new(&created.path).join(".env");
+    for _ in 0..100 {
+        if env_file.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(env_file.exists(), "background provisioning never landed");
+}

--- a/worktree/tests/support/mod.rs
+++ b/worktree/tests/support/mod.rs
@@ -366,12 +366,16 @@ pub struct TestEnv {
 }
 
 pub fn test_config(root: &Path) -> WorkerConfig {
-    WorkerConfig {
+    let mut cfg = WorkerConfig {
         worktree_root: root.join("wts").to_string_lossy().into_owned(),
         git_timeout_ms: 30_000,
         test_timeout_ms: 30_000,
         ..WorkerConfig::default()
-    }
+    };
+    // Behavioral tests exercise the force paths; the gates suite covers the
+    // restrictive defaults explicitly.
+    cfg.gates.allow_force = true;
+    cfg
 }
 
 /// In-process environment against a tempdir: in-memory store, recording

--- a/worktree/tests/support/mod.rs
+++ b/worktree/tests/support/mod.rs
@@ -21,7 +21,7 @@ use tokio::sync::RwLock;
 use worktree::config::WorkerConfig;
 use worktree::error::{codes, WError};
 use worktree::events::{Emitter, EventDeliverer, EventKind, TriggerSets};
-use worktree::functions::Deps;
+use worktree::functions::{create, Deps};
 use worktree::land::test_gate::{TestOutcome, TestRunner};
 use worktree::land::Enqueuer;
 use worktree::locks::RepoLocks;
@@ -176,6 +176,18 @@ pub fn commit_file(dir: &Path, file: &str, content: &str, message: &str) -> Stri
 
 pub fn head_sha(dir: &Path) -> String {
     git(dir, &["rev-parse", "HEAD"])
+}
+
+/// A `worktree::create` request off `repo` with every option unset; suites
+/// override single fields as needed.
+pub fn create_request(repo: &Path) -> create::Request {
+    create::Request {
+        repo_path: repo.to_string_lossy().into_owned(),
+        base_ref: None,
+        branch: None,
+        pr: None,
+        session_id: None,
+    }
 }
 
 pub fn branch_sha(dir: &Path, branch: &str) -> String {

--- a/worktree/tests/trash_removal.rs
+++ b/worktree/tests/trash_removal.rs
@@ -20,6 +20,7 @@ async fn create_wt(env: &TestEnv, repo: &Path) -> create::Response {
             repo_path: repo.to_string_lossy().into_owned(),
             base_ref: None,
             branch: None,
+            pr: None,
             session_id: None,
         },
     )

--- a/worktree/tests/trash_removal.rs
+++ b/worktree/tests/trash_removal.rs
@@ -8,24 +8,15 @@ mod support;
 use std::path::Path;
 use std::time::Duration;
 
-use support::{git, init_repo, make_env, test_config, TestEnv};
+use support::{create_request, git, init_repo, make_env, test_config, TestEnv};
 use worktree::functions::{create, prune, remove};
 use worktree::trash;
 use worktree::types::now_ms;
 
 async fn create_wt(env: &TestEnv, repo: &Path) -> create::Response {
-    create::handle(
-        &env.deps,
-        create::Request {
-            repo_path: repo.to_string_lossy().into_owned(),
-            base_ref: None,
-            branch: None,
-            pr: None,
-            session_id: None,
-        },
-    )
-    .await
-    .unwrap()
+    create::handle(&env.deps, create_request(repo))
+        .await
+        .unwrap()
 }
 
 async fn wait_gone(path: &Path) {

--- a/worktree/tests/trash_removal.rs
+++ b/worktree/tests/trash_removal.rs
@@ -1,0 +1,160 @@
+//! Async trash removal: the worktree directory leaves its original path
+//! immediately, appears under `.trash`, and a detached task deletes it; the
+//! prune sweep clears stale entries; the busy probe refuses removal while a
+//! process holds files open under the worktree.
+
+mod support;
+
+use std::path::Path;
+use std::time::Duration;
+
+use support::{git, init_repo, make_env, test_config, TestEnv};
+use worktree::functions::{create, prune, remove};
+use worktree::trash;
+use worktree::types::now_ms;
+
+async fn create_wt(env: &TestEnv, repo: &Path) -> create::Response {
+    create::handle(
+        &env.deps,
+        create::Request {
+            repo_path: repo.to_string_lossy().into_owned(),
+            base_ref: None,
+            branch: None,
+            session_id: None,
+        },
+    )
+    .await
+    .unwrap()
+}
+
+async fn wait_gone(path: &Path) {
+    for _ in 0..100 {
+        if !path.exists() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("background delete never cleared {}", path.display());
+}
+
+#[tokio::test]
+async fn remove_stages_into_trash_and_deletes_in_background() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    init_repo(&repo);
+    let cfg = test_config(tmp.path());
+    let root = cfg.expanded_worktree_root();
+    let env = make_env(tmp.path(), cfg);
+    let created = create_wt(&env, &repo).await;
+    let wt_path = Path::new(&created.path).to_path_buf();
+
+    let resp = remove::handle(
+        &env.deps,
+        remove::Request {
+            worktree_id: created.worktree_id.clone(),
+            force: false,
+            delete_branch: false,
+        },
+    )
+    .await
+    .unwrap();
+    assert!(resp.removed);
+
+    // Gone from the worktree root immediately; the git admin entry is
+    // pruned synchronously.
+    assert!(!wt_path.exists(), "original path cleared synchronously");
+    let porcelain = git(&repo, &["worktree", "list", "--porcelain"]);
+    assert!(!porcelain.contains(&created.worktree_id));
+
+    // Any surviving staged entry belongs to this worktree and disappears
+    // once the detached delete lands.
+    let trash = trash::trash_dir(&root);
+    if let Ok(entries) = std::fs::read_dir(&trash) {
+        for entry in entries.filter_map(Result::ok) {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            assert!(
+                name.starts_with(&created.worktree_id),
+                "unexpected trash entry {name}"
+            );
+            wait_gone(&entry.path()).await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn prune_sweeps_stale_trash_entries() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    init_repo(&repo);
+    let cfg = test_config(tmp.path());
+    let root = cfg.expanded_worktree_root();
+    let env = make_env(tmp.path(), cfg);
+
+    let trash = trash::trash_dir(&root);
+    std::fs::create_dir_all(&trash).unwrap();
+    let stale_secs = (now_ms() - trash::TRASH_MAX_AGE_MS - 60_000) / 1000;
+    let stale = trash.join(format!("wt_stale000-{stale_secs}"));
+    let fresh = trash.join(format!("wt_fresh000-{}", now_ms() / 1000));
+    std::fs::create_dir_all(&stale).unwrap();
+    std::fs::write(stale.join("f.txt"), "x").unwrap();
+    std::fs::create_dir_all(&fresh).unwrap();
+
+    prune::handle(
+        &env.deps,
+        prune::Request {
+            repo_path: None,
+            dry_run: false,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert!(!stale.exists(), "stale trash entry swept");
+    assert!(
+        fresh.exists(),
+        "fresh trash entry kept for its detached delete"
+    );
+}
+
+#[tokio::test]
+async fn busy_worktree_refuses_removal_until_forced() {
+    if which::which("lsof").is_err() {
+        eprintln!("skipping: lsof not available");
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let repo = tmp.path().join("repo");
+    init_repo(&repo);
+    let env = make_env(tmp.path(), test_config(tmp.path()));
+    let created = create_wt(&env, &repo).await;
+    let wt_path = Path::new(&created.path).to_path_buf();
+
+    // Hold a file open under the worktree so `lsof +D` sees this process.
+    let held = std::fs::File::open(wt_path.join("README.md")).unwrap();
+    let err = remove::handle(
+        &env.deps,
+        remove::Request {
+            worktree_id: created.worktree_id.clone(),
+            force: false,
+            delete_branch: false,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, "W222");
+
+    // force bypasses the probe (test_config opens gates.allow_force).
+    let resp = remove::handle(
+        &env.deps,
+        remove::Request {
+            worktree_id: created.worktree_id,
+            force: true,
+            delete_branch: false,
+        },
+    )
+    .await
+    .unwrap();
+    assert!(resp.removed);
+    drop(held);
+    assert!(!wt_path.exists());
+}


### PR DESCRIPTION
**Operator safety and lifecycle hardening for the `worktree` worker (v0.2.0): destructive operations become deny-by-config, force paths ship closed, and the prune blind spot for squash-landed branches is fixed.**

Follow-up to the initial worker. The theme is safety-first operation at parallel-agent scale: one config flip turns off whole classes of destruction, every denial names the exact key to flip, and the git surface gets data-safety anchors for the operations that can lose work.

## Gates

A new hot-reloadable `[gates]` block, checked FIRST by every mutating handler:

* `allow_remove`, `allow_branch_delete`, `allow_land`, `allow_prune` (default open) and `allow_force` (default CLOSED: remove force, claim takeover, release force, land force_restart are opt-in).
* `land_targets` globs pin which branches `worktree::land` may target (`["main"]` for mainline-only lands).
* `repos` globs pin which repositories `worktree::create` may branch from, matched over the canonicalized path so symlink spellings cannot dodge the list; `max_worktrees_per_repo` caps live worktrees per repository at create time (orphaned records excluded, counted under the repo lock). Both are create-time checks, so narrowing the config later never breaks existing worktrees.
* Structured denials: `W500` op disabled, `W501` force disabled, `W502` land target not allowed, `W503` repo not allowed, `W504` budget exceeded. Every message names the key, e.g. `worktree::remove is disabled by configuration; set gates.allow_remove: true to enable`.

## Integration detection

`worktree::status` now reports `integrated` plus an `integration_reason`, from a cheapest-first chain over real git state: same commit, ancestor, no added changes since the merge base, matching trees (rebase), an in-memory merge that adds nothing to the target (squash), and a patch-id fallback for squashes whose files were retouched on the target (target walk capped at 500 commits, plumbing diffs so user diff config never skews ids). `worktree::prune` treats integrated-but-ahead worktrees as prunable, fixing the blind spot where squash- or rebase-landed branches were held forever, while still honoring clean, expiry, claims, and gates.

## Async removal and busy guard

`worktree::remove` renames the directory into `<worktree_root>/.trash/<id>-<epoch>` (a same-filesystem metadata rename) and returns immediately; a detached task deletes it and the cron sweep clears trash older than 24 hours as the crash backstop. Git worktree metadata is pruned synchronously. Before removal, a best-effort `lsof` probe (2s bound, silently skipped when unavailable) refuses with `W222` while running processes hold files open under the worktree; force bypasses the probe and nothing is ever signaled or killed.

## Land data safety

* A backup ref `refs/iii/wt-backup/<id>` pins the pre-rebase branch head; a blocked land keeps the anchor for recovery and a successful finalize deletes it.
* Finalize branch cleanup is now a compare-and-swap ref delete: the branch is dropped only while it still points at the exact commit the land merged; a branch that moved is retained.
* Ref- and rev-taking git invocations carry `--end-of-options` fencing on top of the existing leading-dash validation; every fenced command is exercised by the suite against real git.

## Creation sources and ports

* `worktree::create` accepts `pr: <number>`: fetches `refs/pull/<n>/head` from `origin` through the hardened runner and branches `<prefix>pr-<n>` at it, erroring cleanly when the remote publishes no such ref.
* `branch_naming: codename` mints deterministic `<adjective>-<noun>-<4hex>` names from the worktree id (embedded word lists, no new dependencies), collision-checked like every branch.
* Every worktree carries an advisory `dev_port` (10000 + stable id hash mod 10000) on its record and across create/get/list/status: deterministic and collision-improbable for parallel dev servers, reserved nowhere.

## Provisioning

Opt-in `[provision]` block: on create, a detached task replicates the source repo's gitignored files (.env files, caches) into the fresh worktree. Include/exclude globs filter the set; VCS metadata dirs, the managed worktree root, and registered worktree paths are always excluded; copies use the platform's cheapest mechanism (APFS clones via `cp -c` with a per-entry plain fallback, `cp --reflink=auto` on Linux) bounded by `max_copy_bytes` (default 2GiB). Best-effort by contract: the create response never waits, failures only log, retries skip files that already landed.

## Console follow-through

The worktree zod schemas learn the new fields as optionals so older workers keep parsing; graph nodes show a subtle merge glyph (detection reason in the tooltip) when a branch is already contained in its target; the detail panel gains dev port and integrated rows; fixtures and parse tests cover both the absent-field and present-field shapes.

## Configuration

```yaml
branch_naming: "id"            # or "codename"
provision:
  copy_ignored: false
  include: []                  # globs; empty = every ignored path
  exclude: []
  max_copy_bytes: 2147483648
gates:
  allow_remove: true
  allow_force: false           # ships closed
  allow_branch_delete: true
  allow_land: true
  allow_prune: true
  land_targets: ["*"]          # pin to ["main"] for mainline-only lands
  repos: ["*"]                 # canonical repo paths creates may branch from
  max_worktrees_per_repo: 0    # live-worktree budget per repo; 0 = unlimited
```

## Verification

* 96 Rust tests: the gates matrix (every deny path with its key named, all four force paths, land-target and repo globs, budget boundary with orphaned records excluded), the integration chain against real repositories (ancestor merge, squash with a moved target, squash with retouched files through the patch-id fallback, cherry-pick, revert, and a diverged branch that must never read integrated), trash staging plus background delete plus sweep, backup-ref lifecycle across a blocked and a successful land, CAS branch-delete refusal when the branch moved, the pr source against a file:// origin fixture, codename determinism, dev-port range, provisioning filter matrix with the byte cap and the clone-flag fallback, schema goldens, and redelivery at every land phase boundary.
* 919 console web tests; biome, tsc, and the production build green.

Fixes MOT-3878


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for showing worktree dev ports and integration status in worktree details, lists, graphs, and status views.
  * Added pull request-based worktree creation and deterministic branch naming options.
  * Added new background provisioning behavior to copy selected ignored files into fresh worktrees.

* **Bug Fixes**
  * Improved worktree removal with busy-file detection, safer trash-based deletion, and better cleanup.
  * Tightened worktree land, remove, claim, release, and prune safeguards with clearer configuration-based allow/deny handling.
  * Made status and validation more reliable across repository path formats and worker version differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->