### PR TITLE
(MOT-4210) fix(harness): reject mismatched reaction specs across a join's predecessors

### DIFF
--- a/harness/src/functions/react.rs
+++ b/harness/src/functions/react.rs
@@ -299,6 +299,33 @@ impl ReactResult {
     }
 }
 
+/// Canonical reaction-spec fingerprint for a join predecessor registration:
+/// the metadata minus this predecessor's own `join.key` and the harness
+/// stamps (which legitimately differ per predecessor). `None` when the spec
+/// is not a join predecessor.
+///
+/// All predecessors of one join id must agree on this fingerprint — the join
+/// fires with the COMPLETING predecessor's spec (`join_edge` → `spec.task`),
+/// so a divergent spec on a later predecessor (e.g. `task: "placeholder"`)
+/// silently replaces the real reaction. The registration interceptor rejects
+/// mismatches against live predecessors using it.
+pub fn join_canon(metadata: Option<&Value>) -> Option<(String, Value)> {
+    let m = metadata?;
+    let join_id = m.pointer("/join/id")?.as_str()?.to_string();
+    let mut canon = m.clone();
+    if let Some(obj) = canon.as_object_mut() {
+        // Stamps differ per registration by design; strip them defensively
+        // even though the interceptor fingerprints pre-stamp metadata.
+        obj.remove("__subscription_id");
+        obj.remove("__once");
+        obj.remove(crate::subscriptions::OWNER_SESSION_KEY);
+        if let Some(j) = obj.get_mut("join").and_then(Value::as_object_mut) {
+            j.remove("key");
+        }
+    }
+    Some((join_id, canon))
+}
+
 /// Registration-time validation for subscriptions targeting `harness::react`:
 /// once bound, a bad spec would only surface as a silent no-op when the event
 /// fires, so reject it loudly at `engine::register_trigger` time instead.
@@ -1523,6 +1550,54 @@ fn pretty(v: &Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn join_canon_none_for_non_join_specs() {
+        assert!(join_canon(None).is_none());
+        let md = serde_json::json!({"model": "m", "task": "t"});
+        assert!(join_canon(Some(&md)).is_none());
+    }
+
+    #[test]
+    fn join_canon_strips_per_predecessor_fields_only() {
+        let md = |key: &str, sub: &str| {
+            serde_json::json!({
+                "model": "m", "task": "the real task",
+                "join": {"id": "j1", "expect": ["a", "b"], "key": key},
+                "__subscription_id": sub, "__once": true,
+                "__owner_session_id": "s1",
+            })
+        };
+        let (id_a, canon_a) = join_canon(Some(&md("a", "sub_1"))).unwrap();
+        let (id_b, canon_b) = join_canon(Some(&md("b", "sub_2"))).unwrap();
+        assert_eq!(id_a, "j1");
+        assert_eq!(id_b, "j1");
+        // Same reaction, different key/stamps → identical fingerprint.
+        assert_eq!(canon_a, canon_b);
+        // The reaction fields survive; the per-predecessor ones are gone.
+        assert_eq!(canon_a["task"], "the real task");
+        assert_eq!(canon_a["join"]["expect"], serde_json::json!(["a", "b"]));
+        assert!(canon_a["join"].get("key").is_none());
+        assert!(canon_a.get("__subscription_id").is_none());
+    }
+
+    /// The rctest-x7k2 failure shape: full task on one predecessor,
+    /// "placeholder" on another — the fingerprints must differ so the
+    /// interceptor can reject the second registration.
+    #[test]
+    fn join_canon_differs_when_the_reaction_differs() {
+        let full = serde_json::json!({
+            "model": "m", "task": "verify and report",
+            "join": {"id": "j1", "expect": ["w1", "w2"], "key": "w1"},
+        });
+        let placeholder = serde_json::json!({
+            "model": "m", "task": "placeholder",
+            "join": {"id": "j1", "expect": ["w1", "w2"], "key": "w2"},
+        });
+        let (_, canon_full) = join_canon(Some(&full)).unwrap();
+        let (_, canon_ph) = join_canon(Some(&placeholder)).unwrap();
+        assert_ne!(canon_full, canon_ph);
+    }
 
     #[test]
     fn fire_gate_caps_per_key_within_window_and_recovers() {

--- a/harness/src/functions/subscribe.rs
+++ b/harness/src/functions/subscribe.rs
@@ -659,10 +659,7 @@ async fn handle_react(
     if let Some((join_id, canon)) = join_probe {
         deps.subscriptions.set_join_probe(
             &sub_id,
-            crate::subscriptions::registry::JoinProbe {
-                id: join_id,
-                canon,
-            },
+            crate::subscriptions::registry::JoinProbe { id: join_id, canon },
         );
     }
 

--- a/harness/src/functions/subscribe.rs
+++ b/harness/src/functions/subscribe.rs
@@ -612,6 +612,24 @@ async fn handle_react(
             .await
             .map_err(HarnessError::InvalidRequest)?;
     }
+    // Join predecessors must agree on the reaction spec: the join fires with
+    // the COMPLETING predecessor's spec, so a divergent spec on any
+    // predecessor (e.g. a `task: "placeholder"` shorthand on later ones)
+    // would silently replace the real reaction at fire time. Fingerprinted
+    // post-`inherit_model` so same-session registrations compare stamped
+    // metadata consistently.
+    let join_probe = crate::functions::react::join_canon(req.metadata.as_ref());
+    if let Some((join_id, canon)) = &join_probe {
+        if let Some(conflict) = deps.subscriptions.conflicting_join_spec(join_id, canon) {
+            return Err(HarnessError::InvalidRequest(format!(
+                "join `{join_id}`: this predecessor's reaction spec differs from live \
+                 predecessor {conflict}'s. Every predecessor of a join must carry the \
+                 IDENTICAL spec (task/call, model, session_id, options, expect) — only \
+                 `join.key` may differ. Repeat the full spec on every registration; the \
+                 join fires with the completing predecessor's spec."
+            )));
+        }
+    }
     if let Some(existing) = deps.subscriptions.find_duplicate(session_id, &dedup) {
         return Ok(SubscribeResponse {
             subscription_id: existing,
@@ -637,6 +655,16 @@ async fn handle_react(
                 subscriptions::MAX_SUBSCRIPTIONS_PER_SESSION
             ))
         })?;
+
+    if let Some((join_id, canon)) = join_probe {
+        deps.subscriptions.set_join_probe(
+            &sub_id,
+            crate::subscriptions::registry::JoinProbe {
+                id: join_id,
+                canon,
+            },
+        );
+    }
 
     // Stamp the owning session into the metadata so startup reconciliation can
     // GC this binding if the session is deleted while the harness is down.

--- a/harness/src/subscriptions/registry.rs
+++ b/harness/src/subscriptions/registry.rs
@@ -19,6 +19,19 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use serde_json::Value;
 
+/// Reaction-spec fingerprint of a live join predecessor. All predecessors of
+/// one join id must agree on it — the join fires with the COMPLETING
+/// predecessor's spec, so a divergent spec on any predecessor would silently
+/// replace the real reaction at fire time.
+#[derive(Debug, Clone, PartialEq)]
+pub struct JoinProbe {
+    /// The shared join id (the accumulator record key — globally namespaced).
+    pub id: String,
+    /// The canonicalized reaction spec minus per-predecessor fields (see
+    /// `react::join_canon`).
+    pub canon: Value,
+}
+
 /// One live subscription's local bookkeeping. Held in an `Arc` so a firing
 /// handler reads it without holding the registry lock.
 pub struct SubEntry {
@@ -40,6 +53,10 @@ pub struct SubEntry {
     /// `harness::turn-completed` — a session with an armed wake completes
     /// non-terminally. Standing watchers and react bindings don't count.
     wake: bool,
+    /// Set post-insert for join-predecessor react bindings (see
+    /// [`set_join_probe`](SubscriptionRegistry::set_join_probe)); dies with
+    /// the entry, so conflict checks never see retired predecessors.
+    join: Mutex<Option<JoinProbe>>,
 }
 
 impl SubEntry {
@@ -50,6 +67,7 @@ impl SubEntry {
             trigger_id: Mutex::new(None),
             dedup_key,
             wake,
+            join: Mutex::new(None),
         }
     }
 }
@@ -186,6 +204,36 @@ impl SubscriptionRegistry {
         }
     }
 
+    /// Attach a join-predecessor fingerprint after a successful insert. Same
+    /// race posture as [`set_trigger_id`](Self::set_trigger_id): `false` means
+    /// the entry is already gone.
+    pub fn set_join_probe(&self, sub_id: &str, probe: JoinProbe) -> bool {
+        match self.lock().by_id.get(sub_id) {
+            Some(entry) => {
+                *entry.join.lock().unwrap_or_else(|p| p.into_inner()) = Some(probe);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Find a LIVE join predecessor of `join_id` whose reaction spec differs
+    /// from `canon`. Join ids are globally namespaced (the accumulator record
+    /// key), so this scans across sessions. `Some(sub_id)` names the
+    /// conflicting predecessor for the registration error.
+    pub fn conflicting_join_spec(&self, join_id: &str, canon: &Value) -> Option<String> {
+        let inner = self.lock();
+        for (sub_id, entry) in inner.by_id.iter() {
+            let guard = entry.join.lock().unwrap_or_else(|p| p.into_inner());
+            if let Some(probe) = guard.as_ref() {
+                if probe.id == join_id && probe.canon != *canon {
+                    return Some(sub_id.clone());
+                }
+            }
+        }
+        None
+    }
+
     /// Claim a fired subscription against local liveness/ownership. One-shot
     /// fires remove the entry and return the trigger id for teardown; recurring
     /// fires keep the entry and return a monotonic notification entry id.
@@ -307,6 +355,43 @@ mod tests {
         assert!(reg.try_insert("sub_3", "s", 2).is_err());
         // A different session has its own budget.
         assert!(reg.try_insert("sub_4", "s2", 2).is_ok());
+    }
+
+    #[test]
+    fn join_probe_conflict_detection_and_lifecycle() {
+        let reg = SubscriptionRegistry::new();
+        let canon = serde_json::json!({"task": "the real task", "model": "m"});
+        reg.try_insert("sub_w1", "s", 8).unwrap();
+        assert!(reg.set_join_probe(
+            "sub_w1",
+            JoinProbe {
+                id: "j1".into(),
+                canon: canon.clone()
+            }
+        ));
+
+        // Identical spec on another predecessor: no conflict.
+        assert!(reg.conflicting_join_spec("j1", &canon).is_none());
+        // Divergent spec (the "placeholder" shape): conflict names the live twin.
+        let placeholder = serde_json::json!({"task": "placeholder", "model": "m"});
+        assert_eq!(
+            reg.conflicting_join_spec("j1", &placeholder).as_deref(),
+            Some("sub_w1")
+        );
+        // A different join id is unaffected.
+        assert!(reg.conflicting_join_spec("j2", &placeholder).is_none());
+
+        // The probe dies with the entry — retired predecessors never conflict.
+        assert!(reg.take("sub_w1").is_some());
+        assert!(reg.conflicting_join_spec("j1", &placeholder).is_none());
+        // And a probe cannot attach to a gone entry.
+        assert!(!reg.set_join_probe(
+            "sub_w1",
+            JoinProbe {
+                id: "j1".into(),
+                canon
+            }
+        ));
     }
 
     #[test]

--- a/harness/tests/e2e/README.md
+++ b/harness/tests/e2e/README.md
@@ -14,6 +14,7 @@ No provider key or network access is required.
 | E2E-001 | `streamed-text` | direct | streamed text reaches durable completion |
 | E2E-002 | `exactly-once-function` | direct | a native function executes exactly once |
 | E2E-003 | `reseed-parked-message` | direct | a message parked during a turn's failing final step is delivered by a harness-reseeded turn |
+| E2E-004 | `join-spec-mismatch` | direct | a join predecessor registered with a divergent reaction spec is rejected at registration |
 | UI-001 | `console-streamed-text` | playground | a message sent by the Console streams to durable completion |
 | UI-002 | `multi-turn-traces` | playground | a native function turn and a Console turn expose distinct traces and function-call events |
 

--- a/harness/tests/e2e/src/evidence_data.rs
+++ b/harness/tests/e2e/src/evidence_data.rs
@@ -205,6 +205,35 @@ impl RunEvidence {
             .iter()
             .filter_map(|item| item.get("message"))
     }
+
+    /// Durable `function_result` messages for one function id, in transcript
+    /// order. For harness-intercepted builtins (e.g. `engine::register_trigger`)
+    /// the transcript is the only evidence surface — they never produce
+    /// `execute` spans like controlled functions do.
+    pub fn function_results(&self, function_id: &str) -> Vec<&Value> {
+        self.messages()
+            .filter(|message| role(message) == Some("function_result"))
+            .filter(|message| {
+                message.get("function_id").and_then(Value::as_str) == Some(function_id)
+            })
+            .collect()
+    }
+}
+
+/// Concatenated text blocks of one message's `content` array.
+pub fn message_text(message: &Value) -> String {
+    message
+        .get("content")
+        .and_then(Value::as_array)
+        .map(|blocks| {
+            blocks
+                .iter()
+                .filter(|block| block.get("type").and_then(Value::as_str) == Some("text"))
+                .filter_map(|block| block.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .concat()
+        })
+        .unwrap_or_default()
 }
 
 fn role(message: &Value) -> Option<&str> {

--- a/harness/tests/e2e/src/fixtures/tests.rs
+++ b/harness/tests/e2e/src/fixtures/tests.rs
@@ -9,14 +9,16 @@ fn all_selection_returns_the_checked_in_fixtures() {
         .collect::<std::collections::BTreeSet<_>>();
     assert_eq!(
         ids,
-        std::collections::BTreeSet::from(["E2E-001", "E2E-002", "E2E-003", "UI-001", "UI-002"])
+        std::collections::BTreeSet::from([
+            "E2E-001", "E2E-002", "E2E-003", "E2E-004", "UI-001", "UI-002"
+        ])
     );
     assert_eq!(
         fixtures
             .iter()
             .filter(|fixture| fixture.driver == crate::scenarios::ScenarioDriver::Direct)
             .count(),
-        3
+        4
     );
 }
 

--- a/harness/tests/e2e/src/scenarios/dsl.rs
+++ b/harness/tests/e2e/src/scenarios/dsl.rs
@@ -191,6 +191,16 @@ impl Send {
         self
     }
 
+    /// Allow a function the scripted worker does NOT provide — a real engine
+    /// or harness builtin (e.g. `engine::register_trigger`) the scenario
+    /// drives through the model.
+    pub(super) fn allow_id(mut self, function_id: &str) -> Self {
+        if !self.allowed_functions.iter().any(|id| id == function_id) {
+            self.allowed_functions.push(function_id.to_string());
+        }
+        self
+    }
+
     fn compile(self, scenario_id: &str, model: &ModelFixtureV1) -> CompiledSendV1 {
         CompiledSendV1 {
             session_id: "{{session_id}}".to_string(),
@@ -313,6 +323,19 @@ impl Request {
         self.messages = Some(JsonMatcherV1::Exact {
             expected: Value::Array(messages),
             normalize: Some(normalize),
+        });
+        self
+    }
+
+    /// Positional subset match over the assembled history: element `i` of
+    /// `messages` is compared as a subset of history element `i` — pin the
+    /// stable keys (`role`, `function_call_id`, `is_error`) of each entry and
+    /// leave nondeterministic content (subscription ids, …) unmatched. The
+    /// history must still have at least `messages.len()` entries.
+    pub(super) fn messages_subset(mut self, messages: impl IntoIterator<Item = Value>) -> Self {
+        self.messages = Some(JsonMatcherV1::Subset {
+            expected: Value::Array(messages.into_iter().collect()),
+            normalize: None,
         });
         self
     }
@@ -497,10 +520,28 @@ impl Response {
         input_tokens: u64,
         output_tokens: u64,
     ) -> Self {
+        Self::function_call_raw(
+            call_id,
+            function.id(),
+            arguments,
+            input_tokens,
+            output_tokens,
+        )
+    }
+
+    /// A scripted call to a function id the scripted worker does not own —
+    /// a real engine/harness builtin (pair with [`Send::allow_id`]).
+    pub(super) fn function_call_raw(
+        call_id: &str,
+        function_id: &str,
+        arguments: Value,
+        input_tokens: u64,
+        output_tokens: u64,
+    ) -> Self {
         Self {
             kind: ResponseKind::FunctionCall {
                 call_id: call_id.to_string(),
-                function_id: function.id().to_string(),
+                function_id: function_id.to_string(),
                 arguments,
             },
             usage: usage(input_tokens, output_tokens),

--- a/harness/tests/e2e/src/scenarios/join_spec_mismatch.rs
+++ b/harness/tests/e2e/src/scenarios/join_spec_mismatch.rs
@@ -1,0 +1,200 @@
+//! E2E-004 — a join predecessor registered with a divergent reaction spec is
+//! rejected at `engine::register_trigger` time.
+//!
+//! The rctest-x7k2 postmortem shape: the agent registers the full downstream
+//! task on the first predecessor and a `task: "placeholder"` shorthand on the
+//! second. A join fires with the COMPLETING predecessor's spec, so before the
+//! interceptor enforced spec equality the placeholder silently replaced the
+//! real reaction. This scenario drives both registrations through the real
+//! harness interceptor and pins the contract: first succeeds, second is
+//! rejected with the corrective error.
+
+use serde_json::{json, Value};
+
+use super::dsl::{Generation, Message, Model, Request, Response, Scenario, Send};
+use super::ScenarioDriver;
+use crate::evidence_data::message_text;
+use crate::fixtures::ScenarioFixture;
+
+const REGISTER: &str = "engine::register_trigger";
+
+/// One join-predecessor registration payload. `key` and `task` are the only
+/// per-call variations — the same join id makes the second registration a
+/// spec-mismatch the interceptor must reject.
+fn register(key: &str, task: &str) -> Value {
+    json!({
+        "trigger_type": "harness::turn-completed",
+        "config": { "session_id": format!("{{{{run_id}}}}-{key}") },
+        "function_id": "harness::react",
+        "metadata": {
+            "task": task,
+            "join": {
+                "id": "{{run_id}}-join",
+                "expect": ["w1", "w2"],
+                "key": key
+            }
+        }
+    })
+}
+
+pub(super) fn scenario() -> ScenarioFixture {
+    const ID: &str = "E2E-004";
+    const MESSAGE: &str = "Wire the join predecessors.";
+
+    let model = Model::scripted("fixture-model");
+
+    Scenario::new(
+        ID,
+        "join-spec-mismatch",
+        "A join predecessor with a divergent reaction spec is rejected at registration.",
+        ScenarioDriver::Direct,
+        model.clone(),
+    )
+    .send(
+        Send::message(MESSAGE)
+            .idempotency_key("{{run_id}}:e2e-004")
+            .allow_id(REGISTER),
+    )
+    .generation(
+        Generation::new(1)
+            .expect(
+                Request::new()
+                    .turn_request()
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_exact([Message::user(MESSAGE)])
+                    .without_tools(),
+            )
+            .respond(Response::function_call_raw(
+                "call-w1",
+                REGISTER,
+                register(
+                    "w1",
+                    "You are the finalizer: verify every writer and report.",
+                ),
+                8,
+                4,
+            )),
+    )
+    // History from here on carries the first registration's result — a random
+    // subscription id — so later generations pin the stable shape via
+    // positional subset instead of exact history.
+    .generation(
+        Generation::new(2)
+            .expect(
+                Request::new()
+                    .turn_request()
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_subset([
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant", "content": [
+                            { "type": "function_call", "id": "call-w1", "function_id": REGISTER }
+                        ] }),
+                        json!({ "role": "function_result", "function_call_id": "call-w1",
+                                "is_error": false }),
+                    ])
+                    .without_tools(),
+            )
+            .respond(Response::function_call_raw(
+                "call-w2",
+                REGISTER,
+                register("w2", "placeholder"),
+                8,
+                4,
+            )),
+    )
+    .generation(
+        Generation::new(3)
+            .expect(
+                Request::new()
+                    .turn_request()
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_subset([
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant" }),
+                        json!({ "role": "function_result", "function_call_id": "call-w1",
+                                "is_error": false }),
+                        json!({ "role": "assistant", "content": [
+                            { "type": "function_call", "id": "call-w2", "function_id": REGISTER }
+                        ] }),
+                        // The rejection: the mismatch surfaces as an error
+                        // function_result the model can read and correct.
+                        json!({ "role": "function_result", "function_call_id": "call-w2",
+                                "is_error": true }),
+                    ])
+                    .without_tools(),
+            )
+            .respond(Response::text("join mismatch rejected", 12, 3)),
+    )
+    .verify(|run| {
+        run.expect_assistant_texts(["join mismatch rejected"])?;
+
+        let results = run.function_results(REGISTER);
+        anyhow::ensure!(
+            results.len() == 2,
+            "expected 2 register_trigger results, got {}",
+            results.len()
+        );
+
+        let first = results[0];
+        anyhow::ensure!(
+            first.get("is_error").and_then(Value::as_bool) == Some(false),
+            "first predecessor registration must succeed: {first}"
+        );
+        anyhow::ensure!(
+            message_text(first).contains("subscription_id"),
+            "first registration must return a subscription id: {first}"
+        );
+
+        let second = results[1];
+        anyhow::ensure!(
+            second.get("is_error").and_then(Value::as_bool) == Some(true),
+            "divergent predecessor registration must be REJECTED — a placeholder \
+             spec that registers silently replaces the real reaction at fire \
+             time: {second}"
+        );
+        let text = message_text(second);
+        anyhow::ensure!(
+            text.contains("differs from live predecessor"),
+            "rejection must name the conflict: {text}"
+        );
+        anyhow::ensure!(
+            text.contains("only `join.key` may differ"),
+            "rejection must tell the agent how to fix the registration: {text}"
+        );
+
+        run.expect_no_duplicate_messages()
+    })
+    .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixture_is_valid() {
+        scenario().validate().unwrap();
+    }
+
+    /// The fixture's premise: both registrations target the same join id with
+    /// different keys AND different tasks — the exact shape the interceptor
+    /// must reject on the second registration.
+    #[test]
+    fn registrations_share_the_join_id_and_differ_only_where_intended() {
+        let a = register("w1", "the real task");
+        let b = register("w2", "placeholder");
+        assert_eq!(
+            a.pointer("/metadata/join/id"),
+            b.pointer("/metadata/join/id")
+        );
+        assert_ne!(
+            a.pointer("/metadata/join/key"),
+            b.pointer("/metadata/join/key")
+        );
+        assert_ne!(a.pointer("/metadata/task"), b.pointer("/metadata/task"));
+        assert_ne!(
+            a.pointer("/config/session_id"),
+            b.pointer("/config/session_id")
+        );
+    }
+}

--- a/harness/tests/e2e/src/scenarios/mod.rs
+++ b/harness/tests/e2e/src/scenarios/mod.rs
@@ -3,6 +3,7 @@
 mod console_streamed_text;
 mod dsl;
 mod exactly_once_function;
+mod join_spec_mismatch;
 mod multi_turn_traces;
 mod reseed_parked_message;
 mod streamed_text;
@@ -24,6 +25,7 @@ pub fn all() -> Vec<ScenarioFixture> {
     vec![
         console_streamed_text::scenario(),
         exactly_once_function::scenario(),
+        join_spec_mismatch::scenario(),
         multi_turn_traces::scenario(),
         reseed_parked_message::scenario(),
         streamed_text::scenario(),
@@ -37,7 +39,7 @@ mod tests {
     #[test]
     fn every_fixture_is_unique_and_valid() {
         let fixtures = all();
-        assert_eq!(fixtures.len(), 5);
+        assert_eq!(fixtures.len(), 6);
         let mut slugs = std::collections::BTreeSet::new();
         let mut ids = std::collections::BTreeSet::new();
         for fixture in fixtures {


### PR DESCRIPTION
## What

A join fires its downstream reaction with the **completing predecessor's** spec. Nothing stopped an agent from registering the full task on one predecessor and a shorthand on the rest — whichever arrived last silently replaced the real reaction.

Observed live (rctest-x7k2 postmortem): the orchestrator registered the full 7-step finalizer task on the `w1` join predecessor and literally `"task": "placeholder"` on `w2`/`w3`. `w3` completed the join, so the finalizer spawned with the seed message "placeholder" — its report, completion-signal, and cleanup instructions were all lost, and the run never communicated its end.

## How

The `JoinSpec` contract already required identical specs ("Every predecessor's subscription carries the same `id` + `expect` and its own `key`"); this enforces it at `engine::register_trigger` time, matching `validate_spec`'s reject-loudly posture:

- `react::join_canon` — fingerprints a join registration: metadata minus the per-predecessor `join.key` and harness stamps (`__subscription_id`, `__once`, `__owner_session_id`)
- `SubscriptionRegistry` — tracks the fingerprint per live entry (`JoinProbe`, attached post-insert like `set_trigger_id`; dies with the entry so retired predecessors never block re-registration) and surfaces the conflicting subscription id
- the subscribe interceptor rejects a divergent registration before binding, with an error naming the live twin and telling the agent to repeat the full spec

Join ids are globally namespaced (they key the shared accumulator record), so the conflict check scans across sessions. Fingerprinting runs post-`inherit_model`, so same-session registrations compare stamped metadata consistently. With enforcement in place, "completing predecessor's spec wins" becomes harmless — all predecessors are provably identical.

## Verification

- `cargo test` in harness: **264 unit + 7 integration pass, 0 failed**
- New tests pin the mechanism at both layers, including the exact rctest failure shape:
  - `join_canon_strips_per_predecessor_fields_only` / `join_canon_differs_when_the_reaction_differs`
  - `join_probe_conflict_detection_and_lifecycle`

Companion PR: #581 (state worker dropped the fire-time metadata sidecar — the other half of the rctest postmortem).

No version bump / changelog per repo convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure all active predecessors for a join use the same reaction specification.
  * Registrations with conflicting reaction details are now rejected with an invalid request error.
  * Differences limited to predecessor-specific keys remain supported.
  * Conflict tracking is cleared when a predecessor subscription is retired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->