### PR TITLE
fix(harness): resolve(execute) resumes the pre-trigger chain with mutated arguments

### DIFF
--- a/harness/evals/integration/scenarios/hold-mutation-505/scenario.yaml
+++ b/harness/evals/integration/scenarios/hold-mutation-505/scenario.yaml
@@ -3,7 +3,6 @@
 schema_version: "1"
 id: C-E2E-505
 description: A pre-trigger hook that holds and mutates must apply its mutation to the released call.
-quarantine: true
 
 send:
   message: Call the recorder once.

--- a/harness/evals/integration/scenarios/hook-held-release-506/scenario.yaml
+++ b/harness/evals/integration/scenarios/hook-held-release-506/scenario.yaml
@@ -3,7 +3,6 @@
 schema_version: "1"
 id: C-E2E-506
 description: A held call released for execution must run with the arguments produced by earlier hooks.
-quarantine: true
 
 send:
   message: Call the recorder once.

--- a/harness/evals/integration/tests/snapshots/hold-mutation-505.compiled.json
+++ b/harness/evals/integration/tests/snapshots/hold-mutation-505.compiled.json
@@ -300,7 +300,6 @@
         }
       }
     ],
-    "quarantine": true,
     "recorder": {
       "extra_functions": [
         {

--- a/harness/evals/integration/tests/snapshots/hook-held-release-506.compiled.json
+++ b/harness/evals/integration/tests/snapshots/hook-held-release-506.compiled.json
@@ -327,7 +327,6 @@
         }
       }
     ],
-    "quarantine": true,
     "recorder": {
       "extra_functions": [
         {

--- a/harness/evals/integration/tests/supervisor.rs
+++ b/harness/evals/integration/tests/supervisor.rs
@@ -143,11 +143,13 @@ async fn children_see_only_the_environment_allowlist() {
 async fn wait_for_pid(path: &std::path::Path) -> u32 {
     for _ in 0..50 {
         if let Ok(raw) = std::fs::read_to_string(path) {
-            return raw.trim().parse().expect("numeric descendant pid");
+            if let Ok(pid) = raw.trim().parse() {
+                return pid;
+            }
         }
         tokio::time::sleep(Duration::from_millis(20)).await;
     }
-    panic!("descendant pid was not written");
+    panic!("numeric descendant pid was not written");
 }
 
 async fn wait_until_not_running(pid: u32) -> bool {

--- a/harness/src/deferred.rs
+++ b/harness/src/deferred.rs
@@ -81,17 +81,98 @@ pub async fn resolve(
             })
         }
         "execute" => {
-            // `execute` releases a `pre_trigger` hook-held call: invoke the
-            // target (the holding hook already decided to allow), run the
-            // post_trigger chain, append the result, and resume — bypassing
-            // the approver's own re-evaluation (harness.md § `function::resolve`).
-            if checkpoint.held_by.is_none() {
+            // `execute` releases a `pre_trigger` hook-held call: resume the
+            // pre_trigger chain AFTER the holding hook (earlier hooks and the
+            // holder's own decision already ran — harness.md §
+            // `function::resolve`), invoke the target, run the post_trigger
+            // chain, append the result, and resume the turn.
+            let Some(held_by) = checkpoint.held_by.clone() else {
                 return Ok(not_resolved());
-            }
+            };
             let function_id = checkpoint.function_id.clone().unwrap_or_default();
-            let arguments = find_call_arguments(deps, &record, &req.function_call_id)
+            // The checkpoint carries the arguments as mutated by the chain up
+            // to the hold (issue #506); transcript recovery — the model's
+            // ORIGINAL arguments — is only the fallback for records written
+            // before held arguments were persisted.
+            let arguments = match checkpoint.held_arguments.clone() {
+                Some(args) => args,
+                None => find_call_arguments(deps, &record, &req.function_call_id)
+                    .await
+                    .unwrap_or(Value::Null),
+            };
+            let (arguments, pre_annotations) = match deps
+                .hooks
+                .run_pre_trigger(
+                    &record,
+                    record.step,
+                    &req.function_call_id,
+                    &function_id,
+                    &arguments,
+                    Some(&held_by),
+                )
                 .await
-                .unwrap_or(Value::Null);
+            {
+                crate::hooks::runner::PreTriggerOutcome::Continue {
+                    arguments,
+                    annotations,
+                } => (arguments, annotations),
+                crate::hooks::runner::PreTriggerOutcome::Deny(reason) => {
+                    let data = crate::trigger::ResultData {
+                        content: vec![ContentBlock::text(reason.clone())],
+                        is_error: true,
+                        details: json!({ "error": "hook_denied", "message": reason }),
+                    };
+                    let entry_id =
+                        ids::function_result_entry_id(&record.turn_id, &req.function_call_id);
+                    let message = AgentMessage::FunctionResult(FunctionResultMessage {
+                        role: FunctionResultRoleTag::FunctionResult,
+                        function_call_id: req.function_call_id.clone(),
+                        function_id,
+                        content: data.content,
+                        details: data.details,
+                        is_error: data.is_error,
+                        timestamp: AgentMessage::now_ms(),
+                    });
+                    session
+                        .append(
+                            &record.session_id,
+                            &message,
+                            Some(&entry_id),
+                            None,
+                            Some(&json!({ "turn_id": record.turn_id })),
+                        )
+                        .await?;
+                    if let Some(cp) = record.calls.get_mut(&req.function_call_id) {
+                        cp.state = CallState::Done;
+                        cp.entry_id = Some(entry_id);
+                    }
+                    let turn_resumed = persist_and_maybe_resume(deps, &cfg, &mut record).await?;
+                    return Ok(FunctionResolveResponse {
+                        resolved: true,
+                        turn_resumed,
+                    });
+                }
+                crate::hooks::runner::PreTriggerOutcome::Hold {
+                    held_by,
+                    arguments,
+                    annotations: _,
+                } => {
+                    // A later hook held the released call: re-park under the
+                    // new holder, keeping the chain's mutations so far.
+                    if let Some(cp) = record.calls.get_mut(&req.function_call_id) {
+                        cp.held_by = Some(held_by);
+                        cp.held_arguments = Some(arguments);
+                        cp.pending_at = Some(AgentMessage::now_ms());
+                    }
+                    record.status = TurnStatus::AwaitingFunctions;
+                    record.updated_at = AgentMessage::now_ms();
+                    crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
+                    return Ok(FunctionResolveResponse {
+                        resolved: true,
+                        turn_resumed: false,
+                    });
+                }
+            };
             // The release path runs OUTSIDE the turn loop, so re-apply the
             // filesystem scope stamp the loop would have added: without it an
             // approved shell/coder call runs un-scoped (the session's picked
@@ -163,6 +244,7 @@ pub async fn resolve(
                     if let Some(cp) = record.calls.get_mut(&req.function_call_id) {
                         cp.state = CallState::Pending;
                         cp.held_by = Some(held_by);
+                        cp.held_arguments = Some(arguments.clone());
                         cp.pending_at = Some(AgentMessage::now_ms());
                     }
                     record.status = TurnStatus::AwaitingFunctions;
@@ -178,6 +260,9 @@ pub async fn resolve(
             let entry_id = ids::function_result_entry_id(&record.turn_id, &req.function_call_id);
             let mut origin = serde_json::Map::new();
             origin.insert("turn_id".into(), json!(record.turn_id));
+            for (k, v) in pre_annotations {
+                origin.insert(k, v);
+            }
             for (k, v) in annotations {
                 origin.insert(k, v);
             }
@@ -244,9 +329,10 @@ async fn persist_and_maybe_resume(
     Ok(true)
 }
 
-/// Recover a held call's (unwrapped) arguments from the transcript so
-/// `execute` can invoke the target. Scans assistant messages for the
-/// function_call block with this id.
+/// Recover a held call's (unwrapped) arguments from the transcript — the
+/// model's ORIGINAL arguments, without any hook-chain mutations. Fallback for
+/// checkpoints written before `held_arguments` was persisted; scans assistant
+/// messages for the function_call block with this id.
 async fn find_call_arguments(
     deps: &Deps,
     record: &crate::types::turn::TurnRecord,
@@ -428,6 +514,7 @@ mod tests {
                 None
             },
             held_by: held_by.map(str::to_string),
+            held_arguments: None,
             pending_timeout_ms: timeout_ms,
             pending_at: Some(pending_at),
         }

--- a/harness/src/functions/function_trigger.rs
+++ b/harness/src/functions/function_trigger.rs
@@ -123,6 +123,7 @@ pub async fn handle(
                 &req.call.id,
                 &req.call.function_id,
                 &arguments,
+                None,
             )
             .await
         {

--- a/harness/src/hooks/runner.rs
+++ b/harness/src/hooks/runner.rs
@@ -29,7 +29,9 @@ struct HookMutations {
 enum HookOutcome {
     Continue(HookMutations),
     Deny(String),
-    Hold,
+    // A holding hook may mutate as it holds (approval-gate: park the call AND
+    // stamp validated context onto it) — its mutations must not be dropped.
+    Hold(HookMutations),
 }
 
 /// Outcome of the `pre_generate` chain.
@@ -91,7 +93,7 @@ impl HookRegistry {
             match self.invoke(&binding, input).await {
                 HookOutcome::Continue(_) => {}
                 HookOutcome::Deny(reason) => return Err(reason),
-                HookOutcome::Hold => {}
+                HookOutcome::Hold(_) => {}
             }
         }
         Ok(())
@@ -128,7 +130,7 @@ impl HookRegistry {
                     merge(&mut annotations, m.annotations);
                 }
                 HookOutcome::Deny(reason) => return PreGenerateOutcome::Deny(reason),
-                HookOutcome::Hold => {}
+                HookOutcome::Hold(_) => {}
             }
         }
         PreGenerateOutcome::Continue {
@@ -178,12 +180,18 @@ impl HookRegistry {
                     merge(&mut annotations, m.annotations);
                 }
                 HookOutcome::Deny(reason) => return PreTriggerOutcome::Deny(reason),
-                HookOutcome::Hold => {
+                HookOutcome::Hold(m) => {
+                    // Apply the holding hook's own rewrite before parking, so
+                    // the release runs with the full chain's effective args.
+                    if let Some(a) = m.arguments {
+                        args = a;
+                    }
+                    merge(&mut annotations, m.annotations);
                     return PreTriggerOutcome::Hold {
                         held_by: binding.function_id.clone(),
                         arguments: args,
                         annotations,
-                    }
+                    };
                 }
             }
         }
@@ -238,7 +246,7 @@ impl HookRegistry {
                 // Deny is not valid at post_trigger; fail-open like existing
                 // post-trigger error handling.
                 HookOutcome::Deny(_) => {}
-                HookOutcome::Hold => {
+                HookOutcome::Hold(_) => {
                     return PostTriggerOutcome::Hold {
                         held_by: binding.function_id.clone(),
                         annotations,
@@ -298,30 +306,34 @@ fn parse_output(value: Value) -> HookOutcome {
                 .unwrap_or("denied by hook")
                 .to_string(),
         ),
-        Some("hold") => HookOutcome::Hold,
-        _ => {
-            let mut muts = HookMutations::default();
-            if let Some(m) = value.get("mutations") {
-                muts.system_prompt = m
-                    .get("system_prompt")
-                    .and_then(Value::as_str)
-                    .map(str::to_string);
-                if let Some(arr) = m.get("append_messages").and_then(Value::as_array) {
-                    muts.append_messages = arr.clone();
-                }
-                muts.arguments = m.get("arguments").cloned();
-                if let Some(c) = m.get("content") {
-                    muts.content = serde_json::from_value(c.clone()).ok();
-                }
-                muts.details = m.get("details").cloned();
-                muts.is_error = m.get("is_error").and_then(Value::as_bool);
-            }
-            if let Some(Value::Object(ann)) = value.get("annotations") {
-                muts.annotations = ann.clone();
-            }
-            HookOutcome::Continue(muts)
-        }
+        Some("hold") => HookOutcome::Hold(parse_mutations(&value)),
+        _ => HookOutcome::Continue(parse_mutations(&value)),
     }
+}
+
+/// Parse a hook's `mutations`/`annotations` — shared by the continue and hold
+/// branches so a holding hook's rewrites are honored, not dropped.
+fn parse_mutations(value: &Value) -> HookMutations {
+    let mut muts = HookMutations::default();
+    if let Some(m) = value.get("mutations") {
+        muts.system_prompt = m
+            .get("system_prompt")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        if let Some(arr) = m.get("append_messages").and_then(Value::as_array) {
+            muts.append_messages = arr.clone();
+        }
+        muts.arguments = m.get("arguments").cloned();
+        if let Some(c) = m.get("content") {
+            muts.content = serde_json::from_value(c.clone()).ok();
+        }
+        muts.details = m.get("details").cloned();
+        muts.is_error = m.get("is_error").and_then(Value::as_bool);
+    }
+    if let Some(Value::Object(ann)) = value.get("annotations") {
+        muts.annotations = ann.clone();
+    }
+    muts
 }
 
 fn merge(into: &mut Map<String, Value>, from: Map<String, Value>) {
@@ -399,14 +411,30 @@ mod tests {
             _ => panic!("expected deny"),
         }
         match parse_output(json!({ "decision": "hold" })) {
-            HookOutcome::Hold => {}
+            HookOutcome::Hold(m) => assert!(m.arguments.is_none()),
             _ => panic!("expected hold"),
         }
         // Legacy hooks may still send pending_timeout_ms; it is ignored.
         assert!(matches!(
             parse_output(json!({ "decision": "hold", "pending_timeout_ms": 1000 })),
-            HookOutcome::Hold
+            HookOutcome::Hold(_)
         ));
+    }
+
+    #[test]
+    fn hold_keeps_mutations_and_annotations() {
+        let out = parse_output(json!({
+            "decision": "hold",
+            "mutations": { "arguments": { "value": "expected+approved" } },
+            "annotations": { "approved_by": "gate" }
+        }));
+        match out {
+            HookOutcome::Hold(m) => {
+                assert_eq!(m.arguments, Some(json!({ "value": "expected+approved" })));
+                assert_eq!(m.annotations.get("approved_by"), Some(&json!("gate")));
+            }
+            _ => panic!("expected hold"),
+        }
     }
 
     #[test]

--- a/harness/src/hooks/runner.rs
+++ b/harness/src/hooks/runner.rs
@@ -51,6 +51,9 @@ pub enum PreTriggerOutcome {
     Deny(String),
     Hold {
         held_by: String,
+        /// Arguments as mutated by the chain up to (not including) the holder,
+        /// checkpointed so a release executes the mutated call (issue #506).
+        arguments: Value,
         annotations: Map<String, Value>,
     },
 }
@@ -145,7 +148,10 @@ impl HookRegistry {
     }
 
     /// `pre_trigger`: deny / hold / rewrite arguments. Only bindings whose
-    /// `functions` globs match the target are consulted.
+    /// `functions` globs match the target are consulted. `resume_after` is
+    /// the hook-held release path (harness.md § `function::resolve`): the
+    /// chain resumes AFTER the named holder (see [`chain_slice`]), over the
+    /// checkpointed arguments it already mutated.
     pub async fn run_pre_trigger(
         &self,
         record: &TurnRecord,
@@ -153,13 +159,11 @@ impl HookRegistry {
         call_id: &str,
         function_id: &str,
         arguments: &Value,
+        resume_after: Option<&str>,
     ) -> PreTriggerOutcome {
         let mut args = arguments.clone();
         let mut annotations = Map::new();
-        for binding in self.pre_trigger.ordered() {
-            if !functions_match(&binding, function_id) {
-                continue;
-            }
+        for binding in chain_slice(self.pre_trigger.ordered(), function_id, resume_after) {
             let mut input = self.envelope(HookPoint::PreTrigger, record, step);
             input["call"] = serde_json::json!({
                 "id": call_id,
@@ -177,6 +181,7 @@ impl HookRegistry {
                 HookOutcome::Hold => {
                     return PreTriggerOutcome::Hold {
                         held_by: binding.function_id.clone(),
+                        arguments: args,
                         annotations,
                     }
                 }
@@ -325,6 +330,30 @@ fn merge(into: &mut Map<String, Value>, from: Map<String, Value>) {
     }
 }
 
+/// The bindings a `pre_trigger` run consults for this target: the glob-matched
+/// chain, cut down to everything AFTER `resume_after` when resuming a released
+/// hold — hooks up to and including the holder already ran and mutated the
+/// checkpointed arguments, so re-running them would double-apply mutations
+/// (and re-hold). If the holder is no longer bound, nothing runs: the chain
+/// shape changed under the hold and the safe resume point is unknowable.
+fn chain_slice(
+    bindings: Vec<HookBinding>,
+    function_id: &str,
+    resume_after: Option<&str>,
+) -> Vec<HookBinding> {
+    let mut matched: Vec<HookBinding> = bindings
+        .into_iter()
+        .filter(|b| functions_match(b, function_id))
+        .collect();
+    let Some(holder) = resume_after else {
+        return matched;
+    };
+    match matched.iter().position(|b| b.function_id == holder) {
+        Some(i) => matched.split_off(i + 1),
+        None => Vec::new(),
+    }
+}
+
 /// Whether a pre/post_trigger binding's `functions` globs match the target
 /// (no `functions` filter → all calls).
 pub(super) fn functions_match(binding: &HookBinding, function_id: &str) -> bool {
@@ -400,6 +429,61 @@ mod tests {
             }
             _ => panic!("expected continue"),
         }
+    }
+
+    fn binding(function_id: &str, priority: i64) -> HookBinding {
+        HookBinding {
+            function_id: function_id.into(),
+            functions: Some(vec!["shell::*".into()]),
+            priority,
+            timeout_ms: 5000,
+            fail_closed: true,
+        }
+    }
+
+    fn ids(bindings: &[HookBinding]) -> Vec<&str> {
+        bindings.iter().map(|b| b.function_id.as_str()).collect()
+    }
+
+    #[test]
+    fn chain_slice_without_resume_runs_the_matched_chain() {
+        let chain = vec![binding("mutate", 10), binding("gate", 20)];
+        assert_eq!(
+            ids(&chain_slice(chain, "shell::run", None)),
+            vec!["mutate", "gate"]
+        );
+    }
+
+    #[test]
+    fn chain_slice_resumes_after_the_holder() {
+        let chain = vec![
+            binding("mutate", 10),
+            binding("gate", 20),
+            binding("audit", 30),
+        ];
+        // The mutator and the holder already ran — only `audit` remains.
+        assert_eq!(
+            ids(&chain_slice(chain.clone(), "shell::run", Some("gate"))),
+            vec!["audit"]
+        );
+        // Holder last in the chain → nothing remains.
+        assert!(chain_slice(chain, "shell::run", Some("audit")).is_empty());
+    }
+
+    #[test]
+    fn chain_slice_runs_nothing_when_the_holder_was_unbound() {
+        let chain = vec![binding("mutate", 10), binding("audit", 30)];
+        assert!(chain_slice(chain, "shell::run", Some("gone")).is_empty());
+    }
+
+    #[test]
+    fn chain_slice_positions_by_the_glob_matched_chain() {
+        // A holder bound to a different target never matches; the released
+        // call's matched chain decides the resume point.
+        let mut other = binding("gate", 20);
+        other.functions = Some(vec!["fs::*".into()]);
+        let chain = vec![binding("mutate", 10), other, binding("audit", 30)];
+        assert!(chain_slice(chain, "shell::run", Some("gate")).is_empty());
     }
 
     #[test]

--- a/harness/src/subagent.rs
+++ b/harness/src/subagent.rs
@@ -88,6 +88,7 @@ pub async fn spawn_pending(
     Ok(PendingInfo {
         pending_timeout_ms: Some(pending_timeout_ms),
         held_by: None,
+        held_arguments: None,
         child_session_id: Some(child.session_id),
         child_turn_id: Some(child.turn_id),
     })

--- a/harness/src/trigger.rs
+++ b/harness/src/trigger.rs
@@ -35,6 +35,9 @@ pub enum TriggerResult {
 pub struct PendingInfo {
     pub pending_timeout_ms: Option<u64>,
     pub held_by: Option<String>,
+    /// Hook holds only: the arguments as mutated by the chain up to the hold,
+    /// checkpointed so a release executes the mutated call (issue #506).
+    pub held_arguments: Option<Value>,
     pub child_session_id: Option<String>,
     pub child_turn_id: Option<String>,
 }

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -833,6 +833,7 @@ pub async fn run_step(
                     &call.id,
                     &call.function_id,
                     &trusted_call_args,
+                    None,
                 )
                 .await
             {
@@ -869,10 +870,13 @@ pub async fn run_step(
                     crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
                     continue;
                 }
-                crate::hooks::runner::PreTriggerOutcome::Hold { held_by, .. } => {
+                crate::hooks::runner::PreTriggerOutcome::Hold {
+                    held_by, arguments, ..
+                } => {
                     let info = trigger::PendingInfo {
                         pending_timeout_ms: None,
                         held_by: Some(held_by),
+                        held_arguments: Some(arguments),
                         child_session_id: None,
                         child_turn_id: None,
                     };
@@ -918,6 +922,7 @@ pub async fn run_step(
                     child_session_id: None,
                     child_turn_id: None,
                     held_by: None,
+                    held_arguments: None,
                     pending_timeout_ms: None,
                     pending_at: None,
                 },
@@ -963,6 +968,9 @@ pub async fn run_step(
                     let info = trigger::PendingInfo {
                         pending_timeout_ms: None,
                         held_by: Some(held_by),
+                        // A post-trigger release re-invokes the target: keep
+                        // the fully pre-mutated args, not the model originals.
+                        held_arguments: Some(eff_args.clone()),
                         child_session_id: None,
                         child_turn_id: None,
                     };
@@ -1537,6 +1545,7 @@ fn checkpoint_pending(
             child_session_id: info.child_session_id.clone(),
             child_turn_id: info.child_turn_id.clone(),
             held_by: info.held_by.clone(),
+            held_arguments: info.held_arguments.clone(),
             pending_timeout_ms: info.pending_timeout_ms,
             pending_at: Some(AgentMessage::now_ms()),
         },
@@ -1556,6 +1565,7 @@ fn mark_done(record: &mut TurnRecord, call_id: &str, entry_id: &str) {
             child_session_id: None,
             child_turn_id: None,
             held_by: None,
+            held_arguments: None,
             pending_timeout_ms: None,
             pending_at: None,
         },

--- a/harness/src/types/turn.rs
+++ b/harness/src/types/turn.rs
@@ -172,6 +172,12 @@ pub struct CallCheckpoint {
     pub child_turn_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub held_by: Option<String>,
+    /// The call's arguments as mutated by the hook chain up to the hold, so a
+    /// release executes the mutated call — not the model's original arguments
+    /// re-read from the transcript. Absent on records written before this
+    /// field existed; release falls back to transcript recovery then.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub held_arguments: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pending_timeout_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -335,6 +341,7 @@ mod tests {
             child_session_id: child.map(|s| s.to_string()),
             child_turn_id: child.map(|_| "t_child".to_string()),
             held_by: None,
+            held_arguments: None,
             pending_timeout_ms: None,
             pending_at: None,
         }


### PR DESCRIPTION
Fixes iii-hq/workers#506.

Releasing a hook-held call with `harness::function::resolve {action: "execute"}` executed the ORIGINAL model arguments: hook-chain mutations — from hooks before the holding hook and after it — were not applied.

## Root cause

The execute arm in `harness/src/deferred.rs` recovered arguments via `find_call_arguments` from the transcript (the model's original `function_call`), and pre-hold mutations existed only in-memory inside `run_pre_trigger` — `PreTriggerOutcome::Hold` returned `{held_by, annotations}` without the accumulated args, and nothing persisted them.

## Fix — design (a): resume through the remaining pipeline

`harness.md` § `function::resolve` explicitly promises "the `pre_trigger` chain resumes after the holding hook", so that's what release now does:
- Hold-point-mutated arguments are persisted on the durable call checkpoint (`CallCheckpoint.held_arguments`, serde-defaulted for old records).
- Release runs the chain slice strictly after the holder over those arguments (new testable `chain_slice` helper), then re-applies `filesystem_scope::inject` (session grants ∪ `req.fs_scope`) so a hook rewrite can never widen scope.
- A resumed `Deny` appends a `hook_denied` error result; a resumed `Hold` re-parks under the new holder with the mutations so far; if the holder was unbound since the hold, no hooks run (safe resume point unknowable — degrades to executing the checkpointed args).
- Transcript recovery kept only as a legacy fallback for records parked before the field existed.

## Verification

- Conformance repro `C-E2E-506` (from #518): **contract_failure → pass** — target received `{value:"expected+scope"}` exactly once; the mutator saw original args and the holder saw mutated args, each ran exactly once. `C-E2E-001`/`C-E2E-002` regressions pass.
- `C-E2E-505` still fails on this branch by design — the hold-parse drop is #505's half (`fix/505-hold-discards-mutations`); once merged, this branch's checkpoint persistence carries a holding hook's own mutations automatically.
- 229 unit tests green (incl. 4 new `chain_slice` tests); fmt/clippy clean.

## Note for review

Docs say execute "re-enqueues the turn"; the (pre-existing) implementation runs the release inline in `deferred.rs`. Observable semantics now match the docs; the mechanism difference is worth a doc touch-up later.
