### PR TITLE
(MOT-3963) fix(console): don't drop sends while another session streams

### DIFF
--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -1082,6 +1082,20 @@ export function ChatView({
       } catch (err) {
         if (!isAbortError(err)) {
           console.warn('[chat] stream errored', err)
+          // A dead send must never be silent: without this notice the user
+          // sees only their message and an eternal shimmer.
+          const detail = err instanceof Error ? err.message : String(err)
+          const noticeContent = `send failed — ${detail}`
+          const notice: SystemMessage = {
+            id: uid(),
+            role: 'system',
+            kind: 'notice',
+            content: noticeContent,
+            tone: 'error',
+            createdAt: Date.now(),
+          }
+          onAppendMessage(conversationId, notice)
+          announcer.announceAssertive(noticeContent)
         }
       } finally {
         if (thoughtId) {

--- a/console/web/src/hooks/use-conversations.ts
+++ b/console/web/src/hooks/use-conversations.ts
@@ -806,11 +806,17 @@ export function useConversations(
         })
         patchConversation(id, (c) => ({
           ...mergeConversationMeta(
-            { ...c, draft: false, hydrated: true },
+            { ...c, draft: false, hydrated: false },
             resp.meta,
           ),
           draft: false,
-          hydrated: true,
+          // Leave the session un-hydrated: the transcript subscription only
+          // mounts after this patch re-renders, so the first server events
+          // can fire before the binding exists (at-most-once, no replay).
+          // The hydration read-back then recovers anything missed; it folds
+          // through applyEntryUpsert, so the optimistic user row and any
+          // events that race the fetch survive.
+          hydrated: false,
         }))
       } catch (err) {
         if (import.meta.env.DEV) {

--- a/console/web/src/lib/backend/approval-events-live.ts
+++ b/console/web/src/lib/backend/approval-events-live.ts
@@ -36,7 +36,13 @@ function bind<P>(
   onEvent: (payload: P) => void,
 ): () => void {
   const off = client.on(handlerFn, (payload: unknown) => {
-    if (payload && typeof payload === 'object') onEvent(payload as P)
+    if (!payload || typeof payload !== 'object') return
+    // The handler id is shared by every live stream (client.on fans out);
+    // the engine-side trigger filter is per-binding, so another session's
+    // events also land here — drop them.
+    const sid = (payload as { session_id?: unknown }).session_id
+    if (typeof sid === 'string' && sid !== sessionId) return
+    onEvent(payload as P)
   })
   const offTrigger = client.registerTrigger({
     type: triggerType,

--- a/console/web/src/lib/backend/turn-events-live.ts
+++ b/console/web/src/lib/backend/turn-events-live.ts
@@ -42,7 +42,13 @@ function bind<P>(
   onEvent: (payload: P) => void,
 ): () => void {
   const off = client.on(handlerFn, (payload: unknown) => {
-    if (payload && typeof payload === 'object') onEvent(payload as P)
+    if (!payload || typeof payload !== 'object') return
+    // The handler id is shared by every live stream (client.on fans out);
+    // the engine-side trigger filter is per-binding, so another session's
+    // events also land here — drop them.
+    const sid = (payload as { session_id?: unknown }).session_id
+    if (typeof sid === 'string' && sid !== sessionId) return
+    onEvent(payload as P)
   })
   // `on()` registers under `<fn>::<browserId>`; the trigger targets that id.
   const offTrigger = client.registerTrigger({

--- a/console/web/src/lib/iii-client.test.ts
+++ b/console/web/src/lib/iii-client.test.ts
@@ -1,0 +1,92 @@
+/**
+ * `wrapSdk.on()` fan-out: the underlying SDK throws on a duplicate function
+ * id, but two live streams legitimately bind the same constant handler id.
+ * The wrapper must multiplex listeners over one SDK registration (regression:
+ * a second session's send died silently while another session streamed).
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { ISdk, RemoteFunctionHandler } from 'iii-browser-sdk'
+import { wrapSdk } from './iii-client'
+
+function fakeSdk() {
+  const functions = new Map<string, RemoteFunctionHandler>()
+  const sdk = {
+    registerFunction(id: string, handler: RemoteFunctionHandler) {
+      // Mirror iii-browser-sdk's duplicate guard (dist/index.mjs:291).
+      if (functions.has(id))
+        throw new Error(`function id already registered: ${id}`)
+      functions.set(id, handler)
+      return {
+        unregister: () => {
+          functions.delete(id)
+        },
+      }
+    },
+    registerTrigger: () => ({ unregister: () => {} }),
+    trigger: async () => null,
+    addConnectionStateListener: () => () => {},
+    shutdown: async () => {},
+  } as unknown as ISdk
+  return { sdk, functions }
+}
+
+const BROWSER_ID = 'console-test'
+const FN = 'iii::console::turn_completed'
+const SDK_ID = `${FN}::${BROWSER_ID}`
+
+describe('wrapSdk on() fan-out', () => {
+  it('allows two listeners on the same function id and delivers to both', async () => {
+    const { sdk, functions } = fakeSdk()
+    const client = wrapSdk(sdk, BROWSER_ID)
+
+    const seenA: unknown[] = []
+    const seenB: unknown[] = []
+    client.on(FN, (p) => void seenA.push(p))
+    // Before the fix this threw `function id already registered`.
+    client.on(FN, (p) => void seenB.push(p))
+
+    expect(functions.size).toBe(1)
+    await functions.get(SDK_ID)?.({ session_id: 's1' })
+    expect(seenA).toEqual([{ session_id: 's1' }])
+    expect(seenB).toEqual([{ session_id: 's1' }])
+  })
+
+  it('detaching one listener keeps the other live; last detach releases the SDK registration', async () => {
+    const { sdk, functions } = fakeSdk()
+    const client = wrapSdk(sdk, BROWSER_ID)
+
+    const seenA: unknown[] = []
+    const seenB: unknown[] = []
+    const offA = client.on(FN, (p) => void seenA.push(p))
+    const offB = client.on(FN, (p) => void seenB.push(p))
+
+    offA()
+    await functions.get(SDK_ID)?.({ session_id: 's2' })
+    expect(seenA).toEqual([])
+    expect(seenB).toEqual([{ session_id: 's2' }])
+
+    offB()
+    expect(functions.size).toBe(0)
+
+    // A fresh subscription after full release re-registers cleanly.
+    const seenC: unknown[] = []
+    client.on(FN, (p) => void seenC.push(p))
+    await functions.get(SDK_ID)?.({ session_id: 's3' })
+    expect(seenC).toEqual([{ session_id: 's3' }])
+  })
+
+  it('one listener throwing does not starve the others', async () => {
+    const { sdk, functions } = fakeSdk()
+    const client = wrapSdk(sdk, BROWSER_ID)
+
+    const seen: unknown[] = []
+    client.on(FN, () => {
+      throw new Error('boom')
+    })
+    client.on(FN, (p) => void seen.push(p))
+
+    await functions.get(SDK_ID)?.({ session_id: 's4' })
+    expect(seen).toEqual([{ session_id: 's4' }])
+  })
+})

--- a/console/web/src/lib/iii-client.ts
+++ b/console/web/src/lib/iii-client.ts
@@ -122,7 +122,7 @@ async function bootstrap(deps: Deps): Promise<IiiClient> {
   return wrapSdk(sdk, browserId)
 }
 
-function wrapSdk(sdk: ISdk, browserId: string): IiiClient {
+export function wrapSdk(sdk: ISdk, browserId: string): IiiClient {
   // Track per-functionId unregister fns so dispose() can clean them all up
   // even if individual `on()` callers forgot.
   const handlerUnregisters = new Set<() => void>()
@@ -140,35 +140,68 @@ function wrapSdk(sdk: ISdk, browserId: string): IiiClient {
     })
   }
 
+  // One SDK registration per function id, fanned out to every attached
+  // listener. The SDK throws on a duplicate id, but two live streams
+  // legitimately bind the same constant handler id (e.g. a still-streaming
+  // session's turn-completed handler alongside a new session's) — letting
+  // that throw killed the new session's send silently. The SDK registration
+  // is released when the last listener detaches.
+  const fanouts = new Map<
+    string,
+    {
+      listeners: Set<(data: unknown) => void | Promise<void>>
+      release: () => void
+    }
+  >()
+
   function on<P>(
     functionId: string,
     handler: (payload: P) => void | Promise<void>,
     options?: RegisterFunctionOptions,
   ): () => void {
     const id = `${functionId}::${browserId}`
-    // Wrap to satisfy the SDK's RemoteFunctionHandler signature (returns
-    // Promise<unknown>). We never want to send a result back.
-    const wrapped: RemoteFunctionHandler = async (data: unknown) => {
-      await handler(data as P)
-      return null
+    let entry = fanouts.get(id)
+    if (!entry) {
+      const listeners = new Set<(data: unknown) => void | Promise<void>>()
+      // Wrap to satisfy the SDK's RemoteFunctionHandler signature (returns
+      // Promise<unknown>). We never want to send a result back, and one
+      // listener's failure must not starve the others.
+      const wrapped: RemoteFunctionHandler = async (data: unknown) => {
+        await Promise.allSettled([...listeners].map(async (fn) => fn(data)))
+        return null
+      }
+      // Every handler registered here is a browser-local console plumbing fn
+      // (traces, sessions, worktree events, ...) — none are meant for other
+      // workers (e.g. harness) to discover, so default them out of
+      // `engine::functions::list`. Callers can still override via `options`.
+      const ref = sdk.registerFunction(id, wrapped, {
+        metadata: { internal: true },
+        ...options,
+      })
+      entry = {
+        listeners,
+        release: () => {
+          try {
+            ref.unregister()
+          } catch {
+            // SDK already disposed; nothing to do.
+          }
+        },
+      }
+      fanouts.set(id, entry)
     }
-    // Every handler registered here is a browser-local console plumbing fn
-    // (traces, sessions, worktree events, ...) — none are meant for other
-    // workers (e.g. harness) to discover, so default them out of
-    // `engine::functions::list`. Callers can still override via `options`.
-    const ref = sdk.registerFunction(id, wrapped, {
-      metadata: { internal: true },
-      ...options,
-    })
+    const fanout = entry
+    const listener = (data: unknown) => handler(data as P)
+    fanout.listeners.add(listener)
     let active = true
     const unregister = () => {
       if (!active) return
       active = false
       handlerUnregisters.delete(unregister)
-      try {
-        ref.unregister()
-      } catch {
-        // SDK already disposed; nothing to do.
+      fanout.listeners.delete(listener)
+      if (fanout.listeners.size === 0) {
+        fanouts.delete(id)
+        fanout.release()
       }
     }
     handlerUnregisters.add(unregister)


### PR DESCRIPTION
## Symptom

With one session's turn streaming, sending from a new console session did nothing: the session appeared in the sidebar with a title but stayed "waiting" forever (`session::ensure` succeeded, `message_count: 0`, no harness turn record), and re-sending didn't help. Verified live on the engine with two stuck sessions.

## Root causes

1. **Send killed client-side before dispatch.** `realStream` registers browser-local handler functions under constant ids (`iii::console::turn_completed::<browserId>`). The old session's stream loop survives ChatView unmount and still holds them, so the new session's stream hits `iii-browser-sdk`'s duplicate-id throw (`registerFunction`) **before** `sendTurn` — `harness::send` is never dispatched, and the error was swallowed by a `console.warn`.
2. **Successful sends could still render nothing.** The per-session transcript subscription mounts only after `ensureSession`'s re-render (after the send fired), trigger registration results are discarded by the SDK, delivery is at-most-once with no replay, and `ensureSession` pinned `hydrated: true` so the recovering read-back never ran.

## Fix

- `lib/iii-client.ts`: `on()` fans out to multiple listeners over one SDK registration per function id (released on last detach) — the duplicate-id throw can no longer occur; one listener throwing doesn't starve the rest.
- `lib/backend/turn-events-live.ts`, `lib/backend/approval-events-live.ts`: `session_id` guard in `bind()` — required with fan-out, matches `sessions/events.ts`.
- `hooks/use-conversations.ts`: `ensureSession` leaves the session un-hydrated; the hydration read-back (which folds through `applyEntryUpsert`) recovers events missed during the subscription race.
- `components/chat/ChatView.tsx`: stream-setup errors append an error notice instead of being silent (also clears the stuck shimmer).
- New `lib/iii-client.test.ts` pinning the fan-out semantics.

## Verification

- `tsc --noEmit` clean; vitest 930/930 pass (biome unavailable locally — OOM on unchanged files too).
- Not yet exercised in a live browser: needs a rebuilt console bundle; repro is send → open new session mid-stream → send.

Fixes MOT-3963.

Engine-side amplifiers (registration ack/replay, bounded outbound channel) and the harness pre-persistence router call are noted as follow-ups in MOT-3963.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat errors are now displayed in the conversation with an accessible alert instead of only being logged.
  * Live approval and turn events are filtered to the active session, preventing unrelated events from appearing.
  * Conversation transcripts are more reliably recovered during session setup.
  * Multiple listeners can now receive the same event without interfering with one another.

* **Tests**
  * Added coverage for listener sharing, cleanup, and error isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->