### PR TITLE
(MOT-4155) feat(workers-dev): branch display, engine control, dependency-aware start & inspector, dialog overhaul

### DIFF
--- a/workers-dev/README.md
+++ b/workers-dev/README.md
@@ -30,8 +30,10 @@ Workers are **discovered automatically** from top-level `*/iii.worker.yaml` in t
 
 | Group | Workers | Started by |
 |-------|---------|------------|
-| **harness stack** | `session-manager`, `llm-router`, `context-manager`, `provider-anthropic`, `provider-openai`, `approval-gate`, `harness` | `workers-dev up`, `Ctrl+u` in TUI, `workers-dev start` |
-| **other** | All remaining repo workers (e.g. `telegram-bot`, `shell`, `console`, …) | `workers-dev start <name>`, `workers-dev start --all`, `Ctrl+a` in TUI |
+| **harness stack** | The stack roots (`session-manager`, `llm-router`, `context-manager`, `provider-anthropic`, `provider-openai`, `approval-gate`, `harness`) **plus everything they transitively depend on**, derived live from each worker's `iii.worker.yaml` dependencies | `workers-dev up`, `Ctrl+u` in TUI, `workers-dev start` (starts the roots; missing deps are pulled in, connected ones left alone) |
+| **other** | All remaining repo workers (e.g. `telegram-bot`, `console`, …) | `workers-dev start <name>`, `workers-dev start --all`, `Ctrl+a` in TUI |
+
+Press `d` on any worker in the TUI to see its direct dependencies and its transitive dependents (the `r` restart blast radius), each with live status.
 
 Only **Rust `deploy: binary`** workers can be started with `cargo run`. Non-Rust (Node/bundle) workers show **Process: external** — install them via the iii registry (`iii worker add`) instead.
 
@@ -44,11 +46,13 @@ workers-dev up                    # start harness stack + TUI
 workers-dev                       # TUI only
 workers-dev start                 # harness stack (CLI, waits for connect)
 workers-dev start --all           # every discovered Rust worker
-workers-dev start telegram-bot    # one worker (+ deps)
+workers-dev start telegram-bot    # one worker (+ missing deps)
 workers-dev restart llm-router    # rebuild + restart dependents
 workers-dev logs harness -f
 workers-dev status
 ```
+
+Starting a worker (CLI `start <name>` or `s` in the TUI) pulls in its dependencies, but a dependency **already connected to the engine is left running as-is** — no rebuild, no restart, no duplicate spawn. Explicitly requested workers always (re)start; use `restart` when a dependency itself needs a rebuild. The group commands count every member as explicitly requested: `up`, bare `start`, and `Ctrl+u` always restart the whole harness stack, `start --all` and `Ctrl+a` every managed Rust worker.
 
 Global flags: `--repo`, `--url`, `--port`, `--release`, `--config workers-dev.yaml`, `--stop-on-exit`, `--color auto|always|never`.
 
@@ -68,13 +72,16 @@ Use `--color never` or `NO_COLOR=1` to force plain output. Default `--color auto
 | Key | Action |
 |-----|--------|
 | `↑`/`↓` (or `k`/`j`) | Select worker (skips group headers) |
+| `g`/`G` (or `Home`/`End`) | Jump to the first / last worker |
 | `s` | Start selected worker |
 | `x` | Stop selected worker |
-| `r` | Restart selected worker + dependents (confirm shows the blast radius) |
+| `r` | Restart selected worker + dependents (confirm lists the blast radius with live status) |
+| `d` | Show selected worker's dependencies + dependents with live status |
 | `f` | Toggle live-follow of the selected worker's logs |
 | `PgUp`/`PgDn` | Scroll the log pane (pauses follow; resumes at the bottom) |
 | `+`/`-` | Resize the log pane (drags the divider in two columns, the height when stacked) |
 | `/` | Filter workers by name (Enter applies, Esc clears) |
+| `e` | Start the iii engine (`iii -c harness/engine.config.yaml`) |
 | `Ctrl+u` | Start harness stack |
 | `Ctrl+a` | Start all managed Rust workers |
 | `?` | Toggle the key-reference overlay |
@@ -82,7 +89,7 @@ Use `--color never` or `NO_COLOR=1` to force plain output. Default `--color auto
 
 On a wide terminal the dashboard is a two-column **master/detail** layout: the worker list on the left (sized to fit its columns), the selected worker's logs filling the rest on the right, with `+`/`-` dragging the divider between them. Below ~100 columns the two panes stack vertically instead, and `+`/`-` trade height.
 
-The header shows an at-a-glance health summary (`●` connected, `◐` compiling, `✗` crashed, `○` stopped) and flags the engine as `⚠ unreachable` when a status query fails. The log pane shows the **selected worker only**, scrollable through the full ring buffer, following the live tail by default. Crashed workers show their exit code inline. Lines are sanitized (no ANSI, no `\r` overwrite garbage).
+The header shows the repo's current git branch (`⎇ feat/my-branch`, refreshed live; detached HEAD shows as `@<short-hash>`) so side-by-side instances on different worktrees or checkouts are easy to tell apart — the terminal/tmux pane title is set to `workers-dev ⎇ <branch>` too — plus an at-a-glance health summary (`●` connected, `◐` compiling, `✗` crashed, `○` stopped). When an engine status query fails the header flags `⚠ unreachable` and gains a line with the remedy (`press e to start the engine`) and the underlying error. The worker list's title shows the selection position (`Workers 3/48`). The log pane shows the **selected worker only**, scrollable through the full ring buffer, following the live tail by default. Crashed workers show their exit code inline. Lines are sanitized (no ANSI, no `\r` overwrite garbage).
 
 ## Config (`workers-dev.yaml`)
 
@@ -92,10 +99,11 @@ engine_url: ws://127.0.0.1:49134
 release: false
 workers:          # optional override; default = all discovered
   - session-manager
-  - harness
-harness_stack:    # optional override; default = harness stack subset
-  - session-manager
   - llm-router
+  - harness
+harness_stack:    # optional roots override (must be a subset of `workers`);
+  - session-manager   # the dashboard's stack group is always these roots
+  - llm-router        # plus their transitive dependencies
   - harness
 color: auto   # auto | always | never (respects NO_COLOR)
 ```
@@ -108,7 +116,7 @@ Usually caused by cargo `\r` progress lines or ANSI color codes. Current version
 
 **Engine not reachable**
 
-Start the engine: `iii -c harness/engine.config.yaml`
+Press `e` in the TUI, or start the engine manually: `iii -c harness/engine.config.yaml`
 
 **Non-Rust worker won't start**
 

--- a/workers-dev/src/config.rs
+++ b/workers-dev/src/config.rs
@@ -4,7 +4,9 @@ use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 
 use crate::color::ColorMode;
-use crate::discover::{discover_repo_workers, harness_stack_names, order_worker_names, WorkerSpec};
+use crate::discover::{
+    assign_groups, discover_repo_workers, harness_stack_names, order_worker_names, WorkerSpec,
+};
 
 pub const DEFAULT_ENGINE_URL: &str = "ws://127.0.0.1:49134";
 pub const DEFAULT_POLL_INTERVAL_MS: u64 = 2000;
@@ -63,10 +65,23 @@ impl Config {
         };
 
         let repo_root = resolve_repo_root(repo.or(file_cfg.repo))?;
-        let worker_specs = discover_repo_workers(&repo_root)?;
+        let mut worker_specs = discover_repo_workers(&repo_root)?;
         if worker_specs.is_empty() {
             bail!("no workers discovered under {}", repo_root.display());
         }
+
+        // Resolve the stack roots before deriving worker order: an overridden
+        // `harness_stack:` changes the roots, and the dashboard's stack group
+        // (roots + transitive deps) must be regrouped before the display order
+        // is captured below. Filtered against the managed `workers` list further
+        // down — a root outside it would make `up`/`Ctrl+u` bail at start.
+        let stack_roots = match file_cfg.harness_stack {
+            Some(roots) => {
+                assign_groups(&mut worker_specs, &roots);
+                roots
+            }
+            None => harness_stack_names(&worker_specs),
+        };
 
         let raw_engine_url = engine_url
             .or(file_cfg.engine_url)
@@ -107,9 +122,24 @@ impl Config {
             }
             None => discovered_names,
         };
-        let harness_stack = file_cfg
-            .harness_stack
-            .unwrap_or_else(|| harness_stack_names(&worker_specs));
+
+        // Keep only stack roots that survived into the managed `workers` set:
+        // the WorkerGraph is built over `workers`, so a root outside it makes
+        // `workers-dev up` / `Ctrl+u` bail with "unknown worker" before the TUI
+        // even opens. Drop with a warning, mirroring the `workers:` handling.
+        let managed: std::collections::HashSet<&str> = workers.iter().map(String::as_str).collect();
+        let harness_stack: Vec<String> = stack_roots
+            .into_iter()
+            .filter(|w| {
+                let ok = managed.contains(w.as_str());
+                if !ok {
+                    eprintln!(
+                        "warning: skipping harness_stack worker {w}: not in the managed workers list"
+                    );
+                }
+                ok
+            })
+            .collect();
 
         let color_mode = color
             .or(file_cfg.color)

--- a/workers-dev/src/discover.rs
+++ b/workers-dev/src/discover.rs
@@ -1,10 +1,13 @@
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
-/// Core harness loop workers — shown first in the dashboard and started by `workers-dev up`.
+/// Harness-stack *roots*: what `workers-dev up` / `Ctrl+u` start by name.
+/// The dashboard's "harness stack" group is these plus everything they
+/// transitively depend on — see `assign_groups`.
 pub const HARNESS_STACK: &[&str] = &[
     "session-manager",
     "llm-router",
@@ -42,6 +45,9 @@ pub struct WorkerSpec {
     pub dir: PathBuf,
     pub group: WorkerGroup,
     pub spawn: SpawnKind,
+    /// Direct dependencies declared in iii.worker.yaml, filtered to workers
+    /// that actually exist in this repo, sorted.
+    pub deps: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -49,6 +55,7 @@ struct WorkerYaml {
     name: Option<String>,
     language: Option<String>,
     deploy: Option<String>,
+    dependencies: Option<HashMap<String, String>>,
 }
 
 pub fn discover_repo_workers(repo_root: &Path) -> Result<Vec<WorkerSpec>> {
@@ -82,23 +89,68 @@ pub fn discover_repo_workers(repo_root: &Path) -> Result<Vec<WorkerSpec>> {
             continue;
         }
 
-        let group = if HARNESS_STACK.contains(&name.as_str()) {
+        let spawn = classify_spawn(&dir, &parsed);
+        let deps: Vec<String> = parsed
+            .dependencies
+            .unwrap_or_default()
+            .into_keys()
+            .collect();
+        specs.push(WorkerSpec {
+            name,
+            dir,
+            group: WorkerGroup::Other, // assigned below once all names are known
+            spawn,
+            deps,
+        });
+    }
+
+    // Deps can name registry workers that aren't in this repo — keep only the
+    // ones we discovered, so the graph and grouping stay within managed workers.
+    let names: HashSet<String> = specs.iter().map(|s| s.name.clone()).collect();
+    for spec in &mut specs {
+        spec.deps.retain(|d| names.contains(d));
+        spec.deps.sort_unstable();
+    }
+
+    let default_roots: Vec<String> = HARNESS_STACK
+        .iter()
+        .filter(|n| names.contains(**n))
+        .map(|n| n.to_string())
+        .collect();
+    assign_groups(&mut specs, &default_roots);
+    Ok(specs)
+}
+
+/// Group workers by deriving the harness stack from the dependency graph:
+/// the stack is `roots` plus everything they transitively depend on, so a
+/// newly declared dependency joins the stack group automatically instead of
+/// waiting for someone to extend a hardcoded list. Re-sorts specs into
+/// display order (stack first, alphabetical within a group).
+pub fn assign_groups(specs: &mut [WorkerSpec], roots: &[String]) {
+    let deps_by_name: HashMap<&str, &[String]> = specs
+        .iter()
+        .map(|s| (s.name.as_str(), s.deps.as_slice()))
+        .collect();
+    let mut stack: HashSet<&str> = HashSet::new();
+    let mut queue: VecDeque<&str> = roots.iter().map(String::as_str).collect();
+    while let Some(name) = queue.pop_front() {
+        if !stack.insert(name) {
+            continue;
+        }
+        if let Some(deps) = deps_by_name.get(name) {
+            queue.extend(deps.iter().map(String::as_str));
+        }
+    }
+    let stack: HashSet<String> = stack.into_iter().map(str::to_string).collect();
+
+    for spec in specs.iter_mut() {
+        spec.group = if stack.contains(&spec.name) {
             WorkerGroup::HarnessStack
         } else {
             WorkerGroup::Other
         };
-
-        let spawn = classify_spawn(&dir, &parsed);
-        specs.push(WorkerSpec {
-            name,
-            dir,
-            group,
-            spawn,
-        });
     }
-
     specs.sort_by(|a, b| a.group.cmp(&b.group).then_with(|| a.name.cmp(&b.name)));
-    Ok(specs)
 }
 
 fn classify_spawn(dir: &Path, yaml: &WorkerYaml) -> SpawnKind {
@@ -148,6 +200,45 @@ mod tests {
         if with_cargo {
             fs::write(dir.join("Cargo.toml"), "[workspace]\n").unwrap();
         }
+    }
+
+    fn write_worker_with_deps(tmp: &TempDir, name: &str, deps: &[&str]) {
+        let dir = tmp.path().join(name);
+        fs::create_dir_all(&dir).unwrap();
+        let mut yaml =
+            format!("iii: v1\nname: {name}\nlanguage: rust\ndeploy: binary\ndescription: test\n");
+        if !deps.is_empty() {
+            yaml.push_str("dependencies:\n");
+            for dep in deps {
+                yaml.push_str(&format!("  {dep}: \"^1.0.0\"\n"));
+            }
+        }
+        fs::write(dir.join("iii.worker.yaml"), yaml).unwrap();
+        fs::write(dir.join("Cargo.toml"), "[workspace]\n").unwrap();
+    }
+
+    /// The stack group is derived from the graph: roots plus transitive deps.
+    /// A dependency two hops from `harness` lands in the stack group without
+    /// appearing in any hardcoded list; unmanaged dep names are dropped.
+    #[test]
+    fn harness_stack_group_follows_dependencies() {
+        let tmp = TempDir::new().unwrap();
+        write_worker_with_deps(&tmp, "harness", &["state", "configuration"]);
+        write_worker_with_deps(&tmp, "state", &["iii-directory"]);
+        write_worker_with_deps(&tmp, "iii-directory", &[]);
+        write_worker_with_deps(&tmp, "telegram-bot", &[]);
+
+        let specs = discover_repo_workers(tmp.path()).unwrap();
+        let group = |n: &str| specs.iter().find(|s| s.name == n).unwrap().group;
+        assert_eq!(group("harness"), WorkerGroup::HarnessStack);
+        assert_eq!(group("state"), WorkerGroup::HarnessStack);
+        assert_eq!(group("iii-directory"), WorkerGroup::HarnessStack);
+        assert_eq!(group("telegram-bot"), WorkerGroup::Other);
+        // `configuration` isn't a repo worker — dropped from the spec's deps.
+        assert_eq!(
+            specs.iter().find(|s| s.name == "harness").unwrap().deps,
+            vec!["state".to_string()]
+        );
     }
 
     #[test]

--- a/workers-dev/src/git.rs
+++ b/workers-dev/src/git.rs
@@ -1,0 +1,128 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Current branch of the repo at `repo_root`, read straight from `.git/HEAD`
+/// rather than a `git` subprocess, so the TUI can refresh it on the poll
+/// cadence for pennies. Returns the branch name, `@<short-hash>` for a
+/// detached HEAD, or `None` when `repo_root` isn't a git checkout (or its
+/// HEAD is unreadable/garbled) — callers just omit the display.
+pub fn current_branch(repo_root: &Path) -> Option<String> {
+    let head = fs::read_to_string(git_dir(repo_root)?.join("HEAD")).ok()?;
+    let head = head.trim();
+    if let Some(branch) = head.strip_prefix("ref: refs/heads/") {
+        return (!branch.is_empty()).then(|| branch.to_string());
+    }
+    // Symbolic ref outside refs/heads (rare; e.g. mid-bisect states): show the
+    // ref path itself rather than pretending it's a branch.
+    if let Some(other) = head.strip_prefix("ref: ") {
+        return (!other.is_empty()).then(|| other.to_string());
+    }
+    // Detached HEAD: a bare commit hash.
+    if head.len() >= 40 && head.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Some(format!("@{}", &head[..8]));
+    }
+    None
+}
+
+/// Resolve the actual git dir for `repo_root`. `.git` is a directory in a
+/// normal checkout, but a `gitdir: <path>` pointer *file* in linked worktrees
+/// and submodules — the very setups where telling instances apart matters.
+fn git_dir(repo_root: &Path) -> Option<PathBuf> {
+    let dot_git = repo_root.join(".git");
+    if dot_git.is_dir() {
+        return Some(dot_git);
+    }
+    let pointer = fs::read_to_string(&dot_git).ok()?;
+    let target = pointer.trim().strip_prefix("gitdir:")?.trim();
+    if target.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(target);
+    if path.is_absolute() {
+        Some(path)
+    } else {
+        Some(repo_root.join(path))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, contents: &str) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn branch_from_normal_checkout() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join(".git/HEAD"), "ref: refs/heads/main\n");
+        assert_eq!(current_branch(tmp.path()).as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn branch_with_slashes() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(
+            &tmp.path().join(".git/HEAD"),
+            "ref: refs/heads/feat/workers-dev-improvement\n",
+        );
+        assert_eq!(
+            current_branch(tmp.path()).as_deref(),
+            Some("feat/workers-dev-improvement")
+        );
+    }
+
+    #[test]
+    fn worktree_gitdir_pointer_absolute() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("main-clone/.git/worktrees/wt");
+        write(&real.join("HEAD"), "ref: refs/heads/feature-x\n");
+        let wt = tmp.path().join("wt");
+        write(&wt.join(".git"), &format!("gitdir: {}\n", real.display()));
+        assert_eq!(current_branch(&wt).as_deref(), Some("feature-x"));
+    }
+
+    #[test]
+    fn worktree_gitdir_pointer_relative() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(
+            &tmp.path().join("real/HEAD"),
+            "ref: refs/heads/relative-branch\n",
+        );
+        let wt = tmp.path().join("wt");
+        write(&wt.join(".git"), "gitdir: ../real\n");
+        assert_eq!(current_branch(&wt).as_deref(), Some("relative-branch"));
+    }
+
+    #[test]
+    fn detached_head_shows_short_hash() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(
+            &tmp.path().join(".git/HEAD"),
+            "0123456789abcdef0123456789abcdef01234567\n",
+        );
+        assert_eq!(current_branch(tmp.path()).as_deref(), Some("@01234567"));
+    }
+
+    #[test]
+    fn non_repo_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(current_branch(tmp.path()), None);
+    }
+
+    #[test]
+    fn garbage_head_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join(".git/HEAD"), "not a ref at all");
+        assert_eq!(current_branch(tmp.path()), None);
+    }
+
+    #[test]
+    fn empty_gitdir_pointer_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join(".git"), "gitdir: \n");
+        assert_eq!(current_branch(tmp.path()), None);
+    }
+}

--- a/workers-dev/src/main.rs
+++ b/workers-dev/src/main.rs
@@ -2,6 +2,7 @@ mod color;
 mod commands;
 mod config;
 mod discover;
+mod git;
 mod graph;
 mod logs;
 mod orchestrator;

--- a/workers-dev/src/orchestrator.rs
+++ b/workers-dev/src/orchestrator.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 
@@ -14,6 +14,11 @@ use crate::graph::WorkerGraph;
 use crate::logs;
 use crate::runtime::{ProcState, SharedRuntimes, WorkerRuntime};
 use crate::status::{self, EngineWorker, WorkerView};
+
+/// Engine config path, relative to the repo root. `ensure_engine` launches
+/// `iii -c <this>`; the TUI's engine-down banner names it so the remedy shown
+/// matches what `e` actually runs.
+pub const ENGINE_CONFIG_REL: &str = "harness/engine.config.yaml";
 
 pub struct Orchestrator {
     pub config: Config,
@@ -106,13 +111,26 @@ impl Orchestrator {
     /// Ensure the engine is running, starting `iii -c harness/engine.config.yaml`
     /// if it isn't. The engine is detached (own process group, no kill-on-drop)
     /// so it outlives the dashboard, like the workers it hosts; then we wait for
-    /// it to accept connections.
+    /// it to accept connections. Streams progress to stderr — call only before
+    /// the TUI takes the screen.
     pub async fn ensure_engine(&self) -> Result<()> {
+        self.ensure_engine_inner(true, self.config.connect_timeout_ms)
+            .await
+    }
+
+    /// `ensure_engine` for the TUI's `e` key: silent (stderr would corrupt the
+    /// alt-screen) and with a short reachability wait — once the spawn worked,
+    /// the dashboard poller shows the engine coming up on its own.
+    pub async fn start_engine_quiet(&self, wait_ms: u64) -> Result<()> {
+        self.ensure_engine_inner(false, wait_ms).await
+    }
+
+    async fn ensure_engine_inner(&self, verbose: bool, wait_ms: u64) -> Result<()> {
         if self.engine_reachable().await {
             return Ok(());
         }
 
-        let config_rel = "harness/engine.config.yaml";
+        let config_rel = ENGINE_CONFIG_REL;
         let config_path = self.config.repo_root.join(config_rel);
         if !config_path.is_file() {
             bail!(
@@ -122,10 +140,12 @@ impl Orchestrator {
             );
         }
 
-        eprintln!(
-            "engine not reachable at {} — starting `iii -c {config_rel}`…",
-            self.config.engine_url
-        );
+        if verbose {
+            eprintln!(
+                "engine not reachable at {} — starting `iii -c {config_rel}`…",
+                self.config.engine_url
+            );
+        }
 
         let mut cmd = Command::new("iii");
         cmd.arg("-c").arg(config_rel);
@@ -138,30 +158,59 @@ impl Orchestrator {
         cmd.stderr(Stdio::null());
         #[cfg(unix)]
         cmd.process_group(0);
-        cmd.spawn().context("spawn iii engine")?;
+        let mut child = cmd.spawn().context("spawn iii engine")?;
 
-        let deadline = Instant::now() + Duration::from_millis(self.config.connect_timeout_ms);
+        let deadline = Instant::now() + Duration::from_millis(wait_ms);
         while Instant::now() < deadline {
             time::sleep(Duration::from_millis(200)).await;
+            // `iii` dying (e.g. a config error) with its stderr nulled would
+            // otherwise mean spinning out the whole wait to report a vague
+            // timeout — surface the exit immediately instead.
+            if let Ok(Some(status)) = child.try_wait() {
+                bail!(
+                    "iii exited immediately ({status}) — run `iii -c {config_rel}` manually to see its output"
+                );
+            }
             if self.engine_reachable().await {
-                eprintln!("engine is up at {}", self.config.engine_url);
+                if verbose {
+                    eprintln!("engine is up at {}", self.config.engine_url);
+                }
                 return Ok(());
             }
         }
-        bail!(
-            "started the engine but it did not become reachable within {}ms",
-            self.config.connect_timeout_ms
-        );
+        // Dropping `child` leaves the engine running (no kill-on-drop): it may
+        // still come up late; under the TUI the poller will show it if so.
+        let hint = if verbose {
+            ""
+        } else {
+            " (it keeps trying in the background — watch the header)"
+        };
+        bail!("started the engine but it was not reachable within {wait_ms}ms{hint}");
     }
 
-    pub async fn engine_preflight(&self) -> Result<()> {
-        self.engine_workers().await.with_context(|| {
+    /// Engine preflight that also returns which workers the engine currently
+    /// reports as connected, so start paths can leave healthy dependencies
+    /// alone. Errors carry the start-the-engine remedy.
+    async fn connected_worker_names(&self) -> Result<HashSet<String>> {
+        let workers = self.engine_workers().await.with_context(|| {
             format!(
-                "engine not reachable at {} (start with: iii -c harness/engine.config.yaml)",
+                "engine not reachable at {} (start with: iii -c {ENGINE_CONFIG_REL})",
                 self.config.engine_url
             )
         })?;
-        Ok(())
+        Ok(workers
+            .into_iter()
+            .filter(|w| w.status == "connected")
+            .filter_map(|w| w.name)
+            .collect())
+    }
+
+    /// True when `worker` is only in the start set as a pulled-in dependency
+    /// (not asked for by name) and the engine already has it connected.
+    /// Recompiling and restarting such a worker would only disrupt a healthy
+    /// process — or spawn a duplicate of one started outside workers-dev.
+    fn skip_connected_dep(names: &[String], worker: &str, connected: &HashSet<String>) -> bool {
+        !names.iter().any(|n| n == worker) && connected.contains(worker)
     }
 
     pub async fn start_harness_stack(&self, wait_connected: bool) -> Result<()> {
@@ -191,7 +240,8 @@ impl Orchestrator {
     }
 
     pub async fn start_workers(&self, names: &[String], wait_connected: bool) -> Result<()> {
-        self.engine_preflight().await?;
+        // Doubles as the engine preflight; bails with the remedy when down.
+        let connected = self.connected_worker_names().await?;
         let order = if names.is_empty() {
             self.graph.topo_start_order(self.graph.workers())?
         } else {
@@ -199,6 +249,15 @@ impl Orchestrator {
         };
 
         for worker in order {
+            // A dependency that's already connected to the engine is doing its
+            // job — don't recompile/restart it. Only workers asked for by name
+            // always (re)start.
+            if Self::skip_connected_dep(names, &worker, &connected) {
+                if self.progress {
+                    eprintln!("↷ {worker}: already connected to the engine, left running");
+                }
+                continue;
+            }
             // Non-spawnable workers pulled in as dependencies run externally
             // (`iii worker add`); skip them. Bail only when the user asked for
             // that worker by name.
@@ -717,6 +776,33 @@ mod tests {
             .closure_with_deps(&["harness".to_string()])
             .unwrap();
         assert!(order.contains(&"scrapling".to_string()));
+    }
+
+    /// Dependencies already connected to the engine are left alone; only
+    /// workers asked for by name always (re)start.
+    #[test]
+    fn skip_connected_dep_spares_healthy_deps_only() {
+        let names = vec!["harness".to_string()];
+        let connected: HashSet<String> = ["session-manager", "harness"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        // Pulled-in dep, already connected → skipped.
+        assert!(Orchestrator::skip_connected_dep(
+            &names,
+            "session-manager",
+            &connected
+        ));
+        // Asked for by name → restarted even though connected.
+        assert!(!Orchestrator::skip_connected_dep(
+            &names, "harness", &connected
+        ));
+        // Dep not connected → started.
+        assert!(!Orchestrator::skip_connected_dep(
+            &names,
+            "approval-gate",
+            &connected
+        ));
     }
 
     /// A worker started via `cargo run` forks the real worker binary as a

--- a/workers-dev/src/tui/mod.rs
+++ b/workers-dev/src/tui/mod.rs
@@ -8,8 +8,9 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
 use crossterm::execute;
+use crossterm::style::Print;
 use crossterm::terminal::{
-    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen, SetTitle,
 };
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -23,9 +24,9 @@ use crate::logs;
 use crate::orchestrator::Orchestrator;
 use crate::status::WorkerView;
 use theme::{
-    confirm_prompt_style, engine_style, engine_url_style, footer_style, group_header_style,
-    header_accent_style, hint_style, log_title_style, muted_cell_style, non_spawnable_style,
-    overlay_bg_style, process_style, selection_row_style, status_style,
+    branch_style, confirm_prompt_style, engine_style, engine_url_style, footer_style,
+    group_header_style, header_accent_style, hint_style, log_title_style, muted_cell_style,
+    non_spawnable_style, overlay_bg_style, process_style, selection_row_style, status_style,
 };
 
 /// Spinner frames cycled through for workers in the compiling state.
@@ -53,6 +54,15 @@ const TABLE_WIDTH_MIN: u16 = 50;
 /// 1-col gutter keeps the two pane borders from fusing into a double seam.
 const PANE_GUTTER: u16 = 1;
 const TWO_COL_MIN_WIDTH: u16 = TABLE_PANE_WIDTH + PANE_GUTTER + MIN_LOG_PANE_WIDTH;
+/// Longest branch name shown in the header before truncation, so a
+/// pathological name can't push the health summary out of view.
+const BRANCH_MAX: usize = 40;
+/// How long the `e` (start engine) action waits for the engine to become
+/// reachable before reporting failure. The Busy overlay blocks all input
+/// while an action runs, so this is kept short: a dead `iii` is detected
+/// within a poll tick, a healthy engine binds within a couple of seconds,
+/// and a slow one keeps coming up in the background where the poller shows it.
+const ENGINE_START_WAIT_MS: u64 = 8_000;
 
 /// Footer help, by available width. The narrowest tier always keeps the two
 /// keys a lost user needs (help, quit).
@@ -67,6 +77,13 @@ enum UiMode {
     Filter,
     /// Full key reference overlay; any key returns to the dashboard.
     Help,
+    /// Dependency inspector for one worker; any key returns to the dashboard.
+    /// Statuses are looked up live at draw time, so the overlay stays current.
+    Deps {
+        name: String,
+        deps: Vec<String>,
+        dependents: Vec<String>,
+    },
     ConfirmRestart {
         name: String,
         dependents: Vec<String>,
@@ -78,6 +95,7 @@ enum ModeKind {
     Dashboard,
     Filter,
     Help,
+    Deps,
     Confirm,
     Busy,
 }
@@ -87,6 +105,7 @@ fn mode_kind(mode: &UiMode) -> ModeKind {
         UiMode::Dashboard => ModeKind::Dashboard,
         UiMode::Filter => ModeKind::Filter,
         UiMode::Help => ModeKind::Help,
+        UiMode::Deps { .. } => ModeKind::Deps,
         UiMode::ConfirmRestart { .. } => ModeKind::Confirm,
         UiMode::Busy(_) => ModeKind::Busy,
     }
@@ -108,6 +127,10 @@ struct Actions {
 struct DashboardState {
     views: Vec<WorkerView>,
     engine_error: Option<String>,
+    /// Current branch of the repo this instance orchestrates, so multiple
+    /// checkouts/worktrees are easy to tell apart. Re-read on the poll cadence
+    /// to track mid-session branch switches; None when repo isn't a checkout.
+    repo_branch: Option<String>,
 }
 
 enum DisplayRowKind {
@@ -122,6 +145,7 @@ struct DisplayRow {
 /// Everything `draw_ui` needs for one frame, bundled to keep the signature sane.
 struct UiCtx<'a> {
     engine_url: &'a str,
+    repo_branch: Option<&'a str>,
     views: &'a [WorkerView],
     engine_error: Option<&'a str>,
     display_rows: &'a [DisplayRow],
@@ -143,7 +167,9 @@ struct UiCtx<'a> {
 
 pub async fn run(orchestrator: Arc<Orchestrator>) -> Result<()> {
     enable_raw_mode()?;
-    execute!(io::stdout(), EnterAlternateScreen)?;
+    // Save the terminal's title (XTWINOPS push; ignored where unsupported)
+    // before set_terminal_title overwrites it, so quitting can restore it.
+    execute!(io::stdout(), EnterAlternateScreen, Print("\x1b[22;0t"))?;
 
     let result: Result<()> = async {
         let stdout = io::stdout();
@@ -153,9 +179,12 @@ pub async fn run(orchestrator: Arc<Orchestrator>) -> Result<()> {
         // Poll the engine on a background task so a slow or unreachable engine
         // query can't freeze keyboard input.
         let (initial_views, initial_err) = orchestrator.dashboard_snapshot().await;
+        let initial_branch = crate::git::current_branch(&orchestrator.config.repo_root);
+        set_terminal_title(initial_branch.as_deref());
         let (state_tx, mut state_rx) = tokio::sync::watch::channel(DashboardState {
             views: initial_views,
             engine_error: initial_err,
+            repo_branch: initial_branch,
         });
         let poll_interval = Duration::from_millis(orchestrator.config.poll_interval_ms);
         let poller = {
@@ -168,6 +197,7 @@ pub async fn run(orchestrator: Arc<Orchestrator>) -> Result<()> {
                         .send(DashboardState {
                             views,
                             engine_error,
+                            repo_branch: crate::git::current_branch(&orchestrator.config.repo_root),
                         })
                         .is_err()
                     {
@@ -218,7 +248,7 @@ pub async fn run(orchestrator: Arc<Orchestrator>) -> Result<()> {
             let compiling = state.views.iter().any(|v| v.display_status == "compiling");
 
             if needs_redraw {
-                if compiling {
+                if compiling || matches!(mode, UiMode::Busy(_)) {
                     spinner_frame = spinner_frame.wrapping_add(1);
                 }
                 let selected_name =
@@ -232,6 +262,7 @@ pub async fn run(orchestrator: Arc<Orchestrator>) -> Result<()> {
                 };
                 let ctx = UiCtx {
                     engine_url: &orchestrator.config.engine_url,
+                    repo_branch: state.repo_branch.as_deref(),
                     views: &state.views,
                     engine_error: state.engine_error.as_deref(),
                     display_rows: &display_rows,
@@ -262,9 +293,11 @@ pub async fn run(orchestrator: Arc<Orchestrator>) -> Result<()> {
                 }
             }
 
-            // Animate the spinner while compiling and refresh live logs while
-            // following; otherwise stay idle until something actually changes.
-            let spinner_due = compiling && last_redraw.elapsed() >= Duration::from_millis(120);
+            // Animate the spinner while compiling or an action runs (Busy
+            // dialog) and refresh live logs while following; otherwise stay
+            // idle until something actually changes.
+            let spinner_due = (compiling || matches!(mode, UiMode::Busy(_)))
+                && last_redraw.elapsed() >= Duration::from_millis(120);
             let live_logs_due = follow
                 && matches!(mode_kind(&mode), ModeKind::Dashboard | ModeKind::Filter)
                 && last_redraw.elapsed() >= Duration::from_millis(500);
@@ -287,7 +320,8 @@ pub async fn run(orchestrator: Arc<Orchestrator>) -> Result<()> {
                                     &state.views,
                                 );
                             }
-                            ModeKind::Help => mode = UiMode::Dashboard, // any key closes help
+                            // Any key closes the help / dependency overlays.
+                            ModeKind::Help | ModeKind::Deps => mode = UiMode::Dashboard,
                             ModeKind::Confirm => handle_confirm_key(key, &mut mode, &actions),
                             ModeKind::Busy => {
                                 if key.code == KeyCode::Esc && in_flight.load(Ordering::SeqCst) == 0
@@ -334,7 +368,12 @@ pub async fn run(orchestrator: Arc<Orchestrator>) -> Result<()> {
             }
 
             if state_rx.has_changed().unwrap_or(false) {
-                state = state_rx.borrow_and_update().clone();
+                let fresh = state_rx.borrow_and_update().clone();
+                // Keep the terminal/tmux pane title tracking the branch.
+                if fresh.repo_branch != state.repo_branch {
+                    set_terminal_title(fresh.repo_branch.as_deref());
+                }
+                state = fresh;
                 needs_redraw = true;
             }
         }
@@ -345,7 +384,15 @@ pub async fn run(orchestrator: Arc<Orchestrator>) -> Result<()> {
     .await;
 
     let _ = disable_raw_mode();
-    let _ = execute!(io::stdout(), LeaveAlternateScreen);
+    // Clear our title, then pop the saved one: terminals with a title stack
+    // restore the original; elsewhere the title at least stops claiming a
+    // workers-dev instance that no longer exists.
+    let _ = execute!(
+        io::stdout(),
+        LeaveAlternateScreen,
+        SetTitle(""),
+        Print("\x1b[23;0t")
+    );
     result
 }
 
@@ -385,8 +432,42 @@ fn handle_dashboard_key(
                 *log_scroll = 0;
             }
         }
+        // Jump to the first/last worker — the list runs to ~50 rows, and
+        // stepping there one `j` at a time is a chore.
+        KeyCode::Char('g') | KeyCode::Home | KeyCode::Char('G') | KeyCode::End => {
+            let target = if matches!(key.code, KeyCode::Char('g') | KeyCode::Home) {
+                first_worker_row(display_rows)
+            } else {
+                display_rows
+                    .iter()
+                    .rposition(|row| matches!(row.kind, DisplayRowKind::Worker(_)))
+            };
+            // Like Up/Down, only re-follow when the selection actually moves —
+            // `g` on the first row shouldn't yank a scrolled log pane back down.
+            if target.is_some() && target != selected {
+                table_state.select(target);
+                *follow = true;
+                *log_scroll = 0;
+            }
+        }
         KeyCode::Char('/') => *mode = UiMode::Filter,
         KeyCode::Char('?') => *mode = UiMode::Help,
+        KeyCode::Char('d') => {
+            if let Some(name) = worker_name {
+                let mut deps = actions.orchestrator.graph.dependencies(&name).to_vec();
+                deps.sort_unstable();
+                let dependents = actions
+                    .orchestrator
+                    .graph
+                    .reverse_dependents(&name)
+                    .unwrap_or_default();
+                *mode = UiMode::Deps {
+                    name,
+                    deps,
+                    dependents,
+                };
+            }
+        }
         KeyCode::Char('f') => {
             *follow = !*follow;
             if *follow {
@@ -458,13 +539,19 @@ fn handle_dashboard_key(
                 }
             }
         }
+        KeyCode::Char('e') => {
+            spawn_start_engine(actions);
+            *mode = UiMode::Busy("starting engine…".to_string());
+        }
         KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
             spawn_start_harness_stack(actions);
             *mode = UiMode::Busy("starting harness stack…".to_string());
         }
         KeyCode::Char('a') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-            let names = actions.orchestrator.config.workers.clone();
-            spawn_start(actions, names);
+            // Via start_all_managed (like CLI `start --all`), which pre-filters
+            // to spawnable workers — naming the non-Rust ones directly would
+            // bail at the first one, stranding the rest unstarted.
+            spawn_start_all_managed(actions);
             *mode = UiMode::Busy("starting all managed workers…".to_string());
         }
         _ => {}
@@ -515,6 +602,17 @@ fn not_startable_msg() -> UiMode {
     UiMode::Busy("worker not startable from workers-dev (use iii worker add)".into())
 }
 
+/// Name the surrounding terminal window / tmux pane after this instance, so
+/// side-by-side instances are tellable apart from the window list without
+/// looking inside. Re-applied whenever the branch changes.
+fn set_terminal_title(branch: Option<&str>) {
+    let title = match branch {
+        Some(b) => format!("workers-dev ⎇ {b}"),
+        None => "workers-dev".to_string(),
+    };
+    let _ = execute!(io::stdout(), SetTitle(title));
+}
+
 /// Run a worker action on a detached task, counting it as in-flight for the
 /// whole duration so the UI keeps the Busy overlay up and refuses overlapping
 /// actions until it finishes. Failures are sent back to the UI (not printed,
@@ -545,6 +643,20 @@ fn spawn_start_harness_stack(actions: &Actions) {
     let orchestrator = actions.orchestrator.clone();
     spawn_action(actions, async move {
         orchestrator.start_harness_stack(false).await
+    });
+}
+
+fn spawn_start_all_managed(actions: &Actions) {
+    let orchestrator = actions.orchestrator.clone();
+    spawn_action(actions, async move {
+        orchestrator.start_all_managed(false).await
+    });
+}
+
+fn spawn_start_engine(actions: &Actions) {
+    let orchestrator = actions.orchestrator.clone();
+    spawn_action(actions, async move {
+        orchestrator.start_engine_quiet(ENGINE_START_WAIT_MS).await
     });
 }
 
@@ -648,10 +760,12 @@ fn draw_ui(f: &mut Frame, table_state: &mut TableState, ctx: &UiCtx) {
     let area = f.area();
     // Header and footer span full width; the body between them carries the
     // two panes.
+    // The header grows a line while the engine is down to carry the remedy.
+    let header_h = if ctx.engine_error.is_some() { 4 } else { 3 };
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3),
+            Constraint::Length(header_h),
             Constraint::Min(MIN_TABLE_HEIGHT),
             Constraint::Length(1),
         ])
@@ -701,23 +815,184 @@ fn draw_ui(f: &mut Frame, table_state: &mut TableState, ctx: &UiCtx) {
     // Modals center over the whole content area so they keep their width in
     // either layout.
     if let UiMode::ConfirmRestart { name, dependents } = ctx.mode {
-        draw_confirm_overlay(f, body, name, dependents, ctx.color_enabled);
+        draw_confirm_overlay(f, body, name, dependents, ctx);
+    }
+    if let UiMode::Busy(msg) = ctx.mode {
+        draw_busy_overlay(f, body, msg, ctx);
+    }
+    if let UiMode::Deps {
+        name,
+        deps,
+        dependents,
+    } = ctx.mode
+    {
+        draw_deps_overlay(f, body, name, deps, dependents, ctx);
     }
     if matches!(ctx.mode, UiMode::Help) {
         draw_help_overlay(f, area, ctx.color_enabled);
     }
 }
 
+/// "   ● name …… status" with the table's live glyph and color for `name`.
+/// Shared by the dependency and confirm-restart dialogs so every list of
+/// workers in a dialog reads exactly like the worker table.
+fn worker_status_line(ctx: &UiCtx, name: &str) -> Line<'static> {
+    let (icon, status) = ctx
+        .views
+        .iter()
+        .find(|v| v.name == name)
+        .map(|v| {
+            (
+                status_icon(&v.display_status, ctx.spinner_frame),
+                v.display_status.clone(),
+            )
+        })
+        .unwrap_or(("○", "unknown".to_string()));
+    let st = styled_if(ctx.color_enabled, status_style(&status));
+    Line::from(vec![
+        Span::styled(format!("   {icon} "), st),
+        Span::raw(format!("{name:<24}")),
+        Span::styled(status, st),
+    ])
+}
+
+/// A blank spacer line (no visible glyphs). Trailing ones don't count as
+/// content when measuring overflow, so a lone padding blank never triggers a
+/// spurious "N more".
+fn is_blank_line(line: &Line) -> bool {
+    line.spans.iter().all(|s| s.content.trim().is_empty())
+}
+
+/// Render a centered dialog `width` wide inside `area`, titled and bordered.
+/// `body` truncates when it doesn't fit — its tail is replaced by a single
+/// "   … N more (resize to see all)" marker so a clipped dialog never looks
+/// complete under an intact border. `pinned` lines (e.g. the y/n action row)
+/// always render at the bottom and are never dropped; the truncation happens
+/// only in the body above them.
+fn draw_dialog(
+    f: &mut Frame,
+    area: Rect,
+    title: String,
+    mut body: Vec<Line<'static>>,
+    pinned: Vec<Line<'static>>,
+    width: u16,
+    color: bool,
+) {
+    // Trailing blank spacers are padding, not content: trimming them keeps the
+    // overflow test and the hidden-count honest (a lone trailing blank must not
+    // push a dialog that otherwise fits into truncation).
+    while body.last().is_some_and(is_blank_line) {
+        body.pop();
+    }
+
+    let want_h = (body.len() + pinned.len()) as u16 + 2;
+    let h = want_h.min(area.height.max(3));
+    let inner = h.saturating_sub(2) as usize;
+    // Pinned lines are reserved first; the body gets whatever height remains.
+    let body_budget = inner.saturating_sub(pinned.len());
+
+    let mut lines: Vec<Line> = if body.len() > body_budget {
+        let keep = body_budget.saturating_sub(1);
+        let hidden = body.len() - keep;
+        let mut shown: Vec<Line> = body.into_iter().take(keep).collect();
+        shown.push(Line::from(Span::styled(
+            format!("   … {hidden} more (resize to see all)"),
+            styled_if(color, hint_style()),
+        )));
+        shown
+    } else {
+        body
+    };
+    lines.extend(pinned);
+
+    let popup = centered_rect_fixed(width, h, area);
+    f.render_widget(Clear, popup);
+    f.render_widget(
+        Paragraph::new(lines).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(title)
+                .style(styled_if(color, overlay_bg_style())),
+        ),
+        popup,
+    );
+}
+
+/// Dependency inspector: the selected worker's direct dependencies and
+/// transitive dependents (the `r` blast radius), each with its live status —
+/// so "can I start this?" and "what breaks if I bounce it?" are one keypress.
+fn draw_deps_overlay(
+    f: &mut Frame,
+    area: Rect,
+    name: &str,
+    deps: &[String],
+    dependents: &[String],
+    ctx: &UiCtx,
+) {
+    let color = ctx.color_enabled;
+    let section = |lines: &mut Vec<Line>, title: &str, workers: &[String]| {
+        lines.push(Line::from(Span::styled(
+            format!("   {title}"),
+            styled_if(color, Style::default().add_modifier(Modifier::BOLD)),
+        )));
+        if workers.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "   (none)",
+                styled_if(color, hint_style()),
+            )));
+        }
+        for w in workers {
+            lines.push(worker_status_line(ctx, w));
+        }
+    };
+
+    let mut lines = vec![Line::from("")];
+    section(&mut lines, "depends on (direct)", deps);
+    lines.push(Line::from(""));
+    section(&mut lines, "needed by (restart blast radius)", dependents);
+    lines.push(Line::from(""));
+
+    draw_dialog(
+        f,
+        area,
+        format!(" deps: {name} · any key to close "),
+        lines,
+        Vec::new(),
+        58,
+        color,
+    );
+}
+
 fn draw_header(f: &mut Frame, area: Rect, ctx: &UiCtx) {
     let color = ctx.color_enabled;
-    let mut spans = vec![
-        Span::styled(
-            "workers-dev",
-            styled_if(color, header_accent_style()).add_modifier(Modifier::BOLD),
-        ),
-        Span::raw("  "),
-        Span::styled(ctx.engine_url, styled_if(color, engine_url_style())),
-    ];
+    let mut spans = vec![Span::styled(
+        "workers-dev",
+        styled_if(color, header_accent_style()).add_modifier(Modifier::BOLD),
+    )];
+
+    // The branch sits right after the title — it's the one thing that tells
+    // two side-by-side instances (worktrees, checkouts) apart, so it must
+    // survive narrow terminals, which clip the header from the right.
+    if let Some(branch) = ctx.repo_branch {
+        let shown: String = if branch.chars().count() > BRANCH_MAX {
+            let mut s: String = branch.chars().take(BRANCH_MAX - 1).collect();
+            s.push('…');
+            s
+        } else {
+            branch.to_string()
+        };
+        spans.push(Span::raw("  "));
+        spans.push(Span::styled(
+            format!("⎇ {shown}"),
+            styled_if(color, branch_style()).add_modifier(Modifier::BOLD),
+        ));
+    }
+
+    spans.push(Span::raw("  "));
+    spans.push(Span::styled(
+        ctx.engine_url,
+        styled_if(color, engine_url_style()),
+    ));
 
     if ctx.engine_error.is_some() {
         spans.push(Span::styled(
@@ -769,8 +1044,26 @@ fn draw_header(f: &mut Frame, area: Rect, ctx: &UiCtx) {
         ));
     }
 
+    let mut lines = vec![Line::from(spans)];
+    // Engine down: a bare "unreachable" is a dead end — say how to fix it.
+    // Remedy before error detail, so right-edge clipping on a narrow terminal
+    // eats the diagnostics rather than the fix.
+    if let Some(err) = ctx.engine_error {
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!(
+                    "press e to start the engine (iii -c {})",
+                    crate::orchestrator::ENGINE_CONFIG_REL
+                ),
+                styled_if(color, Style::default().fg(Color::Yellow)),
+            ),
+            Span::raw("  ·  "),
+            Span::styled(err.to_string(), styled_if(color, muted_cell_style())),
+        ]));
+    }
+
     // No box title: the accent "workers-dev" span already names the pane.
-    let header = Paragraph::new(Line::from(spans)).block(Block::default().borders(Borders::ALL));
+    let header = Paragraph::new(lines).block(Block::default().borders(Borders::ALL));
     f.render_widget(header, area);
 }
 
@@ -834,6 +1127,25 @@ fn draw_table(f: &mut Frame, area: Rect, table_state: &mut TableState, ctx: &UiC
         })
         .collect();
 
+    // Title carries selection position ("Workers 3/48") so a long list is
+    // navigable — you can tell where you are and how much is below the fold.
+    let worker_count = |rows: &[DisplayRow]| {
+        rows.iter()
+            .filter(|r| matches!(r.kind, DisplayRowKind::Worker(_)))
+            .count()
+    };
+    let total = worker_count(ctx.display_rows);
+    let title = match table_state.selected() {
+        Some(sel) if sel < ctx.display_rows.len() => {
+            format!(
+                " Workers {}/{} ",
+                worker_count(&ctx.display_rows[..=sel]),
+                total
+            )
+        }
+        _ => format!(" Workers ({total}) "),
+    };
+
     // Content-fit, left-packed widths: the worker name sits right next to its
     // status. Worker only has to fit a name now (label/exit moved to Process),
     // so it's tight; Uptime (Min) absorbs the right slack.
@@ -851,7 +1163,7 @@ fn draw_table(f: &mut Frame, area: Rect, table_state: &mut TableState, ctx: &UiC
         Row::new(vec!["Worker", "Process", "Engine", "PID", "Uptime"])
             .style(Style::default().add_modifier(Modifier::BOLD)),
     )
-    .block(Block::default().borders(Borders::ALL).title(" Workers "))
+    .block(Block::default().borders(Borders::ALL).title(title))
     .row_highlight_style(styled_if(color, selection_row_style()));
     f.render_stateful_widget(table, area, table_state);
 }
@@ -972,8 +1284,9 @@ fn draw_footer(f: &mut Frame, area: Rect, ctx: &UiCtx) {
         f.render_widget(banner, area);
         return;
     }
+    // Busy messages render as a centered dialog now, so the footer keeps its
+    // help line in that mode.
     let (text, style) = match ctx.mode {
-        UiMode::Busy(msg) => (msg.clone(), styled_if(color, footer_style())),
         UiMode::Filter => (
             format!(" filter: {}_   (Enter apply · Esc clear) ", ctx.filter),
             styled_if(color, Style::default().fg(Color::Yellow)),
@@ -992,53 +1305,92 @@ fn draw_footer(f: &mut Frame, area: Rect, ctx: &UiCtx) {
     f.render_widget(Paragraph::new(text).style(style), area);
 }
 
-fn draw_confirm_overlay(
-    f: &mut Frame,
-    area: Rect,
-    name: &str,
-    dependents: &[String],
-    color_enabled: bool,
-) {
-    let mut lines = vec![Line::from(format!("Restart {name} and its dependents?"))];
+/// Dependents listed in the confirm dialog before it truncates; the deps
+/// overlay (`d`) always shows the full list.
+const CONFIRM_DEPENDENTS_SHOWN: usize = 8;
+
+/// Confirm-restart dialog: the blast radius as a status-annotated list (a
+/// comma-joined line clips for wide radii like llm-router's), so `y` is an
+/// informed choice — a stopped dependent will be *started* by the restart,
+/// and that's visible here instead of being a surprise.
+fn draw_confirm_overlay(f: &mut Frame, area: Rect, name: &str, dependents: &[String], ctx: &UiCtx) {
+    let color = ctx.color_enabled;
+    let mut lines = vec![Line::from("")];
     if dependents.is_empty() {
         lines.push(Line::from(Span::styled(
-            "no dependents — only this worker restarts",
-            styled_if(color_enabled, hint_style()),
+            format!("   Restart {name}?"),
+            styled_if(color, confirm_prompt_style()),
+        )));
+        lines.push(Line::from(Span::styled(
+            "   no dependents — only this worker restarts",
+            styled_if(color, hint_style()),
         )));
     } else {
+        let n = dependents.len();
+        let s = if n == 1 { "" } else { "s" };
         lines.push(Line::from(Span::styled(
-            format!("also restarts: {}", dependents.join(", ")),
-            styled_if(color_enabled, Style::default().fg(Color::Yellow)),
+            format!("   Restart {name} and {n} dependent{s}?"),
+            styled_if(color, confirm_prompt_style()),
         )));
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "   also restarts (stopped ones will start)",
+            styled_if(color, Style::default().add_modifier(Modifier::BOLD)),
+        )));
+        for w in dependents.iter().take(CONFIRM_DEPENDENTS_SHOWN) {
+            lines.push(worker_status_line(ctx, w));
+        }
+        if n > CONFIRM_DEPENDENTS_SHOWN {
+            lines.push(Line::from(Span::styled(
+                format!(
+                    "   … and {} more (d lists the full blast radius)",
+                    n - CONFIRM_DEPENDENTS_SHOWN
+                ),
+                styled_if(color, hint_style()),
+            )));
+        }
     }
-    lines.push(Line::from(""));
-    lines.push(Line::from("y/Enter  yes        n/Esc  no"));
-
-    let popup = centered_rect(64, 40, area);
-    f.render_widget(Clear, popup);
-    f.render_widget(
-        Paragraph::new(lines)
-            .style(styled_if(color_enabled, confirm_prompt_style()))
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .title(" confirm restart ")
-                    .style(styled_if(color_enabled, overlay_bg_style())),
+    // The action row is pinned: it must survive even when the blast-radius
+    // list is truncated on a short terminal — dropping it would leave a
+    // blocking modal with no visible way to confirm or cancel.
+    let pinned = vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                "   y/Enter ",
+                styled_if(color, Style::default().fg(Color::Cyan)),
             ),
-        popup,
+            Span::raw("restart      "),
+            Span::styled("n/Esc ", styled_if(color, Style::default().fg(Color::Cyan))),
+            Span::raw("cancel"),
+        ]),
+        Line::from(""),
+    ];
+
+    draw_dialog(
+        f,
+        area,
+        " confirm restart ".to_string(),
+        lines,
+        pinned,
+        58,
+        color,
     );
 }
 
 fn draw_help_overlay(f: &mut Frame, area: Rect, color: bool) {
     let keys = [
         ("↑ ↓  k j", "select worker"),
+        ("g G", "jump to first / last worker"),
         ("s", "start selected worker"),
         ("x", "stop selected worker"),
         ("r", "restart selected + dependents"),
+        ("d", "show dependencies + dependents"),
         ("f", "toggle live log follow"),
         ("PgUp PgDn", "scroll logs"),
         ("+ -", "resize the log pane"),
         ("/", "filter workers by name"),
+        ("e", "start the iii engine"),
         ("Ctrl+u", "start the harness stack"),
         ("Ctrl+a", "start all managed workers"),
         ("?", "toggle this help"),
@@ -1079,36 +1431,48 @@ fn draw_help_overlay(f: &mut Frame, area: Rect, color: bool) {
         "   elsewhere = connected, started outside workers-dev",
         styled_if(color, hint_style()),
     )));
-    let popup = centered_rect(58, 75, area);
+    draw_dialog(
+        f,
+        area,
+        " keys · any key to close ".to_string(),
+        lines,
+        Vec::new(),
+        58,
+        color,
+    );
+}
+
+/// Center a fixed-size rect inside `r`, clamped to fit.
+fn centered_rect_fixed(width: u16, height: u16, r: Rect) -> Rect {
+    let w = width.min(r.width);
+    let h = height.min(r.height);
+    Rect::new(r.x + (r.width - w) / 2, r.y + (r.height - h) / 2, w, h)
+}
+
+/// Busy notice as a small centered dialog with an animated spinner. Input is
+/// blocked while an action runs; a dialog makes the cause obvious where a
+/// footer-only message was easy to miss.
+fn draw_busy_overlay(f: &mut Frame, area: Rect, msg: &str, ctx: &UiCtx) {
+    let color = ctx.color_enabled;
+    let spin = SPINNER[ctx.spinner_frame % SPINNER.len()];
+    let line = Line::from(vec![
+        Span::styled(
+            format!("  {spin} "),
+            styled_if(color, Style::default().fg(Color::Yellow)),
+        ),
+        Span::raw(format!("{msg}  ")),
+    ]);
+    let w = (msg.chars().count() as u16).saturating_add(8).max(24);
+    let popup = centered_rect_fixed(w, 3, area);
     f.render_widget(Clear, popup);
     f.render_widget(
-        Paragraph::new(lines).block(
+        Paragraph::new(vec![line]).block(
             Block::default()
                 .borders(Borders::ALL)
-                .title(" keys · any key to close ")
                 .style(styled_if(color, overlay_bg_style())),
         ),
         popup,
     );
-}
-
-fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
-    let popup_layout = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Percentage((100 - percent_y) / 2),
-            Constraint::Percentage(percent_y),
-            Constraint::Percentage((100 - percent_y) / 2),
-        ])
-        .split(r);
-    Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Percentage((100 - percent_x) / 2),
-            Constraint::Percentage(percent_x),
-            Constraint::Percentage((100 - percent_x) / 2),
-        ])
-        .split(popup_layout[1])[1]
 }
 
 fn status_icon(status: &str, spinner_frame: usize) -> &'static str {

--- a/workers-dev/src/tui/theme.rs
+++ b/workers-dev/src/tui/theme.rs
@@ -12,6 +12,12 @@ pub fn engine_url_style() -> Style {
     muted_cell_style()
 }
 
+/// Branch badge in the header. Magenta so the one identifying detail that
+/// differs between instances doesn't blend into the cyan title or dim URL.
+pub fn branch_style() -> Style {
+    Style::default().fg(Color::Magenta)
+}
+
 pub fn footer_style() -> Style {
     muted_cell_style()
 }


### PR DESCRIPTION
Fixes MOT-4155

## What

Quality-of-life improvements to `workers-dev`, the local dev orchestrator TUI. All changes are scoped to `workers-dev/`.

### Instance identification
- **Git branch in the header** (`⎇ <branch>`), read straight from `.git/HEAD` (new `git.rs`) so it refreshes on the poll cadence and resolves `.git` pointer files used by linked worktrees. Detached HEAD shows as `@<short-hash>`; non-repos omit the badge.
- **Terminal/tmux pane title** set to `workers-dev ⎇ <branch>` and restored on exit, so side-by-side instances are easy to tell apart.

### Engine + navigation
- **`e`** starts the iii engine from inside the TUI (quiet variant of `ensure_engine`, fast-fails if `iii` dies on spawn). The engine-down header now shows the remedy instead of a dead-end `⚠ unreachable`.
- **`g`/`G`** (and `Home`/`End`) jump to the first/last worker; the list title shows selection position (`Workers N/M`).

### Dependency-aware behavior
- Starting a worker **no longer recompiles/restarts a dependency that is already connected** to the engine — only explicitly requested workers always (re)start.
- The **"harness stack" group is derived from the dependency graph** (roots + transitive deps) instead of a hardcoded list, so it tracks `iii.worker.yaml` changes automatically.
- `Ctrl+a` routes through `start_all_managed` (matching `start --all`) instead of bailing at the first non-Rust worker.
- `harness_stack` roots are validated against the managed workers list (warn + drop) so `up`/`Ctrl+u` can't bail with "unknown worker".

### Dependency inspector + dialog overhaul
- **`d`** shows a worker's direct dependencies and its transitive dependents (the restart blast radius), each with live status.
- All modal dialogs share one **content-sized renderer that never silently clips**: overflow is replaced with a single `… N more (resize to see all)` marker, and the confirm dialog's action row is **pinned** so it always survives truncation. Busy is now an animated spinner dialog. The confirm dialog lists the blast radius with live status instead of a comma-joined line that used to clip.

## Testing
- `cargo build`, `cargo clippy --all-targets`, `cargo fmt` all clean.
- **26 unit tests pass** (new coverage: `git.rs` branch resolution incl. worktree pointer files and detached HEAD; dependency-derived grouping; skip-connected-dependency decision).
- TUI paths exercised live in tmux against the real 47-worker repo: branch header + pane title, `e`/`g`/`G`/`d` keys, `Workers N/M` counter, skip-connected-deps (stable PID / no recompile on already-connected deps), and all dialogs (confirm truncation with pinned action row, deps-overlay overflow marker, animated busy dialog).

## Review provenance
Developed and reviewed iteratively across **five rounds of multi-agent adversarial review** in the authoring session (three review lenses + majority-vote refutation per finding). Every confirmed finding was fixed and re-verified, including: a 20s input lockout on the `e` action, stale pane title on exit, help-overlay clipping, a pre-existing `Ctrl+a` abort, the `harness_stack` "unknown worker" bail, and dialog double-truncation dropping the confirm key row.

## Notes
- `workers-dev` is `publish = false` (a local dev tool), so no version bump / CHANGELOG entry — versioning of deployed workers is handled post-merge by `workers-ci[bot]`.
- Base branch `main` was merged in before testing; the diff is `workers-dev/` only.
