### PR TITLE
chore: wire provider-openai-codex into the release pipeline

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -35,6 +35,7 @@ on:
           - provider-anthropic
           - provider-llamacpp
           - provider-openai
+          - provider-openai-codex
           - provider-xai
           - provider-zai
           - pubsub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ on:
       - 'provider-anthropic/v*'
       - 'provider-llamacpp/v*'
       - 'provider-openai/v*'
+      - 'provider-openai-codex/v*'
       - 'provider-xai/v*'
       - 'provider-zai/v*'
       - 'pubsub/v*'


### PR DESCRIPTION
## Summary
- provider-openai-codex shipped in #382 but was never wired per the new-worker onboarding SOP (docs/sops/new-worker.md §6) — it's missing from both Create Tag's worker dropdown and Release's push-tag patterns, so a tag push for it fires nothing.
- Adds `provider-openai-codex` to `create-tag.yml`'s `inputs.worker.options` and `'provider-openai-codex/v*'` to `release.yml`'s `on.push.tags`, mirroring the existing provider-llamacpp entry.
- No skills/ dir on this worker, so no change needed to ALLOWED_WORKERS or BOOTSTRAP_WORKERS.

## Test plan
- [ ] Confirm Create Tag now offers `provider-openai-codex` as a worker option
- [ ] Run Create Tag for provider-openai-codex and confirm the release pipeline fires end to end