### PR TITLE
(MOT-3955) fix(console): restore the missing select option title field

### DIFF
--- a/console/web/src/components/ui/Select.tsx
+++ b/console/web/src/components/ui/Select.tsx
@@ -5,6 +5,8 @@ import { cn } from '@/lib/utils'
 interface SelectOption<T extends string> {
   value: T
   label: string
+  /** Optional hover tooltip on the option row. */
+  title?: string
 }
 
 interface SelectGroup<T extends string> {
@@ -189,6 +191,7 @@ export function Select<T extends string>({
                         key={opt.value}
                         value={opt.value}
                         label={opt.label}
+                        title={opt.title}
                       />
                     ))}
                   </SelectPrimitive.Group>
@@ -198,6 +201,7 @@ export function Select<T extends string>({
                     key={opt.value}
                     value={opt.value}
                     label={opt.label}
+                    title={opt.title}
                   />
                 ))}
           </SelectPrimitive.Viewport>
@@ -223,12 +227,14 @@ export function Select<T extends string>({
 interface SelectItemProps {
   value: string
   label: string
+  title?: string
 }
 
-function SelectItem({ value, label }: SelectItemProps) {
+function SelectItem({ value, label, title }: SelectItemProps) {
   return (
     <SelectPrimitive.Item
       value={value}
+      title={title}
       className={cn(
         'relative flex items-center pl-7 pr-3 py-1.5 cursor-pointer outline-none select-none',
         'data-[highlighted]:bg-rule data-[highlighted]:text-ink',


### PR DESCRIPTION
## What

Main does not build: `PermissionModePicker` passes a `title` tooltip on its approval-mode options (landed in #469), but `SelectOption` never gained the field. `tsc -b` fails, which breaks `pnpm build` and therefore the console worker's `build.rs` web build on any clean checkout.

This adds `title?: string` to `SelectOption` and forwards it to the option row as the native tooltip — the behavior #469 intended.

## Notes

- #477 currently carries this same one-file fix so its own CI can pass; once either lands, the other merges cleanly (identical change).
- Verified: `pnpm build` fails on bare origin/main and passes with only this change applied; 946 web tests pass.

Refs MOT-3955

https://github.com/iii-hq/workers/pull/469