### PR TITLE
fix(llm-router): stamp call id on FunctioncallDelta frames

### DIFF
--- a/harness/src/clients/router.rs
+++ b/harness/src/clients/router.rs
@@ -233,8 +233,14 @@ impl RouterClient {
                     terminal_error.get_or_insert(msg);
                 }
                 other => {
-                    if let AssistantMessageEvent::FunctioncallDelta { partial, delta } = &other {
-                        if let Some(id) = open_call_id(partial) {
+                    if let AssistantMessageEvent::FunctioncallDelta { partial, delta, id } = &other
+                    {
+                        let id = if id.is_empty() {
+                            open_call_id(partial) // pre-id producers: guess
+                        } else {
+                            Some(id.as_str())
+                        };
+                        if let Some(id) = id {
                             args_acc.entry(id.to_string()).or_default().push_str(delta);
                         }
                     }
@@ -443,8 +449,8 @@ impl StreamSink for CapturingSink {
     }
 }
 
-/// The call currently receiving argument deltas: blocks stream in order, so
-/// it is the last function_call block of the partial.
+/// Fallback attribution for id-less delta frames (pre-id producers): blocks
+/// stream in order, so guess the last function_call block of the partial.
 fn open_call_id(partial: &AssistantMessage) -> Option<&str> {
     partial.content.iter().rev().find_map(|b| match b {
         crate::types::content::ContentBlock::FunctionCall { id, .. } => Some(id.as_str()),
@@ -578,5 +584,23 @@ mod streaming_args_tests {
         let s = format!("{}é", "x".repeat(1499));
         assert!(utf8_tail(&s, 1500).len() <= 1500);
         assert!(utf8_tail(&s, 1500).ends_with('é'));
+    }
+
+    #[test]
+    fn functioncall_delta_frames_parse_with_and_without_id() {
+        // Pre-id producers stream id-less deltas — they must still parse
+        // (frames that fail to parse are silently dropped by the read loop).
+        let partial = serde_json::to_value(empty_assistant("p", "m")).unwrap();
+        let old = format!(r#"{{"type":"functioncall_delta","partial":{partial},"delta":"x"}}"#);
+        match serde_json::from_str::<AssistantMessageEvent>(&old).unwrap() {
+            AssistantMessageEvent::FunctioncallDelta { id, .. } => assert_eq!(id, ""),
+            other => panic!("want functioncall_delta, got {other:?}"),
+        }
+        let new =
+            format!(r#"{{"type":"functioncall_delta","partial":{partial},"delta":"x","id":"c1"}}"#);
+        match serde_json::from_str::<AssistantMessageEvent>(&new).unwrap() {
+            AssistantMessageEvent::FunctioncallDelta { id, .. } => assert_eq!(id, "c1"),
+            other => panic!("want functioncall_delta, got {other:?}"),
+        }
     }
 }

--- a/harness/src/types/event.rs
+++ b/harness/src/types/event.rs
@@ -84,6 +84,9 @@ pub enum AssistantMessageEvent {
     FunctioncallDelta {
         partial: AssistantMessage,
         delta: String,
+        /// Call id receiving this delta; empty from pre-id producers.
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        id: String,
     },
     FunctioncallEnd {
         partial: AssistantMessage,

--- a/llm-router/src/types/events.rs
+++ b/llm-router/src/types/events.rs
@@ -80,6 +80,9 @@ pub enum AssistantMessageEvent {
     FunctioncallDelta {
         partial: AssistantMessage,
         delta: String,
+        /// Call id receiving this delta; empty from pre-id producers.
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        id: String,
     },
     FunctioncallEnd {
         partial: AssistantMessage,

--- a/provider-anthropic/src/sse.rs
+++ b/provider-anthropic/src/sse.rs
@@ -357,6 +357,7 @@ pub fn handle_sse_event(
                     events.push(AssistantMessageEvent::FunctioncallDelta {
                         partial: build_partial(state, model),
                         delta: json.to_string(),
+                        id: state.function_calls[idx].id.clone(),
                     });
                 }
                 Some(BlockSlot::Thinking(idx)) if delta_type == "thinking_delta" => {

--- a/provider-openai-codex/src/sse.rs
+++ b/provider-openai-codex/src/sse.rs
@@ -328,6 +328,11 @@ pub fn handle_chunk(
             events.push(AssistantMessageEvent::FunctioncallDelta {
                 partial: build_partial(state, model),
                 delta,
+                id: state
+                    .tool_calls
+                    .last()
+                    .map(|c| c.id.clone())
+                    .unwrap_or_default(),
             });
         }
         n if n.contains("completed") => {

--- a/provider-openai/src/sse.rs
+++ b/provider-openai/src/sse.rs
@@ -278,6 +278,7 @@ pub fn handle_chunk(
                         events.push(AssistantMessageEvent::FunctioncallDelta {
                             partial: build_partial(state, model),
                             delta: args.to_string(),
+                            id: state.function_calls[index].id.clone(),
                         });
                     }
                 }
@@ -435,6 +436,28 @@ mod tests {
         assert_eq!(starts, 2);
         let final_msg = build_final(&state, "gpt-test");
         assert_eq!(final_msg.content.len(), 2);
+    }
+
+    #[test]
+    fn interleaved_tool_call_deltas_carry_their_call_id() {
+        let (_, events) = run(&[
+            json!({"choices":[{"index":0,"delta":{"tool_calls":[
+                {"index":0,"id":"call_a","function":{"name":"f__a","arguments":"{\"x\":"}}]}}]}),
+            json!({"choices":[{"index":0,"delta":{"tool_calls":[
+                {"index":1,"id":"call_b","function":{"name":"f__b","arguments":"{}"}}]}}]}),
+            json!({"choices":[{"index":0,"delta":{"tool_calls":[
+                {"index":0,"function":{"arguments":"1}"}}]}}]}),
+            json!({"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}),
+        ]);
+        let ids: Vec<&str> = events
+            .iter()
+            .filter_map(|e| match e {
+                AssistantMessageEvent::FunctioncallDelta { id, .. } => Some(id.as_str()),
+                _ => None,
+            })
+            .collect();
+        // The last delta belongs to call_a even though call_b opened after it.
+        assert_eq!(ids, vec!["call_a", "call_b", "call_a"]);
     }
 
     #[test]

--- a/provider-xai/src/sse.rs
+++ b/provider-xai/src/sse.rs
@@ -310,6 +310,7 @@ pub fn handle_chunk(
                         events.push(AssistantMessageEvent::FunctioncallDelta {
                             partial: build_partial(state, model),
                             delta: args.to_string(),
+                            id: state.function_calls[index].id.clone(),
                         });
                     }
                 }

--- a/provider-zai/src/sse.rs
+++ b/provider-zai/src/sse.rs
@@ -317,6 +317,7 @@ pub fn handle_chunk(
                         events.push(AssistantMessageEvent::FunctioncallDelta {
                             partial: build_partial(state, model),
                             delta: args.to_string(),
+                            id: state.function_calls[index].id.clone(),
                         });
                     }
                 }


### PR DESCRIPTION
## Summary
- `FunctioncallDelta` streaming events carried no call id, so consumers guessed which in-flight call an argument delta belonged to (last-opened block) — wrong when two tool calls stream in parallel and their deltas interleave.
- All 5 providers (Anthropic, OpenAI, OpenAI-Codex, xAI, zai) already track the id internally at the delta emit site; this threads it onto the event instead of dropping it.
- Wire-compatible: the new `id` field defaults to empty string and is omitted from JSON when empty, so old producers still parse; the harness keeps the guess-based fallback for id-less frames.

Fixes [MOT-3956](https://linear.app/motia/issue/MOT-3956/llm-router-functioncalldelta-carries-no-call-id-live-streaming-args).

## Test plan
- [x] `cargo test` green across all 7 touched crates (llm-router, harness, provider-anthropic, provider-openai, provider-xai, provider-zai, provider-openai-codex) — 686 tests
- [x] New regression test: interleaved parallel tool-call deltas carry their correct call id (provider-openai)
- [x] New regression test: `FunctioncallDelta` parses both with and without the `id` field (harness, wire back-compat)
- [x] `cargo fmt --check` and `cargo clippy --tests` clean on all touched crates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming tool-call handling by preserving call IDs across incremental argument updates.
  * Correctly associates interleaved function-call argument chunks with their respective calls.
  * Added fallback handling for streamed updates that omit a call ID.

* **Tests**
  * Added coverage for call-ID parsing, missing IDs, and interleaved tool-call streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->