### PR TITLE
(MOT-4053) feat(provider-llamacpp): native embeddings surface

### DIFF
--- a/provider-llamacpp/Cargo.lock
+++ b/provider-llamacpp/Cargo.lock
@@ -738,7 +738,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.1.1"
+version = "1.1.3"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-llamacpp/README.md
+++ b/provider-llamacpp/README.md
@@ -12,6 +12,10 @@ Default upstream: `http://127.0.0.1:8080/v1/chat/completions` — `llama-server`
 own default bind address and port. Point `api_url` at any running
 `llama-server` instance (local, LAN, or a remote box) to use it.
 
+## Embeddings
+
+`provider::llamacpp::embed` serves batch text embeddings from the same configured server when llama-server runs with `--embeddings` and an embedding-capable model (e.g. a nomic-embed GGUF). One vector per input, order preserved; behind `router::embed`, this gives the memory worker fully local semantic recall with no cloud call.
+
 ## Behavior
 
 - **Registration:** self-declares via `router::provider::register` with

--- a/provider-llamacpp/iii-permissions.yaml
+++ b/provider-llamacpp/iii-permissions.yaml
@@ -8,3 +8,4 @@ rules:
   - '!provider::llamacpp::stream'
   - '!provider::llamacpp::refresh_models'
   - '!provider::llamacpp::on_router_ready'
+  - '!provider::llamacpp::embed'

--- a/provider-llamacpp/src/embed.rs
+++ b/provider-llamacpp/src/embed.rs
@@ -26,6 +26,7 @@ pub struct EmbedRequest {
     #[serde(default)]
     pub model: Option<String>,
     /// Texts to embed, one vector returned per input, order preserved.
+    #[schemars(length(min = 1, max = 512))]
     pub input: Vec<String>,
 }
 

--- a/provider-llamacpp/src/embed.rs
+++ b/provider-llamacpp/src/embed.rs
@@ -1,0 +1,180 @@
+//! `provider::llamacpp::embed` — batch text embeddings against the
+//! configured llama-server, which exposes an OpenAI-compatible
+//! `/v1/embeddings` when started with `--embeddings` and an
+//! embedding-capable GGUF. Consumers (llm-router's `router::embed`, and
+//! through it the memory worker's semantic recall) treat this as the
+//! provider protocol's embedding surface. Fully local: no cloud, no
+//! credential unless the server was started with `--api-key`.
+
+use iii_sdk::errors::Error;
+use iii_sdk::IIIClient;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::config::{config_from_resolve, ConfigError};
+use crate::{router_client, state};
+
+/// Embeddings requests are bounded and non-streaming; a tight budget keeps
+/// hook callers (memory recall) inside their own timeouts.
+const EMBED_TIMEOUT_SECS: u64 = 20;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct EmbedRequest {
+    /// Model name passed through to the server. llama-server embeds with
+    /// its loaded model regardless; the field is echoed for parity with
+    /// the other providers.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Texts to embed, one vector returned per input, order preserved.
+    pub input: Vec<String>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct EmbedResponse {
+    pub model: String,
+    /// One embedding per input, in input order.
+    pub embeddings: Vec<Vec<f32>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WireEmbedding {
+    index: usize,
+    embedding: Vec<f32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WireResponse {
+    data: Vec<WireEmbedding>,
+    #[serde(default)]
+    model: Option<String>,
+}
+
+/// Embeddings endpoint for the configured chat `api_url`: the sibling
+/// `/embeddings` on the same host and version prefix, so a nonstandard
+/// port or path prefix keeps working.
+fn embed_url(chat_api_url: &str) -> String {
+    let fallback = || crate::config::DEFAULT_API_URL.replace("/chat/completions", "/embeddings");
+    let Ok(mut url) = reqwest::Url::parse(chat_api_url) else {
+        return fallback();
+    };
+    let path = url.path().trim_end_matches('/').to_string();
+    let new_path = if let Some(base) = path.strip_suffix("/chat/completions") {
+        format!("{base}/embeddings")
+    } else {
+        format!("{path}/embeddings")
+    };
+    url.set_path(&new_path);
+    url.set_query(None);
+    url.to_string()
+}
+
+pub async fn handle(
+    iii: &IIIClient,
+    http: &reqwest::Client,
+    req: EmbedRequest,
+) -> Result<EmbedResponse, Error> {
+    if req.input.is_empty() || req.input.len() > 512 {
+        return Err(Error::Handler(
+            "invalid_input: input must contain 1..=512 texts".into(),
+        ));
+    }
+    let model = req
+        .model
+        .filter(|m| !m.trim().is_empty())
+        .unwrap_or_else(|| "default".to_string());
+
+    let token = state::load_token(iii).await;
+    let resolved = router_client::resolve(iii, token.as_deref()).await?;
+    let cfg = config_from_resolve(&model, None, &resolved).map_err(|e| match e {
+        ConfigError::InvalidApiUrl(u) => {
+            Error::Handler(format!("provider/config: invalid endpoint url {u:?}"))
+        }
+    })?;
+
+    let mut request = http
+        .post(embed_url(&cfg.api_url))
+        .timeout(std::time::Duration::from_secs(EMBED_TIMEOUT_SECS))
+        .json(&serde_json::json!({ "model": model, "input": req.input }));
+    // Local llama-server usually runs with no --api-key; only send the
+    // header when a credential resolved.
+    if let Some(credential) = &cfg.credential_value {
+        request = request.bearer_auth(credential);
+    }
+    let response = request
+        .send()
+        .await
+        .map_err(|e| Error::Handler(format!("provider/upstream: {e}")))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        let excerpt: String = body.chars().take(300).collect();
+        return Err(Error::Handler(format!(
+            "provider/upstream_status: {status}: {excerpt} \
+             (llama-server needs --embeddings and an embedding-capable model)"
+        )));
+    }
+    let wire: WireResponse = response
+        .json()
+        .await
+        .map_err(|e| Error::Handler(format!("provider/bad_response: {e}")))?;
+
+    // One-vector-per-input contract: a silent gap would attach the wrong
+    // vector to the wrong text downstream.
+    let expected = req.input.len();
+    if wire.data.len() != expected {
+        return Err(Error::Handler(format!(
+            "provider/bad_response: {} embeddings for {expected} inputs",
+            wire.data.len()
+        )));
+    }
+    let mut data = wire.data;
+    data.sort_by_key(|d| d.index);
+    if data.iter().enumerate().any(|(i, d)| d.index != i) {
+        return Err(Error::Handler(
+            "provider/bad_response: duplicate or out-of-range embedding indices".into(),
+        ));
+    }
+    Ok(EmbedResponse {
+        model: wire.model.unwrap_or(model),
+        embeddings: data.into_iter().map(|d| d.embedding).collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embed_url_follows_the_configured_endpoint() {
+        assert_eq!(
+            embed_url("http://127.0.0.1:8080/v1/chat/completions"),
+            "http://127.0.0.1:8080/v1/embeddings"
+        );
+        assert_eq!(
+            embed_url("http://gpu-box:9000/llama/v1/chat/completions"),
+            "http://gpu-box:9000/llama/v1/embeddings"
+        );
+        assert_eq!(
+            embed_url("not a url"),
+            "http://127.0.0.1:8080/v1/embeddings"
+        );
+    }
+
+    #[test]
+    fn wire_response_orders_and_validates() {
+        let raw = r#"{"data":[{"index":1,"embedding":[0.3]},{"index":0,"embedding":[0.1]}],"model":"nomic"}"#;
+        let wire: WireResponse = serde_json::from_str(raw).unwrap();
+        let mut data = wire.data;
+        data.sort_by_key(|d| d.index);
+        assert_eq!(data[0].embedding, vec![0.1]);
+        assert!(!data.iter().enumerate().any(|(i, d)| d.index != i));
+
+        let gap = r#"{"data":[{"index":0,"embedding":[0.1]},{"index":2,"embedding":[0.2]}]}"#;
+        let wire: WireResponse = serde_json::from_str(gap).unwrap();
+        let mut data = wire.data;
+        data.sort_by_key(|d| d.index);
+        assert!(data.iter().enumerate().any(|(i, d)| d.index != i));
+        assert!(wire.model.is_none());
+    }
+}

--- a/provider-llamacpp/src/lib.rs
+++ b/provider-llamacpp/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod config;
 pub mod discovery;
+pub mod embed;
 pub mod errors;
 pub mod manifest;
 pub mod register;

--- a/provider-llamacpp/src/register.rs
+++ b/provider-llamacpp/src/register.rs
@@ -132,6 +132,20 @@ pub async fn register_provider(iii: IIIClient) -> Result<(), Error> {
             .description(surface::REFRESH_MODELS_DESC),
     );
 
+    {
+        let iii_embed = iii.clone();
+        let http_embed = http.clone();
+        iii.register_function(
+            surface::EMBED_ID,
+            RegisterFunction::new_async(move |req: crate::embed::EmbedRequest| {
+                let (iii, http) = (iii_embed.clone(), http_embed.clone());
+                async move { crate::embed::handle(&iii, &http, req).await }
+            })
+            .description(surface::EMBED_DESC)
+            .metadata(json!({ "internal": true })),
+        );
+    }
+
     // Re-declare when the router restarts: bind to the router::ready trigger type.
     {
         let iii_ready = iii.clone();

--- a/provider-llamacpp/src/register.rs
+++ b/provider-llamacpp/src/register.rs
@@ -132,20 +132,6 @@ pub async fn register_provider(iii: IIIClient) -> Result<(), Error> {
             .description(surface::REFRESH_MODELS_DESC),
     );
 
-    {
-        let iii_embed = iii.clone();
-        let http_embed = http.clone();
-        iii.register_function(
-            surface::EMBED_ID,
-            RegisterFunction::new_async(move |req: crate::embed::EmbedRequest| {
-                let (iii, http) = (iii_embed.clone(), http_embed.clone());
-                async move { crate::embed::handle(&iii, &http, req).await }
-            })
-            .description(surface::EMBED_DESC)
-            .metadata(json!({ "internal": true })),
-        );
-    }
-
     // Re-declare when the router restarts: bind to the router::ready trigger type.
     {
         let iii_ready = iii.clone();
@@ -161,6 +147,20 @@ pub async fn register_provider(iii: IIIClient) -> Result<(), Error> {
                 }
             })
             .description(surface::ON_ROUTER_READY_DESC),
+        );
+    }
+
+    {
+        let iii_embed = iii.clone();
+        let http_embed = http.clone();
+        iii.register_function(
+            surface::EMBED_ID,
+            RegisterFunction::new_async(move |req: crate::embed::EmbedRequest| {
+                let (iii, http) = (iii_embed.clone(), http_embed.clone());
+                async move { crate::embed::handle(&iii, &http, req).await }
+            })
+            .description(surface::EMBED_DESC)
+            .metadata(json!({ "internal": true })),
         );
     }
     let _ = iii.register_trigger(RegisterTriggerInput {

--- a/provider-llamacpp/src/surface.rs
+++ b/provider-llamacpp/src/surface.rs
@@ -27,6 +27,12 @@ pub const ON_ROUTER_READY_ID: &str = "provider::llamacpp::on_router_ready";
 pub const ON_ROUTER_READY_DESC: &str =
     "Internal: router::ready subscriber that re-declares this provider and refreshes its catalog.";
 
+pub const EMBED_ID: &str = "provider::llamacpp::embed";
+pub const EMBED_DESC: &str =
+    "Batch text embeddings via the configured llama-server's /v1/embeddings (requires \
+     --embeddings and an embedding-capable model). One vector per input, order preserved. \
+     Fully local; credential only when the server runs with --api-key.";
+
 /// One function's complete agent-facing wire surface: id, registration
 /// description, and the schemars-derived request/response schemas.
 pub struct FunctionSpec {
@@ -62,5 +68,6 @@ pub fn catalog() -> Vec<FunctionSpec> {
         spec::<ProviderStreamInput, ProviderStreamOutput>(STREAM_ID, STREAM_DESC),
         spec::<RefreshModelsRequest, RefreshModelsResponse>(REFRESH_MODELS_ID, REFRESH_MODELS_DESC),
         spec::<RouterReadyEvent, ProviderReadyAck>(ON_ROUTER_READY_ID, ON_ROUTER_READY_DESC),
+        spec::<crate::embed::EmbedRequest, crate::embed::EmbedResponse>(EMBED_ID, EMBED_DESC),
     ]
 }

--- a/provider-llamacpp/tests/golden/schemas/provider.llamacpp.embed.json
+++ b/provider-llamacpp/tests/golden/schemas/provider.llamacpp.embed.json
@@ -9,6 +9,8 @@
         "items": {
           "type": "string"
         },
+        "maxItems": 512,
+        "minItems": 1,
         "type": "array"
       },
       "model": {

--- a/provider-llamacpp/tests/golden/schemas/provider.llamacpp.embed.json
+++ b/provider-llamacpp/tests/golden/schemas/provider.llamacpp.embed.json
@@ -1,0 +1,54 @@
+{
+  "description": "Batch text embeddings via the configured llama-server's /v1/embeddings (requires --embeddings and an embedding-capable model). One vector per input, order preserved. Fully local; credential only when the server runs with --api-key.",
+  "function_id": "provider::llamacpp::embed",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "input": {
+        "description": "Texts to embed, one vector returned per input, order preserved.",
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "model": {
+        "default": null,
+        "description": "Model name passed through to the server. llama-server embeds with its loaded model regardless; the field is echoed for parity with the other providers.",
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "required": [
+      "input"
+    ],
+    "title": "EmbedRequest",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "embeddings": {
+        "description": "One embedding per input, in input order.",
+        "items": {
+          "items": {
+            "format": "float",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "type": "array"
+      },
+      "model": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "embeddings",
+      "model"
+    ],
+    "title": "EmbedResponse",
+    "type": "object"
+  }
+}

--- a/provider-llamacpp/tests/schemas.rs
+++ b/provider-llamacpp/tests/schemas.rs
@@ -42,6 +42,7 @@ fn catalog_lists_all_functions_in_registration_order() {
             "provider::llamacpp::stream",
             "provider::llamacpp::refresh_models",
             "provider::llamacpp::on_router_ready",
+            "provider::llamacpp::embed",
         ]
     );
 }


### PR DESCRIPTION
Adds `provider::llamacpp::embed`: batch text embeddings from the configured llama-server, which exposes an OpenAI-compatible `/v1/embeddings` when started with `--embeddings` and an embedding-capable model. The endpoint derives from the configured chat `api_url` (sibling path), the credential is optional to match the chat path (local servers usually run without `--api-key`), and the one-vector-per-input contract is enforced with count and index validation. Behind `router::embed`'s registry walk this gives the memory worker fully local semantic recall.

Live-verified on a rig: llama-server with a nomic-embed GGUF on a custom port; `provider::llamacpp::embed` directly and `router::embed { provider: llamacpp }` both returned correct 768-dim vectors, provider available in the registry. Wire schema golden committed; 67 tests green. The 3 integration tests that need an isolated engine fail identically on clean main on this host (environment) and are untouched.

Fixes MOT-4053

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added local batch text embeddings through the configured llama-server.
  - Supports one embedding vector per input while preserving input order.
  - Enables local semantic memory recall through the router without cloud calls.
  - Requires llama-server embeddings support and an embedding-capable GGUF model.

- **Documentation**
  - Documented embeddings setup, behavior, and requirements.

- **Security**
  - Restricted direct embedding calls so they can only be invoked through the router.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->