### PR TITLE
(MOT-3982) fix(approval-gate): align runtime dependency ranges

### DIFF
--- a/.github/scripts/tests/test_worker_dependency_compatibility.py
+++ b/.github/scripts/tests/test_worker_dependency_compatibility.py
@@ -1,0 +1,27 @@
+"""Regression tests for shared worker dependency ranges."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def dependencies(worker: str) -> dict[str, str]:
+    manifest = REPO_ROOT / worker / "iii.worker.yaml"
+    data = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    return data.get("dependencies", {})
+
+
+def test_approval_gate_uses_shared_runtime_dependency_ranges() -> None:
+    approval_gate = dependencies("approval-gate")
+
+    expected_ranges = {
+        "configuration": dependencies("iii-directory")["configuration"],
+        "iii-state": dependencies("harness")["iii-state"],
+    }
+
+    for dependency, expected in expected_ranges.items():
+        assert approval_gate[dependency] == expected

--- a/approval-gate/iii.worker.yaml
+++ b/approval-gate/iii.worker.yaml
@@ -7,7 +7,7 @@ bin: approval-gate
 description: Policy and decision surface for human-held function calls — pre_trigger gate, pending inbox, per-session permission settings, and two notification trigger types.
 
 dependencies:
-  iii-state: "^0.19.0"
-  configuration: "^0.19.0"
+  iii-state: "^0.21.3"
+  configuration: "^0.21.3"
   iii-directory: "^1.0.0"
   session-manager: "^1.0.0"


### PR DESCRIPTION
Installing the current approval-gate worker failed before startup because its dependency graph requested incompatible configuration versions. This aligns approval-gate with the current runtime dependency family so the worker can resolve and start normally.

## Technical details

- Bump `iii-state` and `configuration` from `^0.19.0` to `^0.21.3`.
- Add a regression test that keeps approval-gate aligned with `iii-directory` and Harness core ranges.
- Verification: 115 scripts tests and 170 approval-gate Rust tests pass.

Fixes MOT-3982


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the approval-gate worker to use compatible versions of its shared runtime dependencies.
  * Added regression coverage to help prevent future dependency version mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->