### PR TITLE
(MOT-4018) fix(console): composer option row wraps instead of clipping in narrow docks

### DIFF
--- a/console/web/src/components/chat/BankPicker.tsx
+++ b/console/web/src/components/chat/BankPicker.tsx
@@ -66,7 +66,7 @@ export function BankPicker({ value, onChange, disabled }: BankPickerProps) {
       onChange={(next) => onChange(next === AUTO ? null : next)}
       disabled={disabled}
       aria-label="memory bank"
-      className="min-w-[120px] shrink-0"
+      className="min-w-[96px] max-w-[160px]"
       options={options}
     />
   )

--- a/console/web/src/components/chat/ChatDock.tsx
+++ b/console/web/src/components/chat/ChatDock.tsx
@@ -58,6 +58,12 @@ export function ChatDock({
     return () => window.removeEventListener('resize', onResize)
   }, [])
 
+  // The persisted width may come from a wider window (or the window may
+  // shrink after mount); rendering it unclamped pushes the main pane past
+  // the viewport and the whole app scrolls horizontally. Clamp at render,
+  // not just during drag.
+  const effectiveWidth = Math.min(width, maxWidth)
+
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault()
@@ -104,7 +110,7 @@ export function ChatDock({
     <>
       <aside
         id="chat-dock"
-        style={{ width }}
+        style={{ width: effectiveWidth }}
         onKeyDown={(e) => {
           if (e.key !== 'Escape') return
           const target = e.target as HTMLElement | null

--- a/console/web/src/components/chat/Composer.tsx
+++ b/console/web/src/components/chat/Composer.tsx
@@ -330,7 +330,7 @@ export function Composer({
       </div>
 
       <div className="flex min-w-0 items-center gap-2 border-t border-rule-2 px-3 py-2">
-        <div className="flex min-w-0 flex-1 items-center gap-2">
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
           <ModePicker
             value={mode}
             onChange={onModeChange}


### PR DESCRIPTION
In a narrow chat dock the composer's mode/directory/bank row overflowed and the memory bank picker clipped at the pane edge (regression from adding the bank picker). The left option group now wraps to a second row and the bank picker gets a bounded width instead of `shrink-0`.

Refs MOT-4018