### PR TITLE
feat(provider-xai): add grok-4.5 family metadata and reasoning effort

### DIFF
--- a/provider-xai/src/curated.rs
+++ b/provider-xai/src/curated.rs
@@ -4,9 +4,9 @@
 //! in everything the API cannot provide: per-family metadata for known grok
 //! families, conservative defaults for unknown ones, and the legacy denylist.
 //!
-//! Pricing for grok-4.3 and grok-build is taken from docs.x.ai; other rows
-//! are best-effort and only affect cost display, never routing. A missing row
-//! degrades display polish, not behaviour.
+//! Pricing for grok-4.5, grok-4.3 and grok-build is taken from docs.x.ai;
+//! other rows are best-effort and only affect cost display, never routing.
+//! A missing row degrades display polish, not behaviour.
 use crate::PROVIDER_ID;
 use llm_router::types::model::{Model, Pricing};
 
@@ -38,6 +38,10 @@ fn family_meta(base: &str) -> Option<(u64, u64, bool, bool, Pricing)> {
     }
     if b.contains("code-fast") {
         return Some((256_000, 16_384, true, false, price(0.20, 1.50)));
+    }
+    if b.starts_with("grok-4.5") {
+        // 500k context and $2/$6 from docs.x.ai; max-output/vision best-effort.
+        return Some((500_000, 64_000, true, true, price(2.0, 6.0)));
     }
     if b.starts_with("grok-4.3") {
         return Some((1_000_000, 64_000, true, false, price(1.25, 2.5)));
@@ -169,6 +173,21 @@ mod tests {
         let mini = enrich("grok-3-mini");
         assert_eq!(mini.display_name.as_deref(), Some("Grok 3 Mini"));
         assert_eq!(mini.supports_thinking, Some(true));
+    }
+
+    #[test]
+    fn grok_4_5_gets_its_own_row_not_the_generic_grok4_bucket() {
+        let m = enrich("grok-4.5");
+        assert_eq!(m.display_name.as_deref(), Some("Grok 4.5"));
+        assert_eq!(m.context_window, 500_000);
+        assert_eq!(m.supports_thinking, Some(true));
+        // grok-4.5 takes low/medium/high, never xhigh (only grok-4.3 does)
+        assert_eq!(m.supports_xhigh, Some(false));
+        let pricing = m.pricing.as_ref().unwrap();
+        assert_eq!(pricing.input, Some(2.0));
+        assert_eq!(pricing.output, Some(6.0));
+        // a dated snapshot resolves to the same family row
+        assert_eq!(enrich("grok-4.5-0710").context_window, 500_000);
     }
 
     #[test]

--- a/provider-xai/src/reasoning.rs
+++ b/provider-xai/src/reasoning.rs
@@ -3,6 +3,7 @@
 //! fails the whole request.
 //!
 //! xAI specifics (verified empirically against api.x.ai, 2026-06):
+//!   - `grok-4.5` accepts `low`/`medium`/`high` (docs.x.ai; default `high`).
 //!   - `grok-4.3` accepts the full ladder `none`/`low`/`medium`/`high`/`xhigh`.
 //!   - `grok-3-mini` accepts `low`/`high` only.
 //!   - every other current model — `grok-build`, the `grok-4.20-*` snapshots
@@ -29,6 +30,9 @@ pub fn is_reasoning_model(model: &str, catalog_supports_thinking: Option<bool>) 
 /// `low`/`high`, and every other current model rejects the param with a 400.
 fn supported_efforts(model: &str) -> &'static [&'static str] {
     let id = model.to_ascii_lowercase();
+    if id.starts_with("grok-4.5") {
+        return &["low", "medium", "high"];
+    }
     if id.starts_with("grok-4.3") {
         return &["none", "low", "medium", "high", "xhigh"];
     }
@@ -90,6 +94,16 @@ mod tests {
 
     #[test]
     fn effort_param_per_model_matches_api() {
+        // grok-4.5 takes low/medium/high (no none, no xhigh)
+        assert_eq!(
+            reasoning_effort_for(Some(ThinkingLevel::Medium), "grok-4.5"),
+            Some("medium")
+        );
+        // xhigh has no equivalent on grok-4.5 → nearest below is high
+        assert_eq!(
+            reasoning_effort_for(Some(ThinkingLevel::Xhigh), "grok-4.5"),
+            Some("high")
+        );
         // grok-4.3 takes the full ladder
         assert_eq!(
             reasoning_effort_for(Some(ThinkingLevel::High), "grok-4.3"),


### PR DESCRIPTION
## What

Adds a dedicated `grok-4.5` family row to provider-xai.

## Why

`grok-4.5` is admitted by live `/v1/models` discovery, so it already routes for chat. But it fell into the generic `grok-4` branch, which gave it:

- Wrong display metadata: 256K context and $3/$15 pricing (real: 500K, $2/$6).
- No `reasoning_effort` support: `supported_efforts("grok-4.5")` returned empty, so `thinking_level` was silently dropped on every request. grok-4.5 accepts low/medium/high.

## Changes

- `curated.rs`: `grok-4.5` family row before the generic `grok-4` catch: 500K context, $2/$6 pricing (docs.x.ai), reasoning + vision. max-output (64K) and vision are best-effort family defaults, consistent with the existing table.
- `reasoning.rs`: `grok-4.5` effort ladder `low`/`medium`/`high` (default high; no `xhigh`, which only 4.3 accepts).
- Dated snapshots (`grok-4.5-0710`) resolve to the same row via `base_id`. `supports_xhigh` stays false, which is correct.

## Verification

- `cargo fmt --check`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test`: 77/77 lib tests pass, integration + schema suites green. New tests cover the grok-4.5 catalog row and effort mapping.

Model id, context window, and pricing verified against docs.x.ai.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `grok-4.5` model family, including its display details, limits, capabilities, and pricing.
  * Updated reasoning-effort handling for `grok-4.5` so supported effort levels are matched correctly.

* **Bug Fixes**
  * Ensured `grok-4.5` and its dated snapshot resolve to the correct model family instead of a more generic grouping.
  * Requests for unsupported high effort levels now fall back to the nearest supported option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->