### PR TITLE
chore(harness): refresh stale worker dependency pins

### DIFF
--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -19,5 +19,5 @@ dependencies:
   context-manager: "^1.0.0"
   provider-anthropic: "^1.0.0"
   provider-openai: "^1.0.0"
-  shell: "^0.7.0"
+  shell: "^0.8.0"
   web: "^1.1.2"

--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -7,12 +7,12 @@ bin: harness
 description: Thin durable turn loop that wires session-manager, context-manager, and llm-router into an agent loop; spawns sub-agents as child sessions.
 
 dependencies:
-  iii-state: "^0.19.0"
-  iii-queue: "^0.19.0"
-  iii-cron: "^0.19.0"
-  configuration: "^0.19.0"
-  iii-observability: "^0.19.0"
-  iii-stream: "^0.19.0"
+  iii-state: "^0.21.3"
+  iii-queue: "^0.21.3"
+  iii-cron: "^0.21.3"
+  configuration: "^0.21.3"
+  iii-observability: "^0.21.3"
+  iii-stream: "^0.21.3"
   iii-directory: "^1.0.0"
   llm-router: "^1.0.0"
   session-manager: "^1.0.0"


### PR DESCRIPTION
## Summary
- `harness/iii.worker.yaml` declared several stale dependency pins, understating what harness actually requires:
  - `shell: "^0.7.0"` — shell just released `0.8.0` (deny-only policy, allowlist removed); 0.x caret ranges exclude the next minor, so the manifest undersold the real minimum.
  - `iii-state`, `iii-queue`, `iii-cron`, `configuration`, `iii-observability`, `iii-stream` — all pinned `^0.19.0`, two minors behind the engine harness is actually compiled against (`iii-sdk = "=0.21.2-next.1"` in `harness/Cargo.toml`) and behind the current stable engine release (`iii/v0.21.3`).
- Bumps `shell` to `^0.8.0` and the six builtin engine worker deps to `^0.21.3`.
- Note: `worktree/iii.worker.yaml` has the same stale `shell: "^0.7.0"` pin — left untouched, out of scope for this change.

## Test plan
- [ ] Confirm harness's manifest dependency check (if any) resolves shell 0.8.0 and the builtin workers at 0.21.3 correctly