### PR TITLE
fix(harness): pre-trigger hold keeps its argument mutations

### DIFF
--- a/harness/evals/conformance/scenarios/hold-mutation-505/scenario.yaml
+++ b/harness/evals/conformance/scenarios/hold-mutation-505/scenario.yaml
@@ -8,17 +8,14 @@
 # The runner releases the parked call with
 # `harness::function::resolve { action: "execute" }`.
 #
-# QUARANTINED: the invariants assert the issue's EXPECTED behavior — the
-# released call executes with the gate's mutated arguments. Source inspection
-# shows the mutations are discarded at parse time (`parse_output` in
-# harness/src/hooks/runner.rs maps `decision: "hold"` to a mutation-less
-# outcome), and the release path re-reads the transcript's original args
-# regardless (#506). Unquarantine when #505 lands.
+# Regression gate for #505 (fixed: a holding hook's own `mutations` are
+# parsed and folded into the effective arguments checkpointed at hold, and
+# the release runs with those). Pairs with #506, which persists and resumes
+# the chain over the checkpointed args.
 schema_version: "1"
 id: C-E2E-505
 description: A pre-trigger hook that holds AND mutates must have its mutation applied to the released call.
 stack_profile: harness-core
-quarantine: true
 send:
   session_id: "{{session_id}}"
   message: "Call the recorder once."

--- a/harness/src/hooks/runner.rs
+++ b/harness/src/hooks/runner.rs
@@ -29,7 +29,9 @@ struct HookMutations {
 enum HookOutcome {
     Continue(HookMutations),
     Deny(String),
-    Hold,
+    // A holding hook may mutate as it holds (approval-gate: park the call AND
+    // stamp validated context onto it) — its mutations must not be dropped.
+    Hold(HookMutations),
 }
 
 /// Outcome of the `pre_generate` chain.
@@ -91,7 +93,7 @@ impl HookRegistry {
             match self.invoke(&binding, input).await {
                 HookOutcome::Continue(_) => {}
                 HookOutcome::Deny(reason) => return Err(reason),
-                HookOutcome::Hold => {}
+                HookOutcome::Hold(_) => {}
             }
         }
         Ok(())
@@ -128,7 +130,7 @@ impl HookRegistry {
                     merge(&mut annotations, m.annotations);
                 }
                 HookOutcome::Deny(reason) => return PreGenerateOutcome::Deny(reason),
-                HookOutcome::Hold => {}
+                HookOutcome::Hold(_) => {}
             }
         }
         PreGenerateOutcome::Continue {
@@ -178,12 +180,18 @@ impl HookRegistry {
                     merge(&mut annotations, m.annotations);
                 }
                 HookOutcome::Deny(reason) => return PreTriggerOutcome::Deny(reason),
-                HookOutcome::Hold => {
+                HookOutcome::Hold(m) => {
+                    // Apply the holding hook's own rewrite before parking, so
+                    // the release runs with the full chain's effective args.
+                    if let Some(a) = m.arguments {
+                        args = a;
+                    }
+                    merge(&mut annotations, m.annotations);
                     return PreTriggerOutcome::Hold {
                         held_by: binding.function_id.clone(),
                         arguments: args,
                         annotations,
-                    }
+                    };
                 }
             }
         }
@@ -238,7 +246,7 @@ impl HookRegistry {
                 // Deny is not valid at post_trigger; fail-open like existing
                 // post-trigger error handling.
                 HookOutcome::Deny(_) => {}
-                HookOutcome::Hold => {
+                HookOutcome::Hold(_) => {
                     return PostTriggerOutcome::Hold {
                         held_by: binding.function_id.clone(),
                         annotations,
@@ -298,30 +306,34 @@ fn parse_output(value: Value) -> HookOutcome {
                 .unwrap_or("denied by hook")
                 .to_string(),
         ),
-        Some("hold") => HookOutcome::Hold,
-        _ => {
-            let mut muts = HookMutations::default();
-            if let Some(m) = value.get("mutations") {
-                muts.system_prompt = m
-                    .get("system_prompt")
-                    .and_then(Value::as_str)
-                    .map(str::to_string);
-                if let Some(arr) = m.get("append_messages").and_then(Value::as_array) {
-                    muts.append_messages = arr.clone();
-                }
-                muts.arguments = m.get("arguments").cloned();
-                if let Some(c) = m.get("content") {
-                    muts.content = serde_json::from_value(c.clone()).ok();
-                }
-                muts.details = m.get("details").cloned();
-                muts.is_error = m.get("is_error").and_then(Value::as_bool);
-            }
-            if let Some(Value::Object(ann)) = value.get("annotations") {
-                muts.annotations = ann.clone();
-            }
-            HookOutcome::Continue(muts)
-        }
+        Some("hold") => HookOutcome::Hold(parse_mutations(&value)),
+        _ => HookOutcome::Continue(parse_mutations(&value)),
     }
+}
+
+/// Parse a hook's `mutations`/`annotations` — shared by the continue and hold
+/// branches so a holding hook's rewrites are honored, not dropped.
+fn parse_mutations(value: &Value) -> HookMutations {
+    let mut muts = HookMutations::default();
+    if let Some(m) = value.get("mutations") {
+        muts.system_prompt = m
+            .get("system_prompt")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        if let Some(arr) = m.get("append_messages").and_then(Value::as_array) {
+            muts.append_messages = arr.clone();
+        }
+        muts.arguments = m.get("arguments").cloned();
+        if let Some(c) = m.get("content") {
+            muts.content = serde_json::from_value(c.clone()).ok();
+        }
+        muts.details = m.get("details").cloned();
+        muts.is_error = m.get("is_error").and_then(Value::as_bool);
+    }
+    if let Some(Value::Object(ann)) = value.get("annotations") {
+        muts.annotations = ann.clone();
+    }
+    muts
 }
 
 fn merge(into: &mut Map<String, Value>, from: Map<String, Value>) {
@@ -399,14 +411,30 @@ mod tests {
             _ => panic!("expected deny"),
         }
         match parse_output(json!({ "decision": "hold" })) {
-            HookOutcome::Hold => {}
+            HookOutcome::Hold(m) => assert!(m.arguments.is_none()),
             _ => panic!("expected hold"),
         }
         // Legacy hooks may still send pending_timeout_ms; it is ignored.
         assert!(matches!(
             parse_output(json!({ "decision": "hold", "pending_timeout_ms": 1000 })),
-            HookOutcome::Hold
+            HookOutcome::Hold(_)
         ));
+    }
+
+    #[test]
+    fn hold_keeps_mutations_and_annotations() {
+        let out = parse_output(json!({
+            "decision": "hold",
+            "mutations": { "arguments": { "value": "expected+approved" } },
+            "annotations": { "approved_by": "gate" }
+        }));
+        match out {
+            HookOutcome::Hold(m) => {
+                assert_eq!(m.arguments, Some(json!({ "value": "expected+approved" })));
+                assert_eq!(m.annotations.get("approved_by"), Some(&json!("gate")));
+            }
+            _ => panic!("expected hold"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes iii-hq/workers#505.

A `harness::hook::pre-trigger` hook returning `decision: "hold"` together with `mutations.arguments` had the mutations silently discarded, so a released call executed pre-hold arguments — the approval-gate pattern (hold AND stamp validated context) was impossible.

## Root cause

Two compounding drops:
1. `parse_output` (`harness/src/hooks/runner.rs`) mapped `decision:"hold"` to the data-less `HookOutcome::Hold` — anything under `mutations` was dropped at parse time.
2. `PreTriggerOutcome::Hold` carried no arguments, and the `resolve {action:"execute"}` path (`harness/src/deferred.rs`) recovered arguments from the transcript — the model's original call.

## Fix

- `HookOutcome::Hold(HookMutations)` — hold parses mutations via a shared `parse_mutations` helper.
- `run_pre_trigger` folds the holding hook's rewrite into the accumulated chain arguments and returns them in `PreTriggerOutcome::Hold`.
- New durable `CallCheckpoint.arguments` populated when the call parks (old records stay deserializable); the post-trigger hold park checkpoints effective args too.
- The execute release prefers checkpointed arguments; transcript recovery remains only as a legacy fallback. `filesystem_scope::inject` is re-stamped at release so a hook rewrite can never widen scope.

## Verification

- Conformance repro `C-E2E-505` (from #518): **contract_failure → pass** — the target executes `{value:"expected+approved"}` exactly once; the gate held once seeing the original args. `C-E2E-506` also passes with this change; `C-E2E-001`/`C-E2E-002` regressions pass.
- 226 unit tests green (incl. new `hold_keeps_mutations_and_annotations`); fmt/clippy clean.

## Note for review

Overlaps with the #506 fix branch (`fix/506-release-runs-original-args`): both persist held arguments on the call checkpoint but choose different release semantics (this branch: execute checkpointed args; #506's: resume the remaining chain after the holder, per harness.md). Suggest merging #506's mechanism and grafting this branch's hold-parses-mutations onto it, reconciling the checkpoint field (`arguments` vs `held_arguments`).
