### PR TITLE
(MOT-4213) fix(cron): deliver registration metadata as the fire-time trigger sidecar

### DIFF
--- a/cron/src/boot.rs
+++ b/cron/src/boot.rs
@@ -61,17 +61,20 @@ impl Invoker for SdkInvoker {
         &self,
         function_id: &str,
         payload: serde_json::Value,
+        metadata: Option<serde_json::Value>,
     ) -> Result<Option<serde_json::Value>, String> {
-        self.iii
-            .trigger(TriggerRequest {
-                function_id: function_id.to_string(),
-                payload,
-                action: None,
-                timeout_ms: None,
-            })
-            .await
-            .map(Some)
-            .map_err(|e| e.to_string())
+        let request = TriggerRequest {
+            function_id: function_id.to_string(),
+            payload,
+            action: None,
+            timeout_ms: None,
+        };
+        match metadata {
+            Some(m) => self.iii.trigger(request.metadata(m)).await,
+            None => self.iii.trigger(request).await,
+        }
+        .map(Some)
+        .map_err(|e| e.to_string())
     }
 }
 

--- a/cron/src/scheduler.rs
+++ b/cron/src/scheduler.rs
@@ -14,12 +14,18 @@ use tokio::task::JoinHandle;
 
 use crate::locks::CronLock;
 
+/// `metadata` is the binding's registration metadata, delivered as the
+/// fire-time sidecar (engine `fire_triggers` parity). Handlers like
+/// `harness::react` / `harness::notify_agent` resolve which reaction or
+/// subscription fired from it and silently no-op without it — a plain call
+/// here kills every cron-triggered harness reaction and wake-up.
 #[async_trait]
 pub trait Invoker: Send + Sync + 'static {
     async fn call(
         &self,
         function_id: &str,
         payload: serde_json::Value,
+        metadata: Option<serde_json::Value>,
     ) -> Result<Option<serde_json::Value>, String>;
 }
 
@@ -29,6 +35,8 @@ pub struct JobSpec {
     pub expression: String,
     pub function_id: String,
     pub condition_function_id: Option<String>,
+    /// Registration metadata, replayed as the fire-time sidecar.
+    pub metadata: Option<serde_json::Value>,
 }
 
 struct JobEntry {
@@ -131,7 +139,9 @@ fn spawn_job(
             });
 
             if let Some(cond) = &spec.condition_function_id {
-                match invoker.call(cond, payload.clone()).await {
+                // Conditions are plain function calls, not trigger fires — no
+                // sidecar.
+                match invoker.call(cond, payload.clone(), None).await {
                     Ok(Some(v)) if v.as_bool() == Some(false) => {
                         lock.release(&spec.trigger_id).await;
                         continue;
@@ -145,7 +155,10 @@ fn spawn_job(
                 }
             }
 
-            if let Err(e) = invoker.call(&spec.function_id, payload).await {
+            if let Err(e) = invoker
+                .call(&spec.function_id, payload, spec.metadata.clone())
+                .await
+            {
                 tracing::error!(trigger_id = %spec.trigger_id, function_id = %spec.function_id, error = %e, "cron fire failed");
             }
             lock.release(&spec.trigger_id).await;
@@ -158,9 +171,11 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    #[derive(Default)]
     struct CountingInvoker {
         calls: AtomicUsize,
         last_payload: Mutex<Option<serde_json::Value>>,
+        last_metadata: Mutex<Option<serde_json::Value>>,
         condition_result: Option<serde_json::Value>,
     }
 
@@ -170,12 +185,14 @@ mod tests {
             &self,
             function_id: &str,
             payload: serde_json::Value,
+            metadata: Option<serde_json::Value>,
         ) -> Result<Option<serde_json::Value>, String> {
             if function_id.starts_with("cond::") {
                 return Ok(self.condition_result.clone());
             }
             self.calls.fetch_add(1, Ordering::SeqCst);
             *self.last_payload.lock().await = Some(payload);
+            *self.last_metadata.lock().await = metadata;
             Ok(None)
         }
     }
@@ -193,6 +210,7 @@ mod tests {
         let inv = Arc::new(CountingInvoker {
             calls: AtomicUsize::new(0),
             last_payload: Mutex::new(None),
+            last_metadata: Mutex::new(None),
             condition_result: None,
         });
         let s = scheduler_with(inv);
@@ -202,6 +220,7 @@ mod tests {
                 expression: "".into(),
                 function_id: "f".into(),
                 condition_function_id: None,
+                metadata: None,
             })
             .await
             .unwrap_err();
@@ -213,6 +232,7 @@ mod tests {
         let inv = Arc::new(CountingInvoker {
             calls: AtomicUsize::new(0),
             last_payload: Mutex::new(None),
+            last_metadata: Mutex::new(None),
             condition_result: None,
         });
         let s = scheduler_with(inv);
@@ -221,6 +241,7 @@ mod tests {
             expression: every_second().into(),
             function_id: "f".into(),
             condition_function_id: None,
+            metadata: None,
         })
         .await
         .unwrap();
@@ -230,6 +251,7 @@ mod tests {
                 expression: every_second().into(),
                 function_id: "f".into(),
                 condition_function_id: None,
+                metadata: None,
             })
             .await
             .unwrap_err();
@@ -242,6 +264,7 @@ mod tests {
         let inv = Arc::new(CountingInvoker {
             calls: AtomicUsize::new(0),
             last_payload: Mutex::new(None),
+            last_metadata: Mutex::new(None),
             condition_result: None,
         });
         let s = scheduler_with(inv.clone());
@@ -250,6 +273,7 @@ mod tests {
             expression: every_second().into(),
             function_id: "backend".into(),
             condition_function_id: None,
+            metadata: None,
         })
         .await
         .unwrap();
@@ -268,11 +292,41 @@ mod tests {
         s.shutdown().await;
     }
 
+    /// The rctest-k7m3 run-4 failure: the deadline cron fired but the plain
+    /// invocation dropped the registration metadata, so harness::notify_agent
+    /// could not resolve the subscription and the waiting session never woke.
+    #[tokio::test]
+    async fn fire_delivers_registration_metadata_sidecar() {
+        let inv = Arc::new(CountingInvoker::default());
+        let s = scheduler_with(inv.clone());
+        s.register(JobSpec {
+            trigger_id: "t1".into(),
+            expression: every_second().into(),
+            function_id: "backend".into(),
+            condition_function_id: None,
+            metadata: Some(serde_json::json!({"subscription_id": "sub_1", "once": true})),
+        })
+        .await
+        .unwrap();
+        for _ in 0..25 {
+            if inv.calls.load(Ordering::SeqCst) >= 1 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        assert!(inv.calls.load(Ordering::SeqCst) >= 1, "job never fired");
+        let metadata = inv.last_metadata.lock().await.clone();
+        let m = metadata.expect("registration metadata must be delivered at fire time");
+        assert_eq!(m["subscription_id"], "sub_1");
+        s.shutdown().await;
+    }
+
     #[tokio::test]
     async fn condition_false_blocks_fire() {
         let inv = Arc::new(CountingInvoker {
             calls: AtomicUsize::new(0),
             last_payload: Mutex::new(None),
+            last_metadata: Mutex::new(None),
             condition_result: Some(serde_json::json!(false)),
         });
         let s = scheduler_with(inv.clone());
@@ -281,6 +335,7 @@ mod tests {
             expression: every_second().into(),
             function_id: "backend".into(),
             condition_function_id: Some("cond::c".into()),
+            metadata: None,
         })
         .await
         .unwrap();
@@ -298,6 +353,7 @@ mod tests {
         let inv = Arc::new(CountingInvoker {
             calls: AtomicUsize::new(0),
             last_payload: Mutex::new(None),
+            last_metadata: Mutex::new(None),
             condition_result: None,
         });
         let s = scheduler_with(inv.clone());
@@ -306,6 +362,7 @@ mod tests {
             expression: every_second().into(),
             function_id: "backend".into(),
             condition_function_id: None,
+            metadata: None,
         })
         .await
         .unwrap();

--- a/cron/src/trigger.rs
+++ b/cron/src/trigger.rs
@@ -47,6 +47,7 @@ impl TriggerHandler for CronTriggerHandler {
                 expression: spec.expression,
                 function_id: config.function_id,
                 condition_function_id: spec.condition_function_id,
+                metadata: config.metadata,
             })
             .await
             .map_err(|e| Error::Handler(e.to_string()))
@@ -78,6 +79,7 @@ mod tests {
             &self,
             _function_id: &str,
             _payload: serde_json::Value,
+            _metadata: Option<serde_json::Value>,
         ) -> Result<Option<serde_json::Value>, String> {
             self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok(None)
@@ -117,6 +119,20 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(h.scheduler.read().await.job_specs().await.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn register_retains_metadata_for_fire_time_sidecar() {
+        let h = handler();
+        let mut cfg = trigger_config("t1", serde_json::json!({"expression": "0 0 * * * *"}));
+        cfg.metadata = Some(serde_json::json!({"task": "wake me", "session_id": "s1"}));
+        h.register_trigger(cfg).await.unwrap();
+        let specs = h.scheduler.read().await.job_specs().await;
+        assert_eq!(
+            specs[0].metadata.as_ref().unwrap()["task"],
+            "wake me",
+            "metadata must survive registration — it is the fire-time sidecar"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Same bug class as the state worker fix (#581 / MOT-4209), observed live in rctest-k7m3 run 4: the 2-minute deadline cron **fired**, but the scheduler invoked the bound function as a plain call — no metadata sidecar — so `harness::notify_agent` couldn't resolve the subscription and silently no-opped. The waiting console session never woke. Registration also dropped `TriggerConfig.metadata` outright (`JobSpec` had no field for it).

## Fix (the state recipe)

- `scheduler.rs` — `JobSpec` retains the registration metadata; the fire path delivers it via `TriggerRequest::metadata(...)`; the `Invoker` trait carries it. Condition checks stay plain calls (function calls, not trigger fires).
- `trigger.rs` — `register_trigger` passes `config.metadata` through instead of discarding it.

## Verification

- `cargo test`: 24 unit + 1 integration pass, incl. two new regression tests: `register_retains_metadata_for_fire_time_sidecar` and `fire_delivers_registration_metadata_sidecar` (the run-4 failure shape, doc-commented)
- clippy/fmt clean

## Fleet audit (context)

A sweep of all 16 trigger-type-owning workers found this is systemic — the "port of the builtin" pattern replicated the dropped-sidecar bug everywhere. Only `state` (fixed) delivers the sidecar; **12 more workers are broken** the same way: approval-gate, browser, email, http, iii-directory, llm-router, memory, pubsub, queue, session-manager, storage, worktree (console UI-asset triggers and the stubbed database row-change are N/A). `iii-directory` and `llm-router` already retain metadata and only need the fire-path half; `pubsub`/`queue` need adapter-trait plumbing. Tracked separately — this PR fixes cron, the one confirmed live-broken in the rctest runs.

No version bump / changelog per repo convention.