### PR TITLE
(MOT-4170) fix(console): make the UI work over insecure origins (http://<LAN-IP>)

### DIFF
--- a/console/README.md
+++ b/console/README.md
@@ -217,7 +217,7 @@ The SPA bundle is embedded into the binary at compile time via [`rust-embed`](ht
 | Data fetching | [TanStack Query 5](https://tanstack.com/query) |
 | Trace graphs | [`@xyflow/react` 12](https://reactflow.dev) + [dagre](https://github.com/dagrejs/dagre), [TanStack Virtual](https://tanstack.com/virtual) |
 | Markdown | [react-markdown](https://github.com/remarkjs/react-markdown) + [remark-gfm](https://github.com/remarkjs/remark-gfm), [prism-react-renderer](https://github.com/FormidableLabs/prism-react-renderer) |
-| Browser SDK | [`iii-browser-sdk` 0.12](https://www.npmjs.com/package/iii-browser-sdk) |
+| Browser SDK | [`iii-browser-sdk` 0.21.6](https://www.npmjs.com/package/iii-browser-sdk) |
 
 <details>
 <summary><strong>Build from source (contributors only)</strong></summary>

--- a/console/web/package.json
+++ b/console/web/package.json
@@ -32,7 +32,7 @@
     "@tanstack/react-virtual": "^3.13.24",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "iii-browser-sdk": "^0.12.0",
+    "iii-browser-sdk": "^0.21.6",
     "lexical": "^0.44.0",
     "lucide-react": "^1.16.0",
     "prism-react-renderer": "^2.4.1",

--- a/console/web/pnpm-lock.yaml
+++ b/console/web/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       iii-browser-sdk:
-        specifier: ^0.12.0
-        version: 0.12.0
+        specifier: ^0.21.6
+        version: 0.21.6
       lexical:
         specifier: ^0.44.0
         version: 0.44.0
@@ -2173,8 +2173,8 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
-  iii-browser-sdk@0.12.0:
-    resolution: {integrity: sha512-Z8L/YEjBMtqBNKCxt12xn28K9BkWiKMXTJxF1N9tJ2+y7qDMMncDTyOfsymNfRO5usKmIXldhzbk3dicJ1tT2w==}
+  iii-browser-sdk@0.21.6:
+    resolution: {integrity: sha512-ZyVvWAG3ar6P6Xi+OTKpVwWeoFPjsCH3AtFfV7UCva/pMj7fo5u1DzxZ7Kz7Vc/g9KBCn9dy3KOo5fBpmirYDA==}
 
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
@@ -4925,7 +4925,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  iii-browser-sdk@0.12.0: {}
+  iii-browser-sdk@0.21.6: {}
 
   indent-string@4.0.0: {}
 

--- a/console/web/src/hooks/use-conversations.ts
+++ b/console/web/src/hooks/use-conversations.ts
@@ -27,6 +27,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { getIiiClient } from '@/lib/iii-client'
+import { newSessionId } from '@/lib/session-id'
 import {
   deleteSession,
   ensureSession as ensureSessionApi,
@@ -71,17 +72,6 @@ function uid(): string {
  *  only costs are the RPC and one JSONL append per flush). */
 const DRAFT_SAVE_DEBOUNCE_MS = 500
 
-/** Draft ids double as engine session ids — minted with the console prefix. */
-function newConversationId(): string {
-  if (
-    typeof crypto !== 'undefined' &&
-    typeof crypto.randomUUID === 'function'
-  ) {
-    return `console-${crypto.randomUUID()}`
-  }
-  return `console-${uid()}`
-}
-
 function deriveTitle(text: string): string {
   const clean = text.replace(/\s+/g, ' ').trim().toLowerCase()
   if (!clean) return 'new chat'
@@ -91,7 +81,7 @@ function deriveTitle(text: string): string {
 function emptyConversation(defaultModel: ModelId | null): Conversation {
   const now = Date.now()
   return {
-    id: newConversationId(),
+    id: newSessionId(),
     title: 'new chat',
     model: defaultModel,
     mode: DEFAULT_MODE,

--- a/console/web/src/lib/backend/real.ts
+++ b/console/web/src/lib/backend/real.ts
@@ -14,7 +14,7 @@
 
 import { parseCatalogModelKey } from '@/lib/catalog-model-key'
 import { getIiiClient } from '@/lib/iii-client'
-import { newMessageId } from '@/lib/session-id'
+import { newMessageId, newSessionId } from '@/lib/session-id'
 import { appendCustomEntry, fetchTranscript } from '@/lib/sessions/api'
 import { COMPACTION_CUSTOM_TYPE } from '@/lib/sessions/entry-mapper'
 import type { AgentMessage } from '@/lib/sessions/types'
@@ -208,7 +208,7 @@ async function realQueueMessage(
   opts?: ChatStreamOptions,
 ): Promise<void> {
   const client = await getIiiClient()
-  const sessionId = opts?.sessionId ?? `console-${crypto.randomUUID()}`
+  const sessionId = opts?.sessionId ?? newSessionId()
   const messageId = opts?.messageId ?? newMessageId()
   const req = await buildSendRequest(
     prompt,
@@ -301,7 +301,7 @@ async function* realStream(
 ): AsyncGenerator<StreamEvent> {
   const signal = opts?.signal
   const client = await getIiiClient()
-  const sessionId = opts?.sessionId ?? `console-${crypto.randomUUID()}`
+  const sessionId = opts?.sessionId ?? newSessionId()
   const messageId = opts?.messageId ?? newMessageId()
   // The `approval::*` functions live on the optional standalone approval-gate
   // worker. When it's absent, skip every approval subscription / read so we

--- a/console/web/src/lib/crypto-polyfill.test.ts
+++ b/console/web/src/lib/crypto-polyfill.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { installRandomUUIDPolyfill } from './crypto-polyfill'
+
+const UUID_V4 =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+/** `crypto` as seen on an insecure origin: getRandomValues, no randomUUID. */
+function insecureContextCrypto(): Crypto {
+  return {
+    getRandomValues: globalThis.crypto.getRandomValues.bind(globalThis.crypto),
+  } as unknown as Crypto
+}
+
+describe('installRandomUUIDPolyfill', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('installs a spec-shaped UUIDv4 generator when randomUUID is missing', () => {
+    vi.stubGlobal('crypto', insecureContextCrypto())
+    installRandomUUIDPolyfill()
+    expect(typeof crypto.randomUUID).toBe('function')
+    expect(crypto.randomUUID()).toMatch(UUID_V4)
+    expect(crypto.randomUUID()).not.toBe(crypto.randomUUID())
+  })
+
+  it('leaves the native implementation alone in secure contexts', () => {
+    const native = () => 'native-uuid' as ReturnType<Crypto['randomUUID']>
+    vi.stubGlobal('crypto', {
+      ...insecureContextCrypto(),
+      randomUUID: native,
+    })
+    installRandomUUIDPolyfill()
+    expect(crypto.randomUUID).toBe(native)
+  })
+
+  it('is a no-op when crypto itself is undefined', () => {
+    // Ancient WebViews / stripped-down embedders: no `crypto` global at all.
+    vi.stubGlobal('crypto', undefined)
+    expect(() => installRandomUUIDPolyfill()).not.toThrow()
+    expect(globalThis.crypto).toBeUndefined()
+  })
+
+  it('swallows defineProperty failures instead of crashing boot', () => {
+    // A frozen `crypto` rejects new properties; the install must not throw
+    // — guarded call sites still have their own fallbacks.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.stubGlobal('crypto', Object.freeze(insecureContextCrypto()))
+    expect(() => installRandomUUIDPolyfill()).not.toThrow()
+    expect(crypto.randomUUID).toBeUndefined()
+    expect(warn).toHaveBeenCalledOnce()
+    warn.mockRestore()
+  })
+
+  it('is idempotent: a second call keeps the installed generator', () => {
+    vi.stubGlobal('crypto', insecureContextCrypto())
+    installRandomUUIDPolyfill()
+    const installed = crypto.randomUUID
+    installRandomUUIDPolyfill()
+    expect(crypto.randomUUID).toBe(installed)
+  })
+
+  it('does not install without getRandomValues (crypto-stripped WebViews)', () => {
+    // Installing a randomUUID that throws would defeat every
+    // `typeof crypto.randomUUID === 'function'` guard in the app and turn
+    // their working fallbacks into a first-render crash.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.stubGlobal('crypto', {} as unknown as Crypto)
+    expect(() => installRandomUUIDPolyfill()).not.toThrow()
+    expect(crypto.randomUUID).toBeUndefined()
+    expect(warn).toHaveBeenCalledOnce()
+    warn.mockRestore()
+  })
+})

--- a/console/web/src/lib/crypto-polyfill.ts
+++ b/console/web/src/lib/crypto-polyfill.ts
@@ -1,0 +1,54 @@
+/**
+ * `crypto.randomUUID` polyfill for insecure contexts.
+ *
+ * The API only exists in secure contexts (https / localhost), and the
+ * console is routinely opened over plain http on a LAN IP
+ * (`http://192.168.x.x:3113`), where dependencies that call it bare —
+ * e.g. iii-browser-sdk ≤ 0.21.6 minting invocation ids — throw and the
+ * page renders with no data. `crypto.getRandomValues` IS available in
+ * insecure contexts, so back-fill a spec-shaped UUIDv4.
+ *
+ * Self-installs on import AND is called explicitly by `main.tsx` as its
+ * first import — the named-import call keeps the module alive even if
+ * `"sideEffects": false` is ever added to package.json, and both paths
+ * run before any SDK code can touch `crypto.randomUUID`.
+ */
+
+function uuidV4(): `${string}-${string}-${string}-${string}-${string}` {
+  const bytes = crypto.getRandomValues(new Uint8Array(16))
+  bytes[6] = (bytes[6] & 0x0f) | 0x40 // version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80 // RFC 4122 variant
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}
+
+export function installRandomUUIDPolyfill(): void {
+  if (typeof crypto === 'undefined') return
+  if (typeof crypto.randomUUID === 'function') return
+  // No CSPRNG → don't install. A randomUUID that throws would defeat every
+  // `typeof crypto.randomUUID === 'function'` guard in the app (session-id
+  // mintId, iii-client makeBrowserId, …) and turn their working fallbacks
+  // into a first-render crash on crypto-stripped WebViews.
+  if (typeof crypto.getRandomValues !== 'function') {
+    console.warn(
+      '[crypto-polyfill] crypto.getRandomValues unavailable — randomUUID not installed; guarded fallbacks stay active',
+    )
+    return
+  }
+  try {
+    // defineProperty rather than assignment: `crypto` can carry
+    // non-writable properties, and a failed install must never crash boot
+    // — guarded call sites still have their own fallbacks.
+    Object.defineProperty(crypto, 'randomUUID', {
+      value: uuidV4,
+      configurable: true,
+      writable: true,
+    })
+  } catch (err) {
+    // Leave the API missing; only unguarded third-party calls lose out —
+    // but say so, or a LAN no-data report is undiagnosable from the console.
+    console.warn('[crypto-polyfill] install failed', err)
+  }
+}
+
+installRandomUUIDPolyfill()

--- a/console/web/src/lib/iii-client.ts
+++ b/console/web/src/lib/iii-client.ts
@@ -283,14 +283,14 @@ function resolveWsUrl(): string {
 }
 
 function makeBrowserId(): string {
-  // crypto.randomUUID() is available in all evergreen browsers.
+  // crypto.randomUUID() only exists in secure contexts (https / localhost);
+  // http://<LAN-IP> origins have `crypto` without it, hence the guard.
   if (
     typeof crypto !== 'undefined' &&
     typeof crypto.randomUUID === 'function'
   ) {
     return `console-${crypto.randomUUID()}`
   }
-  // Fallback for environments without crypto.randomUUID (older WebViews).
   const rand = Math.random().toString(36).slice(2, 10)
   return `console-${Date.now().toString(36)}-${rand}`
 }

--- a/console/web/src/lib/session-id.test.ts
+++ b/console/web/src/lib/session-id.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { newMessageId, newSessionId } from './session-id'
+
+describe('newSessionId', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('mints console-prefixed ids', () => {
+    expect(newSessionId()).toMatch(/^console-/)
+  })
+
+  it('mints unique ids per call', () => {
+    expect(newSessionId()).not.toBe(newSessionId())
+  })
+
+  it('falls back when crypto.randomUUID is unavailable (insecure context)', () => {
+    // http://<LAN-IP> origins have `crypto` but no `randomUUID` — the
+    // secure-context-only API. The helper must not throw there.
+    vi.stubGlobal('crypto', {})
+    const a = newSessionId()
+    const b = newSessionId()
+    expect(a).toMatch(/^console-/)
+    expect(b).toMatch(/^console-/)
+    expect(a).not.toBe(b)
+  })
+
+  it('falls back when crypto itself is undefined', () => {
+    vi.stubGlobal('crypto', undefined)
+    const a = newSessionId()
+    const b = newSessionId()
+    expect(a).toMatch(/^console-/)
+    expect(a).not.toBe(b)
+  })
+
+  it('uses crypto.randomUUID when available', () => {
+    vi.stubGlobal('crypto', {
+      randomUUID: () => '00000000-0000-4000-8000-000000000000',
+    })
+    expect(newSessionId()).toBe('console-00000000-0000-4000-8000-000000000000')
+  })
+})
+
+describe('newMessageId', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uses crypto.randomUUID when available', () => {
+    vi.stubGlobal('crypto', {
+      randomUUID: () => '00000000-0000-4000-8000-000000000000',
+    })
+    expect(newMessageId()).toBe('msg-00000000-0000-4000-8000-000000000000')
+  })
+
+  it('falls back when crypto.randomUUID is unavailable (insecure context)', () => {
+    vi.stubGlobal('crypto', {})
+    const a = newMessageId()
+    expect(a).toMatch(/^msg-/)
+    expect(a).not.toBe(newMessageId())
+  })
+
+  it('falls back when crypto itself is undefined', () => {
+    vi.stubGlobal('crypto', undefined)
+    const a = newMessageId()
+    expect(a).toMatch(/^msg-/)
+    expect(a).not.toBe(newMessageId())
+  })
+})

--- a/console/web/src/lib/session-id.ts
+++ b/console/web/src/lib/session-id.ts
@@ -1,5 +1,5 @@
 /**
- * Message ID helper.
+ * Message / session ID helpers.
  *
  * One fresh `msg-<uuid>` per send. It flows into the engine via baggage so
  * the traces UI can "Group by message", and rides `harness::send` as the
@@ -8,12 +8,29 @@
  * console's optimistic user row reconciles in place (see
  * `predictedUserEntryId` in lib/backend/harness-send.ts).
  *
- * (Conversation ids are minted with the `console-` prefix directly in
- * use-conversations and double as the engine session_id, so there is no
+ * (Conversation ids are minted with the `console-` prefix via
+ * [`newSessionId`] and double as the engine session_id, so there is no
  * separate session-id mapper anymore.)
  */
 
 const MESSAGE_PREFIX = 'msg-'
+const SESSION_PREFIX = 'console-'
+
+/**
+ * `crypto.randomUUID` only exists in secure contexts (https / localhost) —
+ * a console served over `http://<LAN-IP>` has `crypto` without it — so
+ * fall back to a timestamp+random id rather than throwing.
+ */
+function mintId(prefix: string): string {
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.randomUUID === 'function'
+  ) {
+    return `${prefix}${crypto.randomUUID()}`
+  }
+  const rand = Math.random().toString(36).slice(2, 10)
+  return `${prefix}${Date.now().toString(36)}-${rand}`
+}
 
 /**
  * Mint a fresh message_id for a single turn. Called once per `send()`
@@ -21,13 +38,13 @@ const MESSAGE_PREFIX = 'msg-'
  * the traces UI's "Group by message" view.
  */
 export function newMessageId(): string {
-  if (
-    typeof crypto !== 'undefined' &&
-    typeof crypto.randomUUID === 'function'
-  ) {
-    return `${MESSAGE_PREFIX}${crypto.randomUUID()}`
-  }
-  // Fallback for environments without crypto.randomUUID (older WebViews).
-  const rand = Math.random().toString(36).slice(2, 10)
-  return `${MESSAGE_PREFIX}${Date.now().toString(36)}-${rand}`
+  return mintId(MESSAGE_PREFIX)
+}
+
+/**
+ * Mint a fresh `console-<uuid>` session/conversation id (doubles as the
+ * engine session_id).
+ */
+export function newSessionId(): string {
+  return mintId(SESSION_PREFIX)
 }

--- a/console/web/src/main.test.ts
+++ b/console/web/src/main.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The crypto polyfill must evaluate before the SDK-bearing module graph
+ * (`./App` → iii-client → iii-browser-sdk) so `crypto.randomUUID` exists
+ * before any SDK code touches it — on insecure origins (http://<LAN-IP>)
+ * the native API is missing and unguarded callers throw. Every vitest run
+ * happens under Node where the API exists, so only these source checks
+ * can catch the wiring being dropped or demoted; the runtime symptom
+ * (blank data on LAN access) never shows up in unit tests.
+ */
+describe('main.tsx polyfill wiring', () => {
+  const src = readFileSync(new URL('./main.tsx', import.meta.url), 'utf8')
+
+  it('imports the crypto polyfill before the App module graph', () => {
+    const polyfillAt = src.indexOf("from '@/lib/crypto-polyfill'")
+    const appAt = src.indexOf("from './App'")
+    expect(polyfillAt).toBeGreaterThan(-1)
+    expect(appAt).toBeGreaterThan(-1)
+    expect(polyfillAt).toBeLessThan(appAt)
+  })
+
+  it('calls the polyfill installer explicitly (tree-shake proof)', () => {
+    expect(src).toContain('installRandomUUIDPolyfill()')
+  })
+})

--- a/console/web/src/main.tsx
+++ b/console/web/src/main.tsx
@@ -2,9 +2,17 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { TooltipProvider } from '@/components/ui/Tooltip'
+import { installRandomUUIDPolyfill } from '@/lib/crypto-polyfill'
 import { App } from './App'
 import faviconUrl from './icons/favicon.svg?url'
 import './index.css'
+
+// Back-fills crypto.randomUUID on insecure origins (http://<LAN-IP>) —
+// iii-browser-sdk ≤ 0.21.6 calls it bare on every invocation. The module
+// also self-installs on import (which biome sorts before './App', the
+// SDK-bearing graph); this explicit call is the tree-shake-proof anchor
+// (main.test.ts guards both).
+installRandomUUIDPolyfill()
 
 const favicon =
   document.querySelector<HTMLLinkElement>('link[rel="icon"]') ??


### PR DESCRIPTION
Fixes MOT-4170

## Summary

The console rendered but showed **no data** when opened from another machine (`http://192.168.1.206:3113`) while working fine on the server via `http://127.0.0.1:3113`. Root cause: `crypto.randomUUID` only exists in **secure contexts** (https / localhost origins). `iii-browser-sdk` calls it bare when minting invocation and trigger-registration ids, so on a plain-http LAN origin every data fetch threw `TypeError: crypto.randomUUID is not a function` before reaching the wire. The server side (`0.0.0.0` bind, `/ws` proxy) was never the problem — the failure was origin-dependent, not machine-dependent.

**Fix (`fix(console)`):**
- `lib/crypto-polyfill.ts` — back-fills a spec-shaped UUIDv4 built on `crypto.getRandomValues` (which insecure contexts do have) when `randomUUID` is missing. Never touches a native implementation; bails out with a `console.warn` breadcrumb when `getRandomValues` is also absent (a throwing stub would defeat every downstream `typeof crypto.randomUUID === 'function'` guard and turn crypto-stripped WebViews into a first-render crash); swallows `defineProperty` failures with a warn instead of crashing boot. Self-installs on import and is called explicitly from `main.tsx` before render; `main.test.ts` pins both the import-before-`./App` ordering and the explicit call (tree-shake-proof against a future `"sideEffects": false`).
- `lib/session-id.ts` — shared guarded `mintId()` now backs `newMessageId()` and the new `newSessionId()`; the two bare `crypto.randomUUID()` chat-send fallbacks in `lib/backend/real.ts` and the duplicate helper in `hooks/use-conversations.ts` now go through it.
- `lib/iii-client.ts` — corrected the false "available in all evergreen browsers" comment on `makeBrowserId`'s guard.

**Dependency (`chore(console)`):** `iii-browser-sdk` `^0.12.0` → `^0.21.6`. Wire format, invocation timeouts, and reconnect behavior verified unchanged for the console's usage (dists diffed); the removed `createChannel`/`createStream`/`RegisterService` APIs were never used here.

> **Upstream note:** the SDK-side guard (iii repo PR #1964, commit `5622bc6a`, repo-tagged `0.21.6`) is **missing from the published npm `0.21.6` tarball** — only `0.21.8-next.*` prereleases contain it. Until a stable SDK release ships the guard, the polyfill in this PR is the load-bearing fix; the bump alone does not fix LAN access.

**Docs (`docs(console)`):** README tech-stack table updated to the new SDK version.

## Test Coverage

Tests: 1054 → 1065 (+11 new). All unit-testable branches of the new code are covered (9/9); wiring is covered end-to-end (below).

```
DIFF COVERAGE MAP  (crypto.randomUUID polyfill for insecure origins)
=====================================================================
lib/crypto-polyfill.ts  installRandomUUIDPolyfill()          [NEW]
 +-- typeof crypto === 'undefined' -> early return         [UNIT] no-op, no throw
 +-- crypto.randomUUID is a function -> early return       [UNIT] native kept (identity)
 +-- no crypto.getRandomValues -> bail + warn              [UNIT] guards stay intact
 +-- install via Object.defineProperty
 |    +-- succeeds -> uuidV4 installed                     [UNIT] v4 nibble + RFC variant + unique
 |    |    +-- repeat call -> keeps installed fn           [UNIT] idempotency (identity)
 |    +-- throws (frozen crypto) -> caught + warn          [UNIT] randomUUID stays absent
 +-- module side effect + explicit main.tsx call           [UNIT] source-order tripwire + [E2E]

lib/session-id.ts  mintId()/newSessionId()/newMessageId()
 +-- crypto.randomUUID available -> prefix-<uuid>          [UNIT] exact output w/ stubbed uuid
 +-- crypto present, no randomUUID -> ts36+rand            [UNIT] prefix + unique, no throw
 +-- crypto undefined -> ts36+rand fallback                [UNIT] prefix + unique

wiring (e2e-verified: headless Chromium on http://<LAN-IP>:
        4 uncaught TypeErrors + empty UI before -> 0 errors + live data after)
 +-- lib/backend/real.ts realQueueMessage/realStream: ?? newSessionId()   [E2E]
 +-- hooks/use-conversations.ts dup helper deleted -> shared helper       [E2E + UNIT]
 +-- main.tsx polyfill wiring (ordering + explicit call)                  [E2E + UNIT]
 +-- package.json iii-browser-sdk ^0.12.0 -> ^0.21.6                      [E2E]
```

## Pre-Landing Review

7 findings (0 critical, 7 informational) from testing + maintainability + performance specialists — 6 auto-fixed, 1 deferred:

- [AUTO-FIXED] `main.tsx` — load-bearing polyfill wiring had no regression guard → added `main.test.ts` source-order tripwire
- [AUTO-FIXED] `session-id.ts` — `newMessageId` (same guard class as the bug) had no direct tests → added 3 mirror tests
- [AUTO-FIXED] `session-id.ts` — `newSessionId` duplicated `newMessageId` verbatim → extracted shared `mintId(prefix)`
- [AUTO-FIXED] `session-id.ts` — stale "older WebViews" fallback comment → replaced with the secure-context explanation
- [AUTO-FIXED] `session-id.ts` — stale module docstring title → covers message + session ids
- [AUTO-FIXED] `iii-client.ts:286` — comment claimed `crypto.randomUUID()` is "available in all evergreen browsers" (falsified by this bug) → corrected
- [DEFERRED] `use-conversations.ts` — relocating the exported `uid()` helper (3 importers) and consolidating `makeBrowserId`/`newViewId` onto `mintId` is consistency churn beyond this fix's scope

## Adversarial Review

Claude adversarial subagent (Codex not installed). Two FIXABLE findings, both fixed in this PR:

1. **Polyfill could defeat its own safety net** — installing on a `crypto` that lacks `getRandomValues` (crypto-stripped WebViews) creates a *throwing* `randomUUID` whose mere presence passes every feature-detection guard, converting previously-degraded-but-working environments into a first-render crash → added the bail-out + warn + regression test.
2. **Silent install failure** — the bare `catch {}` left LAN no-data reports undiagnosable → both failure paths now `console.warn`.

Confirmed by the same pass: UUIDv4 polyfill is spec-shaped (version/variant bits, 122 CSPRNG bits, no prototype pollution, never downgrades a native implementation); SDK 0.12→0.21.6 is behaviorally inert for the console's API surface; no other realm (worker/iframe) loads the SDK today.

## Scope Drift

Scope Check: CLEAN — intent (fix LAN no-data) matches delivery (polyfill + guards + SDK bump + tests + doc sync).

## Plan Completion

No plan file detected.

## Documentation

- `console/README.md` — tech-stack table: `iii-browser-sdk` 0.12 → 0.21.6, matching the `^0.21.6` bump in `console/web/package.json`.
- No other doc changes needed: no console doc discusses LAN/remote access or browser requirements, so the insecure-origin fix contradicts nothing. The behavior is documented in-code (`console/web/src/lib/crypto-polyfill.ts` docblock and the `main.tsx` boot comment).
- No CHANGELOG exists for console — intentionally not created.

### Documentation Debt
- ⚠️ LAN / insecure-origin access (`http://<LAN-IP>:3113`) — shipped capability with zero doc coverage; a short access/troubleshooting note in `console/README.md` would fill it.
- ⚠️ `console/web/README.md` — pre-existing staleness: still framed as the mocked "chat-app scaffold"; its `src/` layout tree lists ~10 of 40+ `lib/` files.
- ⚠️ Discoverability — `console/PRODUCT.md`, `console/DESIGN.md`, and `console/docs/*.md` are not linked from `console/README.md`.

## Test plan

- [x] Vitest: 1065 tests / 83 files pass (`console/web`, on merged main)
- [x] Cargo: 21 tests pass (`console` crate, includes embedded-bundle + proxy tests)
- [x] Typecheck (`tsc -b`) + Biome clean on all touched files
- [x] E2E repro of the reported bug: headless Chromium against `http://192.168.1.206:<port>` (insecure LAN origin) — **before:** 4 × `Uncaught TypeError: crypto.randomUUID is not a function`, page renders with zero data; **after:** 0 console errors, `isSecureContext:false` with `typeof crypto.randomUUID === "function"` (polyfill active), live engine data renders (workers list, traces timeline)
- [x] Loopback control (`http://127.0.0.1`): secure context keeps the native `randomUUID`, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

