### PR TITLE
(MOT-3887) feat(console): conversation search bar in sidebar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Agent guide
+
+Conventions for AI coding agents (and humans) working in this repo.
+
+## Commit & PR conventions
+
+- No AI/assistant references in commit messages or PR descriptions: no
+  session trailers, no tool URLs, no attribution or co-author lines.
+- No internal-workflow references in commits/PRs/changelogs: no plan,
+  sub-task, skill, or agent mentions. Describe the change itself — what it
+  does and why.
+- Branch names: `feat/<slug>`, `fix/<slug>`, `chore/…`, `refactor/…`,
+  `docs/…` — never Linear's generated `user/mot-####` branch names.
+- Commit messages and PR titles carry the Linear ticket as a prefix:
+  `(MOT-##) <type>: <description>` (scoped types fine:
+  `(MOT-123) feat(console): …`). PRs squash-merge, so the PR title is what
+  lands on main and MUST carry the prefix — the `PR Linear Check` workflow
+  fails without it.
+- PR body adds `Fixes MOT-###` when merging should transition the ticket
+  (Linear state automation); `Refs MOT-###` for secondary tickets. No
+  ticket yet? Create one on the iii team in the matching project first.
+- Genuinely ticketless work (version bumps, typo/CI-only) drops the prefix
+  and the PR gets the `no-ticket` label instead.
+
+## Linear ticket conventions
+
+- Ticket title and the opening paragraph are user-facing: plain product
+  language, no jargon — they feed release notes. Implementation notes go
+  after, under a `## Technical details` heading.
+- Don't flood Linear: correlated PRs share one ticket (`Fixes` on the main
+  PR, `Refs MOT-###` on the others). If a piece genuinely needs its own
+  tracking, create a sub-issue under the main ticket, not a new top-level
+  ticket.

--- a/console/web/src/components/sidebar/ConversationSidebar.tsx
+++ b/console/web/src/components/sidebar/ConversationSidebar.tsx
@@ -1,12 +1,14 @@
 import { PanelLeftClose, PanelLeftOpen, Plus } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
 import {
   clampSidebarWidth,
   SIDEBAR_DEFAULT_WIDTH,
   SIDEBAR_MAX_WIDTH,
   SIDEBAR_MIN_WIDTH,
 } from '@/hooks/use-sidebar-width'
+import { filterConversations } from '@/lib/conversation-filter'
 import {
   buildConversationTree,
   flattenConversationTree,
@@ -84,14 +86,24 @@ export function ConversationSidebar({
     })
   }, [])
 
-  const rows = useMemo(
-    () =>
-      flattenConversationTree(
-        buildConversationTree(conversations),
-        collapsedNodes,
-      ),
-    [conversations, collapsedNodes],
-  )
+  const [query, setQuery] = useState('')
+
+  const rows = useMemo(() => {
+    const q = query.trim()
+    if (q) {
+      /* Flat matches while searching: a matched child under an unmatched
+         parent has no tree context to render, so no indent/caret. */
+      return filterConversations(conversations, q).map((conversation) => ({
+        conversation,
+        depth: 0,
+        hasChildren: false,
+      }))
+    }
+    return flattenConversationTree(
+      buildConversationTree(conversations),
+      collapsedNodes,
+    )
+  }, [conversations, collapsedNodes, query])
 
   /* Drag-resize, lifted from ChatDock: anchored left, drag right = wider.
      Only active when a width setter is wired. */
@@ -192,16 +204,29 @@ export function ConversationSidebar({
           ) : null}
         </div>
 
-        <div className="px-3 py-2">
+        <div className="px-3 py-2 space-y-2">
           <div className="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-faint">
             conversations
           </div>
+          <Input
+            type="search"
+            value={query}
+            onChange={setQuery}
+            placeholder="search"
+            aria-label="search conversations"
+            className="h-7 text-[12px]"
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') setQuery('')
+            }}
+          />
         </div>
 
         <div className="flex-1 overflow-y-auto divide-y divide-rule-2">
           {rows.length === 0 ? (
             <div className="px-3 py-6 font-mono text-[12px] text-ink-ghost lowercase">
-              no conversations yet. start one above.
+              {query.trim()
+                ? 'no matches.'
+                : 'no conversations yet. start one above.'}
             </div>
           ) : (
             rows.map(({ conversation: c, depth, hasChildren }) => (

--- a/console/web/src/lib/conversation-filter.test.ts
+++ b/console/web/src/lib/conversation-filter.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import type { Conversation } from '@/types/chat'
+import { filterConversations } from './conversation-filter'
+
+let clock = 0
+function conv(id: string, title: string, at = clock++): Conversation {
+  return {
+    id,
+    title,
+    model: null,
+    mode: 'agent',
+    messages: [],
+    createdAt: at,
+    updatedAt: at,
+  }
+}
+
+const list = [
+  conv('a', 'fix harness todo'),
+  conv('b', 'Console Search Bar'),
+  conv('c', 'shell deny policy'),
+]
+
+describe('filterConversations', () => {
+  it('matches case-insensitively on title substring', () => {
+    expect(filterConversations(list, 'search').map((c) => c.id)).toEqual(['b'])
+    expect(filterConversations(list, 'CONSOLE').map((c) => c.id)).toEqual(['b'])
+  })
+
+  it('trims the query and returns the input unchanged when empty', () => {
+    expect(filterConversations(list, '')).toBe(list)
+    expect(filterConversations(list, '   ')).toBe(list)
+    expect(filterConversations(list, '  shell ').map((c) => c.id)).toEqual([
+      'c',
+    ])
+  })
+
+  it('preserves input order and returns empty on no match', () => {
+    expect(filterConversations(list, 'o').map((c) => c.id)).toEqual([
+      'a',
+      'b',
+      'c',
+    ])
+    expect(filterConversations(list, 'zzz')).toEqual([])
+  })
+})

--- a/console/web/src/lib/conversation-filter.ts
+++ b/console/web/src/lib/conversation-filter.ts
@@ -1,0 +1,17 @@
+/**
+ * Title-only conversation search for the sidebar (MOT-3887). Case-insensitive
+ * substring match; trims the query; empty query returns the input list
+ * unchanged; preserves input order. Content search is out of scope (would
+ * need a server-side session-manager function).
+ */
+
+import type { Conversation } from '@/types/chat'
+
+export function filterConversations(
+  conversations: Conversation[],
+  query: string,
+): Conversation[] {
+  const q = query.trim().toLowerCase()
+  if (!q) return conversations
+  return conversations.filter((c) => c.title.toLowerCase().includes(q))
+}


### PR DESCRIPTION
Adds a search input to the console sidebar that filters conversations by
title as you type.

- Client-side, title-only: pure `filterConversations` helper over the
  in-memory list; no session-manager changes.
- While a query is active the list renders flat matches (no tree
  indent/caret); clearing — or Esc — restores the tree with collapse state
  intact.
- `no matches.` empty state; input hidden while the sidebar is collapsed.

Out of scope: full-text search over message content (needs a server-side
session-manager search function).

Fixes MOT-3887

## Test plan
- [x] `pnpm test` in console/web — 924 passing (3 new unit tests for the filter helper)
- [x] `pnpm typecheck` + biome clean
- [x] Manual against the live engine: typed "todo" → 204 rows narrowed to 5 flat matches; uppercase "TODO" → same 5; "zzzqqq" → "no matches."; Esc → full tree restored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conversation search in the sidebar, with live filtering and a search field.
  * Search now matches conversation titles case-insensitively and ignores extra whitespace.

* **Bug Fixes**
  * Improved empty-state messaging to distinguish between “no conversations yet” and “no matches.”

* **Tests**
  * Added coverage for search behavior, including trimming, ordering, and no-match results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->