### PR TITLE
(MOT-4100) fix(harness): stop button — prompt cancellation end to end

### DIFF
--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -1288,7 +1288,10 @@ export function ChatView({
     setStopping((already) => {
       if (!already) {
         abortRef.current?.abort()
-        void backend.abortRun?.(sessionId).catch(() => {})
+        // Re-enable the button if the stop RPC fails while the server still
+        // reports working — otherwise `stopping` never clears (the reset
+        // effect waits on the indicator) and the user can't retry.
+        void backend.abortRun?.(sessionId).catch(() => setStopping(false))
       }
       return true
     })

--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -180,10 +180,17 @@ export function ChatView({
   const streamingIndicator = isStreaming || serverWorking
 
   // Stop requested but not yet finalized server-side. Disables the stop button
-  // (and dedupes harness::stop) until status-changed flips the indicator off.
+  // until status-changed flips the indicator off. The ref is the dedupe guard:
+  // synchronous (two clicks in one frame can't both pass, unlike closure
+  // state) and readable outside a state updater (React forbids side effects
+  // inside updaters — Strict Mode double-invokes them).
   const [stopping, setStopping] = useState(false)
+  const stopRequestedRef = useRef(false)
   useEffect(() => {
-    if (!streamingIndicator) setStopping(false)
+    if (!streamingIndicator) {
+      stopRequestedRef.current = false
+      setStopping(false)
+    }
   }, [streamingIndicator])
 
   // Messages queued mid-stream (MOT-3837): shown above the composer until the
@@ -1285,15 +1292,16 @@ export function ChatView({
   )
 
   const handleStop = useCallback(() => {
-    setStopping((already) => {
-      if (!already) {
-        abortRef.current?.abort()
-        // Re-enable the button if the stop RPC fails while the server still
-        // reports working — otherwise `stopping` never clears (the reset
-        // effect waits on the indicator) and the user can't retry.
-        void backend.abortRun?.(sessionId).catch(() => setStopping(false))
-      }
-      return true
+    if (stopRequestedRef.current) return
+    stopRequestedRef.current = true
+    setStopping(true)
+    abortRef.current?.abort()
+    // Re-enable the button if the stop RPC fails while the server still
+    // reports working — otherwise `stopping` never clears (the reset
+    // effect waits on the indicator) and the user can't retry.
+    void backend.abortRun?.(sessionId).catch(() => {
+      stopRequestedRef.current = false
+      setStopping(false)
     })
   }, [backend, sessionId])
 

--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -179,6 +179,13 @@ export function ChatView({
   const serverWorking = conversation.status === 'working'
   const streamingIndicator = isStreaming || serverWorking
 
+  // Stop requested but not yet finalized server-side. Disables the stop button
+  // (and dedupes harness::stop) until status-changed flips the indicator off.
+  const [stopping, setStopping] = useState(false)
+  useEffect(() => {
+    if (!streamingIndicator) setStopping(false)
+  }, [streamingIndicator])
+
   // Messages queued mid-stream (MOT-3837): shown above the composer until the
   // harness drains them into the transcript. Each draft carries the predicted
   // entry id of its eventual transcript row.
@@ -1278,8 +1285,13 @@ export function ChatView({
   )
 
   const handleStop = useCallback(() => {
-    abortRef.current?.abort()
-    void backend.abortRun?.(sessionId).catch(() => {})
+    setStopping((already) => {
+      if (!already) {
+        abortRef.current?.abort()
+        void backend.abortRun?.(sessionId).catch(() => {})
+      }
+      return true
+    })
   }, [backend, sessionId])
 
   // Rescue a parked stream loop: the session hit a terminal error server-side
@@ -1729,6 +1741,7 @@ export function ChatView({
             onTextChange={handleComposerTextChange}
             onSubmit={handleSubmit}
             onStop={handleStop}
+            stopping={stopping}
             queuedForEdit={backend.editQueued ? queuedForEdit : undefined}
             onEditQueued={backend.editQueued ? handleEditQueued : undefined}
             onBrowseChange={setBrowsedQueuedId}

--- a/console/web/src/components/chat/Composer.tsx
+++ b/console/web/src/components/chat/Composer.tsx
@@ -4,7 +4,7 @@ import {
   $getRoot,
   type LexicalEditor,
 } from 'lexical'
-import { ArrowUp, Square } from 'lucide-react'
+import { ArrowUp, Loader2, Square } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { PermissionModePicker } from '@/components/permissions/PermissionModePicker'
 import type { PermissionMode } from '@/lib/backend/approval-settings'
@@ -87,6 +87,8 @@ interface ComposerProps {
   onPermissionModeChange: (next: PermissionMode) => void
   onSubmit: (payload: ComposerSubmitPayload) => void
   onStop?: () => void
+  /** A stop was requested and the server hasn't finalized the turn yet. */
+  stopping?: boolean
   isStreaming?: boolean
   /**
    * When true, the editor stays unlocked while streaming: a submit queues the
@@ -160,6 +162,7 @@ export function Composer({
   onPermissionModeChange,
   onSubmit,
   onStop,
+  stopping,
   isStreaming,
   queueWhileStreaming,
   blocked,
@@ -389,10 +392,15 @@ export function Composer({
             <button
               type="button"
               onClick={onStop}
-              aria-label="stop generating"
+              disabled={stopping}
+              aria-label={stopping ? 'stopping' : 'stop generating'}
               className={actionButtonClass}
             >
-              <Square size={16} aria-hidden className="fill-black/90" />
+              {stopping ? (
+                <Loader2 size={16} aria-hidden className="animate-spin" />
+              ) : (
+                <Square size={16} aria-hidden className="fill-black/90" />
+              )}
             </button>
           ) : (
             <button

--- a/console/web/src/lib/backend/translate.test.ts
+++ b/console/web/src/lib/backend/translate.test.ts
@@ -177,7 +177,12 @@ describe('translateTurnSource — turn-completed', () => {
         completed({ status: 'cancelled', reason: 'stopped' }),
       ),
     ).toEqual([
-      { kind: 'stop-reason', reason: 'aborted', message: 'stopped' },
+      {
+        kind: 'stop-reason',
+        reason: 'aborted',
+        message: 'stopped',
+        entryId: 'e_t-1_stopped',
+      },
       { kind: 'assistant-end' },
     ])
   })

--- a/console/web/src/lib/backend/translate.ts
+++ b/console/web/src/lib/backend/translate.ts
@@ -108,7 +108,14 @@ export function translateTurnSource(event: TurnSourceEvent): StreamEvent[] {
 function translateTurnCompleted(event: TurnCompletedEvent): StreamEvent[] {
   const out: StreamEvent[] = []
   if (event.status === 'cancelled') {
-    out.push({ kind: 'stop-reason', reason: 'aborted', message: event.reason })
+    out.push({
+      kind: 'stop-reason',
+      reason: 'aborted',
+      message: event.reason,
+      // Same id as the harness's durable "stopped" notice entry, so the live
+      // notice and the reconciled transcript row dedupe instead of doubling.
+      entryId: `e_${event.turn_id}_stopped`,
+    })
   } else if (event.status === 'failed' || event.result_error) {
     const message = event.result_error ?? event.reason
     out.push({

--- a/harness/src/clients/router.rs
+++ b/harness/src/clients/router.rs
@@ -19,7 +19,7 @@ use iii_sdk::protocol::TriggerRequest;
 use iii_sdk::IIIClient;
 use serde_json::{json, Value};
 use tokio::sync::mpsc;
-use tokio::sync::Notify;
+use tokio::sync::{watch, Notify};
 
 use crate::error::HarnessError;
 use crate::types::event::{AssistantMessageEvent, StopReason};
@@ -70,10 +70,17 @@ impl RouterClient {
     }
 
     /// Stream one assistant turn, forwarding coalesced partials to `sink`.
+    ///
+    /// `abort_rx` is the harness-local cancel backstop: `router::abort` is the
+    /// happy path (the router closes the stream → EOF), but it's a no-op when
+    /// it races ahead of the router's stream registration or after a router
+    /// restart — then only this local signal cuts the await (which otherwise
+    /// blocks up to `router_timeout_ms`).
     pub async fn chat(
         &self,
         params: ChatParams,
         sink: &dyn StreamSink,
+        mut abort_rx: watch::Receiver<bool>,
     ) -> Result<ChatOutcome, HarnessError> {
         let channel = create_channel(&self.iii, None)
             .await
@@ -113,6 +120,7 @@ impl RouterClient {
             }
         });
 
+        let request_id = params.request_id.clone();
         let mut payload = json!({
             "writer_ref": channel.writer_ref,
             "request_id": params.request_id,
@@ -186,6 +194,15 @@ impl RouterClient {
         // then fall through to the outcome handling below.
         let mut response: Option<Result<Value, iii_sdk::errors::Error>> = None;
         let mut drain_deadline = Instant::now();
+        // Resolves when harness::stop fires the turn's local cancel; a dropped
+        // sender (registry cleared — no stop can arrive) parks forever instead
+        // of busy-looping the select.
+        let abort_fired = async move {
+            if abort_rx.wait_for(|a| *a).await.is_err() {
+                std::future::pending::<()>().await;
+            }
+        };
+        tokio::pin!(abort_fired);
         loop {
             let frame = if response.is_some() {
                 match tokio::time::timeout(Duration::from_millis(750), rx.recv()).await {
@@ -208,6 +225,44 @@ impl RouterClient {
             } else {
                 tokio::select! {
                     f = rx.recv() => f,
+                    // Local cancel backstop: cut the await now, return the
+                    // partial as Aborted. No arm in the post-ack drain branch
+                    // above — that path is bounded (≤10s) already.
+                    _ = &mut abort_fired => {
+                        cancel.notify_waiters();
+                        let _ = pump.await;
+                        // Kill the held-open router::chat task; the router's
+                        // own teardown was already requested via router::abort.
+                        trigger.abort();
+                        // Re-request the router abort: stop.rs's router::abort
+                        // can race ahead of the router's stream registration
+                        // and no-op — by now the stream is certainly
+                        // registered, so this lands and the provider stops
+                        // generating instead of streaming into the closed
+                        // channel until its own terminal. Detached: an abort
+                        // against a hung router must not block the stop path.
+                        let client = self.clone();
+                        let rid = request_id.clone();
+                        tokio::spawn(async move {
+                            client.abort(&rid).await;
+                        });
+                        let mut message = tracker
+                            .current()
+                            .or(final_message)
+                            .unwrap_or_else(|| {
+                                empty_assistant(
+                                    params.provider.as_deref().unwrap_or(""),
+                                    &params.model,
+                                )
+                            });
+                        message.stop_reason = StopReason::Aborted;
+                        return Ok(ChatOutcome {
+                            ok: false,
+                            stop_reason: Some(StopReason::Aborted),
+                            message,
+                            error: None,
+                        });
+                    }
                     r = &mut trigger => {
                         response = Some(r.map_err(|e| {
                             HarnessError::Internal(format!("router::chat task: {e}"))

--- a/harness/src/clients/router.rs
+++ b/harness/src/clients/router.rs
@@ -229,7 +229,12 @@ impl RouterClient {
                     // partial as Aborted. No arm in the post-ack drain branch
                     // above — that path is bounded (≤10s) already.
                     _ = &mut abort_fired => {
-                        cancel.notify_waiters();
+                        // notify_one, not notify_waiters: it stores a permit
+                        // when the pump task hasn't polled its notified() yet
+                        // (a pre-fired cancel can get here before the spawned
+                        // pump first runs), so the wakeup can't be lost and
+                        // pump.await can't hang on next_binary().
+                        cancel.notify_one();
                         let _ = pump.await;
                         // Kill the held-open router::chat task; the router's
                         // own teardown was already requested via router::abort.
@@ -246,9 +251,12 @@ impl RouterClient {
                         tokio::spawn(async move {
                             client.abort(&rid).await;
                         });
-                        let mut message = tracker
-                            .current()
-                            .or(final_message)
+                        // Prefer a terminal frame's complete message over the
+                        // tracker's partial: a stop landing between a Done
+                        // frame and EOF must not replace the full assistant
+                        // entry with the stale pre-Done partial.
+                        let mut message = final_message
+                            .or_else(|| tracker.current())
                             .unwrap_or_else(|| {
                                 empty_assistant(
                                     params.provider.as_deref().unwrap_or(""),
@@ -328,7 +336,8 @@ impl RouterClient {
         }
 
         // Stream drained; stop the pump and collect the trigger ack.
-        cancel.notify_waiters();
+        // notify_one: latched — safe even if the pump task hasn't polled yet.
+        cancel.notify_one();
         let _ = pump.await;
         let response = match response {
             Some(r) => r,

--- a/harness/src/deps.rs
+++ b/harness/src/deps.rs
@@ -12,7 +12,7 @@ use crate::configuration::ConfigCell;
 use crate::discovery::{FunctionsCell, FunctionsSnapshot};
 use crate::events::TurnEvents;
 use crate::hooks::HookRegistry;
-use crate::locks::SessionLocks;
+use crate::locks::{SessionLocks, TurnCancels};
 use crate::subscriptions::SubscriptionRegistry;
 
 #[derive(Clone)]
@@ -23,6 +23,7 @@ pub struct Deps {
     pub events: TurnEvents,
     pub hooks: HookRegistry,
     pub locks: SessionLocks,
+    pub cancels: TurnCancels,
     pub subscriptions: Arc<SubscriptionRegistry>,
     /// react's per-subscription fire-rate breaker (loop breaker #3).
     pub react_gate: Arc<crate::functions::react::FireGate>,
@@ -43,6 +44,7 @@ impl Deps {
             events,
             hooks,
             locks: SessionLocks::new(),
+            cancels: TurnCancels::new(),
             subscriptions: Arc::new(SubscriptionRegistry::new()),
             react_gate: Arc::new(crate::functions::react::FireGate::default()),
         }

--- a/harness/src/functions/stop.rs
+++ b/harness/src/functions/stop.rs
@@ -44,9 +44,28 @@ pub async fn handle(deps: &Deps, req: StopRequest) -> Result<StopResponse, Harne
     if record.status.is_terminal() {
         return Ok(StopResponse { stopping: false });
     }
+    // Idempotent: a prior stop already fired the cancel signal, cascaded to
+    // children, and requested the router abort — repeat clicks become one read.
+    if record.abort {
+        return Ok(StopResponse { stopping: true });
+    }
     // Pin the turn we observed so the write under the lock can't land on a newer
     // turn that started in between (matters when `turn_id` was omitted).
     let target_turn = record.turn_id.clone();
+
+    // In-process cancel signal, fired lock-free BEFORE anything that awaits:
+    // it cuts the in-flight `router.chat` await (backstop when router::abort
+    // is a no-op) and is observed between tool executions, where the durable
+    // flag write below is blocked on the session lock.
+    deps.cancels.fire(&target_turn);
+
+    // Acknowledge the stop immediately via the existing phase-reason channel
+    // (status stays "working" — same semantics as "waiting for <model>"), so
+    // UIs can show "stopping" before the turn finalises.
+    let session = deps.session().await;
+    let _ = session
+        .set_status(&req.session_id, "working", Some("stopping"))
+        .await;
 
     // Cascade to non-terminal spawned children BEFORE taking this session's
     // lock (harness.md § Cancellation cascade): each child stop acquires its

--- a/harness/src/functions/stop.rs
+++ b/harness/src/functions/stop.rs
@@ -59,14 +59,6 @@ pub async fn handle(deps: &Deps, req: StopRequest) -> Result<StopResponse, Harne
     // flag write below is blocked on the session lock.
     deps.cancels.fire(&target_turn);
 
-    // Acknowledge the stop immediately via the existing phase-reason channel
-    // (status stays "working" — same semantics as "waiting for <model>"), so
-    // UIs can show "stopping" before the turn finalises.
-    let session = deps.session().await;
-    let _ = session
-        .set_status(&req.session_id, "working", Some("stopping"))
-        .await;
-
     // Cascade to non-terminal spawned children BEFORE taking this session's
     // lock (harness.md § Cancellation cascade): each child stop acquires its
     // OWN session lock, so holding the parent lock here could deadlock against a
@@ -118,6 +110,16 @@ pub async fn handle(deps: &Deps, req: StopRequest) -> Result<StopResponse, Harne
     record.abort = true;
     record.updated_at = crate::types::message::AgentMessage::now_ms();
     crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
+
+    // "stopping" ack on the existing phase-reason channel (status stays
+    // "working" — same semantics as "waiting for <model>"). UNDER the lock and
+    // after the terminal re-check: every finalizer emits its own set_status
+    // while holding this lock, so a lock-free ack here could land AFTER a
+    // concurrent finalize's "done" and leave the session stuck on "working".
+    let session = deps.session().await;
+    let _ = session
+        .set_status(&req.session_id, "working", Some("stopping"))
+        .await;
 
     Ok(StopResponse { stopping: true })
 }

--- a/harness/src/locks.rs
+++ b/harness/src/locks.rs
@@ -35,9 +35,55 @@ impl SessionLocks {
     }
 }
 
+/// Per-turn in-process cancel signals. `harness::stop` fires one lock-free so
+/// the running step can observe the stop where durable state can't reach it:
+/// inside the `router::chat` await (via `watch`) and between tool executions
+/// (via `is_fired`) — the tool phase holds the session lock, so the durable
+/// abort write is blocked behind it by construction. Level-triggered `watch`
+/// channels: a fire before subscribe is still observed. Keyed by turn_id so a
+/// stale fire can never cancel a newer turn. Same single-process caveat as
+/// `SessionLocks` above.
+#[derive(Clone, Default)]
+pub struct TurnCancels {
+    map: Arc<Mutex<HashMap<String, tokio::sync::watch::Sender<bool>>>>,
+}
+
+impl TurnCancels {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Signal cancellation for `turn_id` (idempotent).
+    pub fn fire(&self, turn_id: &str) {
+        let mut map = self.map.lock().unwrap_or_else(|p| p.into_inner());
+        map.entry(turn_id.to_string())
+            .or_insert_with(|| tokio::sync::watch::channel(false).0)
+            .send_replace(true);
+    }
+
+    pub fn is_fired(&self, turn_id: &str) -> bool {
+        let map = self.map.lock().unwrap_or_else(|p| p.into_inner());
+        map.get(turn_id).is_some_and(|s| *s.borrow())
+    }
+
+    /// Subscribe to `turn_id`'s cancel signal, creating it on first use.
+    pub fn watch(&self, turn_id: &str) -> tokio::sync::watch::Receiver<bool> {
+        let mut map = self.map.lock().unwrap_or_else(|p| p.into_inner());
+        map.entry(turn_id.to_string())
+            .or_insert_with(|| tokio::sync::watch::channel(false).0)
+            .subscribe()
+    }
+
+    /// Drop `turn_id`'s signal once the turn is terminal.
+    pub fn clear(&self, turn_id: &str) {
+        let mut map = self.map.lock().unwrap_or_else(|p| p.into_inner());
+        map.remove(turn_id);
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::SessionLocks;
+    use super::{SessionLocks, TurnCancels};
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
     use std::sync::Arc;
 
@@ -83,5 +129,19 @@ mod tests {
         // A different session acquires without waiting on `held`.
         let _other = locks.guard("b").await;
         drop(held);
+    }
+
+    /// The property the chat-abort backstop relies on: level-triggering. A fire
+    /// BEFORE anyone subscribes is still observed by a later watch/is_fired.
+    #[tokio::test]
+    async fn cancel_fired_before_subscribe_is_observed() {
+        let cancels = TurnCancels::new();
+        cancels.fire("t1");
+        assert!(cancels.is_fired("t1"));
+        let rx = cancels.watch("t1");
+        assert!(*rx.borrow());
+        assert!(!cancels.is_fired("t2"));
+        cancels.clear("t1");
+        assert!(!cancels.is_fired("t1"));
     }
 }

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -1494,6 +1494,11 @@ pub async fn fail_turn(
 ) -> TurnStepResult {
     let cfg = deps.cfg().await;
     let session = deps.session().await;
+    // Serialize with stop/resolve/sweep like every other turn-record writer
+    // (locks.rs). Safe: the only caller runs after run_step returned, so its
+    // guard is gone. Lock-free, this finalize could interleave with
+    // harness::stop's under-lock "stopping" ack and strand the session status.
+    let _guard = deps.locks.guard(session_id).await;
     let record = crate::state::get_turn(&deps.iii, session_id, cfg.session_timeout_ms)
         .await
         .ok()

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -520,6 +520,15 @@ pub async fn run_step(
     record.stream_request_id = Some(params.request_id.clone());
     crate::state::put_turn(&deps.iii, &record, cfg.session_timeout_ms).await?;
 
+    // A stop that landed during context assembly (its durable write blocked on
+    // the guard held here) is only visible via the in-process signal. Bail
+    // before dispatching generation at all — otherwise the provider starts a
+    // stream that is dead on arrival.
+    if deps.cancels.is_fired(&record.turn_id) {
+        record.abort = true;
+        return finalize_cancelled(deps, &session, &mut record, "cancelled").await;
+    }
+
     // Release the per-session lock across the generation RPC. The loop writes no
     // turn record between here and the post-generation cancellation check
     // (router::chat streams into the SESSION, not the turn record), so dropping
@@ -536,7 +545,25 @@ pub async fn run_step(
         .await;
 
     let router = deps.router().await;
-    let outcome = router.chat(params, &sink).await?;
+    // Harness-local cancel backstop: cuts this await even when router::abort
+    // was a no-op (registration race / router restart). Level-triggered, so a
+    // stop fired before this subscribe is still observed.
+    let abort_rx = deps.cancels.watch(&record.turn_id);
+    let mut outcome = router.chat(params, &sink, abort_rx).await?;
+
+    // A stop mid-generation truncates tool-call blocks before their arguments
+    // stream. An argument-less call can never execute (the turn is cancelled)
+    // and renders as an empty generic card — drop it from the persisted
+    // partial. Calls with partial arguments are kept: they show what was
+    // forming when the user stopped.
+    if outcome.message.stop_reason == crate::types::event::StopReason::Aborted {
+        outcome.message.content.retain(|b| {
+            !matches!(b, ContentBlock::FunctionCall { arguments, .. }
+                if arguments.is_null()
+                    || arguments.as_str().is_some_and(str::is_empty)
+                    || arguments.as_object().is_some_and(serde_json::Map::is_empty))
+        });
+    }
 
     // Generation consumed: advance the steering watermark (persisted by the
     // advance()/finalize call that ends this step).
@@ -699,6 +726,16 @@ pub async fn run_step(
                 .await?;
         let filesystem_root = record.options.filesystem_root().map(str::to_string);
         for call in trigger_calls.iter().copied() {
+            // Cancel check between tool calls. Only the in-process signal can
+            // be observed here: this phase holds the session lock, so the
+            // durable abort write in harness::stop is blocked behind it by
+            // construction. Executed calls are already checkpointed per-call,
+            // so finalizing mid-loop loses nothing.
+            if deps.cancels.is_fired(&record.turn_id) {
+                record.abort = true;
+                return finalize_cancelled(deps, &session, &mut record, "cancelled").await;
+            }
+
             // Per-call checkpoint: skip done/pending, recover an interrupted
             // trigger.
             match record.calls.get(&call.id).map(|c| c.state) {
@@ -1161,6 +1198,7 @@ async fn finalize_completed(
     record.result_error = None;
     record.updated_at = AgentMessage::now_ms();
     crate::state::put_turn(&deps.iii, record, cfg.session_timeout_ms).await?;
+    deps.cancels.clear(&record.turn_id);
     let _ = session.set_status(&record.session_id, "done", None).await;
     deps.events
         .emit_completed(
@@ -1204,6 +1242,7 @@ async fn finalize_failed(
     record.updated_at = AgentMessage::now_ms();
     record_failure_telemetry(record, reason, failure);
     crate::state::put_turn(&deps.iii, record, cfg.session_timeout_ms).await?;
+    deps.cancels.clear(&record.turn_id);
     let _ = session
         .append_custom(
             &record.session_id,
@@ -1403,6 +1442,19 @@ async fn finalize_cancelled(
     record.status = TurnStatus::Cancelled;
     record.updated_at = AgentMessage::now_ms();
     crate::state::put_turn(&deps.iii, record, cfg.session_timeout_ms).await?;
+    deps.cancels.clear(&record.turn_id);
+    // Durable stop marker: without it the transcript just ends mid-thought
+    // after a reload. Deterministic id so the live `stop-reason` notice
+    // (translate.ts) dedupes against this entry, mirroring `e_{turn}_error`.
+    let _ = session
+        .append_custom(
+            &record.session_id,
+            "notice",
+            json!({ "reason": "stopped", "message": "stopped by user." }),
+            &format!("e_{}_stopped", record.turn_id),
+            Some(&origin(&record.turn_id)),
+        )
+        .await;
     let _ = session.set_status(&record.session_id, "done", None).await;
     deps.events
         .emit_completed(

--- a/llm-router/src/chat/chat.rs
+++ b/llm-router/src/chat/chat.rs
@@ -270,7 +270,34 @@ impl ChatPipeline {
             }
             let channel = create_router_channel(&self.iii).await?;
             let mut reader = channel.reader;
-            inflight.set_closer(reader.closer());
+            // router::abort closes the relay AND actively cancels the
+            // provider's upstream via `provider::<id>::abort` — without it the
+            // provider only notices the closed channel on its next (ping)
+            // write, billing tokens meanwhile. Detached + best-effort: a
+            // provider without the function (or a stale request id) is a
+            // harmless error/no-op.
+            inflight.set_closer({
+                let close = reader.closer();
+                let iii = self.iii.clone();
+                let provider = provider.to_string();
+                let rid = request_id.to_string();
+                Arc::new(move || {
+                    close();
+                    let iii = iii.clone();
+                    let function_id = format!("provider::{}::abort", provider);
+                    let payload = serde_json::json!({ "request_id": rid });
+                    tokio::spawn(async move {
+                        let _ = iii
+                            .trigger(TriggerRequest {
+                                function_id,
+                                payload,
+                                action: None,
+                                timeout_ms: Some(10_000),
+                            })
+                            .await;
+                    });
+                })
+            });
 
             let stream_input = build_stream_input(
                 call,

--- a/llm-router/src/provider_scaffold/aborts.rs
+++ b/llm-router/src/provider_scaffold/aborts.rs
@@ -53,6 +53,44 @@ impl StreamAborts {
         let mut map = self.map.lock().unwrap_or_else(|p| p.into_inner());
         map.remove(request_id);
     }
+
+    /// RAII registration: subscribe on create, deregister on Drop. Register
+    /// BEFORE the stream fn's first await so an abort during setup latches,
+    /// and hold the guard across the call so cleanup runs on every exit —
+    /// including the executor cancelling the handler future mid-await, which
+    /// sequential cleanup after the call would silently miss.
+    pub fn register(&self, request_id: &str) -> AbortGuard {
+        AbortGuard {
+            rx: self.watch(request_id),
+            aborts: self.clone(),
+            request_id: request_id.to_string(),
+        }
+    }
+}
+
+pub struct AbortGuard {
+    aborts: StreamAborts,
+    request_id: String,
+    rx: watch::Receiver<bool>,
+}
+
+impl AbortGuard {
+    /// A receiver for `pump_abortable` (level-triggered; clone per pump).
+    pub fn watch(&self) -> watch::Receiver<bool> {
+        self.rx.clone()
+    }
+
+    /// True once the abort fired (also observable via a pre-fired `watch`).
+    pub fn is_fired(&self) -> bool {
+        *self.rx.borrow()
+    }
+}
+
+impl Drop for AbortGuard {
+    fn drop(&mut self) {
+        // A fired abort already consumed the entry — harmless no-op then.
+        self.aborts.remove(&self.request_id);
+    }
 }
 
 /// The `provider::<id>::abort` handler, ready to register: signals the
@@ -99,5 +137,24 @@ mod tests {
         let rx = aborts.watch("r1");
         assert!(aborts.abort("r1"));
         assert!(*rx.borrow());
+    }
+
+    /// The RAII property the providers rely on: dropping the guard (any exit,
+    /// including a cancelled future) deregisters; a pre-drop abort still
+    /// reaches the guard's receiver.
+    #[test]
+    fn guard_deregisters_on_drop_and_latches_aborts() {
+        let aborts = StreamAborts::new();
+        let guard = aborts.register("r1");
+        assert!(!guard.is_fired());
+        assert!(aborts.abort("r1"));
+        assert!(guard.is_fired());
+        assert!(*guard.watch().borrow());
+        drop(guard);
+        assert!(!aborts.abort("r1"), "entry gone after guard drop");
+
+        let guard2 = aborts.register("r2");
+        drop(guard2);
+        assert!(!aborts.abort("r2"), "unfired entry removed by guard drop");
     }
 }

--- a/llm-router/src/provider_scaffold/aborts.rs
+++ b/llm-router/src/provider_scaffold/aborts.rs
@@ -1,0 +1,103 @@
+//! request_id → in-flight upstream cancel, backing `provider::<id>::abort`.
+//! Provider-side mirror of the router's `chat::inflight`: the stream fn
+//! registers its request id before spawning the upstream, the abort function
+//! signals it, and `pump_abortable` returns on the signal — dropping the
+//! upstream receiver, which aborts the upstream task and its in-flight HTTP
+//! request. Level-triggered watch channels: an abort that lands between
+//! `watch` and the pump's first poll is still observed. `abort` signals
+//! existing entries only (no create), so stray aborts for finished requests
+//! can't leak entries — the ping-write backstop in the pump covers that race.
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use futures::future::BoxFuture;
+use iii_sdk::errors::Error;
+use tokio::sync::watch;
+
+use crate::types::router::{ProviderAbortRequest, ProviderAbortResponse};
+
+#[derive(Clone, Default)]
+pub struct StreamAborts {
+    map: Arc<Mutex<HashMap<String, watch::Sender<bool>>>>,
+}
+
+impl StreamAborts {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Subscribe for `request_id`, creating the entry. Call before spawning
+    /// the upstream; pair with `remove` when the stream ends.
+    pub fn watch(&self, request_id: &str) -> watch::Receiver<bool> {
+        let mut map = self.map.lock().unwrap_or_else(|p| p.into_inner());
+        map.entry(request_id.to_string())
+            .or_insert_with(|| watch::channel(false).0)
+            .subscribe()
+    }
+
+    /// Signal cancellation. `false` when the request is unknown — already
+    /// finished, never started, or previously aborted (idempotent).
+    pub fn abort(&self, request_id: &str) -> bool {
+        let mut map = self.map.lock().unwrap_or_else(|p| p.into_inner());
+        match map.remove(request_id) {
+            Some(tx) => {
+                tx.send_replace(true);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Drop `request_id`'s entry once its stream is over.
+    pub fn remove(&self, request_id: &str) {
+        let mut map = self.map.lock().unwrap_or_else(|p| p.into_inner());
+        map.remove(request_id);
+    }
+}
+
+/// The `provider::<id>::abort` handler, ready to register: signals the
+/// stream registered under `request_id` (see `StreamAborts`).
+pub fn make_abort(
+    aborts: StreamAborts,
+) -> impl Fn(ProviderAbortRequest) -> BoxFuture<'static, Result<ProviderAbortResponse, Error>>
+       + Send
+       + Sync
+       + 'static {
+    move |req: ProviderAbortRequest| {
+        let aborted = aborts.abort(&req.request_id);
+        Box::pin(async move { Ok(ProviderAbortResponse { aborted }) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn abort_signals_registered_watchers_once() {
+        let aborts = StreamAborts::new();
+        let rx = aborts.watch("r1");
+        assert!(!*rx.borrow());
+        assert!(aborts.abort("r1"));
+        assert!(*rx.borrow());
+        // entry consumed: a second abort is an idempotent no-op
+        assert!(!aborts.abort("r1"));
+    }
+
+    #[test]
+    fn abort_of_unknown_request_is_a_noop() {
+        let aborts = StreamAborts::new();
+        assert!(!aborts.abort("never-registered"));
+    }
+
+    /// The sender lives in the registry (not the subscriber), so a watcher
+    /// subscribing and dropping doesn't invalidate a later abort signal.
+    #[test]
+    fn resubscribing_sees_a_pre_subscribe_state() {
+        let aborts = StreamAborts::new();
+        drop(aborts.watch("r1"));
+        let rx = aborts.watch("r1");
+        assert!(aborts.abort("r1"));
+        assert!(*rx.borrow());
+    }
+}

--- a/llm-router/src/provider_scaffold/mod.rs
+++ b/llm-router/src/provider_scaffold/mod.rs
@@ -8,6 +8,7 @@
 //! genuinely theirs: request building, SSE event decoding, and error
 //! classification.
 
+pub mod aborts;
 pub mod cache;
 pub mod names;
 pub mod pump;

--- a/llm-router/src/provider_scaffold/pump.rs
+++ b/llm-router/src/provider_scaffold/pump.rs
@@ -8,7 +8,14 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 
 /// Heartbeat cadence while the upstream is silent (spec: at least every 30s).
-pub const PING_INTERVAL: Duration = Duration::from_secs(30);
+///
+/// Also the abort-detection bound: a failed ping write is how a provider
+/// notices the router closed the channel (`router::abort`) while the upstream
+/// is silent — e.g. Anthropic server-buffering a large tool_use input,
+/// generating (billed) tokens with no frames flowing. Worst-case waste after
+/// a stop is ~2 intervals (one ping trips the forwarder, the next observes
+/// it), so keep this small: 2s bounds it to ~4s where 30s allowed ~60s.
+pub const PING_INTERVAL: Duration = Duration::from_secs(2);
 
 /// `Err(())` means only "the sink is gone — stop writing"; there is no
 /// error detail to carry, so the unit error is the whole contract.
@@ -26,12 +33,34 @@ pub fn send_event(sink: &dyn FrameSink, ev: &AssistantMessageEvent) -> Result<()
 /// done / no terminal / caller gone) so providers can react to specific
 /// failures — e.g. dropping a cached credential on `AuthExpired`.
 pub async fn pump(
-    mut rx: mpsc::Receiver<AssistantMessageEvent>,
+    rx: mpsc::Receiver<AssistantMessageEvent>,
     sink: &dyn FrameSink,
     ping_interval: Duration,
 ) -> Option<ErrorKind> {
+    // Held so the never-fired abort arm stays pending instead of erroring.
+    let (_hold, abort_rx) = tokio::sync::watch::channel(false);
+    pump_abortable(rx, sink, ping_interval, abort_rx).await
+}
+
+/// [`pump`] with an active cancel: returns immediately when `abort_rx` fires
+/// (`provider::<id>::abort` via [`super::aborts::StreamAborts`]) — even
+/// mid-silence, without waiting for a ping write to fail. Returning drops
+/// `rx`, which aborts the upstream task and its in-flight HTTP request.
+pub async fn pump_abortable(
+    mut rx: mpsc::Receiver<AssistantMessageEvent>,
+    sink: &dyn FrameSink,
+    ping_interval: Duration,
+    mut abort_rx: tokio::sync::watch::Receiver<bool>,
+) -> Option<ErrorKind> {
     loop {
-        match tokio::time::timeout(ping_interval, rx.recv()).await {
+        let recv = tokio::select! {
+            r = tokio::time::timeout(ping_interval, rx.recv()) => r,
+            // Level-triggered: a fire before this poll is still observed.
+            // Err (sender gone before firing) can only follow an abort's
+            // send_replace(true), so wait_for resolves Ok on the value first.
+            _ = abort_rx.wait_for(|a| *a) => return None,
+        };
+        match recv {
             Ok(Some(ev)) => {
                 let terminal = ev.is_terminal();
                 let error_kind = match &ev {

--- a/llm-router/src/types/router.rs
+++ b/llm-router/src/types/router.rs
@@ -241,6 +241,23 @@ pub struct RefreshModelsResponse {
     pub count: usize,
 }
 
+/// Input of a provider's `provider::<id>::abort`: actively cancel the
+/// in-flight upstream stream for `request_id` (the router's `request_id`,
+/// delivered to the provider as `resolution_key`) so billed generation stops
+/// immediately instead of waiting for the provider to notice the closed
+/// channel on its next write.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ProviderAbortRequest {
+    pub request_id: String,
+}
+
+/// Output of `provider::<id>::abort`. `aborted: false` means the request was
+/// unknown — already finished, never started, or aborted before (idempotent).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ProviderAbortResponse {
+    pub aborted: bool,
+}
+
 /// Event delivered to a provider's `provider::<id>::on_router_ready` (the
 /// `router::ready` trigger payload, currently `{}`). Unknown fields are ignored.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]

--- a/provider-anthropic/Cargo.lock
+++ b/provider-anthropic/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-anthropic/src/register.rs
+++ b/provider-anthropic/src/register.rs
@@ -9,6 +9,7 @@ use crate::{router_client, state, PROVIDER_ID};
 use iii_sdk::errors::Error;
 use iii_sdk::protocol::RegisterTriggerInput;
 use iii_sdk::{IIIClient, RegisterFunction};
+use llm_router::provider_scaffold::aborts::{make_abort, StreamAborts};
 use llm_router::provider_scaffold::cache::ScaffoldCache;
 use llm_router::types::router::{
     ProviderDeclaration, ProviderDefaults, ProviderReadyAck, RouterReadyEvent,
@@ -135,13 +136,26 @@ pub async fn register_provider(iii: IIIClient) -> Result<(), Error> {
         .build()
         .expect("reqwest client");
 
+    // request_id → live upstream cancel, shared by stream (registers) and
+    // abort (signals) — see llm_router::provider_scaffold::aborts.
+    let aborts = StreamAborts::new();
+
     iii.register_function(
         surface::STREAM_ID,
         RegisterFunction::new_async_with_bad_request(
-            make_stream(iii.clone(), http.clone(), cache.clone()),
+            make_stream(iii.clone(), http.clone(), cache.clone(), aborts.clone()),
             invalid_request_from_serde,
         )
         .description(surface::STREAM_DESC)
+        .metadata(json!({ "internal": true })),
+    );
+    iii.register_function(
+        surface::ABORT_ID,
+        RegisterFunction::new_async_with_bad_request(
+            make_abort(aborts),
+            invalid_request_from_serde,
+        )
+        .description(surface::ABORT_DESC)
         .metadata(json!({ "internal": true })),
     );
     iii.register_function(

--- a/provider-anthropic/src/stream_fn.rs
+++ b/provider-anthropic/src/stream_fn.rs
@@ -36,7 +36,10 @@ pub fn make_stream(
             // opens must latch, not hit an unknown id. The RAII guard
             // deregisters on every exit — early returns and an executor
             // cancelling this future mid-await alike.
-            let abort_reg = input.resolution_key.as_ref().map(|rid| aborts.register(rid));
+            let abort_reg = input
+                .resolution_key
+                .as_ref()
+                .map(|rid| aborts.register(rid));
             let sink = open_sink(&iii, &input.writer_ref).await?;
             run_stream_call(&iii, http, &cache, abort_reg.as_ref(), input, sink.as_ref()).await;
             sink.close();

--- a/provider-anthropic/src/stream_fn.rs
+++ b/provider-anthropic/src/stream_fn.rs
@@ -14,7 +14,7 @@ use iii_sdk::errors::Error;
 use iii_sdk::IIIClient;
 use llm_router::channels::open_sink;
 use llm_router::chat::relay::FrameSink;
-use llm_router::provider_scaffold::aborts::StreamAborts;
+use llm_router::provider_scaffold::aborts::{AbortGuard, StreamAborts};
 use llm_router::provider_scaffold::cache::ScaffoldCache;
 use llm_router::provider_scaffold::pump::{pump, pump_abortable, send_event, PING_INTERVAL};
 use llm_router::types::events::ErrorKind;
@@ -32,14 +32,13 @@ pub fn make_stream(
     move |input: ProviderStreamInput| {
         let (iii, http, cache, aborts) = (iii.clone(), http.clone(), cache.clone(), aborts.clone());
         Box::pin(async move {
+            // Register BEFORE the first await: an abort landing while the sink
+            // opens must latch, not hit an unknown id. The RAII guard
+            // deregisters on every exit — early returns and an executor
+            // cancelling this future mid-await alike.
+            let abort_reg = input.resolution_key.as_ref().map(|rid| aborts.register(rid));
             let sink = open_sink(&iii, &input.writer_ref).await?;
-            let request_id = input.resolution_key.clone();
-            run_stream_call(&iii, http, &cache, &aborts, input, sink.as_ref()).await;
-            // Single cleanup point covering every exit path (early returns
-            // included). A fired abort already consumed the entry — no-op.
-            if let Some(rid) = &request_id {
-                aborts.remove(rid);
-            }
+            run_stream_call(&iii, http, &cache, abort_reg.as_ref(), input, sink.as_ref()).await;
             sink.close();
             // ProviderStreamOutput (spec § stream contract)
             Ok(ProviderStreamOutput { ok: true })
@@ -51,16 +50,10 @@ async fn run_stream_call(
     iii: &IIIClient,
     http: reqwest::Client,
     cache: &ScaffoldCache,
-    aborts: &StreamAborts,
+    abort_reg: Option<&AbortGuard>,
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
-    // Subscribe FIRST: an abort landing during credential resolve / config /
-    // model_meta — before any upstream exists — must latch (level-triggered
-    // watch), or the request would start after its own cancellation. The
-    // caller removes the entry when this returns.
-    let abort_rx = input.resolution_key.as_ref().map(|rid| aborts.watch(rid));
-
     let model = input.model.clone();
 
     let mut warnings = Vec::new();
@@ -152,7 +145,7 @@ async fn run_stream_call(
     let headers = build_headers(&cfg);
 
     // Aborted while we were setting up — never start the upstream request.
-    if abort_rx.as_ref().is_some_and(|rx| *rx.borrow()) {
+    if abort_reg.is_some_and(|g| g.is_fired()) {
         return;
     }
     let rx = spawn_upstream(
@@ -165,8 +158,8 @@ async fn run_stream_call(
             warnings,
         },
     );
-    let kind = match abort_rx {
-        Some(abort_rx) => pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await,
+    let kind = match abort_reg {
+        Some(g) => pump_abortable(rx, sink, PING_INTERVAL, g.watch()).await,
         None => pump(rx, sink, PING_INTERVAL).await,
     };
     // An upstream auth terminal means the cached credential was rotated

--- a/provider-anthropic/src/stream_fn.rs
+++ b/provider-anthropic/src/stream_fn.rs
@@ -59,10 +59,7 @@ async fn run_stream_call(
     // model_meta — before any upstream exists — must latch (level-triggered
     // watch), or the request would start after its own cancellation. The
     // caller removes the entry when this returns.
-    let abort_rx = input
-        .resolution_key
-        .as_ref()
-        .map(|rid| aborts.watch(rid));
+    let abort_rx = input.resolution_key.as_ref().map(|rid| aborts.watch(rid));
 
     let model = input.model.clone();
 

--- a/provider-anthropic/src/stream_fn.rs
+++ b/provider-anthropic/src/stream_fn.rs
@@ -14,8 +14,9 @@ use iii_sdk::errors::Error;
 use iii_sdk::IIIClient;
 use llm_router::channels::open_sink;
 use llm_router::chat::relay::FrameSink;
+use llm_router::provider_scaffold::aborts::StreamAborts;
 use llm_router::provider_scaffold::cache::ScaffoldCache;
-use llm_router::provider_scaffold::pump::{pump, send_event, PING_INTERVAL};
+use llm_router::provider_scaffold::pump::{pump, pump_abortable, send_event, PING_INTERVAL};
 use llm_router::types::events::ErrorKind;
 use llm_router::types::router::{ProviderStreamInput, ProviderStreamOutput};
 
@@ -23,15 +24,16 @@ pub fn make_stream(
     iii: IIIClient,
     http: reqwest::Client,
     cache: ScaffoldCache,
+    aborts: StreamAborts,
 ) -> impl Fn(ProviderStreamInput) -> BoxFuture<'static, Result<ProviderStreamOutput, Error>>
        + Send
        + Sync
        + 'static {
     move |input: ProviderStreamInput| {
-        let (iii, http, cache) = (iii.clone(), http.clone(), cache.clone());
+        let (iii, http, cache, aborts) = (iii.clone(), http.clone(), cache.clone(), aborts.clone());
         Box::pin(async move {
             let sink = open_sink(&iii, &input.writer_ref).await?;
-            run_stream_call(&iii, http, &cache, input, sink.as_ref()).await;
+            run_stream_call(&iii, http, &cache, &aborts, input, sink.as_ref()).await;
             sink.close();
             // ProviderStreamOutput (spec § stream contract)
             Ok(ProviderStreamOutput { ok: true })
@@ -43,6 +45,7 @@ async fn run_stream_call(
     iii: &IIIClient,
     http: reqwest::Client,
     cache: &ScaffoldCache,
+    aborts: &StreamAborts,
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
@@ -146,9 +149,21 @@ async fn run_stream_call(
             warnings,
         },
     );
+    // Register for `provider::anthropic::abort` only while the upstream is
+    // live — the phases before it burn no tokens. Pre-upstream phases keep
+    // the plain pump; earlier returns therefore need no cleanup.
+    let kind = match &input.resolution_key {
+        Some(request_id) => {
+            let abort_rx = aborts.watch(request_id);
+            let kind = pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await;
+            aborts.remove(request_id);
+            kind
+        }
+        None => pump(rx, sink, PING_INTERVAL).await,
+    };
     // An upstream auth terminal means the cached credential was rotated
     // out from under us: drop the cache so the next attempt re-resolves.
-    if pump(rx, sink, PING_INTERVAL).await == Some(ErrorKind::AuthExpired) {
+    if kind == Some(ErrorKind::AuthExpired) {
         cache.invalidate();
     }
 }

--- a/provider-anthropic/src/stream_fn.rs
+++ b/provider-anthropic/src/stream_fn.rs
@@ -33,7 +33,13 @@ pub fn make_stream(
         let (iii, http, cache, aborts) = (iii.clone(), http.clone(), cache.clone(), aborts.clone());
         Box::pin(async move {
             let sink = open_sink(&iii, &input.writer_ref).await?;
+            let request_id = input.resolution_key.clone();
             run_stream_call(&iii, http, &cache, &aborts, input, sink.as_ref()).await;
+            // Single cleanup point covering every exit path (early returns
+            // included). A fired abort already consumed the entry — no-op.
+            if let Some(rid) = &request_id {
+                aborts.remove(rid);
+            }
             sink.close();
             // ProviderStreamOutput (spec § stream contract)
             Ok(ProviderStreamOutput { ok: true })
@@ -49,6 +55,15 @@ async fn run_stream_call(
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
+    // Subscribe FIRST: an abort landing during credential resolve / config /
+    // model_meta — before any upstream exists — must latch (level-triggered
+    // watch), or the request would start after its own cancellation. The
+    // caller removes the entry when this returns.
+    let abort_rx = input
+        .resolution_key
+        .as_ref()
+        .map(|rid| aborts.watch(rid));
+
     let model = input.model.clone();
 
     let mut warnings = Vec::new();
@@ -139,6 +154,10 @@ async fn run_stream_call(
     );
     let headers = build_headers(&cfg);
 
+    // Aborted while we were setting up — never start the upstream request.
+    if abort_rx.as_ref().is_some_and(|rx| *rx.borrow()) {
+        return;
+    }
     let rx = spawn_upstream(
         http,
         UpstreamArgs {
@@ -149,16 +168,8 @@ async fn run_stream_call(
             warnings,
         },
     );
-    // Register for `provider::anthropic::abort` only while the upstream is
-    // live — the phases before it burn no tokens. Pre-upstream phases keep
-    // the plain pump; earlier returns therefore need no cleanup.
-    let kind = match &input.resolution_key {
-        Some(request_id) => {
-            let abort_rx = aborts.watch(request_id);
-            let kind = pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await;
-            aborts.remove(request_id);
-            kind
-        }
+    let kind = match abort_rx {
+        Some(abort_rx) => pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await,
         None => pump(rx, sink, PING_INTERVAL).await,
     };
     // An upstream auth terminal means the cached credential was rotated

--- a/provider-anthropic/src/surface.rs
+++ b/provider-anthropic/src/surface.rs
@@ -9,13 +9,17 @@
 //! registration emits.
 
 use llm_router::types::router::{
-    ProviderReadyAck, ProviderStreamInput, ProviderStreamOutput, RefreshModelsRequest,
-    RefreshModelsResponse, RouterReadyEvent,
+    ProviderAbortRequest, ProviderAbortResponse, ProviderReadyAck, ProviderStreamInput,
+    ProviderStreamOutput, RefreshModelsRequest, RefreshModelsResponse, RouterReadyEvent,
 };
 
 pub const STREAM_ID: &str = "provider::anthropic::stream";
 pub const STREAM_DESC: &str = "Stream an Anthropic chat completion: resolve credentials, call the \
      upstream Messages API, and relay AssistantMessageEvent frames to writer_ref.";
+
+pub const ABORT_ID: &str = "provider::anthropic::abort";
+pub const ABORT_DESC: &str = "Cancel the in-flight upstream stream for a request_id \
+     (router::abort fan-out), stopping billed generation immediately.";
 
 pub const REFRESH_MODELS_ID: &str = "provider::anthropic::refresh_models";
 pub const REFRESH_MODELS_DESC: &str =
@@ -59,6 +63,7 @@ where
 pub fn catalog() -> Vec<FunctionSpec> {
     vec![
         spec::<ProviderStreamInput, ProviderStreamOutput>(STREAM_ID, STREAM_DESC),
+        spec::<ProviderAbortRequest, ProviderAbortResponse>(ABORT_ID, ABORT_DESC),
         spec::<RefreshModelsRequest, RefreshModelsResponse>(REFRESH_MODELS_ID, REFRESH_MODELS_DESC),
         spec::<RouterReadyEvent, ProviderReadyAck>(ON_ROUTER_READY_ID, ON_ROUTER_READY_DESC),
     ]

--- a/provider-anthropic/src/upstream.rs
+++ b/provider-anthropic/src/upstream.rs
@@ -29,7 +29,16 @@ pub fn spawn_upstream(
 ) -> mpsc::Receiver<AssistantMessageEvent> {
     let (tx, rx) = mpsc::channel(64);
     tokio::spawn(async move {
-        run_upstream(client, args, tx).await;
+        // Race the call against receiver-side closure: send errors alone only
+        // observe a dropped receiver at the next send, so a silent upstream
+        // (parked in a chunk read, nothing to send) would otherwise keep the
+        // HTTP stream — and billed generation — alive until the next frame or
+        // the read timeout. This makes the module contract above immediate.
+        let closed = tx.clone();
+        tokio::select! {
+            _ = run_upstream(client, args, tx) => {}
+            _ = closed.closed() => {}
+        }
     });
     rx
 }

--- a/provider-anthropic/tests/golden/schemas/provider.anthropic.abort.json
+++ b/provider-anthropic/tests/golden/schemas/provider.anthropic.abort.json
@@ -1,0 +1,32 @@
+{
+  "description": "Cancel the in-flight upstream stream for a request_id (router::abort fan-out), stopping billed generation immediately.",
+  "function_id": "provider::anthropic::abort",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Input of a provider's `provider::<id>::abort`: actively cancel the in-flight upstream stream for `request_id` (the router's `request_id`, delivered to the provider as `resolution_key`) so billed generation stops immediately instead of waiting for the provider to notice the closed channel on its next write.",
+    "properties": {
+      "request_id": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "request_id"
+    ],
+    "title": "ProviderAbortRequest",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Output of `provider::<id>::abort`. `aborted: false` means the request was unknown — already finished, never started, or aborted before (idempotent).",
+    "properties": {
+      "aborted": {
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "aborted"
+    ],
+    "title": "ProviderAbortResponse",
+    "type": "object"
+  }
+}

--- a/provider-anthropic/tests/schemas.rs
+++ b/provider-anthropic/tests/schemas.rs
@@ -40,6 +40,7 @@ fn catalog_lists_all_functions_in_registration_order() {
         ids,
         vec![
             "provider::anthropic::stream",
+            "provider::anthropic::abort",
             "provider::anthropic::refresh_models",
             "provider::anthropic::on_router_ready",
         ]

--- a/provider-kimi/Cargo.lock
+++ b/provider-kimi/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-kimi/src/register.rs
+++ b/provider-kimi/src/register.rs
@@ -9,6 +9,7 @@ use crate::{router_client, state, PROVIDER_ID};
 use iii_sdk::errors::Error;
 use iii_sdk::protocol::RegisterTriggerInput;
 use iii_sdk::{IIIClient, RegisterFunction};
+use llm_router::provider_scaffold::aborts::{make_abort, StreamAborts};
 use llm_router::types::router::{
     ProviderDeclaration, ProviderDefaults, ProviderReadyAck, RouterReadyEvent,
 };
@@ -114,13 +115,25 @@ pub async fn register_provider(iii: IIIClient) -> Result<(), Error> {
         .build()
         .expect("reqwest client");
 
+    // request_id → live upstream cancel, shared by stream (registers) and
+    // abort (signals) — see llm_router::provider_scaffold::aborts.
+    let aborts = StreamAborts::new();
+
     iii.register_function(
         surface::STREAM_ID,
         RegisterFunction::new_async_with_bad_request(
-            make_stream(iii.clone(), http.clone()),
+            make_stream(iii.clone(), http.clone(), aborts.clone()),
             invalid_request_from_serde,
         )
         .description(surface::STREAM_DESC),
+    );
+    iii.register_function(
+        surface::ABORT_ID,
+        RegisterFunction::new_async_with_bad_request(
+            make_abort(aborts),
+            invalid_request_from_serde,
+        )
+        .description(surface::ABORT_DESC),
     );
     iii.register_function(
         surface::REFRESH_MODELS_ID,

--- a/provider-kimi/src/register.rs
+++ b/provider-kimi/src/register.rs
@@ -133,7 +133,10 @@ pub async fn register_provider(iii: IIIClient) -> Result<(), Error> {
             make_abort(aborts),
             invalid_request_from_serde,
         )
-        .description(surface::ABORT_DESC),
+        .description(surface::ABORT_DESC)
+        // Control-plane callback (router::abort fan-out) — hide from the
+        // agent-facing catalog like the other providers' abort functions.
+        .metadata(serde_json::json!({ "internal": true })),
     );
     iii.register_function(
         surface::REFRESH_MODELS_ID,

--- a/provider-kimi/src/sse.rs
+++ b/provider-kimi/src/sse.rs
@@ -257,7 +257,7 @@ pub fn handle_chunk(
                 }
                 state.thinking.push_str(reasoning);
                 events.push(AssistantMessageEvent::ThinkingDelta {
-                    partial: build_partial(state, model),
+                    partial: None,
                     delta: reasoning.to_string(),
                 });
             }
@@ -273,7 +273,7 @@ pub fn handle_chunk(
                 }
                 state.text.push_str(text);
                 events.push(AssistantMessageEvent::TextDelta {
-                    partial: build_partial(state, model),
+                    partial: None,
                     delta: text.to_string(),
                 });
             }
@@ -306,7 +306,7 @@ pub fn handle_chunk(
                     if !args.is_empty() {
                         state.function_calls[index].args_json.push_str(args);
                         events.push(AssistantMessageEvent::FunctioncallDelta {
-                            partial: build_partial(state, model),
+                            partial: None,
                             delta: args.to_string(),
                             id: state.function_calls[index].id.clone(),
                         });

--- a/provider-kimi/src/stream_fn.rs
+++ b/provider-kimi/src/stream_fn.rs
@@ -12,6 +12,8 @@ use iii_sdk::errors::Error;
 use iii_sdk::IIIClient;
 use llm_router::channels::open_sink;
 use llm_router::chat::relay::FrameSink;
+use llm_router::provider_scaffold::aborts::StreamAborts;
+use llm_router::provider_scaffold::pump::pump_abortable;
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind};
 use llm_router::types::router::{ProviderStreamInput, ProviderStreamOutput};
 use std::time::Duration;
@@ -23,15 +25,16 @@ pub const PING_INTERVAL: Duration = Duration::from_secs(30);
 pub fn make_stream(
     iii: IIIClient,
     http: reqwest::Client,
+    aborts: StreamAborts,
 ) -> impl Fn(ProviderStreamInput) -> BoxFuture<'static, Result<ProviderStreamOutput, Error>>
        + Send
        + Sync
        + 'static {
     move |input: ProviderStreamInput| {
-        let (iii, http) = (iii.clone(), http.clone());
+        let (iii, http, aborts) = (iii.clone(), http.clone(), aborts.clone());
         Box::pin(async move {
             let sink = open_sink(&iii, &input.writer_ref).await?;
-            run_stream_call(&iii, http, input, sink.as_ref()).await;
+            run_stream_call(&iii, http, &aborts, input, sink.as_ref()).await;
             sink.close();
             // ProviderStreamOutput (spec § stream contract)
             Ok(ProviderStreamOutput { ok: true })
@@ -47,6 +50,7 @@ fn send_event(sink: &dyn FrameSink, ev: &AssistantMessageEvent) -> Result<(), ()
 async fn run_stream_call(
     iii: &IIIClient,
     http: reqwest::Client,
+    aborts: &StreamAborts,
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
@@ -122,7 +126,16 @@ async fn run_stream_call(
             warnings,
         },
     );
-    pump(rx, sink, PING_INTERVAL).await;
+    // Register for `provider::kimi::abort` only while the upstream is live —
+    // the phases before it burn no tokens; earlier returns need no cleanup.
+    match &input.resolution_key {
+        Some(request_id) => {
+            let abort_rx = aborts.watch(request_id);
+            let _ = pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await;
+            aborts.remove(request_id);
+        }
+        None => pump(rx, sink, PING_INTERVAL).await,
+    }
 }
 
 /// Forward upstream events to the sink; ping through silence; stop on the

--- a/provider-kimi/src/stream_fn.rs
+++ b/provider-kimi/src/stream_fn.rs
@@ -12,7 +12,7 @@ use iii_sdk::errors::Error;
 use iii_sdk::IIIClient;
 use llm_router::channels::open_sink;
 use llm_router::chat::relay::FrameSink;
-use llm_router::provider_scaffold::aborts::StreamAborts;
+use llm_router::provider_scaffold::aborts::{AbortGuard, StreamAborts};
 use llm_router::provider_scaffold::pump::pump_abortable;
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind};
 use llm_router::types::router::{ProviderStreamInput, ProviderStreamOutput};
@@ -33,14 +33,16 @@ pub fn make_stream(
     move |input: ProviderStreamInput| {
         let (iii, http, aborts) = (iii.clone(), http.clone(), aborts.clone());
         Box::pin(async move {
+            // Register BEFORE the first await: an abort landing while the sink
+            // opens must latch, not hit an unknown id. The RAII guard
+            // deregisters on every exit — early returns and an executor
+            // cancelling this future mid-await alike.
+            let abort_reg = input
+                .resolution_key
+                .as_ref()
+                .map(|rid| aborts.register(rid));
             let sink = open_sink(&iii, &input.writer_ref).await?;
-            let request_id = input.resolution_key.clone();
-            run_stream_call(&iii, http, &aborts, input, sink.as_ref()).await;
-            // Single cleanup point covering every exit path (early returns
-            // included). A fired abort already consumed the entry — no-op.
-            if let Some(rid) = &request_id {
-                aborts.remove(rid);
-            }
+            run_stream_call(&iii, http, abort_reg.as_ref(), input, sink.as_ref()).await;
             sink.close();
             // ProviderStreamOutput (spec § stream contract)
             Ok(ProviderStreamOutput { ok: true })
@@ -56,16 +58,10 @@ fn send_event(sink: &dyn FrameSink, ev: &AssistantMessageEvent) -> Result<(), ()
 async fn run_stream_call(
     iii: &IIIClient,
     http: reqwest::Client,
-    aborts: &StreamAborts,
+    abort_reg: Option<&AbortGuard>,
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
-    // Subscribe FIRST: an abort landing during credential resolve / config —
-    // before any upstream exists — must latch (level-triggered watch), or the
-    // request would start after its own cancellation. The caller removes the
-    // entry when this returns.
-    let abort_rx = input.resolution_key.as_ref().map(|rid| aborts.watch(rid));
-
     let model = input.model.clone();
     let mut warnings = Vec::new();
 
@@ -129,7 +125,7 @@ async fn run_stream_call(
     let headers = build_headers(&cfg);
 
     // Aborted while we were setting up — never start the upstream request.
-    if abort_rx.as_ref().is_some_and(|rx| *rx.borrow()) {
+    if abort_reg.is_some_and(|g| g.is_fired()) {
         return;
     }
     let rx = spawn_upstream(
@@ -143,9 +139,9 @@ async fn run_stream_call(
         },
     );
     // kimi discards the terminal error_kind (no cached credential to drop).
-    match abort_rx {
-        Some(abort_rx) => {
-            pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await;
+    match abort_reg {
+        Some(g) => {
+            pump_abortable(rx, sink, PING_INTERVAL, g.watch()).await;
         }
         None => pump(rx, sink, PING_INTERVAL).await,
     }

--- a/provider-kimi/src/stream_fn.rs
+++ b/provider-kimi/src/stream_fn.rs
@@ -34,7 +34,13 @@ pub fn make_stream(
         let (iii, http, aborts) = (iii.clone(), http.clone(), aborts.clone());
         Box::pin(async move {
             let sink = open_sink(&iii, &input.writer_ref).await?;
+            let request_id = input.resolution_key.clone();
             run_stream_call(&iii, http, &aborts, input, sink.as_ref()).await;
+            // Single cleanup point covering every exit path (early returns
+            // included). A fired abort already consumed the entry — no-op.
+            if let Some(rid) = &request_id {
+                aborts.remove(rid);
+            }
             sink.close();
             // ProviderStreamOutput (spec § stream contract)
             Ok(ProviderStreamOutput { ok: true })
@@ -54,6 +60,12 @@ async fn run_stream_call(
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
+    // Subscribe FIRST: an abort landing during credential resolve / config —
+    // before any upstream exists — must latch (level-triggered watch), or the
+    // request would start after its own cancellation. The caller removes the
+    // entry when this returns.
+    let abort_rx = input.resolution_key.as_ref().map(|rid| aborts.watch(rid));
+
     let model = input.model.clone();
     let mut warnings = Vec::new();
 
@@ -116,6 +128,10 @@ async fn run_stream_call(
     });
     let headers = build_headers(&cfg);
 
+    // Aborted while we were setting up — never start the upstream request.
+    if abort_rx.as_ref().is_some_and(|rx| *rx.borrow()) {
+        return;
+    }
     let rx = spawn_upstream(
         http,
         UpstreamArgs {
@@ -126,13 +142,10 @@ async fn run_stream_call(
             warnings,
         },
     );
-    // Register for `provider::kimi::abort` only while the upstream is live —
-    // the phases before it burn no tokens; earlier returns need no cleanup.
-    match &input.resolution_key {
-        Some(request_id) => {
-            let abort_rx = aborts.watch(request_id);
-            let _ = pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await;
-            aborts.remove(request_id);
+    // kimi discards the terminal error_kind (no cached credential to drop).
+    match abort_rx {
+        Some(abort_rx) => {
+            pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await;
         }
         None => pump(rx, sink, PING_INTERVAL).await,
     }

--- a/provider-kimi/src/surface.rs
+++ b/provider-kimi/src/surface.rs
@@ -9,14 +9,18 @@
 //! registration emits.
 
 use llm_router::types::router::{
-    ProviderReadyAck, ProviderStreamInput, ProviderStreamOutput, RefreshModelsRequest,
-    RefreshModelsResponse, RouterReadyEvent,
+    ProviderAbortRequest, ProviderAbortResponse, ProviderReadyAck, ProviderStreamInput,
+    ProviderStreamOutput, RefreshModelsRequest, RefreshModelsResponse, RouterReadyEvent,
 };
 
 pub const STREAM_ID: &str = "provider::kimi::stream";
 pub const STREAM_DESC: &str =
     "Stream a Kimi (Moonshot) chat completion: resolve credentials, call \
      the upstream Chat Completions API, and relay AssistantMessageEvent frames to writer_ref.";
+
+pub const ABORT_ID: &str = "provider::kimi::abort";
+pub const ABORT_DESC: &str = "Cancel the in-flight upstream stream for a request_id \
+     (router::abort fan-out), stopping billed generation immediately.";
 
 pub const REFRESH_MODELS_ID: &str = "provider::kimi::refresh_models";
 pub const REFRESH_MODELS_DESC: &str = "Refresh the Kimi catalog slice from GET /v1/models and \
@@ -59,6 +63,7 @@ where
 pub fn catalog() -> Vec<FunctionSpec> {
     vec![
         spec::<ProviderStreamInput, ProviderStreamOutput>(STREAM_ID, STREAM_DESC),
+        spec::<ProviderAbortRequest, ProviderAbortResponse>(ABORT_ID, ABORT_DESC),
         spec::<RefreshModelsRequest, RefreshModelsResponse>(REFRESH_MODELS_ID, REFRESH_MODELS_DESC),
         spec::<RouterReadyEvent, ProviderReadyAck>(ON_ROUTER_READY_ID, ON_ROUTER_READY_DESC),
     ]

--- a/provider-kimi/src/upstream.rs
+++ b/provider-kimi/src/upstream.rs
@@ -23,7 +23,16 @@ pub fn spawn_upstream(
 ) -> mpsc::Receiver<AssistantMessageEvent> {
     let (tx, rx) = mpsc::channel(64);
     tokio::spawn(async move {
-        run_upstream(client, args, tx).await;
+        // Race the call against receiver-side closure: send errors alone only
+        // observe a dropped receiver at the next send, so a silent upstream
+        // (parked in a chunk read, nothing to send) would otherwise keep the
+        // HTTP stream — and billed generation — alive until the next frame or
+        // the read timeout.
+        let closed = tx.clone();
+        tokio::select! {
+            _ = run_upstream(client, args, tx) => {}
+            _ = closed.closed() => {}
+        }
     });
     rx
 }

--- a/provider-kimi/tests/golden/schemas/provider.kimi.abort.json
+++ b/provider-kimi/tests/golden/schemas/provider.kimi.abort.json
@@ -1,0 +1,32 @@
+{
+  "description": "Cancel the in-flight upstream stream for a request_id (router::abort fan-out), stopping billed generation immediately.",
+  "function_id": "provider::kimi::abort",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Input of a provider's `provider::<id>::abort`: actively cancel the in-flight upstream stream for `request_id` (the router's `request_id`, delivered to the provider as `resolution_key`) so billed generation stops immediately instead of waiting for the provider to notice the closed channel on its next write.",
+    "properties": {
+      "request_id": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "request_id"
+    ],
+    "title": "ProviderAbortRequest",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Output of `provider::<id>::abort`. `aborted: false` means the request was unknown — already finished, never started, or aborted before (idempotent).",
+    "properties": {
+      "aborted": {
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "aborted"
+    ],
+    "title": "ProviderAbortResponse",
+    "type": "object"
+  }
+}

--- a/provider-kimi/tests/schemas.rs
+++ b/provider-kimi/tests/schemas.rs
@@ -40,6 +40,7 @@ fn catalog_lists_all_functions_in_registration_order() {
         ids,
         vec![
             "provider::kimi::stream",
+            "provider::kimi::abort",
             "provider::kimi::refresh_models",
             "provider::kimi::on_router_ready",
         ]

--- a/provider-llamacpp/Cargo.lock
+++ b/provider-llamacpp/Cargo.lock
@@ -738,7 +738,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-llamacpp/src/register.rs
+++ b/provider-llamacpp/src/register.rs
@@ -139,9 +139,12 @@ pub async fn register_provider(iii: IIIClient) -> Result<(), Error> {
     );
     iii.register_function(
         surface::ABORT_ID,
-        RegisterFunction::new_async_with_bad_request(make_abort(aborts), invalid_request_from_serde)
-            .description(surface::ABORT_DESC)
-            .metadata(json!({ "internal": true })),
+        RegisterFunction::new_async_with_bad_request(
+            make_abort(aborts),
+            invalid_request_from_serde,
+        )
+        .description(surface::ABORT_DESC)
+        .metadata(json!({ "internal": true })),
     );
     iii.register_function(
         surface::REFRESH_MODELS_ID,

--- a/provider-llamacpp/src/register.rs
+++ b/provider-llamacpp/src/register.rs
@@ -9,6 +9,7 @@ use crate::{router_client, state, PROVIDER_ID};
 use iii_sdk::errors::Error;
 use iii_sdk::protocol::RegisterTriggerInput;
 use iii_sdk::{IIIClient, RegisterFunction};
+use llm_router::provider_scaffold::aborts::{make_abort, StreamAborts};
 use llm_router::provider_scaffold::cache::ScaffoldCache;
 use llm_router::types::router::{
     ProviderDeclaration, ProviderDefaults, ProviderReadyAck, RouterReadyEvent,
@@ -124,13 +125,23 @@ pub async fn register_provider(iii: IIIClient) -> Result<(), Error> {
         .build()
         .expect("reqwest client");
 
+    // request_id → live upstream cancel, shared by stream (registers) and
+    // abort (signals) — see llm_router::provider_scaffold::aborts.
+    let aborts = StreamAborts::new();
+
     iii.register_function(
         surface::STREAM_ID,
         RegisterFunction::new_async_with_bad_request(
-            make_stream(iii.clone(), http.clone(), cache.clone()),
+            make_stream(iii.clone(), http.clone(), cache.clone(), aborts.clone()),
             invalid_request_from_serde,
         )
         .description(surface::STREAM_DESC),
+    );
+    iii.register_function(
+        surface::ABORT_ID,
+        RegisterFunction::new_async_with_bad_request(make_abort(aborts), invalid_request_from_serde)
+            .description(surface::ABORT_DESC)
+            .metadata(json!({ "internal": true })),
     );
     iii.register_function(
         surface::REFRESH_MODELS_ID,

--- a/provider-llamacpp/src/stream_fn.rs
+++ b/provider-llamacpp/src/stream_fn.rs
@@ -12,8 +12,9 @@ use iii_sdk::errors::Error;
 use iii_sdk::IIIClient;
 use llm_router::channels::open_sink;
 use llm_router::chat::relay::FrameSink;
+use llm_router::provider_scaffold::aborts::StreamAborts;
 use llm_router::provider_scaffold::cache::ScaffoldCache;
-use llm_router::provider_scaffold::pump::{pump, send_event, PING_INTERVAL};
+use llm_router::provider_scaffold::pump::{pump, pump_abortable, send_event, PING_INTERVAL};
 use llm_router::types::events::ErrorKind;
 use llm_router::types::router::{ProviderStreamInput, ProviderStreamOutput};
 
@@ -21,15 +22,16 @@ pub fn make_stream(
     iii: IIIClient,
     http: reqwest::Client,
     cache: ScaffoldCache,
+    aborts: StreamAborts,
 ) -> impl Fn(ProviderStreamInput) -> BoxFuture<'static, Result<ProviderStreamOutput, Error>>
        + Send
        + Sync
        + 'static {
     move |input: ProviderStreamInput| {
-        let (iii, http, cache) = (iii.clone(), http.clone(), cache.clone());
+        let (iii, http, cache, aborts) = (iii.clone(), http.clone(), cache.clone(), aborts.clone());
         Box::pin(async move {
             let sink = open_sink(&iii, &input.writer_ref).await?;
-            run_stream_call(&iii, http, &cache, input, sink.as_ref()).await;
+            run_stream_call(&iii, http, &cache, &aborts, input, sink.as_ref()).await;
             sink.close();
             // ProviderStreamOutput (spec § stream contract)
             Ok(ProviderStreamOutput { ok: true })
@@ -41,6 +43,7 @@ async fn run_stream_call(
     iii: &IIIClient,
     http: reqwest::Client,
     cache: &ScaffoldCache,
+    aborts: &StreamAborts,
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
@@ -122,9 +125,21 @@ async fn run_stream_call(
             warnings,
         },
     );
+    // Register for `provider::llamacpp::abort` only while the upstream is
+    // live — the phases before it burn no tokens. Pre-upstream phases keep
+    // the plain pump; earlier returns therefore need no cleanup.
+    let kind = match &input.resolution_key {
+        Some(request_id) => {
+            let abort_rx = aborts.watch(request_id);
+            let kind = pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await;
+            aborts.remove(request_id);
+            kind
+        }
+        None => pump(rx, sink, PING_INTERVAL).await,
+    };
     // An upstream auth terminal means the cached credential was rotated
     // out from under us: drop the cache so the next attempt re-resolves.
-    if pump(rx, sink, PING_INTERVAL).await == Some(ErrorKind::AuthExpired) {
+    if kind == Some(ErrorKind::AuthExpired) {
         cache.invalidate();
     }
 }

--- a/provider-llamacpp/src/stream_fn.rs
+++ b/provider-llamacpp/src/stream_fn.rs
@@ -31,7 +31,13 @@ pub fn make_stream(
         let (iii, http, cache, aborts) = (iii.clone(), http.clone(), cache.clone(), aborts.clone());
         Box::pin(async move {
             let sink = open_sink(&iii, &input.writer_ref).await?;
+            let request_id = input.resolution_key.clone();
             run_stream_call(&iii, http, &cache, &aborts, input, sink.as_ref()).await;
+            // Single cleanup point covering every exit path (early returns
+            // included). A fired abort already consumed the entry — no-op.
+            if let Some(rid) = &request_id {
+                aborts.remove(rid);
+            }
             sink.close();
             // ProviderStreamOutput (spec § stream contract)
             Ok(ProviderStreamOutput { ok: true })
@@ -47,6 +53,12 @@ async fn run_stream_call(
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
+    // Subscribe FIRST: an abort landing during credential resolve / config —
+    // before any upstream exists — must latch (level-triggered watch), or the
+    // request would start after its own cancellation. The caller removes the
+    // entry when this returns.
+    let abort_rx = input.resolution_key.as_ref().map(|rid| aborts.watch(rid));
+
     let model = input.model.clone();
     let mut warnings = Vec::new();
 
@@ -115,6 +127,10 @@ async fn run_stream_call(
     });
     let headers = build_headers(&cfg);
 
+    // Aborted while we were setting up — never start the upstream request.
+    if abort_rx.as_ref().is_some_and(|rx| *rx.borrow()) {
+        return;
+    }
     let rx = spawn_upstream(
         http,
         UpstreamArgs {
@@ -125,16 +141,8 @@ async fn run_stream_call(
             warnings,
         },
     );
-    // Register for `provider::llamacpp::abort` only while the upstream is
-    // live — the phases before it burn no tokens. Pre-upstream phases keep
-    // the plain pump; earlier returns therefore need no cleanup.
-    let kind = match &input.resolution_key {
-        Some(request_id) => {
-            let abort_rx = aborts.watch(request_id);
-            let kind = pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await;
-            aborts.remove(request_id);
-            kind
-        }
+    let kind = match abort_rx {
+        Some(abort_rx) => pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await,
         None => pump(rx, sink, PING_INTERVAL).await,
     };
     // An upstream auth terminal means the cached credential was rotated

--- a/provider-llamacpp/src/stream_fn.rs
+++ b/provider-llamacpp/src/stream_fn.rs
@@ -12,7 +12,7 @@ use iii_sdk::errors::Error;
 use iii_sdk::IIIClient;
 use llm_router::channels::open_sink;
 use llm_router::chat::relay::FrameSink;
-use llm_router::provider_scaffold::aborts::StreamAborts;
+use llm_router::provider_scaffold::aborts::{AbortGuard, StreamAborts};
 use llm_router::provider_scaffold::cache::ScaffoldCache;
 use llm_router::provider_scaffold::pump::{pump, pump_abortable, send_event, PING_INTERVAL};
 use llm_router::types::events::ErrorKind;
@@ -30,14 +30,16 @@ pub fn make_stream(
     move |input: ProviderStreamInput| {
         let (iii, http, cache, aborts) = (iii.clone(), http.clone(), cache.clone(), aborts.clone());
         Box::pin(async move {
+            // Register BEFORE the first await: an abort landing while the sink
+            // opens must latch, not hit an unknown id. The RAII guard
+            // deregisters on every exit — early returns and an executor
+            // cancelling this future mid-await alike.
+            let abort_reg = input
+                .resolution_key
+                .as_ref()
+                .map(|rid| aborts.register(rid));
             let sink = open_sink(&iii, &input.writer_ref).await?;
-            let request_id = input.resolution_key.clone();
-            run_stream_call(&iii, http, &cache, &aborts, input, sink.as_ref()).await;
-            // Single cleanup point covering every exit path (early returns
-            // included). A fired abort already consumed the entry — no-op.
-            if let Some(rid) = &request_id {
-                aborts.remove(rid);
-            }
+            run_stream_call(&iii, http, &cache, abort_reg.as_ref(), input, sink.as_ref()).await;
             sink.close();
             // ProviderStreamOutput (spec § stream contract)
             Ok(ProviderStreamOutput { ok: true })
@@ -49,16 +51,10 @@ async fn run_stream_call(
     iii: &IIIClient,
     http: reqwest::Client,
     cache: &ScaffoldCache,
-    aborts: &StreamAborts,
+    abort_reg: Option<&AbortGuard>,
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
-    // Subscribe FIRST: an abort landing during credential resolve / config —
-    // before any upstream exists — must latch (level-triggered watch), or the
-    // request would start after its own cancellation. The caller removes the
-    // entry when this returns.
-    let abort_rx = input.resolution_key.as_ref().map(|rid| aborts.watch(rid));
-
     let model = input.model.clone();
     let mut warnings = Vec::new();
 
@@ -128,7 +124,7 @@ async fn run_stream_call(
     let headers = build_headers(&cfg);
 
     // Aborted while we were setting up — never start the upstream request.
-    if abort_rx.as_ref().is_some_and(|rx| *rx.borrow()) {
+    if abort_reg.is_some_and(|g| g.is_fired()) {
         return;
     }
     let rx = spawn_upstream(
@@ -141,8 +137,8 @@ async fn run_stream_call(
             warnings,
         },
     );
-    let kind = match abort_rx {
-        Some(abort_rx) => pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await,
+    let kind = match abort_reg {
+        Some(g) => pump_abortable(rx, sink, PING_INTERVAL, g.watch()).await,
         None => pump(rx, sink, PING_INTERVAL).await,
     };
     // An upstream auth terminal means the cached credential was rotated

--- a/provider-llamacpp/src/surface.rs
+++ b/provider-llamacpp/src/surface.rs
@@ -9,14 +9,18 @@
 //! registration emits.
 
 use llm_router::types::router::{
-    ProviderReadyAck, ProviderStreamInput, ProviderStreamOutput, RefreshModelsRequest,
-    RefreshModelsResponse, RouterReadyEvent,
+    ProviderAbortRequest, ProviderAbortResponse, ProviderReadyAck, ProviderStreamInput,
+    ProviderStreamOutput, RefreshModelsRequest, RefreshModelsResponse, RouterReadyEvent,
 };
 
 pub const STREAM_ID: &str = "provider::llamacpp::stream";
 pub const STREAM_DESC: &str = "Stream a llama.cpp server chat completion: resolve credentials \
      (optional — most local servers run with no --api-key), call the upstream Chat Completions \
      API, and relay AssistantMessageEvent frames to writer_ref.";
+
+pub const ABORT_ID: &str = "provider::llamacpp::abort";
+pub const ABORT_DESC: &str = "Cancel the in-flight upstream stream for a request_id \
+     (router::abort fan-out), stopping billed generation immediately.";
 
 pub const REFRESH_MODELS_ID: &str = "provider::llamacpp::refresh_models";
 pub const REFRESH_MODELS_DESC: &str = "Discover the resolved llama.cpp server's live model \
@@ -66,6 +70,7 @@ where
 pub fn catalog() -> Vec<FunctionSpec> {
     vec![
         spec::<ProviderStreamInput, ProviderStreamOutput>(STREAM_ID, STREAM_DESC),
+        spec::<ProviderAbortRequest, ProviderAbortResponse>(ABORT_ID, ABORT_DESC),
         spec::<RefreshModelsRequest, RefreshModelsResponse>(REFRESH_MODELS_ID, REFRESH_MODELS_DESC),
         spec::<RouterReadyEvent, ProviderReadyAck>(ON_ROUTER_READY_ID, ON_ROUTER_READY_DESC),
         spec::<crate::embed::EmbedRequest, crate::embed::EmbedResponse>(EMBED_ID, EMBED_DESC),

--- a/provider-llamacpp/src/upstream.rs
+++ b/provider-llamacpp/src/upstream.rs
@@ -27,7 +27,16 @@ pub fn spawn_upstream(
 ) -> mpsc::Receiver<AssistantMessageEvent> {
     let (tx, rx) = mpsc::channel(64);
     tokio::spawn(async move {
-        run_upstream(client, args, tx).await;
+        // Race the call against receiver-side closure: send errors alone only
+        // observe a dropped receiver at the next send, so a silent upstream
+        // (parked in a chunk read, nothing to send) would otherwise keep the
+        // HTTP stream — and billed generation — alive until the next frame or
+        // the read timeout. This makes the module contract above immediate.
+        let closed = tx.clone();
+        tokio::select! {
+            _ = run_upstream(client, args, tx) => {}
+            _ = closed.closed() => {}
+        }
     });
     rx
 }

--- a/provider-llamacpp/tests/golden/schemas/provider.llamacpp.abort.json
+++ b/provider-llamacpp/tests/golden/schemas/provider.llamacpp.abort.json
@@ -1,0 +1,32 @@
+{
+  "description": "Cancel the in-flight upstream stream for a request_id (router::abort fan-out), stopping billed generation immediately.",
+  "function_id": "provider::llamacpp::abort",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Input of a provider's `provider::<id>::abort`: actively cancel the in-flight upstream stream for `request_id` (the router's `request_id`, delivered to the provider as `resolution_key`) so billed generation stops immediately instead of waiting for the provider to notice the closed channel on its next write.",
+    "properties": {
+      "request_id": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "request_id"
+    ],
+    "title": "ProviderAbortRequest",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Output of `provider::<id>::abort`. `aborted: false` means the request was unknown — already finished, never started, or aborted before (idempotent).",
+    "properties": {
+      "aborted": {
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "aborted"
+    ],
+    "title": "ProviderAbortResponse",
+    "type": "object"
+  }
+}

--- a/provider-llamacpp/tests/schemas.rs
+++ b/provider-llamacpp/tests/schemas.rs
@@ -40,6 +40,7 @@ fn catalog_lists_all_functions_in_registration_order() {
         ids,
         vec![
             "provider::llamacpp::stream",
+            "provider::llamacpp::abort",
             "provider::llamacpp::refresh_models",
             "provider::llamacpp::on_router_ready",
             "provider::llamacpp::embed",

--- a/provider-openai-codex/Cargo.lock
+++ b/provider-openai-codex/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openai-codex/src/register.rs
+++ b/provider-openai-codex/src/register.rs
@@ -11,6 +11,7 @@ use crate::{auth, router_client, state, PROVIDER_ID};
 use iii_sdk::errors::Error;
 use iii_sdk::protocol::RegisterTriggerInput;
 use iii_sdk::{IIIClient, RegisterFunction};
+use llm_router::provider_scaffold::aborts::{make_abort, StreamAborts};
 use llm_router::provider_scaffold::cache::ScaffoldCache;
 use llm_router::types::router::{
     ProviderDeclaration, ProviderDefaults, ProviderReadyAck, RouterReadyEvent,
@@ -140,13 +141,26 @@ pub async fn register_provider(iii: IIIClient) -> Result<(), Error> {
         .expect("reqwest client");
     let refresh_state = Arc::new(CatalogRefreshState::default());
 
+    // request_id → live upstream cancel, shared by stream (registers) and
+    // abort (signals) — see llm_router::provider_scaffold::aborts.
+    let aborts = StreamAborts::new();
+
     iii.register_function(
         surface::STREAM_ID,
         RegisterFunction::new_async_with_bad_request(
-            make_stream(iii.clone(), http.clone(), cache.clone()),
+            make_stream(iii.clone(), http.clone(), cache.clone(), aborts.clone()),
             invalid_request_from_serde,
         )
         .description(surface::STREAM_DESC)
+        .metadata(json!({ "internal": true })),
+    );
+    iii.register_function(
+        surface::ABORT_ID,
+        RegisterFunction::new_async_with_bad_request(
+            make_abort(aborts),
+            invalid_request_from_serde,
+        )
+        .description(surface::ABORT_DESC)
         .metadata(json!({ "internal": true })),
     );
     iii.register_function(

--- a/provider-openai-codex/src/stream_fn.rs
+++ b/provider-openai-codex/src/stream_fn.rs
@@ -15,7 +15,7 @@ use iii_sdk::errors::Error;
 use iii_sdk::IIIClient;
 use llm_router::channels::open_sink;
 use llm_router::chat::relay::FrameSink;
-use llm_router::provider_scaffold::aborts::StreamAborts;
+use llm_router::provider_scaffold::aborts::{AbortGuard, StreamAborts};
 use llm_router::provider_scaffold::cache::ScaffoldCache;
 use llm_router::provider_scaffold::pump::{pump, pump_abortable, send_event, PING_INTERVAL};
 use llm_router::types::events::ErrorKind;
@@ -35,14 +35,16 @@ pub fn make_stream(
     move |input: ProviderStreamInput| {
         let (iii, http, cache, aborts) = (iii.clone(), http.clone(), cache.clone(), aborts.clone());
         Box::pin(async move {
+            // Register BEFORE the first await: an abort landing while the sink
+            // opens must latch, not hit an unknown id. The RAII guard
+            // deregisters on every exit — early returns and an executor
+            // cancelling this future mid-await alike.
+            let abort_reg = input
+                .resolution_key
+                .as_ref()
+                .map(|rid| aborts.register(rid));
             let sink = open_sink(&iii, &input.writer_ref).await?;
-            let request_id = input.resolution_key.clone();
-            run_stream_call(&iii, http, &cache, &aborts, input, sink.as_ref()).await;
-            // Single cleanup point covering every exit path (early returns
-            // included). A fired abort already consumed the entry — no-op.
-            if let Some(rid) = &request_id {
-                aborts.remove(rid);
-            }
+            run_stream_call(&iii, http, &cache, abort_reg.as_ref(), input, sink.as_ref()).await;
             sink.close();
             Ok(ProviderStreamOutput { ok: true })
         })
@@ -63,16 +65,10 @@ async fn run_stream_call(
     iii: &IIIClient,
     http: reqwest::Client,
     cache: &ScaffoldCache,
-    aborts: &StreamAborts,
+    abort_reg: Option<&AbortGuard>,
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
-    // Subscribe FIRST: an abort landing during credential resolve / config /
-    // model_meta — before any upstream exists — must latch (level-triggered
-    // watch), or the request would start after its own cancellation. The
-    // caller removes the entry when this returns.
-    let abort_rx = input.resolution_key.as_ref().map(|rid| aborts.watch(rid));
-
     let model = input.model.clone(); // router id (e.g. codex/gpt-5.5)
     let mut warnings = Vec::new();
 
@@ -165,7 +161,7 @@ async fn run_stream_call(
     let headers = build_headers(&cfg);
 
     // Aborted while we were setting up — never start the upstream request.
-    if abort_rx.as_ref().is_some_and(|rx| *rx.borrow()) {
+    if abort_reg.is_some_and(|g| g.is_fired()) {
         return;
     }
     let rx = spawn_upstream(
@@ -178,8 +174,8 @@ async fn run_stream_call(
             warnings,
         },
     );
-    let kind = match abort_rx {
-        Some(abort_rx) => pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await,
+    let kind = match abort_reg {
+        Some(g) => pump_abortable(rx, sink, PING_INTERVAL, g.watch()).await,
         None => pump(rx, sink, PING_INTERVAL).await,
     };
     // An upstream auth terminal usually means the VAULT token expired (the

--- a/provider-openai-codex/src/stream_fn.rs
+++ b/provider-openai-codex/src/stream_fn.rs
@@ -15,8 +15,9 @@ use iii_sdk::errors::Error;
 use iii_sdk::IIIClient;
 use llm_router::channels::open_sink;
 use llm_router::chat::relay::FrameSink;
+use llm_router::provider_scaffold::aborts::StreamAborts;
 use llm_router::provider_scaffold::cache::ScaffoldCache;
-use llm_router::provider_scaffold::pump::{pump, send_event, PING_INTERVAL};
+use llm_router::provider_scaffold::pump::{pump, pump_abortable, send_event, PING_INTERVAL};
 use llm_router::types::events::ErrorKind;
 use llm_router::types::router::{
     CredentialSource, ProviderResolveResponse, ProviderStreamInput, ProviderStreamOutput,
@@ -26,15 +27,16 @@ pub fn make_stream(
     iii: IIIClient,
     http: reqwest::Client,
     cache: ScaffoldCache,
+    aborts: StreamAborts,
 ) -> impl Fn(ProviderStreamInput) -> BoxFuture<'static, Result<ProviderStreamOutput, Error>>
        + Send
        + Sync
        + 'static {
     move |input: ProviderStreamInput| {
-        let (iii, http, cache) = (iii.clone(), http.clone(), cache.clone());
+        let (iii, http, cache, aborts) = (iii.clone(), http.clone(), cache.clone(), aborts.clone());
         Box::pin(async move {
             let sink = open_sink(&iii, &input.writer_ref).await?;
-            run_stream_call(&iii, http, &cache, input, sink.as_ref()).await;
+            run_stream_call(&iii, http, &cache, &aborts, input, sink.as_ref()).await;
             sink.close();
             Ok(ProviderStreamOutput { ok: true })
         })
@@ -55,6 +57,7 @@ async fn run_stream_call(
     iii: &IIIClient,
     http: reqwest::Client,
     cache: &ScaffoldCache,
+    aborts: &StreamAborts,
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
@@ -159,10 +162,22 @@ async fn run_stream_call(
             warnings,
         },
     );
+    // Register for `provider::openai-codex::abort` only while the upstream is
+    // live — the phases before it burn no tokens. Pre-upstream phases keep the
+    // plain pump; earlier returns therefore need no cleanup.
+    let kind = match &input.resolution_key {
+        Some(request_id) => {
+            let abort_rx = aborts.watch(request_id);
+            let kind = pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await;
+            aborts.remove(request_id);
+            kind
+        }
+        None => pump(rx, sink, PING_INTERVAL).await,
+    };
     // An upstream auth terminal usually means the VAULT token expired (the
     // existing vault flow handles refresh); invalidating the resolve/token
     // cache is harmless — the next attempt just re-fetches both.
-    if pump(rx, sink, PING_INTERVAL).await == Some(ErrorKind::AuthExpired) {
+    if kind == Some(ErrorKind::AuthExpired) {
         cache.invalidate();
     }
 }

--- a/provider-openai-codex/src/stream_fn.rs
+++ b/provider-openai-codex/src/stream_fn.rs
@@ -71,10 +71,7 @@ async fn run_stream_call(
     // model_meta — before any upstream exists — must latch (level-triggered
     // watch), or the request would start after its own cancellation. The
     // caller removes the entry when this returns.
-    let abort_rx = input
-        .resolution_key
-        .as_ref()
-        .map(|rid| aborts.watch(rid));
+    let abort_rx = input.resolution_key.as_ref().map(|rid| aborts.watch(rid));
 
     let model = input.model.clone(); // router id (e.g. codex/gpt-5.5)
     let mut warnings = Vec::new();

--- a/provider-openai-codex/src/stream_fn.rs
+++ b/provider-openai-codex/src/stream_fn.rs
@@ -36,7 +36,13 @@ pub fn make_stream(
         let (iii, http, cache, aborts) = (iii.clone(), http.clone(), cache.clone(), aborts.clone());
         Box::pin(async move {
             let sink = open_sink(&iii, &input.writer_ref).await?;
+            let request_id = input.resolution_key.clone();
             run_stream_call(&iii, http, &cache, &aborts, input, sink.as_ref()).await;
+            // Single cleanup point covering every exit path (early returns
+            // included). A fired abort already consumed the entry — no-op.
+            if let Some(rid) = &request_id {
+                aborts.remove(rid);
+            }
             sink.close();
             Ok(ProviderStreamOutput { ok: true })
         })
@@ -61,6 +67,15 @@ async fn run_stream_call(
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
+    // Subscribe FIRST: an abort landing during credential resolve / config /
+    // model_meta — before any upstream exists — must latch (level-triggered
+    // watch), or the request would start after its own cancellation. The
+    // caller removes the entry when this returns.
+    let abort_rx = input
+        .resolution_key
+        .as_ref()
+        .map(|rid| aborts.watch(rid));
+
     let model = input.model.clone(); // router id (e.g. codex/gpt-5.5)
     let mut warnings = Vec::new();
 
@@ -152,6 +167,10 @@ async fn run_stream_call(
     });
     let headers = build_headers(&cfg);
 
+    // Aborted while we were setting up — never start the upstream request.
+    if abort_rx.as_ref().is_some_and(|rx| *rx.borrow()) {
+        return;
+    }
     let rx = spawn_upstream(
         http,
         UpstreamArgs {
@@ -162,16 +181,8 @@ async fn run_stream_call(
             warnings,
         },
     );
-    // Register for `provider::openai-codex::abort` only while the upstream is
-    // live — the phases before it burn no tokens. Pre-upstream phases keep the
-    // plain pump; earlier returns therefore need no cleanup.
-    let kind = match &input.resolution_key {
-        Some(request_id) => {
-            let abort_rx = aborts.watch(request_id);
-            let kind = pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await;
-            aborts.remove(request_id);
-            kind
-        }
+    let kind = match abort_rx {
+        Some(abort_rx) => pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await,
         None => pump(rx, sink, PING_INTERVAL).await,
     };
     // An upstream auth terminal usually means the VAULT token expired (the

--- a/provider-openai-codex/src/surface.rs
+++ b/provider-openai-codex/src/surface.rs
@@ -9,14 +9,18 @@
 //! registration emits.
 
 use llm_router::types::router::{
-    ProviderReadyAck, ProviderStreamInput, ProviderStreamOutput, RefreshModelsRequest,
-    RefreshModelsResponse, RouterReadyEvent,
+    ProviderAbortRequest, ProviderAbortResponse, ProviderReadyAck, ProviderStreamInput,
+    ProviderStreamOutput, RefreshModelsRequest, RefreshModelsResponse, RouterReadyEvent,
 };
 
 pub const STREAM_ID: &str = "provider::openai-codex::stream";
 pub const STREAM_DESC: &str = "Stream an OpenAI Codex completion: resolve a ChatGPT OAuth token \
      from the vault, call the upstream Responses API, and relay AssistantMessageEvent frames to \
      writer_ref.";
+
+pub const ABORT_ID: &str = "provider::openai-codex::abort";
+pub const ABORT_DESC: &str = "Cancel the in-flight upstream stream for a request_id \
+     (router::abort fan-out), stopping billed generation immediately.";
 
 pub const REFRESH_MODELS_ID: &str = "provider::openai-codex::refresh_models";
 pub const REFRESH_MODELS_DESC: &str = "Fetch the authenticated Codex model catalog and replace \
@@ -59,6 +63,7 @@ where
 pub fn catalog() -> Vec<FunctionSpec> {
     vec![
         spec::<ProviderStreamInput, ProviderStreamOutput>(STREAM_ID, STREAM_DESC),
+        spec::<ProviderAbortRequest, ProviderAbortResponse>(ABORT_ID, ABORT_DESC),
         spec::<RefreshModelsRequest, RefreshModelsResponse>(REFRESH_MODELS_ID, REFRESH_MODELS_DESC),
         spec::<RouterReadyEvent, ProviderReadyAck>(ON_ROUTER_READY_ID, ON_ROUTER_READY_DESC),
     ]

--- a/provider-openai-codex/src/upstream.rs
+++ b/provider-openai-codex/src/upstream.rs
@@ -26,7 +26,16 @@ pub fn spawn_upstream(
 ) -> mpsc::Receiver<AssistantMessageEvent> {
     let (tx, rx) = mpsc::channel(64);
     tokio::spawn(async move {
-        run_upstream(client, args, tx).await;
+        // Race the call against receiver-side closure: send errors alone only
+        // observe a dropped receiver at the next send, so a silent upstream
+        // (parked in a chunk read, nothing to send) would otherwise keep the
+        // HTTP stream — and billed generation — alive until the next frame or
+        // the read timeout. This makes the module contract above immediate.
+        let closed = tx.clone();
+        tokio::select! {
+            _ = run_upstream(client, args, tx) => {}
+            _ = closed.closed() => {}
+        }
     });
     rx
 }

--- a/provider-openai-codex/tests/golden/schemas/provider.openai-codex.abort.json
+++ b/provider-openai-codex/tests/golden/schemas/provider.openai-codex.abort.json
@@ -1,0 +1,32 @@
+{
+  "description": "Cancel the in-flight upstream stream for a request_id (router::abort fan-out), stopping billed generation immediately.",
+  "function_id": "provider::openai-codex::abort",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Input of a provider's `provider::<id>::abort`: actively cancel the in-flight upstream stream for `request_id` (the router's `request_id`, delivered to the provider as `resolution_key`) so billed generation stops immediately instead of waiting for the provider to notice the closed channel on its next write.",
+    "properties": {
+      "request_id": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "request_id"
+    ],
+    "title": "ProviderAbortRequest",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Output of `provider::<id>::abort`. `aborted: false` means the request was unknown — already finished, never started, or aborted before (idempotent).",
+    "properties": {
+      "aborted": {
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "aborted"
+    ],
+    "title": "ProviderAbortResponse",
+    "type": "object"
+  }
+}

--- a/provider-openai-codex/tests/schemas.rs
+++ b/provider-openai-codex/tests/schemas.rs
@@ -40,6 +40,7 @@ fn catalog_lists_all_functions_in_registration_order() {
         ids,
         vec![
             "provider::openai-codex::stream",
+            "provider::openai-codex::abort",
             "provider::openai-codex::refresh_models",
             "provider::openai-codex::on_router_ready",
         ]

--- a/provider-openai/Cargo.lock
+++ b/provider-openai/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openai/src/register.rs
+++ b/provider-openai/src/register.rs
@@ -149,9 +149,12 @@ pub async fn register_provider(iii: IIIClient) -> Result<(), Error> {
     );
     iii.register_function(
         surface::ABORT_ID,
-        RegisterFunction::new_async_with_bad_request(make_abort(aborts), invalid_request_from_serde)
-            .description(surface::ABORT_DESC)
-            .metadata(json!({ "internal": true })),
+        RegisterFunction::new_async_with_bad_request(
+            make_abort(aborts),
+            invalid_request_from_serde,
+        )
+        .description(surface::ABORT_DESC)
+        .metadata(json!({ "internal": true })),
     );
     iii.register_function(
         surface::REFRESH_MODELS_ID,

--- a/provider-openai/src/register.rs
+++ b/provider-openai/src/register.rs
@@ -9,6 +9,7 @@ use crate::{router_client, state, PROVIDER_ID};
 use iii_sdk::errors::Error;
 use iii_sdk::protocol::RegisterTriggerInput;
 use iii_sdk::{IIIClient, RegisterFunction};
+use llm_router::provider_scaffold::aborts::{make_abort, StreamAborts};
 use llm_router::provider_scaffold::cache::ScaffoldCache;
 use llm_router::types::router::{
     ProviderDeclaration, ProviderDefaults, ProviderReadyAck, RouterReadyEvent,
@@ -133,14 +134,24 @@ pub async fn register_provider(iii: IIIClient) -> Result<(), Error> {
         .build()
         .expect("reqwest client");
 
+    // request_id → live upstream cancel, shared by stream (registers) and
+    // abort (signals) — see llm_router::provider_scaffold::aborts.
+    let aborts = StreamAborts::new();
+
     iii.register_function(
         surface::STREAM_ID,
         RegisterFunction::new_async_with_bad_request(
-            make_stream(iii.clone(), http.clone(), cache.clone()),
+            make_stream(iii.clone(), http.clone(), cache.clone(), aborts.clone()),
             invalid_request_from_serde,
         )
         .description(surface::STREAM_DESC)
         .metadata(json!({ "internal": true })),
+    );
+    iii.register_function(
+        surface::ABORT_ID,
+        RegisterFunction::new_async_with_bad_request(make_abort(aborts), invalid_request_from_serde)
+            .description(surface::ABORT_DESC)
+            .metadata(json!({ "internal": true })),
     );
     iii.register_function(
         surface::REFRESH_MODELS_ID,

--- a/provider-openai/src/stream_fn.rs
+++ b/provider-openai/src/stream_fn.rs
@@ -13,7 +13,7 @@ use iii_sdk::errors::Error;
 use iii_sdk::IIIClient;
 use llm_router::channels::open_sink;
 use llm_router::chat::relay::FrameSink;
-use llm_router::provider_scaffold::aborts::StreamAborts;
+use llm_router::provider_scaffold::aborts::{AbortGuard, StreamAborts};
 use llm_router::provider_scaffold::cache::ScaffoldCache;
 use llm_router::provider_scaffold::pump::{pump, pump_abortable, send_event, PING_INTERVAL};
 use llm_router::types::events::ErrorKind;
@@ -48,14 +48,16 @@ pub fn make_stream(
     move |input: ProviderStreamInput| {
         let (iii, http, cache, aborts) = (iii.clone(), http.clone(), cache.clone(), aborts.clone());
         Box::pin(async move {
+            // Register BEFORE the first await: an abort landing while the sink
+            // opens must latch, not hit an unknown id. The RAII guard
+            // deregisters on every exit — early returns and an executor
+            // cancelling this future mid-await alike.
+            let abort_reg = input
+                .resolution_key
+                .as_ref()
+                .map(|rid| aborts.register(rid));
             let sink = open_sink(&iii, &input.writer_ref).await?;
-            let request_id = input.resolution_key.clone();
-            run_stream_call(&iii, http, &cache, &aborts, input, sink.as_ref()).await;
-            // Single cleanup point covering every exit path (early returns
-            // included). A fired abort already consumed the entry — no-op.
-            if let Some(rid) = &request_id {
-                aborts.remove(rid);
-            }
+            run_stream_call(&iii, http, &cache, abort_reg.as_ref(), input, sink.as_ref()).await;
             sink.close();
             // ProviderStreamOutput (spec § stream contract)
             Ok(ProviderStreamOutput { ok: true })
@@ -67,16 +69,10 @@ async fn run_stream_call(
     iii: &IIIClient,
     http: reqwest::Client,
     cache: &ScaffoldCache,
-    aborts: &StreamAborts,
+    abort_reg: Option<&AbortGuard>,
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
-    // Subscribe FIRST: an abort landing during credential resolve / config /
-    // model_meta — before any upstream exists — must latch (level-triggered
-    // watch), or the request would start after its own cancellation. The
-    // caller removes the entry when this returns.
-    let abort_rx = input.resolution_key.as_ref().map(|rid| aborts.watch(rid));
-
     let model = input.model.clone();
     let mut warnings = Vec::new();
 
@@ -170,7 +166,7 @@ async fn run_stream_call(
     let headers = build_headers(&cfg);
 
     // Aborted while we were setting up — never start the upstream request.
-    if abort_rx.as_ref().is_some_and(|rx| *rx.borrow()) {
+    if abort_reg.is_some_and(|g| g.is_fired()) {
         return;
     }
     let rx = spawn_upstream(
@@ -183,8 +179,8 @@ async fn run_stream_call(
             warnings,
         },
     );
-    let kind = match abort_rx {
-        Some(abort_rx) => pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await,
+    let kind = match abort_reg {
+        Some(g) => pump_abortable(rx, sink, PING_INTERVAL, g.watch()).await,
         None => pump(rx, sink, PING_INTERVAL).await,
     };
     // An upstream auth terminal means the cached credential was rotated

--- a/provider-openai/src/stream_fn.rs
+++ b/provider-openai/src/stream_fn.rs
@@ -49,7 +49,13 @@ pub fn make_stream(
         let (iii, http, cache, aborts) = (iii.clone(), http.clone(), cache.clone(), aborts.clone());
         Box::pin(async move {
             let sink = open_sink(&iii, &input.writer_ref).await?;
+            let request_id = input.resolution_key.clone();
             run_stream_call(&iii, http, &cache, &aborts, input, sink.as_ref()).await;
+            // Single cleanup point covering every exit path (early returns
+            // included). A fired abort already consumed the entry — no-op.
+            if let Some(rid) = &request_id {
+                aborts.remove(rid);
+            }
             sink.close();
             // ProviderStreamOutput (spec § stream contract)
             Ok(ProviderStreamOutput { ok: true })
@@ -65,6 +71,12 @@ async fn run_stream_call(
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
+    // Subscribe FIRST: an abort landing during credential resolve / config /
+    // model_meta — before any upstream exists — must latch (level-triggered
+    // watch), or the request would start after its own cancellation. The
+    // caller removes the entry when this returns.
+    let abort_rx = input.resolution_key.as_ref().map(|rid| aborts.watch(rid));
+
     let model = input.model.clone();
     let mut warnings = Vec::new();
 
@@ -157,6 +169,10 @@ async fn run_stream_call(
     );
     let headers = build_headers(&cfg);
 
+    // Aborted while we were setting up — never start the upstream request.
+    if abort_rx.as_ref().is_some_and(|rx| *rx.borrow()) {
+        return;
+    }
     let rx = spawn_upstream(
         http,
         UpstreamArgs {
@@ -167,16 +183,8 @@ async fn run_stream_call(
             warnings,
         },
     );
-    // Register for `provider::openai::abort` only while the upstream is
-    // live — the phases before it burn no tokens. Pre-upstream phases keep
-    // the plain pump; earlier returns therefore need no cleanup.
-    let kind = match &input.resolution_key {
-        Some(request_id) => {
-            let abort_rx = aborts.watch(request_id);
-            let kind = pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await;
-            aborts.remove(request_id);
-            kind
-        }
+    let kind = match abort_rx {
+        Some(abort_rx) => pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await,
         None => pump(rx, sink, PING_INTERVAL).await,
     };
     // An upstream auth terminal means the cached credential was rotated

--- a/provider-openai/src/stream_fn.rs
+++ b/provider-openai/src/stream_fn.rs
@@ -13,8 +13,9 @@ use iii_sdk::errors::Error;
 use iii_sdk::IIIClient;
 use llm_router::channels::open_sink;
 use llm_router::chat::relay::FrameSink;
+use llm_router::provider_scaffold::aborts::StreamAborts;
 use llm_router::provider_scaffold::cache::ScaffoldCache;
-use llm_router::provider_scaffold::pump::{pump, send_event, PING_INTERVAL};
+use llm_router::provider_scaffold::pump::{pump, pump_abortable, send_event, PING_INTERVAL};
 use llm_router::types::events::ErrorKind;
 use llm_router::types::router::{ProviderStreamInput, ProviderStreamOutput};
 
@@ -39,15 +40,16 @@ pub fn make_stream(
     iii: IIIClient,
     http: reqwest::Client,
     cache: ScaffoldCache,
+    aborts: StreamAborts,
 ) -> impl Fn(ProviderStreamInput) -> BoxFuture<'static, Result<ProviderStreamOutput, Error>>
        + Send
        + Sync
        + 'static {
     move |input: ProviderStreamInput| {
-        let (iii, http, cache) = (iii.clone(), http.clone(), cache.clone());
+        let (iii, http, cache, aborts) = (iii.clone(), http.clone(), cache.clone(), aborts.clone());
         Box::pin(async move {
             let sink = open_sink(&iii, &input.writer_ref).await?;
-            run_stream_call(&iii, http, &cache, input, sink.as_ref()).await;
+            run_stream_call(&iii, http, &cache, &aborts, input, sink.as_ref()).await;
             sink.close();
             // ProviderStreamOutput (spec § stream contract)
             Ok(ProviderStreamOutput { ok: true })
@@ -59,6 +61,7 @@ async fn run_stream_call(
     iii: &IIIClient,
     http: reqwest::Client,
     cache: &ScaffoldCache,
+    aborts: &StreamAborts,
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
@@ -164,9 +167,21 @@ async fn run_stream_call(
             warnings,
         },
     );
+    // Register for `provider::openai::abort` only while the upstream is
+    // live — the phases before it burn no tokens. Pre-upstream phases keep
+    // the plain pump; earlier returns therefore need no cleanup.
+    let kind = match &input.resolution_key {
+        Some(request_id) => {
+            let abort_rx = aborts.watch(request_id);
+            let kind = pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await;
+            aborts.remove(request_id);
+            kind
+        }
+        None => pump(rx, sink, PING_INTERVAL).await,
+    };
     // An upstream auth terminal means the cached credential was rotated
     // out from under us: drop the cache so the next attempt re-resolves.
-    if pump(rx, sink, PING_INTERVAL).await == Some(ErrorKind::AuthExpired) {
+    if kind == Some(ErrorKind::AuthExpired) {
         cache.invalidate();
     }
 }

--- a/provider-openai/src/surface.rs
+++ b/provider-openai/src/surface.rs
@@ -9,14 +9,18 @@
 //! registration emits.
 
 use llm_router::types::router::{
-    ProviderReadyAck, ProviderStreamInput, ProviderStreamOutput, RefreshModelsRequest,
-    RefreshModelsResponse, RouterReadyEvent,
+    ProviderAbortRequest, ProviderAbortResponse, ProviderReadyAck, ProviderStreamInput,
+    ProviderStreamOutput, RefreshModelsRequest, RefreshModelsResponse, RouterReadyEvent,
 };
 
 pub const STREAM_ID: &str = "provider::openai::stream";
 pub const STREAM_DESC: &str =
     "Stream an OpenAI response: resolve credentials, call the configured \
      Responses or Chat Completions endpoint, and relay AssistantMessageEvent frames to writer_ref.";
+
+pub const ABORT_ID: &str = "provider::openai::abort";
+pub const ABORT_DESC: &str = "Cancel the in-flight upstream stream for a request_id \
+     (router::abort fan-out), stopping billed generation immediately.";
 
 pub const REFRESH_MODELS_ID: &str = "provider::openai::refresh_models";
 pub const REFRESH_MODELS_DESC: &str = "Refresh the OpenAI catalog slice from GET /v1/models and \
@@ -64,6 +68,7 @@ where
 pub fn catalog() -> Vec<FunctionSpec> {
     vec![
         spec::<ProviderStreamInput, ProviderStreamOutput>(STREAM_ID, STREAM_DESC),
+        spec::<ProviderAbortRequest, ProviderAbortResponse>(ABORT_ID, ABORT_DESC),
         spec::<RefreshModelsRequest, RefreshModelsResponse>(REFRESH_MODELS_ID, REFRESH_MODELS_DESC),
         spec::<RouterReadyEvent, ProviderReadyAck>(ON_ROUTER_READY_ID, ON_ROUTER_READY_DESC),
         spec::<crate::embed::EmbedRequest, crate::embed::EmbedResponse>(EMBED_ID, EMBED_DESC),

--- a/provider-openai/src/upstream.rs
+++ b/provider-openai/src/upstream.rs
@@ -27,7 +27,16 @@ pub fn spawn_upstream(
 ) -> mpsc::Receiver<AssistantMessageEvent> {
     let (tx, rx) = mpsc::channel(64);
     tokio::spawn(async move {
-        run_upstream(client, args, tx).await;
+        // Race the call against receiver-side closure: send errors alone only
+        // observe a dropped receiver at the next send, so a silent upstream
+        // (parked in a chunk read, nothing to send) would otherwise keep the
+        // HTTP stream — and billed generation — alive until the next frame or
+        // the read timeout. This makes the module contract above immediate.
+        let closed = tx.clone();
+        tokio::select! {
+            _ = run_upstream(client, args, tx) => {}
+            _ = closed.closed() => {}
+        }
     });
     rx
 }

--- a/provider-openai/tests/golden/schemas/provider.openai.abort.json
+++ b/provider-openai/tests/golden/schemas/provider.openai.abort.json
@@ -1,0 +1,32 @@
+{
+  "description": "Cancel the in-flight upstream stream for a request_id (router::abort fan-out), stopping billed generation immediately.",
+  "function_id": "provider::openai::abort",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Input of a provider's `provider::<id>::abort`: actively cancel the in-flight upstream stream for `request_id` (the router's `request_id`, delivered to the provider as `resolution_key`) so billed generation stops immediately instead of waiting for the provider to notice the closed channel on its next write.",
+    "properties": {
+      "request_id": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "request_id"
+    ],
+    "title": "ProviderAbortRequest",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Output of `provider::<id>::abort`. `aborted: false` means the request was unknown — already finished, never started, or aborted before (idempotent).",
+    "properties": {
+      "aborted": {
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "aborted"
+    ],
+    "title": "ProviderAbortResponse",
+    "type": "object"
+  }
+}

--- a/provider-openai/tests/schemas.rs
+++ b/provider-openai/tests/schemas.rs
@@ -40,6 +40,7 @@ fn catalog_lists_all_functions_in_registration_order() {
         ids,
         vec![
             "provider::openai::stream",
+            "provider::openai::abort",
             "provider::openai::refresh_models",
             "provider::openai::on_router_ready",
             "provider::openai::embed",

--- a/provider-xai/Cargo.lock
+++ b/provider-xai/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-xai/src/register.rs
+++ b/provider-xai/src/register.rs
@@ -9,6 +9,7 @@ use crate::{router_client, state, PROVIDER_ID};
 use iii_sdk::errors::Error;
 use iii_sdk::protocol::RegisterTriggerInput;
 use iii_sdk::{IIIClient, RegisterFunction};
+use llm_router::provider_scaffold::aborts::{make_abort, StreamAborts};
 use llm_router::provider_scaffold::cache::ScaffoldCache;
 use llm_router::types::router::{
     ProviderDeclaration, ProviderDefaults, ProviderReadyAck, RouterReadyEvent,
@@ -166,14 +167,24 @@ pub async fn register_provider(iii: IIIClient) -> Result<(), Error> {
         });
     }
 
+    // request_id → live upstream cancel, shared by stream (registers) and
+    // abort (signals) — see llm_router::provider_scaffold::aborts.
+    let aborts = StreamAborts::new();
+
     iii.register_function(
         surface::STREAM_ID,
         RegisterFunction::new_async_with_bad_request(
-            make_stream(iii.clone(), http.clone(), cell.clone(), cache.clone()),
+            make_stream(iii.clone(), http.clone(), cell.clone(), cache.clone(), aborts.clone()),
             invalid_request_from_serde,
         )
         .description(surface::STREAM_DESC)
         .metadata(json!({ "internal": true })),
+    );
+    iii.register_function(
+        surface::ABORT_ID,
+        RegisterFunction::new_async_with_bad_request(make_abort(aborts), invalid_request_from_serde)
+            .description(surface::ABORT_DESC)
+            .metadata(json!({ "internal": true })),
     );
     iii.register_function(
         surface::REFRESH_MODELS_ID,

--- a/provider-xai/src/register.rs
+++ b/provider-xai/src/register.rs
@@ -174,7 +174,13 @@ pub async fn register_provider(iii: IIIClient) -> Result<(), Error> {
     iii.register_function(
         surface::STREAM_ID,
         RegisterFunction::new_async_with_bad_request(
-            make_stream(iii.clone(), http.clone(), cell.clone(), cache.clone(), aborts.clone()),
+            make_stream(
+                iii.clone(),
+                http.clone(),
+                cell.clone(),
+                cache.clone(),
+                aborts.clone(),
+            ),
             invalid_request_from_serde,
         )
         .description(surface::STREAM_DESC)
@@ -182,9 +188,12 @@ pub async fn register_provider(iii: IIIClient) -> Result<(), Error> {
     );
     iii.register_function(
         surface::ABORT_ID,
-        RegisterFunction::new_async_with_bad_request(make_abort(aborts), invalid_request_from_serde)
-            .description(surface::ABORT_DESC)
-            .metadata(json!({ "internal": true })),
+        RegisterFunction::new_async_with_bad_request(
+            make_abort(aborts),
+            invalid_request_from_serde,
+        )
+        .description(surface::ABORT_DESC)
+        .metadata(json!({ "internal": true })),
     );
     iii.register_function(
         surface::REFRESH_MODELS_ID,

--- a/provider-xai/src/responses.rs
+++ b/provider-xai/src/responses.rs
@@ -288,7 +288,16 @@ pub fn spawn_responses_upstream(
 ) -> mpsc::Receiver<AssistantMessageEvent> {
     let (tx, rx) = mpsc::channel(64);
     tokio::spawn(async move {
-        run_responses_upstream(client, args, tx).await;
+        // Race the call against receiver-side closure: send errors alone only
+        // observe a dropped receiver at the next send, so a silent upstream
+        // (parked in a chunk read, nothing to send) would otherwise keep the
+        // HTTP stream — and billed generation — alive until the next frame or
+        // the read timeout.
+        let closed = tx.clone();
+        tokio::select! {
+            _ = run_responses_upstream(client, args, tx) => {}
+            _ = closed.closed() => {}
+        }
     });
     rx
 }

--- a/provider-xai/src/stream_fn.rs
+++ b/provider-xai/src/stream_fn.rs
@@ -17,26 +17,35 @@ use iii_sdk::errors::Error;
 use iii_sdk::IIIClient;
 use llm_router::channels::open_sink;
 use llm_router::chat::relay::FrameSink;
+use llm_router::provider_scaffold::aborts::StreamAborts;
 use llm_router::provider_scaffold::cache::ScaffoldCache;
-use llm_router::provider_scaffold::pump::{pump, send_event, PING_INTERVAL};
-use llm_router::types::events::ErrorKind;
+use llm_router::provider_scaffold::pump::{pump, pump_abortable, send_event, PING_INTERVAL};
+use llm_router::types::events::{AssistantMessageEvent, ErrorKind};
 use llm_router::types::router::{ProviderStreamInput, ProviderStreamOutput};
+use tokio::sync::mpsc;
 
 pub fn make_stream(
     iii: IIIClient,
     http: reqwest::Client,
     cell: ConfigCell,
     cache: ScaffoldCache,
+    aborts: StreamAborts,
 ) -> impl Fn(ProviderStreamInput) -> BoxFuture<'static, Result<ProviderStreamOutput, Error>>
        + Send
        + Sync
        + 'static {
     move |input: ProviderStreamInput| {
-        let (iii, http, cell, cache) = (iii.clone(), http.clone(), cell.clone(), cache.clone());
+        let (iii, http, cell, cache, aborts) = (
+            iii.clone(),
+            http.clone(),
+            cell.clone(),
+            cache.clone(),
+            aborts.clone(),
+        );
         Box::pin(async move {
             let sink = open_sink(&iii, &input.writer_ref).await?;
             let wc = { cell.read().await.clone() };
-            run_stream_call(&iii, http, &cache, &wc, input, sink.as_ref()).await;
+            run_stream_call(&iii, http, &cache, &aborts, &wc, input, sink.as_ref()).await;
             sink.close();
             // ProviderStreamOutput (spec § stream contract)
             Ok(ProviderStreamOutput { ok: true })
@@ -44,10 +53,32 @@ pub fn make_stream(
     }
 }
 
+/// Pump the upstream, abortable via `provider::xai::abort` while it's live:
+/// the abort registration exists only for the pump's duration — the phases
+/// before it burn no tokens, so a missing `resolution_key` (or an earlier
+/// return) needs no cleanup. Returns the pump's terminal `ErrorKind`.
+async fn pump_stream(
+    rx: mpsc::Receiver<AssistantMessageEvent>,
+    sink: &dyn FrameSink,
+    aborts: &StreamAborts,
+    resolution_key: Option<&str>,
+) -> Option<ErrorKind> {
+    match resolution_key {
+        Some(request_id) => {
+            let abort_rx = aborts.watch(request_id);
+            let kind = pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await;
+            aborts.remove(request_id);
+            kind
+        }
+        None => pump(rx, sink, PING_INTERVAL).await,
+    }
+}
+
 async fn run_stream_call(
     iii: &IIIClient,
     http: reqwest::Client,
     cache: &ScaffoldCache,
+    aborts: &StreamAborts,
     wc: &crate::config::WorkerConfig,
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
@@ -139,7 +170,9 @@ async fn run_stream_call(
         );
         // An upstream auth terminal means the cached credential was rotated
         // out from under us: drop the cache so the next attempt re-resolves.
-        if pump(rx, sink, PING_INTERVAL).await == Some(ErrorKind::AuthExpired) {
+        if pump_stream(rx, sink, aborts, input.resolution_key.as_deref()).await
+            == Some(ErrorKind::AuthExpired)
+        {
             cache.invalidate();
         }
         return;
@@ -196,7 +229,9 @@ async fn run_stream_call(
     );
     // An upstream auth terminal means the cached credential was rotated
     // out from under us: drop the cache so the next attempt re-resolves.
-    if pump(rx, sink, PING_INTERVAL).await == Some(ErrorKind::AuthExpired) {
+    if pump_stream(rx, sink, aborts, input.resolution_key.as_deref()).await
+        == Some(ErrorKind::AuthExpired)
+    {
         cache.invalidate();
     }
 }

--- a/provider-xai/src/stream_fn.rs
+++ b/provider-xai/src/stream_fn.rs
@@ -17,7 +17,7 @@ use iii_sdk::errors::Error;
 use iii_sdk::IIIClient;
 use llm_router::channels::open_sink;
 use llm_router::chat::relay::FrameSink;
-use llm_router::provider_scaffold::aborts::StreamAborts;
+use llm_router::provider_scaffold::aborts::{AbortGuard, StreamAborts};
 use llm_router::provider_scaffold::cache::ScaffoldCache;
 use llm_router::provider_scaffold::pump::{pump, pump_abortable, send_event, PING_INTERVAL};
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind};
@@ -43,15 +43,26 @@ pub fn make_stream(
             aborts.clone(),
         );
         Box::pin(async move {
+            // Register BEFORE the first await: an abort landing while the sink
+            // opens must latch, not hit an unknown id. The RAII guard
+            // deregisters on every exit — early returns and an executor
+            // cancelling this future mid-await alike.
+            let abort_reg = input
+                .resolution_key
+                .as_ref()
+                .map(|rid| aborts.register(rid));
             let sink = open_sink(&iii, &input.writer_ref).await?;
             let wc = { cell.read().await.clone() };
-            let request_id = input.resolution_key.clone();
-            run_stream_call(&iii, http, &cache, &aborts, &wc, input, sink.as_ref()).await;
-            // Single cleanup point covering every exit path (early returns
-            // included). A fired abort already consumed the entry — no-op.
-            if let Some(rid) = &request_id {
-                aborts.remove(rid);
-            }
+            run_stream_call(
+                &iii,
+                http,
+                &cache,
+                abort_reg.as_ref(),
+                &wc,
+                input,
+                sink.as_ref(),
+            )
+            .await;
             sink.close();
             // ProviderStreamOutput (spec § stream contract)
             Ok(ProviderStreamOutput { ok: true })
@@ -60,9 +71,9 @@ pub fn make_stream(
 }
 
 /// Pump the upstream, abortable via `provider::xai::abort` while it's live.
-/// Takes the entry receiver subscribed once in `run_stream_call`; the caller
-/// (`make_stream`) removes the registry entry on return. Returns the pump's
-/// terminal `ErrorKind`.
+/// Takes a receiver cloned from the call's `AbortGuard`, whose Drop in
+/// `make_stream` deregisters the entry. Returns the pump's terminal
+/// `ErrorKind`.
 async fn pump_stream(
     rx: mpsc::Receiver<AssistantMessageEvent>,
     sink: &dyn FrameSink,
@@ -78,17 +89,11 @@ async fn run_stream_call(
     iii: &IIIClient,
     http: reqwest::Client,
     cache: &ScaffoldCache,
-    aborts: &StreamAborts,
+    abort_reg: Option<&AbortGuard>,
     wc: &crate::config::WorkerConfig,
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
-    // Subscribe FIRST: an abort landing during credential resolve / config /
-    // model_meta — before any upstream exists — must latch (level-triggered
-    // watch), or the request would start after its own cancellation. The
-    // caller removes the entry when this returns.
-    let abort_rx = input.resolution_key.as_ref().map(|rid| aborts.watch(rid));
-
     let model = input.model.clone();
     let mut warnings = Vec::new();
 
@@ -165,7 +170,7 @@ async fn run_stream_call(
         );
         let headers = build_headers(&cfg);
         // Aborted while we were setting up — never start the upstream request.
-        if abort_rx.as_ref().is_some_and(|rx| *rx.borrow()) {
+        if abort_reg.is_some_and(|g| g.is_fired()) {
             return;
         }
         let rx = spawn_responses_upstream(
@@ -180,7 +185,8 @@ async fn run_stream_call(
         );
         // An upstream auth terminal means the cached credential was rotated
         // out from under us: drop the cache so the next attempt re-resolves.
-        if pump_stream(rx, sink, abort_rx.clone()).await == Some(ErrorKind::AuthExpired) {
+        if pump_stream(rx, sink, abort_reg.map(|g| g.watch())).await == Some(ErrorKind::AuthExpired)
+        {
             cache.invalidate();
         }
         return;
@@ -226,7 +232,7 @@ async fn run_stream_call(
     let headers = build_headers(&cfg);
 
     // Aborted while we were setting up — never start the upstream request.
-    if abort_rx.as_ref().is_some_and(|rx| *rx.borrow()) {
+    if abort_reg.is_some_and(|g| g.is_fired()) {
         return;
     }
     let rx = spawn_upstream(
@@ -241,7 +247,7 @@ async fn run_stream_call(
     );
     // An upstream auth terminal means the cached credential was rotated
     // out from under us: drop the cache so the next attempt re-resolves.
-    if pump_stream(rx, sink, abort_rx.clone()).await == Some(ErrorKind::AuthExpired) {
+    if pump_stream(rx, sink, abort_reg.map(|g| g.watch())).await == Some(ErrorKind::AuthExpired) {
         cache.invalidate();
     }
 }

--- a/provider-xai/src/stream_fn.rs
+++ b/provider-xai/src/stream_fn.rs
@@ -22,7 +22,7 @@ use llm_router::provider_scaffold::cache::ScaffoldCache;
 use llm_router::provider_scaffold::pump::{pump, pump_abortable, send_event, PING_INTERVAL};
 use llm_router::types::events::{AssistantMessageEvent, ErrorKind};
 use llm_router::types::router::{ProviderStreamInput, ProviderStreamOutput};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 
 pub fn make_stream(
     iii: IIIClient,
@@ -45,7 +45,13 @@ pub fn make_stream(
         Box::pin(async move {
             let sink = open_sink(&iii, &input.writer_ref).await?;
             let wc = { cell.read().await.clone() };
+            let request_id = input.resolution_key.clone();
             run_stream_call(&iii, http, &cache, &aborts, &wc, input, sink.as_ref()).await;
+            // Single cleanup point covering every exit path (early returns
+            // included). A fired abort already consumed the entry — no-op.
+            if let Some(rid) = &request_id {
+                aborts.remove(rid);
+            }
             sink.close();
             // ProviderStreamOutput (spec § stream contract)
             Ok(ProviderStreamOutput { ok: true })
@@ -53,23 +59,17 @@ pub fn make_stream(
     }
 }
 
-/// Pump the upstream, abortable via `provider::xai::abort` while it's live:
-/// the abort registration exists only for the pump's duration — the phases
-/// before it burn no tokens, so a missing `resolution_key` (or an earlier
-/// return) needs no cleanup. Returns the pump's terminal `ErrorKind`.
+/// Pump the upstream, abortable via `provider::xai::abort` while it's live.
+/// Takes the entry receiver subscribed once in `run_stream_call`; the caller
+/// (`make_stream`) removes the registry entry on return. Returns the pump's
+/// terminal `ErrorKind`.
 async fn pump_stream(
     rx: mpsc::Receiver<AssistantMessageEvent>,
     sink: &dyn FrameSink,
-    aborts: &StreamAborts,
-    resolution_key: Option<&str>,
+    abort_rx: Option<watch::Receiver<bool>>,
 ) -> Option<ErrorKind> {
-    match resolution_key {
-        Some(request_id) => {
-            let abort_rx = aborts.watch(request_id);
-            let kind = pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await;
-            aborts.remove(request_id);
-            kind
-        }
+    match abort_rx {
+        Some(abort_rx) => pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await,
         None => pump(rx, sink, PING_INTERVAL).await,
     }
 }
@@ -83,6 +83,12 @@ async fn run_stream_call(
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
+    // Subscribe FIRST: an abort landing during credential resolve / config /
+    // model_meta — before any upstream exists — must latch (level-triggered
+    // watch), or the request would start after its own cancellation. The
+    // caller removes the entry when this returns.
+    let abort_rx = input.resolution_key.as_ref().map(|rid| aborts.watch(rid));
+
     let model = input.model.clone();
     let mut warnings = Vec::new();
 
@@ -158,6 +164,10 @@ async fn run_stream_call(
             cfg.max_tokens,
         );
         let headers = build_headers(&cfg);
+        // Aborted while we were setting up — never start the upstream request.
+        if abort_rx.as_ref().is_some_and(|rx| *rx.borrow()) {
+            return;
+        }
         let rx = spawn_responses_upstream(
             http,
             ResponsesUpstreamArgs {
@@ -170,9 +180,7 @@ async fn run_stream_call(
         );
         // An upstream auth terminal means the cached credential was rotated
         // out from under us: drop the cache so the next attempt re-resolves.
-        if pump_stream(rx, sink, aborts, input.resolution_key.as_deref()).await
-            == Some(ErrorKind::AuthExpired)
-        {
+        if pump_stream(rx, sink, abort_rx.clone()).await == Some(ErrorKind::AuthExpired) {
             cache.invalidate();
         }
         return;
@@ -217,6 +225,10 @@ async fn run_stream_call(
     });
     let headers = build_headers(&cfg);
 
+    // Aborted while we were setting up — never start the upstream request.
+    if abort_rx.as_ref().is_some_and(|rx| *rx.borrow()) {
+        return;
+    }
     let rx = spawn_upstream(
         http,
         UpstreamArgs {
@@ -229,9 +241,7 @@ async fn run_stream_call(
     );
     // An upstream auth terminal means the cached credential was rotated
     // out from under us: drop the cache so the next attempt re-resolves.
-    if pump_stream(rx, sink, aborts, input.resolution_key.as_deref()).await
-        == Some(ErrorKind::AuthExpired)
-    {
+    if pump_stream(rx, sink, abort_rx.clone()).await == Some(ErrorKind::AuthExpired) {
         cache.invalidate();
     }
 }

--- a/provider-xai/src/surface.rs
+++ b/provider-xai/src/surface.rs
@@ -9,13 +9,17 @@
 //! registration emits.
 
 use llm_router::types::router::{
-    ProviderReadyAck, ProviderStreamInput, ProviderStreamOutput, RefreshModelsRequest,
-    RefreshModelsResponse, RouterReadyEvent,
+    ProviderAbortRequest, ProviderAbortResponse, ProviderReadyAck, ProviderStreamInput,
+    ProviderStreamOutput, RefreshModelsRequest, RefreshModelsResponse, RouterReadyEvent,
 };
 
 pub const STREAM_ID: &str = "provider::xai::stream";
 pub const STREAM_DESC: &str = "Stream an xAI chat completion: resolve credentials, call the \
      upstream Chat Completions API, and relay AssistantMessageEvent frames to writer_ref.";
+
+pub const ABORT_ID: &str = "provider::xai::abort";
+pub const ABORT_DESC: &str = "Cancel the in-flight upstream stream for a request_id \
+     (router::abort fan-out), stopping billed generation immediately.";
 
 pub const REFRESH_MODELS_ID: &str = "provider::xai::refresh_models";
 pub const REFRESH_MODELS_DESC: &str = "Refresh the xAI catalog slice from GET /v1/models and \
@@ -58,6 +62,7 @@ where
 pub fn catalog() -> Vec<FunctionSpec> {
     vec![
         spec::<ProviderStreamInput, ProviderStreamOutput>(STREAM_ID, STREAM_DESC),
+        spec::<ProviderAbortRequest, ProviderAbortResponse>(ABORT_ID, ABORT_DESC),
         spec::<RefreshModelsRequest, RefreshModelsResponse>(REFRESH_MODELS_ID, REFRESH_MODELS_DESC),
         spec::<RouterReadyEvent, ProviderReadyAck>(ON_ROUTER_READY_ID, ON_ROUTER_READY_DESC),
     ]

--- a/provider-xai/src/upstream.rs
+++ b/provider-xai/src/upstream.rs
@@ -26,7 +26,16 @@ pub fn spawn_upstream(
 ) -> mpsc::Receiver<AssistantMessageEvent> {
     let (tx, rx) = mpsc::channel(64);
     tokio::spawn(async move {
-        run_upstream(client, args, tx).await;
+        // Race the call against receiver-side closure: send errors alone only
+        // observe a dropped receiver at the next send, so a silent upstream
+        // (parked in a chunk read, nothing to send) would otherwise keep the
+        // HTTP stream — and billed generation — alive until the next frame or
+        // the read timeout. This makes the module contract above immediate.
+        let closed = tx.clone();
+        tokio::select! {
+            _ = run_upstream(client, args, tx) => {}
+            _ = closed.closed() => {}
+        }
     });
     rx
 }

--- a/provider-xai/tests/golden/schemas/provider.xai.abort.json
+++ b/provider-xai/tests/golden/schemas/provider.xai.abort.json
@@ -1,0 +1,32 @@
+{
+  "description": "Cancel the in-flight upstream stream for a request_id (router::abort fan-out), stopping billed generation immediately.",
+  "function_id": "provider::xai::abort",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Input of a provider's `provider::<id>::abort`: actively cancel the in-flight upstream stream for `request_id` (the router's `request_id`, delivered to the provider as `resolution_key`) so billed generation stops immediately instead of waiting for the provider to notice the closed channel on its next write.",
+    "properties": {
+      "request_id": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "request_id"
+    ],
+    "title": "ProviderAbortRequest",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Output of `provider::<id>::abort`. `aborted: false` means the request was unknown — already finished, never started, or aborted before (idempotent).",
+    "properties": {
+      "aborted": {
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "aborted"
+    ],
+    "title": "ProviderAbortResponse",
+    "type": "object"
+  }
+}

--- a/provider-xai/tests/schemas.rs
+++ b/provider-xai/tests/schemas.rs
@@ -40,6 +40,7 @@ fn catalog_lists_all_functions_in_registration_order() {
         ids,
         vec![
             "provider::xai::stream",
+            "provider::xai::abort",
             "provider::xai::refresh_models",
             "provider::xai::on_router_ready",
         ]

--- a/provider-zai/Cargo.lock
+++ b/provider-zai/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-zai/src/register.rs
+++ b/provider-zai/src/register.rs
@@ -9,6 +9,7 @@ use crate::{router_client, state, PROVIDER_ID};
 use iii_sdk::errors::Error;
 use iii_sdk::protocol::RegisterTriggerInput;
 use iii_sdk::{IIIClient, RegisterFunction};
+use llm_router::provider_scaffold::aborts::{make_abort, StreamAborts};
 use llm_router::provider_scaffold::cache::ScaffoldCache;
 use llm_router::types::router::{
     ProviderDeclaration, ProviderDefaults, ProviderReadyAck, RouterReadyEvent,
@@ -136,13 +137,26 @@ pub async fn register_provider(iii: IIIClient) -> Result<(), Error> {
         .build()
         .expect("reqwest client");
 
+    // request_id → live upstream cancel, shared by stream (registers) and
+    // abort (signals) — see llm_router::provider_scaffold::aborts.
+    let aborts = StreamAborts::new();
+
     iii.register_function(
         surface::STREAM_ID,
         RegisterFunction::new_async_with_bad_request(
-            make_stream(iii.clone(), http.clone(), cache.clone()),
+            make_stream(iii.clone(), http.clone(), cache.clone(), aborts.clone()),
             invalid_request_from_serde,
         )
         .description(surface::STREAM_DESC)
+        .metadata(json!({ "internal": true })),
+    );
+    iii.register_function(
+        surface::ABORT_ID,
+        RegisterFunction::new_async_with_bad_request(
+            make_abort(aborts),
+            invalid_request_from_serde,
+        )
+        .description(surface::ABORT_DESC)
         .metadata(json!({ "internal": true })),
     );
     iii.register_function(

--- a/provider-zai/src/stream_fn.rs
+++ b/provider-zai/src/stream_fn.rs
@@ -32,7 +32,13 @@ pub fn make_stream(
         let (iii, http, cache, aborts) = (iii.clone(), http.clone(), cache.clone(), aborts.clone());
         Box::pin(async move {
             let sink = open_sink(&iii, &input.writer_ref).await?;
+            let request_id = input.resolution_key.clone();
             run_stream_call(&iii, http, &cache, &aborts, input, sink.as_ref()).await;
+            // Single cleanup point covering every exit path (early returns
+            // included). A fired abort already consumed the entry — no-op.
+            if let Some(rid) = &request_id {
+                aborts.remove(rid);
+            }
             sink.close();
             // ProviderStreamOutput (spec § stream contract)
             Ok(ProviderStreamOutput { ok: true })
@@ -48,6 +54,12 @@ async fn run_stream_call(
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
+    // Subscribe FIRST: an abort landing during credential resolve / config /
+    // model_meta — before any upstream exists — must latch (level-triggered
+    // watch), or the request would start after its own cancellation. The
+    // caller removes the entry when this returns.
+    let abort_rx = input.resolution_key.as_ref().map(|rid| aborts.watch(rid));
+
     let model = input.model.clone();
     let mut warnings = Vec::new();
 
@@ -136,6 +148,10 @@ async fn run_stream_call(
     });
     let headers = build_headers(&cfg);
 
+    // Aborted while we were setting up — never start the upstream request.
+    if abort_rx.as_ref().is_some_and(|rx| *rx.borrow()) {
+        return;
+    }
     let rx = spawn_upstream(
         http,
         UpstreamArgs {
@@ -146,16 +162,8 @@ async fn run_stream_call(
             warnings,
         },
     );
-    // Register for `provider::zai::abort` only while the upstream is live —
-    // the phases before it burn no tokens. Pre-upstream phases keep the plain
-    // pump; earlier returns therefore need no cleanup.
-    let kind = match &input.resolution_key {
-        Some(request_id) => {
-            let abort_rx = aborts.watch(request_id);
-            let kind = pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await;
-            aborts.remove(request_id);
-            kind
-        }
+    let kind = match abort_rx {
+        Some(abort_rx) => pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await,
         None => pump(rx, sink, PING_INTERVAL).await,
     };
     // An upstream auth terminal means the cached credential was rotated

--- a/provider-zai/src/stream_fn.rs
+++ b/provider-zai/src/stream_fn.rs
@@ -13,8 +13,9 @@ use iii_sdk::errors::Error;
 use iii_sdk::IIIClient;
 use llm_router::channels::open_sink;
 use llm_router::chat::relay::FrameSink;
+use llm_router::provider_scaffold::aborts::StreamAborts;
 use llm_router::provider_scaffold::cache::ScaffoldCache;
-use llm_router::provider_scaffold::pump::{pump, send_event, PING_INTERVAL};
+use llm_router::provider_scaffold::pump::{pump, pump_abortable, send_event, PING_INTERVAL};
 use llm_router::types::events::ErrorKind;
 use llm_router::types::router::{ProviderStreamInput, ProviderStreamOutput};
 
@@ -22,15 +23,16 @@ pub fn make_stream(
     iii: IIIClient,
     http: reqwest::Client,
     cache: ScaffoldCache,
+    aborts: StreamAborts,
 ) -> impl Fn(ProviderStreamInput) -> BoxFuture<'static, Result<ProviderStreamOutput, Error>>
        + Send
        + Sync
        + 'static {
     move |input: ProviderStreamInput| {
-        let (iii, http, cache) = (iii.clone(), http.clone(), cache.clone());
+        let (iii, http, cache, aborts) = (iii.clone(), http.clone(), cache.clone(), aborts.clone());
         Box::pin(async move {
             let sink = open_sink(&iii, &input.writer_ref).await?;
-            run_stream_call(&iii, http, &cache, input, sink.as_ref()).await;
+            run_stream_call(&iii, http, &cache, &aborts, input, sink.as_ref()).await;
             sink.close();
             // ProviderStreamOutput (spec § stream contract)
             Ok(ProviderStreamOutput { ok: true })
@@ -42,6 +44,7 @@ async fn run_stream_call(
     iii: &IIIClient,
     http: reqwest::Client,
     cache: &ScaffoldCache,
+    aborts: &StreamAborts,
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
@@ -143,9 +146,21 @@ async fn run_stream_call(
             warnings,
         },
     );
+    // Register for `provider::zai::abort` only while the upstream is live —
+    // the phases before it burn no tokens. Pre-upstream phases keep the plain
+    // pump; earlier returns therefore need no cleanup.
+    let kind = match &input.resolution_key {
+        Some(request_id) => {
+            let abort_rx = aborts.watch(request_id);
+            let kind = pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await;
+            aborts.remove(request_id);
+            kind
+        }
+        None => pump(rx, sink, PING_INTERVAL).await,
+    };
     // An upstream auth terminal means the cached credential was rotated
     // out from under us: drop the cache so the next attempt re-resolves.
-    if pump(rx, sink, PING_INTERVAL).await == Some(ErrorKind::AuthExpired) {
+    if kind == Some(ErrorKind::AuthExpired) {
         cache.invalidate();
     }
 }

--- a/provider-zai/src/stream_fn.rs
+++ b/provider-zai/src/stream_fn.rs
@@ -13,7 +13,7 @@ use iii_sdk::errors::Error;
 use iii_sdk::IIIClient;
 use llm_router::channels::open_sink;
 use llm_router::chat::relay::FrameSink;
-use llm_router::provider_scaffold::aborts::StreamAborts;
+use llm_router::provider_scaffold::aborts::{AbortGuard, StreamAborts};
 use llm_router::provider_scaffold::cache::ScaffoldCache;
 use llm_router::provider_scaffold::pump::{pump, pump_abortable, send_event, PING_INTERVAL};
 use llm_router::types::events::ErrorKind;
@@ -31,14 +31,16 @@ pub fn make_stream(
     move |input: ProviderStreamInput| {
         let (iii, http, cache, aborts) = (iii.clone(), http.clone(), cache.clone(), aborts.clone());
         Box::pin(async move {
+            // Register BEFORE the first await: an abort landing while the sink
+            // opens must latch, not hit an unknown id. The RAII guard
+            // deregisters on every exit — early returns and an executor
+            // cancelling this future mid-await alike.
+            let abort_reg = input
+                .resolution_key
+                .as_ref()
+                .map(|rid| aborts.register(rid));
             let sink = open_sink(&iii, &input.writer_ref).await?;
-            let request_id = input.resolution_key.clone();
-            run_stream_call(&iii, http, &cache, &aborts, input, sink.as_ref()).await;
-            // Single cleanup point covering every exit path (early returns
-            // included). A fired abort already consumed the entry — no-op.
-            if let Some(rid) = &request_id {
-                aborts.remove(rid);
-            }
+            run_stream_call(&iii, http, &cache, abort_reg.as_ref(), input, sink.as_ref()).await;
             sink.close();
             // ProviderStreamOutput (spec § stream contract)
             Ok(ProviderStreamOutput { ok: true })
@@ -50,16 +52,10 @@ async fn run_stream_call(
     iii: &IIIClient,
     http: reqwest::Client,
     cache: &ScaffoldCache,
-    aborts: &StreamAborts,
+    abort_reg: Option<&AbortGuard>,
     input: ProviderStreamInput,
     sink: &dyn FrameSink,
 ) {
-    // Subscribe FIRST: an abort landing during credential resolve / config /
-    // model_meta — before any upstream exists — must latch (level-triggered
-    // watch), or the request would start after its own cancellation. The
-    // caller removes the entry when this returns.
-    let abort_rx = input.resolution_key.as_ref().map(|rid| aborts.watch(rid));
-
     let model = input.model.clone();
     let mut warnings = Vec::new();
 
@@ -149,7 +145,7 @@ async fn run_stream_call(
     let headers = build_headers(&cfg);
 
     // Aborted while we were setting up — never start the upstream request.
-    if abort_rx.as_ref().is_some_and(|rx| *rx.borrow()) {
+    if abort_reg.is_some_and(|g| g.is_fired()) {
         return;
     }
     let rx = spawn_upstream(
@@ -162,8 +158,8 @@ async fn run_stream_call(
             warnings,
         },
     );
-    let kind = match abort_rx {
-        Some(abort_rx) => pump_abortable(rx, sink, PING_INTERVAL, abort_rx).await,
+    let kind = match abort_reg {
+        Some(g) => pump_abortable(rx, sink, PING_INTERVAL, g.watch()).await,
         None => pump(rx, sink, PING_INTERVAL).await,
     };
     // An upstream auth terminal means the cached credential was rotated

--- a/provider-zai/src/surface.rs
+++ b/provider-zai/src/surface.rs
@@ -9,13 +9,17 @@
 //! registration emits.
 
 use llm_router::types::router::{
-    ProviderReadyAck, ProviderStreamInput, ProviderStreamOutput, RefreshModelsRequest,
-    RefreshModelsResponse, RouterReadyEvent,
+    ProviderAbortRequest, ProviderAbortResponse, ProviderReadyAck, ProviderStreamInput,
+    ProviderStreamOutput, RefreshModelsRequest, RefreshModelsResponse, RouterReadyEvent,
 };
 
 pub const STREAM_ID: &str = "provider::zai::stream";
 pub const STREAM_DESC: &str = "Stream a Z.AI chat completion: resolve credentials, call the \
      upstream Chat Completions API, and relay AssistantMessageEvent frames to writer_ref.";
+
+pub const ABORT_ID: &str = "provider::zai::abort";
+pub const ABORT_DESC: &str = "Cancel the in-flight upstream stream for a request_id \
+     (router::abort fan-out), stopping billed generation immediately.";
 
 pub const REFRESH_MODELS_ID: &str = "provider::zai::refresh_models";
 pub const REFRESH_MODELS_DESC: &str = "Reconcile the curated Z.AI catalog slice through the \
@@ -58,6 +62,7 @@ where
 pub fn catalog() -> Vec<FunctionSpec> {
     vec![
         spec::<ProviderStreamInput, ProviderStreamOutput>(STREAM_ID, STREAM_DESC),
+        spec::<ProviderAbortRequest, ProviderAbortResponse>(ABORT_ID, ABORT_DESC),
         spec::<RefreshModelsRequest, RefreshModelsResponse>(REFRESH_MODELS_ID, REFRESH_MODELS_DESC),
         spec::<RouterReadyEvent, ProviderReadyAck>(ON_ROUTER_READY_ID, ON_ROUTER_READY_DESC),
     ]

--- a/provider-zai/src/upstream.rs
+++ b/provider-zai/src/upstream.rs
@@ -27,7 +27,16 @@ pub fn spawn_upstream(
 ) -> mpsc::Receiver<AssistantMessageEvent> {
     let (tx, rx) = mpsc::channel(64);
     tokio::spawn(async move {
-        run_upstream(client, args, tx).await;
+        // Race the call against receiver-side closure: send errors alone only
+        // observe a dropped receiver at the next send, so a silent upstream
+        // (parked in a chunk read, nothing to send) would otherwise keep the
+        // HTTP stream — and billed generation — alive until the next frame or
+        // the read timeout. This makes the module contract above immediate.
+        let closed = tx.clone();
+        tokio::select! {
+            _ = run_upstream(client, args, tx) => {}
+            _ = closed.closed() => {}
+        }
     });
     rx
 }

--- a/provider-zai/tests/golden/schemas/provider.zai.abort.json
+++ b/provider-zai/tests/golden/schemas/provider.zai.abort.json
@@ -1,0 +1,32 @@
+{
+  "description": "Cancel the in-flight upstream stream for a request_id (router::abort fan-out), stopping billed generation immediately.",
+  "function_id": "provider::zai::abort",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Input of a provider's `provider::<id>::abort`: actively cancel the in-flight upstream stream for `request_id` (the router's `request_id`, delivered to the provider as `resolution_key`) so billed generation stops immediately instead of waiting for the provider to notice the closed channel on its next write.",
+    "properties": {
+      "request_id": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "request_id"
+    ],
+    "title": "ProviderAbortRequest",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Output of `provider::<id>::abort`. `aborted: false` means the request was unknown — already finished, never started, or aborted before (idempotent).",
+    "properties": {
+      "aborted": {
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "aborted"
+    ],
+    "title": "ProviderAbortResponse",
+    "type": "object"
+  }
+}

--- a/provider-zai/tests/schemas.rs
+++ b/provider-zai/tests/schemas.rs
@@ -40,6 +40,7 @@ fn catalog_lists_all_functions_in_registration_order() {
         ids,
         vec![
             "provider::zai::stream",
+            "provider::zai::abort",
             "provider::zai::refresh_models",
             "provider::zai::on_router_ready",
         ]


### PR DESCRIPTION
## Problem

Clicking stop (■) fired `harness::stop` (~4ms ack) but the turn kept running for seconds — up to `router_timeout_ms` (320s) worst case — with no UI feedback and a still-clickable button (users click 6+ times), no transcript record of the stop, and the provider's upstream HTTP stream kept generating billed tokens after the abort.

## What changed

**harness** — stop actually stops:
- `TurnCancels`: per-turn, level-triggered in-process cancel registry, fired lock-free by `harness::stop`
- `router.chat` gains an abort arm: cuts the await immediately, persists the partial as `Aborted`, re-fires `router::abort` (a stop can race ahead of the router's stream registration), kills the held-open trigger task
- cancel observed between tool calls and before dispatching generation (the durable flag can't reach either spot — the tool phase holds the session lock, context assembly precedes the flag write)
- idempotent stop; "stopping" status ack; durable `stopped by user.` notice (`e_{turn}_stopped`); argument-less tool-call blocks truncated by the cut are dropped from the persisted partial

**console** — feedback + dedupe:
- stop button disables with a spinner while stopping; repeat clicks don't re-fire the RPC; re-enables if the abort RPC fails
- live cancelled notice shares the durable entry id, so live + reconciled rows dedupe

**llm-router + all 7 providers** — the provider stream dies too:
- `router::abort` fans out to a new `provider::<id>::abort` (request correlation via the existing `resolution_key`)
- scaffold `StreamAborts` registry + `pump_abortable`: the abort cuts the pump even mid-silence; upstream spawns race `Sender::closed()` so the parked HTTP future cancels instantly instead of at its next send
- abort subscription latches from stream-fn entry (an abort during credential resolve/config prevents the upstream from ever starting); `PING_INTERVAL` 30s → 2s as the passive backstop when the active abort is lost

Also carries `fix(provider-kimi): emit slim (partial: None) delta frames` (cherry-pick) — kimi didn't compile against the slim-delta contract on this base.

A post-implementation review round (commits `fa1710bd`/`6e5b552e`/`e8dddbd5`) closed the races it found: stopping-ack vs finalizer status ordering (incl. making `fail_turn` take the session lock), a losable pump wakeup (`notify_one`), terminal-frame-vs-partial preference on abort, and the two provider gaps above.

## Verification

- `cargo clippy` + tests green on harness (230), llm-router (107), and all seven provider crates; console `tsc` + 1021 vitest
- Live on the dev stack (claude-sonnet-5): stop mid-generation → **one** `harness::stop` trace per click (was 6+), turn cancels in <1s (server-driven case <100ms), spinner while stopping, durable notice survives reload, `provider::anthropic::abort` fires in ~300μs beside `router::abort`, remaining queued tool calls never run (verified with 3×`sleep 8`)
- Known pre-existing failure, untouched: provider-anthropic's live-catalog test asserts a model id Anthropic no longer lists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable cancellation for in-progress chat responses across supported providers.
  * Stop requests now immediately halt generation, including during setup and tool execution.
  * Added visual feedback while a response is stopping, preventing duplicate stop actions.
  * Cancelled conversations now retain a clear “stopped” notice after reloads.

* **Bug Fixes**
  * Prevented upstream requests and background streams from lingering after cancellation.
  * Improved retry behavior when stopping a response fails.
  * Reduced the chance of sessions becoming stuck in a working state.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->