### PR TITLE
(MOT-4018) fix(memory-consolidate): typed cron tick payload for the publish gate

### DIFF
--- a/memory-consolidate/src/functions.rs
+++ b/memory-consolidate/src/functions.rs
@@ -249,6 +249,21 @@ pub async fn status(deps: &Deps, _req: StatusRequest) -> Result<StatusResponse, 
     })
 }
 
+/// The cron worker's tick payload (all advisory; the handler re-derives
+/// due-ness from persisted state). Typed so the published interface
+/// carries a real schema.
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+pub struct TickInput {
+    #[serde(default)]
+    pub trigger: Option<String>,
+    #[serde(default)]
+    pub job_id: Option<String>,
+    #[serde(default)]
+    pub scheduled_time: Option<String>,
+    #[serde(default)]
+    pub actual_time: Option<String>,
+}
+
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct TickResponse {
     /// A pass actually ran (false = not due yet or disabled).

--- a/memory-consolidate/src/main.rs
+++ b/memory-consolidate/src/main.rs
@@ -73,7 +73,7 @@ fn bind_schedule(iii: Arc<IIIClient>, deps: Arc<Deps>) {
     let deps_for_fn = deps.clone();
     iii.register_function(
         functions::TICK_ID,
-        RegisterFunction::new_async(move |_payload: serde_json::Value| {
+        RegisterFunction::new_async(move |_payload: functions::TickInput| {
             let deps = deps_for_fn.clone();
             async move { functions::tick(&deps).await }
         })


### PR DESCRIPTION
Registry publish for memory-consolidate v0.1.1 failed its interface gate: `memory-consolidate::on-tick.request_schema` was untyped (AnyValue) because the handler took a raw JSON value for the cron payload.

The handler now deserializes a typed `TickInput` (trigger, job_id, scheduled_time, actual_time; all advisory, due-ness still re-derived from persisted state), so the published interface carries a real schema per the binary-worker SOP.

After merge: Create Tag for memory-consolidate (patch, 0.1.2) re-runs the release.

Refs MOT-4026

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a defined schema for cron worker tick events, including optional trigger, job, and timing details.
  * Scheduled heartbeat handlers now accept structured tick event data for improved consistency and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->