### PR TITLE
feat: better filters

### DIFF
--- a/console/web/src/pages/TracesV2/components/timeline/TimelineStrip.tsx
+++ b/console/web/src/pages/TracesV2/components/timeline/TimelineStrip.tsx
@@ -73,7 +73,11 @@ import { IconToggleButton } from '../IconToggleButton'
 import { computeTicks, effectiveEnd, type TimelineSpan } from './layout'
 import { SpanFilterMenu } from './SpanFilterMenu'
 import { SpanHoverCard } from './SpanHoverCard'
-import { deriveSpanGroups, reparentThroughHidden } from './spanVisibility'
+import {
+  deriveSpanGroups,
+  isSpanBarHidden,
+  reparentThroughHidden,
+} from './spanVisibility'
 import { resolveColor } from './spanVisuals'
 
 export interface TimelineStripProps {
@@ -781,15 +785,10 @@ export function TimelineStrip({
   // nearest kept ancestor so the hierarchy stays connected.
   const spans = useMemo(() => {
     if (!spanFilter) return allSpans
-    return reparentThroughHidden(allSpans, (s: TimelineSpan) => {
-      // Internal bars hide by default; the family must be explicitly shown.
-      if (s.internalKey != null && !spanFilter.shownInternal.has(s.internalKey))
-        return false
-      return (
-        !(s.groupKey != null && spanFilter.hiddenGroups.has(s.groupKey)) &&
-        !(s.workerKey != null && spanFilter.hiddenWorkers.has(s.workerKey))
-      )
-    })
+    return reparentThroughHidden(
+      allSpans,
+      (s: TimelineSpan) => !isSpanBarHidden(s, spanFilter),
+    )
   }, [allSpans, spanFilter])
 
   // While any bar is live, tick the evaluation clock so the prune window

--- a/console/web/src/pages/TracesV2/components/timeline/spanVisibility.ts
+++ b/console/web/src/pages/TracesV2/components/timeline/spanVisibility.ts
@@ -38,6 +38,39 @@ export type SpanGroupKey = (
 /** Grouping key for the filter menu's workers section. */
 export const workerGroupKey: SpanGroupKey = (span) => getWorkerName(span)
 
+/** The resolved filter-key triple a bar carries (a `TimelineSpan`'s
+ *  `groupKey` / `workerKey` / `internalKey`). */
+export interface SpanFilterKeys {
+  groupKey?: string
+  workerKey?: string
+  internalKey?: string
+}
+
+/**
+ * THE hidden-span predicate: whether the selection hides a span carrying
+ * these keys. Internal spans hide by DEFAULT — `shownInternal` lists the
+ * families the user revealed; groups and workers hide only when picked.
+ * Every surface that applies the funnel selection (the strip's bars, the
+ * detail views via [`applyHiddenSpanFilters`], the trace list's rows via
+ * `hooks/useSpanFilteredTraceRows`) routes through this one function so
+ * they can never disagree on what "hidden" means.
+ */
+export function isSpanBarHidden(
+  keys: SpanFilterKeys,
+  selection: SpanFilterSelection,
+): boolean {
+  if (
+    keys.internalKey != null &&
+    !selection.shownInternal.has(keys.internalKey)
+  ) {
+    return true
+  }
+  if (keys.groupKey != null && selection.hiddenGroups.has(keys.groupKey)) {
+    return true
+  }
+  return keys.workerKey != null && selection.hiddenWorkers.has(keys.workerKey)
+}
+
 export interface SpanGroup {
   key: string
   /** Spans carrying this key (subtree descendants not included). */
@@ -86,18 +119,16 @@ export function applyHiddenSpanFilters(
   keyOf: SpanGroupKey,
   selection: SpanFilterSelection,
 ): WaterfallData {
-  const { hiddenGroups, hiddenWorkers, shownInternal } = selection
-
   const spansById = new Map(data.spans.map((s) => [s.span_id, s]))
-  const matches = (span: VisualizationSpan) => {
-    // Internal spans (`iii.tag.hidden` call-site tag) hide by DEFAULT;
-    // `shownInternal` holds the families the user revealed.
-    const family = internalFamilyOf(span.attributes)
-    if (family != null && !shownInternal.has(family)) return true
-    if (hiddenWorkers.has(getWorkerName(span))) return true
-    const key = keyOf(span, spansById)
-    return key != null && hiddenGroups.has(key)
-  }
+  const matches = (span: VisualizationSpan) =>
+    isSpanBarHidden(
+      {
+        groupKey: keyOf(span, spansById) ?? undefined,
+        workerKey: getWorkerName(span),
+        internalKey: internalFamilyOf(span.attributes) ?? undefined,
+      },
+      selection,
+    )
 
   const hidden = new Set<string>()
   for (const span of data.spans) {

--- a/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.test.ts
+++ b/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it } from 'vitest'
+import type { StoredSpan } from '../api/traces'
+import type { TimelineSpan } from '../components/timeline/layout'
+import type { SpanFilterSelection } from '../lib/spanFilters'
+import {
+  mergeFetchedVerdicts,
+  reconcileTraceVisibility,
+  rowRootFilterKeys,
+} from './useSpanFilteredTraceRows'
+import type { TraceListItem } from './useTraceData'
+
+function bar(overrides: Partial<TimelineSpan> & { id: string }): TimelineSpan {
+  return {
+    traceId: 't-1',
+    startTime: 0,
+    endTime: 1,
+    ...overrides,
+  }
+}
+
+/** A row whose ROOT belongs to `group` — the shape `mapSpanToListItem`
+ *  produces for a trace rooted in that function's dispatch span. */
+function row(
+  traceId: string,
+  group = 'fn',
+  overrides: Partial<TraceListItem> = {},
+): TraceListItem {
+  return {
+    traceId,
+    rootOperation: `enqueue ${group} → q`,
+    status: 'ok',
+    startTime: 0,
+    spanCount: 1,
+    workers: ['worker'],
+    attributes: { function_id: group },
+    ...overrides,
+  }
+}
+
+function selection(
+  overrides: Partial<SpanFilterSelection> = {},
+): SpanFilterSelection {
+  return {
+    hiddenGroups: new Set(),
+    hiddenWorkers: new Set(),
+    shownInternal: new Set(),
+    ...overrides,
+  }
+}
+
+function stored(
+  overrides: Partial<StoredSpan> & { span_id: string },
+): StoredSpan {
+  return {
+    trace_id: 't-1',
+    name: 'op',
+    start_time_unix_nano: 1_000_000,
+    end_time_unix_nano: 2_000_000,
+    status: 'OK',
+    attributes: [],
+    events: [],
+    links: [],
+    ...overrides,
+  }
+}
+
+const ids = (rows: readonly TraceListItem[]) => rows.map((r) => r.traceId)
+
+describe('rowRootFilterKeys', () => {
+  it('keys the root like the feed would: explicit function id, worker, internal family', () => {
+    expect(
+      rowRootFilterKeys(
+        row('t-1', 'session::update-message', {
+          workers: ['session-manager'],
+          attributes: {
+            function_id: 'session::update-message',
+            'iii.tag.hidden': 'session events',
+          },
+        }),
+      ),
+    ).toEqual({
+      groupKey: 'session::update-message',
+      workerKey: 'session-manager',
+      internalKey: 'session events',
+    })
+  })
+
+  it("undoes the list's 'unknown' worker sentinel so the fallback matches the feed's", () => {
+    const keys = rowRootFilterKeys(
+      row('t-1', 'fn', {
+        rootOperation: 'gateway.request',
+        workers: ['unknown'],
+        attributes: {},
+      }),
+    )
+    expect(keys.workerKey).toBe('gateway')
+  })
+})
+
+describe('reconcileTraceVisibility', () => {
+  it('hides a row once every bar of its trace is hidden', () => {
+    const sel = selection({
+      hiddenGroups: new Set(['session::update-message']),
+    })
+    const bars = [
+      bar({ id: 's1', groupKey: 'session::update-message' }),
+      bar({ id: 's2', groupKey: 'session::update-message' }),
+    ]
+    const kept = reconcileTraceVisibility(
+      new Map(),
+      bars,
+      [
+        row('t-1', 'session::update-message'),
+        row('t-2', 'session::update-message'),
+      ],
+      sel,
+    )
+    // t-2 has no coverage yet (hidden root, feed silent) → visible until a
+    // composition read decides.
+    expect(ids(kept)).toEqual(['t-2'])
+  })
+
+  it('keeps the row while any bar of its trace survives — a hidden root is not enough', () => {
+    // The turn-trace shape: dispatch root in a producer-default-hidden
+    // group, real work below it.
+    const bars = [
+      bar({ id: 'root', groupKey: 'harness::turn' }),
+      bar({ id: 'step', groupKey: 'harness::turn step' }),
+    ]
+    const kept = reconcileTraceVisibility(
+      new Map(),
+      bars,
+      [row('t-1', 'harness::turn')],
+      selection({ hiddenGroups: new Set(['harness::turn']) }),
+    )
+    expect(ids(kept)).toEqual(['t-1'])
+  })
+
+  it('keeps a row whose visible ROOT outlived the feed (partial tail all hidden)', () => {
+    const bars = [bar({ id: 'tail', groupKey: 'session::update-message' })]
+    const kept = reconcileTraceVisibility(
+      new Map(),
+      bars,
+      [row('t-1', 'chat.respond')],
+      selection({ hiddenGroups: new Set(['session::update-message']) }),
+    )
+    expect(ids(kept)).toEqual(['t-1'])
+  })
+
+  it('hides worker-hidden traces', () => {
+    const bars = [bar({ id: 's1', groupKey: 'fn', workerKey: 'noisy' })]
+    const kept = reconcileTraceVisibility(
+      new Map(),
+      bars,
+      [row('t-1', 'fn', { workers: ['noisy'] })],
+      selection({ hiddenWorkers: new Set(['noisy']) }),
+    )
+    expect(kept).toEqual([])
+  })
+
+  it('hides default-hidden internal fan-outs, shows them once the family is revealed', () => {
+    const bars = [bar({ id: 's1', internalKey: 'session events' })]
+    const rows = [
+      row('t-1', 'fn', {
+        attributes: { function_id: 'fn', 'iii.tag.hidden': 'session events' },
+      }),
+    ]
+    expect(
+      ids(reconcileTraceVisibility(new Map(), bars, rows, selection())),
+    ).toEqual([])
+    expect(
+      ids(
+        reconcileTraceVisibility(
+          new Map(),
+          bars,
+          rows,
+          selection({ shownInternal: new Set(['session events']) }),
+        ),
+      ),
+    ).toEqual(['t-1'])
+  })
+
+  it('remembers a verdict after the trace prunes out of the feed', () => {
+    const verdicts = new Map<string, boolean>()
+    const sel = selection({ hiddenGroups: new Set(['fn']) })
+    const rows = [row('t-1', 'fn')]
+    reconcileTraceVisibility(
+      verdicts,
+      [bar({ id: 's1', groupKey: 'fn' })],
+      rows,
+      sel,
+    )
+    // Feed pruned the trace's spans; the listed row must stay hidden.
+    expect(ids(reconcileTraceVisibility(verdicts, [], rows, sel))).toEqual([])
+  })
+
+  it('flips a live trace visible when a surviving span arrives', () => {
+    const verdicts = new Map<string, boolean>()
+    const sel = selection({ hiddenGroups: new Set(['harness::turn']) })
+    const rows = [row('t-1', 'harness::turn')]
+    const dispatch = bar({ id: 'root', groupKey: 'harness::turn' })
+    expect(
+      ids(reconcileTraceVisibility(verdicts, [dispatch], rows, sel)),
+    ).toEqual([])
+    const step = bar({ id: 'step', groupKey: 'harness::turn step' })
+    expect(
+      ids(reconcileTraceVisibility(verdicts, [dispatch, step], rows, sel)),
+    ).toEqual(['t-1'])
+  })
+
+  it('drops cached verdicts once the trace leaves the list too', () => {
+    const verdicts = new Map<string, boolean>()
+    const sel = selection({ hiddenGroups: new Set(['fn']) })
+    reconcileTraceVisibility(
+      verdicts,
+      [bar({ id: 's1', groupKey: 'fn' })],
+      [row('t-1', 'fn')],
+      sel,
+    )
+    expect(verdicts.has('t-1')).toBe(true)
+    reconcileTraceVisibility(verdicts, [], [row('t-2', 'fn')], sel)
+    expect(verdicts.has('t-1')).toBe(false)
+  })
+
+  it('returns the rows array unchanged when nothing hides', () => {
+    const rows = [row('t-1'), row('t-2')]
+    const kept = reconcileTraceVisibility(
+      new Map(),
+      [bar({ id: 's1', groupKey: 'fn' })],
+      rows,
+      selection(),
+    )
+    expect(kept).toBe(rows)
+  })
+})
+
+describe('mergeFetchedVerdicts', () => {
+  const sel = selection({ hiddenGroups: new Set(['fn']) })
+
+  it('judges each requested trace by its fetched spans', () => {
+    const verdicts = new Map<string, boolean>()
+    mergeFetchedVerdicts(
+      verdicts,
+      ['t-hidden', 't-mixed', 't-gone'],
+      [
+        stored({
+          span_id: 'h1',
+          trace_id: 't-hidden',
+          attributes: [['function_id', 'fn']],
+        }),
+        stored({
+          span_id: 'm1',
+          trace_id: 't-mixed',
+          attributes: [['function_id', 'fn']],
+        }),
+        stored({
+          span_id: 'm2',
+          trace_id: 't-mixed',
+          name: 'llm.completion',
+        }),
+      ],
+      sel,
+    )
+    expect(verdicts.get('t-hidden')).toBe(false)
+    expect(verdicts.get('t-mixed')).toBe(true)
+    // No stored spans left → the detail would be empty → hidden.
+    expect(verdicts.get('t-gone')).toBe(false)
+  })
+
+  it('does not let engine builtins keep a row alive — the detail view never shows them', () => {
+    const verdicts = new Map<string, boolean>()
+    mergeFetchedVerdicts(
+      verdicts,
+      ['t-1'],
+      [
+        stored({
+          span_id: 'h1',
+          attributes: [['function_id', 'fn']],
+        }),
+        stored({
+          span_id: 'b1',
+          name: 'call state::get',
+          parent_span_id: 'h1',
+          attributes: [
+            ['function_id', 'state::get'],
+            ['iii.function.kind', 'internal'],
+          ],
+        }),
+      ],
+      sel,
+    )
+    expect(verdicts.get('t-1')).toBe(false)
+  })
+
+  it('only trusts positive verdicts from a truncated response', () => {
+    const verdicts = new Map<string, boolean>()
+    const spans = [
+      stored({
+        span_id: 'h1',
+        trace_id: 't-hidden',
+        attributes: [['function_id', 'fn']],
+      }),
+      stored({ span_id: 'v1', trace_id: 't-visible', name: 'llm.completion' }),
+    ]
+    mergeFetchedVerdicts(verdicts, ['t-hidden', 't-visible'], spans, sel, 2)
+    expect(verdicts.get('t-visible')).toBe(true)
+    expect(verdicts.has('t-hidden')).toBe(false)
+  })
+})

--- a/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.ts
+++ b/console/web/src/pages/TracesV2/hooks/useSpanFilteredTraceRows.ts
@@ -1,0 +1,260 @@
+// Span-filter fallout on the trace LIST: hide rows whose trace is
+// completely composed of hidden spans.
+//
+// The funnel selection (`useSpanFilterSelection`) already de-noises the
+// strip and the detail views span-by-span; this hook extends it to the
+// list, so a trace with NO visible span left — session bookkeeping once
+// its family is hidden, the default-hidden internal fan-outs — stops
+// occupying a row (its detail would render empty anyway). A trace keeps
+// its row while ANY of its spans survives the filter. Root-only matching
+// would be wrong in both directions: turn traces are ROOTED in the
+// producer-default-hidden `harness::turn` dispatch group (a root-only rule
+// would wipe real work off the list), and a visible root over a fully
+// hidden subtree is still a visible bar.
+//
+// Verdicts (traceId → "has a visible span") come from three sources, in
+// order:
+//
+// 1. the row's OWN root span — visible root ⇒ visible trace, no more data
+//    needed (the common case: most rows are rooted in unhidden work);
+// 2. the all-spans feed (`useAllSpans`) — the spans the strip draws;
+// 3. a one-shot batched read of the trace's stored spans for hidden-rooted
+//    rows the feed doesn't cover (the feed retains ~2min; the list's 500
+//    rows reach much further back).
+//
+// Both span sources count only what the DETAIL views can render: engine
+// builtin spans (`include_internal: false` drops them from the detail
+// read) never keep a row alive, so a kept row always opens to a non-empty
+// detail.
+//
+// Feed verdicts recompute on every frame (a live trace must flip visible
+// the moment a surviving span arrives — the first frames of a turn are all
+// dispatch plumbing) and STICK once the trace prunes out of the feed: a
+// settled trace's composition never changes. Fetched verdicts land in the
+// same cache. The cache resets when the selection changes; a row stays
+// visible while its verdict is unknown or its read failed — better to
+// show a hideable row than to hide real work on a guess.
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { fetchTraces, type StoredSpan } from '../api/traces'
+import type { TimelineSpan } from '../components/timeline/layout'
+import {
+  isSpanBarHidden,
+  type SpanFilterKeys,
+} from '../components/timeline/spanVisibility'
+import type { SpanFilterSelection } from '../lib/spanFilters'
+import { internalFamilyOf } from '../lib/spanLabel'
+import {
+  spanFilterGroupKey,
+  storedSpansToTimelineSpans,
+} from '../lib/timelineSpans'
+import { getWorkerName } from '../lib/traceUtils'
+import type { TraceListItem } from './useTraceData'
+
+/** Traces per composition read — small enough that `FETCH_SPAN_LIMIT`
+ *  practically never truncates (bookkeeping traces run a handful of spans;
+ *  turn traces a few hundred). */
+const FETCH_TRACE_CHUNK = 20
+const FETCH_SPAN_LIMIT = 10_000
+
+/**
+ * The row's ROOT span rendered as filter keys, mirroring how
+ * `storedSpansToTimelineSpans` keys the same span in the feed (a listed
+ * root has no ancestry, so the inherited tag kind is undefined).
+ * Exported for tests.
+ */
+export function rowRootFilterKeys(row: TraceListItem): SpanFilterKeys {
+  const attrs = row.attributes ?? {}
+  // `mapSpanToListItem` collapses a missing service_name to the 'unknown'
+  // sentinel; undo it so the worker key falls back exactly like the feed's.
+  const service = row.workers[0] === 'unknown' ? undefined : row.workers[0]
+  return {
+    groupKey: spanFilterGroupKey(row.rootOperation, attrs, undefined),
+    workerKey: getWorkerName({
+      service_name: service,
+      name: row.rootOperation,
+    }),
+    internalKey: internalFamilyOf(attrs) ?? undefined,
+  }
+}
+
+/**
+ * One reconcile pass: refresh `verdicts` from the bars currently in the
+ * feed, seed visible-root verdicts from the rows themselves, drop entries
+ * for traces gone from both the feed and the list, and return the rows
+ * that survive (unknown verdicts stay visible). Mutates `verdicts` — the
+ * hook owns the map across renders. Exported for tests.
+ */
+export function reconcileTraceVisibility(
+  verdicts: Map<string, boolean>,
+  bars: readonly TimelineSpan[],
+  rows: readonly TraceListItem[],
+  selection: SpanFilterSelection,
+): readonly TraceListItem[] {
+  const inFeed = new Set<string>()
+  for (const bar of bars) {
+    const traceId = bar.traceId
+    if (!traceId) continue
+    if (!inFeed.has(traceId)) {
+      inFeed.add(traceId)
+      verdicts.set(traceId, false)
+    }
+    if (!verdicts.get(traceId) && !isSpanBarHidden(bar, selection)) {
+      verdicts.set(traceId, true)
+    }
+  }
+  // A visible root IS a visible span — worth recording even over a feed
+  // verdict of hidden, since the feed may hold only a partial tail of an
+  // older trace while the row carries the actual root.
+  for (const row of rows) {
+    if (verdicts.get(row.traceId)) continue
+    if (!isSpanBarHidden(rowRootFilterKeys(row), selection)) {
+      verdicts.set(row.traceId, true)
+    }
+  }
+  const listed = new Set(rows.map((r) => r.traceId))
+  for (const traceId of [...verdicts.keys()]) {
+    if (!inFeed.has(traceId) && !listed.has(traceId)) {
+      verdicts.delete(traceId)
+    }
+  }
+  const kept = rows.filter((r) => verdicts.get(r.traceId) !== false)
+  // Identity-stable when nothing is hidden, so downstream memos hold.
+  return kept.length === rows.length ? rows : kept
+}
+
+/**
+ * Mirrors the engine's `include_internal` exclusion in `traces::list`:
+ * spans whose own attributes mark engine machinery/builtins (`call
+ * state::get`, `engine::*`). The DETAIL views read with
+ * `include_internal: false`, so these spans never render there — a trace
+ * whose only surviving spans are builtins would still open empty on
+ * click, and must not keep its row. (They stay in the CONVERSION input so
+ * parent chains resolve; they just never count as visible.)
+ */
+function isEngineInternalStoredSpan(span: StoredSpan): boolean {
+  return span.attributes.some(
+    ([k, v]) =>
+      (k === 'iii.function.kind' && v === 'internal') ||
+      (k === 'function_id' &&
+        typeof v === 'string' &&
+        v.startsWith('engine::')),
+  )
+}
+
+/** Bars that count toward "the trace still shows something": converted
+ *  with full parent chains, then stripped of engine builtins — exactly
+ *  what the detail views can render. */
+function verdictBars(spans: readonly StoredSpan[]): TimelineSpan[] {
+  const builtins = new Set(
+    spans.filter(isEngineInternalStoredSpan).map((s) => s.span_id),
+  )
+  const bars = storedSpansToTimelineSpans(spans)
+  return builtins.size === 0 ? bars : bars.filter((b) => !builtins.has(b.id))
+}
+
+/**
+ * Fold one composition read into the verdicts: every requested trace's
+ * verdict is "any of its bars survives the filter" — a trace the store no
+ * longer has spans for counts as hidden (its detail would be empty). A
+ * truncated response (span count at the limit) only trusts POSITIVE
+ * verdicts: a visible span proves visibility, but "all hidden" might just
+ * mean the visible spans were cut off. Exported for tests.
+ */
+export function mergeFetchedVerdicts(
+  verdicts: Map<string, boolean>,
+  requested: readonly string[],
+  spans: readonly StoredSpan[],
+  selection: SpanFilterSelection,
+  spanLimit: number = FETCH_SPAN_LIMIT,
+): void {
+  const visible = new Set<string>()
+  for (const bar of verdictBars(spans)) {
+    if (bar.traceId && !isSpanBarHidden(bar, selection)) {
+      visible.add(bar.traceId)
+    }
+  }
+  const truncated = spans.length >= spanLimit
+  for (const traceId of requested) {
+    if (visible.has(traceId)) verdicts.set(traceId, true)
+    else if (!truncated) verdicts.set(traceId, false)
+  }
+}
+
+export function useSpanFilteredTraceRows(
+  rows: readonly TraceListItem[],
+  feedSpans: readonly StoredSpan[],
+  selection: SpanFilterSelection,
+): readonly TraceListItem[] {
+  // The strip's own mapping (routing wrappers skipped, filter keys
+  // resolved) minus engine builtins, run on the UNPRUNED feed so verdicts
+  // reach the full retention window rather than the strip's visible one.
+  const bars = useMemo(() => verdictBars(feedSpans), [feedSpans])
+
+  // Verdict cache, keyed by selection IDENTITY: `useSpanFilterSelection`
+  // memoizes its controls object on the effective selection, so a new
+  // reference means the selection changed and every cached verdict is
+  // stale. `requested` remembers which traces already went through a
+  // composition read (in-flight, done, or failed) so they are asked once
+  // per selection.
+  const cacheRef = useRef<{
+    selection: SpanFilterSelection
+    verdicts: Map<string, boolean>
+    requested: Set<string>
+  } | null>(null)
+
+  // Bumped when a composition read lands verdicts, to re-run the memo.
+  const [fetchTick, setFetchTick] = useState(0)
+
+  // fetchTick isn't read in the body — it signals `cache.verdicts` grew.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see above
+  const visibleRows = useMemo(() => {
+    let cache = cacheRef.current
+    if (!cache || cache.selection !== selection) {
+      cache = { selection, verdicts: new Map(), requested: new Set() }
+      cacheRef.current = cache
+    }
+    return reconcileTraceVisibility(cache.verdicts, bars, rows, selection)
+  }, [rows, bars, selection, fetchTick])
+
+  // Composition reads for the rows neither source could judge: hidden
+  // root, no feed coverage. Runs after the memo above, so feed verdicts
+  // are already in the cache. Deliberately NO cancellation on dep churn —
+  // live row appends must not orphan an in-flight read (its traces would
+  // stay `requested` but never verdicted); a stale SELECTION is detected
+  // by cache identity instead. Failed reads leave their traces visible
+  // and unretried until the selection changes.
+  useEffect(() => {
+    const cache = cacheRef.current
+    if (!cache || cache.selection !== selection) return
+    const unknown = rows
+      .filter(
+        (r) =>
+          !cache.verdicts.has(r.traceId) && !cache.requested.has(r.traceId),
+      )
+      .map((r) => r.traceId)
+    if (unknown.length === 0) return
+    for (const traceId of unknown) cache.requested.add(traceId)
+    void (async () => {
+      for (let i = 0; i < unknown.length; i += FETCH_TRACE_CHUNK) {
+        const chunk = unknown.slice(i, i + FETCH_TRACE_CHUNK)
+        try {
+          const res = await fetchTraces({
+            trace_ids: chunk,
+            search_all_spans: true,
+            include_internal: true,
+            limit: FETCH_SPAN_LIMIT,
+          })
+          if (cacheRef.current !== cache) return
+          mergeFetchedVerdicts(cache.verdicts, chunk, res.spans, selection)
+          setFetchTick((t) => t + 1)
+        } catch {
+          // Traces unavailable (memory exporter off, transient error) —
+          // the rows simply stay visible.
+        }
+      }
+    })()
+  }, [rows, selection])
+
+  return visibleRows
+}

--- a/console/web/src/pages/TracesV2/index.tsx
+++ b/console/web/src/pages/TracesV2/index.tsx
@@ -58,6 +58,7 @@ import { WorkerBreakdown } from './components/WorkerBreakdown'
 import { useAllSpans } from './hooks/useAllSpans'
 import { useFollowLiveTurn } from './hooks/useFollowLiveTurn'
 import { useFollowTurns } from './hooks/useFollowTurns'
+import { useSpanFilteredTraceRows } from './hooks/useSpanFilteredTraceRows'
 import { useSpanFilterSelection } from './hooks/useSpanFilterSelection'
 import { useSpanPanelResize } from './hooks/useSpanPanelResize'
 import { useTraceActivity } from './hooks/useTraceActivity'
@@ -263,12 +264,23 @@ export function TracesV2({ initialTraceId }: TracesV2Props) {
   const conversationsCtx = useConversationsCtxOptional()
   const { followTurns, toggleFollowTurns } = useFollowTurns()
 
+  // Span-filter fallout on the LIST: a row hides while its trace has no
+  // visible span left under the funnel selection (composition read from the
+  // all-spans feed — see the hook). Everything list-shaped below (paging,
+  // stats, empty state) works off the filtered rows; the raw `traceGroups`
+  // keep feeding the group-by key suggestions above.
+  const visibleTraceGroups = useSpanFilteredTraceRows(
+    traceGroups,
+    allSpans,
+    spanFilter,
+  )
+
   const totalPages = Math.max(
     1,
-    Math.ceil(traceGroups.length / filterState.pageSize),
+    Math.ceil(visibleTraceGroups.length / filterState.pageSize),
   )
   const start = (filterState.page - 1) * filterState.pageSize
-  const paged = traceGroups.slice(start, start + filterState.pageSize)
+  const paged = visibleTraceGroups.slice(start, start + filterState.pageSize)
 
   // Liveness evaluation instant for the list rows' pulsing dot — only ticked
   // while a visible row is actually live, mirroring the strip's clock
@@ -297,15 +309,15 @@ export function TracesV2({ initialTraceId }: TracesV2Props) {
 
   const stats = useMemo(
     () => ({
-      totalTraces: traceGroups.length,
-      errorCount: traceGroups.filter((t) => t.status === 'error').length,
+      totalTraces: visibleTraceGroups.length,
+      errorCount: visibleTraceGroups.filter((t) => t.status === 'error').length,
       avgDuration:
-        traceGroups.length > 0
-          ? traceGroups.reduce((sum, t) => sum + (t.duration ?? 0), 0) /
-            traceGroups.length
+        visibleTraceGroups.length > 0
+          ? visibleTraceGroups.reduce((sum, t) => sum + (t.duration ?? 0), 0) /
+            visibleTraceGroups.length
           : 0,
     }),
-    [traceGroups],
+    [visibleTraceGroups],
   )
 
   const containerRef = useRef<HTMLDivElement>(null)
@@ -670,7 +682,7 @@ export function TracesV2({ initialTraceId }: TracesV2Props) {
               </div>
             ) : (
               <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
-                {isQueryLoading && traceGroups.length === 0 ? (
+                {isQueryLoading && visibleTraceGroups.length === 0 ? (
                   <div className="flex flex-col">
                     {(
                       [
@@ -697,7 +709,7 @@ export function TracesV2({ initialTraceId }: TracesV2Props) {
                       </div>
                     ))}
                   </div>
-                ) : traceGroups.length === 0 ? (
+                ) : visibleTraceGroups.length === 0 ? (
                   <div className="p-9">
                     <EmptyState
                       icon={GitBranch}
@@ -757,7 +769,7 @@ export function TracesV2({ initialTraceId }: TracesV2Props) {
                       <Pagination
                         currentPage={filterState.page}
                         totalPages={totalPages}
-                        totalItems={traceGroups.length}
+                        totalItems={visibleTraceGroups.length}
                         pageSize={filterState.pageSize}
                         onPageChange={(p) => updateFilter('page', p)}
                         onPageSizeChange={(s) => {

--- a/console/web/src/pages/TracesV2/lib/timelineSpans.ts
+++ b/console/web/src/pages/TracesV2/lib/timelineSpans.ts
@@ -148,18 +148,20 @@ export function isTraceLive(
  *  then tag ROOTS under their own span name (a producer's scope span like
  *  `harness::turn step` is a first-class segment, not machinery of the
  *  function whose baggage it inherits), then the baggage-stamped
- *  `iii.function.id`, then the span name. */
-function storedSpanGroupKey(
-  span: StoredSpan,
+ *  `iii.function.id`, then the span name. Also keys the trace LIST's root
+ *  rows (`useSpanFilteredTraceRows`), which is why it takes the bare
+ *  name + normalized attributes rather than a `StoredSpan`. */
+export function spanFilterGroupKey(
+  name: string,
   attrs: Record<string, unknown>,
   inheritedKind: string | undefined,
 ): string {
-  const explicit = explicitFunctionId({ name: span.name, attributes: attrs })
+  const explicit = explicitFunctionId({ name, attributes: attrs })
   if (explicit) return explicit
-  if (tagRootKind(attrs, inheritedKind)) return span.name
+  if (tagRootKind(attrs, inheritedKind)) return name
   const baggage = attrs['iii.function.id']
   if (typeof baggage === 'string' && baggage !== '') return baggage
-  return span.name
+  return name
 }
 
 interface ShapedStoredSpan {
@@ -261,7 +263,7 @@ export function storedSpansToTimelineSpans(
       kind: kindForOtelSpan({ ...shaped, kind: span.kind }),
       label: resolveSpanLabel(shaped, inherited.displayName),
       meta: `${worker} · ${span.trace_id.slice(0, 8)}`,
-      groupKey: storedSpanGroupKey(span, attrs, inherited.kind),
+      groupKey: spanFilterGroupKey(span.name, attrs, inherited.kind),
       workerKey: worker,
       internalKey: internalFamilyOf(attrs) ?? undefined,
     })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trace lists now reflect active span filters, hiding traces without matching visible spans.
  * Timeline span visibility rules are applied consistently across the timeline and trace list.
  * Pagination, counts, loading states, and empty states now reflect filtered results.

* **Bug Fixes**
  * Improved handling of hidden roots, workers, internal spans, and truncated trace data.
  * Preserved trace visibility while additional span information is being loaded.

* **Tests**
  * Added comprehensive coverage for filtering, visibility updates, caching, and fetched trace data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->