### PR TITLE
MOT-4176 feat(llm-router,providers): provider-side env-var credential fallback

### DIFF
--- a/llm-router/src/provider_scaffold/cache.rs
+++ b/llm-router/src/provider_scaffold/cache.rs
@@ -68,13 +68,15 @@ impl ScaffoldCache {
         iii: &IIIClient,
         provider_id: &str,
         token: Option<&str>,
+        credential_env_var: Option<&str>,
     ) -> Result<ProviderResolveResponse, Error> {
         if let Some(resolved) = self.fresh_resolve() {
             return Ok(resolved);
         }
         // The lock is never held across the await; concurrent misses may
         // duplicate one resolve, which is harmless.
-        let resolved = super::router_client::resolve(iii, provider_id, token).await?;
+        let resolved =
+            super::router_client::resolve(iii, provider_id, token, credential_env_var).await?;
         *self.resolve.write().expect("resolve cache lock poisoned") =
             Some((resolved.clone(), Instant::now()));
         Ok(resolved)

--- a/llm-router/src/provider_scaffold/router_client.rs
+++ b/llm-router/src/provider_scaffold/router_client.rs
@@ -105,9 +105,9 @@ pub fn apply_credential_env_fallback(
 
 #[cfg(test)]
 mod fallback_tests {
+    use super::with_api_key_fallback;
     use crate::types::credential::Credential;
     use crate::types::router::{CredentialSource, ProviderResolveResponse};
-    use super::with_api_key_fallback;
 
     fn none_resp() -> ProviderResolveResponse {
         ProviderResolveResponse {
@@ -122,18 +122,30 @@ mod fallback_tests {
     #[test]
     fn router_credential_wins_over_env() {
         let mut resp = none_resp();
-        resp.credential = Some(Credential::ApiKey { key: "from-router".into() });
+        resp.credential = Some(Credential::ApiKey {
+            key: "from-router".into(),
+        });
         resp.source = CredentialSource::Config;
         resp.configured = true;
         let out = with_api_key_fallback(resp, Some("from-env".into()));
-        assert_eq!(out.credential, Some(Credential::ApiKey { key: "from-router".into() }));
+        assert_eq!(
+            out.credential,
+            Some(Credential::ApiKey {
+                key: "from-router".into()
+            })
+        );
         assert_eq!(out.source, CredentialSource::Config);
     }
 
     #[test]
     fn injects_env_when_router_has_none() {
         let out = with_api_key_fallback(none_resp(), Some("sk-abc".into()));
-        assert_eq!(out.credential, Some(Credential::ApiKey { key: "sk-abc".into() }));
+        assert_eq!(
+            out.credential,
+            Some(Credential::ApiKey {
+                key: "sk-abc".into()
+            })
+        );
         assert_eq!(out.source, CredentialSource::Env);
         assert!(out.configured);
     }
@@ -147,13 +159,24 @@ mod fallback_tests {
 
     #[test]
     fn empty_and_whitespace_are_not_injected() {
-        assert_eq!(with_api_key_fallback(none_resp(), Some("".into())).credential, None);
-        assert_eq!(with_api_key_fallback(none_resp(), Some("  \n".into())).credential, None);
+        assert_eq!(
+            with_api_key_fallback(none_resp(), Some("".into())).credential,
+            None
+        );
+        assert_eq!(
+            with_api_key_fallback(none_resp(), Some("  \n".into())).credential,
+            None
+        );
     }
 
     #[test]
     fn injected_key_is_trimmed() {
         let out = with_api_key_fallback(none_resp(), Some(" sk-abc\n".into()));
-        assert_eq!(out.credential, Some(Credential::ApiKey { key: "sk-abc".into() }));
+        assert_eq!(
+            out.credential,
+            Some(Credential::ApiKey {
+                key: "sk-abc".into()
+            })
+        );
     }
 }

--- a/llm-router/src/provider_scaffold/router_client.rs
+++ b/llm-router/src/provider_scaffold/router_client.rs
@@ -1,8 +1,9 @@
 //! Thin wrappers over the router's provider-protocol functions. All calls
 //! carry the registration token (identity binding, spec adaptation #1).
 //! `provider_id` is the caller's declared provider id (e.g. "anthropic").
+use crate::types::credential::Credential;
 use crate::types::model::Model;
-use crate::types::router::ProviderResolveResponse;
+use crate::types::router::{CredentialSource, ProviderResolveResponse};
 use iii_sdk::errors::Error;
 use iii_sdk::protocol::TriggerRequest;
 use iii_sdk::IIIClient;
@@ -69,4 +70,88 @@ pub async fn models_get(iii: &IIIClient, provider_id: &str, model_id: &str) -> O
 /// `router::provider::register` — returns the registration token to persist.
 pub async fn register(iii: &IIIClient, declaration: Value) -> Result<Value, Error> {
     call(iii, "router::provider::register", declaration).await
+}
+
+/// Inject an env-sourced ApiKey only when the router resolved nothing.
+/// Pure: takes the already-read value so tests never touch process env.
+fn with_api_key_fallback(
+    mut resp: ProviderResolveResponse,
+    key: Option<String>,
+) -> ProviderResolveResponse {
+    if resp.credential.is_some() {
+        return resp; // router / config credential always wins
+    }
+    if let Some(k) = key {
+        let k = k.trim();
+        if !k.is_empty() {
+            resp.credential = Some(Credential::ApiKey { key: k.to_string() });
+            resp.source = CredentialSource::Env;
+            resp.configured = true;
+        }
+    }
+    resp
+}
+
+/// Read the provider's declared env var and apply the fallback.
+pub fn apply_credential_env_fallback(
+    resp: ProviderResolveResponse,
+    credential_env_var: Option<&str>,
+) -> ProviderResolveResponse {
+    let key = credential_env_var.and_then(|name| std::env::var(name).ok());
+    with_api_key_fallback(resp, key)
+}
+
+#[cfg(test)]
+mod fallback_tests {
+    use crate::types::credential::Credential;
+    use crate::types::router::{CredentialSource, ProviderResolveResponse};
+    use super::with_api_key_fallback;
+
+    fn none_resp() -> ProviderResolveResponse {
+        ProviderResolveResponse {
+            configured: false,
+            source: CredentialSource::None,
+            credential: None,
+            api_url: None,
+            max_tokens: None,
+        }
+    }
+
+    #[test]
+    fn router_credential_wins_over_env() {
+        let mut resp = none_resp();
+        resp.credential = Some(Credential::ApiKey { key: "from-router".into() });
+        resp.source = CredentialSource::Config;
+        resp.configured = true;
+        let out = with_api_key_fallback(resp, Some("from-env".into()));
+        assert_eq!(out.credential, Some(Credential::ApiKey { key: "from-router".into() }));
+        assert_eq!(out.source, CredentialSource::Config);
+    }
+
+    #[test]
+    fn injects_env_when_router_has_none() {
+        let out = with_api_key_fallback(none_resp(), Some("sk-abc".into()));
+        assert_eq!(out.credential, Some(Credential::ApiKey { key: "sk-abc".into() }));
+        assert_eq!(out.source, CredentialSource::Env);
+        assert!(out.configured);
+    }
+
+    #[test]
+    fn no_key_leaves_none() {
+        let out = with_api_key_fallback(none_resp(), None);
+        assert_eq!(out.credential, None);
+        assert!(!out.configured);
+    }
+
+    #[test]
+    fn empty_and_whitespace_are_not_injected() {
+        assert_eq!(with_api_key_fallback(none_resp(), Some("".into())).credential, None);
+        assert_eq!(with_api_key_fallback(none_resp(), Some("  \n".into())).credential, None);
+    }
+
+    #[test]
+    fn injected_key_is_trimmed() {
+        let out = with_api_key_fallback(none_resp(), Some(" sk-abc\n".into()));
+        assert_eq!(out.credential, Some(Credential::ApiKey { key: "sk-abc".into() }));
+    }
 }

--- a/llm-router/src/provider_scaffold/router_client.rs
+++ b/llm-router/src/provider_scaffold/router_client.rs
@@ -24,17 +24,19 @@ pub async fn resolve(
     iii: &IIIClient,
     provider_id: &str,
     token: Option<&str>,
+    credential_env_var: Option<&str>,
 ) -> Result<ProviderResolveResponse, Error> {
     let mut payload = json!({ "id": provider_id });
     if let Some(t) = token {
         payload["token"] = json!(t);
     }
     let raw = call(iii, "router::provider::resolve", payload).await?;
-    serde_json::from_value(raw).map_err(|e| Error::Remote {
+    let resp: ProviderResolveResponse = serde_json::from_value(raw).map_err(|e| Error::Remote {
         code: "provider/bad_resolve_response".into(),
         message: e.to_string(),
         stacktrace: None,
-    })
+    })?;
+    Ok(apply_credential_env_fallback(resp, credential_env_var))
 }
 
 /// `router::models::reconcile` — replace this provider's catalog slice.

--- a/provider-anthropic/src/register.rs
+++ b/provider-anthropic/src/register.rs
@@ -18,11 +18,14 @@ use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+/// Env var the router (and, as a fallback, this provider) reads for the key.
+pub const CREDENTIAL_ENV_VAR: &str = "ANTHROPIC_API_KEY";
+
 pub fn declaration() -> ProviderDeclaration {
     ProviderDeclaration {
         id: PROVIDER_ID.into(),
         display_name: Some("Anthropic".into()),
-        credential_env_var: Some("ANTHROPIC_API_KEY".into()),
+        credential_env_var: Some(CREDENTIAL_ENV_VAR.into()),
         defaults: Some(ProviderDefaults {
             api_url: Some(DEFAULT_API_URL.into()),
             max_tokens: Some(DEFAULT_MAX_TOKENS),
@@ -209,5 +212,14 @@ mod tests {
         assert!(prompt.starts_with("You are an iii agent worker."));
         assert!(prompt.contains("agent_trigger"));
         assert!(prompt.contains("IMPORTANT: NEVER invent function ids"));
+    }
+
+    #[test]
+    fn declaration_uses_credential_env_var_const() {
+        assert_eq!(super::CREDENTIAL_ENV_VAR, "ANTHROPIC_API_KEY");
+        assert_eq!(
+            declaration().credential_env_var.as_deref(),
+            Some(super::CREDENTIAL_ENV_VAR)
+        );
     }
 }

--- a/provider-anthropic/src/router_client.rs
+++ b/provider-anthropic/src/router_client.rs
@@ -14,7 +14,13 @@ pub async fn resolve(
     iii: &IIIClient,
     token: Option<&str>,
 ) -> Result<ProviderResolveResponse, Error> {
-    scaffold::resolve(iii, PROVIDER_ID, token).await
+    scaffold::resolve(
+        iii,
+        PROVIDER_ID,
+        token,
+        Some(crate::register::CREDENTIAL_ENV_VAR),
+    )
+    .await
 }
 
 /// `router::models::reconcile` — replace this provider's catalog slice.

--- a/provider-anthropic/src/stream_fn.rs
+++ b/provider-anthropic/src/stream_fn.rs
@@ -74,7 +74,12 @@ async fn run_stream_call(
     // stays the router's job.
     let token = cache.load_token(iii, state::STATE_SCOPE).await;
     let resolved = match cache
-        .resolve(iii, crate::PROVIDER_ID, token.as_deref())
+        .resolve(
+            iii,
+            crate::PROVIDER_ID,
+            token.as_deref(),
+            Some(crate::register::CREDENTIAL_ENV_VAR),
+        )
         .await
     {
         Ok(r) => r,

--- a/provider-kimi/src/register.rs
+++ b/provider-kimi/src/register.rs
@@ -17,11 +17,14 @@ use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+/// Env var the router (and, as a fallback, this provider) reads for the key.
+pub const CREDENTIAL_ENV_VAR: &str = "MOONSHOT_API_KEY";
+
 pub fn declaration() -> ProviderDeclaration {
     ProviderDeclaration {
         id: PROVIDER_ID.into(),
         display_name: Some("Kimi".into()),
-        credential_env_var: Some("MOONSHOT_API_KEY".into()),
+        credential_env_var: Some(CREDENTIAL_ENV_VAR.into()),
         defaults: Some(ProviderDefaults {
             api_url: Some(DEFAULT_API_URL.into()),
             max_tokens: Some(DEFAULT_MAX_TOKENS),
@@ -183,5 +186,14 @@ mod tests {
         assert!(prompt.starts_with("You are an iii agent worker."));
         assert!(prompt.contains("agent_trigger"));
         assert!(prompt.contains("Never invent function ids"));
+    }
+
+    #[test]
+    fn declaration_uses_credential_env_var_const() {
+        assert_eq!(super::CREDENTIAL_ENV_VAR, "MOONSHOT_API_KEY");
+        assert_eq!(
+            declaration().credential_env_var.as_deref(),
+            Some(super::CREDENTIAL_ENV_VAR)
+        );
     }
 }

--- a/provider-kimi/src/router_client.rs
+++ b/provider-kimi/src/router_client.rs
@@ -33,10 +33,12 @@ pub async fn resolve(
         message: e.to_string(),
         stacktrace: None,
     })?;
-    Ok(llm_router::provider_scaffold::router_client::apply_credential_env_fallback(
-        resp,
-        Some(crate::register::CREDENTIAL_ENV_VAR),
-    ))
+    Ok(
+        llm_router::provider_scaffold::router_client::apply_credential_env_fallback(
+            resp,
+            Some(crate::register::CREDENTIAL_ENV_VAR),
+        ),
+    )
 }
 
 /// `router::models::reconcile` — replace this provider's catalog slice.

--- a/provider-kimi/src/router_client.rs
+++ b/provider-kimi/src/router_client.rs
@@ -28,11 +28,15 @@ pub async fn resolve(
         payload["token"] = json!(t);
     }
     let raw = call(iii, "router::provider::resolve", payload).await?;
-    serde_json::from_value(raw).map_err(|e| Error::Remote {
+    let resp: ProviderResolveResponse = serde_json::from_value(raw).map_err(|e| Error::Remote {
         code: "provider/bad_resolve_response".into(),
         message: e.to_string(),
         stacktrace: None,
-    })
+    })?;
+    Ok(llm_router::provider_scaffold::router_client::apply_credential_env_fallback(
+        resp,
+        Some(crate::register::CREDENTIAL_ENV_VAR),
+    ))
 }
 
 /// `router::models::reconcile` — replace this provider's catalog slice.

--- a/provider-llamacpp/src/embed.rs
+++ b/provider-llamacpp/src/embed.rs
@@ -94,7 +94,12 @@ pub async fn handle(
     // stays the router's job.
     let token = cache.load_token(iii, state::STATE_SCOPE).await;
     let resolved = cache
-        .resolve(iii, crate::PROVIDER_ID, token.as_deref())
+        .resolve(
+            iii,
+            crate::PROVIDER_ID,
+            token.as_deref(),
+            Some(crate::register::CREDENTIAL_ENV_VAR),
+        )
         .await
         .inspect_err(|e| {
             if classify_bus_error(e) == ErrorKind::AuthExpired {

--- a/provider-llamacpp/src/register.rs
+++ b/provider-llamacpp/src/register.rs
@@ -18,11 +18,14 @@ use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+/// Env var the router (and, as a fallback, this provider) reads for the key.
+pub const CREDENTIAL_ENV_VAR: &str = "LLAMACPP_API_KEY";
+
 pub fn declaration() -> ProviderDeclaration {
     ProviderDeclaration {
         id: PROVIDER_ID.into(),
         display_name: Some("llama.cpp".into()),
-        credential_env_var: Some("LLAMACPP_API_KEY".into()),
+        credential_env_var: Some(CREDENTIAL_ENV_VAR.into()),
         defaults: Some(ProviderDefaults {
             api_url: Some(DEFAULT_API_URL.into()),
             max_tokens: Some(DEFAULT_MAX_TOKENS),
@@ -212,5 +215,14 @@ mod tests {
         assert!(prompt.starts_with("You are an iii agent worker."));
         assert!(prompt.contains("agent_trigger"));
         assert!(prompt.contains("IMPORTANT: NEVER invent function ids"));
+    }
+
+    #[test]
+    fn declaration_uses_credential_env_var_const() {
+        assert_eq!(super::CREDENTIAL_ENV_VAR, "LLAMACPP_API_KEY");
+        assert_eq!(
+            declaration().credential_env_var.as_deref(),
+            Some(super::CREDENTIAL_ENV_VAR)
+        );
     }
 }

--- a/provider-llamacpp/src/router_client.rs
+++ b/provider-llamacpp/src/router_client.rs
@@ -14,7 +14,13 @@ pub async fn resolve(
     iii: &IIIClient,
     token: Option<&str>,
 ) -> Result<ProviderResolveResponse, Error> {
-    scaffold::resolve(iii, PROVIDER_ID, token).await
+    scaffold::resolve(
+        iii,
+        PROVIDER_ID,
+        token,
+        Some(crate::register::CREDENTIAL_ENV_VAR),
+    )
+    .await
 }
 
 /// `router::models::reconcile` — replace this provider's catalog slice.

--- a/provider-llamacpp/src/stream_fn.rs
+++ b/provider-llamacpp/src/stream_fn.rs
@@ -64,7 +64,12 @@ async fn run_stream_call(
     // stays the router's job.
     let token = cache.load_token(iii, state::STATE_SCOPE).await;
     let resolved = match cache
-        .resolve(iii, crate::PROVIDER_ID, token.as_deref())
+        .resolve(
+            iii,
+            crate::PROVIDER_ID,
+            token.as_deref(),
+            Some(crate::register::CREDENTIAL_ENV_VAR),
+        )
         .await
     {
         Ok(r) => r,

--- a/provider-openai-codex/src/router_client.rs
+++ b/provider-openai-codex/src/router_client.rs
@@ -66,7 +66,7 @@ pub async fn resolve(
     iii: &IIIClient,
     token: Option<&str>,
 ) -> Result<ProviderResolveResponse, Error> {
-    scaffold::resolve(iii, PROVIDER_ID, token).await
+    scaffold::resolve(iii, PROVIDER_ID, token, None).await
 }
 
 /// `router::models::reconcile` — replace this provider's catalog slice.

--- a/provider-openai-codex/src/stream_fn.rs
+++ b/provider-openai-codex/src/stream_fn.rs
@@ -81,7 +81,7 @@ async fn run_stream_call(
     // An auth-classified failure drops the cache so the next attempt
     // re-resolves fresh — retrying stays the router's job.
     let resolved = match cache
-        .resolve(iii, crate::PROVIDER_ID, token.as_deref())
+        .resolve(iii, crate::PROVIDER_ID, token.as_deref(), None)
         .await
     {
         Ok(r) => r,

--- a/provider-openai/src/embed.rs
+++ b/provider-openai/src/embed.rs
@@ -93,7 +93,12 @@ pub async fn handle(
     // stays the router's job.
     let token = cache.load_token(iii, state::STATE_SCOPE).await;
     let resolved = match cache
-        .resolve(iii, crate::PROVIDER_ID, token.as_deref())
+        .resolve(
+            iii,
+            crate::PROVIDER_ID,
+            token.as_deref(),
+            Some(crate::register::CREDENTIAL_ENV_VAR),
+        )
         .await
     {
         Ok(r) => r,

--- a/provider-openai/src/register.rs
+++ b/provider-openai/src/register.rs
@@ -18,11 +18,14 @@ use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+/// Env var the router (and, as a fallback, this provider) reads for the key.
+pub const CREDENTIAL_ENV_VAR: &str = "OPENAI_API_KEY";
+
 pub fn declaration() -> ProviderDeclaration {
     ProviderDeclaration {
         id: PROVIDER_ID.into(),
         display_name: Some("OpenAI".into()),
-        credential_env_var: Some("OPENAI_API_KEY".into()),
+        credential_env_var: Some(CREDENTIAL_ENV_VAR.into()),
         defaults: Some(ProviderDefaults {
             api_url: Some(DEFAULT_API_URL.into()),
             max_tokens: Some(DEFAULT_MAX_TOKENS),
@@ -222,5 +225,14 @@ mod tests {
         assert!(prompt.starts_with("You are an iii agent worker."));
         assert!(prompt.contains("agent_trigger"));
         assert!(prompt.contains("## Autonomy and persistence"));
+    }
+
+    #[test]
+    fn declaration_uses_credential_env_var_const() {
+        assert_eq!(super::CREDENTIAL_ENV_VAR, "OPENAI_API_KEY");
+        assert_eq!(
+            declaration().credential_env_var.as_deref(),
+            Some(super::CREDENTIAL_ENV_VAR)
+        );
     }
 }

--- a/provider-openai/src/router_client.rs
+++ b/provider-openai/src/router_client.rs
@@ -14,7 +14,13 @@ pub async fn resolve(
     iii: &IIIClient,
     token: Option<&str>,
 ) -> Result<ProviderResolveResponse, Error> {
-    scaffold::resolve(iii, PROVIDER_ID, token).await
+    scaffold::resolve(
+        iii,
+        PROVIDER_ID,
+        token,
+        Some(crate::register::CREDENTIAL_ENV_VAR),
+    )
+    .await
 }
 
 /// `router::models::reconcile` — replace this provider's catalog slice.

--- a/provider-openai/src/stream_fn.rs
+++ b/provider-openai/src/stream_fn.rs
@@ -82,7 +82,12 @@ async fn run_stream_call(
     // stays the router's job.
     let token = cache.load_token(iii, state::STATE_SCOPE).await;
     let resolved = match cache
-        .resolve(iii, crate::PROVIDER_ID, token.as_deref())
+        .resolve(
+            iii,
+            crate::PROVIDER_ID,
+            token.as_deref(),
+            Some(crate::register::CREDENTIAL_ENV_VAR),
+        )
         .await
     {
         Ok(r) => r,

--- a/provider-xai/src/register.rs
+++ b/provider-xai/src/register.rs
@@ -18,11 +18,14 @@ use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+/// Env var the router (and, as a fallback, this provider) reads for the key.
+pub const CREDENTIAL_ENV_VAR: &str = "XAI_API_KEY";
+
 pub fn declaration() -> ProviderDeclaration {
     ProviderDeclaration {
         id: PROVIDER_ID.into(),
         display_name: Some("xAI".into()),
-        credential_env_var: Some("XAI_API_KEY".into()),
+        credential_env_var: Some(CREDENTIAL_ENV_VAR.into()),
         defaults: Some(ProviderDefaults {
             api_url: Some(DEFAULT_API_URL.into()),
             max_tokens: Some(DEFAULT_MAX_TOKENS),
@@ -246,5 +249,14 @@ mod tests {
         assert!(prompt.starts_with("You are an iii agent worker."));
         assert!(prompt.contains("agent_trigger"));
         assert!(prompt.contains("## Autonomy and persistence"));
+    }
+
+    #[test]
+    fn declaration_uses_credential_env_var_const() {
+        assert_eq!(super::CREDENTIAL_ENV_VAR, "XAI_API_KEY");
+        assert_eq!(
+            declaration().credential_env_var.as_deref(),
+            Some(super::CREDENTIAL_ENV_VAR)
+        );
     }
 }

--- a/provider-xai/src/router_client.rs
+++ b/provider-xai/src/router_client.rs
@@ -14,7 +14,13 @@ pub async fn resolve(
     iii: &IIIClient,
     token: Option<&str>,
 ) -> Result<ProviderResolveResponse, Error> {
-    scaffold::resolve(iii, PROVIDER_ID, token).await
+    scaffold::resolve(
+        iii,
+        PROVIDER_ID,
+        token,
+        Some(crate::register::CREDENTIAL_ENV_VAR),
+    )
+    .await
 }
 
 /// `router::models::reconcile` — replace this provider's catalog slice.

--- a/provider-xai/src/stream_fn.rs
+++ b/provider-xai/src/stream_fn.rs
@@ -103,7 +103,12 @@ async fn run_stream_call(
     // stays the router's job.
     let token = cache.load_token(iii, state::STATE_SCOPE).await;
     let resolved = match cache
-        .resolve(iii, crate::PROVIDER_ID, token.as_deref())
+        .resolve(
+            iii,
+            crate::PROVIDER_ID,
+            token.as_deref(),
+            Some(crate::register::CREDENTIAL_ENV_VAR),
+        )
         .await
     {
         Ok(r) => r,

--- a/provider-zai/src/register.rs
+++ b/provider-zai/src/register.rs
@@ -18,11 +18,14 @@ use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+/// Env var the router (and, as a fallback, this provider) reads for the key.
+pub const CREDENTIAL_ENV_VAR: &str = "ZAI_API_KEY";
+
 pub fn declaration() -> ProviderDeclaration {
     ProviderDeclaration {
         id: PROVIDER_ID.into(),
         display_name: Some("Z.AI".into()),
-        credential_env_var: Some("ZAI_API_KEY".into()),
+        credential_env_var: Some(CREDENTIAL_ENV_VAR.into()),
         defaults: Some(ProviderDefaults {
             api_url: Some(DEFAULT_API_URL.into()),
             max_tokens: Some(DEFAULT_MAX_TOKENS),
@@ -209,5 +212,14 @@ mod tests {
         assert!(prompt.starts_with("You are an iii agent worker."));
         assert!(prompt.contains("agent_trigger"));
         assert!(prompt.contains("IMPORTANT: NEVER invent function ids"));
+    }
+
+    #[test]
+    fn declaration_uses_credential_env_var_const() {
+        assert_eq!(super::CREDENTIAL_ENV_VAR, "ZAI_API_KEY");
+        assert_eq!(
+            declaration().credential_env_var.as_deref(),
+            Some(super::CREDENTIAL_ENV_VAR)
+        );
     }
 }

--- a/provider-zai/src/router_client.rs
+++ b/provider-zai/src/router_client.rs
@@ -14,7 +14,13 @@ pub async fn resolve(
     iii: &IIIClient,
     token: Option<&str>,
 ) -> Result<ProviderResolveResponse, Error> {
-    scaffold::resolve(iii, PROVIDER_ID, token).await
+    scaffold::resolve(
+        iii,
+        PROVIDER_ID,
+        token,
+        Some(crate::register::CREDENTIAL_ENV_VAR),
+    )
+    .await
 }
 
 /// `router::models::reconcile` — replace this provider's catalog slice.

--- a/provider-zai/src/stream_fn.rs
+++ b/provider-zai/src/stream_fn.rs
@@ -65,7 +65,12 @@ async fn run_stream_call(
     // stays the router's job.
     let token = cache.load_token(iii, state::STATE_SCOPE).await;
     let resolved = match cache
-        .resolve(iii, crate::PROVIDER_ID, token.as_deref())
+        .resolve(
+            iii,
+            crate::PROVIDER_ID,
+            token.as_deref(),
+            Some(crate::register::CREDENTIAL_ENV_VAR),
+        )
         .await
     {
         Ok(r) => r,


### PR DESCRIPTION
## Summary

A provider's API key set in the **provider's own environment** was never loaded: every provider declares `credential_env_var` (e.g. `ZAI_API_KEY`) in its `ProviderDeclaration`, but the only `std::env::var` read happens inside **llm-router's** process during `router::provider::resolve` (`registry/resolve.rs`). If the router runs under a different supervisor/environment than the provider, the key is present-but-unreachable and the provider fails `NotConfigured`.

**Fix:** when the router resolves **no** credential, the provider now falls back to reading its own declared env var from its own process. Strictly subordinate — any router-resolved credential (config slice or router-process env) always wins, so nothing that works today changes.

Per commit:
- **feat(llm-router):** pure `with_api_key_fallback` + env-reading `apply_credential_env_fallback` in `provider_scaffold/router_client.rs`. Injects `Credential::ApiKey` with `source=Env`, `configured=true` only when the router returned `credential: None` and the var is non-empty after trim (whitespace-only keys are rejected — stricter than the router's own `is_empty()` check).
- **refactor(providers):** each keyed provider hoists its env-var literal into `pub const CREDENTIAL_ENV_VAR`, reused by `declaration()` and the resolve call sites (single source of truth).
- **feat(providers):** `scaffold::resolve` + `ScaffoldCache::resolve` gain a trailing `credential_env_var: Option<&str>` and apply the fallback before returning/caching. All call sites wired atomically: anthropic/zai/openai/xai/llamacpp pass `Some(CREDENTIAL_ENV_VAR)` on both hot (`stream_fn`, `embed`) and discovery paths (via each crate's `router_client` wrapper, whose external 2-arg signature is unchanged); **openai-codex** passes `None` (OAuth-only); **kimi**'s inlined resolve wraps its response with the shared helper. llamacpp's no-key local flow is untouched (unset var = no-op).

Env vars: `ANTHROPIC_API_KEY`, `ZAI_API_KEY`, `MOONSHOT_API_KEY`, `OPENAI_API_KEY`, `XAI_API_KEY`, `LLAMACPP_API_KEY`.

Out of scope (unchanged): router-side resolve precedence, `CredentialSource` protocol enum (reuses `Env`), OAuth handling, version bumps.

## Test Coverage

```
DIFF COVERAGE MAP  (env-var credential fallback)
================================================
with_api_key_fallback (pure — never touches process env)
 +-- router credential present -> unchanged (source kept)   [UNIT] router_credential_wins_over_env
 +-- none + key -> ApiKey, source=Env, configured=true      [UNIT] injects_env_when_router_has_none
 +-- none + no key -> credential stays None                 [UNIT] no_key_leaves_none
 +-- "" / whitespace-only -> no injection                   [UNIT] empty_and_whitespace_are_not_injected
 +-- " sk-abc\n" -> trimmed to "sk-abc"                     [UNIT] injected_key_is_trimmed
CREDENTIAL_ENV_VAR consts (x6)
 +-- const value + declaration() wiring                     [UNIT] declaration_uses_credential_env_var_const
```

Per-crate (each crate is its own standalone Cargo workspace; built+tested from its own dir):
llm-router 94 lib (+13/+4 int); anthropic 83; zai 62; kimi 61; openai 78; xai 75; llamacpp 63; openai-codex 56 — all green, plus each crate's doc/integration suites.

**Known pre-existing failure (not this PR):** `provider-llamacpp` integration `provider_registers_with_persisted_token_and_discovers_catalog_without_a_credential` (catalog count 0 vs 1) reproduces identically at the pre-branch commit in an isolated worktree; the fallback wiring lands only in the final commit, after the failure already exists.

## Pre-Landing Review

Per-task spec+quality reviews (all approved) plus a final whole-branch review: verdict **ready to merge**, no Critical/Important findings. Deferred minors: (1) the no-credential integration tests are now coupled to ambient env — a CI shell exporting e.g. `LLAMACPP_API_KEY` could flip them (suggest hermetic `remove_var` in a follow-up); (2) env-injected keys ride the existing 30s resolve-cache TTL (matches current semantics; informational).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API credentials can now be supplied through configured environment variables when no credential is returned by the router.
  * Environment-provided credentials are trimmed and clearly marked as the active source.
  * Supported providers now expose standardized credential environment variable settings.

* **Bug Fixes**
  * Existing router-provided credentials continue to take precedence over environment values.
  * Empty or whitespace-only environment variables are ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->