### PR TITLE
chore(workers): finish stale configuration/iii-state dependency pin refresh

### DIFF
--- a/context-manager/iii.worker.yaml
+++ b/context-manager/iii.worker.yaml
@@ -7,5 +7,5 @@ bin: context-manager
 description: Turns a raw conversation history plus a target model into a model-ready context — token counting, function-result pruning, and history compaction.
 
 dependencies:
-  configuration: "^0.19.0"
+  configuration: "^0.21.3"
   llm-router: "^1.0.0"

--- a/iii-directory/iii.worker.yaml
+++ b/iii-directory/iii.worker.yaml
@@ -7,4 +7,4 @@ bin: iii-directory
 description: Engine introspection (functions / triggers / workers), workers registry proxy, and filesystem-backed skill + prompt reader.
 
 dependencies:
-  configuration: "^0.19.0"
+  configuration: "^0.21.3"

--- a/llm-router/iii.worker.yaml
+++ b/llm-router/iii.worker.yaml
@@ -7,5 +7,5 @@ bin: llm-router
 description: One front door + provider protocol in front of every LLM provider.
 
 dependencies:
-  iii-state: "^0.19.0"
-  configuration: "^0.19.0"
+  iii-state: "^0.21.3"
+  configuration: "^0.21.3"

--- a/provider-anthropic/iii.worker.yaml
+++ b/provider-anthropic/iii.worker.yaml
@@ -7,5 +7,5 @@ bin: provider-anthropic
 description: Anthropic Messages API provider worker; implements provider::anthropic::stream and provider::anthropic::refresh_models behind llm-router.
 
 dependencies:
-  iii-state: "^0.19.0"
+  iii-state: "^0.21.3"
   llm-router: "^1.0.0"

--- a/provider-openai/iii.worker.yaml
+++ b/provider-openai/iii.worker.yaml
@@ -7,5 +7,5 @@ bin: provider-openai
 description: OpenAI Chat Completions provider worker; implements provider::openai::stream and provider::openai::refresh_models behind llm-router.
 
 dependencies:
-  iii-state: "^0.19.0"
+  iii-state: "^0.21.3"
   llm-router: "^1.0.0"

--- a/session-manager/iii.worker.yaml
+++ b/session-manager/iii.worker.yaml
@@ -7,4 +7,4 @@ bin: session-manager
 description: Durable, reactive, branching store of typed conversation entries with six emitted trigger types.
 
 dependencies:
-  configuration: "^0.19.0"
+  configuration: "^0.21.3"

--- a/web/iii.worker.yaml
+++ b/web/iii.worker.yaml
@@ -7,4 +7,4 @@ bin: web
 description: Outbound HTTP client on the iii bus (web::fetch).
 
 dependencies:
-  configuration: "^0.19.0"
+  configuration: "^0.21.3"


### PR DESCRIPTION
## Summary
- #456 bumped harness's own builtin-engine pins (configuration, iii-state, iii-queue, iii-cron, iii-observability, iii-stream) from `^0.19.0` to `^0.21.3`, but every worker harness depends on still declared `^0.19.0` for `configuration`/`iii-state`.
- `^0.19.0` and `^0.21.3` don't overlap, so resolving harness's dependency graph now fails: `iii worker reinstall harness` → HTTP 422 `version_conflict`, `dependency_path: harness -> iii-directory -> configuration`.
- Bumps the same pins to `^0.21.3` in the seven affected manifests: `iii-directory`, `llm-router` (`iii-state` + `configuration`), `session-manager`, `context-manager`, `web`, `provider-anthropic` (`iii-state`), `provider-openai` (`iii-state`).

## Test plan
- [x] `git diff` scoped to exactly these 7 `iii.worker.yaml` files, no stray changes
- [ ] After merge, cut a patch release for each of the 7 workers (Create Tag workflow) so the registry has manifests declaring the new range
- [ ] Confirm `iii worker reinstall harness` resolves cleanly once all 7 are republished

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraints across several workers to align with newer releases.
  * Brought core configuration and state packages up to a newer compatible version range.
  * No user-facing behavior or public interfaces were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->