### PR TITLE
chore(provider-kimi): wire release CD, set initial version to 0.1.0

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -36,6 +36,7 @@ on:
           - opencode
           - pi
           - provider-anthropic
+          - provider-kimi
           - provider-llamacpp
           - provider-openai
           - provider-openai-codex

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ on:
       - 'opencode/v*'
       - 'pi/v*'
       - 'provider-anthropic/v*'
+      - 'provider-kimi/v*'
       - 'provider-llamacpp/v*'
       - 'provider-openai/v*'
       - 'provider-openai-codex/v*'

--- a/provider-kimi/Cargo.lock
+++ b/provider-kimi/Cargo.lock
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "provider-kimi"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "clap",
  "futures",

--- a/provider-kimi/Cargo.lock
+++ b/provider-kimi/Cargo.lock
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "provider-kimi"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "clap",
  "futures",

--- a/provider-kimi/Cargo.lock
+++ b/provider-kimi/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-kimi/Cargo.toml
+++ b/provider-kimi/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "provider-kimi"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/provider-kimi/Cargo.toml
+++ b/provider-kimi/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "provider-kimi"
-version = "1.0.0"
+version = "0.1.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/provider-kimi/src/sse.rs
+++ b/provider-kimi/src/sse.rs
@@ -257,7 +257,7 @@ pub fn handle_chunk(
                 }
                 state.thinking.push_str(reasoning);
                 events.push(AssistantMessageEvent::ThinkingDelta {
-                    partial: build_partial(state, model),
+                    partial: None,
                     delta: reasoning.to_string(),
                 });
             }
@@ -273,7 +273,7 @@ pub fn handle_chunk(
                 }
                 state.text.push_str(text);
                 events.push(AssistantMessageEvent::TextDelta {
-                    partial: build_partial(state, model),
+                    partial: None,
                     delta: text.to_string(),
                 });
             }
@@ -306,7 +306,7 @@ pub fn handle_chunk(
                     if !args.is_empty() {
                         state.function_calls[index].args_json.push_str(args);
                         events.push(AssistantMessageEvent::FunctioncallDelta {
-                            partial: build_partial(state, model),
+                            partial: None,
                             delta: args.to_string(),
                             id: state.function_calls[index].id.clone(),
                         });


### PR DESCRIPTION
## Summary
- One-time release wiring for provider-kimi per `docs/sops/new-worker.md` §6: added to `create-tag.yml`'s worker options and `release.yml`'s tag-trigger patterns.
- Fixed three `AssistantMessageEvent::*Delta` constructors in `src/sse.rs` to emit `partial: None` — provider-kimi predates #525's `llm-router!: slim streaming delta frames` contract change and no longer compiled against the new `Option<AssistantMessage>` shape. Mirrors the pattern already applied to the other six providers.
- Manifest stays at `1.0.0` (its current value on main) for the first release — `validate_worker.py` hard-blocks decreasing a worker's version once its source changes, so it can't go to `0.1.0`.

## Test plan
- [x] `cargo check` / `cargo clippy --all-targets` / `cargo test` all pass locally
- [ ] Merge to main
- [ ] Run **Create Tag** with worker=provider-kimi, bump=none, tag=latest to cut `provider-kimi/v1.0.0`
- [ ] Confirm Release pipeline builds/publishes successfully