### PR TITLE
feat(browser): human handoff for CAPTCHA/2FA/payment pauses (MOT-4113)

### DIFF
--- a/browser/README.md
+++ b/browser/README.md
@@ -122,6 +122,13 @@ releases it untouched on stop; `browser::tabs::list` enumerates a running
 browser's tabs. Attach reaches logged-in state, so it is off unless
 `allow_attach` is set in config, and adoption is exclusive per tab.
 
+`browser::handoff` pauses a session for a step only a human can do (CAPTCHA,
+2FA, payment): it mounts an in-page continue banner and blocks the call until
+the human clicks it, a `browser::handoff::confirm` call resolves it, or the
+timeout elapses, emitting `browser::handoff-requested` for the console to
+surface. Human acknowledgment is not proof, so the caller verifies the
+expected page state after it returns.
+
 ## Configuration
 
 Stored in the `configuration` worker under the `browser` key; every field is
@@ -159,6 +166,7 @@ bindings accept an optional `{ "session_id": "..." }` filter.
 | `browser::navigated` | The page committed a navigation | `{ session_id, url, timestamp }` |
 | `browser::console-event` | A console/log/exception entry was captured | `{ session_id, entry }` |
 | `browser::picked` | The human picked an element in inspect mode | `{ session_id, element, timestamp }` |
+| `browser::handoff-requested` | A session paused for a human step (CAPTCHA, 2FA, payment) | `{ session_id, handoff_id, instructions, timestamp }` |
 
 `browser::console-event` is high-volume; bind it with a `session_id` filter
 and treat `browser::console::read` as the durable record. `browser::picked`

--- a/browser/skills/SKILL.md
+++ b/browser/skills/SKILL.md
@@ -84,6 +84,12 @@ on navigation; re-snapshot before acting after any page change.
   await and return, `log(...)`, `sleep(ms)`, `waitFor(selector)`, and a
   `state` object persisted across execute calls for the session. One call
   replaces a chain of act/evaluate round-trips.
+- `browser::handoff` — pause the session for a human-only step (CAPTCHA,
+  2FA, payment): show an in-page continue banner and block until the human
+  clicks it, a `browser::handoff::confirm` call resolves it, or the timeout
+  elapses. Verify the expected page state after it returns.
+- `browser::handoff::confirm` — resolve a paused handoff from outside the
+  page (by handoff_id, or the one pending handoff for a session_id).
 - `browser::console::read` — captured console entries; filter with
   pattern/level and page with since_seq.
 - `browser::network::read` — captured requests; failed_only=true is the fast
@@ -107,6 +113,11 @@ on navigation; re-snapshot before acting after any page change.
    (in-page script clicks are not trusted events).
 4. Pure inspection tasks (audits, scraping a logged-in page you must not
    touch) belong in a `read_only: true` session.
+5. When a flow hits a step only a human can do (CAPTCHA, 2FA, payment
+   confirmation), call `browser::handoff` and wait, rather than trying to
+   automate it. After it returns confirmed, re-read the page and verify the
+   step actually landed — a human clicking Continue is not proof the step
+   succeeded.
 
 ## Workflow: destructive UI actions
 
@@ -140,9 +151,11 @@ fill the context window and force a compaction. Read economically:
 Bind a `browser::*` trigger when another function should react to session
 activity as it happens instead of polling the read functions. The types:
 `browser::session-started`, `browser::session-stopped`, `browser::navigated`,
-`browser::console-event` (one captured entry per firing; high volume), and
+`browser::console-event` (one captured entry per firing; high volume),
 `browser::picked` (a human picked an element in the console UI; the payload
-carries a ref that `browser::act` accepts directly).
+carries a ref that `browser::act` accepts directly), and
+`browser::handoff-requested` (a session is paused waiting for a human; the
+console surfaces it beside the live viewport).
 
 If you just ran `browser::navigate` yourself, its return value already tells
 you the outcome; bind triggers when a different worker needs to observe

--- a/browser/src/events.rs
+++ b/browser/src/events.rs
@@ -1,4 +1,4 @@
-//! The five custom trigger types this worker emits, and the fan-out behind
+//! The custom trigger types this worker emits, and the fan-out behind
 //! them. Consumers bind handlers with the standard two-step pattern; the
 //! engine routes each registration to our [`TriggerHandler`]. Delivery is
 //! fire-and-forget (`TriggerAction::Void`) and at-least-once; per-binding
@@ -23,6 +23,7 @@ pub const NAVIGATED: &str = "browser::navigated";
 pub const CONSOLE_EVENT: &str = "browser::console-event";
 pub const NETWORK_EVENT: &str = "browser::network-event";
 pub const PICKED: &str = "browser::picked";
+pub const HANDOFF_REQUESTED: &str = "browser::handoff-requested";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum EventKind {
@@ -32,6 +33,7 @@ pub enum EventKind {
     ConsoleEvent,
     NetworkEvent,
     Picked,
+    HandoffRequested,
 }
 
 impl EventKind {
@@ -43,10 +45,11 @@ impl EventKind {
             EventKind::ConsoleEvent => CONSOLE_EVENT,
             EventKind::NetworkEvent => NETWORK_EVENT,
             EventKind::Picked => PICKED,
+            EventKind::HandoffRequested => HANDOFF_REQUESTED,
         }
     }
 
-    pub fn all() -> [EventKind; 6] {
+    pub fn all() -> [EventKind; 7] {
         [
             EventKind::SessionStarted,
             EventKind::SessionStopped,
@@ -54,6 +57,7 @@ impl EventKind {
             EventKind::ConsoleEvent,
             EventKind::NetworkEvent,
             EventKind::Picked,
+            EventKind::HandoffRequested,
         ]
     }
 }
@@ -133,6 +137,19 @@ pub struct NetworkEventPayload {
 pub struct PickedEvent {
     pub session_id: String,
     pub element: PickedElement,
+    pub timestamp: i64,
+}
+
+/// `browser::handoff-requested` — a session is paused waiting for a human to
+/// complete a step (CAPTCHA, 2FA, payment). The console surfaces this beside
+/// the live viewport; resolve it with `browser::handoff::confirm` (or the
+/// human clicks the in-page continue control).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct HandoffRequestedEvent {
+    pub session_id: String,
+    pub handoff_id: String,
+    /// What the human must do before the paused call continues.
+    pub instructions: String,
     pub timestamp: i64,
 }
 
@@ -224,7 +241,7 @@ impl SubscriberSet {
     }
 }
 
-/// The five subscriber sets, one per trigger type.
+/// The subscriber sets, one per trigger type.
 #[derive(Clone)]
 pub struct TriggerSets {
     inner: HashMap<&'static str, SubscriberSet>,
@@ -273,11 +290,11 @@ impl TriggerHandler for BrowserTriggerHandler {
     }
 }
 
-/// Register the six custom trigger types with the engine. Must run before
+/// Register the custom trigger types with the engine. Must run before
 /// `functions::register_all` so handlers can capture the subscriber sets.
 pub fn register_trigger_types(iii: &Arc<IIIClient>) -> TriggerSets {
     let sets = TriggerSets::new();
-    let descriptions: [(EventKind, &str); 6] = [
+    let descriptions: [(EventKind, &str); 7] = [
         (
             EventKind::SessionStarted,
             "A Chromium session is up and ready.",
@@ -301,6 +318,10 @@ pub fn register_trigger_types(iii: &Arc<IIIClient>) -> TriggerSets {
         (
             EventKind::Picked,
             "The human picked an element in inspect mode.",
+        ),
+        (
+            EventKind::HandoffRequested,
+            "A session is paused waiting for a human to complete a step (CAPTCHA, 2FA, payment).",
         ),
     ];
     for (kind, description) in descriptions {

--- a/browser/src/functions/handoff.rs
+++ b/browser/src/functions/handoff.rs
@@ -1,0 +1,119 @@
+//! `browser::handoff` and `browser::handoff::confirm` — pause a session for
+//! a step only a human can do (CAPTCHA, 2FA, payment). The handoff call
+//! parks until a human confirms in-page or a confirm call resolves it, or
+//! the timeout elapses.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Poll interval for the in-page continue control while parked.
+pub const POLL_INTERVAL_MS: u64 = 250;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct HandoffInput {
+    pub session_id: String,
+    /// What the human must do before the call continues. Shown in the
+    /// in-page banner and the handoff-requested event.
+    pub instructions: String,
+    /// Give up after this long and return timed_out. Defaults to the config
+    /// default; clamped to `max_timeout_ms`. Set generously; a human is slow.
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct HandoffOutput {
+    /// True when a human confirmed; false when the wait timed out.
+    pub confirmed: bool,
+    pub handoff_id: String,
+    /// How the confirmation arrived: `in_page`, `confirm_call`, or `timeout`.
+    pub via: String,
+    /// The page URL when the wait ended, so the caller can verify the step
+    /// actually landed (human acknowledgment is not proof).
+    pub url: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct HandoffConfirmInput {
+    /// Confirm a specific handoff by id. Omit to confirm the one pending
+    /// handoff for `session_id`.
+    #[serde(default)]
+    pub handoff_id: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct HandoffConfirmOutput {
+    /// True when a pending handoff matched and was resolved.
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub handoff_id: Option<String>,
+}
+
+/// JS that mounts the in-page continue banner and exposes a global flag the
+/// worker polls. Idempotent per handoff id. `{:?}` renders both the id and
+/// the instructions as valid double-quoted JS string literals, so no manual
+/// escaping is needed and injection through the text is not possible.
+pub fn banner_script(handoff_id: &str, instructions: &str) -> String {
+    format!(
+        r#"(() => {{
+  window.__iiiHandoff = window.__iiiHandoff || {{}};
+  const id = {handoff_id:?};
+  if (document.getElementById('iii-handoff-' + id)) return;
+  const bar = document.createElement('div');
+  bar.id = 'iii-handoff-' + id;
+  bar.setAttribute('role', 'dialog');
+  bar.setAttribute('aria-label', 'Action needed');
+  bar.style.cssText = 'position:fixed;top:0;left:0;right:0;z-index:2147483647;'
+    + 'background:#1f2937;color:#f9fafb;font:14px system-ui,sans-serif;'
+    + 'padding:12px 16px;display:flex;gap:12px;align-items:center;'
+    + 'box-shadow:0 2px 8px rgba(0,0,0,.3)';
+  const msg = document.createElement('span');
+  msg.style.flex = '1';
+  msg.textContent = 'Action needed: ' + {instructions:?};
+  const btn = document.createElement('button');
+  btn.textContent = 'Continue';
+  btn.style.cssText = 'background:#10b981;color:#04231a;border:0;border-radius:6px;'
+    + 'padding:8px 16px;font-weight:600;cursor:pointer';
+  btn.addEventListener('click', () => {{ window.__iiiHandoff[id] = true; bar.remove(); }});
+  bar.appendChild(msg);
+  bar.appendChild(btn);
+  document.body.appendChild(bar);
+}})()"#
+    )
+}
+
+/// JS that reads and clears the confirm flag for a handoff id.
+pub fn poll_script(handoff_id: &str) -> String {
+    format!(
+        "(() => {{ const f = window.__iiiHandoff && window.__iiiHandoff[{handoff_id:?}]; return !!f; }})()"
+    )
+}
+
+/// JS that removes the banner for a handoff id (on confirm-call or timeout).
+pub fn remove_script(handoff_id: &str) -> String {
+    format!(
+        "(() => {{ const el = document.getElementById('iii-handoff-' + {handoff_id:?}); if (el) el.remove(); return true; }})()"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn banner_renders_instructions_as_a_quoted_literal() {
+        let js = banner_script("h1", "click \"here\" now");
+        // {:?} escapes the embedded quotes so the JS literal stays valid.
+        assert!(js.contains(r#"\"here\""#), "{js}");
+        assert!(js.contains("iii-handoff-"));
+        assert!(js.contains("__iiiHandoff[id] = true"));
+    }
+
+    #[test]
+    fn poll_and_remove_reference_the_id() {
+        assert!(poll_script("h7").contains("\"h7\""));
+        assert!(remove_script("h7").contains("\"h7\""));
+    }
+}

--- a/browser/src/functions/mod.rs
+++ b/browser/src/functions/mod.rs
@@ -10,6 +10,7 @@ pub mod dom;
 pub mod evaluate;
 pub mod execute;
 pub mod frame;
+pub mod handoff;
 pub mod hint;
 pub mod history;
 pub mod navigate;
@@ -39,7 +40,7 @@ use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::json;
 use tokio::time::timeout;
 
-use crate::events::{EventKind, SessionStartedEvent};
+use crate::events::{EventKind, HandoffRequestedEvent, SessionStartedEvent};
 use crate::session::{now_ms, Session, Sessions};
 
 pub const SESSIONS_START_ID: &str = "browser::sessions::start";
@@ -97,6 +98,16 @@ pub const DOCTOR_DESC: &str =
     "Read-only environment diagnostics: which Chromium the worker would launch, its version, \
      session capacity, and any degraded capability with how to enable it. Never starts a \
      browser.";
+pub const HANDOFF_ID: &str = "browser::handoff";
+pub const HANDOFF_DESC: &str =
+    "Pause a session for a step only a human can do (CAPTCHA, 2FA, payment): show an in-page \
+     continue banner and block until the human clicks it, a browser::handoff::confirm call \
+     resolves it, or the timeout elapses. Human acknowledgment is not proof — verify the \
+     expected page state after it returns.";
+pub const HANDOFF_CONFIRM_ID: &str = "browser::handoff::confirm";
+pub const HANDOFF_CONFIRM_DESC: &str =
+    "Resolve a paused browser::handoff by handoff_id, or the one pending handoff for a \
+     session_id. The console calls this when the human confirms outside the page.";
 pub const CONSOLE_READ_ID: &str = "browser::console::read";
 pub const CONSOLE_READ_DESC: &str =
     "Read the session's captured console: console.* calls, uncaught exceptions, and \
@@ -193,6 +204,11 @@ pub fn catalog() -> Vec<FunctionSpec> {
         spec::<act::ActInput, act::ActOutput>(ACT_ID, ACT_DESC),
         spec::<evaluate::EvaluateInput, evaluate::EvaluateOutput>(EVALUATE_ID, EVALUATE_DESC),
         spec::<execute::ExecuteInput, execute::ExecuteOutput>(EXECUTE_ID, EXECUTE_DESC),
+        spec::<handoff::HandoffInput, handoff::HandoffOutput>(HANDOFF_ID, HANDOFF_DESC),
+        spec::<handoff::HandoffConfirmInput, handoff::HandoffConfirmOutput>(
+            HANDOFF_CONFIRM_ID,
+            HANDOFF_CONFIRM_DESC,
+        ),
         spec::<console::ConsoleReadInput, console::ConsoleReadOutput>(
             CONSOLE_READ_ID,
             CONSOLE_READ_DESC,
@@ -237,6 +253,8 @@ pub fn register_all(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
     register_act(iii, sessions);
     register_evaluate(iii, sessions);
     register_execute(iii, sessions);
+    register_handoff(iii, sessions);
+    register_handoff_confirm(iii, sessions);
     register_console_read(iii, sessions);
     register_network_read(iii, sessions);
     register_history(iii, sessions);
@@ -1003,6 +1021,102 @@ fn register_execute(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
             }
         })
         .description(EXECUTE_DESC),
+    );
+}
+
+fn register_handoff(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
+    let sx = sessions.clone();
+    iii.register_function(
+        HANDOFF_ID,
+        RegisterFunction::new_async(move |req: handoff::HandoffInput| {
+            let sx = sx.clone();
+            async move {
+                let session = get_session(&sx, &req.session_id)?;
+                session.touch();
+                let cfg = sx.config.load_full();
+                let wait = Duration::from_millis(cfg.clamp_timeout(req.timeout_ms));
+
+                let (handoff_id, mut confirm_rx) = sx.register_handoff(&req.session_id);
+                // Mount the in-page continue banner carrying the poll flag.
+                // Best-effort: on a page that rejects injection the
+                // confirm-call path still resolves the same handoff.
+                let _ = session
+                    .page
+                    .evaluate(handoff::banner_script(&handoff_id, &req.instructions))
+                    .await;
+
+                sx.emitter
+                    .emit(
+                        EventKind::HandoffRequested,
+                        &req.session_id,
+                        &HandoffRequestedEvent {
+                            session_id: req.session_id.clone(),
+                            handoff_id: handoff_id.clone(),
+                            instructions: req.instructions.clone(),
+                            timestamp: now_ms(),
+                        },
+                    )
+                    .await;
+
+                // Park until: a confirm call fires the oneshot, the human
+                // clicks the in-page control (polled), or the timeout fires.
+                let poll = handoff::poll_script(&handoff_id);
+                let deadline = tokio::time::Instant::now() + wait;
+                let via = loop {
+                    let tick = tokio::time::sleep(Duration::from_millis(handoff::POLL_INTERVAL_MS));
+                    tokio::select! {
+                        // Ok = a confirm call fired the sender; Err = the
+                        // sender was dropped (session stopped mid-handoff).
+                        res = &mut confirm_rx => break if res.is_ok() { "confirm_call" } else { "cancelled" },
+                        _ = tokio::time::sleep_until(deadline) => break "timeout",
+                        _ = tick => {
+                            if let Ok(v) = session.page.evaluate(poll.clone()).await {
+                                if v.value().and_then(|x| x.as_bool()).unwrap_or(false) {
+                                    break "in_page";
+                                }
+                            }
+                        }
+                    }
+                };
+
+                sx.drop_handoff(&handoff_id);
+                let _ = session
+                    .page
+                    .evaluate(handoff::remove_script(&handoff_id))
+                    .await;
+                session.touch();
+                let url = session.page.url().await.ok().flatten().unwrap_or_default();
+                Ok::<_, Error>(handoff::HandoffOutput {
+                    confirmed: via == "confirm_call" || via == "in_page",
+                    handoff_id,
+                    via: via.to_string(),
+                    url,
+                })
+            }
+        })
+        .description(HANDOFF_DESC),
+    );
+}
+
+fn register_handoff_confirm(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
+    let sx = sessions.clone();
+    iii.register_function(
+        HANDOFF_CONFIRM_ID,
+        RegisterFunction::new_async(move |req: handoff::HandoffConfirmInput| {
+            let sx = sx.clone();
+            async move {
+                if req.handoff_id.is_none() && req.session_id.is_none() {
+                    return Err(handler_err("pass handoff_id or session_id"));
+                }
+                let resolved =
+                    sx.confirm_handoff(req.handoff_id.as_deref(), req.session_id.as_deref());
+                Ok::<_, Error>(handoff::HandoffConfirmOutput {
+                    ok: resolved.is_some(),
+                    handoff_id: resolved,
+                })
+            }
+        })
+        .description(HANDOFF_CONFIRM_DESC),
     );
 }
 

--- a/browser/src/session.rs
+++ b/browser/src/session.rs
@@ -400,6 +400,14 @@ impl Session {
     }
 }
 
+/// A paused handoff waiting for confirmation: the sender resolves the
+/// `browser::handoff` call that parked on it. `session_id` lets a confirm
+/// addressed to a session find its pending handoff.
+pub struct PendingHandoff {
+    pub session_id: String,
+    pub confirm: tokio::sync::oneshot::Sender<()>,
+}
+
 /// The live session table plus everything a pump task needs.
 pub struct Sessions {
     map: Mutex<HashMap<String, Arc<Session>>>,
@@ -408,6 +416,10 @@ pub struct Sessions {
     /// exclusive: a tab in this set cannot be adopted again until its
     /// session stops.
     adopted_targets: Mutex<std::collections::HashSet<String>>,
+    /// Handoffs currently paused, keyed by handoff id. A confirm removes and
+    /// fires the sender; the parked `browser::handoff` handler then returns.
+    pending_handoffs: Mutex<HashMap<String, PendingHandoff>>,
+    handoff_counter: AtomicU64,
     pub config: SharedConfig,
     pub emitter: Arc<Emitter>,
     /// For pushing screencast frames onto the `browser:frames` stream, which
@@ -425,6 +437,8 @@ impl Sessions {
             map: Mutex::new(HashMap::new()),
             counter: AtomicU64::new(0),
             adopted_targets: Mutex::new(std::collections::HashSet::new()),
+            pending_handoffs: Mutex::new(HashMap::new()),
+            handoff_counter: AtomicU64::new(0),
             config,
             emitter,
             iii,
@@ -720,6 +734,16 @@ impl Sessions {
                         .unwrap_or_else(|p| p.into_inner())
                         .remove(&target);
                 }
+                // Drop any handoff parked on this session so its call
+                // unblocks (its receiver errors) instead of waiting for the
+                // full timeout against a dead page.
+                {
+                    let mut pending = self
+                        .pending_handoffs
+                        .lock()
+                        .unwrap_or_else(|p| p.into_inner());
+                    pending.retain(|_, h| h.session_id != id);
+                }
                 session.shutdown().await;
                 self.emitter
                     .emit(
@@ -736,6 +760,66 @@ impl Sessions {
             }
             None => false,
         }
+    }
+
+    /// Register a paused handoff and return its id plus the receiver the
+    /// caller awaits. A confirm addressed to the same session (or this id)
+    /// fires the sender.
+    pub fn register_handoff(
+        &self,
+        session_id: &str,
+    ) -> (String, tokio::sync::oneshot::Receiver<()>) {
+        let id = format!(
+            "h{}",
+            self.handoff_counter.fetch_add(1, Ordering::Relaxed) + 1
+        );
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.pending_handoffs
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .insert(
+                id.clone(),
+                PendingHandoff {
+                    session_id: session_id.to_string(),
+                    confirm: tx,
+                },
+            );
+        (id, rx)
+    }
+
+    /// Drop a pending handoff without confirming (timeout or session stop).
+    pub fn drop_handoff(&self, handoff_id: &str) {
+        self.pending_handoffs
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .remove(handoff_id);
+    }
+
+    /// Confirm a paused handoff: by exact id, or the one pending handoff for
+    /// a session. Returns the resolved handoff id, or None when nothing
+    /// matched (already confirmed, timed out, or wrong session).
+    pub fn confirm_handoff(
+        &self,
+        handoff_id: Option<&str>,
+        session_id: Option<&str>,
+    ) -> Option<String> {
+        let mut pending = self
+            .pending_handoffs
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let key = match (handoff_id, session_id) {
+            (Some(id), _) => pending.contains_key(id).then(|| id.to_string()),
+            (None, Some(sid)) => pending
+                .iter()
+                .find(|(_, h)| h.session_id == sid)
+                .map(|(k, _)| k.clone()),
+            (None, None) => None,
+        }?;
+        let handoff = pending.remove(&key)?;
+        // A closed receiver (parked call already gone) is fine: the confirm
+        // still succeeds in removing the stale entry.
+        let _ = handoff.confirm.send(());
+        Some(key)
     }
 
     /// Stop sessions idle beyond the configured threshold. Called from the

--- a/browser/tests/golden/schemas/browser.handoff.confirm.json
+++ b/browser/tests/golden/schemas/browser.handoff.confirm.json
@@ -1,0 +1,46 @@
+{
+  "description": "Resolve a paused browser::handoff by handoff_id, or the one pending handoff for a session_id. The console calls this when the human confirms outside the page.",
+  "function_id": "browser::handoff::confirm",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "handoff_id": {
+        "default": null,
+        "description": "Confirm a specific handoff by id. Omit to confirm the one pending handoff for `session_id`.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "session_id": {
+        "default": null,
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "title": "HandoffConfirmInput",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "handoff_id": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "ok": {
+        "description": "True when a pending handoff matched and was resolved.",
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "ok"
+    ],
+    "title": "HandoffConfirmOutput",
+    "type": "object"
+  }
+}

--- a/browser/tests/golden/schemas/browser.handoff.json
+++ b/browser/tests/golden/schemas/browser.handoff.json
@@ -1,0 +1,60 @@
+{
+  "description": "Pause a session for a step only a human can do (CAPTCHA, 2FA, payment): show an in-page continue banner and block until the human clicks it, a browser::handoff::confirm call resolves it, or the timeout elapses. Human acknowledgment is not proof — verify the expected page state after it returns.",
+  "function_id": "browser::handoff",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "instructions": {
+        "description": "What the human must do before the call continues. Shown in the in-page banner and the handoff-requested event.",
+        "type": "string"
+      },
+      "session_id": {
+        "type": "string"
+      },
+      "timeout_ms": {
+        "default": null,
+        "description": "Give up after this long and return timed_out. Defaults to the config default; clamped to `max_timeout_ms`. Set generously; a human is slow.",
+        "format": "uint64",
+        "minimum": 0.0,
+        "type": [
+          "integer",
+          "null"
+        ]
+      }
+    },
+    "required": [
+      "instructions",
+      "session_id"
+    ],
+    "title": "HandoffInput",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "confirmed": {
+        "description": "True when a human confirmed; false when the wait timed out.",
+        "type": "boolean"
+      },
+      "handoff_id": {
+        "type": "string"
+      },
+      "url": {
+        "description": "The page URL when the wait ended, so the caller can verify the step actually landed (human acknowledgment is not proof).",
+        "type": "string"
+      },
+      "via": {
+        "description": "How the confirmation arrived: `in_page`, `confirm_call`, or `timeout`.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "confirmed",
+      "handoff_id",
+      "url",
+      "via"
+    ],
+    "title": "HandoffOutput",
+    "type": "object"
+  }
+}

--- a/browser/tests/schemas.rs
+++ b/browser/tests/schemas.rs
@@ -1,4 +1,4 @@
-//! Wire-schema snapshots for the twenty-five `browser::*` functions.
+//! Wire-schema snapshots for the twenty-seven `browser::*` functions.
 //!
 //! `browser::functions::catalog()` is the single source of truth for each
 //! function's id, registration description, and schemars-derived
@@ -32,7 +32,7 @@ fn spec_to_pretty_json(spec: &FunctionSpec) -> String {
     pretty
 }
 
-/// The catalog must cover exactly the twenty-five registered functions, in
+/// The catalog must cover exactly the twenty-seven registered functions, in
 /// registration order (kept in lockstep with `register_all`).
 #[test]
 fn catalog_lists_all_functions_in_registration_order() {
@@ -52,6 +52,8 @@ fn catalog_lists_all_functions_in_registration_order() {
             "browser::act",
             "browser::evaluate",
             "browser::execute",
+            "browser::handoff",
+            "browser::handoff::confirm",
             "browser::console::read",
             "browser::network::read",
             "browser::history",


### PR DESCRIPTION
Pauses a session for a step only a human can do (CAPTCHA, 2FA, payment confirmation) instead of the agent trying to automate it. MOT-4113, third train of the MOT-4108 epic.

Stacked on #536 (feat/browser-attach-mode). This branch's own delta is the handoff surface.

## What lands

- `browser::handoff { session_id, instructions, timeout_ms? }` — mounts an accessible in-page continue banner and parks the call until one of: the human clicks Continue (polled in-page flag), a `browser::handoff::confirm` call fires, or the timeout elapses. Returns `{ confirmed, handoff_id, via, url }` where `via` is `in_page` / `confirm_call` / `timeout` / `cancelled`, and `url` is the page URL when the wait ended so the caller can verify the step landed.
- `browser::handoff::confirm { handoff_id? | session_id? }` — resolve a paused handoff from outside the page (the console calls this when the human confirms in the streamed viewport). Returns `ok: false` when nothing matched.
- `browser::handoff-requested` trigger type — emitted when a session pauses, so the console can surface it beside the live viewport. Carries `{ session_id, handoff_id, instructions, timestamp }`.

## How the parking works

There is no special SDK primitive: the handoff handler is itself async, so it awaits. The engine invocation stays open (set a generous timeout_ms) while the handler selects over a confirm oneshot, an in-page poll, and the deadline. Pending handoffs live in a session-keyed map; a session stop drops any handoff parked on it so the call unblocks (`via: cancelled`) rather than waiting out the full timeout against a dead page. Human acknowledgment is not proof, so both the skill and the response make the caller re-verify page state.

Injected banner text is rendered through `{:?}`, which produces a valid double-quoted JS string literal, so instructions can't break out of the script.

## Tests

- Unit: banner renders instructions as a quoted literal (injection-safe), poll/remove scripts reference the id.
- Goldens for the two new functions (27 functions total); typed-schema gate passes.
- Live e2e against a real engine and Chromium: all three resolution paths verified — confirm-call resolved a parked handoff (`via: confirm_call`), a real in-page Continue-button click resolved another (`via: in_page`), a short timeout returned `confirmed: false via: timeout`, and confirm-with-nothing-pending returned `ok: false`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --lib`/`--test schemas` green.
