### PR TITLE
(MOT-4018) docs: absolute GitHub links in registry-published worker docs

### DIFF
--- a/approval-gate/README.md
+++ b/approval-gate/README.md
@@ -1,7 +1,7 @@
 # approval-gate
 
 The policy and decision surface for human-held function calls
-([spec](../tech-specs/2026-06-agentic/approval-gate.md)). Four surfaces, one
+([spec](https://github.com/iii-hq/workers/blob/main/tech-specs/2026-06-agentic/approval-gate.md)). Four surfaces, one
 worker:
 
 1. **The gate** — `approval::gate`, a `pre_trigger` hook the worker binds

--- a/browser/README.md
+++ b/browser/README.md
@@ -5,7 +5,7 @@ bus. Agents start a session, read the page as an accessibility-tree outline,
 click and type against element refs, and read the page's own console and
 network history back as data. The single most important thing it gives you:
 "why is my dev server page blank?" becomes answerable, because the page's
-console errors are one `browser::console::read` away. The [console](../console)
+console errors are one `browser::console::read` away. The [console](https://github.com/iii-hq/workers/tree/main/console)
 worker adds the human window: a live Browser page with a streaming viewport
 (Chromium-pushed screencast frames), the console feed, and click-to-pick
 elements into chat.
@@ -45,7 +45,7 @@ machine; point `executable` at a specific binary if auto-detection picks the
 wrong one.
 
 To watch sessions live, pick elements into chat, and follow the agent's
-browsing from a UI, add the [console](../console) worker as well:
+browsing from a UI, add the [console](https://github.com/iii-hq/workers/tree/main/console) worker as well:
 
 ```bash
 iii worker add console

--- a/console/README.md
+++ b/console/README.md
@@ -58,7 +58,7 @@ Full-fledged OpenTelemetry explorer over `engine::traces::*` and `engine::logs::
 
 ### Worktrees
 
-The human window into the [`worktree`](../worktree) worker: parallel agent checkouts, ownership, and land outcomes. Lives in [`web/src/pages/Worktrees/`](web/src/pages/Worktrees) and [`web/src/components/chat/`](web/src/components/chat). The whole surface is presence-gated: it appears only while the worktree worker is connected to the engine (the nav entry and picker tab hide; a direct `#/worktrees` hit lands on an install notice).
+The human window into the [`worktree`](https://github.com/iii-hq/workers/tree/main/worktree) worker: parallel agent checkouts, ownership, and land outcomes. Lives in [`web/src/pages/Worktrees/`](web/src/pages/Worktrees) and [`web/src/components/chat/`](web/src/components/chat). The whole surface is presence-gated: it appears only while the worktree worker is connected to the engine (the nav entry and picker tab hide; a direct `#/worktrees` hit lands on an install notice).
 
 - **Graph page** (`#/worktrees`) — repo, worktree, and owning-session nodes from `worktree::list { include_status: true }`, refreshed live off all six `worktree::*` lifecycle trigger types (poll fallback while bindings are unavailable), with a per-worktree detail panel: branch, base, advisory dev port, clean / ahead / behind, diffstat, and the integrated marker for squash- or rebase-landed branches
 - **Picker tab** — the chat working-directory picker grows a **worktrees** tab next to directory browsing: picking a managed worktree validates the path and claims it for the conversation's session; the console-made claim auto-releases when the conversation points elsewhere (best-effort; the worker's prune sweep is the durable backstop). Worktrees with a land in progress are listed but not retargetable
@@ -67,7 +67,7 @@ The human window into the [`worktree`](../worktree) worker: parallel agent check
 
 ### Memory
 
-The human window into the [`memory`](../memory) worker: named banks of always-injected markdown rules and auto-extracted memories. Lives in [`web/src/pages/Memory/`](web/src/pages/Memory). Presence-gated like Worktrees: the page appears only while the memory worker is connected (a direct `#/memory` hit lands on an install notice).
+The human window into the [`memory`](https://github.com/iii-hq/workers/tree/main/memory) worker: named banks of always-injected markdown rules and auto-extracted memories. Lives in [`web/src/pages/Memory/`](web/src/pages/Memory). Presence-gated like Worktrees: the page appears only while the memory worker is connected (a direct `#/memory` hit lands on an install notice).
 
 - **Bank rail** — every bank with live memory / pinned / rule counts and inline create
 - **Rules tab (first)** — the bank's markdown rules as in-place editors (save appears only on edit; delete asks to confirm); the agent appends learned standing instructions to the auto-managed `learned` rule as you correct it in chat
@@ -118,7 +118,7 @@ The browser hits `/` for the SPA shell and upgrades `/ws` to the engine WebSocke
 
 ### Bring up the chat stack
 
-Chat runs on the [`harness`](../harness) durable turn loop. Its manifest declares the whole stack as dependencies — [`session-manager`](../session-manager) (the conversation store the sidebar, transcripts, and live token rendering are backed by), [`llm-router`](../llm-router) (generation + the model catalog), [`context-manager`](../context-manager) (the `/compact` summariser), [`approval-gate`](../approval-gate) (human-in-the-loop approvals), and the provider workers — so a single command resolves and installs all of it:
+Chat runs on the [`harness`](https://github.com/iii-hq/workers/tree/main/harness) durable turn loop. Its manifest declares the whole stack as dependencies — [`session-manager`](https://github.com/iii-hq/workers/tree/main/session-manager) (the conversation store the sidebar, transcripts, and live token rendering are backed by), [`llm-router`](https://github.com/iii-hq/workers/tree/main/llm-router) (generation + the model catalog), [`context-manager`](https://github.com/iii-hq/workers/tree/main/context-manager) (the `/compact` summariser), [`approval-gate`](https://github.com/iii-hq/workers/tree/main/approval-gate) (human-in-the-loop approvals), and the provider workers — so a single command resolves and installs all of it:
 
 ```bash
 iii worker add harness
@@ -129,7 +129,7 @@ iii worker add harness
 The provider workers install with the harness, but they need credentials before any model appears — until then the model picker reads **no models** and chat won't generate. Add a key either way:
 
 - **In the UI (recommended)** — open the model picker and use **configure anthropic** / **configure openai** to paste a key. It's written to that provider's slice of the `llm-router` configuration entry, and the catalog populates within seconds.
-- **From the environment** — `llm-router` falls back to a provider's credential env var (e.g. `ANTHROPIC_API_KEY`), read in the router's own process. See [`llm-router`](../llm-router#configuration) for the credential model.
+- **From the environment** — `llm-router` falls back to a provider's credential env var (e.g. `ANTHROPIC_API_KEY`), read in the router's own process. See [`llm-router`](https://github.com/iii-hq/workers/tree/main/llm-router#configuration) for the credential model.
 
 Pick a model in the composer and send — the turn streams back through the harness loop.
 

--- a/context-manager/README.md
+++ b/context-manager/README.md
@@ -6,7 +6,7 @@ model's usable token budget. It owns *what the model sees this turn* — token
 counting, function-result pruning, and history compaction (summarisation) —
 and nothing else. It is stateless with respect to conversation storage: pass
 messages in, get results back, persist them yourself (or with
-[`session-manager`](../session-manager/)). Summarisation and model-limit
+[`session-manager`](https://github.com/iii-hq/workers/tree/main/session-manager)). Summarisation and model-limit
 lookups go through `llm-router` when installed; token counting and pruning
 work standalone.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 This folder collects **procedures** (SOPs) and **shared architecture** for
 workers in this monorepo. Per-worker deep docs stay inside each worker folder
-(e.g. [`session-manager/architecture/`](../session-manager/architecture/)).
+(e.g. [`session-manager/architecture/`](https://github.com/iii-hq/workers/tree/main/session-manager/architecture)).
 
 ## I want to…
 
@@ -12,11 +12,11 @@ workers in this monorepo. Per-worker deep docs stay inside each worker folder
 | Scaffold a Rust `deploy: binary` worker | [`sops/binary-worker.md`](sops/binary-worker.md) |
 | Ship a version to the registry | [`sops/release.md`](sops/release.md) |
 | Fix a failed release | [`sops/release.md`](sops/release.md) § Troubleshooting |
-| Write a consumer `README.md` | [`worker-readme.md`](../worker-readme.md) |
-| Author `skills/SKILL.md` | [`DOCUMENTATION_GUIDELINES.md`](../DOCUMENTATION_GUIDELINES.md) |
+| Write a consumer `README.md` | [`worker-readme.md`](https://github.com/iii-hq/workers/blob/main/worker-readme.md) |
+| Author `skills/SKILL.md` | [`DOCUMENTATION_GUIDELINES.md`](https://github.com/iii-hq/workers/blob/main/DOCUMENTATION_GUIDELINES.md) |
 | Understand `iii.worker.yaml` fields | [`architecture/iii-worker-yaml.md`](architecture/iii-worker-yaml.md) |
 | Understand CI gates on a PR | [`architecture/testing-and-ci.md`](architecture/testing-and-ci.md) |
-| Integrate with session-manager | [`session-manager/architecture/integration.md`](../session-manager/architecture/integration.md) |
+| Integrate with session-manager | [`session-manager/architecture/integration.md`](https://github.com/iii-hq/workers/blob/main/session-manager/architecture/integration.md) |
 
 ## Layout
 
@@ -38,6 +38,6 @@ docs/
 
 ## Related docs (repo root)
 
-- [`worker-readme.md`](../worker-readme.md) — consumer README contract
-- [`DOCUMENTATION_GUIDELINES.md`](../DOCUMENTATION_GUIDELINES.md) — `skills/SKILL.md` authoring
-- [`tech-specs/`](../tech-specs/) — product-level specs before or alongside implementation
+- [`worker-readme.md`](https://github.com/iii-hq/workers/blob/main/worker-readme.md) — consumer README contract
+- [`DOCUMENTATION_GUIDELINES.md`](https://github.com/iii-hq/workers/blob/main/DOCUMENTATION_GUIDELINES.md) — `skills/SKILL.md` authoring
+- [`tech-specs/`](https://github.com/iii-hq/workers/tree/main/tech-specs) — product-level specs before or alongside implementation

--- a/email/README.md
+++ b/email/README.md
@@ -210,7 +210,7 @@ laptops without a running engine still pass `@pure` scenarios.
 ### Verification before publishing
 
 The full preflight checklist for binary workers
-([`docs/sops/binary-worker.md`](../docs/sops/binary-worker.md)):
+([`docs/sops/binary-worker.md`](https://github.com/iii-hq/workers/blob/main/docs/sops/binary-worker.md)):
 
 ```bash
 cargo fmt --all -- --check

--- a/harness/README.md
+++ b/harness/README.md
@@ -34,9 +34,9 @@
 workers into an agent. It takes an incoming message, persists it, assembles a
 context, streams a completion, runs any function calls the model requests, and
 repeats until the turn stops — all as durable, resumable steps so a crash or
-restart picks up mid-turn. It wires [`session-manager`](../session-manager)
-(transcript), [`context-manager`](../context-manager) (token budgeting, soft
-dependency), and [`llm-router`](../llm-router) (generation); install those
+restart picks up mid-turn. It wires [`session-manager`](https://github.com/iii-hq/workers/tree/main/session-manager)
+(transcript), [`context-manager`](https://github.com/iii-hq/workers/tree/main/context-manager) (token budgeting, soft
+dependency), and [`llm-router`](https://github.com/iii-hq/workers/tree/main/llm-router) (generation); install those
 alongside it for the full loop.
 
 ## Quickstart
@@ -89,7 +89,7 @@ same recovery, partial-output, and blocked-reaction explanation after refresh.
 The agent-facing function surface is deny-by-default: with no `functions.allow`
 globs, every model-requested call is refused and the harness is a plain chat
 loop. Allow functions in per-send (`options.functions.allow`) and gate them
-with the optional [`approval-gate`](../approval-gate) sibling.
+with the optional [`approval-gate`](https://github.com/iii-hq/workers/tree/main/approval-gate) sibling.
 
 The full function reference (every `harness::*` id and its request/response
 schema) lives in the code and `iii worker info harness`.
@@ -188,5 +188,5 @@ plug into in-path. Bind with the standard two-step pattern.
 
 Event configs accept `{ session_id?, parent_session_id? }`; hook configs accept
 `{ functions?, priority?, timeout_ms?, on_error? }`. See the spec at
-[`tech-specs/2026-06-agentic/harness.md`](../tech-specs/2026-06-agentic/harness.md)
+[`tech-specs/2026-06-agentic/harness.md`](https://github.com/iii-hq/workers/blob/main/tech-specs/2026-06-agentic/harness.md)
 for the hook contract and chain semantics.

--- a/iii-directory/README.md
+++ b/iii-directory/README.md
@@ -155,7 +155,7 @@ paths / prompt names that were materialised in this run.
 
 After every successful download the worker fires the
 `directory::skills::on-change` and/or `directory::prompts::on-change`
-trigger types so that subscribers like the [`mcp`](../mcp/) worker can
+trigger types so that subscribers like the [`mcp`](https://github.com/iii-hq/workers/tree/main/mcp) worker can
 forward MCP `notifications/list_changed` to their clients.
 
 ---

--- a/llm-router/README.md
+++ b/llm-router/README.md
@@ -144,7 +144,7 @@ within seconds — no restart.
 ## Security model
 
 The agent-callable surface is governed by the engine-wide permission policy
-(repo-root [`iii-permissions.yaml`](../iii-permissions.yaml)), not a per-worker
+(repo-root [`iii-permissions.yaml`](https://github.com/iii-hq/workers/blob/main/iii-permissions.yaml)), not a per-worker
 file. In-run agents may only **read** the catalog and provider list:
 
 - **Allowed:** `router::models::list`, `router::models::get`,
@@ -209,9 +209,9 @@ and serves it (unless the config slice sets an override) via
 `router::system_prompt::get`; the harness fetches it at turn creation.
 
 The first real provider implementing this protocol is
-[`provider-anthropic/`](../provider-anthropic/) — useful as a reference
+[`provider-anthropic/`](https://github.com/iii-hq/workers/tree/main/provider-anthropic) — useful as a reference
 implementation alongside the scripted provider in the integration tests.
-[`provider-openai/`](../provider-openai/) follows the same structure for the
+[`provider-openai/`](https://github.com/iii-hq/workers/tree/main/provider-openai) follows the same structure for the
 OpenAI Chat Completions API (native structured output, reasoning_effort).
 
 ## Local development & testing

--- a/lsp/README.md
+++ b/lsp/README.md
@@ -44,8 +44,8 @@ The binary speaks LSP over stdio; spawn it from your editor's LSP client.
 
 Use the bundled VS Code extension, which downloads the matching `lsp` binary on first activation:
 
-- Source: [lsp-vscode/](../lsp-vscode/)
-- Marketplace: see [lsp-vscode/README.md](../lsp-vscode/README.md) for install instructions.
+- Source: [lsp-vscode/](https://github.com/iii-hq/workers/tree/main/lsp-vscode)
+- Marketplace: see [lsp-vscode/README.md](https://github.com/iii-hq/workers/blob/main/lsp-vscode/README.md) for install instructions.
 
 ### Neovim (built-in LSP)
 
@@ -63,5 +63,5 @@ Configure the client to launch the `lsp` binary over stdio for the supported fil
 
 ## See also
 
-- [lsp-vscode/README.md](../lsp-vscode/README.md) — VS Code extension that wraps this binary.
-- [docs/sops/new-worker.md](../docs/sops/new-worker.md) — monorepo conventions and release flow.
+- [lsp-vscode/README.md](https://github.com/iii-hq/workers/blob/main/lsp-vscode/README.md) — VS Code extension that wraps this binary.
+- [docs/sops/new-worker.md](https://github.com/iii-hq/workers/blob/main/docs/sops/new-worker.md) — monorepo conventions and release flow.

--- a/memory-consolidate/README.md
+++ b/memory-consolidate/README.md
@@ -1,6 +1,6 @@
 # memory-consolidate
 
-Scheduled hygiene sibling of the [`memory`](../memory) worker. Finds near-duplicate memories in every bank and merges them: the duplicate retires with a `superseded_by` pointer (never a delete), the survivor absorbs the observation as corroboration. Strictly supersede-only through memory's public functions, pinned memories untouchable, every change visible as a `memory::item-changed` event. Install, stop, or remove it without touching stored memory.
+Scheduled hygiene sibling of the [`memory`](https://github.com/iii-hq/workers/tree/main/memory) worker. Finds near-duplicate memories in every bank and merges them: the duplicate retires with a `superseded_by` pointer (never a delete), the survivor absorbs the observation as corroboration. Strictly supersede-only through memory's public functions, pinned memories untouchable, every change visible as a `memory::item-changed` event. Install, stop, or remove it without touching stored memory.
 
 ## Install
 

--- a/memory/README.md
+++ b/memory/README.md
@@ -96,10 +96,10 @@ Like `llm-router` and its provider workers, memory is a family of narrow sibling
 | Worker | Role | Status |
 |---|---|---|
 | `memory` (this) | Banks, rules, memories: storage, harness injection, background capture, hybrid recall, live trigger types | shipped |
-| [`memory-consolidate`](../memory-consolidate/) | Background hygiene on a schedule: deterministic dedup of near-duplicate memories, catch-up-on-boot scheduling. Supersede-only through `memory::supersede`, never touches pinned records; every change lands as a `memory::item-changed` event | shipped |
+| [`memory-consolidate`](https://github.com/iii-hq/workers/tree/main/memory-consolidate) | Background hygiene on a schedule: deterministic dedup of near-duplicate memories, catch-up-on-boot scheduling. Supersede-only through `memory::supersede`, never touches pinned records; every change lands as a `memory::item-changed` event | shipped |
 
 The split is the point: consolidation can be installed, stopped, or removed without touching stored memory, and this worker never grows a scheduler.
 
 ## Boundaries
 
-Context-manager compresses one history for one turn; this worker is the durable cross-session sibling its spec reserves (see [tech-specs/2026-06-agentic/memory.md](../tech-specs/2026-06-agentic/memory.md)). Recall fuses BM25 with a semantic signal when `router::embed` has an embed-capable provider; `memory::recall.retrieval` names the mode either way. Consolidation belongs to the `memory-consolidate` sibling, not here.
+Context-manager compresses one history for one turn; this worker is the durable cross-session sibling its spec reserves (see [tech-specs/2026-06-agentic/memory.md](https://github.com/iii-hq/workers/blob/main/tech-specs/2026-06-agentic/memory.md)). Recall fuses BM25 with a semantic signal when `router::embed` has an embed-capable provider; `memory::recall.retrieval` names the mode either way. Consolidation belongs to the `memory-consolidate` sibling, not here.

--- a/provider-anthropic/README.md
+++ b/provider-anthropic/README.md
@@ -1,6 +1,6 @@
 # provider-anthropic
 
-Claude models behind [llm-router](../llm-router/). Install this worker next
+Claude models behind [llm-router](https://github.com/iii-hq/workers/tree/main/llm-router). Install this worker next
 to the router, give it an API key, and the Anthropic catalog — streaming,
 extended thinking, tool use, vision, automatic prompt caching — appears
 behind the router's single front door (`router::chat` / `router::complete`).
@@ -46,7 +46,7 @@ const res = await iii.trigger('router::complete', {
 ```
 
 For token-by-token streaming, call `router::chat` with an iii channel — the
-walkthrough lives in [llm-router's Quickstart](../llm-router/README.md).
+walkthrough lives in [llm-router's Quickstart](https://github.com/iii-hq/workers/blob/main/llm-router/README.md).
 Request extended thinking with `thinking_level`; the worker maps the level
 to an Anthropic thinking budget from the model's catalog record. `xhigh`
 degrades to `high` on models that don't support it, and the level is

--- a/provider-llamacpp/README.md
+++ b/provider-llamacpp/README.md
@@ -1,7 +1,7 @@
 # provider-llamacpp
 
 llama.cpp server ([`llama-server`](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md))
-Chat Completions provider worker behind [llm-router](../llm-router/).
+Chat Completions provider worker behind [llm-router](https://github.com/iii-hq/workers/tree/main/llm-router).
 Implements the provider protocol from
 `tech-specs/2026-06-agentic/llm-router.md`: `provider::llamacpp::stream`
 (SSE chunks → `AssistantMessageEvent` frames into a router-owned channel) and

--- a/provider-openai-codex/README.md
+++ b/provider-openai-codex/README.md
@@ -1,7 +1,7 @@
 # provider-openai-codex
 
 OpenAI **Codex (ChatGPT subscription)** provider worker behind
-[llm-router](../llm-router/). It lets the stack generate against a ChatGPT/Codex
+[llm-router](https://github.com/iii-hq/workers/tree/main/llm-router). It lets the stack generate against a ChatGPT/Codex
 subscription (billed to the plan, "Sign in with ChatGPT") instead of a
 pay-per-token API key, by speaking OpenAI's **Responses API** at the Codex
 backend.

--- a/provider-openai/README.md
+++ b/provider-openai/README.md
@@ -1,6 +1,6 @@
 # provider-openai
 
-OpenAI Responses provider worker behind [llm-router](../llm-router/), with a
+OpenAI Responses provider worker behind [llm-router](https://github.com/iii-hq/workers/tree/main/llm-router), with a
 Chat Completions compatibility path for custom gateways.
 Implements the provider protocol from
 `tech-specs/2026-06-agentic/llm-router.md`: `provider::openai::stream`

--- a/provider-xai/README.md
+++ b/provider-xai/README.md
@@ -1,6 +1,6 @@
 # provider-xai
 
-xAI Chat Completions provider worker behind [llm-router](../llm-router/).
+xAI Chat Completions provider worker behind [llm-router](https://github.com/iii-hq/workers/tree/main/llm-router).
 Implements the provider protocol from
 `tech-specs/2026-06-agentic/llm-router.md`: `provider::xai::stream`
 (SSE chunks → `AssistantMessageEvent` frames into a router-owned channel) and

--- a/provider-zai/README.md
+++ b/provider-zai/README.md
@@ -1,6 +1,6 @@
 # provider-zai
 
-Z.AI (GLM) Chat Completions provider worker behind [llm-router](../llm-router/).
+Z.AI (GLM) Chat Completions provider worker behind [llm-router](https://github.com/iii-hq/workers/tree/main/llm-router).
 Implements the provider protocol from
 `tech-specs/2026-06-agentic/llm-router.md`: `provider::zai::stream`
 (SSE chunks → `AssistantMessageEvent` frames into a router-owned channel) and

--- a/rbac-proxy/README.md
+++ b/rbac-proxy/README.md
@@ -15,7 +15,7 @@ listener, while at the boundary it:
 - **rewrites the results of the eight `engine::*` discovery functions** so a
   caller only ever sees the surface it is allowed to invoke.
 
-It is the [`console`](../console) reverse-proxy pattern (`src/proxy.rs`: one
+It is the [`console`](https://github.com/iii-hq/workers/tree/main/console) reverse-proxy pattern (`src/proxy.rs`: one
 outbound engine WebSocket per inbound connection) with an RBAC interceptor
 spliced into the pump and a second proxied route for `/ws/channels/{id}`.
 
@@ -27,7 +27,7 @@ out-of-process *home* for the same contract (it can front a remote or managed
 engine, scale and harden independently, and shrink an auth bug's blast radius
 to the proxy alone).
 
-Full design: [`tech-specs/2026-06-rbac-proxy-worker/`](../tech-specs/2026-06-rbac-proxy-worker/README.md).
+Full design: [`tech-specs/2026-06-rbac-proxy-worker/`](https://github.com/iii-hq/workers/blob/main/tech-specs/2026-06-rbac-proxy-worker/README.md).
 
 ## Install
 

--- a/session-manager/README.md
+++ b/session-manager/README.md
@@ -7,7 +7,7 @@ description, coarse status, app-defined metadata). Any worker or client
 appends and reads over the bus; every mutation fires a trigger type
 consumers bind to, so a chat UI, bot, or dashboard renders live with no
 polling and no separate publish call. It runs no agent logic — it is
-the conversation database the [harness](../harness) family drives, and
+the conversation database the [harness](https://github.com/iii-hq/workers/tree/main/harness) family drives, and
 it is independently useful as a real-time chat store for any app.
 
 ## Install

--- a/slack/skills/SKILL.md
+++ b/slack/skills/SKILL.md
@@ -53,5 +53,5 @@ All fields hot-reload.
 
 Each typed function names the common Slack parameters and passes any extra
 parameters through; the full Slack response payload is returned. See the
-[README](../README.md) for the full list. Use `slack::call` for anything not yet
+[README](https://github.com/iii-hq/workers/blob/main/slack/README.md) for the full list. Use `slack::call` for anything not yet
 typed.

--- a/storage/README.md
+++ b/storage/README.md
@@ -320,7 +320,7 @@ is env-var-gated — see `tests/e2e/run-tests.sh` for the orchestrator.
 ### Verification before publishing
 
 The full preflight checklist for binary workers
-([`docs/sops/binary-worker.md`](../docs/sops/binary-worker.md) §11):
+([`docs/sops/binary-worker.md`](https://github.com/iii-hq/workers/blob/main/docs/sops/binary-worker.md) §11):
 
 ```bash
 cargo fmt --all -- --check

--- a/worker-readme.md
+++ b/worker-readme.md
@@ -8,6 +8,15 @@ and it is the page on the registry. Treat it as a **how-to**, not a
 reference. The reference lives in the code — rustdoc, source links,
 `iii worker info`, IDE autocomplete on function ids.
 
+## Links must be absolute
+
+The README renders on the registry page, not just on GitHub. A relative
+link that escapes the worker folder (`../tech-specs/...`, `../console`)
+resolves against the registry origin and 404s there. Link to anything
+outside the worker folder with a full GitHub URL
+(`https://github.com/iii-hq/workers/tree/main/<dir>` or
+`.../blob/main/<file>`).
+
 ## What the README answers
 
 In order, three questions:

--- a/worktree/README.md
+++ b/worktree/README.md
@@ -5,7 +5,7 @@ isolated, locked worktree off any ref and registers it in a cross-agent
 registry; agents work inside it through their turn's filesystem scope
 (`metadata.fs_scope.root`); `worktree::land`
 rebases the branch onto a target, runs an optional test gate through the
-[shell](../shell) worker, fast-forwards the target with an atomic
+[shell](https://github.com/iii-hq/workers/tree/main/shell) worker, fast-forwards the target with an atomic
 compare-and-swap, and cleans up. Every lifecycle change emits a trigger type
 sibling workers can subscribe to, so a Slack bot can announce lands or a
 harness can react when a sibling's branch merges.


### PR DESCRIPTION
Registry worker pages render the published README, so a relative link that escapes the worker folder resolves against the registry origin and 404s — e.g. https://workers.iii.dev/tech-specs/2026-06-agentic/memory.md from the memory page.

This converts every escaping `../` link across 23 worker READMEs/SKILLs to the full GitHub `tree/main` / `blob/main` URL (targets verified to exist; the one already-dead target, provider-openai-codex's `../auth-credentials/`, is left as-is and noted). `worker-readme.md` gains a short rule so new READMEs keep links absolute.

Refs MOT-4026