### PR TITLE
feat(console): improve composer toolbar layout

### DIFF
--- a/console/web/src/components/chat/Composer.stories.tsx
+++ b/console/web/src/components/chat/Composer.stories.tsx
@@ -40,6 +40,17 @@ const STORY_MODEL_OPTIONS: ModelOption[] = [
     supportsThinking: true,
   },
   {
+    id: 'codex::gpt-5.6-terra',
+    label: 'gpt-5.6-terra (codex)',
+    contextWindow: 400_000,
+    supportsThinking: true,
+    reasoningEfforts: [
+      { effort: 'low', description: 'quick reasoning for routine tasks' },
+      { effort: 'medium', description: 'balanced reasoning and latency' },
+      { effort: 'high', description: 'deeper reasoning for complex tasks' },
+    ],
+  },
+  {
     id: 'openai::gpt-4.1',
     label: 'gpt-4.1',
     contextWindow: 1_000_000,
@@ -82,19 +93,25 @@ function seedWithText() {
 function ComposerHarness({
   initialMode = 'agent',
   initialModel = STORY_MODEL_OPTIONS[0].id,
+  initialThinkingLevel = 'default',
+  initialWorkingDir,
   initialContent,
   initialAttachments,
   isStreaming,
 }: {
   initialMode?: Mode
   initialModel?: ModelId
+  initialThinkingLevel?: ThinkingLevel
+  initialWorkingDir?: string
   initialContent?: () => void
   initialAttachments?: Attachment[]
   isStreaming?: boolean
 }) {
   const [mode, setMode] = useState<Mode>(initialMode)
   const [model, setModel] = useState<ModelId>(initialModel)
-  const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>('default')
+  const [thinkingLevel, setThinkingLevel] =
+    useState<ThinkingLevel>(initialThinkingLevel)
+  const [workingDir, setWorkingDir] = useState(initialWorkingDir)
   return (
     <Composer
       mode={mode}
@@ -103,9 +120,12 @@ function ComposerHarness({
       functionEntries={STATIC_FUNCTIONS}
       permissionMode="manual"
       thinkingLevel={thinkingLevel}
+      showWorkingDir={initialWorkingDir !== undefined}
+      workingDir={workingDir}
       onThinkingLevelChange={setThinkingLevel}
       onModeChange={setMode}
       onModelChange={setModel}
+      onWorkingDirChange={setWorkingDir}
       onPermissionModeChange={fn()}
       onSubmit={fn()}
       onStop={fn()}
@@ -162,6 +182,19 @@ export const WithAttachments: Story = {
       initialModel="openai::gpt-5"
       initialAttachments={sampleAttachments}
     />
+  ),
+}
+
+export const WithReasoningEffort: Story = {
+  name: 'selected reasoning effort',
+  render: () => (
+    <div className="max-w-[640px]">
+      <ComposerHarness
+        initialModel="codex::gpt-5.6-terra"
+        initialThinkingLevel="medium"
+        initialWorkingDir="/workspace/workers"
+      />
+    </div>
   ),
 }
 

--- a/console/web/src/components/chat/Composer.tsx
+++ b/console/web/src/components/chat/Composer.tsx
@@ -32,7 +32,7 @@ export interface ComposerSubmitPayload {
 
 /** Round icon action button (send / queue / stop) at the composer's edge. */
 const actionButtonClass = cn(
-  'inline-flex items-center justify-center size-8 rounded-full bg-bg text-ink',
+  'inline-flex size-9 items-center justify-center rounded-full bg-bg text-ink',
   '[html[data-theme=dark]_&]:bg-white [html[data-theme=dark]_&]:text-[#0a0a0a]',
   'hover:opacity-80 transition-opacity duration-150',
   'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
@@ -320,62 +320,76 @@ export function Composer({
         />
       </div>
 
-      <div className="flex items-center gap-2 flex-wrap px-3 py-2 border-t border-rule-2">
-        <ModePicker value={mode} onChange={onModeChange} />
-        {showWorkingDir && onWorkingDirChange ? (
-          <DirectoryPicker
-            value={workingDir ?? null}
-            onChange={onWorkingDirChange}
-            locked={workingDirLocked}
+      <div className="flex min-w-0 items-center gap-2 border-t border-rule-2 px-3 py-2">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <ModePicker
+            value={mode}
+            onChange={onModeChange}
+            className="shrink-0"
+          />
+          {showWorkingDir && onWorkingDirChange ? (
+            <DirectoryPicker
+              value={workingDir ?? null}
+              onChange={onWorkingDirChange}
+              locked={workingDirLocked}
+              disabled={optionsDisabled}
+              externalError={workingDirError}
+              defaultDir={defaultWorkingDir}
+              worktrees={worktreePicker}
+              className="shrink-0"
+            />
+          ) : null}
+          {showPermissionMode ? (
+            <PermissionModePicker
+              value={permissionMode}
+              onChange={onPermissionModeChange}
+              disabled={optionsDisabled || !!permissionModeLoading}
+            />
+          ) : null}
+          <ModelPicker
+            value={model}
+            options={modelOptions}
+            thinkingLevel={thinkingLevel}
+            onChange={onModelChange}
+            onThinkingLevelChange={onThinkingLevelChange}
             disabled={optionsDisabled}
-            externalError={workingDirError}
-            defaultDir={defaultWorkingDir}
-            worktrees={worktreePicker}
+            loading={catalogLoading}
+            className="min-w-0 flex-1"
           />
-        ) : null}
-        {showPermissionMode ? (
-          <PermissionModePicker
-            value={permissionMode}
-            onChange={onPermissionModeChange}
-            disabled={optionsDisabled || !!permissionModeLoading}
+        </div>
+
+        <div className="flex shrink-0 items-center gap-1">
+          <AttachmentButton
+            onAttach={handleAttach}
+            disabled={inputDisabled}
+            className="size-9"
           />
-        ) : null}
-        <ModelPicker
-          value={model}
-          options={modelOptions}
-          thinkingLevel={thinkingLevel}
-          onChange={onModelChange}
-          onThinkingLevelChange={onThinkingLevelChange}
-          disabled={optionsDisabled}
-          loading={catalogLoading}
-        />
-        <div className="flex-1 min-w-0" />
-        <AttachmentButton onAttach={handleAttach} disabled={inputDisabled} />
-        {/* ONE action button. Mid-stream the slot shows Stop, but the moment
-            the composer holds queueable content (text or attachments) it
-            flips to send — the editor advertises "queue a message…", and the
-            click must queue it, not kill the turn. */}
-        {isStreaming &&
-        !(queueWhileStreaming && (hasText || attachments.length > 0)) ? (
-          <button
-            type="button"
-            onClick={onStop}
-            aria-label="stop generating"
-            className={actionButtonClass}
-          >
-            <Square size={16} aria-hidden className="fill-black/90" />
-          </button>
-        ) : (
-          <button
-            type="button"
-            onClick={handleSubmit}
-            disabled={blocked}
-            aria-label={isStreaming ? 'queue message' : 'send message'}
-            className={actionButtonClass}
-          >
-            <ArrowUp size={20} aria-hidden />
-          </button>
-        )}
+          {/* ONE action button. Mid-stream the slot shows Stop, but the moment
+              the composer holds queueable content (text or attachments) it
+              flips to send — the editor advertises "queue a message…", and the
+              click must queue it, not kill the turn. */}
+          {isStreaming &&
+          !(queueWhileStreaming && (hasText || attachments.length > 0)) ? (
+            <button
+              type="button"
+              onClick={onStop}
+              aria-label="stop generating"
+              className={actionButtonClass}
+            >
+              <Square size={16} aria-hidden className="fill-black/90" />
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={blocked}
+              aria-label={isStreaming ? 'queue message' : 'send message'}
+              className={actionButtonClass}
+            >
+              <ArrowUp size={20} aria-hidden />
+            </button>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/console/web/src/components/chat/DirectoryPicker.tsx
+++ b/console/web/src/components/chat/DirectoryPicker.tsx
@@ -424,7 +424,10 @@ export function DirectoryPicker({
   }
 
   return (
-    <div ref={containerRef} className={cn('relative inline-flex', className)}>
+    <div
+      ref={containerRef}
+      className={cn('relative inline-flex min-w-0', className)}
+    >
       <button
         type="button"
         disabled={disabled}
@@ -434,13 +437,13 @@ export function DirectoryPicker({
         title={value ?? 'choose a working directory'}
         onClick={() => (open ? setOpen(false) : openPanel())}
         className={cn(
-          'inline-flex items-center gap-1 rounded-sm border border-rule px-2 py-1 text-[11px] lowercase transition-colors',
+          'inline-flex h-9 min-w-0 items-center gap-2 border border-rule bg-bg px-3 font-mono text-[13px] lowercase transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-ring',
           externalError ? 'text-warn' : value ? 'text-ink' : 'text-ink-faint',
-          'hover:text-ink disabled:opacity-50',
+          'hover:border-ink hover:text-ink disabled:opacity-50',
         )}
       >
-        <Folder size={12} aria-hidden />
-        <span className="max-w-[160px] truncate">{label}</span>
+        <Folder size={14} aria-hidden className="shrink-0" />
+        <span className="min-w-0 max-w-[160px] truncate">{label}</span>
       </button>
 
       {open ? (

--- a/console/web/src/components/chat/ModelPicker.tsx
+++ b/console/web/src/components/chat/ModelPicker.tsx
@@ -206,7 +206,7 @@ export function ModelPicker({
   }
 
   return (
-    <span className="inline-flex min-w-0 items-center gap-1">
+    <span className={cn('flex min-w-0 items-center gap-1', className)}>
       <DropdownMenuPrimitive.Root open={open} onOpenChange={handleOpenChange}>
         <DropdownMenuPrimitive.Trigger asChild disabled={pickerDisabled}>
           <button
@@ -220,13 +220,17 @@ export function ModelPicker({
             }
             aria-busy={loading || undefined}
             className={cn(
-              'inline-flex h-9 min-w-0 max-w-full items-center justify-between gap-x-2 border border-rule bg-bg px-3 font-mono text-[13px] lowercase text-ink transition-colors focus:border-ink focus:outline-none data-[state=open]:border-ink',
+              'flex h-9 min-w-0 flex-1 items-center justify-between gap-x-2 border border-rule bg-bg px-3 font-mono text-[13px] lowercase text-ink transition-colors focus:border-ink focus:outline-none data-[state=open]:border-ink',
               pickerDisabled && 'pointer-events-none opacity-40',
-              className,
             )}
           >
-            <span className="flex min-w-0 flex-1 items-baseline gap-1.5 truncate text-left">
-              <span className={cn('truncate', !selected && 'text-ink-faint')}>
+            <span className="flex min-w-0 flex-1 items-baseline gap-1.5 overflow-hidden whitespace-nowrap text-left">
+              <span
+                className={cn(
+                  'min-w-0 flex-1 truncate',
+                  !selected && 'text-ink-faint',
+                )}
+              >
                 {selected?.label ?? (loading ? 'loading…' : 'no models')}
               </span>
               {selectedEfforts.length > 1 && thinkingLevel !== 'default' ? (
@@ -415,7 +419,7 @@ export function ModelPicker({
           onClick={() => {
             void ctx.refreshModels()
           }}
-          className="p-1 text-ink-ghost transition-colors hover:text-ink disabled:opacity-50"
+          className="inline-flex size-9 shrink-0 items-center justify-center text-ink-ghost transition-colors hover:text-ink focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50"
         >
           <RefreshCw
             size={12}


### PR DESCRIPTION
## Summary

- keep the composer controls on one responsive toolbar row
- give the directory and model selectors consistent sizing and truncation behavior
- add Storybook coverage for a selected reasoning effort and working directory

## Why

The composer toolbar could wrap or crowd its action buttons when model and directory labels were long. The updated flex behavior preserves space for the attachment and submit controls while truncating variable-width labels cleanly.

## Validation

- `pnpm typecheck`
- `pnpm test` (997 tests)
- `pnpm exec biome check src/components/chat/Composer.stories.tsx src/components/chat/Composer.tsx src/components/chat/DirectoryPicker.tsx src/components/chat/ModelPicker.tsx`

Repo-wide `pnpm lint` still reports existing issues in unrelated files.
