### PR TITLE
feat(browser): viewport recording, ghost cursor, session-status badge (MOT-4114)

### DIFF
--- a/browser/README.md
+++ b/browser/README.md
@@ -129,6 +129,15 @@ timeout elapses, emitting `browser::handoff-requested` for the console to
 surface. Human acknowledgment is not proof, so the caller verifies the
 expected page state after it returns.
 
+`browser::recording::start` / `browser::recording::stop` capture a session's
+live viewport to a webm or mp4 file by piping the screencast through ffmpeg
+(turning screencast on if needed); stop returns the path, duration, and
+frame count. While screencast is active a human watching the viewport also
+sees a ghost cursor following the agent's clicks and a session-status badge;
+both are fixed-position in-page overlays that never touch page content.
+`browser::doctor` reports whether ffmpeg (recording) and attach mode are
+available.
+
 ## Configuration
 
 Stored in the `configuration` worker under the `browser` key; every field is

--- a/browser/skills/SKILL.md
+++ b/browser/skills/SKILL.md
@@ -50,6 +50,9 @@ on navigation; re-snapshot before acting after any page change.
   next navigation and never touch source files. Use them to find the right
   value, then edit the codebase.
 - `browser::pick::*`, `browser::screencast::*`, and `browser::frame` are console-UI plumbing, not agent surface.
+- The ghost cursor and session-status badge are in-page overlays for a human
+  watching the streamed viewport; they appear only while screencast is
+  active and never affect page content or the accessibility snapshot.
 - Navigation is limited to the configured URL schemes (http/https by
   default).
 
@@ -69,7 +72,11 @@ on navigation; re-snapshot before acting after any page change.
 - `browser::tabs::list` — open tabs of a running browser at a CDP endpoint,
   with which are already adopted; read-only.
 - `browser::doctor` — read-only environment report: which Chromium would
-  launch, its version, capacity, and anything degraded with how to enable it.
+  launch, its version, capacity, whether attach and recording are available,
+  and anything degraded with how to enable it.
+- `browser::recording::start` / `browser::recording::stop` — capture a
+  session's live viewport to a webm or mp4 file via ffmpeg; stop returns the
+  path, duration, and frame count. Requires ffmpeg on PATH.
 - `browser::navigate` — go to a URL and wait for the load.
 - `browser::snapshot` — the page as an accessibility outline with `[ref=eN]`
   handles; the default way to read a page. `diff: true` returns only what

--- a/browser/src/functions/doctor.rs
+++ b/browser/src/functions/doctor.rs
@@ -30,7 +30,23 @@ pub struct DoctorOutput {
     pub max_sessions: u64,
     pub active_sessions: u64,
     pub allowed_schemes: Vec<String>,
+    /// Whether attach mode is enabled (allow_attach).
+    pub attach_enabled: bool,
+    /// Whether ffmpeg is on PATH, which browser::recording requires.
+    pub recording_available: bool,
     pub issues: Vec<DoctorIssue>,
+}
+
+/// Whether ffmpeg is invokable, gating `browser::recording`. Blocking; call
+/// from spawn_blocking.
+pub fn ffmpeg_available() -> bool {
+    std::process::Command::new("ffmpeg")
+        .arg("-version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
 }
 
 /// Candidate system installs checked when config `executable` is empty, in

--- a/browser/src/functions/mod.rs
+++ b/browser/src/functions/mod.rs
@@ -15,7 +15,9 @@ pub mod hint;
 pub mod history;
 pub mod navigate;
 pub mod network;
+pub mod overlays;
 pub mod pick;
+pub mod recording;
 pub mod screenshot;
 pub mod sessions;
 pub mod snapshot;
@@ -144,6 +146,15 @@ pub const FRAME_ID: &str = "browser::frame";
 pub const FRAME_DESC: &str =
     "Internal: newest screencast frame, or nothing when since_frame is still current. No \
      capture round-trip; poll fast. Not an agent function.";
+pub const RECORDING_START_ID: &str = "browser::recording::start";
+pub const RECORDING_START_DESC: &str =
+    "Record a session's live viewport to a video file (webm or mp4) by piping the screencast \
+     through ffmpeg. Turns screencast on if needed. Requires ffmpeg on PATH; browser::doctor \
+     reports whether it is available.";
+pub const RECORDING_STOP_ID: &str = "browser::recording::stop";
+pub const RECORDING_STOP_DESC: &str =
+    "Stop a session's recording, finalize the file, and return its path, duration, and frame \
+     count. Idempotent: stopping when nothing is recording returns ok=false.";
 pub const PICK_HINT_ID: &str = "browser::pick::hint";
 pub const PICK_HINT_DESC: &str =
     "Internal: element preview at a viewport point (tag, id, classes, bounds) so the console \
@@ -233,6 +244,14 @@ pub fn catalog() -> Vec<FunctionSpec> {
             SCREENCAST_STOP_DESC,
         ),
         spec::<frame::FrameInput, frame::FrameOutput>(FRAME_ID, FRAME_DESC),
+        spec::<recording::RecordingStartInput, recording::RecordingStartOutput>(
+            RECORDING_START_ID,
+            RECORDING_START_DESC,
+        ),
+        spec::<recording::RecordingStopInput, recording::RecordingStopOutput>(
+            RECORDING_STOP_ID,
+            RECORDING_STOP_DESC,
+        ),
         spec::<hint::PickHintInput, hint::PickHintOutput>(PICK_HINT_ID, PICK_HINT_DESC),
         spec::<pick::PickStartInput, pick::AckOutput>(PICK_START_ID, PICK_START_DESC),
         spec::<pick::PickResolveInput, pick::AckOutput>(PICK_RESOLVE_ID, PICK_RESOLVE_DESC),
@@ -264,6 +283,8 @@ pub fn register_all(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
     register_screencast_start(iii, sessions);
     register_screencast_stop(iii, sessions);
     register_frame(iii, sessions);
+    register_recording_start(iii, sessions);
+    register_recording_stop(iii, sessions);
     register_pick_hint(iii, sessions);
     register_pick_start(iii, sessions);
     register_pick_resolve(iii, sessions);
@@ -643,6 +664,21 @@ fn register_screenshot(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
     );
 }
 
+/// Best-effort: draw the ghost cursor at the acted point so a human watching
+/// the streamed viewport sees where the agent acted. Only injected while
+/// screencast is active (someone is watching); a failed injection is ignored.
+async fn move_ghost_cursor(session: &Session, x: f64, y: f64, click: bool) {
+    if session
+        .screencast_active
+        .load(std::sync::atomic::Ordering::Relaxed)
+    {
+        let _ = session
+            .page
+            .evaluate(overlays::ghost_cursor_script(x, y, click))
+            .await;
+    }
+}
+
 /// Resolve the target point for a ref- or coordinate-addressed action.
 async fn action_point(session: &Session, req: &act::ActInput) -> Result<(f64, f64), Error> {
     if let Some(r) = &req.r#ref {
@@ -756,11 +792,13 @@ fn register_act(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                         let button = req.button.as_deref().unwrap_or("left");
                         let clicks = i64::from(req.click_count.unwrap_or(1));
                         dispatch_click(&session, x, y, button, clicks).await?;
+                        move_ghost_cursor(&session, x, y, true).await;
                         format!("clicked {button} x{clicks} at ({x:.0}, {y:.0})")
                     }
                     "hover" => {
                         let (x, y) = action_point(&session, &req).await?;
                         dispatch_hover(&session, x, y).await?;
+                        move_ghost_cursor(&session, x, y, false).await;
                         format!("hovering at ({x:.0}, {y:.0})")
                     }
                     "type" => {
@@ -1167,6 +1205,16 @@ fn register_doctor(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                     });
                 }
 
+                let recording_available = tokio::task::spawn_blocking(doctor::ffmpeg_available)
+                    .await
+                    .unwrap_or(false);
+                if !recording_available {
+                    issues.push(doctor::DoctorIssue {
+                        what: "ffmpeg not found; browser::recording is unavailable".to_string(),
+                        enable_how: "install ffmpeg and put it on PATH".to_string(),
+                    });
+                }
+
                 Ok::<_, Error>(doctor::DoctorOutput {
                     ok: chromium_path.is_some() && active_sessions < cfg.max_sessions,
                     chromium_path: chromium_path.map(|p| p.display().to_string()),
@@ -1175,6 +1223,8 @@ fn register_doctor(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                     max_sessions: cfg.max_sessions,
                     active_sessions,
                     allowed_schemes: cfg.allowed_schemes.clone(),
+                    attach_enabled: cfg.allow_attach,
+                    recording_available,
                     issues,
                 })
             }
@@ -1770,6 +1820,16 @@ fn register_screencast_start(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                 session
                     .screencast_active
                     .store(true, std::sync::atomic::Ordering::Relaxed);
+                // A human is now watching: show the session-status badge.
+                let mode = if session.read_only {
+                    "read-only"
+                } else {
+                    "active"
+                };
+                let _ = session
+                    .page
+                    .evaluate(overlays::badge_script(&session.id, mode))
+                    .await;
                 Ok::<_, Error>(pick::AckOutput { ok: true })
             }
         })
@@ -1793,6 +1853,13 @@ fn register_screencast_stop(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
                     session
                         .screencast_active
                         .store(false, std::sync::atomic::Ordering::Relaxed);
+                    // Nobody is watching now: remove the status badge and
+                    // ghost cursor so they do not linger in the page.
+                    let _ = session.page.evaluate(overlays::remove_badge_script()).await;
+                    let _ = session
+                        .page
+                        .evaluate(overlays::remove_ghost_cursor_script())
+                        .await;
                     // Drop the last frame from the stream so a later
                     // subscriber does not see a stale image.
                     let _ = sx
@@ -1813,6 +1880,58 @@ fn register_screencast_stop(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
         })
         .description(SCREENCAST_STOP_DESC)
         .metadata(json!({ "internal": true })),
+    );
+}
+
+fn register_recording_start(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
+    let sx = sessions.clone();
+    iii.register_function(
+        RECORDING_START_ID,
+        RegisterFunction::new_async(move |req: recording::RecordingStartInput| {
+            let sx = sx.clone();
+            async move {
+                get_session(&sx, &req.session_id)?;
+                let (format, codec) =
+                    recording::resolve_format(req.format.as_deref()).map_err(handler_err)?;
+                sx.start_recording(&req.session_id, &req.path, codec)
+                    .await
+                    .map_err(handler_err)?;
+                Ok::<_, Error>(recording::RecordingStartOutput {
+                    ok: true,
+                    path: req.path,
+                    format: format.to_string(),
+                })
+            }
+        })
+        .description(RECORDING_START_DESC),
+    );
+}
+
+fn register_recording_stop(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
+    let sx = sessions.clone();
+    iii.register_function(
+        RECORDING_STOP_ID,
+        RegisterFunction::new_async(move |req: recording::RecordingStopInput| {
+            let sx = sx.clone();
+            async move {
+                let output = match sx.stop_recording(&req.session_id).await {
+                    Some((path, duration_ms, frames)) => recording::RecordingStopOutput {
+                        ok: true,
+                        path: Some(path),
+                        duration_ms,
+                        frames,
+                    },
+                    None => recording::RecordingStopOutput {
+                        ok: false,
+                        path: None,
+                        duration_ms: 0,
+                        frames: 0,
+                    },
+                };
+                Ok::<_, Error>(output)
+            }
+        })
+        .description(RECORDING_STOP_DESC),
     );
 }
 

--- a/browser/src/functions/mod.rs
+++ b/browser/src/functions/mod.rs
@@ -668,10 +668,7 @@ fn register_screenshot(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
 /// the streamed viewport sees where the agent acted. Only injected while
 /// screencast is active (someone is watching); a failed injection is ignored.
 async fn move_ghost_cursor(session: &Session, x: f64, y: f64, click: bool) {
-    if session
-        .screencast_active
-        .load(std::sync::atomic::Ordering::Relaxed)
-    {
+    if session.screencast_on() {
         let _ = session
             .page
             .evaluate(overlays::ghost_cursor_script(x, y, click))
@@ -1801,25 +1798,11 @@ fn register_screencast_start(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
             async move {
                 let session = get_session(&sx, &req.session_id)?;
                 session.touch();
-                let cfg = sx.config.load();
-                // every_nth_frame counts COMPOSITOR frames, not wall-clock, so
-                // a value > 1 starves a static page (which may never produce
-                // that many repaints and would then emit no frame at all). Take
-                // every frame and cap the push rate by time in the pump
-                // instead (see FRAME_MIN_INTERVAL_MS).
-                let params = cdp_page::StartScreencastParams::builder()
-                    .format(cdp_page::StartScreencastFormat::Jpeg)
-                    .quality(cfg.screenshot_quality as i64)
-                    .every_nth_frame(1)
-                    .build();
-                session
-                    .page
-                    .execute(params)
-                    .await
-                    .map_err(|e| handler_err(format!("screencast start failed: {e}")))?;
-                session
-                    .screencast_active
-                    .store(true, std::sync::atomic::Ordering::Relaxed);
+                // Register a console viewer as a screencast consumer; the CDP
+                // screencast starts on the first consumer (see
+                // Sessions::acquire_screencast, which uses every_nth_frame(1)
+                // and caps the push rate by time in the pump).
+                sx.acquire_screencast(&session).await.map_err(handler_err)?;
                 // A human is now watching: show the session-status badge.
                 let mode = if session.read_only {
                     "read-only"
@@ -1846,15 +1829,11 @@ fn register_screencast_stop(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
             let sx = sx.clone();
             async move {
                 if let Some(session) = sx.get(&req.session_id) {
-                    let _ = session
-                        .page
-                        .execute(cdp_page::StopScreencastParams::default())
-                        .await;
-                    session
-                        .screencast_active
-                        .store(false, std::sync::atomic::Ordering::Relaxed);
-                    // Nobody is watching now: remove the status badge and
-                    // ghost cursor so they do not linger in the page.
+                    // Release this console viewer; the CDP screencast stops
+                    // only if no other consumer (e.g. a recording) remains.
+                    sx.release_screencast(&session).await;
+                    // The viewer's overlays go regardless; they belong to the
+                    // watching human, not to a recording consumer.
                     let _ = session.page.evaluate(overlays::remove_badge_script()).await;
                     let _ = session
                         .page
@@ -1943,9 +1922,7 @@ fn register_frame(iii: &Arc<IIIClient>, sessions: &Arc<Sessions>) {
             let sx = sx.clone();
             async move {
                 let session = get_session(&sx, &req.session_id)?;
-                let active = session
-                    .screencast_active
-                    .load(std::sync::atomic::Ordering::Relaxed);
+                let active = session.screencast_on();
                 // Clone the Arc under the lock and release it before copying
                 // the base64 payload, so the push-rate pump never waits
                 // behind this poll-rate copy.

--- a/browser/src/functions/overlays.rs
+++ b/browser/src/functions/overlays.rs
@@ -1,0 +1,79 @@
+//! In-page overlays a human watching the streamed viewport can see: the
+//! ghost cursor (where the agent is acting) and the session-status badge
+//! (which session controls the tab and in what mode). Both are injected JS,
+//! idempotent, and confined to fixed-position elements with a sentinel id so
+//! they never collide with page content.
+
+/// Mount (once) the ghost-cursor element and move it to `(x, y)`. `click`
+/// flashes it. Injected on each act so the overlay follows the agent.
+pub fn ghost_cursor_script(x: f64, y: f64, click: bool) -> String {
+    format!(
+        r#"(() => {{
+  let c = document.getElementById('iii-ghost-cursor');
+  if (!c) {{
+    c = document.createElement('div');
+    c.id = 'iii-ghost-cursor';
+    c.style.cssText = 'position:fixed;width:18px;height:18px;margin:-9px 0 0 -9px;'
+      + 'border-radius:50%;background:rgba(16,185,129,.6);border:2px solid #10b981;'
+      + 'z-index:2147483646;pointer-events:none;transition:left .08s,top .08s,transform .1s';
+    (document.body || document.documentElement).appendChild(c);
+  }}
+  c.style.left = {x} + 'px';
+  c.style.top = {y} + 'px';
+  if ({click}) {{
+    c.style.transform = 'scale(1.8)';
+    setTimeout(() => {{ const e = document.getElementById('iii-ghost-cursor'); if (e) e.style.transform = 'scale(1)'; }}, 120);
+  }}
+  return true;
+}})()"#
+    )
+}
+
+/// Mount or update the session-status badge. `mode` is a short label
+/// (active, read-only, handoff pending). Removed by `remove_badge_script`.
+pub fn badge_script(session_id: &str, mode: &str) -> String {
+    format!(
+        r#"(() => {{
+  let b = document.getElementById('iii-session-badge');
+  if (!b) {{
+    b = document.createElement('div');
+    b.id = 'iii-session-badge';
+    b.style.cssText = 'position:fixed;bottom:8px;right:8px;z-index:2147483646;'
+      + 'background:rgba(17,24,39,.85);color:#f9fafb;font:11px system-ui,sans-serif;'
+      + 'padding:4px 8px;border-radius:6px;pointer-events:none';
+    (document.body || document.documentElement).appendChild(b);
+  }}
+  b.textContent = {session_id:?} + ' · ' + {mode:?};
+  return true;
+}})()"#
+    )
+}
+
+pub fn remove_badge_script() -> String {
+    "(() => { const b = document.getElementById('iii-session-badge'); if (b) b.remove(); return true; })()".to_string()
+}
+
+pub fn remove_ghost_cursor_script() -> String {
+    "(() => { const c = document.getElementById('iii-ghost-cursor'); if (c) c.remove(); return true; })()".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ghost_cursor_positions_and_flags_click() {
+        let js = ghost_cursor_script(12.0, 34.0, true);
+        assert!(js.contains("12 + 'px'"));
+        assert!(js.contains("34 + 'px'"));
+        assert!(js.contains("if (true)"));
+        assert!(js.contains("iii-ghost-cursor"));
+    }
+
+    #[test]
+    fn badge_renders_id_and_mode_as_literals() {
+        let js = badge_script("b1", "read-only");
+        assert!(js.contains("\"b1\""));
+        assert!(js.contains("\"read-only\""));
+    }
+}

--- a/browser/src/functions/recording.rs
+++ b/browser/src/functions/recording.rs
@@ -64,8 +64,19 @@ pub fn ffmpeg_args(codec: &str, path: &str) -> Vec<String> {
         codec.into(),
         "-pix_fmt".into(),
         "yuv420p".into(),
-        path.into(),
+        sanitize_output_path(path),
     ]
+}
+
+/// Keep a relative path that begins with `-` from being read as an ffmpeg
+/// option by prefixing `./`. Absolute paths and ordinary relative paths pass
+/// through unchanged.
+fn sanitize_output_path(path: &str) -> String {
+    if path.starts_with('-') && !std::path::Path::new(path).is_absolute() {
+        format!("./{path}")
+    } else {
+        path.to_string()
+    }
 }
 
 #[cfg(test)]
@@ -85,5 +96,14 @@ mod tests {
         assert!(args.contains(&"image2pipe".to_string()));
         assert_eq!(args.last().unwrap(), "/tmp/out.mp4");
         assert!(args.windows(2).any(|w| w == ["-c:v", "libx264"]));
+    }
+
+    #[test]
+    fn dash_prefixed_relative_path_is_escaped() {
+        // A leading dash would otherwise be read as an ffmpeg option.
+        assert_eq!(sanitize_output_path("-weird.mp4"), "./-weird.mp4");
+        // Absolute and ordinary relative paths are untouched.
+        assert_eq!(sanitize_output_path("/tmp/-weird.mp4"), "/tmp/-weird.mp4");
+        assert_eq!(sanitize_output_path("out.mp4"), "out.mp4");
     }
 }

--- a/browser/src/functions/recording.rs
+++ b/browser/src/functions/recording.rs
@@ -1,0 +1,89 @@
+//! `browser::recording::start` / `stop` — capture a session's live viewport
+//! to a video file by piping the screencast JPEG frames through ffmpeg.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RecordingStartInput {
+    pub session_id: String,
+    /// Output file path. The extension should match `format`.
+    pub path: String,
+    /// `webm` (VP9) or `mp4` (H.264). Defaults to webm.
+    #[serde(default)]
+    pub format: Option<String>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct RecordingStartOutput {
+    pub ok: bool,
+    pub path: String,
+    pub format: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RecordingStopInput {
+    pub session_id: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct RecordingStopOutput {
+    /// False when no recording was running.
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// Wall-clock duration captured, milliseconds.
+    pub duration_ms: i64,
+    /// Frames written to the encoder.
+    pub frames: u64,
+}
+
+/// Resolve a requested format string to (canonical name, ffmpeg codec).
+/// Unknown formats fail closed so a typo does not silently pick a default.
+pub fn resolve_format(format: Option<&str>) -> Result<(&'static str, &'static str), String> {
+    match format.unwrap_or("webm").to_ascii_lowercase().as_str() {
+        "webm" => Ok(("webm", "libvpx-vp9")),
+        "mp4" => Ok(("mp4", "libx264")),
+        other => Err(format!("unknown format '{other}' (use webm or mp4)")),
+    }
+}
+
+/// ffmpeg args to read a stream of JPEG frames on stdin and encode to
+/// `path`. `-framerate` is the assumed input rate (the pump caps at ~15fps);
+/// `yuv420p` keeps the result playable in browsers and QuickTime.
+pub fn ffmpeg_args(codec: &str, path: &str) -> Vec<String> {
+    vec![
+        "-y".into(),
+        "-f".into(),
+        "image2pipe".into(),
+        "-framerate".into(),
+        "15".into(),
+        "-i".into(),
+        "-".into(),
+        "-c:v".into(),
+        codec.into(),
+        "-pix_fmt".into(),
+        "yuv420p".into(),
+        path.into(),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_resolution() {
+        assert_eq!(resolve_format(None).unwrap(), ("webm", "libvpx-vp9"));
+        assert_eq!(resolve_format(Some("MP4")).unwrap(), ("mp4", "libx264"));
+        assert!(resolve_format(Some("gif")).is_err());
+    }
+
+    #[test]
+    fn ffmpeg_args_read_stdin_pipe() {
+        let args = ffmpeg_args("libx264", "/tmp/out.mp4");
+        assert!(args.contains(&"image2pipe".to_string()));
+        assert_eq!(args.last().unwrap(), "/tmp/out.mp4");
+        assert!(args.windows(2).any(|w| w == ["-c:v", "libx264"]));
+    }
+}

--- a/browser/src/functions/snapshot.rs
+++ b/browser/src/functions/snapshot.rs
@@ -31,12 +31,18 @@ pub struct SnapshotOutput {
     /// Indented outline; lines carry `[ref=eN]` handles for `browser::act`.
     /// Empty when `diff` is populated.
     pub tree: String,
-    /// True when the tree hit `max_snapshot_nodes` and was cut short.
+    /// True when the tree hit `max_snapshot_nodes` and was cut short. Also
+    /// the signal that a `diff` may be incomplete: the diff is computed over
+    /// emitted nodes only, so when either snapshot was truncated a node that
+    /// was emitted before and capped out now can show up in `removed` even
+    /// though it still exists (and vice versa for `added`).
     pub truncated: bool,
     /// Document generation the refs belong to; navigation advances it and
     /// kills every ref from earlier generations.
     pub generation: u64,
     /// Present when the caller asked for `diff: true` and a baseline existed.
+    /// Covers only the emitted nodes of both snapshots; check `truncated`
+    /// before trusting it as a complete change set.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diff: Option<SnapshotDiff>,
 }

--- a/browser/src/session.rs
+++ b/browser/src/session.rs
@@ -9,6 +9,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
 use chromiumoxide::browser::{Browser, BrowserConfig};
 use chromiumoxide::cdp::browser_protocol::dom;
 use chromiumoxide::cdp::browser_protocol::log as cdp_log;
@@ -220,6 +222,19 @@ pub enum SessionKind {
     Attached { owns_page: bool },
 }
 
+/// An in-progress screen recording: the ffmpeg child the screencast pump
+/// feeds decoded JPEG frames, plus the bookkeeping `recording::stop` returns.
+pub struct Recording {
+    pub child: tokio::process::Child,
+    pub stdin: tokio::process::ChildStdin,
+    pub path: String,
+    pub started_ms: i64,
+    pub frames: u64,
+    /// True when `recording::start` turned screencast on; `stop` turns it
+    /// back off only in that case, leaving a console-owned screencast alone.
+    pub started_screencast: bool,
+}
+
 pub struct Session {
     pub id: String,
     pub headless: bool,
@@ -240,6 +255,9 @@ pub struct Session {
     ephemeral_profile: Option<std::path::PathBuf>,
     pub latest_frame: Mutex<Option<LatestFrame>>,
     pub screencast_active: std::sync::atomic::AtomicBool,
+    /// Set while a `browser::recording` is capturing; the screencast pump
+    /// writes decoded frames into it.
+    pub recording: tokio::sync::Mutex<Option<Recording>>,
     frame_seq: AtomicU64,
     browser: tokio::sync::Mutex<Browser>,
     pub page: Page,
@@ -368,6 +386,19 @@ impl Session {
     /// `Sessions::stop` removes the session from the map first, so a second
     /// stop never reaches here.
     pub async fn shutdown(&self) {
+        // Finalize any recording first: dropping stdin lets ffmpeg flush the
+        // file, then reap the child so it is not orphaned. Bound the wait so
+        // an ffmpeg that ignores its closed stdin cannot block shutdown
+        // forever; on timeout, kill it and reap.
+        if let Some(mut recording) = self.recording.lock().await.take() {
+            drop(recording.stdin);
+            let reap =
+                tokio::time::timeout(std::time::Duration::from_secs(5), recording.child.wait())
+                    .await;
+            if reap.is_err() {
+                let _ = recording.child.kill().await;
+            }
+        }
         for task in self
             .tasks
             .lock()
@@ -528,6 +559,7 @@ impl Sessions {
             ephemeral_profile,
             latest_frame: Mutex::new(None),
             screencast_active: std::sync::atomic::AtomicBool::new(false),
+            recording: tokio::sync::Mutex::new(None),
             frame_seq: AtomicU64::new(0),
             browser: tokio::sync::Mutex::new(browser),
             page: page.clone(),
@@ -622,6 +654,7 @@ impl Sessions {
             ephemeral_profile: None,
             latest_frame: Mutex::new(None),
             screencast_active: std::sync::atomic::AtomicBool::new(false),
+            recording: tokio::sync::Mutex::new(None),
             frame_seq: AtomicU64::new(0),
             browser: tokio::sync::Mutex::new(browser),
             page: page.clone(),
@@ -831,6 +864,119 @@ impl Sessions {
         // still succeeds in removing the stale entry.
         let _ = handoff.confirm.send(());
         Some(key)
+    }
+
+    /// Start recording a session's viewport to `path`, encoded as `codec`
+    /// via ffmpeg reading the screencast JPEG stream on stdin. Ensures
+    /// screencast is on (remembering whether we turned it on) so a plain
+    /// `recording::start` works without a separate screencast call.
+    pub async fn start_recording(
+        &self,
+        session_id: &str,
+        path: &str,
+        codec: &str,
+    ) -> Result<(), String> {
+        let session = self
+            .get(session_id)
+            .ok_or_else(|| format!("unknown session '{session_id}'"))?;
+        {
+            let rec = session.recording.lock().await;
+            if rec.is_some() {
+                return Err(format!(
+                    "session '{session_id}' is already recording; stop it first"
+                ));
+            }
+        }
+
+        let started_screencast = !session
+            .screencast_active
+            .load(std::sync::atomic::Ordering::Relaxed);
+        if started_screencast {
+            self.start_screencast(&session).await?;
+        }
+
+        let args = crate::functions::recording::ffmpeg_args(codec, path);
+        let mut child = tokio::process::Command::new("ffmpeg")
+            .args(&args)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .map_err(|e| {
+                format!("failed to launch ffmpeg ({e}); install ffmpeg and put it on PATH")
+            })?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "ffmpeg stdin unavailable".to_string())?;
+
+        let mut rec = session.recording.lock().await;
+        *rec = Some(Recording {
+            child,
+            stdin,
+            path: path.to_string(),
+            started_ms: now_ms(),
+            frames: 0,
+            started_screencast,
+        });
+        Ok(())
+    }
+
+    /// Stop a session's recording: close ffmpeg's stdin so it finalizes the
+    /// file, wait for it, and turn screencast back off if recording started
+    /// it. Returns None when nothing was recording.
+    pub async fn stop_recording(&self, session_id: &str) -> Option<(String, i64, u64)> {
+        let session = self.get(session_id)?;
+        let recording = session.recording.lock().await.take()?;
+        let Recording {
+            mut child,
+            stdin,
+            path,
+            started_ms,
+            frames,
+            started_screencast,
+        } = recording;
+        // Dropping stdin closes the pipe; ffmpeg then flushes and exits.
+        drop(stdin);
+        let _ = child.wait().await;
+        if started_screencast {
+            let _ = self.stop_screencast(&session).await;
+        }
+        Some((path, now_ms() - started_ms, frames))
+    }
+
+    /// Turn on Chromium screencast for a session (shared by the internal
+    /// screencast-start function and recording).
+    pub async fn start_screencast(&self, session: &Arc<Session>) -> Result<(), String> {
+        use chromiumoxide::cdp::browser_protocol::page as cdp_page;
+        let quality = self.config.load().screenshot_quality as i64;
+        let params = cdp_page::StartScreencastParams::builder()
+            .format(cdp_page::StartScreencastFormat::Jpeg)
+            .quality(quality)
+            .every_nth_frame(1)
+            .build();
+        session
+            .page
+            .execute(params)
+            .await
+            .map_err(|e| format!("screencast start failed: {e}"))?;
+        session
+            .screencast_active
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        Ok(())
+    }
+
+    /// Turn off Chromium screencast for a session.
+    pub async fn stop_screencast(&self, session: &Arc<Session>) -> Result<(), String> {
+        use chromiumoxide::cdp::browser_protocol::page as cdp_page;
+        let _ = session
+            .page
+            .execute(cdp_page::StopScreencastParams::default())
+            .await;
+        session
+            .screencast_active
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+        Ok(())
     }
 
     /// Stop sessions idle beyond the configured threshold. Called from the
@@ -1152,6 +1298,23 @@ async fn spawn_event_pumps(
                     // Push onto the stream (the console subscribes to it); the
                     // in-memory slot stays as the seed for a fresh subscriber.
                     push_frame_stream(&sx.iii, &s.id, &stream_frame).await;
+                    // Feed the recorder the same capped frame flow, decoded to
+                    // JPEG bytes on ffmpeg's stdin. A broken pipe (ffmpeg gone)
+                    // is logged and dropped; recording::stop reaps the child.
+                    {
+                        let mut rec = s.recording.lock().await;
+                        if let Some(recording) = rec.as_mut() {
+                            let data: &str = stream_frame.frame.data.as_ref();
+                            if let Ok(bytes) = STANDARD.decode(data) {
+                                use tokio::io::AsyncWriteExt;
+                                if recording.stdin.write_all(&bytes).await.is_ok() {
+                                    recording.frames += 1;
+                                } else {
+                                    tracing::debug!(session_id = %s.id, "recording write failed");
+                                }
+                            }
+                        }
+                    }
                     let mut slot = s.latest_frame.lock().unwrap_or_else(|p| p.into_inner());
                     *slot = Some(stream_frame);
                 }

--- a/browser/src/session.rs
+++ b/browser/src/session.rs
@@ -226,13 +226,41 @@ pub enum SessionKind {
 /// feeds decoded JPEG frames, plus the bookkeeping `recording::stop` returns.
 pub struct Recording {
     pub child: tokio::process::Child,
-    pub stdin: tokio::process::ChildStdin,
+    /// Bounded queue the screencast pump feeds decoded JPEG frames onto with
+    /// `try_send` (dropping frames when full) so the pump never awaits ffmpeg
+    /// I/O. Drained by `writer`.
+    pub tx: tokio::sync::mpsc::Sender<Vec<u8>>,
+    /// Dedicated task that writes queued frames to ffmpeg's stdin and bumps
+    /// `frames` per successful write.
+    pub writer: tokio::task::JoinHandle<()>,
+    /// Frames actually written to ffmpeg, shared with the writer task.
+    pub frames: Arc<AtomicU64>,
     pub path: String,
     pub started_ms: i64,
-    pub frames: u64,
-    /// True when `recording::start` turned screencast on; `stop` turns it
-    /// back off only in that case, leaving a console-owned screencast alone.
-    pub started_screencast: bool,
+}
+
+/// Bounded frame queue depth: a few frames of slack so a brief ffmpeg stall
+/// doesn't drop everything, small enough that memory stays bounded and stale
+/// frames are dropped rather than buffered forever.
+const RECORDING_QUEUE_DEPTH: usize = 8;
+
+/// Drain decoded frames onto ffmpeg's stdin, counting successful writes.
+/// Exits when the channel closes (recording stopped) or the pipe breaks
+/// (ffmpeg gone), shutting stdin so ffmpeg can finalize the file.
+async fn recording_writer(
+    mut stdin: tokio::process::ChildStdin,
+    mut rx: tokio::sync::mpsc::Receiver<Vec<u8>>,
+    frames: Arc<AtomicU64>,
+) {
+    use tokio::io::AsyncWriteExt;
+    while let Some(bytes) = rx.recv().await {
+        if stdin.write_all(&bytes).await.is_ok() {
+            frames.fetch_add(1, Ordering::Relaxed);
+        } else {
+            break;
+        }
+    }
+    let _ = stdin.shutdown().await;
 }
 
 pub struct Session {
@@ -254,7 +282,12 @@ pub struct Session {
     /// `user_data_dir` mode.
     ephemeral_profile: Option<std::path::PathBuf>,
     pub latest_frame: Mutex<Option<LatestFrame>>,
-    pub screencast_active: std::sync::atomic::AtomicBool,
+    /// Number of live consumers of the Chromium screencast: each console
+    /// viewer and each recording counts as one. The CDP screencast runs
+    /// while this is > 0; it starts on the 0->1 transition and stops on
+    /// 1->0, so stopping a recording never cuts off a UI viewer (and vice
+    /// versa).
+    pub screencast_consumers: std::sync::atomic::AtomicUsize,
     /// Set while a `browser::recording` is capturing; the screencast pump
     /// writes decoded frames into it.
     pub recording: tokio::sync::Mutex<Option<Recording>>,
@@ -331,6 +364,12 @@ impl Session {
         self.generation.load(Ordering::Relaxed)
     }
 
+    /// True while the Chromium screencast is running (at least one consumer:
+    /// a console viewer and/or a recording).
+    pub fn screencast_on(&self) -> bool {
+        self.screencast_consumers.load(Ordering::Relaxed) > 0
+    }
+
     /// Merge new snapshot refs into the table. Names are session-monotonic
     /// so this never overwrites an older snapshot's names; the safety valve
     /// clears everything if the table grows past `MAX_REFS` (subsequent old
@@ -386,18 +425,22 @@ impl Session {
     /// `Sessions::stop` removes the session from the map first, so a second
     /// stop never reaches here.
     pub async fn shutdown(&self) {
-        // Finalize any recording first: dropping stdin lets ffmpeg flush the
-        // file, then reap the child so it is not orphaned. Bound the wait so
-        // an ffmpeg that ignores its closed stdin cannot block shutdown
-        // forever; on timeout, kill it and reap.
-        if let Some(mut recording) = self.recording.lock().await.take() {
-            drop(recording.stdin);
-            let reap =
-                tokio::time::timeout(std::time::Duration::from_secs(5), recording.child.wait())
-                    .await;
-            if reap.is_err() {
-                let _ = recording.child.kill().await;
+        // Finalize any recording first: closing the sender ends the writer,
+        // which shuts ffmpeg's stdin so it flushes the file; then reap the
+        // child so it is not orphaned. Bound the wait so an ffmpeg that
+        // ignores its closed stdin cannot block shutdown forever; on timeout,
+        // kill it and reap the terminated process.
+        if let Some(recording) = self.recording.lock().await.take() {
+            let mut child = recording.child;
+            drop(recording.tx);
+            if tokio::time::timeout(std::time::Duration::from_secs(5), child.wait())
+                .await
+                .is_err()
+            {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
             }
+            let _ = recording.writer.await;
         }
         for task in self
             .tasks
@@ -558,7 +601,7 @@ impl Sessions {
             created_ms: now,
             ephemeral_profile,
             latest_frame: Mutex::new(None),
-            screencast_active: std::sync::atomic::AtomicBool::new(false),
+            screencast_consumers: std::sync::atomic::AtomicUsize::new(0),
             recording: tokio::sync::Mutex::new(None),
             frame_seq: AtomicU64::new(0),
             browser: tokio::sync::Mutex::new(browser),
@@ -653,7 +696,7 @@ impl Sessions {
             created_ms: now,
             ephemeral_profile: None,
             latest_frame: Mutex::new(None),
-            screencast_active: std::sync::atomic::AtomicBool::new(false),
+            screencast_consumers: std::sync::atomic::AtomicUsize::new(0),
             recording: tokio::sync::Mutex::new(None),
             frame_seq: AtomicU64::new(0),
             browser: tokio::sync::Mutex::new(browser),
@@ -879,45 +922,58 @@ impl Sessions {
         let session = self
             .get(session_id)
             .ok_or_else(|| format!("unknown session '{session_id}'"))?;
-        {
-            let rec = session.recording.lock().await;
-            if rec.is_some() {
-                return Err(format!(
-                    "session '{session_id}' is already recording; stop it first"
-                ));
-            }
+
+        // Hold the recording lock across the whole check-and-set so two
+        // concurrent starts cannot both spawn ffmpeg and overwrite each
+        // other's Recording (leaking a process).
+        let mut guard = session.recording.lock().await;
+        if guard.is_some() {
+            return Err(format!(
+                "session '{session_id}' is already recording; stop it first"
+            ));
         }
 
-        let started_screencast = !session
-            .screencast_active
-            .load(std::sync::atomic::Ordering::Relaxed);
-        if started_screencast {
-            self.start_screencast(&session).await?;
-        }
+        // Acquire a screencast consumer (starts CDP screencast if we are the
+        // first). Released again on any failure below.
+        self.acquire_screencast(&session).await?;
 
         let args = crate::functions::recording::ffmpeg_args(codec, path);
-        let mut child = tokio::process::Command::new("ffmpeg")
+        let spawn = tokio::process::Command::new("ffmpeg")
             .args(&args)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
-            .spawn()
-            .map_err(|e| {
-                format!("failed to launch ffmpeg ({e}); install ffmpeg and put it on PATH")
-            })?;
-        let stdin = child
-            .stdin
-            .take()
-            .ok_or_else(|| "ffmpeg stdin unavailable".to_string())?;
+            .spawn();
+        let mut child = match spawn {
+            Ok(c) => c,
+            Err(e) => {
+                self.release_screencast(&session).await;
+                return Err(format!(
+                    "failed to launch ffmpeg ({e}); install ffmpeg and put it on PATH"
+                ));
+            }
+        };
+        let stdin = match child.stdin.take() {
+            Some(s) => s,
+            None => {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+                self.release_screencast(&session).await;
+                return Err("ffmpeg stdin unavailable".to_string());
+            }
+        };
 
-        let mut rec = session.recording.lock().await;
-        *rec = Some(Recording {
+        let (tx, rx) = tokio::sync::mpsc::channel::<Vec<u8>>(RECORDING_QUEUE_DEPTH);
+        let frames = Arc::new(AtomicU64::new(0));
+        let writer = tokio::spawn(recording_writer(stdin, rx, frames.clone()));
+
+        *guard = Some(Recording {
             child,
-            stdin,
+            tx,
+            writer,
+            frames,
             path: path.to_string(),
             started_ms: now_ms(),
-            frames: 0,
-            started_screencast,
         });
         Ok(())
     }
@@ -930,53 +986,77 @@ impl Sessions {
         let recording = session.recording.lock().await.take()?;
         let Recording {
             mut child,
-            stdin,
+            tx,
+            writer,
+            frames,
             path,
             started_ms,
-            frames,
-            started_screencast,
         } = recording;
-        // Dropping stdin closes the pipe; ffmpeg then flushes and exits.
-        drop(stdin);
-        let _ = child.wait().await;
-        if started_screencast {
-            let _ = self.stop_screencast(&session).await;
+        // Closing the sender ends the writer, which drains queued frames and
+        // shuts ffmpeg's stdin so ffmpeg finalizes the file.
+        drop(tx);
+        // Bound the reap so an ffmpeg that ignores its closed stdin cannot
+        // hang the caller; on timeout kill and reap the terminated process.
+        if tokio::time::timeout(std::time::Duration::from_secs(5), child.wait())
+            .await
+            .is_err()
+        {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
         }
-        Some((path, now_ms() - started_ms, frames))
+        // The child is done (or killed), so the writer's pipe is closed and
+        // it exits promptly; awaiting it makes the frame count final.
+        let _ = writer.await;
+        self.release_screencast(&session).await;
+        Some((path, now_ms() - started_ms, frames.load(Ordering::Relaxed)))
     }
 
-    /// Turn on Chromium screencast for a session (shared by the internal
-    /// screencast-start function and recording).
-    pub async fn start_screencast(&self, session: &Arc<Session>) -> Result<(), String> {
+    /// Register a screencast consumer (a console viewer or a recording).
+    /// Starts the Chromium screencast on the 0->1 transition; later
+    /// acquisitions just bump the count. On a CDP start failure the count is
+    /// rolled back so it stays honest.
+    pub async fn acquire_screencast(&self, session: &Arc<Session>) -> Result<(), String> {
         use chromiumoxide::cdp::browser_protocol::page as cdp_page;
+        let prev = session
+            .screencast_consumers
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if prev > 0 {
+            return Ok(());
+        }
         let quality = self.config.load().screenshot_quality as i64;
         let params = cdp_page::StartScreencastParams::builder()
             .format(cdp_page::StartScreencastFormat::Jpeg)
             .quality(quality)
             .every_nth_frame(1)
             .build();
-        session
-            .page
-            .execute(params)
-            .await
-            .map_err(|e| format!("screencast start failed: {e}"))?;
-        session
-            .screencast_active
-            .store(true, std::sync::atomic::Ordering::Relaxed);
+        if let Err(e) = session.page.execute(params).await {
+            session
+                .screencast_consumers
+                .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+            return Err(format!("screencast start failed: {e}"));
+        }
         Ok(())
     }
 
-    /// Turn off Chromium screencast for a session.
-    pub async fn stop_screencast(&self, session: &Arc<Session>) -> Result<(), String> {
+    /// Release a screencast consumer. Stops the Chromium screencast on the
+    /// 1->0 transition, leaving it running while any other consumer remains
+    /// (so stopping a recording never cuts off a UI viewer). Never underflows.
+    pub async fn release_screencast(&self, session: &Arc<Session>) {
         use chromiumoxide::cdp::browser_protocol::page as cdp_page;
-        let _ = session
-            .page
-            .execute(cdp_page::StopScreencastParams::default())
-            .await;
-        session
-            .screencast_active
-            .store(false, std::sync::atomic::Ordering::Relaxed);
-        Ok(())
+        let prev = session
+            .screencast_consumers
+            .fetch_update(
+                std::sync::atomic::Ordering::Relaxed,
+                std::sync::atomic::Ordering::Relaxed,
+                |n| n.checked_sub(1),
+            )
+            .unwrap_or(0);
+        if prev == 1 {
+            let _ = session
+                .page
+                .execute(cdp_page::StopScreencastParams::default())
+                .await;
+        }
     }
 
     /// Stop sessions idle beyond the configured threshold. Called from the
@@ -1298,20 +1378,17 @@ async fn spawn_event_pumps(
                     // Push onto the stream (the console subscribes to it); the
                     // in-memory slot stays as the seed for a fresh subscriber.
                     push_frame_stream(&sx.iii, &s.id, &stream_frame).await;
-                    // Feed the recorder the same capped frame flow, decoded to
-                    // JPEG bytes on ffmpeg's stdin. A broken pipe (ffmpeg gone)
-                    // is logged and dropped; recording::stop reaps the child.
+                    // Feed the recorder the same capped frame flow. Decode to
+                    // JPEG bytes and hand them to the writer task via a bounded
+                    // queue with try_send: the pump never awaits ffmpeg I/O
+                    // (nor holds a lock across it), and frames are dropped
+                    // rather than backing up if the encoder falls behind.
                     {
-                        let mut rec = s.recording.lock().await;
-                        if let Some(recording) = rec.as_mut() {
+                        let rec = s.recording.lock().await;
+                        if let Some(recording) = rec.as_ref() {
                             let data: &str = stream_frame.frame.data.as_ref();
                             if let Ok(bytes) = STANDARD.decode(data) {
-                                use tokio::io::AsyncWriteExt;
-                                if recording.stdin.write_all(&bytes).await.is_ok() {
-                                    recording.frames += 1;
-                                } else {
-                                    tracing::debug!(session_id = %s.id, "recording write failed");
-                                }
+                                let _ = recording.tx.try_send(bytes);
                             }
                         }
                     }

--- a/browser/tests/golden/schemas/browser.doctor.json
+++ b/browser/tests/golden/schemas/browser.doctor.json
@@ -38,6 +38,10 @@
         },
         "type": "array"
       },
+      "attach_enabled": {
+        "description": "Whether attach mode is enabled (allow_attach).",
+        "type": "boolean"
+      },
       "chromium_path": {
         "type": [
           "string",
@@ -67,15 +71,21 @@
       "ok": {
         "description": "True when sessions can start right now.",
         "type": "boolean"
+      },
+      "recording_available": {
+        "description": "Whether ffmpeg is on PATH, which browser::recording requires.",
+        "type": "boolean"
       }
     },
     "required": [
       "active_sessions",
       "allowed_schemes",
+      "attach_enabled",
       "headless_default",
       "issues",
       "max_sessions",
-      "ok"
+      "ok",
+      "recording_available"
     ],
     "title": "DoctorOutput",
     "type": "object"

--- a/browser/tests/golden/schemas/browser.recording.start.json
+++ b/browser/tests/golden/schemas/browser.recording.start.json
@@ -1,0 +1,51 @@
+{
+  "description": "Record a session's live viewport to a video file (webm or mp4) by piping the screencast through ffmpeg. Turns screencast on if needed. Requires ffmpeg on PATH; browser::doctor reports whether it is available.",
+  "function_id": "browser::recording::start",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "format": {
+        "default": null,
+        "description": "`webm` (VP9) or `mp4` (H.264). Defaults to webm.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "path": {
+        "description": "Output file path. The extension should match `format`.",
+        "type": "string"
+      },
+      "session_id": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "path",
+      "session_id"
+    ],
+    "title": "RecordingStartInput",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "format": {
+        "type": "string"
+      },
+      "ok": {
+        "type": "boolean"
+      },
+      "path": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "format",
+      "ok",
+      "path"
+    ],
+    "title": "RecordingStartOutput",
+    "type": "object"
+  }
+}

--- a/browser/tests/golden/schemas/browser.recording.stop.json
+++ b/browser/tests/golden/schemas/browser.recording.stop.json
@@ -1,0 +1,50 @@
+{
+  "description": "Stop a session's recording, finalize the file, and return its path, duration, and frame count. Idempotent: stopping when nothing is recording returns ok=false.",
+  "function_id": "browser::recording::stop",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "session_id": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "session_id"
+    ],
+    "title": "RecordingStopInput",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "duration_ms": {
+        "description": "Wall-clock duration captured, milliseconds.",
+        "format": "int64",
+        "type": "integer"
+      },
+      "frames": {
+        "description": "Frames written to the encoder.",
+        "format": "uint64",
+        "minimum": 0.0,
+        "type": "integer"
+      },
+      "ok": {
+        "description": "False when no recording was running.",
+        "type": "boolean"
+      },
+      "path": {
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "required": [
+      "duration_ms",
+      "frames",
+      "ok"
+    ],
+    "title": "RecordingStopOutput",
+    "type": "object"
+  }
+}

--- a/browser/tests/golden/schemas/browser.snapshot.json
+++ b/browser/tests/golden/schemas/browser.snapshot.json
@@ -64,7 +64,7 @@
             "type": "null"
           }
         ],
-        "description": "Present when the caller asked for `diff: true` and a baseline existed."
+        "description": "Present when the caller asked for `diff: true` and a baseline existed. Covers only the emitted nodes of both snapshots; check `truncated` before trusting it as a complete change set."
       },
       "generation": {
         "description": "Document generation the refs belong to; navigation advances it and kills every ref from earlier generations.",
@@ -83,7 +83,7 @@
         "type": "string"
       },
       "truncated": {
-        "description": "True when the tree hit `max_snapshot_nodes` and was cut short.",
+        "description": "True when the tree hit `max_snapshot_nodes` and was cut short. Also the signal that a `diff` may be incomplete: the diff is computed over emitted nodes only, so when either snapshot was truncated a node that was emitted before and capped out now can show up in `removed` even though it still exists (and vice versa for `added`).",
         "type": "boolean"
       },
       "url": {

--- a/browser/tests/schemas.rs
+++ b/browser/tests/schemas.rs
@@ -1,4 +1,4 @@
-//! Wire-schema snapshots for the twenty-seven `browser::*` functions.
+//! Wire-schema snapshots for the twenty-nine `browser::*` functions.
 //!
 //! `browser::functions::catalog()` is the single source of truth for each
 //! function's id, registration description, and schemars-derived
@@ -32,7 +32,7 @@ fn spec_to_pretty_json(spec: &FunctionSpec) -> String {
     pretty
 }
 
-/// The catalog must cover exactly the twenty-seven registered functions, in
+/// The catalog must cover exactly the twenty-nine registered functions, in
 /// registration order (kept in lockstep with `register_all`).
 #[test]
 fn catalog_lists_all_functions_in_registration_order() {
@@ -63,6 +63,8 @@ fn catalog_lists_all_functions_in_registration_order() {
             "browser::screencast::start",
             "browser::screencast::stop",
             "browser::frame",
+            "browser::recording::start",
+            "browser::recording::stop",
             "browser::pick::hint",
             "browser::pick::start",
             "browser::pick::resolve",


### PR DESCRIPTION
Re-files the viewport recording work (MOT-4114) onto main. The original PR #538 showed "merged" but its base was the stacked `feat/browser-handoff` branch, not main, so the recording code merged into a side branch that never itself reached main. main (and browser 0.1.2) shipped with 27 functions and no recording; this brings it to 29.

Content is the recording delta from #538, cleanly rebased onto current main (which now carries execute + attach + handoff + the review fixes). No conflicts.

## What lands

- `browser::recording::start { session_id, path, format? }` / `browser::recording::stop { session_id }` — pipe the session's screencast JPEG frames through ffmpeg into a webm (VP9) or mp4 (H.264) file. Start turns screencast on if it was off (and stop turns it back off only in that case). Stop closes ffmpeg's stdin so the file finalizes and returns `{ path, duration_ms, frames }`. Idempotent: stopping when nothing is recording returns `ok: false`. Session shutdown finalizes any in-progress recording with a bounded 5s reap (then kill) so ffmpeg is never orphaned or able to hang shutdown.
- Ghost cursor — a fixed-position overlay following the agent's clicks and hovers, injected from `browser::act` only while screencast is active.
- Session-status badge — a small overlay naming the session and its mode, mounted when screencast starts and removed when it stops.
- `browser::doctor` gains `recording_available` (ffmpeg on PATH) and `attach_enabled`, each with an issue + `enable_how` when off.

## Tests

- Unit + goldens for the two new functions and the extended doctor output (29 functions total); typed-schema gate passes.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --lib`/`--test schemas` green.
- Previously live-verified against a real engine and Chromium: doctor reported `recording_available: true`, badge and ghost cursor mounted, and a recording produced a valid H.264 1280x800 mp4 confirmed by ffprobe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added viewport recording with WebM and MP4 output options.
  * Recording results include the file path, duration, and frame count.
  * Added status reporting for recording and attach-mode availability.
  * Added live screencast overlays for session status and pointer activity.

* **Documentation**
  * Documented recording behavior, requirements, supported formats, and overlay visibility.
  * Clarified how truncated snapshots may affect diff results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->