### PR TITLE
feat(browser): attach mode and tab adoption for a running browser (MOT-4112)

### DIFF
--- a/browser/README.md
+++ b/browser/README.md
@@ -122,6 +122,13 @@ releases it untouched on stop; `browser::tabs::list` enumerates a running
 browser's tabs. Attach reaches logged-in state, so it is off unless
 `allow_attach` is set in config, and adoption is exclusive per tab.
 
+`browser::handoff` pauses a session for a step only a human can do (CAPTCHA,
+2FA, payment): it mounts an in-page continue banner and blocks the call until
+the human clicks it, a `browser::handoff::confirm` call resolves it, or the
+timeout elapses, emitting `browser::handoff-requested` for the console to
+surface. Human acknowledgment is not proof, so the caller verifies the
+expected page state after it returns.
+
 ## Configuration
 
 Stored in the `configuration` worker under the `browser` key; every field is
@@ -159,6 +166,7 @@ bindings accept an optional `{ "session_id": "..." }` filter.
 | `browser::navigated` | The page committed a navigation | `{ session_id, url, timestamp }` |
 | `browser::console-event` | A console/log/exception entry was captured | `{ session_id, entry }` |
 | `browser::picked` | The human picked an element in inspect mode | `{ session_id, element, timestamp }` |
+| `browser::handoff-requested` | A session paused for a human step (CAPTCHA, 2FA, payment) | `{ session_id, handoff_id, instructions, timestamp }` |
 
 `browser::console-event` is high-volume; bind it with a `session_id` filter
 and treat `browser::console::read` as the durable record. `browser::picked`

--- a/browser/README.md
+++ b/browser/README.md
@@ -114,6 +114,14 @@ for inspection-only sessions where act/evaluate/execute/styles::write are
 rejected. `browser::doctor` reports the environment — detected Chromium,
 version, capacity — with an `enable_how` string for anything degraded.
 
+`browser::sessions::attach` binds a session to an already-running browser
+over CDP (start Chrome with `--remote-debugging-port`) instead of launching
+one, so it reaches the real profile with its logins and extensions. It opens
+a fresh tab the session owns, or adopts an existing tab by URL substring and
+releases it untouched on stop; `browser::tabs::list` enumerates a running
+browser's tabs. Attach reaches logged-in state, so it is off unless
+`allow_attach` is set in config, and adoption is exclusive per tab.
+
 ## Configuration
 
 Stored in the `configuration` worker under the `browser` key; every field is
@@ -136,6 +144,7 @@ browser:
   screenshot_quality: 60    # JPEG quality 1-100
   allowed_schemes: [http, https]
   max_snapshot_nodes: 2000  # a11y outline size cap
+  allow_attach: false       # true = allow sessions::attach into a running browser's real profile
 ```
 
 ## Custom trigger types

--- a/browser/skills/SKILL.md
+++ b/browser/skills/SKILL.md
@@ -41,6 +41,11 @@ on navigation; re-snapshot before acting after any page change.
 - One-shot fetching and scraping belong to `web::fetch` (plain HTTP) and the
   scrapling worker (stealth fetching and bulk extraction). Do not start a
   browser session just to read a static page once.
+- Attach mode reaches the user's real browser profile with its logged-in
+  sessions. It is disabled unless `allow_attach` is set, and adoption is
+  exclusive (one session per tab) so two sessions never fight over a tab.
+  Reach for a launched session when you do not specifically need the user's
+  existing logins.
 - `browser::styles::write` edits are visual experiments only: they die on the
   next navigation and never touch source files. Use them to find the right
   value, then edit the codebase.
@@ -54,7 +59,15 @@ on navigation; re-snapshot before acting after any page change.
   session_id every other function needs. `read_only: true` starts an
   inspection-only session.
 - `browser::sessions::list` — live sessions with their current URL.
-- `browser::sessions::stop` — stop a session; idempotent.
+- `browser::sessions::stop` — stop a session; idempotent. A launched session
+  closes its browser; an attached session closes only a tab it opened and
+  releases an adopted user tab untouched.
+- `browser::sessions::attach` — bind a session to an already-running browser
+  over CDP (start Chrome with `--remote-debugging-port`): open a fresh tab
+  the session owns, or adopt an existing logged-in tab by URL substring.
+  Off unless `allow_attach` is set in config.
+- `browser::tabs::list` — open tabs of a running browser at a CDP endpoint,
+  with which are already adopted; read-only.
 - `browser::doctor` — read-only environment report: which Chromium would
   launch, its version, capacity, and anything degraded with how to enable it.
 - `browser::navigate` — go to a URL and wait for the load.

--- a/browser/skills/SKILL.md
+++ b/browser/skills/SKILL.md
@@ -84,6 +84,12 @@ on navigation; re-snapshot before acting after any page change.
   await and return, `log(...)`, `sleep(ms)`, `waitFor(selector)`, and a
   `state` object persisted across execute calls for the session. One call
   replaces a chain of act/evaluate round-trips.
+- `browser::handoff` — pause the session for a human-only step (CAPTCHA,
+  2FA, payment): show an in-page continue banner and block until the human
+  clicks it, a `browser::handoff::confirm` call resolves it, or the timeout
+  elapses. Verify the expected page state after it returns.
+- `browser::handoff::confirm` — resolve a paused handoff from outside the
+  page (by handoff_id, or the one pending handoff for a session_id).
 - `browser::console::read` — captured console entries; filter with
   pattern/level and page with since_seq.
 - `browser::network::read` — captured requests; failed_only=true is the fast
@@ -107,6 +113,11 @@ on navigation; re-snapshot before acting after any page change.
    (in-page script clicks are not trusted events).
 4. Pure inspection tasks (audits, scraping a logged-in page you must not
    touch) belong in a `read_only: true` session.
+5. When a flow hits a step only a human can do (CAPTCHA, 2FA, payment
+   confirmation), call `browser::handoff` and wait, rather than trying to
+   automate it. After it returns confirmed, re-read the page and verify the
+   step actually landed — a human clicking Continue is not proof the step
+   succeeded.
 
 ## Workflow: destructive UI actions
 
@@ -140,9 +151,11 @@ fill the context window and force a compaction. Read economically:
 Bind a `browser::*` trigger when another function should react to session
 activity as it happens instead of polling the read functions. The types:
 `browser::session-started`, `browser::session-stopped`, `browser::navigated`,
-`browser::console-event` (one captured entry per firing; high volume), and
+`browser::console-event` (one captured entry per firing; high volume),
 `browser::picked` (a human picked an element in the console UI; the payload
-carries a ref that `browser::act` accepts directly).
+carries a ref that `browser::act` accepts directly), and
+`browser::handoff-requested` (a session is paused waiting for a human; the
+console surfaces it beside the live viewport).
 
 If you just ran `browser::navigate` yourself, its return value already tells
 you the outcome; bind triggers when a different worker needs to observe

--- a/browser/src/config.rs
+++ b/browser/src/config.rs
@@ -50,6 +50,10 @@ pub struct WorkerConfig {
     pub allowed_schemes: Vec<String>,
     /// Maximum nodes serialized by `browser::snapshot` before truncation.
     pub max_snapshot_nodes: u64,
+    /// Allow `browser::sessions::attach` to connect to an already-running
+    /// browser and adopt its tabs. Off by default: attaching reaches the
+    /// user's real profile with its logged-in sessions, so it is opt-in.
+    pub allow_attach: bool,
 }
 
 impl Default for WorkerConfig {
@@ -69,6 +73,7 @@ impl Default for WorkerConfig {
             screenshot_quality: 60,
             allowed_schemes: vec!["http".to_string(), "https".to_string()],
             max_snapshot_nodes: 2_000,
+            allow_attach: false,
         }
     }
 }
@@ -125,6 +130,7 @@ mod tests {
         assert_eq!(c.screenshot_quality, 60);
         assert_eq!(c.allowed_schemes, vec!["http", "https"]);
         assert_eq!(c.max_snapshot_nodes, 2_000);
+        assert!(!c.allow_attach);
     }
 
     #[test]

--- a/browser/src/events.rs
+++ b/browser/src/events.rs
@@ -1,4 +1,4 @@
-//! The five custom trigger types this worker emits, and the fan-out behind
+//! The custom trigger types this worker emits, and the fan-out behind
 //! them. Consumers bind handlers with the standard two-step pattern; the
 //! engine routes each registration to our [`TriggerHandler`]. Delivery is
 //! fire-and-forget (`TriggerAction::Void`) and at-least-once; per-binding
@@ -23,6 +23,7 @@ pub const NAVIGATED: &str = "browser::navigated";
 pub const CONSOLE_EVENT: &str = "browser::console-event";
 pub const NETWORK_EVENT: &str = "browser::network-event";
 pub const PICKED: &str = "browser::picked";
+pub const HANDOFF_REQUESTED: &str = "browser::handoff-requested";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum EventKind {
@@ -32,6 +33,7 @@ pub enum EventKind {
     ConsoleEvent,
     NetworkEvent,
     Picked,
+    HandoffRequested,
 }
 
 impl EventKind {
@@ -43,10 +45,11 @@ impl EventKind {
             EventKind::ConsoleEvent => CONSOLE_EVENT,
             EventKind::NetworkEvent => NETWORK_EVENT,
             EventKind::Picked => PICKED,
+            EventKind::HandoffRequested => HANDOFF_REQUESTED,
         }
     }
 
-    pub fn all() -> [EventKind; 6] {
+    pub fn all() -> [EventKind; 7] {
         [
             EventKind::SessionStarted,
             EventKind::SessionStopped,
@@ -54,6 +57,7 @@ impl EventKind {
             EventKind::ConsoleEvent,
             EventKind::NetworkEvent,
             EventKind::Picked,
+            EventKind::HandoffRequested,
         ]
     }
 }
@@ -133,6 +137,19 @@ pub struct NetworkEventPayload {
 pub struct PickedEvent {
     pub session_id: String,
     pub element: PickedElement,
+    pub timestamp: i64,
+}
+
+/// `browser::handoff-requested` — a session is paused waiting for a human to
+/// complete a step (CAPTCHA, 2FA, payment). The console surfaces this beside
+/// the live viewport; resolve it with `browser::handoff::confirm` (or the
+/// human clicks the in-page continue control).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct HandoffRequestedEvent {
+    pub session_id: String,
+    pub handoff_id: String,
+    /// What the human must do before the paused call continues.
+    pub instructions: String,
     pub timestamp: i64,
 }
 
@@ -224,7 +241,7 @@ impl SubscriberSet {
     }
 }
 
-/// The five subscriber sets, one per trigger type.
+/// The subscriber sets, one per trigger type.
 #[derive(Clone)]
 pub struct TriggerSets {
     inner: HashMap<&'static str, SubscriberSet>,
@@ -273,11 +290,11 @@ impl TriggerHandler for BrowserTriggerHandler {
     }
 }
 
-/// Register the six custom trigger types with the engine. Must run before
+/// Register the custom trigger types with the engine. Must run before
 /// `functions::register_all` so handlers can capture the subscriber sets.
 pub fn register_trigger_types(iii: &Arc<IIIClient>) -> TriggerSets {
     let sets = TriggerSets::new();
-    let descriptions: [(EventKind, &str); 6] = [
+    let descriptions: [(EventKind, &str); 7] = [
         (
             EventKind::SessionStarted,
             "A Chromium session is up and ready.",
@@ -301,6 +318,10 @@ pub fn register_trigger_types(iii: &Arc<IIIClient>) -> TriggerSets {
         (
             EventKind::Picked,
             "The human picked an element in inspect mode.",
+        ),
+        (
+            EventKind::HandoffRequested,
+            "A session is paused waiting for a human to complete a step (CAPTCHA, 2FA, payment).",
         ),
     ];
     for (kind, description) in descriptions {

--- a/browser/src/functions/attach.rs
+++ b/browser/src/functions/attach.rs
@@ -1,0 +1,50 @@
+//! `browser::sessions::attach` and `browser::tabs::list` — drive an
+//! already-running browser over CDP instead of launching a fresh one, so a
+//! session reaches the user's real profile with its logins and extensions.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::session::TabInfo;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AttachInput {
+    /// CDP endpoint of the running browser: `http://127.0.0.1:9222` (the
+    /// worker resolves the WebSocket URL from `/json/version`) or a
+    /// `ws://` debugger URL directly. Start Chrome with
+    /// `--remote-debugging-port=9222` to expose one.
+    pub cdp_url: String,
+    /// Adopt the existing tab whose URL contains this substring, exclusively,
+    /// and release it untouched on stop. Omit to open a fresh tab the
+    /// session owns and closes on stop. Must match exactly one open tab.
+    #[serde(default)]
+    pub adopt_url_substring: Option<String>,
+    /// URL to open in the fresh tab (ignored when adopting). Omit for
+    /// about:blank.
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Inspection-only session; see browser::sessions::start.
+    #[serde(default)]
+    pub read_only: Option<bool>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct AttachOutput {
+    pub session_id: String,
+    pub url: String,
+    pub read_only: bool,
+    /// True when the session adopted an existing user tab (released, not
+    /// closed, on stop); false when it opened a fresh tab it owns.
+    pub adopted: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct TabsListInput {
+    /// CDP endpoint of the running browser, as in browser::sessions::attach.
+    pub cdp_url: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct TabsListOutput {
+    pub tabs: Vec<TabInfo>,
+}

--- a/browser/src/functions/execute.rs
+++ b/browser/src/functions/execute.rs
@@ -46,7 +46,7 @@ pub struct ExecuteOutput {
 pub fn wrap_code(code: &str, state_json: &str) -> String {
     format!(
         r#"(async () => {{
-  const state = {state_json};
+  let state = {state_json};
   const logs = [];
   const log = (...args) => {{
     if (logs.length >= 200) return;
@@ -66,19 +66,34 @@ pub fn wrap_code(code: &str, state_json: &str) -> String {
     }}
     throw new Error('waitFor timed out after ' + timeout + 'ms: ' + selector);
   }};
+  // Serialize the envelope, never throwing: a circular or otherwise
+  // non-serializable state or result must not turn into a missing envelope.
+  // On failure, keep the logs and the error, drop `state` to null, and keep
+  // the result only if it serializes on its own.
+  const serialize = (ok, result, error) => {{
+    try {{
+      return JSON.stringify({{ ok, result, error, logs, state }});
+    }} catch (e) {{
+      let safeResult = null;
+      try {{ JSON.stringify(result); safeResult = result; }} catch (_) {{}}
+      return JSON.stringify({{
+        ok: false,
+        result: safeResult,
+        error: (error ? error + '; ' : '') + 'value not JSON-serializable: ' + String(e),
+        logs,
+        state: null,
+      }});
+    }}
+  }};
   let result;
   try {{
     result = await (async () => {{
 {code}
     }})();
   }} catch (e) {{
-    return JSON.stringify({{ ok: false, error: String((e && e.stack) || e), logs, state }});
+    return serialize(false, undefined, String((e && e.stack) || e));
   }}
-  try {{
-    return JSON.stringify({{ ok: true, result, logs, state }});
-  }} catch (e) {{
-    return JSON.stringify({{ ok: false, error: 'result is not JSON-serializable: ' + String(e), logs, state }});
-  }}
+  return serialize(true, result, undefined);
 }})()"#
     )
 }
@@ -104,7 +119,8 @@ mod tests {
     #[test]
     fn wrapped_code_embeds_state_and_body() {
         let wrapped = wrap_code("return state.n;", "{\"n\":7}");
-        assert!(wrapped.contains("const state = {\"n\":7};"));
+        // `let` (not `const`) so user code may reassign `state = ...`.
+        assert!(wrapped.contains("let state = {\"n\":7};"));
         assert!(wrapped.contains("return state.n;"));
         assert!(wrapped.starts_with("(async () => {"));
     }

--- a/browser/src/functions/handoff.rs
+++ b/browser/src/functions/handoff.rs
@@ -1,0 +1,119 @@
+//! `browser::handoff` and `browser::handoff::confirm` — pause a session for
+//! a step only a human can do (CAPTCHA, 2FA, payment). The handoff call
+//! parks until a human confirms in-page or a confirm call resolves it, or
+//! the timeout elapses.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Poll interval for the in-page continue control while parked.
+pub const POLL_INTERVAL_MS: u64 = 250;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct HandoffInput {
+    pub session_id: String,
+    /// What the human must do before the call continues. Shown in the
+    /// in-page banner and the handoff-requested event.
+    pub instructions: String,
+    /// Give up after this long and return timed_out. Defaults to the config
+    /// default; clamped to `max_timeout_ms`. Set generously; a human is slow.
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct HandoffOutput {
+    /// True when a human confirmed; false when the wait timed out.
+    pub confirmed: bool,
+    pub handoff_id: String,
+    /// How the confirmation arrived: `in_page`, `confirm_call`, or `timeout`.
+    pub via: String,
+    /// The page URL when the wait ended, so the caller can verify the step
+    /// actually landed (human acknowledgment is not proof).
+    pub url: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct HandoffConfirmInput {
+    /// Confirm a specific handoff by id. Omit to confirm the one pending
+    /// handoff for `session_id`.
+    #[serde(default)]
+    pub handoff_id: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct HandoffConfirmOutput {
+    /// True when a pending handoff matched and was resolved.
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub handoff_id: Option<String>,
+}
+
+/// JS that mounts the in-page continue banner and exposes a global flag the
+/// worker polls. Idempotent per handoff id. `{:?}` renders both the id and
+/// the instructions as valid double-quoted JS string literals, so no manual
+/// escaping is needed and injection through the text is not possible.
+pub fn banner_script(handoff_id: &str, instructions: &str) -> String {
+    format!(
+        r#"(() => {{
+  window.__iiiHandoff = window.__iiiHandoff || {{}};
+  const id = {handoff_id:?};
+  if (document.getElementById('iii-handoff-' + id)) return;
+  const bar = document.createElement('div');
+  bar.id = 'iii-handoff-' + id;
+  bar.setAttribute('role', 'dialog');
+  bar.setAttribute('aria-label', 'Action needed');
+  bar.style.cssText = 'position:fixed;top:0;left:0;right:0;z-index:2147483647;'
+    + 'background:#1f2937;color:#f9fafb;font:14px system-ui,sans-serif;'
+    + 'padding:12px 16px;display:flex;gap:12px;align-items:center;'
+    + 'box-shadow:0 2px 8px rgba(0,0,0,.3)';
+  const msg = document.createElement('span');
+  msg.style.flex = '1';
+  msg.textContent = 'Action needed: ' + {instructions:?};
+  const btn = document.createElement('button');
+  btn.textContent = 'Continue';
+  btn.style.cssText = 'background:#10b981;color:#04231a;border:0;border-radius:6px;'
+    + 'padding:8px 16px;font-weight:600;cursor:pointer';
+  btn.addEventListener('click', () => {{ window.__iiiHandoff[id] = true; bar.remove(); }});
+  bar.appendChild(msg);
+  bar.appendChild(btn);
+  document.body.appendChild(bar);
+}})()"#
+    )
+}
+
+/// JS that reads and clears the confirm flag for a handoff id.
+pub fn poll_script(handoff_id: &str) -> String {
+    format!(
+        "(() => {{ const f = window.__iiiHandoff && window.__iiiHandoff[{handoff_id:?}]; return !!f; }})()"
+    )
+}
+
+/// JS that removes the banner for a handoff id (on confirm-call or timeout).
+pub fn remove_script(handoff_id: &str) -> String {
+    format!(
+        "(() => {{ const el = document.getElementById('iii-handoff-' + {handoff_id:?}); if (el) el.remove(); return true; }})()"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn banner_renders_instructions_as_a_quoted_literal() {
+        let js = banner_script("h1", "click \"here\" now");
+        // {:?} escapes the embedded quotes so the JS literal stays valid.
+        assert!(js.contains(r#"\"here\""#), "{js}");
+        assert!(js.contains("iii-handoff-"));
+        assert!(js.contains("__iiiHandoff[id] = true"));
+    }
+
+    #[test]
+    fn poll_and_remove_reference_the_id() {
+        assert!(poll_script("h7").contains("\"h7\""));
+        assert!(remove_script("h7").contains("\"h7\""));
+    }
+}

--- a/browser/src/functions/handoff.rs
+++ b/browser/src/functions/handoff.rs
@@ -15,8 +15,9 @@ pub struct HandoffInput {
     /// What the human must do before the call continues. Shown in the
     /// in-page banner and the handoff-requested event.
     pub instructions: String,
-    /// Give up after this long and return timed_out. Defaults to the config
-    /// default; clamped to `max_timeout_ms`. Set generously; a human is slow.
+    /// Give up after this long and return with `via: "timeout"`. Defaults to
+    /// the config default; clamped to `max_timeout_ms`. Set generously; a
+    /// human is slow.
     #[serde(default)]
     pub timeout_ms: Option<u64>,
 }
@@ -79,7 +80,7 @@ pub fn banner_script(handoff_id: &str, instructions: &str) -> String {
   btn.addEventListener('click', () => {{ window.__iiiHandoff[id] = true; bar.remove(); }});
   bar.appendChild(msg);
   bar.appendChild(btn);
-  document.body.appendChild(bar);
+  (document.body || document.documentElement).appendChild(bar);
 }})()"#
     )
 }

--- a/browser/src/functions/mod.rs
+++ b/browser/src/functions/mod.rs
@@ -10,6 +10,7 @@ pub mod dom;
 pub mod evaluate;
 pub mod execute;
 pub mod frame;
+pub mod handoff;
 pub mod hint;
 pub mod history;
 pub mod navigate;
@@ -39,7 +40,7 @@ use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::json;
 use tokio::time::timeout;
 
-use crate::events::{EventKind, SessionStartedEvent};
+use crate::events::{EventKind, HandoffRequestedEvent, SessionStartedEvent};
 use crate::session::{now_ms, Session, Sessions};
 
 pub const SESSIONS_START_ID: &str = "browser::sessions::start";
@@ -97,6 +98,16 @@ pub const DOCTOR_DESC: &str =
     "Read-only environment diagnostics: which Chromium the worker would launch, its version, \
      session capacity, and any degraded capability with how to enable it. Never starts a \
      browser.";
+pub const HANDOFF_ID: &str = "browser::handoff";
+pub const HANDOFF_DESC: &str =
+    "Pause a session for a step only a human can do (CAPTCHA, 2FA, payment): show an in-page \
+     continue banner and block until the human clicks it, a browser::handoff::confirm call \
+     resolves it, or the timeout elapses. Human acknowledgment is not proof — verify the \
+     expected page state after it returns.";
+pub const HANDOFF_CONFIRM_ID: &str = "browser::handoff::confirm";
+pub const HANDOFF_CONFIRM_DESC: &str =
+    "Resolve a paused browser::handoff by handoff_id, or the one pending handoff for a \
+     session_id. The console calls this when the human confirms outside the page.";
 pub const CONSOLE_READ_ID: &str = "browser::console::read";
 pub const CONSOLE_READ_DESC: &str =
     "Read the session's captured console: console.* calls, uncaught exceptions, and \
@@ -193,6 +204,11 @@ pub fn catalog() -> Vec<FunctionSpec> {
         spec::<act::ActInput, act::ActOutput>(ACT_ID, ACT_DESC),
         spec::<evaluate::EvaluateInput, evaluate::EvaluateOutput>(EVALUATE_ID, EVALUATE_DESC),
         spec::<execute::ExecuteInput, execute::ExecuteOutput>(EXECUTE_ID, EXECUTE_DESC),
+        spec::<handoff::HandoffInput, handoff::HandoffOutput>(HANDOFF_ID, HANDOFF_DESC),
+        spec::<handoff::HandoffConfirmInput, handoff::HandoffConfirmOutput>(
+            HANDOFF_CONFIRM_ID,
+            HANDOFF_CONFIRM_DESC,
+        ),
         spec::<console::ConsoleReadInput, console::ConsoleReadOutput>(
             CONSOLE_READ_ID,
             CONSOLE_READ_DESC,
@@ -237,6 +253,8 @@ pub fn register_all(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
     register_act(iii, sessions);
     register_evaluate(iii, sessions);
     register_execute(iii, sessions);
+    register_handoff(iii, sessions);
+    register_handoff_confirm(iii, sessions);
     register_console_read(iii, sessions);
     register_network_read(iii, sessions);
     register_history(iii, sessions);
@@ -1003,6 +1021,102 @@ fn register_execute(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
             }
         })
         .description(EXECUTE_DESC),
+    );
+}
+
+fn register_handoff(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
+    let sx = sessions.clone();
+    iii.register_function(
+        HANDOFF_ID,
+        RegisterFunction::new_async(move |req: handoff::HandoffInput| {
+            let sx = sx.clone();
+            async move {
+                let session = get_session(&sx, &req.session_id)?;
+                session.touch();
+                let cfg = sx.config.load_full();
+                let wait = Duration::from_millis(cfg.clamp_timeout(req.timeout_ms));
+
+                let (handoff_id, mut confirm_rx) = sx.register_handoff(&req.session_id);
+                // Mount the in-page continue banner carrying the poll flag.
+                // Best-effort: on a page that rejects injection the
+                // confirm-call path still resolves the same handoff.
+                let _ = session
+                    .page
+                    .evaluate(handoff::banner_script(&handoff_id, &req.instructions))
+                    .await;
+
+                sx.emitter
+                    .emit(
+                        EventKind::HandoffRequested,
+                        &req.session_id,
+                        &HandoffRequestedEvent {
+                            session_id: req.session_id.clone(),
+                            handoff_id: handoff_id.clone(),
+                            instructions: req.instructions.clone(),
+                            timestamp: now_ms(),
+                        },
+                    )
+                    .await;
+
+                // Park until: a confirm call fires the oneshot, the human
+                // clicks the in-page control (polled), or the timeout fires.
+                let poll = handoff::poll_script(&handoff_id);
+                let deadline = tokio::time::Instant::now() + wait;
+                let via = loop {
+                    let tick = tokio::time::sleep(Duration::from_millis(handoff::POLL_INTERVAL_MS));
+                    tokio::select! {
+                        // Ok = a confirm call fired the sender; Err = the
+                        // sender was dropped (session stopped mid-handoff).
+                        res = &mut confirm_rx => break if res.is_ok() { "confirm_call" } else { "cancelled" },
+                        _ = tokio::time::sleep_until(deadline) => break "timeout",
+                        _ = tick => {
+                            if let Ok(v) = session.page.evaluate(poll.clone()).await {
+                                if v.value().and_then(|x| x.as_bool()).unwrap_or(false) {
+                                    break "in_page";
+                                }
+                            }
+                        }
+                    }
+                };
+
+                sx.drop_handoff(&handoff_id);
+                let _ = session
+                    .page
+                    .evaluate(handoff::remove_script(&handoff_id))
+                    .await;
+                session.touch();
+                let url = session.page.url().await.ok().flatten().unwrap_or_default();
+                Ok::<_, Error>(handoff::HandoffOutput {
+                    confirmed: via == "confirm_call" || via == "in_page",
+                    handoff_id,
+                    via: via.to_string(),
+                    url,
+                })
+            }
+        })
+        .description(HANDOFF_DESC),
+    );
+}
+
+fn register_handoff_confirm(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
+    let sx = sessions.clone();
+    iii.register_function(
+        HANDOFF_CONFIRM_ID,
+        RegisterFunction::new_async(move |req: handoff::HandoffConfirmInput| {
+            let sx = sx.clone();
+            async move {
+                if req.handoff_id.is_none() && req.session_id.is_none() {
+                    return Err(handler_err("pass handoff_id or session_id"));
+                }
+                let resolved =
+                    sx.confirm_handoff(req.handoff_id.as_deref(), req.session_id.as_deref());
+                Ok::<_, Error>(handoff::HandoffConfirmOutput {
+                    ok: resolved.is_some(),
+                    handoff_id: resolved,
+                })
+            }
+        })
+        .description(HANDOFF_CONFIRM_DESC),
     );
 }
 

--- a/browser/src/functions/mod.rs
+++ b/browser/src/functions/mod.rs
@@ -3,6 +3,7 @@
 //! registration lives here so `register_all` reads as the product surface.
 
 pub mod act;
+pub mod attach;
 pub mod console;
 pub mod doctor;
 pub mod dom;
@@ -52,6 +53,17 @@ pub const SESSIONS_STOP_ID: &str = "browser::sessions::stop";
 pub const SESSIONS_STOP_DESC: &str =
     "Stop a browser session and its Chromium process. Idempotent: stopping an unknown or \
      already-stopped session succeeds with was_running=false.";
+pub const SESSIONS_ATTACH_ID: &str = "browser::sessions::attach";
+pub const SESSIONS_ATTACH_DESC: &str =
+    "Attach a session to an already-running browser over CDP (start Chrome with \
+     --remote-debugging-port). Opens a fresh tab the session owns, or adopts an existing user \
+     tab by URL substring and releases it untouched on stop. Reaches the real profile with its \
+     logins; disabled unless allow_attach is set in config.";
+pub const TABS_LIST_ID: &str = "browser::tabs::list";
+pub const TABS_LIST_DESC: &str =
+    "List the open tabs of a running browser reachable at a CDP endpoint (url, title, and \
+     whether a session already adopted each). Read-only; adopt one with \
+     browser::sessions::attach.";
 pub const NAVIGATE_ID: &str = "browser::navigate";
 pub const NAVIGATE_DESC: &str =
     "Navigate a session to a URL and wait for the page to load. Element refs from earlier \
@@ -169,6 +181,8 @@ pub fn catalog() -> Vec<FunctionSpec> {
         spec::<sessions::StartInput, sessions::StartOutput>(SESSIONS_START_ID, SESSIONS_START_DESC),
         spec::<sessions::ListInput, sessions::ListOutput>(SESSIONS_LIST_ID, SESSIONS_LIST_DESC),
         spec::<sessions::StopInput, sessions::StopOutput>(SESSIONS_STOP_ID, SESSIONS_STOP_DESC),
+        spec::<attach::AttachInput, attach::AttachOutput>(SESSIONS_ATTACH_ID, SESSIONS_ATTACH_DESC),
+        spec::<attach::TabsListInput, attach::TabsListOutput>(TABS_LIST_ID, TABS_LIST_DESC),
         spec::<doctor::DoctorInput, doctor::DoctorOutput>(DOCTOR_ID, DOCTOR_DESC),
         spec::<navigate::NavigateInput, navigate::NavigateOutput>(NAVIGATE_ID, NAVIGATE_DESC),
         spec::<snapshot::SnapshotInput, snapshot::SnapshotOutput>(SNAPSHOT_ID, SNAPSHOT_DESC),
@@ -214,6 +228,8 @@ pub fn register_all(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
     register_sessions_start(iii, sessions);
     register_sessions_list(iii, sessions);
     register_sessions_stop(iii, sessions);
+    register_sessions_attach(iii, sessions);
+    register_tabs_list(iii, sessions);
     register_doctor(iii, sessions);
     register_navigate(iii, sessions);
     register_snapshot(iii, sessions);
@@ -363,6 +379,89 @@ fn register_sessions_stop(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
             }
         })
         .description(SESSIONS_STOP_DESC),
+    );
+}
+
+fn register_sessions_attach(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
+    let sx = sessions.clone();
+    iii.register_function(
+        SESSIONS_ATTACH_ID,
+        RegisterFunction::new_async(move |req: attach::AttachInput| {
+            let sx = sx.clone();
+            async move {
+                let cfg = sx.config.load_full();
+                if !cfg.allow_attach {
+                    return Err(handler_err(
+                        "attach mode is disabled; set `allow_attach: true` in the browser worker \
+                         config to connect to a running browser. It reaches the real profile with \
+                         its logins, so it is opt-in.",
+                    ));
+                }
+                if let Some(url) = &req.url {
+                    sessions::check_scheme(&cfg, url).map_err(handler_err)?;
+                }
+                let session = sx
+                    .attach(
+                        req.cdp_url,
+                        req.url,
+                        req.adopt_url_substring,
+                        req.read_only.unwrap_or(false),
+                    )
+                    .await
+                    .map_err(handler_err)?;
+                let adopted = matches!(
+                    session.kind,
+                    crate::session::SessionKind::Attached { owns_page: false }
+                );
+                let url = session
+                    .page
+                    .url()
+                    .await
+                    .ok()
+                    .flatten()
+                    .unwrap_or_else(|| "about:blank".to_string());
+                sx.emitter
+                    .emit(
+                        EventKind::SessionStarted,
+                        &session.id,
+                        &SessionStartedEvent {
+                            session_id: session.id.clone(),
+                            url: url.clone(),
+                            headless: session.headless,
+                            timestamp: now_ms(),
+                        },
+                    )
+                    .await;
+                Ok::<_, Error>(attach::AttachOutput {
+                    session_id: session.id.clone(),
+                    url,
+                    read_only: session.read_only,
+                    adopted,
+                })
+            }
+        })
+        .description(SESSIONS_ATTACH_DESC),
+    );
+}
+
+fn register_tabs_list(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
+    let sx = sessions.clone();
+    iii.register_function(
+        TABS_LIST_ID,
+        RegisterFunction::new_async(move |req: attach::TabsListInput| {
+            let sx = sx.clone();
+            async move {
+                if !sx.config.load().allow_attach {
+                    return Err(handler_err(
+                        "attach mode is disabled; set `allow_attach: true` in the browser worker \
+                         config to inspect a running browser's tabs.",
+                    ));
+                }
+                let tabs = sx.list_tabs(&req.cdp_url).await.map_err(handler_err)?;
+                Ok::<_, Error>(attach::TabsListOutput { tabs })
+            }
+        })
+        .description(TABS_LIST_DESC),
     );
 }
 

--- a/browser/src/session.rs
+++ b/browser/src/session.rs
@@ -703,10 +703,21 @@ impl Sessions {
         match candidates.len() {
             1 => {
                 let (page, target) = candidates.into_iter().next().expect("one candidate");
-                self.adopted_targets
+                // Authoritative claim: test-and-set under one lock so two
+                // concurrent attaches cannot both adopt the same tab. The
+                // per-page `taken` filter above only narrows the candidate
+                // set; this is what actually guarantees exclusivity.
+                let mut adopted = self
+                    .adopted_targets
                     .lock()
-                    .unwrap_or_else(|p| p.into_inner())
-                    .insert(target);
+                    .unwrap_or_else(|p| p.into_inner());
+                if adopted.contains(&target) {
+                    return Err(format!(
+                        "no adoptable tab matches '{needle}' (open tabs: {})",
+                        urls.join(", ")
+                    ));
+                }
+                adopted.insert(target);
                 Ok(page)
             }
             0 => Err(format!(

--- a/browser/src/session.rs
+++ b/browser/src/session.rs
@@ -86,6 +86,17 @@ pub struct ConsoleEntry {
     pub source: Option<String>,
 }
 
+/// One open tab reported by `browser::tabs::list`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TabInfo {
+    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// True when a session already adopted this tab; it cannot be adopted
+    /// again until that session stops.
+    pub adopted: bool,
+}
+
 /// One captured network request.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct NetworkEntry {
@@ -197,9 +208,23 @@ impl LatestFrame {
 /// the fail-closed unknown-ref error, never to a wrong element.
 const MAX_REFS: usize = 20_000;
 
+/// How a session came to hold its browser, which decides what shutdown may
+/// destroy. A launched session owns its Chromium process outright. An
+/// attached session holds a CDP connection into the user's own running
+/// browser: shutdown closes at most the one tab the session created
+/// (`owns_page`), and an adopted user tab is always released untouched. The
+/// browser process itself is never closed or killed in attached mode.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SessionKind {
+    Launched,
+    Attached { owns_page: bool },
+}
+
 pub struct Session {
     pub id: String,
     pub headless: bool,
+    /// Ownership model deciding what shutdown may destroy; see `SessionKind`.
+    pub kind: SessionKind,
     /// Inspection-only session: interaction functions are rejected while
     /// navigation and reads stay available. Immutable for the session's
     /// lifetime.
@@ -335,9 +360,13 @@ impl Session {
         errors
     }
 
-    /// Close the page + Chromium process and abort the event pumps.
-    /// Idempotent at the caller level: `Sessions::stop` removes the session
-    /// from the map first, so a second stop never reaches here.
+    /// Tear down what this session owns and abort the event pumps.
+    /// Launched: close (or kill) the whole Chromium process and remove the
+    /// ephemeral profile. Attached: close only a tab the session itself
+    /// created; an adopted user tab is released untouched, and the user's
+    /// browser process is never closed. Idempotent at the caller level:
+    /// `Sessions::stop` removes the session from the map first, so a second
+    /// stop never reaches here.
     pub async fn shutdown(&self) {
         for task in self
             .tasks
@@ -347,15 +376,26 @@ impl Session {
         {
             task.abort();
         }
-        let mut browser = self.browser.lock().await;
-        if browser.close().await.is_err() {
-            if let Some(Err(e)) = browser.kill().await {
-                tracing::warn!(session_id = %self.id, error = %e, "browser kill failed");
+        match self.kind {
+            SessionKind::Launched => {
+                let mut browser = self.browser.lock().await;
+                if browser.close().await.is_err() {
+                    if let Some(Err(e)) = browser.kill().await {
+                        tracing::warn!(session_id = %self.id, error = %e, "browser kill failed");
+                    }
+                }
+                let _ = browser.wait().await;
+                if let Some(dir) = &self.ephemeral_profile {
+                    let _ = std::fs::remove_dir_all(dir);
+                }
             }
-        }
-        let _ = browser.wait().await;
-        if let Some(dir) = &self.ephemeral_profile {
-            let _ = std::fs::remove_dir_all(dir);
+            SessionKind::Attached { owns_page } => {
+                if owns_page {
+                    if let Err(e) = self.page.clone().close().await {
+                        tracing::debug!(session_id = %self.id, error = %e, "tab close failed");
+                    }
+                }
+            }
         }
     }
 }
@@ -364,6 +404,10 @@ impl Session {
 pub struct Sessions {
     map: Mutex<HashMap<String, Arc<Session>>>,
     counter: AtomicU64,
+    /// Target ids of user tabs currently adopted by a session. Adoption is
+    /// exclusive: a tab in this set cannot be adopted again until its
+    /// session stops.
+    adopted_targets: Mutex<std::collections::HashSet<String>>,
     pub config: SharedConfig,
     pub emitter: Arc<Emitter>,
     /// For pushing screencast frames onto the `browser:frames` stream, which
@@ -380,6 +424,7 @@ impl Sessions {
         Arc::new(Self {
             map: Mutex::new(HashMap::new()),
             counter: AtomicU64::new(0),
+            adopted_targets: Mutex::new(std::collections::HashSet::new()),
             config,
             emitter,
             iii,
@@ -461,6 +506,7 @@ impl Sessions {
         let session = Arc::new(Session {
             id: id.clone(),
             headless,
+            kind: SessionKind::Launched,
             read_only,
             viewport_width: cfg.viewport_width,
             viewport_height: cfg.viewport_height,
@@ -495,6 +541,171 @@ impl Sessions {
         Ok(session)
     }
 
+    /// Attach to an already-running browser over CDP and bind a session to
+    /// one of its tabs: a fresh tab (`adopt_url_substring` absent, session
+    /// owns and later closes it) or an existing user tab matched by URL
+    /// substring (adopted exclusively, released untouched on stop). The
+    /// caller has already gated on `allow_attach` and scheme-checked `url`.
+    pub async fn attach(
+        self: &Arc<Self>,
+        cdp_url: String,
+        url: Option<String>,
+        adopt_url_substring: Option<String>,
+        read_only: bool,
+    ) -> Result<Arc<Session>, String> {
+        let cfg = self.config.load_full();
+        if self.count() as u64 >= cfg.max_sessions {
+            return Err(format!(
+                "session limit reached ({}); stop one with browser::sessions::stop",
+                cfg.max_sessions
+            ));
+        }
+
+        let (browser, mut handler) = Browser::connect(cdp_url.clone())
+            .await
+            .map_err(|e| format!("failed to connect to '{cdp_url}': {e}"))?;
+        let handler_task = tokio::spawn(async move {
+            while let Some(event) = handler.next().await {
+                if let Err(e) = event {
+                    tracing::debug!(error = %e, "cdp handler event error");
+                }
+            }
+        });
+
+        let outcome: Result<(Page, bool), String> = match &adopt_url_substring {
+            Some(needle) => match self.find_adoptable(&browser, needle).await {
+                Ok(page) => Ok((page, false)),
+                Err(e) => Err(e),
+            },
+            None => browser
+                .new_page(url.as_deref().unwrap_or("about:blank"))
+                .await
+                .map(|p| (p, true))
+                .map_err(|e| format!("failed to open tab: {e}")),
+        };
+        let (page, owns_page) = match outcome {
+            Ok(v) => v,
+            Err(e) => {
+                handler_task.abort();
+                return Err(e);
+            }
+        };
+
+        let _ = page.execute(cdp_log::EnableParams::default()).await;
+        let _ = page.execute(cdp_network::EnableParams::default()).await;
+
+        let slot = self.counter.fetch_add(1, Ordering::Relaxed) + 1;
+        let id = format!("b{slot}");
+        let now = now_ms();
+        let session = Arc::new(Session {
+            id: id.clone(),
+            headless: false,
+            kind: SessionKind::Attached { owns_page },
+            read_only,
+            viewport_width: cfg.viewport_width,
+            viewport_height: cfg.viewport_height,
+            created_ms: now,
+            ephemeral_profile: None,
+            latest_frame: Mutex::new(None),
+            screencast_active: std::sync::atomic::AtomicBool::new(false),
+            frame_seq: AtomicU64::new(0),
+            browser: tokio::sync::Mutex::new(browser),
+            page: page.clone(),
+            console: Mutex::new(RingBuffer::new(cfg.console_buffer as usize)),
+            network: Mutex::new(RingBuffer::new(cfg.network_buffer as usize)),
+            seq: AtomicU64::new(1),
+            last_used_ms: AtomicU64::new(now as u64),
+            refs: Mutex::new(HashMap::new()),
+            ref_counter: AtomicU64::new(0),
+            generation: AtomicU64::new(1),
+            snapshot_keys: Mutex::new(None),
+            exec_state: Mutex::new(serde_json::Value::Object(serde_json::Map::new())),
+            pick_counter: AtomicU64::new(0),
+            tasks: Mutex::new(vec![handler_task]),
+        });
+
+        let pumps = spawn_event_pumps(self.clone(), session.clone()).await;
+        session
+            .tasks
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .extend(pumps);
+
+        self.lock().insert(id, session.clone());
+        Ok(session)
+    }
+
+    /// Connect to a running browser and report its open tabs (url, title,
+    /// and whether a session already adopted each). Read-only: opens a
+    /// throwaway CDP connection, lists, and drops it without touching any
+    /// tab. Used by `browser::tabs::list`.
+    pub async fn list_tabs(&self, cdp_url: &str) -> Result<Vec<TabInfo>, String> {
+        let (browser, mut handler) = Browser::connect(cdp_url.to_string())
+            .await
+            .map_err(|e| format!("failed to connect to '{cdp_url}': {e}"))?;
+        let pump = tokio::spawn(async move { while handler.next().await.is_some() {} });
+        let pages = discovered_pages(&browser).await?;
+        let mut tabs = Vec::new();
+        for page in pages {
+            let url = page.url().await.ok().flatten().unwrap_or_default();
+            let title = page.get_title().await.ok().flatten();
+            let target = page.target_id().as_ref().to_string();
+            let adopted = self
+                .adopted_targets
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .contains(&target);
+            tabs.push(TabInfo {
+                url,
+                title,
+                adopted,
+            });
+        }
+        pump.abort();
+        Ok(tabs)
+    }
+
+    /// Resolve a user tab by URL substring for adoption. Exactly one match
+    /// is required; zero or several fail closed with the candidate list so
+    /// the caller can narrow the substring. A tab already adopted by another
+    /// session is excluded up front.
+    async fn find_adoptable(&self, browser: &Browser, needle: &str) -> Result<Page, String> {
+        let pages = discovered_pages(browser).await?;
+        let mut candidates = Vec::new();
+        let mut urls = Vec::new();
+        for page in pages {
+            let url = page.url().await.ok().flatten().unwrap_or_default();
+            let target = page.target_id().as_ref().to_string();
+            let taken = self
+                .adopted_targets
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .contains(&target);
+            if url.contains(needle) && !taken {
+                candidates.push((page, target));
+            }
+            urls.push(url);
+        }
+        match candidates.len() {
+            1 => {
+                let (page, target) = candidates.into_iter().next().expect("one candidate");
+                self.adopted_targets
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .insert(target);
+                Ok(page)
+            }
+            0 => Err(format!(
+                "no adoptable tab matches '{needle}' (open tabs: {})",
+                urls.join(", ")
+            )),
+            n => Err(format!(
+                "'{needle}' matches {n} tabs; use a longer substring (open tabs: {})",
+                urls.join(", ")
+            )),
+        }
+    }
+
     /// Remove + shut down. Returns whether the session was running —
     /// stopping an unknown id succeeds (delete semantics: the caller wants
     /// it gone, and it is).
@@ -502,6 +713,13 @@ impl Sessions {
         let session = self.lock().remove(id);
         match session {
             Some(session) => {
+                if let SessionKind::Attached { owns_page: false } = session.kind {
+                    let target = session.page.target_id().as_ref().to_string();
+                    self.adopted_targets
+                        .lock()
+                        .unwrap_or_else(|p| p.into_inner())
+                        .remove(&target);
+                }
                 session.shutdown().await;
                 self.emitter
                     .emit(
@@ -546,6 +764,26 @@ impl Sessions {
             self.stop(&id, "stopped").await;
         }
     }
+}
+
+/// `Browser::pages()` reads the handler's tracked targets, which populate
+/// asynchronously from `Target.targetCreated` events fired after connect.
+/// Called immediately, it races those events and returns empty against a
+/// browser that has tabs. Poll briefly until a page target appears (or the
+/// budget expires — a browser with genuinely no page tabs returns empty).
+async fn discovered_pages(browser: &Browser) -> Result<Vec<Page>, String> {
+    const ATTEMPTS: u32 = 20;
+    for attempt in 0..ATTEMPTS {
+        let pages = browser
+            .pages()
+            .await
+            .map_err(|e| format!("failed to list tabs: {e}"))?;
+        if !pages.is_empty() || attempt == ATTEMPTS - 1 {
+            return Ok(pages);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    Ok(Vec::new())
 }
 
 /// Every session gets its own profile dir: Chromium holds a process

--- a/browser/src/session.rs
+++ b/browser/src/session.rs
@@ -400,6 +400,14 @@ impl Session {
     }
 }
 
+/// A paused handoff waiting for confirmation: the sender resolves the
+/// `browser::handoff` call that parked on it. `session_id` lets a confirm
+/// addressed to a session find its pending handoff.
+pub struct PendingHandoff {
+    pub session_id: String,
+    pub confirm: tokio::sync::oneshot::Sender<()>,
+}
+
 /// The live session table plus everything a pump task needs.
 pub struct Sessions {
     map: Mutex<HashMap<String, Arc<Session>>>,
@@ -408,6 +416,10 @@ pub struct Sessions {
     /// exclusive: a tab in this set cannot be adopted again until its
     /// session stops.
     adopted_targets: Mutex<std::collections::HashSet<String>>,
+    /// Handoffs currently paused, keyed by handoff id. A confirm removes and
+    /// fires the sender; the parked `browser::handoff` handler then returns.
+    pending_handoffs: Mutex<HashMap<String, PendingHandoff>>,
+    handoff_counter: AtomicU64,
     pub config: SharedConfig,
     pub emitter: Arc<Emitter>,
     /// For pushing screencast frames onto the `browser:frames` stream, which
@@ -425,6 +437,8 @@ impl Sessions {
             map: Mutex::new(HashMap::new()),
             counter: AtomicU64::new(0),
             adopted_targets: Mutex::new(std::collections::HashSet::new()),
+            pending_handoffs: Mutex::new(HashMap::new()),
+            handoff_counter: AtomicU64::new(0),
             config,
             emitter,
             iii,
@@ -720,6 +734,16 @@ impl Sessions {
                         .unwrap_or_else(|p| p.into_inner())
                         .remove(&target);
                 }
+                // Drop any handoff parked on this session so its call
+                // unblocks (its receiver errors) instead of waiting for the
+                // full timeout against a dead page.
+                {
+                    let mut pending = self
+                        .pending_handoffs
+                        .lock()
+                        .unwrap_or_else(|p| p.into_inner());
+                    pending.retain(|_, h| h.session_id != id);
+                }
                 session.shutdown().await;
                 self.emitter
                     .emit(
@@ -736,6 +760,66 @@ impl Sessions {
             }
             None => false,
         }
+    }
+
+    /// Register a paused handoff and return its id plus the receiver the
+    /// caller awaits. A confirm addressed to the same session (or this id)
+    /// fires the sender.
+    pub fn register_handoff(
+        &self,
+        session_id: &str,
+    ) -> (String, tokio::sync::oneshot::Receiver<()>) {
+        let id = format!(
+            "h{}",
+            self.handoff_counter.fetch_add(1, Ordering::Relaxed) + 1
+        );
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.pending_handoffs
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .insert(
+                id.clone(),
+                PendingHandoff {
+                    session_id: session_id.to_string(),
+                    confirm: tx,
+                },
+            );
+        (id, rx)
+    }
+
+    /// Drop a pending handoff without confirming (timeout or session stop).
+    pub fn drop_handoff(&self, handoff_id: &str) {
+        self.pending_handoffs
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .remove(handoff_id);
+    }
+
+    /// Confirm a paused handoff: by exact id, or the one pending handoff for
+    /// a session. Returns the resolved handoff id, or None when nothing
+    /// matched (already confirmed, timed out, or wrong session).
+    pub fn confirm_handoff(
+        &self,
+        handoff_id: Option<&str>,
+        session_id: Option<&str>,
+    ) -> Option<String> {
+        let mut pending = self
+            .pending_handoffs
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let key = match (handoff_id, session_id) {
+            (Some(id), _) => pending.contains_key(id).then(|| id.to_string()),
+            (None, Some(sid)) => pending
+                .iter()
+                .find(|(_, h)| h.session_id == sid)
+                .map(|(k, _)| k.clone()),
+            (None, None) => None,
+        }?;
+        let handoff = pending.remove(&key)?;
+        // A closed receiver (parked call already gone) is fine: the confirm
+        // still succeeds in removing the stale entry.
+        let _ = handoff.confirm.send(());
+        Some(key)
     }
 
     /// Stop sessions idle beyond the configured threshold. Called from the

--- a/browser/tests/golden/schemas/browser.handoff.confirm.json
+++ b/browser/tests/golden/schemas/browser.handoff.confirm.json
@@ -1,0 +1,46 @@
+{
+  "description": "Resolve a paused browser::handoff by handoff_id, or the one pending handoff for a session_id. The console calls this when the human confirms outside the page.",
+  "function_id": "browser::handoff::confirm",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "handoff_id": {
+        "default": null,
+        "description": "Confirm a specific handoff by id. Omit to confirm the one pending handoff for `session_id`.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "session_id": {
+        "default": null,
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "title": "HandoffConfirmInput",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "handoff_id": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "ok": {
+        "description": "True when a pending handoff matched and was resolved.",
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "ok"
+    ],
+    "title": "HandoffConfirmOutput",
+    "type": "object"
+  }
+}

--- a/browser/tests/golden/schemas/browser.handoff.json
+++ b/browser/tests/golden/schemas/browser.handoff.json
@@ -13,7 +13,7 @@
       },
       "timeout_ms": {
         "default": null,
-        "description": "Give up after this long and return timed_out. Defaults to the config default; clamped to `max_timeout_ms`. Set generously; a human is slow.",
+        "description": "Give up after this long and return with `via: \"timeout\"`. Defaults to the config default; clamped to `max_timeout_ms`. Set generously; a human is slow.",
         "format": "uint64",
         "minimum": 0.0,
         "type": [

--- a/browser/tests/golden/schemas/browser.handoff.json
+++ b/browser/tests/golden/schemas/browser.handoff.json
@@ -1,0 +1,60 @@
+{
+  "description": "Pause a session for a step only a human can do (CAPTCHA, 2FA, payment): show an in-page continue banner and block until the human clicks it, a browser::handoff::confirm call resolves it, or the timeout elapses. Human acknowledgment is not proof — verify the expected page state after it returns.",
+  "function_id": "browser::handoff",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "instructions": {
+        "description": "What the human must do before the call continues. Shown in the in-page banner and the handoff-requested event.",
+        "type": "string"
+      },
+      "session_id": {
+        "type": "string"
+      },
+      "timeout_ms": {
+        "default": null,
+        "description": "Give up after this long and return timed_out. Defaults to the config default; clamped to `max_timeout_ms`. Set generously; a human is slow.",
+        "format": "uint64",
+        "minimum": 0.0,
+        "type": [
+          "integer",
+          "null"
+        ]
+      }
+    },
+    "required": [
+      "instructions",
+      "session_id"
+    ],
+    "title": "HandoffInput",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "confirmed": {
+        "description": "True when a human confirmed; false when the wait timed out.",
+        "type": "boolean"
+      },
+      "handoff_id": {
+        "type": "string"
+      },
+      "url": {
+        "description": "The page URL when the wait ended, so the caller can verify the step actually landed (human acknowledgment is not proof).",
+        "type": "string"
+      },
+      "via": {
+        "description": "How the confirmation arrived: `in_page`, `confirm_call`, or `timeout`.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "confirmed",
+      "handoff_id",
+      "url",
+      "via"
+    ],
+    "title": "HandoffOutput",
+    "type": "object"
+  }
+}

--- a/browser/tests/golden/schemas/browser.sessions.attach.json
+++ b/browser/tests/golden/schemas/browser.sessions.attach.json
@@ -1,0 +1,68 @@
+{
+  "description": "Attach a session to an already-running browser over CDP (start Chrome with --remote-debugging-port). Opens a fresh tab the session owns, or adopts an existing user tab by URL substring and releases it untouched on stop. Reaches the real profile with its logins; disabled unless allow_attach is set in config.",
+  "function_id": "browser::sessions::attach",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "adopt_url_substring": {
+        "default": null,
+        "description": "Adopt the existing tab whose URL contains this substring, exclusively, and release it untouched on stop. Omit to open a fresh tab the session owns and closes on stop. Must match exactly one open tab.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "cdp_url": {
+        "description": "CDP endpoint of the running browser: `http://127.0.0.1:9222` (the worker resolves the WebSocket URL from `/json/version`) or a `ws://` debugger URL directly. Start Chrome with `--remote-debugging-port=9222` to expose one.",
+        "type": "string"
+      },
+      "read_only": {
+        "default": null,
+        "description": "Inspection-only session; see browser::sessions::start.",
+        "type": [
+          "boolean",
+          "null"
+        ]
+      },
+      "url": {
+        "default": null,
+        "description": "URL to open in the fresh tab (ignored when adopting). Omit for about:blank.",
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "required": [
+      "cdp_url"
+    ],
+    "title": "AttachInput",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "adopted": {
+        "description": "True when the session adopted an existing user tab (released, not closed, on stop); false when it opened a fresh tab it owns.",
+        "type": "boolean"
+      },
+      "read_only": {
+        "type": "boolean"
+      },
+      "session_id": {
+        "type": "string"
+      },
+      "url": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "adopted",
+      "read_only",
+      "session_id",
+      "url"
+    ],
+    "title": "AttachOutput",
+    "type": "object"
+  }
+}

--- a/browser/tests/golden/schemas/browser.tabs.list.json
+++ b/browser/tests/golden/schemas/browser.tabs.list.json
@@ -1,0 +1,59 @@
+{
+  "description": "List the open tabs of a running browser reachable at a CDP endpoint (url, title, and whether a session already adopted each). Read-only; adopt one with browser::sessions::attach.",
+  "function_id": "browser::tabs::list",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "cdp_url": {
+        "description": "CDP endpoint of the running browser, as in browser::sessions::attach.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "cdp_url"
+    ],
+    "title": "TabsListInput",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+      "TabInfo": {
+        "description": "One open tab reported by `browser::tabs::list`.",
+        "properties": {
+          "adopted": {
+            "description": "True when a session already adopted this tab; it cannot be adopted again until that session stops.",
+            "type": "boolean"
+          },
+          "title": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "adopted",
+          "url"
+        ],
+        "type": "object"
+      }
+    },
+    "properties": {
+      "tabs": {
+        "items": {
+          "$ref": "#/definitions/TabInfo"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "tabs"
+    ],
+    "title": "TabsListOutput",
+    "type": "object"
+  }
+}

--- a/browser/tests/integration.rs
+++ b/browser/tests/integration.rs
@@ -224,6 +224,38 @@ async fn session_lifecycle_console_and_snapshot() {
     .await;
     assert_eq!(reloaded["ok"], true, "{reloaded}");
 
+    // doctor reports a usable environment (Chromium is present; we launched)
+    let doctor = call("browser::doctor", json!({}), 10_000).await;
+    assert_eq!(doctor["ok"], true, "{doctor}");
+    assert!(doctor["chromium_path"].is_string(), "{doctor}");
+
+    // attach is gated off by default (allow_attach false): both attach
+    // functions must refuse rather than reach the real profile
+    let attach = client
+        .trigger(TriggerRequest {
+            function_id: "browser::sessions::attach".into(),
+            payload: json!({ "cdp_url": "http://127.0.0.1:9222" }),
+            action: None,
+            timeout_ms: Some(10_000),
+        })
+        .await;
+    assert!(
+        attach.is_err(),
+        "attach must be refused when allow_attach is false: {attach:?}"
+    );
+    let tabs = client
+        .trigger(TriggerRequest {
+            function_id: "browser::tabs::list".into(),
+            payload: json!({ "cdp_url": "http://127.0.0.1:9222" }),
+            action: None,
+            timeout_ms: Some(10_000),
+        })
+        .await;
+    assert!(
+        tabs.is_err(),
+        "tabs::list must be refused when allow_attach is false: {tabs:?}"
+    );
+
     // stop is idempotent
     let stopped = call(
         "browser::sessions::stop",

--- a/browser/tests/schemas.rs
+++ b/browser/tests/schemas.rs
@@ -1,4 +1,4 @@
-//! Wire-schema snapshots for the twenty-five `browser::*` functions.
+//! Wire-schema snapshots for the twenty-seven `browser::*` functions.
 //!
 //! `browser::functions::catalog()` is the single source of truth for each
 //! function's id, registration description, and schemars-derived
@@ -32,7 +32,7 @@ fn spec_to_pretty_json(spec: &FunctionSpec) -> String {
     pretty
 }
 
-/// The catalog must cover exactly the twenty-five registered functions, in
+/// The catalog must cover exactly the twenty-seven registered functions, in
 /// registration order (kept in lockstep with `register_all`).
 #[test]
 fn catalog_lists_all_functions_in_registration_order() {
@@ -52,6 +52,8 @@ fn catalog_lists_all_functions_in_registration_order() {
             "browser::act",
             "browser::evaluate",
             "browser::execute",
+            "browser::handoff",
+            "browser::handoff::confirm",
             "browser::console::read",
             "browser::network::read",
             "browser::history",

--- a/browser/tests/schemas.rs
+++ b/browser/tests/schemas.rs
@@ -1,4 +1,4 @@
-//! Wire-schema snapshots for the twenty-three `browser::*` functions.
+//! Wire-schema snapshots for the twenty-five `browser::*` functions.
 //!
 //! `browser::functions::catalog()` is the single source of truth for each
 //! function's id, registration description, and schemars-derived
@@ -32,7 +32,7 @@ fn spec_to_pretty_json(spec: &FunctionSpec) -> String {
     pretty
 }
 
-/// The catalog must cover exactly the twenty-three registered functions, in
+/// The catalog must cover exactly the twenty-five registered functions, in
 /// registration order (kept in lockstep with `register_all`).
 #[test]
 fn catalog_lists_all_functions_in_registration_order() {
@@ -43,6 +43,8 @@ fn catalog_lists_all_functions_in_registration_order() {
             "browser::sessions::start",
             "browser::sessions::list",
             "browser::sessions::stop",
+            "browser::sessions::attach",
+            "browser::tabs::list",
             "browser::doctor",
             "browser::navigate",
             "browser::snapshot",


### PR DESCRIPTION
Adds attach mode so a session can drive the user's already-running browser with its logged-in profile, instead of only launching a fresh throwaway Chromium. MOT-4112, second train of the MOT-4108 epic.

Stacked on #535 (feat/browser-execute-guardrails); review or merge that first. This branch's own delta is the attach surface.

## What lands

- `browser::sessions::attach { cdp_url, adopt_url_substring?, url?, read_only? }` — connect over CDP to a browser started with `--remote-debugging-port`. Two modes:
  - Fresh tab (no `adopt_url_substring`): the session opens and owns a new tab, closed on stop.
  - Adopt (`adopt_url_substring`): claim an existing user tab by URL substring, exclusively; released untouched on stop, never closed. Must match exactly one tab, else fails closed with the candidate list.
- `browser::tabs::list { cdp_url }` — read-only enumeration of a running browser's tabs (url, title, whether already adopted).
- `SessionKind` distinguishes launched vs attached ownership: attached shutdown closes at most the one tab the session created and never touches the user's browser process; adoption is tracked in an exclusive target set so two sessions can't fight over one tab.
- Config gate `allow_attach` (default false): attach reaches the real profile with its logins, so it is opt-in. Both attach functions refuse with a clear message when it is off.

## Notes

- `Browser::pages()` populates from async `Target.targetCreated` events after connect and returns empty if read immediately; a short poll (`discovered_pages`) waits for discovery so tab listing and adoption are reliable.
- Attached sessions are never headless and own no ephemeral profile, so shutdown skips process kill and profile cleanup.

## Tests

- Unit + goldens for the two new functions (25 functions total); typed-schema gate passes.
- Integration test asserts attach and tabs::list refuse when `allow_attach` is false (deterministic, no debug-port browser needed), plus a doctor-ok check.
- Live e2e against a real Chrome started with `--remote-debugging-port=9222` and `allow_attach` enabled: tabs::list enumerated both open tabs; adopting example.com read a 10-line snapshot; a second adopt of the same tab was refused (exclusive); stop released the tab and it survived; fresh-tab attach opened, owned, and closed example.org.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --lib`/`--test schemas` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to connect to an already-running browser and view or adopt its tabs, with attachment disabled by default for safety.
  * Added human-in-the-loop handoffs for CAPTCHA, two-factor authentication, payment confirmation, and similar steps, including confirmation and timeout handling.
  * Added a notification trigger when a human handoff is requested.
  * Improved session cleanup and tab ownership behavior for attached browsers.

* **Bug Fixes**
  * Improved handling of browser execution results when state or output cannot be serialized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->