### PR TITLE
(MOT-4107) fix(harness): harden integration runner contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,14 +493,38 @@ jobs:
         run: make -C harness integration-validate
 
       - name: Run integration scenarios
-        run: make -C harness integration-e2e III_BIN="${{ steps.engine.outputs.bin }}"
+        run: make -C harness integration-e2e III_BIN="${{ steps.engine.outputs.bin }}" INTEGRATION_REPEAT=2
+
+      - name: Verify integration report links
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          reports=(target/integration/*/execution.json)
+          ((${#reports[@]} > 0)) || { echo "no execution reports found"; exit 3; }
+          for execution in "${reports[@]}"; do
+            run_dir=$(dirname "$execution")
+            result_path=$(jq -er '.result_path' "$execution")
+            [[ "$result_path" == "result.json" ]] || {
+              echo "$execution: unexpected result_path $result_path"
+              exit 3
+            }
+            expected=$(jq -er '.result_sha256' "$execution")
+            actual=$(sha256sum "$run_dir/$result_path" | cut -d' ' -f1)
+            [[ "$actual" == "$expected" ]] || {
+              echo "$execution: result digest mismatch"
+              exit 3
+            }
+          done
 
       - name: Upload compact results
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: integration-results
-          path: target/integration/*/result.json
+          path: |
+            target/integration/*/result.json
+            target/integration/*/execution.json
+            target/integration/*/teardown.json
           if-no-files-found: ignore
 
       - name: Upload full non-pass artifacts

--- a/harness/Makefile
+++ b/harness/Makefile
@@ -319,6 +319,7 @@ INTEGRATION_WORKERS := queue iii-directory session-manager context-manager
 INTEGRATION_PROFILE ?= release
 INTEGRATION_FLAG    := $(if $(filter release,$(INTEGRATION_PROFILE)),--release,)
 INTEGRATION_SCENARIO ?= all
+INTEGRATION_REPEAT ?= 1
 INTEGRATION_ARTIFACTS ?= $(REPO_ROOT)/target/integration
 
 integration-e2e:
@@ -342,6 +343,7 @@ integration-e2e:
 	  --worker-bin "session-manager=$(REPO_ROOT)/session-manager/target/$(INTEGRATION_PROFILE)/session-manager" \
 	  --worker-bin "context-manager=$(REPO_ROOT)/context-manager/target/$(INTEGRATION_PROFILE)/context-manager" \
 	  --scenario "$(INTEGRATION_SCENARIO)" \
+	  --repeat "$(INTEGRATION_REPEAT)" \
 	  --artifacts-dir "$(INTEGRATION_ARTIFACTS)"
 
 integration-validate:

--- a/harness/evals/integration/Cargo.toml
+++ b/harness/evals/integration/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 iii-sdk = "=0.21.6"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/harness/evals/integration/README.md
+++ b/harness/evals/integration/README.md
@@ -24,7 +24,8 @@ harness-integration run \
   --worker-bin session-manager=<session-manager> \
   --worker-bin context-manager=<context-manager> \
   --worker-bin iii-directory=<iii-directory> \
-  --scenario C-E2E-001
+  --scenario C-E2E-001 \
+  --repeat 2
 ```
 
 The engine is never downloaded by the runner. CI builds the source revision
@@ -36,6 +37,9 @@ Exit codes are:
 - `0`: every selected scenario passed;
 - `2`: contract failure or scenario timeout;
 - `3`: setup, process, or runner error.
+
+`--repeat N` boots a fresh stack for every repetition and requires the
+byte-stable result contract to be identical. A mismatch is a runner error.
 
 ## Create a scenario
 
@@ -143,11 +147,13 @@ release → await → collect → grade → teardown → report.
   one hard cleanup budget.
 - Router and grader comparisons use explicit JSON array policies.
 
-Each run writes detailed evidence below
-`target/integration/<run-id>/scenarios/<scenario-id>/`. `result.json` contains
-the stable byte-comparable verdict; `execution.json` contains the run id,
-timestamps, and duration. Passing runs retain the compact reports and remove
-heavyweight stack state unless `--retain-success` is supplied.
+Each run writes `result.json`, `execution.json`, `teardown.json`, and
+`stack.json` below `target/integration/<run-id>/`; scenario evidence lives
+under `scenarios/<scenario-id>/`. `result.json` contains the stable
+byte-comparable verdict. `execution.json` contains the run id, timing,
+scenario id, and SHA-256 of the exact `result.json` bytes. Passing runs retain
+the compact reports and remove heavyweight stack state unless
+`--retain-success` is supplied.
 
 The shared `scenarios/system-prompt.txt` is the single prompt golden. The
 compiler appends the inferred session and function policy, then hashes the

--- a/harness/evals/integration/scenarios/crash-recovery-507/scenario.yaml
+++ b/harness/evals/integration/scenarios/crash-recovery-507/scenario.yaml
@@ -21,8 +21,6 @@ functions:
       content:
         - { type: text, text: recorded }
       is_error: false
-    # Leaves a deterministic fault-injection window after durable recording.
-    response_delay_ms: 8000
 
 router:
   generations:

--- a/harness/evals/integration/schemas/compiled-fixture.v1.json
+++ b/harness/evals/integration/schemas/compiled-fixture.v1.json
@@ -420,6 +420,183 @@
       ],
       "type": "string"
     },
+    "CompiledFaultV1": {
+      "additionalProperties": false,
+      "properties": {
+        "after_target_calls": {
+          "format": "uint64",
+          "minimum": 1.0,
+          "type": "integer"
+        },
+        "function_id": {
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/definitions/FaultKind"
+        },
+        "restart_delay_ms": {
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "after_target_calls",
+        "function_id",
+        "kind",
+        "restart_delay_ms"
+      ],
+      "type": "object"
+    },
+    "CompiledFunctionExposureV1": {
+      "enum": [
+        "native"
+      ],
+      "type": "string"
+    },
+    "CompiledFunctionPolicyV1": {
+      "additionalProperties": false,
+      "properties": {
+        "allow": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "deny": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "expose": {
+          "$ref": "#/definitions/CompiledFunctionExposureV1"
+        }
+      },
+      "required": [
+        "allow",
+        "deny",
+        "expose"
+      ],
+      "type": "object"
+    },
+    "CompiledScenarioV1": {
+      "additionalProperties": false,
+      "description": "Strict runtime scenario produced from [`super::AuthoredScenarioV1`].",
+      "properties": {
+        "bindings": {
+          "items": {
+            "$ref": "#/definitions/TriggerBindingV1"
+          },
+          "type": "array"
+        },
+        "deadlines": {
+          "$ref": "#/definitions/DeadlinesV1"
+        },
+        "description": {
+          "type": "string"
+        },
+        "fault": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CompiledFaultV1"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9_-]+$",
+          "type": "string"
+        },
+        "invariants": {
+          "items": {
+            "$ref": "#/definitions/InvariantSpecV1"
+          },
+          "type": "array"
+        },
+        "quarantine": {
+          "type": "boolean"
+        },
+        "recorder": {
+          "$ref": "#/definitions/RecorderConfigV1"
+        },
+        "release": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ReleaseV1"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "schema_version": {
+          "$ref": "#/definitions/SchemaVersion1"
+        },
+        "send": {
+          "$ref": "#/definitions/CompiledSendV1"
+        }
+      },
+      "required": [
+        "deadlines",
+        "description",
+        "id",
+        "invariants",
+        "recorder",
+        "schema_version",
+        "send"
+      ],
+      "type": "object"
+    },
+    "CompiledSendOptionsV1": {
+      "additionalProperties": false,
+      "properties": {
+        "functions": {
+          "$ref": "#/definitions/CompiledFunctionPolicyV1"
+        }
+      },
+      "required": [
+        "functions"
+      ],
+      "type": "object"
+    },
+    "CompiledSendV1": {
+      "additionalProperties": false,
+      "description": "The deliberately narrow `harness::send` request emitted by the scenario compiler. Keeping this typed prevents compiler changes from silently introducing fields outside the live harness contract.",
+      "properties": {
+        "idempotency_key": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/CompiledSendOptionsV1"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "session_id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "idempotency_key",
+        "message",
+        "model",
+        "options",
+        "provider",
+        "session_id"
+      ],
+      "type": "object"
+    },
     "ContentBlock": {
       "oneOf": [
         {
@@ -617,245 +794,85 @@
       ],
       "type": "object"
     },
-    "ExpectationsV1": {
-      "additionalProperties": false,
-      "description": "Typed oracle vocabulary. Common send/completion/lifecycle/router checks have defaults, leaving each fixture to state only scenario-specific facts.",
-      "properties": {
-        "assistant_text": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "calls": {
-          "items": {
-            "$ref": "#/definitions/TargetCallsExpectationV1"
-          },
-          "type": "array"
-        },
-        "calls_closed": {
-          "type": "boolean"
-        },
-        "function_results": {
-          "items": {
-            "$ref": "#/definitions/FunctionResultExpectationV1"
-          },
-          "type": "array"
-        },
-        "lifecycle": {
-          "$ref": "#/definitions/LifecycleExpectationV1"
-        },
-        "message_counts": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/MessageCountsExpectationV1"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "no_duplicates": {
-          "type": "boolean"
-        },
-        "send_flags": {
-          "$ref": "#/definitions/SendFlagsExpectationV1"
-        },
-        "terminal": {
-          "$ref": "#/definitions/TerminalExpectationV1"
-        }
-      },
-      "type": "object"
-    },
     "FaultKind": {
       "enum": [
         "engine_sigkill"
       ],
       "type": "string"
     },
-    "FaultV1": {
+    "GenerationMatchV1": {
       "additionalProperties": false,
+      "description": "The 12 router-request fields; compiled scenarios always make every matcher explicit.",
       "properties": {
-        "after_target_calls": {
-          "format": "uint64",
-          "minimum": 1.0,
-          "type": "integer"
+        "max_output_tokens": {
+          "$ref": "#/definitions/JsonMatcherV1"
         },
-        "function": {
-          "description": "Controlled function alias to interrupt. Omitted means the first authored function call.",
-          "type": [
-            "string",
-            "null"
-          ]
+        "messages": {
+          "$ref": "#/definitions/JsonMatcherV1"
         },
-        "kind": {
-          "$ref": "#/definitions/FaultKind"
+        "metadata": {
+          "$ref": "#/definitions/JsonMatcherV1"
         },
-        "restart_delay_ms": {
-          "format": "uint64",
-          "minimum": 0.0,
-          "type": "integer"
+        "model": {
+          "$ref": "#/definitions/JsonMatcherV1"
+        },
+        "provider": {
+          "$ref": "#/definitions/JsonMatcherV1"
+        },
+        "provider_options": {
+          "$ref": "#/definitions/JsonMatcherV1"
+        },
+        "request_id": {
+          "$ref": "#/definitions/JsonMatcherV1"
+        },
+        "response_format": {
+          "$ref": "#/definitions/JsonMatcherV1"
+        },
+        "system_prompt": {
+          "$ref": "#/definitions/JsonMatcherV1"
+        },
+        "thinking_level": {
+          "$ref": "#/definitions/JsonMatcherV1"
+        },
+        "tools": {
+          "$ref": "#/definitions/JsonMatcherV1"
+        },
+        "writer_ref": {
+          "$ref": "#/definitions/JsonMatcherV1"
         }
       },
       "required": [
-        "kind"
+        "max_output_tokens",
+        "messages",
+        "metadata",
+        "model",
+        "provider",
+        "provider_options",
+        "request_id",
+        "response_format",
+        "system_prompt",
+        "thinking_level",
+        "tools",
+        "writer_ref"
       ],
       "type": "object"
     },
-    "FunctionResultExpectationV1": {
+    "InvariantSpecV1": {
       "additionalProperties": false,
+      "description": "Stable wire form persisted in compiled scenarios.",
       "properties": {
-        "content": {
-          "items": true,
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "function": {
-          "description": "Optional function alias; omitted when any result closing the call is acceptable (for example, a synthesized crash-recovery error).",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "function_call_id": {
-          "default": "call-1",
+        "id": {
           "type": "string"
         },
-        "is_error": {
-          "type": [
-            "boolean",
-            "null"
-          ]
+        "parameters": {
+          "additionalProperties": true,
+          "default": {},
+          "type": "object"
         }
       },
-      "type": "object"
-    },
-    "GenerationMatchOverridesV1": {
-      "additionalProperties": false,
-      "properties": {
-        "max_output_tokens": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/JsonMatcherV1"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "messages": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/JsonMatcherV1"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "metadata": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/JsonMatcherV1"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "model": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/JsonMatcherV1"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "provider": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/JsonMatcherV1"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "provider_options": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/JsonMatcherV1"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "request_id": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/JsonMatcherV1"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "response_format": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/JsonMatcherV1"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "system_prompt": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/JsonMatcherV1"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "thinking_level": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/JsonMatcherV1"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "tools": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/JsonMatcherV1"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "writer_ref": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/JsonMatcherV1"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
+      "required": [
+        "id"
+      ],
       "type": "object"
     },
     "JsonMatcherV1": {
@@ -1002,41 +1019,17 @@
       ],
       "type": "object"
     },
-    "LifecycleExpectationV1": {
-      "additionalProperties": false,
-      "properties": {
-        "allow_identical_duplicates": {
-          "default": true,
-          "type": "boolean"
-        }
-      },
-      "type": "object"
-    },
-    "MessageCountsExpectationV1": {
-      "additionalProperties": false,
-      "properties": {
-        "assistant": {
-          "format": "uint64",
-          "minimum": 0.0,
-          "type": "integer"
-        },
-        "function_result": {
-          "format": "uint64",
-          "minimum": 0.0,
-          "type": "integer"
-        },
-        "user": {
-          "format": "uint64",
-          "minimum": 0.0,
-          "type": "integer"
-        }
-      },
-      "required": [
-        "assistant",
-        "function_result",
-        "user"
+    "LifecycleFunctionId": {
+      "enum": [
+        "integration-recorder::lifecycle"
       ],
-      "type": "object"
+      "type": "string"
+    },
+    "LifecycleTriggerType": {
+      "enum": [
+        "harness::turn-completed"
+      ],
+      "type": "string"
     },
     "ModelFixtureV1": {
       "additionalProperties": false,
@@ -1206,6 +1199,81 @@
       ],
       "type": "object"
     },
+    "RecorderConfigV1": {
+      "additionalProperties": false,
+      "properties": {
+        "extra_functions": {
+          "description": "Additional run-scoped controlled functions (e.g. hook implementations for `harness::hook::*` scenarios). Registered exactly like the target: declared description/schema verbatim, every call durably recorded, declared response returned.",
+          "items": {
+            "$ref": "#/definitions/RecorderTargetV1"
+          },
+          "type": "array"
+        },
+        "lifecycle": {
+          "$ref": "#/definitions/RecorderLifecycleV1"
+        },
+        "target": {
+          "$ref": "#/definitions/RecorderTargetV1"
+        }
+      },
+      "required": [
+        "lifecycle",
+        "target"
+      ],
+      "type": "object"
+    },
+    "RecorderLifecycleV1": {
+      "additionalProperties": false,
+      "properties": {
+        "function_id": {
+          "$ref": "#/definitions/LifecycleFunctionId"
+        },
+        "trigger_type": {
+          "$ref": "#/definitions/LifecycleTriggerType"
+        }
+      },
+      "required": [
+        "function_id",
+        "trigger_type"
+      ],
+      "type": "object"
+    },
+    "RecorderTargetV1": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "function_id": {
+          "description": "Must be prefixed by `<run_id>::` — enforced by `configure`.",
+          "type": "string"
+        },
+        "hold_response_at": {
+          "description": "One-based call ordinal whose response is held behind a runner-owned, in-process gate after the call has been durably appended. Derived from `fault.after_target_calls`; never authored directly.",
+          "format": "uint64",
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "request_schema": {
+          "additionalProperties": true,
+          "description": "Registered verbatim; the same schema must appear in native tool exposure (that registration is part of the oracle).",
+          "type": "object"
+        },
+        "response": {
+          "description": "Declared response returned for every target call."
+        }
+      },
+      "required": [
+        "description",
+        "function_id",
+        "request_schema",
+        "response"
+      ],
+      "type": "object"
+    },
     "ReleaseActionV1": {
       "enum": [
         "execute",
@@ -1279,207 +1347,30 @@
       ],
       "type": "object"
     },
-    "RouterReplyV1": {
-      "oneOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "chunks": {
-              "description": "Non-empty chunks produce the complete streaming frame sequence. Omitted chunks produce one terminal `done` frame.",
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "text": {
-              "type": "string"
-            },
-            "type": {
-              "enum": [
-                "text"
-              ],
-              "type": "string"
-            },
-            "usage": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Usage"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
-          },
-          "required": [
-            "text",
-            "type"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "arguments": true,
-            "function": {
-              "description": "Function alias from `functions`.",
-              "type": "string"
-            },
-            "id": {
-              "description": "Defaults to `call-<function-call ordinal>`.",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "type": {
-              "enum": [
-                "function_call"
-              ],
-              "type": "string"
-            },
-            "usage": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Usage"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
-          },
-          "required": [
-            "arguments",
-            "function",
-            "type"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "description": "Full strict wire contract for cases the typed replies cannot express.",
-          "properties": {
-            "frames": {
-              "items": {
-                "$ref": "#/definitions/AssistantMessageEvent"
-              },
-              "type": "array"
-            },
-            "response": {
-              "$ref": "#/definitions/RouterChatResponse"
-            },
-            "type": {
-              "enum": [
-                "raw"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "frames",
-            "response",
-            "type"
-          ],
-          "type": "object"
-        }
-      ]
-    },
-    "ScenarioFunctionV1": {
-      "additionalProperties": false,
-      "properties": {
-        "description": {
-          "type": "string"
-        },
-        "expose": {
-          "description": "Exposed to the model by default. Hook-only controlled functions set this to false.",
-          "type": "boolean"
-        },
-        "request_schema": {
-          "additionalProperties": true,
-          "type": "object"
-        },
-        "response": true
-      },
-      "required": [
-        "description",
-        "request_schema",
-        "response"
-      ],
-      "type": "object"
-    },
-    "ScenarioGenerationV1": {
-      "additionalProperties": false,
-      "properties": {
-        "match_overrides": {
-          "allOf": [
-            {
-              "$ref": "#/definitions/GenerationMatchOverridesV1"
-            }
-          ],
-          "description": "Escape hatch for fields whose history is intentionally unstable, such as the post-crash request in a recovery reproduction."
-        },
-        "reply": {
-          "$ref": "#/definitions/RouterReplyV1"
-        }
-      },
-      "required": [
-        "reply"
-      ],
-      "type": "object"
-    },
-    "ScenarioRouterV1": {
+    "RouterScriptV1": {
       "additionalProperties": false,
       "properties": {
         "generations": {
           "items": {
-            "$ref": "#/definitions/ScenarioGenerationV1"
+            "$ref": "#/definitions/ScriptedGenerationV1"
           },
           "type": "array"
         },
         "model": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ModelFixtureV1"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Omitted for the deterministic `fixture-model` / `scripted` catalog entry used by the integration stack."
-        }
-      },
-      "required": [
-        "generations"
-      ],
-      "type": "object"
-    },
-    "ScenarioSendV1": {
-      "additionalProperties": false,
-      "properties": {
-        "allow": {
-          "description": "Allowed function aliases. Omitted means every function whose `expose` flag is true; an empty list disables function dispatch.",
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
+          "$ref": "#/definitions/ModelFixtureV1"
         },
-        "idempotency_key": {
-          "description": "Omitted values are derived deterministically from the scenario id.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "message": {
+        "scenario_id": {
           "type": "string"
+        },
+        "schema_version": {
+          "$ref": "#/definitions/SchemaVersion1"
         }
       },
       "required": [
-        "message"
+        "generations",
+        "model",
+        "scenario_id",
+        "schema_version"
       ],
       "type": "object"
     },
@@ -1490,22 +1381,33 @@
       ],
       "type": "string"
     },
-    "SendFlagsExpectationV1": {
+    "ScriptedGenerationV1": {
       "additionalProperties": false,
       "properties": {
-        "deduplicated": {
-          "default": false,
-          "type": "boolean"
+        "frames": {
+          "items": {
+            "$ref": "#/definitions/AssistantMessageEvent"
+          },
+          "type": "array"
         },
-        "merged": {
-          "default": false,
-          "type": "boolean"
+        "match": {
+          "$ref": "#/definitions/GenerationMatchV1"
         },
-        "queued": {
-          "default": false,
-          "type": "boolean"
+        "ordinal": {
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
+        },
+        "response": {
+          "$ref": "#/definitions/RouterChatResponse"
         }
       },
+      "required": [
+        "frames",
+        "match",
+        "ordinal",
+        "response"
+      ],
       "type": "object"
     },
     "StopReason": {
@@ -1518,93 +1420,23 @@
       ],
       "type": "string"
     },
-    "TargetCallsExpectationV1": {
+    "TriggerBindingV1": {
       "additionalProperties": false,
       "properties": {
-        "count": {
-          "format": "uint64",
-          "minimum": 0.0,
-          "type": "integer"
-        },
-        "function": {
+        "config": true,
+        "function_id": {
           "type": "string"
         },
-        "payload": true,
-        "payload_subset": true
-      },
-      "required": [
-        "count",
-        "function"
-      ],
-      "type": "object"
-    },
-    "TerminalExpectationV1": {
-      "additionalProperties": false,
-      "properties": {
-        "pending_calls": {
-          "format": "uint64",
-          "minimum": 0.0,
-          "type": "integer"
-        },
-        "queued_messages": {
-          "format": "uint64",
-          "minimum": 0.0,
-          "type": "integer"
-        },
-        "status": {
-          "$ref": "#/definitions/TerminalStatusV1"
+        "trigger_type": {
+          "type": "string"
         }
       },
       "required": [
-        "pending_calls",
-        "queued_messages",
-        "status"
+        "config",
+        "function_id",
+        "trigger_type"
       ],
       "type": "object"
-    },
-    "TerminalStatusV1": {
-      "enum": [
-        "completed",
-        "failed",
-        "cancelled"
-      ],
-      "type": "string"
-    },
-    "TriggerBindingSpecV1": {
-      "additionalProperties": false,
-      "properties": {
-        "function": {
-          "description": "Controlled function alias invoked by the trigger.",
-          "type": "string"
-        },
-        "functions": {
-          "description": "Exposed function aliases selected by this hook.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "priority": {
-          "format": "int64",
-          "type": "integer"
-        },
-        "trigger": {
-          "$ref": "#/definitions/TriggerKindV1"
-        }
-      },
-      "required": [
-        "function",
-        "functions",
-        "priority",
-        "trigger"
-      ],
-      "type": "object"
-    },
-    "TriggerKindV1": {
-      "enum": [
-        "hook_pre_trigger"
-      ],
-      "type": "string"
     },
     "Usage": {
       "additionalProperties": false,
@@ -1660,81 +1492,22 @@
       "type": "object"
     }
   },
-  "description": "The single-file scenario authors maintain in `scenarios/<slug>/scenario.yaml`.",
   "properties": {
-    "bindings": {
-      "items": {
-        "$ref": "#/definitions/TriggerBindingSpecV1"
-      },
-      "type": "array"
+    "scenario": {
+      "$ref": "#/definitions/CompiledScenarioV1"
     },
-    "description": {
+    "script": {
+      "$ref": "#/definitions/RouterScriptV1"
+    },
+    "system_prompt_template": {
       "type": "string"
-    },
-    "expect": {
-      "$ref": "#/definitions/ExpectationsV1"
-    },
-    "fault": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/FaultV1"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "functions": {
-      "additionalProperties": {
-        "$ref": "#/definitions/ScenarioFunctionV1"
-      },
-      "description": "Alias → controlled function. Aliases are expanded to `{{run_id}}::<alias>` by the compiler.",
-      "propertyNames": {
-        "minLength": 1,
-        "pattern": "^[A-Za-z0-9_-]+$",
-        "type": "string"
-      },
-      "type": "object"
-    },
-    "id": {
-      "maxLength": 128,
-      "minLength": 1,
-      "pattern": "^[A-Za-z0-9_-]+$",
-      "type": "string"
-    },
-    "quarantine": {
-      "type": "boolean"
-    },
-    "release": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ReleaseV1"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "router": {
-      "$ref": "#/definitions/ScenarioRouterV1"
-    },
-    "schema_version": {
-      "$ref": "#/definitions/SchemaVersion1"
-    },
-    "send": {
-      "$ref": "#/definitions/ScenarioSendV1"
-    },
-    "timeouts": {
-      "$ref": "#/definitions/DeadlinesV1"
     }
   },
   "required": [
-    "description",
-    "id",
-    "router",
-    "schema_version",
-    "send"
+    "scenario",
+    "script",
+    "system_prompt_template"
   ],
-  "title": "AuthoredScenarioV1",
+  "title": "CompiledFixtureV1",
   "type": "object"
 }

--- a/harness/evals/integration/schemas/compiled-scenario.v1.json
+++ b/harness/evals/integration/schemas/compiled-scenario.v1.json
@@ -30,6 +30,83 @@
       ],
       "type": "object"
     },
+    "CompiledFunctionExposureV1": {
+      "enum": [
+        "native"
+      ],
+      "type": "string"
+    },
+    "CompiledFunctionPolicyV1": {
+      "additionalProperties": false,
+      "properties": {
+        "allow": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "deny": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "expose": {
+          "$ref": "#/definitions/CompiledFunctionExposureV1"
+        }
+      },
+      "required": [
+        "allow",
+        "deny",
+        "expose"
+      ],
+      "type": "object"
+    },
+    "CompiledSendOptionsV1": {
+      "additionalProperties": false,
+      "properties": {
+        "functions": {
+          "$ref": "#/definitions/CompiledFunctionPolicyV1"
+        }
+      },
+      "required": [
+        "functions"
+      ],
+      "type": "object"
+    },
+    "CompiledSendV1": {
+      "additionalProperties": false,
+      "description": "The deliberately narrow `harness::send` request emitted by the scenario compiler. Keeping this typed prevents compiler changes from silently introducing fields outside the live harness contract.",
+      "properties": {
+        "idempotency_key": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/CompiledSendOptionsV1"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "session_id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "idempotency_key",
+        "message",
+        "model",
+        "options",
+        "provider",
+        "session_id"
+      ],
+      "type": "object"
+    },
     "DeadlinesV1": {
       "additionalProperties": false,
       "properties": {
@@ -86,7 +163,6 @@
     },
     "LifecycleTriggerType": {
       "enum": [
-        "harness::turn-started",
         "harness::turn-completed"
       ],
       "type": "string"
@@ -140,6 +216,15 @@
           "description": "Must be prefixed by `<run_id>::` — enforced by `configure`.",
           "type": "string"
         },
+        "hold_response_at": {
+          "description": "One-based call ordinal whose response is held behind a runner-owned, in-process gate after the call has been durably appended. Derived from `fault.after_target_calls`; never authored directly.",
+          "format": "uint64",
+          "minimum": 1.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "request_schema": {
           "additionalProperties": true,
           "description": "Registered verbatim; the same schema must appear in native tool exposure (that registration is part of the oracle).",
@@ -147,15 +232,6 @@
         },
         "response": {
           "description": "Declared response returned for every target call."
-        },
-        "response_delay_ms": {
-          "description": "Delay between the durable append and the response, opening a window for fault injection while the dispatched call is executing (crash-recovery scenarios). Omitted = respond immediately.",
-          "format": "uint64",
-          "minimum": 0.0,
-          "type": [
-            "integer",
-            "null"
-          ]
         }
       },
       "required": [
@@ -214,7 +290,7 @@
       "type": "object"
     }
   },
-  "description": "Strict runtime scenario produced from [`super::IntegrationScenarioV1`].",
+  "description": "Strict runtime scenario produced from [`super::AuthoredScenarioV1`].",
   "properties": {
     "bindings": {
       "items": {
@@ -269,7 +345,9 @@
     "schema_version": {
       "$ref": "#/definitions/SchemaVersion1"
     },
-    "send": true
+    "send": {
+      "$ref": "#/definitions/CompiledSendV1"
+    }
   },
   "required": [
     "deadlines",

--- a/harness/evals/integration/schemas/execution-report.v1.json
+++ b/harness/evals/integration/schemas/execution-report.v1.json
@@ -20,7 +20,13 @@
     "result_path": {
       "type": "string"
     },
+    "result_sha256": {
+      "type": "string"
+    },
     "run_id": {
+      "type": "string"
+    },
+    "scenario_id": {
       "type": "string"
     },
     "schema_version": {
@@ -33,7 +39,9 @@
   "required": [
     "duration_ms",
     "result_path",
+    "result_sha256",
     "run_id",
+    "scenario_id",
     "schema_version",
     "started_at"
   ],

--- a/harness/evals/integration/src/expand.rs
+++ b/harness/evals/integration/src/expand.rs
@@ -14,9 +14,10 @@ mod validation;
 #[cfg(test)]
 mod tests;
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::types::scenario::{CompiledScenarioV1, IntegrationScenarioV1};
+use crate::types::scenario::{AuthoredScenarioV1, CompiledScenarioV1};
 use crate::types::script::{ModelFixtureV1, RouterScriptV1};
 
 pub use render::{render_authored_yaml, render_compiled};
@@ -27,7 +28,7 @@ const DEFAULT_MODEL: &str = "fixture-model";
 const DEFAULT_PROVIDER: &str = "scripted";
 const SYNTHETIC_FUNCTION_ALIAS: &str = "unused";
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct CompiledFixtureV1 {
     pub scenario: CompiledScenarioV1,
@@ -82,7 +83,7 @@ struct CompiledFunctionCall {
 /// Compile the concise authored contract to the strict structures consumed by
 /// the runner and scripted router.
 pub fn compile_scenario(
-    authored: &IntegrationScenarioV1,
+    authored: &AuthoredScenarioV1,
     system_prompt_base: &str,
 ) -> anyhow::Result<CompiledFixtureV1> {
     validation::validate_identity(authored)?;
@@ -105,11 +106,14 @@ pub fn compile_scenario(
         .map(|alias| function_ids[alias].clone())
         .collect();
     let tools = functions::compile_tools(authored, &allowed_aliases, &function_ids);
-    let recorder = functions::compile_recorder(authored, &allowed_aliases, &function_ids);
+    let mut recorder = functions::compile_recorder(authored, &allowed_aliases, &function_ids);
     let bindings = functions::compile_bindings(authored, &allowed_aliases, &function_ids)?;
     let calls = functions::function_call_ids(authored, &function_ids, &allowed_aliases)?;
     validation::validate_release(authored, &calls)?;
     let fault = functions::compile_fault(authored, &function_ids, &calls)?;
+    if let Some(fault) = &fault {
+        functions::hold_fault_target(&mut recorder, &fault.function_id, fault.after_target_calls)?;
+    }
 
     let send = functions::compile_send(authored, &model, &allowed_ids)?;
     let script = router::compile_router(authored, &model, &tools, &function_ids, &calls)?;

--- a/harness/evals/integration/src/expand/expectations.rs
+++ b/harness/evals/integration/src/expand/expectations.rs
@@ -3,13 +3,13 @@ use std::collections::BTreeMap;
 use anyhow::Context;
 
 use crate::types::scenario::{
-    FunctionResultInvariantV1, IntegrationScenarioV1, InvariantSpecV1, TargetCallsInvariantV1,
+    AuthoredScenarioV1, FunctionResultInvariantV1, InvariantSpecV1, TargetCallsInvariantV1,
 };
 
 use super::{CompiledFunctionCall, SYNTHETIC_FUNCTION_ALIAS};
 
 pub(super) fn compile_expectations(
-    authored: &IntegrationScenarioV1,
+    authored: &AuthoredScenarioV1,
     function_ids: &BTreeMap<String, String>,
     calls: &[CompiledFunctionCall],
     generation_count: usize,
@@ -62,7 +62,10 @@ pub(super) fn compile_expectations(
         invariants.push(InvariantSpecV1::transcript_no_duplicates());
     }
     invariants.push(InvariantSpecV1::status_terminal(expect.terminal));
-    invariants.push(InvariantSpecV1::lifecycle_completed_once(expect.lifecycle));
+    invariants.push(InvariantSpecV1::lifecycle_completed_once(
+        expect.lifecycle,
+        expect.terminal.status,
+    ));
     invariants.push(InvariantSpecV1::router_generations_consumed(
         generation_count as u64,
     ));

--- a/harness/evals/integration/src/expand/functions.rs
+++ b/harness/evals/integration/src/expand/functions.rs
@@ -9,7 +9,7 @@ use crate::types::recorder::{
     RecorderTargetV1,
 };
 use crate::types::scenario::{
-    CompiledFaultV1, IntegrationScenarioV1, RouterReplyV1, ScenarioFunctionV1, TriggerBindingV1,
+    AuthoredScenarioV1, CompiledFaultV1, RouterReplyV1, ScenarioFunctionV1, TriggerBindingV1,
 };
 use crate::types::script::ModelFixtureV1;
 
@@ -18,7 +18,7 @@ use super::{
     CompiledFunctionCall, SYNTHETIC_FUNCTION_ALIAS,
 };
 
-pub(super) fn function_ids(authored: &IntegrationScenarioV1) -> BTreeMap<String, String> {
+pub(super) fn function_ids(authored: &AuthoredScenarioV1) -> BTreeMap<String, String> {
     authored
         .functions
         .keys()
@@ -26,7 +26,7 @@ pub(super) fn function_ids(authored: &IntegrationScenarioV1) -> BTreeMap<String,
         .collect()
 }
 
-pub(super) fn allowed_aliases(authored: &IntegrationScenarioV1) -> anyhow::Result<Vec<String>> {
+pub(super) fn allowed_aliases(authored: &AuthoredScenarioV1) -> anyhow::Result<Vec<String>> {
     let mut aliases = match &authored.send.allow {
         Some(aliases) => aliases.clone(),
         None => authored
@@ -50,7 +50,7 @@ pub(super) fn allowed_aliases(authored: &IntegrationScenarioV1) -> anyhow::Resul
 }
 
 pub(super) fn compile_tools(
-    authored: &IntegrationScenarioV1,
+    authored: &AuthoredScenarioV1,
     allowed_aliases: &[String],
     function_ids: &BTreeMap<String, String>,
 ) -> Value {
@@ -71,7 +71,7 @@ pub(super) fn compile_tools(
 }
 
 pub(super) fn compile_recorder(
-    authored: &IntegrationScenarioV1,
+    authored: &AuthoredScenarioV1,
     allowed_aliases: &[String],
     function_ids: &BTreeMap<String, String>,
 ) -> RecorderConfigV1 {
@@ -111,7 +111,7 @@ fn compile_function(function_id: &str, function: &ScenarioFunctionV1) -> Recorde
         description: function.description.clone(),
         request_schema: function.request_schema.clone(),
         response: function.response.clone(),
-        response_delay_ms: function.response_delay_ms,
+        hold_response_at: None,
     }
 }
 
@@ -130,7 +130,7 @@ fn synthetic_target() -> RecorderTargetV1 {
             "content": [{ "type": "text", "text": "unused" }],
             "is_error": false
         }),
-        response_delay_ms: None,
+        hold_response_at: None,
     }
 }
 
@@ -142,7 +142,7 @@ fn compiled_lifecycle() -> RecorderLifecycleV1 {
 }
 
 pub(super) fn compile_bindings(
-    authored: &IntegrationScenarioV1,
+    authored: &AuthoredScenarioV1,
     allowed_aliases: &[String],
     function_ids: &BTreeMap<String, String>,
 ) -> anyhow::Result<Vec<TriggerBindingV1>> {
@@ -203,7 +203,7 @@ pub(super) fn compile_bindings(
 }
 
 pub(super) fn function_call_ids(
-    authored: &IntegrationScenarioV1,
+    authored: &AuthoredScenarioV1,
     function_ids: &BTreeMap<String, String>,
     allowed_aliases: &[String],
 ) -> anyhow::Result<Vec<CompiledFunctionCall>> {
@@ -308,7 +308,7 @@ fn register_call(
 }
 
 pub(super) fn compile_fault(
-    authored: &IntegrationScenarioV1,
+    authored: &AuthoredScenarioV1,
     function_ids: &BTreeMap<String, String>,
     calls: &[CompiledFunctionCall],
 ) -> anyhow::Result<Option<CompiledFaultV1>> {
@@ -336,12 +336,6 @@ pub(super) fn compile_fault(
             fault.after_target_calls
         );
     }
-    let delay = authored.functions[function].response_delay_ms.unwrap_or(0);
-    if delay == 0 {
-        anyhow::bail!(
-            "fault target {function:?} requires response_delay_ms > 0 for a deterministic interruption window"
-        );
-    }
     Ok(Some(CompiledFaultV1 {
         kind: fault.kind,
         function_id: function_id.clone(),
@@ -350,24 +344,44 @@ pub(super) fn compile_fault(
     }))
 }
 
+pub(super) fn hold_fault_target(
+    recorder: &mut RecorderConfigV1,
+    function_id: &str,
+    call_ordinal: u64,
+) -> anyhow::Result<()> {
+    let target = std::iter::once(&mut recorder.target)
+        .chain(recorder.extra_functions.iter_mut())
+        .find(|target| target.function_id == function_id)
+        .with_context(|| format!("fault target {function_id:?} is not a controlled function"))?;
+    target.hold_response_at = Some(call_ordinal);
+    Ok(())
+}
+
 pub(super) fn compile_send(
-    authored: &IntegrationScenarioV1,
+    authored: &AuthoredScenarioV1,
     model: &ModelFixtureV1,
     allowed_ids: &[String],
-) -> anyhow::Result<Value> {
-    Ok(json!({
-        "session_id": "{{session_id}}",
-        "message": authored.send.message,
-        "model": model.id,
-        "provider": model.provider,
-        "idempotency_key": authored.send.idempotency_key.clone()
+) -> anyhow::Result<crate::types::scenario::CompiledSendV1> {
+    use crate::types::scenario::{
+        CompiledFunctionExposureV1, CompiledFunctionPolicyV1, CompiledSendOptionsV1, CompiledSendV1,
+    };
+
+    Ok(CompiledSendV1 {
+        session_id: "{{session_id}}".to_string(),
+        message: authored.send.message.clone(),
+        model: model.id.clone(),
+        provider: model.provider.clone(),
+        idempotency_key: authored
+            .send
+            .idempotency_key
+            .clone()
             .unwrap_or_else(|| format!("{{{{run_id}}}}:{}", authored.id.to_ascii_lowercase())),
-        "options": {
-            "functions": {
-            "allow": allowed_ids,
-            "deny": [],
-            "expose": "native"
-            }
-        }
-    }))
+        options: CompiledSendOptionsV1 {
+            functions: CompiledFunctionPolicyV1 {
+                allow: allowed_ids.to_vec(),
+                deny: Vec::new(),
+                expose: CompiledFunctionExposureV1::Native,
+            },
+        },
+    })
 }

--- a/harness/evals/integration/src/expand/render.rs
+++ b/harness/evals/integration/src/expand/render.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use serde_json::json;
 
 use super::{expand_compiled_fixture, CompiledFixtureV1};
-use crate::types::scenario::IntegrationScenarioV1;
+use crate::types::scenario::AuthoredScenarioV1;
 
 pub(super) fn validate_placeholders(fixture: &CompiledFixtureV1) -> anyhow::Result<()> {
     render_compiled(fixture)
@@ -26,7 +26,7 @@ pub fn render_compiled(fixture: &CompiledFixtureV1) -> anyhow::Result<String> {
 }
 
 /// Serialize an authored scenario in stable YAML for `init`.
-pub fn render_authored_yaml(scenario: &IntegrationScenarioV1) -> anyhow::Result<String> {
+pub fn render_authored_yaml(scenario: &AuthoredScenarioV1) -> anyhow::Result<String> {
     let mut rendered = serde_yaml::to_string(scenario)?;
     if !rendered.ends_with('\n') {
         rendered.push('\n');

--- a/harness/evals/integration/src/expand/router.rs
+++ b/harness/evals/integration/src/expand/router.rs
@@ -7,7 +7,7 @@ use crate::types::frames::{
     AssistantMessage, AssistantMessageEvent, AssistantRoleTag, ContentBlock, RouterChatResponse,
     StopReason,
 };
-use crate::types::scenario::{IntegrationScenarioV1, RouterReplyV1};
+use crate::types::scenario::{AuthoredScenarioV1, RouterReplyV1};
 use crate::types::script::{
     GenerationMatchV1, JsonMatcherV1, JsonNormalizerV1, ModelFixtureV1, NormalizerOperation,
     RouterScriptV1, SchemaVersion1, ScriptedGenerationV1,
@@ -22,7 +22,7 @@ struct CompiledReply {
 }
 
 pub(super) fn compile_router(
-    authored: &IntegrationScenarioV1,
+    authored: &AuthoredScenarioV1,
     model: &ModelFixtureV1,
     tools: &Value,
     function_ids: &BTreeMap<String, String>,
@@ -161,7 +161,7 @@ fn compile_reply(
     reply: &RouterReplyV1,
     ordinal: u64,
     model: &ModelFixtureV1,
-    authored: &IntegrationScenarioV1,
+    authored: &AuthoredScenarioV1,
     function_ids: &BTreeMap<String, String>,
     call_id: Option<&str>,
 ) -> anyhow::Result<CompiledReply> {

--- a/harness/evals/integration/src/expand/templates.rs
+++ b/harness/evals/integration/src/expand/templates.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use serde_json::json;
 
 use crate::types::scenario::{
-    ExpectationsV1, FunctionResultExpectationV1, IntegrationScenarioV1, MessageCountsExpectationV1,
+    AuthoredScenarioV1, ExpectationsV1, FunctionResultExpectationV1, MessageCountsExpectationV1,
     RouterReplyV1, ScenarioFunctionV1, TargetCallsExpectationV1,
 };
 use crate::types::script::{JsonMatcherV1, SchemaVersion1};
@@ -21,7 +21,7 @@ pub fn scenario_template(
     id: &str,
     description: &str,
     kind: ScenarioTemplateKind,
-) -> IntegrationScenarioV1 {
+) -> AuthoredScenarioV1 {
     let mut functions = BTreeMap::new();
     let record = ScenarioFunctionV1 {
         description: "Record one integration fixture value.".to_string(),
@@ -38,7 +38,6 @@ pub fn scenario_template(
             "content": [{ "type": "text", "text": "recorded" }],
             "is_error": false
         }),
-        response_delay_ms: None,
         expose: true,
     };
     if kind != ScenarioTemplateKind::Text {
@@ -59,7 +58,6 @@ pub fn scenario_template(
                     .cloned()
                     .expect("object"),
                 response: json!({ "decision": "hold" }),
-                response_delay_ms: None,
                 expose: false,
             },
         );
@@ -75,10 +73,6 @@ pub fn scenario_template(
         });
     }
     if kind == ScenarioTemplateKind::Crash {
-        functions
-            .get_mut("record")
-            .expect("crash template has record")
-            .response_delay_ms = Some(8_000);
         fault = Some(crate::types::scenario::FaultV1 {
             kind: crate::types::scenario::FaultKind::EngineSigkill,
             function: Some("record".to_string()),
@@ -178,7 +172,7 @@ pub fn scenario_template(
         }
     };
 
-    IntegrationScenarioV1 {
+    AuthoredScenarioV1 {
         schema_version: SchemaVersion1::V1,
         id: id.to_string(),
         description: description.to_string(),

--- a/harness/evals/integration/src/expand/tests.rs
+++ b/harness/evals/integration/src/expand/tests.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use serde_json::json;
 
 use crate::types::scenario::{
-    IntegrationScenarioV1, RouterReplyV1, ScenarioGenerationV1, ScenarioRouterV1, ScenarioSendV1,
+    AuthoredScenarioV1, RouterReplyV1, ScenarioGenerationV1, ScenarioRouterV1, ScenarioSendV1,
 };
 use crate::types::script::{JsonMatcherV1, SchemaVersion1};
 
@@ -12,8 +12,8 @@ use super::{
     ScenarioTemplateKind,
 };
 
-fn minimal(reply: RouterReplyV1) -> IntegrationScenarioV1 {
-    IntegrationScenarioV1 {
+fn minimal(reply: RouterReplyV1) -> AuthoredScenarioV1 {
+    AuthoredScenarioV1 {
         schema_version: SchemaVersion1::V1,
         id: "C-E2E-T".to_string(),
         description: "A focused compiler fixture.".to_string(),
@@ -48,10 +48,7 @@ fn text_reply_compiles_stream_and_common_defaults() {
     });
     let compiled = compile_scenario(&authored, "base\n").unwrap();
     assert_eq!(compiled.script.generations[0].frames.len(), 7);
-    assert_eq!(
-        compiled.scenario.send["options"]["functions"]["allow"],
-        json!([])
-    );
+    assert!(compiled.scenario.send.options.functions.allow.is_empty());
     assert_eq!(compiled.scenario.deadlines.teardown_ms, 15_000);
     assert!(compiled
         .scenario
@@ -161,15 +158,13 @@ fn tools_are_canonicalized_and_function_contracts_validate() {
         "alpha".to_string(),
     ]);
     let compiled = compile_scenario(&authored, "base").unwrap();
-    let allowed = compiled.scenario.send["options"]["functions"]["allow"]
-        .as_array()
-        .unwrap();
+    let allowed = &compiled.scenario.send.options.functions.allow;
     assert_eq!(
         allowed,
         &[
-            json!("{{run_id}}::alpha"),
-            json!("{{run_id}}::record"),
-            json!("{{run_id}}::zeta")
+            "{{run_id}}::alpha".to_string(),
+            "{{run_id}}::record".to_string(),
+            "{{run_id}}::zeta".to_string()
         ]
     );
     let JsonMatcherV1::Exact { expected, .. } = &compiled.script.generations[0].match_.tools else {
@@ -265,13 +260,23 @@ fn bindings_release_and_fault_fail_fast_when_incoherent() {
         "Validate fault relationships.",
         ScenarioTemplateKind::Crash,
     );
-    crash.functions.get_mut("record").unwrap().response_delay_ms = None;
-    assert!(
-        format!("{:#}", compile_scenario(&crash, "base").unwrap_err())
-            .contains("response_delay_ms > 0")
+    let compiled = compile_scenario(&crash, "base").unwrap();
+    assert_eq!(
+        compiled.scenario.recorder.target.hold_response_at,
+        Some(1),
+        "fault targets receive the compiler-owned response-gate ordinal"
     );
 
-    crash.functions.get_mut("record").unwrap().response_delay_ms = Some(1);
+    let second_call = crash.router.generations[0].clone();
+    crash.router.generations.insert(1, second_call);
+    crash.fault.as_mut().unwrap().after_target_calls = 2;
+    let compiled = compile_scenario(&crash, "base").unwrap();
+    assert_eq!(
+        compiled.scenario.recorder.target.hold_response_at,
+        Some(2),
+        "earlier calls must return before the selected fault ordinal is held"
+    );
+
     crash.fault.as_mut().unwrap().after_target_calls = 0;
     assert!(
         format!("{:#}", compile_scenario(&crash, "base").unwrap_err())
@@ -289,7 +294,7 @@ fn templates_compile_and_render_deterministically() {
     ] {
         let authored = scenario_template("C-E2E-NEW", "A generated scenario.", kind);
         let yaml = render_authored_yaml(&authored).unwrap();
-        let reparsed: IntegrationScenarioV1 = serde_yaml::from_str(&yaml).unwrap();
+        let reparsed: AuthoredScenarioV1 = serde_yaml::from_str(&yaml).unwrap();
         let fixture = compile_scenario(&reparsed, "base\n").unwrap();
         assert_eq!(
             render_compiled(&fixture).unwrap(),

--- a/harness/evals/integration/src/expand/validation.rs
+++ b/harness/evals/integration/src/expand/validation.rs
@@ -3,11 +3,11 @@ use std::collections::BTreeMap;
 use anyhow::Context;
 use serde_json::Value;
 
-use crate::types::scenario::{validate_scenario_id, IntegrationScenarioV1, RouterReplyV1};
+use crate::types::scenario::{validate_scenario_id, AuthoredScenarioV1, RouterReplyV1};
 
 use super::CompiledFunctionCall;
 
-pub(super) fn validate_identity(authored: &IntegrationScenarioV1) -> anyhow::Result<()> {
+pub(super) fn validate_identity(authored: &AuthoredScenarioV1) -> anyhow::Result<()> {
     validate_scenario_id(&authored.id)?;
     if authored.description.trim().is_empty() {
         anyhow::bail!("scenario description must not be empty");
@@ -38,7 +38,7 @@ fn validate_alias(alias: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn validate_function_schemas(authored: &IntegrationScenarioV1) -> anyhow::Result<()> {
+fn validate_function_schemas(authored: &AuthoredScenarioV1) -> anyhow::Result<()> {
     for (alias, function) in &authored.functions {
         let schema = Value::Object(function.request_schema.clone());
         jsonschema::JSONSchema::compile(&schema).map_err(|error| {
@@ -49,7 +49,7 @@ fn validate_function_schemas(authored: &IntegrationScenarioV1) -> anyhow::Result
 }
 
 pub(super) fn validate_function_arguments(
-    authored: &IntegrationScenarioV1,
+    authored: &AuthoredScenarioV1,
     function: &str,
     arguments: &Value,
     context: &str,
@@ -96,7 +96,7 @@ pub(super) fn validate_hook_response(alias: &str, response: &Value) -> anyhow::R
 }
 
 pub(super) fn validate_release(
-    authored: &IntegrationScenarioV1,
+    authored: &AuthoredScenarioV1,
     calls: &[CompiledFunctionCall],
 ) -> anyhow::Result<()> {
     let Some(release) = &authored.release else {
@@ -131,7 +131,7 @@ pub(super) fn validate_release(
 pub(super) fn validate_reply(
     reply: &RouterReplyV1,
     ordinal: u64,
-    authored: &IntegrationScenarioV1,
+    authored: &AuthoredScenarioV1,
     function_ids: &BTreeMap<String, String>,
 ) -> anyhow::Result<()> {
     match reply {

--- a/harness/evals/integration/src/fixtures.rs
+++ b/harness/evals/integration/src/fixtures.rs
@@ -7,6 +7,7 @@
 mod discovery;
 mod loading;
 mod script_validation;
+mod stream_validation;
 
 pub use discovery::{ensure_scenario_id_available, scenario_fixtures};
 pub use loading::ScenarioFixture;

--- a/harness/evals/integration/src/fixtures/loading.rs
+++ b/harness/evals/integration/src/fixtures/loading.rs
@@ -4,13 +4,13 @@ use anyhow::Context;
 
 use super::script_validation::validate_script;
 use crate::expand::{compile_scenario, CompiledFixtureV1};
-use crate::types::scenario::{CompiledScenarioV1, IntegrationScenarioV1};
+use crate::types::scenario::{AuthoredScenarioV1, CompiledScenarioV1};
 use crate::types::script::RouterScriptV1;
 
 #[derive(Debug, Clone)]
 pub struct ScenarioFixture {
     pub dir: PathBuf,
-    pub authored: IntegrationScenarioV1,
+    pub authored: AuthoredScenarioV1,
     pub scenario: CompiledScenarioV1,
     pub script: RouterScriptV1,
     /// Compiled shared golden plus inferred session/policy aid.
@@ -20,7 +20,7 @@ pub struct ScenarioFixture {
 impl ScenarioFixture {
     pub fn load(dir: &Path) -> anyhow::Result<Self> {
         let scenario_path = dir.join("scenario.yaml");
-        let scenario: IntegrationScenarioV1 = serde_yaml::from_str(
+        let scenario: AuthoredScenarioV1 = serde_yaml::from_str(
             &std::fs::read_to_string(&scenario_path)
                 .with_context(|| format!("reading {}", scenario_path.display()))?,
         )

--- a/harness/evals/integration/src/fixtures/script_validation.rs
+++ b/harness/evals/integration/src/fixtures/script_validation.rs
@@ -102,24 +102,159 @@ fn validate_response_agreement(
                     generation.ordinal
                 );
             }
-            if let Some(stop_reason) = generation.response.stop_reason {
-                if stop_reason != message.stop_reason {
-                    anyhow::bail!(
-                        "generation {}: response stop_reason disagrees with done message",
-                        generation.ordinal
-                    );
-                }
+            if generation.response.error.is_some() {
+                anyhow::bail!(
+                    "generation {}: successful response must not carry an error",
+                    generation.ordinal
+                );
             }
+            validate_terminal_message(generation, message)?;
+            validate_stream_agreement(generation, message)?;
         }
-        Frame::Error { .. } => {
+        Frame::Error { error } => {
             if generation.response.ok || generation.response.error.is_none() {
                 anyhow::bail!(
                     "generation {}: error frame requires ok:false and an error shape",
                     generation.ordinal
                 );
             }
+            validate_terminal_message(generation, error)?;
+            let response_error = generation.response.error.as_ref().expect("checked");
+            let message_error = error.error_message.as_deref();
+            if message_error != Some(response_error.message.as_str()) {
+                anyhow::bail!(
+                    "generation {}: response error message disagrees with terminal error frame",
+                    generation.ordinal
+                );
+            }
+            let message_code = error.error_kind.map(|kind| {
+                serde_json::to_value(kind)
+                    .expect("error kind serializes")
+                    .as_str()
+                    .expect("error kind is a string")
+                    .to_string()
+            });
+            if message_code.as_deref() != Some(response_error.code.as_str()) {
+                anyhow::bail!(
+                    "generation {}: response error code disagrees with terminal error frame",
+                    generation.ordinal
+                );
+            }
+            validate_stream_agreement(generation, error)?;
         }
         _ => unreachable!("terminal position validated"),
+    }
+    Ok(())
+}
+
+fn validate_terminal_message(
+    generation: &crate::types::script::ScriptedGenerationV1,
+    message: &crate::types::frames::AssistantMessage,
+) -> anyhow::Result<()> {
+    if generation.response.provider != message.provider {
+        anyhow::bail!(
+            "generation {}: response provider disagrees with terminal message",
+            generation.ordinal
+        );
+    }
+    if generation.response.model != message.model {
+        anyhow::bail!(
+            "generation {}: response model disagrees with terminal message",
+            generation.ordinal
+        );
+    }
+    if generation.response.stop_reason != Some(message.stop_reason) {
+        anyhow::bail!(
+            "generation {}: response stop_reason disagrees with terminal message",
+            generation.ordinal
+        );
+    }
+    if generation.response.usage != message.usage {
+        anyhow::bail!(
+            "generation {}: response usage disagrees with terminal message",
+            generation.ordinal
+        );
+    }
+    Ok(())
+}
+
+fn validate_stream_agreement(
+    generation: &crate::types::script::ScriptedGenerationV1,
+    terminal: &crate::types::frames::AssistantMessage,
+) -> anyhow::Result<()> {
+    use crate::types::frames::AssistantMessageEvent as Frame;
+
+    let mut streamed_usage = None;
+    let mut streamed_stop = None;
+
+    for frame in &generation.frames[..generation.frames.len() - 1] {
+        let partial = match frame {
+            Frame::Start { partial }
+            | Frame::TextStart { partial }
+            | Frame::TextEnd { partial }
+            | Frame::ThinkingStart { partial }
+            | Frame::ThinkingEnd { partial }
+            | Frame::FunctioncallStart { partial }
+            | Frame::FunctioncallEnd { partial } => Some(partial),
+            Frame::TextDelta {
+                partial: Some(partial),
+                ..
+            }
+            | Frame::ThinkingDelta {
+                partial: Some(partial),
+                ..
+            }
+            | Frame::FunctioncallDelta {
+                partial: Some(partial),
+                ..
+            } => Some(partial),
+            _ => None,
+        };
+        if let Some(partial) = partial {
+            if partial.provider != terminal.provider || partial.model != terminal.model {
+                anyhow::bail!(
+                    "generation {}: streamed partial provider/model disagrees with terminal message",
+                    generation.ordinal
+                );
+            }
+        }
+
+        match frame {
+            Frame::Usage { usage } => streamed_usage = Some(usage.clone()),
+            Frame::Stop {
+                stop_reason,
+                error_message,
+                error_kind,
+            } => {
+                streamed_stop = Some((*stop_reason, error_message.clone(), *error_kind));
+            }
+            _ => {}
+        }
+    }
+
+    super::stream_validation::validate_stream_content(
+        &generation.frames[..generation.frames.len() - 1],
+        terminal,
+        generation.ordinal,
+    )?;
+    if let Some(usage) = streamed_usage {
+        if terminal.usage.as_ref() != Some(&usage) {
+            anyhow::bail!(
+                "generation {}: streamed usage disagrees with terminal message",
+                generation.ordinal
+            );
+        }
+    }
+    if let Some((stop_reason, error_message, error_kind)) = streamed_stop {
+        if stop_reason != terminal.stop_reason
+            || error_message != terminal.error_message
+            || error_kind != terminal.error_kind
+        {
+            anyhow::bail!(
+                "generation {}: stop frame disagrees with terminal message",
+                generation.ordinal
+            );
+        }
     }
     Ok(())
 }

--- a/harness/evals/integration/src/fixtures/stream_validation.rs
+++ b/harness/evals/integration/src/fixtures/stream_validation.rs
@@ -1,0 +1,343 @@
+//! Content-level agreement between streamed frames and the terminal message.
+//!
+//! Boundary snapshots are authoritative for reconstruction, but they must not
+//! hide contradictory deltas that consumers already observed. Validate each
+//! open block before accepting its end snapshot, then compare the fully
+//! reconstructed content with the terminal frame.
+
+use crate::types::frames::{AssistantMessage, AssistantMessageEvent as Frame, ContentBlock};
+
+#[derive(Default)]
+struct StreamState {
+    base: Option<AssistantMessage>,
+    open: Option<OpenBlock>,
+    saw_content: bool,
+}
+
+enum OpenBlock {
+    Text { seed: String, deltas: String },
+    Thinking { seed: String, deltas: String },
+    FunctionCall { id: String, arguments: String },
+}
+
+pub(super) fn validate_stream_content(
+    frames: &[Frame],
+    terminal: &AssistantMessage,
+    ordinal: u64,
+) -> anyhow::Result<()> {
+    let mut state = StreamState::default();
+    for frame in frames {
+        state.apply(frame, ordinal)?;
+    }
+    if !state.saw_content {
+        return Ok(());
+    }
+
+    let reconstructed = state.reconstructed_content(ordinal)?;
+    if !content_equal_allowing_pending_thinking_signature(&reconstructed, &terminal.content) {
+        anyhow::bail!("generation {ordinal}: streamed content disagrees with terminal message");
+    }
+    Ok(())
+}
+
+impl StreamState {
+    fn apply(&mut self, frame: &Frame, ordinal: u64) -> anyhow::Result<()> {
+        match frame {
+            Frame::Start { partial } => {
+                self.base = Some(partial.clone());
+                self.open = None;
+                self.saw_content |= !partial.content.is_empty();
+            }
+            Frame::TextStart { partial } => {
+                self.start_text(partial);
+            }
+            Frame::TextDelta {
+                partial: Some(partial),
+                ..
+            } => {
+                self.base = Some(partial.clone());
+                self.open = None;
+                self.saw_content = true;
+            }
+            Frame::TextDelta {
+                partial: None,
+                delta,
+            } => {
+                self.saw_content = true;
+                match &mut self.open {
+                    Some(OpenBlock::Text { deltas, .. }) => deltas.push_str(delta),
+                    Some(_) => anyhow::bail!(
+                        "generation {ordinal}: text delta arrived while another block was open"
+                    ),
+                    None => {
+                        self.open = Some(OpenBlock::Text {
+                            seed: String::new(),
+                            deltas: delta.clone(),
+                        });
+                    }
+                }
+            }
+            Frame::TextEnd { partial } => {
+                self.validate_boundary(partial, BoundaryKind::Text, ordinal)?;
+                self.base = Some(partial.clone());
+                self.open = None;
+                self.saw_content = true;
+            }
+            Frame::ThinkingStart { partial } => {
+                self.start_thinking(partial);
+            }
+            Frame::ThinkingDelta {
+                partial: Some(partial),
+                ..
+            } => {
+                self.base = Some(partial.clone());
+                self.open = None;
+                self.saw_content = true;
+            }
+            Frame::ThinkingDelta {
+                partial: None,
+                delta,
+            } => {
+                self.saw_content = true;
+                match &mut self.open {
+                    Some(OpenBlock::Thinking { deltas, .. }) => deltas.push_str(delta),
+                    Some(_) => anyhow::bail!(
+                        "generation {ordinal}: thinking delta arrived while another block was open"
+                    ),
+                    None => {
+                        self.open = Some(OpenBlock::Thinking {
+                            seed: String::new(),
+                            deltas: delta.clone(),
+                        });
+                    }
+                }
+            }
+            Frame::ThinkingEnd { partial } => {
+                self.validate_boundary(partial, BoundaryKind::Thinking, ordinal)?;
+                self.base = Some(partial.clone());
+                self.open = None;
+                self.saw_content = true;
+            }
+            Frame::FunctioncallStart { partial } => {
+                self.base = Some(partial.clone());
+                self.open = Some(OpenBlock::FunctionCall {
+                    id: String::new(),
+                    arguments: String::new(),
+                });
+                self.saw_content = true;
+            }
+            Frame::FunctioncallDelta {
+                partial: Some(partial),
+                ..
+            } => {
+                self.base = Some(partial.clone());
+                self.open = None;
+                self.saw_content = true;
+            }
+            Frame::FunctioncallDelta {
+                partial: None,
+                delta,
+                id,
+            } => {
+                self.saw_content = true;
+                match &mut self.open {
+                    Some(OpenBlock::FunctionCall {
+                        id: open_id,
+                        arguments,
+                    }) => {
+                        if !id.is_empty() {
+                            if !open_id.is_empty() && open_id != id {
+                                anyhow::bail!(
+                                    "generation {ordinal}: function-call delta changed call id"
+                                );
+                            }
+                            *open_id = id.clone();
+                        }
+                        arguments.push_str(delta);
+                    }
+                    Some(_) => anyhow::bail!(
+                        "generation {ordinal}: function-call delta arrived while another block was open"
+                    ),
+                    None => {
+                        self.open = Some(OpenBlock::FunctionCall {
+                            id: id.clone(),
+                            arguments: delta.clone(),
+                        });
+                    }
+                }
+            }
+            Frame::FunctioncallEnd { partial } => {
+                self.validate_boundary(partial, BoundaryKind::FunctionCall, ordinal)?;
+                self.base = Some(partial.clone());
+                self.open = None;
+                self.saw_content = true;
+            }
+            Frame::Usage { .. }
+            | Frame::Ping
+            | Frame::Stop { .. }
+            | Frame::Done { .. }
+            | Frame::Error { .. } => {}
+        }
+        Ok(())
+    }
+
+    fn start_text(&mut self, partial: &AssistantMessage) {
+        let mut base = partial.clone();
+        let seed = match base.content.last() {
+            Some(ContentBlock::Text { text }) => {
+                let text = text.clone();
+                base.content.pop();
+                text
+            }
+            _ => String::new(),
+        };
+        self.base = Some(base);
+        self.open = Some(OpenBlock::Text {
+            seed,
+            deltas: String::new(),
+        });
+        self.saw_content = true;
+    }
+
+    fn start_thinking(&mut self, partial: &AssistantMessage) {
+        let mut base = partial.clone();
+        let seed = match base.content.last() {
+            Some(ContentBlock::Thinking { text, .. }) => {
+                let text = text.clone();
+                base.content.pop();
+                text
+            }
+            _ => String::new(),
+        };
+        self.base = Some(base);
+        self.open = Some(OpenBlock::Thinking {
+            seed,
+            deltas: String::new(),
+        });
+        self.saw_content = true;
+    }
+
+    fn validate_boundary(
+        &self,
+        partial: &AssistantMessage,
+        expected_kind: BoundaryKind,
+        ordinal: u64,
+    ) -> anyhow::Result<()> {
+        let Some(open) = &self.open else {
+            return Ok(());
+        };
+        if open.kind() != expected_kind {
+            anyhow::bail!("generation {ordinal}: stream block ended with the wrong frame type");
+        }
+        let reconstructed = self.reconstructed_content(ordinal)?;
+        let agrees = match expected_kind {
+            BoundaryKind::Thinking => {
+                content_equal_ignoring_thinking_signatures(&reconstructed, &partial.content)
+            }
+            BoundaryKind::Text | BoundaryKind::FunctionCall => reconstructed == partial.content,
+        };
+        if !agrees {
+            anyhow::bail!(
+                "generation {ordinal}: streamed deltas disagree with the block-end snapshot"
+            );
+        }
+        Ok(())
+    }
+
+    fn reconstructed_content(&self, ordinal: u64) -> anyhow::Result<Vec<ContentBlock>> {
+        let mut content = self
+            .base
+            .as_ref()
+            .map(|base| base.content.clone())
+            .unwrap_or_default();
+        match &self.open {
+            None => {}
+            Some(OpenBlock::Text { seed, deltas }) => content.push(ContentBlock::Text {
+                text: format!("{seed}{deltas}"),
+            }),
+            Some(OpenBlock::Thinking { seed, deltas }) => {
+                content.push(ContentBlock::Thinking {
+                    text: format!("{seed}{deltas}"),
+                    signature: None,
+                });
+            }
+            Some(OpenBlock::FunctionCall { id, arguments }) => {
+                let parsed = serde_json::from_str::<serde_json::Value>(arguments)
+                    .map_err(|error| {
+                        anyhow::anyhow!(
+                            "generation {ordinal}: streamed function-call arguments are not complete JSON: {error}"
+                        )
+                    })?;
+                if !parsed.is_object() {
+                    anyhow::bail!(
+                        "generation {ordinal}: streamed function-call arguments must be an object"
+                    );
+                }
+                let Some(ContentBlock::FunctionCall {
+                    id: base_id,
+                    arguments: base_arguments,
+                    ..
+                }) = content
+                    .iter_mut()
+                    .rev()
+                    .find(|block| matches!(block, ContentBlock::FunctionCall { .. }))
+                else {
+                    anyhow::bail!(
+                        "generation {ordinal}: function-call deltas require a start snapshot"
+                    );
+                };
+                if !id.is_empty() && base_id != id {
+                    anyhow::bail!(
+                        "generation {ordinal}: streamed function-call id disagrees with its snapshot"
+                    );
+                }
+                *base_arguments = parsed;
+            }
+        }
+        Ok(content)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BoundaryKind {
+    Text,
+    Thinking,
+    FunctionCall,
+}
+
+impl OpenBlock {
+    fn kind(&self) -> BoundaryKind {
+        match self {
+            OpenBlock::Text { .. } => BoundaryKind::Text,
+            OpenBlock::Thinking { .. } => BoundaryKind::Thinking,
+            OpenBlock::FunctionCall { .. } => BoundaryKind::FunctionCall,
+        }
+    }
+}
+
+fn content_equal_allowing_pending_thinking_signature(
+    reconstructed: &[ContentBlock],
+    terminal: &[ContentBlock],
+) -> bool {
+    content_equal_ignoring_thinking_signatures(reconstructed, terminal)
+}
+
+fn content_equal_ignoring_thinking_signatures(
+    left: &[ContentBlock],
+    right: &[ContentBlock],
+) -> bool {
+    let strip = |blocks: &[ContentBlock]| {
+        blocks
+            .iter()
+            .cloned()
+            .map(|block| match block {
+                ContentBlock::Thinking { text, .. } => ContentBlock::Thinking {
+                    text,
+                    signature: None,
+                },
+                block => block,
+            })
+            .collect::<Vec<_>>()
+    };
+    strip(left) == strip(right)
+}

--- a/harness/evals/integration/src/fixtures/tests.rs
+++ b/harness/evals/integration/src/fixtures/tests.rs
@@ -91,6 +91,16 @@ fn response_frame_disagreement_is_rejected() {
         script["generations"][0]["response"]["stop_reason"] = json!("length");
     });
     assert!(error_chain(script).contains("disagrees"));
+
+    let script = minimal_script(|script| {
+        script["generations"][0]["response"]["provider"] = json!("other");
+    });
+    assert!(error_chain(script).contains("provider"));
+
+    let script = minimal_script(|script| {
+        script["generations"][0]["response"]["usage"] = json!({ "input": 1 });
+    });
+    assert!(error_chain(script).contains("usage"));
 }
 
 #[test]
@@ -146,18 +156,91 @@ fn removed_barriers_are_rejected_as_unknown_fields() {
 #[test]
 fn slim_and_fat_deltas_both_validate() {
     let slim = minimal_script(|script| {
-        let done = script["generations"][0]["frames"][0].clone();
+        let mut done = script["generations"][0]["frames"][0].clone();
+        done["message"]["content"] = json!([{ "type": "text", "text": "x" }]);
         script["generations"][0]["frames"] = json!([{ "type": "text_delta", "delta": "x" }, done]);
     });
     validate(slim).unwrap();
 
     let fat = minimal_script(|script| {
-        let done = script["generations"][0]["frames"][0].clone();
+        let mut done = script["generations"][0]["frames"][0].clone();
+        done["message"]["content"] = json!([{ "type": "text", "text": "x" }]);
         let partial = done["message"].clone();
         script["generations"][0]["frames"] =
             json!([{ "type": "text_delta", "partial": partial, "delta": "x" }, done]);
     });
     validate(fat).unwrap();
+}
+
+#[test]
+fn streamed_text_must_agree_with_terminal_message() {
+    let script = minimal_script(|script| {
+        let mut done = script["generations"][0]["frames"][0].clone();
+        done["message"]["content"] = json!([{ "type": "text", "text": "different" }]);
+        script["generations"][0]["frames"] =
+            json!([{ "type": "text_delta", "delta": "streamed" }, done]);
+    });
+    assert!(error_chain(script).contains("streamed content disagrees"));
+}
+
+#[test]
+fn block_end_cannot_hide_incorrect_text_or_thinking_deltas() {
+    for (start_type, delta_type, end_type, block_type) in [
+        ("text_start", "text_delta", "text_end", "text"),
+        (
+            "thinking_start",
+            "thinking_delta",
+            "thinking_end",
+            "thinking",
+        ),
+    ] {
+        let script = minimal_script(|script| {
+            let mut done = script["generations"][0]["frames"][0].clone();
+            done["message"]["content"] = json!([{ "type": block_type, "text": "authoritative" }]);
+            let mut start = done["message"].clone();
+            start["content"] = json!([{ "type": block_type, "text": "" }]);
+            let end = done["message"].clone();
+            script["generations"][0]["frames"] = json!([
+                { "type": start_type, "partial": start },
+                { "type": delta_type, "delta": "contradictory" },
+                { "type": end_type, "partial": end },
+                done
+            ]);
+        });
+        assert!(
+            error_chain(script).contains("deltas disagree"),
+            "{block_type} stream was accepted"
+        );
+    }
+}
+
+#[test]
+fn function_call_end_cannot_hide_incorrect_argument_deltas() {
+    let script = minimal_script(|script| {
+        let mut done = script["generations"][0]["frames"][0].clone();
+        done["message"]["stop_reason"] = json!("function_call");
+        done["message"]["content"] = json!([{
+            "type": "function_call",
+            "id": "call-1",
+            "function_id": "run::target",
+            "arguments": { "value": "authoritative" }
+        }]);
+        script["generations"][0]["response"]["stop_reason"] = json!("function_call");
+        let mut start = done["message"].clone();
+        start["content"][0]["arguments"] = json!({});
+        let end = done["message"].clone();
+        script["generations"][0]["frames"] = json!([
+            { "type": "functioncall_start", "partial": start },
+            {
+                "type": "functioncall_delta",
+                "id": "call-1",
+                "delta": "{\"value\":\"contradictory\"}"
+            },
+            { "type": "functioncall_end", "partial": end },
+            done
+        ]);
+    });
+    assert!(error_chain(script).contains("deltas disagree"));
 }
 
 #[test]

--- a/harness/evals/integration/src/grader/status_lifecycle.rs
+++ b/harness/evals/integration/src/grader/status_lifecycle.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use serde_json::{json, Map, Value};
 
 use crate::types::recorder::RecorderEventKind;
@@ -42,15 +44,24 @@ pub(super) fn grade_completed_once(
         .get("allow_identical_duplicates")
         .and_then(Value::as_bool)
         .unwrap_or(true);
+    let expected_status = params
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("completed");
     let expected = json!({
         "delivery_count_valid": true,
         "all_deliveries_identical_after_timestamp_normalization": true,
-        "session_and_turn_match": true,
+        "contract_shape_valid": true,
+        "function_status_session_and_turn_match": true,
+        "sequence_order_valid": true,
     });
-    let payloads: Vec<Value> = evidence
+    let lifecycle: Vec<_> = evidence
         .recorder_events
         .iter()
         .filter(|event| event.kind == RecorderEventKind::Lifecycle)
+        .collect();
+    let payloads: Vec<Value> = lifecycle
+        .iter()
         .map(|event| event.payload.clone())
         .collect();
     let normalized: Vec<Value> = payloads
@@ -64,13 +75,49 @@ pub(super) fn grade_completed_once(
         })
         .collect();
     let identical = normalized.windows(2).all(|window| window[0] == window[1]);
-    let bound_ok = payloads.iter().all(|payload| {
-        payload.get("session_id").and_then(Value::as_str) == Some(evidence.session_id.as_str())
+    let bound_ok = lifecycle.iter().all(|event| {
+        event.function_id == "integration-recorder::lifecycle"
+            && event.payload.get("status").and_then(Value::as_str) == Some(expected_status)
+            && event.payload.get("session_id").and_then(Value::as_str)
+                == Some(evidence.session_id.as_str())
             && match &evidence.turn_id {
-                Some(turn) => payload.get("turn_id").and_then(Value::as_str) == Some(turn),
+                Some(turn) => event.payload.get("turn_id").and_then(Value::as_str) == Some(turn),
                 None => false,
             }
     });
+    let allowed_keys = BTreeSet::from([
+        "session_id",
+        "turn_id",
+        "status",
+        "timestamp",
+        "result",
+        "result_error",
+        "reason",
+        "parent",
+        "parent_session_id",
+        "reactive_depth",
+    ]);
+    let contract_shape_valid = payloads.iter().all(|payload| {
+        let Some(map) = payload.as_object() else {
+            return false;
+        };
+        map.get("timestamp").and_then(Value::as_i64).is_some()
+            && map.keys().all(|key| allowed_keys.contains(key.as_str()))
+    });
+    let sequence_monotonic = lifecycle
+        .windows(2)
+        .all(|window| window[0].sequence < window[1].sequence);
+    let last_target_sequence = evidence
+        .recorder_events
+        .iter()
+        .filter(|event| event.kind == RecorderEventKind::TargetCall)
+        .map(|event| event.sequence)
+        .max()
+        .unwrap_or(0);
+    let follows_target_calls = lifecycle
+        .first()
+        .is_none_or(|event| event.sequence > last_target_sequence);
+    let sequence_order_valid = sequence_monotonic && follows_target_calls;
     let delivery_count_valid = if allow_identical_duplicates {
         !payloads.is_empty()
     } else {
@@ -79,8 +126,14 @@ pub(super) fn grade_completed_once(
     let actual = json!({
         "delivery_count_valid": delivery_count_valid,
         "all_deliveries_identical_after_timestamp_normalization": identical,
-        "session_and_turn_match": bound_ok,
+        "contract_shape_valid": contract_shape_valid,
+        "function_status_session_and_turn_match": bound_ok,
+        "sequence_order_valid": sequence_order_valid,
     });
-    let passed = delivery_count_valid && identical && bound_ok;
+    let passed = delivery_count_valid
+        && identical
+        && contract_shape_valid
+        && bound_ok
+        && sequence_order_valid;
     (passed, expected, actual, vec!["lifecycle-events.json"])
 }

--- a/harness/evals/integration/src/grader/tests.rs
+++ b/harness/evals/integration/src/grader/tests.rs
@@ -108,6 +108,7 @@ fn lifecycle_accepts_identical_duplicates_and_rejects_conflicts() {
             duplicate,
         ),
     ];
+    evidence.recorder_events[1].sequence = 2;
     let ok = grade(
         &[spec(
             "lifecycle.completed_once",
@@ -131,13 +132,74 @@ fn lifecycle_accepts_identical_duplicates_and_rejects_conflicts() {
 
     let mut conflicting = completed;
     conflicting["status"] = json!("failed");
-    evidence.recorder_events.push(event(
+    let mut conflicting_event = event(
         RecorderEventKind::Lifecycle,
         "integration-recorder::lifecycle",
         conflicting,
-    ));
+    );
+    conflicting_event.sequence = 3;
+    evidence.recorder_events.push(conflicting_event);
     let bad = grade(&[spec("lifecycle.completed_once", json!({}))], &evidence);
     assert!(!bad[0].passed, "conflicting terminals must fail");
+}
+
+#[test]
+fn lifecycle_rejects_wrong_sink_shape_and_order() {
+    let mut evidence = base_evidence();
+    let payload = json!({
+        "session_id": "s_1",
+        "turn_id": "t_1",
+        "status": "completed",
+        "timestamp": 1
+    });
+    let mut target = event(
+        RecorderEventKind::TargetCall,
+        "r::record",
+        json!({ "value": "expected" }),
+    );
+    target.sequence = 2;
+    let lifecycle = event(RecorderEventKind::Lifecycle, "wrong::sink", payload);
+    evidence.recorder_events = vec![lifecycle, target];
+
+    let result = grade(&[spec("lifecycle.completed_once", json!({}))], &evidence);
+    assert!(!result[0].passed);
+    assert_eq!(
+        result[0].actual["function_status_session_and_turn_match"],
+        false
+    );
+    assert_eq!(result[0].actual["sequence_order_valid"], false);
+
+    evidence.recorder_events[0].function_id = "integration-recorder::lifecycle".into();
+    evidence.recorder_events[0].payload["unexpected"] = json!(true);
+    let result = grade(&[spec("lifecycle.completed_once", json!({}))], &evidence);
+    assert!(!result[0].actual["contract_shape_valid"].as_bool().unwrap());
+}
+
+#[test]
+fn lifecycle_status_uses_the_compiled_terminal_expectation() {
+    let mut evidence = base_evidence();
+    evidence.recorder_events = vec![event(
+        RecorderEventKind::Lifecycle,
+        "integration-recorder::lifecycle",
+        json!({
+            "session_id": "s_1",
+            "turn_id": "t_1",
+            "status": "failed",
+            "timestamp": 1
+        }),
+    )];
+
+    let result = grade(
+        &[spec(
+            "lifecycle.completed_once",
+            json!({
+                "allow_identical_duplicates": true,
+                "status": "failed"
+            }),
+        )],
+        &evidence,
+    );
+    assert!(result[0].passed, "{:?}", result[0]);
 }
 
 #[test]

--- a/harness/evals/integration/src/main.rs
+++ b/harness/evals/integration/src/main.rs
@@ -62,6 +62,11 @@ struct RunArgs {
     /// Keep heavyweight artifacts for passing scenarios.
     #[arg(long)]
     retain_success: bool,
+
+    /// Run every selected scenario this many times and require an identical
+    /// stable result from each repetition.
+    #[arg(long, default_value_t = 1, value_parser = parse_repeat)]
+    repeat: u16,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -130,6 +135,16 @@ fn parse_worker_bin(raw: &str) -> Result<(String, PathBuf), String> {
         return Err(format!("expected name=path, got {raw:?}"));
     }
     Ok((name.to_string(), PathBuf::from(path)))
+}
+
+fn parse_repeat(raw: &str) -> Result<u16, String> {
+    let repeat = raw
+        .parse::<u16>()
+        .map_err(|error| format!("invalid repeat count {raw:?}: {error}"))?;
+    if repeat == 0 {
+        return Err("repeat count must be at least 1".to_string());
+    }
+    Ok(repeat)
 }
 
 fn main() {
@@ -201,29 +216,53 @@ async fn run(args: RunArgs) -> i32 {
     let mut exit_code = 0;
     for fixture in &fixtures {
         let scenario_id = fixture.scenario.id.clone();
-        tracing::info!(scenario = %scenario_id, "running");
-        let outcome = run_scenario(&bins, fixture, &artifacts_dir, args.retain_success).await;
-        let classification = outcome.result.classification;
-        let failed: Vec<&str> = outcome
-            .result
-            .invariants
-            .iter()
-            .filter(|invariant| !invariant.passed)
-            .map(|invariant| invariant.id.as_str())
-            .collect();
-        println!(
-            "{scenario_id}: {}{} — run {} ({} ms), artifacts: {}",
-            classification_str(classification),
-            if failed.is_empty() {
-                String::new()
+        let mut stable_result = None;
+        for repetition in 1..=args.repeat {
+            tracing::info!(
+                scenario = %scenario_id,
+                repetition,
+                repeat = args.repeat,
+                "running"
+            );
+            let outcome = run_scenario(&bins, fixture, &artifacts_dir, args.retain_success).await;
+            let classification = outcome.result.classification;
+            let failed: Vec<&str> = outcome
+                .result
+                .invariants
+                .iter()
+                .filter(|invariant| !invariant.passed)
+                .map(|invariant| invariant.id.as_str())
+                .collect();
+            let repetition_label = if args.repeat > 1 {
+                format!(" [{repetition}/{}]", args.repeat)
             } else {
-                format!(" — failed invariants: {}", failed.join(", "))
-            },
-            outcome.run_id,
-            outcome.duration_ms,
-            outcome.run_root.display(),
-        );
-        exit_code = exit_code.max(classification.exit_code());
+                String::new()
+            };
+            println!(
+                "{scenario_id}{repetition_label}: {}{} — run {} ({} ms), artifacts: {}",
+                classification_str(classification),
+                if failed.is_empty() {
+                    String::new()
+                } else {
+                    format!(" — failed invariants: {}", failed.join(", "))
+                },
+                outcome.run_id,
+                outcome.duration_ms,
+                outcome.run_root.display(),
+            );
+            exit_code = exit_code.max(classification.exit_code());
+
+            match &stable_result {
+                None => stable_result = Some(outcome.result),
+                Some(expected) if expected == &outcome.result => {}
+                Some(_) => {
+                    eprintln!(
+                        "runner_error: {scenario_id} produced a different stable result on repetition {repetition}"
+                    );
+                    exit_code = exit_code.max(3);
+                }
+            }
+        }
     }
     exit_code
 }
@@ -387,5 +426,13 @@ mod tests {
         for valid in ["streamed-text", "case_507", "C505"] {
             validate_slug(valid).unwrap();
         }
+    }
+
+    #[test]
+    fn repeat_count_must_be_positive() {
+        assert_eq!(parse_repeat("1").unwrap(), 1);
+        assert_eq!(parse_repeat("2").unwrap(), 2);
+        assert!(parse_repeat("0").is_err());
+        assert!(parse_repeat("many").is_err());
     }
 }

--- a/harness/evals/integration/src/process.rs
+++ b/harness/evals/integration/src/process.rs
@@ -10,7 +10,9 @@ mod supervisor;
 
 pub use child::SupervisedChild;
 pub use spec::ProcessSpec;
-pub use supervisor::{EarlyExit, ProcessSupervisor, DEFAULT_TEARDOWN_BUDGET};
+pub use supervisor::{
+    EarlyExit, ProcessSupervisor, TeardownIssue, TeardownReport, DEFAULT_TEARDOWN_BUDGET,
+};
 
 #[cfg(test)]
 mod tests;

--- a/harness/evals/integration/src/process/supervisor.rs
+++ b/harness/evals/integration/src/process/supervisor.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use nix::sys::signal::Signal;
+use serde::Serialize;
 
 use super::child::{SupervisedChild, REAP_INTERVAL};
 use super::spec::ProcessSpec;
@@ -9,11 +10,32 @@ use super::spec::ProcessSpec;
 pub const DEFAULT_TEARDOWN_BUDGET: Duration = Duration::from_secs(15);
 const SIGTERM_GRACE: Duration = Duration::from_secs(5);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct EarlyExit {
     pub name: String,
     pub status: String,
     pub stderr_log: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TeardownIssue {
+    pub process: String,
+    pub operation: String,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct TeardownReport {
+    pub deadline_exceeded: bool,
+    pub escalated_to_sigkill: Vec<String>,
+    pub remaining_processes: Vec<String>,
+    pub issues: Vec<TeardownIssue>,
+}
+
+impl TeardownReport {
+    pub fn complete(&self) -> bool {
+        !self.deadline_exceeded && self.remaining_processes.is_empty() && self.issues.is_empty()
+    }
 }
 
 pub struct ProcessSupervisor {
@@ -80,10 +102,11 @@ impl ProcessSupervisor {
     /// SIGTERM all process groups in reverse start order, then SIGKILL any
     /// group that survives the grace period. The grace and final reap are
     /// both bounded by `teardown_budget`.
-    pub async fn teardown(&mut self) {
+    pub async fn teardown(&mut self) -> TeardownReport {
         let started = tokio::time::Instant::now();
         let final_deadline = started + self.teardown_budget;
         let term_deadline = started + SIGTERM_GRACE.min(self.teardown_budget);
+        let mut report = TeardownReport::default();
 
         for supervised in self.children.iter().rev() {
             if supervised.group_is_alive() {
@@ -93,6 +116,11 @@ impl ProcessSupervisor {
                         worker = %supervised.name(),
                         "SIGTERM failed: {error}"
                     );
+                    report.issues.push(TeardownIssue {
+                        process: supervised.name().to_string(),
+                        operation: "sigterm".to_string(),
+                        error: format!("{error:#}"),
+                    });
                 }
             }
         }
@@ -101,6 +129,9 @@ impl ProcessSupervisor {
 
         for supervised in self.children.iter().rev() {
             if supervised.group_is_alive() {
+                report
+                    .escalated_to_sigkill
+                    .push(supervised.name().to_string());
                 tracing::warn!(
                     target: "harness_integration::process",
                     worker = %supervised.name(),
@@ -112,13 +143,28 @@ impl ProcessSupervisor {
                         worker = %supervised.name(),
                         "SIGKILL failed: {error}"
                     );
+                    report.issues.push(TeardownIssue {
+                        process: supervised.name().to_string(),
+                        operation: "sigkill".to_string(),
+                        error: format!("{error:#}"),
+                    });
                 }
             }
         }
 
         self.wait_for_groups_until(final_deadline).await;
-        self.finalize_direct_children();
+        for supervised in &mut self.children {
+            if supervised.child_is_alive() || supervised.group_is_alive() {
+                report
+                    .remaining_processes
+                    .push(supervised.name().to_string());
+            }
+        }
+        report.deadline_exceeded =
+            !report.remaining_processes.is_empty() && tokio::time::Instant::now() >= final_deadline;
+        report.issues.extend(self.finalize_direct_children());
         self.children.clear();
+        report
     }
 
     async fn wait_for_groups_until(&mut self, deadline: tokio::time::Instant) {
@@ -139,7 +185,8 @@ impl ProcessSupervisor {
         }
     }
 
-    fn finalize_direct_children(&mut self) {
+    fn finalize_direct_children(&mut self) -> Vec<TeardownIssue> {
+        let mut issues = Vec::new();
         for supervised in &mut self.children {
             if let Err(error) = supervised.finalize_direct_child(true) {
                 tracing::warn!(
@@ -147,9 +194,15 @@ impl ProcessSupervisor {
                     worker = %supervised.name(),
                     "reaping child failed: {error}"
                 );
+                issues.push(TeardownIssue {
+                    process: supervised.name().to_string(),
+                    operation: "reap".to_string(),
+                    error: error.to_string(),
+                });
                 supervised.defer_reap();
             }
         }
+        issues
     }
 }
 
@@ -178,6 +231,6 @@ impl Drop for ProcessSupervisor {
         {
             std::thread::sleep(Duration::from_millis(1));
         }
-        self.finalize_direct_children();
+        let _ = self.finalize_direct_children();
     }
 }

--- a/harness/evals/integration/src/process/tests.rs
+++ b/harness/evals/integration/src/process/tests.rs
@@ -127,3 +127,22 @@ fn process_is_running(pid: u32) -> bool {
         .and_then(|(_, rest)| rest.chars().next())
         .is_some_and(|state| state != 'Z')
 }
+
+#[tokio::test]
+async fn teardown_reports_complete_cleanup() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut supervisor = ProcessSupervisor::new(Duration::from_secs(1));
+    let running = ProcessSpec::new(
+        "running",
+        "/bin/sh",
+        dir.path(),
+        dir.path().join("running.out"),
+        dir.path().join("running.err"),
+    )
+    .args(["-c", "exec sleep 60"]);
+    supervisor.spawn(running).unwrap();
+
+    let report = supervisor.teardown().await;
+    assert!(report.complete(), "{report:?}");
+    assert!(report.remaining_processes.is_empty());
+}

--- a/harness/evals/integration/src/readiness.rs
+++ b/harness/evals/integration/src/readiness.rs
@@ -3,14 +3,22 @@
 //! reports **every** missing surface by name (classification `setup_error`).
 
 mod catalog;
+mod contracts;
 mod probe;
 mod spec;
 
 pub use catalog::{
     config_failure, has_function, has_registered_trigger, missing_functions, missing_trigger_types,
-    topic_failures,
+    registered_trigger_count, registered_trigger_failures, topic_failures,
+};
+pub use contracts::{
+    contract_failures, validation_schema, ExpectedFunctionContract, ExpectedTriggerBinding,
+    SchemaComparison,
 };
 pub use probe::probe;
 pub use spec::{ReadinessReport, ReadinessSpec};
 
-pub(crate) use probe::{wait_for_functions, wait_for_registered_triggers};
+pub(crate) use contracts::{controlled_contracts, router_contract};
+pub(crate) use probe::{
+    registered_trigger_snapshot, wait_for_contracts, wait_for_registered_triggers,
+};

--- a/harness/evals/integration/src/readiness/catalog.rs
+++ b/harness/evals/integration/src/readiness/catalog.rs
@@ -2,15 +2,15 @@ use std::collections::BTreeSet;
 
 use serde_json::Value;
 
-use super::ReadinessSpec;
+use super::{ExpectedTriggerBinding, ReadinessSpec};
 
 /// Pure check: required function ids against a discovery listing.
 pub fn missing_functions(spec: &ReadinessSpec, listed: &Value) -> Vec<String> {
     let ids = collect_ids(listed, &["function_id", "id"]);
     spec.functions
         .iter()
-        .filter(|required| !ids.contains(*required))
-        .map(|required| format!("function {required}"))
+        .filter(|required| !ids.contains(&required.function_id))
+        .map(|required| format!("function {}", required.function_id))
         .collect()
 }
 
@@ -24,8 +24,71 @@ pub fn has_registered_trigger(listed: &Value, function_id: &str) -> bool {
     collect_ids(listed, &["function_id", "id"]).contains(function_id)
 }
 
-pub(super) fn has_all_discovery_ids(listed: &Value, function_ids: &[String]) -> bool {
-    contains_all_ids(listed, function_ids, &["function_id", "id"])
+pub fn registered_trigger_failures(
+    expected: &[ExpectedTriggerBinding],
+    listed: &Value,
+) -> Vec<String> {
+    let rows = listed
+        .get("registered_triggers")
+        .and_then(Value::as_array)
+        .or_else(|| listed.as_array())
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+    let mut failures = Vec::new();
+
+    for binding in expected {
+        let for_function = rows
+            .iter()
+            .filter(|row| {
+                row.get("function_id").and_then(Value::as_str) == Some(binding.function_id.as_str())
+            })
+            .collect::<Vec<_>>();
+        let exact = for_function
+            .iter()
+            .filter(|row| {
+                row.get("trigger_type").and_then(Value::as_str)
+                    == Some(binding.trigger_type.as_str())
+                    && row.get("config") == Some(&binding.config)
+            })
+            .count();
+        if exact != 1 {
+            failures.push(format!(
+                "trigger binding {} -> {} with config {}: expected exactly one, got {exact}",
+                binding.trigger_type, binding.function_id, binding.config
+            ));
+        }
+
+        let expected_for_function = expected
+            .iter()
+            .filter(|candidate| candidate.function_id == binding.function_id)
+            .count();
+        if for_function.len() != expected_for_function {
+            failures.push(format!(
+                "trigger binding target {}: expected {expected_for_function} total registration(s), got {}",
+                binding.function_id,
+                for_function.len()
+            ));
+        }
+    }
+    failures.sort();
+    failures.dedup();
+    failures
+}
+
+pub fn registered_trigger_count(listed: &Value, expected: &ExpectedTriggerBinding) -> usize {
+    listed
+        .get("registered_triggers")
+        .and_then(Value::as_array)
+        .or_else(|| listed.as_array())
+        .into_iter()
+        .flatten()
+        .filter(|row| {
+            row.get("function_id").and_then(Value::as_str) == Some(expected.function_id.as_str())
+                && row.get("trigger_type").and_then(Value::as_str)
+                    == Some(expected.trigger_type.as_str())
+                && row.get("config") == Some(&expected.config)
+        })
+        .count()
 }
 
 /// Pure check: required trigger types against a trigger-type listing.
@@ -82,11 +145,6 @@ pub fn config_failure(id: &str, expected: &Value, resp: &Value) -> Option<String
     }
 }
 
-fn contains_all_ids(listed: &Value, required: &[String], keys: &[&str]) -> bool {
-    let ids = collect_ids(listed, keys);
-    required.iter().all(|id| ids.contains(id))
-}
-
 /// Collect id strings from a list response of unknown exact shape: an array
 /// of descriptors (or `{functions: [...]}`/`{items: [...]}`), each carrying
 /// the id under one of `keys`.
@@ -111,4 +169,8 @@ fn collect_ids(listed: &Value, keys: &[&str]) -> BTreeSet<String> {
                 .map(String::from)
         })
         .collect()
+}
+
+pub(super) fn listed_ids(listed: &Value) -> BTreeSet<String> {
+    collect_ids(listed, &["function_id", "id"])
 }

--- a/harness/evals/integration/src/readiness/contracts.rs
+++ b/harness/evals/integration/src/readiness/contracts.rs
@@ -1,0 +1,396 @@
+use serde_json::Value;
+
+use crate::types::recorder::{
+    LifecycleAcceptedV1, LifecycleEventV1, RecorderConfigV1, RecorderTargetV1,
+};
+
+/// Validation-relevant function contract expected from the live engine
+/// registry. A missing optional field means that field is intentionally not
+/// part of this readiness assertion.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExpectedFunctionContract {
+    pub function_id: String,
+    pub description: Option<String>,
+    pub request_schema: Option<Value>,
+    pub response_schema: Option<Value>,
+    pub schema_comparison: SchemaComparison,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExpectedTriggerBinding {
+    pub trigger_type: String,
+    pub function_id: String,
+    pub config: Value,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchemaComparison {
+    /// Producer-owned mirrors may differ only in JSON Schema annotations
+    /// that do not affect validation.
+    AnnotationInsensitive,
+    /// Authored target schemas are model-visible and must survive registry
+    /// registration byte-for-byte after canonical object-key ordering.
+    Exact,
+}
+
+impl ExpectedFunctionContract {
+    pub fn id_only(function_id: impl Into<String>) -> Self {
+        Self {
+            function_id: function_id.into(),
+            description: None,
+            request_schema: None,
+            response_schema: None,
+            schema_comparison: SchemaComparison::AnnotationInsensitive,
+        }
+    }
+
+    pub fn from_golden(raw: &str) -> Self {
+        let value: Value = serde_json::from_str(raw).expect("checked-in function golden is JSON");
+        Self {
+            function_id: required_string(&value, "function_id"),
+            description: value
+                .get("description")
+                .and_then(Value::as_str)
+                .map(String::from),
+            request_schema: value.get("request_schema").cloned(),
+            response_schema: value.get("response_schema").cloned(),
+            schema_comparison: SchemaComparison::AnnotationInsensitive,
+        }
+    }
+}
+
+pub(crate) fn router_contract(function_id: &str) -> ExpectedFunctionContract {
+    router_contracts()
+        .into_iter()
+        .find(|contract| contract.function_id == function_id)
+        .unwrap_or_else(|| panic!("no scripted-router contract for {function_id}"))
+}
+
+pub(crate) fn router_contracts() -> Vec<ExpectedFunctionContract> {
+    [
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../../llm-router/tests/golden/schemas/router.chat.json"
+        )),
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../../llm-router/tests/golden/schemas/router.abort.json"
+        )),
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../../llm-router/tests/golden/schemas/router.models.list.json"
+        )),
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../../llm-router/tests/golden/schemas/router.models.get.json"
+        )),
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../../llm-router/tests/golden/schemas/router.models.supports.json"
+        )),
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../../llm-router/tests/golden/schemas/router.system_prompt.get.json"
+        )),
+    ]
+    .into_iter()
+    .map(ExpectedFunctionContract::from_golden)
+    .collect()
+}
+
+pub(crate) fn pre_harness_contracts() -> Vec<ExpectedFunctionContract> {
+    let mut contracts = [
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../../session-manager/tests/golden/schemas/session.messages.json"
+        )),
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../../context-manager/tests/golden/schemas/context.assemble.json"
+        )),
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../../context-manager/tests/golden/schemas/context.count-tokens.json"
+        )),
+    ]
+    .into_iter()
+    .map(ExpectedFunctionContract::from_golden)
+    .collect::<Vec<_>>();
+    contracts.extend(router_contracts());
+    contracts.push(lifecycle_contract());
+    // Queue readiness is asserted semantically by calling this function and
+    // validating its topic response. There is no worker-owned golden for its
+    // engine builtin descriptor.
+    contracts.push(ExpectedFunctionContract::id_only(
+        "engine::queue::list_topics",
+    ));
+    contracts
+}
+
+pub(crate) fn harness_contracts() -> Vec<ExpectedFunctionContract> {
+    [
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../../harness/tests/golden/schemas/harness.send.json"
+        )),
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../../harness/tests/golden/schemas/harness.status.json"
+        )),
+    ]
+    .into_iter()
+    .map(ExpectedFunctionContract::from_golden)
+    .collect()
+}
+
+pub(crate) fn controlled_contracts(config: &RecorderConfigV1) -> Vec<ExpectedFunctionContract> {
+    std::iter::once(&config.target)
+        .chain(config.extra_functions.iter())
+        .map(controlled_contract)
+        .collect()
+}
+
+fn controlled_contract(target: &RecorderTargetV1) -> ExpectedFunctionContract {
+    ExpectedFunctionContract {
+        function_id: target.function_id.clone(),
+        description: Some(target.description.clone()),
+        request_schema: Some(Value::Object(target.request_schema.clone())),
+        response_schema: Some(crate::recorder::const_response_schema(&target.response)),
+        schema_comparison: SchemaComparison::Exact,
+    }
+}
+
+fn lifecycle_contract() -> ExpectedFunctionContract {
+    ExpectedFunctionContract {
+        function_id: "integration-recorder::lifecycle".to_string(),
+        description: Some("Durable sink for harness lifecycle trigger deliveries.".to_string()),
+        request_schema: Some(schema_for::<LifecycleEventV1>()),
+        response_schema: Some(schema_for::<LifecycleAcceptedV1>()),
+        schema_comparison: SchemaComparison::Exact,
+    }
+}
+
+pub fn contract_failures(expected: &ExpectedFunctionContract, actual: &Value) -> Vec<String> {
+    let descriptor = actual.get("function").unwrap_or(actual);
+    let mut failures = Vec::new();
+
+    let actual_id = descriptor
+        .get("function_id")
+        .or_else(|| descriptor.get("id"))
+        .and_then(Value::as_str);
+    if actual_id != Some(expected.function_id.as_str()) {
+        failures.push(format!(
+            "function {} id: expected {:?}, got {:?}",
+            expected.function_id, expected.function_id, actual_id
+        ));
+    }
+
+    if let Some(description) = &expected.description {
+        let actual_description = descriptor.get("description").and_then(Value::as_str);
+        if actual_description != Some(description.as_str()) {
+            failures.push(format!(
+                "function {} description mismatch: expected {:?}, got {:?}",
+                expected.function_id, description, actual_description
+            ));
+        }
+    }
+
+    compare_schema(
+        &mut failures,
+        expected,
+        descriptor,
+        "request",
+        "request_schema",
+        "request_format",
+        expected.request_schema.as_ref(),
+    );
+    compare_schema(
+        &mut failures,
+        expected,
+        descriptor,
+        "response",
+        "response_schema",
+        "response_format",
+        expected.response_schema.as_ref(),
+    );
+    failures
+}
+
+fn compare_schema(
+    failures: &mut Vec<String>,
+    expected_contract: &ExpectedFunctionContract,
+    descriptor: &Value,
+    side: &str,
+    primary_key: &str,
+    compatibility_key: &str,
+    expected: Option<&Value>,
+) {
+    let Some(expected) = expected else {
+        return;
+    };
+    let actual = descriptor
+        .get(primary_key)
+        .or_else(|| descriptor.get(compatibility_key))
+        .filter(|schema| !schema.is_null());
+    let Some(actual) = actual else {
+        failures.push(format!(
+            "function {} {side} schema missing",
+            expected_contract.function_id
+        ));
+        return;
+    };
+    let (expected, actual) = match expected_contract.schema_comparison {
+        SchemaComparison::AnnotationInsensitive => {
+            (validation_schema(expected), validation_schema(actual))
+        }
+        SchemaComparison::Exact => (expected.clone(), actual.clone()),
+    };
+    if actual != expected {
+        failures.push(format!(
+            "function {} {side} schema mismatch: expected_sha256={}, actual_sha256={}",
+            expected_contract.function_id,
+            crate::canonical::sha256_of_canonical(&expected),
+            crate::canonical::sha256_of_canonical(&actual)
+        ));
+    }
+}
+
+/// Strip only JSON Schema annotation keywords. Validation-affecting
+/// keywords, including `default` (part of the callable contract in this
+/// repository), remain in the comparison.
+pub fn validation_schema(schema: &Value) -> Value {
+    const ANNOTATIONS: &[&str] = &[
+        "$comment",
+        "$schema",
+        "deprecated",
+        "description",
+        "examples",
+        "readOnly",
+        "title",
+        "writeOnly",
+    ];
+    match schema {
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .filter(|(key, _)| !ANNOTATIONS.contains(&key.as_str()))
+                .map(|(key, value)| (key.clone(), validation_schema(value)))
+                .collect(),
+        ),
+        Value::Array(values) => Value::Array(values.iter().map(validation_schema).collect()),
+        value => value.clone(),
+    }
+}
+
+fn schema_for<T: schemars::JsonSchema>() -> Value {
+    serde_json::to_value(schemars::schema_for!(T)).expect("JSON schema serializes")
+}
+
+fn required_string(value: &Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("checked-in function golden is missing {key}"))
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn annotation_only_schema_changes_are_ignored() {
+        let left = json!({
+            "$schema": "draft",
+            "title": "Left",
+            "type": "object",
+            "properties": { "value": { "type": "string", "description": "left" } }
+        });
+        let right = json!({
+            "title": "Right",
+            "type": "object",
+            "properties": { "value": { "type": "string", "description": "right" } }
+        });
+        assert_eq!(validation_schema(&left), validation_schema(&right));
+    }
+
+    #[test]
+    fn validation_keywords_still_mismatch() {
+        let expected = ExpectedFunctionContract {
+            function_id: "test::function".into(),
+            description: None,
+            request_schema: Some(json!({ "type": "string" })),
+            response_schema: None,
+            schema_comparison: SchemaComparison::AnnotationInsensitive,
+        };
+        let failures = contract_failures(
+            &expected,
+            &json!({
+                "function_id": "test::function",
+                "request_schema": { "type": "integer" }
+            }),
+        );
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].contains("request schema mismatch"));
+    }
+
+    #[test]
+    fn exact_target_contract_keeps_property_descriptions() {
+        let expected = ExpectedFunctionContract {
+            function_id: "run::target".into(),
+            description: Some("target".into()),
+            request_schema: Some(json!({
+                "type": "object",
+                "properties": {
+                    "value": { "type": "string", "description": "authoritative" }
+                }
+            })),
+            response_schema: Some(json!({ "const": { "ok": true } })),
+            schema_comparison: SchemaComparison::Exact,
+        };
+        let failures = contract_failures(
+            &expected,
+            &json!({
+                "function_id": "run::target",
+                "description": "target",
+                "request_schema": {
+                    "type": "object",
+                    "properties": {
+                        "value": { "type": "string", "description": "changed" }
+                    }
+                },
+                "response_schema": { "const": { "ok": true } }
+            }),
+        );
+        assert!(failures
+            .iter()
+            .any(|failure| failure.contains("request schema mismatch")));
+    }
+
+    #[test]
+    fn exact_target_contract_checks_description_and_response_schema() {
+        let expected = ExpectedFunctionContract {
+            function_id: "run::target".into(),
+            description: Some("authoritative target".into()),
+            request_schema: Some(json!({ "type": "object" })),
+            response_schema: Some(json!({ "const": { "ok": true } })),
+            schema_comparison: SchemaComparison::Exact,
+        };
+        let failures = contract_failures(
+            &expected,
+            &json!({
+                "function_id": "run::target",
+                "description": "changed target",
+                "request_schema": { "type": "object" },
+                "response_schema": { "const": { "ok": false } }
+            }),
+        );
+        assert_eq!(failures.len(), 2);
+        assert!(failures
+            .iter()
+            .any(|failure| failure.contains("description mismatch")));
+        assert!(failures
+            .iter()
+            .any(|failure| failure.contains("response schema mismatch")));
+    }
+}

--- a/harness/evals/integration/src/readiness/probe.rs
+++ b/harness/evals/integration/src/readiness/probe.rs
@@ -6,9 +6,13 @@ use crate::client::{Client, DEFAULT_CALL_TIMEOUT_MS};
 use crate::deadline::Deadline;
 
 use super::catalog::{
-    config_failure, has_all_discovery_ids, missing_functions, missing_trigger_types, topic_failures,
+    config_failure, missing_functions, missing_trigger_types, registered_trigger_failures,
+    topic_failures,
 };
-use super::{ReadinessReport, ReadinessSpec};
+use super::{
+    contract_failures, ExpectedFunctionContract, ExpectedTriggerBinding, ReadinessReport,
+    ReadinessSpec,
+};
 
 const READINESS_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const DISCOVERY_POLL_INTERVAL: Duration = Duration::from_millis(200);
@@ -31,64 +35,60 @@ pub async fn probe(
     }
 }
 
-/// Wait until every controlled function id is present in engine discovery.
-pub(crate) async fn wait_for_functions(
+/// Wait until every controlled function is present with its exact live
+/// descriptor contract.
+pub(crate) async fn wait_for_contracts(
     client: &Client,
-    function_ids: &[String],
+    contracts: &[ExpectedFunctionContract],
     deadline: Deadline,
-) -> anyhow::Result<()> {
-    wait_for_catalog(
-        client,
-        function_ids,
-        deadline,
-        "engine::functions::list",
-        "controlled function discovery",
-        has_all_discovery_ids,
-    )
-    .await
+) -> Result<(), ReadinessReport> {
+    loop {
+        let missing = inspect_function_contracts(client, contracts, deadline).await;
+        if missing.is_empty() {
+            return Ok(());
+        }
+        if deadline.is_expired() {
+            return Err(ReadinessReport { missing });
+        }
+        tokio::time::sleep(DISCOVERY_POLL_INTERVAL.min(deadline.remaining())).await;
+    }
 }
 
 /// Wait until every bound function id is present in registered-trigger
 /// discovery.
 pub(crate) async fn wait_for_registered_triggers(
     client: &Client,
-    function_ids: &[String],
+    bindings: &[ExpectedTriggerBinding],
     deadline: Deadline,
-) -> anyhow::Result<()> {
-    wait_for_catalog(
-        client,
-        function_ids,
-        deadline,
-        "engine::registered-triggers::list",
-        "registered trigger discovery",
-        has_all_discovery_ids,
-    )
-    .await
+) -> Result<(), ReadinessReport> {
+    loop {
+        let failures = match registered_trigger_snapshot(client, deadline).await {
+            Ok(listed) => registered_trigger_failures(bindings, &listed),
+            Err(error) => vec![format!("registered trigger discovery unavailable: {error}")],
+        };
+        if failures.is_empty() {
+            return Ok(());
+        }
+        if deadline.is_expired() {
+            return Err(ReadinessReport { missing: failures });
+        }
+        tokio::time::sleep(DISCOVERY_POLL_INTERVAL.min(deadline.remaining())).await;
+    }
 }
 
-async fn wait_for_catalog(
+pub(crate) async fn registered_trigger_snapshot(
     client: &Client,
-    function_ids: &[String],
     deadline: Deadline,
-    method: &'static str,
-    operation: &'static str,
-    contains_all: fn(&Value, &[String]) -> bool,
-) -> anyhow::Result<()> {
-    deadline
-        .poll_until(operation, DISCOVERY_POLL_INTERVAL, || async {
-            let listed = client
-                .call_with_deadline(
-                    method,
-                    json!({ "include_internal": true }),
-                    deadline,
-                    DEFAULT_CALL_TIMEOUT_MS,
-                )
-                .await;
-            Ok(listed
-                .ok()
-                .and_then(|listed| contains_all(&listed, function_ids).then_some(())))
-        })
+) -> anyhow::Result<Value> {
+    client
+        .call_with_deadline(
+            "engine::registered-triggers::list",
+            json!({ "include_internal": true }),
+            deadline,
+            DEFAULT_CALL_TIMEOUT_MS,
+        )
         .await
+        .map_err(anyhow::Error::msg)
 }
 
 async fn probe_once(client: &Client, spec: &ReadinessSpec, deadline: Deadline) -> ReadinessReport {
@@ -104,7 +104,17 @@ async fn probe_once(client: &Client, spec: &ReadinessSpec, deadline: Deadline) -
         )
         .await
     {
-        Ok(listed) => missing.extend(missing_functions(spec, &listed)),
+        Ok(listed) => {
+            missing.extend(missing_functions(spec, &listed));
+            let available = super::catalog::listed_ids(&listed);
+            let contracts = spec
+                .functions
+                .iter()
+                .filter(|contract| available.contains(&contract.function_id))
+                .cloned()
+                .collect::<Vec<_>>();
+            missing.extend(inspect_function_contracts(client, &contracts, deadline).await);
+        }
         Err(error) => missing.push(format!("engine::functions::list unavailable: {error}")),
     }
 
@@ -162,4 +172,30 @@ async fn probe_once(client: &Client, spec: &ReadinessSpec, deadline: Deadline) -
     }
 
     ReadinessReport { missing }
+}
+
+async fn inspect_function_contracts(
+    client: &Client,
+    contracts: &[ExpectedFunctionContract],
+    deadline: Deadline,
+) -> Vec<String> {
+    let mut failures = Vec::new();
+    for contract in contracts {
+        match client
+            .call_with_deadline(
+                "engine::functions::info",
+                json!({ "function_id": contract.function_id }),
+                deadline,
+                DEFAULT_CALL_TIMEOUT_MS,
+            )
+            .await
+        {
+            Ok(actual) => failures.extend(contract_failures(contract, &actual)),
+            Err(error) => failures.push(format!(
+                "function {} descriptor unavailable: {error}",
+                contract.function_id
+            )),
+        }
+    }
+    failures
 }

--- a/harness/evals/integration/src/readiness/spec.rs
+++ b/harness/evals/integration/src/readiness/spec.rs
@@ -1,16 +1,20 @@
 use serde_json::Value;
 
+use super::contracts::{harness_contracts, pre_harness_contracts};
+use super::ExpectedFunctionContract;
+
 #[derive(Debug, Clone)]
 pub struct ReadinessSpec {
-    /// Exact function ids that must be registered. Internal functions are
-    /// visible because the probe passes `include_internal: true`.
-    pub functions: Vec<String>,
+    /// Exact live function contracts that must be registered. Internal
+    /// functions are visible because discovery passes
+    /// `include_internal: true`.
+    pub functions: Vec<ExpectedFunctionContract>,
     /// Trigger types that must be registered (e.g. `harness::turn-completed`).
     pub trigger_types: Vec<String>,
     /// Queue topics that must exist as (name, expected broker type).
     pub queue_topics: Vec<(String, String)>,
-    /// `configuration::get` id → expected seeded value (canonical-JSON
-    /// byte-compare).
+    /// `configuration::get` id → authoritative seeded subset. Every seeded
+    /// value must match canonically; worker-installed defaults may add fields.
     pub config_entries: Vec<(String, Value)>,
 }
 
@@ -18,30 +22,8 @@ impl ReadinessSpec {
     /// The surface required before Arm — everything except the harness,
     /// which is spawned after Arm (see `stack::WORKER_START_ORDER`).
     pub fn pre_harness(config_entries: Vec<(String, Value)>) -> Self {
-        let functions = [
-            // Session durability.
-            "session::messages",
-            // Context manager is mandatory and fails closed when absent.
-            "context::assemble",
-            "context::count-tokens",
-            // The scripted router owns the fixed router ids.
-            "router::chat",
-            "router::abort",
-            "router::models::list",
-            "router::models::get",
-            "router::models::supports",
-            "router::system_prompt::get",
-            // Recorder's only public engine surface. Configuration,
-            // reset, and snapshots stay inside the runner process.
-            "integration-recorder::lifecycle",
-            // Queue surface consumed by the probe itself.
-            "engine::queue::list_topics",
-        ]
-        .into_iter()
-        .map(String::from)
-        .collect();
         Self {
-            functions,
+            functions: pre_harness_contracts(),
             trigger_types: Vec::new(),
             queue_topics: Vec::new(),
             config_entries,
@@ -53,7 +35,7 @@ impl ReadinessSpec {
     /// `harness-turn` topic, and the harness's own seeded config entry.
     pub fn harness_surface(config_entries: Vec<(String, Value)>) -> Self {
         Self {
-            functions: vec!["harness::send".to_string(), "harness::status".to_string()],
+            functions: harness_contracts(),
             trigger_types: vec![
                 "harness::turn-started".to_string(),
                 "harness::turn-completed".to_string(),

--- a/harness/evals/integration/src/recorder.rs
+++ b/harness/evals/integration/src/recorder.rs
@@ -10,6 +10,7 @@
 mod service;
 mod store;
 
+pub(crate) use service::const_response_schema;
 pub use service::Recorder;
 
 #[cfg(test)]

--- a/harness/evals/integration/src/recorder/service.rs
+++ b/harness/evals/integration/src/recorder/service.rs
@@ -1,8 +1,9 @@
 //! SDK-facing recorder service and controlled-function registration.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
 use iii_sdk::errors::Error;
 use iii_sdk::protocol::RegisterTriggerInput;
@@ -12,7 +13,8 @@ use serde_json::{json, Value};
 use super::store::EventStore;
 use crate::client::Client;
 use crate::types::recorder::{
-    RecorderConfigV1, RecorderEventKind, RecorderEventV1, RecorderTargetV1,
+    LifecycleAcceptedV1, LifecycleEventV1, RecorderConfigV1, RecorderEventKind, RecorderEventV1,
+    RecorderTargetV1,
 };
 
 const LIFECYCLE_FUNCTION_ID: &str = "integration-recorder::lifecycle";
@@ -20,13 +22,55 @@ const LIFECYCLE_FUNCTION_ID: &str = "integration-recorder::lifecycle";
 pub struct Recorder {
     client: Client,
     store: Arc<EventStore>,
+    response_gates: Arc<Mutex<BTreeMap<String, Arc<ResponseGate>>>>,
+}
+
+pub(super) struct ResponseGate {
+    hold_at: u64,
+    calls: AtomicU64,
+    released: AtomicBool,
+    notify: tokio::sync::Notify,
+}
+
+impl ResponseGate {
+    pub(super) fn new(hold_at: u64) -> Self {
+        Self {
+            hold_at,
+            calls: AtomicU64::new(0),
+            released: AtomicBool::new(false),
+            notify: tokio::sync::Notify::new(),
+        }
+    }
+
+    pub(super) async fn wait_if_selected(&self) {
+        let ordinal = self.calls.fetch_add(1, Ordering::AcqRel) + 1;
+        if ordinal != self.hold_at {
+            return;
+        }
+        loop {
+            let notified = self.notify.notified();
+            if self.released.load(Ordering::Acquire) {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    pub(super) fn release(&self) {
+        self.released.store(true, Ordering::Release);
+        self.notify.notify_waiters();
+    }
 }
 
 impl Recorder {
     pub async fn start(ws_url: &str, log_path: PathBuf) -> anyhow::Result<Self> {
         let client = Client::connect(ws_url, "integration-recorder");
         let store = Arc::new(EventStore::new(log_path));
-        let recorder = Recorder { client, store };
+        let recorder = Recorder {
+            client,
+            store,
+            response_gates: Arc::new(Mutex::new(BTreeMap::new())),
+        };
         recorder.register_lifecycle();
         Ok(recorder)
     }
@@ -38,6 +82,7 @@ impl Recorder {
             RegisterFunction::new_async(move |payload: Value| {
                 let store = store.clone();
                 async move {
+                    let payload = parse_lifecycle_payload(payload).map_err(Error::Handler)?;
                     append_handler_event(
                         &store,
                         RecorderEventKind::Lifecycle,
@@ -45,16 +90,19 @@ impl Recorder {
                         payload,
                         "integration/lifecycle",
                     )?;
-                    Ok::<Value, Error>(json!({ "accepted": true }))
+                    serde_json::to_value(LifecycleAcceptedV1 { accepted: true }).map_err(|error| {
+                        Error::Handler(format!("integration/lifecycle_response_serialize: {error}"))
+                    })
                 }
             })
-            .description("Durable sink for harness lifecycle trigger deliveries."),
+            .description("Durable sink for harness lifecycle trigger deliveries.")
+            .request_format(schema_for::<LifecycleEventV1>())
+            .response_format(schema_for::<LifecycleAcceptedV1>()),
         );
     }
 
     /// Configure and register the run-scoped controlled functions directly.
-    /// Returns the canonical digest of the target request schema.
-    pub fn configure(&self, run_id: &str, config: &RecorderConfigV1) -> anyhow::Result<String> {
+    pub fn configure(&self, run_id: &str, config: &RecorderConfigV1) -> anyhow::Result<()> {
         let prefix = format!("{run_id}::");
         let mut function_ids = BTreeSet::new();
         for declared in controlled_functions(config) {
@@ -71,12 +119,34 @@ impl Recorder {
         }
 
         self.store.configure(run_id)?;
+        let mut gates = self
+            .response_gates
+            .lock()
+            .map_err(|_| anyhow::anyhow!("recorder response gate lock poisoned"))?;
+        gates.clear();
         for declared in controlled_functions(config) {
-            register_controlled_function(self.client.inner(), &self.store, declared);
+            let gate = declared
+                .hold_response_at
+                .map(|hold_at| Arc::new(ResponseGate::new(hold_at)));
+            if let Some(gate) = &gate {
+                gates.insert(declared.function_id.clone(), Arc::clone(gate));
+            }
+            register_controlled_function(self.client.inner(), &self.store, declared, gate);
         }
+        Ok(())
+    }
 
-        let schema = Value::Object(config.target.request_schema.clone());
-        Ok(crate::canonical::sha256_of_canonical(&schema))
+    /// Release a private response gate after the runner has applied a fault.
+    pub fn release_response(&self, function_id: &str) -> anyhow::Result<()> {
+        let gates = self
+            .response_gates
+            .lock()
+            .map_err(|_| anyhow::anyhow!("recorder response gate lock poisoned"))?;
+        let gate = gates
+            .get(function_id)
+            .ok_or_else(|| anyhow::anyhow!("no response gate configured for {function_id}"))?;
+        gate.release();
+        Ok(())
     }
 
     /// Durably clear evidence for a run and restart event sequencing.
@@ -129,20 +199,27 @@ impl Recorder {
     }
 }
 
+pub(super) fn parse_lifecycle_payload(payload: Value) -> Result<Value, String> {
+    let payload = strip_engine_fields(payload);
+    let event: LifecycleEventV1 = serde_json::from_value(payload)
+        .map_err(|error| format!("integration/lifecycle_contract: {error}"))?;
+    serde_json::to_value(event).map_err(|error| format!("integration/lifecycle_serialize: {error}"))
+}
+
 fn controlled_functions(config: &RecorderConfigV1) -> impl Iterator<Item = &RecorderTargetV1> {
     std::iter::once(&config.target).chain(config.extra_functions.iter())
 }
 
 /// Register one declared controlled function: verbatim description/schema,
-/// durable append per call, declared response (after the optional
-/// fault-injection delay).
+/// durable append per call, and the declared response (after an optional
+/// compiler-owned fault gate).
 fn register_controlled_function(
     iii: &iii_sdk::IIIClient,
     store: &Arc<EventStore>,
     declared: &RecorderTargetV1,
+    response_gate: Option<Arc<ResponseGate>>,
 ) {
     let response = declared.response.clone();
-    let delay_ms = declared.response_delay_ms.unwrap_or(0);
     let store = store.clone();
     let function_id = declared.function_id.clone();
     let handler_function_id = function_id.clone();
@@ -152,6 +229,7 @@ fn register_controlled_function(
             let store = store.clone();
             let response = response.clone();
             let function_id = handler_function_id.clone();
+            let response_gate = response_gate.clone();
             async move {
                 append_handler_event(
                     &store,
@@ -160,17 +238,27 @@ fn register_controlled_function(
                     payload,
                     "integration/target_append",
                 )?;
-                if delay_ms > 0 {
-                    // Fault-injection window: the call is durably observed
-                    // but still executing.
-                    tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                if let Some(gate) = response_gate {
+                    gate.wait_if_selected().await;
                 }
                 Ok::<Value, Error>(response)
             }
         })
         .description(declared.description.clone())
-        .request_format(Value::Object(declared.request_schema.clone())),
+        .request_format(Value::Object(declared.request_schema.clone()))
+        .response_format(const_response_schema(&declared.response)),
     );
+}
+
+pub(crate) fn const_response_schema(response: &Value) -> Value {
+    json!({
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "const": response
+    })
+}
+
+fn schema_for<T: schemars::JsonSchema>() -> Value {
+    serde_json::to_value(schemars::schema_for!(T)).expect("JSON schema serializes")
 }
 
 fn append_handler_event(

--- a/harness/evals/integration/src/recorder/tests.rs
+++ b/harness/evals/integration/src/recorder/tests.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use serde_json::json;
 
-use super::service::strip_engine_fields;
+use super::service::{parse_lifecycle_payload, strip_engine_fields, ResponseGate};
 use super::store::EventStore;
 use crate::types::recorder::RecorderEventKind;
 
@@ -126,6 +126,53 @@ fn engine_fields_are_only_removed_from_the_payload_top_level() {
             }
         })
     );
+}
+
+#[test]
+fn lifecycle_contract_strips_only_engine_fields_and_rejects_unknown_shape() {
+    let valid = json!({
+        "_caller_worker_id": "harness",
+        "session_id": "s_1",
+        "turn_id": "t_1",
+        "status": "completed",
+        "timestamp": 1,
+        "parent": {
+            "session_id": "s_parent",
+            "turn_id": "t_parent",
+            "function_call_id": "call-1"
+        }
+    });
+    let parsed = parse_lifecycle_payload(valid).expect("valid lifecycle");
+    assert!(parsed.get("_caller_worker_id").is_none());
+
+    let mut unknown_top_level = parsed.clone();
+    unknown_top_level["surprise"] = json!(true);
+    assert!(parse_lifecycle_payload(unknown_top_level).is_err());
+
+    let mut unknown_nested = parsed;
+    unknown_nested["parent"]["surprise"] = json!(true);
+    assert!(parse_lifecycle_payload(unknown_nested).is_err());
+}
+
+#[tokio::test]
+async fn response_gate_holds_only_the_selected_call_ordinal() {
+    let gate = std::sync::Arc::new(ResponseGate::new(2));
+    gate.wait_if_selected().await;
+
+    let waiting = {
+        let gate = std::sync::Arc::clone(&gate);
+        tokio::spawn(async move { gate.wait_if_selected().await })
+    };
+    tokio::task::yield_now().await;
+    assert!(!waiting.is_finished(), "the selected call must remain held");
+
+    gate.release();
+    tokio::time::timeout(std::time::Duration::from_secs(1), waiting)
+        .await
+        .expect("released gate should wake")
+        .expect("gate task should not panic");
+
+    gate.wait_if_selected().await;
 }
 
 #[cfg(target_os = "linux")]

--- a/harness/evals/integration/src/scenario/phases/completion.rs
+++ b/harness/evals/integration/src/scenario/phases/completion.rs
@@ -24,11 +24,13 @@ impl ScenarioRunner<'_> {
         let phase = RunPhase::Await;
         let deadline = active.deadline;
         let last_status = Arc::new(Mutex::new(Value::Null));
+        let last_status_error = Arc::new(Mutex::new(None::<String>));
         let session_id = self.session_id.clone();
 
         let terminal = deadline
             .poll_until("terminal harness status", STATUS_POLL_INTERVAL, || {
                 let last_status = Arc::clone(&last_status);
+                let last_status_error = Arc::clone(&last_status_error);
                 let session_id = session_id.clone();
                 async move {
                     let response = services
@@ -40,8 +42,19 @@ impl ScenarioRunner<'_> {
                             DEFAULT_CALL_TIMEOUT_MS,
                         )
                         .await;
-                    let Ok(status) = response else {
-                        return Ok(None);
+                    let status = match response {
+                        Ok(status) => {
+                            *last_status_error.lock().map_err(|_| {
+                                anyhow::anyhow!("last status error lock poisoned")
+                            })? = None;
+                            status
+                        }
+                        Err(error) => {
+                            *last_status_error.lock().map_err(|_| {
+                                anyhow::anyhow!("last status error lock poisoned")
+                            })? = Some(error);
+                            return Ok(None);
+                        }
                     };
                     *last_status
                         .lock()
@@ -59,6 +72,24 @@ impl ScenarioRunner<'_> {
         match terminal {
             Ok(status) => active.final_status = status,
             Err(error) if deadline.is_expired() => {
+                if let Some(status_error) = last_status_error
+                    .lock()
+                    .map_err(|_| {
+                        RunError::new(
+                            phase,
+                            RunErrorKind::Runner,
+                            "last status error lock poisoned",
+                        )
+                    })?
+                    .clone()
+                {
+                    return Err(RunError::with_source(
+                        phase,
+                        RunErrorKind::Runner,
+                        "harness::status remained unavailable at the scenario deadline",
+                        anyhow::anyhow!(status_error),
+                    ));
+                }
                 active.timed_out = true;
                 active.final_status = last_status
                     .lock()

--- a/harness/evals/integration/src/scenario/phases/evidence.rs
+++ b/harness/evals/integration/src/scenario/phases/evidence.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+use std::time::Duration;
 
 use serde_json::{json, Value};
 
@@ -9,9 +10,10 @@ use crate::runtime::{RunError, RunErrorKind, RunPhase};
 use crate::services::RunServices;
 use crate::types::recorder::RecorderEventKind;
 
-use super::super::report::rpc_failure;
 use super::super::runner::ScenarioRunner;
 use super::super::state::{ActiveTurn, PreparedRun};
+
+const COLLECTION_TIMEOUT: Duration = Duration::from_secs(30);
 
 impl ScenarioRunner<'_> {
     pub(in crate::scenario) async fn collect(
@@ -21,14 +23,12 @@ impl ScenarioRunner<'_> {
         active: &mut ActiveTurn,
     ) -> Result<(), RunError> {
         let phase = RunPhase::Collect;
-        let deadline = active.deadline;
-
-        if deadline.is_expired() {
-            active.timed_out = true;
-            active.transcript = Vec::new();
-        } else {
-            active.transcript = self.collect_transcript(services.client(), deadline).await?;
-        }
+        // Evidence transport is runner infrastructure, not subject
+        // completion. Give it an independent bounded deadline so an RPC
+        // failure here is runner_error even when the subject deadline has
+        // already elapsed in Await.
+        let deadline = Deadline::after(COLLECTION_TIMEOUT);
+        active.transcript = self.collect_transcript(services.client(), deadline).await?;
         self.write_artifact(
             &prepared.scenario.id,
             "transcript.json",
@@ -72,9 +72,6 @@ impl ScenarioRunner<'_> {
             &lifecycle_events,
             phase,
         )?;
-        if deadline.is_expired() {
-            active.timed_out = true;
-        }
         Ok(())
     }
 
@@ -102,9 +99,9 @@ impl ScenarioRunner<'_> {
 
         if active.timed_out {
             return Err(RunError::new(
-                phase,
+                RunPhase::Await,
                 RunErrorKind::Timeout,
-                "scenario deadline elapsed before evidence collection completed",
+                "terminal status did not arrive before the scenario deadline",
             ));
         }
         if self.invariants.iter().any(|invariant| !invariant.passed)
@@ -147,12 +144,11 @@ impl ScenarioRunner<'_> {
                 )
                 .await
                 .map_err(|error| {
-                    rpc_failure(
+                    RunError::with_source(
                         phase,
                         RunErrorKind::Runner,
-                        deadline,
                         "collect session transcript",
-                        error,
+                        anyhow::anyhow!(error),
                     )
                 })?;
             if let Some(items) = page.get("messages").and_then(Value::as_array) {

--- a/harness/evals/integration/src/scenario/phases/execution.rs
+++ b/harness/evals/integration/src/scenario/phases/execution.rs
@@ -4,9 +4,10 @@ use serde_json::{json, Value};
 
 use crate::client::DEFAULT_CALL_TIMEOUT_MS;
 use crate::deadline::Deadline;
+use crate::readiness::{self, ReadinessSpec};
 use crate::runtime::{RunError, RunErrorKind, RunPhase};
 use crate::services::RunServices;
-use crate::stack::Stack;
+use crate::stack::{expected_config_entries, expected_harness_config_entry, Stack};
 use crate::types::recorder::RecorderEventKind;
 use crate::types::scenario::FaultKind;
 
@@ -38,7 +39,14 @@ impl ScenarioRunner<'_> {
             .client()
             .call_with_deadline(
                 "harness::send",
-                prepared.scenario.send.clone(),
+                serde_json::to_value(&prepared.scenario.send).map_err(|error| {
+                    RunError::with_source(
+                        phase,
+                        RunErrorKind::Runner,
+                        "serialize compiled harness::send request",
+                        error,
+                    )
+                })?,
                 deadline,
                 SEND_TIMEOUT_MS,
             )
@@ -58,7 +66,6 @@ impl ScenarioRunner<'_> {
                 Err(rpc_failure(
                     phase,
                     RunErrorKind::Contract,
-                    deadline,
                     "harness::send failed",
                     error,
                 ))
@@ -80,7 +87,7 @@ impl ScenarioRunner<'_> {
         let deadline = active.deadline;
 
         let FaultKind::EngineSigkill = fault.kind;
-        deadline
+        let observed = deadline
             .poll_until("fault trigger", TARGET_POLL_INTERVAL, || async {
                 let events = services.recorder().snapshot(None)?;
                 let count = events
@@ -92,25 +99,48 @@ impl ScenarioRunner<'_> {
                     .count() as u64;
                 Ok((count >= fault.after_target_calls).then_some(()))
             })
-            .await
+            .await;
+        if let Err(error) = observed {
+            services
+                .recorder()
+                .release_response(&fault.function_id)
+                .map_err(|release_error| {
+                    RunError::with_source(
+                        phase,
+                        RunErrorKind::Runner,
+                        "release controlled response gate after fault trigger failure",
+                        release_error,
+                    )
+                })?;
+            let kind = if deadline.is_expired() {
+                RunErrorKind::Contract
+            } else {
+                RunErrorKind::Runner
+            };
+            return Err(RunError::with_source(
+                phase,
+                kind,
+                format!(
+                    "fewer than {} target calls observed before fault",
+                    fault.after_target_calls
+                ),
+                error,
+            ));
+        }
+
+        let kill_result = stack.kill_engine().await;
+        services
+            .recorder()
+            .release_response(&fault.function_id)
             .map_err(|error| {
-                let kind = if deadline.is_expired() {
-                    RunErrorKind::Timeout
-                } else {
-                    RunErrorKind::Runner
-                };
                 RunError::with_source(
                     phase,
-                    kind,
-                    format!(
-                        "fewer than {} target calls observed before fault",
-                        fault.after_target_calls
-                    ),
+                    RunErrorKind::Runner,
+                    "release controlled response gate after fault",
                     error,
                 )
             })?;
-
-        stack.kill_engine().await.map_err(|error| {
+        kill_result.map_err(|error| {
             RunError::with_source(
                 phase,
                 RunErrorKind::Runner,
@@ -127,7 +157,7 @@ impl ScenarioRunner<'_> {
             .map_err(|error| {
                 RunError::with_source(
                     phase,
-                    RunErrorKind::Timeout,
+                    RunErrorKind::Runner,
                     "fault restart delay exceeded scenario deadline",
                     error,
                 )
@@ -140,6 +170,149 @@ impl ScenarioRunner<'_> {
                 error,
             )
         })?;
+        self.restore_after_engine_restart(stack, services, prepared, deadline)
+            .await?;
+        Ok(())
+    }
+
+    async fn restore_after_engine_restart(
+        &mut self,
+        stack: &Stack,
+        services: &RunServices,
+        prepared: &PreparedRun,
+        deadline: Deadline,
+    ) -> Result<(), RunError> {
+        let phase = RunPhase::Fault;
+        let scenario = &prepared.scenario;
+
+        let pre_harness = ReadinessSpec::pre_harness(expected_config_entries(&stack.paths));
+        if let Err(report) = readiness::probe(services.client(), &pre_harness, deadline).await {
+            self.write_artifact(
+                &scenario.id,
+                "readiness-failure.json",
+                &json!({ "phase": "post_restart_pre_harness", "missing": report.missing }),
+                phase,
+            )?;
+            return Err(RunError::new(
+                phase,
+                RunErrorKind::Runner,
+                "base contracts did not recover after engine restart",
+            ));
+        }
+
+        let controlled = readiness::controlled_contracts(&scenario.recorder);
+        if let Err(report) =
+            readiness::wait_for_contracts(services.client(), &controlled, deadline).await
+        {
+            self.write_artifact(
+                &scenario.id,
+                "readiness-failure.json",
+                &json!({ "phase": "post_restart_controlled", "missing": report.missing }),
+                phase,
+            )?;
+            return Err(RunError::new(
+                phase,
+                RunErrorKind::Runner,
+                "controlled contracts did not recover after engine restart",
+            ));
+        }
+
+        let harness = ReadinessSpec::harness_surface(expected_harness_config_entry(&stack.paths));
+        if let Err(report) = readiness::probe(services.client(), &harness, deadline).await {
+            self.write_artifact(
+                &scenario.id,
+                "readiness-failure.json",
+                &json!({ "phase": "post_restart_harness", "missing": report.missing }),
+                phase,
+            )?;
+            return Err(RunError::new(
+                phase,
+                RunErrorKind::Runner,
+                "harness contracts did not recover after engine restart",
+            ));
+        }
+
+        let expected_bindings = super::expected_trigger_bindings(scenario, &self.session_id);
+        let registered = readiness::registered_trigger_snapshot(services.client(), deadline)
+            .await
+            .map_err(|error| {
+                RunError::with_source(
+                    phase,
+                    RunErrorKind::Runner,
+                    "inspect trigger bindings after engine restart",
+                    error,
+                )
+            })?;
+
+        for (index, expected) in expected_bindings.iter().enumerate() {
+            match readiness::registered_trigger_count(&registered, expected) {
+                1 => {}
+                0 if index == 0 => services
+                    .recorder()
+                    .bind_lifecycle(
+                        scenario.recorder.lifecycle.trigger_type.as_str(),
+                        &self.session_id,
+                    )
+                    .await
+                    .map_err(|error| {
+                        RunError::with_source(
+                            phase,
+                            RunErrorKind::Runner,
+                            "restore lifecycle binding after engine restart",
+                            error,
+                        )
+                    })?,
+                0 => {
+                    let binding = &scenario.bindings[index - 1];
+                    services
+                        .recorder()
+                        .bind(
+                            &binding.trigger_type,
+                            &binding.function_id,
+                            binding.config.clone(),
+                        )
+                        .await
+                        .map_err(|error| {
+                            RunError::with_source(
+                                phase,
+                                RunErrorKind::Runner,
+                                format!(
+                                    "restore trigger {} -> {} after engine restart",
+                                    binding.trigger_type, binding.function_id
+                                ),
+                                error,
+                            )
+                        })?;
+                }
+                count => {
+                    return Err(RunError::new(
+                        phase,
+                        RunErrorKind::Runner,
+                        format!(
+                            "trigger binding {} -> {} appeared {count} times after engine restart",
+                            expected.trigger_type, expected.function_id
+                        ),
+                    ));
+                }
+            }
+        }
+
+        if let Err(report) =
+            readiness::wait_for_registered_triggers(services.client(), &expected_bindings, deadline)
+                .await
+        {
+            self.write_artifact(
+                &scenario.id,
+                "readiness-failure.json",
+                &json!({ "phase": "post_restart_bindings", "missing": report.missing }),
+                phase,
+            )?;
+            return Err(RunError::new(
+                phase,
+                RunErrorKind::Runner,
+                "trigger bindings did not recover after engine restart",
+            ));
+        }
         Ok(())
     }
 
@@ -186,7 +359,7 @@ impl ScenarioRunner<'_> {
             .map_err(|error| {
                 RunError::with_source(
                     phase,
-                    RunErrorKind::Timeout,
+                    RunErrorKind::Contract,
                     format!(
                         "call {} never appeared as pending",
                         release.function_call_id
@@ -230,7 +403,6 @@ impl ScenarioRunner<'_> {
                 Err(rpc_failure(
                     phase,
                     RunErrorKind::Contract,
-                    deadline,
                     "harness::function::resolve failed",
                     error,
                 ))

--- a/harness/evals/integration/src/scenario/phases/mod.rs
+++ b/harness/evals/integration/src/scenario/phases/mod.rs
@@ -1,5 +1,10 @@
 use std::time::Duration;
 
+use serde_json::json;
+
+use crate::readiness::ExpectedTriggerBinding;
+use crate::types::scenario::CompiledScenarioV1;
+
 mod completion;
 mod evidence;
 mod execution;
@@ -7,3 +12,30 @@ mod readiness;
 
 const STATUS_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const TARGET_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+fn expected_trigger_bindings(
+    scenario: &CompiledScenarioV1,
+    session_id: &str,
+) -> Vec<ExpectedTriggerBinding> {
+    std::iter::once(ExpectedTriggerBinding {
+        trigger_type: scenario
+            .recorder
+            .lifecycle
+            .trigger_type
+            .as_str()
+            .to_string(),
+        function_id: "integration-recorder::lifecycle".to_string(),
+        config: json!({ "session_id": session_id }),
+    })
+    .chain(
+        scenario
+            .bindings
+            .iter()
+            .map(|binding| ExpectedTriggerBinding {
+                trigger_type: binding.trigger_type.clone(),
+                function_id: binding.function_id.clone(),
+                config: binding.config.clone(),
+            }),
+    )
+    .collect()
+}

--- a/harness/evals/integration/src/scenario/phases/readiness.rs
+++ b/harness/evals/integration/src/scenario/phases/readiness.rs
@@ -1,4 +1,4 @@
-use serde_json::{json, Value};
+use serde_json::json;
 
 use crate::readiness::{self, ReadinessSpec};
 use crate::runtime::{RunError, RunErrorKind, RunPhase};
@@ -44,7 +44,7 @@ impl ScenarioRunner<'_> {
         let recorder = services.recorder();
         let scenario = &prepared.scenario;
 
-        let digest = recorder
+        recorder
             .configure(&self.run_id, &scenario.recorder)
             .map_err(|error| {
                 RunError::with_source(
@@ -54,16 +54,6 @@ impl ScenarioRunner<'_> {
                     error,
                 )
             })?;
-        let expected_digest = crate::canonical::sha256_of_canonical(&Value::Object(
-            scenario.recorder.target.request_schema.clone(),
-        ));
-        if digest != expected_digest {
-            return Err(RunError::new(
-                phase,
-                RunErrorKind::Setup,
-                format!("target schema digest mismatch: {digest} != {expected_digest}"),
-            ));
-        }
 
         recorder.reset(&self.run_id).map_err(|error| {
             RunError::with_source(
@@ -92,25 +82,27 @@ impl ScenarioRunner<'_> {
             ));
         }
 
-        let controlled_function_ids: Vec<String> = std::iter::once(&scenario.recorder.target)
-            .chain(scenario.recorder.extra_functions.iter())
-            .map(|function| function.function_id.clone())
-            .collect();
+        let controlled_contracts = readiness::controlled_contracts(&scenario.recorder);
         let discovery_deadline = prepared.readiness_deadline;
-        readiness::wait_for_functions(
+        if let Err(report) = readiness::wait_for_contracts(
             services.client(),
-            &controlled_function_ids,
+            &controlled_contracts,
             discovery_deadline,
         )
         .await
-        .map_err(|error| {
-            RunError::with_source(
+        {
+            self.write_artifact(
+                &scenario.id,
+                "readiness-failure.json",
+                &json!({ "phase": "controlled_functions", "missing": report.missing }),
+                phase,
+            )?;
+            return Err(RunError::new(
                 phase,
                 RunErrorKind::Setup,
-                "controlled functions did not appear in discovery",
-                error,
-            )
-        })?;
+                "controlled function contracts did not match live discovery",
+            ));
+        }
 
         stack.spawn_harness(self.bins).map_err(|error| {
             RunError::with_source(
@@ -167,30 +159,27 @@ impl ScenarioRunner<'_> {
                 })?;
         }
 
-        let bound_function_ids: Vec<String> =
-            std::iter::once("integration-recorder::lifecycle".to_string())
-                .chain(
-                    scenario
-                        .bindings
-                        .iter()
-                        .map(|binding| binding.function_id.clone()),
-                )
-                .collect();
+        let expected_bindings = super::expected_trigger_bindings(scenario, &self.session_id);
         let binding_deadline = prepared.readiness_deadline;
-        readiness::wait_for_registered_triggers(
+        if let Err(report) = readiness::wait_for_registered_triggers(
             services.client(),
-            &bound_function_ids,
+            &expected_bindings,
             binding_deadline,
         )
         .await
-        .map_err(|error| {
-            RunError::with_source(
+        {
+            self.write_artifact(
+                &scenario.id,
+                "readiness-failure.json",
+                &json!({ "phase": "trigger_bindings", "missing": report.missing }),
+                phase,
+            )?;
+            return Err(RunError::new(
                 phase,
                 RunErrorKind::Setup,
-                "trigger bindings did not appear in discovery",
-                error,
-            )
-        })?;
+                "trigger bindings did not match live discovery",
+            ));
+        }
 
         self.sink
             .as_mut()

--- a/harness/evals/integration/src/scenario/report.rs
+++ b/harness/evals/integration/src/scenario/report.rs
@@ -4,7 +4,6 @@ use serde::Serialize;
 use serde_json::json;
 
 use crate::artifacts::write_json;
-use crate::deadline::Deadline;
 use crate::runtime::{RunError, RunErrorKind, RunPhase};
 use crate::stack::EarlyExit;
 use crate::types::scenario::{Classification, ExecutionReportV1, IntegrationResultV1};
@@ -13,6 +12,36 @@ use crate::types::script::SchemaVersion1;
 use super::runner::ScenarioRunner;
 
 impl ScenarioRunner<'_> {
+    pub(super) fn write_run_artifact<T>(
+        &mut self,
+        name: &str,
+        value: &T,
+        phase: RunPhase,
+    ) -> Result<(), RunError>
+    where
+        T: Serialize + ?Sized,
+    {
+        self.sink
+            .as_mut()
+            .ok_or_else(|| {
+                RunError::new(
+                    phase,
+                    RunErrorKind::Runner,
+                    "artifact sink is not initialized",
+                )
+            })?
+            .write_json(name, value)
+            .map(|_| ())
+            .map_err(|error| {
+                RunError::with_source(
+                    phase,
+                    RunErrorKind::Runner,
+                    format!("write run artifact {name}"),
+                    error,
+                )
+            })
+    }
+
     pub(super) fn write_artifact<T>(
         &mut self,
         scenario_id: &str,
@@ -76,6 +105,15 @@ impl ScenarioRunner<'_> {
                     stderr = %exit.stderr_log.display(),
                     "subject process exited before teardown"
                 );
+                if let Err(artifact_error) =
+                    self.write_run_artifact("process-exit.json", &exit, RunPhase::Teardown)
+                {
+                    tracing::error!(
+                        target: "harness_integration::scenario",
+                        "process-exit artifact could not be written: {artifact_error:#}"
+                    );
+                    error = Some(artifact_error);
+                }
                 ProcessState::Crashed
             }
             None => ProcessState::Running,
@@ -170,16 +208,10 @@ pub(super) fn classify(error: Option<&RunError>, process_state: ProcessState) ->
 
 pub(super) fn rpc_failure(
     phase: RunPhase,
-    default_kind: RunErrorKind,
-    deadline: Deadline,
+    kind: RunErrorKind,
     message: impl Into<String>,
     error: String,
 ) -> RunError {
-    let kind = if deadline.is_expired() {
-        RunErrorKind::Timeout
-    } else {
-        default_kind
-    };
     RunError::with_source(phase, kind, message, anyhow::anyhow!(error))
 }
 

--- a/harness/evals/integration/src/scenario/runner.rs
+++ b/harness/evals/integration/src/scenario/runner.rs
@@ -1,10 +1,13 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use serde::Serialize;
+
 use crate::artifacts::ArtifactSink;
 use crate::deadline::Deadline;
 use crate::expand::{expand_compiled_fixture, ExpandedFixtureV1};
 use crate::fixtures::ScenarioFixture;
+use crate::process::TeardownReport;
 use crate::runtime::{RunError, RunErrorKind, RunPhase};
 use crate::services::RunServices;
 use crate::stack::{RunPaths, Stack, StackBins};
@@ -21,6 +24,26 @@ pub struct RunOutcome {
     pub run_id: String,
     pub run_root: PathBuf,
     pub duration_ms: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct SupportServicesTeardown {
+    deadline_exceeded: bool,
+    error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct RunTeardownReport {
+    support_services: SupportServicesTeardown,
+    processes: TeardownReport,
+}
+
+impl RunTeardownReport {
+    fn complete(&self) -> bool {
+        !self.support_services.deadline_exceeded
+            && self.support_services.error.is_none()
+            && self.processes.complete()
+    }
 }
 
 pub async fn run_scenario(
@@ -47,18 +70,21 @@ pub async fn run_scenario(
     let mut classification = runner.execute(artifacts_dir).await;
     let mut result = runner.result(classification);
     let duration_ms = started.elapsed().as_millis() as u64;
-    let execution = ExecutionReportV1 {
+    let mut execution = ExecutionReportV1 {
         schema_version: SchemaVersion1::V1,
         run_id: run_id.clone(),
+        scenario_id: result.scenario_id.clone(),
         started_at,
         duration_ms,
         result_path: "result.json".to_string(),
+        result_sha256: result_digest(&result),
     };
 
     if let Err(error) = runner.write_reports(&result, &execution, artifacts_dir) {
         tracing::error!(target: "harness_integration::scenario", "reporting failed: {error:#}");
         classification = classification.combine(classify(Some(&error), ProcessState::Running));
         result.classification = classification;
+        execution.result_sha256 = result_digest(&result);
 
         // A first write may have succeeded before the second failed. Rewrite
         // both reports with the final runner_error classification.
@@ -82,6 +108,12 @@ pub async fn run_scenario(
         run_root,
         duration_ms,
     }
+}
+
+pub(super) fn result_digest(result: &IntegrationResultV1) -> String {
+    let value = serde_json::to_value(result).expect("integration result serializes");
+    let rendered = crate::canonical::canonical_json_pretty(&value);
+    crate::canonical::sha256_of_bytes(rendered.as_bytes())
 }
 
 pub(super) struct ScenarioRunner<'a> {
@@ -123,7 +155,7 @@ impl ScenarioRunner<'_> {
                     "expand compiled fixture",
                     error,
                 );
-                return self.finish(Err(error), None);
+                return self.finish_without_stack(error);
             }
         };
         let teardown_budget = Duration::from_millis(scenario.deadlines.teardown_ms);
@@ -136,19 +168,30 @@ impl ScenarioRunner<'_> {
                 "allocate scenario artifact directory",
                 error,
             );
-            return self.finish(Err(error), None);
+            return self.finish_without_stack(error);
         }
 
         let mut stack = match Stack::boot(self.bins, paths).await {
             Ok(stack) => stack,
-            Err(error) => {
+            Err(failure) => {
                 let error = RunError::with_source(
                     RunPhase::Boot,
                     RunErrorKind::Setup,
                     "boot isolated stack",
-                    error,
+                    failure.error,
                 );
-                return self.finish(Err(error), None);
+                let teardown = RunTeardownReport {
+                    support_services: SupportServicesTeardown {
+                        deadline_exceeded: false,
+                        error: None,
+                    },
+                    processes: failure.teardown,
+                };
+                let teardown_complete = teardown.complete();
+                let artifact =
+                    self.write_run_artifact("teardown.json", &teardown, RunPhase::Teardown);
+                let classification = self.finish(Err(error), None);
+                return combine_teardown(classification, teardown_complete, artifact);
             }
         };
         stack.set_teardown_budget(teardown_budget);
@@ -169,8 +212,18 @@ impl ScenarioRunner<'_> {
                     error,
                 );
                 let early_exit = stack.early_exit();
-                stack.teardown().await;
-                return self.finish(Err(error), early_exit);
+                let teardown = RunTeardownReport {
+                    support_services: SupportServicesTeardown {
+                        deadline_exceeded: false,
+                        error: None,
+                    },
+                    processes: stack.teardown().await,
+                };
+                let teardown_complete = teardown.complete();
+                let artifact =
+                    self.write_run_artifact("teardown.json", &teardown, RunPhase::Teardown);
+                let classification = self.finish(Err(error), early_exit);
+                return combine_teardown(classification, teardown_complete, artifact);
             }
         };
 
@@ -181,7 +234,7 @@ impl ScenarioRunner<'_> {
         // inspection catches a child that exits during that boundary.
         let mut early_exit = stack.early_exit();
         let teardown_deadline = Deadline::after(teardown_budget);
-        if let Err(error) = teardown_deadline
+        let support_services = if let Err(error) = teardown_deadline
             .timeout("support service shutdown", services.shutdown())
             .await
         {
@@ -189,14 +242,31 @@ impl ScenarioRunner<'_> {
                 target: "harness_integration::scenario",
                 "support service shutdown exceeded teardown budget: {error}"
             );
-        }
+            SupportServicesTeardown {
+                deadline_exceeded: true,
+                error: Some(error.to_string()),
+            }
+        } else {
+            SupportServicesTeardown {
+                deadline_exceeded: false,
+                error: None,
+            }
+        };
         if early_exit.is_none() {
             early_exit = stack.early_exit();
         }
         stack.set_teardown_budget(teardown_deadline.remaining());
-        stack.teardown().await;
+        let processes = stack.teardown().await;
+        let teardown = RunTeardownReport {
+            support_services,
+            processes,
+        };
+        let teardown_complete = teardown.complete();
+        let teardown_artifact =
+            self.write_run_artifact("teardown.json", &teardown, RunPhase::Teardown);
 
-        self.finish(outcome, early_exit)
+        let classification = self.finish(outcome, early_exit);
+        combine_teardown(classification, teardown_complete, teardown_artifact)
     }
 
     async fn run_phases(
@@ -214,4 +284,39 @@ impl ScenarioRunner<'_> {
         self.collect(services, prepared, &mut active).await?;
         self.grade(services, prepared, &active)
     }
+
+    fn finish_without_stack(&mut self, error: RunError) -> Classification {
+        let teardown = RunTeardownReport {
+            support_services: SupportServicesTeardown {
+                deadline_exceeded: false,
+                error: None,
+            },
+            processes: TeardownReport::default(),
+        };
+        let artifact = self.write_run_artifact("teardown.json", &teardown, RunPhase::Teardown);
+        let classification = self.finish(Err(error), None);
+        combine_teardown(classification, true, artifact)
+    }
+}
+
+pub(super) fn combine_teardown(
+    classification: Classification,
+    teardown_complete: bool,
+    artifact: Result<(), RunError>,
+) -> Classification {
+    if let Err(error) = artifact {
+        tracing::error!(
+            target: "harness_integration::scenario",
+            "teardown artifact could not be written: {error:#}"
+        );
+        return classification.combine(Classification::RunnerError);
+    }
+    if !teardown_complete {
+        tracing::error!(
+            target: "harness_integration::scenario",
+            "teardown was incomplete; see teardown.json"
+        );
+        return classification.combine(Classification::RunnerError);
+    }
+    classification
 }

--- a/harness/evals/integration/src/scenario/tests.rs
+++ b/harness/evals/integration/src/scenario/tests.rs
@@ -1,7 +1,9 @@
 use crate::runtime::{RunError, RunErrorKind, RunPhase};
-use crate::types::scenario::Classification;
+use crate::types::scenario::{Classification, IntegrationResultV1};
+use crate::types::script::SchemaVersion1;
 
-use super::report::{classify, ProcessState};
+use super::report::{classify, rpc_failure, ProcessState};
+use super::runner::{combine_teardown, result_digest};
 
 #[test]
 fn process_exit_is_combined_with_phase_failure_by_precedence() {
@@ -20,4 +22,46 @@ fn process_exit_is_combined_with_phase_failure_by_precedence() {
         classify(None, ProcessState::Crashed),
         Classification::ProcessCrash
     );
+}
+
+#[test]
+fn incomplete_teardown_always_becomes_runner_error() {
+    assert_eq!(
+        combine_teardown(Classification::Pass, false, Ok(())),
+        Classification::RunnerError
+    );
+    assert_eq!(
+        combine_teardown(Classification::ContractFailure, false, Ok(())),
+        Classification::RunnerError
+    );
+}
+
+#[test]
+fn result_digest_matches_the_exact_persisted_bytes() {
+    let result = IntegrationResultV1 {
+        schema_version: SchemaVersion1::V1,
+        scenario_id: "C-E2E-DIGEST".into(),
+        classification: Classification::Pass,
+        invariants: Vec::new(),
+        artifacts: vec!["scenarios/C-E2E-DIGEST/invariants.json".into()],
+    };
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("result.json");
+    crate::artifacts::write_json(temp.path(), &path, &result).unwrap();
+    let bytes = std::fs::read(path).unwrap();
+    assert_eq!(
+        result_digest(&result),
+        crate::canonical::sha256_of_bytes(&bytes)
+    );
+}
+
+#[test]
+fn public_rpc_failures_do_not_invent_subject_timeouts() {
+    let error = rpc_failure(
+        RunPhase::Send,
+        RunErrorKind::Contract,
+        "harness::send failed",
+        "transport deadline".into(),
+    );
+    assert_eq!(error.classification(), Classification::ContractFailure);
 }

--- a/harness/evals/integration/src/scripted_router.rs
+++ b/harness/evals/integration/src/scripted_router.rs
@@ -88,12 +88,14 @@ impl ScriptedRouter {
             let address = address.clone();
             iii.register_function(
                 "router::chat",
-                RegisterFunction::new_async(move |input: Value| {
-                    let state = state.clone();
-                    let address = address.clone();
-                    async move { chat(state, address, input).await }
-                })
-                .description("Scripted integration chat: replays fixture generations.")
+                with_router_contract(
+                    RegisterFunction::new_async(move |input: Value| {
+                        let state = state.clone();
+                        let address = address.clone();
+                        async move { chat(state, address, input).await }
+                    }),
+                    "router::chat",
+                )
                 .metadata(json!({ "internal": true })),
             );
         }
@@ -101,26 +103,28 @@ impl ScriptedRouter {
             let state = self.state.clone();
             iii.register_function(
                 "router::abort",
-                RegisterFunction::new_async(move |input: Value| {
-                    let state = state.clone();
-                    async move {
-                        let request_id = input
-                            .get("request_id")
-                            .and_then(Value::as_str)
-                            .unwrap_or_default()
-                            .to_string();
-                        let mut state = state.lock().expect("router state");
-                        let aborted = match state.live.get_mut(&request_id) {
-                            Some(already @ false) => {
-                                *already = true;
-                                true
-                            }
-                            _ => false,
-                        };
-                        Ok::<Value, Error>(json!({ "aborted": aborted }))
-                    }
-                })
-                .description("Scripted integration abort: first abort of a live call wins.")
+                with_router_contract(
+                    RegisterFunction::new_async(move |input: Value| {
+                        let state = state.clone();
+                        async move {
+                            let request_id = input
+                                .get("request_id")
+                                .and_then(Value::as_str)
+                                .unwrap_or_default()
+                                .to_string();
+                            let mut state = state.lock().expect("router state");
+                            let aborted = match state.live.get_mut(&request_id) {
+                                Some(already @ false) => {
+                                    *already = true;
+                                    true
+                                }
+                                _ => false,
+                            };
+                            Ok::<Value, Error>(json!({ "aborted": aborted }))
+                        }
+                    }),
+                    "router::abort",
+                )
                 .metadata(json!({ "internal": true })),
             );
         }
@@ -128,84 +132,92 @@ impl ScriptedRouter {
             let state = self.state.clone();
             iii.register_function(
                 "router::models::list",
-                RegisterFunction::new_async(move |input: Value| {
-                    let state = state.clone();
-                    async move {
-                        let model = fixture_model(&state);
-                        let provider = input.get("provider").and_then(Value::as_str);
-                        let capability = input.get("capability").and_then(Value::as_str);
-                        let matches_provider =
-                            provider.is_none_or(|p| p.is_empty() || p == model.provider);
-                        let matches_capability =
-                            capability.is_none_or(|c| model_supports(&model, c));
-                        let models: Vec<ModelFixtureV1> = if matches_provider && matches_capability
-                        {
-                            vec![model]
-                        } else {
-                            vec![]
-                        };
-                        Ok::<Value, Error>(json!({ "models": models }))
-                    }
-                })
-                .description("Scripted integration catalog: the single fixture model."),
+                with_router_contract(
+                    RegisterFunction::new_async(move |input: Value| {
+                        let state = state.clone();
+                        async move {
+                            let model = fixture_model(&state);
+                            let provider = input.get("provider").and_then(Value::as_str);
+                            let capability = input.get("capability").and_then(Value::as_str);
+                            let matches_provider =
+                                provider.is_none_or(|p| p.is_empty() || p == model.provider);
+                            let matches_capability =
+                                capability.is_none_or(|c| model_supports(&model, c));
+                            let models: Vec<ModelFixtureV1> =
+                                if matches_provider && matches_capability {
+                                    vec![model]
+                                } else {
+                                    vec![]
+                                };
+                            Ok::<Value, Error>(json!({ "models": models }))
+                        }
+                    }),
+                    "router::models::list",
+                ),
             );
         }
         {
             let state = self.state.clone();
             iii.register_function(
                 "router::models::get",
-                RegisterFunction::new_async(move |input: Value| {
-                    let state = state.clone();
-                    async move {
-                        let model = fixture_model(&state);
-                        let provider = input.get("provider").and_then(Value::as_str);
-                        let id = input.get("id").and_then(Value::as_str).unwrap_or_default();
-                        let provider_ok =
-                            provider.is_none_or(|p| p.is_empty() || p == model.provider);
-                        if provider_ok && id == model.id {
-                            Ok::<Value, Error>(json!({ "model": model }))
-                        } else {
-                            Ok(Value::Null)
+                with_router_contract(
+                    RegisterFunction::new_async(move |input: Value| {
+                        let state = state.clone();
+                        async move {
+                            let model = fixture_model(&state);
+                            let provider = input.get("provider").and_then(Value::as_str);
+                            let id = input.get("id").and_then(Value::as_str).unwrap_or_default();
+                            let provider_ok =
+                                provider.is_none_or(|p| p.is_empty() || p == model.provider);
+                            if provider_ok && id == model.id {
+                                Ok::<Value, Error>(json!({ "model": model }))
+                            } else {
+                                Ok(Value::Null)
+                            }
                         }
-                    }
-                })
-                .description("Scripted integration catalog lookup."),
+                    }),
+                    "router::models::get",
+                ),
             );
         }
         {
             let state = self.state.clone();
             iii.register_function(
                 "router::models::supports",
-                RegisterFunction::new_async(move |input: Value| {
-                    let state = state.clone();
-                    async move {
-                        let model = fixture_model(&state);
-                        let provider = input
-                            .get("provider")
-                            .and_then(Value::as_str)
-                            .unwrap_or_default();
-                        let id = input.get("id").and_then(Value::as_str).unwrap_or_default();
-                        let capability = input
-                            .get("capability")
-                            .and_then(Value::as_str)
-                            .unwrap_or_default();
-                        let supported = (provider.is_empty() || provider == model.provider)
-                            && id == model.id
-                            && model_supports(&model, capability);
-                        Ok::<Value, Error>(json!({ "supported": supported }))
-                    }
-                })
-                .description("Scripted integration capability check."),
+                with_router_contract(
+                    RegisterFunction::new_async(move |input: Value| {
+                        let state = state.clone();
+                        async move {
+                            let model = fixture_model(&state);
+                            let provider = input
+                                .get("provider")
+                                .and_then(Value::as_str)
+                                .unwrap_or_default();
+                            let id = input.get("id").and_then(Value::as_str).unwrap_or_default();
+                            let capability = input
+                                .get("capability")
+                                .and_then(Value::as_str)
+                                .unwrap_or_default();
+                            let supported = (provider.is_empty() || provider == model.provider)
+                                && id == model.id
+                                && model_supports(&model, capability);
+                            Ok::<Value, Error>(json!({ "supported": supported }))
+                        }
+                    }),
+                    "router::models::supports",
+                ),
             );
         }
         iii.register_function(
             "router::system_prompt::get",
-            RegisterFunction::new_async(move |_input: Value| async move {
-                // `system_prompt` omitted: the harness falls back to its
-                // checked-in built-in prompt (spec § scripted-router contract).
-                Ok::<Value, Error>(json!({ "provider": "scripted" }))
-            })
-            .description("Scripted integration system prompt: defers to the harness built-in."),
+            with_router_contract(
+                RegisterFunction::new_async(move |_input: Value| async move {
+                    // `system_prompt` omitted: the harness falls back to its
+                    // checked-in built-in prompt (spec § scripted-router contract).
+                    Ok::<Value, Error>(json!({ "provider": "scripted" }))
+                }),
+                "router::system_prompt::get",
+            ),
         );
     }
 
@@ -246,6 +258,26 @@ impl ScriptedRouter {
     pub async fn shutdown(&self) {
         self.client.shutdown().await;
     }
+}
+
+fn with_router_contract(registration: RegisterFunction, function_id: &str) -> RegisterFunction {
+    let contract = crate::readiness::router_contract(function_id);
+    registration
+        .description(
+            contract
+                .description
+                .expect("router golden must declare a description"),
+        )
+        .request_format(
+            contract
+                .request_schema
+                .expect("router golden must declare a request schema"),
+        )
+        .response_format(
+            contract
+                .response_schema
+                .expect("router golden must declare a response schema"),
+        )
 }
 
 fn fixture_model(state: &Arc<Mutex<State>>) -> ModelFixtureV1 {

--- a/harness/evals/integration/src/stack.rs
+++ b/harness/evals/integration/src/stack.rs
@@ -21,7 +21,7 @@ pub use config::{
     WORKER_START_ORDER,
 };
 pub use layout::RunLayout;
-pub use supervisor::{free_loopback_port, Stack};
+pub use supervisor::{free_loopback_port, Stack, StackBootFailure};
 
 /// Compatibility name retained for callers of the original stack API.
 pub type RunPaths = RunLayout;

--- a/harness/evals/integration/src/stack/manifest.rs
+++ b/harness/evals/integration/src/stack/manifest.rs
@@ -1,16 +1,19 @@
 use std::path::Path;
 
+use anyhow::Context;
 use serde_json::{json, Value};
 
 use super::config::{ENV_ALLOWLIST, WORKER_START_ORDER};
 use super::{RunLayout, StackBins};
+
+const STACK_PROFILE: &str = "harness-core-v1";
 
 pub(crate) fn write_stack_manifest(
     bins: &StackBins,
     layout: &RunLayout,
     port: u16,
 ) -> anyhow::Result<()> {
-    let info = stack_info(bins, layout, port);
+    let info = stack_info(bins, layout, port)?;
     std::fs::write(
         layout.stack_manifest_path(),
         crate::canonical::canonical_json_pretty(&info),
@@ -18,28 +21,52 @@ pub(crate) fn write_stack_manifest(
     Ok(())
 }
 
-pub(crate) fn stack_info(bins: &StackBins, layout: &RunLayout, port: u16) -> Value {
+pub(crate) fn stack_info(bins: &StackBins, layout: &RunLayout, port: u16) -> anyhow::Result<Value> {
     let mut binaries = serde_json::Map::new();
-    let mut record = |name: &str, path: &Path| {
-        let absolute = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let mut record = |name: &str, path: &Path| -> anyhow::Result<()> {
+        let absolute = path
+            .canonicalize()
+            .with_context(|| format!("resolve {name} binary {}", path.display()))?;
         let digest = std::fs::read(&absolute)
             .map(|bytes| crate::canonical::sha256_of_bytes(&bytes))
-            .unwrap_or_else(|error| format!("unreadable: {error}"));
+            .with_context(|| format!("read {name} binary {}", absolute.display()))?;
         binaries.insert(
             name.to_string(),
-            json!({ "path": absolute.to_string_lossy(), "sha256": digest }),
+            json!({
+                "path": absolute.to_string_lossy(),
+                "sha256": digest,
+                "version": Value::Null
+            }),
         );
+        Ok(())
     };
-    record("engine", &bins.engine);
-    record("harness", &bins.harness);
+    record("engine", &bins.engine)?;
+    record("harness", &bins.harness)?;
     for (name, path) in &bins.workers {
-        record(name, path);
+        record(name, path)?;
     }
-    json!({
+    let external_workers = WORKER_START_ORDER
+        .iter()
+        .copied()
+        .chain(std::iter::once("harness"))
+        .collect::<Vec<_>>();
+    Ok(json!({
+        "profile": STACK_PROFILE,
+        "components": {
+            "engine_builtins": ["configuration", "state", "stream", "cron"],
+            "external_workers": external_workers,
+            "controlled_services": ["scripted-router", "integration-recorder"]
+        },
         "port": port,
         "run_root": layout.root.to_string_lossy(),
         "binaries": Value::Object(binaries),
+        "provenance": {
+            "engine_lock": include_str!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/engine.lock"
+            )).trim()
+        },
         "env_allowlist": ENV_ALLOWLIST,
         "start_order": WORKER_START_ORDER,
-    })
+    }))
 }

--- a/harness/evals/integration/src/stack/supervisor.rs
+++ b/harness/evals/integration/src/stack/supervisor.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use crate::process::{ProcessSpec, ProcessSupervisor, DEFAULT_TEARDOWN_BUDGET};
+use crate::process::{ProcessSpec, ProcessSupervisor, TeardownReport, DEFAULT_TEARDOWN_BUDGET};
 
 use super::config::{write_engine_config, write_seed, ENV_ALLOWLIST, WORKER_START_ORDER};
 use super::manifest::write_stack_manifest;
@@ -17,37 +17,48 @@ pub struct Stack {
     engine_restarts: u32,
 }
 
+#[derive(Debug)]
+pub struct StackBootFailure {
+    pub error: anyhow::Error,
+    pub teardown: TeardownReport,
+}
+
 impl Stack {
     /// Spawn the engine and every pre-harness worker in declared order.
-    pub async fn boot(bins: &StackBins, paths: RunLayout) -> anyhow::Result<Stack> {
+    pub async fn boot(bins: &StackBins, paths: RunLayout) -> Result<Stack, StackBootFailure> {
         match Self::boot_once(bins, &paths).await {
             Ok(stack) => Ok(stack),
-            Err(BootError::BindRace) => {
+            Err(BootError::BindRace(teardown)) if teardown.complete() => {
                 tracing::warn!(
                     target: "harness_integration::stack",
                     "engine bind race; retrying with a fresh port set"
                 );
                 Self::boot_once(bins, &paths)
                     .await
-                    .map_err(BootError::into_anyhow)
+                    .map_err(BootError::into_failure)
             }
-            Err(error) => Err(error.into_anyhow()),
+            Err(BootError::BindRace(teardown)) => Err(StackBootFailure {
+                error: anyhow::anyhow!("engine bind race cleanup was incomplete"),
+                teardown,
+            }),
+            Err(error) => Err(error.into_failure()),
         }
     }
 
     async fn boot_once(bins: &StackBins, paths: &RunLayout) -> Result<Stack, BootError> {
         let missing = bins.missing_workers();
         if !missing.is_empty() {
-            return Err(BootError::Other(anyhow::anyhow!(
+            return Err(BootError::without_processes(anyhow::anyhow!(
                 "missing --worker-bin for: {}",
                 missing.join(", ")
             )));
         }
 
-        let port = free_loopback_port().map_err(BootError::Other)?;
+        let port = free_loopback_port().map_err(BootError::without_processes)?;
         let ws_url = format!("ws://127.0.0.1:{port}");
-        let engine_yaml_path = write_engine_config(paths, port).map_err(BootError::Other)?;
-        write_stack_manifest(bins, paths, port).map_err(BootError::Other)?;
+        let engine_yaml_path =
+            write_engine_config(paths, port).map_err(BootError::without_processes)?;
+        write_stack_manifest(bins, paths, port).map_err(BootError::without_processes)?;
 
         let engine_args = vec![
             "--config".to_string(),
@@ -66,22 +77,27 @@ impl Stack {
             engine_restarts: 0,
         };
 
-        stack
-            .spawn_child("engine", &bins.engine, &engine_args, &paths.engine_dir)
-            .map_err(BootError::Other)?;
+        if let Err(error) =
+            stack.spawn_child("engine", &bins.engine, &engine_args, &paths.engine_dir)
+        {
+            let teardown = stack.teardown().await;
+            return Err(BootError::Other { error, teardown });
+        }
 
-        // Classify an immediate engine death as the one retryable bind race.
+        // Retry only an explicit address-in-use failure. Other immediate
+        // exits are configuration/binary failures, not port collisions.
         tokio::time::sleep(Duration::from_millis(600)).await;
         if let Some(exit) = stack.early_exit() {
-            stack.teardown().await;
-            if exit.name == "engine" {
-                return Err(BootError::BindRace);
+            let retryable_bind_race =
+                exit.name == "engine" && stderr_indicates_bind_race(&exit.stderr_log);
+            let teardown = stack.teardown().await;
+            if retryable_bind_race {
+                return Err(BootError::BindRace(teardown));
             }
-            return Err(BootError::Other(anyhow::anyhow!(
-                "{} exited during boot: {}",
-                exit.name,
-                exit.status
-            )));
+            return Err(BootError::Other {
+                error: anyhow::anyhow!("{} exited during boot: {}", exit.name, exit.status),
+                teardown,
+            });
         }
 
         for worker in WORKER_START_ORDER {
@@ -89,7 +105,10 @@ impl Stack {
                 .resolve(worker)
                 .expect("presence checked above")
                 .to_path_buf();
-            stack.spawn_worker(worker, &bin).map_err(BootError::Other)?;
+            if let Err(error) = stack.spawn_worker(worker, &bin) {
+                let teardown = stack.teardown().await;
+                return Err(BootError::Other { error, teardown });
+            }
         }
 
         Ok(stack)
@@ -195,8 +214,8 @@ impl Stack {
         self.processes.early_exit()
     }
 
-    pub async fn teardown(&mut self) {
-        self.processes.teardown().await;
+    pub async fn teardown(&mut self) -> TeardownReport {
+        self.processes.teardown().await
     }
 }
 
@@ -208,15 +227,44 @@ pub fn free_loopback_port() -> anyhow::Result<u16> {
 }
 
 enum BootError {
-    BindRace,
-    Other(anyhow::Error),
+    BindRace(TeardownReport),
+    Other {
+        error: anyhow::Error,
+        teardown: TeardownReport,
+    },
 }
 
 impl BootError {
-    fn into_anyhow(self) -> anyhow::Error {
-        match self {
-            BootError::BindRace => anyhow::anyhow!("engine failed to bind twice in a row"),
-            BootError::Other(error) => error,
+    fn without_processes(error: anyhow::Error) -> Self {
+        Self::Other {
+            error,
+            teardown: TeardownReport::default(),
         }
     }
+
+    fn into_failure(self) -> StackBootFailure {
+        match self {
+            BootError::BindRace(teardown) => StackBootFailure {
+                error: anyhow::anyhow!("engine failed to bind twice in a row"),
+                teardown,
+            },
+            BootError::Other { error, teardown } => StackBootFailure { error, teardown },
+        }
+    }
+}
+
+fn stderr_indicates_bind_race(path: &Path) -> bool {
+    let Ok(stderr) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let stderr = stderr.to_ascii_lowercase();
+    [
+        "address already in use",
+        "addrinuse",
+        "os error 48",
+        "os error 98",
+        "failed to bind",
+    ]
+    .iter()
+    .any(|needle| stderr.contains(needle))
 }

--- a/harness/evals/integration/src/stack/tests.rs
+++ b/harness/evals/integration/src/stack/tests.rs
@@ -56,8 +56,45 @@ fn manifest_is_canonical_and_uses_layout_paths() {
 
     manifest::write_stack_manifest(&bins, &layout, 3210).unwrap();
     let committed = std::fs::read_to_string(layout.stack_manifest_path()).unwrap();
-    let value = manifest::stack_info(&bins, &layout, 3210);
+    let value = manifest::stack_info(&bins, &layout, 3210).unwrap();
     assert_eq!(committed, crate::canonical::canonical_json_pretty(&value));
+    assert_eq!(value["profile"], "harness-core-v1");
+    assert_eq!(
+        value["components"]["controlled_services"],
+        serde_json::json!(["scripted-router", "integration-recorder"])
+    );
     assert_eq!(value["run_root"], layout.root.to_string_lossy().as_ref());
     assert_eq!(value["port"], 3210);
+}
+
+#[test]
+fn manifest_fails_when_a_binary_cannot_be_identified() {
+    let artifacts = tempfile::tempdir().unwrap();
+    let layout = RunLayout::allocate(artifacts.path(), "run-001").unwrap();
+    let missing = artifacts.path().join("missing-bin");
+    let bins = StackBins {
+        engine: missing.clone(),
+        harness: missing.clone(),
+        workers: BTreeMap::new(),
+    };
+    let error = manifest::stack_info(&bins, &layout, 3210).unwrap_err();
+    assert!(format!("{error:#}").contains("resolve engine binary"));
+}
+
+#[tokio::test]
+async fn boot_failure_carries_a_complete_typed_teardown() {
+    let artifacts = tempfile::tempdir().unwrap();
+    let layout = RunLayout::allocate(artifacts.path(), "run-boot-failure").unwrap();
+    let bins = StackBins {
+        engine: PathBuf::from("/bin/true"),
+        harness: PathBuf::from("/bin/true"),
+        workers: BTreeMap::new(),
+    };
+
+    let failure = match Stack::boot(&bins, layout).await {
+        Ok(_) => panic!("missing workers must fail before boot"),
+        Err(failure) => failure,
+    };
+    assert!(failure.teardown.complete());
+    assert!(format!("{:#}", failure.error).contains("missing --worker-bin"));
 }

--- a/harness/evals/integration/src/types/recorder.rs
+++ b/harness/evals/integration/src/types/recorder.rs
@@ -31,11 +31,12 @@ pub struct RecorderTargetV1 {
     pub request_schema: serde_json::Map<String, serde_json::Value>,
     /// Declared response returned for every target call.
     pub response: serde_json::Value,
-    /// Delay between the durable append and the response, opening a window
-    /// for fault injection while the dispatched call is executing
-    /// (crash-recovery scenarios). Omitted = respond immediately.
+    /// One-based call ordinal whose response is held behind a runner-owned,
+    /// in-process gate after the call has been durably appended. Derived from
+    /// `fault.after_target_calls`; never authored directly.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub response_delay_ms: Option<u64>,
+    #[schemars(range(min = 1))]
+    pub hold_response_at: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -47,8 +48,6 @@ pub struct RecorderLifecycleV1 {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub enum LifecycleTriggerType {
-    #[serde(rename = "harness::turn-started")]
-    TurnStarted,
     #[serde(rename = "harness::turn-completed")]
     TurnCompleted,
 }
@@ -56,7 +55,6 @@ pub enum LifecycleTriggerType {
 impl LifecycleTriggerType {
     pub fn as_str(self) -> &'static str {
         match self {
-            LifecycleTriggerType::TurnStarted => "harness::turn-started",
             LifecycleTriggerType::TurnCompleted => "harness::turn-completed",
         }
     }
@@ -73,6 +71,52 @@ pub enum LifecycleFunctionId {
 pub enum RecorderEventKind {
     TargetCall,
     Lifecycle,
+}
+
+/// Exact wire shape accepted by the private lifecycle sink. The harness
+/// trigger can attach optional parent/reaction/result context, but the
+/// session, turn, terminal status, and timestamp are always present.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct LifecycleEventV1 {
+    pub session_id: String,
+    pub turn_id: String,
+    pub status: LifecycleStatusV1,
+    pub timestamp: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent: Option<LifecycleParentV1>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reactive_depth: Option<u32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum LifecycleStatusV1 {
+    Completed,
+    Cancelled,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct LifecycleParentV1 {
+    pub session_id: String,
+    pub turn_id: String,
+    pub function_call_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct LifecycleAcceptedV1 {
+    pub accepted: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]

--- a/harness/evals/integration/src/types/scenario/authored.rs
+++ b/harness/evals/integration/src/types/scenario/authored.rs
@@ -11,7 +11,7 @@ use super::ExpectationsV1;
 /// The single-file scenario authors maintain in `scenarios/<slug>/scenario.yaml`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
-pub struct IntegrationScenarioV1 {
+pub struct AuthoredScenarioV1 {
     pub schema_version: SchemaVersion1,
     #[schemars(length(min = 1, max = 128), regex(pattern = "^[A-Za-z0-9_-]+$"))]
     pub id: String,
@@ -36,6 +36,10 @@ pub struct IntegrationScenarioV1 {
     #[serde(default, skip_serializing_if = "ExpectationsV1::is_default")]
     pub expect: ExpectationsV1,
 }
+
+/// Compatibility name retained for callers compiled against the first
+/// single-file authoring API. New code should use [`AuthoredScenarioV1`].
+pub type IntegrationScenarioV1 = AuthoredScenarioV1;
 
 /// Scenario ids are also artifact directory names, so keep them to one safe,
 /// portable path component.
@@ -71,8 +75,6 @@ pub struct ScenarioFunctionV1 {
     pub description: String,
     pub request_schema: serde_json::Map<String, serde_json::Value>,
     pub response: serde_json::Value,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub response_delay_ms: Option<u64>,
     /// Exposed to the model by default. Hook-only controlled functions set
     /// this to false.
     #[serde(default = "default_true", skip_serializing_if = "is_true")]

--- a/harness/evals/integration/src/types/scenario/compiled.rs
+++ b/harness/evals/integration/src/types/scenario/compiled.rs
@@ -6,7 +6,7 @@ use crate::types::script::SchemaVersion1;
 
 use super::{DeadlinesV1, FaultKind, InvariantSpecV1, ReleaseV1};
 
-/// Strict runtime scenario produced from [`super::IntegrationScenarioV1`].
+/// Strict runtime scenario produced from [`super::AuthoredScenarioV1`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct CompiledScenarioV1 {
@@ -14,7 +14,7 @@ pub struct CompiledScenarioV1 {
     #[schemars(length(min = 1, max = 128), regex(pattern = "^[A-Za-z0-9_-]+$"))]
     pub id: String,
     pub description: String,
-    pub send: serde_json::Value,
+    pub send: CompiledSendV1,
     pub recorder: RecorderConfigV1,
     pub deadlines: DeadlinesV1,
     pub invariants: Vec<InvariantSpecV1>,
@@ -26,6 +26,40 @@ pub struct CompiledScenarioV1 {
     pub release: Option<ReleaseV1>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub quarantine: bool,
+}
+
+/// The deliberately narrow `harness::send` request emitted by the scenario
+/// compiler. Keeping this typed prevents compiler changes from silently
+/// introducing fields outside the live harness contract.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CompiledSendV1 {
+    pub session_id: String,
+    pub message: String,
+    pub model: String,
+    pub provider: String,
+    pub idempotency_key: String,
+    pub options: CompiledSendOptionsV1,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CompiledSendOptionsV1 {
+    pub functions: CompiledFunctionPolicyV1,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CompiledFunctionPolicyV1 {
+    pub allow: Vec<String>,
+    pub deny: Vec<String>,
+    pub expose: CompiledFunctionExposureV1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CompiledFunctionExposureV1 {
+    Native,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]

--- a/harness/evals/integration/src/types/scenario/invariants.rs
+++ b/harness/evals/integration/src/types/scenario/invariants.rs
@@ -4,7 +4,7 @@ use serde_json::{Map, Value};
 
 use super::{
     LifecycleExpectationV1, MessageCountsExpectationV1, SendFlagsExpectationV1,
-    TerminalExpectationV1,
+    TerminalExpectationV1, TerminalStatusV1,
 };
 
 macro_rules! invariant_registry {
@@ -73,6 +73,13 @@ pub struct FunctionResultInvariantV1 {
 #[serde(deny_unknown_fields)]
 pub struct GenerationsConsumedInvariantV1 {
     pub count: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct LifecycleInvariantV1 {
+    pub allow_identical_duplicates: bool,
+    pub status: TerminalStatusV1,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -157,8 +164,17 @@ impl InvariantSpecV1 {
         Self::typed(InvariantKind::StatusTerminal, parameters)
     }
 
-    pub fn lifecycle_completed_once(parameters: LifecycleExpectationV1) -> Self {
-        Self::typed(InvariantKind::LifecycleCompletedOnce, parameters)
+    pub fn lifecycle_completed_once(
+        parameters: LifecycleExpectationV1,
+        status: TerminalStatusV1,
+    ) -> Self {
+        Self::typed(
+            InvariantKind::LifecycleCompletedOnce,
+            LifecycleInvariantV1 {
+                allow_identical_duplicates: parameters.allow_identical_duplicates,
+                status,
+            },
+        )
     }
 
     pub fn router_generations_consumed(count: u64) -> Self {

--- a/harness/evals/integration/src/types/scenario/result.rs
+++ b/harness/evals/integration/src/types/scenario/result.rs
@@ -74,9 +74,11 @@ pub struct IntegrationResultV1 {
 pub struct ExecutionReportV1 {
     pub schema_version: SchemaVersion1,
     pub run_id: String,
+    pub scenario_id: String,
     pub started_at: String,
     pub duration_ms: u64,
     pub result_path: String,
+    pub result_sha256: String,
 }
 
 #[cfg(test)]

--- a/harness/evals/integration/tests/readiness.rs
+++ b/harness/evals/integration/tests/readiness.rs
@@ -5,7 +5,7 @@
 
 use harness_integration::readiness::{
     config_failure, has_function, has_registered_trigger, missing_functions, missing_trigger_types,
-    topic_failures, ReadinessSpec,
+    registered_trigger_failures, topic_failures, ExpectedTriggerBinding, ReadinessSpec,
 };
 use serde_json::json;
 
@@ -60,6 +60,47 @@ fn registered_trigger_catalog_requires_every_bound_function_id() {
     assert!(!required
         .iter()
         .all(|id| has_registered_trigger(&incomplete, id)));
+}
+
+#[test]
+fn registered_trigger_contract_requires_exact_type_config_and_cardinality() {
+    let expected = vec![ExpectedTriggerBinding {
+        trigger_type: "harness::turn-completed".into(),
+        function_id: "integration-recorder::lifecycle".into(),
+        config: json!({ "session_id": "s_1" }),
+    }];
+    let exact = json!({ "registered_triggers": [{
+        "id": "trigger-1",
+        "trigger_type": "harness::turn-completed",
+        "function_id": "integration-recorder::lifecycle",
+        "worker_name": "integration-recorder",
+        "config": { "session_id": "s_1" },
+        "config_summary": "{}"
+    }]});
+    assert!(registered_trigger_failures(&expected, &exact).is_empty());
+
+    let wrong_session = json!({ "registered_triggers": [{
+        "id": "trigger-1",
+        "trigger_type": "harness::turn-completed",
+        "function_id": "integration-recorder::lifecycle",
+        "worker_name": "integration-recorder",
+        "config": { "session_id": "s_other" },
+        "config_summary": "{}"
+    }]});
+    assert!(!registered_trigger_failures(&expected, &wrong_session).is_empty());
+
+    let duplicate = json!({ "registered_triggers": [
+        exact["registered_triggers"][0].clone(),
+        {
+            "id": "trigger-2",
+            "trigger_type": "harness::turn-completed",
+            "function_id": "integration-recorder::lifecycle",
+            "worker_name": "integration-recorder",
+            "config": { "session_id": "s_1" },
+            "config_summary": "{}"
+        }
+    ]});
+    assert!(!registered_trigger_failures(&expected, &duplicate).is_empty());
 }
 
 #[test]

--- a/harness/evals/integration/tests/schemas.rs
+++ b/harness/evals/integration/tests/schemas.rs
@@ -7,11 +7,12 @@
 //! `REGEN_SCHEMAS=1 cargo test --test schemas`
 
 use harness_integration::canonical::canonical_json_pretty;
-use harness_integration::types::recorder::RecorderEventV1;
+use harness_integration::expand::CompiledFixtureV1;
+use harness_integration::types::recorder::{RecorderEventKind, RecorderEventV1};
 use harness_integration::types::scenario::{
-    CompiledScenarioV1, ExecutionReportV1, IntegrationResultV1, IntegrationScenarioV1,
+    AuthoredScenarioV1, Classification, CompiledScenarioV1, ExecutionReportV1, IntegrationResultV1,
 };
-use harness_integration::types::script::RouterScriptV1;
+use harness_integration::types::script::{RouterScriptV1, SchemaVersion1};
 
 fn goldens() -> Vec<(&'static str, serde_json::Value)> {
     fn schema<T: schemars::JsonSchema>() -> serde_json::Value {
@@ -19,8 +20,9 @@ fn goldens() -> Vec<(&'static str, serde_json::Value)> {
     }
     vec![
         ("router-script.v1", schema::<RouterScriptV1>()),
-        ("authored-scenario.v1", schema::<IntegrationScenarioV1>()),
+        ("authored-scenario.v1", schema::<AuthoredScenarioV1>()),
         ("compiled-scenario.v1", schema::<CompiledScenarioV1>()),
+        ("compiled-fixture.v1", schema::<CompiledFixtureV1>()),
         ("integration-result.v1", schema::<IntegrationResultV1>()),
         ("execution-report.v1", schema::<ExecutionReportV1>()),
         ("recorder-event.v1", schema::<RecorderEventV1>()),
@@ -75,7 +77,7 @@ fn committed_scenarios_compile_and_round_trip() {
         }
         let fixture = ScenarioFixture::load(&dir).unwrap();
         let authored_value = serde_json::to_value(&fixture.authored).unwrap();
-        let authored_again: IntegrationScenarioV1 = serde_json::from_value(authored_value).unwrap();
+        let authored_again: AuthoredScenarioV1 = serde_json::from_value(authored_value).unwrap();
         assert_eq!(fixture.authored, authored_again);
 
         let compiled_value = serde_json::to_value(&fixture.scenario).unwrap();
@@ -85,16 +87,90 @@ fn committed_scenarios_compile_and_round_trip() {
         let script_value = serde_json::to_value(&fixture.script).unwrap();
         let script_again: RouterScriptV1 = serde_json::from_value(script_value).unwrap();
         assert_eq!(fixture.script, script_again);
+
+        let compiled_fixture = fixture.compiled();
+        let fixture_value = serde_json::to_value(&compiled_fixture).unwrap();
+        let fixture_again: CompiledFixtureV1 = serde_json::from_value(fixture_value).unwrap();
+        assert_eq!(compiled_fixture, fixture_again);
         checked += 1;
     }
     assert!(checked > 0, "expected at least one committed scenario");
 }
 
 #[test]
+fn evidence_and_report_contracts_round_trip() {
+    fn round_trip<T>(value: T)
+    where
+        T: serde::Serialize + serde::de::DeserializeOwned + PartialEq + std::fmt::Debug,
+    {
+        let encoded = serde_json::to_value(&value).unwrap();
+        let decoded: T = serde_json::from_value(encoded).unwrap();
+        assert_eq!(value, decoded);
+    }
+
+    round_trip(RecorderEventV1 {
+        schema_version: SchemaVersion1::V1,
+        run_id: "run-1".into(),
+        sequence: 1,
+        kind: RecorderEventKind::TargetCall,
+        function_id: "run-1::target".into(),
+        payload: serde_json::json!({ "value": "expected" }),
+        received_at: "2026-07-19T00:00:00Z".into(),
+    });
+    round_trip(IntegrationResultV1 {
+        schema_version: SchemaVersion1::V1,
+        scenario_id: "C-E2E-ROUND-TRIP".into(),
+        classification: Classification::Pass,
+        invariants: Vec::new(),
+        artifacts: vec!["teardown.json".into()],
+    });
+    round_trip(ExecutionReportV1 {
+        schema_version: SchemaVersion1::V1,
+        run_id: "run-1".into(),
+        scenario_id: "C-E2E-ROUND-TRIP".into(),
+        started_at: "2026-07-19T00:00:00Z".into(),
+        duration_ms: 1,
+        result_path: "result.json".into(),
+        result_sha256: "0".repeat(64),
+    });
+}
+
+#[test]
+fn compiled_send_is_accepted_by_the_authoritative_harness_contract() {
+    use harness_integration::fixtures::ScenarioFixture;
+
+    let golden: serde_json::Value = serde_json::from_str(include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../../harness/tests/golden/schemas/harness.send.json"
+    )))
+    .unwrap();
+    let validator = jsonschema::JSONSchema::compile(&golden["request_schema"]).unwrap();
+    let scenarios = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("scenarios");
+    for entry in std::fs::read_dir(scenarios).unwrap() {
+        let dir = entry.unwrap().path();
+        if !dir.join("scenario.yaml").is_file() {
+            continue;
+        }
+        let fixture = ScenarioFixture::load(&dir).unwrap();
+        let send = serde_json::to_value(&fixture.scenario.send).unwrap();
+        let errors = validator
+            .validate(&send)
+            .err()
+            .map(|errors| errors.map(|error| error.to_string()).collect::<Vec<_>>())
+            .unwrap_or_default();
+        assert!(
+            errors.is_empty(),
+            "{} compiled an invalid harness::send request: {errors:?}",
+            fixture.scenario.id
+        );
+    }
+}
+
+#[test]
 fn authored_schema_matches_compiler_safety_constraints() {
     use harness_integration::expand::{scenario_template, ScenarioTemplateKind};
 
-    let schema = serde_json::to_value(schemars::schema_for!(IntegrationScenarioV1)).unwrap();
+    let schema = serde_json::to_value(schemars::schema_for!(AuthoredScenarioV1)).unwrap();
     let validator = jsonschema::JSONSchema::compile(&schema).unwrap();
     let valid = serde_json::to_value(scenario_template(
         "C-E2E-SCHEMA",

--- a/harness/evals/integration/tests/snapshots/crash-recovery-507.compiled.json
+++ b/harness/evals/integration/tests/snapshots/crash-recovery-507.compiled.json
@@ -277,7 +277,8 @@
       {
         "id": "lifecycle.completed_once",
         "parameters": {
-          "allow_identical_duplicates": true
+          "allow_identical_duplicates": true,
+          "status": "completed"
         }
       },
       {
@@ -306,6 +307,7 @@
       "target": {
         "description": "Record one integration fixture value.",
         "function_id": "{{run_id}}::record",
+        "hold_response_at": 1,
         "request_schema": {
           "additionalProperties": false,
           "properties": {
@@ -326,8 +328,7 @@
             }
           ],
           "is_error": false
-        },
-        "response_delay_ms": 8000
+        }
       }
     },
     "schema_version": "1",

--- a/harness/evals/integration/tests/snapshots/exactly-once-function.compiled.json
+++ b/harness/evals/integration/tests/snapshots/exactly-once-function.compiled.json
@@ -357,7 +357,8 @@
       {
         "id": "lifecycle.completed_once",
         "parameters": {
-          "allow_identical_duplicates": true
+          "allow_identical_duplicates": true,
+          "status": "completed"
         }
       },
       {

--- a/harness/evals/integration/tests/snapshots/hold-mutation-505.compiled.json
+++ b/harness/evals/integration/tests/snapshots/hold-mutation-505.compiled.json
@@ -263,7 +263,8 @@
       {
         "id": "lifecycle.completed_once",
         "parameters": {
-          "allow_identical_duplicates": true
+          "allow_identical_duplicates": true,
+          "status": "completed"
         }
       },
       {

--- a/harness/evals/integration/tests/snapshots/hook-held-release-506.compiled.json
+++ b/harness/evals/integration/tests/snapshots/hook-held-release-506.compiled.json
@@ -273,7 +273,8 @@
       {
         "id": "lifecycle.completed_once",
         "parameters": {
-          "allow_identical_duplicates": true
+          "allow_identical_duplicates": true,
+          "status": "completed"
         }
       },
       {

--- a/harness/evals/integration/tests/snapshots/streamed-text.compiled.json
+++ b/harness/evals/integration/tests/snapshots/streamed-text.compiled.json
@@ -222,7 +222,8 @@
       {
         "id": "lifecycle.completed_once",
         "parameters": {
-          "allow_identical_duplicates": true
+          "allow_identical_duplicates": true,
+          "status": "completed"
         }
       },
       {


### PR DESCRIPTION
## Summary

Review-hardening pass over the integration runner's contracts, following the scenario-runner decomposition merged in #534. One commit, stacked on `refactor/harness-integration-runtime`.

- **New golden**: `schemas/compiled-fixture.v1.json`; `compiled-scenario` and `execution-report` goldens updated to match the hardened types.
- **Stream validation**: new `fixtures/stream_validation.rs` — streamed text/thinking/function-call deltas must agree with the terminal `done` message; `block_end`/`function_call_end` frames can no longer hide incorrect deltas. `script_validation` strengthened alongside.
- **Scripted router**: tightened generation matching and contract-failure evidence paths.
- **Grader/lifecycle**: `status_lifecycle` fixes with expanded duplicate/conflict/malformed/out-of-order delivery tests.
- **Supervisor/manifest**: stack manifest and supervisor hardening, recorder type tightening.
- **CI/Makefile**: engine.lock validation and integration job tightening.

## Verification

- `cargo test` in `harness/evals/integration`: all suites green.
- `make -C harness integration-validate`: 5 scenario fixture(s) valid.
- Compiled snapshots regenerated deliberately where invariants changed (see per-file diffs).
