### PR TITLE
(MOT-4156) feat(fp,harness,console): scoped pipe steps under the harness fs_scope + trigger visualization

### DIFF
--- a/approval-gate/Cargo.lock
+++ b/approval-gate/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/console/web/src/components/chat/engine/RegisterTriggerView.tsx
+++ b/console/web/src/components/chat/engine/RegisterTriggerView.tsx
@@ -1,8 +1,14 @@
 import type { ReactNode } from 'react'
+import { PipeStepList } from '@/components/chat/fp/PipeView'
+import {
+  pipeRequestSchema,
+  safeParseRequest as safeParseFpRequest,
+} from '@/components/chat/fp/parsers'
 import { Chip, MetaRow, StatusPill } from '@/components/chat/sandbox/shared'
 import { JsonHighlight } from '@/lib/syntax'
 import {
   configFilters,
+  describeCron,
   type ReactOptions,
   type ReactSpec,
   type RegisterTriggerRequest,
@@ -43,12 +49,25 @@ export function RegisterTriggerView({
   // than an empty terminal pane (the switch always mounts this component).
   if (!req) return <LabeledJson label="request" value={input} />
 
-  const react =
+  // A `harness::react` binding runs in one of two modes: spawn a sub-agent
+  // (`task`, + `model`) or dispatch a plain function call (`call`). The
+  // non-strict schema parses ANY object, so the mode fields decide whether
+  // this is really a react spec; neither present → raw metadata fallback.
+  const parsedReact =
     req.function_id === 'harness::react'
       ? safeParseRequest<ReactSpec>(reactSpecSchema, req.metadata)
       : null
-  const allow = react
-    ? safeParseRequest<ReactOptions>(reactOptionsSchema, react.options)
+  const react = parsedReact?.task || parsedReact?.call ? parsedReact : null
+  const call = react?.call ?? null
+  const spawn = call ? null : react
+  // A call-mode target that is itself a pipe renders as its step route —
+  // the whole point of the binding is legible as event → pipeline.
+  const callPipe =
+    call?.function_id === 'fp::pipe'
+      ? (safeParseFpRequest(pipeRequestSchema, call.payload)?.through ?? null)
+      : null
+  const allow = spawn
+    ? safeParseRequest<ReactOptions>(reactOptionsSchema, spawn.options)
         ?.functions?.allow
     : undefined
   const allowUniq = allow ? Array.from(new Set(allow)) : []
@@ -62,8 +81,22 @@ export function RegisterTriggerView({
   const regId = resp?.id ?? resp?.subscription_id
   const once = resp?.once ?? req.once
 
+  // Cron schedules read as WHEN content, not as an opaque config dump: the
+  // expression chip plus (for the common shapes) a human reading of it.
+  const cronExpression =
+    req.trigger_type === 'cron' &&
+    req.config &&
+    typeof req.config === 'object' &&
+    typeof (req.config as { expression?: unknown }).expression === 'string'
+      ? (req.config as { expression: string }).expression
+      : null
+  const cronHuman = cronExpression ? describeCron(cronExpression) : null
+  const cronOnlyConfig =
+    cronExpression != null &&
+    Object.keys(req.config as Record<string, unknown>).length === 1
+
   const filters = configFilters(req.config)
-  const showRawConfig = !filters && !isEmpty(req.config)
+  const showRawConfig = !filters && !isEmpty(req.config) && !cronOnlyConfig
 
   return (
     <div className="border-t border-rule-2 bg-bg">
@@ -93,7 +126,16 @@ export function RegisterTriggerView({
         <span className="font-mono text-[13px] text-ink break-all">
           {req.trigger_type}
         </span>
-        {filters ? (
+        {cronExpression ? (
+          <div className="flex flex-wrap items-center gap-1.5">
+            {cronHuman ? (
+              <span className="font-mono text-[12px] text-ink">
+                {cronHuman}
+              </span>
+            ) : null}
+            <FilterChip label="expression" value={cronExpression} />
+          </div>
+        ) : filters ? (
           <div className="flex flex-wrap items-center gap-1.5">
             {filters.map((f) => (
               <FilterChip key={f.label} label={f.label} value={f.value} />
@@ -111,11 +153,17 @@ export function RegisterTriggerView({
       <div className="px-3 py-2 border-b border-rule-2 bg-bg flex flex-col gap-1.5">
         <div className="flex items-baseline gap-2 flex-wrap">
           <span className="font-mono text-[11px] uppercase tracking-[0.06em] text-ink-faint">
-            {react ? 'spawn sub-agent' : req.function_id ? 'call' : 'notify'}
+            {spawn ? 'spawn sub-agent' : call || req.function_id ? 'call' : 'notify'}
           </span>
-          {react ? (
+          {spawn ? (
             <span className="font-mono text-[12.5px] text-accent break-all">
-              {react.model}
+              {spawn.model ?? 'inherited model'}
+            </span>
+          ) : call ? (
+            // The binding's real effect is the inner target, not the
+            // harness::react plumbing it rides on.
+            <span className="font-mono text-[12.5px] text-accent break-all">
+              {call.function_id}
             </span>
           ) : req.function_id ? (
             <span className="font-mono text-[12.5px] text-accent break-all">
@@ -126,14 +174,17 @@ export function RegisterTriggerView({
               this session
             </span>
           )}
-          {react?.session_id ? (
+          {call?.event_into ? (
+            <FilterChip label="event into" value={call.event_into} />
+          ) : null}
+          {spawn?.session_id ? (
             <>
               <span className="font-mono text-[11px] text-ink-ghost">→</span>
               <span
                 className="font-mono text-[11.5px] text-ink-faint"
-                title={react.session_id}
+                title={spawn.session_id}
               >
-                {shortenId(react.session_id)}
+                {shortenId(spawn.session_id)}
               </span>
             </>
           ) : null}
@@ -177,9 +228,16 @@ export function RegisterTriggerView({
         ) : null}
       </div>
 
-      {react ? (
-        <LabeledText label="task" text={react.task} />
-      ) : req.metadata !== undefined && !isEmpty(req.metadata) ? (
+      {callPipe?.length ? (
+        <div>
+          <PaneLabel>pipeline</PaneLabel>
+          <PipeStepList through={callPipe} />
+        </div>
+      ) : call?.payload !== undefined && !isEmpty(call.payload) ? (
+        <LabeledJson label="payload" value={call.payload} />
+      ) : spawn?.task ? (
+        <LabeledText label="task" text={spawn.task} />
+      ) : !react && req.metadata !== undefined && !isEmpty(req.metadata) ? (
         <LabeledJson label="metadata" value={req.metadata} />
       ) : null}
     </div>

--- a/console/web/src/components/chat/engine/__tests__/parsers.test.ts
+++ b/console/web/src/components/chat/engine/__tests__/parsers.test.ts
@@ -602,8 +602,13 @@ describe('describeCron', () => {
     expect(describeCron('* * * * * *')).toBe('every second')
     expect(describeCron('0 15 * * * *')).toBe('at :15 every hour')
     expect(describeCron('0 0 */6 * * *')).toBe('every 6h at :00')
-    expect(describeCron('0 0 9 * * 1')).toBe('every Mon at 09:00')
-    expect(describeCron('0 0 9 * * 1,5')).toBe('every Mon, Fri at 09:00')
+    // seconds-first form = Rust cron crate dialect: weekdays 1=Sun..7=Sat
+    expect(describeCron('0 0 9 * * 1')).toBe('every Sun at 09:00')
+    expect(describeCron('0 0 9 * * 2,6')).toBe('every Mon, Fri at 09:00')
+    // classic five-field cron: weekdays 0=Sun..6=Sat, 7 also Sunday
+    expect(describeCron('0 9 * * 1')).toBe('every Mon at 09:00')
+    expect(describeCron('0 9 * * 0')).toBe('every Sun at 09:00')
+    expect(describeCron('0 9 * * 7')).toBe('every Sun at 09:00')
     expect(describeCron('0 0 0 1 * *')).toBe('at 00:00 on day 1 of every month')
     expect(describeCron('0 0 12 * 7 *')).toBe('at 12:00 in Jul')
   })
@@ -614,6 +619,10 @@ describe('describeCron', () => {
     expect(describeCron('0 0 9 L * *')).toBeNull() // L extension
     expect(describeCron('0 0 25 * * *')).toBeNull() // hour out of range
     expect(describeCron('0 0 17 21 7 * 2027')).toBeNull() // pinned year
+    // wild seconds fire 60×/min — "at 17:00" would hide that
+    expect(describeCron('* 0 17 * * *')).toBeNull()
+    expect(describeCron('30 0 17 * * *')).toBeNull() // nonzero seconds pin
+    expect(describeCron('0 0 9 * * 0')).toBeNull() // 0 invalid in Rust dialect
     expect(describeCron('nonsense')).toBeNull()
     expect(describeCron('')).toBeNull()
   })

--- a/console/web/src/components/chat/engine/__tests__/parsers.test.ts
+++ b/console/web/src/components/chat/engine/__tests__/parsers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   coerceJsonObject,
   configFilters,
+  describeCron,
   ENGINE_FUNCTION_IDS,
   functionDetailSchema,
   functionInfoRequestSchema,
@@ -478,6 +479,32 @@ describe('engine::register_trigger', () => {
     ).toBeNull()
   })
 
+  it('parses a call-mode react spec (no model/task, a call target)', () => {
+    // The exact live shape that fell through to a raw metadata dump: a
+    // turn-completed binding whose reaction is an fp::pipe dispatch.
+    const react = safeParseRequest(reactSpecSchema, {
+      call: {
+        function_id: 'fp::pipe',
+        payload: {
+          through: [
+            { function: 'database::query', payload: { db: 'sqlite_db' } },
+            { function: 'fp::get', payload: { path: '/rows/0/n' } },
+            { function: 'fp::when', payload: { op: '>=', to: 12 } },
+            { function: 'state::set', into: '/value/batches_done' },
+          ],
+        },
+      },
+    })
+    expect(react?.call?.function_id).toBe('fp::pipe')
+    expect(react?.model).toBeUndefined()
+    // event_into passthrough
+    expect(
+      safeParseRequest(reactSpecSchema, {
+        call: { function_id: 'state::set', event_into: '/value' },
+      })?.call?.event_into,
+    ).toBe('/value')
+  })
+
   it('parses the harness subscribe variant (no function_id, has label/once)', () => {
     const req = safeParseRequest(registerTriggerRequestSchema, {
       trigger_type: 'state',
@@ -561,5 +588,33 @@ describe('unwrapEnvelope re-export', () => {
   it('peels the harness envelope', () => {
     const inner = { functions: [] }
     expect(unwrapEnvelope(wrap(inner))).toEqual(inner)
+  })
+})
+
+describe('describeCron', () => {
+  it('humanizes the common shapes', () => {
+    // the live screenshot shape: seconds-first, one-shot date+time
+    expect(describeCron('0 0 17 21 7 *')).toBe('at 17:00 on Jul 21')
+    expect(describeCron('0 30 9 * * *')).toBe('every day at 09:30')
+    expect(describeCron('30 9 * * *')).toBe('every day at 09:30') // 5-field classic
+    expect(describeCron('0 */5 * * * *')).toBe('every 5 min')
+    expect(describeCron('0 * * * * *')).toBe('every minute')
+    expect(describeCron('* * * * * *')).toBe('every second')
+    expect(describeCron('0 15 * * * *')).toBe('at :15 every hour')
+    expect(describeCron('0 0 */6 * * *')).toBe('every 6h at :00')
+    expect(describeCron('0 0 9 * * 1')).toBe('every Mon at 09:00')
+    expect(describeCron('0 0 9 * * 1,5')).toBe('every Mon, Fri at 09:00')
+    expect(describeCron('0 0 0 1 * *')).toBe('at 00:00 on day 1 of every month')
+    expect(describeCron('0 0 12 * 7 *')).toBe('at 12:00 in Jul')
+  })
+
+  it('falls back to null on shapes a translation would get wrong', () => {
+    expect(describeCron('0 0 17 21 7 1')).toBeNull() // dom+dow = OR semantics
+    expect(describeCron('0 0-30 9 * * *')).toBeNull() // ranges
+    expect(describeCron('0 0 9 L * *')).toBeNull() // L extension
+    expect(describeCron('0 0 25 * * *')).toBeNull() // hour out of range
+    expect(describeCron('0 0 17 21 7 * 2027')).toBeNull() // pinned year
+    expect(describeCron('nonsense')).toBeNull()
+    expect(describeCron('')).toBeNull()
   })
 })

--- a/console/web/src/components/chat/engine/parsers.ts
+++ b/console/web/src/components/chat/engine/parsers.ts
@@ -337,9 +337,25 @@ export const joinSpecSchema = z.object({
 })
 export type JoinSpec = z.infer<typeof joinSpecSchema>
 
+/** Call-mode reaction target (`harness/src/functions/react.rs` `CallSpec`):
+ * the event dispatches a plain function call instead of spawning a
+ * sub-agent. `event_into` is the JSON pointer where the event lands in the
+ * payload (default `/event`). */
+export const callSpecSchema = z.object({
+  function_id: z.string(),
+  payload: z.unknown().optional(),
+  event_into: z.string().optional(),
+})
+export type CallSpec = z.infer<typeof callSpecSchema>
+
+/** `model`/`task` are optional on the wire: call-mode reactions carry `call`
+ * instead, and agent-mode registrations may omit `model` (inherited from the
+ * registering turn). The VIEW decides the mode: `call` present → call mode;
+ * `task` present → spawn mode; neither → not a react spec at all. */
 export const reactSpecSchema = z.object({
-  model: z.string(),
-  task: z.string(),
+  model: z.string().optional(),
+  task: z.string().optional(),
+  call: callSpecSchema.optional(),
   session_id: z.string().optional(),
   provider: z.string().optional(),
   options: z.unknown().optional(),
@@ -381,6 +397,94 @@ export function configFilters(
     pick('condition_function_id', 'if'),
   ].filter((x): x is { label: string; value: string } => x !== null)
   return chips.length ? chips : null
+}
+
+const MONTHS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+]
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+/**
+ * Humanize the COMMON cron shapes — fixed time, minute steps, single
+ * day-of-month/month, weekday lists — and return `null` for anything
+ * fancier (ranges, multi-field lists, `L`/`#` extensions), where the raw
+ * expression is less misleading than a wrong translation. Accepts 5-field
+ * classic and the 6/7-field seconds-first form the Rust `cron` crate uses
+ * (`"0 0 17 21 7 *"` → "at 17:00 on Jul 21").
+ */
+export function describeCron(expression: string): string | null {
+  const f = expression.trim().split(/\s+/)
+  if (f.length < 5 || f.length > 7) return null
+  const withSeconds = f.length >= 6
+  const [min, hour, dom, mon, dow] = withSeconds ? f.slice(1) : f
+  const sec = withSeconds ? f[0] : '0'
+  const year = f.length === 7 ? f[6] : '*'
+  if (year !== '*') return null
+  if (sec !== '*' && !/^\d+$/.test(sec)) return null
+
+  const num = (s: string, max: number): number | null =>
+    /^\d+$/.test(s) && Number(s) <= max ? Number(s) : null
+  const step = (s: string): number | null => {
+    const m = /^\*\/(\d+)$/.exec(s)
+    return m ? Number(m[1]) : null
+  }
+  const pad = (n: number) => String(n).padStart(2, '0')
+
+  const h = num(hour, 23)
+  const m = num(min, 59)
+  let time: string | null = null
+  let daily = false
+  if (h != null && m != null) {
+    time = `at ${pad(h)}:${pad(m)}`
+    daily = true
+  } else if (hour === '*') {
+    const minStep = step(min)
+    if (minStep != null) time = `every ${minStep} min`
+    else if (min === '*') time = sec === '*' ? 'every second' : 'every minute'
+    else if (m != null) time = `at :${pad(m)} every hour`
+    else return null
+  } else {
+    const hourStep = step(hour)
+    if (hourStep != null && m != null) time = `every ${hourStep}h at :${pad(m)}`
+    else return null
+  }
+
+  const dn = num(dom, 31)
+  const mn = num(mon, 12)
+  if (dom !== '*' && (dn == null || dn < 1)) return null
+  if (mon !== '*' && (mn == null || mn < 1)) return null
+  let date: string | null = null
+  if (dn != null && mn != null) date = `on ${MONTHS[mn - 1]} ${dn}`
+  else if (dn != null) date = `on day ${dn} of every month`
+  else if (mn != null) date = `in ${MONTHS[mn - 1]}`
+
+  let week: string | null = null
+  if (dow !== '*' && dow !== '?') {
+    const names = dow.split(',').map((d) => {
+      const n = num(d, 7)
+      return n != null ? WEEKDAYS[n % 7] : null
+    })
+    if (names.some((n) => n == null)) return null
+    week = `every ${names.join(', ')}`
+  }
+
+  // Both a day-of-month AND a weekday restriction is OR semantics in cron —
+  // subtle enough that the raw expression is the honest rendering.
+  if (date && week) return null
+  if (week) return daily ? `${week} ${time}` : `${time} ${week}`
+  if (date) return `${time} ${date}`
+  return daily ? `every day ${time}` : (time as string)
 }
 
 /** Engine returns `{ id }`; the harness-intercepted path returns

--- a/console/web/src/components/chat/engine/parsers.ts
+++ b/console/web/src/components/chat/engine/parsers.ts
@@ -431,10 +431,12 @@ export function describeCron(expression: string): string | null {
   const sec = withSeconds ? f[0] : '0'
   const year = f.length === 7 ? f[6] : '*'
   if (year !== '*') return null
-  if (sec !== '*' && !/^\d+$/.test(sec)) return null
 
   const num = (s: string, max: number): number | null =>
     /^\d+$/.test(s) && Number(s) <= max ? Number(s) : null
+  const secondsWild = sec === '*'
+  const secNum = num(sec, 59)
+  if (!secondsWild && secNum == null) return null
   const step = (s: string): number | null => {
     const m = /^\*\/(\d+)$/.exec(s)
     return m ? Number(m[1]) : null
@@ -459,6 +461,11 @@ export function describeCron(expression: string): string | null {
     if (hourStep != null && m != null) time = `every ${hourStep}h at :${pad(m)}`
     else return null
   }
+  // Every description except "every second" speaks at minute granularity, so
+  // it is only honest when the schedule fires once per matching minute
+  // (seconds pinned to 0). `* 0 17 * * *` fires every second DURING 17:00 —
+  // saying "at 17:00" would hide sixty firings; a nonzero pin drops detail.
+  if (time !== 'every second' && (secondsWild || secNum !== 0)) return null
 
   const dn = num(dom, 31)
   const mn = num(mon, 12)
@@ -473,7 +480,12 @@ export function describeCron(expression: string): string | null {
   if (dow !== '*' && dow !== '?') {
     const names = dow.split(',').map((d) => {
       const n = num(d, 7)
-      return n != null ? WEEKDAYS[n % 7] : null
+      if (n == null) return null
+      // Numeric weekday numbering differs by dialect: the seconds-first form
+      // is the Rust `cron` crate's (Quartz-style, 1=Sun..7=Sat); classic
+      // five-field cron is 0=Sun..6=Sat with 7 also Sunday.
+      if (withSeconds) return n >= 1 ? WEEKDAYS[n - 1] : null
+      return WEEKDAYS[n % 7]
     })
     if (names.some((n) => n == null)) return null
     week = `every ${names.join(', ')}`

--- a/console/web/src/components/chat/fp/PipeView.tsx
+++ b/console/web/src/components/chat/fp/PipeView.tsx
@@ -118,6 +118,20 @@ export function PipeView({ input, output, running }: PipeViewProps) {
             value={`${threaded.toLocaleString()} chars`}
           />
         ) : null}
+        {/* The harness-stamped scope shell/coder steps run under — an
+            approver must see where relative paths anchor, since this view
+            replaces the raw request pane. */}
+        {req.fs_scope?.root ? (
+          <>
+            <FilterChip label="scope" value={req.fs_scope.root} />
+            {req.fs_scope.grants?.length ? (
+              <FilterChip
+                label="grants"
+                value={String(req.fs_scope.grants.length)}
+              />
+            ) : null}
+          </>
+        ) : null}
       </MetaRow>
       <PipeStepList through={req.through} receipts={receipts} />
       {running ? (

--- a/console/web/src/components/chat/fp/PipeView.tsx
+++ b/console/web/src/components/chat/fp/PipeView.tsx
@@ -41,6 +41,53 @@ function StepFunctionLabel({ functionId }: { functionId: string }) {
   )
 }
 
+/** The numbered step route of a pipe — one row per step: function id,
+    optional `into` chip, payload one-liner, and (when receipts exist) the
+    per-step threaded size. Shared between the `fp::pipe` call card and the
+    register-trigger THEN pane (a reaction whose call target is a pipe). */
+export function PipeStepList({
+  through,
+  receipts,
+}: {
+  through: { function: string; payload?: unknown; into?: string | null }[]
+  receipts?: { chars: number }[] | null
+}) {
+  return (
+    <ul className="divide-y divide-rule-2">
+      {through.map((step, i) => {
+        const receipt = receipts?.[i]
+        const payload = compactPayload(step.payload)
+        return (
+          <li
+            key={`${i}-${step.function}`}
+            className="px-3 py-1.5 font-mono text-[12.5px]"
+          >
+            <div className="flex items-center gap-2">
+              <span className="w-4 shrink-0 text-right text-ink-ghost">
+                {i + 1}
+              </span>
+              <span className="min-w-0 truncate">
+                <StepFunctionLabel functionId={step.function} />
+              </span>
+              {step.into ? <FilterChip label="into" value={step.into} /> : null}
+              {receipt?.chars != null ? (
+                <span className="ml-auto shrink-0 text-[11px] text-ink-faint">
+                  → {receipt.chars.toLocaleString()} chars
+                </span>
+              ) : null}
+            </div>
+            {payload ? (
+              <div className="mt-0.5 break-all pl-6 text-[11px] leading-[1.5] text-ink-faint line-clamp-2">
+                {payload}
+              </div>
+            ) : null}
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
 /** `fp::pipe` — the step route with per-step receipt sizes, then the
     final value preview. The threaded values themselves never reach the chat
     (that is the point of the pipe), so there is no value pane. */
@@ -72,40 +119,7 @@ export function PipeView({ input, output, running }: PipeViewProps) {
           />
         ) : null}
       </MetaRow>
-      <ul className="divide-y divide-rule-2">
-        {req.through.map((step, i) => {
-          const receipt = receipts?.[i]
-          const payload = compactPayload(step.payload)
-          return (
-            <li
-              key={`${i}-${step.function}`}
-              className="px-3 py-1.5 font-mono text-[12.5px]"
-            >
-              <div className="flex items-center gap-2">
-                <span className="w-4 shrink-0 text-right text-ink-ghost">
-                  {i + 1}
-                </span>
-                <span className="min-w-0 truncate">
-                  <StepFunctionLabel functionId={step.function} />
-                </span>
-                {step.into ? (
-                  <FilterChip label="into" value={step.into} />
-                ) : null}
-                {receipt?.chars != null ? (
-                  <span className="ml-auto shrink-0 text-[11px] text-ink-faint">
-                    → {receipt.chars.toLocaleString()} chars
-                  </span>
-                ) : null}
-              </div>
-              {payload ? (
-                <div className="mt-0.5 break-all pl-6 text-[11px] leading-[1.5] text-ink-faint line-clamp-2">
-                  {payload}
-                </div>
-              ) : null}
-            </li>
-          )
-        })}
-      </ul>
+      <PipeStepList through={req.through} receipts={receipts} />
       {running ? (
         <div className="px-3 py-3 font-mono text-[12.5px] text-ink-ghost animate-pulse">
           · piping…

--- a/console/web/src/components/chat/fp/parsers.ts
+++ b/console/web/src/components/chat/fp/parsers.ts
@@ -68,9 +68,21 @@ export const pipeStepSchema = z.object({
 })
 export type PipeStep = z.infer<typeof pipeStepSchema>
 
+/** The harness-stamped trusted filesystem scope riding on a pipe call
+    (harness/src/filesystem_scope.rs). Rendered so an approver reviewing
+    relative shell/coder steps can see where they will run — the pipe call
+    is the approval surface. */
+export const pipeFsScopeSchema = z.object({
+  root: z.string().nullish(),
+  grants: z.array(z.string()).nullish(),
+  boundary: z.string().nullish(),
+})
+export type PipeFsScope = z.infer<typeof pipeFsScopeSchema>
+
 export const pipeRequestSchema = z.object({
   through: z.array(pipeStepSchema).nullish(),
   preview_chars: z.number().nullish(),
+  fs_scope: pipeFsScopeSchema.nullish(),
 })
 export type PipeRequest = z.infer<typeof pipeRequestSchema>
 

--- a/console/web/src/stories/fixtures/engine-fixtures.ts
+++ b/console/web/src/stories/fixtures/engine-fixtures.ts
@@ -595,6 +595,49 @@ export const engineRegisterTriggerCron = base(
   wrapHarness({ id: 'trg-cron-01' }),
 )
 
+/** Call-mode reaction: the event dispatches an fp::pipe instead of spawning
+ * a sub-agent — the THEN pane renders the pipeline's step route. Mirrors a
+ * live turn-completed → count-check → state::set binding. */
+export const engineRegisterTriggerCallPipe = base(
+  'engine-register-trigger-call-pipe',
+  'engine::register_trigger',
+  {
+    trigger_type: 'harness::turn-completed',
+    function_id: 'harness::react',
+    config: {
+      parent_session_id: 'console-b048edc6-3a09-41f7-884e-fec9ba1b17e2',
+    },
+    metadata: {
+      call: {
+        function_id: 'fp::pipe',
+        payload: {
+          through: [
+            {
+              function: 'database::query',
+              payload: {
+                db: 'sqlite_db',
+                sql: "SELECT COUNT(*) AS n FROM scan_progress WHERE scan_run = 'sec-m8k4' AND status IN ('done','failed')",
+              },
+            },
+            { function: 'fp::get', payload: { path: '/rows/0/n' } },
+            { function: 'fp::when', payload: { op: '>=', to: 12 } },
+            {
+              function: 'state::set',
+              into: '/value/batches_done',
+              payload: {
+                key: 'turn_complete',
+                scope: 'run-sec-m8k4',
+                value: { done: true, run_id: 'sec-m8k4' },
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+  wrapHarness({ id: 'sub_2a77e6f39bad' }),
+)
+
 export const engineRegisterTriggerSubscribe = base(
   'engine-register-trigger-subscribe',
   'engine::register_trigger',
@@ -644,6 +687,7 @@ export const engineFixtures = [
   engineWorkerRegisterRunning,
   engineRegisterTriggerReact,
   engineRegisterTriggerCron,
+  engineRegisterTriggerCallPipe,
   engineRegisterTriggerSubscribe,
   engineRegisterTriggerRunning,
   engineRunning,

--- a/fp/README.md
+++ b/fp/README.md
@@ -95,8 +95,15 @@ fp::pipe { through: [
   surface (an approver sees the full step list). For that reason the pipe is
   not agent-callable without approval by default; the pure transforms are.
   See `iii-permissions.yaml`.
-- Statically refused as steps: `shell::*`/`coder::*` (need the harness
-  fs_scope stamp), `engine::register_trigger`/`engine::unregister_trigger`
+- `shell::*`/`coder::*` steps run under the harness-forwarded filesystem
+  scope: the harness stamps the trusted `fs_scope` onto the `fp::pipe` call
+  itself (`harness/src/filesystem_scope.rs`) and fp re-stamps it onto each
+  scoped step as the last write before dispatch, overwriting anything
+  authored or threaded at `/fs_scope`. Without a stamp (no session working
+  directory, or a non-harness caller — cron, worker-to-worker) scoped steps
+  are refused, fail-closed. A path-access rejection inside a pipe just fails
+  the step; only a direct call offers the access-grant ladder.
+- Statically refused as steps: `engine::register_trigger`/`engine::unregister_trigger`
   (need the harness trusted-session stamp), nested pipes, and every class the
   agent policy hard-denies — `session::*`/`approval::*`,
   `configuration::*`/`oauth::*` (credentials), `router::*`/`provider::*`

--- a/fp/iii-permissions.yaml
+++ b/fp/iii-permissions.yaml
@@ -5,8 +5,10 @@
 # agent to call without approval. `fp::pipe` is deliberately NOT listed:
 # its steps run with this worker's (worker-to-worker) authority, outside the
 # calling agent's per-step dispatch policy, so it stays at the needs_approval
-# default — an approver sees the full step list in the pipe call. Flip it to
-# allow here if your deployment wants agents to pipe freely.
+# default — an approver sees the full step list in the pipe call (including
+# the harness-stamped filesystem scope for shell::*/coder::* steps). Flip it
+# to allow here if your deployment wants agents to pipe freely — knowing that
+# also grants un-approved shell::*/coder::* execution via pipe steps.
 #
 # NOTE: the policy the checked-in harness actually loads is the repo-root
 # iii-permissions.yaml (harness/iii-permissions.yaml symlinks to it), which

--- a/fp/src/guidance.rs
+++ b/fp/src/guidance.rs
@@ -48,6 +48,12 @@ in the next step's payload at `into` (default "/value"). Pure transforms run inl
 getOr, flatten, sortBy, reverse, when}` with lodash
 semantics — their input arrives at `value`, and what they thread onward is the transformed
 value itself (the `{value}` wrapper appears only on direct calls, never between steps).
+Transform args beyond `value` (no schema lookup needed): get{path} getOr{path,default}
+pick/omit{paths} take/drop{n} nth{n, -1=last} map{path} filter{matches: partial object}
+split/join{separator} sortBy{path} when{path?,op,to?} — the rest take only `value`.
+Producer responses are OBJECTS (search: {content_matches,path_matches}, grep: {matches},
+exec: {stdout,…}, fetch: {content,…}) — `fp::get` the array/string field out before
+reshaping it.
 Producer steps too: `state::get` in a pipe hands the stored value onward BARE — never follow
 it with `fp::get { path: "/value" }`; state::get's response IS the stored value (the `{value}`
 wrapper is the transforms' direct-call shape, never a producer's).
@@ -76,7 +82,12 @@ fails cheaply, naming the keys that WERE available). Plan ONE pipe per outcome: 
 fields in the final step's payload plus `into` compose the stored shape in place — ending in
 { function: "state::set", payload: { scope, key, value: { url } }, into: "/value/content" }
 stores { url, content } in one step; don't store, inspect, re-store.
-`shell::*`/`coder::*`, trigger-control, session/approval, credential/config, LLM-routing, and
+`shell::*`/`coder::*` steps work in a pipe and run under the session's filesystem scope —
+the pattern for bulk code results: `coder::search` → `fp::get {path:"/content_matches"}` →
+`fp::map {path:"/path"}` → `fp::uniq` → `state::set`, one call, nothing through the chat.
+Caveat: a path-access rejection inside a pipe just fails
+the step — only a DIRECT call offers the access-grant prompt.
+Trigger-control, session/approval, credential/config, LLM-routing, and
 turn-control steps are excluded — call those directly."#;
 
 /// The slice of the `pre_generate` hook envelope we read (lenient: ignores
@@ -256,7 +267,11 @@ mod tests {
             "engine::functions::info",
             "ONE pipe per outcome",
             "into: \"/value/content\"",
-            "`shell::*`/`coder::*`",
+            "`shell::*`/`coder::*` steps work in a pipe",
+            "only a DIRECT call offers the access-grant prompt",
+            "no schema lookup needed",
+            "Producer responses are OBJECTS",
+            "fp::get {path:\"/content_matches\"}",
         ] {
             assert!(GUIDANCE.contains(needle), "missing: {needle}");
         }

--- a/fp/src/pipe.rs
+++ b/fp/src/pipe.rs
@@ -141,6 +141,16 @@ fn is_scoped_step(function_id: &str) -> bool {
 /// exposes fp::pipe while denying shell::* could launder a scope through a
 /// non-harness call; shell-side caller verification is tracked follow-up.
 fn forbidden_step(function_id: &str) -> Option<&'static str> {
+    // Shell control-plane ids sit inside the scoped shell::* prefix but are
+    // NOT session tools: config-status is agent-policy hard-denied (it can
+    // surface operator paths) and workspace::* is console picker plumbing —
+    // both ignore fs_scope, so the stamp gate below would admit them.
+    if function_id == "shell::config-status" || function_id.starts_with("shell::workspace::") {
+        return Some(
+            "shell control-plane functions are not supported in a pipe — steps run with \
+             worker authority, which would bypass the agent-level deny on them",
+        );
+    }
     if function_id == PIPE_ID {
         return Some(
             "pipes do not nest — to start from a literal value, seed the FIRST transform \
@@ -304,7 +314,11 @@ fn inject(payload: Value, pointer: &str, value: Value) -> Result<Value, String> 
 /// on a scoped step (full key replace: subkeys can't survive either).
 /// Non-scoped steps pass through untouched — the scope must not leak to
 /// arbitrary workers.
-fn bus_step_args(function_id: &str, args: Value, fs_scope: Option<&Value>) -> Result<Value, String> {
+fn bus_step_args(
+    function_id: &str,
+    args: Value,
+    fs_scope: Option<&Value>,
+) -> Result<Value, String> {
     if !is_scoped_step(function_id) {
         return Ok(args);
     }
@@ -560,6 +574,8 @@ mod tests {
         // reason — mirroring every agent-policy hard-denied class
         // (iii-permissions.yaml), state::* excepted on purpose
         for (function, needle) in [
+            ("shell::config-status", "control-plane"),
+            ("shell::workspace::roots", "control-plane"),
             ("fp::pipe", "nest"),
             ("engine::register_trigger", "trigger control"),
             ("session::append", "worker"),
@@ -688,7 +704,10 @@ mod tests {
             bus_step_args("state::set", args.clone(), Some(&trusted)).unwrap(),
             args
         );
-        assert_eq!(bus_step_args("state::set", args.clone(), None).unwrap(), args);
+        assert_eq!(
+            bus_step_args("state::set", args.clone(), None).unwrap(),
+            args
+        );
 
         // predicate mirror spot-checks (harness is_scoped_function parity)
         assert!(is_scoped_step("shell::exec"));

--- a/fp/src/pipe.rs
+++ b/fp/src/pipe.rs
@@ -36,12 +36,15 @@ pub const PIPE_DESC: &str =
      {function:'fp::get', payload:{path:'/content'}}, \
      {function:'fp::take', payload:{n:20000}}, \
      {function:'state::set', payload:{scope,key}}]. Returns per-step sizes and a preview, not \
-     the value.";
+     the value. shell::*/coder::* steps run under the session's harness-stamped filesystem \
+     scope; without one (no working directory, or a non-harness caller) they are refused — \
+     call them directly instead.";
 
-/// ponytail: v1 ceilings — no shell/coder steps (they need the harness
-/// fs_scope stamp), no nested pipes, no trigger-control or session/approval
-/// steps, and a held (approval) release re-runs steps from scratch is
-/// unsupported: the pipe call itself is what approvers review.
+/// ponytail: remaining ceilings — no nested pipes, no trigger-control or
+/// session/approval steps, 120s per bus step, and a held (approval) release
+/// re-runs steps from scratch is unsupported: the pipe call itself is what
+/// approvers review. shell::*/coder::* steps ride the harness-forwarded
+/// fs_scope stamp (see `bus_step_args`) and are refused without one.
 const MAX_STEPS: usize = 12;
 const DEFAULT_PREVIEW_CHARS: usize = 400;
 /// Hard cap on `preview_chars`: the receipt is a glimpse (or a slice to
@@ -68,6 +71,14 @@ pub struct PipeRequest {
     /// 8000).
     #[serde(default)]
     pub preview_chars: Option<u32>,
+    // Trusted filesystem scope stamped by the harness onto the pipe call
+    // (harness/src/filesystem_scope.rs); forwarded opaquely onto each scoped
+    // step by `bus_step_args`. Never model-supplied: the harness overwrites or
+    // strips it before dispatch. (`//` on purpose — a `///` doc comment would
+    // publish this plumbing field in the fp::pipe schema.)
+    #[serde(default)]
+    #[schemars(skip)]
+    pub fs_scope: Option<Value>,
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -109,18 +120,27 @@ pub struct PipeResponse {
     pub short_circuited: bool,
 }
 
+/// Mirror of harness `filesystem_scope::is_scoped_function` — keep
+/// byte-identical, or a function the harness stamps but fp doesn't (or vice
+/// versa) becomes a scope gap. `shell::filesystem::*` is the unscoped
+/// control plane on both sides.
+fn is_scoped_step(function_id: &str) -> bool {
+    (function_id.starts_with("shell::") && !function_id.starts_with("shell::filesystem::"))
+        || function_id.starts_with("coder::")
+}
+
 /// Step functions a pipe refuses. Steps run with THIS worker's authority, so
 /// every class the agent policy hard-denies (iii-permissions.yaml) must be
 /// refused here too — an allowlisted or approve-always `fp::pipe` would
 /// otherwise be a standing policy bypass. `state::*` is the deliberate
 /// exception: persisting the threaded value is the pipe's purpose, and the
-/// pipe call itself is the approval surface an approver reviews.
+/// pipe call itself is the approval surface an approver reviews. Note that
+/// the same reasoning makes allowlisting `fp::pipe` grant un-approved
+/// shell::*/coder::* execution (scoped steps, gated in `validate`) — the
+/// pipe must stay needs_approval. Residual, accepted: an rbac boundary that
+/// exposes fp::pipe while denying shell::* could launder a scope through a
+/// non-harness call; shell-side caller verification is tracked follow-up.
 fn forbidden_step(function_id: &str) -> Option<&'static str> {
-    if (function_id.starts_with("shell::") && !function_id.starts_with("shell::filesystem::"))
-        || function_id.starts_with("coder::")
-    {
-        return Some("filesystem-scoped functions (shell::*/coder::*) are not supported in a pipe — call them directly");
-    }
     if function_id == PIPE_ID {
         return Some(
             "pipes do not nest — to start from a literal value, seed the FIRST transform \
@@ -187,6 +207,33 @@ pub fn validate(req: &PipeRequest) -> Result<(), String> {
         if let Some(reason) = forbidden_step(&step.function) {
             return Err(format!("step {} ({}): {reason}", i + 1, step.function));
         }
+        if is_scoped_step(&step.function) {
+            if req.fs_scope.is_none() {
+                return Err(format!(
+                    "step {} ({}): filesystem-scoped steps (shell::*/coder::*) run only under a \
+                     harness-stamped filesystem scope, and this call carries none (no session \
+                     working directory, or a non-harness caller) — call the function directly",
+                    i + 1,
+                    step.function
+                ));
+            }
+            // Loud static refusal beats a silent overwrite by the stamp in
+            // `bus_step_args` — the pointer can only be a mistake or an attack.
+            let first_token = step
+                .into
+                .as_deref()
+                .and_then(|p| p.strip_prefix('/'))
+                .and_then(|p| p.split('/').next())
+                .map(|t| t.replace("~1", "/").replace("~0", "~"));
+            if first_token.as_deref() == Some("fs_scope") {
+                return Err(format!(
+                    "step {} ({}): `into` must not target `fs_scope` — that field is \
+                     harness-stamped, never threaded",
+                    i + 1,
+                    step.function
+                ));
+            }
+        }
     }
     // Fail fast on an unseeded leading transform (live-tested trap: serde's
     // bare "missing field `value`" taught nothing). Only our own transforms
@@ -250,6 +297,26 @@ fn inject(payload: Value, pointer: &str, value: Value) -> Result<Value, String> 
     let map = cursor.as_object_mut().expect("object cursor");
     map.insert(parts[parts.len() - 1].clone(), value);
     Ok(root)
+}
+
+/// Dispatch-ready args for a bus step. The trusted scope stamps LAST — after
+/// `into` threading — so nothing authored or threaded survives at `/fs_scope`
+/// on a scoped step (full key replace: subkeys can't survive either).
+/// Non-scoped steps pass through untouched — the scope must not leak to
+/// arbitrary workers.
+fn bus_step_args(function_id: &str, args: Value, fs_scope: Option<&Value>) -> Result<Value, String> {
+    if !is_scoped_step(function_id) {
+        return Ok(args);
+    }
+    // unreachable after validate(); fail closed anyway
+    let Some(scope) = fs_scope else {
+        return Err("filesystem-scoped step without a harness fs_scope stamp".into());
+    };
+    let Value::Object(mut map) = args else {
+        return Err("a filesystem-scoped step's payload must be an object".into());
+    };
+    map.insert("fs_scope".into(), scope.clone());
+    Ok(Value::Object(map))
 }
 
 /// Requested preview length, clamped to [0, MAX_PREVIEW_CHARS].
@@ -355,15 +422,21 @@ pub async fn run(iii: &IIIClient, req: PipeRequest) -> Result<PipeResponse, Stri
 
         let value = match util::apply(&step.function, &args) {
             Some(result) => result.map_err(|msg| step_error(i, &step.function, &msg, &receipts))?,
-            None => iii
-                .trigger(TriggerRequest {
+            None => {
+                // SECURITY: the stamp must be the LAST write to args before
+                // dispatch — after `into` threading above — or a threaded
+                // value at /fs_scope would reach the shell worker as trusted.
+                let args = bus_step_args(&step.function, args, req.fs_scope.as_ref())
+                    .map_err(|msg| step_error(i, &step.function, &msg, &receipts))?;
+                iii.trigger(TriggerRequest {
                     function_id: step.function.clone(),
                     payload: args,
                     action: None,
                     timeout_ms: Some(STEP_TIMEOUT_MS),
                 })
                 .await
-                .map_err(|e| step_error(i, &step.function, &e.to_string(), &receipts))?,
+                .map_err(|e| step_error(i, &step.function, &e.to_string(), &receipts))?
+            }
         };
 
         receipts.push(StepReceipt {
@@ -483,11 +556,10 @@ mod tests {
         .unwrap_err()
         .contains("pick"));
 
-        // scoped / control / nested / worker-authority steps are refused with
-        // a reason — mirroring every agent-policy hard-denied class
+        // control / nested / worker-authority steps are refused with a
+        // reason — mirroring every agent-policy hard-denied class
         // (iii-permissions.yaml), state::* excepted on purpose
         for (function, needle) in [
-            ("shell::exec", "filesystem-scoped"),
             ("fp::pipe", "nest"),
             ("engine::register_trigger", "trigger control"),
             ("session::append", "worker"),
@@ -520,6 +592,109 @@ mod tests {
 
         let empty = parse(json!({ "through": [] })).unwrap();
         assert!(validate(&empty).is_err());
+    }
+
+    fn scope() -> Value {
+        json!({ "root": "/work/session-7", "grants": [], "boundary": "workspace" })
+    }
+
+    #[test]
+    fn scoped_steps_require_the_harness_stamp() {
+        // no stamp (cron / worker-to-worker / no working directory) → refused,
+        // teachably: names the stamp and points at direct calls
+        for function in ["shell::exec", "coder::search", "shell::fs::grep"] {
+            let req = parse(json!({ "through": [{ "function": function }] })).unwrap();
+            let err = validate(&req).unwrap_err();
+            assert!(err.contains("harness-stamped"), "{function}: {err}");
+            assert!(err.contains("call the function directly"), "{function}");
+        }
+
+        // with the stamp, the motivating pipeline is accepted
+        let req = parse(json!({
+            "fs_scope": scope(),
+            "through": [
+                { "function": "coder::search", "payload": { "query": "TODO" } },
+                { "function": "fp::map", "payload": { "path": "/path" } },
+                { "function": "state::set", "payload": { "scope": "s", "key": "k" } },
+            ],
+        }))
+        .unwrap();
+        assert!(validate(&req).is_ok());
+
+        // the shell::filesystem::* control plane stays unscoped on both sides
+        // (harness is_scoped_function parity) — allowed with no stamp
+        let req = parse(json!({ "through": [
+            { "function": "shell::filesystem::validate", "payload": { "path": "/p" } },
+        ]}))
+        .unwrap();
+        assert!(validate(&req).is_ok());
+
+        // `into` aimed at /fs_scope (or below) is an attack or a mistake —
+        // statically refused, never silently overwritten
+        for into in ["/fs_scope", "/fs_scope/root"] {
+            let req = parse(json!({
+                "fs_scope": scope(),
+                "through": [
+                    { "function": "state::get", "payload": { "scope": "s", "key": "k" } },
+                    { "function": "shell::exec", "into": into,
+                      "payload": { "command": "ls" } },
+                ],
+            }))
+            .unwrap();
+            assert!(validate(&req).unwrap_err().contains("fs_scope"), "{into}");
+        }
+    }
+
+    #[test]
+    fn bus_step_args_stamps_last_and_overwrites_forgeries() {
+        let trusted = scope();
+
+        // scoped step gets the trusted scope
+        let out = bus_step_args("shell::exec", json!({ "command": "ls" }), Some(&trusted)).unwrap();
+        assert_eq!(out, json!({ "command": "ls", "fs_scope": trusted }));
+
+        // a forged literal fs_scope in the authored payload is REPLACED whole
+        let out = bus_step_args(
+            "coder::search",
+            json!({ "query": "q", "fs_scope": { "root": "/", "grants": ["/"] } }),
+            Some(&trusted),
+        )
+        .unwrap();
+        assert_eq!(out, json!({ "query": "q", "fs_scope": trusted }));
+
+        // ordering proof: even a value threaded to /fs_scope by inject() (the
+        // vector validate() also refuses) loses to the stamp, because the
+        // stamp runs after threading
+        let threaded = inject(
+            json!({ "command": "ls" }),
+            "/fs_scope",
+            json!({ "root": "/", "boundary": "configured_roots" }),
+        )
+        .unwrap();
+        let out = bus_step_args("shell::exec", threaded, Some(&trusted)).unwrap();
+        assert_eq!(out, json!({ "command": "ls", "fs_scope": trusted }));
+
+        // fail closed: no stamp, or a non-object payload
+        assert!(bus_step_args("shell::exec", json!({}), None)
+            .unwrap_err()
+            .contains("without a harness fs_scope stamp"));
+        assert!(bus_step_args("shell::exec", json!("ls"), Some(&trusted))
+            .unwrap_err()
+            .contains("must be an object"));
+
+        // non-scoped steps pass through untouched — the scope must not leak
+        let args = json!({ "scope": "s", "key": "k" });
+        assert_eq!(
+            bus_step_args("state::set", args.clone(), Some(&trusted)).unwrap(),
+            args
+        );
+        assert_eq!(bus_step_args("state::set", args.clone(), None).unwrap(), args);
+
+        // predicate mirror spot-checks (harness is_scoped_function parity)
+        assert!(is_scoped_step("shell::exec"));
+        assert!(is_scoped_step("coder::fs::read"));
+        assert!(!is_scoped_step("shell::filesystem::validate"));
+        assert!(!is_scoped_step("state::set"));
     }
 
     #[test]

--- a/fp/src/util.rs
+++ b/fp/src/util.rs
@@ -358,10 +358,7 @@ pub fn pick(value: Value, paths: &[String]) -> Result<Value, String> {
                 .filter_map(|k| map.remove(k).map(|v| (k.clone(), v)))
                 .collect::<Map<String, Value>>(),
         )),
-        other => Err(format!(
-            "pick needs an object value (got {})",
-            kind_of(&other)
-        )),
+        other => Err(needs("pick", "an object value", &other)),
     }
 }
 
@@ -373,10 +370,7 @@ pub fn omit(value: Value, paths: &[String]) -> Result<Value, String> {
             }
             Ok(Value::Object(map))
         }
-        other => Err(format!(
-            "omit needs an object value (got {})",
-            kind_of(&other)
-        )),
+        other => Err(needs("omit", "an object value", &other)),
     }
 }
 
@@ -390,10 +384,7 @@ pub fn take(value: Value, n: usize) -> Result<Value, String> {
             items.truncate(n);
             Ok(Value::Array(items))
         }
-        other => Err(format!(
-            "take needs a string or array value (got {}); use fp::get to select one first",
-            kind_of(&other)
-        )),
+        other => Err(needs("take", "a string or array value", &other)),
     }
 }
 
@@ -404,10 +395,7 @@ pub fn drop(value: Value, n: usize) -> Result<Value, String> {
             None => String::new(),
         })),
         Value::Array(items) => Ok(Value::Array(items.into_iter().skip(n).collect())),
-        other => Err(format!(
-            "drop needs a string or array value (got {}); use fp::get to select one first",
-            kind_of(&other)
-        )),
+        other => Err(needs("drop", "a string or array value", &other)),
     }
 }
 
@@ -448,10 +436,7 @@ pub fn map(value: Value, path: &str) -> Result<Value, String> {
             }
             Ok(Value::Array(plucked))
         }
-        other => Err(format!(
-            "map needs an array value (got {})",
-            kind_of(&other)
-        )),
+        other => Err(needs("map", "an array value", &other)),
     }
 }
 
@@ -463,10 +448,7 @@ pub fn filter(value: Value, matches: &Map<String, Value>) -> Result<Value, Strin
                 .filter(|el| matches.iter().all(|(k, want)| el.get(k) == Some(want)))
                 .collect(),
         )),
-        other => Err(format!(
-            "filter needs an array value (got {})",
-            kind_of(&other)
-        )),
+        other => Err(needs("filter", "an array value", &other)),
     }
 }
 
@@ -480,10 +462,7 @@ pub fn split(value: Value, separator: &str) -> Result<Value, String> {
                 .map(|p| Value::String(p.to_string()))
                 .collect(),
         )),
-        other => Err(format!(
-            "split needs a string value (got {})",
-            kind_of(&other)
-        )),
+        other => Err(needs("split", "a string value", &other)),
     }
 }
 
@@ -499,10 +478,7 @@ pub fn join(value: Value, separator: &str) -> Result<Value, String> {
                 .collect::<Vec<_>>()
                 .join(separator),
         )),
-        other => Err(format!(
-            "join needs an array value (got {})",
-            kind_of(&other)
-        )),
+        other => Err(needs("join", "an array value", &other)),
     }
 }
 
@@ -518,10 +494,7 @@ pub fn uniq(value: Value) -> Result<Value, String> {
                     .collect(),
             ))
         }
-        other => Err(format!(
-            "uniq needs an array value (got {})",
-            kind_of(&other)
-        )),
+        other => Err(needs("uniq", "an array value", &other)),
     }
 }
 
@@ -532,10 +505,7 @@ pub fn size(value: &Value) -> Result<Value, String> {
         Value::Object(m) => Ok(json_len(m.len())),
         // Deviates from lodash (_.size(5) == 0): a 0 for a non-collection
         // would thread garbage into a take/drop downstream.
-        other => Err(format!(
-            "size needs an array, string, or object value (got {})",
-            kind_of(other)
-        )),
+        other => Err(needs("size", "an array, string, or object value", other)),
     }
 }
 
@@ -546,10 +516,7 @@ pub fn compact(value: Value) -> Result<Value, String> {
         Value::Array(items) => Ok(Value::Array(
             items.into_iter().filter(|el| !el.is_null()).collect(),
         )),
-        other => Err(format!(
-            "compact needs an array value (got {})",
-            kind_of(&other)
-        )),
+        other => Err(needs("compact", "an array value", &other)),
     }
 }
 
@@ -570,10 +537,7 @@ pub fn nth(value: Value, n: i64) -> Result<Value, String> {
                 .nth(idx as usize)
                 .expect("index bounds checked"))
         }
-        other => Err(format!(
-            "nth needs an array value (got {})",
-            kind_of(&other)
-        )),
+        other => Err(needs("nth", "an array value", &other)),
     }
 }
 
@@ -592,10 +556,7 @@ pub fn flatten(value: Value) -> Result<Value, String> {
                 })
                 .collect(),
         )),
-        other => Err(format!(
-            "flatten needs an array value (got {})",
-            kind_of(&other)
-        )),
+        other => Err(needs("flatten", "an array value", &other)),
     }
 }
 
@@ -604,10 +565,7 @@ pub fn flatten(value: Value) -> Result<Value, String> {
 // garbage, so it errors naming what it found.
 pub fn sort_by(value: Value, path: &str) -> Result<Value, String> {
     let Value::Array(items) = value else {
-        return Err(format!(
-            "sortBy needs an array value (got {})",
-            kind_of(&value)
-        ));
+        return Err(needs("sortBy", "an array value", &value));
     };
     let mut keyed: Vec<(Value, Value)> = Vec::with_capacity(items.len());
     for (i, el) in items.into_iter().enumerate() {
@@ -659,10 +617,7 @@ pub fn reverse(value: Value) -> Result<Value, String> {
             items.reverse();
             Ok(Value::Array(items))
         }
-        other => Err(format!(
-            "reverse needs an array value (got {})",
-            kind_of(&other)
-        )),
+        other => Err(needs("reverse", "an array value", &other)),
     }
 }
 
@@ -757,6 +712,22 @@ fn top_level_keys(v: &Value) -> String {
     }
 }
 
+/// Type-mismatch error for a transform. For an OBJECT input, name its keys
+/// and the fix — the live trap (hit twice in one session) is piping a
+/// producer's object response (search: {content_matches,…}, grep:
+/// {matches,…}) straight into an array/string transform without selecting
+/// the field first.
+fn needs(name: &str, what: &str, got: &Value) -> String {
+    match got {
+        Value::Object(m) if !m.is_empty() => format!(
+            "{name} needs {what} but got an object with keys: {} — insert a fp::get step \
+             before this one to select the field",
+            top_level_keys(got)
+        ),
+        other => format!("{name} needs {what} (got {})", kind_of(other)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -827,6 +798,25 @@ mod tests {
         // (the live session tried lodash's `/length` on strings)
         let err = map(json!(["apple", "banana"]), "/length").unwrap_err();
         assert!(err.contains("string") && err.contains("computed"));
+    }
+
+    #[test]
+    fn object_input_errors_name_the_keys_and_the_fix() {
+        // The live trap, hit twice in one session: a producer's OBJECT
+        // response (coder::search, shell::fs::grep) piped straight into an
+        // array transform. The error must name the keys and the fp::get fix —
+        // fp::get's miss message is the model for this.
+        let search_shape = json!({ "content_matches": [], "path_matches": [], "truncated": false });
+        let err = map(search_shape.clone(), "/path").unwrap_err();
+        assert!(err.contains("content_matches") && err.contains("fp::get"), "{err}");
+        let err = take(json!({ "matches": [], "truncated": false }), 500).unwrap_err();
+        assert!(err.contains("matches") && err.contains("fp::get"), "{err}");
+        // non-objects keep the plain kind message
+        let err = uniq(json!(5)).unwrap_err();
+        assert!(err.contains("number") && !err.contains("fp::get"), "{err}");
+        // an empty object names no keys — plain kind message, not "keys: "
+        let err = uniq(json!({})).unwrap_err();
+        assert!(err.contains("object") && !err.contains("keys"), "{err}");
     }
 
     #[test]

--- a/fp/src/util.rs
+++ b/fp/src/util.rs
@@ -808,7 +808,10 @@ mod tests {
         // fp::get's miss message is the model for this.
         let search_shape = json!({ "content_matches": [], "path_matches": [], "truncated": false });
         let err = map(search_shape.clone(), "/path").unwrap_err();
-        assert!(err.contains("content_matches") && err.contains("fp::get"), "{err}");
+        assert!(
+            err.contains("content_matches") && err.contains("fp::get"),
+            "{err}"
+        );
         let err = take(json!({ "matches": [], "truncated": false }), 500).unwrap_err();
         assert!(err.contains("matches") && err.contains("fp::get"), "{err}");
         // non-objects keep the plain kind message

--- a/harness/src/filesystem_scope.rs
+++ b/harness/src/filesystem_scope.rs
@@ -12,6 +12,10 @@ use serde_json::{json, Value};
 
 pub const FS_SCOPE_FIELD: &str = "fs_scope";
 pub const FILESYSTEM_ACCESS_WATCH_ID: &str = "approval::filesystem-access-watch";
+/// fp::pipe runs scoped steps under fp's worker authority; the harness stamps
+/// the same trusted scope onto the pipe call and fp forwards it per scoped
+/// step (fp/src/pipe.rs `is_scoped_step` mirrors `is_scoped_function`).
+pub const PIPE_FUNCTION_ID: &str = "fp::pipe";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -36,6 +40,12 @@ fn is_scoped_function(function_id: &str) -> bool {
         || function_id.starts_with("coder::")
 }
 
+/// Functions that receive the trusted stamp: scoped calls themselves, plus
+/// fp::pipe, which carries the stamp on behalf of its scoped steps.
+fn is_stamped_function(function_id: &str) -> bool {
+    is_scoped_function(function_id) || function_id == PIPE_FUNCTION_ID
+}
+
 /// Stamp the trusted filesystem scope onto a scoped call's arguments.
 pub fn inject(
     function_id: &str,
@@ -44,7 +54,7 @@ pub fn inject(
     grants: &[String],
     boundary: FilesystemBoundary,
 ) -> Value {
-    if !is_scoped_function(function_id) {
+    if !is_stamped_function(function_id) {
         return args;
     }
     let Value::Object(mut map) = args else {
@@ -148,6 +158,36 @@ mod tests {
             FilesystemBoundary::ConfiguredRoots,
         );
         assert_eq!(out, json!({ "command": "ls" }));
+    }
+
+    #[test]
+    fn stamps_fs_scope_onto_pipe_calls_beside_through() {
+        let out = inject(
+            "fp::pipe",
+            json!({ "through": [{ "function": "coder::search", "payload": { "query": "q" } }] }),
+            Some("/work/session-7"),
+            &[],
+            workspace(),
+        );
+        assert_eq!(
+            out,
+            json!({
+                "through": [{ "function": "coder::search", "payload": { "query": "q" } }],
+                "fs_scope": { "root": "/work/session-7", "grants": [], "boundary": "workspace" }
+            })
+        );
+    }
+
+    #[test]
+    fn strips_forged_pipe_fs_scope_when_root_absent() {
+        let out = inject(
+            "fp::pipe",
+            json!({ "through": [], "fs_scope": { "root": "/etc", "grants": ["/model"] } }),
+            None,
+            &[],
+            FilesystemBoundary::ConfiguredRoots,
+        );
+        assert_eq!(out, json!({ "through": [] }));
     }
 
     #[test]

--- a/harness/src/functions/react.rs
+++ b/harness/src/functions/react.rs
@@ -894,6 +894,20 @@ async fn dispatch_call(
             )));
         }
     };
+    // SECURITY: a reaction's call payload is model-authored at registration
+    // time and dispatches OUTSIDE the turn loop, so it never passes the
+    // trusted fs_scope stamp path. Strip any authored scope from stamped
+    // targets (shell::*/coder::*/fp::pipe) — root=None is the fail-closed
+    // strip — AFTER event injection, so a scope threaded via `event_into`
+    // cannot survive either. Scoped calls from reactions are therefore
+    // refused downstream until a trusted per-reaction scope source exists.
+    let payload = crate::filesystem_scope::inject(
+        &call.function_id,
+        payload,
+        None,
+        &[],
+        crate::filesystem_scope::FilesystemBoundary::ConfiguredRoots,
+    );
     match deps
         .iii
         .trigger(TriggerRequest {
@@ -1598,6 +1612,44 @@ mod tests {
                 .unwrap_err()
                 .contains("must name the function")
         );
+    }
+
+    #[test]
+    fn call_dispatch_strips_an_authored_fs_scope_from_stamped_targets() {
+        // The dispatch_call composition: a model-authored scope in the call
+        // payload — literal, or threaded to /fs_scope via event_into — must
+        // not survive to a stamped target (the reaction path never runs the
+        // turn loop's trusted stamp, so anything left here would arrive at
+        // shell/fp as trusted).
+        let forged = json!({ "root": "/", "grants": ["/"], "boundary": "configured_roots" });
+        let authored = json!({ "path": "/etc/hosts", "fs_scope": forged });
+        let threaded = inject_at(authored, "/fs_scope", json!({ "root": "/" })).unwrap();
+        let out = crate::filesystem_scope::inject(
+            "shell::fs::read",
+            threaded,
+            None,
+            &[],
+            crate::filesystem_scope::FilesystemBoundary::ConfiguredRoots,
+        );
+        assert_eq!(out, json!({ "path": "/etc/hosts" }));
+        // fp::pipe is a stamped target too; non-stamped targets pass through.
+        let out = crate::filesystem_scope::inject(
+            "fp::pipe",
+            json!({ "through": [], "fs_scope": { "root": "/" } }),
+            None,
+            &[],
+            crate::filesystem_scope::FilesystemBoundary::ConfiguredRoots,
+        );
+        assert_eq!(out, json!({ "through": [] }));
+        let unscoped = json!({ "scope": "s", "key": "k", "fs_scope": { "root": "/" } });
+        let out = crate::filesystem_scope::inject(
+            "state::set",
+            unscoped.clone(),
+            None,
+            &[],
+            crate::filesystem_scope::FilesystemBoundary::ConfiguredRoots,
+        );
+        assert_eq!(out, unscoped);
     }
 
     #[test]

--- a/harness/src/hooks/mod.rs
+++ b/harness/src/hooks/mod.rs
@@ -257,6 +257,16 @@ impl HookRegistry {
         &self,
         target_function_id: &str,
     ) -> crate::filesystem_scope::FilesystemBoundary {
+        // fp::pipe is stamped on behalf of its scoped steps: give it the
+        // boundary a direct scoped call would get, or a pipe step would run
+        // under a WIDER jail than the same call made directly. shell::exec
+        // represents the watch's fixed shell::*/coder::* binding set.
+        let target_function_id = if target_function_id == crate::filesystem_scope::PIPE_FUNCTION_ID
+        {
+            "shell::exec"
+        } else {
+            target_function_id
+        };
         if self.post_trigger.has_function_binding(
             crate::filesystem_scope::FILESYSTEM_ACCESS_WATCH_ID,
             target_function_id,
@@ -335,6 +345,50 @@ mod tests {
             crate::filesystem_scope::FILESYSTEM_ACCESS_WATCH_ID,
             "shell::fs::ls"
         ));
+    }
+
+    #[test]
+    fn pipe_boundary_matches_a_direct_scoped_call() {
+        let registry = HookRegistry {
+            iii: Arc::new(IIIClient::new("ws://127.0.0.1:0")),
+            pre_turn: HookSet::default(),
+            pre_generate: HookSet::default(),
+            post_generate: HookSet::default(),
+            pre_trigger: HookSet::default(),
+            post_trigger: HookSet::default(),
+        };
+        use crate::filesystem_scope::FilesystemBoundary;
+        // no access watch bound: both direct scoped calls and the pipe run at
+        // the default boundary
+        assert_eq!(
+            registry.filesystem_boundary("fp::pipe"),
+            FilesystemBoundary::ConfiguredRoots
+        );
+        registry
+            .post_trigger
+            .add(
+                HookPoint::PostTrigger,
+                cfg(
+                    "access-watch",
+                    crate::filesystem_scope::FILESYSTEM_ACCESS_WATCH_ID,
+                    json!({ "functions": ["shell::*", "coder::*"] }),
+                ),
+            )
+            .unwrap();
+        // watch bound to shell::*/coder::* only — the pipe must still pick up
+        // Workspace, or its steps would run under a wider jail than direct calls
+        assert_eq!(
+            registry.filesystem_boundary("shell::exec"),
+            FilesystemBoundary::Workspace
+        );
+        assert_eq!(
+            registry.filesystem_boundary("fp::pipe"),
+            FilesystemBoundary::Workspace
+        );
+        assert_eq!(
+            registry.filesystem_boundary("web::fetch"),
+            FilesystemBoundary::ConfiguredRoots
+        );
     }
 
     #[test]

--- a/iii-permissions.yaml
+++ b/iii-permissions.yaml
@@ -203,7 +203,9 @@ rules:
   # I/O, no authority). fp::pipe stays at the needs_approval default ON
   # PURPOSE: its steps run with the fp worker's authority, so the pipe
   # call itself is the surface an approver reviews (the worker statically
-  # refuses hard-denied classes as steps; see fp/src/pipe.rs).
+  # refuses hard-denied classes as steps; see fp/src/pipe.rs). Allowlisting
+  # fp::pipe would also grant un-approved shell::*/coder::* execution: scoped
+  # steps ride the harness-stamped filesystem scope on the pipe call.
   - fp::get
   - fp::pick
   - fp::omit

--- a/provider-anthropic/Cargo.lock
+++ b/provider-anthropic/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-kimi/Cargo.lock
+++ b/provider-kimi/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-llamacpp/Cargo.lock
+++ b/provider-llamacpp/Cargo.lock
@@ -738,7 +738,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openai-codex/Cargo.lock
+++ b/provider-openai-codex/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.3.0"
+version = "1.3.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openai-codex/Cargo.lock
+++ b/provider-openai-codex/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openai/Cargo.lock
+++ b/provider-openai/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-xai/Cargo.lock
+++ b/provider-xai/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-zai/Cargo.lock
+++ b/provider-zai/Cargo.lock
@@ -776,7 +776,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.2.0"
+version = "1.3.2"
 dependencies = [
  "async-trait",
  "clap",


### PR DESCRIPTION
## What

Lets `shell::*`/`coder::*` run as `fp::pipe` steps under the session's trusted filesystem scope — closing the biggest token sink the pipe could not cover (`coder::search → fp::get → fp::map → state::set` with the results never entering the chat) — plus the console rendering to make cron and pipe-reaction bindings legible.

## How

**Scope forwarding (fail-closed at every hop)**
- harness stamps the same trusted `fs_scope` it puts on direct shell/coder calls onto `fp::pipe` call args (`is_stamped_function`); all six `inject()` sites ride the one guard change, including approval release. `filesystem_boundary()` probes `fp::pipe` as a representative scoped call so pipe steps get the same jail as direct calls.
- fp forwards the stamp per scoped step as the **last write before dispatch** (`bus_step_args`, after `into` threading, full key replace) — neither an authored `payload.fs_scope` nor a value threaded to `/fs_scope` survives. No stamp (cron, worker-to-worker, no working directory) → scoped steps refused with a teachable error. `into` pointers targeting `/fs_scope` are statically refused.
- `harness::react` call dispatch strips authored scopes from stamped targets (a registered reaction dispatches outside the turn loop; the direct-shell variant of that hole pre-dated this branch).
- Shell control-plane ids inside the scoped prefix (`shell::config-status`, `shell::workspace::*`) stay statically forbidden as steps.

**fp usability (from live-session evidence)**
- Object-input transform errors name the object's keys and the `fp::get` fix — the top live failure was piping a producer's object response straight into an array transform.
- Injected guidance: recipe now includes the select step, carries transform arg signatures (kills ~30k-token `engine::functions::info` dumps), and names producer response shapes.

**Console**
- Cron bindings: WHEN pane reads "at 17:00 on Jul 21" beside the expression chip; `describeCron` covers common shapes and returns null (raw expression) for anything a translation would get wrong — ranges, `L`/`#`, dom+dow OR semantics, wild/nonzero seconds, and dialect-correct weekday ordinals (Rust cron crate is Quartz-style 1=Sun, verified against `cron-0.12.1`).
- Call-mode reactions (`metadata.call` → `fp::pipe`): THEN pane names the real target and renders the pipeline step route (`PipeStepList`, shared with the fp::pipe chat card). `PipeView` surfaces the stamped scope so approvers see where relative steps anchor.

## Security posture

The pipe call remains the single `needs_approval` surface; the approver sees `through[]` plus the harness-stamped scope (stamped before hooks). Permissions comments now state that allowlisting `fp::pipe` grants un-approved shell/coder execution. Documented residual: a direct bus caller can still hand-craft a scope — but such a caller can already call shell directly; shell-side caller verification is tracked follow-up.

## Verified

- `cargo test` + clippy + fmt clean: harness (245), fp (34); console web: 1052 tests, typecheck clean.
- Live end-to-end: `coder::search → fp::map → fp::uniq → state::set` (3225ch → 360ch stored, receipt only), `shell::exec → fp::get /stdout → fp::split → fp::when → state::set` anchored in the session root, forged payload scopes overwritten, `into:"/fs_scope"` statically refused, unstamped callers fail closed.
- Rollout-order safe: either half shipping alone keeps scoped steps refused.