### PR TITLE
(MOT-3945) fix(provider-openai-codex): align iii-state dependency range

### DIFF
--- a/provider-openai-codex/iii.worker.yaml
+++ b/provider-openai-codex/iii.worker.yaml
@@ -7,5 +7,5 @@ bin: provider-openai-codex
 description: OpenAI Codex (ChatGPT subscription) provider; implements provider::openai-codex::stream and provider::openai-codex::refresh_models behind llm-router, sourcing credentials from the auth-credentials vault.
 
 dependencies:
-  iii-state: "^0.19.0"
+  iii-state: "^0.21.3"
   llm-router: "^1.0.0"


### PR DESCRIPTION
Fixes MOT-3945

The published Codex provider still declares iii-state ^0.19.0 while llm-router v1.0.6 requires ^0.21.3. The ranges do not overlap, causing reinstall to fail with HTTP 422 version_conflict.

Updates provider-openai-codex/iii.worker.yaml to iii-state ^0.21.3. The next patch release is required after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to a newer version, keeping the project aligned with the latest supported release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->