### PR TITLE
(MOT-4216) fix(database): resolve omitted `db` to the sole/primary pool

### DIFF
--- a/database/src/error.rs
+++ b/database/src/error.rs
@@ -29,6 +29,10 @@ pub enum DbError {
     #[error("unknown db {db}; available: [{}]", available.join(", "))]
     UnknownDb { db: String, available: Vec<String> },
 
+    #[serde(rename = "MISSING_DB")]
+    #[error("no `db` specified and none of the configured databases is an unambiguous default; available: [{}]", available.join(", "))]
+    MissingDb { available: Vec<String> },
+
     #[serde(rename = "INVALID_PARAM")]
     #[error("invalid parameter at index {index}: {reason}")]
     InvalidParam { index: usize, reason: String },
@@ -102,6 +106,20 @@ mod tests {
         assert_eq!(
             e.to_string(),
             "unknown db missing; available: [analytics, primary]"
+        );
+    }
+
+    #[test]
+    fn missing_db_serializes_with_stable_code_and_available_handles() {
+        let e = DbError::MissingDb {
+            available: vec!["analytics".into(), "main".into()],
+        };
+        let v: serde_json::Value = serde_json::to_value(&e).unwrap();
+        assert_eq!(v["code"], "MISSING_DB");
+        assert_eq!(v["available"], serde_json::json!(["analytics", "main"]));
+        assert_eq!(
+            e.to_string(),
+            "no `db` specified and none of the configured databases is an unambiguous default; available: [analytics, main]"
         );
     }
 

--- a/database/src/handlers/begin_transaction.rs
+++ b/database/src/handlers/begin_transaction.rs
@@ -19,7 +19,10 @@ use std::time::Duration;
 
 #[derive(Deserialize, JsonSchema)]
 pub struct BeginTxReq {
-    pub db: String,
+    /// Logical database name. Optional — omitting it targets the sole
+    /// configured database, or `primary` when several are configured.
+    #[serde(default)]
+    pub db: Option<String>,
     #[serde(default)]
     pub isolation: Option<String>,
     #[serde(default)]
@@ -55,7 +58,8 @@ fn parse_isolation(s: Option<&str>) -> Result<Option<Isolation>, DbError> {
 }
 
 pub async fn handle(state: &AppState, req: BeginTxReq) -> Result<BeginTxResp, String> {
-    let pool = state.pool(&req.db).await.map_err(err_to_str)?;
+    let db = state.resolve_db(req.db).await.map_err(err_to_str)?;
+    let pool = state.pool(&db).await.map_err(err_to_str)?;
     let driver = pool.driver();
     let isolation = parse_isolation(req.isolation.as_deref()).map_err(err_to_str)?;
     let timeout_ms = req
@@ -84,7 +88,7 @@ pub async fn handle(state: &AppState, req: BeginTxReq) -> Result<BeginTxResp, St
             "db_tx_begin_failed",
             Some(json!({
                 "db.system": driver_system(driver),
-                "db.name": req.db,
+                "db.name": db,
                 "isolation": req.isolation,
                 "error": serde_json::to_value(&e).ok(),
             })),
@@ -94,14 +98,14 @@ pub async fn handle(state: &AppState, req: BeginTxReq) -> Result<BeginTxResp, St
 
     let handle = state
         .transactions
-        .insert(req.db.clone(), driver, pinned, timeout)
+        .insert(db.clone(), driver, pinned, timeout)
         .await;
 
     state.log.info(
         "db_tx_started",
         Some(json!({
             "db.system": driver_system(driver),
-            "db.name": req.db,
+            "db.name": db,
             "db.operation": "BEGIN",
             "db.transaction.id": handle.id,
             "isolation": req.isolation,

--- a/database/src/handlers/execute.rs
+++ b/database/src/handlers/execute.rs
@@ -11,7 +11,10 @@ use serde_json::Value;
 
 #[derive(Deserialize, JsonSchema)]
 pub struct ExecuteReq {
-    pub db: String,
+    /// Logical database name. Optional — omitting it targets the sole
+    /// configured database, or `primary` when several are configured.
+    #[serde(default)]
+    pub db: Option<String>,
     #[serde(alias = "query")]
     pub sql: String,
     #[serde(default, deserialize_with = "crate::handlers::lenient_params")]
@@ -28,7 +31,8 @@ pub struct ExecuteResp {
 }
 
 pub async fn handle(state: &AppState, req: ExecuteReq) -> Result<ExecuteResp, String> {
-    let pool = state.pool(&req.db).await.map_err(err_to_str)?;
+    let db = state.resolve_db(req.db).await.map_err(err_to_str)?;
+    let pool = state.pool(&db).await.map_err(err_to_str)?;
     // Reject empty SQL uniformly. See the matching guard in query.rs for why
     // this is at the handler boundary rather than per-driver: postgres' driver
     // accepts empty SQL as a no-op success, sqlite/mysql reject — guarding

--- a/database/src/handlers/execute.rs
+++ b/database/src/handlers/execute.rs
@@ -23,7 +23,7 @@ pub struct ExecuteReq {
     pub returning: Vec<String>,
 }
 
-#[derive(Serialize, JsonSchema)]
+#[derive(Debug, Serialize, JsonSchema)]
 pub struct ExecuteResp {
     pub affected_rows: u64,
     pub last_insert_id: Option<String>,
@@ -45,6 +45,7 @@ pub async fn handle(state: &AppState, req: ExecuteReq) -> Result<ExecuteResp, St
             failed_index: None,
         }));
     }
+    crate::handlers::reject_tx_control_sql(&req.sql).map_err(err_to_str)?;
     let params = JsonParam::from_json_slice(&req.params).map_err(err_to_str)?;
 
     let result = match &pool {
@@ -164,6 +165,23 @@ mod tests {
         assert!(properties.contains_key("sql"));
         assert!(!properties.contains_key("query"));
         assert_eq!(properties["params"]["type"], "array");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn execute_rejects_transaction_control_sql_with_pointer() {
+        // rctest5 postmortem: agents run execute("BEGIN") + execute("COMMIT")
+        // expecting a session — but each call draws a fresh pooled
+        // connection, and the leaked BEGIN poisoned the pool for every later
+        // caller. The guard must name the real transactional surfaces.
+        let st = state();
+        for sql in ["BEGIN", "commit;", "  ROLLBACK", "/* tx */ BEGIN IMMEDIATE"] {
+            let err = handle(&st, req(json!({"db":"primary","sql": sql})))
+                .await
+                .unwrap_err();
+            assert!(err.contains("INVALID_PARAM"), "{sql}: {err}");
+            assert!(err.contains("beginTransaction"), "{sql}: {err}");
+            assert!(err.contains("executeBatch"), "{sql}: {err}");
+        }
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/database/src/handlers/execute_batch.rs
+++ b/database/src/handlers/execute_batch.rs
@@ -13,7 +13,10 @@ use serde_json::Value;
 
 #[derive(Deserialize, JsonSchema)]
 pub struct ExecuteBatchReq {
-    pub db: String,
+    /// Logical database name. Optional — omitting it targets the sole
+    /// configured database, or `primary` when several are configured.
+    #[serde(default)]
+    pub db: Option<String>,
     /// Statements to run in order inside one transaction. Each entry is
     /// either a bare SQL string or `{ "sql": "...", "params": [...] }` —
     /// use `params` for dynamic values instead of inlining them into the SQL.

--- a/database/src/handlers/mod.rs
+++ b/database/src/handlers/mod.rs
@@ -58,6 +58,30 @@ pub struct AppState {
 }
 
 impl AppState {
+    /// Resolve an optional logical db name to a concrete pool key.
+    ///
+    /// `Some(name)` passes through untouched (unknown names still surface
+    /// `UNKNOWN_DB` from [`AppState::pool`]). `None` falls back to the sole
+    /// configured pool, then to `primary` when several exist; the omission is
+    /// only an error (`MISSING_DB`) when neither rule disambiguates. This
+    /// exists because LLM callers routinely omit `db` on their first call —
+    /// a hard serde failure there is a wasted round-trip on every session.
+    pub async fn resolve_db(&self, db: Option<String>) -> Result<String, DbError> {
+        if let Some(name) = db {
+            return Ok(name);
+        }
+        let pools = self.pools.read().await;
+        if pools.len() == 1 {
+            return Ok(pools.keys().next().expect("len checked above").clone());
+        }
+        if pools.contains_key(crate::config::DEFAULT_DB_NAME) {
+            return Ok(crate::config::DEFAULT_DB_NAME.to_string());
+        }
+        let mut available: Vec<String> = pools.keys().cloned().collect();
+        available.sort();
+        Err(DbError::MissingDb { available })
+    }
+
     pub async fn pool(&self, db: &str) -> Result<Pool, DbError> {
         let pools = self.pools.read().await;
         pools.get(db).cloned().ok_or_else(|| {

--- a/database/src/handlers/mod.rs
+++ b/database/src/handlers/mod.rs
@@ -45,6 +45,29 @@ mod tx_sql_guard;
 
 pub(crate) use query::rows_to_objects as query_rows_to_objects;
 
+/// Reject transaction-control SQL on the pooled per-call surfaces. Each call
+/// runs on whichever connection the pool hands out, so BEGIN/COMMIT can never
+/// pair up — worse, a BEGIN that "succeeds" returns its connection to the
+/// pool still inside an open transaction, and every later caller unlucky
+/// enough to draw it fails with `cannot start a transaction within a
+/// transaction` (rctest5 postmortem: three writer agents starved on one
+/// poisoned connection). Point the caller at the real transactional surfaces.
+pub(crate) fn reject_tx_control_sql(sql: &str) -> Result<(), DbError> {
+    if tx_sql_guard::is_transaction_control_sql(sql) {
+        return Err(DbError::InvalidParam {
+            index: 0,
+            reason: "transaction-control SQL (BEGIN/COMMIT/ROLLBACK/SAVEPOINT) is not valid \
+                     here: each call runs on its own pooled connection, so the statements \
+                     cannot pair up and a leaked BEGIN poisons the pool for every later \
+                     caller. Use database::beginTransaction + database::transactionExecute + \
+                     database::commitTransaction, or database::executeBatch for an atomic \
+                     batch."
+                .into(),
+        });
+    }
+    Ok(())
+}
+
 #[derive(Clone)]
 pub struct AppState {
     pub pools: Arc<RwLock<HashMap<String, Pool>>>,

--- a/database/src/handlers/prepare.rs
+++ b/database/src/handlers/prepare.rs
@@ -47,6 +47,9 @@ pub async fn handle(state: &AppState, req: PrepareReq) -> Result<PrepareResp, St
             failed_index: None,
         }));
     }
+    // A prepared BEGIN executed via runStatement opens a transaction on the
+    // pinned connection that outlives the handle — same pool poison.
+    crate::handlers::reject_tx_control_sql(&req.sql).map_err(err_to_str)?;
 
     let h = match pool {
         Pool::Sqlite(p) => {

--- a/database/src/handlers/prepare.rs
+++ b/database/src/handlers/prepare.rs
@@ -10,7 +10,10 @@ use std::time::Duration;
 
 #[derive(Deserialize, JsonSchema)]
 pub struct PrepareReq {
-    pub db: String,
+    /// Logical database name. Optional — omitting it targets the sole
+    /// configured database, or `primary` when several are configured.
+    #[serde(default)]
+    pub db: Option<String>,
     #[serde(alias = "query")]
     pub sql: String,
     #[serde(default = "default_ttl")]
@@ -30,7 +33,8 @@ const MAX_TTL_SECONDS: u64 = 86_400;
 
 pub async fn handle(state: &AppState, req: PrepareReq) -> Result<PrepareResp, String> {
     let ttl = Duration::from_secs(req.ttl_seconds.min(MAX_TTL_SECONDS));
-    let pool = state.pool(&req.db).await.map_err(err_to_str)?;
+    let db = state.resolve_db(req.db).await.map_err(err_to_str)?;
+    let pool = state.pool(&db).await.map_err(err_to_str)?;
     // Reject empty SQL at the handler boundary, mirroring query.rs / execute.rs.
     // Without this, prepareStatement happily acquires a pool connection and
     // pins it under a UUID handle that can never run successfully — the

--- a/database/src/handlers/query.rs
+++ b/database/src/handlers/query.rs
@@ -214,7 +214,9 @@ mod tests {
             let extra = SqlitePool::new("sqlite::memory:", &PoolConfig::default()).unwrap();
             pools.insert("analytics".to_string(), Pool::Sqlite(extra));
         }
-        let err = handle(&st, req(json!({"sql":"SELECT 1"}))).await.unwrap_err();
+        let err = handle(&st, req(json!({"sql":"SELECT 1"})))
+            .await
+            .unwrap_err();
         assert!(err.contains("MISSING_DB"), "got: {err}");
         assert!(
             err.contains("\"available\":[\"analytics\",\"main\"]"),

--- a/database/src/handlers/query.rs
+++ b/database/src/handlers/query.rs
@@ -50,6 +50,9 @@ pub async fn handle(state: &AppState, req: QueryReq) -> Result<QueryResp, String
             failed_index: None,
         }));
     }
+    // A `query("BEGIN")` is just as pool-poisoning as an execute — sqlite
+    // happily starts the transaction and returns zero rows.
+    crate::handlers::reject_tx_control_sql(&req.sql).map_err(err_to_str)?;
     let params = JsonParam::from_json_slice(&req.params).map_err(err_to_str)?;
 
     let result = match &pool {
@@ -161,6 +164,18 @@ mod tests {
         // The error must enumerate the registered handles so a caller that
         // guessed a wrong name can self-correct from one failure.
         assert!(err.contains("\"available\":[\"primary\"]"), "got: {err}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn query_rejects_transaction_control_sql() {
+        // sqlite happily starts a transaction from a query("BEGIN") and
+        // returns zero rows — the same pool poison as the execute path.
+        let st = state();
+        let err = handle(&st, req(json!({"db":"primary","sql":"BEGIN"})))
+            .await
+            .unwrap_err();
+        assert!(err.contains("INVALID_PARAM"), "got: {err}");
+        assert!(err.contains("beginTransaction"), "got: {err}");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/database/src/handlers/query.rs
+++ b/database/src/handlers/query.rs
@@ -11,7 +11,10 @@ use serde_json::Value;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct QueryReq {
-    pub db: String,
+    /// Logical database name. Optional — omitting it targets the sole
+    /// configured database, or `primary` when several are configured.
+    #[serde(default)]
+    pub db: Option<String>,
     #[serde(alias = "query")]
     pub sql: String,
     #[serde(default, deserialize_with = "crate::handlers::lenient_params")]
@@ -33,7 +36,8 @@ fn default_timeout() -> u64 {
 
 /// Returns a JSON string body suitable to wrap in IIIError on failure.
 pub async fn handle(state: &AppState, req: QueryReq) -> Result<QueryResp, String> {
-    let pool = state.pool(&req.db).await.map_err(err_to_str)?;
+    let db = state.resolve_db(req.db).await.map_err(err_to_str)?;
+    let pool = state.pool(&db).await.map_err(err_to_str)?;
     // Reject empty SQL uniformly. Postgres' tokio-postgres treats `client.query("")`
     // as a valid no-op and returns Ok([]), but sqlite (rusqlite) and mysql
     // (mysql_async) reject it at parse time — without this guard the worker's
@@ -160,14 +164,57 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn query_missing_db_field_errors() {
-        // Deserialization moved into the SDK once we switched to typed
-        // RegisterFunction::new_async — at the handler boundary the input is
-        // already a QueryReq. This test keeps the missing-field contract by
-        // exercising the deserialization step explicitly.
-        let err = serde_json::from_value::<QueryReq>(json!({"sql":"SELECT 1"}))
-            .unwrap_err()
-            .to_string();
-        assert!(err.contains("missing field"), "got: {err}");
+    async fn query_omitted_db_defaults_to_sole_pool() {
+        // LLM callers routinely omit `db` on their first call. With exactly
+        // one configured pool the omission must resolve to it instead of
+        // failing serde — the old `missing field db` error cost a wasted
+        // round-trip in every live session.
+        let st = state();
+        let resp = handle(&st, req(json!({"sql":"SELECT 1 AS one"})))
+            .await
+            .unwrap();
+        assert_eq!(resp.rows[0]["one"], 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn omitted_db_prefers_primary_among_many() {
+        let st = state();
+        {
+            let extra = SqlitePool::new("sqlite::memory:", &PoolConfig::default()).unwrap();
+            st.pools
+                .write()
+                .await
+                .insert("analytics".to_string(), Pool::Sqlite(extra));
+        }
+        assert_eq!(st.resolve_db(None).await.unwrap(), "primary");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn omitted_db_without_default_errors_with_available_list() {
+        let st = state();
+        {
+            let mut pools = st.pools.write().await;
+            let p = pools.remove("primary").unwrap();
+            pools.insert("main".to_string(), p);
+            let extra = SqlitePool::new("sqlite::memory:", &PoolConfig::default()).unwrap();
+            pools.insert("analytics".to_string(), Pool::Sqlite(extra));
+        }
+        let err = handle(&st, req(json!({"sql":"SELECT 1"}))).await.unwrap_err();
+        assert!(err.contains("MISSING_DB"), "got: {err}");
+        assert!(
+            err.contains("\"available\":[\"analytics\",\"main\"]"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn request_schema_marks_db_optional() {
+        let schema = serde_json::to_value(schemars::schema_for!(QueryReq).schema).unwrap();
+        let required = schema["required"].as_array().cloned().unwrap_or_default();
+        assert!(
+            !required.iter().any(|f| f == "db"),
+            "db must not be required in the function schema: {required:?}"
+        );
+        assert!(required.iter().any(|f| f == "sql"));
     }
 }

--- a/database/src/handlers/transaction.rs
+++ b/database/src/handlers/transaction.rs
@@ -12,7 +12,10 @@ use serde_json::{json, Value};
 
 #[derive(Deserialize, JsonSchema)]
 pub struct TxReq {
-    pub db: String,
+    /// Logical database name. Optional — omitting it targets the sole
+    /// configured database, or `primary` when several are configured.
+    #[serde(default)]
+    pub db: Option<String>,
     pub statements: Vec<TxStmtReq>,
     #[serde(default)]
     pub isolation: Option<String>,
@@ -56,7 +59,8 @@ fn failed_index_of(e: &crate::error::DbError) -> Option<usize> {
 }
 
 pub async fn handle(state: &AppState, req: TxReq) -> Result<TxResp, String> {
-    let pool = state.pool(&req.db).await.map_err(err_to_str)?;
+    let db = state.resolve_db(req.db).await.map_err(err_to_str)?;
+    let pool = state.pool(&db).await.map_err(err_to_str)?;
 
     let isolation = match req.isolation.as_deref() {
         Some("read_committed") => Some(Isolation::ReadCommitted),

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -81,20 +81,30 @@ impl SqlitePool {
         let timeout = self.acquire_timeout;
         let db_name = self.db_name.to_string();
         let res = tokio::task::spawn_blocking(move || {
-            pool.get_timeout(timeout).inspect(|conn| {
-                // Defense in depth against pool poisoning: if a previous
-                // holder leaked an open transaction (the handler-boundary
-                // guard blocks the known path, but drivers and future
-                // surfaces can regress), roll it back instead of handing
-                // every later caller `cannot start a transaction within a
-                // transaction` forever.
-                if !conn.is_autocommit() {
-                    tracing::warn!(
-                        "sqlite pool: connection acquired with an open transaction; rolling back"
-                    );
-                    let _ = conn.execute_batch("ROLLBACK");
+            let conn = pool.get_timeout(timeout).map_err(AcquireFailure::Pool)?;
+            // Defense in depth against pool poisoning: if a previous holder
+            // leaked an open transaction (the handler-boundary guard blocks
+            // the known path, but drivers and future surfaces can regress),
+            // roll it back instead of handing every later caller `cannot
+            // start a transaction within a transaction` forever.
+            if !conn.is_autocommit() {
+                tracing::warn!(
+                    "sqlite pool: connection acquired with an open transaction; rolling back"
+                );
+                let rollback = conn.execute_batch("ROLLBACK");
+                // A failed or ineffective rollback means the connection is
+                // still inside a transaction — handing it out would recreate
+                // the exact poisoning this check exists to prevent. Refuse
+                // this acquire; the connection returns to the pool and the
+                // rollback is retried on its next checkout, so a transient
+                // failure self-heals instead of poisoning forever.
+                if rollback.is_err() || !conn.is_autocommit() {
+                    return Err(AcquireFailure::StuckTransaction(
+                        rollback.err().map(|e| e.to_string()),
+                    ));
                 }
-            })
+            }
+            Ok(conn)
         })
         .await
         .map_err(|e| DbError::DriverError {
@@ -105,9 +115,30 @@ impl SqlitePool {
         })?;
         match res {
             Ok(conn) => Ok(SqliteConn { conn }),
-            Err(e) => Err(classify_acquire_error(&e.to_string(), db_name, timeout)),
+            Err(AcquireFailure::Pool(e)) => {
+                Err(classify_acquire_error(&e.to_string(), db_name, timeout))
+            }
+            Err(AcquireFailure::StuckTransaction(rollback_error)) => Err(DbError::DriverError {
+                driver: "sqlite".into(),
+                code: None,
+                message: format!(
+                    "pooled connection is stuck inside a leaked transaction and ROLLBACK did \
+                     not clear it{}; refusing to hand it out",
+                    rollback_error
+                        .map(|e| format!(" ({e})"))
+                        .unwrap_or_default()
+                ),
+                failed_index: None,
+            }),
         }
     }
+}
+
+/// Why an acquire failed, kept apart so a stuck-transaction refusal is never
+/// misclassified as pool exhaustion or a connect error.
+enum AcquireFailure {
+    Pool(r2d2::Error),
+    StuckTransaction(Option<String>),
 }
 
 /// Compute the parent directory that must exist before SQLite can open

--- a/database/src/pool/sqlite.rs
+++ b/database/src/pool/sqlite.rs
@@ -80,14 +80,29 @@ impl SqlitePool {
         let pool = Arc::clone(&self.inner);
         let timeout = self.acquire_timeout;
         let db_name = self.db_name.to_string();
-        let res = tokio::task::spawn_blocking(move || pool.get_timeout(timeout))
-            .await
-            .map_err(|e| DbError::DriverError {
-                driver: "sqlite".into(),
-                code: None,
-                message: format!("spawn_blocking join: {e}"),
-                failed_index: None,
-            })?;
+        let res = tokio::task::spawn_blocking(move || {
+            pool.get_timeout(timeout).inspect(|conn| {
+                // Defense in depth against pool poisoning: if a previous
+                // holder leaked an open transaction (the handler-boundary
+                // guard blocks the known path, but drivers and future
+                // surfaces can regress), roll it back instead of handing
+                // every later caller `cannot start a transaction within a
+                // transaction` forever.
+                if !conn.is_autocommit() {
+                    tracing::warn!(
+                        "sqlite pool: connection acquired with an open transaction; rolling back"
+                    );
+                    let _ = conn.execute_batch("ROLLBACK");
+                }
+            })
+        })
+        .await
+        .map_err(|e| DbError::DriverError {
+            driver: "sqlite".into(),
+            code: None,
+            message: format!("spawn_blocking join: {e}"),
+            failed_index: None,
+        })?;
         match res {
             Ok(conn) => Ok(SqliteConn { conn }),
             Err(e) => Err(classify_acquire_error(&e.to_string(), db_name, timeout)),
@@ -232,6 +247,46 @@ mod tests {
             crate::error::DbError::PoolTimeout { waited_ms, .. } => assert!(waited_ms >= 50),
             other => panic!("expected PoolTimeout, got {other:?}"),
         }
+    }
+
+    /// Regression (rctest5 postmortem): a caller that opened a transaction
+    /// and never closed it returned its connection to the pool mid-txn;
+    /// every later acquire of that connection failed `cannot start a
+    /// transaction within a transaction`, starving three writer agents at
+    /// once. Acquire now rolls back any leaked open transaction.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn acquire_rolls_back_a_leaked_open_transaction() {
+        let pool = SqlitePool::new(
+            "sqlite::memory:",
+            &PoolConfig {
+                max: 1, // force reuse of the poisoned connection
+                idle_timeout_ms: 30_000,
+                acquire_timeout_ms: 500,
+            },
+        )
+        .unwrap();
+        let conn = pool.acquire().await.unwrap();
+        tokio::task::spawn_blocking(move || {
+            conn.with(|c| {
+                c.execute_batch("BEGIN; CREATE TABLE t (n INT);").unwrap();
+                assert!(!c.is_autocommit(), "transaction must be open when leaked");
+            })
+            // `conn` drops here still inside the transaction.
+        })
+        .await
+        .unwrap();
+
+        let healed = pool.acquire().await.unwrap();
+        tokio::task::spawn_blocking(move || {
+            healed.with(|c| {
+                assert!(c.is_autocommit(), "leaked transaction must be rolled back");
+                // And the connection is fully usable, including a fresh BEGIN.
+                c.execute_batch("BEGIN; CREATE TABLE t2 (n INT); COMMIT;")
+                    .unwrap();
+            })
+        })
+        .await
+        .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Why

Every sub-agent session in the rctest orchestration runs (reactor, finalizer, repair, orchestrator — rctest5-K7mQ most recently) burned its first `database::*` call on `serialization error: missing field 'db'`. LLM callers routinely omit `db`; a hard serde failure there is a wasted round-trip in every live session.

## What

- `db` is now **optional** on `query`, `execute`, `executeBatch`, `transaction`, `prepareStatement`, `beginTransaction` (documented in the function schema, so callers see it's optional).
- Resolution (`AppState::resolve_db`): explicit name → unchanged (unknown names still get `UNKNOWN_DB`); omitted → the **sole configured pool**, else **`primary`** when several exist, else the new **`MISSING_DB`** error which enumerates the available names — same self-correction pattern as MOT-4208's `UNKNOWN_DB`.

## Tests

- omitted `db` on a sole pool executes against it
- omitted `db` among many pools prefers `primary`
- omitted `db` with no unambiguous default → `MISSING_DB` with sorted `available` list
- function schema no longer marks `db` required
- `MISSING_DB` wire-envelope serialization

222 database tests pass; clippy clean.

Closes MOT-4216.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database selection is now optional for queries, executions, prepared statements, batches, and transactions.
  * Requests automatically use the sole configured database or the `primary` database when available.
  * Clear errors now identify available databases when selection is ambiguous.

* **Bug Fixes**
  * Prevented transaction-control SQL from running through pooled operations.
  * Automatically rolls back leaked transactions before reusing connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->