### PR TITLE
chore(workers): bump state dependency to ^0.21.2

### DIFF
--- a/approval-gate/iii.worker.yaml
+++ b/approval-gate/iii.worker.yaml
@@ -8,7 +8,7 @@ tags: [approval, human-in-the-loop, permissions, policy, security]
 description: Policy and decision surface for human-held function calls — pre_trigger gate, pending inbox, per-session permission settings, and two notification trigger types.
 
 dependencies:
-  state: "^0.21.0"
+  state: "^0.21.2"
   configuration: "^0.21.6"
   iii-directory: "^1.0.0"
   session-manager: "^1.0.0"

--- a/claude-code/iii.worker.yaml
+++ b/claude-code/iii.worker.yaml
@@ -13,5 +13,5 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: "^0.21.0"
+  state: "^0.21.2"
   iii-stream: "^0.21.6"

--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -8,7 +8,7 @@ tags: [agent, harness, loop, autonomous]
 description: Thin durable turn loop that wires session-manager, context-manager, and llm-router into an agent loop; spawns sub-agents as child sessions.
 
 dependencies:
-  state: "^0.21.0"
+  state: "^0.21.2"
   queue: "^0.2.0"
   cron: "^0.21.0"
   configuration: "^0.21.6"

--- a/harness/tests/manifest.rs
+++ b/harness/tests/manifest.rs
@@ -70,7 +70,7 @@ fn worker_manifest_uses_the_standalone_state_worker() {
 
     assert_eq!(
         dependencies.get(serde_yaml::Value::String("state".into())),
-        Some(&serde_yaml::Value::String("^0.21.0".into()))
+        Some(&serde_yaml::Value::String("^0.21.2".into()))
     );
     assert!(!dependencies.contains_key(serde_yaml::Value::String("iii-state".into())));
 }

--- a/llm-router/iii.worker.yaml
+++ b/llm-router/iii.worker.yaml
@@ -8,5 +8,5 @@ tags: [llm, router, models, providers]
 description: One front door + provider protocol in front of every LLM provider.
 
 dependencies:
-  state: "^0.21.0"
+  state: "^0.21.2"
   configuration: "^0.21.6"

--- a/memory-consolidate/iii.worker.yaml
+++ b/memory-consolidate/iii.worker.yaml
@@ -10,4 +10,4 @@ description: Scheduled hygiene for the memory worker — deterministic dedup of 
 dependencies:
   memory: "^0.1.0"
   configuration: "^0.21.3"
-  state: "^0.21.0"
+  state: "^0.21.2"

--- a/memory/iii.worker.yaml
+++ b/memory/iii.worker.yaml
@@ -11,5 +11,5 @@ dependencies:
   configuration: "^0.21.3"
   session-manager: "^1.0.0"
   llm-router: "^1.0.0"
-  state: "^0.21.0"
+  state: "^0.21.2"
   queue: "^0.2.0"

--- a/opencode/iii.worker.yaml
+++ b/opencode/iii.worker.yaml
@@ -13,5 +13,5 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: "^0.21.0"
+  state: "^0.21.2"
   iii-stream: "^0.21.6"

--- a/pi/iii.worker.yaml
+++ b/pi/iii.worker.yaml
@@ -13,5 +13,5 @@ scripts:
   start: node ./index.mjs
 
 dependencies:
-  state: "^0.21.0"
+  state: "^0.21.2"
   iii-stream: "^0.21.6"

--- a/provider-anthropic/iii.worker.yaml
+++ b/provider-anthropic/iii.worker.yaml
@@ -8,5 +8,5 @@ tags: [llm, anthropic, claude, messages, provider]
 description: Anthropic Messages API provider worker; implements provider::anthropic::stream and provider::anthropic::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.21.0"
+  state: "^0.21.2"
   llm-router: "^1.0.0"

--- a/provider-llamacpp/iii.worker.yaml
+++ b/provider-llamacpp/iii.worker.yaml
@@ -8,5 +8,5 @@ tags: [llm, llama.cpp, local, open-source, provider]
 description: llama.cpp server (llama-server) Chat Completions provider worker; implements provider::llamacpp::stream and provider::llamacpp::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.21.0"
+  state: "^0.21.2"
   llm-router: "^1.0.0"

--- a/provider-openai-codex/iii.worker.yaml
+++ b/provider-openai-codex/iii.worker.yaml
@@ -8,5 +8,5 @@ tags: [llm, openai, codex, chatgpt, subscription, provider]
 description: OpenAI Codex (ChatGPT subscription) provider; implements provider::openai-codex::stream and provider::openai-codex::refresh_models behind llm-router, sourcing credentials from the auth-credentials vault.
 
 dependencies:
-  state: "^0.21.0"
+  state: "^0.21.2"
   llm-router: "^1.0.0"

--- a/provider-openai/iii.worker.yaml
+++ b/provider-openai/iii.worker.yaml
@@ -8,5 +8,5 @@ tags: [llm, openai, responses, chat-completions, provider]
 description: OpenAI Responses provider worker with Chat Completions compatibility; implements provider::openai::stream and provider::openai::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.21.0"
+  state: "^0.21.2"
   llm-router: "^1.0.0"

--- a/provider-xai/iii.worker.yaml
+++ b/provider-xai/iii.worker.yaml
@@ -8,5 +8,5 @@ tags: [llm, xai, grok, chat-completions, provider]
 description: xAI Chat Completions provider worker; implements provider::xai::stream and provider::xai::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.21.0"
+  state: "^0.21.2"
   llm-router: "^1.0.0"

--- a/provider-zai/iii.worker.yaml
+++ b/provider-zai/iii.worker.yaml
@@ -8,5 +8,5 @@ tags: [llm, zai, glm, chat-completions, provider]
 description: Z.AI Chat Completions provider worker; implements provider::zai::stream and provider::zai::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.21.0"
+  state: "^0.21.2"
   llm-router: "^1.0.0"

--- a/slack/iii.worker.yaml
+++ b/slack/iii.worker.yaml
@@ -9,6 +9,6 @@ description: Slack as an iii worker — exposes the Slack Web API as slack::* fu
 
 dependencies:
   configuration: "^0.21.6"
-  state: "^0.21.0"
+  state: "^0.21.2"
   harness: "^1.0.0"
   session-manager: "^1.0.0"

--- a/telegram-bot/iii.worker.yaml
+++ b/telegram-bot/iii.worker.yaml
@@ -8,7 +8,7 @@ tags: [telegram, bot, messaging, chat, webhook]
 description: Telegram bridge to the harness stack — polling or webhook ingress, live message edits, approvals, and configurable verbosity.
 
 dependencies:
-  state: "^0.21.0"
+  state: "^0.21.2"
   queue: "^0.2.0"
   configuration: "^0.21.6"
   session-manager: "^1.0.0"

--- a/worktree/iii.worker.yaml
+++ b/worktree/iii.worker.yaml
@@ -9,5 +9,5 @@ description: Git worktree lifecycle for parallel agents — mint, claim, and tra
 
 dependencies:
   configuration: "^0.21.6"
-  state: "^0.21.0"
+  state: "^0.21.2"
   shell: "^0.7.0"


### PR DESCRIPTION
## What

Bump `state` dependency constraint from `^0.21.0` to `^0.21.2` across all workers that depend on it.

`state` worker was published at v0.21.2 ([release run](https://github.com/iii-hq/workers/actions/runs/29865844834)); this refreshes the consumer pins to match, following repo convention (caret pinned to latest published version).

## Workers updated (17)

`claude-code`, `memory`, `provider-xai`, `telegram-bot`, `approval-gate`, `provider-anthropic`, `memory-consolidate`, `worktree`, `provider-openai-codex`, `provider-openai`, `harness`, `pi`, `llm-router`, `provider-zai`, `slack`, `provider-llamacpp`, `opencode`

## Scope

Only `iii.worker.yaml` dependency constraints changed. No source or Cargo manifest changes.