### PR TITLE
fix(http): propagate trace context onto outbound trigger

### DIFF
--- a/http/src/handler.rs
+++ b/http/src/handler.rs
@@ -534,15 +534,30 @@ pub async fn dynamic_handler(
         let iii = state.iii.clone();
         let function_id = route.function_id.clone();
         let timeout_ms = config.default_timeout;
-        tokio::spawn(async move {
-            iii.trigger(TriggerRequest {
-                function_id,
-                payload,
-                action: None,
-                timeout_ms: Some(timeout_ms),
-            })
-            .await
-        })
+        // Propagate THIS request's HTTP-span trace context onto the outbound
+        // trigger so `request -> worker -> function` is one unified trace. The
+        // enclosing block is `.instrument(span)`, but `tokio::spawn` starts a
+        // detached task that inherits neither the tracing span nor the OTel
+        // `Context::current()` that the SDK's `inject_traceparent` reads. Capture
+        // the span's OTel context here (still inside the instrumented scope) and
+        // attach it to the spawned future via `with_context`, mirroring the SDK's
+        // own invocation handler (iii `iii.rs`). Without this the SDK injects no
+        // `traceparent` and the callee starts a disconnected trace.
+        use iii_helpers::observability::opentelemetry::trace::FutureExt as OtelFutureExt;
+        use tracing_opentelemetry::OpenTelemetrySpanExt;
+        let otel_cx = tracing::Span::current().context();
+        tokio::spawn(
+            async move {
+                iii.trigger(TriggerRequest {
+                    function_id,
+                    payload,
+                    action: None,
+                    timeout_ms: Some(timeout_ms),
+                })
+                .await
+            }
+            .with_context(otel_cx),
+        )
     };
 
     // Overall bound for the streaming drain. The engine bounds an open response

--- a/http/tests/common/backend.rs
+++ b/http/tests/common/backend.rs
@@ -2,7 +2,7 @@
 //! Test backend: an echo function bound to an `http` trigger.
 
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use iii_sdk::errors::Error;
 use iii_sdk::protocol::RegisterTriggerInput;
@@ -45,6 +45,54 @@ pub async fn register_echo_backend(iii: &Arc<IIIClient>, api_path: &str, http_me
         metadata: None,
     })
     .expect("register http trigger");
+}
+
+/// Register `test.trace` bound to an `http` trigger; on every invocation the
+/// function records the W3C trace id it runs under — i.e. the trace context the
+/// http worker propagated onto the outbound trigger — into the returned slot.
+///
+/// The captured value is 32 lowercase hex chars; an all-zero id
+/// (`00000000000000000000000000000000`) means the function ran under no/invalid
+/// trace context. An outbound trace-propagation test compares this against the
+/// worker's HTTP span trace id to prove `request -> worker -> function` is one
+/// unified trace.
+pub async fn register_trace_capturing_backend(
+    iii: &Arc<IIIClient>,
+    api_path: &str,
+    http_method: &str,
+) -> Arc<Mutex<Option<String>>> {
+    let function_id = format!("test.trace {http_method} {api_path}");
+    let slot = Arc::new(Mutex::new(None));
+    let sink = slot.clone();
+
+    iii.register_function(
+        function_id.clone(),
+        RegisterFunction::new_async(move |req: HttpRequest| {
+            let sink = sink.clone();
+            async move {
+                use opentelemetry::trace::TraceContextExt;
+                let trace_id = opentelemetry::Context::current()
+                    .span()
+                    .span_context()
+                    .trace_id();
+                *sink.lock().unwrap() = Some(format!("{trace_id}"));
+                Ok::<Value, Error>(json!({
+                    "status_code": 200,
+                    "body": { "method": req.method },
+                }))
+            }
+        }),
+    );
+
+    iii.register_trigger(RegisterTriggerInput {
+        trigger_type: iii_http::TRIGGER_TYPE.to_string(),
+        function_id,
+        config: json!({ "api_path": api_path, "http_method": http_method }),
+        metadata: None,
+    })
+    .expect("register http trigger");
+
+    slot
 }
 
 /// Like [`register_echo_backend`], but returns the trigger handle so a test can

--- a/http/tests/e2e_otel.rs
+++ b/http/tests/e2e_otel.rs
@@ -66,6 +66,13 @@ fn install_capture() {
             .with_simple_exporter(exported_spans().clone())
             .build();
         let tracer = opentelemetry::trace::TracerProvider::tracer(&provider, "e2e-otel-test");
+        // Install the same provider as the process-wide OTel tracer, so the
+        // receiving SDK's `global::tracer("iii-rust-sdk")` (which builds the
+        // `execute <fn>` span for each invocation) produces real, trace-id-
+        // bearing spans. Without this the global tracer is a no-op and a
+        // backend function's `Context::current()` trace id would be all-zero,
+        // making the outbound-propagation assertion meaningless.
+        opentelemetry::global::set_tracer_provider(provider.clone());
         // Keep the provider alive for the whole test binary; dropping it would
         // shut down the exporter.
         Box::leak(Box::new(provider));
@@ -325,6 +332,57 @@ async fn otel_span_propagates_inbound_traceparent() {
         .map(|kv| kv.value.as_str().to_string())
         .expect("event should carry parent.trace_id");
     assert_eq!(parent_trace_id, KNOWN_TRACE_ID);
+
+    boot.shutdown().await;
+}
+
+/// Phase 3 (outbound): the worker must propagate its HTTP span's trace context
+/// onto the trigger it fires at the matched function, so `HTTP GET -> worker ->
+/// function` is ONE trace rather than two disjoint ones. We register a backend
+/// that records the trace id it runs under, drive a request with NO inbound
+/// `traceparent` (so the worker's HTTP span is the trace root), and assert the
+/// function ran under the SAME trace id as the worker's exported HTTP span.
+///
+/// Buggy behaviour (no context attached to the outbound trigger): the worker
+/// injects no `traceparent`, the receiving SDK starts a fresh root trace, and
+/// the function's trace id differs from the HTTP span's -> assertion fails.
+#[tokio::test]
+#[serial]
+async fn otel_span_propagates_outbound_traceparent_to_function() {
+    install_capture();
+    let Some(iii) = engine::get_or_init().await else {
+        return;
+    };
+    let boot = worker::start_http_worker(iii.clone()).await;
+    let captured_trace_id =
+        backend::register_trace_capturing_backend(&iii, "/otel/outbound/:id", "GET").await;
+    common::wait_for_route(&boot.routes, "GET", "/otel/outbound/:id").await;
+
+    let url = format!("http://{}/otel/outbound/9", boot.local_addr);
+    let resp = reqwest::Client::new().get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let _ = resp.bytes().await.unwrap();
+
+    let span = wait_for_exported_span("/otel/outbound/9").await;
+    let http_trace_id = format!("{}", span.span_context.trace_id());
+
+    // The function may record its trace id slightly after the response returns.
+    let mut function_trace_id = None;
+    for _ in 0..40 {
+        if let Some(id) = captured_trace_id.lock().unwrap().clone() {
+            function_trace_id = Some(id);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    let function_trace_id =
+        function_trace_id.expect("backend function should have recorded a trace id");
+
+    assert_eq!(
+        function_trace_id, http_trace_id,
+        "the invoked function must run under the worker's HTTP-span trace \
+         (one unified trace), not a disconnected trace"
+    );
 
     boot.shutdown().await;
 }


### PR DESCRIPTION
## Problem

Flows like `HTTP GET -> http worker -> get_function()` show up as **two separate traces** instead of one. The http worker never injects `traceparent` on the trigger it fires at the matched function.

### Root cause

`dynamic_handler` applies the per-request `HTTP` span to the handler body via `.instrument(span)`, but the matched function is invoked inside a bare `tokio::spawn` (`handler.rs`). Two stacking breaks:

1. `.instrument(span)` sets the **tracing** current span, not the **opentelemetry** `Context::current()` — they're separate task-locals and `tracing-opentelemetry` does not sync one into the other.
2. `tokio::spawn` starts a detached task that inherits neither.

So when the SDK's `trigger()` calls `inject_traceparent()` (which reads `OtelContext::current()`), it gets an empty context and ships `traceparent: None`. The callee's SDK then `extract_context(None)` → starts a fresh root trace → two disjoint traces.

Inbound propagation already worked (`set_parent` lives purely in the tracing/otel layer, needs no `Context::current()`), which is the asymmetry that hid this.

## Fix (worker-side)

Capture the HTTP span's OTel context **before** the spawn — `tracing::Span::current().context()`, still inside the instrumented scope — and attach it to the spawned future via `FutureExt::with_context(cx)`, mirroring the SDK's own invocation handler. The outbound `traceparent` now carries the HTTP span's trace.


https://github.com/user-attachments/assets/ae4a8585-a153-4a9f-8e16-c20235d0ff5b


## Test

Adds the missing **outbound**-direction e2e coverage (`e2e_otel.rs` only asserted inbound). A backend records the trace id it runs under; the test asserts it equals the worker's exported HTTP-span trace id. Fails on the old code (two different ids), passes with the fix.

## Verified end-to-end (Jaeger)

- **Before:** one request → two traces — `[http] POST /math/add-two-numbers` alone, and `[iii-node] execute http::add_two_numbers → math::add_two_numbers` separate.
- **After:** one unified trace — `[http] POST` → `execute http::add_two_numbers` → `execute math::add_two_numbers` all nested.

Full `iii-http` suite green (84 unit + all e2e), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distributed tracing for HTTP-triggered functions.
  * Outbound function calls now retain the originating HTTP request’s trace context, producing connected traces instead of separate ones.

* **Tests**
  * Added end-to-end coverage to verify trace context propagation between HTTP requests and triggered functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->