### PR TITLE
(MOT-4149) fix: honor engine-injected III_URL in every worker URL arg

### DIFF
--- a/acp/src/main.rs
+++ b/acp/src/main.rs
@@ -14,7 +14,7 @@ struct Args {
     #[arg(
         long,
         short = 'e',
-        env = "IIIACP_ENGINE_URL",
+        env = "III_URL",
         default_value = "ws://localhost:49134"
     )]
     engine_url: String,

--- a/approval-gate/Cargo.toml
+++ b/approval-gate/Cargo.toml
@@ -24,7 +24,7 @@ anyhow = "1"
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 async-trait = "0.1"
 # Must stay on the same schemars major as iii-sdk so the derived
 # `JsonSchema` impls satisfy `RegisterFunction::new_async` /

--- a/approval-gate/src/main.rs
+++ b/approval-gate/src/main.rs
@@ -50,7 +50,7 @@ struct Cli {
     #[arg(long)]
     config: Option<String>,
 
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 
     #[arg(long)]

--- a/browser/Cargo.toml
+++ b/browser/Cargo.toml
@@ -24,7 +24,7 @@ serde_yaml = "0.9"
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 schemars = "0.8"
 async-trait = "0.1"
 futures = "0.3"

--- a/browser/src/main.rs
+++ b/browser/src/main.rs
@@ -24,7 +24,7 @@ struct Cli {
     /// Optional YAML seed used to populate `initial_value` on first registration.
     #[arg(long)]
     config: Option<String>,
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
     #[arg(long)]
     manifest: bool,

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -23,7 +23,7 @@ anyhow = "1"
 thiserror = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 schemars = "0.8"
 async-trait = "0.1"
 url = "2"

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -30,7 +30,7 @@ struct Cli {
     config: String,
 
     /// iii engine WebSocket URL.
-    #[arg(long, default_value = config::DEFAULT_ENGINE_URL)]
+    #[arg(long, env = "III_URL", default_value = config::DEFAULT_ENGINE_URL)]
     url: String,
 
     /// TCP port for `/`, `/assets/*`, and `/ws`. Overrides `http_port`

--- a/context-manager/Cargo.toml
+++ b/context-manager/Cargo.toml
@@ -24,7 +24,7 @@ anyhow = "1"
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 async-trait = "0.1"
 # Must stay on the same schemars major as iii-sdk so the derived
 # `JsonSchema` impls satisfy `RegisterFunction::new_async`.

--- a/context-manager/src/main.rs
+++ b/context-manager/src/main.rs
@@ -47,7 +47,7 @@ struct Cli {
     #[arg(long)]
     config: Option<String>,
 
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 
     #[arg(long)]

--- a/cron/Cargo.toml
+++ b/cron/Cargo.toml
@@ -27,7 +27,7 @@ serde_yaml = "0.9"
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 schemars = "0.8"
 cron = "0.12"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/cron/src/main.rs
+++ b/cron/src/main.rs
@@ -16,7 +16,7 @@ struct Cli {
     /// authoritative source and `--config` is ignored for the stored value.
     #[arg(long)]
     config: Option<String>,
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
     #[arg(long)]
     manifest: bool,

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -25,7 +25,7 @@ anyhow = "1"
 thiserror = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 async-trait = "0.1"
 uuid = { version = "1", features = ["v4", "serde"] }
 url = "2"

--- a/database/src/main.rs
+++ b/database/src/main.rs
@@ -35,7 +35,7 @@ struct Cli {
     config: Option<String>,
 
     /// WebSocket URL of the iii engine
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 }
 

--- a/fp/Cargo.toml
+++ b/fp/Cargo.toml
@@ -26,4 +26,4 @@ serde_json = "1"
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }

--- a/fp/src/main.rs
+++ b/fp/src/main.rs
@@ -17,7 +17,7 @@ use fp::{guidance, pipe, util};
     about = "Lodash-style transforms and worker-side pipelines on the iii bus."
 )]
 struct Cli {
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 }
 

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -29,7 +29,7 @@ anyhow = "1"
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 async-trait = "0.1"
 # Must stay on the same schemars major as iii-sdk so the derived
 # `JsonSchema` impls satisfy `RegisterFunction::new_async`.

--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -44,7 +44,7 @@ struct Cli {
     #[arg(long)]
     config: Option<String>,
 
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 
     #[arg(long)]

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -38,7 +38,7 @@ colored = "3"
 chrono = "0.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 schemars = "0.8"
 axum = "0.7"
 tower = { version = "0.5", features = ["limit"] }

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -25,7 +25,7 @@ struct Cli {
     /// authoritative source and `--config` is ignored for the stored value.
     #[arg(long)]
     config: Option<String>,
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
     #[arg(long)]
     manifest: bool,

--- a/iii-directory/Cargo.toml
+++ b/iii-directory/Cargo.toml
@@ -25,7 +25,7 @@ anyhow = "1"
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 async-trait = "0.1"
 schemars = { version = "0.8", features = ["chrono", "uuid1"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/iii-directory/src/main.rs
+++ b/iii-directory/src/main.rs
@@ -56,7 +56,7 @@ struct Cli {
     #[arg(long)]
     config: Option<String>,
 
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 
     #[arg(long)]

--- a/image-resize/Cargo.toml
+++ b/image-resize/Cargo.toml
@@ -21,4 +21,4 @@ serde_yaml = "0.9"
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }

--- a/image-resize/src/main.rs
+++ b/image-resize/src/main.rs
@@ -15,7 +15,7 @@ struct Cli {
     config: String,
 
     /// WebSocket URL of the III engine (port 49134 = engine main WS, not StreamModule 3112)
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 }
 

--- a/llm-router/src/main.rs
+++ b/llm-router/src/main.rs
@@ -22,7 +22,7 @@ struct Cli {
     #[arg(long, default_value = "./config.yaml")]
     config: String,
 
-    #[arg(long, env = "III_WS_URL", default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 
     #[arg(long)]

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -24,7 +24,7 @@ serde_yaml = "0.9"
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 schemars = "0.8"
 regex = "1"
 

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -27,7 +27,7 @@ struct Cli {
     #[arg(long, default_value = "./config.yaml")]
     config: String,
 
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 
     #[arg(long)]

--- a/memory-consolidate/Cargo.toml
+++ b/memory-consolidate/Cargo.toml
@@ -24,7 +24,7 @@ anyhow = "1"
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 # Must stay on the same schemars major as iii-sdk so the derived
 # `JsonSchema` impls satisfy `RegisterFunction::new_async`.
 schemars = "0.8"

--- a/memory-consolidate/src/main.rs
+++ b/memory-consolidate/src/main.rs
@@ -29,7 +29,7 @@ use memory_consolidate::{config, configuration, manifest};
 )]
 struct Cli {
     /// Engine WebSocket URL.
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 
     /// Optional YAML seed config (only seeds the FIRST configuration

--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -24,7 +24,7 @@ anyhow = "1"
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 async-trait = "0.1"
 # Must stay on the same schemars major as iii-sdk so the derived
 # `JsonSchema` impls satisfy `RegisterFunction::new_async` /

--- a/memory/src/main.rs
+++ b/memory/src/main.rs
@@ -48,7 +48,7 @@ struct Cli {
     #[arg(long)]
     config: Option<String>,
 
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 
     #[arg(long)]

--- a/provider-anthropic/src/main.rs
+++ b/provider-anthropic/src/main.rs
@@ -22,7 +22,7 @@ struct Cli {
     #[arg(long, default_value = "./config.yaml")]
     config: String,
 
-    #[arg(long, env = "III_WS_URL", default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 
     #[arg(long)]

--- a/provider-kimi/src/main.rs
+++ b/provider-kimi/src/main.rs
@@ -22,7 +22,7 @@ struct Cli {
     #[arg(long, default_value = "./config.yaml")]
     config: String,
 
-    #[arg(long, env = "III_WS_URL", default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 
     #[arg(long)]

--- a/provider-llamacpp/src/main.rs
+++ b/provider-llamacpp/src/main.rs
@@ -22,7 +22,7 @@ struct Cli {
     #[arg(long, default_value = "./config.yaml")]
     config: String,
 
-    #[arg(long, env = "III_WS_URL", default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 
     #[arg(long)]

--- a/provider-openai-codex/src/main.rs
+++ b/provider-openai-codex/src/main.rs
@@ -22,7 +22,7 @@ struct Cli {
     #[arg(long, default_value = "./config.yaml")]
     config: String,
 
-    #[arg(long, env = "III_WS_URL", default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 
     #[arg(long)]

--- a/provider-openai/src/main.rs
+++ b/provider-openai/src/main.rs
@@ -22,7 +22,7 @@ struct Cli {
     #[arg(long, default_value = "./config.yaml")]
     config: String,
 
-    #[arg(long, env = "III_WS_URL", default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 
     #[arg(long)]

--- a/provider-xai/src/main.rs
+++ b/provider-xai/src/main.rs
@@ -22,7 +22,7 @@ struct Cli {
     #[arg(long, default_value = "./config.yaml")]
     config: String,
 
-    #[arg(long, env = "III_WS_URL", default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 
     #[arg(long)]

--- a/provider-zai/src/main.rs
+++ b/provider-zai/src/main.rs
@@ -22,7 +22,7 @@ struct Cli {
     #[arg(long, default_value = "./config.yaml")]
     config: String,
 
-    #[arg(long, env = "III_WS_URL", default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 
     #[arg(long)]

--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -27,7 +27,7 @@ serde_yaml = "0.9"
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 schemars = "0.8"
 futures = "0.3"
 redis = { version = "0.27", features = ["tokio-comp", "connection-manager"] }

--- a/pubsub/src/main.rs
+++ b/pubsub/src/main.rs
@@ -23,7 +23,7 @@ struct Cli {
     /// authoritative source.
     #[arg(long)]
     config: Option<String>,
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
     #[arg(long)]
     manifest: bool,

--- a/queue/Cargo.toml
+++ b/queue/Cargo.toml
@@ -38,7 +38,7 @@ anyhow = "1"
 tracing = "0.1"
 tracing-opentelemetry = "0.32"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 schemars = "0.8"
 uuid = { version = "1", features = ["v4"] }
 futures = "0.3"

--- a/queue/src/main.rs
+++ b/queue/src/main.rs
@@ -17,7 +17,7 @@ struct Cli {
     /// authoritative.
     #[arg(long)]
     config: Option<String>,
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
     #[arg(long)]
     manifest: bool,

--- a/rbac-proxy/Cargo.toml
+++ b/rbac-proxy/Cargo.toml
@@ -24,7 +24,7 @@ anyhow = "1"
 thiserror = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 async-trait = "0.1"
 url = "2"
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/rbac-proxy/src/main.rs
+++ b/rbac-proxy/src/main.rs
@@ -31,7 +31,7 @@ use rbac_proxy::{functions, manifest, redact_url};
 struct Cli {
     /// iii engine WebSocket URL for the control connection (and the default
     /// upstream for the data plane).
-    #[arg(long, default_value = config::DEFAULT_ENGINE_URL)]
+    #[arg(long, env = "III_URL", default_value = config::DEFAULT_ENGINE_URL)]
     url: String,
 
     /// Optional one-time seed config (YAML) installed as the `configuration`

--- a/session-manager/Cargo.toml
+++ b/session-manager/Cargo.toml
@@ -27,7 +27,7 @@ anyhow = "1"
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 async-trait = "0.1"
 # Must stay on the same schemars major as iii-sdk so the derived
 # `JsonSchema` impls satisfy `RegisterFunction::new_async` /

--- a/session-manager/src/main.rs
+++ b/session-manager/src/main.rs
@@ -50,7 +50,7 @@ struct Cli {
     #[arg(long)]
     config: Option<String>,
 
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 
     #[arg(long)]

--- a/slack/Cargo.toml
+++ b/slack/Cargo.toml
@@ -23,7 +23,7 @@ serde_yaml = "0.9"
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 schemars = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "multipart"] }
 base64 = "0.22"

--- a/slack/src/main.rs
+++ b/slack/src/main.rs
@@ -22,7 +22,7 @@ struct Cli {
     #[arg(long)]
     config: Option<String>,
 
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 
     #[arg(long)]

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -30,7 +30,7 @@ serde_yaml = "0.9"
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 schemars = "0.8"
 # Store port (engine/src/builtins/kv.rs): insertion-ordered scope maps + the
 # byte-identical rkyv on-disk format.

--- a/state/src/main.rs
+++ b/state/src/main.rs
@@ -25,7 +25,7 @@ struct Cli {
     /// authoritative source and `--config` is ignored for the stored value.
     #[arg(long)]
     config: Option<String>,
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
     #[arg(long)]
     manifest: bool,

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -24,7 +24,7 @@ anyhow = "1"
 thiserror = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 async-trait = "0.1"
 url = "2"
 percent-encoding = "2"

--- a/storage/src/main.rs
+++ b/storage/src/main.rs
@@ -27,7 +27,7 @@ struct Cli {
     /// Optional seed config.yaml used to populate `initial_value` on first register.
     #[arg(long)]
     config: Option<String>,
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
     /// Print the registry publish manifest as JSON and exit. No engine connection.
     #[arg(long)]

--- a/telegram-bot/Cargo.toml
+++ b/telegram-bot/Cargo.toml
@@ -24,7 +24,7 @@ serde_yaml = "0.9"
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 schemars = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 dashmap = "6"

--- a/telegram-bot/src/main.rs
+++ b/telegram-bot/src/main.rs
@@ -23,7 +23,7 @@ struct Cli {
     #[arg(long)]
     config: Option<String>,
 
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 
     #[arg(long)]

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -25,7 +25,7 @@ anyhow = "1"
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 async-trait = "0.1"
 schemars = "0.8"
 futures = "0.3"

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -21,7 +21,7 @@ struct Cli {
     /// Optional YAML seed used to populate `initial_value` on first registration.
     #[arg(long)]
     config: Option<String>,
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
     #[arg(long)]
     manifest: bool,

--- a/workflow/Cargo.toml
+++ b/workflow/Cargo.toml
@@ -25,7 +25,7 @@ anyhow = "1"
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 async-trait = "0.1"
 schemars = "0.8"
 uuid = { version = "1", features = ["v4"] }

--- a/workflow/src/main.rs
+++ b/workflow/src/main.rs
@@ -39,7 +39,7 @@ struct Cli {
     #[arg(long)]
     config: Option<String>,
 
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 
     #[arg(long)]

--- a/worktree/Cargo.toml
+++ b/worktree/Cargo.toml
@@ -24,7 +24,7 @@ anyhow = "1"
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 async-trait = "0.1"
 globset = "0.4"
 # Must stay on the same schemars major as iii-sdk so the derived

--- a/worktree/src/main.rs
+++ b/worktree/src/main.rs
@@ -44,7 +44,7 @@ struct Cli {
     #[arg(long)]
     config: Option<String>,
 
-    #[arg(long, default_value = "ws://127.0.0.1:49134")]
+    #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]
     url: String,
 
     #[arg(long)]


### PR DESCRIPTION
Part of #526 (link 3). The engine-side spawn-chain fix is iii-hq/iii#2000; MOT-3970 covered the daemon link earlier.

## Problem
The engine injects `III_URL`/`III_ENGINE_URL` into spawned workers, but:
- **8 workers** (llm-router + all providers) read `env = "III_WS_URL"` — a variable nothing has ever set, anywhere
- **26 workers** read no env at all (`--url` flag/default only)

So any non-default `iii-worker-manager` port strands them retrying `ws://127.0.0.1:49134`.

## Changes (one line per file, uniform)
- URL clap arg gains `env = "III_URL"` (flag > env > default): 8 swaps off `III_WS_URL`, 26 additions
- clap `env` feature enabled in the 25 Cargo.tomls that lacked it
- **Breaking note**: `acp`'s private `IIIACP_ENGINE_URL` fallback is replaced by `III_URL`
- Untouched (already correct): codex, devin, email, github, grok, shell, lsp, bridge, claude-code, opencode, pi, hermes, scrapling

No version bumps (release dispatches happen separately per worker).

MOT-4149

https://claude.ai/code/session_01UM4FHiZB9tL4ZvhDqmzWq9