### PR TITLE
chore(workers): migrate iii-state/iii-cron deps to standalone state/cron

### DIFF
--- a/.github/scripts/tests/test_worker_dependency_compatibility.py
+++ b/.github/scripts/tests/test_worker_dependency_compatibility.py
@@ -20,7 +20,7 @@ def test_approval_gate_uses_shared_runtime_dependency_ranges() -> None:
 
     expected_ranges = {
         "configuration": dependencies("iii-directory")["configuration"],
-        "iii-state": dependencies("harness")["iii-state"],
+        "state": dependencies("harness")["state"],
     }
 
     for dependency, expected in expected_ranges.items():

--- a/approval-gate/iii.worker.yaml
+++ b/approval-gate/iii.worker.yaml
@@ -7,7 +7,7 @@ bin: approval-gate
 description: Policy and decision surface for human-held function calls — pre_trigger gate, pending inbox, per-session permission settings, and two notification trigger types.
 
 dependencies:
-  iii-state: "^0.21.6"
+  state: "^0.21.0"
   configuration: "^0.21.6"
   iii-directory: "^1.0.0"
   session-manager: "^1.0.0"

--- a/claude-code/iii.worker.yaml
+++ b/claude-code/iii.worker.yaml
@@ -12,5 +12,5 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  iii-state: "^0.21.6"
+  state: "^0.21.0"
   iii-stream: "^0.21.6"

--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -7,9 +7,9 @@ bin: harness
 description: Thin durable turn loop that wires session-manager, context-manager, and llm-router into an agent loop; spawns sub-agents as child sessions.
 
 dependencies:
-  iii-state: "^0.21.6"
+  state: "^0.21.0"
   queue: "^0.2.0"
-  iii-cron: "^0.21.6"
+  cron: "^0.21.0"
   configuration: "^0.21.6"
   iii-observability: "^0.21.6"
   iii-stream: "^0.21.6"

--- a/harness/tests/manifest.rs
+++ b/harness/tests/manifest.rs
@@ -58,3 +58,35 @@ fn worker_manifest_uses_the_standalone_queue_worker() {
     );
     assert!(!dependencies.contains_key(serde_yaml::Value::String("iii-queue".into())));
 }
+
+#[test]
+fn worker_manifest_uses_the_standalone_state_worker() {
+    let manifest_path = format!("{}/iii.worker.yaml", env!("CARGO_MANIFEST_DIR"));
+    let source = std::fs::read_to_string(manifest_path).expect("read iii.worker.yaml");
+    let manifest: serde_yaml::Value = serde_yaml::from_str(&source).expect("parse worker manifest");
+    let dependencies = manifest["dependencies"]
+        .as_mapping()
+        .expect("dependencies is a mapping");
+
+    assert_eq!(
+        dependencies.get(serde_yaml::Value::String("state".into())),
+        Some(&serde_yaml::Value::String("^0.21.0".into()))
+    );
+    assert!(!dependencies.contains_key(serde_yaml::Value::String("iii-state".into())));
+}
+
+#[test]
+fn worker_manifest_uses_the_standalone_cron_worker() {
+    let manifest_path = format!("{}/iii.worker.yaml", env!("CARGO_MANIFEST_DIR"));
+    let source = std::fs::read_to_string(manifest_path).expect("read iii.worker.yaml");
+    let manifest: serde_yaml::Value = serde_yaml::from_str(&source).expect("parse worker manifest");
+    let dependencies = manifest["dependencies"]
+        .as_mapping()
+        .expect("dependencies is a mapping");
+
+    assert_eq!(
+        dependencies.get(serde_yaml::Value::String("cron".into())),
+        Some(&serde_yaml::Value::String("^0.21.0".into()))
+    );
+    assert!(!dependencies.contains_key(serde_yaml::Value::String("iii-cron".into())));
+}

--- a/llm-router/iii.worker.yaml
+++ b/llm-router/iii.worker.yaml
@@ -7,5 +7,5 @@ bin: llm-router
 description: One front door + provider protocol in front of every LLM provider.
 
 dependencies:
-  iii-state: "^0.21.6"
+  state: "^0.21.0"
   configuration: "^0.21.6"

--- a/memory-consolidate/iii.worker.yaml
+++ b/memory-consolidate/iii.worker.yaml
@@ -9,4 +9,4 @@ description: Scheduled hygiene for the memory worker — deterministic dedup of 
 dependencies:
   memory: "^0.1.0"
   configuration: "^0.21.3"
-  iii-state: "^0.21.3"
+  state: "^0.21.0"

--- a/memory/iii.worker.yaml
+++ b/memory/iii.worker.yaml
@@ -10,5 +10,5 @@ dependencies:
   configuration: "^0.21.3"
   session-manager: "^1.0.0"
   llm-router: "^1.0.0"
-  iii-state: "^0.21.3"
+  state: "^0.21.0"
   queue: "^0.2.0"

--- a/opencode/iii.worker.yaml
+++ b/opencode/iii.worker.yaml
@@ -12,5 +12,5 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  iii-state: "^0.21.6"
+  state: "^0.21.0"
   iii-stream: "^0.21.6"

--- a/pi/iii.worker.yaml
+++ b/pi/iii.worker.yaml
@@ -12,5 +12,5 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  iii-state: "^0.21.6"
+  state: "^0.21.0"
   iii-stream: "^0.21.6"

--- a/provider-anthropic/iii.worker.yaml
+++ b/provider-anthropic/iii.worker.yaml
@@ -7,5 +7,5 @@ bin: provider-anthropic
 description: Anthropic Messages API provider worker; implements provider::anthropic::stream and provider::anthropic::refresh_models behind llm-router.
 
 dependencies:
-  iii-state: "^0.21.6"
+  state: "^0.21.0"
   llm-router: "^1.0.0"

--- a/provider-llamacpp/iii.worker.yaml
+++ b/provider-llamacpp/iii.worker.yaml
@@ -7,5 +7,5 @@ bin: provider-llamacpp
 description: llama.cpp server (llama-server) Chat Completions provider worker; implements provider::llamacpp::stream and provider::llamacpp::refresh_models behind llm-router.
 
 dependencies:
-  iii-state: "^0.21.6"
+  state: "^0.21.0"
   llm-router: "^1.0.0"

--- a/provider-openai-codex/iii.worker.yaml
+++ b/provider-openai-codex/iii.worker.yaml
@@ -7,5 +7,5 @@ bin: provider-openai-codex
 description: OpenAI Codex (ChatGPT subscription) provider; implements provider::openai-codex::stream and provider::openai-codex::refresh_models behind llm-router, sourcing credentials from the auth-credentials vault.
 
 dependencies:
-  iii-state: "^0.21.6"
+  state: "^0.21.0"
   llm-router: "^1.0.0"

--- a/provider-openai/iii.worker.yaml
+++ b/provider-openai/iii.worker.yaml
@@ -7,5 +7,5 @@ bin: provider-openai
 description: OpenAI Responses provider worker with Chat Completions compatibility; implements provider::openai::stream and provider::openai::refresh_models behind llm-router.
 
 dependencies:
-  iii-state: "^0.21.6"
+  state: "^0.21.0"
   llm-router: "^1.0.0"

--- a/provider-xai/iii.worker.yaml
+++ b/provider-xai/iii.worker.yaml
@@ -7,5 +7,5 @@ bin: provider-xai
 description: xAI Chat Completions provider worker; implements provider::xai::stream and provider::xai::refresh_models behind llm-router.
 
 dependencies:
-  iii-state: "^0.21.6"
+  state: "^0.21.0"
   llm-router: "^1.0.0"

--- a/provider-zai/iii.worker.yaml
+++ b/provider-zai/iii.worker.yaml
@@ -7,5 +7,5 @@ bin: provider-zai
 description: Z.AI Chat Completions provider worker; implements provider::zai::stream and provider::zai::refresh_models behind llm-router.
 
 dependencies:
-  iii-state: "^0.21.6"
+  state: "^0.21.0"
   llm-router: "^1.0.0"

--- a/slack/iii.worker.yaml
+++ b/slack/iii.worker.yaml
@@ -8,6 +8,6 @@ description: Slack as an iii worker — exposes the Slack Web API as slack::* fu
 
 dependencies:
   configuration: "^0.21.6"
-  iii-state: "^0.21.6"
+  state: "^0.21.0"
   harness: "^1.0.0"
   session-manager: "^1.0.0"

--- a/telegram-bot/iii.worker.yaml
+++ b/telegram-bot/iii.worker.yaml
@@ -7,7 +7,7 @@ bin: telegram-bot
 description: Telegram bridge to the harness stack — polling or webhook ingress, live message edits, approvals, and configurable verbosity.
 
 dependencies:
-  iii-state: "^0.21.6"
+  state: "^0.21.0"
   queue: "^0.2.0"
   configuration: "^0.21.6"
   session-manager: "^1.0.0"

--- a/worktree/iii.worker.yaml
+++ b/worktree/iii.worker.yaml
@@ -8,5 +8,5 @@ description: Git worktree lifecycle for parallel agents — mint, claim, and tra
 
 dependencies:
   configuration: "^0.21.6"
-  iii-state: "^0.21.6"
+  state: "^0.21.0"
   shell: "^0.7.0"


### PR DESCRIPTION
Migrates every worker that declares the deprecated registry packages `iii-state` and `iii-cron` onto their standalone equivalents `state` and `cron`.

## Why

`iii-state` and `iii-cron` are deprecated on the registry (they were engine builtins extracted into standalone workers). Now that 0.22 dropped the builtins and deployments run the standalone workers, the manifests should depend on the standalone packages by name.

## Scope

Only `iii-state` (17 workers) and `iii-cron` (harness only) are declared as dependencies anywhere. The other renamed packages are out of scope: `iii-http`/`iii-pubsub`/`iii-bridge` are builtins consumed by namespace (not declared deps), and `queue`/`coder→shell` were already migrated.

**This is a dependency-declaration change only.** The function and trigger namespaces are preserved across the rename (`state::get`, the `state` trigger, `cron` are identical between the old builtin and the new standalone package), so no runtime code changes — confirmed by a branch-wide grep showing the only non-manifest edits are two test files.

## What changed

- **17 `iii.worker.yaml`**: `iii-state: "^0.21.x"` → `state: "^0.21.0"`, plus harness's `iii-cron: "^0.21.6"` → `cron: "^0.21.0"`. The range drops to `^0.21.0` because the standalone packages are published at 0.21.0 and the old `^0.21.6` floor cannot be satisfied by them.
- **`.github/scripts/tests/test_worker_dependency_compatibility.py`**: the regression test does a literal `["iii-state"]` key lookup coupling harness and approval-gate; the key is renamed to `state` in lockstep. harness and approval-gate migrate together for this reason.
- **`harness/tests/manifest.rs`**: two new tests asserting the standalone `state`/`cron` are present and the old names absent, mirroring the existing `queue` migration test.

## Verification

- Branch-wide grep: zero `iii-state`/`iii-cron` dependency declarations remain.
- `pytest .github/scripts/tests/`: 115 passed.
- `cargo test --test manifest` (harness): 4 passed (new state + cron, existing queue, json).

## After merge

Each of the 17 edited workers needs its own release (Create Tag → bump patch) to republish the updated manifest to the registry — the registry only re-reads `dependencies` when a new tag is cut.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated worker dependency configuration to use the shared state and cron packages with consistent version ranges.
  - Removed legacy dependency references across supported workers.
  - Improved compatibility checks and validation for standalone worker manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->