### PR TITLE
(MOT-3955) fix(approval): keep follow-up access requests actionable

### DIFF
--- a/approval-gate/src/functions/filesystem_access_watch.rs
+++ b/approval-gate/src/functions/filesystem_access_watch.rs
@@ -107,6 +107,15 @@ async fn evaluate(deps: &Deps, input: &HookInput, hint: AccessRequest) -> HookOu
         Ok(Some(existing)) if existing.access_request.as_ref() == Some(&hint) => {
             return HookOutput::Hold;
         }
+        Ok(Some(existing))
+            if existing.kind == PendingKind::Function
+                && existing.turn_id == input.turn_id
+                && existing.function_id == call.function_id =>
+        {
+            // The generic approval currently being resolved is allowed to
+            // transition atomically into a filesystem approval for the same
+            // call. Keeping it until put() avoids a blind gap in the inbox.
+        }
         Ok(Some(_stale)) => {
             // Clear the stale record so the write below (step 8) is a clean
             // insert rather than racing `hold`'s own duplicate-write
@@ -197,9 +206,20 @@ async fn hold(deps: &Deps, input: &HookInput, call: &HookCall, hint: AccessReque
             );
             HookOutput::Continue
         }
-        // Lost a write race with a concurrent duplicate hold: the first
-        // writer's record (and emission) stands.
-        Ok(Some(_prior)) => HookOutput::Hold,
+        Ok(Some(prior)) => {
+            // A generic pre-trigger approval can transition into this
+            // filesystem approval while approval::resolve is still running.
+            // put() has already replaced it atomically; emit the new request
+            // so the UI explains why the call remains paused. Same-kind
+            // duplicates were returned by evaluate() before reaching here.
+            if pending::parse_record(&prior).is_some_and(|prior| prior.kind != record.kind) {
+                let sink = deps.sink.clone();
+                tokio::spawn(async move {
+                    sink.pending_created(&record).await;
+                });
+            }
+            HookOutput::Hold
+        }
         Ok(None) => {
             let sink = deps.sink.clone();
             tokio::spawn(async move {
@@ -467,6 +487,53 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(out2, HookOutput::Continue);
+        })
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn generic_approval_transitions_into_a_visible_filesystem_approval() {
+        with_stack(BootOpts::needs_approval(), |stack| async move {
+            register_workspace_fakes(&stack, vec![]);
+            let generic = PendingApprovalRecord {
+                session_id: "s_1".into(),
+                turn_id: "t_1".into(),
+                function_call_id: "c_1".into(),
+                function_id: "shell::fs::read".into(),
+                arguments_excerpt: json!({ "path": "/a/b" }),
+                pending_at: 100,
+                session_title: None,
+                session_description: None,
+                session_metadata: None,
+                depth: 0,
+                assistant_excerpt: None,
+                kind: PendingKind::Function,
+                access_request: None,
+            };
+            state_set(
+                &stack.iii,
+                PENDING_SCOPE,
+                "s_1/c_1",
+                serde_json::to_value(generic).unwrap(),
+            )
+            .await;
+
+            let out = handle(&stack.deps, jail_input("s_1", "c_1", "/a/b"))
+                .await
+                .unwrap();
+            assert_eq!(out, HookOutput::Hold);
+
+            let current = state_get(&stack.iii, PENDING_SCOPE, "s_1/c_1").await;
+            assert_eq!(current["kind"], json!("filesystem_access"));
+            assert_eq!(current["access_request"]["requested_root"], json!("/a/b"));
+            assert!(
+                crate::testkit::wait_for(3_000, || { !log_snapshot(&stack.created).is_empty() })
+                    .await
+            );
+            assert_eq!(
+                log_snapshot(&stack.created)[0]["kind"],
+                json!("filesystem_access")
+            );
         })
         .await;
     }

--- a/approval-gate/src/functions/resolve.rs
+++ b/approval-gate/src/functions/resolve.rs
@@ -68,39 +68,72 @@ pub async fn handle(deps: &Deps, req: ResolveRequest) -> Result<ResolveResponse,
         .get("turn_resumed")
         .and_then(serde_json::Value::as_bool);
 
-    match pending::delete_with_gate(iii, &req.session_id, &req.function_call_id).await {
-        Ok(Some(deleted)) => {
-            deps.sink
-                .pending_resolved(&PendingResolvedEvent {
-                    session_id: deleted.session_id,
-                    turn_id: deleted.turn_id,
-                    function_call_id: deleted.function_call_id,
-                    function_id: deleted.function_id,
-                    outcome: match req.decision {
-                        ResolveDecision::Allow => ResolvedOutcome::Allow,
-                        ResolveDecision::Deny => ResolvedOutcome::Deny,
-                    },
-                    reason: match req.decision {
-                        ResolveDecision::Deny => req.reason.clone(),
-                        ResolveDecision::Allow => None,
-                    },
-                    session_metadata: deleted.session_metadata,
-                    resolved_at: now_ms(),
-                })
-                .await;
-        }
-        // A concurrent path already deleted (and emitted): exactly-once
-        // emission is the gate's contract.
-        Ok(None) => {}
+    // Executing an approved call can synchronously hit another hold, most
+    // notably the filesystem-access post-trigger hook. That follow-up replaces
+    // the original record under the same session/call key before harness
+    // returns. Delete only when the key still contains the record we resolved;
+    // otherwise preserve the replacement. A verification failure is also
+    // cleanup-only: the function has already executed, so returning an error
+    // here could encourage a duplicate retry.
+    let next_pending = match pending::get(iii, &req.session_id, &req.function_call_id).await {
+        Ok(current) => current.filter(|current| current != &record),
         Err(e) => {
-            // The decision reached the harness; retry or turn/session cleanup
-            // will collect the orphaned record. Never fail resolve over cleanup.
             tracing::warn!(
                 session_id = %req.session_id,
                 function_call_id = %req.function_call_id,
                 error = %e,
-                "pending record delete failed after resolve; retry or purge will collect it"
+                "pending record verification failed after resolve; preserving it for retry or purge"
             );
+            return Ok(ResolveResponse {
+                resolved: true,
+                turn_resumed,
+            });
+        }
+    };
+
+    if let Some(next) = &next_pending {
+        tracing::info!(
+            session_id = %req.session_id,
+            function_call_id = %req.function_call_id,
+            next_kind = ?next.kind,
+            next_pending_at = next.pending_at,
+            "approved call transitioned to a follow-up approval"
+        );
+    } else {
+        match pending::delete_with_gate(iii, &req.session_id, &req.function_call_id).await {
+            Ok(Some(deleted)) => {
+                deps.sink
+                    .pending_resolved(&PendingResolvedEvent {
+                        session_id: deleted.session_id,
+                        turn_id: deleted.turn_id,
+                        function_call_id: deleted.function_call_id,
+                        function_id: deleted.function_id,
+                        outcome: match req.decision {
+                            ResolveDecision::Allow => ResolvedOutcome::Allow,
+                            ResolveDecision::Deny => ResolvedOutcome::Deny,
+                        },
+                        reason: match req.decision {
+                            ResolveDecision::Deny => req.reason.clone(),
+                            ResolveDecision::Allow => None,
+                        },
+                        session_metadata: deleted.session_metadata,
+                        resolved_at: now_ms(),
+                    })
+                    .await;
+            }
+            // A concurrent path already deleted (and emitted): exactly-once
+            // emission is the gate's contract.
+            Ok(None) => {}
+            Err(e) => {
+                // The decision reached the harness; retry or turn/session cleanup
+                // will collect the orphaned record. Never fail resolve over cleanup.
+                tracing::warn!(
+                    session_id = %req.session_id,
+                    function_call_id = %req.function_call_id,
+                    error = %e,
+                    "pending record delete failed after resolve; retry or purge will collect it"
+                );
+            }
         }
     }
 
@@ -311,6 +344,28 @@ mod tests {
         .await;
     }
 
+    fn filesystem_replacement() -> PendingApprovalRecord {
+        PendingApprovalRecord {
+            session_id: "s_1".into(),
+            turn_id: "t_9".into(),
+            function_call_id: "c_1".into(),
+            function_id: "shell::run".into(),
+            arguments_excerpt: json!({ "cmd": "ls" }),
+            pending_at: 200,
+            session_title: None,
+            session_description: None,
+            session_metadata: Some(serde_json::from_value(json!({ "owner": "u_1" })).unwrap()),
+            depth: 0,
+            assistant_excerpt: None,
+            kind: PendingKind::FilesystemAccess,
+            access_request: Some(AccessRequest {
+                requested_root: "/private/tmp".into(),
+                attempted_path: "/private/tmp".into(),
+                error_code: "S215".into(),
+            }),
+        }
+    }
+
     fn req(decision: ResolveDecision, reason: Option<&str>) -> ResolveRequest {
         ResolveRequest {
             session_id: "s_1".into(),
@@ -339,6 +394,35 @@ mod tests {
                 .await
                 .is_null());
         })
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn allow_preserves_a_followup_approval_created_during_execution() {
+        let replacement = filesystem_replacement();
+        let replacement_value = serde_json::to_value(&replacement).unwrap();
+        with_stack(
+            BootOpts::needs_approval().replacing_pending_on_resolve(replacement_value.clone()),
+            |stack| async move {
+                seed_record(&stack.iii).await;
+
+                let res = handle(&stack.deps, req(ResolveDecision::Allow, None))
+                    .await
+                    .unwrap();
+
+                assert!(res.resolved);
+                assert_eq!(res.turn_resumed, Some(false));
+                assert_eq!(
+                    state_get(&stack.iii, PENDING_SCOPE, "s_1/c_1").await,
+                    replacement_value,
+                    "the follow-up approval must remain actionable"
+                );
+                assert!(
+                    log_snapshot(&stack.resolved).is_empty(),
+                    "the replacement must not be cleared as the old approval"
+                );
+            },
+        )
         .await;
     }
 

--- a/approval-gate/src/testkit/engine.rs
+++ b/approval-gate/src/testkit/engine.rs
@@ -199,6 +199,9 @@ pub struct BootOpts {
     /// When true, spawn the real `harness` worker and skip the fake
     /// `harness::function::resolve` stub.
     pub real_harness: bool,
+    /// Test-only replacement written while the fake function resolver runs,
+    /// modeling a post-trigger hook that parks the same call again.
+    pub function_resolve_replacement: Option<Value>,
 }
 
 impl Default for BootOpts {
@@ -213,6 +216,7 @@ impl BootOpts {
         Self {
             rules: RulesOverride::Empty,
             real_harness: false,
+            function_resolve_replacement: None,
         }
     }
 
@@ -221,6 +225,7 @@ impl BootOpts {
         Self {
             rules: RulesOverride::Empty,
             real_harness: true,
+            function_resolve_replacement: None,
         }
     }
 
@@ -229,6 +234,7 @@ impl BootOpts {
         Self {
             rules: RulesOverride::Custom(vec![json!("*")]),
             real_harness: false,
+            function_resolve_replacement: None,
         }
     }
 
@@ -237,6 +243,7 @@ impl BootOpts {
         Self {
             rules: RulesOverride::Custom(vec![json!(function_id.into())]),
             real_harness: false,
+            function_resolve_replacement: None,
         }
     }
 
@@ -245,6 +252,7 @@ impl BootOpts {
         Self {
             rules: RulesOverride::Custom(vec![json!(format!("!{}", function_id.into()))]),
             real_harness: false,
+            function_resolve_replacement: None,
         }
     }
 
@@ -253,6 +261,7 @@ impl BootOpts {
         Self {
             rules: RulesOverride::Custom(rules),
             real_harness: false,
+            function_resolve_replacement: None,
         }
     }
 
@@ -261,7 +270,13 @@ impl BootOpts {
         Self {
             rules: RulesOverride::Shipped,
             real_harness: false,
+            function_resolve_replacement: None,
         }
+    }
+
+    pub fn replacing_pending_on_resolve(mut self, replacement: Value) -> Self {
+        self.function_resolve_replacement = Some(replacement);
+        self
     }
 }
 
@@ -364,15 +379,32 @@ pub async fn boot(engine: &Engine, opts: BootOpts) -> TestStack {
     let harness_calls: CallLog = Arc::default();
     if !opts.real_harness {
         let log = harness_calls.clone();
+        let iii_for_resolve = iii.clone();
+        let replacement = opts.function_resolve_replacement.clone();
         iii.register_function(
             "harness::function::resolve",
             RegisterFunction::new_async(move |req: Value| {
                 let log = log.clone();
+                let iii = iii_for_resolve.clone();
+                let replacement = replacement.clone();
                 async move {
-                    log_push(&log, req);
-                    Ok::<_, iii_sdk::errors::Error>(
-                        json!({ "resolved": true, "turn_resumed": true }),
-                    )
+                    log_push(&log, req.clone());
+                    let has_replacement = replacement.is_some();
+                    if let Some(replacement) = replacement {
+                        let session_id = req["session_id"].as_str().unwrap_or("s_1");
+                        let call_id = req["function_call_id"].as_str().unwrap_or("c_1");
+                        state_set(
+                            &iii,
+                            crate::pending::PENDING_SCOPE,
+                            &format!("{session_id}/{call_id}"),
+                            replacement,
+                        )
+                        .await;
+                    }
+                    Ok::<_, iii_sdk::errors::Error>(json!({
+                        "resolved": true,
+                        "turn_resumed": !has_replacement,
+                    }))
                 }
             }),
         );

--- a/console/web/src/components/permissions/FilesystemAccessPrompt.tsx
+++ b/console/web/src/components/permissions/FilesystemAccessPrompt.tsx
@@ -69,8 +69,16 @@ export function FilesystemAccessPrompt({
         >
           {requestedRoot}
         </div>
-        <p className="font-mono text-[11px] text-ink-faint">
-          this folder is outside the session's allowed folders.
+        <p
+          role="status"
+          aria-live="polite"
+          className="font-mono text-[11px] text-ink-faint"
+        >
+          the approved function reached this folder and paused before accessing
+          it.
+        </p>
+        <p className="font-mono text-[11px] text-ink-ghost">
+          choose how long to allow access; the function resumes automatically.
         </p>
         {workingDir ? (
           <p className="font-mono text-[11px] text-ink-ghost">
@@ -114,7 +122,7 @@ export function FilesystemAccessPrompt({
         </Button>
         {submitting ? (
           <span className="font-mono text-[12px] text-ink-faint">
-            waiting for the agent to resume…
+            access saved; resuming the function…
           </span>
         ) : null}
       </div>

--- a/console/web/src/lib/backend/approval-events-live.test.ts
+++ b/console/web/src/lib/backend/approval-events-live.test.ts
@@ -5,8 +5,11 @@ import type {
   PendingResolvedEvent,
 } from '@/types/iii-agent-event'
 import {
+  acceptPendingApprovalRevision,
   approvalBelongsToConversationTree,
   listPendingApprovals,
+  pendingApprovalKey,
+  pendingApprovalRevision,
   startApprovalEventsSubscription,
 } from './approval-events-live'
 
@@ -160,6 +163,31 @@ describe('listPendingApprovals', () => {
     expect(trigger).toHaveBeenCalledWith('approval::list-pending', {
       limit: 500,
     })
+  })
+})
+
+describe('pending approval revisions', () => {
+  it('distinguishes a filesystem follow-up from the generic approval for the same call', () => {
+    const followUp: PendingApprovalRecord = {
+      ...record,
+      pending_at: 10,
+      kind: 'filesystem_access',
+      access_request: {
+        requested_root: '/private/tmp',
+        attempted_path: '/private/tmp',
+        error_code: 'S220',
+      },
+    }
+
+    const seen = new Map<string, string>()
+    expect(acceptPendingApprovalRevision(seen, record)).toBe(true)
+    expect(acceptPendingApprovalRevision(seen, { ...record })).toBe(false)
+    expect(pendingApprovalKey(record)).toBe(pendingApprovalKey(followUp))
+    expect(pendingApprovalRevision(record)).not.toBe(
+      pendingApprovalRevision(followUp),
+    )
+    expect(acceptPendingApprovalRevision(seen, followUp)).toBe(true)
+    expect(acceptPendingApprovalRevision(seen, { ...followUp })).toBe(false)
   })
 })
 

--- a/console/web/src/lib/backend/approval-events-live.ts
+++ b/console/web/src/lib/backend/approval-events-live.ts
@@ -29,6 +29,44 @@ export interface ApprovalEventHandlers {
   onResolved: (event: PendingResolvedEvent) => void
 }
 
+type PendingApprovalIdentity = Pick<
+  PendingApprovalRecord,
+  'session_id' | 'function_call_id'
+>
+
+/** Stable inbox slot shared by each approval stage for one function call. */
+export function pendingApprovalKey(record: PendingApprovalIdentity): string {
+  return `${record.session_id}:${record.function_call_id}`
+}
+
+/**
+ * Revision within an inbox slot. A generic approval can transition into a
+ * filesystem approval without changing its function-call id, so deduping by
+ * slot alone hides the follow-up prompt until refresh.
+ */
+export function pendingApprovalRevision(record: PendingApprovalRecord): string {
+  return JSON.stringify([
+    record.pending_at,
+    record.function_id,
+    record.kind ?? 'function',
+    record.access_request?.requested_root ?? null,
+    record.access_request?.attempted_path ?? null,
+    record.access_request?.error_code ?? null,
+  ])
+}
+
+/** Record a pending revision; false means this exact event was already seen. */
+export function acceptPendingApprovalRevision(
+  seen: Map<string, string>,
+  record: PendingApprovalRecord,
+): boolean {
+  const key = pendingApprovalKey(record)
+  const revision = pendingApprovalRevision(record)
+  if (seen.get(key) === revision) return false
+  seen.set(key, revision)
+  return true
+}
+
 function bind<P>(
   client: ClientSubset,
   handlerFn: string,

--- a/console/web/src/lib/backend/real.ts
+++ b/console/web/src/lib/backend/real.ts
@@ -21,7 +21,9 @@ import type { AgentMessage } from '@/lib/sessions/types'
 import type { Mode, ModelId } from '@/types/chat'
 import type { PendingApprovalRecord } from '@/types/iii-agent-event'
 import {
+  acceptPendingApprovalRevision,
   listPendingApprovals,
+  pendingApprovalKey,
   startApprovalEventsSubscription,
 } from './approval-events-live'
 import { loadApprovalGateDefaults } from './approval-gate-config'
@@ -232,7 +234,7 @@ function realWatchApprovals(
 
   let disposed = false
   let stop = () => {}
-  const seenPending = new Set<string>()
+  const seenPending = new Map<string, string>()
   const emit = (event: TurnSourceEvent) => {
     if (disposed) return
     for (const streamEvent of translateTurnSource(event)) {
@@ -258,16 +260,17 @@ function realWatchApprovals(
         : opts.sessionId
       const emitPending = (record: PendingApprovalRecord) => {
         if (!matcher(record)) return
-        const key = `${record.session_id}:${record.function_call_id}`
-        if (seenPending.has(key)) return
-        seenPending.add(key)
+        if (!acceptPendingApprovalRevision(seenPending, record)) return
         emit({ kind: 'approval-created', record })
       }
 
       stop = startApprovalEventsSubscription(client, subscriptionSessionId, {
         onCreated: emitPending,
         onResolved: (event) => {
-          if (matcher(event)) emit({ kind: 'approval-resolved', event })
+          if (matcher(event)) {
+            seenPending.delete(pendingApprovalKey(event))
+            emit({ kind: 'approval-resolved', event })
+          }
         },
       })
       void listPendingApprovals(client, subscriptionSessionId)


### PR DESCRIPTION
## Summary

- preserve a follow-up filesystem access request when an approved function reaches a protected folder
- treat same-call approval replacements as new inbox revisions so the console updates without a page refresh
- explain that the function is paused, what the user needs to choose, and when execution is resuming
- add structured transition logging and regression coverage for both sides of the handoff

## Root cause

The function approval and the later filesystem approval share the same session and function-call key. The filesystem watcher correctly replaced the first record while the approved function was executing, but the outer resolver then unconditionally deleted that key. The harness remained held while the console had no pending request to display.

After preserving the replacement, the console still deduplicated pending events only by session and function-call ID. It discarded the filesystem revision as a duplicate and left the original card in its approving state until a refresh rebuilt the inbox.

## User and developer impact

The second approval remains actionable and appears immediately. The prompt now tells the user why execution paused and confirms that the function resumes automatically after access is saved. Logs identify follow-up approval transitions directly, and the console deduper distinguishes exact duplicate delivery from a new approval stage.

## Verification

- live browser flow: approve shell::fs::ls, receive filesystem access prompt without refresh, allow once, session completes
- cargo test --manifest-path approval-gate/Cargo.toml
- cargo clippy --manifest-path approval-gate/Cargo.toml --all-targets -- -D warnings
- cargo fmt --manifest-path approval-gate/Cargo.toml -- --check
- pnpm --dir console/web test (943 tests)
- pnpm --dir console/web typecheck
- pnpm --dir console/web build
- pnpm --dir console/web exec biome check src/lib/backend/approval-events-live.ts src/lib/backend/approval-events-live.test.ts src/lib/backend/real.ts src/components/permissions/FilesystemAccessPrompt.tsx

Refs MOT-3955

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Filesystem access approvals now remain visible when a generic approval transitions into a folder-specific approval.
  - Follow-up approvals created during resolution remain actionable instead of being cleared.
  - Approval updates now distinguish new revisions from duplicate events.

- **UI Improvements**
  - Filesystem prompts clearly identify the paused folder access and request an access duration.
  - Confirmation text now indicates that access was saved and the function will resume.

- **Bug Fixes**
  - Prevented approval notifications from disappearing or being duplicated during concurrent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->