### PR TITLE
fix(queue): make the effective store visible and surface delivery stats

### DIFF
--- a/queue/src/boot.rs
+++ b/queue/src/boot.rs
@@ -174,9 +174,17 @@ pub async fn build_store(config: &QueueConfig) -> anyhow::Result<Arc<dyn QueueSt
                 .file_path
                 .unwrap_or_else(|| "queue_store_data".to_string());
             let save_interval_ms = builtin.save_interval_ms.unwrap_or(5000);
-            Ok(Arc::new(FileStore::open(path, save_interval_ms).await?))
+            let store = FileStore::open(&path, save_interval_ms).await?;
+            tracing::info!(store = "file_based", path = %path, "queue store ready");
+            Ok(Arc::new(store))
         }
-        "builtin" | "in_memory" => Ok(Arc::new(InMemoryStore::new())),
+        "builtin" | "in_memory" => {
+            tracing::info!(
+                store = "in_memory",
+                "queue store ready; jobs do not survive restarts"
+            );
+            Ok(Arc::new(InMemoryStore::new()))
+        }
         other => anyhow::bail!("unknown builtin queue store_method '{other}'"),
     }
 }

--- a/queue/src/functions.rs
+++ b/queue/src/functions.rs
@@ -94,6 +94,8 @@ pub struct TopicStatsOutput {
     pub depth: u64,
     pub consumer_count: u64,
     pub dlq_depth: u64,
+    pub delivered: u64,
+    pub failed: u64,
     pub config: Option<Value>,
 }
 
@@ -327,6 +329,8 @@ pub async fn topic_stats(
         depth: stats.depth,
         consumer_count: 0,
         dlq_depth: stats.dlq_depth,
+        delivered: stats.delivered,
+        failed: stats.failed,
         config: None,
     })
 }
@@ -713,7 +717,7 @@ mod tests {
         *_mock.topic_stats_result.lock().unwrap() = Some(Ok(TopicStats {
             depth: 1,
             dlq_depth: 1,
-            delivered: 0,
+            delivered: 2,
             failed: 1,
         }));
         let stats = topic_stats(
@@ -726,6 +730,8 @@ mod tests {
         .unwrap();
         assert_eq!(stats.depth, 1);
         assert_eq!(stats.dlq_depth, 1);
+        assert_eq!(stats.delivered, 2);
+        assert_eq!(stats.failed, 1);
     }
 
     #[tokio::test]

--- a/queue/src/main.rs
+++ b/queue/src/main.rs
@@ -89,6 +89,15 @@ async fn main() -> Result<()> {
         .await
         .map_err(anyhow::Error::msg)
         .context("loading queue configuration")?;
+    if let Some(seed) = seed.as_ref() {
+        if seed.adapter != config.adapter {
+            tracing::warn!(
+                seed_adapter = ?seed.adapter,
+                stored_adapter = ?config.adapter,
+                "--config seed adapter ignored; the stored configuration is authoritative"
+            );
+        }
+    }
 
     let boot = iii_queue::boot::start(iii.clone(), config).await?;
     configuration::register_config_trigger(


### PR DESCRIPTION
## Summary

The builtin queue adapter silently falls back to the in-memory store when the stored configuration has no `adapter` entry — even when the `--config` seed explicitly asks for `file_based` persistence. The only boot log line (`loaded seed config path=…`) reads as if the seed took effect, so a stack can run without durability and nothing says so. Hit this on a live dev stack: the store file had been frozen for days while turns ran through an in-memory store.

- Boot now logs the effective store: `store="file_based" path=…` or `store="in_memory"` (with a note that jobs don't survive restarts).
- When a `--config` seed specifies an adapter that differs from the authoritative stored value, boot logs a WARN showing both, instead of discarding the seed silently. The stored value still wins — configuration-worker authority is unchanged.
- `engine::queue::topic_stats` now returns the `delivered`/`failed` counters the store already tracks (additive fields; single construction site, no existing consumers read them).

## Test plan

- [x] `cargo test` in `queue/` — 130 passed, including the extended `list_and_stats_return_adapter_state` assertion on `delivered`/`failed`
- [x] Live boot against a stored config without `adapter`: WARN + `store="in_memory"` lines appear
- [x] Live `configuration::set` adding the adapter: hot-swap logs `store="file_based" path=./data/harness-queue`, store file resumes updating (revision advances, delivered increments)
- [x] Live `engine::queue::topic_stats` returns `delivered`/`failed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Queue topic statistics now report delivered and failed message counts.
* **Bug Fixes**
  * Added validation to detect when a provided configuration differs from the stored queue configuration, with a warning shown while preserving the stored settings.
* **Chores**
  * Improved startup logging for file-based and in-memory queue storage, including the storage location and whether jobs persist across restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->