### PR TITLE
(MOT-4211, MOT-4212) feat(harness): coalesce capped fires; reactions inherit registrant policy

### DIFF
--- a/.github/workflows/_harness-integration.yml
+++ b/.github/workflows/_harness-integration.yml
@@ -120,6 +120,7 @@ jobs:
             session-manager -> target
             context-manager -> target
             iii-directory -> target
+            state -> target
             console -> target
 
       - name: Integration crate unit tests
@@ -161,6 +162,7 @@ jobs:
           III_DIRECTORY_BIN: ${{ github.workspace }}/iii-directory/target/release/iii-directory
           SESSION_MANAGER_BIN: ${{ github.workspace }}/session-manager/target/release/session-manager
           CONTEXT_MANAGER_BIN: ${{ github.workspace }}/context-manager/target/release/context-manager
+          STATE_BIN: ${{ github.workspace }}/state/target/release/state
           CONSOLE_E2E_ARTIFACTS_DIR: ${{ github.workspace }}/target/console-e2e
         run: pnpm test:e2e
 

--- a/console/web/e2e/harness-stack.ts
+++ b/console/web/e2e/harness-stack.ts
@@ -91,6 +91,7 @@ function workerArgs(): string[] {
     ['iii-directory', 'III_DIRECTORY_BIN'],
     ['session-manager', 'SESSION_MANAGER_BIN'],
     ['context-manager', 'CONTEXT_MANAGER_BIN'],
+    ['state', 'STATE_BIN'],
   ].flatMap(([name, env]) => ['--worker-bin', `${name}=${required(env)}`])
 }
 

--- a/harness/Makefile
+++ b/harness/Makefile
@@ -316,7 +316,7 @@ where:
 # scenario against the pinned engine binary. The
 # engine is never downloaded here: pass III_BIN (CI builds it from
 # tests/e2e/engine.lock; locally see that file for the pinned source).
-INTEGRATION_WORKERS := queue iii-directory session-manager context-manager
+INTEGRATION_WORKERS := queue iii-directory session-manager context-manager state
 INTEGRATION_PROFILE ?= release
 INTEGRATION_FLAG    := $(if $(filter release,$(INTEGRATION_PROFILE)),--release,)
 INTEGRATION_SCENARIO ?= all
@@ -344,6 +344,7 @@ integration-e2e:
 	  --worker-bin "iii-directory=$(REPO_ROOT)/iii-directory/target/$(INTEGRATION_PROFILE)/iii-directory" \
 	  --worker-bin "session-manager=$(REPO_ROOT)/session-manager/target/$(INTEGRATION_PROFILE)/session-manager" \
 	  --worker-bin "context-manager=$(REPO_ROOT)/context-manager/target/$(INTEGRATION_PROFILE)/context-manager" \
+	  --worker-bin "state=$(REPO_ROOT)/state/target/$(INTEGRATION_PROFILE)/state" \
 	  --scenario "$(INTEGRATION_SCENARIO)" \
 	  --artifacts-dir "$(INTEGRATION_ARTIFACTS)"
 
@@ -368,6 +369,7 @@ integration-playground:
 	  --worker-bin "iii-directory=$(REPO_ROOT)/iii-directory/target/$(INTEGRATION_PROFILE)/iii-directory" \
 	  --worker-bin "session-manager=$(REPO_ROOT)/session-manager/target/$(INTEGRATION_PROFILE)/session-manager" \
 	  --worker-bin "context-manager=$(REPO_ROOT)/context-manager/target/$(INTEGRATION_PROFILE)/context-manager" \
+	  --worker-bin "state=$(REPO_ROOT)/state/target/$(INTEGRATION_PROFILE)/state" \
 	  --scenario "$(INTEGRATION_PLAYGROUND_SCENARIO)" \
 	  --artifacts-dir "$(INTEGRATION_PLAYGROUND_ARTIFACTS)"
 

--- a/harness/src/functions/react.rs
+++ b/harness/src/functions/react.rs
@@ -108,6 +108,33 @@ const JOIN_SCOPE: &str = "harness::react_join";
 pub const MAX_FIRES_PER_WINDOW: usize = 10;
 pub const FIRE_WINDOW_MS: i64 = 60_000;
 
+/// Effective gate limits. Overridable via `III_HARNESS_MAX_FIRES_PER_WINDOW`
+/// / `III_HARNESS_FIRE_WINDOW_MS` — production never sets them; the
+/// integration suite shrinks the window so a coalescing scenario observes the
+/// trailing fire in seconds instead of parking for a minute. Read once: the
+/// gate's sliding-window math must never see two different window sizes.
+fn max_fires_per_window() -> usize {
+    static LIMIT: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *LIMIT.get_or_init(|| {
+        std::env::var("III_HARNESS_MAX_FIRES_PER_WINDOW")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .filter(|v| *v >= 1)
+            .unwrap_or(MAX_FIRES_PER_WINDOW)
+    })
+}
+
+fn fire_window_ms() -> i64 {
+    static LIMIT: std::sync::OnceLock<i64> = std::sync::OnceLock::new();
+    *LIMIT.get_or_init(|| {
+        std::env::var("III_HARNESS_FIRE_WINDOW_MS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .filter(|v| *v >= 1)
+            .unwrap_or(FIRE_WINDOW_MS)
+    })
+}
+
 /// The latest fire dropped by a capped binding, held for the trailing
 /// coalesced fire. Only the newest event is kept: react patterns are
 /// recompute-style (aggregate from source of truth), so the last event
@@ -151,23 +178,20 @@ impl FireGate {
     /// Record a fire attempt for `key` at `now_ms`; `false` when the key has
     /// exhausted its window budget — the caller must defer instead of react.
     pub fn admit(&self, key: &str, now_ms: i64) -> bool {
+        let window = fire_window_ms();
         let mut map = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         // Opportunistic GC so dead keys can't grow the map unboundedly. Keys
         // with a parked pending fire stay: a trailing task will drain them.
         if map.len() > 1024 {
             map.retain(|_, s| {
-                s.pending.is_some() || s.fires.back().is_some_and(|t| now_ms - t < FIRE_WINDOW_MS)
+                s.pending.is_some() || s.fires.back().is_some_and(|t| now_ms - t < window)
             });
         }
         let s = map.entry(key.to_string()).or_default();
-        while s
-            .fires
-            .front()
-            .is_some_and(|t| now_ms - t >= FIRE_WINDOW_MS)
-        {
+        while s.fires.front().is_some_and(|t| now_ms - t >= window) {
             s.fires.pop_front();
         }
-        if s.fires.len() >= MAX_FIRES_PER_WINDOW {
+        if s.fires.len() >= max_fires_per_window() {
             return false;
         }
         s.fires.push_back(now_ms);
@@ -192,11 +216,9 @@ impl FireGate {
             s.trailing_scheduled = true;
             // Fire when the oldest window entry expires (budget frees). The
             // floor guards clock skew; the ceiling guards a corrupt queue.
-            let delay = s
-                .fires
-                .front()
-                .map_or(FIRE_WINDOW_MS, |t| t + FIRE_WINDOW_MS - now_ms);
-            Some(delay.clamp(1_000, FIRE_WINDOW_MS))
+            let window = fire_window_ms();
+            let delay = s.fires.front().map_or(window, |t| t + window - now_ms);
+            Some(delay.clamp(1_000.min(window), window))
         };
         Deferred {
             dropped,
@@ -593,10 +615,11 @@ pub async fn handle(
             raw_metadata.unwrap_or(Value::Null),
             now_ms,
         );
+        let (max_fires, window_ms) = (max_fires_per_window(), fire_window_ms());
         tracing::warn!(
             subscription = %gate_key,
             dropped = deferred.dropped,
-            "harness::react: fire-rate breaker tripped ({MAX_FIRES_PER_WINDOW} fires/{FIRE_WINDOW_MS}ms); coalescing"
+            "harness::react: fire-rate breaker tripped ({max_fires} fires/{window_ms}ms); coalescing"
         );
         if let Some(delay_ms) = deferred.schedule_delay_ms {
             let deps = deps.clone();
@@ -616,7 +639,7 @@ pub async fn handle(
             });
         }
         let note = format!(
-            "fire-rate cap ({MAX_FIRES_PER_WINDOW} per {FIRE_WINDOW_MS}ms) reached; coalescing — \
+            "fire-rate cap ({max_fires} per {window_ms}ms) reached; coalescing — \
              the latest event fires once the window frees ({} collapsed so far)",
             deferred.dropped
         );

--- a/harness/src/functions/react.rs
+++ b/harness/src/functions/react.rs
@@ -426,10 +426,14 @@ pub fn join_canon(metadata: Option<&Value>) -> Option<(String, Value)> {
     let mut canon = m.clone();
     if let Some(obj) = canon.as_object_mut() {
         // Stamps differ per registration by design; strip them defensively
-        // even though the interceptor fingerprints pre-stamp metadata.
+        // even though the interceptor fingerprints pre-stamp metadata. The
+        // registrant-functions stamp is session-derived like the owner stamp:
+        // keeping it would make identical specs registered from sessions with
+        // different dispatch policies falsely conflict.
         obj.remove("__subscription_id");
         obj.remove("__once");
         obj.remove(crate::subscriptions::OWNER_SESSION_KEY);
+        obj.remove(crate::functions::subscribe::REGISTRANT_FUNCTIONS_KEY);
         if let Some(j) = obj.get_mut("join").and_then(Value::as_object_mut) {
             j.remove("key");
         }
@@ -616,34 +620,47 @@ pub async fn handle(
             now_ms,
         );
         let (max_fires, window_ms) = (max_fires_per_window(), fire_window_ms());
-        tracing::warn!(
-            subscription = %gate_key,
-            dropped = deferred.dropped,
-            "harness::react: fire-rate breaker tripped ({max_fires} fires/{window_ms}ms); coalescing"
-        );
-        if let Some(delay_ms) = deferred.schedule_delay_ms {
-            let deps = deps.clone();
-            let key = gate_key.clone();
-            tokio::spawn(async move {
-                tokio::time::sleep(std::time::Duration::from_millis(delay_ms as u64)).await;
-                let Some(pending) = deps.react_gate.take_pending(&key) else {
-                    return;
-                };
-                let event = stamp_coalesced(pending.event, pending.dropped);
-                // Re-enters the gate: if the window is still hot the fire
-                // parks again and a fresh trailing task takes over.
-                if let Err(e) = handle_boxed(&deps, event, Some(pending.metadata)).await {
-                    tracing::warn!(subscription = %key, error = %e,
-                        "harness::react: trailing coalesced fire failed");
-                }
-            });
-        }
         let note = format!(
             "fire-rate cap ({max_fires} per {window_ms}ms) reached; coalescing — \
              the latest event fires once the window frees ({} collapsed so far)",
             deferred.dropped
         );
-        record_reaction_outcome(deps, &spec, &event, "waiting", &note, None).await;
+        // A runaway burst can park hundreds of fires per window; per-fire
+        // records/warns would spam the session and the log with entries the
+        // trailing fire's own outcome already subsumes. Record the CYCLE
+        // (first deferral schedules the trailing task); mid-cycle overwrites
+        // only debug-log.
+        if let Some(delay_ms) = deferred.schedule_delay_ms {
+            tracing::warn!(
+                subscription = %gate_key,
+                dropped = deferred.dropped,
+                "harness::react: fire-rate breaker tripped ({max_fires} fires/{window_ms}ms); coalescing"
+            );
+            {
+                let deps = deps.clone();
+                let key = gate_key.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_millis(delay_ms as u64)).await;
+                    let Some(pending) = deps.react_gate.take_pending(&key) else {
+                        return;
+                    };
+                    let event = stamp_coalesced(pending.event, pending.dropped);
+                    // Re-enters the gate: if the window is still hot the fire
+                    // parks again and a fresh trailing task takes over.
+                    if let Err(e) = handle_boxed(&deps, event, Some(pending.metadata)).await {
+                        tracing::warn!(subscription = %key, error = %e,
+                            "harness::react: trailing coalesced fire failed");
+                    }
+                });
+            }
+            record_reaction_outcome(deps, &spec, &event, "waiting", &note, None).await;
+        } else {
+            tracing::debug!(
+                subscription = %gate_key,
+                dropped = deferred.dropped,
+                "harness::react: capped fire coalesced into the pending trailing event"
+            );
+        }
         return Ok(ReactResult::note(note));
     }
 
@@ -1766,16 +1783,26 @@ mod tests {
 
     #[test]
     fn join_canon_strips_per_predecessor_fields_only() {
-        let md = |key: &str, sub: &str| {
+        let md = |key: &str, sub: &str, functions: serde_json::Value| {
             serde_json::json!({
                 "model": "m", "task": "the real task",
                 "join": {"id": "j1", "expect": ["a", "b"], "key": key},
                 "__subscription_id": sub, "__once": true,
                 "__owner_session_id": "s1",
+                "__registrant_functions": functions,
             })
         };
-        let (id_a, canon_a) = join_canon(Some(&md("a", "sub_1"))).unwrap();
-        let (id_b, canon_b) = join_canon(Some(&md("b", "sub_2"))).unwrap();
+        // Different keys, stamps, AND registrant policies (cross-session
+        // predecessors legitimately carry different inherited allow-lists) —
+        // the fingerprint must ignore all of them.
+        let (id_a, canon_a) = join_canon(Some(&md(
+            "a",
+            "sub_1",
+            serde_json::json!({"allow": ["state::get"]}),
+        )))
+        .unwrap();
+        let (id_b, canon_b) =
+            join_canon(Some(&md("b", "sub_2", serde_json::json!({"allow": ["*"]})))).unwrap();
         assert_eq!(id_a, "j1");
         assert_eq!(id_b, "j1");
         // Same reaction, different key/stamps → identical fingerprint.
@@ -1785,6 +1812,7 @@ mod tests {
         assert_eq!(canon_a["join"]["expect"], serde_json::json!(["a", "b"]));
         assert!(canon_a["join"].get("key").is_none());
         assert!(canon_a.get("__subscription_id").is_none());
+        assert!(canon_a.get("__registrant_functions").is_none());
     }
 
     /// The rctest-x7k2 failure shape: full task on one predecessor,

--- a/harness/src/functions/react.rs
+++ b/harness/src/functions/react.rs
@@ -108,31 +108,109 @@ const JOIN_SCOPE: &str = "harness::react_join";
 pub const MAX_FIRES_PER_WINDOW: usize = 10;
 pub const FIRE_WINDOW_MS: i64 = 60_000;
 
+/// The latest fire dropped by a capped binding, held for the trailing
+/// coalesced fire. Only the newest event is kept: react patterns are
+/// recompute-style (aggregate from source of truth), so the last event
+/// subsumes the dropped ones; `dropped` carries how many were collapsed.
+pub struct PendingFire {
+    pub event: Value,
+    pub metadata: Value,
+    pub dropped: usize,
+}
+
+/// Outcome of deferring a capped fire: how many fires the pending slot has
+/// collapsed so far, and — on the FIRST deferral of a window — the delay
+/// after which the caller must run the trailing fire.
+pub struct Deferred {
+    pub dropped: usize,
+    pub schedule_delay_ms: Option<i64>,
+}
+
+#[derive(Default)]
+struct GateSlot {
+    fires: std::collections::VecDeque<i64>,
+    pending: Option<PendingFire>,
+    /// A trailing task is already scheduled for this key — deferrals only
+    /// update `pending` until it drains.
+    trailing_scheduled: bool,
+}
+
 /// Sliding-window fire counter per subscription (or per spec-hash for
 /// bindings that carry no `__subscription_id`, e.g. `state`-provider ones).
+///
+/// Capped fires COALESCE instead of dropping: the newest event parks in the
+/// slot and one trailing fire delivers it when the window frees. Bounded: at
+/// most one pending event and one trailing task per key, so a true runaway
+/// still costs at most `MAX_FIRES_PER_WINDOW + 1` reactions per window.
 #[derive(Default)]
 pub struct FireGate {
-    inner: std::sync::Mutex<std::collections::HashMap<String, std::collections::VecDeque<i64>>>,
+    inner: std::sync::Mutex<std::collections::HashMap<String, GateSlot>>,
 }
 
 impl FireGate {
     /// Record a fire attempt for `key` at `now_ms`; `false` when the key has
-    /// exhausted its window budget — the caller must refuse to react.
+    /// exhausted its window budget — the caller must defer instead of react.
     pub fn admit(&self, key: &str, now_ms: i64) -> bool {
         let mut map = self.inner.lock().unwrap_or_else(|p| p.into_inner());
-        // Opportunistic GC so dead keys can't grow the map unboundedly.
+        // Opportunistic GC so dead keys can't grow the map unboundedly. Keys
+        // with a parked pending fire stay: a trailing task will drain them.
         if map.len() > 1024 {
-            map.retain(|_, q| q.back().is_some_and(|t| now_ms - t < FIRE_WINDOW_MS));
+            map.retain(|_, s| {
+                s.pending.is_some() || s.fires.back().is_some_and(|t| now_ms - t < FIRE_WINDOW_MS)
+            });
         }
-        let q = map.entry(key.to_string()).or_default();
-        while q.front().is_some_and(|t| now_ms - t >= FIRE_WINDOW_MS) {
-            q.pop_front();
+        let s = map.entry(key.to_string()).or_default();
+        while s
+            .fires
+            .front()
+            .is_some_and(|t| now_ms - t >= FIRE_WINDOW_MS)
+        {
+            s.fires.pop_front();
         }
-        if q.len() >= MAX_FIRES_PER_WINDOW {
+        if s.fires.len() >= MAX_FIRES_PER_WINDOW {
             return false;
         }
-        q.push_back(now_ms);
+        s.fires.push_back(now_ms);
         true
+    }
+
+    /// Park a capped fire as the key's pending trailing event (newest wins,
+    /// prior drops accumulate). Returns the trailing delay exactly once per
+    /// drain cycle — the caller that receives `Some` owns scheduling.
+    pub fn defer(&self, key: &str, event: Value, metadata: Value, now_ms: i64) -> Deferred {
+        let mut map = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        let s = map.entry(key.to_string()).or_default();
+        let dropped = s.pending.as_ref().map_or(0, |p| p.dropped) + 1;
+        s.pending = Some(PendingFire {
+            event,
+            metadata,
+            dropped,
+        });
+        let schedule_delay_ms = if s.trailing_scheduled {
+            None
+        } else {
+            s.trailing_scheduled = true;
+            // Fire when the oldest window entry expires (budget frees). The
+            // floor guards clock skew; the ceiling guards a corrupt queue.
+            let delay = s
+                .fires
+                .front()
+                .map_or(FIRE_WINDOW_MS, |t| t + FIRE_WINDOW_MS - now_ms);
+            Some(delay.clamp(1_000, FIRE_WINDOW_MS))
+        };
+        Deferred {
+            dropped,
+            schedule_delay_ms,
+        }
+    }
+
+    /// Drain the key's pending fire for the trailing task. Clears the
+    /// scheduled flag: a later deferral starts a new drain cycle.
+    pub fn take_pending(&self, key: &str) -> Option<PendingFire> {
+        let mut map = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        let s = map.get_mut(key)?;
+        s.trailing_scheduled = false;
+        s.pending.take()
     }
 }
 
@@ -407,13 +485,29 @@ pub fn validate_spec(metadata: Option<&Value>) -> Result<(), String> {
     Ok(())
 }
 
+/// Type-erased re-entry for the trailing coalesced fire: `handle` recursing
+/// through `tokio::spawn` can't prove its own future `Send` (the bound is
+/// self-referential); the `dyn` boxing breaks the inference cycle.
+fn handle_boxed<'a>(
+    deps: &'a Deps,
+    event: Value,
+    metadata: Option<Value>,
+) -> std::pin::Pin<
+    Box<dyn std::future::Future<Output = Result<ReactResult, HarnessError>> + Send + 'a>,
+> {
+    Box::pin(handle(deps, event, metadata))
+}
+
 pub async fn handle(
     deps: &Deps,
     event: Value,
     metadata: Option<Value>,
 ) -> Result<ReactResult, HarnessError> {
     // A bad/absent spec must never error out: an erroring trigger target just
-    // spams the engine's dispatch log. Log and no-op instead.
+    // spams the engine's dispatch log. Log and no-op instead. The raw metadata
+    // is kept beside the parsed spec: a capped fire parks it for the trailing
+    // coalesced re-entry.
+    let raw_metadata = metadata.clone();
     let spec: ReactSpec = match metadata {
         Some(m) => match serde_json::from_value(m) {
             Ok(s) => s,
@@ -453,14 +547,49 @@ pub async fn handle(
         .map(|d| d.as_millis() as i64)
         .unwrap_or(0);
     if !deps.react_gate.admit(&gate_key, now_ms) {
+        // Coalesce instead of dropping: react patterns are recompute-style,
+        // so the newest event subsumes the capped ones. Park it and let one
+        // trailing fire deliver it when the window frees — without this, a
+        // burst's TAIL is exactly what gets dropped and aggregates freeze
+        // one step behind the source of truth (rctest-k7m3 postmortem).
+        let deferred = deps.react_gate.defer(
+            &gate_key,
+            event.clone(),
+            raw_metadata.unwrap_or(Value::Null),
+            now_ms,
+        );
         tracing::warn!(
             subscription = %gate_key,
-            "harness::react: fire-rate breaker tripped ({MAX_FIRES_PER_WINDOW} fires/{FIRE_WINDOW_MS}ms); not reacting"
+            dropped = deferred.dropped,
+            "harness::react: fire-rate breaker tripped ({MAX_FIRES_PER_WINDOW} fires/{FIRE_WINDOW_MS}ms); coalescing"
         );
+        if let Some(delay_ms) = deferred.schedule_delay_ms {
+            let deps = deps.clone();
+            let key = gate_key.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(delay_ms as u64)).await;
+                let Some(pending) = deps.react_gate.take_pending(&key) else {
+                    return;
+                };
+                let mut event = pending.event;
+                if let Some(obj) = event.as_object_mut() {
+                    // Tell the reaction it stands in for a collapsed burst.
+                    obj.insert("__coalesced_fires".to_string(), json!(pending.dropped));
+                }
+                // Re-enters the gate: if the window is still hot the fire
+                // parks again and a fresh trailing task takes over.
+                if let Err(e) = handle_boxed(&deps, event, Some(pending.metadata)).await {
+                    tracing::warn!(subscription = %key, error = %e,
+                        "harness::react: trailing coalesced fire failed");
+                }
+            });
+        }
         let note = format!(
-            "fire-rate cap ({MAX_FIRES_PER_WINDOW} per {FIRE_WINDOW_MS}ms) reached for this subscription; not spawning"
+            "fire-rate cap ({MAX_FIRES_PER_WINDOW} per {FIRE_WINDOW_MS}ms) reached; coalescing — \
+             the latest event fires once the window frees ({} collapsed so far)",
+            deferred.dropped
         );
-        record_reaction_outcome(deps, &spec, &event, "failed", &note, None).await;
+        record_reaction_outcome(deps, &spec, &event, "waiting", &note, None).await;
         return Ok(ReactResult::note(note));
     }
 
@@ -1612,6 +1741,80 @@ mod tests {
         assert!(gate.admit("sub-2", t0 + 100));
         // Once the window slides past the early fires, the key recovers.
         assert!(gate.admit("sub-1", t0 + FIRE_WINDOW_MS + 1));
+    }
+
+    /// The coalescing contract: capped fires park (newest event wins, drops
+    /// accumulate), exactly one caller per drain cycle owns scheduling, and
+    /// draining resets the cycle. Without this, a burst's TAIL is exactly
+    /// what gets dropped and recompute-style reactions freeze one step
+    /// behind the source of truth (rctest-k7m3 postmortem).
+    #[test]
+    fn fire_gate_coalesces_capped_fires_newest_wins() {
+        let gate = FireGate::default();
+        let t0 = 1_000_000;
+        for i in 0..MAX_FIRES_PER_WINDOW {
+            assert!(gate.admit("sub-1", t0 + i as i64));
+        }
+        assert!(!gate.admit("sub-1", t0 + 100));
+
+        // First deferral owns scheduling; the delay lands when the oldest
+        // window entry expires.
+        let d1 = gate.defer(
+            "sub-1",
+            serde_json::json!({"seq": 11}),
+            serde_json::json!({"task": "t"}),
+            t0 + 100,
+        );
+        assert_eq!(d1.dropped, 1);
+        let delay = d1.schedule_delay_ms.expect("first deferral schedules");
+        assert_eq!(delay, FIRE_WINDOW_MS - 100);
+
+        // Later deferrals only update the pending slot.
+        let d2 = gate.defer(
+            "sub-1",
+            serde_json::json!({"seq": 12}),
+            serde_json::json!({"task": "t"}),
+            t0 + 200,
+        );
+        assert_eq!(d2.dropped, 2);
+        assert!(
+            d2.schedule_delay_ms.is_none(),
+            "one trailing task per cycle"
+        );
+
+        // The trailing task drains the NEWEST event with the full drop count.
+        let pending = gate.take_pending("sub-1").expect("pending fire parked");
+        assert_eq!(pending.event["seq"], 12);
+        assert_eq!(pending.dropped, 2);
+
+        // Drained: nothing pending, and a new deferral starts a new cycle.
+        assert!(gate.take_pending("sub-1").is_none());
+        let d3 = gate.defer(
+            "sub-1",
+            serde_json::json!({"seq": 13}),
+            serde_json::Value::Null,
+            t0 + 300,
+        );
+        assert_eq!(d3.dropped, 1, "drop count resets after a drain");
+        assert!(d3.schedule_delay_ms.is_some(), "new cycle reschedules");
+    }
+
+    #[test]
+    fn fire_gate_gc_keeps_keys_with_parked_fires() {
+        let gate = FireGate::default();
+        let t0 = 1_000_000;
+        gate.admit("parked", t0);
+        gate.defer("parked", serde_json::json!({}), serde_json::Value::Null, t0);
+        // Blow past the GC threshold with dead keys, long after the window.
+        let later = t0 + 10 * FIRE_WINDOW_MS;
+        for i in 0..1030 {
+            gate.admit(&format!("dead-{i}"), later);
+        }
+        gate.admit("trigger-gc", later);
+        assert!(
+            gate.take_pending("parked").is_some(),
+            "GC must never drop a key holding a parked trailing fire"
+        );
     }
 
     #[test]

--- a/harness/src/functions/react.rs
+++ b/harness/src/functions/react.rs
@@ -323,6 +323,13 @@ pub struct ReactSpec {
     /// carries no session id (state/cron/stream).
     #[serde(default, rename = "__owner_session_id")]
     pub owner_session_id: Option<String>,
+    /// Stamped by the interceptor at registration (never caller-supplied): the
+    /// registering turn's dispatch policy. A reaction with no
+    /// `options.functions` inherits it; explicit options are subset against
+    /// it (narrow, never escalate) — the in-turn child rule. Absent on raw
+    /// engine-side registrations, which keep the read-only-baseline fallback.
+    #[serde(default, rename = "__registrant_functions")]
+    pub registrant_functions: Option<crate::types::turn::FunctionPolicy>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -1635,6 +1642,29 @@ fn build_spawn_payload(task: String, spec: &ReactSpec, parent_session_id: Option
     if let Some(o) = &spec.options {
         payload["options"] = o.clone();
     }
+    // Interceptor-registered reactions inherit the REGISTRANT's dispatch
+    // policy, subset when the spec narrows it (the in-turn child rule).
+    // Without this the spawned turn is parentless and lands on the read-only
+    // baseline — a wrap-up reaction delivered into the registrant's own chat
+    // suddenly can't call what every earlier turn there could (rctest-k7m3:
+    // database::query / state::set / engine::unregister_trigger all denied).
+    // Raw engine-side registrations carry no stamp and keep the baseline.
+    if let Some(registrant) = &spec.registrant_functions {
+        let requested: Option<crate::types::turn::FunctionPolicy> = spec
+            .options
+            .as_ref()
+            .and_then(|o| o.get("functions"))
+            .and_then(|f| serde_json::from_value(f.clone()).ok());
+        if let Some(effective) = crate::policy::subset_policy(Some(registrant), requested.as_ref())
+        {
+            if let Ok(v) = serde_json::to_value(&effective) {
+                if !payload["options"].is_object() {
+                    payload["options"] = json!({});
+                }
+                payload["options"]["functions"] = v;
+            }
+        }
+    }
     if let Some(pp) = parent_session_id {
         payload["parent_session_id"] = json!(pp);
     }
@@ -1845,7 +1875,62 @@ mod tests {
             subscription_id: None,
             once: false,
             owner_session_id: None,
+            registrant_functions: None,
         }
+    }
+
+    /// The rctest-k7m3 wrap-up failure: a reaction registered with no
+    /// `options` used to spawn parentless onto the read-only baseline —
+    /// denied database::query / state::set / engine::unregister_trigger in
+    /// the very chat whose earlier turns could call all three. With the
+    /// registrant stamp, the reaction inherits that policy; explicit options
+    /// subset it and can never escalate past it.
+    #[test]
+    fn spawn_payload_inherits_registrant_policy_and_subsets_requests() {
+        let registrant = crate::types::turn::FunctionPolicy {
+            allow: vec!["database::query".into(), "state::set".into()],
+            deny: vec!["shell::run".into()],
+            expose: Default::default(),
+        };
+
+        // No options: full inheritance.
+        let mut s = spec();
+        s.registrant_functions = Some(registrant.clone());
+        let payload = build_spawn_payload("t".into(), &s, None);
+        assert_eq!(
+            payload["options"]["functions"]["allow"],
+            json!(["database::query", "state::set"])
+        );
+        assert_eq!(
+            payload["options"]["functions"]["deny"],
+            json!(["shell::run"])
+        );
+
+        // Requested subset survives; escalation beyond the registrant is
+        // filtered out.
+        let mut s = spec();
+        s.registrant_functions = Some(registrant);
+        s.options = Some(json!({
+            "functions": { "allow": ["state::set", "engine::unregister_trigger"] },
+            "max_turns": 3
+        }));
+        let payload = build_spawn_payload("t".into(), &s, None);
+        assert_eq!(
+            payload["options"]["functions"]["allow"],
+            json!(["state::set"]),
+            "an option the registrant never held must not survive"
+        );
+        assert_eq!(
+            payload["options"]["max_turns"],
+            json!(3),
+            "other options pass through"
+        );
+
+        // No stamp (raw engine-side registration): payload untouched, the
+        // read-only baseline fallback stays in force downstream.
+        let s = spec();
+        let payload = build_spawn_payload("t".into(), &s, None);
+        assert!(payload.get("options").is_none());
     }
 
     #[test]

--- a/harness/src/functions/react.rs
+++ b/harness/src/functions/react.rs
@@ -271,7 +271,11 @@ pub struct ReactSpec {
     pub model: Option<String>,
     /// The sub-agent's opening task; the event (simple) or all predecessor
     /// results (join) are appended fenced so it sees its inputs. Mutually
-    /// exclusive with `call`.
+    /// exclusive with `call`. Under burst load an event may carry
+    /// `__coalesced_fires`/`__coalesced_note`: it stands in for N fires
+    /// collapsed by the rate cap (only the newest survives) — a task that
+    /// processes single events per key must recompute from the source of
+    /// truth on such a fire.
     #[serde(default)]
     pub task: Option<String>,
     /// Function-call reaction (no sub-agent, no model). Mutually exclusive
@@ -492,6 +496,30 @@ pub fn validate_spec(metadata: Option<&Value>) -> Result<(), String> {
     Ok(())
 }
 
+/// Mark a trailing coalesced event as standing in for a collapsed burst.
+/// Only the NEWEST event survives coalescing, so a reaction that processes
+/// per-key/per-entity state from single events would silently skip the
+/// collapsed ones — rctest-k7m2: a per-writer upsert reactor missed one
+/// writer entirely because its events were among the collapsed. The note
+/// spells out the recovery at the exact moment the reaction reads the event;
+/// the count is machine-readable. Non-object events can't carry the stamp
+/// and pass through unchanged.
+fn stamp_coalesced(mut event: Value, dropped: usize) -> Value {
+    if let Some(obj) = event.as_object_mut() {
+        obj.insert("__coalesced_fires".to_string(), json!(dropped));
+        obj.insert(
+            "__coalesced_note".to_string(),
+            json!(format!(
+                "This event stands in for {dropped} fires collapsed by the rate cap; the \
+                 earlier events were NOT delivered. Do not process it as a single change — \
+                 recompute from the source of truth so the collapsed events' effects are \
+                 covered."
+            )),
+        );
+    }
+    event
+}
+
 /// Type-erased re-entry for the trailing coalesced fire: `handle` recursing
 /// through `tokio::spawn` can't prove its own future `Send` (the bound is
 /// self-referential); the `dyn` boxing breaks the inference cycle.
@@ -578,11 +606,7 @@ pub async fn handle(
                 let Some(pending) = deps.react_gate.take_pending(&key) else {
                     return;
                 };
-                let mut event = pending.event;
-                if let Some(obj) = event.as_object_mut() {
-                    // Tell the reaction it stands in for a collapsed burst.
-                    obj.insert("__coalesced_fires".to_string(), json!(pending.dropped));
-                }
+                let event = stamp_coalesced(pending.event, pending.dropped);
                 // Re-enters the gate: if the window is still hot the fire
                 // parks again and a fresh trailing task takes over.
                 if let Err(e) = handle_boxed(&deps, event, Some(pending.metadata)).await {
@@ -1827,6 +1851,24 @@ mod tests {
         );
         assert_eq!(d3.dropped, 1, "drop count resets after a drain");
         assert!(d3.schedule_delay_ms.is_some(), "new cycle reschedules");
+    }
+
+    /// The rctest-k7m2 lesson: a per-key reactor missed a writer whose
+    /// events were all collapsed. The trailing event must say — in text the
+    /// reacting model reads — that it stands in for the collapsed fires.
+    #[test]
+    fn stamp_coalesced_marks_the_event_with_count_and_recovery_note() {
+        let stamped = stamp_coalesced(serde_json::json!({"seq": 15, "writer": "w3"}), 5);
+        assert_eq!(stamped["__coalesced_fires"], 5);
+        let note = stamped["__coalesced_note"].as_str().unwrap();
+        assert!(note.contains("stands in for 5 fires"));
+        assert!(note.contains("recompute from the source of truth"));
+        // Original payload survives beside the stamps.
+        assert_eq!(stamped["writer"], "w3");
+
+        // Non-object events cannot carry the stamp and pass through unchanged.
+        let passthrough = stamp_coalesced(serde_json::json!("bare"), 3);
+        assert_eq!(passthrough, serde_json::json!("bare"));
     }
 
     #[test]

--- a/harness/src/functions/subscribe.rs
+++ b/harness/src/functions/subscribe.rs
@@ -229,6 +229,27 @@ fn standing_binding_advisory(req: &SubscribeRequest, once: bool) -> Option<Strin
     )
 }
 
+/// Advisory for a `state` binding with no `key` filter: it fires for EVERY
+/// key written in the scope (or every write anywhere, with no scope either) —
+/// order signals, done markers, completion keys, all of it. Registered beside
+/// a keyed binding it double-fires every event and burns the fire-rate budget
+/// twice (rctest-k7m3 postmortem). Purely informative — a deliberate
+/// catch-all watcher ignores it.
+fn state_catchall_advisory(req: &SubscribeRequest) -> Option<String> {
+    if req.trigger_type != "state" || req.config.get("key").is_some() {
+        return None;
+    }
+    let breadth = match req.config.get("scope").and_then(Value::as_str) {
+        Some(scope) => format!("EVERY key written in scope \"{scope}\""),
+        None => "EVERY state write in EVERY scope".to_string(),
+    };
+    Some(format!(
+        "warning: this state binding has no `key` filter — it fires for {breadth} (done \
+         markers, completion signals, everything), each fire spending this subscription's \
+         fire-rate budget. Add a `key` to the config unless you deliberately want a catch-all."
+    ))
+}
+
 /// `once` on a react binding: simple non-cron edges default to one-shot, while
 /// cron remains standing. Callers that truly want a standing state/turn watcher
 /// opt out with `once: false`. Join predecessors ignore this field because the
@@ -409,10 +430,19 @@ async fn handle(
         }
     }
 
+    let notes: Vec<String> = [
+        session_filter_advisory(deps, &req).await,
+        // A key-less state notify wakes the owning session on every write in
+        // the scope — same catch-all hazard as a react binding.
+        state_catchall_advisory(&req),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
     Ok(SubscribeResponse {
         subscription_id: sub_id,
         once,
-        note: session_filter_advisory(deps, &req).await,
+        note: (!notes.is_empty()).then(|| notes.join(" ")),
     })
 }
 
@@ -736,6 +766,7 @@ async fn handle_react(
         session_filter_advisory(deps, &req).await,
         join_wiring_advisory(deps, &req).await,
         standing_binding_advisory(&req, once),
+        state_catchall_advisory(&req),
     ]
     .into_iter()
     .flatten()
@@ -1036,6 +1067,37 @@ mod tests {
         let mut state_req = mk(json!({ "parent_session_id": "s_p" }), join2);
         state_req.trigger_type = "state".into();
         assert!(parent_filter_join_advisory(&state_req).is_none());
+    }
+
+    /// The rctest-k7m3 miswire: a key-less state binding beside a keyed one
+    /// fires for every key in the scope and burns the fire-rate budget twice.
+    #[test]
+    fn state_catchall_advisory_flags_keyless_state_bindings() {
+        let mk = |ty: &str, config: serde_json::Value| -> SubscribeRequest {
+            serde_json::from_value(json!({
+                "trigger_type": ty,
+                "config": config,
+                "function_id": "harness::react",
+                "metadata": { "model": "m", "task": "t" },
+            }))
+            .unwrap()
+        };
+        // Scope without key: warned, naming the scope.
+        let note = state_catchall_advisory(&mk("state", json!({ "scope": "run-1" })));
+        assert!(note.as_deref().unwrap_or("").contains("run-1"));
+        assert!(note.as_deref().unwrap_or("").contains("no `key` filter"));
+        // No scope AND no key: the global catch-all, warned harder.
+        let note = state_catchall_advisory(&mk("state", json!({})));
+        assert!(note.as_deref().unwrap_or("").contains("EVERY scope"));
+        // A key filter silences it, with or without scope.
+        assert!(state_catchall_advisory(&mk(
+            "state",
+            json!({ "scope": "run-1", "key": "change" })
+        ))
+        .is_none());
+        assert!(state_catchall_advisory(&mk("state", json!({ "key": "change" }))).is_none());
+        // Non-state trigger types are not advised on.
+        assert!(state_catchall_advisory(&mk("cron", json!({}))).is_none());
     }
 
     #[test]

--- a/harness/src/functions/subscribe.rs
+++ b/harness/src/functions/subscribe.rs
@@ -65,13 +65,13 @@ pub struct SubscribeRequest {
     /// parent_session_id?, options?, join? }`. Required (with `task`) when
     /// `function_id` is `harness::react`; forwarded verbatim, with `model`
     /// (and `provider`, when unset) defaulted to the registering turn's
-    /// when omitted. A
-    /// trigger-fired sub-agent starts with only the read-only default policy —
-    /// grant what the reaction needs via `options` (same shape as
-    /// `harness::spawn` options, e.g. `{ "functions": { "allow":
-    /// ["state::get"] } }`). Join predecessors auto-unregister after the join
-    /// fires unless `join.rearm: true` keeps them registered for the next
-    /// complete set.
+    /// when omitted. The reaction INHERITS the registering turn's dispatch
+    /// policy; `options.functions` narrows it and can never escalate (same
+    /// shape as `harness::spawn` options, e.g. `{ "functions": { "allow":
+    /// ["state::get"] } }`). Only raw engine-side registrations fall back to
+    /// the read-only default policy. Join predecessors auto-unregister after
+    /// the join fires unless `join.rearm: true` keeps them registered for the
+    /// next complete set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Value>,
 }
@@ -158,12 +158,14 @@ async fn session_filter_advisory(deps: &Deps, req: &SubscribeRequest) -> Option<
     ))
 }
 
-/// The registering turn's model identity, threaded from the dispatch
-/// chokepoints so a model-less react spec can inherit it (see [`inherit_model`]).
+/// The registering turn's model identity and dispatch policy, threaded from
+/// the dispatch chokepoints so a react spec can inherit them (see
+/// [`inherit_model`] and [`stamp_registrant_functions`]).
 #[derive(Clone, Copy)]
 pub struct CallerModel<'a> {
     pub model: &'a str,
     pub provider: Option<&'a str>,
+    pub functions: Option<&'a crate::types::turn::FunctionPolicy>,
 }
 
 impl<'a> CallerModel<'a> {
@@ -171,6 +173,7 @@ impl<'a> CallerModel<'a> {
         Self {
             model: &options.model,
             provider: options.provider.as_deref(),
+            functions: options.functions.as_ref(),
         }
     }
 }
@@ -285,6 +288,31 @@ async fn intercept_register(
 /// (ambiguous ids resolve per-provider). Only a truly absent or empty-string
 /// `model` inherits: present-but-mistyped values (`null`, `false`, `0`) still
 /// fail spec validation loudly rather than silently running on another model.
+/// Metadata key carrying the registering turn's dispatch policy on a react
+/// binding. At fire time a reaction with no `options.functions` inherits it,
+/// and explicit options are subset against it (narrow, never escalate) —
+/// matching the in-turn child rule instead of dropping a reaction delivered
+/// into the registrant's own chat to the read-only baseline (the rctest-k7m3
+/// wrap-up turn was denied database::query / state::set /
+/// engine::unregister_trigger for exactly that reason).
+pub const REGISTRANT_FUNCTIONS_KEY: &str = "__registrant_functions";
+
+/// Stamp the registering turn's dispatch policy onto a react binding's
+/// metadata. Harness stamp, never caller-supplied: any smuggled value is
+/// dropped even when there is no caller policy to stamp.
+fn stamp_registrant_functions(metadata: &mut Option<Value>, caller: Option<CallerModel<'_>>) {
+    let Some(Value::Object(m)) = metadata.as_mut() else {
+        return;
+    };
+    m.remove(REGISTRANT_FUNCTIONS_KEY);
+    let Some(functions) = caller.and_then(|c| c.functions) else {
+        return;
+    };
+    if let Ok(v) = serde_json::to_value(functions) {
+        m.insert(REGISTRANT_FUNCTIONS_KEY.to_string(), v);
+    }
+}
+
 fn inherit_model(metadata: &mut Option<Value>, caller: Option<CallerModel<'_>>) {
     let (Some(Value::Object(m)), Some(caller)) = (metadata.as_mut(), caller) else {
         return;
@@ -635,6 +663,9 @@ async fn handle_react(
     } else {
         inherit_model(&mut req.metadata, caller);
     }
+    // Both modes: strips any smuggled registrant-policy stamp; inert for call
+    // reactions (they dispatch with worker authority, no spawned turn).
+    stamp_registrant_functions(&mut req.metadata, caller);
     crate::functions::react::validate_spec(req.metadata.as_ref())
         .map_err(HarnessError::InvalidRequest)?;
     if !call_mode {
@@ -834,6 +865,7 @@ mod tests {
             Some(CallerModel {
                 model: "claude-opus-4-8",
                 provider: None,
+                functions: None,
             }),
         );
         assert_eq!(md.as_ref().unwrap()["model"], json!("claude-opus-4-8"));
@@ -846,6 +878,7 @@ mod tests {
             Some(CallerModel {
                 model: "claude-opus-4-8",
                 provider: None,
+                functions: None,
             }),
         );
         assert_eq!(explicit.as_ref().unwrap()["model"], json!("kimi-k2"));
@@ -856,6 +889,7 @@ mod tests {
             Some(CallerModel {
                 model: "claude-opus-4-8",
                 provider: None,
+                functions: None,
             }),
         );
         assert_eq!(empty.as_ref().unwrap()["model"], json!("claude-opus-4-8"));
@@ -871,6 +905,7 @@ mod tests {
             Some(CallerModel {
                 model: "m",
                 provider: Some("anthropic"),
+                functions: None,
             }),
         );
         assert_eq!(md.as_ref().unwrap()["model"], json!("m"));
@@ -883,6 +918,7 @@ mod tests {
             Some(CallerModel {
                 model: "m",
                 provider: Some("anthropic"),
+                functions: None,
             }),
         );
         assert_eq!(pinned.as_ref().unwrap()["provider"], json!("openai"));
@@ -894,6 +930,7 @@ mod tests {
             Some(CallerModel {
                 model: "m",
                 provider: Some("anthropic"),
+                functions: None,
             }),
         );
         assert!(explicit.as_ref().unwrap().get("provider").is_none());
@@ -910,6 +947,7 @@ mod tests {
                 Some(CallerModel {
                     model: "m",
                     provider: None,
+                    functions: None,
                 }),
             );
             assert_eq!(md.as_ref().unwrap()["model"], json!(bad), "{bad}");
@@ -937,6 +975,7 @@ mod tests {
             Some(CallerModel {
                 model: "claude-opus-4-8",
                 provider: Some("anthropic"),
+                functions: None,
             }),
         );
         let key_stamped_input = registration_dedup_key(&stamped, react_once(&stamped));
@@ -1071,6 +1110,50 @@ mod tests {
 
     /// The rctest-k7m3 miswire: a key-less state binding beside a keyed one
     /// fires for every key in the scope and burns the fire-rate budget twice.
+    /// The registrant-policy stamp: written from the trusted caller, never
+    /// from the agent's own metadata (a smuggled value is dropped even when
+    /// there is nothing to stamp).
+    #[test]
+    fn stamp_registrant_functions_writes_trusted_policy_and_strips_smuggled() {
+        let policy = crate::types::turn::FunctionPolicy {
+            allow: vec!["database::query".into()],
+            deny: vec![],
+            expose: Default::default(),
+        };
+        let caller = CallerModel {
+            model: "m",
+            provider: None,
+            functions: Some(&policy),
+        };
+
+        // Genuine stamp from the caller.
+        let mut md = Some(json!({ "model": "m", "task": "t" }));
+        stamp_registrant_functions(&mut md, Some(caller));
+        assert_eq!(
+            md.as_ref().unwrap()[REGISTRANT_FUNCTIONS_KEY]["allow"],
+            json!(["database::query"])
+        );
+
+        // A smuggled stamp is replaced by the trusted one...
+        let mut md = Some(json!({
+            "model": "m", "task": "t",
+            REGISTRANT_FUNCTIONS_KEY: { "allow": ["*"] }
+        }));
+        stamp_registrant_functions(&mut md, Some(caller));
+        assert_eq!(
+            md.as_ref().unwrap()[REGISTRANT_FUNCTIONS_KEY]["allow"],
+            json!(["database::query"])
+        );
+
+        // ...and dropped outright when there is no caller policy.
+        let mut md = Some(json!({
+            "model": "m", "task": "t",
+            REGISTRANT_FUNCTIONS_KEY: { "allow": ["*"] }
+        }));
+        stamp_registrant_functions(&mut md, None);
+        assert!(md.as_ref().unwrap().get(REGISTRANT_FUNCTIONS_KEY).is_none());
+    }
+
     #[test]
     fn state_catchall_advisory_flags_keyless_state_bindings() {
         let mk = |ty: &str, config: serde_json::Value| -> SubscribeRequest {

--- a/harness/src/functions/subscribe.rs
+++ b/harness/src/functions/subscribe.rs
@@ -71,7 +71,11 @@ pub struct SubscribeRequest {
     /// ["state::get"] } }`). Only raw engine-side registrations fall back to
     /// the read-only default policy. Join predecessors auto-unregister after
     /// the join fires unless `join.rearm: true` keeps them registered for the
-    /// next complete set.
+    /// next complete set. Under burst load fires past the per-subscription
+    /// rate cap COALESCE: only the newest event is delivered (stamped
+    /// `__coalesced_fires`/`__coalesced_note`), so a reaction task must
+    /// recompute from the source of truth on such a fire rather than treat
+    /// it as one change.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Value>,
 }

--- a/harness/tests/e2e/README.md
+++ b/harness/tests/e2e/README.md
@@ -16,6 +16,7 @@ No provider key or network access is required.
 | E2E-003 | `reseed-parked-message` | direct | a message parked during a turn's failing final step is delivered by a harness-reseeded turn |
 | E2E-004 | `join-spec-mismatch` | direct | a join predecessor registered with a divergent reaction spec is rejected at registration |
 | E2E-005 | `reaction-policy-inheritance` | direct | a reaction with no options inherits the registering turn's dispatch policy |
+| E2E-006 | `state-worker-sidecar` | direct | a state-key reaction fires through the standalone state worker with its metadata sidecar (probe-hook driven) |
 | UI-001 | `console-streamed-text` | playground | a message sent by the Console streams to durable completion |
 | UI-002 | `multi-turn-traces` | playground | a native function turn and a Console turn expose distinct traces and function-call events |
 

--- a/harness/tests/e2e/README.md
+++ b/harness/tests/e2e/README.md
@@ -15,6 +15,7 @@ No provider key or network access is required.
 | E2E-002 | `exactly-once-function` | direct | a native function executes exactly once |
 | E2E-003 | `reseed-parked-message` | direct | a message parked during a turn's failing final step is delivered by a harness-reseeded turn |
 | E2E-004 | `join-spec-mismatch` | direct | a join predecessor registered with a divergent reaction spec is rejected at registration |
+| E2E-005 | `reaction-policy-inheritance` | direct | a reaction with no options inherits the registering turn's dispatch policy |
 | UI-001 | `console-streamed-text` | playground | a message sent by the Console streams to durable completion |
 | UI-002 | `multi-turn-traces` | playground | a native function turn and a Console turn expose distinct traces and function-call events |
 

--- a/harness/tests/e2e/README.md
+++ b/harness/tests/e2e/README.md
@@ -17,6 +17,7 @@ No provider key or network access is required.
 | E2E-004 | `join-spec-mismatch` | direct | a join predecessor registered with a divergent reaction spec is rejected at registration |
 | E2E-005 | `reaction-policy-inheritance` | direct | a reaction with no options inherits the registering turn's dispatch policy |
 | E2E-006 | `state-worker-sidecar` | direct | a state-key reaction fires through the standalone state worker with its metadata sidecar (probe-hook driven) |
+| E2E-007 | `coalesced-fire` | direct | a burst past the fire-rate cap coalesces: cap + 1 dispatches, the trailing one stamped `__coalesced_fires` (shrunken gate via harness env; probe-side whole-run call evidence) |
 | UI-001 | `console-streamed-text` | playground | a message sent by the Console streams to durable completion |
 | UI-002 | `multi-turn-traces` | playground | a native function turn and a Console turn expose distinct traces and function-call events |
 

--- a/harness/tests/e2e/src/evidence_data.rs
+++ b/harness/tests/e2e/src/evidence_data.rs
@@ -21,6 +21,11 @@ pub struct RunEvidence {
     pub generations_total: u64,
     /// Complete trace trees for the run's session.
     pub traces: TraceEvidenceV1,
+    /// Every controlled-function invocation payload the probe served, in
+    /// arrival order — WHOLE-RUN evidence. Session traces miss dispatches
+    /// that never touch the tracked session (a call-mode reaction); the
+    /// serving process sees them all.
+    pub target_calls: Vec<Value>,
 }
 
 /// Compact form published in `playground-result.json`.
@@ -149,6 +154,18 @@ impl RunEvidence {
         anyhow::ensure!(
             actual == expected,
             "message counts (user, assistant, function_result) {actual:?} != {expected:?}"
+        );
+        Ok(())
+    }
+
+    /// Exact probe-side (whole-run) invocation count of the controlled
+    /// function — use instead of [`expect_function_calls`](Self::expect_function_calls)
+    /// when dispatches bypass the tracked session entirely.
+    pub fn expect_target_calls(&self, count: usize) -> anyhow::Result<()> {
+        let actual = self.target_calls.len();
+        anyhow::ensure!(
+            actual == count,
+            "controlled function served {actual} call(s), expected {count}"
         );
         Ok(())
     }
@@ -301,6 +318,7 @@ mod tests {
             generations_consumed: 1,
             generations_total: 1,
             traces: TraceEvidenceV1::new(Vec::new()),
+            target_calls: Vec::new(),
         }
     }
 

--- a/harness/tests/e2e/src/fixtures.rs
+++ b/harness/tests/e2e/src/fixtures.rs
@@ -9,7 +9,7 @@ mod discovery;
 mod loading;
 
 pub use discovery::scenario_fixtures;
-pub use loading::ScenarioFixture;
+pub use loading::{ProbeAction, ScenarioFixture};
 
 #[cfg(test)]
 mod tests;

--- a/harness/tests/e2e/src/fixtures/loading.rs
+++ b/harness/tests/e2e/src/fixtures/loading.rs
@@ -21,6 +21,21 @@ pub struct ScenarioFixture {
     pub system_prompt_template: String,
     /// Scenario-specific checks over the collected run evidence.
     pub verify: VerifyFn,
+    /// Probe-driven actions to fire between terminal turns. Each runs after
+    /// its `after_turns` completion count is observed, so a reaction it trips
+    /// runs while the tracked session is idle (ordinal-clean under the
+    /// scripted router). `{{run_id}}`/`{{session_id}}` in the payload expand.
+    pub probe_actions: Vec<ProbeAction>,
+}
+
+/// A function the PROBE (test infra, not a model turn) invokes at a completion
+/// boundary — the seam that lets a scenario trip a state key after the main
+/// turn is idle instead of mid-turn.
+#[derive(Debug, Clone)]
+pub struct ProbeAction {
+    pub after_turns: usize,
+    pub function_id: String,
+    pub payload: serde_json::Value,
 }
 
 impl ScenarioFixture {
@@ -137,7 +152,11 @@ impl ScenarioFixture {
     /// turns are each externally initiated and trace separately.
     pub fn expected_traces(&self) -> usize {
         match self.driver {
-            ScenarioDriver::Direct => 1,
+            // The send's own trace, plus one per probe action: a probe-tripped
+            // reaction fires from a fresh externally-initiated flow (the
+            // state/cron worker's fan-out), so it forms its own trace tree —
+            // exactly like a Playground-driven external turn.
+            ScenarioDriver::Direct => 1 + self.probe_actions.len(),
             ScenarioDriver::Playground => self.expected_terminal_turns,
         }
     }

--- a/harness/tests/e2e/src/fixtures/loading.rs
+++ b/harness/tests/e2e/src/fixtures/loading.rs
@@ -26,6 +26,20 @@ pub struct ScenarioFixture {
     /// runs while the tracked session is idle (ordinal-clean under the
     /// scripted router). `{{run_id}}`/`{{session_id}}` in the payload expand.
     pub probe_actions: Vec<ProbeAction>,
+    /// Extra environment for the harness process under test. The integration
+    /// knobs live here (e.g. `III_HARNESS_FIRE_WINDOW_MS` to shrink the
+    /// fire-rate window so a coalescing scenario completes in seconds).
+    pub harness_env: Vec<(String, String)>,
+    /// Await this many controlled-function invocations (probe-side, whole-run)
+    /// after every terminal turn arrived. This is the only way to await work
+    /// that produces no session turn — a call-mode reaction's dispatch,
+    /// including a trailing coalesced fire.
+    pub await_target_calls: Option<usize>,
+    /// Session-trace-count override for the floor. `None` keeps the driver
+    /// formula. Needed when probe actions trip CALL-mode reactions, which
+    /// dispatch a function without seeding any session turn — no extra trace
+    /// tree ever forms.
+    pub traces_override: Option<usize>,
 }
 
 /// A function the PROBE (test infra, not a model turn) invokes at a completion
@@ -151,11 +165,16 @@ impl ScenarioFixture {
     /// finalize reseed enqueues from inside the finalizing step); Playground
     /// turns are each externally initiated and trace separately.
     pub fn expected_traces(&self) -> usize {
+        if let Some(traces) = self.traces_override {
+            return traces;
+        }
         match self.driver {
             // The send's own trace, plus one per probe action: a probe-tripped
-            // reaction fires from a fresh externally-initiated flow (the
+            // TASK reaction fires from a fresh externally-initiated flow (the
             // state/cron worker's fan-out), so it forms its own trace tree —
-            // exactly like a Playground-driven external turn.
+            // exactly like a Playground-driven external turn. Scenarios whose
+            // probe actions trip CALL reactions (no session turn, no trace)
+            // override via `traces_override`.
             ScenarioDriver::Direct => 1 + self.probe_actions.len(),
             ScenarioDriver::Playground => self.expected_terminal_turns,
         }

--- a/harness/tests/e2e/src/fixtures/loading.rs
+++ b/harness/tests/e2e/src/fixtures/loading.rs
@@ -94,6 +94,17 @@ impl ScenarioFixture {
                 "unknown terminal turn status {status:?}"
             );
         }
+        // Controlled-call waits depend on a controlled function existing:
+        // `Some(0)` would fail inside `wait_for_target_calls`, and a positive
+        // count with no `target` registered waits until the deadline burns.
+        // Both are authoring mistakes — fail them before the stack boots.
+        if let Some(calls) = self.await_target_calls {
+            anyhow::ensure!(calls > 0, "await_target_calls must be positive");
+            anyhow::ensure!(
+                self.scenario.target.is_some(),
+                "await_target_calls needs a controlled function (`.function(...)`) to count"
+            );
+        }
         anyhow::ensure!(
             self.expected_turn_statuses.last().map(String::as_str) == Some("completed"),
             "the last terminal turn must be completed"

--- a/harness/tests/e2e/src/fixtures/tests.rs
+++ b/harness/tests/e2e/src/fixtures/tests.rs
@@ -10,7 +10,7 @@ fn all_selection_returns_the_checked_in_fixtures() {
     assert_eq!(
         ids,
         std::collections::BTreeSet::from([
-            "E2E-001", "E2E-002", "E2E-003", "E2E-004", "E2E-005", "UI-001", "UI-002"
+            "E2E-001", "E2E-002", "E2E-003", "E2E-004", "E2E-005", "E2E-006", "UI-001", "UI-002"
         ])
     );
     assert_eq!(
@@ -18,7 +18,7 @@ fn all_selection_returns_the_checked_in_fixtures() {
             .iter()
             .filter(|fixture| fixture.driver == crate::scenarios::ScenarioDriver::Direct)
             .count(),
-        5
+        6
     );
 }
 

--- a/harness/tests/e2e/src/fixtures/tests.rs
+++ b/harness/tests/e2e/src/fixtures/tests.rs
@@ -10,7 +10,8 @@ fn all_selection_returns_the_checked_in_fixtures() {
     assert_eq!(
         ids,
         std::collections::BTreeSet::from([
-            "E2E-001", "E2E-002", "E2E-003", "E2E-004", "E2E-005", "E2E-006", "UI-001", "UI-002"
+            "E2E-001", "E2E-002", "E2E-003", "E2E-004", "E2E-005", "E2E-006", "E2E-007", "UI-001",
+            "UI-002"
         ])
     );
     assert_eq!(
@@ -18,7 +19,7 @@ fn all_selection_returns_the_checked_in_fixtures() {
             .iter()
             .filter(|fixture| fixture.driver == crate::scenarios::ScenarioDriver::Direct)
             .count(),
-        6
+        7
     );
 }
 

--- a/harness/tests/e2e/src/fixtures/tests.rs
+++ b/harness/tests/e2e/src/fixtures/tests.rs
@@ -10,7 +10,7 @@ fn all_selection_returns_the_checked_in_fixtures() {
     assert_eq!(
         ids,
         std::collections::BTreeSet::from([
-            "E2E-001", "E2E-002", "E2E-003", "E2E-004", "UI-001", "UI-002"
+            "E2E-001", "E2E-002", "E2E-003", "E2E-004", "E2E-005", "UI-001", "UI-002"
         ])
     );
     assert_eq!(
@@ -18,7 +18,7 @@ fn all_selection_returns_the_checked_in_fixtures() {
             .iter()
             .filter(|fixture| fixture.driver == crate::scenarios::ScenarioDriver::Direct)
             .count(),
-        4
+        5
     );
 }
 

--- a/harness/tests/e2e/src/probe.rs
+++ b/harness/tests/e2e/src/probe.rs
@@ -49,6 +49,13 @@ pub struct ScenarioProbe {
     trace_generation: Arc<AtomicU64>,
     trace_notify: Arc<tokio::sync::Notify>,
     bindings: Mutex<Vec<BoundTrigger>>,
+    /// Every invocation payload the controlled function served, in arrival
+    /// order. Probe-side WHOLE-RUN evidence: the serving process sees every
+    /// execution regardless of which session (or no session at all — e.g. a
+    /// call-mode reaction) dispatched it, where session-scoped trace
+    /// collection cannot.
+    target_calls: Arc<Mutex<Vec<Value>>>,
+    target_notify: Arc<tokio::sync::Notify>,
 }
 
 impl ScenarioProbe {
@@ -62,6 +69,8 @@ impl ScenarioProbe {
             trace_generation: Arc::new(AtomicU64::new(0)),
             trace_notify: Arc::new(tokio::sync::Notify::new()),
             bindings: Mutex::new(Vec::new()),
+            target_calls: Arc::new(Mutex::new(Vec::new())),
+            target_notify: Arc::new(tokio::sync::Notify::new()),
         };
         probe.register_sinks();
         Ok(probe)
@@ -154,8 +163,44 @@ impl ScenarioProbe {
             "integration/target_scope: {} must be prefixed by {prefix}",
             target.function_id
         );
-        register_controlled_function(self.client.inner(), target);
+        register_controlled_function(
+            self.client.inner(),
+            target,
+            Arc::clone(&self.target_calls),
+            Arc::clone(&self.target_notify),
+        );
         Ok(())
+    }
+
+    /// Snapshot of every controlled-function invocation payload so far
+    /// (engine fields stripped), in arrival order.
+    pub fn target_calls(&self) -> Vec<Value> {
+        self.target_calls
+            .lock()
+            .map(|calls| calls.clone())
+            .unwrap_or_default()
+    }
+
+    /// Wait until the controlled function has served at least `expected`
+    /// invocations. This is how a scenario awaits work that produces no
+    /// session turn — a call-mode reaction's dispatch, including the trailing
+    /// coalesced fire that lands only after the rate-cap window frees.
+    pub async fn wait_for_target_calls(
+        &self,
+        expected: usize,
+        deadline: Deadline,
+    ) -> anyhow::Result<Vec<Value>> {
+        anyhow::ensure!(expected > 0, "expected call count must be positive");
+        loop {
+            let notified = self.target_notify.notified();
+            let calls = self.target_calls();
+            if calls.len() >= expected {
+                return Ok(calls);
+            }
+            deadline
+                .timeout("controlled-function call count", notified)
+                .await?;
+        }
     }
 
     /// Bind every observer through acknowledged engine RPCs. Because these
@@ -430,13 +475,28 @@ fn parse_trace_payload(payload: &Value) -> Result<(), String> {
     }
 }
 
-fn register_controlled_function(iii: &iii_sdk::IIIClient, target: &ControlledTargetV1) {
+fn register_controlled_function(
+    iii: &iii_sdk::IIIClient,
+    target: &ControlledTargetV1,
+    calls: Arc<Mutex<Vec<Value>>>,
+    notify: Arc<tokio::sync::Notify>,
+) {
     let response = target.response.clone();
     iii.register_function(
         &target.function_id,
-        RegisterFunction::new_async(move |_payload: Value| {
+        RegisterFunction::new_async(move |mut payload: Value| {
             let response = response.clone();
-            async move { Ok::<Value, Error>(response) }
+            let calls = Arc::clone(&calls);
+            let notify = Arc::clone(&notify);
+            async move {
+                strip_engine_fields(&mut payload);
+                calls
+                    .lock()
+                    .map_err(|_| Error::Handler("integration/target_calls_lock_poisoned".into()))?
+                    .push(payload);
+                notify.notify_waiters();
+                Ok::<Value, Error>(response)
+            }
         })
         .description(target.description.clone())
         .request_format(Value::Object(target.request_schema.clone()))

--- a/harness/tests/e2e/src/scenario/floor.rs
+++ b/harness/tests/e2e/src/scenario/floor.rs
@@ -331,6 +331,7 @@ mod tests {
                 trace_id: "trace-turn-1".into(),
                 roots: vec![lifecycle_span("turn-1", completed_lifecycle("turn-1", 1))],
             }]),
+            target_calls: Vec::new(),
         }
     }
 

--- a/harness/tests/e2e/src/scenario/phases/arm.rs
+++ b/harness/tests/e2e/src/scenario/phases/arm.rs
@@ -31,7 +31,7 @@ impl ScenarioRunner<'_> {
             .map_err(|error| RunError::setup(phase, "bind scenario observers", error))?;
 
         stack
-            .spawn_harness(self.bins)
+            .spawn_harness(self.bins, &self.fixture.harness_env)
             .map_err(|error| RunError::setup(phase, "spawn harness under test", error))?;
 
         probe

--- a/harness/tests/e2e/src/scenario/phases/completion.rs
+++ b/harness/tests/e2e/src/scenario/phases/completion.rs
@@ -101,6 +101,34 @@ impl ScenarioRunner<'_> {
             }
         }
 
+        // Turn completions can't witness call-mode reaction dispatches (no
+        // turn is ever seeded), so a scenario that expects them declares a
+        // probe-side call count and the run holds here until the controlled
+        // function served that many — including a trailing coalesced fire
+        // that only lands after the rate-cap window frees.
+        if let Some(expected_calls) = self.fixture.await_target_calls {
+            if let Err(error) = services
+                .probe()
+                .wait_for_target_calls(expected_calls, deadline)
+                .await
+            {
+                if deadline.is_expired() {
+                    active.timed_out = true;
+                    tracing::error!(
+                        target: "harness_integration::scenario",
+                        "await timed out waiting for {expected_calls} controlled-function \
+                         call(s): {error:#}"
+                    );
+                    return Ok(());
+                }
+                return Err(RunError::runner(
+                    phase,
+                    "wait for controlled-function call count",
+                    error,
+                ));
+            }
+        }
+
         self.confirm_terminal_status(services, active).await
     }
 

--- a/harness/tests/e2e/src/scenario/phases/completion.rs
+++ b/harness/tests/e2e/src/scenario/phases/completion.rs
@@ -31,6 +31,37 @@ impl ScenarioRunner<'_> {
         // wait for all n and bind evidence to the latest, mirroring how
         // Playground awaits its externally driven turns.
         let expected = self.fixture.expected_terminal_turns;
+
+        // Probe-driven actions fire at completion boundaries: wait for their
+        // `after_turns` count, invoke the function, then continue. A reaction
+        // the action trips therefore runs while the tracked session is idle,
+        // so its turn is the only active one and the scripted (strict-ordinal)
+        // router matches it deterministically. Sorted so earlier boundaries
+        // fire first; `wait_for_completion_turns` accumulates, so re-waiting a
+        // higher count only blocks on the not-yet-seen turns.
+        if !self.fixture.probe_actions.is_empty() {
+            let mut actions = self.fixture.probe_actions.clone();
+            actions.sort_by_key(|a| a.after_turns);
+            for action in actions {
+                if let Err(error) = services
+                    .probe()
+                    .wait_for_completion_turns(action.after_turns, deadline)
+                    .await
+                {
+                    if deadline.is_expired() {
+                        active.timed_out = true;
+                        return Ok(());
+                    }
+                    return Err(RunError::runner(
+                        phase,
+                        "wait for probe-action completion boundary",
+                        error,
+                    ));
+                }
+                self.fire_probe_action(services, &action, deadline).await?;
+            }
+        }
+
         let latest_turn_id = if expected > 1 {
             services
                 .probe()
@@ -97,6 +128,36 @@ impl ScenarioRunner<'_> {
             active.turn_id = Some(observation.event.turn_id.clone());
         }
         self.confirm_terminal_status(services, active).await
+    }
+
+    /// Invoke a probe action, expanding `{{run_id}}`/`{{session_id}}` in its
+    /// payload first. A failed dispatch is a runner error — the scenario's
+    /// premise (the reaction it should trip) can't hold without it.
+    async fn fire_probe_action(
+        &self,
+        services: &RunServices,
+        action: &crate::fixtures::ProbeAction,
+        deadline: Deadline,
+    ) -> Result<(), RunError> {
+        let mut payload = action.payload.clone();
+        crate::expand::Placeholders::new(&self.run_id, &self.session_id)
+            .expand_value(&mut payload)
+            .map_err(|error| {
+                RunError::runner(RunPhase::Await, "expand probe-action payload", error)
+            })?;
+        services
+            .client()
+            .call_with_deadline(
+                &action.function_id,
+                payload,
+                deadline,
+                DEFAULT_CALL_TIMEOUT_MS,
+            )
+            .await
+            .map_err(|error| {
+                RunError::runner(RunPhase::Await, "fire probe action", anyhow::anyhow!(error))
+            })?;
+        Ok(())
     }
 
     async fn confirm_terminal_status(

--- a/harness/tests/e2e/src/scenario/phases/evidence.rs
+++ b/harness/tests/e2e/src/scenario/phases/evidence.rs
@@ -86,6 +86,7 @@ impl ScenarioRunner<'_> {
             generations_consumed: services.router().generations_consumed(),
             generations_total: services.router().total_generations(),
             traces: active.traces.clone(),
+            target_calls: services.probe().target_calls(),
         }
     }
 

--- a/harness/tests/e2e/src/scenarios/coalesced_fire.rs
+++ b/harness/tests/e2e/src/scenarios/coalesced_fire.rs
@@ -173,10 +173,14 @@ pub(super) fn scenario() -> ScenarioFixture {
             );
             let trailing_seq = seq_of(trailing)
                 .ok_or_else(|| anyhow::anyhow!("trailing fire has no seq: {trailing}"))?;
+            // NEWEST wins, exactly: the probe issues the burst sequentially
+            // (each state::set awaited), so the last capped arrival is seq
+            // BURST — a first-parked implementation would surface an earlier
+            // capped seq here and must fail.
             anyhow::ensure!(
-                (1..=BURST as u64).contains(&trailing_seq) && !seen.contains(&trailing_seq),
-                "the trailing event must be one of the CAPPED fires (newest wins), got seq \
-                 {trailing_seq} vs delivered {seen:?}"
+                trailing_seq == BURST as u64,
+                "the trailing event must be the NEWEST capped fire (seq {BURST}), got seq \
+                 {trailing_seq}; delivered {seen:?}"
             );
             // 4 of 5 seqs observed: exactly one capped fire was collapsed
             // into its newer sibling — the coalescing contract.

--- a/harness/tests/e2e/src/scenarios/coalesced_fire.rs
+++ b/harness/tests/e2e/src/scenarios/coalesced_fire.rs
@@ -1,0 +1,210 @@
+//! E2E-007 — capped fires COALESCE: burst past the rate cap, observe exactly
+//! `cap + 1` reaction dispatches, the last stamped as the coalesced stand-in.
+//!
+//! This gates the MOT-4211 coalescing path end-to-end: a CALL-mode reaction
+//! bound to a state key is fired 5 times under a shrunken gate
+//! (`III_HARNESS_MAX_FIRES_PER_WINDOW=3`, `III_HARNESS_FIRE_WINDOW_MS=2000`
+//! — the env override exists for exactly this scenario). Three fires deliver
+//! immediately; the two capped ones park, newest-wins, and ONE trailing fire
+//! delivers after the window frees, stamped `__coalesced_fires: 2` with the
+//! self-describing recovery note. Without coalescing (pre-MOT-4211 drop
+//! semantics) the run times out waiting for the 4th dispatch.
+//!
+//! Two runner capabilities make this observable at all — call-mode reactions
+//! seed no turn and no session trace, so turn completions and session traces
+//! are both blind to them:
+//! * probe-side WHOLE-RUN call evidence (the probe serves the controlled
+//!   function, so it records every dispatch regardless of origin), and
+//! * `await_target_calls`, which holds the await phase until the trailing
+//!   fire lands.
+
+use serde_json::{json, Value};
+
+use super::dsl::{ControlledFunction, Generation, Message, Model, Request, Response, Scenario, Send};
+use super::ScenarioDriver;
+use crate::fixtures::ScenarioFixture;
+
+const REGISTER: &str = "engine::register_trigger";
+const SCOPE: &str = "e2e-007";
+const KEY: &str = "burst";
+const BURST: usize = 5;
+const CAP: usize = 3;
+
+pub(super) fn scenario() -> ScenarioFixture {
+    const ID: &str = "E2E-007";
+    const MESSAGE: &str = "Arm a call reaction on the burst key.";
+
+    let model = Model::scripted("fixture-model");
+    let record = ControlledFunction::new("{{run_id}}::record", "Record one event.")
+        .request_schema(json!({
+            "type": "object",
+            "additionalProperties": true,
+            "properties": { "event": { "type": "object" } }
+        }))
+        .returns_text("recorded");
+
+    // CALL mode: each fire dispatches the recorder directly (no model turn),
+    // with the state event injected at `/event`. `once: false` keeps the
+    // binding standing for the whole burst.
+    let register_args = json!({
+        "trigger_type": "state",
+        "config": { "scope": SCOPE, "key": KEY },
+        "function_id": "harness::react",
+        "once": false,
+        "metadata": { "call": { "function_id": "{{run_id}}::record" } }
+    });
+
+    let mut scenario = Scenario::new(
+        ID,
+        "coalesced-fire",
+        "Burst past the fire-rate cap; capped fires coalesce into one stamped trailing dispatch.",
+        ScenarioDriver::Direct,
+        model.clone(),
+    )
+    .send(
+        Send::message(MESSAGE)
+            .idempotency_key("{{run_id}}:e2e-007")
+            .allow_id(REGISTER)
+            .allow_function(&record),
+    )
+    // Shrink the gate so the trailing fire lands in ~2s instead of ~60s.
+    .harness_env("III_HARNESS_MAX_FIRES_PER_WINDOW", "3")
+    .harness_env("III_HARNESS_FIRE_WINDOW_MS", "2000")
+    // The burst + the trailing coalesced fire — cap + 1 dispatches total.
+    .await_target_calls(CAP + 1)
+    // Call reactions seed no turn: only Send's own trace tree exists.
+    .expect_traces(1)
+    .function(record.clone())
+    .generation(
+        Generation::new(1)
+            .expect(
+                Request::new()
+                    .turn_request()
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_exact([Message::user(MESSAGE)])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::function_call_raw(
+                "call-arm",
+                REGISTER,
+                register_args,
+                8,
+                4,
+            )),
+    )
+    .generation(
+        Generation::new(2)
+            .expect(
+                Request::new()
+                    .turn_request()
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_subset([
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant", "content": [
+                            { "type": "function_call", "id": "call-arm", "function_id": REGISTER }
+                        ] }),
+                        json!({ "role": "function_result", "function_call_id": "call-arm",
+                                "is_error": false }),
+                    ])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::text("armed", 10, 2)),
+    );
+    // The burst: 5 sequential writes to one key after the main turn is idle.
+    // Under cap=3 the gate admits three and parks the rest.
+    for seq in 1..=BURST {
+        scenario = scenario.probe_after(
+            1,
+            "state::set",
+            json!({ "scope": SCOPE, "key": KEY, "value": { "seq": seq } }),
+        );
+    }
+    scenario
+        .verify(|run| {
+            run.expect_assistant_texts(["armed"])?;
+            // cap + 1: the burst floods 5 fires, exactly 3 deliver plus ONE
+            // trailing coalesced stand-in. 5 dispatches would mean the cap
+            // never engaged; 3 would mean the capped tail was dropped
+            // (pre-MOT-4211 semantics).
+            run.expect_target_calls(CAP + 1)?;
+
+            let events: Vec<Value> = run
+                .target_calls
+                .iter()
+                .map(|call| call.get("event").cloned().unwrap_or(Value::Null))
+                .collect();
+            let seq_of = |event: &Value| {
+                event
+                    .get("new_value")
+                    .and_then(|value| value.get("seq"))
+                    .and_then(Value::as_u64)
+            };
+
+            let mut seen = std::collections::BTreeSet::new();
+            for (index, event) in events[..CAP].iter().enumerate() {
+                anyhow::ensure!(
+                    event.get("__coalesced_fires").is_none(),
+                    "delivered fire {index} must not carry a coalesced stamp: {event}"
+                );
+                let seq = seq_of(event)
+                    .ok_or_else(|| anyhow::anyhow!("delivered fire {index} has no seq: {event}"))?;
+                anyhow::ensure!(
+                    (1..=BURST as u64).contains(&seq) && seen.insert(seq),
+                    "delivered fires must carry distinct burst seqs, got {seq} in {seen:?}"
+                );
+            }
+
+            let trailing = &events[CAP];
+            anyhow::ensure!(
+                trailing.get("__coalesced_fires").and_then(Value::as_u64)
+                    == Some((BURST - CAP) as u64),
+                "trailing fire must be stamped __coalesced_fires={}: {trailing}",
+                BURST - CAP
+            );
+            let note = trailing
+                .get("__coalesced_note")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            anyhow::ensure!(
+                note.contains("NOT delivered") && note.contains("recompute"),
+                "coalesced note must self-describe the recovery contract: {note:?}"
+            );
+            let trailing_seq = seq_of(trailing)
+                .ok_or_else(|| anyhow::anyhow!("trailing fire has no seq: {trailing}"))?;
+            anyhow::ensure!(
+                (1..=BURST as u64).contains(&trailing_seq) && !seen.contains(&trailing_seq),
+                "the trailing event must be one of the CAPPED fires (newest wins), got seq \
+                 {trailing_seq} vs delivered {seen:?}"
+            );
+            // 4 of 5 seqs observed: exactly one capped fire was collapsed
+            // into its newer sibling — the coalescing contract.
+
+            run.expect_no_duplicate_messages()
+        })
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixture_declares_gate_env_burst_probes_and_call_await() {
+        let fixture = scenario();
+        fixture.validate().unwrap();
+        assert_eq!(fixture.expected_terminal_turns, 1);
+        assert_eq!(fixture.probe_actions.len(), BURST);
+        assert_eq!(fixture.await_target_calls, Some(CAP + 1));
+        // Call reactions leave no session trace: the override pins the floor
+        // to Send's own trace instead of the 1-per-probe-action formula.
+        assert_eq!(fixture.expected_traces(), 1);
+        assert!(fixture
+            .harness_env
+            .iter()
+            .any(|(k, v)| k == "III_HARNESS_MAX_FIRES_PER_WINDOW" && v == "3"));
+        assert!(fixture
+            .harness_env
+            .iter()
+            .any(|(k, v)| k == "III_HARNESS_FIRE_WINDOW_MS" && v == "2000"));
+    }
+}

--- a/harness/tests/e2e/src/scenarios/coalesced_fire.rs
+++ b/harness/tests/e2e/src/scenarios/coalesced_fire.rs
@@ -20,7 +20,9 @@
 
 use serde_json::{json, Value};
 
-use super::dsl::{ControlledFunction, Generation, Message, Model, Request, Response, Scenario, Send};
+use super::dsl::{
+    ControlledFunction, Generation, Message, Model, Request, Response, Scenario, Send,
+};
 use super::ScenarioDriver;
 use crate::fixtures::ScenarioFixture;
 

--- a/harness/tests/e2e/src/scenarios/dsl.rs
+++ b/harness/tests/e2e/src/scenarios/dsl.rs
@@ -56,6 +56,9 @@ pub(super) struct Scenario {
     expected_turn_statuses: Vec<String>,
     verify: Option<VerifyFn>,
     probe_actions: Vec<crate::fixtures::ProbeAction>,
+    harness_env: Vec<(String, String)>,
+    await_target_calls: Option<usize>,
+    traces_override: Option<usize>,
 }
 
 impl Scenario {
@@ -78,6 +81,9 @@ impl Scenario {
             expected_turn_statuses: vec!["completed".to_string()],
             verify: None,
             probe_actions: Vec::new(),
+            harness_env: Vec::new(),
+            await_target_calls: None,
+            traces_override: None,
         }
     }
 
@@ -110,6 +116,30 @@ impl Scenario {
             function_id: function_id.to_string(),
             payload,
         });
+        self
+    }
+
+    /// Extra environment for the harness process under test (integration
+    /// knobs like `III_HARNESS_FIRE_WINDOW_MS`).
+    pub(super) fn harness_env(mut self, key: &str, value: &str) -> Self {
+        self.harness_env.push((key.to_string(), value.to_string()));
+        self
+    }
+
+    /// After every terminal turn arrived, additionally await `count`
+    /// controlled-function invocations (probe-side, whole-run) before
+    /// collecting evidence. Required to observe call-mode reaction dispatches
+    /// — they seed no turn and no session trace.
+    pub(super) fn await_target_calls(mut self, count: usize) -> Self {
+        assert!(count > 0, "await_target_calls must be positive");
+        self.await_target_calls = Some(count);
+        self
+    }
+
+    /// Override the floor's session-trace count when the driver formula does
+    /// not apply (probe actions tripping call-mode reactions leave no trace).
+    pub(super) fn expect_traces(mut self, count: usize) -> Self {
+        self.traces_override = Some(count);
         self
     }
 
@@ -172,6 +202,9 @@ impl Scenario {
             system_prompt_template: system_prompt(&allowed_functions),
             verify: self.verify.expect("scenario verification is required"),
             probe_actions: self.probe_actions,
+            harness_env: self.harness_env,
+            await_target_calls: self.await_target_calls,
+            traces_override: self.traces_override,
         }
     }
 }

--- a/harness/tests/e2e/src/scenarios/dsl.rs
+++ b/harness/tests/e2e/src/scenarios/dsl.rs
@@ -55,6 +55,7 @@ pub(super) struct Scenario {
     generations: Vec<Generation>,
     expected_turn_statuses: Vec<String>,
     verify: Option<VerifyFn>,
+    probe_actions: Vec<crate::fixtures::ProbeAction>,
 }
 
 impl Scenario {
@@ -76,6 +77,7 @@ impl Scenario {
             generations: Vec::new(),
             expected_turn_statuses: vec!["completed".to_string()],
             verify: None,
+            probe_actions: Vec::new(),
         }
     }
 
@@ -91,6 +93,23 @@ impl Scenario {
 
     pub(super) fn generation(mut self, generation: Generation) -> Self {
         self.generations.push(generation);
+        self
+    }
+
+    /// Fire `function_id(payload)` from the probe once `after_turns` terminal
+    /// completions are observed — trips a reaction while the tracked session
+    /// is idle, so its turn runs alone and ordinal-clean.
+    pub(super) fn probe_after(
+        mut self,
+        after_turns: usize,
+        function_id: &str,
+        payload: serde_json::Value,
+    ) -> Self {
+        self.probe_actions.push(crate::fixtures::ProbeAction {
+            after_turns,
+            function_id: function_id.to_string(),
+            payload,
+        });
         self
     }
 
@@ -152,6 +171,7 @@ impl Scenario {
             },
             system_prompt_template: system_prompt(&allowed_functions),
             verify: self.verify.expect("scenario verification is required"),
+            probe_actions: self.probe_actions,
         }
     }
 }

--- a/harness/tests/e2e/src/scenarios/mod.rs
+++ b/harness/tests/e2e/src/scenarios/mod.rs
@@ -7,6 +7,7 @@ mod join_spec_mismatch;
 mod multi_turn_traces;
 mod reaction_policy_inheritance;
 mod reseed_parked_message;
+mod state_worker_sidecar;
 mod streamed_text;
 
 use crate::evidence_data::RunEvidence;
@@ -29,6 +30,7 @@ pub fn all() -> Vec<ScenarioFixture> {
         join_spec_mismatch::scenario(),
         multi_turn_traces::scenario(),
         reaction_policy_inheritance::scenario(),
+        state_worker_sidecar::scenario(),
         reseed_parked_message::scenario(),
         streamed_text::scenario(),
     ]
@@ -41,7 +43,7 @@ mod tests {
     #[test]
     fn every_fixture_is_unique_and_valid() {
         let fixtures = all();
-        assert_eq!(fixtures.len(), 7);
+        assert_eq!(fixtures.len(), 8);
         let mut slugs = std::collections::BTreeSet::new();
         let mut ids = std::collections::BTreeSet::new();
         for fixture in fixtures {

--- a/harness/tests/e2e/src/scenarios/mod.rs
+++ b/harness/tests/e2e/src/scenarios/mod.rs
@@ -5,6 +5,7 @@ mod dsl;
 mod exactly_once_function;
 mod join_spec_mismatch;
 mod multi_turn_traces;
+mod reaction_policy_inheritance;
 mod reseed_parked_message;
 mod streamed_text;
 
@@ -27,6 +28,7 @@ pub fn all() -> Vec<ScenarioFixture> {
         exactly_once_function::scenario(),
         join_spec_mismatch::scenario(),
         multi_turn_traces::scenario(),
+        reaction_policy_inheritance::scenario(),
         reseed_parked_message::scenario(),
         streamed_text::scenario(),
     ]
@@ -39,7 +41,7 @@ mod tests {
     #[test]
     fn every_fixture_is_unique_and_valid() {
         let fixtures = all();
-        assert_eq!(fixtures.len(), 6);
+        assert_eq!(fixtures.len(), 7);
         let mut slugs = std::collections::BTreeSet::new();
         let mut ids = std::collections::BTreeSet::new();
         for fixture in fixtures {

--- a/harness/tests/e2e/src/scenarios/mod.rs
+++ b/harness/tests/e2e/src/scenarios/mod.rs
@@ -1,5 +1,6 @@
 //! The checked-in integration fixtures.
 
+mod coalesced_fire;
 mod console_streamed_text;
 mod dsl;
 mod exactly_once_function;
@@ -25,6 +26,7 @@ pub enum ScenarioDriver {
 /// Every fixture, in stable slug order.
 pub fn all() -> Vec<ScenarioFixture> {
     vec![
+        coalesced_fire::scenario(),
         console_streamed_text::scenario(),
         exactly_once_function::scenario(),
         join_spec_mismatch::scenario(),
@@ -43,7 +45,7 @@ mod tests {
     #[test]
     fn every_fixture_is_unique_and_valid() {
         let fixtures = all();
-        assert_eq!(fixtures.len(), 8);
+        assert_eq!(fixtures.len(), 9);
         let mut slugs = std::collections::BTreeSet::new();
         let mut ids = std::collections::BTreeSet::new();
         for fixture in fixtures {

--- a/harness/tests/e2e/src/scenarios/reaction_policy_inheritance.rs
+++ b/harness/tests/e2e/src/scenarios/reaction_policy_inheritance.rs
@@ -1,0 +1,200 @@
+//! E2E-005 — a reaction registered with no `options` inherits the registering
+//! turn's dispatch policy.
+//!
+//! The rctest-k7m3 run-3 failure shape: an agent registers a wrap-up reaction
+//! (no `options.functions`) delivered back into its own session; the reaction
+//! turn used to spawn parentless onto the read-only baseline and was denied
+//! the very functions every earlier turn in that chat could call. With the
+//! registrant-policy stamp the reaction turn inherits the registering turn's
+//! policy, so its scripted call to the controlled function must now dispatch
+//! successfully — before the fix that call errors with "not permitted by this
+//! agent's dispatch policy" and the second terminal turn's history pins fail.
+//!
+//! The coalescing half of the same PR is pinned at the unit level
+//! (`fire_gate_coalesces_capped_fires_newest_wins`): its trailing fire lands
+//! when the 60s window frees, which cannot fit the e2e deadline.
+
+use serde_json::{json, Value};
+
+use super::dsl::{
+    ControlledFunction, Generation, Message, Model, Request, Response, Scenario, Send,
+};
+use super::ScenarioDriver;
+use crate::evidence_data::message_text;
+use crate::fixtures::ScenarioFixture;
+
+const REGISTER: &str = "engine::register_trigger";
+
+pub(super) fn scenario() -> ScenarioFixture {
+    const ID: &str = "E2E-005";
+    const MESSAGE: &str = "Arm the wrap-up reaction.";
+
+    let model = Model::scripted("fixture-model");
+    let record = ControlledFunction::new(
+        "{{run_id}}::record",
+        "Record one integration fixture value.",
+    )
+    .request_schema(json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": { "value": { "type": "string" } },
+        "required": ["value"]
+    }))
+    .returns_text("recorded");
+
+    Scenario::new(
+        ID,
+        "reaction-policy-inheritance",
+        "A reaction with no options inherits the registering turn's dispatch policy.",
+        ScenarioDriver::Direct,
+        model.clone(),
+    )
+    .send(
+        Send::message(MESSAGE)
+            .idempotency_key("{{run_id}}:e2e-005")
+            .allow_id(REGISTER)
+            .allow_function(&record),
+    )
+    // Turn 1 completes, the turn-completed binding fires, and the reaction
+    // seeds a SECOND terminal turn in the same session.
+    .terminal_turn_statuses(["completed", "completed"])
+    .generation(
+        Generation::new(1)
+            .expect(
+                Request::new()
+                    .turn_request()
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_exact([Message::user(MESSAGE)])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::function_call_raw(
+                "call-arm",
+                REGISTER,
+                json!({
+                    "trigger_type": "harness::turn-completed",
+                    "config": { "session_id": "{{session_id}}" },
+                    "function_id": "harness::react",
+                    "metadata": {
+                        // Deliberately NO `options`: the reaction must inherit
+                        // the registering turn's policy to call the recorder.
+                        "task": "The wrap-up fired. Call the recorder exactly once \
+                                 with value \"from-reaction\", then stop."
+                    }
+                }),
+                8,
+                4,
+            )),
+    )
+    .generation(
+        Generation::new(2)
+            .expect(
+                Request::new()
+                    .turn_request()
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_subset([
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant", "content": [
+                            { "type": "function_call", "id": "call-arm", "function_id": REGISTER }
+                        ] }),
+                        json!({ "role": "function_result", "function_call_id": "call-arm",
+                                "is_error": false }),
+                    ])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::text("armed", 10, 2)),
+    )
+    // The reaction turn (new turn, steps restart at 0). Its tools carry the
+    // controlled function ONLY because the policy was inherited — the
+    // read-only baseline exposes no worker functions at all.
+    .generation(
+        Generation::new(3)
+            .expect(
+                Request::new()
+                    .turn_request_step(0)
+                    // Reaction turns run the sub-agent prompt, not the default.
+                    .system_prompt_regex(".")
+                    .messages_subset([
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant" }),
+                        json!({ "role": "function_result", "function_call_id": "call-arm" }),
+                        json!({ "role": "assistant" }),
+                        // The reaction seed, fenced with the fired event.
+                        json!({ "role": "user" }),
+                    ])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::function_call(
+                "call-record",
+                &record,
+                json!({ "value": "from-reaction" }),
+                8,
+                4,
+            )),
+    )
+    .generation(
+        Generation::new(4)
+            .expect(
+                Request::new()
+                    .turn_request_step(1)
+                    .system_prompt_regex(".")
+                    .messages_subset([
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant" }),
+                        json!({ "role": "function_result" }),
+                        json!({ "role": "assistant" }),
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant", "content": [
+                            { "type": "function_call", "id": "call-record" }
+                        ] }),
+                        // The dispatch the whole scenario gates on: succeeds
+                        // only under the inherited policy.
+                        json!({ "role": "function_result", "function_call_id": "call-record",
+                                "is_error": false }),
+                    ])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::text("reaction recorded", 12, 3)),
+    )
+    .function(record.clone())
+    .verify(|run| {
+        run.expect_assistant_texts(["armed", "reaction recorded"])?;
+        run.expect_function_calls("record", 1)?;
+        run.expect_call_payload("record", json!({ "value": "from-reaction" }))?;
+
+        let regs = run.function_results(REGISTER);
+        anyhow::ensure!(
+            regs.len() == 1 && regs[0].get("is_error").and_then(Value::as_bool) == Some(false),
+            "the reaction registration must succeed: {regs:?}"
+        );
+
+        // The core claim: nothing in the whole run was policy-denied. Before
+        // the registrant-policy stamp, the reaction turn's recorder call died
+        // here with "not permitted by this agent's dispatch policy".
+        for item in &run.transcript {
+            let msg = item.get("message").cloned().unwrap_or(Value::Null);
+            if msg.get("role").and_then(Value::as_str) == Some("function_result") {
+                let text = message_text(&msg);
+                anyhow::ensure!(
+                    !text.contains("not permitted"),
+                    "a dispatch was policy-denied — the reaction did not inherit \
+                     the registrant's policy: {text}"
+                );
+            }
+        }
+
+        run.expect_no_duplicate_messages()
+    })
+    .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixture_is_valid_and_expects_two_terminal_turns() {
+        let fixture = scenario();
+        fixture.validate().unwrap();
+        assert_eq!(fixture.expected_terminal_turns, 2);
+    }
+}

--- a/harness/tests/e2e/src/scenarios/state_worker_sidecar.rs
+++ b/harness/tests/e2e/src/scenarios/state_worker_sidecar.rs
@@ -1,0 +1,193 @@
+//! E2E-006 — a reaction bound to a `state` key fires through the standalone
+//! state worker, carrying the registration-metadata sidecar.
+//!
+//! This is the cross-worker seam every rctest run turned on (MOT-4209): the
+//! state worker's fan-out must invoke `harness::react` WITH the binding's
+//! metadata, or the reaction silently no-ops. This run's stack includes the
+//! real `state` worker (see `stack/config.rs`); the engine builtin is
+//! disabled, so the standalone worker owns the `state` trigger type exactly
+//! as in production.
+//!
+//! Determinism comes from the probe hook: the main turn only REGISTERS the
+//! state-key reaction and completes. The PROBE then writes the key (after the
+//! first terminal turn), so the reaction fires while the session is idle — its
+//! turn is the only one active and the scripted, strict-ordinal router matches
+//! it cleanly. The reaction's recorder call is the proof the sidecar arrived;
+//! drop it and no second turn is ever seeded and the run times out.
+
+use serde_json::{json, Value};
+
+use super::dsl::{
+    ControlledFunction, Generation, Message, Model, Request, Response, Scenario, Send,
+};
+use super::ScenarioDriver;
+use crate::fixtures::ScenarioFixture;
+
+const REGISTER: &str = "engine::register_trigger";
+const SCOPE: &str = "e2e-006";
+const KEY: &str = "go";
+
+pub(super) fn scenario() -> ScenarioFixture {
+    const ID: &str = "E2E-006";
+    const MESSAGE: &str = "Arm a state-key reaction.";
+
+    let model = Model::scripted("fixture-model");
+    let record = ControlledFunction::new("{{run_id}}::record", "Record one value.")
+        .request_schema(json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": { "value": { "type": "string" } },
+            "required": ["value"]
+        }))
+        .returns_text("recorded");
+
+    // No `options`: the reaction inherits the registering turn's policy
+    // (MOT-4212), which allows the recorder.
+    let register_args = json!({
+        "trigger_type": "state",
+        "config": { "scope": SCOPE, "key": KEY },
+        "function_id": "harness::react",
+        "metadata": {
+            "task": "The state key changed. Call the recorder exactly once with \
+                     value \"from-state-reaction\", then stop."
+        }
+    });
+
+    Scenario::new(
+        ID,
+        "state-worker-sidecar",
+        "A state-key reaction fires through the standalone state worker with its metadata sidecar.",
+        ScenarioDriver::Direct,
+        model.clone(),
+    )
+    .send(
+        Send::message(MESSAGE)
+            .idempotency_key("{{run_id}}:e2e-006")
+            .allow_id(REGISTER)
+            .allow_function(&record),
+    )
+    // Main turn (1) + the state-fired reaction turn (2).
+    .terminal_turn_statuses(["completed", "completed"])
+    // The probe trips the key AFTER the main turn completes, so the reaction
+    // turn runs alone. `state::set` on the standalone worker fans out to the
+    // react binding — the seam under test.
+    .probe_after(
+        1,
+        "state::set",
+        json!({ "scope": SCOPE, "key": KEY, "value": { "seq": 1 } }),
+    )
+    .function(record.clone())
+    .generation(
+        Generation::new(1)
+            .expect(
+                Request::new()
+                    .turn_request()
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_exact([Message::user(MESSAGE)])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::function_call_raw(
+                "call-arm",
+                REGISTER,
+                register_args,
+                8,
+                4,
+            )),
+    )
+    .generation(
+        Generation::new(2)
+            .expect(
+                Request::new()
+                    .turn_request()
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_subset([
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant", "content": [
+                            { "type": "function_call", "id": "call-arm", "function_id": REGISTER }
+                        ] }),
+                        json!({ "role": "function_result", "function_call_id": "call-arm",
+                                "is_error": false }),
+                    ])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::text("armed", 10, 2)),
+    )
+    // The reaction turn — seeded by the state worker's fire, running alone.
+    // Reaction turns run the sub-agent prompt, so match it by presence.
+    .generation(
+        Generation::new(3)
+            .expect(
+                Request::new()
+                    .turn_request_step(0)
+                    .system_prompt_regex(".")
+                    .messages_subset([json!({ "role": "user" })])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::function_call(
+                "call-record",
+                &record,
+                json!({ "value": "from-state-reaction" }),
+                8,
+                4,
+            )),
+    )
+    .generation(
+        Generation::new(4)
+            .expect(
+                Request::new()
+                    .turn_request_step(1)
+                    .system_prompt_regex(".")
+                    // The reaction runs in the registering session, so its
+                    // history begins with the original user message; the
+                    // strict-ordinal router + step already sequence gen3→gen4.
+                    // The recorder call itself is asserted in `verify`.
+                    .messages_subset([json!({ "role": "user" })])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::text("state reaction recorded", 12, 3)),
+    )
+    .verify(|run| {
+        // The second terminal turn exists ONLY if the state worker delivered
+        // the metadata sidecar so harness::react could resolve the task.
+        run.expect_assistant_texts(["armed", "state reaction recorded"])?;
+        run.expect_function_calls("record", 1)?;
+        run.expect_call_payload("record", json!({ "value": "from-state-reaction" }))?;
+
+        for item in &run.transcript {
+            let msg = item.get("message").cloned().unwrap_or(Value::Null);
+            if msg.get("role").and_then(Value::as_str) == Some("function_result") {
+                let text: String = msg
+                    .get("content")
+                    .and_then(Value::as_array)
+                    .map(|blocks| {
+                        blocks
+                            .iter()
+                            .filter_map(|b| b.get("text").and_then(Value::as_str))
+                            .collect::<Vec<_>>()
+                            .concat()
+                    })
+                    .unwrap_or_default();
+                anyhow::ensure!(
+                    !text.contains("not permitted"),
+                    "a dispatch was denied: {text}"
+                );
+            }
+        }
+        run.expect_no_duplicate_messages()
+    })
+    .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixture_is_valid_and_awaits_the_reaction_turn() {
+        let fixture = scenario();
+        fixture.validate().unwrap();
+        assert_eq!(fixture.expected_terminal_turns, 2);
+        assert_eq!(fixture.probe_actions.len(), 1);
+        assert_eq!(fixture.probe_actions[0].after_turns, 1);
+    }
+}

--- a/harness/tests/e2e/src/stack/config.rs
+++ b/harness/tests/e2e/src/stack/config.rs
@@ -6,11 +6,16 @@ use super::RunLayout;
 
 /// Start order matters: the harness retries `queue::define` only briefly at
 /// boot, so queue precedes harness. The harness itself is spawned after Arm.
-pub const WORKER_START_ORDER: [&str; 4] = [
+pub const WORKER_START_ORDER: [&str; 5] = [
     "queue",
     "iii-directory",
     "session-manager",
     "context-manager",
+    // The standalone state worker (NOT the engine builtin): it owns the
+    // `state` trigger type in production, and its fan-out is the fire-time
+    // metadata-sidecar seam MOT-4209 broke on. E2E-006 drives a reaction
+    // through it; the builtin would mask exactly that path.
+    "state",
 ];
 
 /// No provider keys or developer secrets leak into the subject stack.
@@ -30,7 +35,8 @@ workers:
         name: fs
         config:
           directory: {config_dir}
-  - name: iii-state
+  # iii-state deliberately absent: the standalone `state` worker owns the
+  # `state` trigger type (its boot guard refuses to start beside the builtin).
   - name: iii-stream
   - name: iii-cron
   - name: iii-observability

--- a/harness/tests/e2e/src/stack/supervisor.rs
+++ b/harness/tests/e2e/src/stack/supervisor.rs
@@ -127,9 +127,14 @@ impl Stack {
     }
 
     /// Spawn the harness after Arm so its first registry snapshot includes
-    /// the run-scoped target.
-    pub fn spawn_harness(&mut self, bins: &StackBins) -> anyhow::Result<()> {
-        self.spawn_worker("harness", &bins.harness)
+    /// the run-scoped target. `extra_env` carries fixture-declared knobs
+    /// (e.g. a shrunken fire-rate window) into the process under test.
+    pub fn spawn_harness(
+        &mut self,
+        bins: &StackBins,
+        extra_env: &[(String, String)],
+    ) -> anyhow::Result<()> {
+        self.spawn_worker_with_env("harness", &bins.harness, extra_env)
     }
 
     /// Spawn the production Console on a run-scoped loopback port.
@@ -147,13 +152,22 @@ impl Stack {
     }
 
     fn spawn_worker(&mut self, worker: &str, bin: &Path) -> anyhow::Result<()> {
+        self.spawn_worker_with_env(worker, bin, &[])
+    }
+
+    fn spawn_worker_with_env(
+        &mut self,
+        worker: &str,
+        bin: &Path,
+        extra_env: &[(String, String)],
+    ) -> anyhow::Result<()> {
         let paths = self.paths.clone();
         let mut args = vec!["--url".to_string(), self.ws_url.clone()];
         if let Some(seed_path) = write_seed(worker, &paths)? {
             args.push("--config".to_string());
             args.push(seed_path.to_string_lossy().into_owned());
         }
-        self.spawn_child(worker, bin, &args, &paths.root)
+        self.spawn_child_with_env(worker, bin, &args, &paths.root, extra_env)
     }
 
     #[doc(hidden)]
@@ -184,25 +198,28 @@ impl Stack {
         args: &[String],
         cwd: &Path,
     ) -> anyhow::Result<()> {
-        self.spawn_child_logged(name, name, bin, args, cwd)
+        self.spawn_child_with_env(name, bin, args, cwd, &[])
     }
 
-    fn spawn_child_logged(
+    fn spawn_child_with_env(
         &mut self,
         name: &str,
-        log_name: &str,
         bin: &Path,
         args: &[String],
         cwd: &Path,
+        extra_env: &[(String, String)],
     ) -> anyhow::Result<()> {
-        let stdout_log = self.paths.log_path(log_name, "out")?;
-        let stderr_log = self.paths.log_path(log_name, "err")?;
+        let stdout_log = self.paths.log_path(name, "out")?;
+        let stderr_log = self.paths.log_path(name, "err")?;
         let mut spec =
             ProcessSpec::new(name, bin, cwd, stdout_log, stderr_log).args(args.iter().cloned());
         for key in ENV_ALLOWLIST {
             if let Ok(value) = std::env::var(key) {
                 spec = spec.env(key, value);
             }
+        }
+        for (key, value) in extra_env {
+            spec = spec.env(key, value);
         }
         self.processes.spawn(spec).map(|_| ())
     }

--- a/harness/tests/e2e/tests/determinism.rs
+++ b/harness/tests/e2e/tests/determinism.rs
@@ -96,6 +96,7 @@ fn evidence(run_id: &str, session_id: &str, turn_id: &str) -> RunEvidence {
                 ),
             ],
         }]),
+        target_calls: Vec::new(),
     }
 }
 


### PR DESCRIPTION
## What

Follow-up to the rctest-k7m3 postmortem (the wall of `reaction failed — fire-rate cap (10 per 60000ms) reached for this subscription; not spawning`). Two changes:

### 1. Capped fires coalesce instead of dropping

The fire-rate breaker (loop breaker #3, 10/60s per subscription) silently discarded capped fires. For recompute-style reactions that's the worst choice: a burst's **tail** is exactly what gets capped, so aggregates freeze one step behind the source of truth. Observed live: 15 orders in ~30s → 17 dropped reactions → totals stuck at 4/3/3 vs truth 5/5/5, never reconciled.

Now a capped fire **parks** in the gate slot (newest event wins, drops accumulate) and one trailing task per key re-enters `harness::react` when the window frees, delivering the latest event stamped with `__coalesced_fires: N`. The reaction outcome records `waiting` ("coalescing — the latest event fires once the window frees (N collapsed so far)") instead of `failed`.

**The loop-breaker property is preserved by construction**: at most one pending event and one trailing task per key, so a true runaway costs at most `MAX_FIRES_PER_WINDOW + 1` reactions per window. If the window is still hot when the trailing fire lands, it parks again and a fresh cycle takes over.

Known edge (accepted): a binding unregistered while holding a parked fire still delivers that one trailing reaction — consistent with the at-least-once delivery posture.

### 2. Registration advisory for key-less `state` bindings

The same run registered BOTH a keyed and a key-less state binding on one scope; the key-less one fires for EVERY key (done markers, completion signals, everything), doubling the budget burn. Registrations of `state` bindings without a `key` filter now return an advisory note (react and notify paths) naming the scope and the cost — same posture as the existing standing-binding / join-wiring advisories.

## Verification

- `cargo test`: **267 unit + 7 integration pass** — new tests pin the coalescing contract (newest-wins, single scheduler per drain cycle, drop-count reset, GC never evicts parked fires) and the advisory shape (scope-wide vs global vs keyed vs non-state)
- Full e2e suite: E2E-001…004 all pass against the pinned engine (~3.2s each)
- clippy/fmt clean

Replaying rctest-k7m3 against this: the 17 capped fires collapse into 2 trailing reactions (one per binding) that fire ~60s in with the final events — totals converge to 5/5/5 — and both registrations would have carried the catch-all warning telling the agent to key-filter the second binding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reaction fire-rate coalescing (newest-wins) with trailing dispatch support, burst drop reporting, and recovery notes.
  * Reaction-triggered spawns now inherit and safely narrow function permissions from the registration context.
  * Added E2E probe-driven actions and new scenarios: reaction-policy inheritance (E2E-005), state-worker sidecar (E2E-006), coalesced-fire (E2E-007).
* **Bug Fixes**
  * Subscription responses now include clearer advisory when state bindings omit a key filter.
* **Tests / Documentation**
  * Expanded harness probe/evidence tooling and updated E2E scenario documentation/fixtures/runner coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes MOT-4211
Fixes MOT-4212
Fixes MOT-4215