### PR TITLE
(MOT-4164) iii-directory: pre-generate hook injecting a compact skills index

### DIFF
--- a/iii-directory/src/config.rs
+++ b/iii-directory/src/config.rs
@@ -61,6 +61,10 @@ fn default_auto_download() -> bool {
     true
 }
 
+fn default_inject_index() -> bool {
+    false
+}
+
 #[derive(Deserialize, Serialize, Debug, Clone, JsonSchema)]
 pub struct SkillsConfig {
     /// Folder that backs every read (`directory::skills::list`,
@@ -113,6 +117,14 @@ pub struct SkillsConfig {
     /// folder.
     #[serde(default = "default_auto_download")]
     pub auto_download: bool,
+
+    /// When `true`, a `harness::hook::pre-generate` binding appends a compact
+    /// per-worker skills index to the agent system prompt on every
+    /// generation, so agents discover installed skill docs without a
+    /// discovery call. Off by default; toggling it takes effect without a
+    /// restart.
+    #[serde(default = "default_inject_index")]
+    pub inject_index: bool,
 }
 
 impl Default for SkillsConfig {
@@ -125,6 +137,7 @@ impl Default for SkillsConfig {
             registry_cache_ttl_ms: default_registry_cache_ttl_ms(),
             filter_unregistered: default_filter_unregistered(),
             auto_download: default_auto_download(),
+            inject_index: default_inject_index(),
         }
     }
 }

--- a/iii-directory/src/functions/skills.rs
+++ b/iii-directory/src/functions/skills.rs
@@ -367,6 +367,27 @@ fn parse_worker_names(val: &serde_json::Value) -> HashSet<String> {
 /// namespace segment matches a registered (installed) worker name are
 /// returned. On daemon-down or first-boot-no-cache, falls back to
 /// the unfiltered set.
+/// Build the canonical skills-index markdown plus its worker-overview
+/// count. Shared by the directory::skills::index handler and the
+/// pre-generate injection hook (crate::inject_index) so the index has
+/// exactly one semantics: same overview classification, same title and
+/// teaser resolution, same never-drop-a-worker budget policy.
+pub(crate) async fn build_index(
+    cfg: &SkillsConfig,
+    cache: &RegisteredWorkersCache,
+    iii: &IIIClient,
+    fresh: bool,
+) -> (String, usize) {
+    let entries = resolve_visible_skills(cfg, cache, iii, fresh).await;
+    let siblings = id_set(&entries);
+    let rows: Vec<SkillEntry> = entries
+        .into_iter()
+        .map(|fs| skill_entry_from_fs(fs, &siblings))
+        .collect();
+    let workers_count = rows.iter().filter(|e| is_index_overview(e)).count();
+    (render_index_markdown(&rows), workers_count)
+}
+
 pub async fn resolve_visible_skills(
     cfg: &SkillsConfig,
     cache: &RegisteredWorkersCache,
@@ -598,14 +619,7 @@ fn register_index_skills(
             let iii = iii_inner.clone();
             let cache = cache_inner.clone();
             async move {
-                let entries = resolve_visible_skills(&cfg, &cache, &iii, true).await;
-                let siblings = id_set(&entries);
-                let rows: Vec<SkillEntry> = entries
-                    .into_iter()
-                    .map(|fs| skill_entry_from_fs(fs, &siblings))
-                    .collect();
-                let body = render_index_markdown(&rows);
-                let workers_count = rows.iter().filter(|e| is_index_overview(e)).count();
+                let (body, workers_count) = build_index(&cfg, &cache, &iii, true).await;
                 Ok::<_, Error>(IndexSkillsOutput {
                     body,
                     workers_count,

--- a/iii-directory/src/inject_index.rs
+++ b/iii-directory/src/inject_index.rs
@@ -77,25 +77,37 @@ pub struct PreGenerateMutations {
     pub system_prompt: Option<String>,
 }
 
-/// One index row: worker overview id and its teaser text.
+/// One index row: worker name and its teaser text.
 type Entry = (String, String);
 
-/// Scan the merged skill folders and keep one row per worker overview: a
-/// single-segment skill id whose file parses. Teaser precedence matches the
-/// list surface: frontmatter `description`, else empty.
+/// The scanner aliases `<worker>/SKILL.md` to the on-disk id `<worker>/index`
+/// (`rel_to_id`); that row is the worker's overview. Deeper docs carry more
+/// segments and are skipped here — the overview links them.
+fn overview_worker(id: &str) -> Option<&str> {
+    let mut parts = id.split('/');
+    match (parts.next(), parts.next(), parts.next()) {
+        (Some(worker), Some("index"), None) if !worker.is_empty() => Some(worker),
+        _ => None,
+    }
+}
+
+/// Scan the merged skill folders and keep one row per worker overview.
+/// Teaser precedence matches the list surface: frontmatter `description`,
+/// else empty.
 fn collect_entries(cfg: &crate::config::SkillsConfig) -> Vec<Entry> {
     let (skills, _skips) =
         fs_source::scan_skills_merged(&cfg.resolved_skills_folder(), &cfg.local_skills_folder());
     let mut entries: Vec<Entry> = skills
         .iter()
-        .filter(|s| !s.id.contains('/'))
         .filter_map(|s| {
+            let worker = overview_worker(&s.id)?;
             let (fm, _body) = fs_source::read_skill_with_frontmatter(&s.abs_path).ok()?;
             let teaser = fm.description.unwrap_or_default();
-            Some((s.id.clone(), teaser))
+            Some((worker.to_string(), teaser))
         })
         .collect();
     entries.sort();
+    entries.dedup_by(|a, b| a.0 == b.0);
     entries
 }
 
@@ -216,6 +228,15 @@ mod tests {
             .iter()
             .map(|(a, b)| (a.to_string(), b.to_string()))
             .collect()
+    }
+
+    #[test]
+    fn overview_worker_matches_only_the_aliased_skill_md_row() {
+        assert_eq!(overview_worker("harness/index"), Some("harness"));
+        assert_eq!(overview_worker("harness/orchestration"), None);
+        assert_eq!(overview_worker("resend/emails/index"), None);
+        assert_eq!(overview_worker("harness"), None);
+        assert_eq!(overview_worker("/index"), None);
     }
 
     #[test]

--- a/iii-directory/src/inject_index.rs
+++ b/iii-directory/src/inject_index.rs
@@ -1,17 +1,21 @@
-//! `iii-directory::inject-skills-index` — a `pre_generate` hook that appends a
-//! compact per-worker skills index to the agent's system prompt, ONLY while
-//! this worker is connected and `inject_index` is enabled in config. Mirrors
+//! `iii-directory::inject-skills-index` — a `pre_generate` hook that appends
+//! the canonical skills index to the agent's system prompt, ONLY while this
+//! worker is connected and `inject_index` is enabled in config. Mirrors
 //! `fp::inject-guidance` (fp/src/guidance.rs): the binding is requested at
 //! worker startup; the engine parks it as a pending intent until the harness
 //! registers the `harness::hook::pre-generate` trigger type (recoverable
 //! triggers), which also covers a harness restart. Bound `fail_open` so an
 //! error or timeout here can never block a turn.
 //!
-//! The index is built from the on-disk skill set (`scan_skills_merged`), one
-//! line per worker overview (single-segment skill id), teaser from the
-//! frontmatter `description`. Engine-side install filtering is deliberately
-//! skipped: the hook runs in the generation critical path, so it reads disk
-//! through a short-lived cache and never calls back into the engine.
+//! The injected text IS `directory::skills::index` — built by the same
+//! `skills::build_index` the function handler uses, so overview
+//! classification, teaser resolution, and the never-drop-a-worker budget
+//! policy cannot drift between the two surfaces. The hook wraps it in a
+//! short TTL cache and rebuilds OUTSIDE the cache lock, so concurrent
+//! generations are never serialized behind a rebuild; the worker-list
+//! filter runs through the stale-tolerant `RegisteredWorkersCache`
+//! (`fresh: false`), so a rebuild touches the engine at most once per its
+//! TTL.
 
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -25,26 +29,20 @@ use iii_sdk::protocol::RegisterTriggerInput;
 use iii_sdk::{IIIClient, RegisterFunction};
 
 use crate::config::SharedConfig;
-use crate::fs_source;
+use crate::functions::skills::{self, RegisteredWorkersCache};
 
 pub const INDEX_HOOK_ID: &str = "iii-directory::inject-skills-index";
 pub const INDEX_HOOK_DESC: &str =
-    "Internal pre_generate hook: appends a compact installed-skills index to the agent \
-     system prompt when `inject_index` is enabled. Bound to harness::hook::pre-generate \
-     at worker startup; not called directly.";
+    "Internal pre_generate hook: appends the directory::skills::index markdown to the agent \
+     system prompt when `inject_index` is enabled. Bound to harness::hook::pre-generate at \
+     worker startup; not called directly.";
 
 /// The harness-PROVIDED trigger type this worker binds to (NOT an engine
 /// built-in).
 const PRE_GENERATE_TRIGGER_TYPE: &str = "harness::hook::pre-generate";
 
-/// Rebuild the index from disk at most this often.
+/// Rebuild the index at most this often.
 const CACHE_TTL: Duration = Duration::from_secs(10);
-
-/// Keep the injected section token-light: teasers are clipped per line and
-/// the whole section is capped, pointing at `directory::skills::list` for the
-/// rest.
-const TEASER_MAX_CHARS: usize = 140;
-const INDEX_MAX_CHARS: usize = 2500;
 
 /// The slice of the `pre_generate` hook envelope we read (lenient: ignores
 /// every other field the harness sends).
@@ -77,66 +75,6 @@ pub struct PreGenerateMutations {
     pub system_prompt: Option<String>,
 }
 
-/// One index row: worker name and its teaser text.
-type Entry = (String, String);
-
-/// The scanner aliases `<worker>/SKILL.md` to the on-disk id `<worker>/index`
-/// (`rel_to_id`); that row is the worker's overview. Deeper docs carry more
-/// segments and are skipped here — the overview links them.
-fn overview_worker(id: &str) -> Option<&str> {
-    let mut parts = id.split('/');
-    match (parts.next(), parts.next(), parts.next()) {
-        (Some(worker), Some("index"), None) if !worker.is_empty() => Some(worker),
-        _ => None,
-    }
-}
-
-/// Scan the merged skill folders and keep one row per worker overview.
-/// Teaser precedence matches the list surface: frontmatter `description`,
-/// else empty.
-fn collect_entries(cfg: &crate::config::SkillsConfig) -> Vec<Entry> {
-    let (skills, _skips) =
-        fs_source::scan_skills_merged(&cfg.resolved_skills_folder(), &cfg.local_skills_folder());
-    let mut entries: Vec<Entry> = skills
-        .iter()
-        .filter_map(|s| {
-            let worker = overview_worker(&s.id)?;
-            let (fm, _body) = fs_source::read_skill_with_frontmatter(&s.abs_path).ok()?;
-            let teaser = fm.description.unwrap_or_default();
-            Some((worker.to_string(), teaser))
-        })
-        .collect();
-    entries.sort();
-    entries.dedup_by(|a, b| a.0 == b.0);
-    entries
-}
-
-/// Render the index section, or `None` when there is nothing to inject.
-fn format_index(entries: &[Entry]) -> Option<String> {
-    if entries.is_empty() {
-        return None;
-    }
-    let mut out = String::from(
-        "## Installed skill docs\n\nWorkers on this engine ship skill docs. Read one with \
-         `directory::skills::get { id: \"<worker>\" }`; deeper docs are linked inside. \
-         Full list: `directory::skills::list`.\n\n",
-    );
-    for (id, teaser) in entries {
-        let teaser: String = teaser.chars().take(TEASER_MAX_CHARS).collect();
-        let line = if teaser.is_empty() {
-            format!("- {id}\n")
-        } else {
-            format!("- {id}: {teaser}\n")
-        };
-        if out.len() + line.len() > INDEX_MAX_CHARS {
-            out.push_str("- (truncated; see directory::skills::list)\n");
-            break;
-        }
-        out.push_str(&line);
-    }
-    Some(out)
-}
-
 /// Returns NO `system_prompt` when `base` is empty (schema drift must never
 /// replace the assembled prompt with the index alone) or when there is no
 /// index to add. For a real base we append and return the FULL prompt.
@@ -151,21 +89,38 @@ fn mutations_for(base: &str, index: Option<&str>) -> PreGenerateMutations {
 
 struct IndexCache {
     built_at: Instant,
-    index: Option<String>,
+    /// `None` when the last build found no worker overviews (nothing to
+    /// inject).
+    index: Option<Arc<String>>,
+}
+
+/// Fresh-cache fast path: `Ok` with the cached index while it is younger
+/// than [`CACHE_TTL`], else `Err` (rebuild needed). Extracted so the lock
+/// scope stays a single expression.
+fn cached_index(cache: &Mutex<Option<IndexCache>>) -> Result<Option<Arc<String>>, ()> {
+    let guard = cache.lock().unwrap_or_else(|p| p.into_inner());
+    match guard.as_ref() {
+        Some(c) if c.built_at.elapsed() <= CACHE_TTL => Ok(c.index.clone()),
+        _ => Err(()),
+    }
 }
 
 /// Register the index hook function and bind it to the harness pre-generate
 /// trigger type. The `inject_index` config gate is read on every fire, so
 /// toggling it via the configuration worker takes effect without a rebind.
-pub fn setup(iii: &Arc<IIIClient>, cfg: &SharedConfig) {
+pub fn setup(iii: &Arc<IIIClient>, cfg: &SharedConfig, cache: &Arc<RegisteredWorkersCache>) {
     let cfg = cfg.clone();
-    let cache: Arc<Mutex<Option<IndexCache>>> = Arc::new(Mutex::new(None));
+    let workers_cache = cache.clone();
+    let engine = iii.clone();
+    let index_cache: Arc<Mutex<Option<IndexCache>>> = Arc::new(Mutex::new(None));
 
     iii.register_function(
         INDEX_HOOK_ID,
         RegisterFunction::new_async(move |event: PreGenerateEvent| {
             let cfg = cfg.clone();
-            let cache = cache.clone();
+            let workers_cache = workers_cache.clone();
+            let engine = engine.clone();
+            let index_cache = index_cache.clone();
             async move {
                 let snapshot = cfg.load_full();
                 if !snapshot.inject_index {
@@ -173,21 +128,28 @@ pub fn setup(iii: &Arc<IIIClient>, cfg: &SharedConfig) {
                         mutations: PreGenerateMutations::default(),
                     });
                 }
-                let index = {
-                    let mut guard = cache.lock().unwrap_or_else(|p| p.into_inner());
-                    let stale = guard
-                        .as_ref()
-                        .is_none_or(|c| c.built_at.elapsed() > CACHE_TTL);
-                    if stale {
+                let index = match cached_index(&index_cache) {
+                    Ok(index) => index,
+                    Err(()) => {
+                        // Rebuild WITHOUT holding the cache lock: concurrent
+                        // fires may race into a duplicate build (harmless,
+                        // idempotent) but are never serialized behind one.
+                        let (body, workers_count) =
+                            skills::build_index(&snapshot, &workers_cache, &engine, false).await;
+                        let index = (workers_count > 0).then(|| Arc::new(body));
+                        let mut guard = index_cache.lock().unwrap_or_else(|p| p.into_inner());
                         *guard = Some(IndexCache {
                             built_at: Instant::now(),
-                            index: format_index(&collect_entries(&snapshot)),
+                            index: index.clone(),
                         });
+                        index
                     }
-                    guard.as_ref().and_then(|c| c.index.clone())
                 };
                 Ok(PreGenerateResponse {
-                    mutations: mutations_for(&event.generate.system_prompt, index.as_deref()),
+                    mutations: mutations_for(
+                        &event.generate.system_prompt,
+                        index.as_deref().map(|s| s.as_str()),
+                    ),
                 })
             }
         })
@@ -223,52 +185,9 @@ pub fn setup(iii: &Arc<IIIClient>, cfg: &SharedConfig) {
 mod tests {
     use super::*;
 
-    fn entries(pairs: &[(&str, &str)]) -> Vec<Entry> {
-        pairs
-            .iter()
-            .map(|(a, b)| (a.to_string(), b.to_string()))
-            .collect()
-    }
-
-    #[test]
-    fn overview_worker_matches_only_the_aliased_skill_md_row() {
-        assert_eq!(overview_worker("harness/index"), Some("harness"));
-        assert_eq!(overview_worker("harness/orchestration"), None);
-        assert_eq!(overview_worker("resend/emails/index"), None);
-        assert_eq!(overview_worker("harness"), None);
-        assert_eq!(overview_worker("/index"), None);
-    }
-
-    #[test]
-    fn empty_entries_yield_no_index() {
-        assert_eq!(format_index(&[]), None);
-    }
-
-    #[test]
-    fn index_lists_one_line_per_worker_with_teaser() {
-        let out = format_index(&entries(&[
-            ("browser", "Drive a real browser."),
-            ("fp", ""),
-        ]))
-        .expect("index");
-        assert!(out.contains("directory::skills::get"));
-        assert!(out.contains("- browser: Drive a real browser.\n"));
-        assert!(out.contains("- fp\n"));
-    }
-
-    #[test]
-    fn oversized_index_truncates_with_pointer() {
-        let big: Vec<Entry> = (0..500)
-            .map(|i| (format!("worker-{i:03}"), "x".repeat(100)))
-            .collect();
-        let out = format_index(&big).expect("index");
-        assert!(out.len() <= INDEX_MAX_CHARS + 100);
-        assert!(out.contains("(truncated; see directory::skills::list)"));
-    }
-
     #[test]
     fn empty_base_is_preserved_never_replaced() {
-        let m = mutations_for("", Some("## Installed skill docs"));
+        let m = mutations_for("", Some("# Skills index"));
         assert!(m.system_prompt.is_none());
     }
 
@@ -282,5 +201,24 @@ mod tests {
     fn index_appends_after_the_base() {
         let m = mutations_for("BASE", Some("INDEX"));
         assert_eq!(m.system_prompt.as_deref(), Some("BASE\n\nINDEX"));
+    }
+
+    #[test]
+    fn cache_serves_fresh_and_demands_rebuild_when_stale() {
+        let cache = Mutex::new(None);
+        assert!(cached_index(&cache).is_err());
+        *cache.lock().unwrap() = Some(IndexCache {
+            built_at: Instant::now(),
+            index: Some(Arc::new("X".into())),
+        });
+        assert_eq!(
+            cached_index(&cache).unwrap().as_deref().map(|s| s.as_str()),
+            Some("X")
+        );
+        *cache.lock().unwrap() = Some(IndexCache {
+            built_at: Instant::now() - CACHE_TTL - Duration::from_secs(1),
+            index: Some(Arc::new("X".into())),
+        });
+        assert!(cached_index(&cache).is_err());
     }
 }

--- a/iii-directory/src/inject_index.rs
+++ b/iii-directory/src/inject_index.rs
@@ -1,0 +1,265 @@
+//! `iii-directory::inject-skills-index` — a `pre_generate` hook that appends a
+//! compact per-worker skills index to the agent's system prompt, ONLY while
+//! this worker is connected and `inject_index` is enabled in config. Mirrors
+//! `fp::inject-guidance` (fp/src/guidance.rs): the binding is requested at
+//! worker startup; the engine parks it as a pending intent until the harness
+//! registers the `harness::hook::pre-generate` trigger type (recoverable
+//! triggers), which also covers a harness restart. Bound `fail_open` so an
+//! error or timeout here can never block a turn.
+//!
+//! The index is built from the on-disk skill set (`scan_skills_merged`), one
+//! line per worker overview (single-segment skill id), teaser from the
+//! frontmatter `description`. Engine-side install filtering is deliberately
+//! skipped: the hook runs in the generation critical path, so it reads disk
+//! through a short-lived cache and never calls back into the engine.
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use iii_sdk::errors::Error;
+use iii_sdk::protocol::RegisterTriggerInput;
+use iii_sdk::{IIIClient, RegisterFunction};
+
+use crate::config::SharedConfig;
+use crate::fs_source;
+
+pub const INDEX_HOOK_ID: &str = "iii-directory::inject-skills-index";
+pub const INDEX_HOOK_DESC: &str =
+    "Internal pre_generate hook: appends a compact installed-skills index to the agent \
+     system prompt when `inject_index` is enabled. Bound to harness::hook::pre-generate \
+     at worker startup; not called directly.";
+
+/// The harness-PROVIDED trigger type this worker binds to (NOT an engine
+/// built-in).
+const PRE_GENERATE_TRIGGER_TYPE: &str = "harness::hook::pre-generate";
+
+/// Rebuild the index from disk at most this often.
+const CACHE_TTL: Duration = Duration::from_secs(10);
+
+/// Keep the injected section token-light: teasers are clipped per line and
+/// the whole section is capped, pointing at `directory::skills::list` for the
+/// rest.
+const TEASER_MAX_CHARS: usize = 140;
+const INDEX_MAX_CHARS: usize = 2500;
+
+/// The slice of the `pre_generate` hook envelope we read (lenient: ignores
+/// every other field the harness sends).
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+pub struct PreGenerateEvent {
+    #[serde(default)]
+    pub generate: GenerateContext,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+pub struct GenerateContext {
+    /// The system prompt assembled so far (base + any prior hook's mutation).
+    #[serde(default)]
+    pub system_prompt: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct PreGenerateResponse {
+    pub mutations: PreGenerateMutations,
+}
+
+/// The harness applies `system_prompt` only when the key is present, so
+/// `None` serializes to an empty object: the safe no-op that preserves the
+/// harness's assembled prompt.
+#[derive(Debug, Default, Serialize, JsonSchema)]
+pub struct PreGenerateMutations {
+    /// Full replacement system prompt (base + appended index). The harness
+    /// overwrites, it does not merge.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_prompt: Option<String>,
+}
+
+/// One index row: worker overview id and its teaser text.
+type Entry = (String, String);
+
+/// Scan the merged skill folders and keep one row per worker overview: a
+/// single-segment skill id whose file parses. Teaser precedence matches the
+/// list surface: frontmatter `description`, else empty.
+fn collect_entries(cfg: &crate::config::SkillsConfig) -> Vec<Entry> {
+    let (skills, _skips) =
+        fs_source::scan_skills_merged(&cfg.resolved_skills_folder(), &cfg.local_skills_folder());
+    let mut entries: Vec<Entry> = skills
+        .iter()
+        .filter(|s| !s.id.contains('/'))
+        .filter_map(|s| {
+            let (fm, _body) = fs_source::read_skill_with_frontmatter(&s.abs_path).ok()?;
+            let teaser = fm.description.unwrap_or_default();
+            Some((s.id.clone(), teaser))
+        })
+        .collect();
+    entries.sort();
+    entries
+}
+
+/// Render the index section, or `None` when there is nothing to inject.
+fn format_index(entries: &[Entry]) -> Option<String> {
+    if entries.is_empty() {
+        return None;
+    }
+    let mut out = String::from(
+        "## Installed skill docs\n\nWorkers on this engine ship skill docs. Read one with \
+         `directory::skills::get { id: \"<worker>\" }`; deeper docs are linked inside. \
+         Full list: `directory::skills::list`.\n\n",
+    );
+    for (id, teaser) in entries {
+        let teaser: String = teaser.chars().take(TEASER_MAX_CHARS).collect();
+        let line = if teaser.is_empty() {
+            format!("- {id}\n")
+        } else {
+            format!("- {id}: {teaser}\n")
+        };
+        if out.len() + line.len() > INDEX_MAX_CHARS {
+            out.push_str("- (truncated; see directory::skills::list)\n");
+            break;
+        }
+        out.push_str(&line);
+    }
+    Some(out)
+}
+
+/// Returns NO `system_prompt` when `base` is empty (schema drift must never
+/// replace the assembled prompt with the index alone) or when there is no
+/// index to add. For a real base we append and return the FULL prompt.
+fn mutations_for(base: &str, index: Option<&str>) -> PreGenerateMutations {
+    match (base.is_empty(), index) {
+        (false, Some(index)) => PreGenerateMutations {
+            system_prompt: Some(format!("{base}\n\n{index}")),
+        },
+        _ => PreGenerateMutations::default(),
+    }
+}
+
+struct IndexCache {
+    built_at: Instant,
+    index: Option<String>,
+}
+
+/// Register the index hook function and bind it to the harness pre-generate
+/// trigger type. The `inject_index` config gate is read on every fire, so
+/// toggling it via the configuration worker takes effect without a rebind.
+pub fn setup(iii: &Arc<IIIClient>, cfg: &SharedConfig) {
+    let cfg = cfg.clone();
+    let cache: Arc<Mutex<Option<IndexCache>>> = Arc::new(Mutex::new(None));
+
+    iii.register_function(
+        INDEX_HOOK_ID,
+        RegisterFunction::new_async(move |event: PreGenerateEvent| {
+            let cfg = cfg.clone();
+            let cache = cache.clone();
+            async move {
+                let snapshot = cfg.load_full();
+                if !snapshot.inject_index {
+                    return Ok::<_, Error>(PreGenerateResponse {
+                        mutations: PreGenerateMutations::default(),
+                    });
+                }
+                let index = {
+                    let mut guard = cache.lock().unwrap_or_else(|p| p.into_inner());
+                    let stale = guard
+                        .as_ref()
+                        .is_none_or(|c| c.built_at.elapsed() > CACHE_TTL);
+                    if stale {
+                        *guard = Some(IndexCache {
+                            built_at: Instant::now(),
+                            index: format_index(&collect_entries(&snapshot)),
+                        });
+                    }
+                    guard.as_ref().and_then(|c| c.index.clone())
+                };
+                Ok(PreGenerateResponse {
+                    mutations: mutations_for(&event.generate.system_prompt, index.as_deref()),
+                })
+            }
+        })
+        .description(INDEX_HOOK_DESC)
+        .metadata(json!({ "internal": true })),
+    );
+
+    // `on_error: fail_open` is MANDATORY: pre_generate defaults fail-CLOSED,
+    // which would abort generation if this hook ever errored or timed out.
+    // If the harness is not up yet, the engine parks the binding as a pending
+    // intent and activates it when the type registers.
+    match iii.register_trigger(RegisterTriggerInput {
+        trigger_type: PRE_GENERATE_TRIGGER_TYPE.to_string(),
+        function_id: INDEX_HOOK_ID.to_string(),
+        config: json!({ "on_error": "fail_open" }),
+        metadata: None,
+    }) {
+        Ok(_) => tracing::info!(
+            trigger_type = PRE_GENERATE_TRIGGER_TYPE,
+            function_id = INDEX_HOOK_ID,
+            "skills-index hook binding requested"
+        ),
+        Err(e) => tracing::warn!(
+            trigger_type = PRE_GENERATE_TRIGGER_TYPE,
+            function_id = INDEX_HOOK_ID,
+            error = %e,
+            "skills-index hook binding failed"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entries(pairs: &[(&str, &str)]) -> Vec<Entry> {
+        pairs
+            .iter()
+            .map(|(a, b)| (a.to_string(), b.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn empty_entries_yield_no_index() {
+        assert_eq!(format_index(&[]), None);
+    }
+
+    #[test]
+    fn index_lists_one_line_per_worker_with_teaser() {
+        let out = format_index(&entries(&[
+            ("browser", "Drive a real browser."),
+            ("fp", ""),
+        ]))
+        .expect("index");
+        assert!(out.contains("directory::skills::get"));
+        assert!(out.contains("- browser: Drive a real browser.\n"));
+        assert!(out.contains("- fp\n"));
+    }
+
+    #[test]
+    fn oversized_index_truncates_with_pointer() {
+        let big: Vec<Entry> = (0..500)
+            .map(|i| (format!("worker-{i:03}"), "x".repeat(100)))
+            .collect();
+        let out = format_index(&big).expect("index");
+        assert!(out.len() <= INDEX_MAX_CHARS + 100);
+        assert!(out.contains("(truncated; see directory::skills::list)"));
+    }
+
+    #[test]
+    fn empty_base_is_preserved_never_replaced() {
+        let m = mutations_for("", Some("## Installed skill docs"));
+        assert!(m.system_prompt.is_none());
+    }
+
+    #[test]
+    fn no_index_is_a_noop() {
+        let m = mutations_for("BASE", None);
+        assert!(m.system_prompt.is_none());
+    }
+
+    #[test]
+    fn index_appends_after_the_base() {
+        let m = mutations_for("BASE", Some("INDEX"));
+        assert_eq!(m.system_prompt.as_deref(), Some("BASE\n\nINDEX"));
+    }
+}

--- a/iii-directory/src/lib.rs
+++ b/iii-directory/src/lib.rs
@@ -41,6 +41,7 @@ pub mod config;
 pub mod configuration;
 pub mod fs_source;
 pub mod functions;
+pub mod inject_index;
 pub mod manifest;
 pub mod sources;
 pub mod trigger_types;

--- a/iii-directory/src/main.rs
+++ b/iii-directory/src/main.rs
@@ -163,7 +163,7 @@ async fn main() -> Result<()> {
     // Optional pre-generate hook: appends a compact skills index to the agent
     // system prompt while `inject_index` is enabled (read per fire, so the
     // toggle needs no restart). The binding itself is requested once here.
-    iii_directory::inject_index::setup(&iii, &cfg_handle);
+    iii_directory::inject_index::setup(&iii, &cfg_handle, &registered_cache);
 
     // Auto-download: subscribe to worker add events + boot reconcile. Wired
     // from the boot value of `auto_download` (a topology field — changing it

--- a/iii-directory/src/main.rs
+++ b/iii-directory/src/main.rs
@@ -160,6 +160,11 @@ async fn main() -> Result<()> {
     );
     functions::log_fs_health(&cfg_handle.load_full());
 
+    // Optional pre-generate hook: appends a compact skills index to the agent
+    // system prompt while `inject_index` is enabled (read per fire, so the
+    // toggle needs no restart). The binding itself is requested once here.
+    iii_directory::inject_index::setup(&iii, &cfg_handle);
+
     // Auto-download: subscribe to worker add events + boot reconcile. Wired
     // from the boot value of `auto_download` (a topology field — changing it
     // requires a restart).


### PR DESCRIPTION
## What

A `harness::hook::pre-generate` binding that appends a compact installed-skills index to the agent system prompt on every generation:

```
## Installed skill docs

Workers on this engine ship skill docs. Read one with
`directory::skills::get { id: "<worker>" }`; deeper docs are linked inside.
Full list: `directory::skills::list`.

- browser: Drive a real browser...
- harness: The durable agent turn loop...
```

- `src/inject_index.rs`, modeled line-for-line on `fp/src/guidance.rs`: engine parks the binding until the harness registers the trigger type, `on_error: fail_open` so a failure can never block a turn, empty-base guard so schema drift preserves the assembled prompt.
- Index built from `scan_skills_merged` (one row per worker overview, teaser from frontmatter `description`), 10 s cache, per-line and whole-section caps with an explicit truncation pointer. No engine calls in the hook path.
- New `inject_index` config knob, default `false` (opt-in). Read on every fire, so the configuration worker toggle takes effect without a restart or rebind.
- Six unit tests on the pure formatting and mutation paths; 255 lib tests pass, clippy clean.

## Why

Agents currently learn what exists either from a hardcoded prompt (grows forever, drifts) or a discovery call (a turn and a round trip). With this hook the capability map arrives with the prompt, always current, and its cost scales with what is actually installed instead of with what the prompt author anticipated. fp proved the pattern for usage guidance; this generalizes it to discovery.

Pairs with #558 and #560: the minimal core stays static, per-worker guidance rides presence-gated hooks, deep playbooks are pulled on demand.

## Status: live-validated on a rig

Ran the branch build as a second directory worker against a live engine (0.21.6, harness 1.4.2) and walked the full checklist:

- Disabled gate: direct hook invocation returns `{"mutations": {}}` while `inject_index` is false.
- Enabled: index builds from the real skill set on disk, 602 tokens for 30+ workers, capped format as designed.
- Composition in a real generation: a live session confirmed all three layers stacked in its system prompt (router operator override, fp guidance hook, this index) and quoted the section's first rows.
- Worker killed mid-run: the next generation completed normally (`fail_open` plus the binding dying with the worker connection).
- Config restored afterwards; the knob toggles without a restart as designed.

The live run caught one real bug the unit tests could not: the scanner aliases `<worker>/SKILL.md` to the on-disk id `<worker>/index`, so the original single-segment overview filter matched nothing and the index was always empty. Fixed with an explicit `overview_worker` matcher plus a regression test.

Two operational observations from the same run, for reviewers: with two instances of the worker connected, the configuration-update event load-balances to one of them, so the other keeps the old snapshot until reboot (inherent to duplicate instances, not this hook); and the hook function is invisible to `engine::functions::list` search because it registers with `internal: true` metadata, which is intended.

Draft: design review wanted, especially default-off vs default-on and the index format.

## Linear

Closes MOT-4164. Part of MOT-4157.

## Post-review simplification (applied)

A structured cleanup pass reworked the hook onto the canonical machinery: the injected text is now exactly `directory::skills::index`, built by a shared `skills::build_index` used by both the function handler and the hook, so overview classification (`type: index` clause included), teaser resolution, and the never-drop-a-worker budget policy cannot drift between the two surfaces. The cache rebuild moved outside the lock (concurrent generations are never serialized behind it) and the worker filter runs through the stale-tolerant registered-workers cache. Live re-validated: 19 installed workers injected, config gate and restore verified.
