### PR TITLE
fix(harness): bump shell dependency pin to ^0.9.0

### DIFF
--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -19,5 +19,5 @@ dependencies:
   context-manager: "^1.0.0"
   provider-anthropic: "^1.0.0"
   provider-openai: "^1.0.0"
-  shell: "^0.8.0"
+  shell: "^0.9.0"
   web: "^1.1.2"


### PR DESCRIPTION
## Summary
- harness/iii.worker.yaml declared shell: ^0.8.0, which under semver caret
  rules means >=0.8.0 <0.9.0 — no longer matches shell's actual released
  version (0.9.0 since 2026-07-09).
- Bumps the floor to ^0.9.0 to match reality.

## Test plan
- [ ] Metadata-only change, no build/test impact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the shell runtime dependency to a newer compatible version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->