### PR TITLE
(MOT-3889) fix(scrapling): move dependency bootstrap to scripts.install

### DIFF
--- a/.github/scripts/validate_worker.py
+++ b/.github/scripts/validate_worker.py
@@ -131,15 +131,14 @@ def main(argv: list[str] | None = None) -> int:
                     f"with \"Binary '{worker}' not found in archive\""
                 )
         # Mirror the engine's bundle-manifest validator
-        # (iii-worker/src/cli/bundle_download.rs): it executes only
-        # scripts.start and rejects install/setup/base_image at install
-        # time. Catch that at PR time instead of at the user's install.
+        # (iii-worker/src/cli/bundle_download.rs): scripts.install runs
+        # once in the sandbox (prepared-marker guarded), scripts.setup is
+        # rejected, and runtime.base_image must name an engine-preset ref.
+        # Catch violations at PR time instead of at the user's install.
         if m.deploy == "bundle":
             scripts = m.raw.get("scripts") or {}
             if str(scripts.get("setup") or "").strip():
                 hard(f"{worker}/iii.worker.yaml: bundle workers must not declare scripts.setup (engine rejects it)")
-            if str(scripts.get("install") or "").strip():
-                hard(f"{worker}/iii.worker.yaml: bundle workers must not declare scripts.install (engine rejects it)")
             if not str(scripts.get("start") or "").strip():
                 hard(f"{worker}/iii.worker.yaml: bundle workers must declare a non-empty scripts.start")
             base_image = (m.raw.get("runtime") or {}).get("base_image")

--- a/.github/workflows/_bundle.yml
+++ b/.github/workflows/_bundle.yml
@@ -116,13 +116,12 @@ jobs:
 
       # ── Python bundle path ───────────────────────────────────────────
       # Python workers ship as a source bundle (src/ + pyproject.toml +
-      # iii.worker.yaml). The engine's bundle validator executes only
-      # `scripts.start` (scripts.install/setup are rejected, and
-      # runtime.base_image must name an engine-preset ref like
-      # docker.io/iiidev/python:latest), so the manifest's start command
-      # self-bootstraps (e.g. "pip install -e . && python -m src.main").
-      # Native deps and browsers can't be vendored per-arch into one
-      # archive anyway — install-at-start sidesteps that.
+      # iii.worker.yaml). The engine runs `scripts.install` once inside
+      # the sandbox (prepared-marker guarded) and `scripts.start` every
+      # boot; scripts.setup is rejected and runtime.base_image must name
+      # an engine-preset ref like docker.io/iiidev/python:latest. Native
+      # deps and browsers can't be vendored per-arch into one archive
+      # anyway — install-in-sandbox sidesteps that.
       - name: Stage Python artefact
         if: inputs.language == 'python'
         env:

--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -191,11 +191,19 @@ jobs:
               ls -la "$stage_dir"
 
               start_cmd=$(python3 -c 'import sys, yaml; print(yaml.safe_load(open(sys.argv[1]))["scripts"]["start"])' "$stage_dir/iii.worker.yaml")
+              install_cmd=$(python3 -c 'import sys, yaml; print((yaml.safe_load(open(sys.argv[1])).get("scripts") or {}).get("install") or "")' "$stage_dir/iii.worker.yaml")
 
               worker_log="worker-$WORKER.log"
               workspace_root="$PWD"
-              echo "Starting local worker with: (cd $stage_dir && $start_cmd)"
               pushd "$stage_dir" >/dev/null
+              # scripts.install runs once at first boot in the engine
+              # sandbox; mirror that here (synchronously, so failures
+              # fail the release loudly).
+              if [[ -n "$install_cmd" ]]; then
+                echo "Installing worker deps with: (cd $stage_dir && $install_cmd)"
+                sh -c "$install_cmd"
+              fi
+              echo "Starting local worker with: (cd $stage_dir && $start_cmd)"
               sh -c "$start_cmd" > "$workspace_root/$worker_log" 2>&1 &
               echo "$!" > "$workspace_root/worker.pid"
               popd >/dev/null

--- a/scrapling/iii.worker.yaml
+++ b/scrapling/iii.worker.yaml
@@ -1,8 +1,9 @@
 # CI (.github/scripts/validate_worker.py) requires name/language/deploy/manifest
 # and reads the release version from `manifest`. `deploy: bundle` ships a source
 # tarball built by .github/workflows/_bundle.yml. The engine's bundle validator
-# rejects scripts.install/setup and runtime.base_image and executes only
-# scripts.start, so dependency bootstrap lives in scripts.start.
+# rejects scripts.setup and non-preset runtime.base_image; scripts.install runs
+# once inside the sandbox (guarded by the /var/.iii-prepared marker), then
+# scripts.start runs every boot.
 iii: v1
 name: scrapling
 language: python
@@ -28,8 +29,7 @@ resources:
   cpus: 2
 
 scripts:
-  # First boot installs deps + browsers (`scrapling install` downloads the
-  # Camoufox/Chromium used by stealthy-fetch / dynamic-fetch / screenshot);
-  # later boots are fast because pip and the browser cache persist in the
-  # sandbox.
-  start: "pip install -e . && scrapling install && python -m src.main"
+  # Runs once (first boot): deps + browsers (`scrapling install` downloads the
+  # Camoufox/Chromium used by stealthy-fetch / dynamic-fetch / screenshot).
+  install: "pip install -e . && scrapling install"
+  start: "python -m src.main"


### PR DESCRIPTION
## Why

Follow-up to #433. Folding dependency bootstrap into `scripts.start` broke at runtime: the engine's boot script emitted `exec {run_cmd}`, and `exec` binds to the **first** command of a compound string — so `exec pip install -e . && scrapling install && python -m src.main` replaced the shell with pip, which exited after installing, and the VM silently tore down. The worker crash-looped with logs ending at pip success; `scrapling install` and the worker itself never ran.

## What

The engine now allows `scripts.install` for bundle workers (it executes in the same publisher-shell trust context as `scripts.start`, and the boot script's `/var/.iii-prepared` marker already gives run-once semantics), so this restores the clean split:

- **`scrapling/iii.worker.yaml`** — `install: "pip install -e . && scrapling install"` (runs once, first boot), `start: "python -m src.main"` (single command, every boot)
- **`validate_worker.py`** — stop rejecting `scripts.install` for bundles; `scripts.setup` and non-preset `runtime.base_image` still rejected
- **`_publish-registry.yml`** — bundle smoke-boot runs `scripts.install` synchronously before `scripts.start`, mirroring the engine
- **`_bundle.yml`** — comments updated

## Depends on

Engine changes on iii-hq/iii#1937:
- bundle validator accepts `scripts.install` and preset `runtime.base_image` refs
- boot script execs compound `scripts.start` via quoted `sh -c` (the root-cause fix for the silent teardown)

## Verified

Fresh local install with the patched engine: provision (pip + browser download, fully visible in `iii worker logs`) → worker registered in ~90s → `scrapling::fetch {"url":"https://example.com"}` returned a live response. Subsequent boots skip install via the prepared marker.

After merge: cut scrapling v0.2.2 so the registry bundle carries the split manifest.

Fixes MOT-3889