### PR TITLE
(MOT-3909) fix(provider-openai-codex): drop stale auth-credentials manifest dependency

### DIFF
--- a/provider-openai-codex/iii.worker.yaml
+++ b/provider-openai-codex/iii.worker.yaml
@@ -9,4 +9,3 @@ description: OpenAI Codex (ChatGPT subscription) provider; implements provider::
 dependencies:
   iii-state: "^0.19.0"
   llm-router: "^1.0.0"
-  auth-credentials: "^0.1.0"


### PR DESCRIPTION
## Summary
- `provider-openai-codex/iii.worker.yaml` declared a hard dependency on `auth-credentials: "^0.1.0"`. That worker was removed from this repo on 2026-05-18 (#153, old-worker cleanup) and never re-published — it's not in the registry, and provider-openai-codex (added later in #382) is the only worker still declaring it.
- Result: `iii worker add provider-openai-codex` fails with HTTP 422 `worker_not_found` for every user, unconditionally.
- The source already tolerates the vault's absence at runtime (falls back to `~/.codex/auth.json` when no vault is running), so the manifest dependency was never load-bearing.
- Drops the stale `auth-credentials` line from `dependencies:`.

Fixes MOT-3909

## Test plan
- [ ] After merge, cut a provider-openai-codex patch release and confirm `iii worker add provider-openai-codex` resolves successfully