### PR TITLE
Fix pubsub publish response schema

### DIFF
--- a/pubsub/src/boot.rs
+++ b/pubsub/src/boot.rs
@@ -32,6 +32,13 @@ pub struct PubSubInput {
     pub data: Value,
 }
 
+/// Success result for `publish`.
+///
+/// This intentionally serializes as JSON `null` for builtin parity while still
+/// giving the SDK a concrete JsonSchema response type for registry publish.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct PubSubPublishResponse;
+
 pub struct BootHandle {
     pub hub: Arc<Hub>,
     pub invoker: Arc<dyn Invoker>,
@@ -95,7 +102,7 @@ pub async fn start(iii: Arc<IIIClient>, config: PubSubConfig) -> anyhow::Result<
                     .await
                     .map_err(Error::Handler)?;
                 // Builtin returns Success(None) — a null result.
-                Ok::<_, Error>(Value::Null)
+                Ok::<_, Error>(PubSubPublishResponse)
             }
         })
         .description("Publishes an event"),
@@ -176,5 +183,15 @@ mod tests {
     #[test]
     fn missing_key_passes() {
         assert!(!builtin_iii_pubsub_active(&serde_json::json!({})));
+    }
+
+    #[test]
+    fn publish_response_schema_is_typed_null() {
+        assert!(serde_json::to_value(PubSubPublishResponse)
+            .unwrap()
+            .is_null());
+
+        let schema = serde_json::to_value(schemars::schema_for!(PubSubPublishResponse)).unwrap();
+        assert_eq!(schema.get("type"), Some(&serde_json::json!("null")));
     }
 }


### PR DESCRIPTION
## Summary
- fix the `publish` handler response type so the registry publish gate receives a concrete JSON schema
- preserve the external success result as JSON `null` for builtin parity
- add a regression test for the serialized result and response schema

## Root cause
The release job failed before `POST /publish` because `collect_worker_interface.py --assert-typed-schemas` saw `publish.response_schema` as the permissive `AnyValue`/empty schema. The handler returned `serde_json::Value::Null`, so the SDK could not publish a concrete response schema.

## Validation
- `cargo fmt --manifest-path pubsub/Cargo.toml`
- `cargo test --manifest-path pubsub/Cargo.toml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Publish responses now use a typed JSON schema object while still returning `null` in successful cases.
  * Improved response metadata for better consistency with built-in behavior.
* **Tests**
  * Added coverage to confirm the publish response serializes as `null` and exposes the expected JSON schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->