### PR TITLE
(MOT-3980) fix(shell): expose coder functions in zero-config mode

### DIFF
--- a/shell/src/configuration.rs
+++ b/shell/src/configuration.rs
@@ -63,9 +63,6 @@ fn build_code_snapshot(
     ),
     String,
 > {
-    if !cfg.fs.is_jailed() {
-        return Err("coder surface requires a jailed fs.host_roots config".to_string());
-    }
     let code_cfg = Arc::new(cfg.code_resolver_config());
     let resolver = Arc::new(
         PathResolver::new(&code_cfg)
@@ -533,6 +530,21 @@ mod tests {
     }
 
     #[test]
+    fn zero_config_seed_builds_coder_cells_with_narrow_fallback_roots() {
+        let cells = build_code_cells(&ShellConfig::seed_default())
+            .expect("zero-config shell must expose coder functions");
+        let resolver = cells.resolver.blocking_read();
+        let expected_cwd = std::fs::canonicalize(".").expect("current directory exists");
+        let expected_tmp = std::fs::canonicalize("/tmp").expect("/tmp exists");
+
+        assert_eq!(resolver.roots(), &[expected_cwd, expected_tmp]);
+        assert!(
+            cells.config.blocking_read().base_paths.is_empty(),
+            "empty configured roots must keep using the coder-only fallback"
+        );
+    }
+
+    #[test]
     fn prepare_config_accepts_pinned_host_roots() {
         let mut c = ShellConfig::default();
         c.fs.host_roots = vec![std::path::PathBuf::from("/tmp/shell")];
@@ -824,6 +836,26 @@ mod tests {
             "coder resolver must see the newly reloaded shell root"
         );
         assert_eq!(cells.config.read().await.base_paths, vec![dir_b]);
+
+        // Clearing host_roots is an explicit shell::fs::* widening, but coder
+        // remains jailed to its own cwd + /tmp fallback and stays available.
+        let unjailed = ShellConfig::seed_default();
+        let res = reload_serialized(&state, {
+            let unjailed = unjailed.clone();
+            move || async move { Ok::<_, String>(unjailed.to_json()) }
+        })
+        .await;
+        assert!(matches!(res, Ok(ReloadOutcome::Applied)));
+
+        let after = cells.resolver.read().await.clone();
+        assert_eq!(
+            after.roots(),
+            &[
+                std::fs::canonicalize(".").expect("current directory exists"),
+                std::fs::canonicalize("/tmp").expect("/tmp exists"),
+            ]
+        );
+        assert!(cells.config.read().await.base_paths.is_empty());
     }
 
     #[tokio::test]

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -198,19 +198,17 @@ async fn main() -> Result<()> {
         );
     }
 
-    let code_cells = if cfg.fs.is_jailed() {
-        Some(
-            configuration::build_code_cells(&cfg)
-                .map_err(anyhow::Error::msg)
-                .context("building initial code surface state (coder::*)")?,
-        )
-    } else {
-        None
-    };
+    // coder::* remains jailed even when shell::fs::* is explicitly unjailed:
+    // an empty fs.host_roots uses the code resolver's narrow cwd + /tmp
+    // fallback. Building the cells unconditionally keeps the zero-config
+    // worker useful while preserving the coder path boundary.
+    let code_cells = configuration::build_code_cells(&cfg)
+        .map_err(anyhow::Error::msg)
+        .context("building initial code surface state (coder::*)")?;
 
     let state = AppState {
         runtime: std::sync::Arc::new(tokio::sync::RwLock::new(runtime)),
-        code_cells: code_cells.clone(),
+        code_cells: Some(code_cells.clone()),
         iii: iii.clone(),
         reload_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
         reload_status: std::sync::Arc::new(tokio::sync::RwLock::new(
@@ -237,22 +235,12 @@ async fn main() -> Result<()> {
             "boot reconcile of configuration failed (refusing to serve a possibly stale policy)",
         )?;
 
-    // Code surface (folded coder::*): build the path-jail resolver from the
-    // UNIFIED roots (fs.host_roots) + the `code` block's protected globs, then
-    // register the 9 code functions. The resolver IS the jail. A bad glob /
-    // unreachable root makes PathResolver::new fail and aborts startup — the
-    // whole worker fails closed (no half-booted surface). The code surface
-    // requires a jail: unjailed shells don't expose coder::*.
-    if cfg.fs.is_jailed() {
-        let cells = code_cells.expect("code cells exist when fs is jailed");
-        code::register_all(&iii, cells);
-        tracing::info!("code surface (coder::*) registered over the unified fs jail");
-    } else {
-        tracing::warn!(
-            "fs is unjailed (no fs.host_roots) — code surface (coder::*) NOT \
-             registered; coder file functions require a jail root"
-        );
-    }
+    // Code surface (folded coder::*): explicit fs.host_roots are shared with
+    // shell::fs::*; when they are empty, PathResolver supplies its own narrow
+    // cwd + /tmp defaults. In both cases the resolver is a jail. A bad glob or
+    // unreachable root aborts startup so the worker never half-boots.
+    code::register_all(&iii, code_cells);
+    tracing::info!("code surface (coder::*) registered");
 
     // exec / exec_bg / list read the live config snapshot from AppState.
     {


### PR DESCRIPTION
## Summary

Make all nine `coder::*` file tools available when the shell worker uses its shipped zero-config policy.

The coder resolver now uses its existing working-directory plus `/tmp` fallback when `fs.host_roots` is empty, while explicit roots continue to override that fallback. Hot reloads can also move safely between configured roots and the zero-config fallback.

## Why

The default shell configuration deliberately leaves `fs.host_roots` empty, but startup and reload contained separate jail checks that skipped the entire coder surface. As a result, healthy harness sessions had no coder file tools even though the resolver already supported a safe fallback.

## Developer experience

A fresh local stack now exposes coder tools without requiring operators to discover and configure filesystem roots first. Harness-selected workspaces remain available through the trusted per-session filesystem scope.

This does not grant parent directories automatically or weaken `shell::fs::*` confinement. Attempts to leave the selected workspace still require an explicit folder-access grant.

## Verification

- `cargo fmt --manifest-path shell/Cargo.toml -- --check`
- `cargo test --manifest-path shell/Cargo.toml --lib configuration::tests::` — 17 passed
- `cargo test --manifest-path shell/Cargo.toml`
- Live zero-config smoke: all nine `coder::*` functions registered after restarting only the shell worker
- Live session-scope smoke: `coder::read-file` read a file from the selected workspace outside the worker's static fallback roots

Fixes MOT-3980


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Coder functionality now remains available when shell filesystem restrictions are widened or cleared.
  * Improved fallback behavior keeps coder file resolution limited to the current directory and `/tmp` when no explicit base paths are configured.
  * Coder configuration now remains consistent after shell configuration reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->