### PR TITLE
(MOT-4014) fix: guarantee context assembly stays within budget

### DIFF
--- a/context-manager/README.md
+++ b/context-manager/README.md
@@ -67,6 +67,14 @@ system prompt under `# Conversation summary`, and any further compaction
 *updates* it instead of starting over. Callers that skip persistence stay
 correct at the cost of one summariser call per over-budget request.
 
+Every successful `context::assemble` response satisfies `token_count <= usable`.
+Callers should include the complete `tools` array and set
+`options.request_overhead_tokens` for response-format and provider-specific request
+fields. If ordinary pruning and compaction are insufficient, assembly replaces
+oversized function results in its model-facing copy with bounded references to the
+full result retained in the session transcript. Requests that still cannot fit fail
+with `context/overflow`; callers must not issue a provider request in that case.
+
 The other three functions: `context::count-tokens` (estimate messages + tools +
 system prompt vs a model), `context::prune` (replace verbose function outputs
 with `[output pruned: was ~N tokens]` placeholders, no LLM involved), and

--- a/context-manager/src/core/prune.rs
+++ b/context-manager/src/core/prune.rs
@@ -14,14 +14,24 @@
 //! - outputs whose text is at or under `max_output_chars` are not
 //!   "verbose" and stay (pruning them frees almost nothing);
 //! - when everything prunable frees under `min_free_tokens`, nothing is
-//!   touched at all (a no-op beats a destroyed-but-still-over context).
+//!   touched at all. `context::assemble` may subsequently use the
+//!   unconditional emergency pass to enforce its hard budget.
 
 use crate::core::estimate::Estimator;
 use crate::types::{AgentMessage, ContentBlock, Role};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 
 /// Recent user turns that are always exempt, independent of the token
 /// window (prior-art constant, not operator-tunable).
 const PROTECTED_USER_TURNS: usize = 2;
+
+/// Maximum number of Unicode scalar values copied from an oversized
+/// result into its emergency reference.
+const EMERGENCY_PREVIEW_CHARS: usize = 160;
+
+const EMERGENCY_RETRIEVAL_HINT: &str =
+    "The original result remains in the session transcript; retrieve it by function_call_id.";
 
 #[derive(Debug, Clone)]
 pub struct PruneParams {
@@ -135,6 +145,117 @@ pub fn prune(
         pruned_parts: queue.len() as u64,
         scanned_parts: scanned,
     }
+}
+
+/// Unconditionally reduce the largest function results until at least
+/// `required_tokens` have been freed or no result can shrink further.
+///
+/// Unlike [`prune`], this emergency pass has no recent-turn window,
+/// protected-function list, size threshold, or minimum-free guard. It
+/// preserves every message and the call/result identity fields while
+/// replacing both rendered content and opaque details with a bounded,
+/// deterministic reference to the original transcript entry.
+pub fn emergency_reduce(
+    messages: &mut [AgentMessage],
+    required_tokens: u64,
+    estimator: &dyn Estimator,
+) -> PruneStats {
+    let mut candidates: Vec<(usize, u64)> = messages
+        .iter()
+        .enumerate()
+        .filter(|(_, message)| matches!(message, AgentMessage::FunctionResult { .. }))
+        .map(|(idx, message)| (idx, estimator.message(message)))
+        .collect();
+
+    // Stable tie-break by transcript order keeps the reduction fully
+    // deterministic when multiple results have the same estimate.
+    candidates.sort_by(|(left_idx, left_tokens), (right_idx, right_tokens)| {
+        right_tokens
+            .cmp(left_tokens)
+            .then_with(|| left_idx.cmp(right_idx))
+    });
+
+    let mut stats = PruneStats {
+        scanned_parts: candidates.len() as u64,
+        ..PruneStats::default()
+    };
+
+    for (idx, original_tokens) in candidates {
+        if stats.pruned_tokens >= required_tokens {
+            break;
+        }
+
+        let replacement = emergency_reference(&messages[idx], original_tokens);
+        let replacement_tokens = estimator.message(&replacement);
+        let freed = original_tokens.saturating_sub(replacement_tokens);
+        if freed == 0 {
+            continue;
+        }
+
+        messages[idx] = replacement;
+        stats.pruned_tokens = stats.pruned_tokens.saturating_add(freed);
+        stats.pruned_parts += 1;
+    }
+
+    stats
+}
+
+fn emergency_reference(message: &AgentMessage, original_tokens: u64) -> AgentMessage {
+    let AgentMessage::FunctionResult {
+        function_call_id,
+        function_id,
+        content,
+        details,
+        is_error,
+        timestamp,
+    } = message
+    else {
+        unreachable!("emergency references are only built for function results");
+    };
+
+    let serialized = serde_json::to_vec(message)
+        .expect("serializing an AgentMessage containing serde_json::Value cannot fail");
+    let sha256 = format!("{:x}", Sha256::digest(&serialized));
+    let preview = emergency_preview(content, details);
+    let reference = json!({
+        "kind": "function_result_reference",
+        "function_id": function_id,
+        "function_call_id": function_call_id,
+        "original_bytes": serialized.len(),
+        "original_estimated_tokens": original_tokens,
+        "sha256": sha256,
+        "preview": preview,
+        "retrieval_hint": EMERGENCY_RETRIEVAL_HINT,
+    });
+    let rendered = format!(
+        "[function result reduced for context budget] {}",
+        serde_json::to_string(&reference)
+            .expect("serializing a function-result reference cannot fail")
+    );
+
+    AgentMessage::FunctionResult {
+        function_call_id: function_call_id.clone(),
+        function_id: function_id.clone(),
+        content: vec![ContentBlock::Text { text: rendered }],
+        details: json!({ "context_reference": reference }),
+        is_error: *is_error,
+        timestamp: *timestamp,
+    }
+}
+
+fn emergency_preview(content: &[ContentBlock], details: &Value) -> String {
+    let text = text_of(content);
+    let source = if text.is_empty() {
+        serde_json::to_string(details).unwrap_or_else(|_| "<unavailable>".into())
+    } else {
+        text
+    };
+    let mut chars = source.chars();
+    let mut preview: String = chars.by_ref().take(EMERGENCY_PREVIEW_CHARS).collect();
+    if chars.next().is_some() {
+        preview.push('\u{2026}');
+    }
+    preview
 }
 
 #[cfg(test)]
@@ -278,5 +399,142 @@ mod tests {
         let second = prune(&mut messages, &params(), &HeuristicEstimator);
         // The placeholder is tiny, so nothing is verbose any more.
         assert_eq!(second.pruned_parts, 0);
+    }
+
+    #[test]
+    fn emergency_reduces_latest_protected_result_and_preserves_pairing() {
+        let call: AgentMessage = serde_json::from_value(json!({
+            "role": "assistant",
+            "content": [{
+                "type": "function_call", "id": "c2",
+                "function_id": "protected::lookup", "arguments": {}
+            }],
+            "stop_reason": "function_call", "model": "m", "provider": "p", "timestamp": 1
+        }))
+        .unwrap();
+        let latest = result("protected::lookup", 40_000, 2);
+        let mut messages = vec![call.clone(), latest];
+
+        let mut normal_params = params();
+        normal_params.protected_functions = vec!["protected::lookup".into()];
+        normal_params.min_free_tokens = u64::MAX;
+        assert_eq!(
+            prune(&mut messages, &normal_params, &HeuristicEstimator).pruned_parts,
+            0
+        );
+
+        let before_len = messages.len();
+        let stats = emergency_reduce(&mut messages, 1, &HeuristicEstimator);
+        assert_eq!(stats.pruned_parts, 1);
+        assert_eq!(messages.len(), before_len);
+        assert_eq!(messages[0], call);
+
+        let AgentMessage::FunctionResult {
+            function_call_id,
+            function_id,
+            details,
+            ..
+        } = &messages[1]
+        else {
+            panic!("result message kind changed");
+        };
+        assert_eq!(function_call_id, "c2");
+        assert_eq!(function_id, "protected::lookup");
+        assert_eq!(details["context_reference"]["function_call_id"], "c2");
+        assert_eq!(
+            details["context_reference"]["function_id"],
+            "protected::lookup"
+        );
+    }
+
+    #[test]
+    fn emergency_reference_bounds_content_and_details() {
+        let mut message: AgentMessage = serde_json::from_value(json!({
+            "role": "function_result",
+            "function_call_id": "call-large",
+            "function_id": "shell::run",
+            "content": [{ "type": "text", "text": "content".repeat(100_000) }],
+            "details": { "stdout": "details".repeat(100_000) },
+            "is_error": false,
+            "timestamp": 9
+        }))
+        .unwrap();
+
+        emergency_reduce(std::slice::from_mut(&mut message), 1, &HeuristicEstimator);
+
+        let serialized = serde_json::to_string(&message).unwrap();
+        assert!(
+            serialized.len() < 2_000,
+            "reference was {} bytes",
+            serialized.len()
+        );
+        let AgentMessage::FunctionResult {
+            content, details, ..
+        } = &message
+        else {
+            panic!("result message kind changed");
+        };
+        let rendered = text_of(content);
+        assert!(rendered.contains("original_estimated_tokens"));
+        assert!(rendered.contains("original_bytes"));
+        assert!(rendered.contains("session transcript"));
+        assert!(
+            details["context_reference"]["preview"]
+                .as_str()
+                .unwrap()
+                .chars()
+                .count()
+                <= EMERGENCY_PREVIEW_CHARS + 1
+        );
+        assert!(details["context_reference"]["sha256"]
+            .as_str()
+            .is_some_and(|hash| hash.len() == 64));
+    }
+
+    #[test]
+    fn emergency_reference_hash_is_deterministic_for_original_message() {
+        let original: AgentMessage = serde_json::from_value(json!({
+            "role": "function_result",
+            "function_call_id": "hash-call",
+            "function_id": "fs::read",
+            "content": [{ "type": "text", "text": "deterministic payload".repeat(1_000) }],
+            "details": { "path": "/tmp/example" },
+            "is_error": false,
+            "timestamp": 7
+        }))
+        .unwrap();
+        let expected = format!(
+            "{:x}",
+            Sha256::digest(serde_json::to_vec(&original).unwrap())
+        );
+        let mut first = original.clone();
+        let mut second = original;
+
+        emergency_reduce(std::slice::from_mut(&mut first), 1, &HeuristicEstimator);
+        emergency_reduce(std::slice::from_mut(&mut second), 1, &HeuristicEstimator);
+
+        assert_eq!(first, second);
+        for reduced in [&first, &second] {
+            let AgentMessage::FunctionResult { details, .. } = reduced else {
+                panic!("result message kind changed");
+            };
+            assert_eq!(details["context_reference"]["sha256"], expected);
+        }
+    }
+
+    #[test]
+    fn emergency_reduces_largest_results_only_as_needed() {
+        let mut messages = vec![
+            result("small", 4_000, 1),
+            result("largest", 40_000, 2),
+            result("middle", 20_000, 3),
+        ];
+
+        let stats = emergency_reduce(&mut messages, 1, &HeuristicEstimator);
+
+        assert_eq!(stats.pruned_parts, 1);
+        assert_eq!(text_of(messages[0].content()).len(), 4_000);
+        assert!(text_of(messages[1].content()).starts_with("[function result reduced"));
+        assert_eq!(text_of(messages[2].content()).len(), 20_000);
     }
 }

--- a/context-manager/src/error.rs
+++ b/context-manager/src/error.rs
@@ -23,6 +23,13 @@ pub enum ContextError {
     /// A filesystem operation backing the compaction lease failed.
     #[error("context/state: {0}")]
     State(String),
+
+    /// No safe model-facing context can fit within the usable input
+    /// budget after normal pruning, compaction, and emergency reduction.
+    #[error(
+        "context/overflow: assembled context requires {token_count} tokens but usable budget is {usable}"
+    )]
+    Overflow { token_count: u64, usable: u64 },
 }
 
 impl ContextError {
@@ -32,6 +39,7 @@ impl ContextError {
             ContextError::InvalidRequest(_) => "context/invalid_request",
             ContextError::ModelUnresolved(_) => "context/model_unresolved",
             ContextError::State(_) => "context/state",
+            ContextError::Overflow { .. } => "context/overflow",
         }
     }
 }
@@ -68,6 +76,10 @@ mod tests {
             ContextError::InvalidRequest("m".into()),
             ContextError::ModelUnresolved("m".into()),
             ContextError::State("m".into()),
+            ContextError::Overflow {
+                token_count: 101,
+                usable: 100,
+            },
         ];
         for v in variants {
             assert!(
@@ -76,5 +88,26 @@ mod tests {
                 v.code()
             );
         }
+    }
+
+    #[test]
+    fn overflow_carries_budget_values_and_stable_code() {
+        let error = ContextError::Overflow {
+            token_count: 12_345,
+            usable: 10_000,
+        };
+
+        assert_eq!(error.code(), "context/overflow");
+        assert_eq!(
+            error.to_string(),
+            "context/overflow: assembled context requires 12345 tokens but usable budget is 10000"
+        );
+        assert!(matches!(
+            error,
+            ContextError::Overflow {
+                token_count: 12_345,
+                usable: 10_000
+            }
+        ));
     }
 }

--- a/context-manager/src/functions/assemble.rs
+++ b/context-manager/src/functions/assemble.rs
@@ -1,13 +1,14 @@
 //! `context::assemble` — build the model-ready context from a history
 //! (context-manager.md § context::assemble). The pipeline, in order:
 //! count -> (if over) prune function outputs -> (if still over) compact
-//! the head -> assemble the final list.
+//! the head -> (if still over) emergency-reduce function results ->
+//! assemble the final list or return a structured overflow.
 //!
 //! Structural guarantees: `role: "custom"` messages never reach the
 //! model-facing list (nor the count); `applied.tail_start_index`
 //! indexes the *request* messages array so callers can map it onto
-//! their own storage; a busy lease or failed summariser degrades to
-//! best effort instead of erroring the turn.
+//! their own storage; a busy lease or failed summariser falls through
+//! to emergency reduction and the hard budget check.
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -15,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use crate::core::budget::{default_reserved, preserve_recent_budget, usable};
 use crate::core::estimate::{estimator_for_model, Estimator};
 use crate::core::lease;
-use crate::core::prune::{prune as run_prune, PruneParams};
+use crate::core::prune::{emergency_reduce, prune as run_prune, PruneParams};
 use crate::core::selection::select;
 use crate::core::summary::{
     build_system_prompt, render_system_prompt, render_user_prompt, strip_media,
@@ -23,7 +24,7 @@ use crate::core::summary::{
 use crate::error::ContextError;
 use crate::functions::resolve_model;
 use crate::ports::{Deps, SummarizeRequest};
-use crate::types::{AgentMessage, ModelInput, Role, ThinkingLevel};
+use crate::types::{AgentFunction, AgentMessage, ModelInput, Role, ThinkingLevel};
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct AssembleOptions {
@@ -39,9 +40,14 @@ pub struct AssembleOptions {
     /// Default true.
     #[serde(default)]
     pub allow_prune: Option<bool>,
-    /// `function_id`s whose outputs are never pruned.
+    /// `function_id`s exempt from the normal prune pass. Emergency
+    /// safety reduction may still replace their oversized results.
     #[serde(default)]
     pub protected_functions: Option<Vec<String>>,
+    /// Estimated tokens for final provider request fields and framing
+    /// not otherwise represented by the prompt, messages, or tools.
+    #[serde(default)]
+    pub request_overhead_tokens: Option<u64>,
     /// Reserve the model's thinking budget for this tier.
     #[serde(default)]
     pub thinking_level: Option<ThinkingLevel>,
@@ -64,6 +70,9 @@ pub struct AssembleRequest {
     /// Base system prompt to prepend/merge.
     #[serde(default)]
     pub system_prompt: Option<String>,
+    /// Model-facing invocation schemas included in every budget count.
+    #[serde(default)]
+    pub tools: Option<Vec<AgentFunction>>,
     #[serde(default)]
     pub options: Option<AssembleOptions>,
 }
@@ -101,14 +110,32 @@ pub struct AssembleResponse {
     pub system_prompt: String,
     /// Budgeted, ready to send to llm-router.
     pub messages: Vec<AgentMessage>,
-    /// Estimated tokens of the returned context (messages + system
-    /// prompt). Can exceed `usable` when prune/compaction were
-    /// disabled, unavailable, or insufficient — best effort, visible.
+    /// Estimated tokens of the returned context, including the system
+    /// prompt, tools, and request overhead. Always at most `usable`.
     pub token_count: u64,
     /// The budget the context was fit into.
     pub usable: u64,
     pub model_resolved: ModelResolvedWire,
     pub applied: Applied,
+}
+
+fn count_context(
+    messages: &[AgentMessage],
+    prompt: &str,
+    tools: &[AgentFunction],
+    request_overhead_tokens: u64,
+    estimator: &dyn Estimator,
+) -> u64 {
+    let message_tokens = messages.iter().fold(0u64, |total, message| {
+        total.saturating_add(estimator.message(message))
+    });
+    let tool_tokens = tools.iter().fold(0u64, |total, tool| {
+        total.saturating_add(estimator.function(tool))
+    });
+    message_tokens
+        .saturating_add(estimator.text(prompt))
+        .saturating_add(tool_tokens)
+        .saturating_add(request_overhead_tokens)
 }
 
 pub async fn handle(deps: &Deps, req: AssembleRequest) -> Result<AssembleResponse, ContextError> {
@@ -141,9 +168,11 @@ pub async fn handle(deps: &Deps, req: AssembleRequest) -> Result<AssembleRespons
 
     let base_prompt = req.system_prompt.as_deref();
     let mut system_prompt = render_system_prompt(base_prompt, options.previous_summary.as_deref());
+    let tools = req.tools.as_deref().unwrap_or_default();
+    let request_overhead_tokens = options.request_overhead_tokens.unwrap_or(0);
 
     let count = |messages: &[AgentMessage], prompt: &str| -> u64 {
-        messages.iter().map(|m| estimator.message(m)).sum::<u64>() + estimator.text(prompt)
+        count_context(messages, prompt, tools, request_overhead_tokens, estimator)
     };
 
     let mut applied = Applied {
@@ -203,6 +232,29 @@ pub async fn handle(deps: &Deps, req: AssembleRequest) -> Result<AssembleRespons
         }
     }
 
+    // Step 3: enforce the budget by reducing complete function-result
+    // messages, including latest/protected results and their details.
+    // This pass is intentionally independent of all normal-prune knobs.
+    if token_count > usable_budget {
+        let emergency = emergency_reduce(
+            &mut working,
+            token_count.saturating_sub(usable_budget),
+            estimator,
+        );
+        applied.pruned |= emergency.pruned_parts > 0;
+        applied.pruned_tokens = applied
+            .pruned_tokens
+            .saturating_add(emergency.pruned_tokens);
+        token_count = count(&working, &system_prompt);
+    }
+
+    if token_count > usable_budget {
+        return Err(ContextError::Overflow {
+            token_count,
+            usable: usable_budget,
+        });
+    }
+
     Ok(AssembleResponse {
         system_prompt,
         messages: working,
@@ -226,7 +278,7 @@ struct CompactionOutcome {
 
 /// Inline compaction under the lease. `None` means "no compaction this
 /// call" — lease busy, nothing to summarise, or summariser failure —
-/// and assemble degrades to best effort.
+/// and assemble continues to emergency reduction and budget checking.
 #[allow(clippy::too_many_arguments)]
 async fn try_compact(
     deps: &Deps,
@@ -268,9 +320,9 @@ async fn try_compact(
                 tokens_before,
             }),
             Err(err) => {
-                // Assemble never fails the turn on a summariser error;
-                // the caller still gets a (possibly over-budget)
-                // context and can see token_count > usable.
+                // A summariser error skips compaction, after which the
+                // emergency pass either fits the request or returns a
+                // structured context overflow.
                 tracing::warn!(error = %err, "assemble: compaction skipped");
                 None
             }
@@ -280,4 +332,69 @@ async fn try_compact(
 
     lease::release(leases.as_ref(), lease_key, &nonce).await;
     outcome
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::estimate::HeuristicEstimator;
+    use serde_json::json;
+
+    #[test]
+    fn count_includes_tools_and_request_overhead() {
+        let message: AgentMessage = serde_json::from_value(json!({
+            "role": "user",
+            "content": [{ "type": "text", "text": "hello" }],
+            "timestamp": 1
+        }))
+        .unwrap();
+        let tool: AgentFunction = serde_json::from_value(json!({
+            "name": "agent_trigger",
+            "description": "Run an agent function",
+            "parameters": {
+                "type": "object",
+                "properties": { "function_id": { "type": "string" } }
+            }
+        }))
+        .unwrap();
+        let estimator = HeuristicEstimator;
+        let baseline = count_context(std::slice::from_ref(&message), "system", &[], 0, &estimator);
+
+        let counted = count_context(
+            &[message],
+            "system",
+            std::slice::from_ref(&tool),
+            37,
+            &estimator,
+        );
+
+        assert_eq!(counted, baseline + estimator.function(&tool) + 37);
+    }
+
+    #[test]
+    fn assemble_wire_accepts_optional_tools_and_request_overhead() {
+        let request: AssembleRequest = serde_json::from_value(json!({
+            "messages": [],
+            "model": {
+                "id": "m",
+                "limits": { "context_window": 1_000, "max_output_tokens": 100 }
+            },
+            "tools": [{
+                "name": "agent_trigger",
+                "description": "Run an agent function",
+                "parameters": { "type": "object" }
+            }],
+            "options": { "request_overhead_tokens": 41 }
+        }))
+        .unwrap();
+
+        assert_eq!(request.tools.as_ref().unwrap().len(), 1);
+        assert_eq!(
+            request
+                .options
+                .as_ref()
+                .and_then(|options| options.request_overhead_tokens),
+            Some(41)
+        );
+    }
 }

--- a/context-manager/tests/features/assemble.feature
+++ b/context-manager/tests/features/assemble.feature
@@ -5,8 +5,9 @@ Feature: context::assemble — the model-ready context pipeline
   prune function outputs -> (if still over) compact the head ->
   assemble the final list. The response reports what actually happened
   (`applied`), the budget it fit into (`usable`), and how the model was
-  resolved. Degradations (busy lease, failed summariser, disabled
-  steps) are best effort and visible — never an error on the hot path.
+  resolved. Every successful response fits its reported usable budget.
+  Busy leases, failed summarisers, disabled passes, and irreducible
+  inputs fail with context/overflow instead of leaking an invalid request.
 
   # Prevents: the happy path being mangled — a context under budget
   # must pass through byte-identical, with nothing applied and no
@@ -66,9 +67,32 @@ Feature: context::assemble — the model-ready context pipeline
     And call/result pairing is intact in the response messages
     And the summariser was never invoked
 
-  # Prevents: prune running against the caller's explicit wishes — and
-  # proves the over-budget result is still returned, visibly over.
-  Scenario: disabling prune and compaction returns a visible best effort
+  # Regression for MOT-4014: the newest result is inside every normal
+  # protection window, but a multi-megabyte result must still become a
+  # bounded transcript reference before the request reaches a provider.
+  Scenario: a 4.98 MB latest function result is reduced despite recent-turn protection
+    Given inline model "large" with context window 272000 and max output 128000
+    And config "protect_recent_tokens" is 2000000
+    And config "min_free_tokens" is 2000000
+    And a user message "inspect the session"
+    And an assistant function call "latest-call" to "session::messages"
+    And a function result for call "latest-call" from "session::messages" of ~1245000 tokens
+    When I assemble the history with model "large"
+    Then the call succeeds
+    And the response field "applied.pruned" is true
+    And the response field "token_count" does not exceed 124000
+    And response message 2 text does not exceed 1000 chars
+    And response message 2 text contains "session transcript"
+    And the response field "messages.2.details.context_reference.kind" is "function_result_reference"
+    And the response field "messages.2.details.context_reference.original_estimated_tokens" exceeds 1200000
+    And the response field "messages.2.details.context_reference.retrieval_hint" contains "function_call_id"
+    And the response messages have as many messages as the request
+    And every response message keeps its function_call_id
+    And call/result pairing is intact in the response messages
+
+  # The optional normal passes may be disabled, but that does not disable
+  # the terminal safety reduction required to uphold the hard budget.
+  Scenario: disabling normal prune and compaction still cannot return over budget
     Given inline model "small" with context window 5000 and max output 500
     And config "protect_recent_tokens" is 0
     And config "min_free_tokens" is 1
@@ -83,14 +107,15 @@ Feature: context::assemble — the model-ready context pipeline
       { "allow_prune": false, "allow_compaction": false }
       """
     Then the call succeeds
-    And the response field "applied.pruned" is false
+    And the response field "applied.pruned" is true
     And the response field "applied.compacted" is false
-    And the response field "token_count" exceeds 4000
-    And response message 2 text has 20000 chars
+    And the response field "token_count" does not exceed 4000
+    And response message 2 text does not exceed 1000 chars
+    And call/result pairing is intact in the response messages
 
-  # Prevents: protected functions being pruned on the assemble path —
-  # the per-call protection list must reach the prune pass.
-  Scenario: protected functions survive the assemble prune pass
+  # Explicit protection applies to the normal quality-preserving pass,
+  # but cannot authorize an invalid provider request.
+  Scenario: a protected oversized result yields to emergency reduction
     Given inline model "small" with context window 5000 and max output 500
     And config "protect_recent_tokens" is 0
     And config "min_free_tokens" is 1
@@ -104,9 +129,11 @@ Feature: context::assemble — the model-ready context pipeline
       """
       { "protected_functions": ["shell::run"], "allow_compaction": false }
       """
-    Then the response field "applied.pruned" is false
-    And response message 2 text has 20000 chars
-    And the response field "token_count" exceeds 4000
+    Then the call succeeds
+    And the response field "applied.pruned" is true
+    And response message 2 text does not exceed 1000 chars
+    And the response field "token_count" does not exceed 4000
+    And call/result pairing is intact in the response messages
 
   # Prevents: histories with nothing prunable never compacting — when
   # prune cannot help, compaction must take over and the returned tail
@@ -147,6 +174,7 @@ Feature: context::assemble — the model-ready context pipeline
     When I assemble the history with model "small"
     Then the call succeeds
     And the response field "applied.compacted" is true
+    And the response field "token_count" does not exceed 4000
     And the response messages are not empty
     And the response messages start at request message 2
 
@@ -175,8 +203,9 @@ Feature: context::assemble — the model-ready context pipeline
     And the response messages start at request message 5
     And call/result pairing is intact in the response messages
 
-  # Prevents: compaction running against the caller's explicit wishes.
-  Scenario: allow_compaction false leaves an over-budget context as is
+  # Disabling compaction is respected, but an irreducible request fails
+  # locally instead of being returned over budget.
+  Scenario: allow_compaction false reports an irreducible overflow
     Given inline model "small" with context window 5000 and max output 500
     And a user message of ~3000 tokens
     And an assistant message "r0"
@@ -188,14 +217,11 @@ Feature: context::assemble — the model-ready context pipeline
       """
       { "allow_compaction": false }
       """
-    Then the call succeeds
-    And the response field "applied.compacted" is false
-    And the response field "token_count" exceeds 4000
+    Then the call fails with code "context/overflow"
     And the summariser was never invoked
 
-  # Prevents: a busy lease failing the turn — assemble must degrade to
-  # best effort, spend no summariser call, and leave the holder alone.
-  Scenario: a busy lease degrades assemble to best effort
+  # A busy lease cannot weaken the final budget postcondition.
+  Scenario: a busy lease reports overflow for irreducible content
     Given inline model "small" with context window 5000 and max output 500
     And a user message of ~3000 tokens
     And an assistant message "r0"
@@ -205,15 +231,13 @@ Feature: context::assemble — the model-ready context pipeline
     And an assistant message "recent answer"
     And a foreign lease on the history's default key taken 0 ms ago
     When I assemble the history with model "small"
-    Then the call succeeds
-    And the response field "applied.compacted" is false
-    And the response field "token_count" exceeds 4000
+    Then the call fails with code "context/overflow"
     And the summariser was never invoked
     And the lease on the history's default key still belongs to the foreign holder
 
-  # Prevents: a summariser failure erroring the hot path or leaving the
-  # lease stuck — the turn proceeds over budget, the lease is freed.
-  Scenario: a summariser failure degrades assemble to best effort
+  # A summariser failure releases its lease and fails safely when no
+  # remaining deterministic transform can fit the request.
+  Scenario: a summariser failure reports overflow and releases the lease
     Given inline model "small" with context window 5000 and max output 500
     And the summariser fails with "provider exploded"
     And a user message of ~3000 tokens
@@ -223,7 +247,59 @@ Feature: context::assemble — the model-ready context pipeline
     And a user message "recent question"
     And an assistant message "recent answer"
     When I assemble the history with model "small"
-    Then the call succeeds
-    And the response field "applied.compacted" is false
-    And the response field "token_count" exceeds 4000
+    Then the call fails with code "context/overflow"
     And no lease claim remains
+
+  # Invocation schemas are part of the provider input and must participate
+  # in the same hard postcondition as messages and the system prompt.
+  Scenario: tool schema overhead can make an otherwise small request overflow
+    Given inline model "small" with context window 5000 and max output 500
+    And a user message "hello"
+    When I assemble the history with model "small" and request fields:
+      """
+      {
+        "tools": [{
+          "name": "large_tool",
+          "description": "A deliberately verbose invocation contract used to prove that tool schemas are counted during assembly. This description repeats enough contract material to exceed a narrow remaining input budget while the user message itself still fits. The implementation must never omit this schema from the estimate because the exact same schema is serialized into the provider request after context assembly.",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "query": { "type": "string", "description": "A long search query with detailed matching and filtering semantics." },
+              "scope": { "type": "string", "description": "The namespace and tenancy scope used to constrain the operation." },
+              "cursor": { "type": "string", "description": "An opaque continuation cursor for bounded retrieval." }
+            }
+          },
+          "execution_mode": "sequential"
+        }],
+        "options": { "reserved_tokens": 4350, "allow_compaction": false }
+      }
+      """
+    Then the call fails with code "context/overflow"
+
+  # Response-format and provider-specific fields are serialized outside the
+  # message/tool arrays, so callers supply their measured overhead explicitly.
+  Scenario: caller-supplied complete request overhead participates in the budget
+    Given inline model "small" with context window 5000 and max output 500
+    And a user message "hello"
+    When I assemble the history with model "small" and request fields:
+      """
+      {
+        "options": {
+          "reserved_tokens": 4300,
+          "request_overhead_tokens": 500,
+          "allow_compaction": false
+        }
+      }
+      """
+    Then the call fails with code "context/overflow"
+
+  # The advertised output allowance is deducted before input assembly. A
+  # request that would fit only by stealing that allowance must fail locally.
+  Scenario: model output reservation cannot be consumed by input context
+    Given inline model "output-heavy" with context window 5000 and max output 4400
+    And a user message of ~300 tokens
+    When I assemble the history with model "output-heavy" and options:
+      """
+      { "allow_compaction": false }
+      """
+    Then the call fails with code "context/overflow"

--- a/context-manager/tests/features/engine_roundtrip.feature
+++ b/context-manager/tests/features/engine_roundtrip.feature
@@ -58,10 +58,9 @@ Feature: engine round trip — the production surface over a live bus
     And the response field "applied.compacted" is false
     And the response field "system_prompt" is "You are helpful."
 
-  # Prevents: a missing router erroring the hot path — an over-budget
-  # assemble must still answer (best effort), exercising a REAL
-  # state::* lease acquire/release around the failed summarisation.
-  Scenario: over budget without a router degrades to best effort
+  # A missing summariser cannot weaken the hard assembly budget. The
+  # real state::* lease cycle still has to release before overflow returns.
+  Scenario: over budget without a router fails closed
     Given a user message of ~3000 tokens
     And a user message of ~3000 tokens
     And a user message "recent"
@@ -71,9 +70,7 @@ Feature: engine round trip — the production surface over a live bus
         "model": { "id": "small",
                    "limits": { "context_window": 5000, "max_output_tokens": 500 } } }
       """
-    Then the call succeeds
-    And the response field "applied.compacted" is false
-    And the response field "token_count" exceeds 4000
+    Then the call fails with code "context/overflow"
 
   # Prevents: "router absent" surfacing as anything but the documented
   # overflow status — and proves the real lease cycle completes (a

--- a/context-manager/tests/golden/schemas/context.assemble.json
+++ b/context-manager/tests/golden/schemas/context.assemble.json
@@ -4,6 +4,43 @@
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
+      "AgentFunction": {
+        "description": "An invocation-surface schema entry (README.md § AgentFunction) — accepted by `context::count-tokens` so callers can include the `agent_trigger` schema in their estimate.",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "execution_mode": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/ExecutionMode"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "label": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "description": "Invocation surface name (`agent_trigger`, `submit_result`, or a function id in native exposure mode).",
+            "type": "string"
+          },
+          "parameters": {
+            "default": null,
+            "description": "JSON Schema for the function parameters."
+          }
+        },
+        "required": [
+          "description",
+          "name"
+        ],
+        "type": "object"
+      },
       "AgentMessage": {
         "description": "The canonical transcript message union, discriminated by `role`.",
         "oneOf": [
@@ -238,12 +275,22 @@
           },
           "protected_functions": {
             "default": null,
-            "description": "`function_id`s whose outputs are never pruned.",
+            "description": "`function_id`s exempt from the normal prune pass. Emergency safety reduction may still replace their oversized results.",
             "items": {
               "type": "string"
             },
             "type": [
               "array",
+              "null"
+            ]
+          },
+          "request_overhead_tokens": {
+            "default": null,
+            "description": "Estimated tokens for final provider request fields and framing not otherwise represented by the prompt, messages, or tools.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
               "null"
             ]
           },
@@ -423,6 +470,13 @@
         ],
         "type": "string"
       },
+      "ExecutionMode": {
+        "enum": [
+          "parallel",
+          "sequential"
+        ],
+        "type": "string"
+      },
       "ModelInput": {
         "description": "How callers identify the target model (context-manager.md § Model input). Inline `limits` keep the call standalone; `id`/`provider` alone defer limit resolution to `router::models::get`.",
         "properties": {
@@ -590,6 +644,17 @@
         "description": "Base system prompt to prepend/merge.",
         "type": [
           "string",
+          "null"
+        ]
+      },
+      "tools": {
+        "default": null,
+        "description": "Model-facing invocation schemas included in every budget count.",
+        "items": {
+          "$ref": "#/definitions/AgentFunction"
+        },
+        "type": [
+          "array",
           "null"
         ]
       }
@@ -1081,7 +1146,7 @@
         "type": "string"
       },
       "token_count": {
-        "description": "Estimated tokens of the returned context (messages + system prompt). Can exceed `usable` when prune/compaction were disabled, unavailable, or insufficient — best effort, visible.",
+        "description": "Estimated tokens of the returned context, including the system prompt, tools, and request overhead. Always at most `usable`.",
         "format": "uint64",
         "minimum": 0.0,
         "type": "integer"

--- a/context-manager/tests/steps/call_steps.rs
+++ b/context-manager/tests/steps/call_steps.rs
@@ -127,3 +127,22 @@ async fn assemble_system_options(
     });
     world.call_pure("context::assemble", payload).await;
 }
+
+#[when(regex = r#"^I assemble the history with model "([^"]+)" and request fields:$"#)]
+async fn assemble_request_fields(world: &mut ContextWorld, model: String, step: &Step) {
+    let extras = docstring_payload(world, step);
+    let mut payload = json!({
+        "messages": history(world),
+        "model": world.model_input(&model),
+    });
+    let payload_object = payload
+        .as_object_mut()
+        .expect("assemble payload is an object");
+    let extras_object = extras
+        .as_object()
+        .expect("assemble request fields must be a JSON object");
+    for (key, value) in extras_object {
+        payload_object.insert(key.clone(), value.clone());
+    }
+    world.call_pure("context::assemble", payload).await;
+}

--- a/context-manager/tests/steps/invariant_steps.rs
+++ b/context-manager/tests/steps/invariant_steps.rs
@@ -159,6 +159,51 @@ async fn message_text_len(world: &mut ContextWorld, idx: usize, expected: usize)
     assert_eq!(text.len(), expected, "message {idx} text length mismatch");
 }
 
+#[then(regex = r#"^response message (\d+) text contains "([^"]*)"$"#)]
+async fn message_text_contains(world: &mut ContextWorld, idx: usize, expected: String) {
+    if world.soft_skipped {
+        return;
+    }
+    let messages = response_messages(world);
+    let message = messages
+        .get(idx)
+        .unwrap_or_else(|| panic!("no response message at index {idx}"));
+    let text = message
+        .get("content")
+        .and_then(Value::as_array)
+        .and_then(|blocks| blocks.first())
+        .and_then(|block| block.get("text"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        text.contains(&expected),
+        "message {idx} text does not contain `{expected}`: {text}"
+    );
+}
+
+#[then(regex = r#"^response message (\d+) text does not exceed (\d+) chars$"#)]
+async fn message_text_at_most(world: &mut ContextWorld, idx: usize, limit: usize) {
+    if world.soft_skipped {
+        return;
+    }
+    let messages = response_messages(world);
+    let message = messages
+        .get(idx)
+        .unwrap_or_else(|| panic!("no response message at index {idx}"));
+    let text = message
+        .get("content")
+        .and_then(Value::as_array)
+        .and_then(|blocks| blocks.first())
+        .and_then(|block| block.get("text"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        text.len() <= limit,
+        "message {idx} text has {} chars, expected at most {limit}",
+        text.len()
+    );
+}
+
 #[then(regex = r#"^every response message keeps its function_call_id$"#)]
 async fn keeps_call_ids(world: &mut ContextWorld) {
     if world.soft_skipped {

--- a/harness/src/clients/context.rs
+++ b/harness/src/clients/context.rs
@@ -1,6 +1,5 @@
-//! `context-manager` client: `context::assemble`. Soft dependency — when the
-//! worker is absent (function not found) the caller degrades to raw history
-//! plus the base system prompt.
+//! Required `context-manager` client: context assembly and final token
+//! preflight both fail closed so the harness never bypasses provider budgets.
 
 use std::sync::Arc;
 
@@ -10,7 +9,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 
 use crate::types::message::AgentMessage;
-use crate::types::model::ThinkingLevel;
+use crate::types::model::{AgentFunction, ThinkingLevel};
 
 /// The budgeted context returned by `context::assemble`.
 #[derive(Debug, Clone, Deserialize)]
@@ -19,6 +18,8 @@ pub struct AssembleOutput {
     pub system_prompt: String,
     #[serde(default)]
     pub messages: Vec<AgentMessage>,
+    pub token_count: u64,
+    pub usable: u64,
     #[serde(default)]
     pub applied: Applied,
 }
@@ -31,6 +32,8 @@ pub struct Applied {
     pub summary: Option<String>,
     #[serde(default)]
     pub tail_start_index: Option<i64>,
+    #[serde(default)]
+    pub tokens_before: Option<u64>,
 }
 
 pub struct AssembleParams {
@@ -41,6 +44,21 @@ pub struct AssembleParams {
     pub previous_summary: Option<String>,
     pub lease_key: String,
     pub thinking_level: Option<ThinkingLevel>,
+    pub tools: Vec<AgentFunction>,
+    pub request_overhead_tokens: u64,
+}
+
+pub struct CountTokensParams {
+    pub messages: Vec<Value>,
+    pub model_id: String,
+    pub provider: Option<String>,
+    pub system_prompt: Option<String>,
+    pub tools: Vec<AgentFunction>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CountTokensOutput {
+    pub tokens: u64,
 }
 
 #[derive(Clone)]
@@ -54,14 +72,17 @@ impl ContextClient {
         Self { iii, timeout_ms }
     }
 
-    /// Assemble a model-ready context. Returns `Ok(None)` when the worker is
-    /// unreachable (soft dependency → raw-history fallback).
-    pub async fn assemble(&self, params: AssembleParams) -> Result<Option<AssembleOutput>, String> {
+    /// Assemble a model-ready context. The context manager is a required
+    /// dependency: callers must never fall back to unbudgeted raw history.
+    pub async fn assemble(&self, params: AssembleParams) -> Result<AssembleOutput, String> {
         let mut model = json!({ "id": params.model_id });
         if let Some(p) = &params.provider {
             model["provider"] = json!(p);
         }
-        let mut options = json!({ "lease_key": params.lease_key });
+        let mut options = json!({
+            "lease_key": params.lease_key,
+            "request_overhead_tokens": params.request_overhead_tokens,
+        });
         if let Some(s) = &params.previous_summary {
             options["previous_summary"] = json!(s);
         }
@@ -72,6 +93,7 @@ impl ContextClient {
             "messages": params.messages,
             "model": model,
             "options": options,
+            "tools": params.tools,
         });
         if let Some(sp) = &params.system_prompt {
             payload["system_prompt"] = json!(sp);
@@ -89,18 +111,43 @@ impl ContextClient {
 
         match resp {
             Ok(v) => serde_json::from_value::<AssembleOutput>(v)
-                .map(Some)
                 .map_err(|e| format!("context::assemble parse: {e}")),
-            Err(e) if is_unroutable(&e.to_string()) => {
-                tracing::info!("context-manager absent; using raw history");
-                Ok(None)
-            }
             Err(e) => Err(format!("context::assemble: {e}")),
         }
     }
-}
 
-fn is_unroutable(msg: &str) -> bool {
-    let m = msg.to_lowercase();
-    m.contains("function_not_found") || m.contains("not found") || m.contains("no function")
+    /// Count the final model-facing messages, prompt, and complete tool list.
+    pub async fn count_tokens(
+        &self,
+        params: CountTokensParams,
+    ) -> Result<CountTokensOutput, String> {
+        let mut model = json!({ "id": params.model_id });
+        if let Some(p) = &params.provider {
+            model["provider"] = json!(p);
+        }
+        let mut payload = json!({
+            "messages": params.messages,
+            "model": model,
+            "tools": params.tools,
+        });
+        if let Some(sp) = &params.system_prompt {
+            payload["system_prompt"] = json!(sp);
+        }
+
+        let resp = self
+            .iii
+            .trigger(TriggerRequest {
+                function_id: "context::count-tokens".into(),
+                payload,
+                action: None,
+                timeout_ms: Some(self.timeout_ms),
+            })
+            .await;
+
+        match resp {
+            Ok(v) => serde_json::from_value::<CountTokensOutput>(v)
+                .map_err(|e| format!("context::count-tokens parse: {e}")),
+            Err(e) => Err(format!("context::count-tokens: {e}")),
+        }
+    }
 }

--- a/harness/src/clients/mod.rs
+++ b/harness/src/clients/mod.rs
@@ -1,6 +1,7 @@
 //! Typed clients for the workers the loop wires together. Each is a thin
 //! wrapper over `iii.trigger(TriggerRequest { .. })`; `session-manager` and
-//! `llm-router` are required, `context-manager` degrades to raw history.
+//! `llm-router` and `context-manager` are required on the generation path;
+//! context budgeting fails closed rather than degrading to raw history.
 
 pub mod context;
 pub mod engine;

--- a/harness/src/error.rs
+++ b/harness/src/error.rs
@@ -28,6 +28,10 @@ pub enum HarnessError {
     #[error("harness/dependency: {0}")]
     Dependency(String),
 
+    /// No provider-safe context can fit inside the resolved model budget.
+    #[error("harness/context_overflow: {0}")]
+    ContextOverflow(String),
+
     /// A state read/write backing the loop failed.
     #[error("harness/state: {0}")]
     State(String),
@@ -46,6 +50,7 @@ impl HarnessError {
             HarnessError::SpawnDepthExceeded(_) => "harness/spawn_depth_exceeded",
             HarnessError::SpawnFanoutExceeded(_) => "harness/spawn_fanout_exceeded",
             HarnessError::Dependency(_) => "harness/dependency",
+            HarnessError::ContextOverflow(_) => "harness/context_overflow",
             HarnessError::State(_) => "harness/state",
             HarnessError::Internal(_) => "harness/internal",
         }
@@ -70,6 +75,7 @@ mod tests {
             HarnessError::SpawnDepthExceeded("m".into()),
             HarnessError::SpawnFanoutExceeded("m".into()),
             HarnessError::Dependency("m".into()),
+            HarnessError::ContextOverflow("m".into()),
             HarnessError::State("m".into()),
             HarnessError::Internal("m".into()),
         ];
@@ -80,5 +86,15 @@ mod tests {
                 v.code()
             );
         }
+    }
+
+    #[test]
+    fn context_overflow_has_stable_code() {
+        let error = HarnessError::ContextOverflow("request does not fit".into());
+        assert_eq!(error.code(), "harness/context_overflow");
+        assert_eq!(
+            error.to_string(),
+            "harness/context_overflow: request does not fit"
+        );
     }
 }

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -23,6 +23,7 @@ use crate::trigger;
 use crate::types::content::ContentBlock;
 use crate::types::event::ErrorKind;
 use crate::types::message::{empty_assistant, AgentMessage, AssistantMessage};
+use crate::types::model::AgentFunction;
 use crate::types::turn::{
     CallCheckpoint, CallState, ExposeMode, FunctionPolicy, TurnRecord, TurnStatus,
 };
@@ -39,6 +40,32 @@ const INTERNAL_FAILURE: FailureInfo = FailureInfo {
     phase: "execution",
     retryable: false,
 };
+
+const CONTEXT_OVERFLOW_FAILURE: FailureInfo = FailureInfo {
+    code: "harness.context_overflow",
+    phase: "context_assembly",
+    retryable: false,
+};
+
+/// Provider adapters add framing outside the fields visible to the harness.
+/// Keep a small fixed reserve in addition to the deterministic JSON estimate.
+const PROVIDER_FRAMING_ALLOWANCE_TOKENS: u64 = 64;
+
+fn estimate_request_overhead_tokens(
+    response_format: Option<&Value>,
+    provider_options: Option<&Value>,
+) -> u64 {
+    let mut fields = serde_json::Map::new();
+    if let Some(response_format) = response_format {
+        fields.insert("response_format".to_string(), response_format.clone());
+    }
+    if let Some(provider_options) = provider_options {
+        fields.insert("provider_options".to_string(), provider_options.clone());
+    }
+    let serialized_chars = Value::Object(fields).to_string().chars().count() as u64;
+    let serialized_tokens = serialized_chars.saturating_add(3) / 4;
+    PROVIDER_FRAMING_ALLOWANCE_TOKENS.saturating_add(serialized_tokens)
+}
 /// The enqueued `harness::turn` step payload.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct TurnStepPayload {
@@ -229,24 +256,15 @@ pub async fn run_step(
     let prev_watermark = record.watermark_entry_id.clone();
     let watermark = entries.last().map(|e| e.entry_id.clone());
 
-    // Assemble the model-ready context (+ compaction persistence).
-    let mut assembled = assemble_context(
-        deps,
-        &session,
-        &record,
-        &entries,
-        payload.step,
-        prev_watermark.as_deref(),
-    )
-    .await?;
-
+    // Build every deterministic model-facing input before context assembly.
     // Registry-change notice: if the function registry changed since this
     // session last acknowledged its generation, tell the model its cached
-    // contracts may be stale. First sighting stamps silently. Persisted by the
-    // pre-generate put_turn below.
+    // contracts may be stale. First sighting stamps silently.
     let current_generation = deps.functions().await.generation;
+    let mut assembly_system_prompt =
+        with_filesystem_root_aid(record.options.system_prompt.clone(), &record);
     if let Some(notice) = registry_notice(record.functions_generation, current_generation) {
-        assembled.system_prompt = Some(match assembled.system_prompt.take() {
+        assembly_system_prompt = Some(match assembly_system_prompt.take() {
             Some(prompt) if !prompt.is_empty() => format!("{prompt}\n\n{notice}"),
             _ => notice,
         });
@@ -261,6 +279,45 @@ pub async fn run_step(
     if let Some(submit) = strategy.submit_result_tool() {
         tools.push(submit);
     }
+    let response_format = strategy.response_format();
+    let provider_options = record
+        .options
+        .provider_options
+        .as_ref()
+        .and_then(|options| serde_json::to_value(options).ok());
+    let request_overhead_tokens =
+        estimate_request_overhead_tokens(response_format.as_ref(), provider_options.as_ref());
+
+    // Assemble the model-ready context (+ compaction persistence). An
+    // impossible fit is a terminal turn outcome, not an unexpected step error.
+    let assembled = match assemble_context(
+        deps,
+        &session,
+        &record,
+        &entries,
+        payload.step,
+        prev_watermark.as_deref(),
+        ContextAssemblyInputs {
+            system_prompt: assembly_system_prompt,
+            tools: &tools,
+            request_overhead_tokens,
+        },
+    )
+    .await
+    {
+        Ok(assembled) => assembled,
+        Err(HarnessError::ContextOverflow(reason)) => {
+            return finalize_failed(
+                deps,
+                &session,
+                &mut record,
+                &reason,
+                CONTEXT_OVERFLOW_FAILURE,
+            )
+            .await;
+        }
+        Err(error) => return Err(error),
+    };
 
     // pre_generate hooks: extend the system prompt / append bounded messages,
     // or veto. Annotations ride the assistant entry's origin (audit trail).
@@ -331,6 +388,37 @@ pub async fn run_step(
         .await;
     }
 
+    // Hooks and orphan repair can change the assembled request. Re-count the
+    // exact final prompt/messages/tools and include the same non-context
+    // overhead reserve before creating an assistant entry or calling router.
+    let final_count = deps
+        .context()
+        .await
+        .count_tokens(crate::clients::context::CountTokensParams {
+            messages: gen_messages.clone(),
+            model_id: record.options.model.clone(),
+            provider: record.options.provider.clone(),
+            system_prompt: gen_system_prompt.clone(),
+            tools: tools.clone(),
+        })
+        .await
+        .map_err(HarnessError::Dependency)?;
+    let final_request_tokens = final_count.tokens.saturating_add(request_overhead_tokens);
+    if final_request_tokens > assembled.usable {
+        let reason = format!(
+            "final model request exceeds the assembled usable budget: {final_request_tokens} tokens > {} usable",
+            assembled.usable
+        );
+        return finalize_failed(
+            deps,
+            &session,
+            &mut record,
+            &reason,
+            CONTEXT_OVERFLOW_FAILURE,
+        )
+        .await;
+    }
+
     let assistant_origin = origin_with(&record.turn_id, &gen_annotations);
 
     // Generate: append an empty assistant under a deterministic id, stream
@@ -361,13 +449,9 @@ pub async fn run_step(
         system_prompt: gen_system_prompt,
         messages: gen_messages,
         tools,
-        response_format: strategy.response_format(),
+        response_format,
         thinking_level: record.options.thinking_level,
-        provider_options: record
-            .options
-            .provider_options
-            .as_ref()
-            .and_then(|options| serde_json::to_value(options).ok()),
+        provider_options,
     };
     record.stream_request_id = Some(params.request_id.clone());
     crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
@@ -1442,8 +1526,8 @@ async fn has_user_after_watermark(
 }
 
 /// Build the model-ready context: read the latest compaction entry, reduce the
-/// candidate window to its tail, call `context::assemble` (persisting a new
-/// summary when it compacts), or fall back to raw history.
+/// candidate window to its tail, and call required `context::assemble`,
+/// persisting a new summary when it compacts.
 async fn assemble_context(
     deps: &Deps,
     session: &SessionClient,
@@ -1451,6 +1535,7 @@ async fn assemble_context(
     entries: &[LoadedEntry],
     step: u64,
     prev_watermark: Option<&str>,
+    inputs: ContextAssemblyInputs<'_>,
 ) -> Result<Assembled, HarnessError> {
     // Latest compaction custom entry on the path (if any).
     let mut previous_summary: Option<String> = None;
@@ -1515,75 +1600,79 @@ async fn assemble_context(
 
     let context = deps.context().await;
     let params = crate::clients::AssembleParams {
-        messages: candidate_values.clone(),
+        messages: candidate_values,
         model_id: record.options.model.clone(),
         provider: record.options.provider.clone(),
-        system_prompt: record.options.system_prompt.clone(),
+        system_prompt: inputs.system_prompt,
         previous_summary,
         lease_key: record.session_id.clone(),
         thinking_level: record.options.thinking_level,
+        tools: inputs.tools.to_vec(),
+        request_overhead_tokens: inputs.request_overhead_tokens,
     };
 
-    match context.assemble(params).await {
-        Ok(Some(out)) => {
-            if out.applied.compacted {
-                if let Some(summary) = &out.applied.summary {
-                    let tail_entry = out
-                        .applied
-                        .tail_start_index
-                        .and_then(|i| usize::try_from(i).ok())
-                        .and_then(|i| candidate.get(i))
-                        .map(|(id, _)| id.clone());
-                    let data = json!({
-                        "summary": summary,
-                        "tail_start_entry_id": tail_entry,
-                        "tokens_before": out.applied.tail_start_index,
-                    });
-                    let _ = session
-                        .append_custom(
-                            &record.session_id,
-                            "compaction",
-                            data,
-                            &ids::compaction_entry_id(&record.turn_id, step),
-                            Some(&origin(&record.turn_id)),
-                        )
-                        .await;
-                }
-            }
-            let mut messages: Vec<Value> = out
-                .messages
-                .iter()
-                .map(|m| serde_json::to_value(m).unwrap_or(Value::Null))
-                .collect();
-            // Defensive: context::assemble must never strip the model-facing
-            // context down to nothing (the provider rejects an empty messages
-            // array). If it somehow does, fall back to the raw candidate
-            // window — which still begins at a user message.
-            if messages.is_empty() && !candidate_values.is_empty() {
-                tracing::warn!(
-                    session_id = %record.session_id,
-                    "context::assemble returned empty messages; using raw candidate window"
-                );
-                messages = candidate_values.clone();
-            }
-            rotate_mid_generation_users(&mut messages, new_suffix_len);
-            Ok(Assembled {
-                system_prompt: with_filesystem_root_aid(Some(out.system_prompt), record),
-                messages,
-            })
+    let out = match context.assemble(params).await {
+        Ok(out) => out,
+        Err(error) if is_context_overflow_error(&error) => {
+            return Err(HarnessError::ContextOverflow(error));
         }
-        Ok(None) | Err(_) => {
-            let mut messages = candidate_values;
-            rotate_mid_generation_users(&mut messages, new_suffix_len);
-            Ok(Assembled {
-                system_prompt: with_filesystem_root_aid(
-                    record.options.system_prompt.clone(),
-                    record,
-                ),
-                messages,
-            })
+        Err(error) => return Err(HarnessError::Dependency(error)),
+    };
+
+    if out.messages.is_empty() {
+        return Err(HarnessError::ContextOverflow(
+            "context::assemble returned an empty model-facing context".to_string(),
+        ));
+    }
+    // `context::assemble.token_count` already includes tools and the supplied
+    // request overhead; reject any response that violates its hard contract.
+    if out.token_count > out.usable {
+        return Err(HarnessError::ContextOverflow(format!(
+            "context::assemble returned an over-budget context: {} tokens > {} usable",
+            out.token_count, out.usable
+        )));
+    }
+
+    if out.applied.compacted {
+        if let Some(summary) = &out.applied.summary {
+            let tail_entry = out
+                .applied
+                .tail_start_index
+                .and_then(|i| usize::try_from(i).ok())
+                .and_then(|i| candidate.get(i))
+                .map(|(id, _)| id.clone());
+            let data = json!({
+                "summary": summary,
+                "tail_start_entry_id": tail_entry,
+                "tokens_before": out.applied.tokens_before,
+            });
+            let _ = session
+                .append_custom(
+                    &record.session_id,
+                    "compaction",
+                    data,
+                    &ids::compaction_entry_id(&record.turn_id, step),
+                    Some(&origin(&record.turn_id)),
+                )
+                .await;
         }
     }
+
+    let mut messages: Vec<Value> = out
+        .messages
+        .iter()
+        .map(|m| serde_json::to_value(m).unwrap_or(Value::Null))
+        .collect();
+    rotate_mid_generation_users(&mut messages, new_suffix_len);
+    Ok(Assembled {
+        system_prompt: Some(out.system_prompt),
+        messages,
+        usable: out.usable,
+    })
+}
+
+fn is_context_overflow_error(error: &str) -> bool {
+    error.contains("context/overflow:")
 }
 
 /// Append model-facing context aid lines to the system prompt: the session id
@@ -1650,6 +1739,13 @@ fn policy_aid(policy: Option<&FunctionPolicy>) -> Option<String> {
 struct Assembled {
     system_prompt: Option<String>,
     messages: Vec<Value>,
+    usable: u64,
+}
+
+struct ContextAssemblyInputs<'a> {
+    system_prompt: Option<String>,
+    tools: &'a [AgentFunction],
+    request_overhead_tokens: u64,
 }
 
 /// A user entry appended while a step was generating (or assembling — the
@@ -1870,6 +1966,43 @@ mod tests {
     use super::{cancel_requested, transient_resume_allowed};
     use crate::types::content::ContentBlock;
     use crate::types::event::{ErrorKind, StopReason};
+
+    #[test]
+    fn request_overhead_always_reserves_provider_framing() {
+        assert_eq!(
+            super::estimate_request_overhead_tokens(None, None),
+            super::PROVIDER_FRAMING_ALLOWANCE_TOKENS + 1
+        );
+    }
+
+    #[test]
+    fn request_overhead_counts_serialized_optional_fields_with_ceiling() {
+        let response_format = serde_json::json!({ "type": "json" });
+        let provider_options = serde_json::json!({ "temperature": 0.25 });
+        let serialized =
+            r#"{"provider_options":{"temperature":0.25},"response_format":{"type":"json"}}"#;
+        let serialized_tokens = (serialized.chars().count() as u64).div_ceil(4);
+        assert_eq!(
+            super::estimate_request_overhead_tokens(
+                Some(&response_format),
+                Some(&provider_options)
+            ),
+            super::PROVIDER_FRAMING_ALLOWANCE_TOKENS + serialized_tokens
+        );
+    }
+
+    #[test]
+    fn context_overflow_classification_requires_the_stable_context_code() {
+        assert!(super::is_context_overflow_error(
+            "context::assemble: handler failed: context/overflow: assembled context requires 101 tokens but usable budget is 100"
+        ));
+        assert!(!super::is_context_overflow_error(
+            "context::assemble: context/model_unresolved: could not resolve model limits"
+        ));
+        assert!(!super::is_context_overflow_error(
+            "context::assemble: request overflowed while parsing"
+        ));
+    }
 
     #[test]
     fn registry_notice_stamps_silently_then_fires_on_mismatch() {

--- a/tech-specs/2026-06-agentic/context-manager.md
+++ b/tech-specs/2026-06-agentic/context-manager.md
@@ -134,7 +134,10 @@ in [README.md § Cross-cutting contracts](README.md#cross-cutting-contracts).
 ### `context::assemble`
 
 Build a model-ready context. Applies prune and/or compaction as needed to fit `usable`, in this
-order: count -> (if over) prune function outputs -> (if still over) compact head -> assemble final list.
+order: count the complete request -> (if over) prune function outputs -> (if still over) compact
+the head -> (if still over) replace oversized function results with bounded transcript references
+-> assemble the final list. A successful response has the hard postcondition
+`token_count <= usable`.
 
 - Invocation: **sync**
 
@@ -145,12 +148,14 @@ type AssembleRequest = {
   messages: AgentMessage[];        // full candidate history, oldest first
   model: ModelInput;
   system_prompt?: string;          // base system prompt to prepend/merge
+  tools?: AgentFunction[];          // complete invocation schema sent with the request
   options?: {
     reserved_tokens?: number;      // override the default reserve
+    request_overhead_tokens?: number; // response format/provider fields not represented above
     tail_turns?: number;           // user+assistant pairs always kept verbatim (default 2)
     allow_compaction?: boolean;    // default true
     allow_prune?: boolean;         // default true
-    protected_functions?: string[];    // function_ids whose outputs are never pruned
+    protected_functions?: string[];    // function_ids exempt from the normal prune pass
     thinking_level?: ThinkingLevel;    // reserve the model's thinking budget for this tier
     lease_key?: string;            // compaction mutual-exclusion key (e.g. a session id); default: hash of the message set
     previous_summary?: string;     // persisted summary from a prior compaction (see "The compaction round trip")
@@ -164,7 +169,7 @@ Response:
 type AssembleResponse = {
   system_prompt: string;
   messages: AgentMessage[];        // budgeted, ready to send to llm-router
-  token_count: number;             // estimated tokens of the returned context
+  token_count: number;             // messages + prompt + tools + request overhead
   usable: number;                  // the budget it was fit into
   model_resolved: "inline" | "router" | "fallback";
   applied: {
@@ -178,8 +183,16 @@ type AssembleResponse = {
 };
 ```
 
+The emergency reduction pass is a safety boundary, not a preference. It may replace a recent or
+normally protected `function_result` when that single result would otherwise overflow the model.
+The replacement preserves message order and `function_call_id`, and carries a bounded reference
+with the original size, hash, preview, and transcript retrieval hint; the durable session transcript
+retains the full result.
+
 Errors (thrown): `messages is required`; `could not resolve model limits` (only when neither inline
-limits nor `llm-router` are available and the fallback is explicitly disabled).
+limits nor `llm-router` are available and the fallback is explicitly disabled); `context/overflow`
+when no safe combination of pruning and compaction can fit the complete request. An overflow error
+never includes a model-ready response for the caller to send anyway.
 
 Example:
 

--- a/tech-specs/2026-06-agentic/harness.md
+++ b/tech-specs/2026-06-agentic/harness.md
@@ -20,9 +20,10 @@ siblings veto, hold, or mutate in-path — see [Hooks](#hooks)). Children are or
 sessions/turns; orchestration beyond spawn/join stays out of scope, and hook *logic* (the policy
 itself) always lives in the sibling that registers it.
 
-The harness is the only worker in this spec that depends on the other three, and even those are soft:
-without `context-manager` it sends raw history; without function dispatch it is a plain chat loop. It
-needs `session-manager` (to persist/stream) and `llm-router` (to generate).
+The harness is the only worker in this spec that depends on the other three. Function dispatch is
+optional (without it, the harness is a plain chat loop), while `session-manager`, `context-manager`,
+and `llm-router` are required on the generation path. Context budgeting fails closed because raw
+history cannot be proven safe for the selected model.
 
 ## What it wires
 
@@ -79,11 +80,14 @@ attributable to a turn. One `harness::turn` step does:
    before any model spend.
 2. Load active path: `session::messages` with `include_custom: true` (custom entries carry the
    compaction record, below).
-3. Assemble context: read the latest compaction entry (if any) on the active path, reduce the
-   candidate window to it, and call `context::assemble` with `previous_summary` set (see
-   [Compaction persistence](#compaction-persistence)); skipped if `context-manager` absent -> raw
-   messages + base system prompt. If the response reports `applied.compacted`, persist the new
-   summary (same section). Attach the invocation schemas to the router request: the single
+3. Assemble context: resolve the output strategy and complete invocation surface first, then read
+   the latest compaction entry (if any) on the active path, reduce the candidate window to it, and
+   call `context::assemble` with `previous_summary`, the final invocation schemas, deterministic
+   system aids, and non-message request overhead set (see
+   [Compaction persistence](#compaction-persistence)). Context budgeting is fail-closed: an absent
+   context manager, `context/overflow`, or an empty assembly fails the turn before generation; raw
+   history is never substituted. If the response reports `applied.compacted`, persist the new
+   summary (same section). The invocation surface is the single
    `agent_trigger` schema by default (function discovery is runtime — the model calls
    `engine::functions::list` / `engine::functions::info` through it), or one schema per allowed
    function when `functions.expose: "native"` (see
@@ -91,7 +95,9 @@ attributable to a turn. One `harness::turn` step does:
    schema when an [output contract](#output-contract) uses the fallback strategy. Finally run the
    `pre_generate` [hook chain](#hooks) over the assembled context — hooks may extend the system
    prompt or append bounded messages (memory, RAG, guardrails); a `deny` ends the turn as in
-   step 1.
+   step 1. After hooks and call/result repair, the harness counts the complete final request again.
+   If it exceeds the assembly's `usable` budget, the turn fails with
+   `harness.context_overflow` and `router::chat` is not called.
 4. Generate: open a channel, call `router::chat` with `request_id = <turn_id>:<step>` (recorded on
    the turn record as `stream_request_id` for [`harness::stop`](#harnessstop)) and — when the
    [output contract](#output-contract) rides provider-native structured output —
@@ -1016,7 +1022,9 @@ pattern [approval-gate](approval-gate.md#state-lifecycle) mandates for its own s
 - `session-manager` (`session::*`) — persist messages, stream content via `session::update-message`,
   and set status. Required.
 - `llm-router` (`router::chat`) — generation. Required.
-- `context-manager` (`context::assemble`) — context budgeting. Soft; degrades to raw history.
+- `context-manager` (`context::assemble`, `context::count-tokens`) — context budgeting and final
+  request preflight. Required for generation; failures are fail-closed so an unbudgeted request is
+  never sent to a provider.
 - `queue` — the durable `harness-turn` loop. After registering `harness::*` functions, bootstrap
   MUST call `queue::define` and fail before ready if it cannot ensure this queue. Its definition is
   FIFO grouped by `session_id`, concurrency `10`, three retries, 1-second backoff, and 100ms


### PR DESCRIPTION
## Problem

Context assembly could compact repeatedly and still return a successful response whose estimated token count exceeded the model's usable input budget. A multi-megabyte function result in the latest turn was protected by normal pruning and tail-selection rules, so it survived every compaction attempt.

The harness also added tool schemas, system aids, hook messages, response formats, and provider options after assembly. When context-manager was unavailable or returned an unusable result, the harness could fall back to raw history and call the provider without a complete final preflight.

## Solution

- Enforce `token_count <= usable` as a hard postcondition for every successful `context::assemble` response.
- Add an emergency reduction pass that replaces oversized function results—even recent or normally protected ones—with bounded transcript references carrying call identity, size, estimated tokens, SHA-256, preview, and retrieval guidance.
- Count complete tool schemas and caller-supplied request overhead throughout assembly.
- Return stable `context/overflow` and `harness/context_overflow` failures when a safe request cannot be produced.
- Resolve deterministic system text, invocation schemas, response format, provider options, and framing overhead before assembly.
- Recount the final request after pre-generation hooks and call/result repair, before creating an assistant entry or invoking `router::chat`.
- Remove the raw-history fallback and fail closed when context budgeting is unavailable.
- Persist the correct `applied.tokens_before` compaction metric.

## Impact

A 4.98 MB latest function result now becomes a bounded reference and the turn can continue without breaking call/result pairing. Irreducible requests fail locally with a structured context-overflow action and never reach the provider.

## Validation

- `context-manager`: full `cargo test`, including 84 BDD scenarios and 749 steps.
- `harness`: full `cargo test`, including 220 unit tests plus manifest and schema coverage.
- `cargo clippy --all-targets -- -D warnings` for both packages.
- Updated and verified the `context::assemble` wire-schema golden.
- `git diff --check`.

Fixes MOT-4014


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tool schemas and provider request overhead in context budgeting.
  * Added token-counting support for model requests.
  * Oversized function results can now be replaced with bounded transcript references while preserving retrieval details.

* **Bug Fixes**
  * Context assembly now guarantees results fit within the usable token budget.
  * Added clear `context/overflow` and `harness/context_overflow` errors when requests cannot safely fit.
  * Prevented over-budget requests from being sent after final request modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->