### PR TITLE
fix: save selected view in configuration

### DIFF
--- a/console/src/configuration.rs
+++ b/console/src/configuration.rs
@@ -45,6 +45,10 @@ fn schema() -> Value {
                             "required": ["id", "name"],
                             "additionalProperties": true
                         }
+                    },
+                    "activeViewId": {
+                        "type": ["string", "null"],
+                        "description": "Id of the selected view; null = the unfiltered all-traces list. When absent the UI selects the seeded sessions view."
                     }
                 },
                 "additionalProperties": true
@@ -58,9 +62,9 @@ fn schema() -> Value {
 /// configured.
 ///
 /// - `views`: `view-sessions` groups traces by session and labels rows with
-///   the tag message; the frontend selects it by default in browsers that
-///   never made an explicit view choice (`DEFAULT_VIEW_ID` in web
-///   tracesViews.ts — keep the id in sync).
+///   the tag message; `activeViewId` selects it out of the box, and the
+///   frontend falls back to the same id when the pointer is absent
+///   (`DEFAULT_VIEW_ID` in web tracesViews.ts — keep the id in sync).
 /// - `spanFilters`: detail-view funnel defaults — hide the chatty
 ///   `harness::send` span group and the session/context bookkeeping workers.
 fn default_value() -> Value {
@@ -74,6 +78,7 @@ fn default_value() -> Value {
                 "label": { "mode": "attribute", "attribute": "iii.tag.message" },
                 "filters": {}
             }],
+            "activeViewId": "view-sessions",
             "spanFilters": {
                 "hiddenGroups": ["harness::send"],
                 "hiddenWorkers": ["context-manager", "session-manager"]
@@ -103,7 +108,8 @@ pub async fn register_console_config(iii: &IIIClient) {
         "id": CONFIG_ID,
         "name": "Console",
         "description": "Console UI preferences — Traces V2 saved views \
-                        (grouping, filters, display settings, hidden functions).",
+                        (grouping, filters, display settings, hidden functions) \
+                        and the selected view.",
         "schema": schema(),
     });
     if seed {

--- a/console/src/configuration.rs
+++ b/console/src/configuration.rs
@@ -49,6 +49,10 @@ fn schema() -> Value {
                     "activeViewId": {
                         "type": ["string", "null"],
                         "description": "Id of the selected view; null = the unfiltered all-traces list. When absent the UI selects the seeded sessions view."
+                    },
+                    "followTurns": {
+                        "type": "boolean",
+                        "description": "Auto-open the trace of the active chat's live turn. When absent the UI defaults to on."
                     }
                 },
                 "additionalProperties": true
@@ -65,6 +69,8 @@ fn schema() -> Value {
 ///   the tag message; `activeViewId` selects it out of the box, and the
 ///   frontend falls back to the same id when the pointer is absent
 ///   (`DEFAULT_VIEW_ID` in web tracesViews.ts — keep the id in sync).
+/// - `followTurns`: follow the active chat's live turn — on out of the box
+///   (the frontend also defaults to on when the flag is absent).
 /// - `spanFilters`: detail-view funnel defaults — hide the chatty
 ///   `harness::send` span group and the session/context bookkeeping workers.
 fn default_value() -> Value {
@@ -79,6 +85,7 @@ fn default_value() -> Value {
                 "filters": {}
             }],
             "activeViewId": "view-sessions",
+            "followTurns": true,
             "spanFilters": {
                 "hiddenGroups": ["harness::send"],
                 "hiddenWorkers": ["context-manager", "session-manager"]

--- a/console/web/src/lib/storage.ts
+++ b/console/web/src/lib/storage.ts
@@ -65,29 +65,6 @@ export function saveDefaultAllowlist(list: string[]): void {
   }
 }
 
-const TRACES_FOLLOW_TURNS_KEY = 'iii-traces-follow-turns'
-
-/**
- * Per-browser "follow" toggle on the traces masthead: when on, the surface
- * auto-opens the trace of the active chat's live turn (user interactions
- * only — sub-agent turns never steal the view).
- */
-export function loadFollowTurns(): boolean {
-  try {
-    return localStorage.getItem(TRACES_FOLLOW_TURNS_KEY) === '1'
-  } catch {
-    return false
-  }
-}
-
-export function saveFollowTurns(on: boolean): void {
-  try {
-    localStorage.setItem(TRACES_FOLLOW_TURNS_KEY, on ? '1' : '0')
-  } catch {
-    /* best-effort */
-  }
-}
-
 export function loadActiveId(): string | null {
   try {
     return localStorage.getItem(ACTIVE_KEY)

--- a/console/web/src/lib/storage.ts
+++ b/console/web/src/lib/storage.ts
@@ -65,38 +65,6 @@ export function saveDefaultAllowlist(list: string[]): void {
   }
 }
 
-const TRACES_ACTIVE_VIEW_KEY = 'iii-traces-active-view'
-/** Stored when the user explicitly picks "all traces", so an absent key
- *  (fresh browser) stays distinguishable and can default to the seeded view.
- *  Real ids never collide: they are `view-*`. */
-const TRACES_NO_VIEW = 'none'
-
-/**
- * Per-browser pointer to the active traces view. The views themselves are
- * server-side (`console` configuration entry); only the selection is local
- * so two tabs can look at different views without fighting.
- *
- * `undefined` = no choice recorded yet (callers may pick a default);
- * `null` = the user explicitly chose "all traces".
- */
-export function loadActiveTracesViewId(): string | null | undefined {
-  try {
-    const raw = localStorage.getItem(TRACES_ACTIVE_VIEW_KEY)
-    if (raw === null) return undefined
-    return raw === TRACES_NO_VIEW ? null : raw
-  } catch {
-    return undefined
-  }
-}
-
-export function saveActiveTracesViewId(id: string | null): void {
-  try {
-    localStorage.setItem(TRACES_ACTIVE_VIEW_KEY, id ?? TRACES_NO_VIEW)
-  } catch {
-    /* best-effort */
-  }
-}
-
 const TRACES_FOLLOW_TURNS_KEY = 'iii-traces-follow-turns'
 
 /**

--- a/console/web/src/pages/TracesV2/hooks/useFollowTurns.ts
+++ b/console/web/src/pages/TracesV2/hooks/useFollowTurns.ts
@@ -1,0 +1,91 @@
+// Server-persisted "follow turns" toggle for the TRACES tab.
+//
+// The masthead's follow toggle (auto-open the trace of the active chat's
+// live turn) lives in the engine's `console` configuration entry under
+// `traces.followTurns`, next to the saved views. Absent means ON —
+// following is the out-of-the-box experience; the config records an
+// explicit opt-out. Toggles hit local state immediately; persistence is a
+// best-effort read-modify-write of the whole entry (`configuration::set`
+// has no partial-update surface), so an unreachable configuration worker
+// never lags the toggle — the choice then simply lives in memory for the
+// session. Cross-tab concurrency is last-write-wins, same as saved views.
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useCallback, useState } from 'react'
+import {
+  type ConsoleConfigValue,
+  fetchConsoleConfigValue,
+  setConsoleConfigValue,
+} from '@/lib/console-config'
+
+// Same key as `useTraceViews` / `useSpanFilterSelection` — all three hooks
+// read the one `console` entry, sharing the React Query cache.
+const CONSOLE_CONFIG_QUERY_KEY = ['consoleConfig']
+
+/** Parse `traces.followTurns` out of the raw console-config value.
+ *  `undefined` = no choice recorded (callers default to ON). */
+function parseFollowTurns(
+  configValue: Record<string, unknown>,
+): boolean | undefined {
+  const traces = configValue.traces
+  if (!traces || typeof traces !== 'object') return undefined
+  const on = (traces as Record<string, unknown>).followTurns
+  return typeof on === 'boolean' ? on : undefined
+}
+
+/** Write the toggle back into a (copied) console-config value. */
+function withFollowTurns(
+  configValue: Record<string, unknown>,
+  on: boolean,
+): Record<string, unknown> {
+  const traces =
+    configValue.traces && typeof configValue.traces === 'object'
+      ? { ...(configValue.traces as Record<string, unknown>) }
+      : {}
+  traces.followTurns = on
+  return { ...configValue, traces }
+}
+
+export interface UseFollowTurnsReturn {
+  followTurns: boolean
+  toggleFollowTurns: () => void
+}
+
+export function useFollowTurns(): UseFollowTurnsReturn {
+  const qc = useQueryClient()
+
+  const { data } = useQuery<ConsoleConfigValue | null>({
+    queryKey: CONSOLE_CONFIG_QUERY_KEY,
+    queryFn: fetchConsoleConfigValue,
+    staleTime: 30_000,
+    retry: 1,
+  })
+
+  // Choice made in THIS tab; once set it wins over the server value so a
+  // slow write never lags the toggle. `undefined` = no local choice yet.
+  const [chosen, setChosen] = useState<boolean | undefined>(undefined)
+  const stored = data ? parseFollowTurns(data) : undefined
+  const followTurns = chosen ?? stored ?? true
+
+  const mutation = useMutation({
+    mutationFn: async (on: boolean) => {
+      const current = (await fetchConsoleConfigValue()) ?? {}
+      const next = withFollowTurns(current, on)
+      await setConsoleConfigValue(next)
+      return next
+    },
+    onSuccess: (next) => {
+      qc.setQueryData(CONSOLE_CONFIG_QUERY_KEY, next)
+    },
+  })
+
+  const toggleFollowTurns = useCallback(() => {
+    const next = !followTurns
+    setChosen(next)
+    // Best-effort server persist; the in-memory choice stays live even when
+    // the configuration worker is unreachable.
+    mutation.mutateAsync(next).catch(() => {})
+  }, [followTurns, mutation])
+
+  return { followTurns, toggleFollowTurns }
+}

--- a/console/web/src/pages/TracesV2/hooks/useTraceViews.ts
+++ b/console/web/src/pages/TracesV2/hooks/useTraceViews.ts
@@ -1,11 +1,12 @@
 // Server-persisted saved views for the TRACES tab.
 //
 // Views live in the engine's `console` configuration entry under
-// `traces.views` (see `lib/tracesViews.ts` for the model). Every mutation is
-// a read-modify-write of the WHOLE entry value — `configuration::set` has no
-// partial-update surface — serialized through React Query so concurrent
-// saves from this tab don't interleave. Cross-tab concurrency stays
-// last-write-wins.
+// `traces.views`, and the ACTIVE view pointer next to them under
+// `traces.activeViewId` (see `lib/tracesViews.ts` for the model), so the
+// selection follows the engine — not the browser — and a fresh config
+// defaults to the seeded sessions view. Every mutation is a
+// read-modify-write of the WHOLE entry value — `configuration::set` has no
+// partial-update surface. Cross-tab concurrency stays last-write-wins.
 //
 // `available: false` means the configuration worker (or the `console` entry)
 // isn't reachable; callers hide the views UI instead of erroring.
@@ -17,13 +18,14 @@ import {
   fetchConsoleConfigValue,
   setConsoleConfigValue,
 } from '@/lib/console-config'
-import { loadActiveTracesViewId, saveActiveTracesViewId } from '@/lib/storage'
 import {
   DEFAULT_VIEW_ID,
   newViewId,
+  parseActiveViewId,
   parseViews,
   type TracesView,
   type TracesViewConfig,
+  withActiveViewId,
   withViews,
 } from '../lib/tracesViews'
 
@@ -44,13 +46,6 @@ export interface UseTraceViewsReturn {
 
 export function useTraceViews(): UseTraceViewsReturn {
   const qc = useQueryClient()
-  const [activeViewId, setActiveViewIdState] = useState<string | null>(() => {
-    const stored = loadActiveTracesViewId()
-    // Fresh browser (no recorded choice): default to the seeded sessions
-    // view. TracesV2's initial-apply effect clears the selection if that
-    // view doesn't exist on this engine.
-    return stored === undefined ? DEFAULT_VIEW_ID : stored
-  })
 
   const { data, isLoading } = useQuery<ConsoleConfigValue | null>({
     queryKey: CONSOLE_CONFIG_QUERY_KEY,
@@ -62,17 +57,29 @@ export function useTraceViews(): UseTraceViewsReturn {
   const available = data !== null && data !== undefined
   const views = available ? parseViews(data) : []
 
-  const setActiveViewId = useCallback((id: string | null) => {
-    setActiveViewIdState(id)
-    saveActiveTracesViewId(id)
-  }, [])
+  // Selection made in THIS tab; once set it wins over the server pointer so
+  // a slow write (or an unreachable configuration worker) never lags the
+  // dropdown. `undefined` = no local choice yet.
+  const [chosenViewId, setChosenViewId] = useState<string | null | undefined>(
+    undefined,
+  )
+  const storedViewId = available ? parseActiveViewId(data) : undefined
+  // No pointer recorded (fresh engine): default to the seeded sessions
+  // view. TracesV2's initial-apply effect clears the selection if that
+  // view doesn't exist on this engine.
+  const serverViewId =
+    storedViewId === undefined && available ? DEFAULT_VIEW_ID : storedViewId
+  const activeViewId =
+    chosenViewId === undefined ? (serverViewId ?? null) : chosenViewId
 
-  // One mutation funnel: take the freshest server value, transform the views
-  // array, write the whole entry back, then refresh the cache.
+  // One mutation funnel: take the freshest server value, transform the whole
+  // entry value, write it back, then refresh the cache.
   const mutation = useMutation({
-    mutationFn: async (transform: (views: TracesView[]) => TracesView[]) => {
+    mutationFn: async (
+      transform: (value: ConsoleConfigValue) => ConsoleConfigValue,
+    ) => {
       const current = (await fetchConsoleConfigValue()) ?? {}
-      const next = withViews(current, transform(parseViews(current)))
+      const next = transform(current)
       await setConsoleConfigValue(next)
       return next
     },
@@ -81,42 +88,74 @@ export function useTraceViews(): UseTraceViewsReturn {
     },
   })
 
-  const saveView = useCallback(
-    async (name: string, config: TracesViewConfig): Promise<TracesView> => {
-      const view: TracesView = { id: newViewId(), name, ...config }
-      await mutation.mutateAsync((existing) => [...existing, view])
-      return view
+  const setActiveViewId = useCallback(
+    (id: string | null) => {
+      setChosenViewId(id)
+      // Best-effort server persist; the in-memory selection stays live even
+      // when the configuration worker is unreachable.
+      mutation
+        .mutateAsync((value) => withActiveViewId(value, id))
+        .catch(() => {})
     },
     [mutation],
   )
 
+  const mutateViews = useCallback(
+    (transform: (views: TracesView[]) => TracesView[]) =>
+      mutation.mutateAsync((value) =>
+        withViews(value, transform(parseViews(value))),
+      ),
+    [mutation],
+  )
+
+  const saveView = useCallback(
+    async (name: string, config: TracesViewConfig): Promise<TracesView> => {
+      const view: TracesView = { id: newViewId(), name, ...config }
+      await mutateViews((existing) => [...existing, view])
+      return view
+    },
+    [mutateViews],
+  )
+
   const updateView = useCallback(
     async (id: string, config: TracesViewConfig): Promise<void> => {
-      await mutation.mutateAsync((existing) =>
+      await mutateViews((existing) =>
         existing.map((v) =>
           v.id === id ? { ...v, ...config, id, name: v.name } : v,
         ),
       )
     },
-    [mutation],
+    [mutateViews],
   )
 
   const renameView = useCallback(
     async (id: string, name: string): Promise<void> => {
-      await mutation.mutateAsync((existing) =>
+      await mutateViews((existing) =>
         existing.map((v) => (v.id === id ? { ...v, name } : v)),
       )
     },
-    [mutation],
+    [mutateViews],
   )
 
   const deleteView = useCallback(
     async (id: string): Promise<void> => {
-      await mutation.mutateAsync((existing) =>
-        existing.filter((v) => v.id !== id),
-      )
+      // Deleting the selected view also clears the selection — folded into
+      // the SAME write so the two updates can't interleave and the pointer
+      // never dangles. The absent-pointer case resolves to the default view
+      // first, so deleting the seeded view on a fresh engine records an
+      // explicit "all traces" too.
+      if (id === activeViewId) setChosenViewId(null)
+      await mutation.mutateAsync((value) => {
+        const next = withViews(
+          value,
+          parseViews(value).filter((v) => v.id !== id),
+        )
+        const pointer = parseActiveViewId(value)
+        const effective = pointer === undefined ? DEFAULT_VIEW_ID : pointer
+        return effective === id ? withActiveViewId(next, null) : next
+      })
     },
-    [mutation],
+    [mutation, activeViewId],
   )
 
   return {

--- a/console/web/src/pages/TracesV2/index.tsx
+++ b/console/web/src/pages/TracesV2/index.tsx
@@ -40,7 +40,6 @@ import { Skeleton } from '@/components/ui/Skeleton'
 import { StatusPanel } from '@/components/ui/StatusPanel'
 import { useConversationsCtxOptional } from '@/lib/conversations-context'
 import { getIiiClient } from '@/lib/iii-client'
-import { loadFollowTurns, saveFollowTurns } from '@/lib/storage'
 import { startTraceSpansStream } from '@/lib/traces-stream'
 import { cn } from '@/lib/utils'
 import { fetchTraces, type StoredSpan } from './api/traces'
@@ -58,6 +57,7 @@ import { WaterfallChart } from './components/WaterfallChart'
 import { WorkerBreakdown } from './components/WorkerBreakdown'
 import { useAllSpans } from './hooks/useAllSpans'
 import { useFollowLiveTurn } from './hooks/useFollowLiveTurn'
+import { useFollowTurns } from './hooks/useFollowTurns'
 import { useSpanFilterSelection } from './hooks/useSpanFilterSelection'
 import { useSpanPanelResize } from './hooks/useSpanPanelResize'
 import { useTraceActivity } from './hooks/useTraceActivity'
@@ -261,13 +261,7 @@ export function TracesV2({ initialTraceId }: TracesV2Props) {
   // `harness.turn` steps; sub-agent turns never steal the view. Null outside
   // the app shell (Storybook), which also hides the strip's toggle.
   const conversationsCtx = useConversationsCtxOptional()
-  const [followTurns, setFollowTurns] = useState(loadFollowTurns)
-  const toggleFollowTurns = useCallback(() => {
-    setFollowTurns((on) => {
-      saveFollowTurns(!on)
-      return !on
-    })
-  }, [])
+  const { followTurns, toggleFollowTurns } = useFollowTurns()
 
   const totalPages = Math.max(
     1,

--- a/console/web/src/pages/TracesV2/index.tsx
+++ b/console/web/src/pages/TracesV2/index.tsx
@@ -639,10 +639,9 @@ export function TracesV2({ initialTraceId }: TracesV2Props) {
                     if (activeViewId) void renameView(activeViewId, name)
                   }}
                   onDeleteActive={() => {
-                    if (activeViewId) {
-                      void deleteView(activeViewId)
-                      setActiveViewId(null)
-                    }
+                    // deleteView clears the selection itself, in the same
+                    // config write.
+                    if (activeViewId) void deleteView(activeViewId)
                   }}
                 />
               ) : undefined

--- a/console/web/src/pages/TracesV2/lib/tracesViews.ts
+++ b/console/web/src/pages/TracesV2/lib/tracesViews.ts
@@ -2,9 +2,9 @@
 //
 // A view is a named snapshot of EVERYTHING that shapes the list: grouping,
 // hidden functions, row-label display, filters, and sort. Views live in the
-// server-side `console` configuration entry (`traces.views`), so they follow
-// the engine, not the browser; the ACTIVE view id is per-browser
-// (localStorage) so two tabs can look at different views.
+// server-side `console` configuration entry (`traces.views`), and the
+// ACTIVE view pointer next to them (`traces.activeViewId`) — both follow
+// the engine, not the browser.
 //
 // Pure module — capture/apply/compare only. Transport lives in
 // `@/lib/console-config`, React state in `hooks/useTraceViews.ts`.
@@ -49,8 +49,8 @@ export interface TracesView extends TracesViewConfig {
 
 /**
  * Id of the "sessions" view the console worker seeds into a fresh `console`
- * configuration entry (src/configuration.rs — keep the id in sync). Browsers
- * with no recorded view choice select it by default.
+ * configuration entry (src/configuration.rs — keep the id in sync). Selected
+ * by default whenever the config records no `traces.activeViewId` pointer.
  */
 export const DEFAULT_VIEW_ID = 'view-sessions'
 
@@ -168,6 +168,38 @@ export function parseViews(configValue: Record<string, unknown>): TracesView[] {
       typeof (v as TracesView).id === 'string' &&
       typeof (v as TracesView).name === 'string',
   )
+}
+
+/**
+ * Parse the `traces.activeViewId` pointer out of the raw console-config
+ * value. `undefined` = no choice recorded yet (callers may pick a default);
+ * `null` = an explicit "all traces" choice.
+ */
+export function parseActiveViewId(
+  configValue: Record<string, unknown>,
+): string | null | undefined {
+  const traces = configValue.traces
+  if (!traces || typeof traces !== 'object') return undefined
+  if (!('activeViewId' in traces)) return undefined
+  const id = (traces as Record<string, unknown>).activeViewId
+  return typeof id === 'string' && id.length > 0 ? id : null
+}
+
+/**
+ * Write the active-view pointer into a (copied) console-config value.
+ * `null` is written out explicitly so "all traces" stays distinguishable
+ * from a fresh entry (which defaults to the seeded sessions view).
+ */
+export function withActiveViewId(
+  configValue: Record<string, unknown>,
+  id: string | null,
+): Record<string, unknown> {
+  const traces =
+    configValue.traces && typeof configValue.traces === 'object'
+      ? { ...(configValue.traces as Record<string, unknown>) }
+      : {}
+  traces.activeViewId = id
+  return { ...configValue, traces }
 }
 
 /** Write the views array back into a (copied) console-config value. */

--- a/console/web/vite.config.ts
+++ b/console/web/vite.config.ts
@@ -3,6 +3,10 @@ import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 
+// Engine WebSocket URL, same knob as the console binary's `--url`
+// (DEFAULT_ENGINE_URL in src/config.rs).
+const ENGINE_URL = process.env.III_ENGINE_URL ?? 'ws://127.0.0.1:49134'
+
 export default defineConfig({
   // Relative asset paths so the embedded SPA works behind a reverse
   // proxy that mounts the console at an arbitrary subpath.
@@ -13,14 +17,22 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
+  // Dev twin of the console worker's HTTP server (src/server.rs): the same
+  // /ws proxy contract, bound on 0.0.0.0 like the binary so the dev server
+  // is reachable from containers/LAN. The binary's proxy additionally stamps
+  // `metadata.internal = true` on browser `registerfunction` frames, but
+  // only as defense against STALE bundles — dev always serves the current
+  // bundle, which stamps its own registrations (src/lib/iii-client.ts) —
+  // so this proxy stays a dumb pipe.
   server: {
+    host: '0.0.0.0',
     allowedHosts: true,
     proxy: {
       // iii-browser-sdk hits ws(s)://${host}/ws by default; the proxy
-      // forwards to the local engine WebSocket on :49134 in dev. In
-      // prod the `console` worker exposes the same /ws contract.
+      // forwards to the engine WebSocket. In prod the `console` worker
+      // exposes the same /ws contract.
       '/ws': {
-        target: 'ws://127.0.0.1:49134',
+        target: ENGINE_URL,
         ws: true,
         changeOrigin: false,
         rewrite: (path) => path.replace(/^\/ws/, ''),


### PR DESCRIPTION
## Problem

The Traces tab's saved views live server-side in the `console` configuration entry, but the **active view selection** was stored in per-browser localStorage. The selection didn't follow the engine — every new browser (or cleared storage) lost the choice, and the seeded "sessions" view was only selected via a frontend fallback.

## Solution

Persist the pointer next to the views as `traces.activeViewId` in the `console` configuration entry:

- The console worker seeds `activeViewId: "view-sessions"` and documents the field in the entry schema; when the pointer is absent (configs seeded before this change) the UI still defaults to the sessions view.
- `useTraceViews` reads/writes the pointer through the existing read-modify-write mutation funnel; the in-tab selection stays live even when the configuration worker is unreachable.
- Deleting the active view clears the pointer in the **same** config write, so the two updates can't interleave and the pointer never dangles.
- Removed the now-unused localStorage helpers.

Also updates `vite.config.ts` to match the binary's server posture: binds `0.0.0.0` so the dev server accepts external connections, and the `/ws` proxy engine target is configurable via `III_ENGINE_URL` (same default as the binary's `--url`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TRACES V2 now uses server-backed console configuration to select the active view (with an immediate per-tab override that stays responsive if saving fails).
  * “Follow turns” is now persisted via console configuration (defaulting to enabled) and managed through a dedicated toggle hook.
* **Bug Fixes**
  * Deleting the currently active view now reliably clears the selection so it can’t remain dangling.
* **Developer Experience**
  * Dev Engine WebSocket proxy now derives from a configurable Engine URL (with a local fallback).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
