### PR TITLE
(MOT-4187) chore(skills): add type: index to worker skill frontmatter

### DIFF
--- a/bridge/skills/SKILL.md
+++ b/bridge/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: bridge
 tags: bridge, websocket, remote, cross-engine, invoke
 description: >-

--- a/browser/skills/SKILL.md
+++ b/browser/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: browser
 description: >-
   Interactive Chromium sessions for reading and driving real web pages: open a

--- a/claude-code/skills/SKILL.md
+++ b/claude-code/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: claude-code
 description: >-
   Run headless Claude Code turns over the iii bus — file edits, shell, and

--- a/codex/skills/SKILL.md
+++ b/codex/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: codex
 description: >-
   Run headless OpenAI Codex turns over the iii bus — sandboxed shell, file

--- a/cron/skills/SKILL.md
+++ b/cron/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: cron
 tags: cron, scheduling, triggers, jobs
 description: >-

--- a/database/skills/SKILL.md
+++ b/database/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: database
 description: >-
   Run SQL against PostgreSQL, MySQL, or SQLite from the iii engine — reads,

--- a/devin/skills/SKILL.md
+++ b/devin/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: devin
 description: >-
   Drive Devin over the iii bus. Run the local Devin CLI agent (SWE-1.6) with the

--- a/email/skills/SKILL.md
+++ b/email/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: email
 description: >-
   Send and read email from the iii engine — SMTP send, IMAP read, and

--- a/fp/skills/SKILL.md
+++ b/fp/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: fp
 description: >-
   Move and reshape big values between iii functions without routing them

--- a/github/skills/SKILL.md
+++ b/github/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: github
 description: >-
   Operate GitHub through the gh CLI — typed github::* functions for pull

--- a/grok/skills/SKILL.md
+++ b/grok/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: grok
 description: >-
   Run headless xAI Grok CLI turns over the iii bus — shell, file edits, and

--- a/harness/skills/SKILL.md
+++ b/harness/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: harness
 description: >-
   The durable agent turn loop — kick off a turn with `harness::send`, render

--- a/hermes/skills/SKILL.md
+++ b/hermes/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: hermes
 description: >-
   Run headless Hermes agent turns over the iii bus, deliver messages to 27+

--- a/http/skills/SKILL.md
+++ b/http/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: http
 tags: http, routing, triggers, webhooks, endpoints
 description: >-

--- a/iii-directory/skills/SKILL.md
+++ b/iii-directory/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: iii-directory
 description: >-
   Discovery entry point for the engine — read the skill and prompt docs that

--- a/memory/skills/SKILL.md
+++ b/memory/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: memory
 tags: memory, banks, rules, recall, cross-session, pinning
 description: >-

--- a/opencode/skills/SKILL.md
+++ b/opencode/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: opencode
 description: >-
   Run headless OpenCode turns over the iii bus — file edits, shell, and search

--- a/pi/skills/SKILL.md
+++ b/pi/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: pi
 description: >-
   Run headless Pi coding-agent turns over the iii bus — file edits, shell, and

--- a/pubsub/skills/SKILL.md
+++ b/pubsub/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: pubsub
 tags: pubsub, publish, subscribe, events, redis
 description: >-

--- a/queue/skills/SKILL.md
+++ b/queue/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: queue
 tags: queue, durable, retries, dlq, pubsub
 description: >-

--- a/scrapling/skills/SKILL.md
+++ b/scrapling/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: scrapling
 description: >-
   Scrape the web over the iii bus with Scrapling — fast HTTP fetch with TLS

--- a/shell/skills/SKILL.md
+++ b/shell/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: shell
 tags: shell, exec, filesystem, jobs, sandbox
 description: >-

--- a/slack/skills/SKILL.md
+++ b/slack/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: slack
 description: >-
   Drive Slack from iii — expose the Slack Web API as slack::* functions

--- a/state/skills/SKILL.md
+++ b/state/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: state
 tags: state, key-value, storage, triggers, reactive
 description: >-

--- a/telegram-bot/skills/SKILL.md
+++ b/telegram-bot/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: telegram-bot
 description: >-
   Bridge a harness agent onto Telegram — turn inbound chat messages into

--- a/worktree/skills/SKILL.md
+++ b/worktree/skills/SKILL.md
@@ -1,4 +1,5 @@
 ---
+type: index
 name: worktree
 tags: git, worktree, parallel, land, merge, rebase
 description: >-


### PR DESCRIPTION

<img width="1001" height="1301" alt="Screenshot 2026-07-23 at 14 02 43" src="https://github.com/user-attachments/assets/d0b78a01-99f8-4e37-af84-514d22f996cd" />
## Context

`directory::skills::index` selects rows that either declare frontmatter `type: index` or are the namespace-root overview doc (`<ns>/index`, which `SKILL.md` aliases to). The second clause is documented as a bridge for legacy bundles that predate the `type: index` convention; only `web` declares the convention today.

## Change

One frontmatter line, `type: index`, added to 26 workers' `skills/SKILL.md`, moving every bundle onto the declared convention so index membership is explicit in the file rather than inferred from its on-disk name, and the legacy fallback clause can retire once published bundles catch up. No body changes.

Refs MOT-4187


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added index metadata to skill documentation across the available skill guides.
  * Improved consistent categorization and indexing of these guides without changing their documented content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->