### PR TITLE
(MOT-4116) fix(harness): persist the compaction record as a kind:custom session entry

### DIFF
--- a/harness/src/clients/session.rs
+++ b/harness/src/clients/session.rs
@@ -160,23 +160,7 @@ impl SessionClient {
         entry_id: &str,
         origin: Option<&Value>,
     ) -> Result<(), HarnessError> {
-        // session-manager stores custom entries via a `custom` message wrapper
-        // with no model wire mapping; the harness reads them back with
-        // include_custom.
-        let mut payload = json!({
-            "session_id": session_id,
-            "entry_id": entry_id,
-            "message": {
-                "role": "custom",
-                "custom_type": custom_type,
-                "content": [],
-                "details": data,
-                "timestamp": AgentMessage::now_ms(),
-            },
-        });
-        if let Some(o) = origin {
-            payload["origin"] = o.clone();
-        }
+        let payload = custom_append_payload(session_id, custom_type, data, entry_id, origin);
         self.call("session::append", payload).await.map(|_| ())
     }
 
@@ -314,5 +298,63 @@ impl SessionClient {
             }
         }
         Ok(Some(out))
+    }
+}
+
+/// The `session::append` request for a bookkeeping entry. The record MUST ride
+/// the dedicated `custom` field: `session::append` only creates a
+/// `kind: "custom"` entry from it — a `role: "custom"` message wrapper is
+/// stored as a plain `kind: "message"` entry, which `session::messages`
+/// returns with `custom: None`, so the record would never be found on
+/// read-back (the compaction round-trip depends on this).
+fn custom_append_payload(
+    session_id: &str,
+    custom_type: &str,
+    data: Value,
+    entry_id: &str,
+    origin: Option<&Value>,
+) -> Value {
+    let mut payload = json!({
+        "session_id": session_id,
+        "entry_id": entry_id,
+        "custom": {
+            "custom_type": custom_type,
+            "data": data,
+        },
+    });
+    if let Some(o) = origin {
+        payload["origin"] = o.clone();
+    }
+    payload
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Prevents: the compaction record silently persisting as a plain message
+    // entry — `session::append` only creates a `kind: "custom"` entry from
+    // the `custom` field, and the turn loop only reads the record back from
+    // `entry.custom` (a message-wrapped record makes every step reassemble
+    // the full transcript and recompact from scratch).
+    #[test]
+    fn custom_append_rides_the_custom_field() {
+        let origin = json!({ "turn_id": "t_1" });
+        let payload = custom_append_payload(
+            "s_1",
+            "compaction",
+            json!({ "summary": "s", "tail_start_entry_id": "e_9" }),
+            "e_compaction_1",
+            Some(&origin),
+        );
+        assert_eq!(payload["custom"]["custom_type"], "compaction");
+        assert_eq!(payload["custom"]["data"]["summary"], "s");
+        assert_eq!(payload["entry_id"], "e_compaction_1");
+        assert_eq!(payload["origin"], origin);
+        assert!(
+            payload.get("message").is_none(),
+            "custom records must not be message-wrapped (stored as kind: message, \
+             returned with custom: None, invisible to the read-back)"
+        );
     }
 }


### PR DESCRIPTION
## Problem

After a context compaction, every subsequent step reassembled the **full** transcript and recompacted from scratch — one summarizer LLM call and ~30s of latency per step. Observed live in session `console-4690383c-9a82-4588-9ceb-189da2aa35b0`: 12 compactions in a single turn (steps 6–17), `initial_token_count` regrowing from 246k to 752k, and step 7's `248,814 → 9,387` reduction discarded by step 8 (back at 252,188).

## Root cause

A wire-contract mismatch between harness and session-manager, present since harness v1 (#281):

- `SessionClient::append_custom` sent bookkeeping records as a **message wrapper** — `message: { role: "custom", custom_type, details }`.
- `session::append` only creates a `kind: "custom"` entry from the dedicated `custom` request field; the wrapper was stored as a plain `kind: "message"` entry.
- `session::messages` therefore returned it with `custom: None`, and the turn loop reads the compaction record back **exclusively** from `entry.custom` (`turn_loop.rs` `assemble_context`).

So `previous_summary` / `tail_start_entry_id` were never found on read-back: the candidate window was always the full transcript, the summary was never anchored (no convergent updates), and compaction re-ran on every over-budget step.

## Fix

Send the record on the `custom` field (`custom: { custom_type, data }`). Payload construction is extracted into `custom_append_payload` with a unit test pinning the shape (no `message` key, record under `custom`).

Side effects, all verified:
- All `append_custom` call sites (compaction record, max_turns notice, trigger-fired, react join records) become real `kind: "custom"` entries — they also stop inflating `message_count`, matching the documented intent.
- The console entry-mapper already handles both shapes (`item.custom` at `entry-mapper.ts:387`, role-custom message fallback at `:468`), so compaction markers and token estimates keep rendering, including for pre-fix sessions.
- `harness::send` with a `role: "custom"` message is a separate path and is untouched.

## Testing

- `cargo test` (harness): 231 passed, including the new `custom_append_rides_the_custom_field` regression test.
- `cargo clippy --all-targets --all-features`: clean. `cargo fmt --check`: clean.
- session-manager unchanged; its existing tests already pin the `custom` append/read-back contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom session entries are now submitted using the dedicated custom data field.
  * Preserved custom entry details, including type, data, identifier, and optional origin.
  * Prevented custom records from being incorrectly wrapped as messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes MOT-4116