### PR TITLE
feat(http): colorized console logs matching the engine's format

### DIFF
--- a/http/Cargo.lock
+++ b/http/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +92,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
@@ -195,6 +210,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +267,15 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "core-foundation"
@@ -630,6 +667,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,7 +821,9 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "chrono",
  "clap",
+ "colored",
  "dashmap",
  "futures",
  "iii-helpers",
@@ -935,6 +998,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -33,6 +33,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 anyhow = "1"
+# Colorized console log formatting (same crate/version as the engine).
+colored = "3"
+chrono = "0.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 clap = { version = "4", features = ["derive"] }

--- a/http/src/handler.rs
+++ b/http/src/handler.rs
@@ -32,6 +32,7 @@ use axum::{
     response::{IntoResponse, Response},
     Extension,
 };
+use colored::Colorize;
 use iii_helpers::observability::opentelemetry::metrics::Counter;
 use iii_helpers::observability::opentelemetry::KeyValue;
 use iii_sdk::helpers::create_channel;
@@ -250,6 +251,8 @@ pub async fn dynamic_handler(
     // mirror the span tags: method + matched route (captured here) + status.
     let method_attr = method.as_str().to_string();
     let route_attr = route_path.clone();
+    let called_function_id = matched.as_ref().map(|(route, _)| route.function_id.clone());
+    let started = std::time::Instant::now();
     let record_status = move |response: Response| -> Response {
         let code = response.status().as_u16();
         let span = tracing::Span::current();
@@ -262,6 +265,27 @@ pub async fn dynamic_handler(
                 KeyValue::new("http.route", route_attr.clone()),
                 KeyValue::new("http.response.status_code", i64::from(code)),
             ],
+        );
+
+        let status = code.to_string();
+        let status = match code {
+            200..=299 => status.green(),
+            300..=399 => status.cyan(),
+            400..=499 => status.yellow(),
+            _ => status.red(),
+        };
+        tracing::info!(
+            "{} Endpoint {} → {} {} {}",
+            "[CALLED]".blue(),
+            format!("{} {}", method_attr, route_attr)
+                .bright_yellow()
+                .bold(),
+            called_function_id
+                .as_deref()
+                .unwrap_or("<no route>")
+                .purple(),
+            status,
+            format!("({}ms)", started.elapsed().as_millis()).dimmed()
         );
         response
     };

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -8,6 +8,7 @@ pub mod condition;
 pub mod config;
 pub mod configuration;
 pub mod handler;
+pub mod logging;
 pub mod manifest;
 pub mod middleware;
 pub mod observability;

--- a/http/src/logging.rs
+++ b/http/src/logging.rs
@@ -1,0 +1,353 @@
+//! Colorized console log formatting, mirroring the engine's local log output.
+//!
+//! Ported from the engine's `IIILogFormatter` (engine/src/logging.rs): dimmed
+//! `[HH:MM:SS.mmm AM/PM]` timestamp, level colored by severity, cyan bold
+//! header (the event's `function` field, falling back to the tracing target),
+//! white message, and remaining fields rendered as a `├`/`└` tree with values
+//! colored by type (strings cyan, numbers yellow, bools purple, JSON expanded
+//! into a nested colored tree).
+
+use std::fmt;
+
+use chrono::Local;
+use colored::Colorize;
+use tracing::{
+    Event, Level, Subscriber,
+    field::{Field, Visit},
+};
+use tracing_subscriber::{
+    fmt::{self as tracing_fmt, FmtContext, FormatEvent, FormatFields},
+    registry::LookupSpan,
+};
+
+/// Collected field from tracing event
+#[derive(Debug, Clone)]
+enum FieldValue {
+    String(String),
+    I64(i64),
+    U64(u64),
+    F64(f64),
+    Bool(bool),
+    Debug(String),
+}
+
+/// Visitor that collects tracing fields into a Vec
+struct FieldCollector {
+    fields: Vec<(String, FieldValue)>,
+    message: Option<String>,
+    function: Option<String>,
+}
+
+impl FieldCollector {
+    fn new() -> Self {
+        Self {
+            fields: Vec::new(),
+            message: None,
+            function: None,
+        }
+    }
+
+    /// Extract the function field value if it exists
+    fn get_function(&self) -> Option<&str> {
+        self.function.as_deref()
+    }
+
+    /// Get fields excluding the "function" field (always hidden since it's
+    /// shown in the header).
+    fn get_display_fields(&self) -> Vec<(&String, &FieldValue)> {
+        self.fields
+            .iter()
+            .filter(|(name, _)| name != "function")
+            .map(|(name, value)| (name, value))
+            .collect()
+    }
+}
+
+impl Visit for FieldCollector {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        match field.name() {
+            "message" => self.message = Some(value.to_string()),
+            "function" => self.function = Some(value.to_string()),
+            _ => self.fields.push((
+                field.name().to_string(),
+                FieldValue::String(value.to_string()),
+            )),
+        }
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.fields
+            .push((field.name().to_string(), FieldValue::I64(value)));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields
+            .push((field.name().to_string(), FieldValue::U64(value)));
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.fields
+            .push((field.name().to_string(), FieldValue::F64(value)));
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.fields
+            .push((field.name().to_string(), FieldValue::Bool(value)));
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        match field.name() {
+            "message" => self.message = Some(format!("{:?}", value)),
+            "function" => {
+                self.function = Some(format!("{:?}", value).trim_matches('"').to_string())
+            }
+            _ => self.fields.push((
+                field.name().to_string(),
+                FieldValue::Debug(format!("{:?}", value)),
+            )),
+        }
+    }
+}
+
+/// Renders a field value with appropriate coloring
+fn render_field_value(value: &FieldValue) -> String {
+    match value {
+        FieldValue::String(s) => format!("{}", format!("\"{}\"", s).cyan()),
+        FieldValue::I64(n) => format!("{}", n.to_string().yellow()),
+        FieldValue::U64(n) => format!("{}", n.to_string().yellow()),
+        FieldValue::F64(n) => format!("{}", n.to_string().yellow()),
+        FieldValue::Bool(b) => format!("{}", b.to_string().purple()),
+        FieldValue::Debug(s) => {
+            // Try to parse as JSON for pretty printing
+            if let Ok(json_val) = serde_json::from_str::<serde_json::Value>(s) {
+                render_json_value(&json_val, 2)
+            } else {
+                format!("{}", s.bright_black())
+            }
+        }
+    }
+}
+
+/// Renders a serde_json::Value in tree format with colors
+fn render_json_value(value: &serde_json::Value, indent: usize) -> String {
+    let pad = "    ".repeat(indent);
+
+    match value {
+        serde_json::Value::Object(map) => {
+            if map.is_empty() {
+                return format!("{}", "{}".bright_black());
+            }
+            let mut s = format!("{}\n", "{".bright_black());
+            let mut iter = map.iter().peekable();
+            while let Some((key, v)) = iter.next() {
+                let is_last = iter.peek().is_none();
+                let branch = if is_last { "└" } else { "├" };
+                let field = format!("{}", key.white());
+                let rendered = render_json_value(v, indent + 1);
+                s.push_str(&format!("{}{} {}: {}", pad, branch, field, rendered));
+                if !is_last {
+                    s.push('\n');
+                }
+            }
+            s.push_str(&format!(
+                "\n{}{}",
+                "    ".repeat(indent - 1),
+                "}".bright_black()
+            ));
+            s
+        }
+        serde_json::Value::Array(arr) => {
+            if arr.is_empty() {
+                return format!("{}", "[]".bright_black());
+            }
+            let mut s = format!("{}\n", "[".bright_black());
+            for (i, v) in arr.iter().enumerate() {
+                let is_last = i == arr.len() - 1;
+                let branch = if is_last { "└" } else { "├" };
+                let rendered = render_json_value(v, indent + 1);
+                s.push_str(&format!("{}{} {}", pad, branch, rendered));
+                if !is_last {
+                    s.push('\n');
+                }
+            }
+            s.push_str(&format!(
+                "\n{}{}",
+                "    ".repeat(indent - 1),
+                "]".bright_black()
+            ));
+            s
+        }
+        serde_json::Value::String(st) => format!("{}", format!("\"{}\"", st).cyan()),
+        serde_json::Value::Number(num) => format!("{}", num.to_string().yellow()),
+        serde_json::Value::Bool(b) => format!("{}", b.to_string().purple()),
+        serde_json::Value::Null => format!("{}", "null".bright_black()),
+    }
+}
+
+/// Renders collected fields in a tree-like format
+fn render_fields_tree(fields: &[(&String, &FieldValue)]) -> String {
+    if fields.is_empty() {
+        return String::new();
+    }
+
+    let mut result = String::from("\n");
+    let pad = "    ";
+
+    for (i, (name, value)) in fields.iter().enumerate() {
+        let is_last = i == fields.len() - 1;
+        let branch = if is_last { "└" } else { "├" };
+        let field_name = name.white();
+        let field_value = render_field_value(value);
+
+        result.push_str(&format!(
+            "{}{} {}: {}",
+            pad, branch, field_name, field_value
+        ));
+
+        if !is_last {
+            result.push('\n');
+        }
+    }
+
+    result
+}
+
+/// Format timestamp as [HH:MM:SS.mmm AM/PM]
+fn format_timestamp() -> String {
+    let now = Local::now();
+    now.format("[%I:%M:%S%.3f %p]").to_string()
+}
+
+pub struct IIILogFormatter;
+
+impl<S, N> FormatEvent<S, N> for IIILogFormatter
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    fn format_event(
+        &self,
+        _ctx: &FmtContext<'_, S, N>,
+        mut writer: tracing_fmt::format::Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        let meta = event.metadata();
+
+        // Collect fields first to check for "function" field
+        let mut collector = FieldCollector::new();
+        event.record(&mut collector);
+
+        // timestamp in format [09:19:23.241 AM]
+        write!(writer, "{} ", format_timestamp().dimmed())?;
+
+        // level with colors
+        let level = meta.level();
+        let level_str = match *level {
+            Level::TRACE => "TRACE".purple(),
+            Level::DEBUG => "DEBUG".green(),
+            Level::INFO => "INFO".blue(),
+            Level::WARN => "WARN".yellow(),
+            Level::ERROR => "ERROR".red(),
+        };
+        write!(writer, "[{}] ", level_str)?;
+
+        // Header: the event's "function" field if present, else the target.
+        let display_name = collector.get_function().unwrap_or(meta.target());
+        write!(writer, "{} ", display_name.cyan().bold())?;
+
+        // Write message if present
+        if let Some(msg) = &collector.message {
+            write!(writer, "{}", msg.white())?;
+        }
+
+        // Render fields as tree ("function" hidden — it's in the header).
+        let display_fields = collector.get_display_fields();
+        let tree = render_fields_tree(&display_fields);
+        write!(writer, "{}", tree)?;
+
+        writeln!(writer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::{fmt::MakeWriter, layer::SubscriberExt, util::SubscriberInitExt};
+
+    #[derive(Clone, Default)]
+    struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for SharedBuf {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for SharedBuf {
+        type Writer = SharedBuf;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    fn strip_ansi(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut chars = s.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '\x1b' {
+                for n in chars.by_ref() {
+                    if n == 'm' {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+
+    fn capture(f: impl FnOnce()) -> String {
+        let buf = SharedBuf::default();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .event_format(IIILogFormatter)
+                .with_writer(buf.clone()),
+        );
+        let guard = subscriber.set_default();
+        f();
+        drop(guard);
+        let bytes = buf.0.lock().unwrap().clone();
+        strip_ansi(&String::from_utf8(bytes).unwrap())
+    }
+
+    #[test]
+    fn formats_level_target_and_message() {
+        let out = capture(|| tracing::info!("hello world"));
+        assert!(out.contains("[INFO]"), "missing level: {out}");
+        assert!(out.contains("hello world"), "missing message: {out}");
+    }
+
+    #[test]
+    fn function_field_becomes_header_and_is_hidden_from_tree() {
+        let out = capture(|| tracing::info!(function = "my_fn", "msg"));
+        assert!(out.contains("my_fn msg"), "function not in header: {out}");
+        assert!(!out.contains("function:"), "function leaked to tree: {out}");
+    }
+
+    #[test]
+    fn fields_render_as_tree() {
+        let out = capture(|| tracing::info!(port = 8080u64, host = "localhost", "listening"));
+        assert!(out.contains("├ port: 8080"), "missing port branch: {out}");
+        assert!(
+            out.contains("└ host: \"localhost\""),
+            "missing host branch: {out}"
+        );
+    }
+}

--- a/http/src/logging.rs
+++ b/http/src/logging.rs
@@ -12,8 +12,8 @@ use std::fmt;
 use chrono::Local;
 use colored::Colorize;
 use tracing::{
-    Event, Level, Subscriber,
     field::{Field, Visit},
+    Event, Level, Subscriber,
 };
 use tracing_subscriber::{
     fmt::{self as tracing_fmt, FmtContext, FormatEvent, FormatFields},

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<()> {
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
     tracing_subscriber::registry()
         .with(filter)
-        .with(tracing_subscriber::fmt::layer())
+        .with(tracing_subscriber::fmt::layer().event_format(iii_http::logging::IIILogFormatter))
         .with(iii_http::observability::otel_layer())
         .init();
 

--- a/http/src/trigger.rs
+++ b/http/src/trigger.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use colored::Colorize;
 use iii_sdk::errors::Error;
 use iii_sdk::trigger::{TriggerConfig, TriggerHandler};
 use tokio::sync::RwLock;
@@ -119,10 +120,9 @@ impl RouteTable {
         Ok(())
     }
 
-    /// Removes the route registered under `id`, if any. Returns whether a
-    /// route was actually removed.
-    pub fn remove_by_trigger_id(&mut self, id: &str) -> bool {
-        self.by_id.remove(id).is_some()
+    /// Removes and returns the route registered under `id`, if any.
+    pub fn remove_by_trigger_id(&mut self, id: &str) -> Option<Route> {
+        self.by_id.remove(id)
     }
 
     /// Finds the registered route whose method matches (case insensitive) and
@@ -209,14 +209,33 @@ impl TriggerHandler for HttpTriggerHandler {
         self.routes
             .write()
             .await
-            .insert(route)
-            .map_err(Error::Handler)
+            .insert(route.clone())
+            .map_err(Error::Handler)?;
+        // Same registration line as the engine's builtin iii-http (api_core.rs).
+        tracing::info!(
+            "{} Endpoint {} → {}",
+            "[REGISTERED]".green(),
+            format!("{} {}", route.http_method, route.http_path)
+                .bright_yellow()
+                .bold(),
+            route.function_id.purple()
+        );
+        Ok(())
     }
 
     async fn unregister_trigger(&self, config: TriggerConfig) -> Result<(), Error> {
         // The SDK only populates `id` for unregister -- function_id/config
         // are stubs -- so the table must be (and is) keyed by trigger id.
-        self.routes.write().await.remove_by_trigger_id(&config.id);
+        if let Some(route) = self.routes.write().await.remove_by_trigger_id(&config.id) {
+            tracing::info!(
+                "{} Endpoint {} → {}",
+                "[UNREGISTERED]".yellow(),
+                format!("{} {}", route.http_method, route.http_path)
+                    .bright_yellow()
+                    .bold(),
+                route.function_id.purple()
+            );
+        }
         Ok(())
     }
 }
@@ -378,8 +397,8 @@ mod tests {
         let mut table = RouteTable::default();
         table.insert(route("t1", "GET", "/users/:id")).unwrap();
 
-        assert!(table.remove_by_trigger_id("t1"));
-        assert!(!table.remove_by_trigger_id("t1"));
+        assert!(table.remove_by_trigger_id("t1").is_some());
+        assert!(table.remove_by_trigger_id("t1").is_none());
         assert!(table.match_route("GET", "/users/42").is_none());
     }
 


### PR DESCRIPTION
## What

Ports the engine's colorized log formatter (`IIILogFormatter`, `engine/src/logging.rs`) to the standalone `iii-http` worker, and adds endpoint lifecycle + per-request log lines.

![colorized logs demo](https://vhs.charm.sh/vhs-5lyMoEg5QFYZ26mDvVrX2O.gif)

## Changes

- **`http/src/logging.rs` (new)** — verbatim port of the engine's formatter: dimmed `[HH:MM:SS.mmm AM/PM]` timestamp, severity-colored level (TRACE purple, DEBUG green, INFO blue, WARN yellow, ERROR red), cyan bold header (event's `function` field, falling back to the tracing target), white message, and remaining fields rendered as a `├`/`└` tree with values colored by type (strings cyan, numbers yellow, bools purple, JSON expanded into a nested colored tree). The engine's OTEL-passthrough branch is intentionally omitted (engine-specific).
- **`http/src/trigger.rs`** — logs `[REGISTERED]` / `[UNREGISTERED]` when `http` trigger instances add/remove endpoints, same wording and colors as the engine's builtin `iii-http` (`api_core.rs`). `RouteTable::remove_by_trigger_id` now returns the removed `Route` so the unregister line can name it.
- **`http/src/handler.rs`** — logs `[CALLED]` once per request (in the `record_status` closure, covering every return path): method + matched route, function id (`<no route>` on 404/405), status colored by class (2xx green, 3xx cyan, 4xx yellow, 5xx red), and duration. For streaming responses the duration covers time-to-headers.
- **`http/src/main.rs`** — `fmt::layer()` now uses `.event_format(IIILogFormatter)`.
- **`http/Cargo.toml`** — adds `colored = "3"` and `chrono = "0.4"` (same crates/versions as the engine).

## Testing

- 84 lib tests pass, including 3 new formatter tests (level/message layout, `function` field promoted to header and hidden from the tree, field tree rendering).
- Smoke-tested end to end: engine + standalone http worker + a Python SDK todo worker exposing CRUD endpoints via `http` triggers; the gif above is that run (registration lines, per-request lines incl. 400/404, and the ERROR field tree from an intentionally failing function).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer, colorized server logs with timestamps, severity levels, request routes, function identifiers, response statuses, and request duration.
  * Structured log fields are now displayed in an easier-to-read tree format, including nested data when available.

* **Bug Fixes**
  * Improved trigger removal handling so unregistration messages appear only when a matching route is actually removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->