### PR TITLE
fix(queue): raise delivery invocation timeout from 30s default to 30m

### DIFF
--- a/queue/src/trigger.rs
+++ b/queue/src/trigger.rs
@@ -22,6 +22,12 @@ use tokio::sync::Mutex;
 use crate::adapter::{QueueAdapter, SwappableAdapter};
 use crate::subscriber_config::SubscriberQueueConfig;
 
+/// Queue-delivered functions may run for many minutes (e.g. streaming an LLM
+/// response). The iii SDK defaults an omitted timeout to 30 seconds, which
+/// lets the adapter retry an in-flight delivery while the original invocation
+/// is still running. 30 minutes covers the longest intended job budget.
+const FUNCTION_QUEUE_INVOCATION_TIMEOUT_MS: u64 = 30 * 60 * 1_000;
+
 #[async_trait]
 pub trait Invoker: Send + Sync + 'static {
     async fn call(&self, function_id: &str, payload: Value) -> Result<Option<Value>, String>;
@@ -46,7 +52,7 @@ impl Invoker for IiiInvoker {
                 function_id: function_id.to_string(),
                 payload,
                 action: None,
-                timeout_ms: None,
+                timeout_ms: Some(FUNCTION_QUEUE_INVOCATION_TIMEOUT_MS),
             })
             .await
             .map(Some)


### PR DESCRIPTION
## Summary

The queue worker's delivery invoker omitted `timeout_ms`, so every queued function invocation inherited the iii SDK's 30-second default. Long-running jobs — e.g. LLM turns that stream for minutes — timed out mid-flight, and the adapter retried the delivery while the original invocation was still running.

This sets an explicit 30-minute delivery deadline (`FUNCTION_QUEUE_INVOCATION_TIMEOUT_MS`) on queued invocations, matching the longest intended job budget.

## Test plan

- [x] `cargo test --lib` in `queue/` — 99 passed