### PR TITLE
fix: harness empty copy

### DIFF
--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -186,6 +186,12 @@ export function ChatView({
   // inside updaters — Strict Mode double-invokes them).
   const [stopping, setStopping] = useState(false)
   const stopRequestedRef = useRef(false)
+  // Sibling latch for the queue-drain flag: unlike stopRequestedRef it is
+  // NEVER reset by the abortRun-failure retry path or the indicator effect —
+  // only by the next stream this tab opens. A stream that saw ANY stop
+  // attempt must not claim its leftovers are `triggering…` (a cancelled
+  // turn's queue lands in the transcript unreacted).
+  const stopSeenRef = useRef(false)
   useEffect(() => {
     if (!streamingIndicator) {
       stopRequestedRef.current = false
@@ -197,11 +203,16 @@ export function ChatView({
   // harness drains them into the transcript. Each draft carries the predicted
   // entry id of its eventual transcript row.
   const [queuedDrafts, setQueuedDrafts] = useState<UserMessage[]>([])
+  // Queue rows read `triggering…` instead of `queued` while this is set —
+  // see the drain-window block below `queuedStrip` for who sets/clears it.
+  const [drainingQueue, setDrainingQueue] = useState(false)
 
-  // Drafts belong to one conversation; never leak across switches.
+  // Drafts belong to one conversation; never leak across switches. The
+  // drain flag rides along — it describes the previous conversation's turn.
   // biome-ignore lint/correctness/useExhaustiveDependencies: reset on id change only
   useEffect(() => {
     setQueuedDrafts([])
+    setDrainingQueue(false)
   }, [conversation.id])
 
   // Pop a draft into the chat the moment its drained row (same predicted
@@ -375,6 +386,30 @@ export function ChatView({
       .map((row) => ({ id: row.id, text: row.text || '(notification)' }))
     return [...drafts, ...server]
   }, [queuedDrafts, serverQueued, conversation.messages])
+
+  // Delivery window: the turn stream this tab owned finished normally while
+  // messages were still parked — the harness is draining them into the
+  // transcript now (`serverWorking` keeps the strip mounted until each
+  // drained row arrives and pops its entry). Rows read `triggering…` instead
+  // of `queued` for that stretch. The flag is set only by the stream loop's
+  // own clean exit — never by /compact's isStreaming toggle, a stream error,
+  // or a user stop (a cancelled turn's leftovers land in the transcript
+  // unreacted, so `queued` stays truthful there) — and a tab that never
+  // owned the stream just keeps `queued` until the rows pop.
+  const queuedStripCountRef = useRef(0)
+  queuedStripCountRef.current = queuedStrip.length
+  // Empty strip: the drain finished. GROWING strip: a fresh message parked
+  // (this tab or another) — it belongs to the follow-on turn's queue, so the
+  // whole strip honestly reverts to `queued`. Rows popping out (shrinking)
+  // keep the flag.
+  const prevStripLenRef = useRef(0)
+  useEffect(() => {
+    const prev = prevStripLenRef.current
+    prevStripLenRef.current = queuedStrip.length
+    if (queuedStrip.length === 0 || queuedStrip.length > prev) {
+      setDrainingQueue(false)
+    }
+  }, [queuedStrip.length])
 
   // The conversation id IS the engine session_id (console-<uuid> for chats
   // created here). Matches iii.session.id on every span so the traces UI can
@@ -991,6 +1026,8 @@ export function ChatView({
       const controller = new AbortController()
       abortRef.current = controller
       setIsStreaming(true)
+      setDrainingQueue(false)
+      stopSeenRef.current = false
       setTurnPhase('sending')
 
       let thoughtId: string | null = null
@@ -999,6 +1036,7 @@ export function ChatView({
       const fcallMap = new Map<string, string>()
       let assistantId: string | null = null
       let assistantBuffer = ''
+      let streamEndedNormally = false
 
       try {
         for await (const event of backend.stream(
@@ -1236,6 +1274,10 @@ export function ChatView({
             setTurnPhase(null)
           }
         }
+        // NOTE: an aborted generator also exits the loop without throwing;
+        // the stop/rescue cases are filtered below via stopSeenRef and the
+        // strip emptying when the session leaves `working`.
+        streamEndedNormally = true
       } catch (err) {
         if (!isAbortError(err)) {
           console.warn('[chat] stream errored', err)
@@ -1266,6 +1308,15 @@ export function ChatView({
         }
         setIsStreaming(false)
         setTurnPhase(null)
+        // Turn finished cleanly with messages still parked: the harness is
+        // delivering them now — flip the strip's rows to `triggering…`.
+        if (
+          streamEndedNormally &&
+          !stopSeenRef.current &&
+          queuedStripCountRef.current > 0
+        ) {
+          setDrainingQueue(true)
+        }
         abortRef.current = null
       }
     },
@@ -1294,6 +1345,7 @@ export function ChatView({
   const handleStop = useCallback(() => {
     if (stopRequestedRef.current) return
     stopRequestedRef.current = true
+    stopSeenRef.current = true
     setStopping(true)
     abortRef.current?.abort()
     // Re-enable the button if the stop RPC fails while the server still
@@ -1700,11 +1752,15 @@ export function ChatView({
                   >
                     <span className="min-w-0 flex-1 truncate">{row.text}</span>
                     <span className="shrink-0 lowercase text-ink-ghost">
-                      queued
+                      {drainingQueue ? 'triggering…' : 'queued'}
                     </span>
                   </div>
                 ))}
-              {backend.editQueued && queuedDrafts.length > 0 ? (
+              {/* No edit hint while draining — the rows are being delivered,
+                  so inviting an edit would be a race the user loses. */}
+              {backend.editQueued &&
+              queuedDrafts.length > 0 &&
+              !drainingQueue ? (
                 <div className="px-3 py-0.5 text-right text-[10px] lowercase text-ink-ghost">
                   {browsedQueuedId
                     ? '↑ / ↓ cycle · enter saves in place · empty + enter removes'

--- a/console/web/src/components/chat/EmptyState.tsx
+++ b/console/web/src/components/chat/EmptyState.tsx
@@ -1,3 +1,4 @@
+import { FunctionMentionPill } from '@/components/chat/lexical/FunctionMentionNode'
 import { CopyCommandButton } from '@/components/chat/sandbox/terminal/CopyCommandButton'
 import { Terminal } from '@/components/chat/sandbox/terminal/Terminal'
 import { Button } from '@/components/ui/Button'
@@ -90,34 +91,44 @@ export function EmptyState({
   )
 }
 
-/* ---------------- ready (unchanged hero) ---------------- */
+/* ---------------- ready (welcome hero) ---------------- */
+
+const EXPLORE_FUNCTIONS = [
+  { id: 'engine::functions::list', hint: 'see all callable functions' },
+  { id: 'engine::workers::list', hint: 'check connected workers' },
+  { id: 'engine::triggers::list', hint: 'discover trigger types' },
+] as const
 
 function ReadyBody() {
   return (
     <>
-      <h1 className={HEADING_CLASS}>how can i help.</h1>
+      <h1 className={HEADING_CLASS}>welcome to iii! 👋</h1>
+      <div className="flex flex-col gap-2">
+        <p className={BODY_CLASS}>
+          You're in an agent-oriented workspace where you can
+          leverage the power of a full-featured agentic system:
+        </p>
+        <ul className="font-mono text-[13px] leading-[1.7] text-ink-faint flex flex-col gap-1">
+          <li>· trigger functions via the function registry</li>
+          <li>· spawn sub-agents for parallel/async work</li>
+          <li>· register triggers for callbacks &amp; automation</li>
+          <li>· query state and subscribe to events</li>
+        </ul>
+      </div>
+      <div className="flex flex-col gap-2">
+        <p className={BODY_CLASS}>start by exploring what's available:</p>
+        <ul className="font-mono text-[13px] leading-[1.7] text-ink-faint flex flex-col gap-1.5">
+          {EXPLORE_FUNCTIONS.map(({ id, hint }) => (
+            <li key={id}>
+              <FunctionMentionPill functionId={id} /> — {hint}
+            </li>
+          ))}
+        </ul>
+      </div>
       <p className={BODY_CLASS}>
-        pick a mode and a model, attach files if you need to, then send a
-        message. responses are mocked locally — swap{' '}
-        <code className="font-mono text-[12.5px] border border-rule-2 bg-paper-2 text-ink px-1">
-          lib/backend/real.ts
-        </code>{' '}
-        for a real provider when you're ready.
+        need help? ask away. the agent will discover apis on the fly and show
+        you what's possible.
       </p>
-      <ul className="font-mono text-[13px] leading-[1.7] text-ink-faint flex flex-col gap-1">
-        <li>
-          · <span className="text-ink">plan</span> — outline an approach before
-          doing.
-        </li>
-        <li>
-          · <span className="text-ink">ask</span> — answer a question with
-          context.
-        </li>
-        <li>
-          · <span className="text-ink">agent</span> — take action and report
-          back.
-        </li>
-      </ul>
     </>
   )
 }

--- a/console/web/src/components/chat/FunctionCallGroup.stories.tsx
+++ b/console/web/src/components/chat/FunctionCallGroup.stories.tsx
@@ -83,11 +83,11 @@ export const InFlight: Story = {
 }
 
 export const DoneCollapsed: Story = {
-  name: 'done (3 functions, collapsed)',
+  name: 'triggered (3 functions, collapsed)',
   args: { messages: groupDone },
 }
 
 export const DoneExpanded: Story = {
-  name: 'done (3 functions, expanded)',
+  name: 'triggered (3 functions, expanded)',
   args: { messages: groupDone, defaultOpen: true },
 }

--- a/console/web/src/components/chat/FunctionCallMessage.stories.tsx
+++ b/console/web/src/components/chat/FunctionCallMessage.stories.tsx
@@ -67,6 +67,43 @@ const fcallDoneMulti: FCallType = {
   createdAt: Date.now(),
 }
 
+/** Denied at the approval gate: the gate's DenialEnvelope rides in the error
+ *  details — the call never ran, so the header makes no "triggered" claim. */
+const fcallDenied: FCallType = {
+  id: 'f3b',
+  role: 'function-call',
+  functionId: 'shell::run',
+  input: { command: 'rm -rf /tmp/cache' },
+  output: {
+    error: {
+      kind: 'function_error',
+      message: 'Rejected by operator.',
+      details: {
+        schema_version: 1,
+        status: 'denied',
+        denied_by: 'user',
+        function_id: 'shell::run',
+        reason: 'Rejected by operator.',
+      },
+    },
+  },
+  createdAt: Date.now(),
+}
+
+/** TracesV2 sub-span that inherited its function id from the enclosing
+ *  invocation: its 3ms measure machinery inside the call, so the header
+ *  stays verb-less — no "triggered ƒ …" claim. */
+const fcallInheritedIdentity: FCallType = {
+  id: 'f3c',
+  role: 'function-call',
+  functionId: 'directory::index',
+  input: { path: '/repo/src' },
+  output: { rows: 12 },
+  durationMs: 3,
+  identityInherited: true,
+  createdAt: Date.now(),
+}
+
 const fcallError: FCallType = {
   id: 'f4',
   role: 'function-call',
@@ -129,18 +166,28 @@ export const Running: Story = {
 }
 
 export const DoneCollapsed: Story = {
-  name: 'done (collapsed)',
+  name: 'triggered (collapsed)',
   args: { message: fcallDone },
 }
 
 export const DoneExpanded: Story = {
-  name: 'done · single-field (expanded)',
+  name: 'triggered · single-field (expanded)',
   args: { message: fcallDone, defaultOpen: true },
 }
 
 export const DoneMultiFieldExpanded: Story = {
-  name: 'done · multi-field (expanded)',
+  name: 'triggered · multi-field (expanded)',
   args: { message: fcallDoneMulti, defaultOpen: true },
+}
+
+export const DeniedNeverRan: Story = {
+  name: 'denied (never ran)',
+  args: { message: fcallDenied, defaultOpen: true },
+}
+
+export const InheritedIdentity: Story = {
+  name: 'inherited identity (traces sub-span)',
+  args: { message: fcallInheritedIdentity },
 }
 
 export const ErrorCollapsed: Story = {

--- a/console/web/src/components/function-call/FunctionCallCard.test.ts
+++ b/console/web/src/components/function-call/FunctionCallCard.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { parseEmbeddedJson, resultEnvelope } from './FunctionCallCard'
+import {
+  isDeniedOutput,
+  parseEmbeddedJson,
+  resultEnvelope,
+} from './FunctionCallCard'
 
 describe('parseEmbeddedJson', () => {
   it('parses double-encoded objects and arrays', () => {
@@ -14,6 +18,49 @@ describe('parseEmbeddedJson', () => {
     expect(parseEmbeddedJson('true')).toBeUndefined()
     expect(parseEmbeddedJson('plain text')).toBeUndefined()
     expect(parseEmbeddedJson('{broken')).toBeUndefined()
+  })
+})
+
+describe('isDeniedOutput', () => {
+  it('recognizes the approval gate’s denial envelope in the error details', () => {
+    // Shape per approval-gate denial.rs → entry-mapper functionResultOutput:
+    // the envelope rides in the paired result's `details`.
+    expect(
+      isDeniedOutput({
+        error: {
+          kind: 'function_error',
+          message: 'Rejected by operator.',
+          details: {
+            schema_version: 1,
+            status: 'denied',
+            denied_by: 'user',
+            function_id: 'shell::run',
+            reason: 'Rejected by operator.',
+          },
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('leaves genuine run errors and non-errors alone', () => {
+    // A run error without the envelope: the call executed and failed.
+    expect(
+      isDeniedOutput({
+        error: { kind: 'function_error', message: 'boom', details: {} },
+      }),
+    ).toBe(false)
+    expect(
+      isDeniedOutput({ error: { kind: 'function_error', message: 'boom' } }),
+    ).toBe(false)
+    // `status: denied` alone (no denied_by) is not the gate's envelope.
+    expect(
+      isDeniedOutput({
+        error: { kind: 'function_error', details: { status: 'denied' } },
+      }),
+    ).toBe(false)
+    expect(isDeniedOutput({ content: [], details: {} })).toBe(false)
+    expect(isDeniedOutput(undefined)).toBe(false)
+    expect(isDeniedOutput(null)).toBe(false)
   })
 })
 

--- a/console/web/src/components/function-call/FunctionCallCard.tsx
+++ b/console/web/src/components/function-call/FunctionCallCard.tsx
@@ -106,6 +106,26 @@ export function isErrorOutput(v: unknown): boolean {
   )
 }
 
+/**
+ * A deny/timeout resolution from the approval gate: the call was stopped at
+ * the gate and never executed. The gate's structured DenialEnvelope
+ * (approval-gate `denial.rs` — `{ status: "denied", denied_by, reason, … }`)
+ * rides in the result's `details`, which `functionResultOutput` preserves
+ * under `error.details` on both the live pairing and the reload path — so
+ * this is detectable from the output alone, unlike a genuine run error.
+ */
+export function isDeniedOutput(v: unknown): boolean {
+  if (!isErrorOutput(v)) return false
+  const details = (v as { error?: { details?: unknown } }).error?.details
+  return (
+    !!details &&
+    typeof details === 'object' &&
+    !Array.isArray(details) &&
+    (details as Record<string, unknown>).status === 'denied' &&
+    'denied_by' in (details as Record<string, unknown>)
+  )
+}
+
 function formatJson(value: unknown): string {
   try {
     return JSON.stringify(value, null, 2)
@@ -343,6 +363,14 @@ export function FunctionCallCard({
   }, [pending])
 
   const errored = !pending && !running && isErrorOutput(message.output)
+  // "triggered" is an execution claim, so a settled card only makes it when
+  // the call actually ran. Denials are recognized by the gate's envelope in
+  // the error details (see isDeniedOutput) — a plain run error keeps the
+  // verb. A card with neither output nor duration (deny/abort cleared the
+  // approval but no result paired in yet) stays verb-less too.
+  const ran =
+    !isDeniedOutput(message.output) &&
+    (message.output !== undefined || typeof message.durationMs === 'number')
 
   return (
     <div
@@ -390,6 +418,10 @@ export function FunctionCallCard({
                     : 'waiting for your approval to run'}
                 </span>{' '}
               </>
+            ) : message.identityInherited ? null : running ? (
+              <>triggering </>
+            ) : ran ? (
+              <>triggered </>
             ) : null}
             <span className="text-accent italic font-semibold">ƒ</span>{' '}
             {running && message.unresolvedTarget ? (

--- a/console/web/src/pages/TracesV2/lib/functionCallFromSpan.test.ts
+++ b/console/web/src/pages/TracesV2/lib/functionCallFromSpan.test.ts
@@ -164,7 +164,7 @@ describe('functionCallFromSpan', () => {
     expect(functionCallFromSpan(inner, byId(execute, inner))).toBeNull()
   })
 
-  it('keeps the card for an inherited-identity span that captured payload data', () => {
+  it('keeps the card for an inherited-identity span that captured payload data, flagged as inherited', () => {
     const execute = vis({
       span_id: 'execute',
       name: 'execute worker::list',
@@ -178,9 +178,12 @@ describe('functionCallFromSpan', () => {
     const call = functionCallFromSpan(inner, byId(execute, inner))
     expect(call?.functionId).toBe('worker::list')
     expect(call?.input).toEqual({ query: 'x' })
+    // The id names the enclosing invocation, not this sub-span — the card
+    // must not claim "triggered ƒ worker::list" off the sub-span's timing.
+    expect(call?.identityInherited).toBe(true)
   })
 
-  it('keeps the card for an inherited-identity span that errored', () => {
+  it('keeps the card for an inherited-identity span that errored, flagged as inherited', () => {
     const execute = vis({
       span_id: 'execute',
       name: 'execute worker::list',
@@ -200,9 +203,27 @@ describe('functionCallFromSpan', () => {
     })
     const call = functionCallFromSpan(inner, byId(execute, inner))
     expect(call?.output).toEqual({ error: 'boom' })
+    expect(call?.identityInherited).toBe(true)
   })
 
-  it('still renders an empty card for a true invocation span', () => {
+  it('flags a pending inherited-identity span too', () => {
+    const execute = vis({
+      span_id: 'execute',
+      name: 'execute worker::list',
+    })
+    const inner = vis({
+      span_id: 'inner',
+      parent_span_id: 'execute',
+      name: 'tool call',
+      pending: true,
+      attributes: { 'tool.arguments': '{"query":"x"}' },
+    })
+    const call = functionCallFromSpan(inner, byId(execute, inner))
+    expect(call?.running).toBe(true)
+    expect(call?.identityInherited).toBe(true)
+  })
+
+  it('still renders an empty card for a true invocation span, not flagged', () => {
     // The invocation span is the one place "empty" is honest — payload
     // capture may be disabled (III_DISABLE_TRACE_PAYLOADS) yet the call
     // itself is real and worth a card.
@@ -211,5 +232,6 @@ describe('functionCallFromSpan', () => {
     )
     expect(call?.functionId).toBe('worker::list')
     expect(call?.input).toBeUndefined()
+    expect(call?.identityInherited).toBeUndefined()
   })
 })

--- a/console/web/src/pages/TracesV2/lib/functionCallFromSpan.ts
+++ b/console/web/src/pages/TracesV2/lib/functionCallFromSpan.ts
@@ -192,12 +192,12 @@ export function functionCallFromSpan(
   // or baggage above — is machinery inside that call (scope spans, queue
   // wrappers, HTTP/DB clients); the SDK attaches `iii.payload.json` events
   // to the invocation span only, so an inherited span without captured
-  // data would render a card whose panes both read "empty".
-  if (
-    explicitFunctionId(span) === null &&
-    input === undefined &&
-    output === undefined
-  ) {
+  // data would render a card whose panes both read "empty". One that DID
+  // capture data keeps its card but is flagged `identityInherited` — its
+  // duration measures the sub-span, not the invocation, so the card must
+  // not claim "triggering/triggered ƒ <fn>".
+  const inherited = explicitFunctionId(span) === null
+  if (inherited && input === undefined && output === undefined) {
     return null
   }
 
@@ -211,6 +211,7 @@ export function functionCallFromSpan(
       functionId,
       input,
       running: true,
+      ...(inherited ? { identityInherited: true } : {}),
     }
   }
 
@@ -222,5 +223,6 @@ export function functionCallFromSpan(
     input,
     output,
     durationMs: Math.round(span.duration_ms),
+    ...(inherited ? { identityInherited: true } : {}),
   }
 }

--- a/console/web/src/types/chat.ts
+++ b/console/web/src/types/chat.ts
@@ -115,6 +115,13 @@ export interface FunctionCallMessage extends BaseMessage {
    * the literal `agent_trigger` while running.
    */
   unresolvedTarget?: boolean
+  /**
+   * The function id was resolved from an enclosing invocation rather than
+   * this record itself — e.g. TracesV2 rendering an inner span of
+   * `execute <fn>`. The card header stays verb-less: "triggering/triggered
+   * ƒ <fn>" would claim an invocation this card's timing doesn't measure.
+   */
+  identityInherited?: boolean
   /** awaiting user approval before execution; lifecycle: pending → running → done */
   pendingApproval?: boolean
   /** iii function_call_id — set on pending entries so the approve/deny UI can resolve. */


### PR DESCRIPTION

<img width="560" height="194" alt="image" src="https://github.com/user-attachments/assets/841c9587-9ea0-472c-82d8-0c190479850f" />


<img width="560" height="456" alt="image" src="https://github.com/user-attachments/assets/eb378498-90ea-468b-8c1a-f2119230fa47" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive list of available functions to the chat welcome screen.
  * Improved queued-message status updates while messages are being delivered.
  * Added clearer handling for inherited identities and approval-denied function calls.

* **Bug Fixes**
  * Prevented denied function calls from appearing as successfully triggered.
  * Suppressed editing controls while queued messages are actively draining.
  * Avoided displaying empty cards for inherited-identity traces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->