### PR TITLE
(MOT-3907) feat(console): list folders in the # mention typeahead

### DIFF
--- a/console/web/src/components/chat/lexical/FileMentionNode.tsx
+++ b/console/web/src/components/chat/lexical/FileMentionNode.tsx
@@ -138,6 +138,34 @@ interface PillProps {
 }
 
 /**
+ * Hairline glyph for a mention path: folder tab-outline when the path ends
+ * in `/`, rectangle-with-corner-fold otherwise. Shared by the pill and the
+ * `#` typeahead menu.
+ */
+export function PathGlyph({ path }: { path: string }) {
+  return (
+    <svg
+      width="9"
+      height="11"
+      viewBox="0 0 10 12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1"
+      aria-hidden="true"
+    >
+      {path.endsWith('/') ? (
+        <path d="M1 2.5H4L5.5 4H9V10H1V2.5Z" />
+      ) : (
+        <>
+          <path d="M1 1H6L9 4V11H1V1Z" />
+          <path d="M6 1V4H9" />
+        </>
+      )}
+    </svg>
+  )
+}
+
+/**
  * The inserted-token visual. Hairline file glyph in accent, relative path in
  * ink, on a panel background. Rectilinear; no rounded corners; monospace;
  * tight inline-block sizing so it flows with text. When `selected` is true
@@ -161,19 +189,7 @@ export function FileMentionPill({ path, selected, pillRef }: PillProps) {
       )}
     >
       <span aria-hidden className="text-accent leading-none shrink-0">
-        {/* tiny "file" glyph: hairline rectangle with a corner fold */}
-        <svg
-          width="9"
-          height="11"
-          viewBox="0 0 10 12"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1"
-          aria-hidden="true"
-        >
-          <path d="M1 1H6L9 4V11H1V1Z" />
-          <path d="M6 1V4H9" />
-        </svg>
+        <PathGlyph path={path} />
       </span>
       <span className="leading-none truncate max-w-[280px]">{path}</span>
     </span>

--- a/console/web/src/components/chat/lexical/FileMentionsPlugin.tsx
+++ b/console/web/src/components/chat/lexical/FileMentionsPlugin.tsx
@@ -11,7 +11,7 @@ import {
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { fetchFileIndex, fuzzyFilterFiles } from '@/lib/file-index'
-import { $createFileMentionNode } from './FileMentionNode'
+import { $createFileMentionNode, PathGlyph } from './FileMentionNode'
 import { FlipMenu } from './FlipMenu'
 
 class FileMentionOption extends MenuOption {
@@ -31,7 +31,8 @@ interface FileMentionsPluginProps {
 }
 
 /**
- * `#` typeahead over the working directory's files. The index is fetched
+ * `#` typeahead over the working directory's files and folders (folders
+ * carry a trailing `/` in the index). The index is fetched
  * lazily on first open (and re-used through file-index's TTL cache), so a
  * conversation that never mentions files never walks the repo. `minLength: 1`
  * keeps markdown headings (`# foo` — the space ends the match) from flashing
@@ -107,7 +108,7 @@ export function FileMentionsPlugin({
         return createPortal(
           <FlipMenu
             anchorEl={anchorElementRef.current}
-            header="files"
+            header="files & folders"
             options={options}
             selectedIndex={props.selectedIndex}
             selectOptionAndCleanUp={props.selectOptionAndCleanUp}
@@ -119,18 +120,7 @@ export function FileMentionsPlugin({
                   aria-hidden="true"
                   className="text-accent leading-none w-3 flex justify-center shrink-0"
                 >
-                  <svg
-                    width="9"
-                    height="11"
-                    viewBox="0 0 10 12"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="1"
-                    aria-hidden="true"
-                  >
-                    <path d="M1 1H6L9 4V11H1V1Z" />
-                    <path d="M6 1V4H9" />
-                  </svg>
+                  <PathGlyph path={opt.path} />
                 </span>
                 <span className="min-w-0 font-mono text-[13px] text-ink truncate">
                   {opt.path}

--- a/console/web/src/lib/file-index.test.ts
+++ b/console/web/src/lib/file-index.test.ts
@@ -32,13 +32,19 @@ const tree: TreeNodeWire = {
   ],
 }
 
+const flatTree = [
+  'empty/',
+  'no-children-dir/',
+  'README.md',
+  'src/',
+  'src/main.rs',
+  'src/nested/',
+  'src/nested/deep.ts',
+]
+
 describe('flattenTree', () => {
-  it('collects relative file paths, skipping dirs/symlinks and paren paths', () => {
-    expect(flattenTree(tree)).toEqual([
-      'README.md',
-      'src/main.rs',
-      'src/nested/deep.ts',
-    ])
+  it('collects files and trailing-slash folders, skipping symlinks and paren paths', () => {
+    expect(flattenTree(tree)).toEqual(flatTree)
   })
 
   it('returns [] for a childless root', () => {
@@ -68,6 +74,12 @@ describe('fuzzyFilterFiles', () => {
     expect(fuzzyFilterFiles(index, 'dnm')).toEqual(['docs/notes.md'])
   })
 
+  it('ranks folder basenames despite the trailing slash', () => {
+    expect(
+      fuzzyFilterFiles(['src/nested/deep.ts', 'src/nested/'], 'nes'),
+    ).toEqual(['src/nested/', 'src/nested/deep.ts'])
+  })
+
   it('excludes non-matches', () => {
     expect(fuzzyFilterFiles(index, 'zzz')).toEqual([])
   })
@@ -87,7 +99,7 @@ describe('fetchFileIndex', () => {
   it('fetches through coder::tree with the working dir as base_dir', async () => {
     const trigger = vi.fn().mockResolvedValue(treeResponse)
     const index = await fetchFileIndex('/w', trigger)
-    expect(index).toEqual(['README.md', 'src/main.rs', 'src/nested/deep.ts'])
+    expect(index).toEqual(flatTree)
     expect(trigger).toHaveBeenCalledWith(
       TREE_FUNCTION_ID,
       expect.objectContaining({

--- a/console/web/src/lib/file-index.ts
+++ b/console/web/src/lib/file-index.ts
@@ -44,18 +44,21 @@ const cache = new Map<string, CacheEntry>()
 const inFlight = new Map<string, Promise<string[]>>()
 
 /**
- * Flatten a tree snapshot to sorted RELATIVE file paths (the root itself is
- * `''` and never listed). Paths containing `)` are dropped — the
- * `#file(<path>)` token cannot carry them (documented limitation).
+ * Flatten a tree snapshot to sorted RELATIVE paths (the root itself is `''`
+ * and never listed). Directories carry a trailing `/` so downstream consumers
+ * can tell them apart. Paths containing `)` are dropped — the `#file(<path>)`
+ * token cannot carry them (documented limitation).
  */
 export function flattenTree(root: TreeNodeWire): string[] {
   const out: string[] = []
   const walk = (node: TreeNodeWire, prefix: string) => {
     for (const child of node.children ?? []) {
       const path = prefix ? `${prefix}/${child.name}` : child.name
+      if (path.includes(')')) continue
       if (child.kind === 'file') {
-        if (!path.includes(')')) out.push(path)
+        out.push(path)
       } else if (child.kind === 'dir') {
+        out.push(`${path}/`)
         walk(child, path)
       }
     }
@@ -80,7 +83,9 @@ export function fuzzyFilterFiles(
   const ranked: Array<{ path: string; rank: number }> = []
   for (const path of index) {
     const lower = path.toLowerCase()
-    const base = lower.slice(lower.lastIndexOf('/') + 1)
+    /* Folder paths end in `/`; strip it so their basename still ranks. */
+    const trimmed = lower.endsWith('/') ? lower.slice(0, -1) : lower
+    const base = trimmed.slice(trimmed.lastIndexOf('/') + 1)
     let rank: number
     if (base.startsWith(q)) rank = 0
     else if (lower.includes(q)) rank = 1

--- a/console/web/src/lib/file-mentions.test.ts
+++ b/console/web/src/lib/file-mentions.test.ts
@@ -100,6 +100,29 @@ describe('expandFileMentions', () => {
     expect(out.attachments).toEqual([])
   })
 
+  it('skips folder mentions and reads only files', async () => {
+    const trigger = vi.fn().mockResolvedValue({
+      results: [
+        { path: '/w/src/a.rs', success: true, content: 'x', is_utf8: true },
+      ],
+    })
+    const out = await expandFileMentions('/w', ['src/', 'src/a.rs'], trigger)
+    expect(trigger).toHaveBeenCalledWith(READ_FILE_FUNCTION_ID, {
+      paths: ['src/a.rs'],
+      fs_scope: { root: '/w' },
+    })
+    expect(out.blocks).toHaveLength(1)
+    expect(out.blocks[0]).toContain('path="src/a.rs"')
+    expect(out.failures).toEqual([])
+  })
+
+  it('makes no read call when only folders are mentioned', async () => {
+    const trigger = vi.fn()
+    const out = await expandFileMentions('/w', ['src/'], trigger)
+    expect(trigger).not.toHaveBeenCalled()
+    expect(out).toEqual({ blocks: [], attachments: [], failures: [] })
+  })
+
   it('degrades every mention to a failure when the batch call throws', async () => {
     const trigger = vi.fn().mockRejectedValue(new Error('shell worker away'))
     const out = await expandFileMentions('/w', ['a.txt', 'b.txt'], trigger)

--- a/console/web/src/lib/file-mentions.ts
+++ b/console/web/src/lib/file-mentions.ts
@@ -81,13 +81,19 @@ type TriggerFn = (
  * Read every mentioned file in one jail-validated batch call and format the
  * attachment blocks. Batch results come back in request order (the wire
  * contract), so blocks are labeled with the caller's relative paths.
+ *
+ * Folder mentions (trailing `/`) attach nothing: the `#file(dir/)` token
+ * stays in the message text and the agent lists the folder on demand.
  */
 export async function expandFileMentions(
   workingDir: string,
   paths: string[],
   trigger?: TriggerFn,
 ): Promise<ExpandedMentions> {
-  if (paths.length === 0) return { blocks: [], attachments: [], failures: [] }
+  const filePaths = paths.filter((path) => !path.endsWith('/'))
+  if (filePaths.length === 0) {
+    return { blocks: [], attachments: [], failures: [] }
+  }
 
   const call =
     trigger ??
@@ -99,16 +105,16 @@ export async function expandFileMentions(
   let results: ReadEntryResultWire[]
   try {
     const res = (await call(READ_FILE_FUNCTION_ID, {
-      paths,
+      paths: filePaths,
       fs_scope: { root: workingDir },
     })) as ReadFileBatchWire
     results = res?.results ?? []
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err)
     return {
-      blocks: paths.map((path) => failureBlock(path, reason)),
+      blocks: filePaths.map((path) => failureBlock(path, reason)),
       attachments: [],
-      failures: paths.map((path) => ({ path, reason })),
+      failures: filePaths.map((path) => ({ path, reason })),
     }
   }
 
@@ -116,7 +122,7 @@ export async function expandFileMentions(
   const attachments: Array<{ path: string; size: number }> = []
   const failures: FileMentionFailure[] = []
 
-  for (const [i, path] of paths.entries()) {
+  for (const [i, path] of filePaths.entries()) {
     const entry = results[i]
     if (!entry?.success || typeof entry.content !== 'string') {
       const reason = shortReason(entry?.error?.message) ?? 'read failed'


### PR DESCRIPTION
The `#` typeahead in the chat composer now offers directories alongside files, so a whole folder can be pointed at the agent (`#file(src/components/)`) instead of mentioning files one by one.

## How it works

- **Index** — `flattenTree` emits `kind: 'dir'` nodes from the `coder::tree` snapshot with a trailing `/` (they were already in the response, just dropped). The trailing slash is the file/folder discriminator everywhere downstream; paths containing `)` are still excluded.
- **Ranking** — `fuzzyFilterFiles` strips the trailing slash before computing the basename, so typing `nested` ranks `src/nested/` as a basename-prefix match.
- **Send path** — `expandFileMentions` filters trailing-`/` paths out of the `coder::read-file` batch. A folder mention attaches no content and raises no failure notice: the `#file(dir/)` token stays in the message text and the agent lists the folder on demand, which it does better than a pre-chewed listing.
- **Visuals** — new shared `PathGlyph` (folder outline vs file-with-fold) replaces the two duplicated inline SVGs in the mention pill and the typeahead menu; the menu header reads "files & folders".

No new token type: trailing slash inside the existing `#file()` token carries the meaning, so the transform plugin, markdown renderer, and entry mapper are untouched.

## Test plan

- [x] `flattenTree` includes folders with trailing `/`, keeps skipping symlinks and paren paths
- [x] folder basenames rank despite the trailing slash
- [x] folder mentions are excluded from the read batch; folder-only mentions make no read call
- [x] full `console/web` suite: 947 passed, 0 failed; `tsc --noEmit` and biome clean
- [ ] live smoke: type `#` in the composer against a real working dir, mention a folder, confirm the agent resolves it

Fixes MOT-3907

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File mentions and the `#` picker now support folders as well as files.
  * Folder items are shown with a distinct path icon and a trailing slash to make them easier to recognize.

* **Bug Fixes**
  * Folder mentions no longer trigger file-reading behavior or error entries.
  * Search and ranking now handle folder names correctly in typeahead results.

* **Tests**
  * Updated coverage for folder handling in file indexing and mention expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->