### PR TITLE
(MOT-4132) feat(database): tolerate common SDK payload mistakes

### DIFF
--- a/database/src/handlers/execute.rs
+++ b/database/src/handlers/execute.rs
@@ -12,8 +12,9 @@ use serde_json::Value;
 #[derive(Deserialize, JsonSchema)]
 pub struct ExecuteReq {
     pub db: String,
+    #[serde(alias = "query")]
     pub sql: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "crate::handlers::lenient_params")]
     pub params: Vec<Value>,
     #[serde(default)]
     pub returning: Vec<String>,
@@ -85,6 +86,80 @@ mod tests {
 
     fn req(v: Value) -> ExecuteReq {
         serde_json::from_value(v).unwrap()
+    }
+
+    #[test]
+    fn request_accepts_query_alias_and_string_params() {
+        let request = req(json!({
+            "db": "primary",
+            "query": "SELECT 1",
+            "params": "[1,\"a\"]"
+        }));
+
+        assert_eq!(request.sql, "SELECT 1");
+        assert_eq!(request.params, vec![json!(1), json!("a")]);
+    }
+
+    #[test]
+    fn request_does_not_recursively_decode_string_items_inside_array() {
+        let request = req(json!({
+            "db": "primary",
+            "sql": "SELECT 1",
+            "params": ["[1]", "{\"a\":1}"]
+        }));
+
+        assert_eq!(request.params, vec![json!("[1]"), json!("{\"a\":1}")]);
+    }
+
+    #[test]
+    fn request_rejects_invalid_params_forms() {
+        let cases = [
+            (json!(null), "params must be a JSON array"),
+            (json!(""), "params string is not a JSON array"),
+            (json!("   "), "params string is not a JSON array"),
+            (json!("not json"), "params string is not a JSON array"),
+            (json!("null"), "params string is not a JSON array"),
+            (json!("{}"), "params string is not a JSON array"),
+        ];
+
+        for (params, expected) in cases {
+            let error = serde_json::from_value::<ExecuteReq>(json!({
+                "db": "primary",
+                "sql": "SELECT 1",
+                "params": params
+            }))
+            .err()
+            .expect("invalid params should be rejected");
+            assert!(
+                error.to_string().contains(expected),
+                "expected {expected:?} in {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn request_rejects_sql_and_query_together() {
+        let error = serde_json::from_value::<ExecuteReq>(json!({
+            "db": "primary",
+            "sql": "SELECT 1",
+            "query": "SELECT 2"
+        }))
+        .err()
+        .expect("duplicate SQL fields should be rejected");
+
+        assert!(error.to_string().contains("duplicate field"));
+    }
+
+    #[test]
+    fn request_schema_stays_canonical() {
+        let schema = serde_json::to_value(schemars::schema_for!(ExecuteReq).schema).unwrap();
+        let properties = schema["properties"]
+            .as_object()
+            .expect("request schema should have object properties");
+
+        assert!(properties.contains_key("sql"));
+        assert!(!properties.contains_key("query"));
+        assert_eq!(properties["params"]["type"], "array");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/database/src/handlers/mod.rs
+++ b/database/src/handlers/mod.rs
@@ -12,6 +12,23 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+pub(crate) fn lenient_params<'de, D>(de: D) -> Result<Vec<serde_json::Value>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error as _;
+    use serde::Deserialize as _;
+
+    match serde_json::Value::deserialize(de)? {
+        serde_json::Value::Array(items) => Ok(items),
+        serde_json::Value::String(s) => serde_json::from_str(&s)
+            .map_err(|e| D::Error::custom(format!("params string is not a JSON array: {e}"))),
+        _ => Err(D::Error::custom(
+            "params must be a JSON array or a string containing one",
+        )),
+    }
+}
+
 pub mod begin_transaction;
 pub mod commit_transaction;
 pub mod execute;

--- a/database/src/handlers/prepare.rs
+++ b/database/src/handlers/prepare.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 #[derive(Deserialize, JsonSchema)]
 pub struct PrepareReq {
     pub db: String,
+    #[serde(alias = "query")]
     pub sql: String,
     #[serde(default = "default_ttl")]
     pub ttl_seconds: u64,

--- a/database/src/handlers/query.rs
+++ b/database/src/handlers/query.rs
@@ -12,8 +12,9 @@ use serde_json::Value;
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct QueryReq {
     pub db: String,
+    #[serde(alias = "query")]
     pub sql: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "crate::handlers::lenient_params")]
     pub params: Vec<Value>,
     #[serde(default = "default_timeout")]
     pub timeout_ms: u64,

--- a/database/src/handlers/run_statement.rs
+++ b/database/src/handlers/run_statement.rs
@@ -13,7 +13,7 @@ use serde_json::Value;
 #[derive(Deserialize, JsonSchema)]
 pub struct RunReq {
     pub handle_id: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "crate::handlers::lenient_params")]
     pub params: Vec<Value>,
 }
 

--- a/database/src/handlers/transaction.rs
+++ b/database/src/handlers/transaction.rs
@@ -19,8 +19,9 @@ pub struct TxReq {
 
 #[derive(Deserialize, JsonSchema)]
 pub struct TxStmtReq {
+    #[serde(alias = "query")]
     pub sql: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "crate::handlers::lenient_params")]
     pub params: Vec<Value>,
 }
 
@@ -144,6 +145,16 @@ mod tests {
 
     fn tx_req(v: Value) -> TxReq {
         serde_json::from_value(v).unwrap()
+    }
+
+    #[test]
+    fn request_accepts_string_params_in_nested_statement() {
+        let request = tx_req(json!({
+            "db": "primary",
+            "statements": [{"sql": "SELECT 1", "params": "[1]"}]
+        }));
+
+        assert_eq!(request.statements[0].params, vec![json!(1)]);
     }
 
     /// Regression: `failed_index` must stay None for non-step failures

--- a/database/src/handlers/transaction_execute.rs
+++ b/database/src/handlers/transaction_execute.rs
@@ -23,8 +23,9 @@ use serde_json::{json, Value};
 #[derive(Deserialize, JsonSchema)]
 pub struct TxExecuteReq {
     pub transaction_id: String,
+    #[serde(alias = "query")]
     pub sql: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "crate::handlers::lenient_params")]
     pub params: Vec<Value>,
     #[serde(default)]
     pub returning: Vec<String>,

--- a/database/src/handlers/transaction_query.rs
+++ b/database/src/handlers/transaction_query.rs
@@ -27,8 +27,9 @@ use serde_json::{json, Value};
 #[derive(Deserialize, JsonSchema)]
 pub struct TxQueryReq {
     pub transaction_id: String,
+    #[serde(alias = "query")]
     pub sql: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "crate::handlers::lenient_params")]
     pub params: Vec<Value>,
 }
 

--- a/database/tests/e2e/workers/harness/src/cases-protocol.ts
+++ b/database/tests/e2e/workers/harness/src/cases-protocol.ts
@@ -71,13 +71,18 @@ export const PROTOCOL_CASES: TestCase[] = [
     },
   },
   {
-    name: 'execute() with SELECT returns 0 affected_rows (does not throw)',
-    async run({ driver, call }) {
+    name: 'execute() accepts query alias and string-encoded params',
+    async run({ driver, dialect, call }) {
+      const ph1 = dialect.placeholder(1)
       // Contract: execute() is for write-shape SQL but should accept SELECT
       // gracefully. affected_rows is undefined for SELECT in most drivers; the
       // worker normalizes that to 0. Asserting "no throw" is the main goal —
       // the value of affected_rows is a softer assertion.
-      const r = await call('database::execute', { db: driver, sql: 'SELECT 1 AS v' })
+      const r = await call('database::execute', {
+        db: driver,
+        query: `SELECT ${ph1} + 0 AS v`,
+        params: '[42]',
+      })
       expect(typeof r === 'object' && r !== null, 'response is object')
       expectEqual(typeof r.affected_rows, 'number', 'affected_rows is a number')
     },


### PR DESCRIPTION
## Summary

- accept `query` as an alias for `sql` on every SQL-bearing database request
- accept string-encoded `params` only when they decode to a JSON array
- keep generated request schemas canonical and reject invalid or ambiguous payloads
- cover top-level, nested, and cross-driver request compatibility

## Why

Typed SDK payloads are deserialized before database handlers run, so recoverable differences such as `query` or `params: "[42]"` currently fail at the request boundary. Normalizing them in the shared request deserializer gives every database driver the same behavior without widening the published contract.

## Validation

- `cargo fmt --manifest-path database/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path database/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path database/Cargo.toml --all-features`
- database protocol E2E: 114/114 across SQLite, PostgreSQL, and MySQL

Fixes MOT-4132


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SQL requests now accept `query` as an alternative to `sql`.
  * Parameter values can be provided as JSON arrays or JSON-encoded strings across query, execution, preparation, and transaction operations.
  * Missing parameters continue to default to an empty list.

* **Bug Fixes**
  * Improved validation and error handling for invalid parameter formats.
  * Added support for string-encoded parameters in worker database execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->