### PR TITLE
(MOT-3964) feat: show live turn phases in console chat while waiting

### DIFF
--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -143,6 +143,12 @@ export function ChatView({
   onCompactConversation,
 }: ChatViewProps) {
   const [isStreaming, setIsStreaming] = useState(false)
+  // Pre-content phase of this tab's in-flight send, for the thinking
+  // shimmer's detail line: submit → harness::send ack → turn-started.
+  // Null once content streams (or for turns this tab didn't start).
+  const [turnPhase, setTurnPhase] = useState<
+    'sending' | 'accepted' | 'merged' | 'started' | null
+  >(null)
   const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>(
     DEFAULT_THINKING_LEVEL,
   )
@@ -949,6 +955,7 @@ export function ChatView({
       const controller = new AbortController()
       abortRef.current = controller
       setIsStreaming(true)
+      setTurnPhase('sending')
 
       let thoughtId: string | null = null
       let thoughtBuffer = ''
@@ -1131,6 +1138,7 @@ export function ChatView({
                 })
               }
               setIsStreaming(false)
+              setTurnPhase(null)
               assistantId = null
               assistantBuffer = ''
               break
@@ -1152,6 +1160,11 @@ export function ChatView({
               }
               onAppendMessage(conversationId, marker)
               announcer.announce(compactionContent)
+              break
+            }
+            case 'turn-status': {
+              // `queued` renders in the queued-messages strip, not the shimmer.
+              setTurnPhase(event.phase === 'queued' ? null : event.phase)
               break
             }
             case 'stop-reason': {
@@ -1183,6 +1196,8 @@ export function ChatView({
             event.kind === 'thought-start'
           ) {
             setIsStreaming(true)
+            // Content arrived — the pre-content phase line is over.
+            setTurnPhase(null)
           }
         }
       } catch (err) {
@@ -1214,6 +1229,7 @@ export function ChatView({
           onPatchMessage(conversationId, assistantId, { streaming: false })
         }
         setIsStreaming(false)
+        setTurnPhase(null)
         abortRef.current = null
       }
     },
@@ -1273,6 +1289,26 @@ export function ChatView({
       }
       return false
     })()
+
+  // Pre-content phase text for the shimmer. Only trusted while the transcript
+  // still ends at the user's message — on the real backend content arrives via
+  // session events (not stream events), so once anything streamed the phase is
+  // stale and mid-turn gaps fall back to the model line instead.
+  const phaseDetail = (() => {
+    if (!turnPhase) return null
+    const last = conversation.messages[conversation.messages.length - 1] ?? null
+    if (last && last.role !== 'user') return null
+    switch (turnPhase) {
+      case 'sending':
+        return 'sending…'
+      case 'accepted':
+        return 'queued — waiting to start…'
+      case 'merged':
+        return 'added to the running turn…'
+      case 'started':
+        return null
+    }
+  })()
 
   const isDock = density === 'dock'
   const headerPad = isDock ? 'px-4' : 'px-9'
@@ -1485,9 +1521,8 @@ export function ChatView({
         thinkingDetail={
           conversation.status === 'working' && conversation.statusReason
             ? conversation.statusReason
-            : effectiveModel
-              ? `dispatching ${effectiveModel}`
-              : undefined
+            : (phaseDetail ??
+              (effectiveModel ? `dispatching ${effectiveModel}` : undefined))
         }
         density={density}
         onResolveApproval={resolveApproval}

--- a/console/web/src/components/ui/Select.tsx
+++ b/console/web/src/components/ui/Select.tsx
@@ -5,6 +5,8 @@ import { cn } from '@/lib/utils'
 interface SelectOption<T extends string> {
   value: T
   label: string
+  /** Optional hover tooltip on the option row. */
+  title?: string
 }
 
 interface SelectGroup<T extends string> {
@@ -189,6 +191,7 @@ export function Select<T extends string>({
                         key={opt.value}
                         value={opt.value}
                         label={opt.label}
+                        title={opt.title}
                       />
                     ))}
                   </SelectPrimitive.Group>
@@ -198,6 +201,7 @@ export function Select<T extends string>({
                     key={opt.value}
                     value={opt.value}
                     label={opt.label}
+                    title={opt.title}
                   />
                 ))}
           </SelectPrimitive.Viewport>
@@ -223,12 +227,14 @@ export function Select<T extends string>({
 interface SelectItemProps {
   value: string
   label: string
+  title?: string
 }
 
-function SelectItem({ value, label }: SelectItemProps) {
+function SelectItem({ value, label, title }: SelectItemProps) {
   return (
     <SelectPrimitive.Item
       value={value}
+      title={title}
       className={cn(
         'relative flex items-center pl-7 pr-3 py-1.5 cursor-pointer outline-none select-none',
         'data-[highlighted]:bg-rule data-[highlighted]:text-ink',

--- a/console/web/src/lib/backend/real.ts
+++ b/console/web/src/lib/backend/real.ts
@@ -338,6 +338,7 @@ async function* realStream(
 
   const stopTurnEvents = startTurnEventsSubscription(client, sessionId, {
     onCompleted: (event) => push({ kind: 'turn-completed', event }),
+    onStarted: (event) => push({ kind: 'turn-started', event }),
   })
   const stopApprovalEvents = opts?.approvalEventsExternallyManaged
     ? () => {}
@@ -393,13 +394,15 @@ async function* realStream(
       messageId,
       opts,
     )
-    void sendTurn(client, sendRequest).catch((err) => {
-      kickoffError = err instanceof Error ? err : new Error(String(err))
-      if (import.meta.env.DEV) {
-        console.warn('[real-backend] harness::send failed', err)
-      }
-      wake()
-    })
+    void sendTurn(client, sendRequest)
+      .then((response) => push({ kind: 'send-resolved', response }))
+      .catch((err) => {
+        kickoffError = err instanceof Error ? err : new Error(String(err))
+        if (import.meta.env.DEV) {
+          console.warn('[real-backend] harness::send failed', err)
+        }
+        wake()
+      })
 
     while (true) {
       if (signal?.aborted) return

--- a/console/web/src/lib/backend/translate.test.ts
+++ b/console/web/src/lib/backend/translate.test.ts
@@ -4,6 +4,7 @@ import type {
   PendingResolvedEvent,
   TurnCompletedEvent,
 } from '@/types/iii-agent-event'
+import type { HarnessSendResponse } from './harness-send'
 import {
   isTerminalSource,
   type TurnSourceEvent,
@@ -236,6 +237,60 @@ describe('translateTurnSource — turn-completed', () => {
     expect(isTerminalSource(completed({ status: 'completed' }))).toBe(true)
     expect(
       isTerminalSource({ kind: 'approval-created', record: pendingRecord() }),
+    ).toBe(false)
+  })
+})
+
+describe('translateTurnSource — pre-content turn status', () => {
+  function sendResolved(
+    over: Partial<HarnessSendResponse> = {},
+  ): TurnSourceEvent {
+    return {
+      kind: 'send-resolved',
+      response: {
+        session_id: 'sess-a',
+        turn_id: 't-1',
+        accepted: true,
+        ...over,
+      },
+    }
+  }
+
+  it('maps a plain accepted send to phase accepted', () => {
+    expect(translateTurnSource(sendResolved())).toEqual([
+      { kind: 'turn-status', phase: 'accepted' },
+    ])
+  })
+
+  it('maps a merged send to phase merged', () => {
+    expect(translateTurnSource(sendResolved({ merged: true }))).toEqual([
+      { kind: 'turn-status', phase: 'merged' },
+    ])
+  })
+
+  it('maps a queued send to phase queued, even when also flagged merged', () => {
+    expect(
+      translateTurnSource(sendResolved({ queued: true, merged: true })),
+    ).toEqual([{ kind: 'turn-status', phase: 'queued' }])
+  })
+
+  it('maps turn-started to phase started', () => {
+    const event: TurnSourceEvent = {
+      kind: 'turn-started',
+      event: { session_id: 'sess-a', turn_id: 't-1', timestamp: 0 },
+    }
+    expect(translateTurnSource(event)).toEqual([
+      { kind: 'turn-status', phase: 'started' },
+    ])
+  })
+
+  it('is not terminal for send-resolved or turn-started', () => {
+    expect(isTerminalSource(sendResolved())).toBe(false)
+    expect(
+      isTerminalSource({
+        kind: 'turn-started',
+        event: { session_id: 'sess-a', turn_id: 't-1', timestamp: 0 },
+      }),
     ).toBe(false)
   })
 })

--- a/console/web/src/lib/backend/translate.ts
+++ b/console/web/src/lib/backend/translate.ts
@@ -11,6 +11,8 @@
  *   - `approval::pending-resolved` → `fcall-approval-cleared`
  *   - `harness::turn-completed`    → `assistant-end` (+ `stop-reason` when the
  *                                    turn failed / was cancelled)
+ *   - `harness::send` response     → `turn-status` (accepted/merged/queued)
+ *   - `harness::turn-started`      → `turn-status { phase: 'started' }`
  *
  * The translator is stateless: the new gate triggers are already discrete
  * create/resolve events, so no list-diffing (the old `turn_state_changed`
@@ -21,7 +23,9 @@ import type {
   PendingApprovalRecord,
   PendingResolvedEvent,
   TurnCompletedEvent,
+  TurnStartedEvent,
 } from '@/types/iii-agent-event'
+import type { HarnessSendResponse } from './harness-send'
 import type { StreamEvent } from './types'
 
 /** The discriminated union of trigger events `realStream` feeds the translator. */
@@ -29,6 +33,8 @@ export type TurnSourceEvent =
   | { kind: 'approval-created'; record: PendingApprovalRecord }
   | { kind: 'approval-resolved'; event: PendingResolvedEvent }
   | { kind: 'turn-completed'; event: TurnCompletedEvent }
+  | { kind: 'turn-started'; event: TurnStartedEvent }
+  | { kind: 'send-resolved'; response: HarnessSendResponse }
 
 /** True once this event ends the turn (the generator should stop after it). */
 export function isTerminalSource(event: TurnSourceEvent): boolean {
@@ -79,6 +85,23 @@ export function translateTurnSource(event: TurnSourceEvent): StreamEvent[] {
 
     case 'turn-completed':
       return translateTurnCompleted(event.event)
+
+    case 'turn-started':
+      return [{ kind: 'turn-status', phase: 'started' }]
+
+    case 'send-resolved': {
+      const { response } = event
+      return [
+        {
+          kind: 'turn-status',
+          phase: response.queued
+            ? 'queued'
+            : response.merged
+              ? 'merged'
+              : 'accepted',
+        },
+      ]
+    }
   }
 }
 

--- a/console/web/src/lib/backend/types.ts
+++ b/console/web/src/lib/backend/types.ts
@@ -103,6 +103,17 @@ export type StreamEvent =
       /** The assistant output above is preserved evidence, not a successful result. */
       partialResultAvailable?: boolean
     }
+  | {
+      /**
+       * Pre-content turn lifecycle, for the thinking shimmer's detail line.
+       * `accepted` = harness::send seeded a turn (step-0 sits on the durable
+       * queue); `merged` = folded into an in-flight turn; `queued` = parked
+       * in the server-side queue (the queued strip owns that surface);
+       * `started` = harness::turn-started fired, the loop is running.
+       */
+      kind: 'turn-status'
+      phase: 'accepted' | 'merged' | 'queued' | 'started'
+    }
 
 export interface ChatStreamOptions {
   signal?: AbortSignal

--- a/console/web/src/stories/playground/EventLog.tsx
+++ b/console/web/src/stories/playground/EventLog.tsx
@@ -185,6 +185,8 @@ function toneFor(kind: StreamEvent['kind']): string {
       return 'text-warn'
     case 'stop-reason':
       return 'text-warn'
+    case 'turn-status':
+      return 'text-ink-faint'
   }
 }
 

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -166,8 +166,10 @@ pub async fn run_step(
     drain_queued(deps, &session, &record.session_id).await?;
 
     // First-step bookkeeping: mark working + emit turn-started + pre_turn hook.
+    // The reason is the live phase detail UIs render while the shimmer shows;
+    // it advances to "waiting for <model>" right before the generation RPC.
     let _ = session
-        .set_status(&record.session_id, "working", None)
+        .set_status(&record.session_id, "working", Some("preparing context"))
         .await;
     if payload.step == 0 && record.turn_count == 0 {
         deps.events
@@ -379,6 +381,13 @@ pub async fn run_step(
     // flag — observed THIS step by the re-read below — instead of leaving the
     // stop blocked behind the whole step and a step of tool execution leaking.
     drop(_guard);
+
+    // Phase detail: context is assembled, the provider round-trip starts now.
+    // This is the window users actually wait in (provider time-to-first-token).
+    let waiting_reason = format!("waiting for {}", record.options.model);
+    let _ = session
+        .set_status(&record.session_id, "working", Some(&waiting_reason))
+        .await;
 
     let router = deps.router().await;
     let outcome = router.chat(params, &sink).await?;

--- a/session-manager/architecture/internals.md
+++ b/session-manager/architecture/internals.md
@@ -86,9 +86,10 @@ one is a regression even if all types still line up):
 6. **Entry timestamps never change after creation** (they anchor history);
    event timestamps are the mutation time. `meta.updated_at` bumps on every
    mutation of the session.
-7. **`set_status` is spec-strict:** same status ⇒ no write, no event — even if
-   the `reason` differs. `status_reason` is stored only with `error` and
-   cleared by any other status.
+7. **`set_status` is spec-strict:** same status AND same stored reason ⇒ no
+   write, no event. A reason change alone re-emits (live phase detail within
+   one `working` stretch). `status_reason` is stored with `error` (failure
+   cause) and `working` (phase detail), cleared by `idle`/`done`.
 8. **`set_meta` replaces `metadata` wholesale** when supplied (it is the
    tenancy hook; merging would leak stale keys). An all-`None` request is a
    silent no-op.

--- a/session-manager/src/functions/set_status.rs
+++ b/session-manager/src/functions/set_status.rs
@@ -12,8 +12,9 @@ pub struct SetStatusRequest {
     pub session_id: String,
     /// Target status: `idle` / `working` / `done` / `error`.
     pub status: SessionStatus,
-    /// Short cause stored as `status_reason` — kept on `error`,
-    /// cleared on any other status.
+    /// Short cause/phase stored as `status_reason` — kept on `error`
+    /// (failure cause) and `working` (live phase detail), cleared on
+    /// `idle`/`done`.
     pub reason: Option<String>,
 }
 

--- a/session-manager/src/service.rs
+++ b/session-manager/src/service.rs
@@ -349,9 +349,18 @@ impl SessionService {
         let _guard = self.lock_session(&req.session_id).await;
         let mut meta = self.meta_or_not_found(&req.session_id).await?;
 
-        // Spec-strict no-op: same status fires no event, even if the
-        // reason differs.
-        if meta.status == req.status {
+        // Reason is retained while `working` (live phase detail, e.g.
+        // "waiting for <model>") and on `error` (failure cause);
+        // idle/done always clear it.
+        let new_reason = match req.status {
+            SessionStatus::Working | SessionStatus::Error => req.reason,
+            _ => None,
+        };
+
+        // Spec-strict no-op: same status AND same stored reason fires no
+        // event. A reason change alone re-emits so UIs can render live
+        // phase updates within one `working` stretch.
+        if meta.status == req.status && meta.status_reason == new_reason {
             return Ok((
                 SetStatusResponse {
                     status: meta.status,
@@ -363,11 +372,7 @@ impl SessionService {
 
         let previous_status = meta.status;
         meta.status = req.status;
-        meta.status_reason = if req.status == SessionStatus::Error {
-            req.reason
-        } else {
-            None
-        };
+        meta.status_reason = new_reason;
         let now = self.clock.now_ms();
         meta.updated_at = now;
         self.store.put_meta(&meta).await?;

--- a/session-manager/tests/features/status.feature
+++ b/session-manager/tests/features/status.feature
@@ -4,9 +4,12 @@ Feature: session::set-status — the coarse lifecycle status
   Contract (session-manager.md § Session status / session::set-status):
   idle -> working -> done/error is driven by the harness; consumers
   render it directly (spinner, done badge, list filter). set_status is
-  a NO-OP (no event) when the status is unchanged. reason is stored as
-  status_reason — kept on "error", cleared on any other status — so a
-  standalone UI can render failures without asking the harness.
+  a NO-OP (no event) when both the status AND the stored reason are
+  unchanged; a reason change alone re-emits so UIs can render live
+  phase updates within one "working" stretch. reason is stored as
+  status_reason — kept on "error" (failure cause) and "working" (phase
+  detail), cleared on "idle"/"done" — so a standalone UI can render
+  progress and failures without asking the harness.
 
   Background:
     Given a bare session
@@ -50,27 +53,48 @@ Feature: session::set-status — the coarse lifecycle status
     And the response field "previous_status" is "working"
     And function "ui::status" received 1 "session::status-changed" delivery
 
-  # Prevents: spec-strict regression — same status with a DIFFERENT
-  # reason is still a no-op; the stored reason must not silently change
-  # and the second call must not emit a duplicate status_changed.
-  Scenario: same status with a different reason is still a no-op
+  # Prevents: invisible in-turn phases — a reason change within one
+  # "working" stretch must update the stored reason and re-emit so a
+  # UI can walk "preparing context" -> "waiting for <model>" live.
+  Scenario: a working-phase reason change updates and re-emits
     Given a binding "b1" on "session::status-changed" delivering to "ui::status" with config:
       """
       {}
       """
     Given I call "session::set-status" with:
       """
-      { "session_id": "s_001", "status": "error", "reason": "rate limited" }
+      { "session_id": "s_001", "status": "working", "reason": "preparing context" }
       """
     When I call "session::set-status" with:
       """
-      { "session_id": "s_001", "status": "error", "reason": "DIFFERENT" }
+      { "session_id": "s_001", "status": "working", "reason": "waiting for claude" }
       """
     And I call "session::get" with:
       """
       { "session_id": "s_001" }
       """
-    Then the response field "meta.status_reason" is "rate limited"
+    Then the response field "meta.status_reason" is "waiting for claude"
+    And function "ui::status" received 2 "session::status-changed" deliveries
+    And delivery 1 to "ui::status" has "status" = "working"
+    And delivery 1 to "ui::status" has "previous_status" = "working"
+    And delivery 1 to "ui::status" has "status_reason" = "waiting for claude"
+
+  # Prevents: duplicate events on redundant stamps — same status AND
+  # same reason together stay a strict no-op.
+  Scenario: same status with the same reason is still a no-op
+    Given a binding "b1" on "session::status-changed" delivering to "ui::status" with config:
+      """
+      {}
+      """
+    Given I call "session::set-status" with:
+      """
+      { "session_id": "s_001", "status": "working", "reason": "preparing context" }
+      """
+    When I call "session::set-status" with:
+      """
+      { "session_id": "s_001", "status": "working", "reason": "preparing context" }
+      """
+    Then the call succeeds
     And function "ui::status" received 1 "session::status-changed" delivery
 
   # Prevents: failures without a cause — error status must carry the

--- a/session-manager/tests/golden/schemas/session.set-status.json
+++ b/session-manager/tests/golden/schemas/session.set-status.json
@@ -16,7 +16,7 @@
     },
     "properties": {
       "reason": {
-        "description": "Short cause stored as `status_reason` — kept on `error`, cleared on any other status.",
+        "description": "Short cause/phase stored as `status_reason` — kept on `error` (failure cause) and `working` (live phase detail), cleared on `idle`/`done`.",
         "type": [
           "string",
           "null"

--- a/tech-specs/2026-06-agentic/session-manager.md
+++ b/tech-specs/2026-06-agentic/session-manager.md
@@ -29,7 +29,8 @@ Every session has a coarse lifecycle status that consumers can render directly (
 badge, a list filter):
 
 - `idle` — created and waiting; no work has run yet.
-- `working` — the agent is thinking/responding (a turn is running).
+- `working` — the agent is thinking/responding (a turn is running); the optional `status_reason`
+  carries the live phase (e.g. `preparing context`, `waiting for <model>`).
 - `done` — the agent finished the job (completed or cancelled) and the session is at rest.
 - `error` — the last turn failed; the optional `status_reason` carries a short cause. Distinct from
   `done` so a **standalone** UI can render failures without asking the harness.
@@ -187,7 +188,7 @@ type StatusChangedEvent = {
   session_id: string;
   status: SessionStatus;
   previous_status: SessionStatus;
-  status_reason?: string;       // short cause, set on "error"
+  status_reason?: string;       // failure cause on "error", live phase on "working"
   timestamp: number;
 };
 ```
@@ -242,7 +243,7 @@ type SessionMeta = {
   title: string;
   description: string;
   status: SessionStatus;          // "idle" | "working" | "done" | "error"
-  status_reason?: string;         // short cause, set on "error"
+  status_reason?: string;         // failure cause on "error", live phase on "working"
   metadata?: Record<string, unknown>; // app-defined; the tenancy hook (e.g. { owner: "u_1" })
   forked_from?: string | null;
   created_at: number;
@@ -339,8 +340,10 @@ type SetMetaResponse = { meta: SessionMeta };
 
 ### `session::set-status`
 
-Set the session status. Fires `session::status-changed`. No-op (no event) if the status is unchanged.
-`reason` is stored as `status_reason` (typically set with `error`, cleared on any other status).
+Set the session status. Fires `session::status-changed`. No-op (no event) if both the status and the
+stored reason are unchanged; a reason change alone re-emits so UIs can render live phase updates
+within one `working` stretch. `reason` is stored as `status_reason` — kept on `error` (failure
+cause) and `working` (live phase detail), cleared on `idle`/`done`.
 
 - Invocation: **sync**
 


### PR DESCRIPTION
## What

Sending a message in the console chat used to show a bare "thinking…" (or "dispatching <model>") line until the first tokens arrived. The shimmer now walks the real lifecycle, live:

| signal | shimmer shows |
|---|---|
| submit | `sending…` |
| `harness::send` accepted | `queued — waiting to start…` |
| `harness::send` merged into a running turn | `added to the running turn…` |
| turn loop step starts | `preparing context` |
| context assembled, provider RPC begins | `waiting for <model>` |
| first tokens | shimmer clears (unchanged) |

The two server-driven phases come from session state, so they survive reloads and show in every tab viewing the session.

## How

- **console/web**: the `harness::send` response and `harness::turn-started` — both already delivered to the console and previously discarded — translate to a new `turn-status` stream event feeding the shimmer's detail line. Server `status_reason` remains highest precedence, and phase text is only trusted while the transcript still ends at the user's message (content arrives via session events, not stream events).
- **session-manager**: `session::set-status` stores `status_reason` on `working` (live phase detail) as well as `error` (failure cause), and re-emits `session::status-changed` when only the reason changes; the no-op now requires status AND stored reason unchanged. Contract updated in `status.feature` (2 new scenarios), the golden schema, `architecture/internals.md`, and `tech-specs/2026-06-agentic/session-manager.md`.
- **harness**: `turn_loop` stamps `preparing context` at step start and `waiting for <model>` immediately before the `router::chat` RPC — the window users actually wait in.

Also restores the missing `SelectOption.title` field: `PermissionModePicker` passes `title` since #469 but the field never landed, so `tsc -b` (and therefore the console worker's `build.rs` web build) fails on a clean checkout of main.

## Test plan

- [x] `console/web`: `pnpm build` (tsc -b + vite), `pnpm test` — 946 tests pass, incl. new translator cases for `send-resolved`/`turn-started`
- [x] `session-manager`: `cargo test` — 118 BDD scenarios pass, incl. 2 new (`working`-phase reason re-emit; same status+reason no-op); goldens regenerated
- [x] `harness`: `cargo build`, `cargo fmt --check`
- [x] Live smoke on the dev stack: 40ms-interval shimmer recorder captured `sending… → queued — waiting to start… → waiting for claude-sonnet-5 → (tokens)` on a real Sonnet 5 send

Fixes MOT-3964

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed progress updates while an agent request is being prepared, queued, accepted, merged, or started.
  * Improved chat loading indicators with more specific status descriptions.
  * Added optional hover titles to selectable options.

* **Bug Fixes**
  * Status updates now refresh when phase details change, even if the overall status remains the same.

* **Documentation**
  * Clarified status reasons, lifecycle phases, and event emission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->