### PR TITLE
(MOT-4183) fix(ci): stabilize integration and Rust caches

### DIFF
--- a/.github/scripts/discover_changed_workers.py
+++ b/.github/scripts/discover_changed_workers.py
@@ -5,6 +5,7 @@ Outputs a JSON object to stdout AND (if $GITHUB_OUTPUT is set) writes keys:
     changed_workers (alias `all`) : all workers with any change
     source_changed                : workers whose change wasn't only metadata
     rust / node / python          : language buckets (subset of changed_workers)
+    integration_changed          : bool, did an integration-stack input change
     vscode_changed                : bool, did lsp-vscode/ change
     any                           : bool, any worker or vscode change
 """
@@ -44,9 +45,39 @@ VSCODE_DIR = "lsp-vscode"
 # downstream version bumps at tag time.
 FANOUT_PARENT = "harness"
 
+# The integration suite boots this stack directly. Changes to other harness
+# dependencies are covered by the ordinary worker fan-out, but do not need to
+# pay for the full live stack in a pull request.
+INTEGRATION_WORKERS = {
+    "harness",
+    "queue",
+    "session-manager",
+    "context-manager",
+    "iii-directory",
+    "console",
+}
+INTEGRATION_DOC_GLOBS = (
+    "README.md",
+    "**/README.md",
+    "AGENTS.md",
+    "AGENTS-*.md",
+    "**/AGENTS.md",
+    "**/AGENTS-*.md",
+)
+INTEGRATION_INFRA_PATHS = {
+    ".github/scripts/discover_changed_workers.py",
+    ".github/workflows/ci.yml",
+    ".github/workflows/_harness-integration.yml",
+    ".github/workflows/cache-warm.yml",
+}
+
 
 def is_metadata(rel: str) -> bool:
     return any(fnmatch.fnmatch(rel, g) for g in METADATA_GLOBS)
+
+
+def is_integration_doc(rel: str) -> bool:
+    return any(fnmatch.fnmatch(rel, g) for g in INTEGRATION_DOC_GLOBS)
 
 
 def list_worker_dirs(repo_root: pathlib.Path) -> set[str]:
@@ -111,6 +142,12 @@ def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser()
     p.add_argument("--base", required=True, help="base git ref")
     p.add_argument("--head", default="HEAD", help="head git ref (default: HEAD)")
+    p.add_argument(
+        "--force-worker",
+        action="append",
+        default=[],
+        help="include a worker even when it did not change (repeatable)",
+    )
     args = p.parse_args(argv)
 
     repo_root = pathlib.Path(".").resolve()
@@ -130,15 +167,28 @@ def main(argv: list[str] | None = None) -> int:
         if top in workers:
             touched.setdefault(top, []).append(rel)
 
-    forced: set[str] = set()
+    unknown_forced = sorted(set(args.force_worker) - workers)
+    if unknown_forced:
+        p.error(f"unknown --force-worker: {', '.join(unknown_forced)}")
+
+    forced: set[str] = set(args.force_worker)
     parent_rels = touched.get(FANOUT_PARENT, [])
-    if any(not is_metadata(rel) for rel in parent_rels):
+    if FANOUT_PARENT in forced or any(not is_metadata(rel) for rel in parent_rels):
         forced.update(fanout_dependents(repo_root, workers))
 
     changed = sorted(set(touched.keys()) | forced)
     source_changed = sorted(
         w for w, rels in touched.items()
         if any(not is_metadata(rel) for rel in rels)
+    )
+    integration_changed = bool(forced & INTEGRATION_WORKERS) or any(
+        f in INTEGRATION_INFRA_PATHS
+        or (
+            f.split("/", 1)[0] in INTEGRATION_WORKERS
+            and len(f.split("/", 1)) == 2
+            and not is_integration_doc(f.split("/", 1)[1])
+        )
+        for f in files
     )
     by_language: dict[str, list[str]] = {"rust": [], "node": [], "python": []}
     for w in changed:
@@ -152,6 +202,7 @@ def main(argv: list[str] | None = None) -> int:
         "changed_workers": changed,
         "source_changed": source_changed,
         "by_language": by_language,
+        "integration_changed": integration_changed,
         "vscode_changed": vscode_changed,
     }
     print(json.dumps(payload))
@@ -166,6 +217,9 @@ def main(argv: list[str] | None = None) -> int:
             f.write(f"source_changed={json.dumps(source_changed)}\n")
             for lang in ("rust", "node", "python"):
                 f.write(f"{lang}={json.dumps(by_language[lang])}\n")
+            f.write(
+                f"integration_changed={'true' if integration_changed else 'false'}\n"
+            )
             f.write(f"vscode_changed={'true' if vscode_changed else 'false'}\n")
             f.write(f"any={'true' if any_change else 'false'}\n")
 

--- a/.github/scripts/discover_changed_workers.py
+++ b/.github/scripts/discover_changed_workers.py
@@ -37,17 +37,8 @@ IGNORE_DIRS = {".git", ".github", "registry", "target", "node_modules"}
 # Special non-worker dir tracked separately for the vscode-changed gate.
 VSCODE_DIR = "lsp-vscode"
 
-# Source changes in this worker fan out: every in-repo dep listed in its
-# iii.worker.yaml joins the changed-workers matrix so the rust lint+test
-# job exercises them against the new shared crate. Deps are deliberately
-# NOT added to source_changed — version-bump / README / tests/ gates only
-# apply to workers the PR author actually edited. Bundle-release handles
-# downstream version bumps at tag time.
-FANOUT_PARENT = "harness"
-
-# The integration suite boots this stack directly. Changes to other harness
-# dependencies are covered by the ordinary worker fan-out, but do not need to
-# pay for the full live stack in a pull request.
+# The integration suite boots this stack directly. Its path gate is separate
+# from the per-worker matrices, which only contain directly changed workers.
 INTEGRATION_WORKERS = {
     "harness",
     "queue",
@@ -117,27 +108,6 @@ def language_of(worker_dir: pathlib.Path) -> str | None:
     return None
 
 
-def fanout_dependents(repo_root: pathlib.Path, workers: set[str]) -> list[str]:
-    """In-repo workers listed as deps in FANOUT_PARENT/iii.worker.yaml.
-
-    Missing manifest or unreadable yaml → empty list (no fan-out).
-    """
-    meta = repo_root / FANOUT_PARENT / "iii.worker.yaml"
-    if not meta.exists():
-        return []
-    try:
-        import yaml  # type: ignore[import-not-found]
-        data = yaml.safe_load(meta.read_text()) or {}
-    except Exception:  # noqa: BLE001
-        return []
-    if not isinstance(data, dict):
-        return []
-    deps = data.get("dependencies")
-    if not isinstance(deps, dict):
-        return []
-    return sorted(d for d in deps if d in workers and d != FANOUT_PARENT)
-
-
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser()
     p.add_argument("--base", required=True, help="base git ref")
@@ -171,12 +141,8 @@ def main(argv: list[str] | None = None) -> int:
     if unknown_forced:
         p.error(f"unknown --force-worker: {', '.join(unknown_forced)}")
 
-    forced: set[str] = set(args.force_worker)
-    parent_rels = touched.get(FANOUT_PARENT, [])
-    if FANOUT_PARENT in forced or any(not is_metadata(rel) for rel in parent_rels):
-        forced.update(fanout_dependents(repo_root, workers))
-
-    changed = sorted(set(touched.keys()) | forced)
+    forced = set(args.force_worker)
+    changed = sorted(set(touched) | forced)
     source_changed = sorted(
         w for w, rels in touched.items()
         if any(not is_metadata(rel) for rel in rels)

--- a/.github/scripts/tests/test_discover_changed_workers.py
+++ b/.github/scripts/tests/test_discover_changed_workers.py
@@ -51,9 +51,22 @@ def make_repo_with_workers(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def run_script(repo: Path, base: str, head: str = "HEAD") -> subprocess.CompletedProcess[str]:
+def run_script(
+    repo: Path,
+    base: str,
+    head: str = "HEAD",
+    *extra_args: str,
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        [sys.executable, str(SCRIPT), "--base", base, "--head", head],
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--base",
+            base,
+            "--head",
+            head,
+            *extra_args,
+        ],
         capture_output=True,
         text=True,
         cwd=repo,
@@ -107,10 +120,11 @@ class TestDiscoverChangedWorkers:
         assert r.returncode == 0
         data = json.loads(r.stdout)
         assert data["changed_workers"] == []
+        assert data["integration_changed"] is False
 
 
 def make_repo_with_harness(tmp_path: Path) -> Path:
-    """Tmp repo: harness + two in-repo deps + one external dep + one unrelated worker."""
+    """Tmp repo with harness, its deps, Console, and one unrelated worker."""
     def run(*args):
         return subprocess.run(args, cwd=tmp_path, check=True, env=GIT_HERMETIC_ENV)
     run("git", "init", "-q", "-b", "main")
@@ -139,6 +153,17 @@ def make_repo_with_harness(tmp_path: Path) -> Path:
         'iii: v1\nname: dep-node\nlanguage: node\ndeploy: image\nmanifest: package.json\n'
     )
     (tmp_path / "dep-node" / "package.json").write_text('{"name":"dep-node","version":"0.1.0"}')
+    (tmp_path / "console").mkdir()
+    (tmp_path / "console" / "iii.worker.yaml").write_text(
+        'iii: v1\nname: console\nlanguage: node\ndeploy: image\nmanifest: package.json\n'
+    )
+    (tmp_path / "console" / "package.json").write_text(
+        '{"name":"console","version":"0.1.0"}'
+    )
+    (tmp_path / ".github" / "workflows").mkdir(parents=True)
+    (tmp_path / ".github" / "workflows" / "ci.yml").write_text(
+        "name: fixture-ci\n"
+    )
     (tmp_path / "unrelated").mkdir()
     (tmp_path / "unrelated" / "iii.worker.yaml").write_text(
         'iii: v1\nname: unrelated\nlanguage: python\ndeploy: image\nmanifest: pyproject.toml\n'
@@ -164,6 +189,7 @@ class TestHarnessFanOut:
         assert "unrelated" not in data["changed_workers"]
         # External dep listed in harness deps but absent from repo is skipped.
         assert "external-dep" not in data["changed_workers"]
+        assert data["integration_changed"] is True
 
     def test_fanned_out_deps_excluded_from_source_changed(self, tmp_path):
         """Fan-out enters deps into the matrix (so lint+test runs against the
@@ -191,6 +217,7 @@ class TestHarnessFanOut:
         data = json.loads(r.stdout)
         assert data["changed_workers"] == ["harness"]
         assert data["source_changed"] == []
+        assert data["integration_changed"] is False
 
     def test_fanned_out_deps_bucketed_by_language(self, tmp_path):
         repo = make_repo_with_harness(tmp_path)
@@ -203,3 +230,63 @@ class TestHarnessFanOut:
         assert sorted(data["by_language"]["rust"]) == ["dep-rust", "harness"]
         assert data["by_language"]["node"] == ["dep-node"]
         assert data["by_language"]["python"] == []
+
+    def test_harness_manifest_change_runs_integration_without_source_change(self, tmp_path):
+        repo = make_repo_with_harness(tmp_path)
+        manifest = repo / "harness" / "Cargo.toml"
+        manifest.write_text(manifest.read_text() + "\n[features]\ndefault = []\n")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True, env=GIT_HERMETIC_ENV)
+        subprocess.run(["git", "commit", "-q", "-m", "manifest"], cwd=repo, check=True, env=GIT_HERMETIC_ENV)
+        r = run_script(repo, "main~1")
+        assert r.returncode == 0, r.stderr
+        data = json.loads(r.stdout)
+        assert data["source_changed"] == []
+        assert data["integration_changed"] is True
+
+    def test_unrelated_worker_change_skips_integration(self, tmp_path):
+        repo = make_repo_with_harness(tmp_path)
+        (repo / "unrelated" / "worker.py").write_text("# change\n")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True, env=GIT_HERMETIC_ENV)
+        subprocess.run(["git", "commit", "-q", "-m", "unrelated"], cwd=repo, check=True, env=GIT_HERMETIC_ENV)
+        r = run_script(repo, "main~1")
+        assert r.returncode == 0, r.stderr
+        data = json.loads(r.stdout)
+        assert data["integration_changed"] is False
+
+    def test_force_harness_preserves_full_fanout_and_runs_integration(self, tmp_path):
+        repo = make_repo_with_harness(tmp_path)
+        r = run_script(repo, "HEAD", "HEAD", "--force-worker", "harness")
+        assert r.returncode == 0, r.stderr
+        data = json.loads(r.stdout)
+        assert sorted(data["changed_workers"]) == ["dep-node", "dep-rust", "harness"]
+        assert data["source_changed"] == []
+        assert data["integration_changed"] is True
+
+    def test_console_change_runs_integration_without_harness_fanout(self, tmp_path):
+        repo = make_repo_with_harness(tmp_path)
+        (repo / "console" / "ui.ts").write_text("// change\n")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True, env=GIT_HERMETIC_ENV)
+        subprocess.run(["git", "commit", "-q", "-m", "console"], cwd=repo, check=True, env=GIT_HERMETIC_ENV)
+        r = run_script(repo, "main~1")
+        assert r.returncode == 0, r.stderr
+        data = json.loads(r.stdout)
+        assert data["changed_workers"] == ["console"]
+        assert data["integration_changed"] is True
+
+    def test_integration_workflow_change_runs_integration(self, tmp_path):
+        repo = make_repo_with_harness(tmp_path)
+        workflow = repo / ".github" / "workflows" / "ci.yml"
+        workflow.write_text("name: changed-ci\n")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True, env=GIT_HERMETIC_ENV)
+        subprocess.run(["git", "commit", "-q", "-m", "ci"], cwd=repo, check=True, env=GIT_HERMETIC_ENV)
+        r = run_script(repo, "main~1")
+        assert r.returncode == 0, r.stderr
+        data = json.loads(r.stdout)
+        assert data["changed_workers"] == []
+        assert data["integration_changed"] is True
+
+    def test_unknown_forced_worker_is_rejected(self, tmp_path):
+        repo = make_repo_with_harness(tmp_path)
+        r = run_script(repo, "HEAD", "HEAD", "--force-worker", "missing")
+        assert r.returncode == 2
+        assert "unknown --force-worker: missing" in r.stderr

--- a/.github/scripts/tests/test_discover_changed_workers.py
+++ b/.github/scripts/tests/test_discover_changed_workers.py
@@ -176,8 +176,8 @@ def make_repo_with_harness(tmp_path: Path) -> Path:
     return tmp_path
 
 
-class TestHarnessFanOut:
-    def test_harness_source_change_fans_out_to_in_repo_deps(self, tmp_path):
+class TestHarnessSelection:
+    def test_harness_source_change_selects_only_harness(self, tmp_path):
         repo = make_repo_with_harness(tmp_path)
         (repo / "harness" / "lib.rs").write_text("// breaking change\n")
         subprocess.run(["git", "add", "."], cwd=repo, check=True, env=GIT_HERMETIC_ENV)
@@ -185,17 +185,10 @@ class TestHarnessFanOut:
         r = run_script(repo, "main~1")
         assert r.returncode == 0, r.stderr
         data = json.loads(r.stdout)
-        assert sorted(data["changed_workers"]) == ["dep-node", "dep-rust", "harness"]
-        assert "unrelated" not in data["changed_workers"]
-        # External dep listed in harness deps but absent from repo is skipped.
-        assert "external-dep" not in data["changed_workers"]
+        assert data["changed_workers"] == ["harness"]
         assert data["integration_changed"] is True
 
-    def test_fanned_out_deps_excluded_from_source_changed(self, tmp_path):
-        """Fan-out enters deps into the matrix (so lint+test runs against the
-        new harness) but must NOT mark them source_changed. Otherwise the PR
-        gate in validate_worker.py would force the author to bump every dep's
-        Cargo.toml — version bumps belong to bundle release, not PR CI."""
+    def test_harness_source_change_is_the_only_source_change(self, tmp_path):
         repo = make_repo_with_harness(tmp_path)
         (repo / "harness" / "lib.rs").write_text("// edit\n")
         subprocess.run(["git", "add", "."], cwd=repo, check=True, env=GIT_HERMETIC_ENV)
@@ -203,11 +196,10 @@ class TestHarnessFanOut:
         r = run_script(repo, "main~1")
         assert r.returncode == 0, r.stderr
         data = json.loads(r.stdout)
+        assert data["changed_workers"] == ["harness"]
         assert data["source_changed"] == ["harness"]
-        assert "dep-rust" not in data["source_changed"]
-        assert "dep-node" not in data["source_changed"]
 
-    def test_harness_metadata_change_does_not_fan_out(self, tmp_path):
+    def test_harness_metadata_change_stays_direct(self, tmp_path):
         repo = make_repo_with_harness(tmp_path)
         (repo / "harness" / "README.md").write_text("# harness\n")
         subprocess.run(["git", "add", "."], cwd=repo, check=True, env=GIT_HERMETIC_ENV)
@@ -219,7 +211,7 @@ class TestHarnessFanOut:
         assert data["source_changed"] == []
         assert data["integration_changed"] is False
 
-    def test_fanned_out_deps_bucketed_by_language(self, tmp_path):
+    def test_harness_change_is_the_only_rust_worker(self, tmp_path):
         repo = make_repo_with_harness(tmp_path)
         (repo / "harness" / "lib.rs").write_text("// edit\n")
         subprocess.run(["git", "add", "."], cwd=repo, check=True, env=GIT_HERMETIC_ENV)
@@ -227,8 +219,8 @@ class TestHarnessFanOut:
         r = run_script(repo, "main~1")
         assert r.returncode == 0, r.stderr
         data = json.loads(r.stdout)
-        assert sorted(data["by_language"]["rust"]) == ["dep-rust", "harness"]
-        assert data["by_language"]["node"] == ["dep-node"]
+        assert data["by_language"]["rust"] == ["harness"]
+        assert data["by_language"]["node"] == []
         assert data["by_language"]["python"] == []
 
     def test_harness_manifest_change_runs_integration_without_source_change(self, tmp_path):
@@ -253,16 +245,16 @@ class TestHarnessFanOut:
         data = json.loads(r.stdout)
         assert data["integration_changed"] is False
 
-    def test_force_harness_preserves_full_fanout_and_runs_integration(self, tmp_path):
+    def test_force_harness_selects_only_harness_and_runs_integration(self, tmp_path):
         repo = make_repo_with_harness(tmp_path)
         r = run_script(repo, "HEAD", "HEAD", "--force-worker", "harness")
         assert r.returncode == 0, r.stderr
         data = json.loads(r.stdout)
-        assert sorted(data["changed_workers"]) == ["dep-node", "dep-rust", "harness"]
+        assert data["changed_workers"] == ["harness"]
         assert data["source_changed"] == []
         assert data["integration_changed"] is True
 
-    def test_console_change_runs_integration_without_harness_fanout(self, tmp_path):
+    def test_console_change_runs_integration(self, tmp_path):
         repo = make_repo_with_harness(tmp_path)
         (repo / "console" / "ui.ts").write_text("// change\n")
         subprocess.run(["git", "add", "."], cwd=repo, check=True, env=GIT_HERMETIC_ENV)

--- a/.github/workflows/_harness-integration.yml
+++ b/.github/workflows/_harness-integration.yml
@@ -1,0 +1,230 @@
+name: Harness integration E2E
+
+on:
+  workflow_call:
+    inputs:
+      save-cache:
+        description: Save build caches from this trusted invocation
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  integration:
+    name: harness integration e2e
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read and validate engine.lock
+        id: lock
+        run: |
+          set -euo pipefail
+          lock=harness/tests/e2e/engine.lock
+          read_field() {
+            local field=$1 values
+            values=$(sed -n "s/^${field} = \"\\([^\"]*\\)\"$/\\1/p" "$lock")
+            [[ $(printf '%s\n' "$values" | sed '/^$/d' | wc -l) -eq 1 ]] || {
+              echo "engine.lock: $field must appear exactly once"
+              exit 3
+            }
+            printf '%s' "$values"
+          }
+          invalid=$(sed \
+            -e '/^[[:space:]]*$/d' \
+            -e '/^[[:space:]]*#/d' \
+            -e '/^\(repository\|revision\|package\|binary\) = "[^"]*"$/d' \
+            "$lock")
+          [[ -z "$invalid" ]] || {
+            echo "engine.lock: unsupported or malformed entry"
+            printf '%s\n' "$invalid"
+            exit 3
+          }
+          repository=$(read_field repository)
+          revision=$(read_field revision)
+          package=$(read_field package)
+          binary=$(read_field binary)
+          [[ "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || {
+            echo "engine.lock: repository must be an owner/name slug"
+            exit 3
+          }
+          [[ "$revision" =~ ^[0-9a-f]{40}$ ]] || { echo "engine.lock: revision must be 40-hex"; exit 3; }
+          [[ "$package" =~ ^[A-Za-z0-9_-]+$ ]] || {
+            echo "engine.lock: package contains unsupported characters"
+            exit 3
+          }
+          [[ "$binary" =~ ^target/(debug|release)/[A-Za-z0-9_.-]+$ ]] || {
+            echo "engine.lock: binary must be a target profile path"
+            exit 3
+          }
+          {
+            echo "repository=$repository"
+            echo "revision=$revision"
+            echo "package=$package"
+            echo "binary=$binary"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout pinned engine source
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.lock.outputs.repository }}
+          ref: ${{ steps.lock.outputs.revision }}
+          path: target/integration-engine-src
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.13.1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Restore engine build
+        id: engine-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: target/integration-engine-src/target
+          key: integration-engine-${{ runner.os }}-${{ runner.arch }}-${{ steps.lock.outputs.revision }}-${{ hashFiles('target/integration-engine-src/Cargo.lock') }}
+
+      - name: Build pinned engine
+        working-directory: target/integration-engine-src
+        run: cargo build --locked --release -p ${{ steps.lock.outputs.package }}
+
+      - name: Save engine build
+        if: inputs.save-cache && steps.engine-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: target/integration-engine-src/target
+          key: ${{ steps.engine-cache.outputs.cache-primary-key }}
+
+      - name: Record engine digest
+        id: engine
+        run: |
+          set -euo pipefail
+          bin="$GITHUB_WORKSPACE/target/integration-engine-src/${{ steps.lock.outputs.binary }}"
+          [[ -x "$bin" ]] || { echo "engine binary missing at $bin"; exit 3; }
+          sha256sum "$bin"
+          echo "bin=$bin" >> "$GITHUB_OUTPUT"
+
+      - name: Restore integration Rust cache
+        id: stack-cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: harness-integration
+          save-if: ${{ inputs.save-cache }}
+          workspaces: |
+            harness -> target
+            queue -> target
+            session-manager -> target
+            context-manager -> target
+            iii-directory -> target
+            console -> target
+
+      - name: Integration crate unit tests
+        run: cargo test --manifest-path harness/Cargo.toml -p harness-integration
+
+      - name: Validate integration scenarios
+        run: make -C harness integration-validate
+
+      - name: Run integration scenarios
+        run: make -C harness integration-e2e III_BIN="${{ steps.engine.outputs.bin }}"
+
+      - name: Install Console web dependencies
+        working-directory: console/web
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Console web app
+        working-directory: console/web
+        run: pnpm build
+
+      - name: Build Console worker
+        run: cargo build --release --manifest-path console/Cargo.toml
+
+      - name: Install Playwright Chromium
+        working-directory: console/web
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Typecheck Console E2E tests
+        working-directory: console/web
+        run: pnpm typecheck:e2e
+
+      - name: Run Console Playwright scenarios
+        working-directory: console/web
+        env:
+          III_BIN: ${{ steps.engine.outputs.bin }}
+          HARNESS_INTEGRATION_BIN: ${{ github.workspace }}/harness/target/release/harness-integration
+          HARNESS_BIN: ${{ github.workspace }}/harness/target/release/harness
+          CONSOLE_BIN: ${{ github.workspace }}/console/target/release/console
+          QUEUE_BIN: ${{ github.workspace }}/queue/target/release/queue
+          III_DIRECTORY_BIN: ${{ github.workspace }}/iii-directory/target/release/iii-directory
+          SESSION_MANAGER_BIN: ${{ github.workspace }}/session-manager/target/release/session-manager
+          CONTEXT_MANAGER_BIN: ${{ github.workspace }}/context-manager/target/release/context-manager
+          CONSOLE_E2E_ARTIFACTS_DIR: ${{ github.workspace }}/target/console-e2e
+        run: pnpm test:e2e
+
+      - name: Verify integration report links
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          reports=(target/integration/*/execution.json)
+          ((${#reports[@]} > 0)) || { echo "no execution reports found"; exit 3; }
+          for execution in "${reports[@]}"; do
+            run_dir=$(dirname "$execution")
+            result_path=$(jq -er '.result_path' "$execution")
+            [[ "$result_path" == "result.json" ]] || {
+              echo "$execution: unexpected result_path $result_path"
+              exit 3
+            }
+            expected=$(jq -er '.result_sha256' "$execution")
+            actual=$(sha256sum "$run_dir/$result_path" | cut -d' ' -f1)
+            [[ "$actual" == "$expected" ]] || {
+              echo "$execution: result digest mismatch"
+              exit 3
+            }
+          done
+
+      - name: Write cache summary
+        if: always()
+        env:
+          ENGINE_HIT: ${{ steps.engine-cache.outputs.cache-hit }}
+          SAVE_CACHE: ${{ inputs.save-cache }}
+        run: |
+          {
+            echo "### Integration build caches"
+            echo
+            echo "| Cache | Hit | Save enabled |"
+            echo "| --- | --- | --- |"
+            echo "| pinned engine | ${ENGINE_HIT:-false} | $SAVE_CACHE |"
+            echo "| integration Rust | see rust-cache log | $SAVE_CACHE |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload compact results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-results
+          path: |
+            target/integration/*/result.json
+            target/integration/*/execution.json
+            target/integration/*/teardown.json
+          if-no-files-found: ignore
+
+      - name: Upload full non-pass artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-artifacts
+          path: target/integration/
+          retention-days: 14
+          if-no-files-found: ignore
+
+      - name: Upload Console E2E artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: console-e2e-artifacts
+          path: target/console-e2e/
+          retention-days: 14
+          if-no-files-found: ignore

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -121,7 +121,6 @@ jobs:
           FORCE_HARNESS: ${{ steps.refs.outputs.force_harness }}
         run: |
           set -euo pipefail
-          pip install --quiet pyyaml
           args=(--base "$BASE" --head HEAD)
           if [[ "$FORCE_HARNESS" == "true" ]]; then
             args+=(--force-worker harness)

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -1,0 +1,227 @@
+name: Cache warm
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: cache-maintenance-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cleanup-pr:
+    name: Delete closed PR caches
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete caches scoped to the closed PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          ref="refs/pull/$PR_NUMBER/merge"
+          mapfile -t ids < <(
+            gh api --method GET "repos/$REPOSITORY/actions/caches" \
+              -f ref="$ref" -F per_page=100 --paginate \
+              --jq '.actions_caches[].id'
+          )
+          for id in "${ids[@]}"; do
+            gh api --method DELETE "repos/$REPOSITORY/actions/caches/$id"
+          done
+          {
+            echo "### Closed PR cache cleanup"
+            echo
+            echo "Deleted ${#ids[@]} cache(s) for $ref."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  prune-closed-prs:
+    name: Prune caches from previously closed PRs
+    if: github.event_name != 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete caches whose pull request is closed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mapfile -t refs < <(
+            gh api --method GET "repos/$REPOSITORY/actions/caches" \
+              -F per_page=100 --paginate \
+              --jq '.actions_caches[].ref | select(startswith("refs/pull/"))' \
+              | sort -u
+          )
+          deleted=0
+          for ref in "${refs[@]}"; do
+            pr=${ref#refs/pull/}
+            pr=${pr%/merge}
+            state=$(gh api "repos/$REPOSITORY/pulls/$pr" --jq '.state' 2>/dev/null || true)
+            [[ "$state" == "closed" ]] || continue
+            mapfile -t ids < <(
+              gh api --method GET "repos/$REPOSITORY/actions/caches" \
+                -f ref="$ref" -F per_page=100 --paginate \
+                --jq '.actions_caches[].id'
+            )
+            for id in "${ids[@]}"; do
+              gh api --method DELETE "repos/$REPOSITORY/actions/caches/$id"
+              ((deleted += 1))
+            done
+          done
+          echo "Deleted $deleted cache(s) belonging to previously closed PRs." \
+            >> "$GITHUB_STEP_SUMMARY"
+
+  discover:
+    name: Discover caches to warm
+    if: github.event_name != 'pull_request_target'
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.bucket.outputs.rust }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Select comparison and forced workers
+        id: refs
+        env:
+          BEFORE: ${{ github.event.before }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            base="$BEFORE"
+            if [[ -z "$base" || "$base" =~ ^0+$ ]] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+              base=HEAD~1
+            fi
+            force_harness=false
+          else
+            base=HEAD
+            force_harness=true
+          fi
+          {
+            echo "base=$base"
+            echo "force_harness=$force_harness"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Discover worker matrix
+        id: bucket
+        env:
+          BASE: ${{ steps.refs.outputs.base }}
+          FORCE_HARNESS: ${{ steps.refs.outputs.force_harness }}
+        run: |
+          set -euo pipefail
+          pip install --quiet pyyaml
+          args=(--base "$BASE" --head HEAD)
+          if [[ "$FORCE_HARNESS" == "true" ]]; then
+            args+=(--force-worker harness)
+          fi
+          python3 .github/scripts/discover_changed_workers.py "${args[@]}"
+
+  warm-rust:
+    name: "${{ matrix.worker }}: warm Rust cache"
+    needs: discover
+    if: needs.discover.outputs.rust != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        worker: ${{ fromJSON(needs.discover.outputs.rust) }}
+    defaults:
+      run:
+        working-directory: ${{ matrix.worker }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Rewrite SSH to HTTPS for public deps
+        run: git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Restore and save worker Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: worker-${{ matrix.worker }}
+          save-if: true
+          cache-on-failure: false
+          workspaces: ${{ matrix.worker }} -> target
+
+      - name: Setup pnpm for bundled web
+        if: hashFiles(format('{0}/web/package.json', matrix.worker)) != ''
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node for bundled web
+        if: hashFiles(format('{0}/web/package.json', matrix.worker)) != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: ${{ matrix.worker }}/web/pnpm-lock.yaml
+
+      - name: Pre-build SPA bundle
+        if: hashFiles(format('{0}/web/package.json', matrix.worker)) != ''
+        working-directory: ${{ matrix.worker }}/web
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
+      - name: Build default worker binary
+        run: cargo build
+
+      - name: Compile clippy targets
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Compile tests
+        run: cargo test --all-features --no-run
+
+  harness-integration:
+    name: Warm and verify integration stack
+    if: github.event_name != 'pull_request_target'
+    uses: ./.github/workflows/_harness-integration.yml
+    with:
+      save-cache: true
+
+  cache-budget:
+    name: Report cache budget
+    needs: [warm-rust, harness-integration, prune-closed-prs]
+    if: always() && github.event_name != 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report active cache usage
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          usage=$(gh api "repos/$REPOSITORY/actions/cache/usage")
+          bytes=$(jq -r '.active_caches_size_in_bytes' <<< "$usage")
+          count=$(jq -r '.active_caches_count' <<< "$usage")
+          gib=$(awk -v bytes="$bytes" 'BEGIN { printf "%.2f", bytes / 1073741824 }')
+          {
+            echo "### Actions cache budget"
+            echo
+            echo "- Active caches: $count"
+            echo "- Active size: $gib GiB"
+            echo "- Target: at most 8 GiB"
+            echo "- Hard budget: 10 GiB"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if (( bytes > 10737418240 )); then
+            echo "::error::Actions cache usage is above the 10 GiB budget ($gib GiB)"
+            exit 1
+          elif (( bytes > 8589934592 )); then
+            echo "::warning::Actions cache usage is above the 8 GiB target ($gib GiB)"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
           BASE: ${{ steps.base.outputs.ref }}
         run: |
           set -euo pipefail
-          pip install --quiet pyyaml
           python3 .github/scripts/discover_changed_workers.py --base "$BASE"
 
   # ──────────────────────────────────────────────────────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
       python: ${{ steps.bucket.outputs.python }}
       all: ${{ steps.bucket.outputs.all }}
       source_changed: ${{ steps.bucket.outputs.source_changed }}
+      integration_changed: ${{ steps.bucket.outputs.integration_changed }}
       vscode_changed: ${{ steps.bucket.outputs.vscode_changed }}
       any: ${{ steps.bucket.outputs.any }}
     steps:
@@ -123,6 +124,8 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
+          shared-key: worker-${{ matrix.worker }}
+          save-if: false
           workspaces: ${{ matrix.worker }} -> target
 
       # Workers that ship a Vite SPA embedded into the binary (e.g.
@@ -220,6 +223,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: steps.optout.outputs.skip != 'true'
         with:
+          shared-key: worker-${{ matrix.worker }}
+          save-if: false
           workspaces: ${{ matrix.worker }} -> target
 
       # Workers that embed a Vite SPA into the binary (e.g. console) have a
@@ -385,208 +390,19 @@ jobs:
           fi
 
   # ──────────────────────────────────────────────────────────────
-  # Harness integration E2E (non-required): deterministic public-path
-  # regression scenarios against the engine pinned in
-  # harness/tests/e2e/engine.lock (see that crate's README; the
-  # architecture spec lives in the iii repo). Runs on EVERY PR — the
-  # suite is the harness stack's public-contract gate, and engine/worker
-  # builds are cached. The engine is BUILT from the pinned source, never
-  # downloaded; a cache hit is still re-hashed before use. "Non-required"
-  # is enforced by branch protection, not continue-on-error.
+  # Harness integration E2E (non-required). Pull requests only run
+  # the complete live stack when an integration input changed. The
+  # default branch and daily cache warmer run it unconditionally.
   # ──────────────────────────────────────────────────────────────
   harness-integration:
-    name: harness integration e2e
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Read and validate engine.lock
-        id: lock
-        run: |
-          set -euo pipefail
-          lock=harness/tests/e2e/engine.lock
-          read_field() {
-            local field=$1 values
-            values=$(sed -n "s/^${field} = \"\\([^\"]*\\)\"$/\\1/p" "$lock")
-            [[ $(printf '%s\n' "$values" | sed '/^$/d' | wc -l) -eq 1 ]] || {
-              echo "engine.lock: $field must appear exactly once"
-              exit 3
-            }
-            printf '%s' "$values"
-          }
-          invalid=$(sed \
-            -e '/^[[:space:]]*$/d' \
-            -e '/^[[:space:]]*#/d' \
-            -e '/^\(repository\|revision\|package\|binary\) = "[^"]*"$/d' \
-            "$lock")
-          [[ -z "$invalid" ]] || {
-            echo "engine.lock: unsupported or malformed entry"
-            printf '%s\n' "$invalid"
-            exit 3
-          }
-          repository=$(read_field repository)
-          revision=$(read_field revision)
-          package=$(read_field package)
-          binary=$(read_field binary)
-          [[ "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || {
-            echo "engine.lock: repository must be an owner/name slug"
-            exit 3
-          }
-          [[ "$revision" =~ ^[0-9a-f]{40}$ ]] || { echo "engine.lock: revision must be 40-hex"; exit 3; }
-          [[ "$package" =~ ^[A-Za-z0-9_-]+$ ]] || {
-            echo "engine.lock: package contains unsupported characters"
-            exit 3
-          }
-          [[ "$binary" =~ ^target/(debug|release)/[A-Za-z0-9_.-]+$ ]] || {
-            echo "engine.lock: binary must be a target profile path"
-            exit 3
-          }
-          {
-            echo "repository=$repository"
-            echo "revision=$revision"
-            echo "package=$package"
-            echo "binary=$binary"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Checkout pinned engine source
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ steps.lock.outputs.repository }}
-          ref: ${{ steps.lock.outputs.revision }}
-          path: target/integration-engine-src
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 11.13.1
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: 'pnpm'
-          cache-dependency-path: console/web/pnpm-lock.yaml
-
-      - name: Cache engine build
-        uses: actions/cache@v4
-        with:
-          path: target/integration-engine-src/target
-          key: integration-engine-${{ runner.os }}-${{ runner.arch }}-${{ steps.lock.outputs.revision }}-${{ hashFiles('target/integration-engine-src/Cargo.lock') }}
-
-      - name: Build pinned engine
-        working-directory: target/integration-engine-src
-        run: cargo build --locked --release -p ${{ steps.lock.outputs.package }}
-
-      - name: Record engine digest
-        id: engine
-        run: |
-          set -euo pipefail
-          bin="$GITHUB_WORKSPACE/target/integration-engine-src/${{ steps.lock.outputs.binary }}"
-          [[ -x "$bin" ]] || { echo "engine binary missing at $bin"; exit 3; }
-          sha256sum "$bin"
-          echo "bin=$bin" >> "$GITHUB_OUTPUT"
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            harness -> target
-            queue -> target
-            session-manager -> target
-            context-manager -> target
-            iii-directory -> target
-            console -> target
-
-      - name: Integration crate unit tests
-        run: cargo test --manifest-path harness/Cargo.toml -p harness-integration
-
-      - name: Validate integration scenarios
-        run: make -C harness integration-validate
-
-      - name: Run integration scenarios
-        run: make -C harness integration-e2e III_BIN="${{ steps.engine.outputs.bin }}"
-
-      - name: Install Console web dependencies
-        working-directory: console/web
-        run: pnpm install --frozen-lockfile
-
-      - name: Build Console web app
-        working-directory: console/web
-        run: pnpm build
-
-      - name: Build Console worker
-        run: cargo build --release --manifest-path console/Cargo.toml
-
-      - name: Install Playwright Chromium
-        working-directory: console/web
-        run: pnpm exec playwright install --with-deps chromium
-
-      - name: Typecheck Console E2E tests
-        working-directory: console/web
-        run: pnpm typecheck:e2e
-
-      - name: Run Console Playwright scenarios
-        working-directory: console/web
-        env:
-          III_BIN: ${{ steps.engine.outputs.bin }}
-          HARNESS_INTEGRATION_BIN: ${{ github.workspace }}/harness/target/release/harness-integration
-          HARNESS_BIN: ${{ github.workspace }}/harness/target/release/harness
-          CONSOLE_BIN: ${{ github.workspace }}/console/target/release/console
-          QUEUE_BIN: ${{ github.workspace }}/queue/target/release/queue
-          III_DIRECTORY_BIN: ${{ github.workspace }}/iii-directory/target/release/iii-directory
-          SESSION_MANAGER_BIN: ${{ github.workspace }}/session-manager/target/release/session-manager
-          CONTEXT_MANAGER_BIN: ${{ github.workspace }}/context-manager/target/release/context-manager
-          CONSOLE_E2E_ARTIFACTS_DIR: ${{ github.workspace }}/target/console-e2e
-        run: pnpm test:e2e
-
-      - name: Verify integration report links
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          reports=(target/integration/*/execution.json)
-          ((${#reports[@]} > 0)) || { echo "no execution reports found"; exit 3; }
-          for execution in "${reports[@]}"; do
-            run_dir=$(dirname "$execution")
-            result_path=$(jq -er '.result_path' "$execution")
-            [[ "$result_path" == "result.json" ]] || {
-              echo "$execution: unexpected result_path $result_path"
-              exit 3
-            }
-            expected=$(jq -er '.result_sha256' "$execution")
-            actual=$(sha256sum "$run_dir/$result_path" | cut -d' ' -f1)
-            [[ "$actual" == "$expected" ]] || {
-              echo "$execution: result digest mismatch"
-              exit 3
-            }
-          done
-
-      - name: Upload compact results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: integration-results
-          path: |
-            target/integration/*/result.json
-            target/integration/*/execution.json
-            target/integration/*/teardown.json
-          if-no-files-found: ignore
-
-      - name: Upload full non-pass artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: integration-artifacts
-          path: target/integration/
-          retention-days: 14
-          if-no-files-found: ignore
-
-      - name: Upload Console E2E artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: console-e2e-artifacts
-          path: target/console-e2e/
-          retention-days: 14
-          if-no-files-found: ignore
+    needs: discover
+    if: needs.discover.outputs.integration_changed == 'true'
+    permissions:
+      actions: read
+      contents: read
+    uses: ./.github/workflows/_harness-integration.yml
+    with:
+      save-cache: false
 
   # ──────────────────────────────────────────────────────────────
   # Node per-worker lint (biome) + test


### PR DESCRIPTION
## Summary

- run worker fmt, lint, tests, PR checks, and interface smoke only for workers directly changed by the pull request
- run the full harness integration E2E suite only when harness-stack inputs change
- move the integration job into a reusable workflow with restore-only caches for pull requests
- warm the harness Rust cache plus shared engine and integration caches from trusted main, scheduled, and manual runs
- remove caches belonging to closed pull requests and report the repository cache budget

## Why

Pull-request caches were scoped to individual merge refs and could not be reused by sibling PRs or main. The repository had more than 11 GB of active caches against a 10 GiB operating budget, while a cache miss pushed the integration job beyond 20 minutes.

The default branch did not run the main CI workflow after merges, so it never produced reusable caches. Harness changes also expanded every runtime dependency from iii.worker.yaml into the worker matrices, causing unrelated jobs such as shell formatting to run even though those workers do not compile against the local harness source.

This change makes main the cache producer, keeps PR jobs restore-only, and separates integration-stack coverage from per-worker checks.

## Validation

- 127 GitHub script tests passed
- 14 discovery and worker-selection tests passed
- a forced harness warm selects only rust: [harness], with empty Node and Python matrices
- actionlint v1.7.12 passed
- Python bytecode compilation passed
- git diff --check passed
- cache API filtering identified refs/pull/518/merge as a closed PR without deleting it during development

Fixes MOT-4183
Refs MOT-4107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated harness integration end-to-end testing for relevant infrastructure, workflow, and worker changes.
  - Added cache-warming automation for Rust builds, integration testing, and frontend assets.
  - Added explicit worker selection for targeted CI runs.

- **Bug Fixes**
  - Integration tests now run only when integration-related changes are detected.
  - Improved cache cleanup and budget monitoring for pull requests and scheduled runs.
  - Added validation for integration reports and test artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->