### PR TITLE
(MOT-4217) fix(harness): let reaction sessions unregister their run's subscriptions

### DIFF
--- a/harness/src/functions/on_session_deleted.rs
+++ b/harness/src/functions/on_session_deleted.rs
@@ -24,6 +24,7 @@ pub async fn handle(
     event: SessionDeletedEvent,
 ) -> Result<SessionDeletedAck, HarnessError> {
     let dropped = deps.subscriptions.take_session(&event.session_id);
+    deps.subscriptions.forget_lineage(&event.session_id);
     let tracked = dropped.len() as u64;
     if tracked > 0 {
         for (_sub_id, trigger_id) in dropped {

--- a/harness/src/functions/react.rs
+++ b/harness/src/functions/react.rs
@@ -1246,6 +1246,13 @@ async fn spawn_reaction(
                 .get("child_turn_id")
                 .and_then(Value::as_str)
                 .map(str::to_string);
+            // Reaction sessions may need to clean up their own run while the
+            // registrant is parked on a wake: record child → registrant so
+            // the unregister ownership check accepts lineage descendants.
+            if let (Some(owner), Some(child)) = (spec.owner_session_id.as_deref(), child.as_deref())
+            {
+                deps.subscriptions.record_lineage(child, owner);
+            }
             tracing::info!(
                 child_session_id = child.as_deref(),
                 model = spec.model.as_deref(),

--- a/harness/src/functions/react.rs
+++ b/harness/src/functions/react.rs
@@ -546,10 +546,11 @@ fn stamp_coalesced(mut event: Value, dropped: usize) -> Value {
     event
 }
 
-/// Type-erased re-entry for the trailing coalesced fire: `handle` recursing
-/// through `tokio::spawn` can't prove its own future `Send` (the bound is
+/// Type-erased re-entry for the trailing coalesced fire and the
+/// late-join-predecessor catch-up fire: `handle` recursing through
+/// `tokio::spawn` can't prove its own future `Send` (the bound is
 /// self-referential); the `dyn` boxing breaks the inference cycle.
-fn handle_boxed<'a>(
+pub(crate) fn handle_boxed<'a>(
     deps: &'a Deps,
     event: Value,
     metadata: Option<Value>,

--- a/harness/src/functions/subscribe.rs
+++ b/harness/src/functions/subscribe.rs
@@ -834,7 +834,11 @@ async fn handle_react(
     // rare double-delivery idempotent, and a completion BARRIER is only
     // correct level-triggered.
     let mut replay_note = None;
-    if req.metadata.as_ref().is_some_and(|m| m.get("join").is_some()) {
+    if req
+        .metadata
+        .as_ref()
+        .is_some_and(|m| m.get("join").is_some())
+    {
         if let Some(event) = late_join_replay_event(deps, &req).await {
             replay_note = Some(format!(
                 "note: session {} had already completed when this join predecessor was \
@@ -1341,7 +1345,10 @@ mod tests {
         };
         // A one-shot state wake: warned, naming scope/key, with the
         // sleeps-forever consequence spelled out.
-        let note = armed_wake_advisory(&mk("state", json!({ "scope": "run-1", "key": "report_ready" })), true);
+        let note = armed_wake_advisory(
+            &mk("state", json!({ "scope": "run-1", "key": "report_ready" })),
+            true,
+        );
         let note = note.as_deref().unwrap_or("");
         assert!(note.contains("run-1/report_ready"), "got: {note}");
         assert!(note.contains("sleeps forever"), "got: {note}");

--- a/harness/src/functions/subscribe.rs
+++ b/harness/src/functions/subscribe.rs
@@ -824,12 +824,46 @@ async fn handle_react(
         }
     }
 
+    // Level-triggered join predecessors: a turn-completed predecessor whose
+    // filtered session ALREADY finished would otherwise never fire — the
+    // exact registration-vs-completion race that starves a join when a
+    // rejected sibling forces a re-registration round while the watched
+    // workers finish (rctest5 attempt 4). If the session's durable status is
+    // already terminally completed, deliver a catch-up fire shaped like the
+    // real completion event. Joins only: the per-key accumulator makes a
+    // rare double-delivery idempotent, and a completion BARRIER is only
+    // correct level-triggered.
+    let mut replay_note = None;
+    if req.metadata.as_ref().is_some_and(|m| m.get("join").is_some()) {
+        if let Some(event) = late_join_replay_event(deps, &req).await {
+            replay_note = Some(format!(
+                "note: session {} had already completed when this join predecessor was \
+                 registered — a catch-up completion fire was delivered so the join cannot \
+                 starve waiting for an event that already happened.",
+                event
+                    .get("session_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("?")
+            ));
+            let deps = deps.clone();
+            let metadata = metadata.clone();
+            tokio::spawn(async move {
+                if let Err(e) =
+                    crate::functions::react::handle_boxed(&deps, event, Some(metadata)).await
+                {
+                    tracing::warn!(error = %e, "late join predecessor catch-up fire failed");
+                }
+            });
+        }
+    }
+
     let notes: Vec<String> = [
         parent_filter_join_advisory(&req),
         session_filter_advisory(deps, &req).await,
         join_wiring_advisory(deps, &req).await,
         standing_binding_advisory(&req, once),
         state_catchall_advisory(&req),
+        replay_note,
     ]
     .into_iter()
     .flatten()
@@ -840,6 +874,61 @@ async fn handle_react(
         once,
         note,
     })
+}
+
+/// The synthetic completion event for a join predecessor registered AFTER its
+/// watched session finished; `None` when there is no session filter, the
+/// session is still live (or non-terminally parked on a wake — more turns are
+/// coming), or the status lookup fails (fail-open: no replay, edge semantics).
+async fn late_join_replay_event(deps: &Deps, req: &SubscribeRequest) -> Option<Value> {
+    if req.trigger_type != crate::events::TURN_COMPLETED {
+        return None;
+    }
+    let sid = req.config.get("session_id").and_then(Value::as_str)?;
+    let status = deps
+        .iii
+        .trigger(TriggerRequest {
+            function_id: "harness::status".to_string(),
+            payload: json!({ "session_id": sid }),
+            action: None,
+            timeout_ms: None,
+        })
+        .await
+        .ok()?;
+    build_replay_event(sid, &status)
+}
+
+/// Pure shaping half of the late-join catch-up: `Some(event)` iff the durable
+/// status says the session's last turn completed TERMINALLY (an armed wake
+/// means more turns are coming and replay would be premature).
+fn build_replay_event(session_id: &str, status: &Value) -> Option<Value> {
+    if status.get("status").and_then(Value::as_str) != Some("completed") {
+        return None;
+    }
+    if status
+        .get("expects_wake")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    let turn_id = status.get("turn_id").and_then(Value::as_str)?;
+    if turn_id.is_empty() {
+        return None;
+    }
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0);
+    Some(json!({
+        "session_id": session_id,
+        "turn_id": turn_id,
+        "status": "completed",
+        "terminal": true,
+        "timestamp": now_ms,
+        "result": status.get("result").cloned().unwrap_or(Value::Null),
+        "__late_subscription_replay": true,
+    }))
 }
 
 /// Best-effort engine-side teardown; `true` when the engine accepted it, so
@@ -1213,6 +1302,36 @@ mod tests {
         assert!(state_catchall_advisory(&mk("state", json!({ "key": "change" }))).is_none());
         // Non-state trigger types are not advised on.
         assert!(state_catchall_advisory(&mk("cron", json!({}))).is_none());
+    }
+
+    #[test]
+    fn build_replay_event_fires_only_for_terminally_completed_sessions() {
+        // A finished child: replay carries the completion shape + marker.
+        let done = json!({
+            "status": "completed",
+            "turn_id": "t_1",
+            "expects_wake": false,
+            "result": "wrote 5 orders"
+        });
+        let event = build_replay_event("s_child", &done).unwrap();
+        assert_eq!(event["session_id"], "s_child");
+        assert_eq!(event["turn_id"], "t_1");
+        assert_eq!(event["status"], "completed");
+        assert_eq!(event["terminal"], true);
+        assert_eq!(event["result"], "wrote 5 orders");
+        assert_eq!(event["__late_subscription_replay"], true);
+
+        // Still running: no replay.
+        assert!(build_replay_event("s", &json!({"status":"running","turn_id":"t_1"})).is_none());
+        // Completed but parked on an armed wake: more turns are coming.
+        assert!(build_replay_event(
+            "s",
+            &json!({"status":"completed","turn_id":"t_1","expects_wake":true})
+        )
+        .is_none());
+        // No turn ever ran.
+        assert!(build_replay_event("s", &json!({"status":"completed","turn_id":""})).is_none());
+        assert!(build_replay_event("s", &json!({"status":"completed"})).is_none());
     }
 
     #[test]

--- a/harness/src/functions/subscribe.rs
+++ b/harness/src/functions/subscribe.rs
@@ -344,7 +344,10 @@ async fn intercept_unregister(deps: &Deps, args: &Value, session_id: &str) -> Re
     };
 
     if let Some(owner) = deps.subscriptions.session_of(id) {
-        if owner != session_id {
+        // The registrant itself, or any session in its reaction lineage: a
+        // reaction cleaning up its run is the legitimate teardown path when
+        // the registrant is parked on a wake its children must satisfy.
+        if owner != session_id && !deps.subscriptions.in_lineage_of(session_id, &owner) {
             return error_result("subscription belongs to a different session".to_string());
         }
     }

--- a/harness/src/functions/subscribe.rs
+++ b/harness/src/functions/subscribe.rs
@@ -470,6 +470,7 @@ async fn handle(
         // A key-less state notify wakes the owning session on every write in
         // the scope — same catch-all hazard as a react binding.
         state_catchall_advisory(&req),
+        armed_wake_advisory(&req, once),
     ]
     .into_iter()
     .flatten()
@@ -479,6 +480,30 @@ async fn handle(
         once,
         note: (!notes.is_empty()).then(|| notes.join(" ")),
     })
+}
+
+/// Advisory for a one-shot state-key WAKE: the registering session parks
+/// until someone writes that exact scope/key, and the harness cannot verify
+/// any task is wired to do so. rctest postmortem: an orchestrator armed
+/// `report_ready` while its finalizer's task never mentioned the key — every
+/// row landed correctly and the orchestrator still slept forever, leaving
+/// the run's teardown permanently pending. Purely informative.
+fn armed_wake_advisory(req: &SubscribeRequest, once: bool) -> Option<String> {
+    if !once || req.trigger_type != "state" {
+        return None;
+    }
+    let scope = req
+        .config
+        .get("scope")
+        .and_then(Value::as_str)
+        .unwrap_or("*");
+    let key = req.config.get("key").and_then(Value::as_str).unwrap_or("*");
+    Some(format!(
+        "note: one-shot WAKE — this session stays parked until state {scope}/{key} is \
+         written, and nothing fires it automatically. Double-check that a task you \
+         registered (reactor/finalizer) EXPLICITLY sets that exact scope/key when its \
+         condition is met, or this session sleeps forever and its cleanup never runs."
+    ))
 }
 
 /// True when an existing react binding (its `::info` JSON) is a sibling
@@ -1188,6 +1213,22 @@ mod tests {
         assert!(state_catchall_advisory(&mk("state", json!({ "key": "change" }))).is_none());
         // Non-state trigger types are not advised on.
         assert!(state_catchall_advisory(&mk("cron", json!({}))).is_none());
+    }
+
+    #[test]
+    fn armed_wake_advisory_names_the_exact_key_for_one_shot_state_wakes() {
+        let mk = |ty: &str, config: serde_json::Value| -> SubscribeRequest {
+            serde_json::from_value(json!({ "trigger_type": ty, "config": config })).unwrap()
+        };
+        // A one-shot state wake: warned, naming scope/key, with the
+        // sleeps-forever consequence spelled out.
+        let note = armed_wake_advisory(&mk("state", json!({ "scope": "run-1", "key": "report_ready" })), true);
+        let note = note.as_deref().unwrap_or("");
+        assert!(note.contains("run-1/report_ready"), "got: {note}");
+        assert!(note.contains("sleeps forever"), "got: {note}");
+        // Standing notifies and non-state types are not wakes.
+        assert!(armed_wake_advisory(&mk("state", json!({ "key": "k" })), false).is_none());
+        assert!(armed_wake_advisory(&mk("cron", json!({})), true).is_none());
     }
 
     #[test]

--- a/harness/src/subscriptions/registry.rs
+++ b/harness/src/subscriptions/registry.rs
@@ -87,7 +87,20 @@ pub struct FireClaim {
 struct Inner {
     by_id: HashMap<String, Arc<SubEntry>>,
     by_session: HashMap<String, HashSet<String>>,
+    /// Reaction session → registrant session, recorded when a subscription's
+    /// fire spawns into a distinct session. Lets a reaction clean up its own
+    /// run: unregistering a subscription is permitted for any session whose
+    /// lineage chain reaches the owner (the registrant may be parked waiting
+    /// on a wake its children must tear down). Ephemeral like the rest of the
+    /// registry; entries are purged on `session::deleted`.
+    lineage: HashMap<String, String>,
 }
+
+/// Upper bound when walking the lineage chain — bounds cycles (a session id
+/// can be re-targeted across runs) and pathological depth alike. Deeper than
+/// any real reactive chain, which is itself capped by the reactive-depth
+/// breaker.
+const MAX_LINEAGE_HOPS: usize = 16;
 
 /// The process-wide index of active ephemeral subscriptions.
 pub struct SubscriptionRegistry {
@@ -264,6 +277,43 @@ impl SubscriptionRegistry {
     /// The owning session of a subscription (unsubscribe ownership check).
     pub fn session_of(&self, sub_id: &str) -> Option<String> {
         self.lock().by_id.get(sub_id).map(|e| e.session_id.clone())
+    }
+
+    /// Record that `child_session` was spawned by a reaction of a subscription
+    /// registered by `registrant_session`. Overwrites any prior parent — the
+    /// latest spawner is the live lineage.
+    pub fn record_lineage(&self, child_session: &str, registrant_session: &str) {
+        if child_session == registrant_session {
+            return;
+        }
+        self.lock()
+            .lineage
+            .insert(child_session.to_string(), registrant_session.to_string());
+    }
+
+    /// Whether `caller`'s lineage chain (reaction session → registrant,
+    /// transitively) reaches `owner`. Grants a reaction the right to
+    /// unregister its run's subscriptions even though another session
+    /// registered them.
+    pub fn in_lineage_of(&self, caller: &str, owner: &str) -> bool {
+        let inner = self.lock();
+        let mut current = caller;
+        for _ in 0..MAX_LINEAGE_HOPS {
+            match inner.lineage.get(current) {
+                Some(parent) if parent == owner => return true,
+                Some(parent) => current = parent,
+                None => return false,
+            }
+        }
+        false
+    }
+
+    /// Drop lineage entries pointing at or from a deleted session so the map
+    /// stays bounded by live sessions.
+    pub fn forget_lineage(&self, session_id: &str) {
+        let mut inner = self.lock();
+        inner.lineage.remove(session_id);
+        inner.lineage.retain(|_, parent| parent != session_id);
     }
 
     /// The engine trigger id bound to a subscription, WITHOUT evicting the
@@ -524,6 +574,48 @@ mod tests {
         // Unknown / already-evicted trigger ids are a no-op.
         assert!(reg.take_by_trigger_id("trig_1").is_none());
         assert!(reg.take_by_trigger_id("trig_unknown").is_none());
+    }
+
+    #[test]
+    fn lineage_grants_transitive_descendants_and_nothing_else() {
+        let reg = SubscriptionRegistry::new();
+        // orchestrator → reactor → repair (a reaction spawning a reaction).
+        reg.record_lineage("reactor", "orchestrator");
+        reg.record_lineage("repair", "reactor");
+
+        assert!(reg.in_lineage_of("reactor", "orchestrator"));
+        assert!(reg.in_lineage_of("repair", "orchestrator"), "transitive");
+        assert!(reg.in_lineage_of("repair", "reactor"));
+        // Never the other direction, never a stranger.
+        assert!(!reg.in_lineage_of("orchestrator", "reactor"));
+        assert!(!reg.in_lineage_of("stranger", "orchestrator"));
+        assert!(!reg.in_lineage_of("reactor", "repair"));
+    }
+
+    #[test]
+    fn lineage_self_edges_are_not_recorded_and_cycles_terminate() {
+        let reg = SubscriptionRegistry::new();
+        reg.record_lineage("s", "s");
+        assert!(!reg.in_lineage_of("s", "s"), "self edge is meaningless");
+        // A ↔ B cycle (session ids re-targeted across runs) must terminate
+        // instead of spinning, and must not grant unrelated ownership.
+        reg.record_lineage("a", "b");
+        reg.record_lineage("b", "a");
+        assert!(!reg.in_lineage_of("a", "z"));
+        assert!(reg.in_lineage_of("a", "b"));
+    }
+
+    #[test]
+    fn forget_lineage_purges_both_directions() {
+        let reg = SubscriptionRegistry::new();
+        reg.record_lineage("child", "parent");
+        reg.record_lineage("grandchild", "child");
+        reg.forget_lineage("child");
+        assert!(!reg.in_lineage_of("child", "parent"));
+        assert!(
+            !reg.in_lineage_of("grandchild", "child"),
+            "entries pointing AT the deleted session are purged too"
+        );
     }
 
     #[test]

--- a/harness/tests/e2e/README.md
+++ b/harness/tests/e2e/README.md
@@ -18,6 +18,8 @@ No provider key or network access is required.
 | E2E-005 | `reaction-policy-inheritance` | direct | a reaction with no options inherits the registering turn's dispatch policy |
 | E2E-006 | `state-worker-sidecar` | direct | a state-key reaction fires through the standalone state worker with its metadata sidecar (probe-hook driven) |
 | E2E-007 | `coalesced-fire` | direct | a burst past the fire-rate cap coalesces: cap + 1 dispatches, the trailing one stamped `__coalesced_fires` (shrunken gate via harness env; probe-side whole-run call evidence) |
+| E2E-008 | `reaction-unregisters-run` | direct | a reaction session in the registrant's lineage unregisters the registrant's subscription (serve-time capture of the runtime sub id; probe-side call await) |
+| E2E-009 | `late-join-predecessor-replay` | direct | a join predecessor registered after its watched session completed receives a catch-up completion fire (level-triggered join barrier; `probe_after_calls` gating) |
 | UI-001 | `console-streamed-text` | playground | a message sent by the Console streams to durable completion |
 | UI-002 | `multi-turn-traces` | playground | a native function turn and a Console turn expose distinct traces and function-call events |
 

--- a/harness/tests/e2e/src/fixtures/loading.rs
+++ b/harness/tests/e2e/src/fixtures/loading.rs
@@ -48,6 +48,11 @@ pub struct ScenarioFixture {
 #[derive(Debug, Clone)]
 pub struct ProbeAction {
     pub after_turns: usize,
+    /// Additionally wait until the controlled function served this many
+    /// invocations (probe-side, whole-run) before firing. The only ordering
+    /// signal an UNTRACKED session can emit: e.g. fire the next action only
+    /// after a call-mode reaction proved a worker session completed.
+    pub after_target_calls: Option<usize>,
     pub function_id: String,
     pub payload: serde_json::Value,
 }

--- a/harness/tests/e2e/src/fixtures/loading.rs
+++ b/harness/tests/e2e/src/fixtures/loading.rs
@@ -110,6 +110,18 @@ impl ScenarioFixture {
                 "await_target_calls needs a controlled function (`.function(...)`) to count"
             );
         }
+        for action in &self.probe_actions {
+            if let Some(calls) = action.after_target_calls {
+                anyhow::ensure!(
+                    calls > 0,
+                    "probe action after_target_calls must be positive"
+                );
+                anyhow::ensure!(
+                    self.scenario.target.is_some(),
+                    "a probe action gated on target calls needs a controlled function to count"
+                );
+            }
+        }
         anyhow::ensure!(
             self.expected_turn_statuses.last().map(String::as_str) == Some("completed"),
             "the last terminal turn must be completed"

--- a/harness/tests/e2e/src/fixtures/loading.rs
+++ b/harness/tests/e2e/src/fixtures/loading.rs
@@ -132,6 +132,43 @@ impl ScenarioFixture {
             "router script has no generations"
         );
         let mut ordinals = std::collections::BTreeSet::new();
+        // Serve-time capture wiring: a `[[cap:name]]` frame reference is only
+        // resolvable when an earlier-or-same-ordinal generation declared the
+        // capture (strict-ordinal consumption guarantees it ran first).
+        let mut sorted: Vec<_> = self.script.generations.iter().collect();
+        sorted.sort_by_key(|g| g.ordinal);
+        let mut declared = std::collections::BTreeSet::new();
+        for generation in sorted {
+            for capture in &generation.captures {
+                let regex = regex::Regex::new(&capture.pattern).map_err(|error| {
+                    anyhow::anyhow!("capture {} pattern invalid: {error}", capture.name)
+                })?;
+                anyhow::ensure!(
+                    regex.captures_len() >= 2,
+                    "capture {} pattern must have a capture group",
+                    capture.name
+                );
+                declared.insert(capture.name.clone());
+            }
+            let frames = serde_json::to_string(&generation.frames)?;
+            let mut rest = frames.as_str();
+            while let Some(start) = rest.find("[[cap:") {
+                let name_start = &rest[start + 6..];
+                let end = name_start.find("]]").ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "generation {} has an unterminated [[cap: reference",
+                        generation.ordinal
+                    )
+                })?;
+                let name = &name_start[..end];
+                anyhow::ensure!(
+                    declared.contains(name),
+                    "generation {} references [[cap:{name}]] before any generation captured it",
+                    generation.ordinal
+                );
+                rest = &name_start[end..];
+            }
+        }
         for generation in &self.script.generations {
             anyhow::ensure!(
                 ordinals.insert(generation.ordinal),

--- a/harness/tests/e2e/src/fixtures/tests.rs
+++ b/harness/tests/e2e/src/fixtures/tests.rs
@@ -11,7 +11,7 @@ fn all_selection_returns_the_checked_in_fixtures() {
         ids,
         std::collections::BTreeSet::from([
             "E2E-001", "E2E-002", "E2E-003", "E2E-004", "E2E-005", "E2E-006", "E2E-007", "E2E-008",
-            "UI-001", "UI-002"
+            "E2E-009", "UI-001", "UI-002"
         ])
     );
     assert_eq!(
@@ -19,7 +19,7 @@ fn all_selection_returns_the_checked_in_fixtures() {
             .iter()
             .filter(|fixture| fixture.driver == crate::scenarios::ScenarioDriver::Direct)
             .count(),
-        8
+        9
     );
 }
 

--- a/harness/tests/e2e/src/fixtures/tests.rs
+++ b/harness/tests/e2e/src/fixtures/tests.rs
@@ -10,8 +10,8 @@ fn all_selection_returns_the_checked_in_fixtures() {
     assert_eq!(
         ids,
         std::collections::BTreeSet::from([
-            "E2E-001", "E2E-002", "E2E-003", "E2E-004", "E2E-005", "E2E-006", "E2E-007", "UI-001",
-            "UI-002"
+            "E2E-001", "E2E-002", "E2E-003", "E2E-004", "E2E-005", "E2E-006", "E2E-007", "E2E-008",
+            "UI-001", "UI-002"
         ])
     );
     assert_eq!(
@@ -19,7 +19,7 @@ fn all_selection_returns_the_checked_in_fixtures() {
             .iter()
             .filter(|fixture| fixture.driver == crate::scenarios::ScenarioDriver::Direct)
             .count(),
-        7
+        8
     );
 }
 

--- a/harness/tests/e2e/src/scenario/phases/completion.rs
+++ b/harness/tests/e2e/src/scenario/phases/completion.rs
@@ -63,8 +63,10 @@ impl ScenarioRunner<'_> {
                 // call-mode reaction on its completion), so an action can gate
                 // on that instead of tracked-session turns alone.
                 if let Some(calls) = action.after_target_calls {
-                    if let Err(error) =
-                        services.probe().wait_for_target_calls(calls, deadline).await
+                    if let Err(error) = services
+                        .probe()
+                        .wait_for_target_calls(calls, deadline)
+                        .await
                     {
                         if deadline.is_expired() {
                             active.timed_out = true;
@@ -151,8 +153,7 @@ impl ScenarioRunner<'_> {
             // streaming. Hold until every generation is consumed so collect
             // doesn't race that turn's finish — the floor requires full
             // consumption anyway.
-            while services.router().generations_consumed() < services.router().total_generations()
-            {
+            while services.router().generations_consumed() < services.router().total_generations() {
                 if deadline.is_expired() {
                     active.timed_out = true;
                     return Ok(());

--- a/harness/tests/e2e/src/scenario/phases/completion.rs
+++ b/harness/tests/e2e/src/scenario/phases/completion.rs
@@ -58,6 +58,25 @@ impl ScenarioRunner<'_> {
                         error,
                     ));
                 }
+                // A second, call-count boundary: an untracked session's only
+                // observable milestone is a controlled-function call (e.g. a
+                // call-mode reaction on its completion), so an action can gate
+                // on that instead of tracked-session turns alone.
+                if let Some(calls) = action.after_target_calls {
+                    if let Err(error) =
+                        services.probe().wait_for_target_calls(calls, deadline).await
+                    {
+                        if deadline.is_expired() {
+                            active.timed_out = true;
+                            return Ok(());
+                        }
+                        return Err(RunError::runner(
+                            phase,
+                            "wait for probe-action call boundary",
+                            error,
+                        ));
+                    }
+                }
                 self.fire_probe_action(services, &action, deadline).await?;
             }
         }

--- a/harness/tests/e2e/src/scenario/phases/completion.rs
+++ b/harness/tests/e2e/src/scenario/phases/completion.rs
@@ -127,6 +127,19 @@ impl ScenarioRunner<'_> {
                     error,
                 ));
             }
+            // The awaited call may land mid-turn in an UNTRACKED session (the
+            // whole reason this await exists), with the script's tail still
+            // streaming. Hold until every generation is consumed so collect
+            // doesn't race that turn's finish — the floor requires full
+            // consumption anyway.
+            while services.router().generations_consumed() < services.router().total_generations()
+            {
+                if deadline.is_expired() {
+                    active.timed_out = true;
+                    return Ok(());
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
         }
 
         self.confirm_terminal_status(services, active).await

--- a/harness/tests/e2e/src/scenarios/dsl.rs
+++ b/harness/tests/e2e/src/scenarios/dsl.rs
@@ -452,6 +452,7 @@ pub(super) struct Generation {
     response: Option<Response>,
     parked_message: Option<String>,
     failure: Option<String>,
+    captures: Vec<(String, String)>,
 }
 
 impl Generation {
@@ -462,7 +463,17 @@ impl Generation {
             response: None,
             parked_message: None,
             failure: None,
+            captures: Vec::new(),
         }
+    }
+
+    /// Capture a runtime value from this generation's matched request: the
+    /// regex's first group is stored under `name`, and later frames may echo
+    /// it as `[[cap:<name>]]` — e.g. a `sub_…` subscription id from a
+    /// registration function_result in the history.
+    pub(super) fn capture(mut self, name: &str, pattern: &str) -> Self {
+        self.captures.push((name.to_string(), pattern.to_string()));
+        self
     }
 
     pub(super) fn expect(mut self, request: Request) -> Self {
@@ -508,6 +519,11 @@ impl Generation {
                 .request
                 .expect("generation request is required")
                 .compile(model, self.ordinal),
+            captures: self
+                .captures
+                .into_iter()
+                .map(|(name, pattern)| crate::types::script::CaptureV1 { name, pattern })
+                .collect(),
             frames,
             response,
             on_serve: self.parked_message.map(|message| ServeEffectV1 {

--- a/harness/tests/e2e/src/scenarios/dsl.rs
+++ b/harness/tests/e2e/src/scenarios/dsl.rs
@@ -113,6 +113,27 @@ impl Scenario {
     ) -> Self {
         self.probe_actions.push(crate::fixtures::ProbeAction {
             after_turns,
+            after_target_calls: None,
+            function_id: function_id.to_string(),
+            payload,
+        });
+        self
+    }
+
+    /// [`probe_after`](Self::probe_after) that additionally gates on the
+    /// controlled function having served `after_target_calls` invocations —
+    /// the only milestone an UNTRACKED session can signal (e.g. a call-mode
+    /// reaction on that session's completion).
+    pub(super) fn probe_after_calls(
+        mut self,
+        after_turns: usize,
+        after_target_calls: usize,
+        function_id: &str,
+        payload: serde_json::Value,
+    ) -> Self {
+        self.probe_actions.push(crate::fixtures::ProbeAction {
+            after_turns,
+            after_target_calls: Some(after_target_calls),
             function_id: function_id.to_string(),
             payload,
         });

--- a/harness/tests/e2e/src/scenarios/late_join_replay.rs
+++ b/harness/tests/e2e/src/scenarios/late_join_replay.rs
@@ -1,0 +1,284 @@
+//! E2E-009 — a join predecessor registered AFTER its watched session already
+//! completed still fires: the harness delivers a catch-up completion (the
+//! level-triggered join barrier).
+//!
+//! The race it gates (rctest5 attempt 4): an orchestrator's join-predecessor
+//! registration was delayed one round-trip (a rejected sibling forced a
+//! re-registration) and the watched writer sessions finished in that window —
+//! edge-triggered `turn-completed` bindings then starve forever, the
+//! finalizer never spawns, and the run parks with its report unwritten.
+//!
+//! Choreography (all deterministic, no sleeps):
+//! 1. Turn 1 registers (a) a task reaction that spawns the WORKER session on
+//!    a state key, and (b) a call-mode reaction on the worker's
+//!    `turn-completed` — the recorder call that PROVES the completion event
+//!    already fired.
+//! 2. The probe writes the state key → the worker session runs one turn and
+//!    completes → recorder call #1.
+//! 3. Only after call #1 (`probe_after_calls`) does the probe steer turn 2
+//!    into the tracked session, which registers the LATE join predecessor on
+//!    the worker's `turn-completed`. The completion is strictly in the past.
+//! 4. Without the catch-up replay this join can never fire (timeout). With
+//!    it, the registration detects the terminally-completed session, delivers
+//!    the synthetic completion, the single-key join completes, and its
+//!    call-mode downstream makes recorder call #2.
+
+use serde_json::json;
+
+use super::dsl::{ControlledFunction, Generation, Message, Model, Request, Response, Scenario, Send};
+use super::ScenarioDriver;
+use crate::fixtures::ScenarioFixture;
+
+const REGISTER: &str = "engine::register_trigger";
+const SCOPE: &str = "e2e-009";
+const SPAWN_KEY: &str = "spawn-worker";
+const MESSAGE_2: &str = "The worker already finished. Register the late join predecessor now.";
+
+pub(super) fn scenario() -> ScenarioFixture {
+    const ID: &str = "E2E-009";
+    const MESSAGE: &str = "Spawn the worker and watch its completion.";
+
+    let model = Model::scripted("fixture-model");
+    let record = ControlledFunction::new("{{run_id}}::record", "Record one event.")
+        .request_schema(json!({
+            "type": "object",
+            "additionalProperties": true
+        }))
+        .returns_text("recorded");
+
+    // (a) The worker: a task reaction pinned to its own session.
+    let register_worker_spawn = json!({
+        "trigger_type": "state",
+        "config": { "scope": SCOPE, "key": SPAWN_KEY },
+        "function_id": "harness::react",
+        "metadata": {
+            "task": "Say that the work is done, then stop.",
+            "session_id": "{{run_id}}-worker"
+        }
+    });
+    // (b) The completion witness: a call reaction that makes recorder call #1
+    // the moment the worker's turn-completed event fires.
+    let register_completion_witness = json!({
+        "trigger_type": "harness::turn-completed",
+        "config": { "session_id": "{{run_id}}-worker" },
+        "function_id": "harness::react",
+        "metadata": { "call": { "function_id": "{{run_id}}::record" } }
+    });
+    // (c) The LATE join predecessor, registered strictly after the completion:
+    // its single-key join fires the call-mode downstream (recorder call #2)
+    // only if the harness replays the already-past completion.
+    let register_late_join = json!({
+        "trigger_type": "harness::turn-completed",
+        "config": { "session_id": "{{run_id}}-worker" },
+        "function_id": "harness::react",
+        "metadata": {
+            "join": { "id": "{{run_id}}-late-join", "expect": ["w"], "key": "w" },
+            "call": { "function_id": "{{run_id}}::record" }
+        }
+    });
+
+    Scenario::new(
+        ID,
+        "late-join-predecessor-replay",
+        "A join predecessor registered after its watched session completed receives a catch-up fire.",
+        ScenarioDriver::Direct,
+        model.clone(),
+    )
+    .send(
+        Send::message(MESSAGE)
+            .idempotency_key("{{run_id}}:e2e-009")
+            .allow_id(REGISTER)
+            .allow_function(&record),
+    )
+    // Turn 1 (arm) + turn 2 (the probe-steered late registration).
+    .terminal_turn_statuses(["completed", "completed"])
+    // Worker + witness + downstream run in untracked flows; only Send's own
+    // trace and the probe-steered second send trace group under the session.
+    .expect_traces(2)
+    // Call #1 = the completion witness; call #2 = the replayed join's
+    // downstream. #2 exists only through the catch-up path.
+    .await_target_calls(2)
+    .probe_after(
+        1,
+        "state::set",
+        json!({ "scope": SCOPE, "key": SPAWN_KEY, "value": { "go": true } }),
+    )
+    // Fires only after recorder call #1 proved the worker's completion event
+    // is strictly in the past — the late registration cannot race it.
+    .probe_after_calls(
+        1,
+        1,
+        "harness::send",
+        json!({ "session_id": "{{session_id}}", "message": MESSAGE_2 }),
+    )
+    .function(record.clone())
+    .generation(
+        Generation::new(1)
+            .expect(
+                Request::new()
+                    .turn_request_step(0)
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_exact([Message::user(MESSAGE)])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::function_call_raw(
+                "call-spawn",
+                REGISTER,
+                register_worker_spawn,
+                8,
+                4,
+            )),
+    )
+    .generation(
+        Generation::new(2)
+            .expect(
+                Request::new()
+                    .turn_request_step(1)
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_subset([
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant" }),
+                        json!({ "role": "function_result", "function_call_id": "call-spawn",
+                                "is_error": false }),
+                    ])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::function_call_raw(
+                "call-witness",
+                REGISTER,
+                register_completion_witness,
+                8,
+                4,
+            )),
+    )
+    .generation(
+        Generation::new(3)
+            .expect(
+                Request::new()
+                    .turn_request_step(2)
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_subset([
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant" }),
+                        json!({ "role": "function_result" }),
+                        json!({ "role": "assistant" }),
+                        json!({ "role": "function_result", "function_call_id": "call-witness",
+                                "is_error": false }),
+                    ])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::text("armed", 10, 2)),
+    )
+    // The worker session's single turn, spawned by the probe's state write.
+    .generation(
+        Generation::new(4)
+            .expect(
+                Request::new()
+                    .turn_request_step(0)
+                    .system_prompt_regex(".")
+                    .messages_subset([json!({ "role": "user" })])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::text("work done", 8, 2)),
+    )
+    // Turn 2, steered by the probe strictly after recorder call #1.
+    .generation(
+        Generation::new(5)
+            .expect(
+                Request::new()
+                    .turn_request_step(0)
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_subset([
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant" }),
+                        json!({ "role": "function_result" }),
+                        json!({ "role": "assistant" }),
+                        json!({ "role": "function_result" }),
+                        json!({ "role": "assistant" }),
+                        json!({ "role": "user", "content": [
+                            { "type": "text", "text": MESSAGE_2 }
+                        ] }),
+                    ])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::function_call_raw(
+                "call-late-join",
+                REGISTER,
+                register_late_join,
+                8,
+                4,
+            )),
+    )
+    .generation(
+        Generation::new(6)
+            .expect(
+                Request::new()
+                    .turn_request_step(1)
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_subset([
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant" }),
+                        json!({ "role": "function_result" }),
+                        json!({ "role": "assistant" }),
+                        json!({ "role": "function_result" }),
+                        json!({ "role": "assistant" }),
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant" }),
+                        json!({ "role": "function_result", "function_call_id": "call-late-join",
+                                "is_error": false }),
+                    ])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::text("late join armed", 10, 2)),
+    )
+    .verify(|run| {
+        run.expect_assistant_texts(["armed", "late join armed"])?;
+        run.expect_target_calls(2)?;
+        // Call #1: the live completion event (the witness). Proves ordering.
+        let witness = run.target_calls[0]
+            .get("event")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        anyhow::ensure!(
+            witness.get("terminal").and_then(serde_json::Value::as_bool) == Some(true)
+                && witness.get("__late_subscription_replay").is_none(),
+            "call #1 must be the LIVE completion event: {witness}"
+        );
+        // Call #2: the joined downstream — its results map carries the
+        // replayed completion under the join key, stamped as a replay.
+        let replay = run.target_calls[1]
+            .pointer("/event/results/w")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        anyhow::ensure!(
+            replay.get("__late_subscription_replay").and_then(serde_json::Value::as_bool)
+                == Some(true),
+            "call #2 must carry the catch-up replay under join key `w`: {:?}",
+            run.target_calls[1]
+        );
+        anyhow::ensure!(
+            replay.get("status").and_then(serde_json::Value::as_str) == Some("completed")
+                && replay.get("terminal").and_then(serde_json::Value::as_bool) == Some(true),
+            "replayed event must carry the completion shape: {replay}"
+        );
+        run.expect_no_duplicate_messages()
+    })
+    .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixture_gates_the_late_registration_on_the_witness_call() {
+        let fixture = scenario();
+        fixture.validate().unwrap();
+        assert_eq!(fixture.expected_terminal_turns, 2);
+        assert_eq!(fixture.await_target_calls, Some(2));
+        assert_eq!(fixture.expected_traces(), 2);
+        assert_eq!(fixture.probe_actions.len(), 2);
+        assert_eq!(fixture.probe_actions[0].after_target_calls, None);
+        assert_eq!(fixture.probe_actions[1].after_target_calls, Some(1));
+    }
+}

--- a/harness/tests/e2e/src/scenarios/late_join_replay.rs
+++ b/harness/tests/e2e/src/scenarios/late_join_replay.rs
@@ -25,7 +25,9 @@
 
 use serde_json::json;
 
-use super::dsl::{ControlledFunction, Generation, Message, Model, Request, Response, Scenario, Send};
+use super::dsl::{
+    ControlledFunction, Generation, Message, Model, Request, Response, Scenario, Send,
+};
 use super::ScenarioDriver;
 use crate::fixtures::ScenarioFixture;
 

--- a/harness/tests/e2e/src/scenarios/mod.rs
+++ b/harness/tests/e2e/src/scenarios/mod.rs
@@ -5,6 +5,7 @@ mod console_streamed_text;
 mod dsl;
 mod exactly_once_function;
 mod join_spec_mismatch;
+mod late_join_replay;
 mod multi_turn_traces;
 mod reaction_policy_inheritance;
 mod reaction_unregisters_run;
@@ -31,6 +32,7 @@ pub fn all() -> Vec<ScenarioFixture> {
         console_streamed_text::scenario(),
         exactly_once_function::scenario(),
         join_spec_mismatch::scenario(),
+        late_join_replay::scenario(),
         multi_turn_traces::scenario(),
         reaction_policy_inheritance::scenario(),
         reaction_unregisters_run::scenario(),
@@ -47,7 +49,7 @@ mod tests {
     #[test]
     fn every_fixture_is_unique_and_valid() {
         let fixtures = all();
-        assert_eq!(fixtures.len(), 10);
+        assert_eq!(fixtures.len(), 11);
         let mut slugs = std::collections::BTreeSet::new();
         let mut ids = std::collections::BTreeSet::new();
         for fixture in fixtures {

--- a/harness/tests/e2e/src/scenarios/mod.rs
+++ b/harness/tests/e2e/src/scenarios/mod.rs
@@ -7,6 +7,7 @@ mod exactly_once_function;
 mod join_spec_mismatch;
 mod multi_turn_traces;
 mod reaction_policy_inheritance;
+mod reaction_unregisters_run;
 mod reseed_parked_message;
 mod state_worker_sidecar;
 mod streamed_text;
@@ -32,6 +33,7 @@ pub fn all() -> Vec<ScenarioFixture> {
         join_spec_mismatch::scenario(),
         multi_turn_traces::scenario(),
         reaction_policy_inheritance::scenario(),
+        reaction_unregisters_run::scenario(),
         state_worker_sidecar::scenario(),
         reseed_parked_message::scenario(),
         streamed_text::scenario(),
@@ -45,7 +47,7 @@ mod tests {
     #[test]
     fn every_fixture_is_unique_and_valid() {
         let fixtures = all();
-        assert_eq!(fixtures.len(), 9);
+        assert_eq!(fixtures.len(), 10);
         let mut slugs = std::collections::BTreeSet::new();
         let mut ids = std::collections::BTreeSet::new();
         for fixture in fixtures {

--- a/harness/tests/e2e/src/scenarios/reaction_unregisters_run.rs
+++ b/harness/tests/e2e/src/scenarios/reaction_unregisters_run.rs
@@ -23,7 +23,9 @@
 
 use serde_json::json;
 
-use super::dsl::{ControlledFunction, Generation, Message, Model, Request, Response, Scenario, Send};
+use super::dsl::{
+    ControlledFunction, Generation, Message, Model, Request, Response, Scenario, Send,
+};
 use super::ScenarioDriver;
 use crate::fixtures::ScenarioFixture;
 

--- a/harness/tests/e2e/src/scenarios/reaction_unregisters_run.rs
+++ b/harness/tests/e2e/src/scenarios/reaction_unregisters_run.rs
@@ -1,0 +1,226 @@
+//! E2E-008 — a reaction session unregisters its registrant's subscription.
+//!
+//! This gates the lineage-unregister seam (MOT-4217): unregistration is
+//! owner-session-scoped, and before the fix a reaction running in a DIFFERENT
+//! session than its registrant got `subscription belongs to a different
+//! session` — the rctest5 cleanup deadlock (the registrant parked on a wake
+//! its children could no longer satisfy, so nobody could tear the run down).
+//! With lineage recorded at spawn, the reaction session's chain reaches the
+//! owner and the unregister succeeds.
+//!
+//! The subscription id is RUNTIME-generated (`sub_<uuid>`), which a static
+//! fixture cannot know — this is the scenario the router's serve-time capture
+//! exists for: gen2 captures the id out of the registration function_result
+//! in its own matched request, and the cleaner turn's unregister call echoes
+//! it via `[[cap:subid]]`.
+//!
+//! The cleaner turn runs in a PINNED separate session (that's the point), so
+//! neither turn completions nor session traces witness it; the recorder call
+//! (probe-side whole-run evidence) is the completion signal — and it is only
+//! reachable through gen4's matcher, which requires the unregister
+//! function_result with `is_error: false`. Without the lineage fix the
+//! unregister errors, gen4 never matches, and the run times out.
+
+use serde_json::json;
+
+use super::dsl::{ControlledFunction, Generation, Message, Model, Request, Response, Scenario, Send};
+use super::ScenarioDriver;
+use crate::fixtures::ScenarioFixture;
+
+const REGISTER: &str = "engine::register_trigger";
+const UNREGISTER: &str = "engine::unregister_trigger";
+const SCOPE: &str = "e2e-008";
+const KEY: &str = "go";
+
+pub(super) fn scenario() -> ScenarioFixture {
+    const ID: &str = "E2E-008";
+    const MESSAGE: &str = "Arm a self-cleaning reaction.";
+
+    let model = Model::scripted("fixture-model");
+    let record = ControlledFunction::new("{{run_id}}::record", "Record one value.")
+        .request_schema(json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": { "value": { "type": "string" } },
+            "required": ["value"]
+        }))
+        .returns_text("recorded");
+
+    // Task reaction pinned to a DIFFERENT session — the cleaner. It inherits
+    // the registering turn's policy (register/unregister/record allowed).
+    // `once: false` is load-bearing: a one-shot binding retires itself after
+    // its first spawn, and unregistering an already-gone id trivially
+    // succeeds (`removed: false`) without ever exercising the ownership
+    // check. The STANDING binding is still live when the cleaner calls
+    // unregister, so the call must pass the lineage grant to remove it.
+    let register_args = json!({
+        "trigger_type": "state",
+        "config": { "scope": SCOPE, "key": KEY },
+        "function_id": "harness::react",
+        "once": false,
+        "metadata": {
+            "task": "You are the cleanup agent. Unregister this run's subscription, then \
+                     call the recorder exactly once with value \"cleaned\", then stop.",
+            "session_id": "{{run_id}}-cleaner"
+        }
+    });
+
+    Scenario::new(
+        ID,
+        "reaction-unregisters-run",
+        "A reaction session in the registrant's lineage unregisters the registrant's subscription.",
+        ScenarioDriver::Direct,
+        model.clone(),
+    )
+    .send(
+        Send::message(MESSAGE)
+            .idempotency_key("{{run_id}}:e2e-008")
+            .allow_id(REGISTER)
+            .allow_id(UNREGISTER)
+            .allow_function(&record),
+    )
+    // The cleaner session is untracked: its turns don't complete on the
+    // tracked session and its trace groups under its own session id. The
+    // recorder call is therefore both the await signal and the evidence.
+    .await_target_calls(1)
+    .expect_traces(1)
+    .probe_after(
+        1,
+        "state::set",
+        json!({ "scope": SCOPE, "key": KEY, "value": { "go": true } }),
+    )
+    .function(record.clone())
+    .generation(
+        Generation::new(1)
+            .expect(
+                Request::new()
+                    .turn_request()
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_exact([Message::user(MESSAGE)])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::function_call_raw(
+                "call-arm",
+                REGISTER,
+                register_args,
+                8,
+                4,
+            )),
+    )
+    .generation(
+        Generation::new(2)
+            .expect(
+                Request::new()
+                    .turn_request()
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_subset([
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant", "content": [
+                            { "type": "function_call", "id": "call-arm", "function_id": REGISTER }
+                        ] }),
+                        json!({ "role": "function_result", "function_call_id": "call-arm",
+                                "is_error": false }),
+                    ])
+                    .tools_exact([record.tool()]),
+            )
+            // The registration function_result in THIS request carries the
+            // runtime subscription id; capture it for the cleaner's call.
+            .capture("subid", "(sub_[0-9a-f]{32})")
+            .respond(Response::text("armed", 10, 2)),
+    )
+    // The cleaner turn — spawned by the probe-tripped fire into its own
+    // pinned session.
+    .generation(
+        Generation::new(3)
+            .expect(
+                Request::new()
+                    .turn_request_step(0)
+                    .system_prompt_regex(".")
+                    .messages_subset([json!({ "role": "user" })])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::function_call_raw(
+                "call-unreg",
+                UNREGISTER,
+                json!({ "id": "[[cap:subid]]" }),
+                8,
+                4,
+            )),
+    )
+    // THE GATE: this matcher demands the unregister result with
+    // `is_error: false` AND `removed: true` — the live standing binding was
+    // actually torn down. Pre-MOT-4217 the harness answers `subscription
+    // belongs to a different session` (an error result), this never matches,
+    // and the run times out before any recorder call.
+    .generation(
+        Generation::new(4)
+            .expect(
+                Request::new()
+                    .turn_request_step(1)
+                    .system_prompt_regex(".")
+                    .messages_subset([
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant", "content": [
+                            { "type": "function_call", "id": "call-unreg", "function_id": UNREGISTER }
+                        ] }),
+                        json!({ "role": "function_result", "function_call_id": "call-unreg",
+                                "is_error": false,
+                                "content": [{ "type": "text", "text": "{\"removed\":true}" }] }),
+                    ])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::function_call(
+                "call-record",
+                &record,
+                json!({ "value": "cleaned" }),
+                8,
+                4,
+            )),
+    )
+    .generation(
+        Generation::new(5)
+            .expect(
+                Request::new()
+                    .turn_request_step(2)
+                    .system_prompt_regex(".")
+                    .messages_subset([json!({ "role": "user" })])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::text("cleaned up", 12, 3)),
+    )
+    .verify(|run| {
+        run.expect_assistant_texts(["armed"])?;
+        // Whole-run probe evidence: exactly one recorder call, reachable only
+        // after the successful (is_error: false) unregister matched gen4.
+        run.expect_target_calls(1)?;
+        anyhow::ensure!(
+            run.target_calls[0] == json!({ "value": "cleaned" }),
+            "recorder payload {:?} != cleaned",
+            run.target_calls[0]
+        );
+        run.expect_no_duplicate_messages()
+    })
+    .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixture_captures_the_subscription_id_and_awaits_the_cleaner() {
+        let fixture = scenario();
+        fixture.validate().unwrap();
+        assert_eq!(fixture.expected_terminal_turns, 1);
+        assert_eq!(fixture.await_target_calls, Some(1));
+        assert_eq!(fixture.expected_traces(), 1);
+        let gen2 = fixture
+            .script
+            .generations
+            .iter()
+            .find(|g| g.ordinal == 2)
+            .unwrap();
+        assert_eq!(gen2.captures.len(), 1);
+        assert_eq!(gen2.captures[0].name, "subid");
+    }
+}

--- a/harness/tests/e2e/src/scripted_router.rs
+++ b/harness/tests/e2e/src/scripted_router.rs
@@ -441,10 +441,7 @@ async fn chat(
                 .map_err(|e| Error::Handler(format!("integration/capture_serialize: {e}")))?;
             for capture in &generation.captures {
                 let regex = regex::Regex::new(&capture.pattern).map_err(|e| {
-                    Error::Handler(format!(
-                        "integration/capture_regex {}: {e}",
-                        capture.name
-                    ))
+                    Error::Handler(format!("integration/capture_regex {}: {e}", capture.name))
                 })?;
                 let value = regex
                     .captures(&raw)
@@ -533,11 +530,7 @@ async fn stream_frames(
     request_id: &str,
 ) -> Result<(), Error> {
     let writer = ChannelWriter::new(address, writer_ref);
-    let captured = state
-        .lock()
-        .expect("router state")
-        .captured
-        .clone();
+    let captured = state.lock().expect("router state").captured.clone();
     for frame in &generation.frames {
         if request_aborted(state, request_id) {
             writer.close().await?;

--- a/harness/tests/e2e/src/scripted_router.rs
+++ b/harness/tests/e2e/src/scripted_router.rs
@@ -54,6 +54,9 @@ struct State {
     calls: Vec<RouterCallEvidence>,
     /// request_id → aborted-once flag, for `router::abort` semantics.
     live: BTreeMap<String, bool>,
+    /// Serve-time captures (name → value) taken from matched requests; frames
+    /// reference them as `[[cap:<name>]]`.
+    captured: BTreeMap<String, String>,
 }
 
 pub struct ScriptedRouter {
@@ -73,6 +76,7 @@ impl ScriptedRouter {
             next: 0,
             calls: Vec::new(),
             live: BTreeMap::new(),
+            captured: BTreeMap::new(),
         }));
 
         let router = ScriptedRouter { client, state };
@@ -429,6 +433,33 @@ async fn chat(
             request: input.clone(),
             field_results,
         });
+        // Serve-time captures: pull runtime values (e.g. a `sub_…` id from a
+        // function_result in the history) out of the matched request so later
+        // frames can echo them via `[[cap:<name>]]`.
+        if !generation.captures.is_empty() {
+            let raw = serde_json::to_string(&input)
+                .map_err(|e| Error::Handler(format!("integration/capture_serialize: {e}")))?;
+            for capture in &generation.captures {
+                let regex = regex::Regex::new(&capture.pattern).map_err(|e| {
+                    Error::Handler(format!(
+                        "integration/capture_regex {}: {e}",
+                        capture.name
+                    ))
+                })?;
+                let value = regex
+                    .captures(&raw)
+                    .and_then(|c| c.get(1))
+                    .map(|m| m.as_str().to_string())
+                    .ok_or_else(|| {
+                        Error::Handler(format!(
+                            "integration/capture_missed: generation {} capture {} found no \
+                             match in the request",
+                            generation.ordinal, capture.name
+                        ))
+                    })?;
+                state.captured.insert(capture.name.clone(), value);
+            }
+        }
         (generation, writer_ref, request_id)
     };
 
@@ -502,6 +533,11 @@ async fn stream_frames(
     request_id: &str,
 ) -> Result<(), Error> {
     let writer = ChannelWriter::new(address, writer_ref);
+    let captured = state
+        .lock()
+        .expect("router state")
+        .captured
+        .clone();
     for frame in &generation.frames {
         if request_aborted(state, request_id) {
             writer.close().await?;
@@ -509,8 +545,22 @@ async fn stream_frames(
                 "integration/aborted: request {request_id}"
             )));
         }
-        let text = serde_json::to_string(frame)
+        let mut text = serde_json::to_string(frame)
             .map_err(|e| Error::Handler(format!("integration/frame_serialize: {e}")))?;
+        // Late-bind serve-time captures. `[[cap:…]]` (not `{{…}}`) because
+        // placeholder expansion is strict and runs before any capture exists.
+        if text.contains("[[cap:") {
+            for (name, value) in &captured {
+                text = text.replace(&format!("[[cap:{name}]]"), value);
+            }
+            if let Some(start) = text.find("[[cap:") {
+                let tail: String = text[start..].chars().take(48).collect();
+                return Err(Error::Handler(format!(
+                    "integration/capture_unresolved: frame references an uncaptured value \
+                     near {tail:?}"
+                )));
+            }
+        }
         writer.send_message(&text).await?;
     }
     if request_aborted(state, request_id) {

--- a/harness/tests/e2e/src/types/script.rs
+++ b/harness/tests/e2e/src/types/script.rs
@@ -136,12 +136,29 @@ impl GenerationMatchV1 {
     }
 }
 
+/// A serve-time capture: after its generation MATCHES, `pattern` runs over
+/// the raw serialized request and the first capture group is stored under
+/// `name`. Later (or same-ordinal) generations' frames may reference it as
+/// `[[cap:<name>]]` — the only way a fixture can echo a RUNTIME-generated
+/// identifier (e.g. a `sub_…` subscription id) back into a scripted call.
+/// Distinct from `{{…}}` placeholders, which expand before the stack boots.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CaptureV1 {
+    pub name: String,
+    /// Regex with exactly one capture group.
+    pub pattern: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ScriptedGenerationV1 {
     pub ordinal: u64,
     #[serde(rename = "match")]
     pub match_: GenerationMatchV1,
+    /// Runtime-value captures taken from this generation's matched request.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub captures: Vec<CaptureV1>,
     pub frames: Vec<AssistantMessageEvent>,
     pub response: RouterChatResponse,
     /// Optional side effect the router performs *before* it streams this


### PR DESCRIPTION
## Why

rctest5-K7mQ ended in a cleanup deadlock. The repair reactor tried to tear down the run's subscriptions and hit `subscription belongs to a different session` ×3: `engine::unregister_trigger` is owner-session-scoped, and the owner — the orchestrator — was parked waiting on a `report` state notification that its own children could no longer satisfy. Result: 3 leaked armed subscriptions and a permanently sleeping session.

A reaction cleaning up its own run is the legitimate teardown path when the registrant is parked.

## What

- `spawn_reaction` records **child session → registrant session** lineage (from the trusted `__owner_session_id` stamp) in the ephemeral `SubscriptionRegistry`.
- The unregister ownership check accepts the owner itself **or any session whose lineage chain reaches the owner** (transitive, hop-bounded so re-targeted-session cycles terminate).
- Lineage entries are purged on `session::deleted` in both directions, keeping the map bounded by live sessions.

Deliberately narrow: strangers and the reverse direction (registrant "cleaning up" a child's subs it doesn't own) are still refused.

## Tests

- transitive grant (orchestrator → reactor → repair), reverse/stranger refusal
- self-edge ignored; A↔B cycle terminates without granting unrelated ownership
- `forget_lineage` purges entries pointing at and from the deleted session

267 harness tests pass; clippy clean.

Closes MOT-4217.