### PR TITLE
(MOT-3981) fix: relax filesystem scope without approval gate

### DIFF
--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -1532,10 +1532,15 @@ export function ChatView({
               <button
                 type="button"
                 onClick={handleManageFilesystemAccess}
+                title={
+                  approvalEnabled
+                    ? 'Access is limited to this workspace until you approve another folder.'
+                    : 'The working directory sets where commands start; shell configuration controls access.'
+                }
                 className="ml-auto shrink-0 lowercase text-ink-ghost hover:text-ink transition-colors"
               >
-                filesystem access
-                {filesystemGrants.grants.length > 0
+                access: {approvalEnabled ? 'workspace' : 'shell defaults'}
+                {approvalEnabled && filesystemGrants.grants.length > 0
                   ? ` · ${filesystemGrants.grants.length}`
                   : ''}
               </button>
@@ -1633,6 +1638,7 @@ export function ChatView({
           onRevoke={filesystemGrants.revoke}
           onRefreshGrants={filesystemGrants.refresh}
           sessionBusy={streamingIndicator}
+          workspaceScoped={approvalEnabled}
         />
       ) : null}
     </section>

--- a/console/web/src/components/chat/shell/__tests__/parsers.test.ts
+++ b/console/web/src/components/chat/shell/__tests__/parsers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  cleanShellErrorMessage,
   extractEmbeddedSCode,
   fsChmodRequestSchema,
   fsChmodResponseSchema,
@@ -606,11 +607,19 @@ describe('parseShellErrorDisplay', () => {
     expect(out).toEqual({
       variant: 'wire',
       error: {
-        type: 'permission denied',
+        type: 'filesystem access blocked',
         code: 'S215',
         message: 'cwd escapes jail: /etc/passwd',
       },
     })
+  })
+
+  it('keeps filesystem access metadata out of the readable error', () => {
+    expect(
+      cleanShellErrorMessage(
+        'remote error (S215): path escapes the fs jail roots [/work]: /other filesystem_access_request={"v":1,"requested_root":"/other","attempted_path":"/other","error_code":"S215"}',
+      ),
+    ).toBe('path escapes the fs jail roots [/work]: /other')
   })
 
   it('delegates S-code-free denials to the sandbox invocation variant', () => {

--- a/console/web/src/components/chat/shell/parsers.ts
+++ b/console/web/src/components/chat/shell/parsers.ts
@@ -465,7 +465,7 @@ export const S_CODE_LABEL: Record<string, string> = {
   S212: 'wrong file type',
   S213: 'already exists',
   S214: 'directory not empty',
-  S215: 'permission denied',
+  S215: 'filesystem access blocked',
   S216: 'i/o error',
   S217: 'bad regex',
   S218: 'size cap exceeded',
@@ -481,9 +481,16 @@ function shellWire(e: { code: string; message: string }): SandboxErrorDisplay {
     error: {
       type: S_CODE_LABEL[e.code] ?? 'shell error',
       code: e.code,
-      message: e.message,
+      message: cleanShellErrorMessage(e.message),
     },
   }
+}
+
+export function cleanShellErrorMessage(message: string): string {
+  return stripHandlerPrefix(message)
+    .replace(/^remote error \(S\d{3}\):\s*/, '')
+    .replace(/\s+filesystem_access_request=\{[\s\S]*\}\s*$/, '')
+    .trim()
 }
 
 /** exec_bg stringifies its S-code into the message ("S215: …"), and the
@@ -510,7 +517,7 @@ function wireFromText(text: string): SandboxErrorDisplay | null {
   if (!match) return null
   return shellWire({
     code: match[1],
-    message: stripHandlerPrefix(match[2].trim()),
+    message: cleanShellErrorMessage(match[2].trim()),
   })
 }
 

--- a/console/web/src/components/permissions/FilesystemAccessDialog.tsx
+++ b/console/web/src/components/permissions/FilesystemAccessDialog.tsx
@@ -25,6 +25,8 @@ interface FilesystemAccessDialogProps {
   onRefreshGrants: () => void | Promise<void>
   /** Shows a hint that revoking mid-turn may make the agent ask again. */
   sessionBusy?: boolean
+  /** Whether the working directory is an enforced boundary with approval recovery. */
+  workspaceScoped: boolean
 }
 
 /**
@@ -43,6 +45,7 @@ export function FilesystemAccessDialog({
   onRevoke,
   onRefreshGrants,
   sessionBusy,
+  workspaceScoped,
 }: FilesystemAccessDialogProps) {
   const [shellRoots, setShellRoots] = useState<string[] | null>(null)
 
@@ -57,8 +60,17 @@ export function FilesystemAccessDialog({
       <DialogContent className="max-w-lg">
         <DialogTitle className="text-[14px]">filesystem access</DialogTitle>
         <DialogDescription className="mt-1">
-          folders the agent can read and write in this conversation.
+          {workspaceScoped
+            ? 'folders the agent can read and write in this conversation.'
+            : 'the working directory sets where commands start; shell configuration controls access.'}
         </DialogDescription>
+
+        {!workspaceScoped ? (
+          <p className="mt-3 font-mono text-[11px] leading-5 text-ink-faint">
+            filesystem approvals are off. access uses the shell defaults shown
+            below.
+          </p>
+        ) : null}
 
         <div className="mt-5 flex flex-col gap-5">
           <FolderGroup title="workspace">
@@ -78,7 +90,9 @@ export function FilesystemAccessDialog({
                     {workingDir}
                   </span>
                   <span className="block font-mono text-[10px] lowercase text-ink-ghost">
-                    always allowed — change it with the directory picker
+                    {workspaceScoped
+                      ? 'workspace boundary; change it with the directory picker'
+                      : 'command starting folder, not an access boundary'}
                   </span>
                 </div>
               </div>
@@ -89,7 +103,7 @@ export function FilesystemAccessDialog({
             )}
           </FolderGroup>
 
-          {grantsSupported ? (
+          {workspaceScoped && grantsSupported ? (
             <FolderGroup title="allowed this session">
               {sessionBusy ? (
                 <p className="px-2 pb-1.5 font-mono text-[11px] text-ink-faint">

--- a/harness/src/deferred.rs
+++ b/harness/src/deferred.rs
@@ -116,6 +116,7 @@ pub async fn resolve(
                 arguments,
                 filesystem_root.as_deref(),
                 &trusted_roots,
+                deps.hooks.filesystem_boundary(&function_id),
             );
             if let Some(cp) = record.calls.get_mut(&req.function_call_id) {
                 cp.state = CallState::Triggered;

--- a/harness/src/filesystem_scope.rs
+++ b/harness/src/filesystem_scope.rs
@@ -6,9 +6,28 @@
 //! root and grants; this module only stamps trusted metadata and strips any
 //! model-supplied scope.
 
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 pub const FS_SCOPE_FIELD: &str = "fs_scope";
+pub const FILESYSTEM_ACCESS_WATCH_ID: &str = "approval::filesystem-access-watch";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FilesystemBoundary {
+    Workspace,
+    ConfiguredRoots,
+}
+
+impl FilesystemBoundary {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Workspace => "workspace",
+            Self::ConfiguredRoots => "configured_roots",
+        }
+    }
+}
 
 /// True when `function_id` names a filesystem-scoped worker call whose paths
 /// must be constrained by the harness-owned scope.
@@ -18,7 +37,13 @@ fn is_scoped_function(function_id: &str) -> bool {
 }
 
 /// Stamp the trusted filesystem scope onto a scoped call's arguments.
-pub fn inject(function_id: &str, args: Value, root: Option<&str>, grants: &[String]) -> Value {
+pub fn inject(
+    function_id: &str,
+    args: Value,
+    root: Option<&str>,
+    grants: &[String],
+    boundary: FilesystemBoundary,
+) -> Value {
     if !is_scoped_function(function_id) {
         return args;
     }
@@ -32,6 +57,7 @@ pub fn inject(function_id: &str, args: Value, root: Option<&str>, grants: &[Stri
             json!({
                 "root": root,
                 "grants": grants,
+                "boundary": boundary.as_str(),
             }),
         );
     } else {
@@ -46,6 +72,10 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    fn workspace() -> FilesystemBoundary {
+        FilesystemBoundary::Workspace
+    }
+
     #[test]
     fn stamps_fs_scope_for_shell_calls() {
         let out = inject(
@@ -53,10 +83,11 @@ mod tests {
             json!({ "command": "ls" }),
             Some("/work/session-7"),
             &[],
+            workspace(),
         );
         assert_eq!(
             out,
-            json!({ "command": "ls", "fs_scope": { "root": "/work/session-7", "grants": [] } })
+            json!({ "command": "ls", "fs_scope": { "root": "/work/session-7", "grants": [], "boundary": "workspace" } })
         );
     }
 
@@ -67,10 +98,11 @@ mod tests {
             json!({ "path": "src/main.rs" }),
             Some("/work/session-7"),
             &[],
+            workspace(),
         );
         assert_eq!(
             out,
-            json!({ "path": "src/main.rs", "fs_scope": { "root": "/work/session-7", "grants": [] } })
+            json!({ "path": "src/main.rs", "fs_scope": { "root": "/work/session-7", "grants": [], "boundary": "workspace" } })
         );
     }
 
@@ -81,10 +113,11 @@ mod tests {
             json!({ "command": "ls", "fs_scope": { "root": "/etc", "grants": ["/model"] } }),
             Some("/work/session-7"),
             &[],
+            workspace(),
         );
         assert_eq!(
             out,
-            json!({ "command": "ls", "fs_scope": { "root": "/work/session-7", "grants": [] } })
+            json!({ "command": "ls", "fs_scope": { "root": "/work/session-7", "grants": [], "boundary": "workspace" } })
         );
     }
 
@@ -96,17 +129,24 @@ mod tests {
             json!({ "command": "ls", "fs_scope": { "root": "/etc", "grants": ["/model"] } }),
             Some("/work/session-7"),
             &grants,
+            workspace(),
         );
         assert_eq!(
             out,
-            json!({ "command": "ls", "fs_scope": { "root": "/work/session-7", "grants": ["/approved"] } })
+            json!({ "command": "ls", "fs_scope": { "root": "/work/session-7", "grants": ["/approved"], "boundary": "workspace" } })
         );
     }
 
     #[test]
     fn strips_caller_supplied_fs_scope_when_root_absent() {
         let args = json!({ "command": "ls", "fs_scope": { "root": "/etc", "grants": ["/model"] } });
-        let out = inject("shell::exec", args, None, &[]);
+        let out = inject(
+            "shell::exec",
+            args,
+            None,
+            &[],
+            FilesystemBoundary::ConfiguredRoots,
+        );
         assert_eq!(out, json!({ "command": "ls" }));
     }
 
@@ -118,6 +158,7 @@ mod tests {
             args.clone(),
             Some("/work/session-7"),
             &["/approved".to_string()],
+            workspace(),
         );
         assert_eq!(out, args);
     }
@@ -130,6 +171,7 @@ mod tests {
             args.clone(),
             Some("/work/session-7"),
             &["/approved".to_string()],
+            workspace(),
         );
         assert_eq!(out, args);
     }
@@ -137,7 +179,13 @@ mod tests {
     #[test]
     fn passthrough_when_args_not_an_object() {
         let args = json!(["ls", "-la"]);
-        let out = inject("shell::exec", args.clone(), Some("/work/session-7"), &[]);
+        let out = inject(
+            "shell::exec",
+            args.clone(),
+            Some("/work/session-7"),
+            &[],
+            workspace(),
+        );
         assert_eq!(out, args);
 
         let scalar = json!("raw");
@@ -146,7 +194,30 @@ mod tests {
             scalar.clone(),
             Some("/work/session-7"),
             &[],
+            workspace(),
         );
         assert_eq!(out, scalar);
+    }
+
+    #[test]
+    fn configured_roots_boundary_preserves_the_working_directory_anchor() {
+        let out = inject(
+            "shell::fs::ls",
+            json!({ "path": "src" }),
+            Some("/work/session-7"),
+            &[],
+            FilesystemBoundary::ConfiguredRoots,
+        );
+        assert_eq!(
+            out,
+            json!({
+                "path": "src",
+                "fs_scope": {
+                    "root": "/work/session-7",
+                    "grants": [],
+                    "boundary": "configured_roots"
+                }
+            })
+        );
     }
 }

--- a/harness/src/functions/filesystem.rs
+++ b/harness/src/functions/filesystem.rs
@@ -39,6 +39,9 @@ pub struct FilesystemInfoResponse {
     /// send carries no explicit `fs_scope.root`; `null` when defaulting is
     /// disabled (`default_filesystem_root: "off"`) or the cwd is unreadable.
     pub default_root: Option<String>,
+    /// Effective per-session boundary for shell/coder calls. `workspace` when
+    /// the filesystem approval hook can widen it, otherwise `configured_roots`.
+    pub boundary: crate::filesystem_scope::FilesystemBoundary,
 }
 
 /// The resolved default working directory — the value a console pre-fills the
@@ -50,6 +53,7 @@ pub async fn info(
     let cfg = deps.cfg().await;
     Ok(FilesystemInfoResponse {
         default_root: cfg.resolved_default_filesystem_root(),
+        boundary: deps.hooks.filesystem_boundary("shell::fs::ls"),
     })
 }
 

--- a/harness/src/functions/function_trigger.rs
+++ b/harness/src/functions/function_trigger.rs
@@ -106,11 +106,13 @@ pub async fn handle(
         .as_ref()
         .and_then(|rec| rec.options.filesystem_root())
         .map(str::to_string);
+    let filesystem_boundary = deps.hooks.filesystem_boundary(&req.call.function_id);
     let mut arguments = crate::filesystem_scope::inject(
         &req.call.function_id,
         req.call.arguments.clone(),
         filesystem_root.as_deref(),
         &session_grants,
+        filesystem_boundary,
     );
     if let Some(rec) = &record {
         match deps
@@ -130,6 +132,7 @@ pub async fn handle(
                     a,
                     filesystem_root.as_deref(),
                     &session_grants,
+                    filesystem_boundary,
                 );
             }
             PreTriggerOutcome::Deny(reason) => {
@@ -163,6 +166,7 @@ pub async fn handle(
         arguments,
         filesystem_root.as_deref(),
         &session_grants,
+        filesystem_boundary,
     );
 
     // Single invocation chokepoint: subscription control calls are intercepted

--- a/harness/src/hooks/mod.rs
+++ b/harness/src/hooks/mod.rs
@@ -309,13 +309,10 @@ mod tests {
     #[test]
     fn filesystem_boundary_tracks_the_live_access_watch_binding() {
         let set = HookSet::default();
-        assert_eq!(
-            set.has_function_binding(
-                crate::filesystem_scope::FILESYSTEM_ACCESS_WATCH_ID,
-                "shell::fs::ls"
-            ),
-            false
-        );
+        assert!(!set.has_function_binding(
+            crate::filesystem_scope::FILESYSTEM_ACCESS_WATCH_ID,
+            "shell::fs::ls"
+        ));
         set.add(
             HookPoint::PostTrigger,
             cfg(

--- a/harness/src/hooks/mod.rs
+++ b/harness/src/hooks/mod.rs
@@ -159,6 +159,13 @@ impl HookSet {
         self.lock().is_empty()
     }
 
+    pub fn has_function_binding(&self, function_id: &str, target_function_id: &str) -> bool {
+        self.lock().values().any(|binding| {
+            binding.function_id == function_id
+                && runner::functions_match(binding, target_function_id)
+        })
+    }
+
     fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<String, HookBinding>> {
         self.inner.lock().unwrap_or_else(|p| p.into_inner())
     }
@@ -245,6 +252,20 @@ impl HookRegistry {
             HookPoint::PostTrigger => &self.post_trigger,
         }
     }
+
+    pub fn filesystem_boundary(
+        &self,
+        target_function_id: &str,
+    ) -> crate::filesystem_scope::FilesystemBoundary {
+        if self.post_trigger.has_function_binding(
+            crate::filesystem_scope::FILESYSTEM_ACCESS_WATCH_ID,
+            target_function_id,
+        ) {
+            crate::filesystem_scope::FilesystemBoundary::Workspace
+        } else {
+            crate::filesystem_scope::FilesystemBoundary::ConfiguredRoots
+        }
+    }
 }
 
 pub mod runner;
@@ -283,6 +304,40 @@ mod tests {
         .unwrap();
         let order: Vec<String> = set.ordered().into_iter().map(|b| b.function_id).collect();
         assert_eq!(order, vec!["m::hook", "a::hook", "z::hook"]);
+    }
+
+    #[test]
+    fn filesystem_boundary_tracks_the_live_access_watch_binding() {
+        let set = HookSet::default();
+        assert_eq!(
+            set.has_function_binding(
+                crate::filesystem_scope::FILESYSTEM_ACCESS_WATCH_ID,
+                "shell::fs::ls"
+            ),
+            false
+        );
+        set.add(
+            HookPoint::PostTrigger,
+            cfg(
+                "access-watch",
+                crate::filesystem_scope::FILESYSTEM_ACCESS_WATCH_ID,
+                json!({ "functions": ["shell::*", "coder::*"] }),
+            ),
+        )
+        .unwrap();
+        assert!(set.has_function_binding(
+            crate::filesystem_scope::FILESYSTEM_ACCESS_WATCH_ID,
+            "shell::fs::ls"
+        ));
+        assert!(!set.has_function_binding(
+            crate::filesystem_scope::FILESYSTEM_ACCESS_WATCH_ID,
+            "web::fetch"
+        ));
+        set.remove("access-watch");
+        assert!(!set.has_function_binding(
+            crate::filesystem_scope::FILESYSTEM_ACCESS_WATCH_ID,
+            "shell::fs::ls"
+        ));
     }
 
     #[test]

--- a/harness/src/hooks/runner.rs
+++ b/harness/src/hooks/runner.rs
@@ -327,7 +327,7 @@ fn merge(into: &mut Map<String, Value>, from: Map<String, Value>) {
 
 /// Whether a pre/post_trigger binding's `functions` globs match the target
 /// (no `functions` filter → all calls).
-fn functions_match(binding: &HookBinding, function_id: &str) -> bool {
+pub(super) fn functions_match(binding: &HookBinding, function_id: &str) -> bool {
     match &binding.functions {
         None => true,
         Some(globs) if globs.is_empty() => true,

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -631,6 +631,7 @@ pub async fn run_step(
                 call.arguments.clone(),
                 filesystem_root.as_deref(),
                 &session_grants,
+                deps.hooks.filesystem_boundary(&call.function_id),
             );
             let (eff_args, pre_ann) = match deps
                 .hooks
@@ -652,6 +653,7 @@ pub async fn run_step(
                         arguments,
                         filesystem_root.as_deref(),
                         &session_grants,
+                        deps.hooks.filesystem_boundary(&call.function_id),
                     );
                     (arguments, annotations)
                 }

--- a/shell/src/code/functions/create_file.rs
+++ b/shell/src/code/functions/create_file.rs
@@ -98,10 +98,10 @@ pub async fn handle(
             "`files` must not be empty".into(),
         )));
     }
-    let scope_root = crate::fs::scope_root(req.fs_scope.as_ref());
+    let fs_scope = req.fs_scope.as_ref();
     let mut entries = Vec::with_capacity(req.files.len());
     for spec in req.files {
-        match resolver.require_writable_opt(scope_root, &spec.path) {
+        match resolver.require_writable_scope(fs_scope, &spec.path) {
             Ok(abs) => entries.push((spec, Ok(abs))),
             Err(e) if is_jail_scope_error(&e) => return Err(err_to_string(e)),
             Err(e) => entries.push((spec, Err(e))),

--- a/shell/src/code/functions/delete_file.rs
+++ b/shell/src/code/functions/delete_file.rs
@@ -68,10 +68,11 @@ pub async fn handle(
             "`paths` must not be empty".into(),
         )));
     }
-    let scope_root = crate::fs::scope_root(req.fs_scope.as_ref());
+    let fs_scope = req.fs_scope.as_ref();
+    let scope_anchor = crate::fs::scope_anchor(fs_scope);
     let mut entries = Vec::with_capacity(req.paths.len());
     for p in req.paths {
-        match resolver.require_writable_opt(scope_root, &p) {
+        match resolver.require_writable_scope(fs_scope, &p) {
             Ok(abs) => entries.push((p, Ok(abs))),
             Err(e) if is_jail_scope_error(&e) => return Err(err_to_string(e)),
             Err(e) => entries.push((p, Err(e))),
@@ -79,7 +80,7 @@ pub async fn handle(
     }
     let results = entries
         .into_iter()
-        .map(|(p, resolved)| delete_one(&resolver, scope_root, &p, req.recursive, resolved))
+        .map(|(p, resolved)| delete_one(&resolver, scope_anchor, &p, req.recursive, resolved))
         .collect();
     Ok(DeleteFileOutput { results })
 }
@@ -396,6 +397,7 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: session.to_string_lossy().into_owned(),
                     grants: Vec::new(),
+                    boundary: crate::fs::FsBoundary::Workspace,
                 }),
             },
         )
@@ -423,6 +425,7 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: abs,
                     grants: Vec::new(),
+                    boundary: crate::fs::FsBoundary::Workspace,
                 }),
             },
         )
@@ -449,6 +452,7 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: session.to_string_lossy().into_owned(),
                     grants: Vec::new(),
+                    boundary: crate::fs::FsBoundary::Workspace,
                 }),
             },
         )

--- a/shell/src/code/functions/list_folder.rs
+++ b/shell/src/code/functions/list_folder.rs
@@ -107,7 +107,7 @@ fn inner(
     // list-folder uses `resolve`, not `require_writable`, so callers can
     // list a directory that contains non-accessible *children* even if the
     // directory itself happened to match a glob.
-    let abs = resolver.resolve_opt(crate::fs::scope_root(req.fs_scope.as_ref()), &req.path)?;
+    let abs = resolver.resolve_scope(req.fs_scope.as_ref(), &req.path)?;
     // NotFound is intercepted with the wire path in scope so the C211
     // message names the path the caller supplied (standardized wording —
     // REDACTION INVARIANT: identical to the glob-denied message).

--- a/shell/src/code/functions/move_file.rs
+++ b/shell/src/code/functions/move_file.rs
@@ -117,10 +117,10 @@ pub async fn handle(
             "`files` must not be empty".into(),
         )));
     }
-    let scope_root = crate::fs::scope_root(req.fs_scope.as_ref());
+    let fs_scope = req.fs_scope.as_ref();
     for spec in &req.files {
         for path in [&spec.from, &spec.to] {
-            if let Err(e) = resolver.require_writable_opt(scope_root, path) {
+            if let Err(e) = resolver.require_writable_scope(fs_scope, path) {
                 if is_jail_scope_error(&e) {
                     return Err(err_to_string(e));
                 }
@@ -129,7 +129,7 @@ pub async fn handle(
     }
     let mut results = Vec::with_capacity(req.files.len());
     for spec in req.files {
-        results.push(move_one(&resolver, scope_root, spec));
+        results.push(move_one(&resolver, fs_scope, spec));
     }
     Ok(MoveFileOutput { results })
 }
@@ -147,11 +147,11 @@ fn is_jail_scope_error(e: &CoderError) -> bool {
 
 fn move_one(
     resolver: &PathResolver,
-    scope_root: Option<&str>,
+    fs_scope: Option<&crate::fs::FsScope>,
     spec: MoveFileSpec,
 ) -> MoveFileResult {
     // Resolve source.
-    let abs_from = match resolver.require_writable_opt(scope_root, &spec.from) {
+    let abs_from = match resolver.require_writable_scope(fs_scope, &spec.from) {
         Ok(p) => p,
         Err(e) => {
             return MoveFileResult {
@@ -165,7 +165,7 @@ fn move_one(
     };
 
     // Resolve destination (may not exist yet — resolution via fallback is fine).
-    let abs_to = match resolver.require_writable_opt(scope_root, &spec.to) {
+    let abs_to = match resolver.require_writable_scope(fs_scope, &spec.to) {
         Ok(p) => p,
         Err(e) => {
             return MoveFileResult {

--- a/shell/src/code/functions/read_file.rs
+++ b/shell/src/code/functions/read_file.rs
@@ -397,7 +397,7 @@ fn inner(
             let p = p.clone();
             let single_req = SingleReadReq {
                 path: &p,
-                scope_root: crate::fs::scope_root(req.fs_scope.as_ref()),
+                fs_scope: req.fs_scope.as_ref(),
                 line_from: req.line_from,
                 line_to: req.line_to,
                 stat: req.stat,
@@ -420,21 +420,15 @@ fn inner(
         // Batch mode
         (None, Some(targets)) => {
             for target in targets {
-                if let Err(e) = resolver.require_writable_opt(
-                    crate::fs::scope_root(req.fs_scope.as_ref()),
-                    target.path(),
-                ) {
+                if let Err(e) =
+                    resolver.require_writable_scope(req.fs_scope.as_ref(), target.path())
+                {
                     if is_jail_scope_error(&e) {
                         return Err(e);
                     }
                 }
             }
-            let results = batch_read(
-                resolver,
-                cfg,
-                crate::fs::scope_root(req.fs_scope.as_ref()),
-                targets,
-            );
+            let results = batch_read(resolver, cfg, req.fs_scope.as_ref(), targets);
             Ok(ReadFileOutput {
                 path: None,
                 content: None,
@@ -464,7 +458,7 @@ fn is_jail_scope_error(e: &CoderError) -> bool {
 
 struct SingleReadReq<'a> {
     path: &'a str,
-    scope_root: Option<&'a str>,
+    fs_scope: Option<&'a crate::fs::FsScope>,
     line_from: Option<u64>,
     line_to: Option<u64>,
     stat: bool,
@@ -526,7 +520,7 @@ fn single_read(
     // REDACTION ORDERING: resolve + deny-check (C211) BEFORE any metadata
     // syscall — stat on a denied path must be byte-identical to stat on a
     // missing path, and no budget may reclassify either.
-    let abs = resolver.require_writable_opt(req.scope_root, req.path)?;
+    let abs = resolver.require_writable_scope(req.fs_scope, req.path)?;
     let md = std::fs::metadata(&abs).map_err(|e| CoderError::io_for_path(e, req.path))?;
     if !md.is_file() {
         return Err(CoderError::BadInput(format!(
@@ -794,7 +788,7 @@ fn entry_failure(path: String, error: WireError) -> ReadEntryResult {
 fn batch_read(
     resolver: &PathResolver,
     cfg: &CoderConfig,
-    scope_root: Option<&str>,
+    fs_scope: Option<&crate::fs::FsScope>,
     targets: &[ReadTarget],
 ) -> Vec<ReadEntryResult> {
     let mut remaining_budget: u64 = cfg.batch_read_budget_bytes;
@@ -831,7 +825,7 @@ fn batch_read(
 
         // Resolve + accessibility check; failures echo the caller's input
         // verbatim and do NOT consume budget.
-        let abs = match resolver.require_writable_opt(scope_root, wire_path) {
+        let abs = match resolver.require_writable_scope(fs_scope, wire_path) {
             Ok(p) => p,
             Err(e) => {
                 results.push(entry_failure(wire_path.to_string(), e.to_wire_error()));

--- a/shell/src/code/functions/search.rs
+++ b/shell/src/code/functions/search.rs
@@ -194,8 +194,7 @@ fn inner(
     // Use `resolve` rather than `require_writable` so a search rooted at
     // a folder that *contains* non-accessible children still works; the
     // per-file `is_non_accessible` filter below still guards their bytes.
-    let walk_root =
-        resolver.resolve_opt(crate::fs::scope_root(req.fs_scope.as_ref()), &req.path)?;
+    let walk_root = resolver.resolve_scope(req.fs_scope.as_ref(), &req.path)?;
     // NotFound is intercepted with the wire path in scope so the C211
     // message names the path the caller supplied (standardized wording —
     // REDACTION INVARIANT: identical to the glob-denied message).

--- a/shell/src/code/functions/tree.rs
+++ b/shell/src/code/functions/tree.rs
@@ -143,7 +143,7 @@ fn inner(
     cfg: &CoderConfig,
     req: TreeInput,
 ) -> Result<TreeOutput, CoderError> {
-    let abs = resolver.resolve_opt(crate::fs::scope_root(req.fs_scope.as_ref()), &req.path)?;
+    let abs = resolver.resolve_scope(req.fs_scope.as_ref(), &req.path)?;
     // NotFound is intercepted with the wire path in scope so the C211
     // message names the path the caller supplied (standardized wording —
     // REDACTION INVARIANT: identical to the glob-denied message).

--- a/shell/src/code/functions/update_file.rs
+++ b/shell/src/code/functions/update_file.rs
@@ -210,10 +210,10 @@ pub async fn handle(
             "`files` must not be empty".into(),
         )));
     }
-    let scope_root = crate::fs::scope_root(req.fs_scope.as_ref());
+    let fs_scope = req.fs_scope.as_ref();
     let mut entries = Vec::with_capacity(req.files.len());
     for spec in req.files {
-        match resolver.require_writable_opt(scope_root, &spec.path) {
+        match resolver.require_writable_scope(fs_scope, &spec.path) {
             Ok(abs) => entries.push((spec, Ok(abs))),
             Err(e) if is_jail_scope_error(&e) => return Err(err_to_string(e)),
             Err(e) => entries.push((spec, Err(e))),

--- a/shell/src/code/path.rs
+++ b/shell/src/code/path.rs
@@ -466,30 +466,51 @@ impl PathResolver {
         Ok(abs)
     }
 
-    /// Dispatch helper: resolve `path` against `scope_root` when present, else
-    /// use the normal resolver. Handlers thread the per-call `scope_root` straight
-    /// through.
-    pub fn resolve_opt(&self, scope_root: Option<&str>, path: &str) -> Result<PathBuf, CoderError> {
-        match scope_root {
-            Some(b) => self.resolve_in(b, path),
+    fn resolve_from(&self, anchor: &str, path: &str) -> Result<PathBuf, CoderError> {
+        let anchor_path = Path::new(anchor);
+        if !anchor_path.is_absolute() {
+            return Err(CoderError::BadInput(format!(
+                "scope_root must be an absolute path: {anchor}"
+            )));
+        }
+        let anchor_canon = self.canonicalize_wire(anchor, anchor_path)?;
+        if self.containing_root(&anchor_canon).is_none() {
+            return Err(CoderError::OutsideBase(format!(
+                "scope_root is outside every allowed root: {anchor}. {C215_ROOTS_PREFIX}{roots}",
+                roots = self.roots_list()
+            )));
+        }
+        if Path::new(path).is_absolute() {
+            self.resolve(path)
+        } else {
+            self.resolve(&anchor_canon.join(path).to_string_lossy())
+        }
+    }
+
+    pub fn resolve_scope(
+        &self,
+        scope: Option<&crate::fs::FsScope>,
+        path: &str,
+    ) -> Result<PathBuf, CoderError> {
+        match scope {
+            Some(scope) if scope.boundary == crate::fs::FsBoundary::ConfiguredRoots => {
+                self.resolve_from(scope.root(), path)
+            }
+            Some(scope) => self.resolve_in(scope.root(), path),
             None => self.resolve(path),
         }
     }
 
-    /// Dispatch helper mirroring [`resolve_opt`] for mutating/accessibility-
-    /// gated reads: `require_writable_in` when `scope_root` is present, else
-    /// the unchanged `require_writable`.
-    ///
-    /// [`resolve_opt`]: Self::resolve_opt
-    pub fn require_writable_opt(
+    pub fn require_writable_scope(
         &self,
-        scope_root: Option<&str>,
-        rel: &str,
+        scope: Option<&crate::fs::FsScope>,
+        path: &str,
     ) -> Result<PathBuf, CoderError> {
-        match scope_root {
-            Some(b) => self.require_writable_in(b, rel),
-            None => self.require_writable(rel),
+        let abs = self.resolve_scope(scope, path)?;
+        if self.is_non_accessible(&abs) {
+            return Err(CoderError::not_found_or_denied(path));
         }
+        Ok(abs)
     }
 }
 
@@ -1342,50 +1363,32 @@ mod tests {
         assert_eq!(err.code(), "C211");
     }
 
-    /// BACK-COMPAT: the dispatch helpers with scope_root=None must produce
-    /// EXACTLY what resolve()/require_writable() produce — both the Ok path
-    /// and the error path, byte-for-byte. This pins that the None branch is
-    /// the unchanged legacy code.
     #[test]
-    fn resolve_opt_none_is_identical_to_resolve() {
+    fn configured_roots_scope_anchors_relative_paths_and_allows_siblings() {
         let tmp = tempdir().unwrap();
-        std::fs::create_dir(tmp.path().join("sub")).unwrap();
-        std::fs::write(tmp.path().join("sub/a.txt"), b"hi").unwrap();
-        std::fs::write(tmp.path().join(".env"), b"secret").unwrap();
-        let r = PathResolver::new(&cfg_with(tmp.path().to_path_buf(), vec!["**/.env"])).unwrap();
+        std::fs::create_dir_all(tmp.path().join("session")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("sibling")).unwrap();
+        std::fs::write(tmp.path().join("session/local.txt"), b"local").unwrap();
+        std::fs::write(tmp.path().join("sibling/shared.txt"), b"shared").unwrap();
+        let resolver = PathResolver::new(&cfg_with(tmp.path().to_path_buf(), vec![])).unwrap();
+        let scope = crate::fs::FsScope {
+            root: tmp.path().join("session").display().to_string(),
+            grants: Vec::new(),
+            boundary: crate::fs::FsBoundary::ConfiguredRoots,
+        };
 
-        // Ok path: relative, existing nested, dot — all must match resolve().
-        for p in [".", "sub/a.txt", "sub/does/not/exist.txt"] {
-            assert_eq!(
-                r.resolve_opt(None, p).unwrap(),
-                r.resolve(p).unwrap(),
-                "resolve_opt(None) diverged from resolve() for {p:?}"
-            );
-        }
-
-        // Error path: identical code AND identical message text.
-        for p in ["/etc/passwd", "../etc/passwd"] {
-            let via_opt = r.resolve_opt(None, p).unwrap_err();
-            let via_resolve = r.resolve(p).unwrap_err();
-            assert_eq!(via_opt.code(), via_resolve.code());
-            assert_eq!(
-                via_opt.to_string(),
-                via_resolve.to_string(),
-                "resolve_opt(None) error text diverged for {p:?}"
-            );
-        }
-
-        // require_writable_opt(None) must also mirror require_writable,
-        // including the glob-denied C211.
         assert_eq!(
-            r.require_writable_opt(None, ".env")
-                .unwrap_err()
-                .to_string(),
-            r.require_writable(".env").unwrap_err().to_string(),
+            resolver.resolve_scope(Some(&scope), "local.txt").unwrap(),
+            canon(&tmp.path().join("session/local.txt"))
         );
         assert_eq!(
-            r.require_writable_opt(None, "sub/a.txt").unwrap(),
-            r.require_writable("sub/a.txt").unwrap(),
+            resolver
+                .resolve_scope(
+                    Some(&scope),
+                    &tmp.path().join("sibling/shared.txt").display().to_string(),
+                )
+                .unwrap(),
+            canon(&tmp.path().join("sibling/shared.txt"))
         );
     }
 }

--- a/shell/src/code/path.rs
+++ b/shell/src/code/path.rs
@@ -331,21 +331,6 @@ impl PathResolver {
         set.is_match(&rel)
     }
 
-    /// Resolve and reject if the result is on the non-accessible list.
-    /// Used by every mutating operation and by `read-file` so the same
-    /// glob hides both reads and writes.
-    ///
-    /// The C211 message is intentionally identical in wording to the
-    /// not-found case (REDACTION INVARIANT: callers must not be able to
-    /// distinguish "denied" from "missing" by observing the error text).
-    pub fn require_writable(&self, rel: &str) -> Result<PathBuf, CoderError> {
-        let abs = self.resolve(rel)?;
-        if self.is_non_accessible(&abs) {
-            return Err(CoderError::not_found_or_denied(rel));
-        }
-        Ok(abs)
-    }
-
     /// Shared symlink-safe canonicalisation of a joined wire path, with the
     /// standardized C215/C211/C216 error mapping. Extracted verbatim from
     /// `resolve` so `resolve` and `resolve_in` map I/O failures identically
@@ -453,17 +438,6 @@ impl PathResolver {
             )));
         }
         Ok(canon)
-    }
-
-    /// `require_writable` for a session scoped to `scope_root`: resolve via
-    /// `resolve_in`, then apply the same non-accessible glob gate. Mutating
-    /// ops in `scope_root`-present mode call this instead of `require_writable`.
-    pub fn require_writable_in(&self, scope_root: &str, rel: &str) -> Result<PathBuf, CoderError> {
-        let abs = self.resolve_in(scope_root, rel)?;
-        if self.is_non_accessible(&abs) {
-            return Err(CoderError::not_found_or_denied(rel));
-        }
-        Ok(abs)
     }
 
     fn resolve_from(&self, anchor: &str, path: &str) -> Result<PathBuf, CoderError> {
@@ -888,7 +862,12 @@ mod tests {
         let tmp = tempdir().unwrap();
         std::fs::write(tmp.path().join(".env"), b"x").unwrap();
         let r = PathResolver::new(&cfg_with(tmp.path().to_path_buf(), vec!["**/.env"])).unwrap();
-        let err = r.require_writable(".env").unwrap_err();
+        let scope = crate::fs::FsScope {
+            root: tmp.path().display().to_string(),
+            grants: Vec::new(),
+            boundary: crate::fs::FsBoundary::ConfiguredRoots,
+        };
+        let err = r.require_writable_scope(Some(&scope), ".env").unwrap_err();
         assert_eq!(err.code(), "C211");
     }
 
@@ -1002,7 +981,7 @@ mod tests {
         let r = PathResolver::new(&cfg_with(tmp.path().to_path_buf(), vec![])).unwrap();
         let dir = r.resolve("node_modules").unwrap();
         assert!(!r.is_non_accessible(&dir));
-        assert!(r.require_writable("node_modules/x.txt").is_ok());
+        assert!(r.require_writable_scope(None, "node_modules/x.txt").is_ok());
     }
 
     // RECOVERY-PAIR TEST: parse the first allowed root out of the C215 error
@@ -1109,7 +1088,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Per-call scope_root (resolve_in / require_writable_in): a containment
+    // Per-call scope_root (resolve_in / require_writable_scope): a containment
     // check + relative-anchor LAYERED on the existing jail core. These
     // exercise the new C218 DX-1 error and prove scope_root=None is unchanged.
     // -----------------------------------------------------------------------
@@ -1269,7 +1248,14 @@ mod tests {
         let base = selected.path().display().to_string();
 
         let scoped = r.session_scoped(Some(&base), None);
-        let err = scoped.require_writable_in(&base, ".env").unwrap_err();
+        let scope = crate::fs::FsScope {
+            root: base,
+            grants: Vec::new(),
+            boundary: crate::fs::FsBoundary::Workspace,
+        };
+        let err = scoped
+            .require_writable_scope(Some(&scope), ".env")
+            .unwrap_err();
         assert_eq!(err.code(), "C211");
     }
 
@@ -1350,16 +1336,21 @@ mod tests {
         );
     }
 
-    /// require_writable_in applies the non-accessible glob gate on top of
+    /// require_writable_scope applies the non-accessible glob gate on top of
     /// the session containment (C211, identical to require_writable).
     #[test]
-    fn require_writable_in_rejects_non_accessible_with_c211() {
+    fn require_writable_scope_rejects_non_accessible_with_c211() {
         let tmp = tempdir().unwrap();
         std::fs::create_dir(tmp.path().join("session")).unwrap();
         std::fs::write(tmp.path().join("session/.env"), b"x").unwrap();
         let r = PathResolver::new(&cfg_with(tmp.path().to_path_buf(), vec!["**/.env"])).unwrap();
         let base = tmp.path().join("session").display().to_string();
-        let err = r.require_writable_in(&base, ".env").unwrap_err();
+        let scope = crate::fs::FsScope {
+            root: base,
+            grants: Vec::new(),
+            boundary: crate::fs::FsBoundary::Workspace,
+        };
+        let err = r.require_writable_scope(Some(&scope), ".env").unwrap_err();
         assert_eq!(err.code(), "C211");
     }
 

--- a/shell/src/exec/host.rs
+++ b/shell/src/exec/host.rs
@@ -367,9 +367,15 @@ mod tests {
         let mut cfg = test_cfg();
         cfg.fs.host_roots = vec![root.clone()];
 
-        let overrides =
-            crate::exec::policy::build_overrides(Some("workdir"), None, None, None, &cfg)
-                .expect("workdir is inside the jail");
+        let overrides = crate::exec::policy::build_overrides(
+            Some("workdir"),
+            None,
+            None,
+            None,
+            crate::fs::FsBoundary::Workspace,
+            &cfg,
+        )
+        .expect("workdir is inside the jail");
         let out = run_to_completion(&["pwd".into()], &cfg, 5000, &overrides)
             .await
             .unwrap();
@@ -391,8 +397,15 @@ mod tests {
         cfg.fs.host_roots = vec![root.clone()];
         let base = root.join("session").to_string_lossy().into_owned();
 
-        let overrides = crate::exec::policy::build_overrides(None, None, Some(&base), None, &cfg)
-            .expect("session is inside the jail");
+        let overrides = crate::exec::policy::build_overrides(
+            None,
+            None,
+            Some(&base),
+            None,
+            crate::fs::FsBoundary::Workspace,
+            &cfg,
+        )
+        .expect("session is inside the jail");
         let out = run_to_completion(&["pwd".into()], &cfg, 5000, &overrides)
             .await
             .unwrap();
@@ -488,8 +501,15 @@ mod tests {
 
         let mut env = std::collections::BTreeMap::new();
         env.insert("NODE_ENV".to_string(), "from-override".to_string());
-        let overrides = crate::exec::policy::build_overrides(None, Some(&env), None, None, &cfg)
-            .expect("non-dangerous key accepted regardless of env.allow");
+        let overrides = crate::exec::policy::build_overrides(
+            None,
+            Some(&env),
+            None,
+            None,
+            crate::fs::FsBoundary::Workspace,
+            &cfg,
+        )
+        .expect("non-dangerous key accepted regardless of env.allow");
 
         let out = run_to_completion(
             &["printenv".into(), "NODE_ENV".into()],
@@ -511,8 +531,15 @@ mod tests {
         cfg.env.allow = vec![];
         let mut env = std::collections::BTreeMap::new();
         env.insert("LD_PRELOAD".to_string(), "/tmp/evil.so".to_string());
-        let err = crate::exec::policy::build_overrides(None, Some(&env), None, None, &cfg)
-            .expect_err("LD_PRELOAD must always reject");
+        let err = crate::exec::policy::build_overrides(
+            None,
+            Some(&env),
+            None,
+            None,
+            crate::fs::FsBoundary::Workspace,
+            &cfg,
+        )
+        .expect_err("LD_PRELOAD must always reject");
         assert_eq!(err.code, "S210");
         assert!(err.message.contains("LD_PRELOAD"));
     }
@@ -524,8 +551,15 @@ mod tests {
         std::fs::create_dir_all(&root).unwrap();
         let mut cfg = test_cfg();
         cfg.fs.host_roots = vec![root.clone()];
-        let err = crate::exec::policy::build_overrides(Some("../../etc"), None, None, None, &cfg)
-            .expect_err("escape must reject");
+        let err = crate::exec::policy::build_overrides(
+            Some("../../etc"),
+            None,
+            None,
+            None,
+            crate::fs::FsBoundary::Workspace,
+            &cfg,
+        )
+        .expect_err("escape must reject");
         assert_eq!(err.code, "S215");
         std::fs::remove_dir_all(&root).ok();
     }

--- a/shell/src/exec/policy.rs
+++ b/shell/src/exec/policy.rs
@@ -294,24 +294,41 @@ fn validate_env(env: &BTreeMap<String, String>) -> Result<BTreeMap<String, Strin
 pub fn build_overrides(
     cwd: Option<&str>,
     env: Option<&BTreeMap<String, String>>,
-    scope_root: Option<&str>,
+    scope_anchor: Option<&str>,
     scope_grants: Option<&[String]>,
+    boundary: crate::fs::FsBoundary,
     cfg: &ShellConfig,
 ) -> Result<ExecOverrides, ExecError> {
     let (host_roots_canon, denylist_canon) = jail_inputs(cfg)?;
     // Resolve the session directory first: it gates the cwd confinement below
     // and, when no cwd is supplied, becomes the working directory itself.
-    let scope_root_canon = confine_scope_root(scope_root, &denylist_canon)?;
+    let scope_root_canon = confine_scope_root(scope_anchor, &denylist_canon)?;
     let scope_grants_canon = crate::fs::host::confine_scope_grants(scope_grants, &denylist_canon);
+    let confinement_root = (boundary == crate::fs::FsBoundary::Workspace)
+        .then_some(scope_root_canon.as_deref())
+        .flatten();
 
     let cwd = match cwd {
-        Some(c) => Some(confine_cwd(
-            c,
-            &host_roots_canon,
-            scope_root_canon.as_deref(),
-            &scope_grants_canon,
-            &denylist_canon,
-        )?),
+        Some(c) => {
+            let anchored;
+            let c = if boundary == crate::fs::FsBoundary::ConfiguredRoots
+                && !Path::new(c).is_absolute()
+            {
+                anchored = scope_root_canon
+                    .as_ref()
+                    .map(|root| root.join(c).to_string_lossy().into_owned());
+                anchored.as_deref().unwrap_or(c)
+            } else {
+                c
+            };
+            Some(confine_cwd(
+                c,
+                &host_roots_canon,
+                confinement_root,
+                &scope_grants_canon,
+                &denylist_canon,
+            )?)
+        }
         // No explicit cwd: a session scope_root (already validated as an existing
         // directory) becomes the working directory, so the child runs in the
         // session root instead of `cfg.working_dir`. Without scope_root this stays
@@ -491,7 +508,8 @@ mod tests {
     #[test]
     fn build_overrides_both_none_is_empty() {
         let c = ShellConfig::default();
-        let ov = build_overrides(None, None, None, None, &c).expect("ok");
+        let ov = build_overrides(None, None, None, None, crate::fs::FsBoundary::Workspace, &c)
+            .expect("ok");
         assert!(ov.is_empty());
     }
 
@@ -507,7 +525,15 @@ mod tests {
         let base = root.join("session").to_string_lossy().into_owned();
 
         // cwd omitted ⇒ working dir is scope_root.
-        let ov = build_overrides(None, None, Some(&base), None, &c).expect("scope_root is valid");
+        let ov = build_overrides(
+            None,
+            None,
+            Some(&base),
+            None,
+            crate::fs::FsBoundary::Workspace,
+            &c,
+        )
+        .expect("scope_root is valid");
         assert_eq!(
             ov.cwd.as_deref(),
             Some(root.join("session").canonicalize().unwrap().as_path()),
@@ -515,8 +541,15 @@ mod tests {
         );
 
         // relative cwd anchors at scope_root, not the jail root.
-        let ov = build_overrides(Some("inner"), None, Some(&base), None, &c)
-            .expect("inner is under scope_root");
+        let ov = build_overrides(
+            Some("inner"),
+            None,
+            Some(&base),
+            None,
+            crate::fs::FsBoundary::Workspace,
+            &c,
+        )
+        .expect("inner is under scope_root");
         assert_eq!(
             ov.cwd.as_deref(),
             Some(root.join("session/inner").canonicalize().unwrap().as_path()),
@@ -535,8 +568,15 @@ mod tests {
         let c = cfg_jailed(&root);
         let outside = root.join("other").canonicalize().unwrap();
         let base = root.join("session").to_string_lossy().into_owned();
-        let err = build_overrides(Some(outside.to_str().unwrap()), None, Some(&base), None, &c)
-            .expect_err("abs cwd outside scope_root must reject");
+        let err = build_overrides(
+            Some(outside.to_str().unwrap()),
+            None,
+            Some(&base),
+            None,
+            crate::fs::FsBoundary::Workspace,
+            &c,
+        )
+        .expect_err("abs cwd outside scope_root must reject");
         assert_eq!(err.code, "S220", "must be the distinct scope_root code");
         let session_canon = root.join("session").canonicalize().unwrap();
         assert!(
@@ -564,14 +604,28 @@ mod tests {
         std::fs::create_dir_all(selected.join("inner")).unwrap();
         let c = cfg_jailed(&root);
         let selected_raw = selected.to_string_lossy().into_owned();
-        let ov = build_overrides(None, None, Some(&selected_raw), None, &c)
-            .expect("absolute selected scope_root is valid");
+        let ov = build_overrides(
+            None,
+            None,
+            Some(&selected_raw),
+            None,
+            crate::fs::FsBoundary::Workspace,
+            &c,
+        )
+        .expect("absolute selected scope_root is valid");
         assert_eq!(
             ov.cwd.as_deref(),
             Some(selected.canonicalize().unwrap().as_path())
         );
-        let ov = build_overrides(Some("inner"), None, Some(&selected_raw), None, &c)
-            .expect("relative cwd anchors at selected scope_root");
+        let ov = build_overrides(
+            Some("inner"),
+            None,
+            Some(&selected_raw),
+            None,
+            crate::fs::FsBoundary::Workspace,
+            &c,
+        )
+        .expect("relative cwd anchors at selected scope_root");
         assert_eq!(
             ov.cwd.as_deref(),
             Some(selected.join("inner").canonicalize().unwrap().as_path())
@@ -587,8 +641,15 @@ mod tests {
         let root = std::env::temp_dir().join(format!("shell-policy-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&root).unwrap();
         let c = cfg_jailed(&root);
-        let err = build_overrides(None, None, Some("../../etc"), None, &c)
-            .expect_err("relative scope_root is not part of the trusted contract");
+        let err = build_overrides(
+            None,
+            None,
+            Some("../../etc"),
+            None,
+            crate::fs::FsBoundary::Workspace,
+            &c,
+        )
+        .expect_err("relative scope_root is not part of the trusted contract");
         assert_eq!(err.code, "S210");
         std::fs::remove_dir_all(&root).ok();
     }
@@ -602,18 +663,66 @@ mod tests {
         let c = cfg_jailed(&root);
 
         // Omitted cwd + omitted scope_root ⇒ no cwd override (cfg.working_dir wins).
-        let ov = build_overrides(None, None, None, None, &c).expect("ok");
+        let ov = build_overrides(None, None, None, None, crate::fs::FsBoundary::Workspace, &c)
+            .expect("ok");
         assert!(
             ov.cwd.is_none(),
             "no scope_root, no cwd ⇒ None (prior behaviour)"
         );
 
         // Relative cwd still anchors at the primary jail root when scope_root is absent.
-        let ov = build_overrides(Some("sub"), None, None, None, &c).expect("ok");
+        let ov = build_overrides(
+            Some("sub"),
+            None,
+            None,
+            None,
+            crate::fs::FsBoundary::Workspace,
+            &c,
+        )
+        .expect("ok");
         assert_eq!(
             ov.cwd.as_deref(),
             Some(root.join("sub").canonicalize().unwrap().as_path()),
             "relative cwd anchors at the primary jail root when scope_root is absent"
+        );
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn configured_roots_boundary_keeps_default_cwd_but_allows_sibling_cwd() {
+        let root = std::env::temp_dir().join(format!("shell-policy-{}", uuid::Uuid::new_v4()));
+        let session = root.join("session");
+        let sibling = root.join("sibling");
+        std::fs::create_dir_all(&session).unwrap();
+        std::fs::create_dir_all(&sibling).unwrap();
+        let c = cfg_jailed(&root);
+
+        let defaulted = build_overrides(
+            None,
+            None,
+            Some(session.to_str().unwrap()),
+            None,
+            crate::fs::FsBoundary::ConfiguredRoots,
+            &c,
+        )
+        .unwrap();
+        assert_eq!(
+            defaulted.cwd.as_deref(),
+            Some(session.canonicalize().unwrap().as_path())
+        );
+
+        let widened = build_overrides(
+            Some(sibling.to_str().unwrap()),
+            None,
+            Some(session.to_str().unwrap()),
+            None,
+            crate::fs::FsBoundary::ConfiguredRoots,
+            &c,
+        )
+        .expect("sibling cwd is permitted inside configured shell roots");
+        assert_eq!(
+            widened.cwd.as_deref(),
+            Some(sibling.canonicalize().unwrap().as_path())
         );
         std::fs::remove_dir_all(&root).ok();
     }

--- a/shell/src/fs/host.rs
+++ b/shell/src/fs/host.rs
@@ -286,16 +286,25 @@ impl HostFsBackend {
         path: &str,
         scope_root_canon: Option<&Path>,
         scope_grants_canon: &[PathBuf],
+        boundary: crate::fs::FsBoundary,
     ) -> Result<PathBuf, FsError> {
-        let canon = match scope_root_canon {
+        let restrict_to_workspace = boundary == crate::fs::FsBoundary::Workspace;
+        let canon = match (scope_root_canon, restrict_to_workspace) {
             // validate_path already applies the non_accessible gate.
-            None if scope_grants_canon.is_empty() => return self.validate_path(path),
-            None => confine_path(
+            (None, _) if scope_grants_canon.is_empty() => return self.validate_path(path),
+            (None, _) => confine_path(
                 path,
                 &effective_roots(&self.host_roots_canon, None, scope_grants_canon),
                 &self.denylist_canon,
             )?,
-            Some(_) => confine_path_with_scope_root(
+            (Some(base), false) => confine_path_with_anchor(
+                path,
+                &self.host_roots_canon,
+                base,
+                scope_grants_canon,
+                &self.denylist_canon,
+            )?,
+            (Some(_), true) => confine_path_with_scope_root(
                 path,
                 &self.host_roots_canon,
                 scope_root_canon,
@@ -303,7 +312,8 @@ impl HostFsBackend {
                 &self.denylist_canon,
             )?,
         };
-        if self.is_non_accessible_scoped(&canon, scope_root_canon, scope_grants_canon) {
+        let access_scope = restrict_to_workspace.then_some(scope_root_canon).flatten();
+        if self.is_non_accessible_scoped(&canon, access_scope, scope_grants_canon) {
             return Err(FsError::new(
                 "S215",
                 format!("path is protected (non_accessible): {path}"),
@@ -337,6 +347,27 @@ impl HostFsBackend {
             Some(base) => lexical_operand_with(path, Some(base)),
         }
     }
+}
+
+fn confine_path_with_anchor(
+    path: &str,
+    host_roots_canon: &[PathBuf],
+    anchor: &Path,
+    scope_grants_canon: &[PathBuf],
+    denylist_canon: &[PathBuf],
+) -> Result<PathBuf, FsError> {
+    let raw = Path::new(path);
+    let anchored = if raw.is_absolute() {
+        raw.to_path_buf()
+    } else {
+        anchor.join(raw)
+    };
+    let display = anchored.to_string_lossy();
+    confine_path(
+        &display,
+        &effective_roots(host_roots_canon, None, scope_grants_canon),
+        denylist_canon,
+    )
 }
 
 /// Jail-confinement check, factored out of `HostFsBackend::validate_path` so
@@ -944,9 +975,14 @@ impl FsBackend for HostFsBackend {
         // A per-call scope_root (when set) scopes both the relative anchor and the
         // containment ceiling to the session directory; None ⇒ the unchanged
         // configured jail.
-        let base = self.confine_scope_root(crate::fs::scope_root(req.fs_scope.as_ref()))?;
+        let base = self.confine_scope_root(crate::fs::scope_anchor(req.fs_scope.as_ref()))?;
         let extra = self.confine_scope_grants(crate::fs::scope_grants(req.fs_scope.as_ref()));
-        let p = self.validate_path_scoped(&req.path, base.as_deref(), &extra)?;
+        let p = self.validate_path_scoped(
+            &req.path,
+            base.as_deref(),
+            &extra,
+            crate::fs::scope_boundary(req.fs_scope.as_ref()),
+        )?;
         // The symlink_metadata stat, read_dir, and the per-entry
         // symlink_metadata loop are all blocking std::fs work that scales with
         // directory size; move it off the executor (mirrors grep/sed).
@@ -979,9 +1015,14 @@ impl FsBackend for HostFsBackend {
     }
 
     async fn stat(&self, req: StatArgs) -> FsCallResult<StatResponse> {
-        let base = self.confine_scope_root(crate::fs::scope_root(req.fs_scope.as_ref()))?;
+        let base = self.confine_scope_root(crate::fs::scope_anchor(req.fs_scope.as_ref()))?;
         let extra = self.confine_scope_grants(crate::fs::scope_grants(req.fs_scope.as_ref()));
-        let p = self.validate_path_scoped(&req.path, base.as_deref(), &extra)?;
+        let p = self.validate_path_scoped(
+            &req.path,
+            base.as_deref(),
+            &extra,
+            crate::fs::scope_boundary(req.fs_scope.as_ref()),
+        )?;
         let md = std::fs::symlink_metadata(&p).map_err(|e| FsError::from_io(&req.path, e))?;
         let name = p
             .file_name()
@@ -991,9 +1032,14 @@ impl FsBackend for HostFsBackend {
     }
 
     async fn mkdir(&self, req: crate::fs::MkdirArgs) -> FsCallResult<crate::fs::MkdirResponse> {
-        let base = self.confine_scope_root(crate::fs::scope_root(req.fs_scope.as_ref()))?;
+        let base = self.confine_scope_root(crate::fs::scope_anchor(req.fs_scope.as_ref()))?;
         let extra = self.confine_scope_grants(crate::fs::scope_grants(req.fs_scope.as_ref()));
-        let p = self.validate_path_scoped(&req.path, base.as_deref(), &extra)?;
+        let p = self.validate_path_scoped(
+            &req.path,
+            base.as_deref(),
+            &extra,
+            crate::fs::scope_boundary(req.fs_scope.as_ref()),
+        )?;
         let bits = crate::fs::error::parse_mode(&req.mode)?;
         check_special_bits(bits, self.cfg.allow_special_bits)?;
         if p.exists() {
@@ -1043,9 +1089,14 @@ impl FsBackend for HostFsBackend {
         // operate on the lexical path to preserve unlink semantics. Both the
         // validation and the operand anchor at the session scope_root when set,
         // so they cannot diverge.
-        let base = self.confine_scope_root(crate::fs::scope_root(req.fs_scope.as_ref()))?;
+        let base = self.confine_scope_root(crate::fs::scope_anchor(req.fs_scope.as_ref()))?;
         let extra = self.confine_scope_grants(crate::fs::scope_grants(req.fs_scope.as_ref()));
-        self.validate_path_scoped(&req.path, base.as_deref(), &extra)?;
+        self.validate_path_scoped(
+            &req.path,
+            base.as_deref(),
+            &extra,
+            crate::fs::scope_boundary(req.fs_scope.as_ref()),
+        )?;
         let p = self.lexical_operand_scoped(&req.path, base.as_deref(), &extra);
 
         // The symlink_metadata stat, recursive remove_dir_all, the non-recursive
@@ -1088,9 +1139,14 @@ impl FsBackend for HostFsBackend {
     async fn chmod(&self, req: crate::fs::ChmodArgs) -> FsCallResult<crate::fs::ChmodResponse> {
         // Jail validation + mode parsing run here, on the async fn, BEFORE the
         // blocking work. scope_root (when set) scopes the validation + operand.
-        let base = self.confine_scope_root(crate::fs::scope_root(req.fs_scope.as_ref()))?;
+        let base = self.confine_scope_root(crate::fs::scope_anchor(req.fs_scope.as_ref()))?;
         let extra = self.confine_scope_grants(crate::fs::scope_grants(req.fs_scope.as_ref()));
-        self.validate_path_scoped(&req.path, base.as_deref(), &extra)?;
+        self.validate_path_scoped(
+            &req.path,
+            base.as_deref(),
+            &extra,
+            crate::fs::scope_boundary(req.fs_scope.as_ref()),
+        )?;
         let p = self.lexical_operand_scoped(&req.path, base.as_deref(), &extra);
         let bits = crate::fs::error::parse_mode(&req.mode)?;
         check_special_bits(bits, self.cfg.allow_special_bits)?;
@@ -1166,10 +1222,20 @@ impl FsBackend for HostFsBackend {
 
     async fn mv(&self, req: crate::fs::MvArgs) -> FsCallResult<crate::fs::MvResponse> {
         // A single session scope_root scopes BOTH operands.
-        let base = self.confine_scope_root(crate::fs::scope_root(req.fs_scope.as_ref()))?;
+        let base = self.confine_scope_root(crate::fs::scope_anchor(req.fs_scope.as_ref()))?;
         let extra = self.confine_scope_grants(crate::fs::scope_grants(req.fs_scope.as_ref()));
-        self.validate_path_scoped(&req.src, base.as_deref(), &extra)?;
-        self.validate_path_scoped(&req.dst, base.as_deref(), &extra)?;
+        self.validate_path_scoped(
+            &req.src,
+            base.as_deref(),
+            &extra,
+            crate::fs::scope_boundary(req.fs_scope.as_ref()),
+        )?;
+        self.validate_path_scoped(
+            &req.dst,
+            base.as_deref(),
+            &extra,
+            crate::fs::scope_boundary(req.fs_scope.as_ref()),
+        )?;
         let src_p = self.lexical_operand_scoped(&req.src, base.as_deref(), &extra);
         let dst_p = self.lexical_operand_scoped(&req.dst, base.as_deref(), &extra);
         if !src_p.exists() {
@@ -1227,9 +1293,14 @@ impl FsBackend for HostFsBackend {
         })
     }
     async fn grep(&self, req: crate::fs::GrepArgs) -> FsCallResult<crate::fs::GrepResponse> {
-        let base = self.confine_scope_root(crate::fs::scope_root(req.fs_scope.as_ref()))?;
+        let base = self.confine_scope_root(crate::fs::scope_anchor(req.fs_scope.as_ref()))?;
         let extra = self.confine_scope_grants(crate::fs::scope_grants(req.fs_scope.as_ref()));
-        let root = self.validate_path_scoped(&req.path, base.as_deref(), &extra)?;
+        let root = self.validate_path_scoped(
+            &req.path,
+            base.as_deref(),
+            &extra,
+            crate::fs::scope_boundary(req.fs_scope.as_ref()),
+        )?;
         // Cap before compiling: an unbounded pattern stalls compilation and
         // pins memory.
         check_pattern_len(&req.pattern)?;
@@ -1528,7 +1599,7 @@ impl FsBackend for HostFsBackend {
         // blocking closure confines + anchors every operand to it instead of the
         // global jail roots. None ⇒ unchanged jail behaviour.
         let scope_root_canon =
-            self.confine_scope_root(crate::fs::scope_root(req.fs_scope.as_ref()))?;
+            self.confine_scope_root(crate::fs::scope_anchor(req.fs_scope.as_ref()))?;
         let scope_grants_canon =
             self.confine_scope_grants(crate::fs::scope_grants(req.fs_scope.as_ref()));
         let access_roots = access_roots(
@@ -1782,9 +1853,14 @@ impl FsBackend for HostFsBackend {
         })
     }
     async fn write(&self, req: crate::fs::WriteArgs) -> FsCallResult<crate::fs::WriteResponse> {
-        let base = self.confine_scope_root(crate::fs::scope_root(req.fs_scope.as_ref()))?;
+        let base = self.confine_scope_root(crate::fs::scope_anchor(req.fs_scope.as_ref()))?;
         let extra = self.confine_scope_grants(crate::fs::scope_grants(req.fs_scope.as_ref()));
-        let p = self.validate_path_scoped(&req.path, base.as_deref(), &extra)?;
+        let p = self.validate_path_scoped(
+            &req.path,
+            base.as_deref(),
+            &extra,
+            crate::fs::scope_boundary(req.fs_scope.as_ref()),
+        )?;
         let bits = crate::fs::error::parse_mode(&req.mode)?;
         check_special_bits(bits, self.cfg.allow_special_bits)?;
 
@@ -1930,9 +2006,14 @@ impl FsBackend for HostFsBackend {
     async fn read(&self, req: crate::fs::ReadArgs) -> FsCallResult<crate::fs::ReadResponse> {
         use std::os::unix::fs::PermissionsExt;
 
-        let base = self.confine_scope_root(crate::fs::scope_root(req.fs_scope.as_ref()))?;
+        let base = self.confine_scope_root(crate::fs::scope_anchor(req.fs_scope.as_ref()))?;
         let extra = self.confine_scope_grants(crate::fs::scope_grants(req.fs_scope.as_ref()));
-        let p = self.validate_path_scoped(&req.path, base.as_deref(), &extra)?;
+        let p = self.validate_path_scoped(
+            &req.path,
+            base.as_deref(),
+            &extra,
+            crate::fs::scope_boundary(req.fs_scope.as_ref()),
+        )?;
         let md = tokio::fs::symlink_metadata(&p)
             .await
             .map_err(|e| FsError::from_io(&req.path, e))?;
@@ -2252,6 +2333,7 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: session.display().to_string(),
                     grants: Vec::new(),
+                    boundary: crate::fs::FsBoundary::Workspace,
                 }),
             })
             .await
@@ -2264,6 +2346,7 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: session.display().to_string(),
                     grants: vec![granted.display().to_string()],
+                    boundary: crate::fs::FsBoundary::Workspace,
                 }),
             })
             .await
@@ -3991,6 +4074,7 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: base,
                     grants: Vec::new(),
+                    boundary: crate::fs::FsBoundary::Workspace,
                 }),
             })
             .await
@@ -4022,6 +4106,7 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: base,
                     grants: Vec::new(),
+                    boundary: crate::fs::FsBoundary::Workspace,
                 }),
             })
             .await
@@ -4053,6 +4138,7 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: base,
                     grants: Vec::new(),
+                    boundary: crate::fs::FsBoundary::Workspace,
                 }),
             })
             .await
@@ -4086,6 +4172,7 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: base,
                     grants: Vec::new(),
+                    boundary: crate::fs::FsBoundary::Workspace,
                 }),
             })
             .await
@@ -4120,6 +4207,7 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: selected.join("project").to_string_lossy().into_owned(),
                     grants: Vec::new(),
+                    boundary: crate::fs::FsBoundary::Workspace,
                 }),
             })
             .await
@@ -4144,6 +4232,7 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: selected.to_string_lossy().into_owned(),
                     grants: Vec::new(),
+                    boundary: crate::fs::FsBoundary::Workspace,
                 }),
             })
             .await
@@ -4161,6 +4250,7 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: "../../etc".into(),
                     grants: Vec::new(),
+                    boundary: crate::fs::FsBoundary::Workspace,
                 }),
             })
             .await
@@ -4183,6 +4273,7 @@ mod tests {
                 fs_scope: Some(crate::fs::FsScope {
                     root: base,
                     grants: Vec::new(),
+                    boundary: crate::fs::FsBoundary::Workspace,
                 }),
             })
             .await
@@ -4212,5 +4303,38 @@ mod tests {
             "legacy\n",
             "scope_root=None ⇒ anchors at the jail root exactly as before"
         );
+    }
+
+    #[tokio::test]
+    async fn configured_roots_boundary_anchors_relative_paths_without_blocking_siblings() {
+        let root = tmp();
+        fs::create_dir_all(root.join("session")).unwrap();
+        fs::create_dir_all(root.join("sibling")).unwrap();
+        fs::write(root.join("session/local.txt"), "local").unwrap();
+        fs::write(root.join("sibling/shared.txt"), "shared").unwrap();
+        let backend = jailed_backend(&root);
+        let scope = crate::fs::FsScope {
+            root: root.join("session").to_string_lossy().into_owned(),
+            grants: Vec::new(),
+            boundary: crate::fs::FsBoundary::ConfiguredRoots,
+        };
+
+        let relative = backend
+            .stat(crate::fs::StatArgs {
+                path: "local.txt".into(),
+                fs_scope: Some(scope.clone()),
+            })
+            .await
+            .expect("relative paths stay anchored at the working directory");
+        assert_eq!(relative.0.name, "local.txt");
+
+        let sibling = backend
+            .stat(crate::fs::StatArgs {
+                path: root.join("sibling/shared.txt").display().to_string(),
+                fs_scope: Some(scope),
+            })
+            .await
+            .expect("configured-roots mode permits siblings inside shell policy");
+        assert_eq!(sibling.0.name, "shared.txt");
     }
 }

--- a/shell/src/fs/mod.rs
+++ b/shell/src/fs/mod.rs
@@ -21,6 +21,14 @@ pub struct FsScope {
     pub root: String,
     #[serde(default)]
     pub grants: Vec<String>,
+    pub boundary: FsBoundary,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FsBoundary {
+    Workspace,
+    ConfiguredRoots,
 }
 
 impl FsScope {
@@ -38,11 +46,21 @@ impl FsScope {
 }
 
 pub fn scope_root(scope: Option<&FsScope>) -> Option<&str> {
+    scope.and_then(|scope| (scope.boundary == FsBoundary::Workspace).then_some(scope.root()))
+}
+
+pub fn scope_anchor(scope: Option<&FsScope>) -> Option<&str> {
     scope.map(FsScope::root)
 }
 
 pub fn scope_grants(scope: Option<&FsScope>) -> Option<&[String]> {
     scope.and_then(FsScope::grants)
+}
+
+pub fn scope_boundary(scope: Option<&FsScope>) -> FsBoundary {
+    scope
+        .map(|scope| scope.boundary)
+        .unwrap_or(FsBoundary::ConfiguredRoots)
 }
 
 /// Wire-identical mirror of `iii_sdk::channels::StreamChannelRef`. The SDK
@@ -851,6 +869,15 @@ mod tests {
     fn target_defaults_to_host_when_field_missing() {
         let v: Target = serde_json::from_value(serde_json::json!({"kind": "host"})).unwrap();
         assert_eq!(v, Target::Host);
+    }
+
+    #[test]
+    fn fs_scope_requires_an_explicit_boundary() {
+        let scope: Result<FsScope, _> = serde_json::from_value(serde_json::json!({
+            "root": "/work/project",
+            "grants": []
+        }));
+        assert!(scope.is_err());
     }
 
     #[test]

--- a/shell/src/functions/exec.rs
+++ b/shell/src/functions/exec.rs
@@ -38,12 +38,13 @@ pub async fn handle(
     // target so the harness-injected session dir does not surface as a host cwd
     // override and get rejected (see `scope_root_for_target`).
     let scope_root =
-        scope_root_for_target(&req.target, crate::fs::scope_root(req.fs_scope.as_ref()));
+        scope_root_for_target(&req.target, crate::fs::scope_anchor(req.fs_scope.as_ref()));
     let mut overrides = build_overrides(
         req.cwd.as_deref(),
         req.env.as_ref(),
         scope_root,
         crate::fs::scope_grants(req.fs_scope.as_ref()),
+        crate::fs::scope_boundary(req.fs_scope.as_ref()),
         &cfg,
     )
     .map_err(iii_sdk::errors::Error::from)?;

--- a/shell/src/functions/exec_bg.rs
+++ b/shell/src/functions/exec_bg.rs
@@ -48,12 +48,13 @@ pub async fn handle(
     // target so the harness-injected session dir does not surface as a host cwd
     // override and trip the host-only rejection below (see `scope_root_for_target`).
     let scope_root =
-        scope_root_for_target(&req.target, crate::fs::scope_root(req.fs_scope.as_ref()));
+        scope_root_for_target(&req.target, crate::fs::scope_anchor(req.fs_scope.as_ref()));
     let mut overrides = build_overrides(
         req.cwd.as_deref(),
         req.env.as_ref(),
         scope_root,
         crate::fs::scope_grants(req.fs_scope.as_ref()),
+        crate::fs::scope_boundary(req.fs_scope.as_ref()),
         &cfg,
     )
     .map_err(|e| format!("{}: {}", e.code, e.message))?;

--- a/shell/tests/code_path_jail.rs
+++ b/shell/tests/code_path_jail.rs
@@ -169,6 +169,7 @@ async fn scoped_scope_root_blocks_sibling_escape_across_handlers() {
             fs_scope: Some(shell::fs::FsScope {
                 root: scope_root.clone(),
                 grants: Vec::new(),
+                boundary: shell::fs::FsBoundary::Workspace,
             }),
             ..ReadFileInput::default()
         },
@@ -191,6 +192,7 @@ async fn scoped_scope_root_blocks_sibling_escape_across_handlers() {
             fs_scope: Some(shell::fs::FsScope {
                 root: scope_root.clone(),
                 grants: Vec::new(),
+                boundary: shell::fs::FsBoundary::Workspace,
             }),
         },
     )
@@ -210,6 +212,7 @@ async fn scoped_scope_root_blocks_sibling_escape_across_handlers() {
             fs_scope: Some(shell::fs::FsScope {
                 root: scope_root,
                 grants: Vec::new(),
+                boundary: shell::fs::FsBoundary::Workspace,
             }),
         },
     )

--- a/shell/tests/features/coder/path_security.feature
+++ b/shell/tests/features/coder/path_security.feature
@@ -50,6 +50,6 @@ Feature: coder path security
       """
     When I call coder::read-file with payload:
       """
-      {"path":"../outside-session.txt","fs_scope":{"root":"{{session}}"}}
+      {"path":"../outside-session.txt","fs_scope":{"root":"{{session}}","boundary":"workspace"}}
       """
     Then the call failed with code "C218"


### PR DESCRIPTION
## Summary

- select an explicit filesystem boundary for every Harness tool call based on whether the filesystem-access approval hook is currently available
- use the Shell worker's configured roots when approvals are unavailable while keeping the selected workspace as the relative-path and command working-directory anchor
- preserve workspace-scoped access and folder approval prompts when the approval gate is installed
- expose the active boundary through `harness::filesystem::info` and make the Console describe the effective access mode
- simplify filesystem errors shown to users by removing the machine-only access request payload

## Root cause

The Harness always stamped the selected working directory as a hard filesystem scope. Shell and coder tools enforced that scope even when no approval gate existed, so an otherwise allowed parent or sibling directory failed with a jail error that the user had no way to approve.

## User impact

Deployments without an approval gate now use the most permissive access already allowed by Shell configuration. Deployments with approval support keep the narrower workspace boundary and the existing allow-once, session, permanent, and deny flow.

## Validation

- `cargo test --manifest-path shell/Cargo.toml --lib` — 591 passed
- `cargo test --manifest-path harness/Cargo.toml` — 215 passed, including manifest and schema snapshots
- `pnpm --dir console/web test` — 942 passed
- `pnpm --dir console/web typecheck`
- Rust formatting checks for Shell and Harness
- focused Biome check for the four changed Console files
- `git diff --check`

Fixes MOT-3981


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Filesystem access controls now clearly indicate whether access is limited to the workspace or follows shell defaults.
  * Access dialogs provide guidance tailored to the selected scope and display session-specific permissions when applicable.
  * Filesystem and command operations now consistently respect the selected access boundary.

* **Bug Fixes**
  * Improved filesystem-access denial messages by removing technical metadata and using clearer error labels.
  * Corrected path handling for reading, writing, moving, deleting, searching, and listing files across access scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->