### PR TITLE
(MOT-4018) fix(console): explain rule-name validation and slugify pasted names

### DIFF
--- a/console/web/src/pages/Memory/components/RulesPanel.tsx
+++ b/console/web/src/pages/Memory/components/RulesPanel.tsx
@@ -123,9 +123,23 @@ function RuleEditor({
   )
 }
 
+/** A rule name from whatever was typed or pasted: lowercased, separators
+ * dashed, invalid chars dropped, trimmed to the 64-char limit. */
+function slugifyRuleName(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[\s:/\\]+/g, '-')
+    .replace(/[^a-z0-9_-]/g, '')
+    .replace(/-{2,}/g, '-')
+    .replace(/^[-_]+/, '')
+    .slice(0, 64)
+    .replace(/[-_]+$/, '')
+}
+
 export function RulesPanel({ rules, onSet, busy }: RulesPanelProps) {
   const [newName, setNewName] = useState('')
   const validName = /^[a-z0-9][a-z0-9_-]{0,63}$/.test(newName)
+  const suggestion = validName ? '' : slugifyRuleName(newName)
 
   return (
     <div className="flex flex-col gap-3">
@@ -153,32 +167,43 @@ export function RulesPanel({ rules, onSet, busy }: RulesPanelProps) {
         ))
       )}
       <form
-        className="flex items-center gap-2"
+        className="flex flex-col gap-1"
         onSubmit={(e) => {
           e.preventDefault()
-          if (!validName || busy) return
-          void onSet(newName, `# ${newName}\n`).then((ok) => {
+          if (busy) return
+          const name = validName ? newName : suggestion
+          if (!name) return
+          void onSet(name, `# ${name}\n`).then((ok) => {
             if (ok) setNewName('')
           })
         }}
       >
-        <Input
-          value={newName}
-          onChange={setNewName}
-          placeholder="new rule name (e.g. style)"
-          aria-label="new rule name"
-          className="flex-1"
-        />
-        <Button
-          type="submit"
-          variant="ghost"
-          size="sm"
-          disabled={!validName || busy}
-          className="gap-1"
-        >
-          <Plus className="w-3.5 h-3.5" aria-hidden />
-          add rule
-        </Button>
+        <div className="flex items-center gap-2">
+          <Input
+            value={newName}
+            onChange={setNewName}
+            placeholder="name the rule first (e.g. style) — content goes in the editor after"
+            aria-label="new rule name"
+            className="flex-1"
+          />
+          <Button
+            type="submit"
+            variant="ghost"
+            size="sm"
+            disabled={busy || (!validName && !suggestion)}
+            className="gap-1"
+          >
+            <Plus className="w-3.5 h-3.5" aria-hidden />
+            add rule
+          </Button>
+        </div>
+        {newName && !validName ? (
+          <p className="font-mono text-[10px] lowercase text-ink-ghost">
+            {suggestion
+              ? `names are lowercase-with-dashes (it becomes ${suggestion}.md) — adding will create "${suggestion}"; paste the content into its editor after`
+              : 'names are lowercase letters, numbers, and dashes — like style or coding-rules'}
+          </p>
+        ) : null}
       </form>
     </div>
   )


### PR DESCRIPTION
Pasting a whole rule body into the add-rule box silently disabled the button — the input takes a NAME (`[a-z0-9][a-z0-9_-]{0,63}`, it becomes `<name>.md`), but nothing said so.

Now: an invalid input shows a one-line explanation plus the slugified name it would create, and submitting creates that slug; the content goes into the editor card that appears, as before.

Refs MOT-4018

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic suggestions for valid rule filenames when entered names contain unsupported characters or formatting.
  * Rule creation now uses the entered name when valid, or the suggested filename when available.
  * Updated the input guidance and placeholder to clarify the resulting `.md` filename.

* **Bug Fixes**
  * Prevented rule creation when no valid filename can be generated.
  * Updated button availability so rules can be submitted when a valid suggestion exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->