### PR TITLE
(MOT-3978) fix(console): lift WS proxy message size limits

### DIFF
--- a/console/src/proxy.rs
+++ b/console/src/proxy.rs
@@ -21,18 +21,38 @@ use axum::extract::{State, WebSocketUpgrade};
 use axum::response::Response;
 use futures_util::sink::SinkExt;
 use futures_util::stream::StreamExt;
-use tokio_tungstenite::tungstenite::protocol::CloseFrame as TungCloseFrame;
+use tokio_tungstenite::tungstenite::protocol::{CloseFrame as TungCloseFrame, WebSocketConfig};
 use tokio_tungstenite::tungstenite::Message as TungMessage;
 
 /// Axum handler. Splits the upgraded socket into a sender + receiver
 /// and spawns a single `handle_ws` future for the lifetime of the
 /// connection.
+///
+/// Both legs run without message/frame size limits: the proxy must not
+/// impose caps the endpoints themselves don't have. With the default
+/// tungstenite limits (16 MiB frame / 64 MiB message) a single large
+/// engine response (e.g. a traces read on a long-running stack) killed
+/// the connection, and the browser SDK then reconnected, refetched the
+/// same payload, and looped forever.
 pub async fn ws_proxy(ws: WebSocketUpgrade, State(engine_url): State<Arc<String>>) -> Response {
-    ws.on_upgrade(move |socket| handle_ws(socket, engine_url))
+    ws.max_message_size(usize::MAX)
+        .max_frame_size(usize::MAX)
+        .on_upgrade(move |socket| handle_ws(socket, engine_url))
 }
 
 async fn handle_ws(client: WebSocket, engine_url: Arc<String>) {
-    let (engine, _resp) = match tokio_tungstenite::connect_async(engine_url.as_str()).await {
+    let engine_ws_config = WebSocketConfig {
+        max_message_size: None,
+        max_frame_size: None,
+        ..Default::default()
+    };
+    let (engine, _resp) = match tokio_tungstenite::connect_async_with_config(
+        engine_url.as_str(),
+        Some(engine_ws_config),
+        false,
+    )
+    .await
+    {
         Ok(pair) => pair,
         Err(e) => {
             tracing::warn!(
@@ -61,7 +81,7 @@ async fn handle_ws(client: WebSocket, engine_url: Arc<String>) {
             let msg = match msg {
                 Ok(m) => m,
                 Err(e) => {
-                    tracing::debug!(error = %e, "browser -> engine: client read error");
+                    tracing::warn!(error = %e, "browser -> engine: client read error; closing proxied WS");
                     break;
                 }
             };
@@ -91,7 +111,7 @@ async fn handle_ws(client: WebSocket, engine_url: Arc<String>) {
             let msg = match msg {
                 Ok(m) => m,
                 Err(e) => {
-                    tracing::debug!(error = %e, "engine -> browser: engine read error");
+                    tracing::warn!(error = %e, "engine -> browser: engine read error; closing proxied WS");
                     break;
                 }
             };

--- a/console/tests/integration.rs
+++ b/console/tests/integration.rs
@@ -246,3 +246,71 @@ fn resolve_asset_url_joins_relative_paths() {
         "http://127.0.0.1:3113/assets/index.js"
     );
 }
+
+/// Regression test: an engine response bigger than tungstenite's default
+/// limits (16 MiB frame / 64 MiB message) must pass through the proxy
+/// instead of killing the connection. Before the fix the proxy dialed the
+/// engine with default limits, the read errored, and the browser socket
+/// was closed — putting the console SPA into an endless reconnect loop.
+/// Self-contained: uses a fake engine, no `iii` binary needed.
+#[tokio::test]
+async fn ws_proxy_forwards_oversized_engine_message() {
+    use std::sync::Arc;
+
+    const BIG_LEN: usize = 20 * 1024 * 1024; // > 16 MiB default frame cap
+
+    // Fake engine: accept one WS connection, send one oversized text
+    // message, then hold the connection open until the peer closes.
+    let engine_listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fake engine listener");
+    let engine_addr = engine_listener.local_addr().expect("fake engine addr");
+    tokio::spawn(async move {
+        let (stream, _) = engine_listener.accept().await.expect("accept proxy dial");
+        let mut ws = tokio_tungstenite::accept_async(stream)
+            .await
+            .expect("ws handshake from proxy");
+        ws.send(Message::Text("x".repeat(BIG_LEN)))
+            .await
+            .expect("send oversized message");
+        while let Some(Ok(_)) = ws.next().await {}
+    });
+
+    // Console worker's HTTP server (port 0 = OS-assigned) fronting it.
+    let engine_url = Arc::new(format!("ws://{engine_addr}"));
+    let (_shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let (bound_tx, bound_rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(console::server::serve(
+        0,
+        engine_url,
+        shutdown_rx,
+        Some(bound_tx),
+    ));
+    let addr = bound_rx.await.expect("server bound");
+
+    // Browser stand-in: browsers impose no message size limit, so the
+    // test client must not either.
+    let client_config = tokio_tungstenite::tungstenite::protocol::WebSocketConfig {
+        max_message_size: None,
+        max_frame_size: None,
+        ..Default::default()
+    };
+    let (mut ws, _) = tokio_tungstenite::connect_async_with_config(
+        &format!("ws://127.0.0.1:{}/ws", addr.port()),
+        Some(client_config),
+        false,
+    )
+    .await
+    .expect("connect to /ws proxy");
+
+    let msg = timeout(Duration::from_secs(15), ws.next())
+        .await
+        .expect("timed out waiting for proxied message")
+        .expect("proxy closed the connection instead of forwarding")
+        .expect("ws read error from proxy");
+    match msg {
+        Message::Text(t) => assert_eq!(t.len(), BIG_LEN),
+        other => panic!("expected oversized text message, got {other:?}"),
+    }
+    let _ = ws.close(None).await;
+}


### PR DESCRIPTION
## Problem

The console web UI would eventually enter an endless connect/disconnect loop: the engine log fills with `Worker registered` / `Worker unregistered` pairs every ~2s, each cycle re-registering and unregistering the page's ~20 browser-local functions (the repeated `UNREGISTERED` flood reported in the ticket).

Root cause: the console worker's `/ws` proxy dials the engine with tungstenite's default limits (16 MiB max frame / 64 MiB max message). Once a single engine response outgrows the frame cap — e.g. an `engine::traces::list` read after hours of agent activity, since tungstenite does not fragment outgoing messages — the proxy's read pump errors, the browser socket is closed, and the SPA reconnects and refetches the same oversized payload, dying again ~1s later, forever. The failure was invisible: the pump logged the error at `debug` and the engine only sees a clean socket close.

This is why the loop only starts "after a while" — trace data grows until one response crosses 16 MiB, and the loop never recovers until the engine restarts (in-memory store).

## Fix

- Dial the engine with `max_message_size: None, max_frame_size: None` and raise the browser-leg axum limits to match: the proxy is transparent and must not impose caps the endpoints themselves don't have.
- Log read-pump failures at `warn` instead of `debug` so a proxied-connection death is diagnosable.

## Test plan

- [x] New regression test `ws_proxy_forwards_oversized_engine_message`: a fake engine sends a 20 MiB message through the proxy; fails against the old defaults (connection killed), passes with the fix. Self-contained, no `iii` binary needed.
- [x] `cargo test` (21 passed), `cargo fmt --check`, `cargo clippy --all-targets` clean.
- [x] Live-verified on a stack reproducing the loop: swapped the fixed binary in and the register/unregister churn stopped immediately.

Fixes MOT-3978

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket connections can now forward very large messages without size-limit failures.
  * Improved connection error warnings identify the affected communication direction and indicate when the connection is closing.

* **Tests**
  * Added end-to-end coverage confirming oversized messages are successfully forwarded through the WebSocket proxy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->