### PR TITLE
fix(state): default store_method to in_memory to match builtin

### DIFF
--- a/state/iii.worker.yaml
+++ b/state/iii.worker.yaml
@@ -10,7 +10,6 @@ config:
   adapter:
     name: kv
     config:
-      store_method: file_based
-      file_path: ./data/state_store.db
+      store_method: in_memory
 dependencies:
   configuration: "^0.21.6"


### PR DESCRIPTION
## What

Change the external `state` worker's manifest bootstrap default from `file_based` to `in_memory`, matching the engine's built-in `iii-state` default.

## Why

The external `state` worker seeds its config from `state/iii.worker.yaml`:

```yaml
config:
  adapter:
    name: kv
    config:
      store_method: file_based
      file_path: ./data/state_store.db
```

The engine's built-in `iii-state` has no manifest and falls back to the code default `in_memory` (`builtins/kv.rs` -> `unwrap_or_else(|| "in_memory")`).

So migrating `iii-state` -> `state` (the 0.22.x worker rename) silently flips durability: the same rename that the upgrade guide presents as a no-op change would turn a volatile store into a persisted one. Align the external worker to `in_memory` so the swap is behavior-preserving; persistence stays opt-in via `store_method: file_based`.

## Change

- `state/iii.worker.yaml`: `store_method: file_based` (+ `file_path`) -> `store_method: in_memory`.

Docs already describe `in_memory`/`file_based` as neutral options (README table, SKILL.md), so no doc change needed.

## Notes

Draft — open for discussion on whether `state` should intentionally default to persisted (diverging from the builtin) or match it. This PR takes the match-the-builtin position.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Changed state storage to in-memory mode.
  * State data is no longer persisted to a local database file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->