### PR TITLE
(MOT-4147) feat(harness): warn when a detached task reaction filters on parent_session_id

### DIFF
--- a/fp/src/guidance.rs
+++ b/fp/src/guidance.rs
@@ -48,6 +48,9 @@ in the next step's payload at `into` (default "/value"). Pure transforms run inl
 getOr, flatten, sortBy, reverse, when}` with lodash
 semantics — their input arrives at `value`, and what they thread onward is the transformed
 value itself (the `{value}` wrapper appears only on direct calls, never between steps).
+Producer steps too: `state::get` in a pipe hands the stored value onward BARE — never follow
+it with `fp::get { path: "/value" }`; state::get's response IS the stored value (the `{value}`
+wrapper is the transforms' direct-call shape, never a producer's).
 `fp::when { path?, op, to? }` is the guard step: a failing comparison STOPS the pipe
 (`short_circuited: true`), so a trailing write (e.g. `state::set`) runs only when the
 condition holds — the primitive for mechanical threshold checks.
@@ -245,6 +248,8 @@ mod tests {
             "getOr, flatten, sortBy, reverse, when}",
             "short_circuited",
             "wrapper appears only on direct calls",
+            "hands the stored value onward BARE",
+            "never a producer's",
             "The FIRST step has no previous value to receive",
             "preview_chars",
             "the rule is about bulk, not ceremony",

--- a/harness/src/events.rs
+++ b/harness/src/events.rs
@@ -128,6 +128,29 @@ impl SubscriberSet {
     }
 }
 
+/// A task reaction that runs detached (no `session_id` pin, no
+/// `__owner_session_id` stamp — [`crate::subscriptions::OWNER_SESSION_KEY`],
+/// the pin fallback `reaction_delivery_session` actually reads) cannot chain
+/// through a `parent_session_id` filter: children it spawns are parented to
+/// the fresh reaction session, so their completion events never match the
+/// binding and the chain silently stalls after the first reaction-spawned
+/// child. Presence-only by design: a pin that MISMATCHES the filtered parent
+/// also cannot chain, but may be a deliberate non-chaining collector, so it
+/// is not flagged.
+fn detached_task_with_parent_filter(metadata: Option<&Value>, config: &Value) -> bool {
+    let has_task = metadata.is_some_and(|m| m.get("task").is_some());
+    let pinned = metadata.is_some_and(|m| {
+        m.get("session_id")
+            .and_then(Value::as_str)
+            .is_some_and(|s| !s.is_empty())
+            || m.get(crate::subscriptions::OWNER_SESSION_KEY)
+                .and_then(Value::as_str)
+                .is_some_and(|s| !s.is_empty())
+    });
+    let parent_filtered = BindingFilter::parse(config).is_ok_and(|f| f.parent_session_id.is_some());
+    has_task && !pinned && parent_filtered
+}
+
 struct TurnEventTriggerHandler {
     type_id: &'static str,
     set: SubscriberSet,
@@ -150,6 +173,22 @@ impl TriggerHandler for TurnEventTriggerHandler {
             crate::functions::react::validate_model(&self.iii, config.metadata.as_ref())
                 .await
                 .map_err(Error::Handler)?;
+            // Turn-event types only: `message-queued` fires carry no parent
+            // (`emit_queued` fans out with parent/display both `None`), so a
+            // parent filter there never matches at all and the pin advice
+            // below would be wrong.
+            if self.type_id != MESSAGE_QUEUED
+                && detached_task_with_parent_filter(config.metadata.as_ref(), &config.config)
+            {
+                tracing::warn!(
+                    trigger_type = self.type_id,
+                    %id,
+                    "task reaction is filtered on parent_session_id but delivery is detached \
+                     (no metadata.session_id / owner stamp): sub-agents spawned by the reaction \
+                     will not match this filter and the chain will stall — pin \
+                     metadata.session_id to the filtered session"
+                );
+            }
         }
         self.set.add(config).map_err(Error::Handler)?;
         tracing::info!(trigger_type = self.type_id, %id, %function_id, "turn-event subscription registered");
@@ -498,5 +537,47 @@ mod tests {
             BindingFilter::parse(&Value::Null).unwrap(),
             BindingFilter::default()
         );
+    }
+
+    #[test]
+    fn detached_task_parent_filter_predicate() {
+        let filter = json!({ "parent_session_id": "s_p" });
+        // Raw registration, no pin of any kind: detached, warn.
+        assert!(detached_task_with_parent_filter(
+            Some(&json!({ "task": "t" })),
+            &filter
+        ));
+        // The subscribe/interceptor owner stamp pins delivery
+        // (reaction_delivery_session falls back to it) — no warn.
+        assert!(!detached_task_with_parent_filter(
+            Some(&json!({ "task": "t", "__owner_session_id": "s_o" })),
+            &filter
+        ));
+        // Explicit session pin — no warn. Presence-only: a pin that does not
+        // match the filtered parent still suppresses (deliberate collector).
+        assert!(!detached_task_with_parent_filter(
+            Some(&json!({ "task": "t", "session_id": "s_p" })),
+            &filter
+        ));
+        assert!(!detached_task_with_parent_filter(
+            Some(&json!({ "task": "t", "session_id": "s_elsewhere" })),
+            &filter
+        ));
+        // An empty-string pin is no pin (matches the `model` "" precedent in
+        // `validate_spec`) — still detached, warn.
+        assert!(detached_task_with_parent_filter(
+            Some(&json!({ "task": "t", "session_id": "", "__owner_session_id": "" })),
+            &filter
+        ));
+        // Call-mode reaction (no sub-agent chain) — no warn.
+        assert!(!detached_task_with_parent_filter(
+            Some(&json!({ "call": { "function_id": "f::g" } })),
+            &filter
+        ));
+        // No parent filter — no warn.
+        assert!(!detached_task_with_parent_filter(
+            Some(&json!({ "task": "t" })),
+            &json!({})
+        ));
     }
 }


### PR DESCRIPTION
## What

**harness** — registration-time `tracing::warn!` for a silent-stall footgun: a task reaction with no `session_id` pin and no `__owner_session_id` stamp runs in a fresh detached session, so sub-agents it spawns are parented to that fresh session and never re-match the binding's `parent_session_id` filter — the chain stalls after the first reaction-spawned child. The predicate (`detached_task_with_parent_filter`) is extracted and unit-tested.

Heuristic edges, deliberately:
- owner stamp read via `OWNER_SESSION_KEY` (`__owner_session_id`) — the key `reaction_delivery_session` actually falls back to
- empty-string pins count as absent (matches `validate_spec`'s model `""` precedent)
- `message-queued` bindings excluded: its fires carry no parent (`emit_queued` fans out with parent/display `None`), so a parent filter never matches there and the pin advice would be wrong
- presence-only: a pin that mismatches the filtered parent may be a deliberate non-chaining collector, so it is not flagged (documented in the doc comment + test)

**fp** — one guidance clause: models that probe transforms directly learn the `{value}` direct-call envelope and then compose a bogus `fp::get { path: "/value" }` after a `state::get` producer step. The pipe threads the raw trigger response, and `state::get`'s response IS the stored value — the `{value}` wrapper is `UtilResponse`, a transform direct-call shape only. Edit-proofed with `guidance_mandates_present` needles.

## Verification

- `cargo test` — harness 237 passed, fp 31 passed
- `cargo clippy --all-targets` — clean on both crates; `cargo fmt --check` clean
- Reviewed via /review: structured pass + Claude & Codex adversarial passes; the owner-key (`owner_session_id` → `__owner_session_id`), empty-pin, and message-queued edges were caught and fixed pre-PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how pipeline steps pass values between transformations, helping prevent incorrect value-path lookups.

* **Bug Fixes**
  * Added warnings for configurations that could cause child-session event processing to stall.
  * Improved detection of detached event tasks using parent-session filters.

* **Tests**
  * Expanded coverage for session filters, ownership metadata, call modes, and related event-trigger scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->