### PR TITLE
(MOT-3929) fix(provider-anthropic): surface adaptive thinking by default on thinking-capable models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,7 @@ jobs:
         if: steps.optout.outputs.skip != 'true'
         env:
           VERSION: '0.17.0'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           curl -fsSL https://install.iii.dev/iii/main/install.sh -o /tmp/install-iii.sh

--- a/approval-gate/Cargo.lock
+++ b/approval-gate/Cargo.lock
@@ -92,7 +92,7 @@ dependencies = [
  "clap",
  "futures",
  "harness",
- "iii-sdk",
+ "iii-sdk 0.20.0-alpha.2",
  "regex",
  "schemars",
  "serde",
@@ -545,14 +545,14 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "1.1.3"
+version = "1.1.12"
 dependencies = [
  "anyhow",
  "async-trait",
  "clap",
  "globset",
- "iii-helpers",
- "iii-sdk",
+ "iii-helpers 0.21.2-next.1",
+ "iii-sdk 0.21.2-next.1",
  "jsonschema",
  "schemars",
  "serde",
@@ -826,6 +826,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-helpers"
+version = "0.21.2-next.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030839b177b118574ca2f8c03030f33948cd353eb774127f281d200428a4918d"
+dependencies = [
+ "futures-util",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry_sdk",
+ "reqwest",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sysinfo",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "iii-sdk"
 version = "0.20.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,7 +855,28 @@ dependencies = [
  "async-trait",
  "futures-util",
  "hostname",
- "iii-helpers",
+ "iii-helpers 0.20.0-alpha.2",
+ "reqwest",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "iii-sdk"
+version = "0.21.2-next.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1837ea510df889a7f9c9d7b3432c962946674f54741de7e6ec6e8ad2534ee83c"
+dependencies = [
+ "async-trait",
+ "futures-util",
+ "hostname",
+ "iii-helpers 0.21.2-next.1",
  "reqwest",
  "schemars",
  "serde",

--- a/provider-anthropic/Cargo.lock
+++ b/provider-anthropic/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-anthropic/src/thinking.rs
+++ b/provider-anthropic/src/thinking.rs
@@ -42,8 +42,14 @@ pub struct ThinkingBuild {
 pub fn build_thinking_config(level: Option<ThinkingLevel>, model: Option<&Model>) -> ThinkingBuild {
     let mut warnings = Vec::new();
     let Some(level) = level else {
+        // Parity with xai reasoning models, which surface reasoning by default:
+        // with no explicit level, still request adaptive thinking on models that
+        // definitely support it (server default effort, so no output_config).
+        // Gate on Some(true), not the permissive path — an implicit default must
+        // never 400 on a non-thinking or unknown model.
+        let config = (model.and_then(|m| m.supports_thinking) == Some(true)).then_some(ADAPTIVE);
         return ThinkingBuild {
-            config: None,
+            config,
             effort: None,
             warnings,
         };
@@ -99,11 +105,29 @@ mod tests {
     }
 
     #[test]
-    fn absent_level_means_off() {
+    fn absent_level_defaults_on_for_thinking_models() {
+        // Parity with xai: no explicit level still surfaces reasoning on a model
+        // that supports thinking, at the server's default effort (no output_config).
         let built = build_thinking_config(None, Some(&model(Some(true), Some(true))));
-        assert_eq!(built.config, None);
+        assert_eq!(built.config, Some(ADAPTIVE));
         assert_eq!(built.effort, None);
         assert!(built.warnings.is_empty());
+    }
+
+    #[test]
+    fn absent_level_stays_off_without_thinking_support() {
+        // No implicit default when support is unknown or explicitly false, so the
+        // default can never 400 a non-thinking model.
+        for m in [
+            None,
+            Some(model(None, None)),
+            Some(model(Some(false), None)),
+        ] {
+            let built = build_thinking_config(None, m.as_ref());
+            assert_eq!(built.config, None);
+            assert_eq!(built.effort, None);
+            assert!(built.warnings.is_empty());
+        }
     }
 
     #[test]

--- a/provider-llamacpp/Cargo.lock
+++ b/provider-llamacpp/Cargo.lock
@@ -738,7 +738,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.0.4"
+version = "1.0.6"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openai-codex/Cargo.lock
+++ b/provider-openai-codex/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.0.2"
+version = "1.0.6"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openai-codex/src/stream_fn.rs
+++ b/provider-openai-codex/src/stream_fn.rs
@@ -92,17 +92,17 @@ async fn fetch_fresh_credential(iii: &IIIClient) -> Option<Value> {
         .ok()
         .flatten()
     {
-        if near_expiry(&cred) {
-            if matches!(
+        if near_expiry(&cred)
+            && matches!(
                 router_client::refresh_if_available(iii, PROVIDER_ID).await,
                 Ok(true)
-            ) {
-                return router_client::get_token_if_available(iii, PROVIDER_ID)
-                    .await
-                    .ok()
-                    .flatten()
-                    .or(Some(cred));
-            }
+            )
+        {
+            return router_client::get_token_if_available(iii, PROVIDER_ID)
+                .await
+                .ok()
+                .flatten()
+                .or(Some(cred));
         }
         return Some(cred);
     }

--- a/provider-openai/Cargo.lock
+++ b/provider-openai/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-xai/Cargo.lock
+++ b/provider-xai/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.0.2"
+version = "1.0.6"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-zai/Cargo.lock
+++ b/provider-zai/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.0.4"
+version = "1.0.6"
 dependencies = [
  "async-trait",
  "clap",


### PR DESCRIPTION
## Summary
- With no explicit `thinking_level`, `provider-anthropic` always sent `config: None` — thinking-capable models (Sonnet 4.6+, Opus 4.7+, Fable/Mythos 5) never got adaptive thinking unless the caller explicitly requested a level. `provider-xai` surfaces reasoning by default with no explicit level; this brings `provider-anthropic` to parity.
- `build_thinking_config` now requests `ADAPTIVE` (server default effort, no `output_config`) when no level is given and the model's `supports_thinking` is explicitly `Some(true)`. Unknown (`None`) or explicitly `Some(false)` models keep the old behavior, so the implicit default can never 400 a non-thinking or unknown model.
- `Cargo.lock` churn across `approval-gate`/other providers is from the harness v1.1.12 bump (`iii-sdk`/`iii-helpers` version resolution), not a functional change.

## Test plan
- [x] `cargo test thinking` in `provider-anthropic` (14 passed)
- [x] Updated/added unit tests: `absent_level_defaults_on_for_thinking_models`, `absent_level_stays_off_without_thinking_support`

https://linear.app/motia/issue/MOT-3929/provider-anthropic-surface-adaptive-thinking-by-default-on-thinking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated thinking settings so supported models now automatically use adaptive thinking when no level is specified.
  * Kept thinking turned off for models that do not support it or when support is unknown.
  * Ensured the default behavior preserves empty warnings and no extra effort settings when thinking is not enabled.

* **Tests**
  * Added coverage for both supported and unsupported model cases to verify the new default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->