### PR TITLE
(MOT-3905) fix(providers): omit empty assistant turns from Chat Completions wire

### DIFF
--- a/provider-openai/src/wire/messages.rs
+++ b/provider-openai/src/wire/messages.rs
@@ -174,6 +174,18 @@ pub fn to_wire_messages(messages: &[AgentMessage], system_prompt: &str) -> Vec<V
                         _ => None,
                     })
                     .collect();
+                // A content-less, call-less assistant serializes to a bare
+                // {"role":"assistant"} that strict Chat Completions gateways
+                // reject (e.g. Z.AI 400/1214). A dead retry's empty_assistant
+                // placeholder (harness appends it before streaming; a transient
+                // upstream failure can leave it durably empty), a poisoned entry
+                // a prior failed turn left mid-transcript, and a thinking-only
+                // turn (no reasoning replay here) all reduce to this shape. It
+                // carries nothing for the model — omit it, the way
+                // provider-anthropic and provider-openai-codex already do.
+                if text.is_empty() && tool_calls.is_empty() {
+                    continue;
+                }
                 let mut entry = json!({ "role": "assistant" });
                 if !text.is_empty() {
                     entry["content"] = Value::String(text);
@@ -558,5 +570,52 @@ mod tests {
         );
         assert_eq!(wire.len(), 1);
         assert_eq!(wire[0]["role"], "user");
+    }
+
+    #[test]
+    fn empty_assistant_is_omitted_wherever_it_sits() {
+        // A content-less, call-less assistant — a dead retry's empty_assistant
+        // placeholder, a poisoned entry a prior failed turn persisted, or a
+        // thinking-only turn — must never reach the wire as a bare
+        // {"role":"assistant"} row (strict gateways reject it). Dropped
+        // mid-list (poisoned session heals):
+        let wire = to_wire_messages(
+            &[
+                user(vec![ContentBlock::Text {
+                    text: "task".into(),
+                }]),
+                assistant(vec![ContentBlock::Text {
+                    text: "reply".into(),
+                }]),
+                assistant(vec![]),
+                user(vec![ContentBlock::Text {
+                    text: "next".into(),
+                }]),
+            ],
+            "",
+        );
+        let roles: Vec<&str> = wire.iter().map(|r| r["role"].as_str().unwrap()).collect();
+        assert_eq!(roles, ["user", "assistant", "user"], "got: {wire:?}");
+        // Dropped when trailing (the dead-placeholder shape):
+        let wire = to_wire_messages(
+            &[
+                user(vec![ContentBlock::Text {
+                    text: "task".into(),
+                }]),
+                assistant(vec![]),
+            ],
+            "",
+        );
+        assert_eq!(wire.len(), 1);
+        assert_eq!(wire[0]["role"], "user");
+        // A thinking-only assistant reduces to the same empty shape here.
+        let wire = to_wire_messages(
+            &[assistant(vec![ContentBlock::Thinking {
+                text: "hmm".into(),
+                signature: None,
+            }])],
+            "",
+        );
+        assert!(wire.is_empty(), "thinking-only assistant omitted: {wire:?}");
     }
 }

--- a/provider-xai/src/wire/messages.rs
+++ b/provider-xai/src/wire/messages.rs
@@ -174,6 +174,18 @@ pub fn to_wire_messages(messages: &[AgentMessage], system_prompt: &str) -> Vec<V
                         _ => None,
                     })
                     .collect();
+                // A content-less, call-less assistant serializes to a bare
+                // {"role":"assistant"} that strict Chat Completions gateways
+                // reject (e.g. Z.AI 400/1214). A dead retry's empty_assistant
+                // placeholder (harness appends it before streaming; a transient
+                // upstream failure can leave it durably empty), a poisoned entry
+                // a prior failed turn left mid-transcript, and a thinking-only
+                // turn (no reasoning replay here) all reduce to this shape. It
+                // carries nothing for the model — omit it, the way
+                // provider-anthropic and provider-openai-codex already do.
+                if text.is_empty() && tool_calls.is_empty() {
+                    continue;
+                }
                 let mut entry = json!({ "role": "assistant" });
                 if !text.is_empty() {
                     entry["content"] = Value::String(text);
@@ -546,5 +558,52 @@ mod tests {
         );
         assert_eq!(wire.len(), 1);
         assert_eq!(wire[0]["role"], "user");
+    }
+
+    #[test]
+    fn empty_assistant_is_omitted_wherever_it_sits() {
+        // A content-less, call-less assistant — a dead retry's empty_assistant
+        // placeholder, a poisoned entry a prior failed turn persisted, or a
+        // thinking-only turn — must never reach the wire as a bare
+        // {"role":"assistant"} row (strict gateways reject it). Dropped
+        // mid-list (poisoned session heals):
+        let wire = to_wire_messages(
+            &[
+                user(vec![ContentBlock::Text {
+                    text: "task".into(),
+                }]),
+                assistant(vec![ContentBlock::Text {
+                    text: "reply".into(),
+                }]),
+                assistant(vec![]),
+                user(vec![ContentBlock::Text {
+                    text: "next".into(),
+                }]),
+            ],
+            "",
+        );
+        let roles: Vec<&str> = wire.iter().map(|r| r["role"].as_str().unwrap()).collect();
+        assert_eq!(roles, ["user", "assistant", "user"], "got: {wire:?}");
+        // Dropped when trailing (the dead-placeholder shape):
+        let wire = to_wire_messages(
+            &[
+                user(vec![ContentBlock::Text {
+                    text: "task".into(),
+                }]),
+                assistant(vec![]),
+            ],
+            "",
+        );
+        assert_eq!(wire.len(), 1);
+        assert_eq!(wire[0]["role"], "user");
+        // A thinking-only assistant reduces to the same empty shape here.
+        let wire = to_wire_messages(
+            &[assistant(vec![ContentBlock::Thinking {
+                text: "hmm".into(),
+                signature: None,
+            }])],
+            "",
+        );
+        assert!(wire.is_empty(), "thinking-only assistant omitted: {wire:?}");
     }
 }

--- a/provider-zai/src/wire/messages.rs
+++ b/provider-zai/src/wire/messages.rs
@@ -174,6 +174,18 @@ pub fn to_wire_messages(messages: &[AgentMessage], system_prompt: &str) -> Vec<V
                         _ => None,
                     })
                     .collect();
+                // A content-less, call-less assistant serializes to a bare
+                // {"role":"assistant"} that Z.AI rejects with 400/1214 "The
+                // messages parameter is illegal." A dead retry's empty_assistant
+                // placeholder (harness appends it before streaming; a transient
+                // upstream failure can leave it durably empty), a poisoned entry
+                // a prior failed turn left mid-transcript, and a thinking-only
+                // turn (no reasoning replay here) all reduce to this shape. It
+                // carries nothing for the model — omit it, the way
+                // provider-anthropic and provider-openai-codex already do.
+                if text.is_empty() && tool_calls.is_empty() {
+                    continue;
+                }
                 let mut entry = json!({ "role": "assistant" });
                 if !text.is_empty() {
                     entry["content"] = Value::String(text);
@@ -546,5 +558,53 @@ mod tests {
         );
         assert_eq!(wire.len(), 1);
         assert_eq!(wire[0]["role"], "user");
+    }
+
+    #[test]
+    fn empty_assistant_is_omitted_wherever_it_sits() {
+        // Live repro (Z.AI 400/1214 "The messages parameter is illegal"): a
+        // content-less, call-less assistant — a dead retry's empty_assistant
+        // placeholder, a poisoned entry a prior failed turn persisted, or a
+        // thinking-only turn — must never reach the wire as a bare
+        // {"role":"assistant"} row. Dropped mid-list (poisoned session heals):
+        let wire = to_wire_messages(
+            &[
+                user(vec![ContentBlock::Text {
+                    text: "task".into(),
+                }]),
+                assistant(vec![ContentBlock::Text {
+                    text: "reply".into(),
+                }]),
+                assistant(vec![]),
+                user(vec![ContentBlock::Text {
+                    text: "next".into(),
+                }]),
+            ],
+            "",
+        );
+        let roles: Vec<&str> = wire.iter().map(|r| r["role"].as_str().unwrap()).collect();
+        assert_eq!(roles, ["user", "assistant", "user"], "got: {wire:?}");
+        // Dropped when trailing (the dead-placeholder shape) — no assistant-final
+        // row survives to trigger the reject.
+        let wire = to_wire_messages(
+            &[
+                user(vec![ContentBlock::Text {
+                    text: "task".into(),
+                }]),
+                assistant(vec![]),
+            ],
+            "",
+        );
+        assert_eq!(wire.len(), 1);
+        assert_eq!(wire[0]["role"], "user");
+        // A thinking-only assistant reduces to the same empty shape here.
+        let wire = to_wire_messages(
+            &[assistant(vec![ContentBlock::Thinking {
+                text: "hmm".into(),
+                signature: None,
+            }])],
+            "",
+        );
+        assert!(wire.is_empty(), "thinking-only assistant omitted: {wire:?}");
     }
 }


### PR DESCRIPTION
## Symptom

The Z.AI (GLM) provider returned:

```json
{"error":{"code":"1214","message":"The messages parameter is illegal. Please check the documentation."}}
```

## Root cause

A content-less **and** call-less assistant message serializes to a bare `{"role":"assistant"}` row (no `content`, no `tool_calls`). Strict Chat Completions gateways reject that shape — Z.AI with 400/1214. It arises three ways:

- a dead retry's `empty_assistant` placeholder (the harness appends it before streaming; a transient upstream failure can leave it durably empty),
- a poisoned entry a prior failed turn left mid-transcript (this permanently wedges the session — every later turn re-sends it), or
- a thinking-only turn (no reasoning replay on Chat Completions).

`provider-anthropic` (`wire/messages.rs`) and `provider-openai-codex` already omit this shape. `provider-zai`, `provider-openai`, and `provider-xai` were byte-identical copy-pastes that pushed the assistant entry **unconditionally** and missed the guard.

## Fix

Add the guard before pushing the assistant entry, in all three vulnerable mappers:

```rust
if text.is_empty() && tool_calls.is_empty() {
    continue;
}
```

Filtering at the **wire layer** (rather than patching the harness) makes the mapper total over arbitrary transcript shapes and heals already-poisoned sessions with no harness state — the same total-wire-mapper approach the codebase already uses for the orphan/dedup/displaced-result rules.

Each mapper gets a regression test covering the mid-list, trailing, and thinking-only cases.

## Scope note

The branch is named for Z.AI, but `provider-openai` and `provider-xai` carried the **byte-identical latent wedge**. Fixing only zai would knowingly ship the same bug in two siblings, so all three are fixed here.

## Verification

`cargo test` + `cargo fmt --check` + `cargo clippy --all-targets` clean on every touched crate:

- provider-zai: 77 passed
- provider-openai: 80 passed
- provider-xai: 87 passed

Findings came from a max-effort multi-agent review that showed an earlier harness-layer fix was incomplete; the harness change was reverted and the fix moved to the wire layer.

https://claude.ai/code/session_01BrGPTPjdRYMUd5ajzeAZJV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty assistant messages are now skipped when sending chat history, preventing invalid requests from being sent to gateways that reject blank assistant entries.
  * This applies whether the empty assistant turn appears in the middle, at the end, or as a thinking-only response.
  * Improved reliability of message formatting so conversations with only meaningful user/assistant content are transmitted successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->