### PR TITLE
(MOT-3955) fix(console): show approval requests without refreshing

### DIFF
--- a/console/web/src/lib/backend/approval-events-live.test.ts
+++ b/console/web/src/lib/backend/approval-events-live.test.ts
@@ -115,12 +115,28 @@ describe('startApprovalEventsSubscription', () => {
   })
 
   it('can bind unscoped events for a parent chat that filters descendants client-side', () => {
-    const { client, triggers } = fakeClient()
+    const { client, triggers, fire } = fakeClient()
+    const onCreated = vi.fn()
+    const onResolved = vi.fn()
     startApprovalEventsSubscription(client, undefined, {
-      onCreated: () => {},
-      onResolved: () => {},
+      onCreated,
+      onResolved,
     })
     expect(triggers.map((trigger) => trigger.config)).toEqual([{}, {}])
+
+    fire('iii::console::approval_pending_created', record)
+    expect(onCreated).toHaveBeenCalledWith(record)
+
+    const resolved: PendingResolvedEvent = {
+      function_call_id: 'fc-1',
+      function_id: 'shell::fs::write',
+      session_id: 'sess-1',
+      turn_id: 't-1',
+      outcome: 'allow',
+      resolved_at: 9,
+    }
+    fire('iii::console::approval_pending_resolved', resolved)
+    expect(onResolved).toHaveBeenCalledWith(resolved)
   })
 })
 

--- a/console/web/src/lib/backend/approval-events-live.ts
+++ b/console/web/src/lib/backend/approval-events-live.ts
@@ -42,7 +42,8 @@ function bind<P>(
     // the engine-side trigger filter is per-binding, so another session's
     // events also land here — drop them.
     const sid = (payload as { session_id?: unknown }).session_id
-    if (typeof sid === 'string' && sid !== sessionId) return
+    if (sessionId !== undefined && typeof sid === 'string' && sid !== sessionId)
+      return
     onEvent(payload as P)
   })
   const offTrigger = client.registerTrigger({


### PR DESCRIPTION
## Summary

Approval requests now appear as soon as they are created and clear immediately after an approve or deny decision, including requests raised by sub-agents. Users no longer need to refresh the console to discover a blocked call, and successful decisions no longer look stuck.

## Root cause

The console intentionally uses an unscoped approval subscription so it can receive events from the selected conversation and any descendant sessions. The subscription handler still compared each event's session ID against the undefined subscription scope, which discarded every live `pending-created` and `pending-resolved` event. Refreshing appeared to repair the issue because the separate pending-inbox recovery request bypassed that handler.

## Changes

- Apply the session mismatch filter only when the subscription has a concrete session scope.
- Cover live created and resolved delivery through the unscoped subscription path.

## Validation

- `pnpm --dir console/web exec vitest run src/lib/backend/approval-events-live.test.ts`
- `pnpm --dir console/web test` — 942 tests passed
- `pnpm --dir console/web typecheck`
- `pnpm --dir console/web exec biome check src/lib/backend/approval-events-live.ts src/lib/backend/approval-events-live.test.ts`
- `pnpm --dir console/web build`
- Browser smoke: a manual approval appeared without refresh and cleared after Approve

Refs MOT-3955
