### PR TITLE
feat(browser): scripted execution, snapshot diff, read-only sessions, doctor (MOT-4108)

### DIFF
--- a/browser/README.md
+++ b/browser/README.md
@@ -102,6 +102,18 @@ ref or coordinates, left/right/middle and double-click), `browser::evaluate`
 panel backing), and `browser::sessions::list` / `browser::sessions::stop`.
 Function ids and schemas live in the code and `iii worker info browser`.
 
+Beyond single actions: `browser::execute` runs a multi-step async script in
+the page — top-level await, `log(...)`, `sleep(ms)`, `waitFor(selector)`, and
+a `state` object that persists across execute calls for the session — so one
+call replaces a chain of act/evaluate round-trips. `browser::snapshot`
+accepts `diff: true` to return only what changed since the previous
+snapshot, and reports the document `generation` its refs belong to (ref
+names are unique per snapshot and fail closed when stale, never resolving to
+a different element). `browser::sessions::start` accepts `read_only: true`
+for inspection-only sessions where act/evaluate/execute/styles::write are
+rejected. `browser::doctor` reports the environment — detected Chromium,
+version, capacity — with an `enable_how` string for anything degraded.
+
 ## Configuration
 
 Stored in the `configuration` worker under the `browser` key; every field is

--- a/browser/skills/SKILL.md
+++ b/browser/skills/SKILL.md
@@ -51,18 +51,26 @@ on navigation; re-snapshot before acting after any page change.
 ## Functions
 
 - `browser::sessions::start` — launch a Chromium session; returns the
-  session_id every other function needs.
+  session_id every other function needs. `read_only: true` starts an
+  inspection-only session.
 - `browser::sessions::list` — live sessions with their current URL.
 - `browser::sessions::stop` — stop a session; idempotent.
+- `browser::doctor` — read-only environment report: which Chromium would
+  launch, its version, capacity, and anything degraded with how to enable it.
 - `browser::navigate` — go to a URL and wait for the load.
 - `browser::snapshot` — the page as an accessibility outline with `[ref=eN]`
-  handles; the default way to read a page.
+  handles; the default way to read a page. `diff: true` returns only what
+  changed since the previous snapshot.
 - `browser::act` — click, hover, type, press, or scroll, addressed by ref or
   viewport coordinates.
 - `browser::screenshot` — viewable JPEG of the viewport, for when layout or
   rendering matters.
 - `browser::evaluate` — run a JavaScript expression in the page and get the
   completion value.
+- `browser::execute` — run a multi-step async script in the page: top-level
+  await and return, `log(...)`, `sleep(ms)`, `waitFor(selector)`, and a
+  `state` object persisted across execute calls for the session. One call
+  replaces a chain of act/evaluate round-trips.
 - `browser::console::read` — captured console entries; filter with
   pattern/level and page with since_seq.
 - `browser::network::read` — captured requests; failed_only=true is the fast
@@ -72,6 +80,30 @@ on navigation; re-snapshot before acting after any page change.
   accessibility tree hides.
 - `browser::styles::read` / `browser::styles::write` — computed styles and
   live inline CSS edits on one element.
+
+## Workflow: inspect before acting
+
+1. Snapshot first; act on refs from the latest snapshot, never from memory
+   of an earlier one. Refs are unique per snapshot and die on navigation, so
+   a stale ref fails with an error instead of clicking the wrong element.
+2. After an action that changes the page, re-read with
+   `browser::snapshot { diff: true }`: it returns only added and removed
+   lines, which keeps loops cheap.
+3. Use `browser::execute` when a step needs waiting or several dependent
+   reads and writes; use `browser::act` for single trusted input events
+   (in-page script clicks are not trusted events).
+4. Pure inspection tasks (audits, scraping a logged-in page you must not
+   touch) belong in a `read_only: true` session.
+
+## Workflow: destructive UI actions
+
+For destructive page actions (deleting records, cancelling subscriptions)
+use two phases, never one script:
+
+1. Discovery: read candidates and return their exact stable text or ids for
+   the user to approve. Do not act in this call.
+2. Action: operate only on the approved identifiers, read any confirmation
+   dialog text, and abort unless it matches the approved action.
 
 ## Keeping context small
 

--- a/browser/src/functions/doctor.rs
+++ b/browser/src/functions/doctor.rs
@@ -1,0 +1,97 @@
+//! `browser::doctor` — read-only environment diagnostics. Reports what the
+//! worker can and cannot do right now and how to enable what is degraded.
+//! Never launches a browser; the only side effect is running the detected
+//! binary with `--version`.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::config::WorkerConfig;
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+pub struct DoctorInput {}
+
+/// One degraded capability plus the way to enable it.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DoctorIssue {
+    pub what: String,
+    pub enable_how: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct DoctorOutput {
+    /// True when sessions can start right now.
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chromium_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chromium_version: Option<String>,
+    pub headless_default: bool,
+    pub max_sessions: u64,
+    pub active_sessions: u64,
+    pub allowed_schemes: Vec<String>,
+    pub issues: Vec<DoctorIssue>,
+}
+
+/// Candidate system installs checked when config `executable` is empty, in
+/// order. Mirrors the auto-detection the launcher performs.
+#[cfg(target_os = "macos")]
+const CANDIDATES: &[&str] = &[
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+];
+
+#[cfg(target_os = "linux")]
+const CANDIDATES: &[&str] = &[
+    "/usr/bin/google-chrome",
+    "/usr/bin/google-chrome-stable",
+    "/usr/bin/chromium",
+    "/usr/bin/chromium-browser",
+    "/usr/bin/microsoft-edge",
+];
+
+#[cfg(target_os = "windows")]
+const CANDIDATES: &[&str] = &[
+    "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+    "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
+    "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe",
+];
+
+/// Resolve the Chromium binary the worker would launch: the configured
+/// `executable` when set, otherwise the first existing system candidate.
+pub fn detect_chromium(cfg: &WorkerConfig) -> Option<std::path::PathBuf> {
+    if !cfg.executable.is_empty() {
+        let path = std::path::PathBuf::from(&cfg.executable);
+        return path.exists().then_some(path);
+    }
+    CANDIDATES
+        .iter()
+        .map(std::path::PathBuf::from)
+        .find(|p| p.exists())
+}
+
+/// `<binary> --version`, first line. Blocking; call from spawn_blocking.
+pub fn chromium_version(path: &std::path::Path) -> Option<String> {
+    let output = std::process::Command::new(path)
+        .arg("--version")
+        .output()
+        .ok()?;
+    let text = String::from_utf8_lossy(&output.stdout);
+    let line = text.lines().next()?.trim();
+    (!line.is_empty()).then(|| line.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn configured_missing_executable_is_none() {
+        let cfg = WorkerConfig {
+            executable: "/definitely/not/a/real/chromium".to_string(),
+            ..WorkerConfig::default()
+        };
+        assert!(detect_chromium(&cfg).is_none());
+    }
+}

--- a/browser/src/functions/execute.rs
+++ b/browser/src/functions/execute.rs
@@ -1,0 +1,120 @@
+//! `browser::execute` — run a multi-step async script in the page with
+//! helpers and cross-call session state. One call does what would otherwise
+//! cost a round-trip per action.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Ceiling on the serialized envelope coming back from the page. A script
+/// returning more than this gets an error asking for a summary instead of
+/// flooding the transcript.
+pub const MAX_ENVELOPE_BYTES: usize = 1_000_000;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ExecuteInput {
+    pub session_id: String,
+    /// Async JavaScript body run in the page. Top-level `await` and `return`
+    /// work. In scope: `state` (JSON object persisted across execute calls
+    /// for the session), `log(...)` (collected into the response), `sleep(ms)`,
+    /// and `waitFor(selector, { timeout })`. Return plain JSON.
+    pub code: String,
+    /// Upper bound on the run; clamped to `max_timeout_ms`.
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct ExecuteOutput {
+    pub ok: bool,
+    /// The script's return value when `ok`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    /// Exception text when not `ok`. A "context destroyed" error usually
+    /// means the script navigated; split the script at the navigation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// `log(...)` output collected during the run, in order.
+    pub logs: Vec<String>,
+    /// Session state after the run; the next execute call sees this as
+    /// `state`.
+    pub state: serde_json::Value,
+}
+
+/// Wrap the user's code with the helper prelude and the state/log capture.
+/// The page returns one JSON string envelope; the worker parses it, stores
+/// `state` back on the session, and shapes `ExecuteOutput`.
+pub fn wrap_code(code: &str, state_json: &str) -> String {
+    format!(
+        r#"(async () => {{
+  const state = {state_json};
+  const logs = [];
+  const log = (...args) => {{
+    if (logs.length >= 200) return;
+    logs.push(args.map((a) => {{
+      if (typeof a === 'string') return a;
+      try {{ return JSON.stringify(a); }} catch {{ return String(a); }}
+    }}).join(' ').slice(0, 2000));
+  }};
+  const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  const waitFor = async (selector, opts = {{}}) => {{
+    const timeout = opts.timeout ?? 10000;
+    const start = Date.now();
+    while (Date.now() - start < timeout) {{
+      const el = document.querySelector(selector);
+      if (el) return el;
+      await sleep(100);
+    }}
+    throw new Error('waitFor timed out after ' + timeout + 'ms: ' + selector);
+  }};
+  let result;
+  try {{
+    result = await (async () => {{
+{code}
+    }})();
+  }} catch (e) {{
+    return JSON.stringify({{ ok: false, error: String((e && e.stack) || e), logs, state }});
+  }}
+  try {{
+    return JSON.stringify({{ ok: true, result, logs, state }});
+  }} catch (e) {{
+    return JSON.stringify({{ ok: false, error: 'result is not JSON-serializable: ' + String(e), logs, state }});
+  }}
+}})()"#
+    )
+}
+
+/// The envelope shape produced by `wrap_code` in the page.
+#[derive(Debug, Deserialize)]
+pub struct Envelope {
+    pub ok: bool,
+    #[serde(default)]
+    pub result: Option<serde_json::Value>,
+    #[serde(default)]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub logs: Vec<String>,
+    #[serde(default)]
+    pub state: serde_json::Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrapped_code_embeds_state_and_body() {
+        let wrapped = wrap_code("return state.n;", "{\"n\":7}");
+        assert!(wrapped.contains("const state = {\"n\":7};"));
+        assert!(wrapped.contains("return state.n;"));
+        assert!(wrapped.starts_with("(async () => {"));
+    }
+
+    #[test]
+    fn envelope_parses_error_shape() {
+        let e: Envelope =
+            serde_json::from_str(r#"{"ok":false,"error":"boom","logs":["a"],"state":{}}"#).unwrap();
+        assert!(!e.ok);
+        assert_eq!(e.error.as_deref(), Some("boom"));
+        assert_eq!(e.logs, vec!["a"]);
+    }
+}

--- a/browser/src/functions/mod.rs
+++ b/browser/src/functions/mod.rs
@@ -4,8 +4,10 @@
 
 pub mod act;
 pub mod console;
+pub mod doctor;
 pub mod dom;
 pub mod evaluate;
+pub mod execute;
 pub mod frame;
 pub mod hint;
 pub mod history;
@@ -72,6 +74,17 @@ pub const EVALUATE_ID: &str = "browser::evaluate";
 pub const EVALUATE_DESC: &str =
     "Evaluate a JavaScript expression in the page and return its completion value. Use for \
      reads the snapshot can't express; prefer browser::act for interactions.";
+pub const EXECUTE_ID: &str = "browser::execute";
+pub const EXECUTE_DESC: &str =
+    "Run a multi-step async JavaScript script in the page: top-level await and return work, \
+     with log(...), sleep(ms), waitFor(selector), and a state object that persists across \
+     execute calls for the session. One call replaces a chain of act/evaluate round-trips; \
+     returns { result, logs, state }.";
+pub const DOCTOR_ID: &str = "browser::doctor";
+pub const DOCTOR_DESC: &str =
+    "Read-only environment diagnostics: which Chromium the worker would launch, its version, \
+     session capacity, and any degraded capability with how to enable it. Never starts a \
+     browser.";
 pub const CONSOLE_READ_ID: &str = "browser::console::read";
 pub const CONSOLE_READ_DESC: &str =
     "Read the session's captured console: console.* calls, uncaught exceptions, and \
@@ -156,6 +169,7 @@ pub fn catalog() -> Vec<FunctionSpec> {
         spec::<sessions::StartInput, sessions::StartOutput>(SESSIONS_START_ID, SESSIONS_START_DESC),
         spec::<sessions::ListInput, sessions::ListOutput>(SESSIONS_LIST_ID, SESSIONS_LIST_DESC),
         spec::<sessions::StopInput, sessions::StopOutput>(SESSIONS_STOP_ID, SESSIONS_STOP_DESC),
+        spec::<doctor::DoctorInput, doctor::DoctorOutput>(DOCTOR_ID, DOCTOR_DESC),
         spec::<navigate::NavigateInput, navigate::NavigateOutput>(NAVIGATE_ID, NAVIGATE_DESC),
         spec::<snapshot::SnapshotInput, snapshot::SnapshotOutput>(SNAPSHOT_ID, SNAPSHOT_DESC),
         spec::<screenshot::ScreenshotInput, screenshot::ScreenshotOutput>(
@@ -164,6 +178,7 @@ pub fn catalog() -> Vec<FunctionSpec> {
         ),
         spec::<act::ActInput, act::ActOutput>(ACT_ID, ACT_DESC),
         spec::<evaluate::EvaluateInput, evaluate::EvaluateOutput>(EVALUATE_ID, EVALUATE_DESC),
+        spec::<execute::ExecuteInput, execute::ExecuteOutput>(EXECUTE_ID, EXECUTE_DESC),
         spec::<console::ConsoleReadInput, console::ConsoleReadOutput>(
             CONSOLE_READ_ID,
             CONSOLE_READ_DESC,
@@ -199,11 +214,13 @@ pub fn register_all(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
     register_sessions_start(iii, sessions);
     register_sessions_list(iii, sessions);
     register_sessions_stop(iii, sessions);
+    register_doctor(iii, sessions);
     register_navigate(iii, sessions);
     register_snapshot(iii, sessions);
     register_screenshot(iii, sessions);
     register_act(iii, sessions);
     register_evaluate(iii, sessions);
+    register_execute(iii, sessions);
     register_console_read(iii, sessions);
     register_network_read(iii, sessions);
     register_history(iii, sessions);
@@ -232,6 +249,21 @@ fn get_session(sessions: &Sessions, id: &str) -> Result<Arc<Session>, Error> {
     })
 }
 
+/// Read-only guard shared by every interaction function. Inspection and
+/// navigation stay available on a read-only session; anything that dispatches
+/// input or runs script is rejected here.
+fn ensure_writable(session: &Session, what: &str) -> Result<(), Error> {
+    if session.read_only {
+        return Err(handler_err(format!(
+            "session '{}' is read-only: {what} is rejected. Navigation, snapshot, dom/styles \
+             reads, console/network reads, and screenshots still work; start a writable session \
+             with browser::sessions::start.",
+            session.id
+        )));
+    }
+    Ok(())
+}
+
 fn register_sessions_start(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
     let sx = sessions.clone();
     iii.register_function(
@@ -242,7 +274,10 @@ fn register_sessions_start(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                 if let Some(url) = &req.url {
                     sessions::check_scheme(&sx.config.load(), url).map_err(handler_err)?;
                 }
-                let session = sx.start(req.url, req.headful).await.map_err(handler_err)?;
+                let session = sx
+                    .start(req.url, req.headful, req.read_only.unwrap_or(false))
+                    .await
+                    .map_err(handler_err)?;
                 let url = session
                     .page
                     .url()
@@ -266,6 +301,7 @@ fn register_sessions_start(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                     session_id: session.id.clone(),
                     url,
                     headless: session.headless,
+                    read_only: session.read_only,
                 })
             }
         })
@@ -298,6 +334,7 @@ fn register_sessions_list(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                             url: url.ok().flatten().unwrap_or_default(),
                             title: title.ok().flatten(),
                             headless: session.headless,
+                            read_only: session.read_only,
                             created_ms: session.created_ms,
                             last_used_ms: session.last_used_ms(),
                             console_entries,
@@ -384,17 +421,52 @@ fn register_snapshot(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                     .await
                     .map_err(|e| handler_err(format!("accessibility tree failed: {e}")))?;
 
-                let result =
-                    crate::snapshot::serialize(&tree.nodes, cfg.max_snapshot_nodes as usize);
-                session.store_refs(result.refs);
+                let result = crate::snapshot::serialize(
+                    &tree.nodes,
+                    cfg.max_snapshot_nodes as usize,
+                    &session.ref_counter,
+                );
+                session.append_refs(result.refs);
+
+                // Swap in this snapshot's keys as the next diff baseline,
+                // taking the previous baseline out in the same lock.
+                let previous_keys = {
+                    let mut baseline = session
+                        .snapshot_keys
+                        .lock()
+                        .unwrap_or_else(|p| p.into_inner());
+                    baseline.replace(result.keys.clone())
+                };
+
+                let diff = match (req.diff.unwrap_or(false), previous_keys) {
+                    (true, Some(previous)) => {
+                        let d = crate::snapshot::diff_keys(&previous, &result.keys);
+                        Some(snapshot::SnapshotDiff {
+                            added: d
+                                .added
+                                .iter()
+                                .filter_map(|&i| result.lines.get(i).cloned())
+                                .collect(),
+                            removed: d.removed,
+                            unchanged: d.unchanged,
+                        })
+                    }
+                    _ => None,
+                };
 
                 let url = session.page.url().await.ok().flatten().unwrap_or_default();
                 let title = session.page.get_title().await.ok().flatten();
                 Ok::<_, Error>(snapshot::SnapshotOutput {
                     url,
                     title,
-                    tree: result.tree,
+                    tree: if diff.is_some() {
+                        String::new()
+                    } else {
+                        result.tree
+                    },
                     truncated: result.truncated,
+                    generation: session.generation(),
+                    diff,
                 })
             }
         })
@@ -558,6 +630,7 @@ fn register_act(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
             let sx = sx.clone();
             async move {
                 let session = get_session(&sx, &req.session_id)?;
+                ensure_writable(&session, "browser::act")?;
                 session.touch();
 
                 let detail = match req.action.as_str() {
@@ -688,6 +761,7 @@ fn register_evaluate(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
             let sx = sx.clone();
             async move {
                 let session = get_session(&sx, &req.session_id)?;
+                ensure_writable(&session, "browser::evaluate")?;
                 session.touch();
                 let cfg = sx.config.load();
                 let wait = Duration::from_millis(cfg.clamp_timeout(req.timeout_ms));
@@ -714,6 +788,185 @@ fn register_evaluate(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
             }
         })
         .description(EVALUATE_DESC),
+    );
+}
+
+fn register_execute(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
+    let sx = sessions.clone();
+    iii.register_function(
+        EXECUTE_ID,
+        RegisterFunction::new_async(move |req: execute::ExecuteInput| {
+            let sx = sx.clone();
+            async move {
+                let session = get_session(&sx, &req.session_id)?;
+                ensure_writable(&session, "browser::execute")?;
+                session.touch();
+                let cfg = sx.config.load();
+                let wait = Duration::from_millis(cfg.clamp_timeout(req.timeout_ms));
+
+                let state_json = {
+                    let state = session.exec_state.lock().unwrap_or_else(|p| p.into_inner());
+                    serde_json::to_string(&*state).unwrap_or_else(|_| "{}".to_string())
+                };
+                let wrapped = execute::wrap_code(&req.code, &state_json);
+
+                let params = cdp_rt::EvaluateParams::builder()
+                    .expression(wrapped)
+                    .await_promise(true)
+                    .return_by_value(true)
+                    .build()
+                    .map_err(handler_err)?;
+                let evaluated = timeout(wait, session.page.execute(params)).await;
+                session.touch();
+
+                let current_state = || {
+                    session
+                        .exec_state
+                        .lock()
+                        .unwrap_or_else(|p| p.into_inner())
+                        .clone()
+                };
+                let response = match evaluated {
+                    Err(_) => {
+                        return Ok::<_, Error>(execute::ExecuteOutput {
+                            ok: false,
+                            result: None,
+                            error: Some(format!(
+                                "script timed out after {}ms; state was not updated",
+                                wait.as_millis()
+                            )),
+                            logs: Vec::new(),
+                            state: current_state(),
+                        })
+                    }
+                    Ok(Err(e)) => {
+                        let text = e.to_string();
+                        let hint = if text.contains("context") {
+                            "; the execution context was destroyed, which usually means the \
+                             script navigated — split the script at the navigation boundary"
+                        } else {
+                            ""
+                        };
+                        return Ok(execute::ExecuteOutput {
+                            ok: false,
+                            result: None,
+                            error: Some(format!("script failed: {text}{hint}")),
+                            logs: Vec::new(),
+                            state: current_state(),
+                        });
+                    }
+                    Ok(Ok(r)) => r,
+                };
+
+                if let Some(details) = &response.exception_details {
+                    return Ok(execute::ExecuteOutput {
+                        ok: false,
+                        result: None,
+                        error: Some(format!("script threw: {}", details.text)),
+                        logs: Vec::new(),
+                        state: current_state(),
+                    });
+                }
+                let raw = response
+                    .result
+                    .result
+                    .value
+                    .as_ref()
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| handler_err("script returned no envelope"))?;
+                if raw.len() > execute::MAX_ENVELOPE_BYTES {
+                    return Ok(execute::ExecuteOutput {
+                        ok: false,
+                        result: None,
+                        error: Some(format!(
+                            "script result is {} bytes (cap {}); return a summary, not a dump",
+                            raw.len(),
+                            execute::MAX_ENVELOPE_BYTES
+                        )),
+                        logs: Vec::new(),
+                        state: current_state(),
+                    });
+                }
+                let envelope: execute::Envelope = serde_json::from_str(raw)
+                    .map_err(|e| handler_err(format!("script envelope did not parse: {e}")))?;
+
+                if envelope.state.is_object() {
+                    *session.exec_state.lock().unwrap_or_else(|p| p.into_inner()) =
+                        envelope.state.clone();
+                }
+                Ok(execute::ExecuteOutput {
+                    ok: envelope.ok,
+                    result: envelope.result,
+                    error: envelope.error,
+                    logs: envelope.logs,
+                    state: envelope.state,
+                })
+            }
+        })
+        .description(EXECUTE_DESC),
+    );
+}
+
+fn register_doctor(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
+    let sx = sessions.clone();
+    iii.register_function(
+        DOCTOR_ID,
+        RegisterFunction::new_async(move |_req: doctor::DoctorInput| {
+            let sx = sx.clone();
+            async move {
+                let cfg = sx.config.load_full();
+                let mut issues = Vec::new();
+
+                let chromium_path = doctor::detect_chromium(&cfg);
+                let chromium_version = match &chromium_path {
+                    Some(path) => {
+                        let path = path.clone();
+                        tokio::task::spawn_blocking(move || doctor::chromium_version(&path))
+                            .await
+                            .ok()
+                            .flatten()
+                    }
+                    None => None,
+                };
+                if chromium_path.is_none() {
+                    issues.push(doctor::DoctorIssue {
+                        what: if cfg.executable.is_empty() {
+                            "no Chromium/Chrome install found".to_string()
+                        } else {
+                            format!("configured executable '{}' does not exist", cfg.executable)
+                        },
+                        enable_how: "install Google Chrome or Chromium, or point the worker \
+                                     config `executable` at a browser binary"
+                            .to_string(),
+                    });
+                }
+
+                let active_sessions = sx.count() as u64;
+                if active_sessions >= cfg.max_sessions {
+                    issues.push(doctor::DoctorIssue {
+                        what: format!(
+                            "session capacity reached ({active_sessions}/{})",
+                            cfg.max_sessions
+                        ),
+                        enable_how: "stop a session with browser::sessions::stop, or raise \
+                                     `max_sessions` in the worker config"
+                            .to_string(),
+                    });
+                }
+
+                Ok::<_, Error>(doctor::DoctorOutput {
+                    ok: chromium_path.is_some() && active_sessions < cfg.max_sessions,
+                    chromium_path: chromium_path.map(|p| p.display().to_string()),
+                    chromium_version,
+                    headless_default: cfg.headless,
+                    max_sessions: cfg.max_sessions,
+                    active_sessions,
+                    allowed_schemes: cfg.allowed_schemes.clone(),
+                    issues,
+                })
+            }
+        })
+        .description(DOCTOR_DESC),
     );
 }
 
@@ -1133,6 +1386,7 @@ fn register_styles_write(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
             let sx = sx.clone();
             async move {
                 let session = get_session(&sx, &req.session_id)?;
+                ensure_writable(&session, "browser::styles::write")?;
                 session.touch();
                 let backend_id = session.resolve_ref_or_err(&req.r#ref)?;
 

--- a/browser/src/functions/sessions.rs
+++ b/browser/src/functions/sessions.rs
@@ -14,6 +14,11 @@ pub struct StartInput {
     /// `headless` default.
     #[serde(default)]
     pub headful: Option<bool>,
+    /// Inspection-only session: act, evaluate, execute, and styles::write
+    /// are rejected while navigation, snapshots, reads, and screenshots
+    /// work. Immutable for the session's lifetime.
+    #[serde(default)]
+    pub read_only: Option<bool>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -22,6 +27,7 @@ pub struct StartOutput {
     pub session_id: String,
     pub url: String,
     pub headless: bool,
+    pub read_only: bool,
 }
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
@@ -34,6 +40,7 @@ pub struct SessionInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     pub headless: bool,
+    pub read_only: bool,
     pub created_ms: i64,
     pub last_used_ms: i64,
     pub console_entries: u64,

--- a/browser/src/functions/snapshot.rs
+++ b/browser/src/functions/snapshot.rs
@@ -6,6 +6,21 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SnapshotInput {
     pub session_id: String,
+    /// Return only what changed since this session's previous snapshot
+    /// instead of the full outline. Falls back to a full snapshot when
+    /// there is no baseline (first snapshot, or first after a navigation).
+    #[serde(default)]
+    pub diff: Option<bool>,
+}
+
+/// Changes since the previous snapshot. Lines are compared without their
+/// `[ref=eN]` suffix (ref names are unique per snapshot); `added` lines
+/// carry current refs and are directly actionable.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct SnapshotDiff {
+    pub added: Vec<String>,
+    pub removed: Vec<String>,
+    pub unchanged: u64,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -14,7 +29,14 @@ pub struct SnapshotOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// Indented outline; lines carry `[ref=eN]` handles for `browser::act`.
+    /// Empty when `diff` is populated.
     pub tree: String,
     /// True when the tree hit `max_snapshot_nodes` and was cut short.
     pub truncated: bool,
+    /// Document generation the refs belong to; navigation advances it and
+    /// kills every ref from earlier generations.
+    pub generation: u64,
+    /// Present when the caller asked for `diff: true` and a baseline existed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diff: Option<SnapshotDiff>,
 }

--- a/browser/src/session.rs
+++ b/browser/src/session.rs
@@ -191,9 +191,19 @@ impl LatestFrame {
     }
 }
 
+/// Refs kept per session before the safety valve clears the table. Only
+/// reachable without a navigation (navigation clears refs), so hitting it
+/// means thousands of snapshots against one document; clearing degrades to
+/// the fail-closed unknown-ref error, never to a wrong element.
+const MAX_REFS: usize = 20_000;
+
 pub struct Session {
     pub id: String,
     pub headless: bool,
+    /// Inspection-only session: interaction functions are rejected while
+    /// navigation and reads stay available. Immutable for the session's
+    /// lifetime.
+    pub read_only: bool,
     /// Viewport captured at launch. Config viewport is a session-start
     /// setting (a running session keeps the browser it launched with), so
     /// per-call consumers read these fields, not the live config.
@@ -213,8 +223,24 @@ pub struct Session {
     seq: AtomicU64,
     last_used_ms: AtomicU64,
     /// Snapshot/pick refs (`e1`, `p3`, …) → CDP backend node ids. Cleared on
-    /// navigation — backend ids do not survive a document swap.
+    /// navigation — backend ids do not survive a document swap. Snapshot
+    /// refs accumulate (names are session-monotonic), so a ref from an
+    /// earlier snapshot of the same document still resolves to the node it
+    /// named instead of colliding with a newer snapshot's numbering.
     pub refs: Mutex<HashMap<String, i64>>,
+    /// Session-monotonic counter behind snapshot ref names; never reset
+    /// within a session so ref names are unique across snapshots.
+    pub ref_counter: AtomicU64,
+    /// Bumped on every top-document navigation. Snapshots report it so a
+    /// caller can tell which document epoch its refs belong to.
+    generation: AtomicU64,
+    /// Ref-stripped outline lines of the latest snapshot, the baseline for
+    /// `browser::snapshot` diff mode. None before the first snapshot and
+    /// after a navigation.
+    pub snapshot_keys: Mutex<Option<Vec<String>>>,
+    /// Cross-call state for `browser::execute`; lives until the session
+    /// stops.
+    pub exec_state: Mutex<serde_json::Value>,
     pick_counter: AtomicU64,
     tasks: Mutex<Vec<tokio::task::JoinHandle<()>>>,
 }
@@ -250,14 +276,28 @@ impl Session {
     pub fn resolve_ref_or_err(&self, r: &str) -> Result<i64, iii_sdk::errors::Error> {
         self.resolve_ref(r).ok_or_else(|| {
             iii_sdk::errors::Error::Handler(format!(
-                "unknown ref '{r}'; refs come from browser::snapshot / browser::dom::read / a \
-                 pick and die on navigation. Re-snapshot, then use a fresh ref."
+                "unknown ref '{r}' (document generation {}); refs come from browser::snapshot / \
+                 browser::dom::read / a pick and die on navigation. Re-snapshot, then use a \
+                 fresh ref.",
+                self.generation()
             ))
         })
     }
 
-    pub fn store_refs(&self, map: HashMap<String, i64>) {
-        *self.refs.lock().unwrap_or_else(|p| p.into_inner()) = map;
+    pub fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Relaxed)
+    }
+
+    /// Merge new snapshot refs into the table. Names are session-monotonic
+    /// so this never overwrites an older snapshot's names; the safety valve
+    /// clears everything if the table grows past `MAX_REFS` (subsequent old
+    /// refs then fail closed as unknown).
+    pub fn append_refs(&self, map: HashMap<String, i64>) {
+        let mut refs = self.refs.lock().unwrap_or_else(|p| p.into_inner());
+        if refs.len().saturating_add(map.len()) > MAX_REFS {
+            refs.clear();
+        }
+        refs.extend(map);
     }
 
     pub fn add_ref(&self, r: String, backend_node_id: i64) {
@@ -267,8 +307,13 @@ impl Session {
             .insert(r, backend_node_id);
     }
 
+    /// Navigation invalidation: refs die, the diff baseline dies, and the
+    /// document generation advances. `exec_state` survives — it is session
+    /// state, not document state.
     fn clear_refs(&self) {
         self.refs.lock().unwrap_or_else(|p| p.into_inner()).clear();
+        *self.snapshot_keys.lock().unwrap_or_else(|p| p.into_inner()) = None;
+        self.generation.fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn push_console(&self, entry: ConsoleEntry) {
@@ -365,6 +410,7 @@ impl Sessions {
         self: &Arc<Self>,
         url: Option<String>,
         headful_override: Option<bool>,
+        read_only: bool,
     ) -> Result<Arc<Session>, String> {
         let cfg = self.config.load_full();
         if self.count() as u64 >= cfg.max_sessions {
@@ -415,6 +461,7 @@ impl Sessions {
         let session = Arc::new(Session {
             id: id.clone(),
             headless,
+            read_only,
             viewport_width: cfg.viewport_width,
             viewport_height: cfg.viewport_height,
             created_ms: now,
@@ -429,6 +476,10 @@ impl Sessions {
             seq: AtomicU64::new(1),
             last_used_ms: AtomicU64::new(now as u64),
             refs: Mutex::new(HashMap::new()),
+            ref_counter: AtomicU64::new(0),
+            generation: AtomicU64::new(1),
+            snapshot_keys: Mutex::new(None),
+            exec_state: Mutex::new(serde_json::Value::Object(serde_json::Map::new())),
             pick_counter: AtomicU64::new(0),
             tasks: Mutex::new(vec![handler_task]),
         });

--- a/browser/src/snapshot.rs
+++ b/browser/src/snapshot.rs
@@ -4,6 +4,7 @@
 //! CDP backend node ids. Text is what the model reads; refs are how it acts.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use chromiumoxide::cdp::browser_protocol::accessibility::AxNode;
 
@@ -22,6 +23,14 @@ pub struct SnapshotResult {
     pub tree: String,
     pub refs: HashMap<String, i64>,
     pub truncated: bool,
+    /// One entry per emitted line, without the `[ref=eN]` suffix: the
+    /// ref-stable identity used as the diff-mode baseline (ref names are
+    /// session-monotonic, so the same node gets a different name in every
+    /// snapshot and raw lines would always differ).
+    pub keys: Vec<String>,
+    /// The emitted lines with refs, parallel to `keys`; diff mode reports
+    /// added lines in this form so they are directly actionable.
+    pub lines: Vec<String>,
 }
 
 fn ax_value_string(
@@ -38,7 +47,10 @@ fn ax_value_string(
 
 /// Serialize the flat `Accessibility.getFullAXTree` node list into an
 /// indented outline, assigning refs to nodes that are backed by a DOM node.
-pub fn serialize(nodes: &[AxNode], max_nodes: usize) -> SnapshotResult {
+/// `ref_counter` is the session's monotonic counter: names continue from
+/// where the previous snapshot stopped, so refs from different snapshots of
+/// one document never collide.
+pub fn serialize(nodes: &[AxNode], max_nodes: usize, ref_counter: &AtomicU64) -> SnapshotResult {
     let by_id: HashMap<&str, &AxNode> = nodes
         .iter()
         .map(|n| (n.node_id.inner().as_str(), n))
@@ -47,7 +59,8 @@ pub fn serialize(nodes: &[AxNode], max_nodes: usize) -> SnapshotResult {
     let root = nodes.first();
     let mut out = String::new();
     let mut refs = HashMap::new();
-    let mut ref_counter = 0u64;
+    let mut keys = Vec::new();
+    let mut lines = Vec::new();
     let mut emitted = 0usize;
     let mut truncated = false;
 
@@ -88,12 +101,13 @@ pub fn serialize(nodes: &[AxNode], max_nodes: usize) -> SnapshotResult {
         if !value.is_empty() && value != name {
             line.push_str(&format!(" = {}", crate::session::truncate(&value, 120)));
         }
+        keys.push(line.clone());
         if let Some(backend_id) = &node.backend_dom_node_id {
-            ref_counter += 1;
-            let r = format!("e{ref_counter}");
+            let r = format!("e{}", ref_counter.fetch_add(1, Ordering::Relaxed) + 1);
             refs.insert(r.clone(), *backend_id.inner());
             line.push_str(&format!(" [ref={r}]"));
         }
+        lines.push(line.clone());
         out.push_str(&line);
         out.push('\n');
         emitted += 1;
@@ -107,6 +121,50 @@ pub fn serialize(nodes: &[AxNode], max_nodes: usize) -> SnapshotResult {
         tree: out,
         refs,
         truncated,
+        keys,
+        lines,
+    }
+}
+
+/// Diff of the current snapshot against the previous one, over ref-less key
+/// lines. Multiset semantics: a line appearing twice before and once now
+/// counts one removal. `added` holds indices into the current snapshot's
+/// lines so the caller can report the ref-bearing form.
+pub struct SnapshotDiffResult {
+    pub added: Vec<usize>,
+    pub removed: Vec<String>,
+    pub unchanged: u64,
+}
+
+pub fn diff_keys(previous: &[String], current: &[String]) -> SnapshotDiffResult {
+    let mut old_counts: HashMap<&str, i64> = HashMap::new();
+    for k in previous {
+        *old_counts.entry(k.as_str()).or_default() += 1;
+    }
+    let mut added = Vec::new();
+    let mut unchanged = 0u64;
+    for (i, k) in current.iter().enumerate() {
+        match old_counts.get_mut(k.as_str()) {
+            Some(n) if *n > 0 => {
+                *n -= 1;
+                unchanged += 1;
+            }
+            _ => added.push(i),
+        }
+    }
+    let mut removed = Vec::new();
+    for k in previous {
+        if let Some(n) = old_counts.get_mut(k.as_str()) {
+            if *n > 0 {
+                *n -= 1;
+                removed.push(k.clone());
+            }
+        }
+    }
+    SnapshotDiffResult {
+        added,
+        removed,
+        unchanged,
     }
 }
 
@@ -150,12 +208,26 @@ mod tests {
             node("2", "button", "Place order", &[], Some(11)),
             node("3", "generic", "", &[], Some(12)),
         ];
-        let result = serialize(&nodes, 100);
+        let result = serialize(&nodes, 100, &AtomicU64::new(0));
         assert!(result.tree.contains("RootWebArea \"Checkout\" [ref=e1]"));
         assert!(result.tree.contains("  - button \"Place order\" [ref=e2]"));
         assert!(!result.tree.contains("generic"));
         assert_eq!(result.refs.get("e2"), Some(&11));
         assert!(!result.truncated);
+        assert_eq!(result.keys.len(), result.lines.len());
+        assert!(result.keys[1].ends_with("\"Place order\""));
+        assert!(result.lines[1].ends_with("[ref=e2]"));
+    }
+
+    #[test]
+    fn ref_names_continue_across_snapshots() {
+        let nodes = vec![node("1", "RootWebArea", "App", &[], Some(10))];
+        let counter = AtomicU64::new(0);
+        let first = serialize(&nodes, 100, &counter);
+        let second = serialize(&nodes, 100, &counter);
+        assert!(first.refs.contains_key("e1"));
+        assert!(second.refs.contains_key("e2"));
+        assert!(!second.refs.contains_key("e1"));
     }
 
     #[test]
@@ -165,7 +237,7 @@ mod tests {
             node("2", "generic", "", &["3"], Some(20)),
             node("3", "link", "Docs", &[], Some(21)),
         ];
-        let result = serialize(&nodes, 100);
+        let result = serialize(&nodes, 100, &AtomicU64::new(0));
         assert!(result.tree.contains("- link \"Docs\""));
         // link is nested under the root, not under the skipped generic
         assert!(result.tree.contains("\n  - link"));
@@ -183,8 +255,27 @@ mod tests {
                 Some(i),
             ));
         }
-        let result = serialize(&nodes, 2);
+        let result = serialize(&nodes, 2, &AtomicU64::new(0));
         assert!(result.truncated);
         assert!(result.tree.contains("[snapshot truncated"));
+    }
+
+    #[test]
+    fn diff_reports_added_removed_unchanged() {
+        let previous = vec!["- a".to_string(), "- b".to_string(), "- b".to_string()];
+        let current = vec!["- a".to_string(), "- b".to_string(), "- c".to_string()];
+        let diff = diff_keys(&previous, &current);
+        assert_eq!(diff.added, vec![2]);
+        assert_eq!(diff.removed, vec!["- b".to_string()]);
+        assert_eq!(diff.unchanged, 2);
+    }
+
+    #[test]
+    fn diff_of_identical_snapshots_is_empty() {
+        let keys = vec!["- a".to_string(), "- b".to_string()];
+        let diff = diff_keys(&keys, &keys);
+        assert!(diff.added.is_empty());
+        assert!(diff.removed.is_empty());
+        assert_eq!(diff.unchanged, 2);
     }
 }

--- a/browser/tests/golden/schemas/browser.doctor.json
+++ b/browser/tests/golden/schemas/browser.doctor.json
@@ -1,0 +1,83 @@
+{
+  "description": "Read-only environment diagnostics: which Chromium the worker would launch, its version, session capacity, and any degraded capability with how to enable it. Never starts a browser.",
+  "function_id": "browser::doctor",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "DoctorInput",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+      "DoctorIssue": {
+        "description": "One degraded capability plus the way to enable it.",
+        "properties": {
+          "enable_how": {
+            "type": "string"
+          },
+          "what": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "enable_how",
+          "what"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "active_sessions": {
+        "format": "uint64",
+        "minimum": 0.0,
+        "type": "integer"
+      },
+      "allowed_schemes": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "chromium_path": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "chromium_version": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "headless_default": {
+        "type": "boolean"
+      },
+      "issues": {
+        "items": {
+          "$ref": "#/definitions/DoctorIssue"
+        },
+        "type": "array"
+      },
+      "max_sessions": {
+        "format": "uint64",
+        "minimum": 0.0,
+        "type": "integer"
+      },
+      "ok": {
+        "description": "True when sessions can start right now.",
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "active_sessions",
+      "allowed_schemes",
+      "headless_default",
+      "issues",
+      "max_sessions",
+      "ok"
+    ],
+    "title": "DoctorOutput",
+    "type": "object"
+  }
+}

--- a/browser/tests/golden/schemas/browser.execute.json
+++ b/browser/tests/golden/schemas/browser.execute.json
@@ -1,0 +1,67 @@
+{
+  "description": "Run a multi-step async JavaScript script in the page: top-level await and return work, with log(...), sleep(ms), waitFor(selector), and a state object that persists across execute calls for the session. One call replaces a chain of act/evaluate round-trips; returns { result, logs, state }.",
+  "function_id": "browser::execute",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "code": {
+        "description": "Async JavaScript body run in the page. Top-level `await` and `return` work. In scope: `state` (JSON object persisted across execute calls for the session), `log(...)` (collected into the response), `sleep(ms)`, and `waitFor(selector, { timeout })`. Return plain JSON.",
+        "type": "string"
+      },
+      "session_id": {
+        "type": "string"
+      },
+      "timeout_ms": {
+        "default": null,
+        "description": "Upper bound on the run; clamped to `max_timeout_ms`.",
+        "format": "uint64",
+        "minimum": 0.0,
+        "type": [
+          "integer",
+          "null"
+        ]
+      }
+    },
+    "required": [
+      "code",
+      "session_id"
+    ],
+    "title": "ExecuteInput",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "error": {
+        "description": "Exception text when not `ok`. A \"context destroyed\" error usually means the script navigated; split the script at the navigation.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "logs": {
+        "description": "`log(...)` output collected during the run, in order.",
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "result": {
+        "description": "The script's return value when `ok`."
+      },
+      "state": {
+        "description": "Session state after the run; the next execute call sees this as `state`."
+      }
+    },
+    "required": [
+      "logs",
+      "ok",
+      "state"
+    ],
+    "title": "ExecuteOutput",
+    "type": "object"
+  }
+}

--- a/browser/tests/golden/schemas/browser.sessions.list.json
+++ b/browser/tests/golden/schemas/browser.sessions.list.json
@@ -27,6 +27,9 @@
             "format": "int64",
             "type": "integer"
           },
+          "read_only": {
+            "type": "boolean"
+          },
           "session_id": {
             "type": "string"
           },
@@ -45,6 +48,7 @@
           "created_ms",
           "headless",
           "last_used_ms",
+          "read_only",
           "session_id",
           "url"
         ],

--- a/browser/tests/golden/schemas/browser.sessions.start.json
+++ b/browser/tests/golden/schemas/browser.sessions.start.json
@@ -12,6 +12,14 @@
           "null"
         ]
       },
+      "read_only": {
+        "default": null,
+        "description": "Inspection-only session: act, evaluate, execute, and styles::write are rejected while navigation, snapshots, reads, and screenshots work. Immutable for the session's lifetime.",
+        "type": [
+          "boolean",
+          "null"
+        ]
+      },
       "url": {
         "default": null,
         "description": "URL to open immediately. Omit to start on about:blank.",
@@ -30,6 +38,9 @@
       "headless": {
         "type": "boolean"
       },
+      "read_only": {
+        "type": "boolean"
+      },
       "session_id": {
         "description": "Pass this to every other browser function.",
         "type": "string"
@@ -40,6 +51,7 @@
     },
     "required": [
       "headless",
+      "read_only",
       "session_id",
       "url"
     ],

--- a/browser/tests/golden/schemas/browser.snapshot.json
+++ b/browser/tests/golden/schemas/browser.snapshot.json
@@ -4,6 +4,14 @@
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {
+      "diff": {
+        "default": null,
+        "description": "Return only what changed since this session's previous snapshot instead of the full outline. Falls back to a full snapshot when there is no baseline (first snapshot, or first after a navigation).",
+        "type": [
+          "boolean",
+          "null"
+        ]
+      },
       "session_id": {
         "type": "string"
       }
@@ -16,7 +24,54 @@
   },
   "response_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+      "SnapshotDiff": {
+        "description": "Changes since the previous snapshot. Lines are compared without their `[ref=eN]` suffix (ref names are unique per snapshot); `added` lines carry current refs and are directly actionable.",
+        "properties": {
+          "added": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "removed": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "unchanged": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "added",
+          "removed",
+          "unchanged"
+        ],
+        "type": "object"
+      }
+    },
     "properties": {
+      "diff": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/SnapshotDiff"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "description": "Present when the caller asked for `diff: true` and a baseline existed."
+      },
+      "generation": {
+        "description": "Document generation the refs belong to; navigation advances it and kills every ref from earlier generations.",
+        "format": "uint64",
+        "minimum": 0.0,
+        "type": "integer"
+      },
       "title": {
         "type": [
           "string",
@@ -24,7 +79,7 @@
         ]
       },
       "tree": {
-        "description": "Indented outline; lines carry `[ref=eN]` handles for `browser::act`.",
+        "description": "Indented outline; lines carry `[ref=eN]` handles for `browser::act`. Empty when `diff` is populated.",
         "type": "string"
       },
       "truncated": {
@@ -36,6 +91,7 @@
       }
     },
     "required": [
+      "generation",
       "tree",
       "truncated",
       "url"

--- a/browser/tests/schemas.rs
+++ b/browser/tests/schemas.rs
@@ -1,4 +1,4 @@
-//! Wire-schema snapshots for the twenty-one `browser::*` functions.
+//! Wire-schema snapshots for the twenty-three `browser::*` functions.
 //!
 //! `browser::functions::catalog()` is the single source of truth for each
 //! function's id, registration description, and schemars-derived
@@ -32,7 +32,7 @@ fn spec_to_pretty_json(spec: &FunctionSpec) -> String {
     pretty
 }
 
-/// The catalog must cover exactly the twenty-one registered functions, in
+/// The catalog must cover exactly the twenty-three registered functions, in
 /// registration order (kept in lockstep with `register_all`).
 #[test]
 fn catalog_lists_all_functions_in_registration_order() {
@@ -43,11 +43,13 @@ fn catalog_lists_all_functions_in_registration_order() {
             "browser::sessions::start",
             "browser::sessions::list",
             "browser::sessions::stop",
+            "browser::doctor",
             "browser::navigate",
             "browser::snapshot",
             "browser::screenshot",
             "browser::act",
             "browser::evaluate",
+            "browser::execute",
             "browser::console::read",
             "browser::network::read",
             "browser::history",


### PR DESCRIPTION
Closes the per-action round-trip tax and adds the guardrail tier the browser worker was missing. MOT-4108 epic, first train: MOT-4109, MOT-4110, MOT-4111, MOT-4115.

## browser::execute (MOT-4109)

One call runs a full async script in the page instead of a chain of act/evaluate round-trips.

- Top-level `await` and `return`; helpers in scope: `log(...)` (collected into the response), `sleep(ms)`, `waitFor(selector, { timeout })`.
- `state`: a JSON object persisted across execute calls for the session's lifetime, stored worker-side and injected per call.
- Result envelope `{ ok, result, error, logs, state }`; 1MB cap with a "return a summary" error, and a navigation hint when the execution context is destroyed mid-script.

## Snapshot diff + fail-closed refs (MOT-4110)

- `browser::snapshot { diff: true }` returns only added/removed lines against the session's previous snapshot (multiset semantics, compared without ref suffixes). Added lines carry current refs, directly actionable. Big token saver in act/observe loops.
- Ref names are now session-monotonic: a new snapshot never reuses an older snapshot's `eN` names, so a ref from an earlier snapshot keeps resolving to the exact node it named, or fails closed as unknown. Previously each snapshot restarted numbering at `e1` and replaced the table, so a stale ref could silently resolve to a different element.
- Snapshots report the document `generation` (bumped per navigation); the unknown-ref error names it.

## Read-only sessions + doctor (MOT-4111)

- `browser::sessions::start { read_only: true }`: act, evaluate, execute, and styles::write are rejected with a typed error; navigation, snapshot, dom/styles/console/network reads, and screenshots work. Flag is immutable and visible in sessions::list.
- `browser::doctor`: read-only environment report (detected Chromium path and version, capacity, allowed schemes) with an `enable_how` string per degraded capability. Never starts a browser.

## Skill doc (MOT-4115)

SKILL.md gains the inspect-before-act workflow (snapshot first, diff in loops, execute vs act guidance) and the two-phase destructive-UI recipe (discover and return identifiers for approval, then act only on approved identifiers and verify the confirmation dialog).

## Tests

- Unit: monotonic ref naming across snapshots, diff added/removed/unchanged, execute wrapper and envelope shapes, doctor detection miss.
- Goldens regenerated for the two new functions plus the changed sessions/snapshot schemas; typed-schema gate passes (no AnyValue).
- Live e2e against a real engine and Chromium 150: execute with `waitFor` and state persisting across calls (1 then 11), diff returning exactly the injected button's lines with fresh refs, read-only session rejecting act, doctor reporting the detected install.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` green. The integration test's engine-boot race (fails identically on main with a locally installed engine, self-skips in CI) is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `browser::execute` for multi-step asynchronous scripts with logging, waiting, and persistent state.
  * Added `browser::doctor` for browser environment and capability diagnostics.
  * Added inspection-only sessions that prevent action-oriented operations.
  * Added snapshot generations and diff mode to show changes since the previous snapshot.
  * Improved reference stability across snapshots and navigation changes.

* **Documentation**
  * Expanded quickstart and workflow guidance for inspection, scripting, snapshot comparison, and destructive actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->