### PR TITLE
ci: make devin releasable (Create Tag dropdown + release.yml tag trigger) (MOT-3880)

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -13,6 +13,7 @@ on:
           - approval-gate
           - claude-code
           - codex
+          - devin
           - console
           - grok
           - context-manager

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
       - 'approval-gate/v*'
       - 'claude-code/v*'
       - 'codex/v*'
+      - 'devin/v*'
       - 'console/v*'
       - 'grok/v*'
       - 'context-manager/v*'


### PR DESCRIPTION
Linear: [MOT-3880](https://linear.app/motia/issue/MOT-3880/devin-cli-api-as-an-iii-worker-devin) (subtickets MOT-3883/3884/3885/3886)

The `devin` worker is merged to main but two CI workflows still had hardcoded per-worker lists that omit it, so it can't be released:

- `create-tag.yml` — the worker `choice` dropdown; `devin` wasn't selectable in the Create Tag workflow.
- `release.yml` — the `on: push: tags:` trigger lists each `<name>/v*` explicitly; `devin/v*` was missing, so a `devin` tag would be created but never fire the release.

This adds `devin` to both (next to `codex`, with the other agent-CLI workers). Swept the rest of `.github/workflows` + scripts/docs; these two are the only per-worker lists. After merge: Actions -> Create Tag -> `devin` cuts `devin/vX.Y.Z`, and `release.yml` builds + publishes from there.