### PR TITLE
(MOT-4174) feat(console,database): chat copy + open-in-editor on file changes; executeBatch as sole batch id

### DIFF
--- a/console/web/src/components/chat/CopyMessageButton.tsx
+++ b/console/web/src/components/chat/CopyMessageButton.tsx
@@ -1,0 +1,41 @@
+import { Check, Copy } from 'lucide-react'
+import { useState } from 'react'
+import { copyTextToClipboard } from '@/lib/clipboard'
+import { cn } from '@/lib/utils'
+
+/**
+ * Copy affordance for a chat message — the PaneShell copy idiom (12px
+ * Copy→Check flip on success, nothing on failure) lifted to a message
+ * header. Visibility is the parent's job (hover/focus opacity classes);
+ * this component only copies and flips.
+ */
+export function CopyMessageButton({
+  text,
+  className,
+}: {
+  text: string
+  className?: string
+}) {
+  const [copied, setCopied] = useState(false)
+  const copy = () => {
+    void copyTextToClipboard(text).then((ok) => {
+      if (!ok) return
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1200)
+    })
+  }
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      className={cn(
+        'shrink-0 text-ink-ghost hover:text-ink transition-colors',
+        className,
+      )}
+      aria-label={copied ? 'copied' : 'copy message'}
+      title={copied ? 'copied' : 'copy message'}
+    >
+      {copied ? <Check size={12} aria-hidden /> : <Copy size={12} aria-hidden />}
+    </button>
+  )
+}

--- a/console/web/src/components/chat/CopyMessageButton.tsx
+++ b/console/web/src/components/chat/CopyMessageButton.tsx
@@ -11,11 +11,14 @@ import { cn } from '@/lib/utils'
  */
 export function CopyMessageButton({
   text,
+  label = 'copy message',
   className,
 }: {
   /** A thunk defers building large payloads (e.g. serialized function calls)
       until the click, keeping streaming re-renders free. */
   text: string | (() => string)
+  /** Accessible name while idle (aria-label/title); flips to "copied". */
+  label?: string
   className?: string
 }) {
   const [copied, setCopied] = useState(false)
@@ -35,8 +38,8 @@ export function CopyMessageButton({
         'shrink-0 text-ink-ghost hover:text-ink transition-colors',
         className,
       )}
-      aria-label={copied ? 'copied' : 'copy message'}
-      title={copied ? 'copied' : 'copy message'}
+      aria-label={copied ? 'copied' : label}
+      title={copied ? 'copied' : label}
     >
       {copied ? (
         <Check size={12} aria-hidden />

--- a/console/web/src/components/chat/CopyMessageButton.tsx
+++ b/console/web/src/components/chat/CopyMessageButton.tsx
@@ -35,7 +35,11 @@ export function CopyMessageButton({
       aria-label={copied ? 'copied' : 'copy message'}
       title={copied ? 'copied' : 'copy message'}
     >
-      {copied ? <Check size={12} aria-hidden /> : <Copy size={12} aria-hidden />}
+      {copied ? (
+        <Check size={12} aria-hidden />
+      ) : (
+        <Copy size={12} aria-hidden />
+      )}
     </button>
   )
 }

--- a/console/web/src/components/chat/CopyMessageButton.tsx
+++ b/console/web/src/components/chat/CopyMessageButton.tsx
@@ -13,12 +13,15 @@ export function CopyMessageButton({
   text,
   className,
 }: {
-  text: string
+  /** A thunk defers building large payloads (e.g. serialized function calls)
+      until the click, keeping streaming re-renders free. */
+  text: string | (() => string)
   className?: string
 }) {
   const [copied, setCopied] = useState(false)
   const copy = () => {
-    void copyTextToClipboard(text).then((ok) => {
+    const value = typeof text === 'function' ? text() : text
+    void copyTextToClipboard(value).then((ok) => {
       if (!ok) return
       setCopied(true)
       window.setTimeout(() => setCopied(false), 1200)

--- a/console/web/src/components/chat/CopyMessageButton.tsx
+++ b/console/web/src/components/chat/CopyMessageButton.tsx
@@ -35,7 +35,7 @@ export function CopyMessageButton({
       type="button"
       onClick={copy}
       className={cn(
-        'shrink-0 text-ink-ghost hover:text-ink transition-colors',
+        'shrink-0 cursor-pointer text-ink-ghost hover:text-ink transition-colors',
         className,
       )}
       aria-label={copied ? 'copied' : label}

--- a/console/web/src/components/chat/Message.tsx
+++ b/console/web/src/components/chat/Message.tsx
@@ -276,7 +276,7 @@ function UserMessage({ message }: { message: UserMessageType }) {
         {message.content ? (
           <CopyMessageButton
             text={message.content}
-            className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
+            className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-[opacity,color]"
           />
         ) : null}
         <Prompt symbol="$">you</Prompt>
@@ -326,7 +326,7 @@ function AssistantMessage({
         {copySource !== undefined && !message.streaming ? (
           <CopyMessageButton
             text={copySource}
-            className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
+            className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-[opacity,color]"
           />
         ) : null}
       </header>

--- a/console/web/src/components/chat/Message.tsx
+++ b/console/web/src/components/chat/Message.tsx
@@ -12,6 +12,7 @@ import type {
   UserMessage as UserMessageType,
 } from '@/types/chat'
 import { AttachmentChip } from './AttachmentChip'
+import { CopyMessageButton } from './CopyMessageButton'
 import { MemoryChip } from './MemoryChip'
 import { ThoughtMessage } from './ThoughtMessage'
 
@@ -266,8 +267,14 @@ function SpawnTaskMessage({ message }: { message: UserMessageType }) {
 
 function UserMessage({ message }: { message: UserMessageType }) {
   return (
-    <article className="flex flex-col items-end gap-2">
-      <header className="font-mono text-[11px] uppercase tracking-[0.06em] text-ink-ghost">
+    <article className="group flex flex-col items-end gap-2">
+      <header className="font-mono text-[11px] uppercase tracking-[0.06em] text-ink-ghost flex items-center gap-2">
+        {message.content ? (
+          <CopyMessageButton
+            text={message.content}
+            className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
+          />
+        ) : null}
         <Prompt symbol="$">you</Prompt>
       </header>
       <div
@@ -292,7 +299,7 @@ function UserMessage({ message }: { message: UserMessageType }) {
 function AssistantMessage({ message }: { message: AssistantMessageType }) {
   const showCaret = !!message.streaming
   return (
-    <article className="flex flex-col gap-2">
+    <article className="group flex flex-col gap-2">
       <header className="font-mono text-[11px] uppercase tracking-[0.06em] text-ink-ghost flex items-center gap-2 flex-wrap">
         <Prompt symbol=">">assistant</Prompt>
         {message.model ? (
@@ -302,6 +309,12 @@ function AssistantMessage({ message }: { message: AssistantMessageType }) {
           <span className="text-ink-ghost">· {message.mode}</span>
         ) : null}
         {message.memory ? <MemoryChip memory={message.memory} /> : null}
+        {message.content && !message.streaming ? (
+          <CopyMessageButton
+            text={message.content}
+            className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
+          />
+        ) : null}
       </header>
       <div className="pr-1">
         {message.content ? (

--- a/console/web/src/components/chat/Message.tsx
+++ b/console/web/src/components/chat/Message.tsx
@@ -35,6 +35,9 @@ interface MessageProps {
   ) => Promise<void>
   onManageFilesystemAccess?: () => void
   workingDir?: string | null
+  /** Copy payload for an assistant turn (prose + its function calls). Lazy so
+      the string is built on click, not on every streaming re-render. */
+  copyText?: string | (() => string)
 }
 
 export function Message({
@@ -44,6 +47,7 @@ export function Message({
   onResolveFilesystemAccess,
   onManageFilesystemAccess,
   workingDir,
+  copyText,
 }: MessageProps) {
   switch (message.role) {
     case 'user':
@@ -57,7 +61,7 @@ export function Message({
         <UserMessage message={message} />
       )
     case 'assistant':
-      return <AssistantMessage message={message} />
+      return <AssistantMessage message={message} copyText={copyText} />
     case 'thought':
       return <ThoughtMessage message={message} />
     case 'function-call': {
@@ -296,7 +300,13 @@ function UserMessage({ message }: { message: UserMessageType }) {
   )
 }
 
-function AssistantMessage({ message }: { message: AssistantMessageType }) {
+function AssistantMessage({
+  message,
+  copyText,
+}: {
+  message: AssistantMessageType
+  copyText?: string | (() => string)
+}) {
   const showCaret = !!message.streaming
   return (
     <article className="group flex flex-col gap-2">
@@ -311,7 +321,7 @@ function AssistantMessage({ message }: { message: AssistantMessageType }) {
         {message.memory ? <MemoryChip memory={message.memory} /> : null}
         {message.content && !message.streaming ? (
           <CopyMessageButton
-            text={message.content}
+            text={copyText ?? message.content}
             className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
           />
         ) : null}

--- a/console/web/src/components/chat/Message.tsx
+++ b/console/web/src/components/chat/Message.tsx
@@ -308,6 +308,10 @@ function AssistantMessage({
   copyText?: string | (() => string)
 }) {
   const showCaret = !!message.streaming
+  // A tool-only turn has no prose but still carries a copy payload (its
+  // function calls) via copyText; direct renders without a list-provided
+  // payload fall back to the prose gate.
+  const copySource = copyText ?? (message.content || undefined)
   return (
     <article className="group flex flex-col gap-2">
       <header className="font-mono text-[11px] uppercase tracking-[0.06em] text-ink-ghost flex items-center gap-2 flex-wrap">
@@ -319,9 +323,9 @@ function AssistantMessage({
           <span className="text-ink-ghost">· {message.mode}</span>
         ) : null}
         {message.memory ? <MemoryChip memory={message.memory} /> : null}
-        {message.content && !message.streaming ? (
+        {copySource !== undefined && !message.streaming ? (
           <CopyMessageButton
-            text={copyText ?? message.content}
+            text={copySource}
             className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
           />
         ) : null}

--- a/console/web/src/components/chat/MessageList.tsx
+++ b/console/web/src/components/chat/MessageList.tsx
@@ -191,14 +191,14 @@ export function MessageList({
           }
           const m = item.message
           // Assistant turns copy their prose plus the calls that follow them;
-          // the thunk defers building that string until the copy click.
+          // the thunk defers building that string until the copy click. Left
+          // undefined when the turn has nothing to copy (no prose, no calls)
+          // so the header shows no copy affordance.
+          const calls =
+            m.role === 'assistant' ? fcallsByAssistant.get(m.id) : undefined
           const copyText =
-            m.role === 'assistant'
-              ? () =>
-                  assistantCopyText(
-                    m.content,
-                    fcallsByAssistant.get(m.id) ?? [],
-                  )
+            m.role === 'assistant' && (m.content || calls?.length)
+              ? () => assistantCopyText(m.content, calls ?? [])
               : undefined
           return (
             <Message

--- a/console/web/src/components/chat/MessageList.tsx
+++ b/console/web/src/components/chat/MessageList.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useMemo, useRef } from 'react'
 import type { FilesystemAccessAction } from '@/components/permissions/FilesystemAccessPrompt'
 import { useConversationsCtxOptional } from '@/lib/conversations-context'
+import {
+  assistantCopyText,
+  functionCallsByAssistant,
+} from '@/lib/function-call-copy'
 import { cn } from '@/lib/utils'
 import type {
   FunctionCallMessage as FunctionCallMessageType,
@@ -101,6 +105,10 @@ export function MessageList({
   const lastPendingIdRef = useRef<string | null>(null)
 
   const items = useMemo(() => groupConsecutiveFcalls(messages), [messages])
+  const fcallsByAssistant = useMemo(
+    () => functionCallsByAssistant(messages),
+    [messages],
+  )
 
   // Read optionally so isolated renders (Storybook) still work without the
   // ConversationsProvider; the empty state falls back to `ready` there.
@@ -167,29 +175,44 @@ export function MessageList({
   return (
     <div ref={containerRef} className={cn('flex-1 overflow-y-auto', listPad)}>
       <div className="mx-auto max-w-[760px] flex flex-col gap-y-8">
-        {items.map((item) =>
-          item.kind === 'message' ? (
+        {items.map((item) => {
+          if (item.kind === 'fcall-group') {
+            return (
+              <FunctionCallGroup
+                key={item.key}
+                messages={item.messages}
+                onResolveApproval={onResolveApproval}
+                onAlwaysAllow={onAlwaysAllow}
+                onResolveFilesystemAccess={onResolveFilesystemAccess}
+                onManageFilesystemAccess={onManageFilesystemAccess}
+                workingDir={workingDir}
+              />
+            )
+          }
+          const m = item.message
+          // Assistant turns copy their prose plus the calls that follow them;
+          // the thunk defers building that string until the copy click.
+          const copyText =
+            m.role === 'assistant'
+              ? () =>
+                  assistantCopyText(
+                    m.content,
+                    fcallsByAssistant.get(m.id) ?? [],
+                  )
+              : undefined
+          return (
             <Message
               key={item.key}
-              message={item.message}
+              message={m}
+              copyText={copyText}
               onResolveApproval={onResolveApproval}
               onAlwaysAllow={onAlwaysAllow}
               onResolveFilesystemAccess={onResolveFilesystemAccess}
               onManageFilesystemAccess={onManageFilesystemAccess}
               workingDir={workingDir}
             />
-          ) : (
-            <FunctionCallGroup
-              key={item.key}
-              messages={item.messages}
-              onResolveApproval={onResolveApproval}
-              onAlwaysAllow={onAlwaysAllow}
-              onResolveFilesystemAccess={onResolveFilesystemAccess}
-              onManageFilesystemAccess={onManageFilesystemAccess}
-              workingDir={workingDir}
-            />
-          ),
-        )}
+          )
+        })}
         {isThinking ? (
           <div className="font-mono text-[13px] italic thinking-shimmer text-ink-faint">
             {thinkingDetail ?? 'thinking…'}

--- a/console/web/src/components/chat/coder/CreateFileView.tsx
+++ b/console/web/src/components/chat/coder/CreateFileView.tsx
@@ -16,6 +16,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/Tooltip'
 import { CoderNewFilePreview, CoderOverwritePreview } from './CoderDiff'
+import { OpenInEditorButton } from './OpenInEditorButton'
 import {
   createFileRequestSchema,
   createFileResponseSchema,
@@ -99,6 +100,7 @@ export function CreateFileView({
                 <span className="font-mono text-[12px] text-ink">
                   {file.path}
                 </span>
+                <OpenInEditorButton path={result.path} />
               </div>
               {file.overwrite ? (
                 <CoderOverwritePreview

--- a/console/web/src/components/chat/coder/MoveView.tsx
+++ b/console/web/src/components/chat/coder/MoveView.tsx
@@ -15,6 +15,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/Tooltip'
+import { OpenInEditorButton } from './OpenInEditorButton'
 import {
   moveFileRequestSchema,
   moveFileResponseSchema,
@@ -85,6 +86,9 @@ export function MoveView({ input, output, running, preview }: MoveViewProps) {
                     <span>{from}</span>
                     <span className="text-ink-ghost">→</span>
                     <span>{to}</span>
+                    {!pending && result?.success ? (
+                      <OpenInEditorButton path={result.to} />
+                    ) : null}
                     {spec.overwrite ? (
                       <Chip label="overwrite" className="border-warn text-warn">
                         true

--- a/console/web/src/components/chat/coder/OpenInEditorButton.tsx
+++ b/console/web/src/components/chat/coder/OpenInEditorButton.tsx
@@ -46,7 +46,7 @@ export function OpenInEditorButton({
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          className="inline-flex items-center shrink-0 text-ink-ghost hover:text-ink transition-colors"
+          className="inline-flex items-center shrink-0 cursor-pointer text-ink-ghost hover:text-ink transition-colors"
           aria-label="open in editor"
           title="open in editor"
         >

--- a/console/web/src/components/chat/coder/OpenInEditorButton.tsx
+++ b/console/web/src/components/chat/coder/OpenInEditorButton.tsx
@@ -1,0 +1,99 @@
+import { ChevronDown, SquareArrowOutUpRight } from 'lucide-react'
+import { useState } from 'react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/DropdownMenu'
+import { copyTextToClipboard } from '@/lib/clipboard'
+import {
+  EDITORS,
+  type EditorId,
+  editorById,
+  getPreferredEditor,
+  setPreferredEditor,
+} from '@/lib/editor-links'
+
+/**
+ * Split "open in editor" affordance for coder file-change rows: the anchor
+ * opens the preferred editor via its URL scheme (one click), the chevron
+ * menu switches editors (persisting the choice) or copies the path — the
+ * fallback when the browser isn't on the machine that has the files.
+ * Renders nothing for non-absolute paths (result resolution failed —
+ * `coder` results are jail-resolved absolute on success).
+ */
+export function OpenInEditorButton({
+  path,
+  line,
+}: {
+  path: string
+  line?: number
+}) {
+  const [preferred, setPreferred] = useState<EditorId>(getPreferredEditor)
+  const [copied, setCopied] = useState(false)
+  if (!path.startsWith('/')) return null
+
+  const editor = editorById(preferred)
+
+  const openWith = (id: EditorId) => {
+    setPreferred(id)
+    setPreferredEditor(id)
+    window.location.href = editorById(id).buildUrl(path, line)
+  }
+
+  const copyPath = () => {
+    void copyTextToClipboard(path).then((ok) => {
+      if (!ok) return
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1200)
+    })
+  }
+
+  return (
+    <span className="inline-flex items-center gap-0.5 shrink-0">
+      <a
+        href={editor.buildUrl(path, line)}
+        draggable={false}
+        className="text-ink-ghost hover:text-ink transition-colors"
+        aria-label={`open in ${editor.label}`}
+        title={`open in ${editor.label}`}
+      >
+        <SquareArrowOutUpRight size={12} aria-hidden />
+      </a>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="text-ink-ghost hover:text-ink transition-colors"
+            aria-label="editor options"
+            title="editor options"
+          >
+            <ChevronDown size={10} aria-hidden />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          {EDITORS.map((e) => (
+            <DropdownMenuItem key={e.id} onSelect={() => openWith(e.id)}>
+              open in {e.label}
+              {e.id === preferred ? (
+                <span className="text-ink-ghost">· default</span>
+              ) : null}
+            </DropdownMenuItem>
+          ))}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onSelect={(event) => {
+              // Keep the menu open so the "copied" flip is visible.
+              event.preventDefault()
+              copyPath()
+            }}
+          >
+            {copied ? 'copied' : 'copy path'}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </span>
+  )
+}

--- a/console/web/src/components/chat/coder/OpenInEditorButton.tsx
+++ b/console/web/src/components/chat/coder/OpenInEditorButton.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, SquareArrowOutUpRight } from 'lucide-react'
+import { SquareArrowOutUpRight } from 'lucide-react'
 import { useState } from 'react'
 import {
   DropdownMenu,
@@ -8,19 +8,14 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/DropdownMenu'
 import { copyTextToClipboard } from '@/lib/clipboard'
-import {
-  EDITORS,
-  type EditorId,
-  editorById,
-  getPreferredEditor,
-  setPreferredEditor,
-} from '@/lib/editor-links'
+import { EDITORS, type EditorId, editorById } from '@/lib/editor-links'
 
 /**
- * Split "open in editor" affordance for coder file-change rows: the anchor
- * opens the preferred editor via its URL scheme (one click), the chevron
- * menu switches editors (persisting the choice) or copies the path — the
- * fallback when the browser isn't on the machine that has the files.
+ * "open in editor" affordance for coder file-change rows: one button that
+ * always opens a menu of editors (cursor / vs code / zed) — each entry
+ * launches that editor via its URL scheme — plus "copy path", the fallback
+ * when the browser isn't on the machine that has the files. No editor is
+ * privileged; the menu is shown every time so the choice stays explicit.
  * Renders nothing for non-absolute paths (result resolution failed —
  * `coder` results are jail-resolved absolute on success).
  */
@@ -31,15 +26,10 @@ export function OpenInEditorButton({
   path: string
   line?: number
 }) {
-  const [preferred, setPreferred] = useState<EditorId>(getPreferredEditor)
   const [copied, setCopied] = useState(false)
   if (!path.startsWith('/')) return null
 
-  const editor = editorById(preferred)
-
   const openWith = (id: EditorId) => {
-    setPreferred(id)
-    setPreferredEditor(id)
     window.location.href = editorById(id).buildUrl(path, line)
   }
 
@@ -52,48 +42,34 @@ export function OpenInEditorButton({
   }
 
   return (
-    <span className="inline-flex items-center gap-0.5 shrink-0">
-      <a
-        href={editor.buildUrl(path, line)}
-        draggable={false}
-        className="text-ink-ghost hover:text-ink transition-colors"
-        aria-label={`open in ${editor.label}`}
-        title={`open in ${editor.label}`}
-      >
-        <SquareArrowOutUpRight size={12} aria-hidden />
-      </a>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            className="text-ink-ghost hover:text-ink transition-colors"
-            aria-label="editor options"
-            title="editor options"
-          >
-            <ChevronDown size={10} aria-hidden />
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start">
-          {EDITORS.map((e) => (
-            <DropdownMenuItem key={e.id} onSelect={() => openWith(e.id)}>
-              open in {e.label}
-              {e.id === preferred ? (
-                <span className="text-ink-ghost">· default</span>
-              ) : null}
-            </DropdownMenuItem>
-          ))}
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onSelect={(event) => {
-              // Keep the menu open so the "copied" flip is visible.
-              event.preventDefault()
-              copyPath()
-            }}
-          >
-            {copied ? 'copied' : 'copy path'}
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center shrink-0 text-ink-ghost hover:text-ink transition-colors"
+          aria-label="open in editor"
+          title="open in editor"
+        >
+          <SquareArrowOutUpRight size={12} aria-hidden />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {EDITORS.map((e) => (
+          <DropdownMenuItem key={e.id} onSelect={() => openWith(e.id)}>
+            open in {e.label}
           </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </span>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onSelect={(event) => {
+            // Keep the menu open so the "copied" flip is visible.
+            event.preventDefault()
+            copyPath()
+          }}
+        >
+          {copied ? 'copied' : 'copy path'}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }

--- a/console/web/src/components/chat/coder/UpdateFileView.tsx
+++ b/console/web/src/components/chat/coder/UpdateFileView.tsx
@@ -29,6 +29,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/Tooltip'
 import { cn } from '@/lib/utils'
+import { OpenInEditorButton } from './OpenInEditorButton'
 import {
   formatUpdateOp,
   type OpEcho,
@@ -95,6 +96,15 @@ export function contentLineCount(content: string): number {
   if (content === '') return 0
   const parts = content.split('\n')
   return parts[parts.length - 1] === '' ? parts.length - 1 : parts.length
+}
+
+/**
+ * The open-in-editor line anchor for an update-file result: the first
+ * echoed line in wire order, or undefined when the file has no echoes
+ * (a failure, or an echo-less success).
+ */
+export function firstEchoLine(result: UpdateFileResult): number | undefined {
+  return result.echoes[0]?.from_line
 }
 
 /** Mirror of `update_file.rs::ECHO_CONTEXT` — context lines above/below a
@@ -496,6 +506,7 @@ function FileEchoSection({
       <div className="bg-paper-2 border-b border-rule-2 px-3 py-1.5 flex flex-wrap items-center gap-1.5">
         {/* Canonical absolute path from the result, not the request. */}
         <span className="font-mono text-[12px] text-ink">{result.path}</span>
+        <OpenInEditorButton path={result.path} line={firstEchoLine(result)} />
         <Chip label="ops">{file.ops.length}</Chip>
         <Chip label="applied">{result.applied}</Chip>
         <Chip label="lines">{result.new_line_count}</Chip>

--- a/console/web/src/components/chat/coder/__tests__/UpdateFileView.test.ts
+++ b/console/web/src/components/chat/coder/__tests__/UpdateFileView.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import type { OpEcho, UpdateOp } from '../parsers'
-import { contentLineCount, echoRows, groupEchoesByOp } from '../UpdateFileView'
+import {
+  contentLineCount,
+  echoRows,
+  firstEchoLine,
+  groupEchoesByOp,
+} from '../UpdateFileView'
 
 function lineEcho(overrides: Partial<OpEcho> = {}): OpEcho {
   return {
@@ -515,5 +520,31 @@ describe('echoRows — multi-op anchor reconstruction (post-apply coords)', () =
       .filter((r) => r.kind === 'line' && r.added)
       .map((r) => (r.kind === 'line' ? r.text : ''))
     expect(added).toEqual(['1']) // known off-by-shift; ideal would be ['TWO']
+  })
+})
+
+describe('firstEchoLine (open-in-editor anchor)', () => {
+  const base = {
+    path: '/w/a.ts',
+    success: true,
+    applied: 1,
+    new_line_count: 10,
+    echoes_truncated: false,
+  }
+
+  it('returns the first echo from_line (wire order, first op group)', () => {
+    expect(
+      firstEchoLine({
+        ...base,
+        echoes: [
+          lineEcho({ op_index: 0, from_line: 7 }),
+          lineEcho({ op_index: 1, from_line: 30 }),
+        ],
+      }),
+    ).toBe(7)
+  })
+
+  it('returns undefined when there are no echoes (failed or echo-less file)', () => {
+    expect(firstEchoLine({ ...base, echoes: [] })).toBeUndefined()
   })
 })

--- a/console/web/src/components/function-call/FunctionCallCard.tsx
+++ b/console/web/src/components/function-call/FunctionCallCard.tsx
@@ -40,6 +40,7 @@ import {
 import { Button } from '@/components/ui/Button'
 import { StatusDot } from '@/components/ui/StatusDot'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/Tabs'
+import { copyTextToClipboard } from '@/lib/clipboard'
 import { JsonHighlight } from '@/lib/syntax'
 import { cn } from '@/lib/utils'
 import type { FunctionCallMessage as FunctionCallMessageType } from '@/types/chat'
@@ -595,8 +596,8 @@ function PaneShell({
   const [copied, setCopied] = useState(false)
 
   const copy = () => {
-    if (typeof navigator === 'undefined' || !navigator.clipboard) return
-    void navigator.clipboard.writeText(copyText).then(() => {
+    void copyTextToClipboard(copyText).then((ok) => {
+      if (!ok) return
       setCopied(true)
       window.setTimeout(() => setCopied(false), 1200)
     })

--- a/console/web/src/components/function-call/FunctionCallCard.tsx
+++ b/console/web/src/components/function-call/FunctionCallCard.tsx
@@ -4,17 +4,18 @@ import {
   BrowserFunctionIdLabel,
   BrowserToolView,
 } from '@/components/chat/browser'
+import { CopyMessageButton } from '@/components/chat/CopyMessageButton'
 import { CoderFunctionIdLabel, CoderToolView } from '@/components/chat/coder'
 import {
   DirectoryFunctionIdLabel,
   DirectoryToolView,
 } from '@/components/chat/directory'
 import { EngineFunctionIdLabel, EngineToolView } from '@/components/chat/engine'
+import { FpFunctionIdLabel, FpToolView } from '@/components/chat/fp'
 import {
   HarnessFunctionIdLabel,
   HarnessToolView,
 } from '@/components/chat/harness'
-import { FpFunctionIdLabel, FpToolView } from '@/components/chat/fp'
 import { RouterFunctionIdLabel, RouterToolView } from '@/components/chat/router'
 import {
   SandboxFunctionIdLabel,
@@ -381,74 +382,94 @@ export function FunctionCallCard({
       )}
       data-message-id={message.id}
     >
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-        className={cn(
-          'w-full flex items-center justify-between gap-3 px-3 py-2 cursor-pointer text-left',
-          'hover:bg-paper-2 transition-colors',
-        )}
-      >
-        <span className="flex items-center gap-2 min-w-0">
-          {pending || running ? (
-            <StatusDot
-              tone={pending ? 'warn' : 'accent'}
-              pulse={running}
-              className="shrink-0"
-            />
-          ) : errored ? (
-            <X
-              aria-hidden
-              strokeWidth={2.5}
-              className="size-3.5 shrink-0 text-alert"
-            />
-          ) : (
-            <Check
-              aria-hidden
-              strokeWidth={2.5}
-              className="size-3.5 shrink-0 text-ok"
-            />
-          )}
-          <span className="font-mono text-[13px] text-ink truncate">
-            {pending ? (
-              <>
-                <span>
-                  {filesystemAccess
-                    ? 'needs filesystem access to run'
-                    : 'waiting for your approval to run'}
-                </span>{' '}
-              </>
-            ) : message.identityInherited ? null : running ? (
-              <>triggering </>
-            ) : ran ? (
-              <>triggered </>
-            ) : null}
-            <span className="text-accent italic font-semibold">ƒ</span>{' '}
-            {running && message.unresolvedTarget ? (
-              <span className="text-ink-faint">…</span>
-            ) : (
-              <FunctionIdLabel functionId={message.functionId} />
-            )}
-            {!pending && !running && typeof message.durationMs === 'number' ? (
-              <span className="text-ink-faint">
-                {' '}
-                for <span className="tabular-nums">{message.durationMs}</span>
-                ms
-              </span>
-            ) : null}
-          </span>
-        </span>
-        <span
-          aria-hidden
-          className={cn(
-            'text-ink-ghost shrink-0 transition-transform duration-150 inline-block',
-            open && 'rotate-90',
-          )}
+      {/* The copy affordance must be a sibling of the collapse toggle
+          (nested buttons are invalid HTML): the labeled toggle carries the
+          title with the copy icon in flow right after it, and the caret
+          strip is a pointer-only duplicate target so clicking anywhere on
+          the row still collapses. */}
+      <div className="group/fchdr flex items-center gap-2 hover:bg-paper-2 transition-colors">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          className="min-w-0 flex items-center gap-2 pl-3 py-2 cursor-pointer text-left"
         >
-          ▸
-        </span>
-      </button>
+          <span className="flex items-center gap-2 min-w-0">
+            {pending || running ? (
+              <StatusDot
+                tone={pending ? 'warn' : 'accent'}
+                pulse={running}
+                className="shrink-0"
+              />
+            ) : errored ? (
+              <X
+                aria-hidden
+                strokeWidth={2.5}
+                className="size-3.5 shrink-0 text-alert"
+              />
+            ) : (
+              <Check
+                aria-hidden
+                strokeWidth={2.5}
+                className="size-3.5 shrink-0 text-ok"
+              />
+            )}
+            <span className="font-mono text-[13px] text-ink truncate">
+              {pending ? (
+                <>
+                  <span>
+                    {filesystemAccess
+                      ? 'needs filesystem access to run'
+                      : 'waiting for your approval to run'}
+                  </span>{' '}
+                </>
+              ) : message.identityInherited ? null : running ? (
+                <>triggering </>
+              ) : ran ? (
+                <>triggered </>
+              ) : null}
+              <span className="text-accent italic font-semibold">ƒ</span>{' '}
+              {running && message.unresolvedTarget ? (
+                <span className="text-ink-faint">…</span>
+              ) : (
+                <FunctionIdLabel functionId={message.functionId} />
+              )}
+              {!pending &&
+              !running &&
+              typeof message.durationMs === 'number' ? (
+                <span className="text-ink-faint">
+                  {' '}
+                  for <span className="tabular-nums">{message.durationMs}</span>
+                  ms
+                </span>
+              ) : null}
+            </span>
+          </span>
+        </button>
+        {!(running && message.unresolvedTarget) ? (
+          <CopyMessageButton
+            text={message.functionId}
+            label="copy function id"
+            className="opacity-0 group-hover/fchdr:opacity-100 group-focus-within/fchdr:opacity-100 transition-opacity"
+          />
+        ) : null}
+        <button
+          type="button"
+          aria-hidden="true"
+          tabIndex={-1}
+          onClick={() => setOpen((v) => !v)}
+          className="flex-1 self-stretch flex items-center justify-end pr-3 cursor-pointer"
+        >
+          <span
+            className={cn(
+              'text-ink-ghost shrink-0 transition-transform duration-150 inline-block',
+              open && 'rotate-90',
+            )}
+          >
+            ▸
+          </span>
+        </button>
+      </div>
 
       {open ? (
         <div className="border-t border-rule-2">

--- a/console/web/src/components/function-call/FunctionCallCard.tsx
+++ b/console/web/src/components/function-call/FunctionCallCard.tsx
@@ -642,7 +642,7 @@ function PaneShell({
         <button
           type="button"
           onClick={copy}
-          className="shrink-0 text-ink-ghost hover:text-ink transition-colors"
+          className="shrink-0 cursor-pointer text-ink-ghost hover:text-ink transition-colors"
           aria-label={copied ? 'copied' : `copy ${label}`}
           title={copied ? 'copied' : 'copy'}
         >

--- a/console/web/src/components/function-call/FunctionCallCard.tsx
+++ b/console/web/src/components/function-call/FunctionCallCard.tsx
@@ -450,7 +450,7 @@ export function FunctionCallCard({
           <CopyMessageButton
             text={message.functionId}
             label="copy function id"
-            className="opacity-0 group-hover/fchdr:opacity-100 group-focus-within/fchdr:opacity-100 transition-opacity"
+            className="opacity-0 group-hover/fchdr:opacity-100 group-focus-within/fchdr:opacity-100 transition-[opacity,color]"
           />
         ) : null}
         <button

--- a/console/web/src/lib/clipboard.test.ts
+++ b/console/web/src/lib/clipboard.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { copyTextToClipboard } from './clipboard'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/** Minimal document standing in for exactly the DOM the fallback touches. */
+function fakeDocument(copySucceeds: boolean) {
+  const execCommand = vi.fn(() => copySucceeds)
+  const textarea = {
+    value: '',
+    setAttribute: vi.fn(),
+    style: {} as Record<string, string>,
+    select: vi.fn(),
+    remove: vi.fn(),
+  }
+  const doc = {
+    activeElement: null,
+    createElement: vi.fn(() => textarea),
+    body: { appendChild: vi.fn() },
+    execCommand,
+  }
+  return { doc, execCommand, textarea }
+}
+
+describe('copyTextToClipboard', () => {
+  it('uses navigator.clipboard when available', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+    await expect(copyTextToClipboard('hello')).resolves.toBe(true)
+    expect(writeText).toHaveBeenCalledWith('hello')
+  })
+
+  it('falls back to execCommand when the async API is missing (insecure origin)', async () => {
+    vi.stubGlobal('navigator', {})
+    const { doc, execCommand, textarea } = fakeDocument(true)
+    vi.stubGlobal('document', doc)
+    await expect(copyTextToClipboard('over lan')).resolves.toBe(true)
+    expect(execCommand).toHaveBeenCalledWith('copy')
+    expect(textarea.value).toBe('over lan')
+    expect(textarea.remove).toHaveBeenCalled()
+  })
+
+  it('falls back when the async API rejects (permissions)', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+    const { doc, execCommand } = fakeDocument(true)
+    vi.stubGlobal('document', doc)
+    await expect(copyTextToClipboard('x')).resolves.toBe(true)
+    expect(execCommand).toHaveBeenCalledWith('copy')
+  })
+
+  it('returns false when both strategies fail', async () => {
+    vi.stubGlobal('navigator', {})
+    const { doc } = fakeDocument(false)
+    vi.stubGlobal('document', doc)
+    await expect(copyTextToClipboard('x')).resolves.toBe(false)
+  })
+
+  it('returns false with no navigator and no document at all', async () => {
+    vi.stubGlobal('navigator', undefined)
+    vi.stubGlobal('document', undefined)
+    await expect(copyTextToClipboard('x')).resolves.toBe(false)
+  })
+})

--- a/console/web/src/lib/clipboard.ts
+++ b/console/web/src/lib/clipboard.ts
@@ -1,0 +1,44 @@
+/**
+ * Clipboard writes that survive insecure origins. The console is used over
+ * `http://<LAN-IP>`, where `navigator.clipboard` is undefined (it is a
+ * secure-context API) — so copy affordances funnel through this helper:
+ * async clipboard API first, hidden-textarea `document.execCommand('copy')`
+ * second.
+ */
+
+function execCommandFallback(text: string): boolean {
+  if (typeof document === 'undefined') return false
+  const prior = document.activeElement
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  // Off-screen but selectable; readonly keeps mobile keyboards closed.
+  textarea.setAttribute('readonly', '')
+  textarea.style.position = 'fixed'
+  textarea.style.left = '-9999px'
+  document.body.appendChild(textarea)
+  textarea.select()
+  let ok = false
+  try {
+    ok = document.execCommand('copy')
+  } catch {
+    ok = false
+  }
+  textarea.remove()
+  if (typeof HTMLElement !== 'undefined' && prior instanceof HTMLElement) {
+    prior.focus()
+  }
+  return ok
+}
+
+/** True only when a strategy succeeded; never throws. */
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  if (typeof navigator !== 'undefined' && navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    } catch {
+      // Permissions can reject even on secure origins — try the fallback.
+    }
+  }
+  return execCommandFallback(text)
+}

--- a/console/web/src/lib/editor-links.test.ts
+++ b/console/web/src/lib/editor-links.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  EDITORS,
+  editorById,
+  getPreferredEditor,
+  setPreferredEditor,
+} from './editor-links'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function fakeLocalStorage() {
+  const store = new Map<string, string>()
+  return {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+  }
+}
+
+describe('buildUrl', () => {
+  it('builds the three schemes around the same file path', () => {
+    const path = '/home/anderson/project/mod.rs'
+    expect(editorById('cursor').buildUrl(path)).toBe(
+      'cursor://file/home/anderson/project/mod.rs',
+    )
+    expect(editorById('vscode').buildUrl(path)).toBe(
+      'vscode://file/home/anderson/project/mod.rs',
+    )
+    expect(editorById('zed').buildUrl(path)).toBe(
+      'zed://file/home/anderson/project/mod.rs',
+    )
+  })
+
+  it('appends a positive integer line anchor', () => {
+    expect(editorById('cursor').buildUrl('/a/b.ts', 42)).toBe(
+      'cursor://file/a/b.ts:42',
+    )
+  })
+
+  it('omits non-positive or fractional line anchors', () => {
+    expect(editorById('cursor').buildUrl('/a/b.ts', 0)).toBe(
+      'cursor://file/a/b.ts',
+    )
+    expect(editorById('cursor').buildUrl('/a/b.ts', -3)).toBe(
+      'cursor://file/a/b.ts',
+    )
+    expect(editorById('cursor').buildUrl('/a/b.ts', 1.5)).toBe(
+      'cursor://file/a/b.ts',
+    )
+  })
+
+  it('percent-encodes spaces while preserving slashes', () => {
+    expect(editorById('zed').buildUrl('/tmp/my file.txt', 3)).toBe(
+      'zed://file/tmp/my%20file.txt:3',
+    )
+  })
+})
+
+describe('preference', () => {
+  it('defaults to cursor when nothing is stored', () => {
+    vi.stubGlobal('localStorage', fakeLocalStorage())
+    expect(getPreferredEditor()).toBe('cursor')
+  })
+
+  it('round-trips a stored choice', () => {
+    vi.stubGlobal('localStorage', fakeLocalStorage())
+    setPreferredEditor('zed')
+    expect(getPreferredEditor()).toBe('zed')
+  })
+
+  it('resolves unknown stored values to cursor', () => {
+    const ls = fakeLocalStorage()
+    ls.setItem('iii-preferred-editor', 'emacs')
+    vi.stubGlobal('localStorage', ls)
+    expect(getPreferredEditor()).toBe('cursor')
+  })
+
+  it('is best-effort when storage is unavailable (node env: no localStorage)', () => {
+    expect(getPreferredEditor()).toBe('cursor')
+    expect(() => setPreferredEditor('vscode')).not.toThrow()
+  })
+})
+
+it('EDITORS ids are unique and cover the EditorId union', () => {
+  expect(EDITORS.map((e) => e.id).sort()).toEqual(['cursor', 'vscode', 'zed'])
+})

--- a/console/web/src/lib/editor-links.test.ts
+++ b/console/web/src/lib/editor-links.test.ts
@@ -38,6 +38,15 @@ describe('buildUrl', () => {
       'zed://file/tmp/my%20file.txt:3',
     )
   })
+
+  it('percent-encodes URL delimiters (# and ?) in filenames', () => {
+    expect(editorById('cursor').buildUrl('/tmp/notes#1.md')).toBe(
+      'cursor://file/tmp/notes%231.md',
+    )
+    expect(editorById('vscode').buildUrl('/tmp/what?.ts', 7)).toBe(
+      'vscode://file/tmp/what%3F.ts:7',
+    )
+  })
 })
 
 it('EDITORS ids are unique and cover the EditorId union', () => {

--- a/console/web/src/lib/editor-links.test.ts
+++ b/console/web/src/lib/editor-links.test.ts
@@ -1,22 +1,5 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import {
-  EDITORS,
-  editorById,
-  getPreferredEditor,
-  setPreferredEditor,
-} from './editor-links'
-
-afterEach(() => {
-  vi.unstubAllGlobals()
-})
-
-function fakeLocalStorage() {
-  const store = new Map<string, string>()
-  return {
-    getItem: (k: string) => store.get(k) ?? null,
-    setItem: (k: string, v: string) => void store.set(k, v),
-  }
-}
+import { describe, expect, it } from 'vitest'
+import { EDITORS, editorById } from './editor-links'
 
 describe('buildUrl', () => {
   it('builds the three schemes around the same file path', () => {
@@ -54,31 +37,6 @@ describe('buildUrl', () => {
     expect(editorById('zed').buildUrl('/tmp/my file.txt', 3)).toBe(
       'zed://file/tmp/my%20file.txt:3',
     )
-  })
-})
-
-describe('preference', () => {
-  it('defaults to cursor when nothing is stored', () => {
-    vi.stubGlobal('localStorage', fakeLocalStorage())
-    expect(getPreferredEditor()).toBe('cursor')
-  })
-
-  it('round-trips a stored choice', () => {
-    vi.stubGlobal('localStorage', fakeLocalStorage())
-    setPreferredEditor('zed')
-    expect(getPreferredEditor()).toBe('zed')
-  })
-
-  it('resolves unknown stored values to cursor', () => {
-    const ls = fakeLocalStorage()
-    ls.setItem('iii-preferred-editor', 'emacs')
-    vi.stubGlobal('localStorage', ls)
-    expect(getPreferredEditor()).toBe('cursor')
-  })
-
-  it('is best-effort when storage is unavailable (node env: no localStorage)', () => {
-    expect(getPreferredEditor()).toBe('cursor')
-    expect(() => setPreferredEditor('vscode')).not.toThrow()
   })
 })
 

--- a/console/web/src/lib/editor-links.ts
+++ b/console/web/src/lib/editor-links.ts
@@ -1,0 +1,67 @@
+/**
+ * Deep links from chat file-change cards into a local editor, URL-scheme
+ * based (`cursor://file/...`) — the link opens on the machine running the
+ * BROWSER. When that isn't where the files live (LAN browsing), the
+ * dropdown's "copy path" is the fallback; there is deliberately no
+ * backend involvement (spec: docs/superpowers/specs/
+ * 2026-07-22-console-chat-copy-open-editor-design.md).
+ */
+
+export type EditorId = 'cursor' | 'vscode' | 'zed'
+
+export interface Editor {
+  id: EditorId
+  label: string
+  buildUrl: (path: string, line?: number) => string
+}
+
+/** `<scheme>://file<encoded-abs-path>[:<line>]` — the shape all three share. */
+function fileUrl(scheme: string, path: string, line?: number): string {
+  const anchor =
+    typeof line === 'number' && Number.isInteger(line) && line > 0
+      ? `:${line}`
+      : ''
+  return `${scheme}://file${encodeURI(path)}${anchor}`
+}
+
+export const EDITORS: readonly Editor[] = [
+  {
+    id: 'cursor',
+    label: 'cursor',
+    buildUrl: (p, l) => fileUrl('cursor', p, l),
+  },
+  {
+    id: 'vscode',
+    label: 'vs code',
+    buildUrl: (p, l) => fileUrl('vscode', p, l),
+  },
+  { id: 'zed', label: 'zed', buildUrl: (p, l) => fileUrl('zed', p, l) },
+]
+
+const PREFERRED_EDITOR_KEY = 'iii-preferred-editor'
+
+function isEditorId(v: unknown): v is EditorId {
+  return v === 'cursor' || v === 'vscode' || v === 'zed'
+}
+
+export function editorById(id: EditorId): Editor {
+  // EDITORS covers every EditorId; the fallback keeps the type non-optional.
+  return EDITORS.find((e) => e.id === id) ?? EDITORS[0]
+}
+
+export function getPreferredEditor(): EditorId {
+  try {
+    const raw = localStorage.getItem(PREFERRED_EDITOR_KEY)
+    return isEditorId(raw) ? raw : 'cursor'
+  } catch {
+    return 'cursor'
+  }
+}
+
+export function setPreferredEditor(id: EditorId): void {
+  try {
+    localStorage.setItem(PREFERRED_EDITOR_KEY, id)
+  } catch {
+    /* best-effort */
+  }
+}

--- a/console/web/src/lib/editor-links.ts
+++ b/console/web/src/lib/editor-links.ts
@@ -21,7 +21,11 @@ function fileUrl(scheme: string, path: string, line?: number): string {
     typeof line === 'number' && Number.isInteger(line) && line > 0
       ? `:${line}`
       : ''
-  return `${scheme}://file${encodeURI(path)}${anchor}`
+  // encodeURI leaves URL delimiters (#, ?) raw — legal filename bytes that
+  // would truncate the path into a fragment/query — so encode per segment,
+  // keeping only the slashes literal.
+  const encoded = path.split('/').map(encodeURIComponent).join('/')
+  return `${scheme}://file${encoded}${anchor}`
 }
 
 export const EDITORS: readonly Editor[] = [

--- a/console/web/src/lib/editor-links.ts
+++ b/console/web/src/lib/editor-links.ts
@@ -38,30 +38,7 @@ export const EDITORS: readonly Editor[] = [
   { id: 'zed', label: 'zed', buildUrl: (p, l) => fileUrl('zed', p, l) },
 ]
 
-const PREFERRED_EDITOR_KEY = 'iii-preferred-editor'
-
-function isEditorId(v: unknown): v is EditorId {
-  return v === 'cursor' || v === 'vscode' || v === 'zed'
-}
-
 export function editorById(id: EditorId): Editor {
   // EDITORS covers every EditorId; the fallback keeps the type non-optional.
   return EDITORS.find((e) => e.id === id) ?? EDITORS[0]
-}
-
-export function getPreferredEditor(): EditorId {
-  try {
-    const raw = localStorage.getItem(PREFERRED_EDITOR_KEY)
-    return isEditorId(raw) ? raw : 'cursor'
-  } catch {
-    return 'cursor'
-  }
-}
-
-export function setPreferredEditor(id: EditorId): void {
-  try {
-    localStorage.setItem(PREFERRED_EDITOR_KEY, id)
-  } catch {
-    /* best-effort */
-  }
 }

--- a/console/web/src/lib/function-call-copy.test.ts
+++ b/console/web/src/lib/function-call-copy.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  AssistantMessage,
+  FunctionCallMessage,
+  UserMessage,
+} from '@/types/chat'
+import {
+  assistantCopyText,
+  functionCallsByAssistant,
+  functionCallToText,
+} from './function-call-copy'
+
+function fcall(
+  overrides: Partial<FunctionCallMessage> = {},
+): FunctionCallMessage {
+  return {
+    id: 'f1',
+    createdAt: 0,
+    role: 'function-call',
+    functionId: 'shell::exec',
+    input: { command: 'npm test' },
+    ...overrides,
+  }
+}
+
+function assistant(
+  overrides: Partial<AssistantMessage> = {},
+): AssistantMessage {
+  return {
+    id: 'a1',
+    createdAt: 0,
+    role: 'assistant',
+    content: 'running the tests',
+    ...overrides,
+  }
+}
+
+function user(overrides: Partial<UserMessage> = {}): UserMessage {
+  return { id: 'u1', createdAt: 0, role: 'user', content: 'go', ...overrides }
+}
+
+describe('functionCallToText', () => {
+  it('renders the id and pretty-printed arguments', () => {
+    expect(functionCallToText(fcall())).toBe(
+      'ƒ shell::exec\n{\n  "command": "npm test"\n}',
+    )
+  })
+
+  it('omits the argument block when input is empty', () => {
+    expect(functionCallToText(fcall({ input: {} }))).toBe('ƒ shell::exec')
+    expect(functionCallToText(fcall({ input: null }))).toBe('ƒ shell::exec')
+    expect(functionCallToText(fcall({ input: undefined }))).toBe(
+      'ƒ shell::exec',
+    )
+  })
+})
+
+describe('assistantCopyText', () => {
+  it('returns the prose unchanged when there are no calls', () => {
+    expect(assistantCopyText('hello', [])).toBe('hello')
+  })
+
+  it('appends each call under the prose, blank-line separated', () => {
+    const text = assistantCopyText('running the tests', [
+      fcall({ functionId: 'shell::exec', input: { command: 'npm test' } }),
+      fcall({
+        id: 'f2',
+        functionId: 'coder::read-file',
+        input: { path: '/a.ts' },
+      }),
+    ])
+    expect(text).toBe(
+      'running the tests\n\n' +
+        'ƒ shell::exec\n{\n  "command": "npm test"\n}\n\n' +
+        'ƒ coder::read-file\n{\n  "path": "/a.ts"\n}',
+    )
+  })
+
+  it('drops the leading blank line when the message has no prose', () => {
+    expect(assistantCopyText('', [fcall({ input: {} })])).toBe('ƒ shell::exec')
+  })
+})
+
+describe('functionCallsByAssistant', () => {
+  it('maps an assistant to the run of calls that immediately follows it', () => {
+    const a = assistant({ id: 'a1' })
+    const c1 = fcall({ id: 'c1' })
+    const c2 = fcall({ id: 'c2' })
+    expect(functionCallsByAssistant([a, c1, c2]).get('a1')).toEqual([c1, c2])
+  })
+
+  it('starts a fresh run at the next assistant message', () => {
+    const a1 = assistant({ id: 'a1' })
+    const c1 = fcall({ id: 'c1' })
+    const a2 = assistant({ id: 'a2' })
+    const c2 = fcall({ id: 'c2' })
+    const map = functionCallsByAssistant([a1, c1, a2, c2])
+    expect(map.get('a1')).toEqual([c1])
+    expect(map.get('a2')).toEqual([c2])
+  })
+
+  it('does not attach calls separated from the assistant by another role', () => {
+    const a1 = assistant({ id: 'a1' })
+    const c1 = fcall({ id: 'c1' })
+    expect(functionCallsByAssistant([a1, user(), c1]).has('a1')).toBe(false)
+  })
+
+  it('ignores leading calls with no preceding assistant', () => {
+    expect(functionCallsByAssistant([fcall(), assistant()]).size).toBe(0)
+  })
+})

--- a/console/web/src/lib/function-call-copy.test.ts
+++ b/console/web/src/lib/function-call-copy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type {
   AssistantMessage,
   FunctionCallMessage,
+  ThoughtMessage,
   UserMessage,
 } from '@/types/chat'
 import {
@@ -37,6 +38,16 @@ function assistant(
 
 function user(overrides: Partial<UserMessage> = {}): UserMessage {
   return { id: 'u1', createdAt: 0, role: 'user', content: 'go', ...overrides }
+}
+
+function thought(): ThoughtMessage {
+  return {
+    id: 't1',
+    createdAt: 0,
+    role: 'thought',
+    content: 'scouting the workers tree',
+    durationMs: 180,
+  }
 }
 
 describe('functionCallToText', () => {
@@ -105,7 +116,47 @@ describe('functionCallsByAssistant', () => {
     expect(functionCallsByAssistant([a1, user(), c1]).has('a1')).toBe(false)
   })
 
-  it('ignores leading calls with no preceding assistant', () => {
-    expect(functionCallsByAssistant([fcall(), assistant()]).size).toBe(0)
+  it('attributes leading calls forward to the turn-closing assistant', () => {
+    // The canonical agent flow: thought → calls → summarizing prose.
+    const c1 = fcall({ id: 'c1' })
+    const a1 = assistant({ id: 'a1' })
+    const map = functionCallsByAssistant([user(), thought(), c1, a1])
+    expect(map.get('a1')).toEqual([c1])
+  })
+
+  it('treats thought messages as transparent within a trailing run', () => {
+    const a1 = assistant({ id: 'a1' })
+    const c1 = fcall({ id: 'c1' })
+    expect(functionCallsByAssistant([a1, thought(), c1]).get('a1')).toEqual([
+      c1,
+    ])
+  })
+
+  it('drops leading calls when the turn ends without an assistant', () => {
+    const map = functionCallsByAssistant([
+      fcall({ id: 'c1' }),
+      user(),
+      assistant({ id: 'a1' }),
+    ])
+    expect(map.size).toBe(0)
+  })
+
+  it('combines leading and trailing runs chronologically', () => {
+    const c1 = fcall({ id: 'c1' })
+    const a1 = assistant({ id: 'a1' })
+    const c2 = fcall({ id: 'c2' })
+    expect(functionCallsByAssistant([user(), c1, a1, c2]).get('a1')).toEqual([
+      c1,
+      c2,
+    ])
+  })
+
+  it('prefers trailing attribution between two assistants', () => {
+    const a1 = assistant({ id: 'a1' })
+    const c1 = fcall({ id: 'c1' })
+    const a2 = assistant({ id: 'a2' })
+    const map = functionCallsByAssistant([a1, c1, a2])
+    expect(map.get('a1')).toEqual([c1])
+    expect(map.has('a2')).toBe(false)
   })
 })

--- a/console/web/src/lib/function-call-copy.ts
+++ b/console/web/src/lib/function-call-copy.ts
@@ -1,0 +1,76 @@
+/**
+ * Message-level copy payloads for assistant turns. Function calls are their
+ * own messages in the transcript (never embedded in the assistant record),
+ * so the copy button on an assistant turn has to reach the call messages that
+ * follow it — this module makes that association and serializes it.
+ */
+import type { FunctionCallMessage, Message } from '@/types/chat'
+
+/** The "no meaningful value" rule the function-call panes use for `· empty`. */
+function isEmptyInput(v: unknown): boolean {
+  if (v === null || v === undefined) return true
+  if (typeof v === 'string') return v.length === 0
+  if (Array.isArray(v)) return v.length === 0
+  if (typeof v === 'object') {
+    return Object.keys(v as Record<string, unknown>).length === 0
+  }
+  return false
+}
+
+function formatJson(v: unknown): string {
+  try {
+    return JSON.stringify(v, null, 2)
+  } catch {
+    return String(v)
+  }
+}
+
+/**
+ * One function call as copyable plain text: `ƒ <id>` and its arguments. The
+ * call is what the model emitted; the tool result (output) is copyable from
+ * the call card itself and is deliberately left out of the message-level copy.
+ */
+export function functionCallToText(m: FunctionCallMessage): string {
+  if (isEmptyInput(m.input)) return `ƒ ${m.functionId}`
+  return `ƒ ${m.functionId}\n${formatJson(m.input)}`
+}
+
+/**
+ * Copy payload for an assistant turn: its prose followed by every function
+ * call it made, blank-line separated. With no calls the prose is returned
+ * unchanged, so callers can build this unconditionally.
+ */
+export function assistantCopyText(
+  content: string,
+  calls: readonly FunctionCallMessage[],
+): string {
+  if (calls.length === 0) return content
+  const callText = calls.map(functionCallToText).join('\n\n')
+  return content ? `${content}\n\n${callText}` : callText
+}
+
+/**
+ * Map each assistant message id to the contiguous run of function-call
+ * messages that immediately follows it — the calls belonging to that turn. A
+ * message of any other role ends the run, matching the visual adjacency of an
+ * assistant bubble and its call cards in the transcript.
+ */
+export function functionCallsByAssistant(
+  messages: readonly Message[],
+): Map<string, FunctionCallMessage[]> {
+  const byAssistant = new Map<string, FunctionCallMessage[]>()
+  let currentId: string | null = null
+  for (const m of messages) {
+    if (m.role === 'assistant') {
+      currentId = m.id
+    } else if (m.role === 'function-call') {
+      if (currentId === null) continue
+      const run = byAssistant.get(currentId)
+      if (run) run.push(m)
+      else byAssistant.set(currentId, [m])
+    } else {
+      currentId = null
+    }
+  }
+  return byAssistant
+}

--- a/console/web/src/lib/function-call-copy.ts
+++ b/console/web/src/lib/function-call-copy.ts
@@ -50,26 +50,38 @@ export function assistantCopyText(
 }
 
 /**
- * Map each assistant message id to the contiguous run of function-call
- * messages that immediately follows it — the calls belonging to that turn. A
- * message of any other role ends the run, matching the visual adjacency of an
- * assistant bubble and its call cards in the transcript.
+ * Map each assistant message id to the function calls of its turn. Trailing
+ * calls attach to the assistant message they follow; a run with no assistant
+ * before it attaches FORWARD to the turn's next assistant message — the
+ * canonical agent flow is thought → calls → summarizing prose, so the calls
+ * usually precede the message that talks about them. Thought messages are
+ * transparent; user/system messages are turn boundaries and reset both
+ * directions. Between two assistant messages, trailing attribution wins.
  */
 export function functionCallsByAssistant(
   messages: readonly Message[],
 ): Map<string, FunctionCallMessage[]> {
   const byAssistant = new Map<string, FunctionCallMessage[]>()
   let currentId: string | null = null
+  let leading: FunctionCallMessage[] = []
   for (const m of messages) {
     if (m.role === 'assistant') {
       currentId = m.id
+      if (leading.length > 0) {
+        byAssistant.set(m.id, leading)
+        leading = []
+      }
     } else if (m.role === 'function-call') {
-      if (currentId === null) continue
-      const run = byAssistant.get(currentId)
-      if (run) run.push(m)
-      else byAssistant.set(currentId, [m])
-    } else {
+      if (currentId !== null) {
+        const run = byAssistant.get(currentId)
+        if (run) run.push(m)
+        else byAssistant.set(currentId, [m])
+      } else {
+        leading.push(m)
+      }
+    } else if (m.role !== 'thought') {
       currentId = null
+      leading = []
     }
   }
   return byAssistant

--- a/database/README.md
+++ b/database/README.md
@@ -182,7 +182,7 @@ const { rows } = await iii.trigger({
 |---|---|
 | `database::query` | Read SQL. Returns `{ rows, row_count, columns }`. |
 | `database::execute` | Write SQL. Returns `{ affected_rows, last_insert_id, returned_rows }`.<br>**`last_insert_id` semantics:** SQLite/MySQL surface the engine's `last_insert_rowid()` / `LAST_INSERT_ID()` (only populated for INSERT). Postgres has no equivalent — `last_insert_id` is set from the **first column of the first RETURNING row**, so put your PK first: `RETURNING id, name`, not `RETURNING name, id`. |
-| `database::execute_batch` | Convenience form of `transaction`: statements may be bare SQL strings or `{ sql, params }` objects (use `params` for dynamic values instead of inlining them). Same envelope and semantics as `transaction` — atomic, rolls back on first failure, reports `failed_index`, supports `isolation`. Also registered as `database::executeBatch`. |
+| `database::executeBatch` | Convenience form of `transaction`: statements may be bare SQL strings or `{ sql, params }` objects (use `params` for dynamic values instead of inlining them). Same envelope and semantics as `transaction` — atomic, rolls back on first failure, reports `failed_index`, supports `isolation`. |
 | `database::prepareStatement` | Pin a connection and return `{ handle: { id, expires_at } }`. |
 | `database::runStatement` | Run a previously-prepared handle. (No `timeout_ms` — uses the pinned connection's session lifetime; configure via `ttl_seconds` on `prepareStatement`.) |
 | `database::transaction` | Atomic batch sequence; rolls back on first failure. One-shot — pass all statements together. Rejects bare transaction-control SQL (`BEGIN`/`COMMIT`/`ROLLBACK`/…) and empty statements with `INVALID_PARAM`. |
@@ -222,7 +222,7 @@ Returned `IIIError::Handler` bodies carry a stable `code` field:
 | `STATEMENT_NOT_FOUND` | Handle expired or unknown — re-prepare. |
 | `TRANSACTION_NOT_FOUND` | Transaction id unknown, already committed/rolled back, or timed out (auto-rolled-back by the watcher). |
 | `UNKNOWN_DB` | `db` parameter doesn't match any configured database. |
-| `INVALID_PARAM` | JSON value couldn't be coerced for the target driver, transaction-control SQL was sent to `transactionExecute` (use `commitTransaction` / `rollbackTransaction`), or a `transaction`/`execute_batch` batch contained transaction-control SQL or an empty statement. |
+| `INVALID_PARAM` | JSON value couldn't be coerced for the target driver, transaction-control SQL was sent to `transactionExecute` (use `commitTransaction` / `rollbackTransaction`), or a `transaction`/`executeBatch` batch contained transaction-control SQL or an empty statement. |
 | `DRIVER_ERROR` | Wraps underlying driver error with `driver` and `inner_code` (nullable). `inner_code` format is per-driver: Postgres = SQLSTATE 5-char string (e.g. `42P01`), MySQL = server error number as string, SQLite = `rusqlite::ErrorCode` debug name. Pool-acquire failures use the message form `pool connection failed (<class>)` where `<class>` is one of `tls`, `auth`, `network`, `server-policy`, or `unknown` — a redacted hint so untrusted callers can self-triage without seeing host/userinfo/db fragments. The full driver error is in the worker's stderr via `tracing::warn!`. |
 | `REPLICATION_SLOT_EXISTS` | Startup-only: another instance owns the slot. |
 | `UNSUPPORTED` | Operation not supported on the chosen driver. |

--- a/database/skills/SKILL.md
+++ b/database/skills/SKILL.md
@@ -22,7 +22,7 @@ point. Placeholder syntax: `?` for SQLite and MySQL, `$1`/`$2`/… for Postgres.
 - You need to insert, update, delete, or run DDL and read affected-row
   counts or autoincrement ids (`database::execute`).
 - Several statements must commit or roll back together as one unit
-  (`database::transaction`, `database::execute_batch`, or the interactive
+  (`database::transaction`, `database::executeBatch`, or the interactive
   transaction surface).
 - The same parameterized SQL will run many times and you want to skip
   per-call parse/plan cost (`database::prepareStatement` +
@@ -40,7 +40,7 @@ point. Placeholder syntax: `?` for SQLite and MySQL, `$1`/`$2`/… for Postgres.
 - `database::query` is read-oriented; use `database::execute` for writes.
   Running a SELECT through `execute` discards rows.
 - Prepared handles pin a pool connection until TTL expiry — not transactions.
-  Batch `database::transaction` / `database::execute_batch` need every
+  Batch `database::transaction` / `database::executeBatch` need every
   statement up front; use the interactive surface when code must branch
   between steps.
 - MySQL ignores the `returning` option on `execute` (warn-once). SQLite
@@ -53,10 +53,10 @@ point. Placeholder syntax: `?` for SQLite and MySQL, `$1`/`$2`/… for Postgres.
   column metadata.
 - `database::execute` — run write SQL (INSERT/UPDATE/DELETE/DDL) and
   return affected rows, optional last insert id, and optional RETURNING rows.
-- `database::execute_batch` — convenience form of `transaction`: statements
+- `database::executeBatch` — convenience form of `transaction`: statements
   may be bare SQL strings or `{sql, params}` objects (prefer `params` for
   dynamic values). Same atomic semantics, envelope, and `failed_index`
-  reporting as `transaction`. Also callable as `database::executeBatch`.
+  reporting as `transaction`.
 - `database::prepareStatement` — parse and plan SQL once; return a handle
   that pins a pool connection until TTL expiry.
 - `database::runStatement` — re-execute a prepared handle with new bind

--- a/database/src/driver/sqlite.rs
+++ b/database/src/driver/sqlite.rs
@@ -179,7 +179,7 @@ pub async fn execute(
             driver: "sqlite".into(),
             code: Some("MULTI_STATEMENT".into()),
             message: "rusqlite execute() supports only a single statement; \
-                      use multiple execute() calls or execute_batch via DDL"
+                      use multiple execute() calls or database::executeBatch"
                 .into(),
             failed_index: None,
         });

--- a/database/src/handlers/execute_batch.rs
+++ b/database/src/handlers/execute_batch.rs
@@ -1,10 +1,9 @@
-//! `database::execute_batch` — atomic batch of statements.
+//! `database::executeBatch` — atomic batch of statements.
 //!
 //! Thin convenience form of `database::transaction`: each statement may be a
 //! bare SQL string or a full `{ sql, params }` object. Delegates to
 //! `transaction::handle`, so semantics (atomicity, isolation, guards,
-//! response envelope) are identical. Also registered under the camelCase
-//! alias `database::executeBatch`.
+//! response envelope) are identical.
 
 use super::AppState;
 use crate::handlers::transaction::{self, TxReq, TxResp, TxStmtReq};

--- a/database/src/main.rs
+++ b/database/src/main.rs
@@ -145,7 +145,7 @@ async fn main() -> Result<()> {
     {
         let st = state.clone();
         iii.register_function(
-            "database::execute_batch",
+            "database::executeBatch",
             RegisterFunction::new_async(move |req: ExecuteBatchReq| {
                 let st = st.clone();
                 async move {
@@ -156,24 +156,8 @@ async fn main() -> Result<()> {
             })
             .description(
                 "Run an ordered batch of SQL statements atomically (bare strings or \
-                 {sql, params} objects); rolls back on first failure. Also registered \
-                 as database::executeBatch.",
+                 {sql, params} objects); rolls back on first failure.",
             ),
-        );
-    }
-    {
-        let st = state.clone();
-        iii.register_function(
-            "database::executeBatch",
-            RegisterFunction::new_async(move |req: ExecuteBatchReq| {
-                let st = st.clone();
-                async move {
-                    execute_batch::handle(&st, req)
-                        .await
-                        .map_err(iii_sdk::errors::Error::from)
-                }
-            })
-            .description("Alias of database::execute_batch."),
         );
     }
     {
@@ -332,7 +316,7 @@ async fn main() -> Result<()> {
         .context("registering configuration change trigger")?;
 
     tracing::info!(
-        "database worker registered 14 functions and 1 trigger type, waiting for invocations"
+        "database worker registered 13 functions and 1 trigger type, waiting for invocations"
     );
     wait_for_shutdown_signal().await?;
     tracing::info!("database worker shutting down");

--- a/database/tests/e2e/workers/harness/src/cases-transaction.ts
+++ b/database/tests/e2e/workers/harness/src/cases-transaction.ts
@@ -5,7 +5,7 @@ import { expect, expectEqual } from './cases.ts'
  * Transaction edge cases. The function suite covers commit + rollback at
  * failed_index=1; these target shapes the function suite leaves alone:
  * empty / single-statement / mixed-read-write / failure-at-index-0.
- * Also hosts the `database::execute_batch` surface cases — a thin wrapper
+ * Also hosts the `database::executeBatch` surface cases — a thin wrapper
  * over the same transaction machinery.
  *
  * Each test creates its own scratch table to stay independent of `t`.
@@ -132,14 +132,14 @@ export const TRANSACTION_EDGE_CASES: TestCase[] = [
     },
   },
   {
-    name: 'execute_batch bare-string statements commit atomically',
+    name: 'executeBatch bare-string statements commit atomically',
     async run({ driver, call }) {
       await call('database::execute', { db: driver, sql: 'DROP TABLE IF EXISTS eb_plain' })
       await call('database::execute', {
         db: driver,
         sql: 'CREATE TABLE eb_plain (n INT NOT NULL)',
       })
-      const r = await call('database::execute_batch', {
+      const r = await call('database::executeBatch', {
         db: driver,
         statements: ['INSERT INTO eb_plain (n) VALUES (1)', 'INSERT INTO eb_plain (n) VALUES (2)'],
       })
@@ -154,14 +154,14 @@ export const TRANSACTION_EDGE_CASES: TestCase[] = [
     },
   },
   {
-    name: 'execute_batch rolls back on failure and reports failed_index',
+    name: 'executeBatch rolls back on failure and reports failed_index',
     async run({ driver, call }) {
       await call('database::execute', { db: driver, sql: 'DROP TABLE IF EXISTS eb_rb' })
       await call('database::execute', {
         db: driver,
         sql: 'CREATE TABLE eb_rb (n INT NOT NULL)',
       })
-      const r = await call('database::execute_batch', {
+      const r = await call('database::executeBatch', {
         db: driver,
         statements: ['INSERT INTO eb_rb (n) VALUES (1)', 'INSERT INTO eb_rb (n) VALUES (NULL)'],
       })
@@ -176,7 +176,7 @@ export const TRANSACTION_EDGE_CASES: TestCase[] = [
     },
   },
   {
-    name: 'executeBatch alias accepts mixed string and {sql, params} forms',
+    name: 'executeBatch accepts mixed string and {sql, params} forms',
     async run({ driver, dialect, call }) {
       const ph1 = dialect.placeholder(1)
       await call('database::execute', { db: driver, sql: 'DROP TABLE IF EXISTS eb_mixed' })
@@ -191,7 +191,7 @@ export const TRANSACTION_EDGE_CASES: TestCase[] = [
           "INSERT INTO eb_mixed (s) VALUES ('plain')",
         ],
       })
-      expectEqual(r.committed, true, 'committed=true via alias')
+      expectEqual(r.committed, true, 'committed=true')
       const verify = await call('database::query', {
         db: driver,
         sql: 'SELECT s FROM eb_mixed ORDER BY s',
@@ -202,11 +202,11 @@ export const TRANSACTION_EDGE_CASES: TestCase[] = [
     },
   },
   {
-    name: 'execute_batch rejects embedded transaction-control SQL',
+    name: 'executeBatch rejects embedded transaction-control SQL',
     async run({ driver, call }) {
       let rejected = false
       try {
-        await call('database::execute_batch', {
+        await call('database::executeBatch', {
           db: driver,
           statements: ['SELECT 1', 'COMMIT'],
         })


### PR DESCRIPTION
## Summary

**Console chat copy affordances**
- Copy button on user and assistant messages (hover-revealed, PaneShell copy idiom). An assistant turn's copy includes the function calls it made (`ƒ id` + arguments), with turn-scoped attribution that handles the canonical `thought → calls → summarizing prose` ordering (leading call runs attach forward to the turn's assistant message; thoughts are transparent; tool-only turns still get the button).
- Function-call cards: hover copy of the `ƒ` function id in the header (works collapsed, in group children, and in the TracesV2 span tab); the header is restructured so the copy control never nests inside the collapse toggle.
- Request/response pane copy now works on insecure origins (`http://<LAN-IP>`) via a clipboard helper with an `execCommand` fallback — fixes MOT-4174.

**Open in editor on coder file-change cards**
- Settled successful `create-file` / `update-file` / `move` results get an "open in editor" menu: cursor / vs code / zed via URL schemes (`cursor://file/<abs-path>[:line]`), plus a copy-path fallback for LAN browsing. Frontend-only by design — no backend exec endpoint, since the console port is LAN-exposed.
- Editor links percent-encode per path segment, so filenames containing `#`, `?`, or spaces deep-link correctly.

**Database**
- `database::executeBatch` is now the sole registration for atomic batch writes; the snake_case `database::execute_batch` duplicate is removed to match the worker's camelCase ids (`prepareStatement`, `beginTransaction`, …). README, SKILL.md, e2e surface cases, and the sqlite MULTI_STATEMENT hint follow.

**BREAKING CHANGE:** external callers of `database::execute_batch` must switch to `database::executeBatch` (no in-repo callers existed).

Fixes MOT-4174

## Verification
- `console/web`: 1096 vitest tests / 86 files green, `tsc -b` clean, biome clean on all changed files
- `database`: `cargo test` — 225 passed, 0 failed
- Live browser audit (Storybook playground scenarios, driven headless): copy payloads (single + multi-call turns), always-open editor menu, `cursor://file/...` deep-link wiring, copy-path canonical absolute paths, pointer cursors, aria/toggle structure — all verified at HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy controls for chat messages and function-call details, with confirmation feedback.
  * Added options to open completed file changes directly in Cursor, VS Code, or Zed.
  * Added the ability to copy file paths from the editor menu.

* **Updates**
  * Renamed the database batch execution API to `database::executeBatch` across the product and documentation.

* **Bug Fixes**
  * Improved clipboard copying with a fallback for unsupported or restricted browser APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->