### PR TITLE
(MOT-3929) fix(provider-anthropic): sanitize thinking-mode message shapes to avoid 400s

### DIFF
--- a/provider-anthropic/src/request.rs
+++ b/provider-anthropic/src/request.rs
@@ -42,11 +42,23 @@ pub fn build_body(args: &BodyArgs) -> Value {
     if let Some(system) = build_system_field(&args.system_prompt, args.cache_enabled) {
         body["system"] = system;
     }
-    if let Some(t) = &args.thinking {
-        body["thinking"] = serde_json::to_value(t).expect("serializable thinking config");
-    }
-    if let Some(effort) = args.effort {
-        body["output_config"] = json!({ "effort": effort });
+    // Thinking and assistant prefill are mutually exclusive on the Messages API
+    // ("...does not support assistant message prefill. The conversation must end
+    // with a user message."). If the sanitized transcript still ends on an
+    // assistant turn, honor the prefill and drop thinking rather than 400.
+    let is_prefill = body["messages"]
+        .as_array()
+        .and_then(|m| m.last())
+        .and_then(|m| m.get("role"))
+        .and_then(Value::as_str)
+        == Some("assistant");
+    if !is_prefill {
+        if let Some(t) = &args.thinking {
+            body["thinking"] = serde_json::to_value(t).expect("serializable thinking config");
+        }
+        if let Some(effort) = args.effort {
+            body["output_config"] = json!({ "effort": effort });
+        }
     }
     body
 }
@@ -130,6 +142,43 @@ mod tests {
         assert_eq!(body["thinking"]["display"], "summarized");
         assert!(body["thinking"].get("budget_tokens").is_none());
         assert_eq!(body["output_config"]["effort"], "xhigh");
+    }
+
+    #[test]
+    fn thinking_dropped_when_conversation_ends_on_assistant_prefill() {
+        use llm_router::types::events::StopReason;
+        use llm_router::types::messages::{AssistantMessage, AssistantRoleTag};
+        let mut a = args();
+        a.thinking = Some(crate::thinking::ADAPTIVE);
+        a.effort = Some("high");
+        // A trailing call-less assistant (aborted-stream partial or an
+        // intentional prefill) makes the wire end on role:assistant. Thinking +
+        // prefill are mutually exclusive, so thinking must be dropped, not 400.
+        a.messages.push(AgentMessage::Assistant(AssistantMessage {
+            role: AssistantRoleTag::Assistant,
+            content: vec![ContentBlock::Text {
+                text: "the answer is".into(),
+            }],
+            stop_reason: StopReason::End,
+            native_stop_reason: None,
+            error_message: None,
+            error_kind: None,
+            warnings: None,
+            usage: None,
+            model: "m".into(),
+            provider: "anthropic".into(),
+            timestamp: 2,
+        }));
+        let body = build_body(&a);
+        assert_eq!(
+            body["messages"].as_array().unwrap().last().unwrap()["role"],
+            "assistant"
+        );
+        assert!(
+            body.get("thinking").is_none(),
+            "prefill request must not carry thinking"
+        );
+        assert!(body.get("output_config").is_none());
     }
 
     #[test]

--- a/provider-anthropic/src/request.rs
+++ b/provider-anthropic/src/request.rs
@@ -26,8 +26,31 @@ pub struct BodyArgs {
 }
 
 /// No `temperature`: the API default applies (required when thinking is on).
-pub fn build_body(args: &BodyArgs) -> Value {
+pub fn build_body(args: &BodyArgs, warnings: &mut Vec<String>) -> Value {
     let mut wire_messages = to_wire_messages(&args.messages);
+    // Claude 4.6+/Sonnet 5/Fable/Mythos reject any request whose final message
+    // is an assistant turn — "Prefilling assistant messages is not supported
+    // for this model" — with or without thinking. A trailing call-less
+    // assistant here is always a dead partial from an aborted stream (a
+    // tool_use turn always gets a tool_result/placeholder user flushed after
+    // it), so drop it instead of failing the whole turn.
+    let mut dropped_prefill = false;
+    while wire_messages
+        .last()
+        .and_then(|m| m.get("role"))
+        .and_then(Value::as_str)
+        == Some("assistant")
+    {
+        wire_messages.pop();
+        dropped_prefill = true;
+    }
+    if dropped_prefill {
+        warnings.push(
+            "trailing partial assistant message dropped: assistant prefill is not supported \
+             (conversation must end with a user message)"
+                .to_string(),
+        );
+    }
     apply_messages_cache_anchor(&mut wire_messages, args.cache_enabled);
     let mut wire_tools = functions_to_wire(&args.tools);
     apply_tools_cache_control(&mut wire_tools, args.cache_enabled);
@@ -42,23 +65,11 @@ pub fn build_body(args: &BodyArgs) -> Value {
     if let Some(system) = build_system_field(&args.system_prompt, args.cache_enabled) {
         body["system"] = system;
     }
-    // Thinking and assistant prefill are mutually exclusive on the Messages API
-    // ("...does not support assistant message prefill. The conversation must end
-    // with a user message."). If the sanitized transcript still ends on an
-    // assistant turn, honor the prefill and drop thinking rather than 400.
-    let is_prefill = body["messages"]
-        .as_array()
-        .and_then(|m| m.last())
-        .and_then(|m| m.get("role"))
-        .and_then(Value::as_str)
-        == Some("assistant");
-    if !is_prefill {
-        if let Some(t) = &args.thinking {
-            body["thinking"] = serde_json::to_value(t).expect("serializable thinking config");
-        }
-        if let Some(effort) = args.effort {
-            body["output_config"] = json!({ "effort": effort });
-        }
+    if let Some(t) = &args.thinking {
+        body["thinking"] = serde_json::to_value(t).expect("serializable thinking config");
+    }
+    if let Some(effort) = args.effort {
+        body["output_config"] = json!({ "effort": effort });
     }
     body
 }
@@ -115,7 +126,7 @@ mod tests {
 
     #[test]
     fn body_has_required_fields_and_stream_true() {
-        let body = build_body(&args());
+        let body = build_body(&args(), &mut Vec::new());
         assert_eq!(body["model"], "claude-sonnet-4-6");
         assert_eq!(body["max_tokens"], 4096);
         assert_eq!(body["stream"], true);
@@ -129,7 +140,7 @@ mod tests {
     fn empty_system_prompt_omits_the_field() {
         let mut a = args();
         a.system_prompt = String::new();
-        assert!(build_body(&a).get("system").is_none());
+        assert!(build_body(&a, &mut Vec::new()).get("system").is_none());
     }
 
     #[test]
@@ -137,28 +148,19 @@ mod tests {
         let mut a = args();
         a.thinking = Some(crate::thinking::ADAPTIVE);
         a.effort = Some("xhigh");
-        let body = build_body(&a);
+        let body = build_body(&a, &mut Vec::new());
         assert_eq!(body["thinking"]["type"], "adaptive");
         assert_eq!(body["thinking"]["display"], "summarized");
         assert!(body["thinking"].get("budget_tokens").is_none());
         assert_eq!(body["output_config"]["effort"], "xhigh");
     }
 
-    #[test]
-    fn thinking_dropped_when_conversation_ends_on_assistant_prefill() {
+    fn assistant_msg(content: Vec<ContentBlock>) -> AgentMessage {
         use llm_router::types::events::StopReason;
         use llm_router::types::messages::{AssistantMessage, AssistantRoleTag};
-        let mut a = args();
-        a.thinking = Some(crate::thinking::ADAPTIVE);
-        a.effort = Some("high");
-        // A trailing call-less assistant (aborted-stream partial or an
-        // intentional prefill) makes the wire end on role:assistant. Thinking +
-        // prefill are mutually exclusive, so thinking must be dropped, not 400.
-        a.messages.push(AgentMessage::Assistant(AssistantMessage {
+        AgentMessage::Assistant(AssistantMessage {
             role: AssistantRoleTag::Assistant,
-            content: vec![ContentBlock::Text {
-                text: "the answer is".into(),
-            }],
+            content,
             stop_reason: StopReason::End,
             native_stop_reason: None,
             error_message: None,
@@ -168,17 +170,60 @@ mod tests {
             model: "m".into(),
             provider: "anthropic".into(),
             timestamp: 2,
-        }));
-        let body = build_body(&a);
+        })
+    }
+
+    #[test]
+    fn trailing_assistant_prefill_is_dropped_with_warning_and_thinking_kept() {
+        // Claude 4.6+/Sonnet 5/Fable/Mythos 400 on assistant prefill with or
+        // without thinking, so the dead partial tail (aborted-stream retry)
+        // must be dropped — and thinking must survive.
+        let mut a = args();
+        a.thinking = Some(crate::thinking::ADAPTIVE);
+        a.effort = Some("high");
+        a.messages.push(assistant_msg(vec![ContentBlock::Text {
+            text: "the answer is".into(),
+        }]));
+        let mut warnings = Vec::new();
+        let body = build_body(&a, &mut warnings);
         assert_eq!(
             body["messages"].as_array().unwrap().last().unwrap()["role"],
-            "assistant"
+            "user"
         );
-        assert!(
-            body.get("thinking").is_none(),
-            "prefill request must not carry thinking"
-        );
-        assert!(body.get("output_config").is_none());
+        assert_eq!(body["thinking"]["type"], "adaptive");
+        assert_eq!(body["output_config"]["effort"], "high");
+        assert_eq!(warnings.len(), 1, "one warning expected: {warnings:?}");
+        assert!(warnings[0].contains("prefill"));
+    }
+
+    #[test]
+    fn trailing_tool_use_assistant_survives_the_prefill_drop() {
+        // A tool_use turn is always followed by a flushed tool_result /
+        // placeholder user message, so the prefill drop never eats it and
+        // signed-thinking-before-tool_use replay stays intact.
+        let mut a = args();
+        a.thinking = Some(crate::thinking::ADAPTIVE);
+        a.messages.push(assistant_msg(vec![
+            ContentBlock::Thinking {
+                text: "plan".into(),
+                signature: Some("sig".into()),
+            },
+            ContentBlock::FunctionCall {
+                id: "t1".into(),
+                function_id: "shell::exec".into(),
+                arguments: json!({ "cmd": "ls" }),
+            },
+        ]));
+        let mut warnings = Vec::new();
+        let body = build_body(&a, &mut warnings);
+        let msgs = body["messages"].as_array().unwrap();
+        assert_eq!(msgs.last().unwrap()["role"], "user");
+        let assistant = &msgs[msgs.len() - 2];
+        assert_eq!(assistant["role"], "assistant");
+        assert_eq!(assistant["content"][0]["type"], "thinking");
+        assert_eq!(assistant["content"][1]["type"], "tool_use");
+        assert!(warnings.is_empty(), "no warning expected: {warnings:?}");
+        assert_eq!(body["thinking"]["type"], "adaptive");
     }
 
     #[test]

--- a/provider-anthropic/src/stream_fn.rs
+++ b/provider-anthropic/src/stream_fn.rs
@@ -116,16 +116,19 @@ async fn run_stream_call(
         return;
     }
 
-    let body = build_body(&BodyArgs {
-        model: cfg.model.clone(),
-        max_tokens: cfg.max_tokens,
-        system_prompt: input.system_prompt.unwrap_or_default(),
-        messages: input.messages,
-        tools: input.tools.unwrap_or_default(),
-        thinking: thinking_build.config,
-        effort: thinking_build.effort,
-        cache_enabled: cache_enabled(),
-    });
+    let body = build_body(
+        &BodyArgs {
+            model: cfg.model.clone(),
+            max_tokens: cfg.max_tokens,
+            system_prompt: input.system_prompt.unwrap_or_default(),
+            messages: input.messages,
+            tools: input.tools.unwrap_or_default(),
+            thinking: thinking_build.config,
+            effort: thinking_build.effort,
+            cache_enabled: cache_enabled(),
+        },
+        &mut warnings,
+    );
     let headers = build_headers(&cfg);
 
     let rx = spawn_upstream(

--- a/provider-anthropic/src/wire/messages.rs
+++ b/provider-anthropic/src/wire/messages.rs
@@ -159,8 +159,22 @@ pub fn to_wire_messages(messages: &[AgentMessage]) -> Vec<Value> {
                 if !pending.is_empty() {
                     out.push(json!({ "role": "user", "content": std::mem::take(&mut pending) }));
                 }
-                let content: Vec<Value> =
+                let mut content: Vec<Value> =
                     a.content.iter().filter_map(content_block_to_wire).collect();
+                // Anthropic (thinking enabled) 400s when an assistant turn's
+                // final block is `thinking`/`redacted_thinking`. A tail thinking
+                // block is inert for replay — only thinking that PRECEDES a
+                // tool_use is passed back for signature verification, and that
+                // block is never the tail — so strip any trailing thinking.
+                while matches!(
+                    content
+                        .last()
+                        .and_then(|b| b.get("type"))
+                        .and_then(Value::as_str),
+                    Some("thinking") | Some("redacted_thinking")
+                ) {
+                    content.pop();
+                }
                 // Anthropic rejects assistant turns with empty content arrays.
                 if !content.is_empty() {
                     out.push(json!({ "role": "assistant", "content": content }));
@@ -464,13 +478,76 @@ mod tests {
     }
 
     #[test]
-    fn redacted_thinking_replays_on_the_wire() {
+    fn redacted_thinking_replays_before_a_tool_use() {
+        // Mandatory replay is thinking-family that PRECEDES a tool_use; the
+        // tool_use is a non-thinking tail, so the redacted block survives.
+        let wire = to_wire_messages(&[assistant(vec![
+            ContentBlock::RedactedThinking {
+                data: "opaque".into(),
+            },
+            call("t1"),
+        ])]);
+        assert_eq!(wire[0]["content"][0]["type"], "redacted_thinking");
+        assert_eq!(wire[0]["content"][0]["data"], "opaque");
+        assert_eq!(wire[0]["content"][1]["type"], "tool_use");
+    }
+
+    #[test]
+    fn trailing_redacted_thinking_is_stripped() {
+        // A lone/trailing redacted_thinking assistant is both an invalid final
+        // block and a prefill under thinking; stripping empties the turn so it
+        // is omitted (Anthropic 400: "final block ... cannot be `thinking`").
         let wire = to_wire_messages(&[assistant(vec![ContentBlock::RedactedThinking {
             data: "opaque".into(),
         }])]);
+        assert!(wire.is_empty());
+    }
+
+    #[test]
+    fn trailing_signed_thinking_is_stripped_keeping_earlier_blocks() {
+        let wire = to_wire_messages(&[assistant(vec![
+            ContentBlock::Text {
+                text: "answer".into(),
+            },
+            ContentBlock::Thinking {
+                text: "afterthought".into(),
+                signature: Some("sig".into()),
+            },
+        ])]);
+        let content = wire[0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "text");
+    }
+
+    #[test]
+    fn signed_thinking_only_trailing_assistant_is_omitted() {
+        // The aborted-stream placeholder shape (harness persists the partial):
+        // a durable trailing assistant holding only a signed thinking block.
+        // Must not reach the wire as a bare thinking assistant — that is both
+        // the final-block-thinking 400 and the prefill 400 from the report.
+        let wire = to_wire_messages(&[
+            user(vec![ContentBlock::Text { text: "hi".into() }]),
+            assistant(vec![ContentBlock::Thinking {
+                text: "partial".into(),
+                signature: Some("sig".into()),
+            }]),
+        ]);
         assert_eq!(wire.len(), 1);
-        assert_eq!(wire[0]["content"][0]["type"], "redacted_thinking");
-        assert_eq!(wire[0]["content"][0]["data"], "opaque");
+        assert_eq!(wire[0]["role"], "user");
+    }
+
+    #[test]
+    fn signed_thinking_before_tool_use_is_preserved() {
+        let wire = to_wire_messages(&[assistant(vec![
+            ContentBlock::Thinking {
+                text: "plan".into(),
+                signature: Some("sig".into()),
+            },
+            call("t1"),
+        ])]);
+        let content = wire[0]["content"].as_array().unwrap();
+        assert_eq!(content[0]["type"], "thinking");
+        assert_eq!(content[1]["type"], "tool_use");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

With adaptive thinking enabled, the provider produced two Anthropic Messages API `400`s (from the reported session):

- `messages.1: The final block in an assistant message cannot be \`thinking\`.`
- `This model does not support assistant message prefill. The conversation must end with a user message.`

Both surfaced when adaptive thinking became the default on thinking-capable models (MOT-3929).

## Root cause

The harness persists streamed partials into a trailing assistant placeholder (`harness/src/turn_loop.rs:305-363`). An aborted/failed stream leaves a durable assistant whose last (or only) block is a **signed** `thinking` block. `to_wire_messages` replays signed thinking verbatim (`wire/messages.rs:50-52`), so on retry the wire array contains an assistant turn ending in `thinking` **and** ends on `role:assistant` → both 400s.

Sibling providers (`provider-xai`, `provider-openai-codex`) never hit this because they drop reasoning replay entirely — but Anthropic *requires* signed thinking to be replayed immediately before a `tool_use`, so a blanket drop is wrong here.

## Fix (two layers)

- **`wire/messages.rs` — `to_wire_messages`**: strip trailing `thinking`/`redacted_thinking` blocks from each assistant turn. Only thinking that *precedes* a `tool_use` needs replay (signature verification); a tail block is inert. An emptied turn is omitted (consecutive same-role turns are merged server-side, so the resulting adjacency is safe). Unconditional — a tail thinking block is inert in both modes.
- **`request.rs` — `build_body`**: drop the trailing call-less assistant wire message(s) entirely, keep thinking enabled, and push a report-and-continue warning. Per the [Messages API docs](https://platform.claude.com/docs/en/build-with-claude/working-with-messages), prefilling is **not supported at all** on Claude Sonnet 4.6+/5, Opus 4.6/4.7/4.8, Fable 5 and Mythos 5 ("Requests using prefill with these models return a 400 error") — regardless of the thinking param — and that set is exactly the adaptive-thinking-default models, so disabling thinking would not have fixed Error B. Safe to drop: a `tool_use` turn always gets a `tool_result`/placeholder user flushed after it, so a trailing assistant is always a dead call-less partial from an aborted stream, never a live tool loop.

## Tests

- 8 new tests (trailing signed/redacted thinking stripped, thinking-only trailing assistant omitted, thinking-before-tool_use preserved, prefill tail dropped w/ warning + thinking kept, tool_use tail survives the drop).
- Rewrote `redacted_thinking_replays_*` which asserted the old invalid shape.
- `cargo test` 98 passed (5 suites); `cargo clippy --all-targets` clean.

## Note

The deepest cause is harness-side (`finalize_failed`/`finalize_cancelled` leave the partial assistant as the durable tail). This PR fixes it provider-side so both 400s are prevented regardless of harness behavior; a harness-side transcript cleanup can follow separately.

https://claude.ai/code/session_01NYBEfEkPErA9bD5E52Ys86