### PR TITLE
(MOT-3897) feat: default session working directory to the current folder

### DIFF
--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -1,5 +1,5 @@
 import { Copy, Folder } from 'lucide-react'
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { FilesystemAccessDialog } from '@/components/permissions/FilesystemAccessDialog'
 import type { FilesystemAccessAction } from '@/components/permissions/FilesystemAccessPrompt'
 import { FullPermissionsBanner } from '@/components/permissions/FullPermissionsBanner'
@@ -25,6 +25,7 @@ import { expandFileMentions, parseFileMentions } from '@/lib/file-mentions'
 import { formatStopReason } from '@/lib/format-stop-reason'
 import { newMessageId } from '@/lib/session-id'
 import { cn } from '@/lib/utils'
+import { fetchDefaultWorkingDir, validateWorkspaceDir } from '@/lib/working-dir'
 import {
   consoleClaimFor,
   recordConsoleClaim,
@@ -58,6 +59,12 @@ import { ContextUsage } from './ContextUsage'
 import { ExportSessionButton } from './ExportSessionButton'
 import { MessageList } from './MessageList'
 import { WorktreeBadge } from './WorktreeBadge'
+
+/**
+ * Saved dirs already re-validated this page load, keyed sessionId + dir —
+ * one live check per activation, not one per render or per send.
+ */
+const validatedWorkingDirs = new Set<string>()
 
 function isAbortError(err: unknown): boolean {
   return (
@@ -199,6 +206,63 @@ export function ChatView({
   const workingDirEnabled =
     backend.id === 'real' &&
     (conversationsCtx ? conversationsCtx.shellAvailable : false)
+
+  // Default a fresh draft to the stack's current folder (MOT-3897): the
+  // harness-reported launch dir, shell-validated, set only while the chat is
+  // still an untouched draft (prefillWorkingDir re-checks under the patch so
+  // an explicit pick or the first send racing this fetch wins). Visible
+  // immediately in the picker chip — a default, not a silent inheritance.
+  const prefillWorkingDir = conversationsCtx?.prefillWorkingDir
+  useEffect(() => {
+    if (!workingDirEnabled || !prefillWorkingDir) return
+    if (!conversation.draft || conversation.workingDir != null) return
+    let cancelled = false
+    void fetchDefaultWorkingDir().then((dir) => {
+      if (!cancelled && dir) prefillWorkingDir(conversation.id, dir)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [
+    workingDirEnabled,
+    prefillWorkingDir,
+    conversation.draft,
+    conversation.workingDir,
+    conversation.id,
+  ])
+
+  // A saved working dir can be gone by the next visit (deleted, unmounted,
+  // denylisted). Re-validate once per activation against the live shell; on
+  // failure surface the error through the picker (auto-opens) instead of
+  // letting the chat silently operate against a dead folder.
+  const [workingDirError, setWorkingDirError] = useState<string | null>(null)
+  useEffect(() => {
+    if (!workingDirEnabled || conversation.draft) return
+    const dir = conversation.workingDir
+    if (!dir) return
+    const key = `${conversation.id}:${dir}`
+    if (validatedWorkingDirs.has(key)) return
+    let cancelled = false
+    void validateWorkspaceDir(dir).then((res) => {
+      if (cancelled) return
+      if (res.ok) {
+        validatedWorkingDirs.add(key)
+        setWorkingDirError(null)
+      } else {
+        setWorkingDirError(
+          `working directory ${dir} is not usable — ${res.error}. choose another folder.`,
+        )
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [
+    workingDirEnabled,
+    conversation.draft,
+    conversation.workingDir,
+    conversation.id,
+  ])
 
   // The worktrees tab, the working-directory badge, claim/release, and the
   // landed / land-blocked live events all require the optional `worktree`
@@ -772,6 +836,10 @@ export function ChatView({
     (next: string) => {
       const id = conversation.id
       const prev = conversation.workingDir ?? null
+      // Every picker selection is freshly shell-validated; replacing a stale
+      // dir resolves the invalid-folder state.
+      setWorkingDirError(null)
+      validatedWorkingDirs.add(`${id}:${next}`)
       onUpdateWorkingDir(id, next)
       if (!conversation.draft && next !== prev) {
         onAppendMessage(
@@ -944,8 +1012,11 @@ export function ChatView({
                       // dir=rtl keeps the trailing (most-distinguishing) path
                       // segment visible when truncated in the narrow dock.
                       dir="rtl"
-                      className="truncate text-left font-mono"
-                      title={conversation.workingDir}
+                      className={cn(
+                        'truncate text-left font-mono',
+                        workingDirError && 'text-warn',
+                      )}
+                      title={workingDirError ?? conversation.workingDir}
                     >
                       {conversation.workingDir}
                     </span>
@@ -984,6 +1055,7 @@ export function ChatView({
             showWorkingDir={workingDirEnabled}
             workingDir={conversation.workingDir ?? null}
             workingDirLocked={false}
+            workingDirError={workingDirError}
             onWorkingDirChange={handleWorkingDirChange}
             worktreePicker={
               worktreeEnabled

--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -207,6 +207,23 @@ export function ChatView({
     backend.id === 'real' &&
     (conversationsCtx ? conversationsCtx.shellAvailable : false)
 
+  // The stack's default folder, resolved once (cached page-wide): pre-fills
+  // fresh drafts below and feeds the picker's pinned "default" row so the
+  // launch folder stays selectable after a chat re-scopes elsewhere.
+  const [defaultWorkingDir, setDefaultWorkingDir] = useState<string | null>(
+    null,
+  )
+  useEffect(() => {
+    if (!workingDirEnabled) return
+    let cancelled = false
+    void fetchDefaultWorkingDir().then((dir) => {
+      if (!cancelled) setDefaultWorkingDir(dir)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [workingDirEnabled])
+
   // Default a fresh draft to the stack's current folder (MOT-3897): the
   // harness-reported launch dir, shell-validated, set only while the chat is
   // still an untouched draft (prefillWorkingDir re-checks under the patch so
@@ -1056,6 +1073,7 @@ export function ChatView({
             workingDir={conversation.workingDir ?? null}
             workingDirLocked={false}
             workingDirError={workingDirError}
+            defaultWorkingDir={defaultWorkingDir}
             onWorkingDirChange={handleWorkingDirChange}
             worktreePicker={
               worktreeEnabled

--- a/console/web/src/components/chat/Composer.tsx
+++ b/console/web/src/components/chat/Composer.tsx
@@ -53,6 +53,8 @@ interface ComposerProps {
    * picker (e.g. an embedded/read-only surface).
    */
   workingDirLocked?: boolean
+  /** Stale-dir validation failure; auto-opens the picker with the message. */
+  workingDirError?: string | null
   /** Worktrees tab in the picker (real backend + worktree worker only). */
   worktreePicker?: WorktreePickerOptions
   onModeChange: (next: Mode) => void
@@ -86,6 +88,7 @@ export function Composer({
   showWorkingDir,
   workingDir,
   workingDirLocked,
+  workingDirError,
   worktreePicker,
   onModeChange,
   onModelChange,
@@ -170,6 +173,7 @@ export function Composer({
             onChange={onWorkingDirChange}
             locked={workingDirLocked}
             disabled={inputDisabled}
+            externalError={workingDirError}
             worktrees={worktreePicker}
           />
         ) : null}

--- a/console/web/src/components/chat/Composer.tsx
+++ b/console/web/src/components/chat/Composer.tsx
@@ -55,6 +55,8 @@ interface ComposerProps {
   workingDirLocked?: boolean
   /** Stale-dir validation failure; auto-opens the picker with the message. */
   workingDirError?: string | null
+  /** Stack default folder — pinned "default" row in the picker. */
+  defaultWorkingDir?: string | null
   /** Worktrees tab in the picker (real backend + worktree worker only). */
   worktreePicker?: WorktreePickerOptions
   onModeChange: (next: Mode) => void
@@ -89,6 +91,7 @@ export function Composer({
   workingDir,
   workingDirLocked,
   workingDirError,
+  defaultWorkingDir,
   worktreePicker,
   onModeChange,
   onModelChange,
@@ -174,6 +177,7 @@ export function Composer({
             locked={workingDirLocked}
             disabled={inputDisabled}
             externalError={workingDirError}
+            defaultDir={defaultWorkingDir}
             worktrees={worktreePicker}
           />
         ) : null}

--- a/console/web/src/components/chat/DirectoryPicker.tsx
+++ b/console/web/src/components/chat/DirectoryPicker.tsx
@@ -67,6 +67,13 @@ interface DirectoryPickerProps {
    * the message shown so the user can pick a replacement.
    */
   externalError?: string | null
+  /**
+   * The stack's default working directory (harness launch folder). Pinned
+   * at the top of the projects view with a "default" tag: unlike recents it
+   * is never forgettable and survives re-scoping away, so the launch folder
+   * stays one click away. Deduped against the recents list.
+   */
+  defaultDir?: string | null
   /** Show the worktrees tab next to directory browsing. */
   worktrees?: WorktreePickerOptions
   className?: string
@@ -118,6 +125,7 @@ export function DirectoryPicker({
   locked,
   disabled,
   externalError,
+  defaultDir,
   worktrees,
   className,
 }: DirectoryPickerProps) {
@@ -358,10 +366,15 @@ export function DirectoryPicker({
   )
 
   const q = query.trim().toLowerCase()
+  // The pinned default row replaces any identical recents row (a user who
+  // explicitly picked the default lands it in recents too — show it once).
   const filteredProjects = useMemo(
-    () => projects.filter((p) => p.toLowerCase().includes(q)),
-    [projects, q],
+    () =>
+      projects.filter((p) => p !== defaultDir && p.toLowerCase().includes(q)),
+    [projects, q, defaultDir],
   )
+  const showDefaultRow =
+    !!defaultDir && (q === '' || defaultDir.toLowerCase().includes(q))
   const filteredDirs = useMemo(
     () =>
       q
@@ -627,6 +640,33 @@ export function DirectoryPicker({
                 </button>
               ) : null}
 
+              {showDefaultRow && defaultDir ? (
+                <button
+                  type="button"
+                  disabled={validating !== null}
+                  onClick={() => void validateAndSelect(defaultDir)}
+                  className="flex w-full items-center gap-2 px-3 py-1.5 pr-1.5 text-left hover:bg-panel disabled:opacity-50"
+                  title={`${defaultDir} — the folder the stack was started from`}
+                >
+                  <Folder
+                    size={13}
+                    className="shrink-0 text-ink-faint"
+                    aria-hidden
+                  />
+                  <span className="flex min-w-0 flex-1 flex-col">
+                    <span className="truncate text-[12px] text-ink">
+                      {basename(defaultDir)}
+                    </span>
+                    <span className="truncate font-mono text-[10px] text-ink-ghost">
+                      {parentDisplay(defaultDir)}
+                    </span>
+                  </span>
+                  <span className="shrink-0 rounded-sm border border-rule px-1 py-px text-[9px] lowercase text-ink-ghost">
+                    default
+                  </span>
+                </button>
+              ) : null}
+
               {filteredProjects.map((p) => (
                 <div
                   key={p}
@@ -665,7 +705,9 @@ export function DirectoryPicker({
                 </div>
               ))}
 
-              {filteredProjects.length === 0 && !isAbsPath(query) ? (
+              {filteredProjects.length === 0 &&
+              !showDefaultRow &&
+              !isAbsPath(query) ? (
                 <div className="px-3 py-3 text-[11px] leading-relaxed text-ink-faint">
                   {projects.length === 0
                     ? 'no recent projects yet.'

--- a/console/web/src/components/chat/DirectoryPicker.tsx
+++ b/console/web/src/components/chat/DirectoryPicker.tsx
@@ -17,6 +17,13 @@ import { getIiiClient } from '@/lib/iii-client'
 import { loadRecentProjects, removeRecentProject } from '@/lib/storage'
 import { cn } from '@/lib/utils'
 import {
+  errMsg,
+  validateWorkspaceDir,
+  WORKSPACE_LIST_FUNCTION_ID,
+  WORKSPACE_ROOTS_FUNCTION_ID,
+  WORKSPACE_VALIDATE_FUNCTION_ID,
+} from '@/lib/working-dir'
+import {
   lifecycleTone,
   lifecycleToneClass,
   listWorktrees,
@@ -54,6 +61,12 @@ interface DirectoryPickerProps {
   onChange: (dir: string) => void
   locked?: boolean
   disabled?: boolean
+  /**
+   * Externally-detected problem with the current value (e.g. the saved dir
+   * no longer validates against the live shell). Auto-opens the panel with
+   * the message shown so the user can pick a replacement.
+   */
+  externalError?: string | null
   /** Show the worktrees tab next to directory browsing. */
   worktrees?: WorktreePickerOptions
   className?: string
@@ -74,10 +87,6 @@ interface WorkspaceListResult {
   entries?: DirEntry[]
 }
 
-interface WorkspaceValidateResult {
-  path: string
-}
-
 function basename(p: string): string {
   const parts = p.split('/').filter(Boolean)
   return parts.length ? parts[parts.length - 1] : p
@@ -96,27 +105,11 @@ function parentOf(p: string): string {
 
 const isAbsPath = (s: string) => s.trim().startsWith('/')
 
-export const WORKSPACE_ROOTS_FUNCTION_ID = 'shell::workspace::roots'
-export const WORKSPACE_LIST_FUNCTION_ID = 'shell::workspace::list'
-export const WORKSPACE_VALIDATE_FUNCTION_ID = 'shell::workspace::validate'
-
-/**
- * iii triggers reject with a plain object `{ code, message }`, not an Error, and
- * the message is often a nested `handler error: {"code":"C211","message":"…"}`.
- * Pull out the human-readable inner message.
- */
-function errMsg(err: unknown): string {
-  const raw =
-    err instanceof Error
-      ? err.message
-      : err && typeof err === 'object' && 'message' in err
-        ? String((err as { message: unknown }).message)
-        : String(err)
-  // Errors nest: `handler error: {"code":"C211","message":"…"}`. Prefer the
-  // innermost (last) message and tolerate escaped quotes inside it.
-  const matches = [...raw.matchAll(/"message"\s*:\s*"((?:[^"\\]|\\.)*)"/g)]
-  if (matches.length === 0) return raw
-  return matches[matches.length - 1][1].replace(/\\(.)/g, '$1')
+// Re-exported for existing consumers/tests; canonical home is lib/working-dir.
+export {
+  WORKSPACE_LIST_FUNCTION_ID,
+  WORKSPACE_ROOTS_FUNCTION_ID,
+  WORKSPACE_VALIDATE_FUNCTION_ID,
 }
 
 export function DirectoryPicker({
@@ -124,6 +117,7 @@ export function DirectoryPicker({
   onChange,
   locked,
   disabled,
+  externalError,
   worktrees,
   className,
 }: DirectoryPickerProps) {
@@ -171,6 +165,18 @@ export function DirectoryPicker({
     setError(null)
     setOpen(true)
   }, [])
+
+  // A stale saved dir (deleted, unmounted, denylisted) surfaces here: open
+  // the panel with the failure shown so the user picks a replacement instead
+  // of silently chatting against a dead folder.
+  useEffect(() => {
+    if (!externalError || locked || disabled) return
+    setProjects(loadRecentProjects())
+    setView('projects')
+    setQuery('')
+    setError(externalError)
+    setOpen(true)
+  }, [externalError, locked, disabled])
 
   const ensureRoots = useCallback(async (): Promise<string[]> => {
     if (roots !== null) return roots
@@ -310,20 +316,12 @@ export function DirectoryPicker({
       const dir = raw.trim().replace(/\/+$/, '') || '/'
       setError(null)
       setValidating(dir)
-      try {
-        const client = await getIiiClient()
-        const res = await client.trigger<WorkspaceValidateResult>(
-          WORKSPACE_VALIDATE_FUNCTION_ID,
-          { path: dir },
-        )
-        // Select the canonical resolved dir the worker echoes back, not raw
-        // input, so stored recent projects are stable across symlinks.
-        select(res?.path ?? dir)
-      } catch (err) {
-        setError(`can't use ${dir} — ${errMsg(err)}`)
-      } finally {
-        setValidating(null)
-      }
+      // Select the canonical resolved dir the worker echoes back, not raw
+      // input, so stored recent projects are stable across symlinks.
+      const res = await validateWorkspaceDir(dir)
+      if (res.ok) select(res.path)
+      else setError(`can't use ${dir} — ${res.error}`)
+      setValidating(null)
     },
     [select],
   )
@@ -424,7 +422,7 @@ export function DirectoryPicker({
         onClick={() => (open ? setOpen(false) : openPanel())}
         className={cn(
           'inline-flex items-center gap-1 rounded-sm border border-rule px-2 py-1 text-[11px] lowercase transition-colors',
-          value ? 'text-ink' : 'text-ink-faint',
+          externalError ? 'text-warn' : value ? 'text-ink' : 'text-ink-faint',
           'hover:text-ink disabled:opacity-50',
         )}
       >

--- a/console/web/src/hooks/use-conversations.ts
+++ b/console/web/src/hooks/use-conversations.ts
@@ -90,10 +90,11 @@ function emptyConversation(defaultModel: ModelId | null): Conversation {
     title: 'new chat',
     model: defaultModel,
     mode: DEFAULT_MODE,
-    // No silent pre-fill: a new chat starts with NO working dir so the user
-    // makes an explicit, visible choice (the picker opens to recent projects).
-    // Silently inheriting the last-used dir is exactly what made a chat operate
-    // in the wrong directory without the user choosing it.
+    // Drafts start with no working dir; ChatView pre-fills the stack's
+    // default folder (harness::filesystem::info, validated against the live
+    // shell) once known — always visible in the picker chip. What stays
+    // forbidden is silently inheriting the LAST-USED dir: that is what once
+    // made a chat operate in the wrong directory without the user choosing it.
     workingDir: null,
     messages: [],
     status: 'idle',
@@ -215,6 +216,13 @@ export interface ConversationsApi {
   setMode: (id: string, mode: Mode) => void
   /** Per-session working directory; only meaningful while the chat is a draft. */
   setWorkingDir: (id: string, dir: string) => void
+  /**
+   * Seed a draft's working dir with the stack default: patches state only
+   * while the chat is still a draft with no dir (an explicit pick or a
+   * materialised session wins), and deliberately skips the recent-projects
+   * list and the re-scope transcript notice — it is a default, not a choice.
+   */
+  prefillWorkingDir: (id: string, dir: string) => void
   appendMessage: (id: string, message: Message) => void
   updateMessage: (id: string, messageId: string, patch: MessagePatch) => void
   compactConversation: (id: string, marker: Message) => void
@@ -636,6 +644,15 @@ export function useConversations(
     [patchConversation, conversations, writeMeta],
   )
 
+  const prefillWorkingDir = useCallback(
+    (id: string, dir: string) => {
+      patchConversation(id, (c) =>
+        c.draft && c.workingDir == null ? { ...c, workingDir: dir } : c,
+      )
+    },
+    [patchConversation],
+  )
+
   const appendMessage = useCallback(
     (id: string, message: Message) =>
       patchConversation(id, (c) => appendMessageToConversation(c, message)),
@@ -708,6 +725,7 @@ export function useConversations(
     setModel,
     setMode,
     setWorkingDir,
+    prefillWorkingDir,
     appendMessage,
     updateMessage,
     compactConversation,

--- a/console/web/src/lib/working-dir.test.ts
+++ b/console/web/src/lib/working-dir.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  errMsg,
+  fetchDefaultWorkingDir,
+  HARNESS_FILESYSTEM_INFO_FUNCTION_ID,
+  resetDefaultWorkingDirForTests,
+  validateWorkspaceDir,
+  WORKSPACE_VALIDATE_FUNCTION_ID,
+} from './working-dir'
+
+const triggerMock = vi.fn()
+
+vi.mock('@/lib/iii-client', () => ({
+  getIiiClient: async () => ({ trigger: triggerMock }),
+}))
+
+beforeEach(() => {
+  triggerMock.mockReset()
+  resetDefaultWorkingDirForTests()
+})
+
+describe('errMsg', () => {
+  it('unwraps the innermost nested handler message', () => {
+    const raw =
+      'handler error: {"code":"C211","message":"not found or denied: /gone"}'
+    expect(errMsg(new Error(raw))).toBe('not found or denied: /gone')
+  })
+
+  it('falls back to the raw message when nothing nests', () => {
+    expect(errMsg(new Error('plain failure'))).toBe('plain failure')
+  })
+})
+
+describe('validateWorkspaceDir', () => {
+  it('returns the worker-echoed canonical path', async () => {
+    triggerMock.mockResolvedValueOnce({ path: '/real/project' })
+    const res = await validateWorkspaceDir('/link/project')
+    expect(res).toEqual({ ok: true, path: '/real/project' })
+    expect(triggerMock).toHaveBeenCalledWith(WORKSPACE_VALIDATE_FUNCTION_ID, {
+      path: '/link/project',
+    })
+  })
+
+  it('maps a rejection to ok:false with the unwrapped message', async () => {
+    triggerMock.mockRejectedValueOnce({
+      message: 'handler error: {"code":"S212","message":"not a directory"}',
+    })
+    const res = await validateWorkspaceDir('/gone')
+    expect(res).toEqual({ ok: false, error: 'not a directory' })
+  })
+})
+
+describe('fetchDefaultWorkingDir', () => {
+  it('resolves the harness default and stores the shell-canonical path', async () => {
+    triggerMock
+      .mockResolvedValueOnce({ default_root: '/work/stack' })
+      .mockResolvedValueOnce({ path: '/work/stack-canonical' })
+    await expect(fetchDefaultWorkingDir()).resolves.toBe(
+      '/work/stack-canonical',
+    )
+    expect(triggerMock).toHaveBeenNthCalledWith(
+      1,
+      HARNESS_FILESYSTEM_INFO_FUNCTION_ID,
+      {},
+    )
+    expect(triggerMock).toHaveBeenNthCalledWith(
+      2,
+      WORKSPACE_VALIDATE_FUNCTION_ID,
+      { path: '/work/stack' },
+    )
+  })
+
+  it('caches the resolution for the page lifetime', async () => {
+    triggerMock
+      .mockResolvedValueOnce({ default_root: '/work/stack' })
+      .mockResolvedValueOnce({ path: '/work/stack' })
+    await fetchDefaultWorkingDir()
+    await fetchDefaultWorkingDir()
+    expect(triggerMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('is null when the harness reports no default (defaulting off)', async () => {
+    triggerMock.mockResolvedValueOnce({ default_root: null })
+    await expect(fetchDefaultWorkingDir()).resolves.toBeNull()
+    expect(triggerMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('is null when the shell rejects the harness default', async () => {
+    triggerMock
+      .mockResolvedValueOnce({ default_root: '/vm/only/path' })
+      .mockRejectedValueOnce({
+        message: 'handler error: {"code":"S212","message":"not a directory"}',
+      })
+    await expect(fetchDefaultWorkingDir()).resolves.toBeNull()
+  })
+
+  it('is null when the harness function is missing (older harness)', async () => {
+    triggerMock.mockRejectedValueOnce({ message: 'function not found' })
+    await expect(fetchDefaultWorkingDir()).resolves.toBeNull()
+  })
+})

--- a/console/web/src/lib/working-dir.ts
+++ b/console/web/src/lib/working-dir.ts
@@ -1,0 +1,103 @@
+/**
+ * Session working-directory plumbing shared by the picker and ChatView:
+ * the shell workspace control-plane function ids, error unwrapping, live
+ * validation, and the stack's default working directory (the folder the
+ * harness was launched from — `harness::filesystem::info` — which new
+ * chats are pre-filled with so files land where the user is working).
+ */
+
+import { getIiiClient } from '@/lib/iii-client'
+
+export const WORKSPACE_ROOTS_FUNCTION_ID = 'shell::workspace::roots'
+export const WORKSPACE_LIST_FUNCTION_ID = 'shell::workspace::list'
+export const WORKSPACE_VALIDATE_FUNCTION_ID = 'shell::workspace::validate'
+export const HARNESS_FILESYSTEM_INFO_FUNCTION_ID = 'harness::filesystem::info'
+
+interface WorkspaceValidateResult {
+  path: string
+}
+
+interface HarnessFilesystemInfoResult {
+  default_root?: string | null
+}
+
+/**
+ * iii triggers reject with a plain object `{ code, message }`, not an Error,
+ * and the message is often a nested `handler error: {"code":"C211","message":"…"}`.
+ * Pull out the human-readable inner message.
+ */
+export function errMsg(err: unknown): string {
+  const raw =
+    err instanceof Error
+      ? err.message
+      : err && typeof err === 'object' && 'message' in err
+        ? String((err as { message: unknown }).message)
+        : String(err)
+  // Errors nest: `handler error: {"code":"C211","message":"…"}`. Prefer the
+  // innermost (last) message and tolerate escaped quotes inside it.
+  const matches = [...raw.matchAll(/"message"\s*:\s*"((?:[^"\\]|\\.)*)"/g)]
+  if (matches.length === 0) return raw
+  return matches[matches.length - 1][1].replace(/\\(.)/g, '$1')
+}
+
+export type WorkspaceValidation =
+  | { ok: true; path: string }
+  | { ok: false; error: string }
+
+/**
+ * Validate a directory against the LIVE shell worker. On success the result
+ * carries the worker-echoed canonical path — always store that, never the
+ * raw input, so paths stay stable across symlinks.
+ */
+export async function validateWorkspaceDir(
+  dir: string,
+): Promise<WorkspaceValidation> {
+  try {
+    const client = await getIiiClient()
+    const res = await client.trigger<WorkspaceValidateResult>(
+      WORKSPACE_VALIDATE_FUNCTION_ID,
+      { path: dir },
+    )
+    return { ok: true, path: res?.path ?? dir }
+  } catch (err) {
+    return { ok: false, error: errMsg(err) }
+  }
+}
+
+let defaultWorkingDirPromise: Promise<string | null> | null = null
+
+/**
+ * The working directory a new chat defaults to: the harness-reported default
+ * root (its launch folder), accepted only when the live shell validates it.
+ * Resolves to `null` when the harness has no default, the folder is invalid
+ * on the shell host, or either worker is unreachable — callers then leave the
+ * chat unscoped exactly as before. Cached for the page's lifetime (the stack's
+ * launch folder doesn't move).
+ */
+export function fetchDefaultWorkingDir(): Promise<string | null> {
+  if (!defaultWorkingDirPromise) {
+    defaultWorkingDirPromise = resolveDefaultWorkingDir()
+  }
+  return defaultWorkingDirPromise
+}
+
+async function resolveDefaultWorkingDir(): Promise<string | null> {
+  try {
+    const client = await getIiiClient()
+    const info = await client.trigger<HarnessFilesystemInfoResult>(
+      HARNESS_FILESYSTEM_INFO_FUNCTION_ID,
+      {},
+    )
+    const root = info?.default_root
+    if (typeof root !== 'string' || root.length === 0) return null
+    const validated = await validateWorkspaceDir(root)
+    return validated.ok ? validated.path : null
+  } catch {
+    return null
+  }
+}
+
+/** Test hook: drop the page-lifetime cache. */
+export function resetDefaultWorkingDirForTests(): void {
+  defaultWorkingDirPromise = null
+}

--- a/harness/src/config.rs
+++ b/harness/src/config.rs
@@ -81,6 +81,17 @@ pub struct WorkerConfig {
     /// deny-all.
     #[serde(default = "default_functions")]
     pub default_functions: Option<FunctionPolicy>,
+
+    /// Working-directory root stamped onto the FIRST turn of a session whose
+    /// send carries no `metadata.fs_scope.root`. Absent/null → the harness
+    /// process's working directory at boot (the local stack launches every
+    /// worker from the user's project folder, so that cwd IS the current
+    /// folder); the literal string `"off"` → never default (sessions stay
+    /// unscoped unless the caller supplies a root); any other value → that
+    /// path. Explicit roots on the send always win, and existing sessions are
+    /// never retroactively scoped.
+    #[serde(default)]
+    pub default_filesystem_root: Option<String>,
 }
 
 impl WorkerConfig {
@@ -134,6 +145,36 @@ impl WorkerConfig {
             sweep_expression: self.sweep_expression.clone(),
         }
     }
+
+    /// The effective default working-directory root for new sessions (see
+    /// [`WorkerConfig::default_filesystem_root`]): the configured path, the
+    /// boot-time process cwd when unset, or `None` when set to `"off"`.
+    pub fn resolved_default_filesystem_root(&self) -> Option<String> {
+        match self.default_filesystem_root.as_deref() {
+            Some("off") => None,
+            Some(path) => Some(path.to_string()),
+            None => boot_cwd().map(str::to_string),
+        }
+    }
+}
+
+/// The process working directory captured once at first use (workers never
+/// chdir), canonicalized so it matches the paths the shell worker echoes.
+fn boot_cwd() -> Option<&'static str> {
+    static BOOT_CWD: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+    BOOT_CWD
+        .get_or_init(|| {
+            let cwd = match std::env::current_dir() {
+                Ok(cwd) => cwd,
+                Err(e) => {
+                    tracing::warn!(error = %e, "cannot read process cwd; no default filesystem root");
+                    return None;
+                }
+            };
+            let canon = std::fs::canonicalize(&cwd).unwrap_or(cwd);
+            Some(canon.to_string_lossy().into_owned())
+        })
+        .as_deref()
 }
 
 /// Signature of the structurally-bound config (see
@@ -264,6 +305,7 @@ impl Default for WorkerConfig {
             stream_coalesce_ms: default_stream_coalesce_ms(),
             sweep_expression: default_sweep_expression(),
             default_functions: default_functions(),
+            default_filesystem_root: None,
         }
     }
 }

--- a/harness/src/functions/filesystem.rs
+++ b/harness/src/functions/filesystem.rs
@@ -30,6 +30,29 @@ pub struct FilesystemGrantsResponse {
     pub roots: Vec<String>,
 }
 
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct FilesystemInfoRequest {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct FilesystemInfoResponse {
+    /// Working-directory root stamped onto the first turn of a session whose
+    /// send carries no explicit `fs_scope.root`; `null` when defaulting is
+    /// disabled (`default_filesystem_root: "off"`) or the cwd is unreadable.
+    pub default_root: Option<String>,
+}
+
+/// The resolved default working directory — the value a console pre-fills the
+/// picker with so the folder a new chat will be scoped to is visible up front.
+pub async fn info(
+    deps: &Deps,
+    _req: FilesystemInfoRequest,
+) -> Result<FilesystemInfoResponse, HarnessError> {
+    let cfg = deps.cfg().await;
+    Ok(FilesystemInfoResponse {
+        default_root: cfg.resolved_default_filesystem_root(),
+    })
+}
+
 pub async fn grant(
     deps: &Deps,
     req: FilesystemGrantRequest,

--- a/harness/src/functions/mod.rs
+++ b/harness/src/functions/mod.rs
@@ -73,6 +73,10 @@ pub const FILESYSTEM_REVOKE_ID: &str = "harness::filesystem::revoke";
 pub const FILESYSTEM_REVOKE_DESC: &str =
     "Internal control-plane: revoke a session's access to an additional filesystem root.";
 
+pub const FILESYSTEM_INFO_ID: &str = "harness::filesystem::info";
+pub const FILESYSTEM_INFO_DESC: &str =
+    "Internal control-plane: the default working-directory root new sessions are scoped to.";
+
 /// Register one typed handler under `id`, mapping `HarnessError` into the bus
 /// error shape (`code: message`).
 fn register<Req, Resp, F, Fut>(
@@ -179,6 +183,13 @@ pub fn register_all(iii: &Arc<IIIClient>, deps: &Arc<Deps>) {
         FILESYSTEM_REVOKE_ID,
         FILESYSTEM_REVOKE_DESC,
         |d, r| async move { filesystem::revoke(&d, r).await },
+    );
+    register(
+        iii,
+        deps,
+        FILESYSTEM_INFO_ID,
+        FILESYSTEM_INFO_DESC,
+        |d, r| async move { filesystem::info(&d, r).await },
     );
 
     // Internal cron target — registered, but kept off the public catalog.

--- a/harness/src/functions/send.rs
+++ b/harness/src/functions/send.rs
@@ -278,18 +278,41 @@ fn build_options(cfg: &WorkerConfig, req: &SendRequest, identity: Option<&str>) 
     }
 }
 
+/// Default a BRAND-NEW session's working directory (MOT-3897): when the very
+/// first turn arrives without `metadata.fs_scope.root`, scope it to the
+/// configured default (the stack's launch folder). Existing sessions are never
+/// retroactively scoped — their unscoped turns stay unscoped — and an explicit
+/// root on the send always wins.
+fn apply_default_filesystem_root(
+    options: &mut TurnOptions,
+    is_new_session: bool,
+    default_root: Option<&str>,
+) {
+    if !is_new_session || options.filesystem_root().is_some() {
+        return;
+    }
+    if let Some(root) = default_root {
+        options.set_filesystem_root(root);
+    }
+}
+
 /// The turn CAS + merge double-check (harness.md § Concurrency & steering).
 async fn seed_or_merge(
     deps: &Deps,
     cfg: &WorkerConfig,
     session_id: &str,
-    options: TurnOptions,
+    mut options: TurnOptions,
     message_preview: Option<String>,
 ) -> Result<StartOutcome, HarnessError> {
     let existing = crate::state::get_turn(&deps.iii, session_id, cfg.session_timeout_ms).await?;
     // Carry the session's last-acknowledged registry generation onto a new turn
     // so run_step can notice a registry change that landed between turns.
     let prior_generation = existing.as_ref().and_then(|r| r.functions_generation);
+    apply_default_filesystem_root(
+        &mut options,
+        existing.is_none(),
+        cfg.resolved_default_filesystem_root().as_deref(),
+    );
     match existing {
         Some(rec) if !rec.status.is_terminal() => {
             // Merge path: the message is already appended; the running loop's
@@ -500,5 +523,87 @@ mod tests {
         let prompt = opts.system_prompt.expect("enriched prompt");
         assert!(prompt.starts_with("You are an iii agent worker. VOICE."));
         assert!(prompt.ends_with("Speak only in haiku."));
+    }
+
+    fn bare_options() -> TurnOptions {
+        build_options(
+            &WorkerConfig::default(),
+            &SendRequest {
+                session_id: None,
+                message: MessageInput::Text("hi".into()),
+                model: "m".into(),
+                provider: None,
+                idempotency_key: None,
+                session: None,
+                options: None,
+            },
+            None,
+        )
+    }
+
+    #[test]
+    fn default_root_applies_only_to_new_sessions() {
+        let mut opts = bare_options();
+        apply_default_filesystem_root(&mut opts, true, Some("/work/project"));
+        assert_eq!(opts.filesystem_root(), Some("/work/project"));
+
+        // An existing session's scope-less turn stays unscoped.
+        let mut opts = bare_options();
+        apply_default_filesystem_root(&mut opts, false, Some("/work/project"));
+        assert_eq!(opts.filesystem_root(), None);
+    }
+
+    #[test]
+    fn explicit_root_wins_over_default() {
+        let mut opts = bare_options();
+        opts.metadata = Some(serde_json::json!({ "fs_scope": { "root": "/picked" } }));
+        apply_default_filesystem_root(&mut opts, true, Some("/work/project"));
+        assert_eq!(opts.filesystem_root(), Some("/picked"));
+    }
+
+    #[test]
+    fn default_root_merges_into_existing_metadata() {
+        let mut opts = bare_options();
+        opts.metadata = Some(serde_json::json!({ "session_id": "s_1" }));
+        apply_default_filesystem_root(&mut opts, true, Some("/work/project"));
+        assert_eq!(opts.filesystem_root(), Some("/work/project"));
+        assert_eq!(
+            opts.metadata.as_ref().unwrap().get("session_id"),
+            Some(&serde_json::json!("s_1"))
+        );
+    }
+
+    #[test]
+    fn no_default_leaves_options_untouched() {
+        let mut opts = bare_options();
+        apply_default_filesystem_root(&mut opts, true, None);
+        assert_eq!(opts.filesystem_root(), None);
+        assert!(opts.metadata.is_none());
+    }
+
+    #[test]
+    fn resolved_default_filesystem_root_states() {
+        // Absent → the boot cwd (the local stack's launch folder).
+        let cfg = WorkerConfig::default();
+        let cwd = std::fs::canonicalize(std::env::current_dir().unwrap()).unwrap();
+        assert_eq!(
+            cfg.resolved_default_filesystem_root(),
+            Some(cwd.to_string_lossy().into_owned())
+        );
+        // "off" → disabled.
+        let cfg = WorkerConfig {
+            default_filesystem_root: Some("off".into()),
+            ..Default::default()
+        };
+        assert_eq!(cfg.resolved_default_filesystem_root(), None);
+        // Explicit path → that path.
+        let cfg = WorkerConfig {
+            default_filesystem_root: Some("/srv/projects".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            cfg.resolved_default_filesystem_root(),
+            Some("/srv/projects".to_string())
+        );
     }
 }

--- a/harness/src/types/turn.rs
+++ b/harness/src/types/turn.rs
@@ -113,7 +113,12 @@ impl TurnOptions {
         if self.filesystem_root() == Some(root) {
             return false;
         }
+        self.set_filesystem_root(root);
+        true
+    }
 
+    /// Set `metadata.fs_scope.root`, preserving every other metadata key.
+    pub fn set_filesystem_root(&mut self, root: &str) {
         let metadata = self
             .metadata
             .get_or_insert_with(|| Value::Object(Default::default()));
@@ -128,7 +133,6 @@ impl TurnOptions {
             );
             map.insert(FS_SCOPE_KEY.to_string(), Value::Object(fs_scope));
         }
-        true
     }
 }
 


### PR DESCRIPTION
New console sessions now start scoped to the folder the stack was launched from instead of unscoped, so reads, writes, shell commands, and file mentions begin where the user is working.

## Harness
- New `default_filesystem_root` config field: absent → the harness process cwd at boot (canonicalized); `"off"` → never default; any other value → that path.
- `harness::send` stamps the resolved default onto the **first turn of a brand-new session** when the send carries no `metadata.fs_scope.root`. Explicit roots always win; existing scope-less sessions are never retroactively scoped. Everything downstream (per-call `fs_scope` stamping, subagent inheritance, woken turns) already consumed the root and needed no changes.
- New internal control-plane function `harness::filesystem::info` → `{ default_root }`.

## Console
- New chats pre-fill the working-directory chip with the harness default after validating it against the live shell (`shell::workspace::validate`), so the folder a chat will operate in is visible before the first message. The pre-fill skips the recent-projects list and drops no transcript notice — it is a default, not a user choice; picking a different folder works exactly as before.
- Saved working directories are re-validated once per activation: a folder that is gone/denylisted now tints the chip and path banner, and auto-opens the picker with the validation error instead of silently chatting against a dead directory.
- Shared `lib/working-dir.ts` now hosts the workspace function ids, error unwrapping, validation, and the cached default lookup (picker re-exports the ids for existing consumers).

## Tests
- Harness: default applies only to new sessions, explicit root wins, metadata merged not clobbered, `"off"`/path/absent resolution (179 lib tests pass).
- Console: default fetch/validation/caching incl. older-harness fallback (953 vitest, tsc clean).

Fixes MOT-3897

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat now fetches a suggested working directory and pre-fills only for untouched drafts; default suggestions are pinned in the picker.
  * New sessions can be automatically scoped to a default filesystem root when configured.
* **Bug Fixes**
  * Stale/invalid saved working directories now warn in the chat UI and surface an error-driven picker state for replacement.
  * Working-directory selections validate against the live system and normalize to the resolved path.
* **Tests**
  * Added unit tests for working-directory utilities and default-root behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->