### PR TITLE
(MOT-4175) feat(database): add execute_batch atomic batch-write function

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -182,9 +182,10 @@ const { rows } = await iii.trigger({
 |---|---|
 | `database::query` | Read SQL. Returns `{ rows, row_count, columns }`. |
 | `database::execute` | Write SQL. Returns `{ affected_rows, last_insert_id, returned_rows }`.<br>**`last_insert_id` semantics:** SQLite/MySQL surface the engine's `last_insert_rowid()` / `LAST_INSERT_ID()` (only populated for INSERT). Postgres has no equivalent — `last_insert_id` is set from the **first column of the first RETURNING row**, so put your PK first: `RETURNING id, name`, not `RETURNING name, id`. |
+| `database::execute_batch` | Convenience form of `transaction`: statements may be bare SQL strings or `{ sql, params }` objects (use `params` for dynamic values instead of inlining them). Same envelope and semantics as `transaction` — atomic, rolls back on first failure, reports `failed_index`, supports `isolation`. Also registered as `database::executeBatch`. |
 | `database::prepareStatement` | Pin a connection and return `{ handle: { id, expires_at } }`. |
 | `database::runStatement` | Run a previously-prepared handle. (No `timeout_ms` — uses the pinned connection's session lifetime; configure via `ttl_seconds` on `prepareStatement`.) |
-| `database::transaction` | Atomic batch sequence; rolls back on first failure. One-shot — pass all statements together. |
+| `database::transaction` | Atomic batch sequence; rolls back on first failure. One-shot — pass all statements together. Rejects bare transaction-control SQL (`BEGIN`/`COMMIT`/`ROLLBACK`/…) and empty statements with `INVALID_PARAM`. |
 | `database::beginTransaction` | Open an interactive transaction. Returns `{ transaction: { id, expires_at } }`. Configurable `timeout_ms` (default 30 000, max 300 000) auto-rolls back if the deadline elapses. |
 | `database::transactionQuery` | Read SQL inside an interactive transaction. Same envelope as `query`. |
 | `database::transactionExecute` | Write SQL inside an interactive transaction. Same envelope as `execute`. Rejects bare `BEGIN`/`COMMIT`/`ROLLBACK`/`SAVEPOINT`/`SET TRANSACTION` with `INVALID_PARAM` — finalize via the dedicated handlers below. |
@@ -221,7 +222,7 @@ Returned `IIIError::Handler` bodies carry a stable `code` field:
 | `STATEMENT_NOT_FOUND` | Handle expired or unknown — re-prepare. |
 | `TRANSACTION_NOT_FOUND` | Transaction id unknown, already committed/rolled back, or timed out (auto-rolled-back by the watcher). |
 | `UNKNOWN_DB` | `db` parameter doesn't match any configured database. |
-| `INVALID_PARAM` | JSON value couldn't be coerced for the target driver, or transaction-control SQL was sent to `transactionExecute` (use `commitTransaction` / `rollbackTransaction`). |
+| `INVALID_PARAM` | JSON value couldn't be coerced for the target driver, transaction-control SQL was sent to `transactionExecute` (use `commitTransaction` / `rollbackTransaction`), or a `transaction`/`execute_batch` batch contained transaction-control SQL or an empty statement. |
 | `DRIVER_ERROR` | Wraps underlying driver error with `driver` and `inner_code` (nullable). `inner_code` format is per-driver: Postgres = SQLSTATE 5-char string (e.g. `42P01`), MySQL = server error number as string, SQLite = `rusqlite::ErrorCode` debug name. Pool-acquire failures use the message form `pool connection failed (<class>)` where `<class>` is one of `tls`, `auth`, `network`, `server-policy`, or `unknown` — a redacted hint so untrusted callers can self-triage without seeing host/userinfo/db fragments. The full driver error is in the worker's stderr via `tracing::warn!`. |
 | `REPLICATION_SLOT_EXISTS` | Startup-only: another instance owns the slot. |
 | `UNSUPPORTED` | Operation not supported on the chosen driver. |

--- a/database/skills/SKILL.md
+++ b/database/skills/SKILL.md
@@ -22,7 +22,8 @@ point. Placeholder syntax: `?` for SQLite and MySQL, `$1`/`$2`/… for Postgres.
 - You need to insert, update, delete, or run DDL and read affected-row
   counts or autoincrement ids (`database::execute`).
 - Several statements must commit or roll back together as one unit
-  (`database::transaction` or the interactive transaction surface).
+  (`database::transaction`, `database::execute_batch`, or the interactive
+  transaction surface).
 - The same parameterized SQL will run many times and you want to skip
   per-call parse/plan cost (`database::prepareStatement` +
   `database::runStatement`).
@@ -39,8 +40,9 @@ point. Placeholder syntax: `?` for SQLite and MySQL, `$1`/`$2`/… for Postgres.
 - `database::query` is read-oriented; use `database::execute` for writes.
   Running a SELECT through `execute` discards rows.
 - Prepared handles pin a pool connection until TTL expiry — not transactions.
-  Batch `database::transaction` needs every statement up front; use the
-  interactive surface when code must branch between steps.
+  Batch `database::transaction` / `database::execute_batch` need every
+  statement up front; use the interactive surface when code must branch
+  between steps.
 - MySQL ignores the `returning` option on `execute` (warn-once). SQLite
   degrades `read_committed` / `repeatable_read` isolation to serializable.
 - For filesystem or shell operations, use the `shell` worker instead.
@@ -51,6 +53,10 @@ point. Placeholder syntax: `?` for SQLite and MySQL, `$1`/`$2`/… for Postgres.
   column metadata.
 - `database::execute` — run write SQL (INSERT/UPDATE/DELETE/DDL) and
   return affected rows, optional last insert id, and optional RETURNING rows.
+- `database::execute_batch` — convenience form of `transaction`: statements
+  may be bare SQL strings or `{sql, params}` objects (prefer `params` for
+  dynamic values). Same atomic semantics, envelope, and `failed_index`
+  reporting as `transaction`. Also callable as `database::executeBatch`.
 - `database::prepareStatement` — parse and plan SQL once; return a handle
   that pins a pool connection until TTL expiry.
 - `database::runStatement` — re-execute a prepared handle with new bind

--- a/database/src/handlers/execute_batch.rs
+++ b/database/src/handlers/execute_batch.rs
@@ -1,0 +1,252 @@
+//! `database::execute_batch` — atomic batch of statements.
+//!
+//! Thin convenience form of `database::transaction`: each statement may be a
+//! bare SQL string or a full `{ sql, params }` object. Delegates to
+//! `transaction::handle`, so semantics (atomicity, isolation, guards,
+//! response envelope) are identical. Also registered under the camelCase
+//! alias `database::executeBatch`.
+
+use super::AppState;
+use crate::handlers::transaction::{self, TxReq, TxResp, TxStmtReq};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Deserialize, JsonSchema)]
+pub struct ExecuteBatchReq {
+    pub db: String,
+    /// Statements to run in order inside one transaction. Each entry is
+    /// either a bare SQL string or `{ "sql": "...", "params": [...] }` —
+    /// use `params` for dynamic values instead of inlining them into the SQL.
+    #[serde(deserialize_with = "lenient_statements")]
+    pub statements: Vec<BatchStatement>,
+    /// Optional: `read_committed` | `repeatable_read` | `serializable`.
+    #[serde(default)]
+    pub isolation: Option<String>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum BatchStatement {
+    Sql(String),
+    Full(TxStmtReq),
+}
+
+/// Like `handlers::lenient_params`: engine/LLM callers sometimes send the
+/// array JSON-encoded as a string; absorb that instead of failing serde.
+fn lenient_statements<'de, D>(de: D) -> Result<Vec<BatchStatement>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error as _;
+    use serde::Deserialize as _;
+
+    let v = match Value::deserialize(de)? {
+        Value::String(s) => serde_json::from_str(&s)
+            .map_err(|e| D::Error::custom(format!("statements string is not a JSON array: {e}")))?,
+        other => other,
+    };
+    serde_json::from_value(v).map_err(D::Error::custom)
+}
+
+pub async fn handle(state: &AppState, req: ExecuteBatchReq) -> Result<TxResp, String> {
+    let statements = req
+        .statements
+        .into_iter()
+        .map(|s| match s {
+            BatchStatement::Sql(sql) => TxStmtReq {
+                sql,
+                params: Vec::new(),
+            },
+            BatchStatement::Full(stmt) => stmt,
+        })
+        .collect();
+    transaction::handle(
+        state,
+        TxReq {
+            db: req.db,
+            statements,
+            isolation: req.isolation,
+        },
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::handlers::begin_transaction::tests::state;
+    use serde_json::json;
+
+    fn batch_req(v: Value) -> ExecuteBatchReq {
+        serde_json::from_value(v).unwrap()
+    }
+
+    #[test]
+    fn request_accepts_stringified_statements_array() {
+        let req = batch_req(json!({
+            "db": "primary",
+            "statements": "[\"INSERT INTO t VALUES (1)\"]"
+        }));
+        assert_eq!(req.statements.len(), 1);
+        assert!(matches!(&req.statements[0], BatchStatement::Sql(s) if s.contains("INSERT")));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commits_bare_string_statements() {
+        let st = state();
+        crate::handlers::execute::handle(
+            &st,
+            serde_json::from_value(json!({"db": "primary", "sql": "CREATE TABLE t (n INT)"}))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let resp = handle(
+            &st,
+            batch_req(json!({
+                "db": "primary",
+                "statements": ["INSERT INTO t VALUES (1)", "INSERT INTO t VALUES (2)"]
+            })),
+        )
+        .await
+        .unwrap();
+
+        assert!(resp.committed);
+        let results = resp.results.unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].affected_rows, 1);
+        assert!(resp.failed_index.is_none());
+        assert!(resp.error.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn mixed_forms_support_bound_params() {
+        let st = state();
+        crate::handlers::execute::handle(
+            &st,
+            serde_json::from_value(json!({"db": "primary", "sql": "CREATE TABLE t (s TEXT)"}))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        // The bound param carries a semicolon — impossible to inline on
+        // sqlite (multi-statement guard), fine as a param.
+        let resp = handle(
+            &st,
+            batch_req(json!({
+                "db": "primary",
+                "statements": [
+                    {"sql": "INSERT INTO t VALUES (?)", "params": ["hi; bye"]},
+                    "INSERT INTO t VALUES ('plain')",
+                ]
+            })),
+        )
+        .await
+        .unwrap();
+        assert!(resp.committed);
+
+        let rows = crate::handlers::query::handle(
+            &st,
+            serde_json::from_value(json!({"db": "primary", "sql": "SELECT s FROM t ORDER BY s"}))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(rows.rows[0]["s"], json!("hi; bye"));
+        assert_eq!(rows.rows[1]["s"], json!("plain"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rolls_back_and_reports_failed_index_on_error() {
+        let st = state();
+        crate::handlers::execute::handle(
+            &st,
+            serde_json::from_value(json!({
+                "db": "primary",
+                "sql": "CREATE TABLE t (n INT NOT NULL)"
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let resp = handle(
+            &st,
+            batch_req(json!({
+                "db": "primary",
+                "statements": ["INSERT INTO t VALUES (1)", "INSERT INTO t VALUES (NULL)"]
+            })),
+        )
+        .await
+        .unwrap();
+
+        assert!(!resp.committed);
+        assert_eq!(resp.failed_index, Some(1));
+        assert!(resp.error.is_some());
+        assert!(resp.results.is_none());
+
+        let rows = crate::handlers::query::handle(
+            &st,
+            serde_json::from_value(json!({"db": "primary", "sql": "SELECT COUNT(*) AS c FROM t"}))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(rows.rows[0]["c"], json!(0));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rejects_embedded_transaction_control_sql() {
+        let st = state();
+        let err = handle(
+            &st,
+            batch_req(json!({
+                "db": "primary",
+                "statements": ["SELECT 1", "COMMIT"]
+            })),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("INVALID_PARAM"), "got: {err}");
+        assert!(err.contains("transaction-control"), "got: {err}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rejects_empty_statement() {
+        let st = state();
+        let err = handle(&st, batch_req(json!({"db": "primary", "statements": [""]})))
+            .await
+            .unwrap_err();
+        assert!(err.contains("INVALID_PARAM"), "got: {err}");
+        assert!(err.contains("empty SQL"), "got: {err}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn isolation_field_is_honored_not_dropped() {
+        let st = state();
+        let err = handle(
+            &st,
+            batch_req(json!({
+                "db": "primary",
+                "statements": ["SELECT 1"],
+                "isolation": "banana"
+            })),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("unknown isolation"), "got: {err}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_statements_commits_as_no_op() {
+        let st = state();
+        let resp = handle(&st, batch_req(json!({"db": "primary", "statements": []})))
+            .await
+            .unwrap();
+        assert!(resp.committed);
+        assert_eq!(resp.results.unwrap().len(), 0);
+    }
+}

--- a/database/src/handlers/mod.rs
+++ b/database/src/handlers/mod.rs
@@ -32,6 +32,7 @@ where
 pub mod begin_transaction;
 pub mod commit_transaction;
 pub mod execute;
+pub mod execute_batch;
 pub mod list_databases;
 pub mod prepare;
 pub mod query;

--- a/database/src/handlers/transaction.rs
+++ b/database/src/handlers/transaction.rs
@@ -1,5 +1,6 @@
 //! `database::transaction` — atomic sequence of statements.
 
+use super::tx_sql_guard::is_transaction_control_sql;
 use super::AppState;
 use crate::driver::{self, Isolation, TxStatement};
 use crate::handlers::query::err_to_str;
@@ -25,13 +26,13 @@ pub struct TxStmtReq {
     pub params: Vec<Value>,
 }
 
-#[derive(Serialize, JsonSchema)]
+#[derive(Debug, Serialize, JsonSchema)]
 pub struct TxStepResp {
     pub affected_rows: u64,
     pub rows: Vec<Vec<Value>>,
 }
 
-#[derive(Serialize, JsonSchema)]
+#[derive(Debug, Serialize, JsonSchema)]
 pub struct TxResp {
     pub committed: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -71,7 +72,28 @@ pub async fn handle(state: &AppState, req: TxReq) -> Result<TxResp, String> {
     };
 
     let mut stmts: Vec<TxStatement> = Vec::with_capacity(req.statements.len());
-    for s in req.statements {
+    for (i, s) in req.statements.into_iter().enumerate() {
+        // Same handler-boundary guards as the interactive surface
+        // (transaction_execute.rs): drivers diverge on empty SQL (postgres
+        // no-ops, sqlite/mysql error), and embedded transaction-control SQL
+        // would finalize the worker-managed transaction mid-batch, silently
+        // breaking the atomicity contract while reporting committed:false.
+        if s.sql.trim().is_empty() {
+            return Err(err_to_str(crate::error::DbError::InvalidParam {
+                index: i,
+                reason: "empty SQL statement".into(),
+            }));
+        }
+        if is_transaction_control_sql(&s.sql) {
+            return Err(err_to_str(crate::error::DbError::InvalidParam {
+                index: i,
+                reason: "transaction-control SQL (BEGIN/START TRANSACTION/COMMIT/ROLLBACK/\
+                        SAVEPOINT/RELEASE/END/SET TRANSACTION, including comment-prefixed \
+                        forms) is not allowed inside an atomic batch; the worker issues \
+                        BEGIN/COMMIT/ROLLBACK itself"
+                    .into(),
+            }));
+        }
         let params = JsonParam::from_json_slice(&s.params).map_err(err_to_str)?;
         stmts.push(TxStatement { sql: s.sql, params });
     }
@@ -297,5 +319,41 @@ mod tests {
         assert!(v.get("results").is_none());
         assert!(v.get("failed_index").is_some());
         assert!(v.get("error").is_some());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn tx_rejects_transaction_control_sql_with_statement_index() {
+        let st = state();
+        let err = handle(
+            &st,
+            tx_req(json!({
+                "db": "primary",
+                "statements": [
+                    {"sql": "INSERT INTO t VALUES (1)"},
+                    {"sql": "COMMIT"},
+                ]
+            })),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("INVALID_PARAM"), "got: {err}");
+        assert!(err.contains("transaction-control"), "got: {err}");
+        assert!(err.contains("\"index\":1"), "got: {err}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn tx_rejects_empty_statement() {
+        let st = state();
+        let err = handle(
+            &st,
+            tx_req(json!({
+                "db": "primary",
+                "statements": [{"sql": "   "}]
+            })),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("INVALID_PARAM"), "got: {err}");
+        assert!(err.contains("empty SQL"), "got: {err}");
     }
 }

--- a/database/src/main.rs
+++ b/database/src/main.rs
@@ -7,6 +7,7 @@ use database::handlers::{
     begin_transaction::{self, BeginTxReq},
     commit_transaction::{self, CommitTxReq},
     execute::{self, ExecuteReq},
+    execute_batch::{self, ExecuteBatchReq},
     list_databases::{self, ListDatabasesReq},
     prepare::{self, PrepareReq},
     query::{self, QueryReq},
@@ -139,6 +140,40 @@ async fn main() -> Result<()> {
                 }
             })
             .description("Run a write statement (INSERT/UPDATE/DELETE/DDL)."),
+        );
+    }
+    {
+        let st = state.clone();
+        iii.register_function(
+            "database::execute_batch",
+            RegisterFunction::new_async(move |req: ExecuteBatchReq| {
+                let st = st.clone();
+                async move {
+                    execute_batch::handle(&st, req)
+                        .await
+                        .map_err(iii_sdk::errors::Error::from)
+                }
+            })
+            .description(
+                "Run an ordered batch of SQL statements atomically (bare strings or \
+                 {sql, params} objects); rolls back on first failure. Also registered \
+                 as database::executeBatch.",
+            ),
+        );
+    }
+    {
+        let st = state.clone();
+        iii.register_function(
+            "database::executeBatch",
+            RegisterFunction::new_async(move |req: ExecuteBatchReq| {
+                let st = st.clone();
+                async move {
+                    execute_batch::handle(&st, req)
+                        .await
+                        .map_err(iii_sdk::errors::Error::from)
+                }
+            })
+            .description("Alias of database::execute_batch."),
         );
     }
     {
@@ -297,7 +332,7 @@ async fn main() -> Result<()> {
         .context("registering configuration change trigger")?;
 
     tracing::info!(
-        "database worker registered 12 functions and 1 trigger type, waiting for invocations"
+        "database worker registered 14 functions and 1 trigger type, waiting for invocations"
     );
     wait_for_shutdown_signal().await?;
     tracing::info!("database worker shutting down");

--- a/database/tests/e2e/workers/harness/src/cases-transaction.ts
+++ b/database/tests/e2e/workers/harness/src/cases-transaction.ts
@@ -5,6 +5,8 @@ import { expect, expectEqual } from './cases.ts'
  * Transaction edge cases. The function suite covers commit + rollback at
  * failed_index=1; these target shapes the function suite leaves alone:
  * empty / single-statement / mixed-read-write / failure-at-index-0.
+ * Also hosts the `database::execute_batch` surface cases — a thin wrapper
+ * over the same transaction machinery.
  *
  * Each test creates its own scratch table to stay independent of `t`.
  */
@@ -127,6 +129,106 @@ export const TRANSACTION_EDGE_CASES: TestCase[] = [
       expectEqual(r.results[0].rows.length, 1, 'CTE step row count')
       // VALUES → 3 rows
       expectEqual(r.results[1].rows.length, 3, 'VALUES step row count')
+    },
+  },
+  {
+    name: 'execute_batch bare-string statements commit atomically',
+    async run({ driver, call }) {
+      await call('database::execute', { db: driver, sql: 'DROP TABLE IF EXISTS eb_plain' })
+      await call('database::execute', {
+        db: driver,
+        sql: 'CREATE TABLE eb_plain (n INT NOT NULL)',
+      })
+      const r = await call('database::execute_batch', {
+        db: driver,
+        statements: ['INSERT INTO eb_plain (n) VALUES (1)', 'INSERT INTO eb_plain (n) VALUES (2)'],
+      })
+      expectEqual(r.committed, true, 'committed=true')
+      expectEqual(r.results.length, 2, 'two step results')
+      const verify = await call('database::query', {
+        db: driver,
+        sql: 'SELECT COUNT(*) AS c FROM eb_plain',
+      })
+      expectEqual(Number(verify.rows[0].c), 2, 'both rows landed')
+      await call('database::execute', { db: driver, sql: 'DROP TABLE eb_plain' })
+    },
+  },
+  {
+    name: 'execute_batch rolls back on failure and reports failed_index',
+    async run({ driver, call }) {
+      await call('database::execute', { db: driver, sql: 'DROP TABLE IF EXISTS eb_rb' })
+      await call('database::execute', {
+        db: driver,
+        sql: 'CREATE TABLE eb_rb (n INT NOT NULL)',
+      })
+      const r = await call('database::execute_batch', {
+        db: driver,
+        statements: ['INSERT INTO eb_rb (n) VALUES (1)', 'INSERT INTO eb_rb (n) VALUES (NULL)'],
+      })
+      expectEqual(r.committed, false, 'committed=false')
+      expectEqual(r.failed_index, 1, 'failed_index=1')
+      const verify = await call('database::query', {
+        db: driver,
+        sql: 'SELECT COUNT(*) AS c FROM eb_rb',
+      })
+      expectEqual(Number(verify.rows[0].c), 0, 'rollback dropped all writes')
+      await call('database::execute', { db: driver, sql: 'DROP TABLE eb_rb' })
+    },
+  },
+  {
+    name: 'executeBatch alias accepts mixed string and {sql, params} forms',
+    async run({ driver, dialect, call }) {
+      const ph1 = dialect.placeholder(1)
+      await call('database::execute', { db: driver, sql: 'DROP TABLE IF EXISTS eb_mixed' })
+      await call('database::execute', {
+        db: driver,
+        sql: 'CREATE TABLE eb_mixed (s VARCHAR(64) NOT NULL)',
+      })
+      const r = await call('database::executeBatch', {
+        db: driver,
+        statements: [
+          { sql: `INSERT INTO eb_mixed (s) VALUES (${ph1})`, params: ['hi; bye'] },
+          "INSERT INTO eb_mixed (s) VALUES ('plain')",
+        ],
+      })
+      expectEqual(r.committed, true, 'committed=true via alias')
+      const verify = await call('database::query', {
+        db: driver,
+        sql: 'SELECT s FROM eb_mixed ORDER BY s',
+      })
+      expectEqual(verify.rows[0].s, 'hi; bye', 'semicolon value landed via bound param')
+      expectEqual(verify.rows[1].s, 'plain', 'bare-string statement landed')
+      await call('database::execute', { db: driver, sql: 'DROP TABLE eb_mixed' })
+    },
+  },
+  {
+    name: 'execute_batch rejects embedded transaction-control SQL',
+    async run({ driver, call }) {
+      let rejected = false
+      try {
+        await call('database::execute_batch', {
+          db: driver,
+          statements: ['SELECT 1', 'COMMIT'],
+        })
+      } catch (e: any) {
+        rejected = (e?.message ?? String(e)).includes('INVALID_PARAM')
+      }
+      expect(rejected, 'COMMIT inside a batch must be rejected with INVALID_PARAM')
+    },
+  },
+  {
+    name: 'transaction rejects embedded transaction-control SQL',
+    async run({ driver, call }) {
+      let rejected = false
+      try {
+        await call('database::transaction', {
+          db: driver,
+          statements: [{ sql: 'COMMIT' }],
+        })
+      } catch (e: any) {
+        rejected = (e?.message ?? String(e)).includes('INVALID_PARAM')
+      }
+      expect(rejected, 'COMMIT inside a transaction batch must be rejected with INVALID_PARAM')
     },
   },
 ]


### PR DESCRIPTION
## Why

Callers (triggered flows) were invoking `database::execute_batch` with `{db, statements: ["INSERT ...", ...]}` and getting `function_not_found` — the function never existed. The closest surface, `database::transaction`, requires `{sql, params}` objects and doesn't absorb the payload shapes LLM/engine callers actually send.

## What

- **`database::execute_batch`** (+ camelCase alias **`database::executeBatch`**): thin delegation to `transaction::handle`. Statements accept bare SQL strings **or** `{sql, params}` objects (use `params` for dynamic values), JSON-stringified arrays are absorbed per the worker's `lenient_params` convention, `isolation` is honored, and the response is the same `TxResp` envelope (`committed`, per-step `results`, `failed_index`, `error`).
- **Shared batch guards** (`database::transaction` + `execute_batch`): embedded transaction-control SQL (`BEGIN`/`COMMIT`/`ROLLBACK`/`SAVEPOINT`/`START|SET TRANSACTION`, comment-prefixed forms included — via the existing `tx_sql_guard`) and empty statements are now rejected with `INVALID_PARAM` carrying the statement index. Previously a smuggled `COMMIT` would end the worker-managed transaction mid-batch, durably committing earlier statements while the response claimed `committed: false`; empty statements silently behaved differently per driver.
- Docs: README function table + errors table, `skills/SKILL.md` routing/entries updated to differentiate the two batch surfaces.

## Tests

- Unit: 8 new tests across both handlers (commit, rollback + `failed_index`, bound-param semicolon escape hatch, tx-control rejection, empty-statement rejection, isolation passthrough, lenient stringified-array parsing, empty batch no-op). `cargo test -p database`: 225 passed. Clippy + fmt clean.
- E2e: 5 new cases in `cases-transaction.ts` (bare-string commit, rollback, mixed forms via the alias, tx-control rejection on both surfaces) running against sqlite/postgres/mysql via the existing harness. Not executed in this environment (needs the dockerized stack); harness `tsc` clean.

## Notes

- `database::execute_batch` keeps the snake_case name the existing callers use; the `executeBatch` alias keeps the worker's camelCase surface consistent.
- Behavior change on `database::transaction`: batches containing bare transaction-control SQL or empty statements now fail fast with `INVALID_PARAM` (previously undefined/corrupting behavior). The existing e2e bypass suite only asserted this for the interactive surface; a new case covers the one-shot surface.