### PR TITLE
fix(queue): typed function schemas for the registry publish gate

### DIFF
--- a/queue/src/functions.rs
+++ b/queue/src/functions.rs
@@ -54,6 +54,25 @@ pub struct RedriveSingleResult {
     pub redriven: u64,
 }
 
+/// Acknowledgement type for `iii::durable::publish`. The function always
+/// returns `null` on the wire (engine parity — the builtin returns
+/// `Success(None)`); this type exists so the registered response schema is
+/// typed instead of `AnyValue`, which the registry publish gate rejects.
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct PublishAck {}
+
+/// Input for `engine::queue::list_topics`. The function takes no
+/// parameters; any provided fields are ignored (engine parity). The empty
+/// struct keeps the registered request schema typed for the registry
+/// publish gate.
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct ListTopicsInput {}
+
+/// Input for `engine::queue::dlq_topics` — same story as
+/// [`ListTopicsInput`].
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct DlqTopicsInput {}
+
 #[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
 pub struct TopicInfo {
     pub name: String,
@@ -150,7 +169,7 @@ pub fn register_all(iii: &Arc<IIIClient>, adapter: Arc<SwappableAdapter>) {
     let list_adapter = adapter.clone();
     iii.register_function(
         LIST_TOPICS_FN_ID,
-        RegisterFunction::new_async(move |_input: Value| {
+        RegisterFunction::new_async(move |_input: ListTopicsInput| {
             let adapter = list_adapter.clone();
             async move { list_topics(adapter).await }
         })
@@ -170,7 +189,7 @@ pub fn register_all(iii: &Arc<IIIClient>, adapter: Arc<SwappableAdapter>) {
     let dlq_topics_adapter = adapter.clone();
     iii.register_function(
         DLQ_TOPICS_FN_ID,
-        RegisterFunction::new_async(move |_input: Value| {
+        RegisterFunction::new_async(move |_input: DlqTopicsInput| {
             let adapter = dlq_topics_adapter.clone();
             async move { dlq_topics(adapter).await }
         })
@@ -191,11 +210,14 @@ pub fn register_all(iii: &Arc<IIIClient>, adapter: Arc<SwappableAdapter>) {
 pub async fn publish(
     adapter: Arc<SwappableAdapter>,
     input: PublishInput,
-) -> Result<Option<Value>, Error> {
+) -> Result<Option<PublishAck>, Error> {
     if input.topic.is_empty() {
         return Err(Error::Handler("Topic is not set".to_string()));
     }
     adapter.enqueue(&input.topic, input.data, None, None).await;
+    // Always `None` → `null` on the wire, matching the engine builtin's
+    // `Success(None)`. The `PublishAck` type only exists to keep the
+    // registered response schema typed.
     Ok(None)
 }
 

--- a/queue/tests/e2e_durability.rs
+++ b/queue/tests/e2e_durability.rs
@@ -58,14 +58,27 @@ fn register_counting_function(
 }
 
 fn register_subscriber(iii: &Arc<IIIClient>, function_id: &str, queue: &str) {
+    register_subscriber_with_config(iii, function_id, queue, None);
+}
+
+fn register_subscriber_with_config(
+    iii: &Arc<IIIClient>,
+    function_id: &str,
+    queue: &str,
+    queue_config: Option<Value>,
+) {
+    let mut config = json!({
+        "queue": queue,
+        "max_retries": 1,
+        "backoff_ms": 5
+    });
+    if let Some(qc) = queue_config {
+        config["queue_config"] = qc;
+    }
     iii.register_trigger(RegisterTriggerInput {
         trigger_type: TRIGGER_TYPE.to_string(),
         function_id: function_id.to_string(),
-        config: json!({
-            "queue": queue,
-            "max_retries": 1,
-            "backoff_ms": 5
-        }),
+        config,
         metadata: None,
     })
     .expect("register durable subscriber trigger");
@@ -178,13 +191,29 @@ async fn file_based_pending_message_survives_worker_restart_connect_or_skip() {
         .await
         .expect("queue worker should boot");
 
+    // Engine-parity restart scenario: the message must be enqueued onto a
+    // SUBSCRIBED topic (fan-out routes it to the subscriber's internal
+    // queue, which is what the file store persists). A publish with no
+    // subscriber buffers on the bare topic and is never drained by a later
+    // subscribe — same as the engine builtin. `concurrency: 0` pauses
+    // consumption (engine semantics) so the message is still pending when
+    // the worker shuts down.
     let queue_name = format!("e2e-restart-{}", Uuid::new_v4());
+    let function_id = format!("queue.restart.{queue_name}");
+    register_subscriber_with_config(
+        &iii,
+        &function_id,
+        &queue_name,
+        Some(json!({"concurrency": 0})),
+    );
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
     trigger(
         &iii,
         PUBLISH_FN_ID,
         json!({"queue": queue_name, "data": {"survives": true}}),
     )
     .await;
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
     boot.shutdown().await;
     iii.shutdown_async().await;
 
@@ -197,7 +226,8 @@ async fn file_based_pending_message_survives_worker_restart_connect_or_skip() {
 
     let fires = Arc::new(AtomicUsize::new(0));
     let fail = Arc::new(AtomicBool::new(false));
-    let function_id = format!("queue.restart.{}", Uuid::new_v4());
+    // Same function id as before the restart: the persisted job lives in
+    // the internal queue `{topic}::{function_id}`.
     register_counting_function(&iii, &function_id, fires.clone(), fail);
     register_subscriber(&iii, &function_id, &queue_name);
     wait_for_fires(&fires, 1).await;


### PR DESCRIPTION
## Summary
Fixes the failed `queue/v0.1.1` release (run 28902424332): the registry publish gate rejected the worker interface with

```
untyped (AnyValue/empty) schemas in worker-interface.json:
engine::queue::dlq_topics.request_schema, engine::queue::list_topics.request_schema,
iii::durable::publish.response_schema
```

- `ListTopicsInput` / `DlqTopicsInput`: empty typed input structs for the two parameterless functions. Wire-compatible: callers keep sending `{}` (or any object — unknown fields are ignored, engine parity with the builtin's `_input: Value`).
- `PublishAck`: typed nullable response schema for `iii::durable::publish`. The function still returns `None` → `null` on the wire, matching the engine builtin's `Success(None)`.
- Also fixes the restart-survival e2e to match engine fan-out semantics (publish onto a subscribed topic with `concurrency: 0` pausing delivery), which only ever passed via connect-or-skip before — with a live engine it exposed that a subscriber-less publish buffers on the bare topic forever, same as the engine.

## Validation
- Reproduced the CI gate locally: booted a clean engine + the worker, ran `collect_worker_interface.py` with baselines, then `--assert-non-empty --assert-typed-schemas` on the collected interface — passes.
- `cd queue && cargo test` (incl. live-engine e2e: delivery/DLQ/redrive + restart survival, re-run 3x), `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`.

## Notes
- After merge, re-run the release: `gh workflow run create-tag.yml -f worker=queue -f bump=patch -f tag=latest` (→ queue/v0.1.2; the v0.1.1 tag/release shipped binaries but never published to the registry).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved function registration and validation for queue-related actions, making inputs and outputs more strictly typed.
  * Added support for configurable subscriber queue settings during durable registration.

* **Bug Fixes**
  * Publishing now returns a clearer success acknowledgment while keeping the same external behavior.
  * Queue topic listing and dead-letter topic listing now handle empty inputs more consistently.
  * Durable message handling across worker restarts is now more reliable in restart scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->