### PR TITLE
(MOT-4229) feat(harness): max_fires fire budget + unbounded-cron advisory

### DIFF
--- a/harness/src/functions/react.rs
+++ b/harness/src/functions/react.rs
@@ -330,6 +330,14 @@ pub struct ReactSpec {
     /// the failed event and any preserved partial result.
     #[serde(default)]
     pub continue_on_error: bool,
+    /// Caller-supplied lifetime fire budget: after this many delivered fires
+    /// the binding retires itself through the `once` teardown path. THE
+    /// termination guarantee for recurring bindings whose stop condition
+    /// lives in agent logic — rctest7 postmortem: a 10-second gate-check
+    /// cron polled forever when its gate became unreachable, and at 6
+    /// fires/min the fire-rate breaker (correctly) never engaged.
+    #[serde(default)]
+    pub max_fires: Option<u64>,
     /// When present, this subscription is one predecessor of a join barrier.
     #[serde(default)]
     pub join: Option<JoinSpec>,
@@ -519,6 +527,22 @@ pub fn validate_spec(metadata: Option<&Value>) -> Result<(), String> {
             ));
         }
     }
+    if let Some(budget) = spec.max_fires {
+        if budget == 0 {
+            return Err(
+                "`max_fires` must be >= 1 (a binding that may never fire is a mis-registration; \
+                 don't register it instead)"
+                    .into(),
+            );
+        }
+        if spec.join.is_some() {
+            return Err(
+                "`max_fires` cannot combine with `join` — the join lifecycle owns predecessor \
+                 bindings (they auto-unregister when the join fires; `rearm` re-arms them)"
+                    .into(),
+            );
+        }
+    }
     Ok(())
 }
 
@@ -562,7 +586,7 @@ pub(crate) fn handle_boxed<'a>(
 
 pub async fn handle(
     deps: &Deps,
-    event: Value,
+    mut event: Value,
     metadata: Option<Value>,
 ) -> Result<ReactResult, HarnessError> {
     // A bad/absent spec must never error out: an erroring trigger target just
@@ -570,7 +594,7 @@ pub async fn handle(
     // is kept beside the parsed spec: a capped fire parks it for the trailing
     // coalesced re-entry.
     let raw_metadata = metadata.clone();
-    let spec: ReactSpec = match metadata {
+    let mut spec: ReactSpec = match metadata {
         Some(m) => match serde_json::from_value(m) {
             Ok(s) => s,
             Err(e) => {
@@ -665,6 +689,48 @@ pub async fn handle(
         return Ok(ReactResult::note(note));
     }
 
+    // Fire budget: a caller-declared lifetime cap on DELIVERED fires. The
+    // final budgeted fire is delivered normally and then retires the binding
+    // through the exact `once` teardown path (fired records carry
+    // retired: true). This is the platform's termination guarantee for
+    // recurring bindings whose stop condition lives in agent logic — rctest7
+    // postmortem: a 10-second gate-check cron whose gate became unreachable
+    // polled forever, and at 6 fires/min the rate breaker above (correctly)
+    // never engaged. Counted AFTER gate admission so coalesced parks don't
+    // burn budget their trailing fire will spend.
+    if let Some(budget) = spec.max_fires {
+        let count = deps.subscriptions.record_budgeted_fire(&gate_key);
+        if count > budget {
+            // A fire slipped past retirement (teardown raced the source, or
+            // a prior unregister failed and left the engine binding live).
+            // Never deliver; retry the teardown instead.
+            once_unregister(deps, &spec).await;
+            let note =
+                format!("fire budget ({budget}) exhausted; binding retired — not delivering");
+            record_reaction_outcome(deps, &spec, &event, "blocked", &note, None).await;
+            return Ok(ReactResult::note(note));
+        }
+        if count == budget {
+            spec.once = true;
+        }
+        // The delivered reaction (and the e2e evidence) can see where in the
+        // budget this fire sits and that no further fires are coming.
+        if let Some(obj) = event.as_object_mut() {
+            obj.insert("__fire_seq".to_string(), json!(count));
+            obj.insert("__fire_budget".to_string(), json!(budget));
+            if count == budget {
+                obj.insert("__final_fire".to_string(), json!(true));
+                obj.insert(
+                    "__fire_budget_note".to_string(),
+                    json!(format!(
+                        "This is fire {count} of {budget} — the binding's fire budget is now \
+                         exhausted and it has been unregistered; no further fires will arrive."
+                    )),
+                );
+            }
+        }
+    }
+
     // Fire-time model check (task mode only — call reactions have no model):
     // registrations made through OTHER trigger-type providers (e.g. `state`)
     // never pass the harness's registration-time validation, so a
@@ -729,7 +795,6 @@ pub async fn handle(
     // explicit pin wins; otherwise the registering (owner) session, so a
     // reaction with no pin lands as a turn in the chat that wired it instead
     // of a detached child nobody watches.
-    let mut spec = spec;
     spec.session_id = reaction_delivery_session(&spec);
 
     let completion_failure = turn_completion_failure(&event);
@@ -1972,6 +2037,7 @@ mod tests {
             options: None,
             parent_session_id: None,
             continue_on_error: false,
+            max_fires: None,
             join: None,
             subscription_id: None,
             once: false,
@@ -2442,5 +2508,28 @@ mod tests {
         assert!(validate_spec(None).unwrap_err().contains("metadata"));
         let err = validate_spec(Some(&json!({ "model": "m" }))).unwrap_err();
         assert!(err.contains("task"), "{err}");
+    }
+
+    #[test]
+    fn validate_spec_max_fires_bounds_and_join_exclusion() {
+        // A budget bounds task and call reactions alike.
+        assert!(
+            validate_spec(Some(&json!({ "model": "m", "task": "t", "max_fires": 30 }))).is_ok()
+        );
+        assert!(validate_spec(Some(&json!({
+            "call": { "function_id": "state::set" }, "max_fires": 1
+        })))
+        .is_ok());
+        // Zero can never fire — a mis-registration, not a no-op.
+        let err =
+            validate_spec(Some(&json!({ "model": "m", "task": "t", "max_fires": 0 }))).unwrap_err();
+        assert!(err.contains(">= 1"), "{err}");
+        // The join lifecycle owns predecessor bindings.
+        let err = validate_spec(Some(&json!({
+            "model": "m", "task": "t", "max_fires": 2,
+            "join": { "id": "J", "expect": ["a"], "key": "a" }
+        })))
+        .unwrap_err();
+        assert!(err.contains("join"), "{err}");
     }
 }

--- a/harness/src/functions/subscribe.rs
+++ b/harness/src/functions/subscribe.rs
@@ -257,6 +257,41 @@ fn state_catchall_advisory(req: &SubscribeRequest) -> Option<String> {
     ))
 }
 
+/// Advisory for a standing cron binding with no termination path: it fires
+/// every interval FOREVER until something unregisters it. rctest7 postmortem:
+/// a 10-second gate-check cron polled forever when its gate condition became
+/// unreachable (the reactor had aggregated into mistyped tables) — and at 6
+/// fires/min the fire-rate breaker correctly never engaged. `react` bindings
+/// can bound themselves with `metadata.max_fires`; notify bindings only via
+/// an explicit unregister. Purely informative — a deliberate heartbeat with
+/// its own teardown step ignores it.
+fn unbounded_cron_advisory(req: &SubscribeRequest, once: bool, react: bool) -> Option<String> {
+    if req.trigger_type != "cron" || once {
+        return None;
+    }
+    if react
+        && req
+            .metadata
+            .as_ref()
+            .is_some_and(|m| m.get("max_fires").is_some())
+    {
+        return None;
+    }
+    let bound = if react {
+        "Set `metadata.max_fires: N` (the binding retires itself after N fires) and/or give \
+         the task a deadline escape (\"if past <deadline>, engine::unregister_trigger this \
+         subscription and report failure\")."
+    } else {
+        "Make sure some step explicitly calls engine::unregister_trigger when the work is done \
+         or a deadline passes."
+    };
+    Some(format!(
+        "warning: this cron binding fires FOREVER on every tick until \
+         engine::unregister_trigger removes it — nothing terminates it automatically, and a \
+         gate-check whose condition never becomes true polls unbounded. {bound}"
+    ))
+}
+
 /// `once` on a react binding: simple non-cron edges default to one-shot, while
 /// cron remains standing. Callers that truly want a standing state/turn watcher
 /// opt out with `once: false`. Join predecessors ignore this field because the
@@ -471,6 +506,9 @@ async fn handle(
         // the scope — same catch-all hazard as a react binding.
         state_catchall_advisory(&req),
         armed_wake_advisory(&req, once),
+        // A standing cron notify pokes the owning session every tick forever
+        // — same unbounded hazard as a cron react binding, minus max_fires.
+        unbounded_cron_advisory(&req, once, false),
     ]
     .into_iter()
     .flatten()
@@ -654,6 +692,25 @@ async fn handle_react(
     }
 
     let once = react_once(&req);
+
+    // A one-shot binding retires after its first fire, so a `max_fires`
+    // budget above 1 can never be reached — one of the two is a mistake.
+    // (`max_fires: 1` on a once binding is merely redundant; allow it.)
+    if once
+        && req
+            .metadata
+            .as_ref()
+            .and_then(|m| m.get("max_fires"))
+            .and_then(Value::as_u64)
+            .is_some_and(|n| n > 1)
+    {
+        return Err(HarnessError::InvalidRequest(
+            "`max_fires` > 1 on a `once` binding can never be reached — the binding retires \
+             after its first fire. Pass `once: false` for a standing budgeted binding, or drop \
+             `max_fires`."
+                .to_string(),
+        ));
+    }
 
     // Idempotency: same rule as the notify path — an identical re-registration
     // returns the standing subscription instead of a twin reaction that would
@@ -867,6 +924,7 @@ async fn handle_react(
         join_wiring_advisory(deps, &req).await,
         standing_binding_advisory(&req, once),
         state_catchall_advisory(&req),
+        unbounded_cron_advisory(&req, once, true),
         replay_note,
     ]
     .into_iter()
@@ -1355,6 +1413,45 @@ mod tests {
         // Standing notifies and non-state types are not wakes.
         assert!(armed_wake_advisory(&mk("state", json!({ "key": "k" })), false).is_none());
         assert!(armed_wake_advisory(&mk("cron", json!({})), true).is_none());
+    }
+
+    #[test]
+    fn unbounded_cron_advisory_warns_unless_bounded() {
+        let mk = |metadata: Option<serde_json::Value>| -> SubscribeRequest {
+            let mut v =
+                json!({ "trigger_type": "cron", "config": { "schedule": "*/10 * * * * *" } });
+            if let Some(m) = metadata {
+                v["metadata"] = m;
+            }
+            serde_json::from_value(v).unwrap()
+        };
+        // A standing cron react binding with no fire budget: warned, with the
+        // polls-forever consequence and both escape hatches spelled out.
+        let note =
+            unbounded_cron_advisory(&mk(Some(json!({ "task": "check the gate" }))), false, true);
+        let note = note.as_deref().unwrap_or("");
+        assert!(note.contains("FOREVER"), "got: {note}");
+        assert!(note.contains("max_fires"), "got: {note}");
+        assert!(note.contains("deadline"), "got: {note}");
+        // A budgeted binding terminates itself: no warning.
+        assert!(unbounded_cron_advisory(
+            &mk(Some(json!({ "task": "check", "max_fires": 30 }))),
+            false,
+            true
+        )
+        .is_none());
+        // Notify bindings can't carry max_fires — warned toward an explicit
+        // unregister instead.
+        let notify = unbounded_cron_advisory(&mk(None), false, false);
+        let notify = notify.as_deref().unwrap_or("");
+        assert!(notify.contains("unregister_trigger"), "got: {notify}");
+        assert!(!notify.contains("max_fires"), "got: {notify}");
+        // One-shot and non-cron bindings are bounded by construction.
+        assert!(unbounded_cron_advisory(&mk(None), true, true).is_none());
+        let state: SubscribeRequest =
+            serde_json::from_value(json!({ "trigger_type": "state", "config": { "key": "k" } }))
+                .unwrap();
+        assert!(unbounded_cron_advisory(&state, false, true).is_none());
     }
 
     #[test]

--- a/harness/src/subscriptions/registry.rs
+++ b/harness/src/subscriptions/registry.rs
@@ -94,7 +94,18 @@ struct Inner {
     /// on a wake its children must tear down). Ephemeral like the rest of the
     /// registry; entries are purged on `session::deleted`.
     lineage: HashMap<String, String>,
+    /// Lifetime delivered-fire counts for budgeted react bindings
+    /// (`max_fires`), keyed by subscription id — or by the react gate's
+    /// spec-hash fallback for raw engine-side registrations that carry no
+    /// `__subscription_id`. Counters die with their entry; fallback keys are
+    /// pruned once the map outgrows [`MAX_FIRE_COUNTERS`].
+    fire_counts: HashMap<String, u64>,
 }
+
+/// Bound on [`Inner::fire_counts`] growth from spec-hash fallback keys, which
+/// have no eviction event of their own. Far above any realistic number of
+/// distinct live budgeted bindings.
+const MAX_FIRE_COUNTERS: usize = 4096;
 
 /// Upper bound when walking the lineage chain — bounds cycles (a session id
 /// can be re-targeted across runs) and pathological depth alike. Deeper than
@@ -279,6 +290,25 @@ impl SubscriptionRegistry {
         self.lock().by_id.get(sub_id).map(|e| e.session_id.clone())
     }
 
+    /// Count one delivered fire for a budgeted (`max_fires`) binding and
+    /// return the new lifetime total. `key` is the subscription id, or the
+    /// react gate's spec-hash fallback for raw bindings; counters for
+    /// registered subscriptions are dropped with their entry, fallback keys
+    /// are pruned when the map outgrows its bound.
+    pub fn record_budgeted_fire(&self, key: &str) -> u64 {
+        let mut inner = self.lock();
+        if inner.fire_counts.len() >= MAX_FIRE_COUNTERS && !inner.fire_counts.contains_key(key) {
+            // Only fallback keys can accumulate without an eviction event:
+            // keep counters that still back a live subscription entry.
+            let by_id = std::mem::take(&mut inner.by_id);
+            inner.fire_counts.retain(|k, _| by_id.contains_key(k));
+            inner.by_id = by_id;
+        }
+        let count = inner.fire_counts.entry(key.to_string()).or_insert(0);
+        *count += 1;
+        *count
+    }
+
     /// Record that `child_session` was spawned by a reaction of a subscription
     /// registered by `registrant_session`. Overwrites any prior parent — the
     /// latest spawner is the live lineage.
@@ -378,6 +408,7 @@ fn trigger_id(entry: &SubEntry) -> Option<String> {
 
 fn remove_entry(inner: &mut Inner, sub_id: &str) -> Option<Arc<SubEntry>> {
     let entry = inner.by_id.remove(sub_id)?;
+    inner.fire_counts.remove(sub_id);
     if let Some(set) = inner.by_session.get_mut(&entry.session_id) {
         set.remove(sub_id);
         if set.is_empty() {
@@ -616,6 +647,21 @@ mod tests {
             !reg.in_lineage_of("grandchild", "child"),
             "entries pointing AT the deleted session are purged too"
         );
+    }
+
+    #[test]
+    fn budgeted_fire_counts_are_monotonic_and_die_with_their_entry() {
+        let reg = SubscriptionRegistry::new();
+        reg.try_insert("sub_1", "s", 8).unwrap();
+        assert_eq!(reg.record_budgeted_fire("sub_1"), 1);
+        assert_eq!(reg.record_budgeted_fire("sub_1"), 2);
+        // Independent keys have independent budgets (spec-hash fallback).
+        assert_eq!(reg.record_budgeted_fire("spec:abc"), 1);
+        // Retiring the entry resets its counter — a re-registered binding
+        // under a fresh sub id starts a fresh budget anyway, but a reused id
+        // must not inherit spent fires.
+        reg.take("sub_1");
+        assert_eq!(reg.record_budgeted_fire("sub_1"), 1);
     }
 
     #[test]

--- a/harness/tests/e2e/README.md
+++ b/harness/tests/e2e/README.md
@@ -20,6 +20,7 @@ No provider key or network access is required.
 | E2E-007 | `coalesced-fire` | direct | a burst past the fire-rate cap coalesces: cap + 1 dispatches, the trailing one stamped `__coalesced_fires` (shrunken gate via harness env; probe-side whole-run call evidence) |
 | E2E-008 | `reaction-unregisters-run` | direct | a reaction session in the registrant's lineage unregisters the registrant's subscription (serve-time capture of the runtime sub id; probe-side call await) |
 | E2E-009 | `late-join-predecessor-replay` | direct | a join predecessor registered after its watched session completed receives a catch-up completion fire (level-triggered join barrier; `probe_after_calls` gating) |
+| E2E-010 | `fire-budget-retires-binding` | direct | a standing reaction with `max_fires` delivers exactly N stamped fires and then unregisters itself (budget exhaustion; per-fire probe gating) |
 | UI-001 | `console-streamed-text` | playground | a message sent by the Console streams to durable completion |
 | UI-002 | `multi-turn-traces` | playground | a native function turn and a Console turn expose distinct traces and function-call events |
 

--- a/harness/tests/e2e/src/fixtures/tests.rs
+++ b/harness/tests/e2e/src/fixtures/tests.rs
@@ -11,7 +11,7 @@ fn all_selection_returns_the_checked_in_fixtures() {
         ids,
         std::collections::BTreeSet::from([
             "E2E-001", "E2E-002", "E2E-003", "E2E-004", "E2E-005", "E2E-006", "E2E-007", "E2E-008",
-            "E2E-009", "UI-001", "UI-002"
+            "E2E-009", "E2E-010", "UI-001", "UI-002"
         ])
     );
     assert_eq!(
@@ -19,7 +19,7 @@ fn all_selection_returns_the_checked_in_fixtures() {
             .iter()
             .filter(|fixture| fixture.driver == crate::scenarios::ScenarioDriver::Direct)
             .count(),
-        9
+        10
     );
 }
 

--- a/harness/tests/e2e/src/scenarios/fire_budget.rs
+++ b/harness/tests/e2e/src/scenarios/fire_budget.rs
@@ -1,0 +1,252 @@
+//! E2E-010 — a `max_fires` budget retires a standing binding after its Nth
+//! delivered fire.
+//!
+//! This gates the platform's termination guarantee for recurring bindings
+//! (rctest7 postmortem): a 10-second gate-check cron polled FOREVER when its
+//! gate condition became unreachable — at 6 fires/min the fire-rate breaker
+//! correctly never engages, so nothing bounded the loop except the operator.
+//! `metadata.max_fires` is that bound: the final budgeted fire is delivered
+//! normally, stamped `__final_fire`, and the binding then retires through the
+//! `once` teardown path.
+//!
+//! Choreography (all deterministic, no sleeps):
+//! 1. Turn 1 registers a STANDING (`once: false`) call-mode reaction on a
+//!    state key with `max_fires: 2`; gen2 captures the runtime subscription
+//!    id for turn 2.
+//! 2. The probe writes the key twice (each write gated on the previous
+//!    recorder call) — fires 1 and 2 dispatch the recorder, fire 2 carrying
+//!    the `__final_fire` budget stamps and triggering self-retirement.
+//! 3. Only after both calls does the probe steer turn 2, which tries to
+//!    unregister the captured id. The matcher demands `removed: false` — the
+//!    budget already tore the binding down, locally AND engine-side (a
+//!    retained local mapping would answer `removed: true` and never match).
+//! 4. With retirement proven, the probe writes the key a third time: the
+//!    binding is gone at the engine, so no third recorder call can exist —
+//!    verified by the whole-run call count.
+
+use serde_json::json;
+
+use super::dsl::{
+    ControlledFunction, Generation, Message, Model, Request, Response, Scenario, Send,
+};
+use super::ScenarioDriver;
+use crate::fixtures::ScenarioFixture;
+
+const REGISTER: &str = "engine::register_trigger";
+const UNREGISTER: &str = "engine::unregister_trigger";
+const SCOPE: &str = "e2e-010";
+const KEY: &str = "tick";
+const MESSAGE_2: &str = "The budget is spent. Confirm the binding retired itself.";
+
+pub(super) fn scenario() -> ScenarioFixture {
+    const ID: &str = "E2E-010";
+    const MESSAGE: &str = "Arm a budgeted recurring reaction.";
+
+    let model = Model::scripted("fixture-model");
+    let record = ControlledFunction::new("{{run_id}}::record", "Record one event.")
+        .request_schema(json!({
+            "type": "object",
+            "additionalProperties": true
+        }))
+        .returns_text("recorded");
+
+    // Standing call-mode reaction with a lifetime budget of 2 fires.
+    // `once: false` is load-bearing: state edges default to one-shot, and a
+    // one-shot binding would retire after fire 1 without ever exercising the
+    // budget path.
+    let register_args = json!({
+        "trigger_type": "state",
+        "config": { "scope": SCOPE, "key": KEY },
+        "function_id": "harness::react",
+        "once": false,
+        "metadata": {
+            "call": { "function_id": "{{run_id}}::record" },
+            "max_fires": 2
+        }
+    });
+
+    Scenario::new(
+        ID,
+        "fire-budget-retires-binding",
+        "A standing reaction with max_fires delivers exactly N fires and then unregisters itself.",
+        ScenarioDriver::Direct,
+        model.clone(),
+    )
+    .send(
+        Send::message(MESSAGE)
+            .idempotency_key("{{run_id}}:e2e-010")
+            .allow_id(REGISTER)
+            .allow_id(UNREGISTER)
+            .allow_function(&record),
+    )
+    // Turn 1 (arm) + turn 2 (the probe-steered retirement check).
+    .terminal_turn_statuses(["completed", "completed"])
+    // Call-mode fires seed no session turns and no traces: only Send's own
+    // trace and the probe-steered second send trace exist.
+    .expect_traces(2)
+    .await_target_calls(2)
+    .probe_after(
+        1,
+        "state::set",
+        json!({ "scope": SCOPE, "key": KEY, "value": { "n": 1 } }),
+    )
+    // Fire 2 only after fire 1's recorder call is evidence — budgeted fires
+    // must not race each other or the count assertion below is ambiguous.
+    .probe_after_calls(
+        1,
+        1,
+        "state::set",
+        json!({ "scope": SCOPE, "key": KEY, "value": { "n": 2 } }),
+    )
+    // Turn 2 fires only after BOTH budgeted calls landed.
+    .probe_after_calls(
+        1,
+        2,
+        "harness::send",
+        json!({ "session_id": "{{session_id}}", "message": MESSAGE_2 }),
+    )
+    // After turn 2 proved retirement, a third write must fire NOTHING: the
+    // engine binding is gone. The whole-run call count is the witness.
+    .probe_after(
+        2,
+        "state::set",
+        json!({ "scope": SCOPE, "key": KEY, "value": { "n": 3 } }),
+    )
+    .function(record.clone())
+    .generation(
+        Generation::new(1)
+            .expect(
+                Request::new()
+                    .turn_request_step(0)
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_exact([Message::user(MESSAGE)])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::function_call_raw(
+                "call-arm",
+                REGISTER,
+                register_args,
+                8,
+                4,
+            )),
+    )
+    .generation(
+        Generation::new(2)
+            .expect(
+                Request::new()
+                    .turn_request_step(1)
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_subset([
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant", "content": [
+                            { "type": "function_call", "id": "call-arm", "function_id": REGISTER }
+                        ] }),
+                        json!({ "role": "function_result", "function_call_id": "call-arm",
+                                "is_error": false }),
+                    ])
+                    .tools_exact([record.tool()]),
+            )
+            // The registration function_result in THIS request carries the
+            // runtime subscription id; turn 2's unregister echoes it.
+            .capture("subid", "(sub_[0-9a-f]{32})")
+            .respond(Response::text("armed", 10, 2)),
+    )
+    // Turn 2, steered strictly after both budgeted fires delivered.
+    .generation(
+        Generation::new(3)
+            .expect(
+                Request::new()
+                    .turn_request_step(0)
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_subset([
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant" }),
+                        json!({ "role": "function_result" }),
+                        json!({ "role": "assistant" }),
+                        json!({ "role": "user", "content": [
+                            { "type": "text", "text": MESSAGE_2 }
+                        ] }),
+                    ])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::function_call_raw(
+                "call-unreg",
+                UNREGISTER,
+                json!({ "id": "[[cap:subid]]" }),
+                8,
+                4,
+            )),
+    )
+    // THE GATE: `removed: false` — the budget already unregistered the
+    // binding (a live local mapping would answer `removed: true`, this never
+    // matches, and the run times out).
+    .generation(
+        Generation::new(4)
+            .expect(
+                Request::new()
+                    .turn_request_step(1)
+                    .system_prompt_sha256("{{system_prompt_sha256}}")
+                    .messages_subset([
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant" }),
+                        json!({ "role": "function_result" }),
+                        json!({ "role": "assistant" }),
+                        json!({ "role": "user" }),
+                        json!({ "role": "assistant", "content": [
+                            { "type": "function_call", "id": "call-unreg", "function_id": UNREGISTER }
+                        ] }),
+                        json!({ "role": "function_result", "function_call_id": "call-unreg",
+                                "is_error": false,
+                                "content": [{ "type": "text", "text": "{\"removed\":false}" }] }),
+                    ])
+                    .tools_exact([record.tool()]),
+            )
+            .respond(Response::text("budget confirmed", 10, 2)),
+    )
+    .verify(|run| {
+        run.expect_assistant_texts(["armed", "budget confirmed"])?;
+        // Exactly two fires, ever — the third write happened strictly after
+        // retirement was proven, so a third call means the budget leaked.
+        run.expect_target_calls(2)?;
+        let seq = |i: usize, ptr: &str| run.target_calls[i].pointer(&format!("/event/{ptr}")).cloned();
+        anyhow::ensure!(
+            seq(0, "__fire_seq") == Some(json!(1))
+                && seq(0, "__fire_budget") == Some(json!(2))
+                && seq(0, "__final_fire").is_none(),
+            "call #1 must be budgeted fire 1 of 2 and not final: {:?}",
+            run.target_calls[0]
+        );
+        anyhow::ensure!(
+            seq(1, "__fire_seq") == Some(json!(2)) && seq(1, "__final_fire") == Some(json!(true)),
+            "call #2 must be the stamped final fire: {:?}",
+            run.target_calls[1]
+        );
+        let note = seq(1, "__fire_budget_note")
+            .and_then(|v| v.as_str().map(str::to_string))
+            .unwrap_or_default();
+        anyhow::ensure!(
+            note.contains("exhausted") && note.contains("no further fires"),
+            "final fire must explain the exhausted budget: {note:?}"
+        );
+        run.expect_no_duplicate_messages()
+    })
+    .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixture_gates_each_fire_and_the_retirement_check() {
+        let fixture = scenario();
+        fixture.validate().unwrap();
+        assert_eq!(fixture.expected_terminal_turns, 2);
+        assert_eq!(fixture.await_target_calls, Some(2));
+        assert_eq!(fixture.expected_traces(), 2);
+        assert_eq!(fixture.probe_actions.len(), 4);
+        assert_eq!(fixture.probe_actions[1].after_target_calls, Some(1));
+        assert_eq!(fixture.probe_actions[2].after_target_calls, Some(2));
+        assert_eq!(fixture.probe_actions[3].after_turns, 2);
+    }
+}

--- a/harness/tests/e2e/src/scenarios/mod.rs
+++ b/harness/tests/e2e/src/scenarios/mod.rs
@@ -4,6 +4,7 @@ mod coalesced_fire;
 mod console_streamed_text;
 mod dsl;
 mod exactly_once_function;
+mod fire_budget;
 mod join_spec_mismatch;
 mod late_join_replay;
 mod multi_turn_traces;
@@ -31,6 +32,7 @@ pub fn all() -> Vec<ScenarioFixture> {
         coalesced_fire::scenario(),
         console_streamed_text::scenario(),
         exactly_once_function::scenario(),
+        fire_budget::scenario(),
         join_spec_mismatch::scenario(),
         late_join_replay::scenario(),
         multi_turn_traces::scenario(),
@@ -49,7 +51,7 @@ mod tests {
     #[test]
     fn every_fixture_is_unique_and_valid() {
         let fixtures = all();
-        assert_eq!(fixtures.len(), 11);
+        assert_eq!(fixtures.len(), 12);
         let mut slugs = std::collections::BTreeSet::new();
         let mut ids = std::collections::BTreeSet::new();
         for fixture in fixtures {


### PR DESCRIPTION
## Why

rctest7 postmortem: an orchestrator registered a **10-second gate-check cron with no termination path**. Its gate condition became unreachable (the reactor aggregated into mistyped tables — companion PR #592 guards that side), so the cron polled forever: 69 fires in 10 minutes until manually stopped. At 6 fires/min the fire-rate breaker (loop breaker #3) correctly never engages — this loop shape is slow, "legitimate" trigger traffic, and nothing in the platform bounded it.

## What

**1. `metadata.max_fires: N` on react bindings** — a caller-declared lifetime budget of delivered fires:
- every budgeted fire is stamped `__fire_seq` / `__fire_budget`; the Nth also gets `__final_fire: true` + a note explaining the binding is now retired
- the final fire is delivered normally, then the binding retires through the exact `once` teardown path (fired records carry `retired: true`)
- fires past the budget (teardown raced the source / a prior unregister failed) are blocked and re-attempt teardown
- counted after gate admission, so coalesced parks don't burn budget their trailing fire will spend
- rejected on join predecessors (the join owns their lifecycle) and on `once` bindings with budget > 1
- counters live in the subscription registry, die with their entry, bounded for spec-hash fallback keys

**2. Unbounded-cron advisory** — registering a standing cron binding without a termination path appends a registration note: fires FOREVER until unregistered; set `max_fires` (react) and/or give the task a deadline escape (both paths: react + notify).

## Tests

- unit: `validate_spec` budget rules, advisory variants, registry counter lifecycle (278 lib tests green)
- **E2E-010 `fire-budget-retires-binding`**: standing budgeted call-mode reaction; each fire gated on the previous call's evidence; turn 2 proves retirement via `removed: false` on the captured sub id **before** a third write is attempted; whole-run call count pins exactly 2 fires
- full integration suite: 10/10 direct scenarios pass

Fixes MOT-4229