### PR TITLE
chore: align core workers to v0.21.0

### DIFF
--- a/cron/Cargo.lock
+++ b/cron/Cargo.lock
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "iii-cron"
-version = "0.1.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cron/Cargo.toml
+++ b/cron/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "iii-cron"
-version = "0.1.1"
+version = "0.21.0"
 edition = "2021"
 description = "Cron scheduler worker for iii - schedules functions with cron expressions (cron trigger type)"
 license = "Apache-2.0"

--- a/http/Cargo.lock
+++ b/http/Cargo.lock
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "iii-http"
-version = "0.1.2"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "iii-http"
-version = "0.1.2"
+version = "0.21.0"
 edition = "2021"
 description = "HTTP server worker for iii — exposes functions as HTTP endpoints (http trigger type)"
 license = "Apache-2.0"

--- a/pubsub/Cargo.lock
+++ b/pubsub/Cargo.lock
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "iii-pubsub"
-version = "0.1.2"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "iii-pubsub"
-version = "0.1.2"
+version = "0.21.0"
 edition = "2021"
 description = "Pub/sub worker for iii — topic-based publish/subscribe messaging (subscribe trigger type, publish function)"
 license = "Apache-2.0"

--- a/queue/Cargo.lock
+++ b/queue/Cargo.lock
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "iii-queue"
-version = "0.2.2"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/queue/Cargo.toml
+++ b/queue/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "iii-queue"
-version = "0.2.2"
+version = "0.21.0"
 edition = "2021"
 description = "Durable queue worker for iii - durable:subscriber trigger type and queue service functions"
 license = "Apache-2.0"

--- a/state/Cargo.lock
+++ b/state/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "iii-state"
-version = "0.1.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "iii-state"
-version = "0.1.1"
+version = "0.21.0"
 edition = "2024"
 description = "State worker for iii — key-value state with reactive change triggers (state trigger type, state::* functions)"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Align the http, cron, queue, state, and pubsub worker package versions to 0.21.0 and keep their lockfiles synchronized.

This establishes the requested stable version in source before publishing the corresponding worker releases.

## Validation

- cargo check --locked --manifest-path http/Cargo.toml
- cargo check --locked --manifest-path cron/Cargo.toml
- cargo check --locked --manifest-path queue/Cargo.toml
- cargo check --locked --manifest-path state/Cargo.toml
- cargo check --locked --manifest-path pubsub/Cargo.toml
- Manifest and lockfile version verification for all five workers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package versions for the cron, HTTP, pub/sub, queue, and state components to version 0.21.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->