### PR TITLE
fix(worktree): stop failed lands leaking locked, prune-exempt worktrees

### DIFF
--- a/worktree/src/functions/prune.rs
+++ b/worktree/src/functions/prune.rs
@@ -100,14 +100,10 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
                 });
                 continue;
             }
-            Lifecycle::LandBlocked => {
-                skipped.push(PruneSkip {
-                    id: record.worktree_id,
-                    reason: "land-blocked".into(),
-                });
-                continue;
-            }
-            Lifecycle::Active | Lifecycle::Orphaned => {}
+            // LandBlocked joins the expiry sweep: block() unlocks the worktree,
+            // and the clean/ahead checks below preserve any that still hold
+            // unlanded work — only clean, integrated, expired ones are reaped.
+            Lifecycle::Active | Lifecycle::Orphaned | Lifecycle::LandBlocked => {}
         }
 
         let repo = Path::new(&record.repo_path);

--- a/worktree/src/functions/prune.rs
+++ b/worktree/src/functions/prune.rs
@@ -100,9 +100,6 @@ pub async fn handle(deps: &Deps, req: Request) -> Result<Response, WError> {
                 });
                 continue;
             }
-            // LandBlocked joins the expiry sweep: block() unlocks the worktree,
-            // and the clean/ahead checks below preserve any that still hold
-            // unlanded work — only clean, integrated, expired ones are reaped.
             Lifecycle::Active | Lifecycle::Orphaned | Lifecycle::LandBlocked => {}
         }
 

--- a/worktree/src/land/mod.rs
+++ b/worktree/src/land/mod.rs
@@ -460,10 +460,6 @@ async fn block(
     }
     state::clear_active_job_id(deps.state.as_ref(), &job.worktree_id).await?;
 
-    // Release the creation-time git lock so a blocked land does not leak a
-    // permanently locked worktree. The directory stays in place for inspection;
-    // the expiry prune sweep reaps it once clean, and manual removal no longer
-    // fights the lock.
     {
         let repo = Path::new(&job.repo_path);
         let wt = Path::new(&job.worktree_path);

--- a/worktree/src/land/mod.rs
+++ b/worktree/src/land/mod.rs
@@ -460,6 +460,18 @@ async fn block(
     }
     state::clear_active_job_id(deps.state.as_ref(), &job.worktree_id).await?;
 
+    // Release the creation-time git lock so a blocked land does not leak a
+    // permanently locked worktree. The directory stays in place for inspection;
+    // the expiry prune sweep reaps it once clean, and manual removal no longer
+    // fights the lock.
+    {
+        let repo = Path::new(&job.repo_path);
+        let wt = Path::new(&job.worktree_path);
+        if wt.exists() {
+            ops::worktree_unlock(repo, wt, deps.git_timeout_ms).await;
+        }
+    }
+
     tracing::info!(
         job_id = %job.job_id,
         worktree_id = %job.worktree_id,

--- a/worktree/tests/land_machine.rs
+++ b/worktree/tests/land_machine.rs
@@ -153,6 +153,12 @@ async fn dirty_checked_out_primary_blocks_with_w413() {
         .unwrap();
     assert_eq!(record.lifecycle, Lifecycle::LandBlocked);
     assert!(s.wt_path.is_dir(), "worktree kept for another attempt");
+    // A blocked land releases the git lock; the worktree is no longer locked.
+    let porcelain = git(&s.repo, &["worktree", "list", "--porcelain"]);
+    assert!(
+        !porcelain.contains(&format!("locked iii:worktree {}", s.worktree_id)),
+        "blocked worktree must be unlocked, got:\n{porcelain}"
+    );
 }
 
 #[tokio::test]

--- a/worktree/tests/land_machine.rs
+++ b/worktree/tests/land_machine.rs
@@ -13,7 +13,7 @@ use support::{
     branch_sha, commit_file, create_request, git, head_sha, init_repo, make_env,
     make_env_with_runner, test_config, FailingStore, ScriptedTestRunner, TestEnv,
 };
-use worktree::functions::{create, land};
+use worktree::functions::{create, land, prune};
 use worktree::land::{run_step, LandDeps};
 use worktree::state;
 use worktree::types::{LandPhase, Lifecycle};
@@ -158,6 +158,63 @@ async fn dirty_checked_out_primary_blocks_with_w413() {
     assert!(
         !porcelain.contains(&format!("locked iii:worktree {}", s.worktree_id)),
         "blocked worktree must be unlocked, got:\n{porcelain}"
+    );
+}
+
+#[tokio::test]
+async fn prune_preserves_blocked_with_unmerged_then_reaps_integrated() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut cfg = test_config(tmp.path());
+    cfg.prune_expire_hours = 0; // everything is age-eligible
+    let s = setup(make_env(tmp.path(), cfg), tmp.path()).await;
+    let feature_sha = head_sha(&s.wt_path);
+
+    // Reach LandBlocked via W413 (dirty primary): the worktree itself stays
+    // clean, one commit ahead of main, and main is untouched (not integrated).
+    std::fs::write(s.repo.join("README.md"), "local edits\n").unwrap();
+    let job_id = enqueue_land(&s, "main", LandOverrides::default()).await;
+    let deps = land_deps(&s.env).await;
+    run_step(&deps, &job_id).await.unwrap();
+    let rec = state::get_record(s.env.state.as_ref(), &s.worktree_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(rec.lifecycle, Lifecycle::LandBlocked);
+
+    // Unmerged work must be preserved, not reaped.
+    let out = prune::handle(
+        &s.env.deps,
+        prune::Request {
+            repo_path: None,
+            dry_run: false,
+        },
+    )
+    .await
+    .unwrap();
+    assert!(
+        !out.pruned.contains(&s.worktree_id),
+        "must not prune unmerged: {out:?}"
+    );
+    assert!(out
+        .skipped
+        .iter()
+        .any(|k| k.id == s.worktree_id && k.reason == "unmerged work"));
+    assert!(s.wt_path.is_dir());
+
+    // Once the work is integrated, prune reaps it.
+    let _ = git(&s.repo, &["merge", "--ff-only", &feature_sha]);
+    let out2 = prune::handle(
+        &s.env.deps,
+        prune::Request {
+            repo_path: None,
+            dry_run: false,
+        },
+    )
+    .await
+    .unwrap();
+    assert!(
+        out2.pruned.contains(&s.worktree_id),
+        "must reap integrated: {out2:?}"
     );
 }
 

--- a/worktree/tests/land_machine.rs
+++ b/worktree/tests/land_machine.rs
@@ -153,7 +153,6 @@ async fn dirty_checked_out_primary_blocks_with_w413() {
         .unwrap();
     assert_eq!(record.lifecycle, Lifecycle::LandBlocked);
     assert!(s.wt_path.is_dir(), "worktree kept for another attempt");
-    // A blocked land releases the git lock; the worktree is no longer locked.
     let porcelain = git(&s.repo, &["worktree", "list", "--porcelain"]);
     assert!(
         !porcelain.contains(&format!("locked iii:worktree {}", s.worktree_id)),
@@ -165,12 +164,10 @@ async fn dirty_checked_out_primary_blocks_with_w413() {
 async fn prune_preserves_blocked_with_unmerged_then_reaps_integrated() {
     let tmp = tempfile::tempdir().unwrap();
     let mut cfg = test_config(tmp.path());
-    cfg.prune_expire_hours = 0; // everything is age-eligible
+    cfg.prune_expire_hours = 0;
     let s = setup(make_env(tmp.path(), cfg), tmp.path()).await;
     let feature_sha = head_sha(&s.wt_path);
 
-    // Reach LandBlocked via W413 (dirty primary): the worktree itself stays
-    // clean, one commit ahead of main, and main is untouched (not integrated).
     std::fs::write(s.repo.join("README.md"), "local edits\n").unwrap();
     let job_id = enqueue_land(&s, "main", LandOverrides::default()).await;
     let deps = land_deps(&s.env).await;
@@ -181,7 +178,6 @@ async fn prune_preserves_blocked_with_unmerged_then_reaps_integrated() {
         .unwrap();
     assert_eq!(rec.lifecycle, Lifecycle::LandBlocked);
 
-    // Unmerged work must be preserved, not reaped.
     let out = prune::handle(
         &s.env.deps,
         prune::Request {
@@ -201,7 +197,6 @@ async fn prune_preserves_blocked_with_unmerged_then_reaps_integrated() {
         .any(|k| k.id == s.worktree_id && k.reason == "unmerged work"));
     assert!(s.wt_path.is_dir());
 
-    // Once the work is integrated, prune reaps it.
     let _ = git(&s.repo, &["merge", "--ff-only", &feature_sha]);
     let out2 = prune::handle(
         &s.env.deps,


### PR DESCRIPTION
## Problem

A land that hits `block()` — dirty target checkout, rebase conflict, test-gate failure, target moved past the retry bound, etc. — sets the record to `LandBlocked` but **never releases the worktree's creation-time git lock**. Only the `Finalize`/success path unlocks.

`prune` then **skips `LandBlocked` outright**, so a blocked worktree is simultaneously:
- permanently git-locked (nothing unlocks it outside a deletion path), and
- permanently exempt from the expiry sweep.

Net effect: every failed land leaks a locked worktree that accumulates forever and can only be cleared by hand.

## Fix

- **`block()` unlocks the worktree.** It stays on disk in `LandBlocked` for inspection/recovery, but no longer holds the git lock.
- **`prune` treats `LandBlocked` as eligible** for the same expiry sweep as `Active`/`Orphaned`. The existing clean + ahead/integration checks are unchanged, so a blocked worktree that still carries real unlanded work is preserved — only clean, integrated, expired ones are reaped.

## Test

Adds a `land_machine` regression asserting a blocked worktree is unlocked after `block()`. Full worktree worker suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked land operations now release the associated worktree lock, preventing stale locked worktrees from impacting later inspection and cleanup.
  * Pruning now applies the standard reconciliation/cleanup rules to land-blocked records instead of skipping them unconditionally.
* **Tests**
  * Strengthened coverage to verify blocked worktrees are unlocked after W413 dirty-checked-out-primary blocks.
  * Added a prune scenario test ensuring blocked worktrees with unmerged work aren’t reaped until after integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->