### PR TITLE
(MOT-4014) fix: align context compaction with router output budget

### DIFF
--- a/context-manager/architecture/README.md
+++ b/context-manager/architecture/README.md
@@ -56,7 +56,7 @@ flowchart LR
     ports["ports: ModelResolver · Summarizer · LeaseStore · Clock"]
   end
   subgraph deps [Soft dependency]
-    router["llm-router: router::models::get, router::chat"]
+    router["llm-router: router::models::budget, router::chat"]
   end
   leases[("lease_dir: one file per lease")]
   cfg["configuration worker: schema + value"]
@@ -83,6 +83,6 @@ flowchart LR
 | **Summary anchor / round trip** | A prior summary passed back as `previous_summary`. The summariser *updates* it in place instead of starting over, so summaries converge instead of growing. The caller persists the summary; the worker never does. |
 | **`tail_start_index`** | Index into the **request** `messages` array where the verbatim tail begins (`null` = everything was summarised). The worker never sees storage ids; the caller maps this onto its own ids. |
 | **Compaction lease** | A `{ nonce, ts }` claim stored as a file under `lease_dir` (scope `context_lease`), keyed by `lease_key` (e.g. a session id) or a hash of the message set. Mutual exclusion so one logical history is summarised by one caller at a time; TTL-expiring so a crash never deadlocks it. |
-| **`model_resolved`** | How limits were obtained: `inline` (caller supplied), `router` (`router::models::get`), or `fallback` (conservative 8192/1024 default). Echoed so a silent fallback is detectable. |
+| **`model_resolved`** | How limits were obtained: `inline` (caller supplied), `router` (`router::models::budget`), or `fallback` (conservative 8192/1024 default). Echoed so a silent fallback is detectable. |
 | **Estimator** | The token counter behind a trait. v1 ships the `chars/4` heuristic for every model; responses report `estimator: "heuristic"` so a future per-model tokenizer is a visible swap. |
 | **`custom` message** | A `role: "custom"` transcript item (app-facing: UI markers, notices). It has no provider wire mapping, so `assemble` excludes it from the model-facing list and its token count — but `count-tokens` still counts what it is given. |

--- a/context-manager/architecture/integration.md
+++ b/context-manager/architecture/integration.md
@@ -47,7 +47,7 @@ Integration is always some subset of four moves:
 - **Model input**: functions that need limits take a `ModelInput`. Supply
   inline `limits` to stay fully standalone (no `llm-router` needed); supply
   only `id`/`provider` to have the worker resolve limits via
-  `router::models::get`. Resolution order: inline → router → conservative
+  `router::models::budget`. Resolution order: inline → router → conservative
   fallback (`8192`/`1024`); the response's `model_resolved` tells you which ran.
 - **Tokens are estimates.** v1 uses a `chars/4` heuristic for every model
   (`estimator: "heuristic"`). Treat `token_count`/`tokens` as approximate and
@@ -355,7 +355,7 @@ overflow` union, and persists `summary` + `tail_start_index` itself.
 |---|---|---|
 | `configuration` (required) | the worker's own runtime config: schema registration + the authoritative value, hot-reloaded on change | the worker **cannot boot** — `register`/`get` run at startup and a failure aborts it. Not a per-request dependency: once booted, `context::*` calls never touch it. |
 | local filesystem (`lease_dir`) | compaction leases only | a filesystem error makes `compact`/`assemble` treat the lease as busy → compaction is skipped (best effort); `count-tokens`/`prune` unaffected. |
-| `llm-router` (soft) | model-limit resolution (`router::models::get`) + the summariser (`router::chat`) | Limits fall back to `8192`/`1024` (`model_resolved: "fallback"`) unless you pass inline `limits`; `compact` returns `overflow`; `assemble` can prune but not summarise. |
+| `llm-router` (soft) | effective model-budget resolution (`router::models::budget`) + the summariser (`router::chat`) | Limits fall back to `8192`/`1024` (`model_resolved: "fallback"`) unless you pass inline `limits`; `compact` returns `overflow`; `assemble` can prune but not summarise. |
 
 The fully standalone *request* path — inline `limits` + `count-tokens`/`prune`,
 or `assemble` with compaction off — needs no `llm-router` and writes no lease

--- a/context-manager/architecture/internals.md
+++ b/context-manager/architecture/internals.md
@@ -31,7 +31,7 @@ in tests.
 | [src/core/selection.rs](../src/core/selection.rs) | Turn partitioning and token-aware verbatim-tail selection with the safe-cut invariant. |
 | [src/core/summary.rs](../src/core/summary.rs) | Summariser prompt construction (template, previous-summary anchoring), `strip_media`, and the `# Conversation summary` system-prompt rendering. |
 | [src/core/lease.rs](../src/core/lease.rs) | Compaction lease acquire/release protocol + the default sha256 lease key. |
-| [src/adapters/router.rs](../src/adapters/router.rs) | `RouterModelResolver` (`router::models::get`) and `RouterSummarizer` (`router::chat` over an SDK channel). |
+| [src/adapters/router.rs](../src/adapters/router.rs) | `RouterModelResolver` (`router::models::budget`) and `RouterSummarizer` (`router::chat` over an SDK channel). |
 | [src/adapters/fs_lease.rs](../src/adapters/fs_lease.rs) | `FsLeaseStore`: one JSON file per lease key under `lease_dir/<scope>/`, a process-local `Mutex` cache, and atomic `tmp + rename` writes (session-manager's `FsStore` strategy). |
 | [tests/](../tests) | Cucumber BDD (`tests/bdd.rs`, `harness = false`) + schema goldens + manifest subprocess test. See §13. |
 
@@ -331,7 +331,7 @@ The four ports in [ports.rs](../src/ports.rs), production adapters in
 
 | Port | Production adapter | Backed by | Failure posture |
 |---|---|---|---|
-| `ModelResolver` | `RouterModelResolver` | `router::models::get` (5s timeout) | `Ok(None)` = router up but model unknown; `Err` = router absent/unreachable. Both → fallback when allowed. |
+| `ModelResolver` | `RouterModelResolver` | `router::models::budget` (5s timeout; `models::get` compatibility fallback) | `Ok(None)` = router up but model unknown; `Err` = router absent/unreachable. Both → fallback when allowed. |
 | `Summarizer` | `RouterSummarizer` | `router::chat` over an SDK channel | `Unavailable` (router not routable) vs `Failed` (provider/stream error) vs `Empty`. |
 | `LeaseStore` | `FsLeaseStore` | one JSON file per key under `lease_dir` (atomic `tmp + rename`; process-local `Mutex` for `swap`) | Errors surface as busy via `core::lease`. |
 | `Clock` | `SystemClock` | wall clock (ms since epoch) | — |
@@ -367,7 +367,7 @@ I/O is synchronous and never crosses an `.await` while the guard is held.
 
 1. `input.limits` present → `ResolvedModel::from_inline` (`model_resolved:
    "inline"`); no router call. This is the standalone path.
-2. else `router::models::get(provider, id)`:
+2. else `router::models::budget(provider, id)`:
    - `Ok(Some(model))` → `from_router` (`"router"`), carrying the model's
      `thinking_budgets`.
    - `Ok(None)` (unknown) or `Err` (router down/absent) → fall through.

--- a/context-manager/src/adapters/router.rs
+++ b/context-manager/src/adapters/router.rs
@@ -1,5 +1,5 @@
 //! `llm-router` adapters: model-limit resolution via
-//! `router::models::get` and the summariser via `router::chat`.
+//! `router::models::budget` and the summariser via `router::chat`.
 //!
 //! Both are soft dependencies — when the router is absent the resolver
 //! errors (callers degrade to the conservative fallback) and the
@@ -17,7 +17,7 @@ use iii_sdk::IIIClient;
 use serde_json::{json, Value};
 
 use crate::configuration::ConfigCell;
-use crate::ports::{ModelResolver, SummarizeError, SummarizeRequest, Summarizer};
+use crate::ports::{ModelBudget, ModelResolver, SummarizeError, SummarizeRequest, Summarizer};
 use crate::types::Model;
 
 const MODELS_GET_TIMEOUT_MS: u64 = 5_000;
@@ -31,7 +31,7 @@ fn is_unroutable(err: &Error) -> bool {
     msg.contains("function_not_found") || msg.contains("not found") || msg.contains("no function")
 }
 
-/// `router::models::get` — `{ model: Model } | null`.
+/// `router::models::budget` — `{ model, effective_max_output_tokens } | null`.
 pub struct RouterModelResolver {
     iii: Arc<IIIClient>,
 }
@@ -44,21 +44,60 @@ impl RouterModelResolver {
 
 #[async_trait]
 impl ModelResolver for RouterModelResolver {
-    async fn get_model(&self, provider: Option<&str>, id: &str) -> Result<Option<Model>, String> {
+    async fn get_model_budget(
+        &self,
+        provider: Option<&str>,
+        id: &str,
+    ) -> Result<Option<ModelBudget>, String> {
         let mut payload = json!({ "id": id });
         if let Some(p) = provider {
             payload["provider"] = json!(p);
         }
-        let resp = self
+        let resp = match self
             .iii
             .trigger(TriggerRequest {
-                function_id: "router::models::get".to_string(),
-                payload,
+                function_id: "router::models::budget".to_string(),
+                payload: payload.clone(),
                 action: None,
                 timeout_ms: Some(MODELS_GET_TIMEOUT_MS),
             })
             .await
-            .map_err(|e| e.to_string())?;
+        {
+            Ok(resp) => resp,
+            Err(err) if is_unroutable(&err) => {
+                // Rolling upgrades may briefly run a context-manager newer than
+                // the router. Preserve the former, conservative behavior until
+                // `models::budget` is registered instead of dropping all the way
+                // to the 8k fallback model.
+                let response = self
+                    .iii
+                    .trigger(TriggerRequest {
+                        function_id: "router::models::get".to_string(),
+                        payload,
+                        action: None,
+                        timeout_ms: Some(MODELS_GET_TIMEOUT_MS),
+                    })
+                    .await
+                    .map_err(|e| e.to_string())?;
+                if response.is_null() {
+                    return Ok(None);
+                }
+                let model = response.get("model").cloned().ok_or_else(|| {
+                    "router::models::get response has no `model` field".to_string()
+                })?;
+                if model.is_null() {
+                    return Ok(None);
+                }
+                let model = serde_json::from_value::<Model>(model).map_err(|e| {
+                    format!("router::models::get returned an unparseable model: {e}")
+                })?;
+                return Ok(Some(ModelBudget {
+                    effective_max_output_tokens: model.max_output_tokens,
+                    model,
+                }));
+            }
+            Err(err) => return Err(err.to_string()),
+        };
 
         if resp.is_null() {
             return Ok(None);
@@ -66,13 +105,25 @@ impl ModelResolver for RouterModelResolver {
         let model = resp
             .get("model")
             .cloned()
-            .ok_or_else(|| "router::models::get response has no `model` field".to_string())?;
+            .ok_or_else(|| "router::models::budget response has no `model` field".to_string())?;
         if model.is_null() {
             return Ok(None);
         }
+        let effective_max_output_tokens = resp
+            .get("effective_max_output_tokens")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| {
+                "router::models::budget response has no `effective_max_output_tokens` field"
+                    .to_string()
+            })?;
         serde_json::from_value::<Model>(model)
-            .map(Some)
-            .map_err(|e| format!("router::models::get returned an unparseable model: {e}"))
+            .map(|model| {
+                Some(ModelBudget {
+                    model,
+                    effective_max_output_tokens,
+                })
+            })
+            .map_err(|e| format!("router::models::budget returned an unparseable model: {e}"))
     }
 }
 

--- a/context-manager/src/core/budget.rs
+++ b/context-manager/src/core/budget.rs
@@ -66,11 +66,11 @@ impl ResolvedModel {
         }
     }
 
-    pub fn from_router(model: &Model) -> Self {
+    pub fn from_router(model: &Model, effective_max_output_tokens: u64) -> Self {
         Self {
             limits: ModelLimits {
                 context_window: model.context_window,
-                max_output_tokens: model.max_output_tokens,
+                max_output_tokens: effective_max_output_tokens.min(model.max_output_tokens),
                 input_limit: model.input_limit,
             },
             thinking_budgets: model.thinking_budgets.clone(),
@@ -184,6 +184,25 @@ mod tests {
         assert_eq!(f.limits.context_window, 8_192);
         assert_eq!(f.limits.max_output_tokens, 1_024);
         assert_eq!(f.resolved, ModelResolved::Fallback);
+    }
+
+    #[test]
+    fn router_effective_output_cap_prevents_premature_compaction() {
+        let model = Model {
+            id: "gpt-5.4".to_string(),
+            provider: "codex".to_string(),
+            context_window: 272_000,
+            max_output_tokens: 128_000,
+            input_limit: None,
+            thinking_budgets: None,
+        };
+
+        // The model accepts up to 128k output, but the router's configured
+        // request cap is 32k. Context assembly must reserve the amount the
+        // router will actually request, not the catalog ceiling.
+        let resolved = ResolvedModel::from_router(&model, 32_000);
+        assert_eq!(resolved.limits.max_output_tokens, 32_000);
+        assert_eq!(usable(&resolved.limits, 20_000, 0), 220_000);
     }
 
     #[test]

--- a/context-manager/src/functions/assemble.rs
+++ b/context-manager/src/functions/assemble.rs
@@ -89,6 +89,9 @@ pub enum ModelResolvedWire {
 /// What the pipeline actually did this call.
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct Applied {
+    /// Full estimated request size before pruning or compaction, including the
+    /// system prompt, tool schemas, and provider framing overhead.
+    pub initial_token_count: u64,
     pub pruned: bool,
     pub pruned_tokens: u64,
     pub compacted: bool,
@@ -103,6 +106,10 @@ pub struct Applied {
     /// Present when compacted: estimated tokens of the summarised head.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tokens_before: Option<u64>,
+    /// Unambiguous alias for `tokens_before`; retained separately so callers
+    /// do not mistake the summarised head for the full pre-compaction request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summarized_head_tokens: Option<u64>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -115,6 +122,9 @@ pub struct AssembleResponse {
     pub token_count: u64,
     /// The budget the context was fit into.
     pub usable: u64,
+    /// Effective output allocation used to derive `usable`. This is the
+    /// router-resolved request limit, not the model catalog ceiling.
+    pub effective_max_output_tokens: u64,
     pub model_resolved: ModelResolvedWire,
     pub applied: Applied,
 }
@@ -175,16 +185,19 @@ pub async fn handle(deps: &Deps, req: AssembleRequest) -> Result<AssembleRespons
         count_context(messages, prompt, tools, request_overhead_tokens, estimator)
     };
 
+    let initial_token_count = count(&working, &system_prompt);
     let mut applied = Applied {
+        initial_token_count,
         pruned: false,
         pruned_tokens: 0,
         compacted: false,
         summary: None,
         tail_start_index: None,
         tokens_before: None,
+        summarized_head_tokens: None,
     };
 
-    let mut token_count = count(&working, &system_prompt);
+    let mut token_count = initial_token_count;
 
     // Step 1: prune function outputs.
     if token_count > usable_budget && options.allow_prune.unwrap_or(true) {
@@ -227,6 +240,7 @@ pub async fn handle(deps: &Deps, req: AssembleRequest) -> Result<AssembleRespons
             applied.compacted = true;
             applied.tail_start_index = Some(compaction.tail_start_view.map(|v| view_to_orig[v]));
             applied.tokens_before = Some(compaction.tokens_before);
+            applied.summarized_head_tokens = Some(compaction.tokens_before);
             applied.summary = Some(compaction.summary);
             token_count = count(&working, &system_prompt);
         }
@@ -260,6 +274,7 @@ pub async fn handle(deps: &Deps, req: AssembleRequest) -> Result<AssembleRespons
         messages: working,
         token_count,
         usable: usable_budget,
+        effective_max_output_tokens: resolved.limits.max_output_tokens,
         model_resolved: match resolved.resolved {
             crate::core::budget::ModelResolved::Inline => ModelResolvedWire::Inline,
             crate::core::budget::ModelResolved::Router => ModelResolvedWire::Router,

--- a/context-manager/src/functions/mod.rs
+++ b/context-manager/src/functions/mod.rs
@@ -47,7 +47,7 @@ pub const COUNT_TOKENS_DESC: &str =
      prompt) vs a model.";
 
 /// Resolve model limits per the spec order: inline `limits` ->
-/// `router::models::get` -> conservative fallback (when allowed).
+/// `router::models::budget` -> conservative fallback (when allowed).
 pub(crate) async fn resolve_model(
     deps: &Deps,
     input: &ModelInput,
@@ -57,10 +57,15 @@ pub(crate) async fn resolve_model(
     }
     let reason = match deps
         .resolver
-        .get_model(input.provider.as_deref(), &input.id)
+        .get_model_budget(input.provider.as_deref(), &input.id)
         .await
     {
-        Ok(Some(model)) => return Ok(ResolvedModel::from_router(&model)),
+        Ok(Some(budget)) => {
+            return Ok(ResolvedModel::from_router(
+                &budget.model,
+                budget.effective_max_output_tokens,
+            ))
+        }
         Ok(None) => format!("model {} is not in the router catalog", input.id),
         Err(e) => format!("router unavailable: {e}"),
     };

--- a/context-manager/src/main.rs
+++ b/context-manager/src/main.rs
@@ -10,7 +10,7 @@
 //!      `configuration` is a required boot dependency: a failed
 //!      register/fetch aborts startup.
 //!   4. Wire production adapters behind the ports: model limits via
-//!      `router::models::get` and the summariser via `router::chat`
+//!      `router::models::budget` and the summariser via `router::chat`
 //!      (both soft — only compaction degrades without `llm-router`), plus
 //!      compaction leases on the local filesystem (`lease_dir`). The
 //!      summariser reads `summarizer_timeout_ms` from the live snapshot per

--- a/context-manager/src/ports.rs
+++ b/context-manager/src/ports.rs
@@ -15,13 +15,23 @@ use crate::config::WorkerConfig;
 use crate::configuration::ConfigCell;
 use crate::types::Model;
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModelBudget {
+    pub model: Model,
+    pub effective_max_output_tokens: u64,
+}
+
 /// Resolves a model id to its router catalog record.
 #[async_trait]
 pub trait ModelResolver: Send + Sync {
     /// `Ok(None)` when the router is installed but does not know the
     /// model; `Err` when the router is unreachable or absent. Both
     /// degrade to the conservative fallback (when allowed).
-    async fn get_model(&self, provider: Option<&str>, id: &str) -> Result<Option<Model>, String>;
+    async fn get_model_budget(
+        &self,
+        provider: Option<&str>,
+        id: &str,
+    ) -> Result<Option<ModelBudget>, String>;
 }
 
 /// One summariser call. The core renders the prompts (template,

--- a/context-manager/src/types.rs
+++ b/context-manager/src/types.rs
@@ -226,7 +226,7 @@ pub struct ModelLimits {
 
 /// How callers identify the target model (context-manager.md § Model
 /// input). Inline `limits` keep the call standalone; `id`/`provider`
-/// alone defer limit resolution to `router::models::get`.
+/// alone defer limit resolution to `router::models::budget`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ModelInput {
     /// Model id, e.g. `claude-sonnet-4`.

--- a/context-manager/tests/common/fakes.rs
+++ b/context-manager/tests/common/fakes.rs
@@ -12,7 +12,8 @@ use std::sync::Mutex;
 use async_trait::async_trait;
 
 use context_manager::ports::{
-    Clock, LeaseRecord, LeaseStore, ModelResolver, SummarizeError, SummarizeRequest, Summarizer,
+    Clock, LeaseRecord, LeaseStore, ModelBudget, ModelResolver, SummarizeError, SummarizeRequest,
+    Summarizer,
 };
 use context_manager::types::Model;
 
@@ -79,7 +80,11 @@ impl FakeModelResolver {
 
 #[async_trait]
 impl ModelResolver for FakeModelResolver {
-    async fn get_model(&self, provider: Option<&str>, id: &str) -> Result<Option<Model>, String> {
+    async fn get_model_budget(
+        &self,
+        provider: Option<&str>,
+        id: &str,
+    ) -> Result<Option<ModelBudget>, String> {
         self.calls
             .lock()
             .unwrap_or_else(|poison| poison.into_inner())
@@ -92,7 +97,11 @@ impl ModelResolver for FakeModelResolver {
             .lock()
             .unwrap_or_else(|poison| poison.into_inner())
             .get(id)
-            .cloned())
+            .cloned()
+            .map(|model| ModelBudget {
+                effective_max_output_tokens: model.max_output_tokens,
+                model,
+            }))
     }
 }
 

--- a/context-manager/tests/golden/schemas/context.assemble.json
+++ b/context-manager/tests/golden/schemas/context.assemble.json
@@ -478,7 +478,7 @@
         "type": "string"
       },
       "ModelInput": {
-        "description": "How callers identify the target model (context-manager.md § Model input). Inline `limits` keep the call standalone; `id`/`provider` alone defer limit resolution to `router::models::get`.",
+        "description": "How callers identify the target model (context-manager.md § Model input). Inline `limits` keep the call standalone; `id`/`provider` alone defer limit resolution to `router::models::budget`.",
         "properties": {
           "id": {
             "description": "Model id, e.g. `claude-sonnet-4`.",
@@ -872,6 +872,12 @@
           "compacted": {
             "type": "boolean"
           },
+          "initial_token_count": {
+            "description": "Full estimated request size before pruning or compaction, including the system prompt, tool schemas, and provider framing overhead.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
           "pruned": {
             "type": "boolean"
           },
@@ -879,6 +885,15 @@
             "format": "uint64",
             "minimum": 0.0,
             "type": "integer"
+          },
+          "summarized_head_tokens": {
+            "description": "Unambiguous alias for `tokens_before`; retained separately so callers do not mistake the summarised head for the full pre-compaction request.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
           },
           "summary": {
             "description": "Present when compacted; the caller should persist it and pass it back as `options.previous_summary` (compaction round trip).",
@@ -908,6 +923,7 @@
         },
         "required": [
           "compacted",
+          "initial_token_count",
           "pruned",
           "pruned_tokens"
         ],
@@ -1132,6 +1148,12 @@
       "applied": {
         "$ref": "#/definitions/Applied"
       },
+      "effective_max_output_tokens": {
+        "description": "Effective output allocation used to derive `usable`. This is the router-resolved request limit, not the model catalog ceiling.",
+        "format": "uint64",
+        "minimum": 0.0,
+        "type": "integer"
+      },
       "messages": {
         "description": "Budgeted, ready to send to llm-router.",
         "items": {
@@ -1160,6 +1182,7 @@
     },
     "required": [
       "applied",
+      "effective_max_output_tokens",
       "messages",
       "model_resolved",
       "system_prompt",

--- a/context-manager/tests/golden/schemas/context.compact.json
+++ b/context-manager/tests/golden/schemas/context.compact.json
@@ -385,7 +385,7 @@
         "type": "string"
       },
       "ModelInput": {
-        "description": "How callers identify the target model (context-manager.md § Model input). Inline `limits` keep the call standalone; `id`/`provider` alone defer limit resolution to `router::models::get`.",
+        "description": "How callers identify the target model (context-manager.md § Model input). Inline `limits` keep the call standalone; `id`/`provider` alone defer limit resolution to `router::models::budget`.",
         "properties": {
           "id": {
             "description": "Model id, e.g. `claude-sonnet-4`.",

--- a/context-manager/tests/golden/schemas/context.count-tokens.json
+++ b/context-manager/tests/golden/schemas/context.count-tokens.json
@@ -388,7 +388,7 @@
         "type": "string"
       },
       "ModelInput": {
-        "description": "How callers identify the target model (context-manager.md § Model input). Inline `limits` keep the call standalone; `id`/`provider` alone defer limit resolution to `router::models::get`.",
+        "description": "How callers identify the target model (context-manager.md § Model input). Inline `limits` keep the call standalone; `id`/`provider` alone defer limit resolution to `router::models::budget`.",
         "properties": {
           "id": {
             "description": "Model id, e.g. `claude-sonnet-4`.",

--- a/context-manager/tests/golden/schemas/context.prune.json
+++ b/context-manager/tests/golden/schemas/context.prune.json
@@ -344,7 +344,7 @@
         "type": "string"
       },
       "ModelInput": {
-        "description": "How callers identify the target model (context-manager.md § Model input). Inline `limits` keep the call standalone; `id`/`provider` alone defer limit resolution to `router::models::get`.",
+        "description": "How callers identify the target model (context-manager.md § Model input). Inline `limits` keep the call standalone; `id`/`provider` alone defer limit resolution to `router::models::budget`.",
         "properties": {
           "id": {
             "description": "Model id, e.g. `claude-sonnet-4`.",

--- a/harness/src/clients/context.rs
+++ b/harness/src/clients/context.rs
@@ -20,12 +20,15 @@ pub struct AssembleOutput {
     pub messages: Vec<AgentMessage>,
     pub token_count: u64,
     pub usable: u64,
+    pub effective_max_output_tokens: u64,
     #[serde(default)]
     pub applied: Applied,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct Applied {
+    #[serde(default)]
+    pub initial_token_count: u64,
     #[serde(default)]
     pub compacted: bool,
     #[serde(default)]
@@ -34,6 +37,8 @@ pub struct Applied {
     pub tail_start_index: Option<i64>,
     #[serde(default)]
     pub tokens_before: Option<u64>,
+    #[serde(default)]
+    pub summarized_head_tokens: Option<u64>,
 }
 
 pub struct AssembleParams {

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -1645,6 +1645,11 @@ async fn assemble_context(
                 "summary": summary,
                 "tail_start_entry_id": tail_entry,
                 "tokens_before": out.applied.tokens_before,
+                "summarized_head_tokens": out.applied.summarized_head_tokens,
+                "initial_token_count": out.applied.initial_token_count,
+                "assembled_token_count": out.token_count,
+                "usable_input_tokens": out.usable,
+                "effective_max_output_tokens": out.effective_max_output_tokens,
             });
             let _ = session
                 .append_custom(

--- a/iii-permissions.yaml
+++ b/iii-permissions.yaml
@@ -158,6 +158,7 @@ rules:
   - state::list
   - router::models::list
   - router::models::get
+  - router::models::budget
   - router::models::supports
   - router::provider::list
   # harness::status is read-only (current turn status for a session).

--- a/llm-router/src/catalog/handlers.rs
+++ b/llm-router/src/catalog/handlers.rs
@@ -7,8 +7,13 @@ use futures::future::BoxFuture;
 use iii_sdk::errors::Error;
 
 use crate::types::router::{
-    ModelGetRequest, ModelGetResponse, ModelsListRequest, ModelsListResponse,
-    ModelsSupportsRequest, ModelsSupportsResponse,
+    ModelBudgetRequest, ModelBudgetResponse, ModelGetRequest, ModelGetResponse, ModelsListRequest,
+    ModelsListResponse, ModelsSupportsRequest, ModelsSupportsResponse,
+};
+use crate::{
+    chat::output_tokens::resolve_max_output_tokens,
+    config::state::{snapshot, ConfigCell},
+    registry::store::RegistryStore,
 };
 
 use super::queries::{models_get, models_list, models_supports};
@@ -45,6 +50,48 @@ pub fn make_models_get(
             let model = models_get(&catalog, provider, &req.id).await;
             // null when unregistered (the cold-window signal)
             Ok(model.map(|model| ModelGetResponse { model }))
+        })
+    }
+}
+
+pub fn make_models_budget(
+    catalog: Arc<CatalogStore>,
+    registry: Arc<RegistryStore>,
+    config: ConfigCell,
+) -> impl Fn(ModelBudgetRequest) -> BoxFuture<'static, Result<Option<ModelBudgetResponse>, Error>>
+       + Send
+       + Sync
+       + 'static {
+    move |req: ModelBudgetRequest| {
+        let (catalog, registry, config) = (catalog.clone(), registry.clone(), config.clone());
+        Box::pin(async move {
+            let provider = (!req.provider.is_empty()).then_some(req.provider.as_str());
+            let Some(model) = models_get(&catalog, provider, &req.id).await else {
+                return Ok(None);
+            };
+            let Some(record) = registry.get(&model.provider).await else {
+                return Ok(None);
+            };
+            let config = snapshot(&config);
+            let effective_max_output_tokens = resolve_max_output_tokens(
+                req.max_output_tokens,
+                config
+                    .provider_slice(&model.provider)
+                    .and_then(|slice| slice.get("max_tokens"))
+                    .and_then(serde_json::Value::as_u64),
+                Some(model.max_output_tokens),
+                record
+                    .declaration
+                    .defaults
+                    .as_ref()
+                    .and_then(|defaults| defaults.max_tokens)
+                    .unwrap_or(8192),
+                config.settings().output_token_max,
+            );
+            Ok(Some(ModelBudgetResponse {
+                model,
+                effective_max_output_tokens,
+            }))
         })
     }
 }

--- a/llm-router/src/register.rs
+++ b/llm-router/src/register.rs
@@ -15,7 +15,9 @@ use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
 use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::{json, Value};
 
-use crate::catalog::handlers::{make_models_get, make_models_list, make_models_supports};
+use crate::catalog::handlers::{
+    make_models_budget, make_models_get, make_models_list, make_models_supports,
+};
 use crate::catalog::reconcile::make_models_reconcile;
 use crate::catalog::store::CatalogStore;
 use crate::channels::open_sink;
@@ -131,6 +133,16 @@ pub async fn register_router(iii: IIIClient) -> Result<RouterRefs, Error> {
         surface::MODELS_GET_ID,
         RegisterFunction::new_async(make_models_get(catalog.clone()))
             .description(surface::MODELS_GET_DESC),
+    );
+    iii.register_function(
+        surface::MODELS_BUDGET_ID,
+        RegisterFunction::new_async(make_models_budget(
+            catalog.clone(),
+            registry.clone(),
+            config.clone(),
+        ))
+        .description(surface::MODELS_BUDGET_DESC)
+        .metadata(internal_meta()),
     );
     iii.register_function(
         surface::MODELS_SUPPORTS_ID,

--- a/llm-router/src/surface.rs
+++ b/llm-router/src/surface.rs
@@ -13,12 +13,12 @@
 use crate::chat::chat::{ChatCall, ChatFnInput};
 use crate::types::router::{
     AbortRequest, AbortResponse, ChatResponse, CompleteResponse, ConfigChangedEvent,
-    ModelGetRequest, ModelGetResponse, ModelsListRequest, ModelsListResponse,
-    ModelsReconcileRequest, ModelsReconcileResponse, ModelsSupportsRequest, ModelsSupportsResponse,
-    ProviderListRequest, ProviderListResponse, ProviderRegisterRequest, ProviderRegisterResponse,
-    ProviderResolveRequest, ProviderResolveResponse, RouteRequest, RouteResponse, RouterAck,
-    SystemPromptGetRequest, SystemPromptGetResponse, UpdateCredentialRequest,
-    UpdateCredentialResponse,
+    ModelBudgetRequest, ModelBudgetResponse, ModelGetRequest, ModelGetResponse, ModelsListRequest,
+    ModelsListResponse, ModelsReconcileRequest, ModelsReconcileResponse, ModelsSupportsRequest,
+    ModelsSupportsResponse, ProviderListRequest, ProviderListResponse, ProviderRegisterRequest,
+    ProviderRegisterResponse, ProviderResolveRequest, ProviderResolveResponse, RouteRequest,
+    RouteResponse, RouterAck, SystemPromptGetRequest, SystemPromptGetResponse,
+    UpdateCredentialRequest, UpdateCredentialResponse,
 };
 
 // ── function id + description constants — consumed by both register_router and
@@ -44,6 +44,10 @@ pub const MODELS_LIST_DESC: &str =
 pub const MODELS_GET_ID: &str = "router::models::get";
 pub const MODELS_GET_DESC: &str =
     "Read one catalog model by {provider, id}; null when the model is not registered.";
+
+pub const MODELS_BUDGET_ID: &str = "router::models::budget";
+pub const MODELS_BUDGET_DESC: &str =
+    "Resolve the effective model output budget using the same precedence as router::chat.";
 
 pub const MODELS_SUPPORTS_ID: &str = "router::models::supports";
 pub const MODELS_SUPPORTS_DESC: &str =
@@ -120,6 +124,10 @@ pub fn catalog() -> Vec<FunctionSpec> {
         spec::<AbortRequest, AbortResponse>(ABORT_ID, ABORT_DESC),
         spec::<ModelsListRequest, ModelsListResponse>(MODELS_LIST_ID, MODELS_LIST_DESC),
         spec::<ModelGetRequest, Option<ModelGetResponse>>(MODELS_GET_ID, MODELS_GET_DESC),
+        spec::<ModelBudgetRequest, Option<ModelBudgetResponse>>(
+            MODELS_BUDGET_ID,
+            MODELS_BUDGET_DESC,
+        ),
         spec::<ModelsSupportsRequest, ModelsSupportsResponse>(
             MODELS_SUPPORTS_ID,
             MODELS_SUPPORTS_DESC,

--- a/llm-router/src/types/router.rs
+++ b/llm-router/src/types/router.rs
@@ -309,6 +309,28 @@ pub struct ModelGetResponse {
     pub model: Model,
 }
 
+/// Input of `router::models::budget`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ModelBudgetRequest {
+    /// Provider id that owns the model. Empty resolves an unambiguous model id.
+    #[serde(default)]
+    pub provider: String,
+    /// Model id to budget.
+    #[serde(default)]
+    pub id: String,
+    /// Optional caller-requested output budget. When absent, the same provider
+    /// and router defaults used by `router::chat` apply.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_output_tokens: Option<u64>,
+}
+
+/// Effective limits `router::chat` will use for this model and request.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ModelBudgetResponse {
+    pub model: Model,
+    pub effective_max_output_tokens: u64,
+}
+
 /// Input of `router::models::supports`.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ModelsSupportsRequest {

--- a/llm-router/tests/golden/schemas/router.models.budget.json
+++ b/llm-router/tests/golden/schemas/router.models.budget.json
@@ -1,0 +1,222 @@
+{
+  "description": "Resolve the effective model output budget using the same precedence as router::chat.",
+  "function_id": "router::models::budget",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Input of `router::models::budget`.",
+    "properties": {
+      "id": {
+        "default": "",
+        "description": "Model id to budget.",
+        "type": "string"
+      },
+      "max_output_tokens": {
+        "description": "Optional caller-requested output budget. When absent, the same provider and router defaults used by `router::chat` apply.",
+        "format": "uint64",
+        "minimum": 0.0,
+        "type": [
+          "integer",
+          "null"
+        ]
+      },
+      "provider": {
+        "default": "",
+        "description": "Provider id that owns the model. Empty resolves an unambiguous model id.",
+        "type": "string"
+      }
+    },
+    "title": "ModelBudgetRequest",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/ModelBudgetResponse"
+      },
+      {
+        "type": "null"
+      }
+    ],
+    "definitions": {
+      "Model": {
+        "description": "The capability record (README § Model descriptor).",
+        "properties": {
+          "context_window": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "display_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "input_limit": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "max_output_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "pricing": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Pricing"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "provider": {
+            "type": "string"
+          },
+          "reasoning_efforts": {
+            "items": {
+              "$ref": "#/definitions/ReasoningEffort"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "supports_cache": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "supports_structured_output": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "supports_thinking": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "supports_tools": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "supports_vision": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "supports_xhigh": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "thinking_budgets": {
+            "additionalProperties": {
+              "format": "uint64",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "context_window",
+          "id",
+          "max_output_tokens",
+          "provider"
+        ],
+        "type": "object"
+      },
+      "ModelBudgetResponse": {
+        "description": "Effective limits `router::chat` will use for this model and request.",
+        "properties": {
+          "effective_max_output_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "model": {
+            "$ref": "#/definitions/Model"
+          }
+        },
+        "required": [
+          "effective_max_output_tokens",
+          "model"
+        ],
+        "type": "object"
+      },
+      "Pricing": {
+        "properties": {
+          "cache_read": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "cache_write": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "input": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "output": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "ReasoningEffort": {
+        "description": "One provider-native reasoning effort advertised for a specific model.\n\nValues intentionally remain strings: provider catalogs can add efforts without requiring a router-wide enum release first.",
+        "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "effort": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "effort"
+        ],
+        "type": "object"
+      }
+    },
+    "title": "Nullable_ModelBudgetResponse"
+  }
+}

--- a/llm-router/tests/integration.rs
+++ b/llm-router/tests/integration.rs
@@ -865,6 +865,15 @@ async fn paste_a_key_kicks_debounced_discovery_and_models_land() {
     .await
     .unwrap();
     assert_eq!(got["model"]["id"], "disc-1");
+    let budget = call(
+        &router_iii,
+        "router::models::budget",
+        json!({ "provider": "real", "id": "disc-1" }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(budget["model"]["id"], "disc-1");
+    assert_eq!(budget["effective_max_output_tokens"], 8192);
     let sup = call(
         &router_iii,
         "router::models::supports",

--- a/llm-router/tests/schemas.rs
+++ b/llm-router/tests/schemas.rs
@@ -32,7 +32,7 @@ fn spec_to_pretty_json(spec: &FunctionSpec) -> String {
     pretty
 }
 
-/// The catalog must cover exactly the 14 registered functions, in registration
+/// The catalog must cover exactly the 15 registered functions, in registration
 /// order (kept in lockstep with `register::register_router`).
 #[test]
 fn catalog_lists_all_functions_in_registration_order() {
@@ -45,6 +45,7 @@ fn catalog_lists_all_functions_in_registration_order() {
             "router::abort",
             "router::models::list",
             "router::models::get",
+            "router::models::budget",
             "router::models::supports",
             "router::provider::list",
             "router::system_prompt::get",


### PR DESCRIPTION
## Problem

Context assembly reserves the model catalog's maximum output ceiling even when the router will request a smaller effective output allocation. This unnecessarily reduces the usable input budget and can trigger premature compaction for any provider or model whose effective router allocation differs from its catalog ceiling.

## Solution

- add the provider-agnostic `router::models::budget` contract, backed by the same output-token precedence used by `router::chat`
- resolve context-manager limits from the router's effective output allocation, with compatibility fallback during rolling upgrades
- expose full initial size, summarized-head size, assembled size, usable input, and effective output allocation in compaction records
- update schemas and architecture documentation for the new contract

## Impact

Sessions across registered providers and models can use their available input capacity without premature compaction while retaining the existing hard over-budget protection. The effective budget accounts for provider configuration, model ceilings, provider defaults, router limits, and model-specific input limits.

## Validation

- `context-manager`: unit, BDD, integration, manifest, and schema tests
- `llm-router`: unit, live-engine integration, and schema tests
- `harness`: unit, manifest, and schema tests
- formatting and diff validation

Refs MOT-4014


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model budget resolution, including effective output-token limits.
  * Context assembly responses now report effective output limits and additional token-count details.
  * Compaction telemetry now includes expanded token-budget measurements.
  * Added permission support for model budget inspection.

* **Bug Fixes**
  * Model budgeting now respects router-configured output caps.
  * Improved compatibility when token-accounting fields are missing from older responses.

* **Documentation**
  * Updated architecture and integration documentation to reflect the new model budget resolution flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->