### PR TITLE
feat(console): CodeEditor completions prop for as-you-type suggestions

### DIFF
--- a/console/web/src/components/ui/CodeEditor.tsx
+++ b/console/web/src/components/ui/CodeEditor.tsx
@@ -25,6 +25,11 @@ export interface CodeEditorProps {
   /** Observes keys bubbling out of the editor (shortcuts like ⌘S) — keys
       Monaco consumes for editing never reach it. */
   onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>
+  /** Domain identifiers to autocomplete (e.g. SQL table/column names +
+      keywords). Non-empty turns on the as-you-type suggest popup (otherwise
+      the editor stays prose-quiet) and registers a completion provider for
+      the current `language` offering these words. Disposed on unmount. */
+  completions?: readonly string[]
 }
 
 /* The pre-Monaco fallback (and permanent degraded mode if the editor chunk
@@ -95,6 +100,7 @@ export const CodeEditor = React.forwardRef<CodeEditorHandle, CodeEditorProps>(
       id,
       'aria-label': ariaLabel,
       onKeyDown,
+      completions,
     },
     ref,
   ) => {
@@ -199,6 +205,63 @@ export const CodeEditor = React.forwardRef<CodeEditorHandle, CodeEditorProps>(
         if (active instanceof HTMLElement) active.blur()
       }
     }, [ready, readOnly, disabled, placeholder, ariaLabel])
+
+    // Autocomplete: a non-empty `completions` turns on the as-you-type suggest
+    // popup (the default stays prose-quiet) and registers a provider for the
+    // current language offering those words. The joined key keeps the effect
+    // from churning when the parent passes a fresh array of the same words.
+    const completionsKey = (completions ?? []).join('')
+    React.useEffect(() => {
+      const editor = editorRef.current
+      if (!ready || !editor) return
+      const words = completionsKey
+        ? completionsKey.split('').filter(Boolean)
+        : []
+      if (words.length === 0) return
+      editor.updateOptions({
+        quickSuggestions: true,
+        wordBasedSuggestions: 'off',
+      })
+      let disposable: monacoNs.IDisposable | undefined
+      let cancelled = false
+      void import('@/lib/monaco').then(({ monaco }) => {
+        if (cancelled) return
+        disposable = monaco.languages.registerCompletionItemProvider(language, {
+          triggerCharacters: [' ', '.', '('],
+          provideCompletionItems(model, position) {
+            // The provider is registered per-language (global), so only answer
+            // for this editor's own model — otherwise one editor's words would
+            // surface in every other editor of the same language.
+            if (model !== editor.getModel()) return { suggestions: [] }
+            const w = model.getWordUntilPosition(position)
+            const range = {
+              startLineNumber: position.lineNumber,
+              endLineNumber: position.lineNumber,
+              startColumn: w.startColumn,
+              endColumn: w.endColumn,
+            }
+            return {
+              suggestions: words.map((label) => ({
+                label,
+                kind: monaco.languages.CompletionItemKind.Field,
+                insertText: label,
+                range,
+              })),
+            }
+          },
+        })
+      })
+      return () => {
+        cancelled = true
+        disposable?.dispose()
+        // Restore the component's suggest baseline (prose-quiet) rather than
+        // hardcoding — both options return to how the editor was constructed.
+        editorRef.current?.updateOptions({
+          quickSuggestions: MONACO_OPTIONS.quickSuggestions,
+          wordBasedSuggestions: MONACO_OPTIONS.wordBasedSuggestions,
+        })
+      }
+    }, [ready, completionsKey, language])
 
     return (
       // biome-ignore lint/a11y/noStaticElementInteractions: shortcut relay + gap-click focus around a real editor

--- a/database/ui/package.json
+++ b/database/ui/package.json
@@ -8,7 +8,8 @@
     "watch": "node build.mjs --watch"
   },
   "dependencies": {
-    "@iii-dev/console-ui": "workspace:*"
+    "@iii-dev/console-ui": "workspace:*",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",

--- a/database/ui/page.tsx
+++ b/database/ui/page.tsx
@@ -5,18 +5,27 @@
  * asset: ../styles.css ships over `console:style` as database/styles.css —
  * the console mounts and link-swaps it, styles-before-scripts on boot.
  *
- * `setup(host)` registers one contribution: the function-trigger renderer
- * in src/function-trigger-message/ — how every database::* call renders in
- * chat and traces (SQL, request chips, result tables). No page and no
- * config form yet; those slots can be added here later.
+ * `setup(host)` registers two contributions:
+ * - src/function-trigger-message/ — how every database::* call renders in
+ *   chat and traces (SQL, request chips, result tables).
+ * - src/page/ — the `#/ext/database` browser: schema tree, sortable row
+ *   grid, row inspector, and a read-only SQL editor (shared Monaco). Reads
+ *   the live database over `database::query`/`database::listDatabases`.
  *
- * Registration goes through `host` so the loader disposes it on hot
+ * Registrations go through `host` so the loader disposes them on hot
  * reload / worker disconnect.
  */
 
 import type { Host } from '@iii-dev/console-ui'
 import { createDatabaseTriggerRenderer } from './src/function-trigger-message'
+import { DatabasePage } from './src/page'
 
 export default function setup(host: Host) {
   host.functionTriggers.register(createDatabaseTriggerRenderer(host))
+
+  host.pages.register({
+    id: 'database',
+    title: 'database',
+    render: () => <DatabasePage host={host} />,
+  })
 }

--- a/database/ui/src/page/RowDetail.tsx
+++ b/database/ui/src/page/RowDetail.tsx
@@ -5,8 +5,7 @@
  */
 
 import { Button, JsonHighlight } from '@iii-dev/console-ui'
-import { useState } from 'react'
-import { cellText, copyText } from './cells'
+import { useCopyFeedback } from './cells'
 import type { ColumnInfo } from './db-data'
 import { Check, Copy, KeyRound, X } from './icons'
 
@@ -18,18 +17,10 @@ interface RowDetailProps {
 }
 
 export function RowDetail({ table, row, columns, onClose }: RowDetailProps) {
-  const [copied, setCopied] = useState<string | null>(null)
+  const { copied, copy } = useCopyFeedback()
   const names =
     columns.length > 0 ? columns.map((c) => c.name) : Object.keys(row)
   const byName = new Map(columns.map((c) => [c.name, c]))
-
-  const copyValue = (name: string) => {
-    copyText(cellText(row[name]))
-    setCopied(name)
-    window.setTimeout(() => {
-      setCopied((cur) => (cur === name ? null : cur))
-    }, 1200)
-  }
 
   return (
     <aside className="db-rowdetail">
@@ -62,7 +53,7 @@ export function RowDetail({ table, row, columns, onClose }: RowDetailProps) {
               <button
                 type="button"
                 className={`db-field-copy${copied === name ? ' copied' : ''}`}
-                onClick={() => copyValue(name)}
+                onClick={() => copy(name, value)}
                 aria-label={`copy ${name}`}
               >
                 {copied === name ? <Check size={12} /> : <Copy size={12} />}

--- a/database/ui/src/page/RowDetail.tsx
+++ b/database/ui/src/page/RowDetail.tsx
@@ -1,0 +1,92 @@
+/**
+ * Inspector for one selected row: every column with its full (untruncated)
+ * value, JSON pretty-printed, one copy button per field. Complements the
+ * grid, which truncates long values to keep rows scannable.
+ */
+
+import { Button, JsonHighlight } from '@iii-dev/console-ui'
+import { useState } from 'react'
+import { cellText, copyText } from './cells'
+import type { ColumnInfo } from './db-data'
+import { Check, Copy, KeyRound, X } from './icons'
+
+interface RowDetailProps {
+  table: string
+  row: Record<string, unknown>
+  columns: ColumnInfo[]
+  onClose: () => void
+}
+
+export function RowDetail({ table, row, columns, onClose }: RowDetailProps) {
+  const [copied, setCopied] = useState<string | null>(null)
+  const names =
+    columns.length > 0 ? columns.map((c) => c.name) : Object.keys(row)
+  const byName = new Map(columns.map((c) => [c.name, c]))
+
+  const copyValue = (name: string) => {
+    copyText(cellText(row[name]))
+    setCopied(name)
+    window.setTimeout(() => {
+      setCopied((cur) => (cur === name ? null : cur))
+    }, 1200)
+  }
+
+  return (
+    <aside className="db-rowdetail">
+      <div className="db-rowdetail-head">
+        <span className="cap">row · {table}</span>
+        <Button
+          variant="icon"
+          size="icon"
+          onClick={onClose}
+          aria-label="close row detail"
+        >
+          <X size={14} />
+        </Button>
+      </div>
+      {names.map((name) => {
+        const col = byName.get(name)
+        const value = row[name]
+        const isJson =
+          value !== null && value !== undefined && typeof value === 'object'
+        return (
+          <div key={name} className="db-field">
+            <div className="db-field-head">
+              {col?.pk ? (
+                <KeyRound size={10} style={{ color: 'var(--color-accent)' }} />
+              ) : null}
+              <span className="db-field-name">{name}</span>
+              {col?.type ? (
+                <span className="db-field-type">{col.type}</span>
+              ) : null}
+              <button
+                type="button"
+                className={`db-field-copy${copied === name ? ' copied' : ''}`}
+                onClick={() => copyValue(name)}
+                aria-label={`copy ${name}`}
+              >
+                {copied === name ? <Check size={12} /> : <Copy size={12} />}
+              </button>
+            </div>
+            <div className="db-field-value">
+              {value === null || value === undefined ? (
+                <span className="null">NULL</span>
+              ) : isJson ? (
+                <JsonHighlight code={JSON.stringify(value, null, 2)} />
+              ) : typeof value === 'boolean' ? (
+                <span className={value ? 'bool-true' : 'bool-false'}>
+                  {String(value)}
+                </span>
+              ) : (
+                <span className="plain">{String(value)}</span>
+              )}
+            </div>
+            {col?.fkTarget ? (
+              <div className="db-field-fk">references {col.fkTarget}</div>
+            ) : null}
+          </div>
+        )
+      })}
+    </aside>
+  )
+}

--- a/database/ui/src/page/SchemaTree.tsx
+++ b/database/ui/src/page/SchemaTree.tsx
@@ -62,7 +62,9 @@ export function SchemaTree({
       }
       return next
     })
-    if (schemaByTable[table.name] === undefined) {
+    // Retry on re-expand after a failure; a cached schema stays cached.
+    const cached = schemaByTable[table.name]
+    if (cached === undefined || cached === 'error') {
       setSchemaByTable((cur) => ({ ...cur, [table.name]: 'loading' }))
       void Promise.all([
         tableColumns(host, db, driver, table.name),

--- a/database/ui/src/page/SchemaTree.tsx
+++ b/database/ui/src/page/SchemaTree.tsx
@@ -1,0 +1,225 @@
+/**
+ * Sidebar schema explorer, grouped into tables and views. Each entry expands
+ * to its column list (name, type, PK/FK markers) plus indexes for tables,
+ * fetched lazily per table (through the tab's `host`) and cached for the life
+ * of the component — the parent remounts it on db switch / refresh, which is
+ * the cache-invalidation point.
+ */
+
+import { type Host, Skeleton } from '@iii-dev/console-ui'
+import { type ComponentType, useState } from 'react'
+import {
+  type ColumnInfo,
+  type DbDriver,
+  type DbTable,
+  type IndexInfo,
+  tableColumns,
+  tableIndexes,
+} from './db-data'
+import {
+  ChevronRight,
+  Eye,
+  type IconProps,
+  KeyRound,
+  Link2,
+  Table2,
+} from './icons'
+
+interface SchemaTreeProps {
+  host: Host
+  db: string
+  driver: DbDriver
+  tables: DbTable[]
+  selectedTable: string | null
+  onSelectTable: (name: string) => void
+}
+
+interface TableSchema {
+  columns: ColumnInfo[]
+  indexes: IndexInfo[]
+}
+
+export function SchemaTree({
+  host,
+  db,
+  driver,
+  tables,
+  selectedTable,
+  onSelectTable,
+}: SchemaTreeProps) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const [schemaByTable, setSchemaByTable] = useState<
+    Record<string, TableSchema | 'loading' | 'error'>
+  >({})
+
+  const toggle = (table: DbTable) => {
+    setExpanded((cur) => {
+      const next = new Set(cur)
+      if (next.has(table.name)) {
+        next.delete(table.name)
+      } else {
+        next.add(table.name)
+      }
+      return next
+    })
+    if (schemaByTable[table.name] === undefined) {
+      setSchemaByTable((cur) => ({ ...cur, [table.name]: 'loading' }))
+      void Promise.all([
+        tableColumns(host, db, driver, table.name),
+        table.kind === 'table'
+          ? tableIndexes(host, db, driver, table.name).catch(() => [])
+          : Promise.resolve([]),
+      ])
+        .then(([columns, indexes]) => {
+          setSchemaByTable((cur) => ({
+            ...cur,
+            [table.name]: { columns, indexes },
+          }))
+        })
+        .catch(() => {
+          setSchemaByTable((cur) => ({ ...cur, [table.name]: 'error' }))
+        })
+    }
+  }
+
+  const groups: {
+    label: string
+    kind: DbTable['kind']
+    icon: ComponentType<IconProps>
+  }[] = [
+    { label: 'tables', kind: 'table', icon: Table2 },
+    { label: 'views', kind: 'view', icon: Eye },
+  ]
+
+  return (
+    <div className="db-tree">
+      {groups.map((group) => {
+        const entries = tables.filter((t) => t.kind === group.kind)
+        if (entries.length === 0) return null
+        return (
+          <div key={group.kind}>
+            {group.kind === 'view' ? (
+              <div className="db-tree-grouphead">views · {entries.length}</div>
+            ) : null}
+            <ul>
+              {entries.map((table) => {
+                const isOpen = expanded.has(table.name)
+                const isSelected = selectedTable === table.name
+                const schema = schemaByTable[table.name]
+                const Icon = group.icon
+                return (
+                  <li key={table.name}>
+                    <div
+                      className={`db-tree-row${isSelected ? ' active' : ''}`}
+                    >
+                      <button
+                        type="button"
+                        className="db-tree-toggle"
+                        onClick={() => toggle(table)}
+                        aria-label={
+                          isOpen
+                            ? `collapse ${table.name} columns`
+                            : `expand ${table.name} columns`
+                        }
+                      >
+                        <ChevronRight
+                          size={12}
+                          style={{
+                            transform: isOpen ? 'rotate(90deg)' : undefined,
+                            transition: 'transform 0.12s',
+                          }}
+                        />
+                      </button>
+                      <button
+                        type="button"
+                        className="db-tree-name"
+                        onClick={() => onSelectTable(table.name)}
+                        title={table.name}
+                      >
+                        <Icon
+                          size={12}
+                          style={{ color: 'var(--color-ink-ghost)' }}
+                        />
+                        <span className="db-trunc">{table.name}</span>
+                      </button>
+                    </div>
+                    {isOpen ? <TableSchemaRows schema={schema} /> : null}
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function TableSchemaRows({
+  schema,
+}: {
+  schema: TableSchema | 'loading' | 'error' | undefined
+}) {
+  if (schema === 'loading' || schema === undefined) {
+    return (
+      <div style={{ padding: '4px 12px 4px 36px' }}>
+        <Skeleton style={{ display: 'block', height: 14, width: 96 }} />
+      </div>
+    )
+  }
+  if (schema === 'error') {
+    return <p className="db-tree-msg alert">failed to read schema</p>
+  }
+  return (
+    <ul className="db-cols">
+      {schema.columns.length === 0 ? (
+        <li className="db-tree-msg">no columns</li>
+      ) : (
+        schema.columns.map((col) => (
+          <li
+            key={col.name}
+            className="db-col"
+            title={[
+              col.type,
+              col.nullable ? 'nullable' : 'not null',
+              col.pk ? 'primary key' : null,
+              col.fkTarget ? `references ${col.fkTarget}` : null,
+            ]
+              .filter(Boolean)
+              .join(' · ')}
+          >
+            {col.pk ? (
+              <KeyRound size={10} style={{ color: 'var(--color-accent)' }} />
+            ) : col.fkTarget ? (
+              <Link2 size={10} style={{ color: 'var(--color-ink-ghost)' }} />
+            ) : (
+              <span style={{ width: 10, flexShrink: 0 }} />
+            )}
+            <span className="db-col-name">{col.name}</span>
+            <span className="db-col-type">{col.type}</span>
+          </li>
+        ))
+      )}
+      {schema.indexes.length > 0 ? (
+        <>
+          <li className="db-idx-head">indexes</li>
+          {schema.indexes.map((idx) => (
+            <li
+              key={idx.name}
+              className="db-idx"
+              title={[idx.unique ? 'unique' : null, idx.detail]
+                .filter(Boolean)
+                .join(' · ')}
+            >
+              <span style={{ width: 10, flexShrink: 0 }} />
+              <span className="db-idx-name">{idx.name}</span>
+              {idx.unique ? (
+                <span className="db-idx-unique">unique</span>
+              ) : null}
+            </li>
+          ))}
+        </>
+      ) : null}
+    </ul>
+  )
+}

--- a/database/ui/src/page/SqlPanel.tsx
+++ b/database/ui/src/page/SqlPanel.tsx
@@ -124,7 +124,10 @@ export function SqlPanel({ host, db, driver, seedSql, tables }: SqlPanelProps) {
         const next = await runReadOnlySql(host, db, trimmed)
         setOutcome(next)
         setHistory((cur) => {
-          const updated = [trimmed, ...cur.filter((s) => s !== trimmed)]
+          const updated = [trimmed, ...cur.filter((s) => s !== trimmed)].slice(
+            0,
+            HISTORY_LIMIT,
+          )
           saveHistory(db, updated)
           return updated
         })

--- a/database/ui/src/page/SqlPanel.tsx
+++ b/database/ui/src/page/SqlPanel.tsx
@@ -1,0 +1,266 @@
+/**
+ * Ad-hoc read-only SQL: the shared Monaco `CodeEditor` (⌘⏎ runs), an EXPLAIN
+ * action that prefixes the driver-native explain form, per-database history
+ * in localStorage, and results in the shared grid with duration. Write verbs
+ * never leave the browser — `runReadOnlySql` rejects them.
+ */
+
+import {
+  Button,
+  CodeEditor,
+  type CodeEditorHandle,
+  type Host,
+  StatusPanel,
+} from '@iii-dev/console-ui'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  type AdhocResult,
+  type DbDriver,
+  explainPrefix,
+  isReadOnlySql,
+  runReadOnlySql,
+} from './db-data'
+import { AlertCircle, History, Play, X } from './icons'
+import { ResultGrid } from './result-grid'
+
+interface SqlPanelProps {
+  host: Host
+  db: string
+  driver: DbDriver
+  /** Prefill from "query this table" affordances; applied when it changes. */
+  seedSql?: string
+  /** Table names in the active database — fed to the editor's autocomplete
+      alongside the SQL keywords. */
+  tables?: readonly string[]
+}
+
+const HISTORY_LIMIT = 20
+
+/** The keyword slice offered as-you-type; the table names ride alongside. */
+const SQL_KEYWORDS = [
+  'select',
+  'from',
+  'where',
+  'order by',
+  'group by',
+  'having',
+  'limit',
+  'offset',
+  'join',
+  'left join',
+  'inner join',
+  'on',
+  'as',
+  'and',
+  'or',
+  'not',
+  'null',
+  'is null',
+  'is not null',
+  'in',
+  'like',
+  'between',
+  'distinct',
+  'count',
+  'sum',
+  'avg',
+  'min',
+  'max',
+  'asc',
+  'desc',
+]
+
+function historyKey(db: string): string {
+  return `iii-console:database:sql-history:${db}`
+}
+
+function loadHistory(db: string): string[] {
+  try {
+    const raw = window.localStorage.getItem(historyKey(db))
+    const parsed: unknown = raw ? JSON.parse(raw) : []
+    return Array.isArray(parsed)
+      ? parsed.filter((s): s is string => typeof s === 'string')
+      : []
+  } catch {
+    return []
+  }
+}
+
+function saveHistory(db: string, entries: string[]) {
+  try {
+    window.localStorage.setItem(
+      historyKey(db),
+      JSON.stringify(entries.slice(0, HISTORY_LIMIT)),
+    )
+  } catch {
+    // storage full/unavailable — history is a convenience, not state
+  }
+}
+
+export function SqlPanel({ host, db, driver, seedSql, tables }: SqlPanelProps) {
+  const [sql, setSql] = useState(seedSql ?? '')
+  const completions = useMemo(
+    () => Array.from(new Set([...(tables ?? []), ...SQL_KEYWORDS])),
+    [tables],
+  )
+  const [running, setRunning] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [outcome, setOutcome] = useState<AdhocResult | null>(null)
+  const [history, setHistory] = useState<string[]>(() => loadHistory(db))
+  const [historyOpen, setHistoryOpen] = useState(false)
+  const editorRef = useRef<CodeEditorHandle>(null)
+
+  useEffect(() => {
+    if (seedSql) setSql(seedSql)
+  }, [seedSql])
+
+  const run = useCallback(
+    async (statement: string) => {
+      const trimmed = statement.trim()
+      if (!trimmed || running) return
+      setRunning(true)
+      setError(null)
+      try {
+        const next = await runReadOnlySql(host, db, trimmed)
+        setOutcome(next)
+        setHistory((cur) => {
+          const updated = [trimmed, ...cur.filter((s) => s !== trimmed)]
+          saveHistory(db, updated)
+          return updated
+        })
+      } catch (err) {
+        setOutcome(null)
+        setError(err instanceof Error ? err.message : String(err))
+      } finally {
+        setRunning(false)
+      }
+    },
+    [host, db, running],
+  )
+
+  const readOnly = sql.trim() === '' || isReadOnlySql(sql)
+
+  return (
+    <div className="db-sql">
+      <div className="db-sql-top">
+        <div className="db-sql-editor-wrap">
+          <CodeEditor
+            value={sql}
+            onChange={setSql}
+            language="sql"
+            className="db-sql-code"
+            placeholder={`select * from … — read-only, ⌘⏎ runs against ${db}`}
+            aria-label="sql statement"
+            completions={completions}
+            ref={editorRef}
+            onKeyDown={(e) => {
+              if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                e.preventDefault()
+                void run(sql)
+              }
+            }}
+          />
+        </div>
+        <div className="db-sql-actions">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => void run(sql)}
+            disabled={running || sql.trim() === ''}
+          >
+            <Play size={12} aria-hidden />
+            {running ? 'running…' : 'run'}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => void run(`${explainPrefix(driver)}${sql.trim()}`)}
+            disabled={running || sql.trim() === ''}
+          >
+            explain
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setHistoryOpen((v) => !v)}
+            disabled={history.length === 0}
+          >
+            <History size={12} aria-hidden />
+            history · {history.length}
+          </Button>
+          {!readOnly ? (
+            <span className="db-sql-warn">
+              write statements are rejected — this panel is read-only
+            </span>
+          ) : null}
+          {outcome ? (
+            <span className="db-sql-meta">
+              {outcome.result.row_count} row
+              {outcome.result.row_count === 1 ? '' : 's'} · {outcome.durationMs}
+              ms
+            </span>
+          ) : null}
+        </div>
+        {historyOpen && history.length > 0 ? (
+          <div className="db-sql-history">
+            {history.map((entry) => (
+              <div key={entry} className="db-sql-history-row">
+                <button
+                  type="button"
+                  className="db-sql-history-pick"
+                  onClick={() => {
+                    setSql(entry)
+                    setHistoryOpen(false)
+                    editorRef.current?.focus()
+                  }}
+                  title={entry}
+                >
+                  {entry}
+                </button>
+                <button
+                  type="button"
+                  className="db-icon-btn"
+                  onClick={() =>
+                    setHistory((cur) => {
+                      const updated = cur.filter((s) => s !== entry)
+                      saveHistory(db, updated)
+                      return updated
+                    })
+                  }
+                  aria-label="remove from history"
+                >
+                  <X size={12} />
+                </button>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </div>
+      <div className="db-sql-results">
+        {error ? (
+          <div className="db-pad">
+            <StatusPanel
+              variant="alert"
+              icon={<AlertCircle size={18} />}
+              headline="query failed"
+              detail={error}
+            />
+          </div>
+        ) : outcome ? (
+          <ResultGrid
+            columns={outcome.result.columns}
+            rows={outcome.result.rows}
+            rowCount={outcome.result.row_count}
+            stickyHeader
+          />
+        ) : (
+          <p className={`db-sql-placeholder${running ? ' db-pulse' : ''}`}>
+            {running
+              ? 'running…'
+              : 'results appear here. try: select name from sqlite_master limit 10'}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/database/ui/src/page/TableDataPanel.tsx
+++ b/database/ui/src/page/TableDataPanel.tsx
@@ -1,0 +1,209 @@
+/**
+ * Paged read-only view of one table: `SELECT * LIMIT/OFFSET` (plus ORDER BY
+ * when a column header is sorted) through `database::query`, a total row
+ * count for the pager, and column introspection for PK markers + the row
+ * inspector. The grid is the shared `ResultGrid`, so cells render the same
+ * way as in the SQL panel and the chat family.
+ */
+
+import {
+  EmptyState,
+  type Host,
+  Skeleton,
+  StatusPanel,
+} from '@iii-dev/console-ui'
+import { useCallback, useMemo, useState } from 'react'
+import {
+  countTableRows,
+  type DbDriver,
+  fetchTablePage,
+  PAGE_SIZE,
+  type TableSort,
+  tableColumns,
+} from './db-data'
+import { AlertCircle, type IconProps, Table2 } from './icons'
+import { Pagination } from './pagination'
+import { RowDetail } from './RowDetail'
+import { ResultGrid } from './result-grid'
+import { useDatabaseRead } from './useDatabaseRead'
+
+interface TableDataPanelProps {
+  host: Host
+  db: string
+  driver: DbDriver
+  table: string
+  enabled: boolean
+  /** Seed the SQL panel with a SELECT for this table and switch to it. */
+  onOpenInSql?: (table: string) => void
+}
+
+const TableIcon = (p: IconProps) => <Table2 size={28} {...p} />
+
+export function TableDataPanel({
+  host,
+  db,
+  driver,
+  table,
+  enabled,
+  onOpenInSql,
+}: TableDataPanelProps) {
+  const [page, setPage] = useState(0)
+  const [pageSize, setPageSize] = useState(PAGE_SIZE)
+  const [sort, setSort] = useState<TableSort | null>(null)
+  const [selectedRow, setSelectedRow] = useState<number | null>(null)
+
+  const pageFetcher = useCallback(
+    () => fetchTablePage(host, db, driver, table, page, pageSize, sort),
+    [host, db, driver, table, page, pageSize, sort],
+  )
+  const countFetcher = useCallback(
+    () => countTableRows(host, db, driver, table),
+    [host, db, driver, table],
+  )
+  const columnsFetcher = useCallback(
+    () => tableColumns(host, db, driver, table),
+    [host, db, driver, table],
+  )
+  const pageRead = useDatabaseRead(enabled, pageFetcher)
+  const countRead = useDatabaseRead(enabled, countFetcher)
+  const columnsRead = useDatabaseRead(enabled, columnsFetcher)
+
+  const columnInfo = useMemo(() => columnsRead.data ?? [], [columnsRead.data])
+  const primaryKeys = useMemo(
+    () => columnInfo.filter((c) => c.pk).map((c) => c.name),
+    [columnInfo],
+  )
+
+  const total = countRead.data ?? null
+  const hasMore = pageRead.data?.hasMore ?? false
+  const totalPages = useMemo(() => {
+    if (total !== null) return Math.max(1, Math.ceil(total / pageSize))
+    // Unknown count (or count query failed): allow one more page only when the
+    // sentinel row says a next page exists — bounds otherwise-unbounded "next".
+    return hasMore ? page + 2 : page + 1
+  }, [total, hasMore, page, pageSize])
+
+  if (pageRead.error) {
+    return (
+      <StatusPanel
+        variant="alert"
+        icon={<AlertCircle size={18} />}
+        headline="database read failed"
+        detail={pageRead.error}
+      />
+    )
+  }
+
+  if (pageRead.loading && !pageRead.data) {
+    return (
+      <div className="db-skel">
+        <Skeleton style={{ display: 'block', height: 28, width: '100%' }} />
+        <Skeleton style={{ display: 'block', height: 24, width: '100%' }} />
+        <Skeleton style={{ display: 'block', height: 24, width: '100%' }} />
+        <Skeleton style={{ display: 'block', height: 24, width: '66%' }} />
+      </div>
+    )
+  }
+
+  const result = pageRead.data?.result
+  if (!result || (result.row_count === 0 && page === 0)) {
+    return (
+      <EmptyState
+        icon={TableIcon}
+        title="empty table"
+        description={`${table} has no rows`}
+      />
+    )
+  }
+
+  const rows = result.rows
+  const detailRow =
+    selectedRow !== null && selectedRow < rows.length ? rows[selectedRow] : null
+
+  return (
+    <div className="db-data">
+      <div className="db-data-main">
+        <div className="db-data-bar">
+          <span className="name">{table}</span>
+          <span>
+            {result.columns?.length ?? Object.keys(rows[0] ?? {}).length}{' '}
+            columns
+          </span>
+          <span>{total !== null ? `${total} rows` : '… rows'}</span>
+          {sort ? (
+            <button
+              type="button"
+              className="db-linkish"
+              onClick={() => {
+                setSort(null)
+                setPage(0)
+              }}
+            >
+              sorted by {sort.column} {sort.dir} · clear
+            </button>
+          ) : null}
+          {pageRead.loading ? (
+            <span
+              className="db-pulse"
+              style={{ color: 'var(--color-ink-ghost)' }}
+            >
+              refreshing…
+            </span>
+          ) : null}
+          {onOpenInSql ? (
+            <button
+              type="button"
+              className="db-linkish spacer"
+              onClick={() => onOpenInSql(table)}
+            >
+              open in sql
+            </button>
+          ) : null}
+        </div>
+        <div className="db-data-scroll">
+          <ResultGrid
+            columns={result.columns}
+            rows={rows}
+            rowCount={total ?? result.row_count}
+            primaryKeys={primaryKeys}
+            sort={sort}
+            onSort={(next) => {
+              setSort(next)
+              setPage(0)
+              setSelectedRow(null)
+            }}
+            onRowClick={(i) => setSelectedRow((cur) => (cur === i ? null : i))}
+            selectedRow={selectedRow}
+            stickyHeader
+            hideFooter
+          />
+        </div>
+        <div className="db-data-foot">
+          <Pagination
+            currentPage={page + 1}
+            totalPages={totalPages}
+            totalItems={total ?? rows.length + page * pageSize}
+            pageSize={pageSize}
+            onPageChange={(next) => {
+              setPage(next - 1)
+              setSelectedRow(null)
+            }}
+            onPageSizeChange={(next) => {
+              setPageSize(next)
+              setPage(0)
+              setSelectedRow(null)
+            }}
+          />
+        </div>
+      </div>
+      {detailRow ? (
+        <RowDetail
+          table={table}
+          row={detailRow}
+          columns={columnInfo}
+          onClose={() => setSelectedRow(null)}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/database/ui/src/page/cells.ts
+++ b/database/ui/src/page/cells.ts
@@ -1,0 +1,21 @@
+/** Cell-value helpers shared by the result grid and the row inspector. */
+
+/** Copyable string form of a cell value. */
+export function cellText(value: unknown): string {
+  if (value === null || value === undefined) return 'NULL'
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return String(value)
+    }
+  }
+  return String(value)
+}
+
+/** Best-effort clipboard write — the copy affordance is a convenience.
+ *  clipboard may be missing (non-secure context) and writeText may reject
+ *  (permission denied); the `?.catch` swallows both. */
+export function copyText(text: string): void {
+  void navigator.clipboard?.writeText(text)?.catch(() => {})
+}

--- a/database/ui/src/page/cells.ts
+++ b/database/ui/src/page/cells.ts
@@ -1,5 +1,9 @@
 /** Cell-value helpers shared by the result grid and the row inspector. */
 
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const COPIED_MS = 1200
+
 /** Copyable string form of a cell value. */
 export function cellText(value: unknown): string {
   if (value === null || value === undefined) return 'NULL'
@@ -18,4 +22,29 @@ export function cellText(value: unknown): string {
  *  (permission denied); the `?.catch` swallows both. */
 export function copyText(text: string): void {
   void navigator.clipboard?.writeText(text)?.catch(() => {})
+}
+
+export interface CopyFeedback {
+  /** Key of the field copied most recently, until the flash expires. */
+  copied: string | null
+  copy: (key: string, value: unknown) => void
+}
+
+/** Copy a value and flash "copied" against its key. The pending reset is
+ *  cancelled on the next copy and on unmount, so a stale timer can neither
+ *  clear a newer flash nor fire into a gone component. */
+export function useCopyFeedback(): CopyFeedback {
+  const [copied, setCopied] = useState<string | null>(null)
+  const timer = useRef<number | undefined>(undefined)
+
+  useEffect(() => () => window.clearTimeout(timer.current), [])
+
+  const copy = useCallback((key: string, value: unknown) => {
+    copyText(cellText(value))
+    setCopied(key)
+    window.clearTimeout(timer.current)
+    timer.current = window.setTimeout(() => setCopied(null), COPIED_MS)
+  }, [])
+
+  return { copied, copy }
 }

--- a/database/ui/src/page/db-data.ts
+++ b/database/ui/src/page/db-data.ts
@@ -1,0 +1,587 @@
+/**
+ * Read-only RPC surface for the injected database page, built entirely on
+ * `database::query` + `database::listDatabases` — the worker has no
+ * dedicated introspection functions, so table discovery issues the
+ * driver-native catalog query (sqlite_master / information_schema).
+ * Mutations stay in agent flows behind the approval gate.
+ *
+ * Ported from the console's `lib/database.ts`: the catalog SQL and zod
+ * parsing are verbatim; only the transport changed — every call now takes
+ * the tab's `host` and routes through `host.iii.trigger(...)` instead of a
+ * console-internal iii client.
+ */
+
+import type { Host } from '@iii-dev/console-ui'
+import { z } from 'zod'
+
+/* ---------------------------------------------------------------------- *
+ * Response schemas — inlined from the console's `database::*` parsers so
+ * this page carries no dependency on console-internal modules.
+ * ---------------------------------------------------------------------- */
+
+export const columnMetaSchema = z.object({
+  name: z.string(),
+  type: z.string().optional(),
+})
+export type ColumnMeta = z.infer<typeof columnMetaSchema>
+
+export const queryResponseSchema = z.object({
+  rows: z.array(z.record(z.string(), z.unknown())),
+  row_count: z.number(),
+  columns: z.array(columnMetaSchema).optional(),
+})
+export type QueryResponse = z.infer<typeof queryResponseSchema>
+
+export const listDatabasesResponseSchema = z.object({
+  databases: z.array(
+    z.object({
+      name: z.string(),
+      driver: z.string().optional(),
+      url: z.string().optional(),
+      pool: z
+        .object({
+          max: z.number().optional(),
+          idle_timeout_ms: z.number().optional(),
+          acquire_timeout_ms: z.number().optional(),
+        })
+        .optional(),
+      tls: z.object({ mode: z.string().optional() }).optional(),
+    }),
+  ),
+  count: z.number().optional(),
+})
+export type ListDatabasesResponse = z.infer<typeof listDatabasesResponseSchema>
+
+export interface TableSort {
+  column: string
+  dir: 'asc' | 'desc'
+}
+
+export type TypeCategory =
+  | 'numeric'
+  | 'text'
+  | 'bool'
+  | 'date'
+  | 'json'
+  | 'binary'
+  | 'other'
+
+/** Coarse category for a driver-reported column type. */
+export function typeCategory(type: string | undefined): TypeCategory {
+  if (!type) return 'other'
+  const t = type.toLowerCase()
+  if (/bool/.test(t)) return 'bool'
+  if (/int|real|float|double|decimal|numeric|serial|money/.test(t)) {
+    return 'numeric'
+  }
+  if (/date|time|year/.test(t)) return 'date'
+  if (/json/.test(t)) return 'json'
+  if (/blob|bytea|binary/.test(t)) return 'binary'
+  if (/char|text|clob|uuid|enum/.test(t)) return 'text'
+  return 'other'
+}
+
+/* ---------------------------------------------------------------------- */
+
+const DATABASE_QUERY_FN = 'database::query'
+const DATABASE_LIST_FN = 'database::listDatabases'
+
+export const PAGE_SIZE = 50
+
+export type DbDriver = 'sqlite' | 'postgres' | 'mysql' | 'unknown'
+
+export interface DbInfo {
+  name: string
+  driver: DbDriver
+  url?: string
+  poolMax?: number
+}
+
+export interface DbTable {
+  /** Display + query identifier; schema-qualified for postgres. */
+  name: string
+  kind: 'table' | 'view'
+}
+
+function parseDriver(raw: string | undefined): DbDriver {
+  if (raw === 'sqlite' || raw === 'postgres' || raw === 'mysql') return raw
+  return 'unknown'
+}
+
+async function triggerRaw(
+  host: Host,
+  fnId: string,
+  payload: Record<string, unknown>,
+): Promise<unknown> {
+  return host.iii.trigger<unknown>(fnId, payload)
+}
+
+export async function listDbs(host: Host): Promise<DbInfo[]> {
+  const res = listDatabasesResponseSchema.safeParse(
+    await triggerRaw(host, DATABASE_LIST_FN, {}),
+  )
+  if (!res.success) {
+    throw new Error('unexpected response shape from database::listDatabases')
+  }
+  return res.data.databases.map((db) => ({
+    name: db.name,
+    driver: parseDriver(db.driver),
+    url: db.url,
+    poolMax: db.pool?.max,
+  }))
+}
+
+async function runQuery(
+  host: Host,
+  db: string,
+  sql: string,
+  params: unknown[] = [],
+): Promise<QueryResponse> {
+  const res = queryResponseSchema.safeParse(
+    await triggerRaw(host, DATABASE_QUERY_FN, { db, sql, params }),
+  )
+  if (!res.success) {
+    throw new Error('unexpected response shape from database::query')
+  }
+  return res.data
+}
+
+/* ---- identifier quoting ---- */
+
+/**
+ * Quote one identifier for the driver. Table names come from the driver's
+ * own catalog, but quoting is still mandatory — names may contain
+ * uppercase, spaces, or reserved words.
+ */
+export function quoteIdent(driver: DbDriver, ident: string): string {
+  if (driver === 'mysql') {
+    return `\`${ident.replaceAll('`', '``')}\``
+  }
+  return `"${ident.replaceAll('"', '""')}"`
+}
+
+/** Quote a possibly schema-qualified table reference (`schema.table`). */
+function quoteTableRef(driver: DbDriver, table: string): string {
+  if (driver === 'postgres' && table.includes('.')) {
+    const [schema, ...rest] = table.split('.')
+    return `${quoteIdent(driver, schema)}.${quoteIdent(driver, rest.join('.'))}`
+  }
+  return quoteIdent(driver, table)
+}
+
+/* ---- catalog queries ---- */
+
+const TABLE_LIST_SQL: Record<Exclude<DbDriver, 'unknown'>, string> = {
+  sqlite:
+    "SELECT name, CASE type WHEN 'view' THEN 'view' ELSE 'table' END AS kind FROM sqlite_master WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%' ORDER BY kind, name",
+  postgres:
+    "SELECT CASE WHEN table_schema = 'public' THEN table_name ELSE table_schema || '.' || table_name END AS name, CASE table_type WHEN 'VIEW' THEN 'view' ELSE 'table' END AS kind FROM information_schema.tables WHERE table_type IN ('BASE TABLE', 'VIEW') AND table_schema NOT IN ('pg_catalog', 'information_schema') ORDER BY 2, 1",
+  mysql:
+    "SELECT table_name AS name, CASE TABLE_TYPE WHEN 'VIEW' THEN 'view' ELSE 'table' END AS kind FROM information_schema.tables WHERE table_schema = DATABASE() ORDER BY 2, 1",
+}
+
+const tableRowSchema = z.object({
+  name: z.string(),
+  kind: z.string().optional(),
+})
+
+export async function listTables(
+  host: Host,
+  db: string,
+  driver: DbDriver,
+): Promise<DbTable[]> {
+  if (driver === 'unknown') {
+    throw new Error(`cannot introspect tables for an unknown driver`)
+  }
+  const res = await runQuery(host, db, TABLE_LIST_SQL[driver])
+  return res.rows
+    .map((row) => tableRowSchema.safeParse(row))
+    .filter((p) => p.success)
+    .map((p) => ({
+      name: p.data.name,
+      kind: p.data.kind === 'view' ? ('view' as const) : ('table' as const),
+    }))
+}
+
+/* ---- indexes ---- */
+
+export interface IndexInfo {
+  name: string
+  unique: boolean
+  /** Column list or full definition, driver-dependent. */
+  detail: string
+}
+
+const sqliteIndexSchema = z.object({
+  name: z.string(),
+  unique: z.number(),
+  origin: z.string().optional(),
+})
+
+const pgIndexSchema = z.object({
+  name: z.string(),
+  definition: z.string(),
+})
+
+const mysqlIndexSchema = z.object({
+  name: z.string(),
+  unique: z.number(),
+  columns: z.string(),
+})
+
+export async function tableIndexes(
+  host: Host,
+  db: string,
+  driver: DbDriver,
+  table: string,
+): Promise<IndexInfo[]> {
+  if (driver === 'sqlite') {
+    const res = await runQuery(
+      host,
+      db,
+      `PRAGMA index_list(${quoteIdent(driver, table)})`,
+    )
+    return res.rows
+      .map((row) => sqliteIndexSchema.safeParse(row))
+      .filter((p) => p.success)
+      .map((p) => ({
+        name: p.data.name,
+        unique: p.data.unique === 1,
+        detail: p.data.origin === 'pk' ? 'primary key' : '',
+      }))
+  }
+  if (driver === 'postgres') {
+    const { schema, name } = splitTableRef(table)
+    const res = await runQuery(
+      host,
+      db,
+      `SELECT indexname AS name, indexdef AS definition FROM pg_indexes WHERE schemaname = $1 AND tablename = $2 ORDER BY indexname`,
+      [schema ?? 'public', name],
+    )
+    return res.rows
+      .map((row) => pgIndexSchema.safeParse(row))
+      .filter((p) => p.success)
+      .map((p) => ({
+        name: p.data.name,
+        unique: /\bUNIQUE\b/i.test(p.data.definition),
+        detail: p.data.definition.replace(/^.*USING /i, ''),
+      }))
+  }
+  if (driver === 'mysql') {
+    const res = await runQuery(
+      host,
+      db,
+      `SELECT INDEX_NAME AS name, MIN(NON_UNIQUE) = 0 AS \`unique\`, GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) AS columns FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? GROUP BY INDEX_NAME ORDER BY INDEX_NAME`,
+      [splitTableRef(table).name],
+    )
+    return res.rows
+      .map((row) => mysqlIndexSchema.safeParse(row))
+      .filter((p) => p.success)
+      .map((p) => ({
+        name: p.data.name,
+        unique: p.data.unique === 1,
+        detail: `(${p.data.columns})`,
+      }))
+  }
+  return []
+}
+
+/* ---- ad-hoc read-only queries ---- */
+
+/** Strip comments and quoted text (strings + delimited identifiers) so the
+    single-statement and write-form checks never trip on a `;`, `=`, or keyword
+    that lives inside a literal. */
+function stripSqlNoise(sql: string): string {
+  return sql
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/--[^\n]*/g, ' ')
+    .replace(/'(?:''|[^'])*'/g, "''")
+    .replace(/"(?:""|[^"])*"/g, '""')
+    .replace(/`(?:``|[^`])*`/g, '``')
+}
+
+const READ_ONLY_KEYWORDS = new Set([
+  'SELECT',
+  'WITH',
+  'EXPLAIN',
+  'PRAGMA',
+  'SHOW',
+  'DESCRIBE',
+  'VALUES',
+])
+
+/** Write / DDL / maintenance keywords that must not appear anywhere in a
+    read-only statement — catches mutating CTEs (`WITH x AS (DELETE …)`) and
+    `EXPLAIN ANALYZE <write>`, which the leading keyword alone waves through. */
+const WRITE_KEYWORD =
+  /\b(INSERT|UPDATE|DELETE|REPLACE|MERGE|UPSERT|DROP|CREATE|ALTER|TRUNCATE|GRANT|REVOKE|ATTACH|DETACH|REINDEX|VACUUM|ANALYZE|COMMIT|ROLLBACK|BEGIN)\b/i
+
+/**
+ * Console-side gate: the page issues a SINGLE read statement. Defense in depth
+ * (the worker is the real boundary): rejects any statement after the first `;`,
+ * a non-read leading keyword, any write/DDL keyword anywhere (so mutating CTEs
+ * and `EXPLAIN ANALYZE` cannot slip through), and writable `PRAGMA foo = bar`
+ * forms while keeping read PRAGMAs (`PRAGMA table_info(x)`).
+ */
+export function isReadOnlySql(sql: string): boolean {
+  const stripped = stripSqlNoise(sql).trim()
+  const semi = stripped.indexOf(';')
+  if (semi !== -1 && stripped.slice(semi + 1).trim() !== '') return false
+  const keyword = (stripped.split(/[^a-zA-Z_]+/, 1)[0] ?? '').toUpperCase()
+  if (!READ_ONLY_KEYWORDS.has(keyword)) return false
+  if (WRITE_KEYWORD.test(stripped)) return false
+  if (keyword === 'PRAGMA' && stripped.includes('=')) return false
+  return true
+}
+
+export interface AdhocResult {
+  result: QueryResponse
+  durationMs: number
+}
+
+/**
+ * Run one read-only statement from the SQL panel. Write verbs are rejected
+ * before they reach the worker — mutations stay in agent flows behind the
+ * approval gate.
+ */
+export async function runReadOnlySql(
+  host: Host,
+  db: string,
+  sql: string,
+): Promise<AdhocResult> {
+  if (!isReadOnlySql(sql)) {
+    throw new Error(
+      'read-only console: only SELECT / WITH / EXPLAIN / PRAGMA / SHOW run here. write statements go through agent flows and the approval gate.',
+    )
+  }
+  const started = performance.now()
+  const result = await runQuery(host, db, sql)
+  return { result, durationMs: Math.round(performance.now() - started) }
+}
+
+/** Driver-native EXPLAIN prefix for the SQL panel's explain toggle. */
+export function explainPrefix(driver: DbDriver): string {
+  if (driver === 'sqlite') return 'EXPLAIN QUERY PLAN '
+  return 'EXPLAIN '
+}
+
+export async function countTableRows(
+  host: Host,
+  db: string,
+  driver: DbDriver,
+  table: string,
+): Promise<number | null> {
+  const ref = quoteTableRef(driver, table)
+  const res = await runQuery(host, db, `SELECT COUNT(*) AS n FROM ${ref}`)
+  const n = res.rows[0]?.n
+  if (typeof n === 'number') return n
+  if (typeof n === 'string' && /^\d+$/.test(n)) return Number(n)
+  return null
+}
+
+/* ---- column introspection ---- */
+
+export interface ColumnInfo {
+  name: string
+  type: string
+  nullable: boolean
+  pk: boolean
+  /** Referenced `table.column` when this column is a foreign key. */
+  fkTarget?: string
+}
+
+/** Split a possibly schema-qualified table into schema + bare name. */
+function splitTableRef(table: string): { schema: string | null; name: string } {
+  if (!table.includes('.')) return { schema: null, name: table }
+  const [schema, ...rest] = table.split('.')
+  return { schema, name: rest.join('.') }
+}
+
+const sqlitePragmaColumnSchema = z.object({
+  name: z.string(),
+  type: z.string(),
+  notnull: z.number(),
+  pk: z.number(),
+})
+
+const sqlitePragmaFkSchema = z.object({
+  table: z.string(),
+  from: z.string(),
+  to: z.string().nullable(),
+})
+
+async function sqliteColumns(
+  host: Host,
+  db: string,
+  table: string,
+): Promise<ColumnInfo[]> {
+  const ref = quoteIdent('sqlite', table)
+  const cols = await runQuery(host, db, `PRAGMA table_info(${ref})`)
+  let fks: Map<string, string> = new Map()
+  try {
+    const fkRes = await runQuery(host, db, `PRAGMA foreign_key_list(${ref})`)
+    fks = new Map(
+      fkRes.rows
+        .map((row) => sqlitePragmaFkSchema.safeParse(row))
+        .filter((p) => p.success)
+        .map((p) => [p.data.from, `${p.data.table}.${p.data.to ?? 'rowid'}`]),
+    )
+  } catch {
+    // foreign_key_list errors on tables without FKs in some builds; treat
+    // as "no foreign keys" rather than failing the whole column read.
+  }
+  return cols.rows
+    .map((row) => sqlitePragmaColumnSchema.safeParse(row))
+    .filter((p) => p.success)
+    .map((p) => ({
+      name: p.data.name,
+      type: p.data.type || 'any',
+      nullable: p.data.notnull === 0,
+      pk: p.data.pk > 0,
+      fkTarget: fks.get(p.data.name),
+    }))
+}
+
+const infoSchemaColumnSchema = z.object({
+  name: z.string(),
+  type: z.string(),
+  nullable: z.string(),
+  key_kind: z.string().nullable().optional(),
+  fk_target: z.string().nullable().optional(),
+})
+
+async function postgresColumns(
+  host: Host,
+  db: string,
+  table: string,
+): Promise<ColumnInfo[]> {
+  const { schema, name } = splitTableRef(table)
+  const res = await runQuery(
+    host,
+    db,
+    `SELECT c.column_name AS name, c.data_type AS type, c.is_nullable AS nullable,
+       (SELECT tc.constraint_type FROM information_schema.table_constraints tc
+          JOIN information_schema.key_column_usage kcu
+            ON kcu.constraint_name = tc.constraint_name
+           AND kcu.table_schema = tc.table_schema
+         WHERE tc.table_schema = c.table_schema AND tc.table_name = c.table_name
+           AND kcu.column_name = c.column_name AND tc.constraint_type = 'PRIMARY KEY'
+         LIMIT 1) AS key_kind,
+       (SELECT ccu.table_name || '.' || ccu.column_name
+          FROM information_schema.table_constraints tc
+          JOIN information_schema.key_column_usage kcu
+            ON kcu.constraint_name = tc.constraint_name
+           AND kcu.table_schema = tc.table_schema
+          JOIN information_schema.constraint_column_usage ccu
+            ON ccu.constraint_name = tc.constraint_name
+         WHERE tc.table_schema = c.table_schema AND tc.table_name = c.table_name
+           AND kcu.column_name = c.column_name AND tc.constraint_type = 'FOREIGN KEY'
+         LIMIT 1) AS fk_target
+     FROM information_schema.columns c
+     WHERE c.table_schema = $1 AND c.table_name = $2
+     ORDER BY c.ordinal_position`,
+    [schema ?? 'public', name],
+  )
+  return res.rows
+    .map((row) => infoSchemaColumnSchema.safeParse(row))
+    .filter((p) => p.success)
+    .map((p) => ({
+      name: p.data.name,
+      type: p.data.type,
+      nullable: p.data.nullable === 'YES',
+      pk: p.data.key_kind === 'PRIMARY KEY',
+      fkTarget: p.data.fk_target ?? undefined,
+    }))
+}
+
+async function mysqlColumns(
+  host: Host,
+  db: string,
+  table: string,
+): Promise<ColumnInfo[]> {
+  const { name } = splitTableRef(table)
+  const res = await runQuery(
+    host,
+    db,
+    `SELECT c.COLUMN_NAME AS name, c.COLUMN_TYPE AS type, c.IS_NULLABLE AS nullable,
+       c.COLUMN_KEY AS key_kind,
+       (SELECT CONCAT(kcu.REFERENCED_TABLE_NAME, '.', kcu.REFERENCED_COLUMN_NAME)
+          FROM information_schema.KEY_COLUMN_USAGE kcu
+         WHERE kcu.TABLE_SCHEMA = c.TABLE_SCHEMA AND kcu.TABLE_NAME = c.TABLE_NAME
+           AND kcu.COLUMN_NAME = c.COLUMN_NAME
+           AND kcu.REFERENCED_TABLE_NAME IS NOT NULL
+         LIMIT 1) AS fk_target
+     FROM information_schema.COLUMNS c
+     WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = ?
+     ORDER BY c.ORDINAL_POSITION`,
+    [name],
+  )
+  return res.rows
+    .map((row) => infoSchemaColumnSchema.safeParse(row))
+    .filter((p) => p.success)
+    .map((p) => ({
+      name: p.data.name,
+      type: p.data.type,
+      nullable: p.data.nullable === 'YES',
+      pk: p.data.key_kind === 'PRI',
+      fkTarget: p.data.fk_target ?? undefined,
+    }))
+}
+
+export async function tableColumns(
+  host: Host,
+  db: string,
+  driver: DbDriver,
+  table: string,
+): Promise<ColumnInfo[]> {
+  if (driver === 'sqlite') return sqliteColumns(host, db, table)
+  if (driver === 'postgres') return postgresColumns(host, db, table)
+  if (driver === 'mysql') return mysqlColumns(host, db, table)
+  return []
+}
+
+/* ---- paged reads ---- */
+
+export interface TablePage {
+  result: QueryResponse
+  page: number
+  pageSize: number
+  /** True when a `pageSize + 1` sentinel row came back — a next page exists.
+      Lets pagination stay bounded when the total row count is unknown. */
+  hasMore: boolean
+}
+
+export async function fetchTablePage(
+  host: Host,
+  db: string,
+  driver: DbDriver,
+  table: string,
+  page: number,
+  pageSize: number = PAGE_SIZE,
+  sort?: TableSort | null,
+): Promise<TablePage> {
+  const ref = quoteTableRef(driver, table)
+  // Normalize to non-negative integers before interpolating — a fractional or
+  // non-finite page/size would otherwise yield broken or unbounded SQL.
+  const size = Math.max(1, Math.trunc(pageSize) || PAGE_SIZE)
+  const safePage = Math.max(0, Math.trunc(page) || 0)
+  const offset = safePage * size
+  const orderBy = sort
+    ? ` ORDER BY ${quoteIdent(driver, sort.column)} ${sort.dir === 'desc' ? 'DESC' : 'ASC'}`
+    : ''
+  // Fetch one extra sentinel row: its presence means a next page exists, so
+  // navigation stays bounded even when the total count is unknown.
+  const result = await runQuery(
+    host,
+    db,
+    `SELECT * FROM ${ref}${orderBy} LIMIT ${size + 1} OFFSET ${offset}`,
+  )
+  const hasMore = result.rows.length > size
+  const rows = result.rows.slice(0, size)
+  return {
+    result: { ...result, rows, row_count: rows.length },
+    page: safePage,
+    pageSize: size,
+    hasMore,
+  }
+}

--- a/database/ui/src/page/db-data.ts
+++ b/database/ui/src/page/db-data.ts
@@ -161,7 +161,7 @@ export function quoteIdent(driver: DbDriver, ident: string): string {
 }
 
 /** Quote a possibly schema-qualified table reference (`schema.table`). */
-function quoteTableRef(driver: DbDriver, table: string): string {
+export function quoteTableRef(driver: DbDriver, table: string): string {
   if (driver === 'postgres' && table.includes('.')) {
     const [schema, ...rest] = table.split('.')
     return `${quoteIdent(driver, schema)}.${quoteIdent(driver, rest.join('.'))}`

--- a/database/ui/src/page/icons.tsx
+++ b/database/ui/src/page/icons.tsx
@@ -1,0 +1,199 @@
+/**
+ * Small inline SVG icon set — the injected page can't pull in lucide-react
+ * (nothing is bundled but zod), so the handful of glyphs the ported
+ * components used (PK key, FK link, sort arrows, chevrons, …) are hand-drawn
+ * here. Every icon inherits `currentColor` and takes a numeric `size`
+ * (Tailwind `w-*`/`h-*` classes don't apply in injected UI). `className` is
+ * accepted so components like the console's `EmptyState`, which pass one,
+ * type-check.
+ */
+
+import type { CSSProperties, ReactNode } from 'react'
+
+export interface IconProps {
+  size?: number
+  className?: string
+  style?: CSSProperties
+  'aria-hidden'?: boolean
+  'aria-label'?: string
+}
+
+function Svg({
+  size = 12,
+  children,
+  className,
+  style,
+  'aria-hidden': ariaHidden,
+  'aria-label': ariaLabel,
+  ...rest
+}: IconProps & { children: ReactNode }) {
+  // Decorative by default. A caller passing aria-label opts into a labeled,
+  // non-hidden icon (role=img so it reads as a graphic); an explicit
+  // aria-hidden always wins.
+  const labeled = ariaLabel != null
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      style={{ flexShrink: 0, display: 'inline-block', ...style }}
+      role={labeled ? 'img' : undefined}
+      aria-label={ariaLabel}
+      aria-hidden={ariaHidden ?? (labeled ? undefined : true)}
+      {...rest}
+    >
+      {children}
+    </svg>
+  )
+}
+
+export function KeyRound(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <circle cx="7.5" cy="15.5" r="5.5" />
+      <path d="m21 2-9.6 9.6" />
+      <path d="m15.5 7.5 3 3L22 7l-3-3" />
+    </Svg>
+  )
+}
+
+export function Link2(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <path d="M9 17H7A5 5 0 0 1 7 7h2" />
+      <path d="M15 7h2a5 5 0 1 1 0 10h-2" />
+      <line x1="8" x2="16" y1="12" y2="12" />
+    </Svg>
+  )
+}
+
+export function Table2(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <rect x="3" y="3" width="18" height="18" rx="1" />
+      <path d="M3 9h18M3 15h18M9 3v18M15 3v18" />
+    </Svg>
+  )
+}
+
+export function Eye(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
+      <circle cx="12" cy="12" r="3" />
+    </Svg>
+  )
+}
+
+export function ChevronRight(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <path d="m9 18 6-6-6-6" />
+    </Svg>
+  )
+}
+
+export function ChevronLeft(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <path d="m15 18-6-6 6-6" />
+    </Svg>
+  )
+}
+
+export function ArrowUp(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <path d="m5 12 7-7 7 7" />
+      <path d="M12 19V5" />
+    </Svg>
+  )
+}
+
+export function ArrowDown(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <path d="M12 5v14" />
+      <path d="m19 12-7 7-7-7" />
+    </Svg>
+  )
+}
+
+export function Check(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <path d="M20 6 9 17l-5-5" />
+    </Svg>
+  )
+}
+
+export function Copy(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <rect x="9" y="9" width="13" height="13" rx="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </Svg>
+  )
+}
+
+export function X(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <path d="M18 6 6 18M6 6l12 12" />
+    </Svg>
+  )
+}
+
+export function Play(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <path d="m5 3 14 9-14 9V3z" />
+    </Svg>
+  )
+}
+
+export function History(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <path d="M3 12a9 9 0 1 0 3-6.7L3 8" />
+      <path d="M3 3v5h5" />
+      <path d="M12 7v5l3 2" />
+    </Svg>
+  )
+}
+
+export function RefreshCw(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+      <path d="M21 3v5h-5" />
+      <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+      <path d="M3 21v-5h5" />
+    </Svg>
+  )
+}
+
+export function AlertCircle(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <circle cx="12" cy="12" r="10" />
+      <path d="M12 8v4M12 16h.01" />
+    </Svg>
+  )
+}
+
+export function Database(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <ellipse cx="12" cy="5" rx="9" ry="3" />
+      <path d="M3 5v14a9 3 0 0 0 18 0V5" />
+      <path d="M3 12a9 3 0 0 0 18 0" />
+    </Svg>
+  )
+}

--- a/database/ui/src/page/index.tsx
+++ b/database/ui/src/page/index.tsx
@@ -1,0 +1,249 @@
+/**
+ * The database page (#/ext/database): the database worker's read surface —
+ * configured databases, their schema (tables + columns via the driver's own
+ * catalog, since the worker has no introspection functions), and paged,
+ * sortable table contents with a row inspector, plus an ad-hoc read-only SQL
+ * panel. Data loads on demand (db/table switch / refresh) — the worker emits
+ * no change events yet, so there is nothing to subscribe to. Read-only on
+ * purpose: INSERT/UPDATE/DDL stay in agent flows behind the approval gate.
+ *
+ * The host only mounts this page when the database worker is connected, so
+ * there is no presence gate here; a failed `listDatabases` surfaces as the
+ * "worker unavailable" panel below.
+ */
+
+import {
+  Badge,
+  Button,
+  EmptyState,
+  type Host,
+  Select,
+  Skeleton,
+  StatusPanel,
+} from '@iii-dev/console-ui'
+import { useCallback, useEffect, useState } from 'react'
+import {
+  type DbInfo,
+  listDbs,
+  listTables,
+  PAGE_SIZE,
+  quoteIdent,
+} from './db-data'
+import {
+  AlertCircle,
+  Database,
+  type IconProps,
+  RefreshCw,
+  Table2,
+} from './icons'
+import { PAGE_CSS } from './page-styles'
+import { SchemaTree } from './SchemaTree'
+import { SqlPanel } from './SqlPanel'
+import { TableDataPanel } from './TableDataPanel'
+import { useDatabaseRead } from './useDatabaseRead'
+
+type PanelMode = 'data' | 'sql'
+
+const DatabaseIcon = (p: IconProps) => <Database size={28} {...p} />
+const TableIcon = (p: IconProps) => <Table2 size={28} {...p} />
+
+export function DatabasePage({ host }: { host: Host }) {
+  const [selectedDb, setSelectedDb] = useState<string | undefined>(undefined)
+  const [selectedTable, setSelectedTable] = useState<string | null>(null)
+  const [mode, setMode] = useState<PanelMode>('data')
+  const [seedSql, setSeedSql] = useState<string | undefined>(undefined)
+  const [bump, setBump] = useState(0)
+
+  const dbsFetcher = useCallback(() => listDbs(host), [host])
+  const dbsRead = useDatabaseRead(true, dbsFetcher)
+  const dbs = dbsRead.data ?? []
+  const activeDb: DbInfo | undefined =
+    dbs.find((db) => db.name === selectedDb) ?? dbs[0]
+
+  const tablesFetcher = useCallback(() => {
+    if (!activeDb) return Promise.resolve([])
+    return listTables(host, activeDb.name, activeDb.driver)
+  }, [host, activeDb])
+  const tablesRead = useDatabaseRead(!!activeDb, tablesFetcher)
+  const tables = tablesRead.data ?? []
+
+  // Keep the selected table valid when the db or its table list changes.
+  useEffect(() => {
+    if (selectedTable && !tables.some((t) => t.name === selectedTable)) {
+      setSelectedTable(null)
+    }
+  }, [tables, selectedTable])
+
+  const refresh = () => {
+    dbsRead.refresh()
+    tablesRead.refresh()
+    setBump((b) => b + 1)
+  }
+
+  return (
+    <div className="db-page">
+      <style>{PAGE_CSS}</style>
+      <div className="db-head">
+        <div>
+          <div className="db-title">database</div>
+          <div className="db-sub">
+            {activeDb?.url ??
+              (dbsRead.error
+                ? 'worker not connected'
+                : 'no database configured')}
+          </div>
+        </div>
+        <div className="db-controls">
+          {activeDb ? (
+            <>
+              <div className="db-modes">
+                {(['data', 'sql'] as const).map((m) => (
+                  <button
+                    key={m}
+                    type="button"
+                    className={`db-mode${mode === m ? ' active' : ''}`}
+                    aria-pressed={mode === m}
+                    onClick={() => setMode(m)}
+                  >
+                    {m}
+                  </button>
+                ))}
+              </div>
+              <Badge variant="accent">{activeDb.driver}</Badge>
+              {dbs.length > 1 ? (
+                <Select
+                  value={activeDb.name}
+                  options={dbs.map((db) => ({
+                    value: db.name,
+                    label: db.name,
+                    title: db.url,
+                  }))}
+                  onChange={(next) => {
+                    setSelectedDb(next)
+                    setSelectedTable(null)
+                  }}
+                  aria-label="database"
+                />
+              ) : null}
+            </>
+          ) : null}
+          <Button variant="ghost" size="sm" onClick={refresh}>
+            <RefreshCw size={14} aria-hidden />
+            refresh
+          </Button>
+        </div>
+      </div>
+
+      {dbsRead.error ? (
+        <div style={{ marginTop: 16 }}>
+          <StatusPanel
+            variant="alert"
+            icon={<AlertCircle size={18} />}
+            headline="database worker unavailable"
+            detail={dbsRead.error}
+          />
+        </div>
+      ) : dbsRead.loading && dbs.length === 0 ? (
+        <div className="db-msg db-pulse" style={{ marginTop: 16 }}>
+          · loading databases…
+        </div>
+      ) : dbs.length === 0 ? (
+        <div style={{ marginTop: 16 }}>
+          <EmptyState
+            icon={DatabaseIcon}
+            title="no databases configured"
+            description="configure a database in the worker's config (databases: { name: { url } }) and it appears here."
+          />
+        </div>
+      ) : (
+        <div className="db-body">
+          <aside className="db-aside">
+            <div className="db-aside-head">
+              tables
+              {tables.length > 0
+                ? ` · ${tables.filter((t) => t.kind === 'table').length}`
+                : ''}
+            </div>
+            <div className="db-aside-body">
+              {tablesRead.error ? (
+                <p
+                  className="db-tree-msg alert"
+                  style={{ padding: '8px 12px' }}
+                >
+                  {tablesRead.error}
+                </p>
+              ) : tablesRead.loading && tables.length === 0 ? (
+                <div className="db-skel">
+                  <Skeleton
+                    style={{ display: 'block', height: 20, width: '100%' }}
+                  />
+                  <Skeleton
+                    style={{ display: 'block', height: 20, width: '75%' }}
+                  />
+                  <Skeleton
+                    style={{ display: 'block', height: 20, width: '83%' }}
+                  />
+                </div>
+              ) : tables.length === 0 ? (
+                <p className="db-msg">no tables</p>
+              ) : activeDb ? (
+                // Remount on db/refresh so lazily-cached columns re-read.
+                <SchemaTree
+                  key={`${activeDb.name}:${bump}`}
+                  host={host}
+                  db={activeDb.name}
+                  driver={activeDb.driver}
+                  tables={tables}
+                  selectedTable={selectedTable}
+                  onSelectTable={setSelectedTable}
+                />
+              ) : null}
+            </div>
+          </aside>
+          <div className="db-panel">
+            {activeDb ? (
+              mode === 'sql' ? (
+                <SqlPanel
+                  key={`${activeDb.name}:${bump}`}
+                  host={host}
+                  db={activeDb.name}
+                  driver={activeDb.driver}
+                  seedSql={seedSql}
+                  tables={tables.map((t) => t.name)}
+                />
+              ) : !selectedTable ? (
+                <div className="db-pad">
+                  <EmptyState
+                    icon={TableIcon}
+                    title="select a table"
+                    description={
+                      tables.length > 0
+                        ? `${tables.length} table${tables.length === 1 ? '' : 's'} in ${activeDb.name} — pick one to browse its rows, sort columns, and inspect values.`
+                        : `no tables in ${activeDb.name} yet`
+                    }
+                  />
+                </div>
+              ) : (
+                // Remount on db/table/refresh so every fetch hook restarts clean.
+                <TableDataPanel
+                  key={`${activeDb.name}:${selectedTable}:${bump}`}
+                  host={host}
+                  db={activeDb.name}
+                  driver={activeDb.driver}
+                  table={selectedTable}
+                  enabled
+                  onOpenInSql={(table) => {
+                    setSeedSql(
+                      `SELECT * FROM ${quoteIdent(activeDb.driver, table)} LIMIT ${PAGE_SIZE}`,
+                    )
+                    setMode('sql')
+                  }}
+                />
+              )
+            ) : null}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/database/ui/src/page/index.tsx
+++ b/database/ui/src/page/index.tsx
@@ -27,7 +27,7 @@ import {
   listDbs,
   listTables,
   PAGE_SIZE,
-  quoteIdent,
+  quoteTableRef,
 } from './db-data'
 import {
   AlertCircle,
@@ -80,18 +80,22 @@ export function DatabasePage({ host }: { host: Host }) {
     setBump((b) => b + 1)
   }
 
+  // A configured database without a `url` (redacted in the worker's config
+  // response) still counts as configured — fall back to its name, not to the
+  // "nothing here" copy.
+  const subtitle = activeDb
+    ? (activeDb.url ?? activeDb.name)
+    : dbsRead.error
+      ? 'worker not connected'
+      : 'no database configured'
+
   return (
     <div className="db-page">
       <style>{PAGE_CSS}</style>
       <div className="db-head">
         <div>
           <div className="db-title">database</div>
-          <div className="db-sub">
-            {activeDb?.url ??
-              (dbsRead.error
-                ? 'worker not connected'
-                : 'no database configured')}
-          </div>
+          <div className="db-sub">{subtitle}</div>
         </div>
         <div className="db-controls">
           {activeDb ? (
@@ -203,8 +207,10 @@ export function DatabasePage({ host }: { host: Host }) {
           <div className="db-panel">
             {activeDb ? (
               mode === 'sql' ? (
+                // Keyed by db only: a refresh reloads metadata, it must not
+                // wipe an in-progress statement or its results.
                 <SqlPanel
-                  key={`${activeDb.name}:${bump}`}
+                  key={activeDb.name}
                   host={host}
                   db={activeDb.name}
                   driver={activeDb.driver}
@@ -234,7 +240,7 @@ export function DatabasePage({ host }: { host: Host }) {
                   enabled
                   onOpenInSql={(table) => {
                     setSeedSql(
-                      `SELECT * FROM ${quoteIdent(activeDb.driver, table)} LIMIT ${PAGE_SIZE}`,
+                      `SELECT * FROM ${quoteTableRef(activeDb.driver, table)} LIMIT ${PAGE_SIZE}`,
                     )
                     setMode('sql')
                   }}

--- a/database/ui/src/page/page-styles.ts
+++ b/database/ui/src/page/page-styles.ts
@@ -1,0 +1,316 @@
+/**
+ * The database page's own CSS, rendered once as a scoped <style> at the top
+ * of `DatabasePage`. Injected UI can't lean on the console's Tailwind
+ * utility output, so the source's utility classes are ported here as real
+ * rules — every one scoped under `.db-page` and coloured from the console's
+ * design tokens (`var(--color-*)`) so light/dark theming is free.
+ */
+
+export const PAGE_CSS = `
+.db-page {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  color: var(--color-ink);
+  padding: 20px 24px;
+  box-sizing: border-box;
+}
+.db-page *, .db-page *::before, .db-page *::after { box-sizing: border-box; }
+
+.db-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--color-rule);
+}
+.db-title {
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  text-transform: lowercase;
+  color: var(--color-ink);
+}
+.db-sub {
+  font-size: 12px;
+  color: var(--color-ink-faint);
+  margin-top: 2px;
+  text-transform: lowercase;
+  word-break: break-all;
+}
+.db-controls { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+
+.db-modes {
+  display: inline-flex;
+  border: 1px solid var(--color-rule);
+}
+.db-mode {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--color-ink-faint);
+  font: inherit;
+  font-size: 12px;
+  text-transform: lowercase;
+  padding: 3px 12px;
+  cursor: pointer;
+}
+.db-mode + .db-mode { border-left: 1px solid var(--color-rule); }
+.db-mode:hover { color: var(--color-ink); }
+.db-mode.active { background: var(--color-accent); color: var(--color-accent-fg); }
+
+.db-driver-badge {
+  border: 1px solid var(--color-accent);
+  color: var(--color-accent);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 1px 8px;
+}
+
+.db-body {
+  display: grid;
+  grid-template-columns: minmax(200px, 240px) minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
+  margin-top: 16px;
+}
+
+.db-aside {
+  border: 1px solid var(--color-rule);
+  background: var(--color-bg);
+  max-height: 74vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+.db-aside-head {
+  position: sticky;
+  top: 0;
+  background: var(--color-bg);
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--color-rule-2);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-ink-ghost);
+}
+.db-aside-body { flex: 1; padding: 4px 0; }
+
+.db-panel {
+  border: 1px solid var(--color-rule);
+  background: var(--color-bg);
+  min-height: 360px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.db-msg {
+  padding: 10px 12px;
+  font-size: 12px;
+  color: var(--color-ink-ghost);
+  text-transform: lowercase;
+}
+.db-msg.alert { color: var(--color-alert); text-transform: none; word-break: break-all; }
+.db-pulse { animation: db-page-pulse 1.6s ease-in-out infinite; }
+@keyframes db-page-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }
+
+.db-pad { padding: 16px; }
+.db-skel { display: flex; flex-direction: column; gap: 8px; padding: 12px; }
+
+/* ---- schema tree ---- */
+.db-tree-grouphead {
+  padding: 12px 12px 4px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-ink-ghost);
+}
+.db-tree ul { list-style: none; margin: 0; padding: 0; }
+.db-tree-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding-right: 8px;
+  border-left: 2px solid transparent;
+}
+.db-tree-row:hover { background: color-mix(in oklab, var(--color-paper-2) 60%, transparent); }
+.db-tree-row.active { background: var(--color-paper-2); border-left-color: var(--color-accent); }
+.db-tree-toggle {
+  appearance: none; background: transparent; border: 0; cursor: pointer;
+  padding: 6px 0 6px 8px; color: var(--color-ink-ghost); display: inline-flex;
+}
+.db-tree-toggle:hover { color: var(--color-ink); }
+.db-tree-name {
+  appearance: none; background: transparent; border: 0; cursor: pointer;
+  display: flex; align-items: center; gap: 6px; flex: 1; min-width: 0;
+  padding: 6px 0; font: inherit; font-size: 12.5px; text-align: left;
+  color: var(--color-ink-faint);
+}
+.db-tree-name:hover { color: var(--color-ink); }
+.db-tree-row.active .db-tree-name { color: var(--color-ink); }
+.db-trunc { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.db-cols { padding-bottom: 4px; }
+.db-col {
+  display: flex; align-items: center; gap: 6px;
+  padding: 3px 12px 3px 36px; font-size: 11.5px;
+}
+.db-col-name { color: var(--color-ink-faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.db-col-type { color: var(--color-ink-ghost); text-transform: lowercase; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.db-idx-head {
+  padding: 6px 12px 2px 36px; font-size: 9.5px;
+  text-transform: uppercase; letter-spacing: 0.1em; color: var(--color-ink-ghost);
+}
+.db-idx { display: flex; align-items: center; gap: 6px; padding: 3px 12px 3px 36px; font-size: 11px; }
+.db-idx-name { color: var(--color-ink-faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.db-idx-unique { color: var(--color-accent); font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.06em; }
+.db-tree-msg { padding: 4px 12px 4px 36px; font-size: 11px; color: var(--color-ink-ghost); }
+.db-tree-msg.alert { color: var(--color-alert); }
+
+/* ---- result grid ---- */
+.db-grid-wrap { overflow-x: auto; }
+.db-grid { width: 100%; border-collapse: collapse; }
+.db-grid thead.sticky th { position: sticky; top: 0; z-index: 10; }
+.db-grid th {
+  padding: 8px 12px; font-size: 11px; white-space: nowrap;
+  background: var(--color-paper-2); border-bottom: 1px solid var(--color-rule);
+  text-align: left; font-weight: 500;
+}
+.db-grid th.num { text-align: right; }
+.db-grid th .colname { color: var(--color-ink-faint); font-weight: 500; }
+.db-grid th .coltype { color: var(--color-ink-ghost); font-weight: 400; text-transform: lowercase; }
+.db-grid th .sorter {
+  appearance: none; background: transparent; border: 0; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px; font: inherit; color: inherit;
+}
+.db-grid th.num .sorter { flex-direction: row-reverse; }
+.db-grid th .sorter:hover .colname { color: var(--color-ink); }
+.db-grid th .static { display: inline-flex; align-items: center; gap: 6px; }
+.db-grid td {
+  padding: 6px 12px; font-size: 12.5px; vertical-align: top; white-space: nowrap;
+  max-width: 28rem; overflow: hidden; text-overflow: ellipsis;
+  border-bottom: 1px solid var(--color-rule-2);
+}
+.db-grid td.num { text-align: right; }
+.db-grid tbody tr:last-child td { border-bottom: 0; }
+.db-grid tbody tr.clickable { cursor: pointer; }
+.db-grid tbody tr:hover { background: color-mix(in oklab, var(--color-paper-2) 60%, transparent); }
+.db-grid tbody tr.selected { background: var(--color-paper-2); }
+.db-grid td .copycell {
+  appearance: none; background: transparent; border: 0; padding: 0; margin: 0;
+  font: inherit; color: inherit; cursor: copy; text-align: left;
+  max-width: 100%; overflow: hidden; text-overflow: ellipsis;
+}
+.db-cell-null { color: var(--color-ink-ghost); font-style: italic; }
+.db-cell-bool-true { color: var(--color-accent); }
+.db-cell-bool-false { color: var(--color-warn); }
+.db-cell-num { color: var(--color-ink); font-variant-numeric: tabular-nums; }
+.db-cell-json { color: var(--color-ink-faint); }
+.db-cell-str { color: var(--color-ink); }
+.db-cell-date { color: var(--color-ink-faint); }
+.db-copied { display: inline-flex; align-items: center; gap: 4px; font-size: 11px; color: var(--color-accent); }
+
+.db-grid-foot {
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 12px; border-top: 1px solid var(--color-rule-2);
+  font-size: 11px; color: var(--color-ink-faint);
+}
+.db-linkish {
+  appearance: none; background: transparent; border: 0; padding: 0; cursor: pointer;
+  font: inherit; color: var(--color-accent);
+}
+.db-linkish:hover { text-decoration: underline; }
+.db-grid-empty { padding: 12px; font-size: 12.5px; color: var(--color-ink-ghost); }
+
+/* ---- table data panel ---- */
+.db-data { display: flex; min-height: 0; min-width: 0; width: 100%; }
+.db-data-main { flex: 1; display: flex; flex-direction: column; min-width: 0; }
+.db-data-bar {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 12px;
+  padding: 8px 16px; border-bottom: 1px solid var(--color-rule);
+  font-size: 11px; color: var(--color-ink-faint);
+}
+.db-data-bar .name { color: var(--color-ink); font-weight: 500; }
+.db-data-bar .spacer { margin-left: auto; }
+.db-data-scroll { overflow: auto; max-height: 60vh; }
+.db-data-foot { border-top: 1px solid var(--color-rule); padding: 8px 16px; }
+
+/* ---- pagination ---- */
+.db-pager {
+  display: flex; align-items: center; justify-content: space-between; gap: 16px;
+  font-size: 12px; color: var(--color-ink-faint); text-transform: lowercase;
+}
+.db-pager-group { display: flex; align-items: center; gap: 8px; font-variant-numeric: tabular-nums; }
+.db-pager-cap { text-transform: uppercase; letter-spacing: 0.06em; font-size: 11px; }
+.db-pager select {
+  border: 1px solid var(--color-rule); background: var(--color-bg); color: var(--color-ink);
+  font: inherit; font-size: 12px; padding: 2px 6px; border-radius: 0;
+}
+.db-pager select:focus { outline: none; border-color: var(--color-accent); }
+
+/* ---- row inspector ---- */
+.db-rowdetail {
+  width: 320px; flex-shrink: 0; border-left: 1px solid var(--color-rule);
+  overflow-y: auto; max-height: 60vh;
+}
+.db-rowdetail-head {
+  position: sticky; top: 0; background: var(--color-paper-2);
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 8px 12px; border-bottom: 1px solid var(--color-rule);
+}
+.db-rowdetail-head .cap { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--color-ink-faint); }
+.db-field { padding: 8px 12px; border-bottom: 1px solid var(--color-rule-2); }
+.db-field-head { display: flex; align-items: center; gap: 6px; }
+.db-field-name { font-size: 11px; font-weight: 500; color: var(--color-ink-faint); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.db-field-type { font-size: 10px; color: var(--color-ink-ghost); text-transform: lowercase; }
+.db-field-copy { appearance: none; background: transparent; border: 0; padding: 0; cursor: pointer; color: var(--color-ink-ghost); display: inline-flex; }
+.db-field-copy:hover { color: var(--color-ink); }
+.db-field-copy.copied { color: var(--color-accent); }
+.db-field-value { margin-top: 4px; font-size: 12px; word-break: break-all; }
+.db-field-value .null { color: var(--color-ink-ghost); font-style: italic; }
+.db-field-value .bool-true { color: var(--color-accent); }
+.db-field-value .bool-false { color: var(--color-warn); }
+.db-field-value .plain { color: var(--color-ink); white-space: pre-wrap; }
+.db-field-fk { margin-top: 4px; font-size: 10px; color: var(--color-ink-ghost); }
+.db-icon-btn {
+  appearance: none; background: transparent; border: 0; cursor: pointer;
+  color: var(--color-ink-ghost); display: inline-flex; padding: 2px;
+}
+.db-icon-btn:hover { color: var(--color-ink); }
+.db-icon-btn:disabled { opacity: 0.4; cursor: default; }
+
+/* ---- sql panel ---- */
+.db-sql { display: flex; flex-direction: column; min-height: 0; min-width: 0; width: 100%; }
+.db-sql-top { border-bottom: 1px solid var(--color-rule); }
+.db-sql-editor-wrap { max-height: 240px; overflow: auto; background: var(--color-bg); }
+.db-sql-code { min-height: 104px; }
+.db-sql-actions {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
+  padding: 8px 16px; border-top: 1px solid var(--color-rule-2); background: var(--color-paper-2);
+}
+.db-sql-warn { font-size: 11px; color: var(--color-warn); }
+.db-sql-meta { margin-left: auto; font-size: 11px; color: var(--color-ink-faint); font-variant-numeric: tabular-nums; }
+.db-sql-history { border-top: 1px solid var(--color-rule-2); max-height: 160px; overflow-y: auto; }
+.db-sql-history-row {
+  display: flex; align-items: center; gap: 8px; padding: 4px 16px;
+  border-bottom: 1px solid var(--color-rule-2);
+}
+.db-sql-history-row:last-child { border-bottom: 0; }
+.db-sql-history-row:hover { background: color-mix(in oklab, var(--color-paper-2) 60%, transparent); }
+.db-sql-history-pick {
+  appearance: none; background: transparent; border: 0; cursor: pointer; flex: 1; min-width: 0;
+  text-align: left; font: inherit; font-size: 11.5px; color: var(--color-ink-faint);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.db-sql-history-pick:hover { color: var(--color-ink); }
+.db-sql-results { flex: 1; overflow: auto; max-height: 55vh; min-height: 0; }
+.db-sql-placeholder { padding: 16px; font-size: 12px; color: var(--color-ink-ghost); text-transform: lowercase; }
+
+@media (max-width: 720px) {
+  .db-body { grid-template-columns: minmax(0, 1fr); }
+  .db-data { flex-direction: column; }
+  .db-rowdetail { width: auto; border-left: 0; border-top: 1px solid var(--color-rule); }
+}
+`

--- a/database/ui/src/page/pagination.tsx
+++ b/database/ui/src/page/pagination.tsx
@@ -1,0 +1,75 @@
+/**
+ * Pagination bar for the table data panel — ported from the console's
+ * `ui/Pagination`. Prev/next use the shared `Button` (icon variant); the
+ * page-size select is a raw `<select>` styled from design tokens.
+ */
+
+import { Button } from '@iii-dev/console-ui'
+import { ChevronLeft, ChevronRight } from './icons'
+
+interface PaginationProps {
+  currentPage: number
+  totalPages: number
+  totalItems: number
+  pageSize: number
+  onPageChange: (page: number) => void
+  onPageSizeChange: (pageSize: number) => void
+  pageSizeOptions?: number[]
+}
+
+export function Pagination({
+  currentPage,
+  totalPages,
+  totalItems,
+  pageSize,
+  onPageChange,
+  onPageSizeChange,
+  pageSizeOptions = [25, 50, 100],
+}: PaginationProps) {
+  const start = totalItems === 0 ? 0 : (currentPage - 1) * pageSize + 1
+  const end = Math.min(currentPage * pageSize, totalItems)
+  return (
+    <div className="db-pager">
+      <div className="db-pager-group">
+        <span className="db-pager-cap">show</span>
+        <select
+          value={pageSize}
+          onChange={(e) => onPageSizeChange(Number(e.target.value))}
+          aria-label="rows per page"
+        >
+          {pageSizeOptions.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="db-pager-group">
+        <span>
+          {start}–{end} of {totalItems}
+        </span>
+        <Button
+          variant="icon"
+          size="icon"
+          aria-label="previous page"
+          disabled={currentPage <= 1}
+          onClick={() => onPageChange(currentPage - 1)}
+        >
+          <ChevronLeft size={14} />
+        </Button>
+        <span className="db-pager-cap">
+          page {currentPage} of {totalPages}
+        </span>
+        <Button
+          variant="icon"
+          size="icon"
+          aria-label="next page"
+          disabled={currentPage >= totalPages}
+          onClick={() => onPageChange(currentPage + 1)}
+        >
+          <ChevronRight size={14} />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/database/ui/src/page/result-grid.tsx
+++ b/database/ui/src/page/result-grid.tsx
@@ -1,0 +1,290 @@
+/**
+ * ResultGrid — tabular rendering for `QueryResp`-shaped payloads
+ * (`{ rows, row_count, columns }`). Cells render by value type: NULL is a
+ * ghost literal, booleans and numbers are monospace (numbers right-aligned),
+ * JSON values collapse to a compact preview, long strings truncate with the
+ * full value on hover. Every cell copies its value on click.
+ *
+ * Ported from the console's chat `ResultGrid` for the injected page: the
+ * source already rendered a real `<table>`, so the port keeps the markup and
+ * swaps Tailwind utilities for the page's scoped classes + design tokens.
+ */
+
+import { useState } from 'react'
+import { cellText, copyText } from './cells'
+import { type ColumnMeta, type TableSort, typeCategory } from './db-data'
+import { ArrowDown, ArrowUp, Check, KeyRound } from './icons'
+
+const CLAMP_ROWS = 30
+const STRING_TRUNCATE = 160
+const JSON_PREVIEW = 80
+
+interface ResultGridProps {
+  columns?: ColumnMeta[]
+  rows: Record<string, unknown>[]
+  rowCount?: number
+  /** Column names that form the primary key — marked with a key glyph. */
+  primaryKeys?: string[]
+  /** Current sort; render an indicator on the sorted column. */
+  sort?: TableSort | null
+  /** When set, headers become buttons cycling asc → desc → off. */
+  onSort?: (sort: TableSort | null) => void
+  /** When set, rows highlight on hover and clicking selects one. */
+  onRowClick?: (index: number) => void
+  selectedRow?: number | null
+  /** Sticky header + no clamp — the page's scroll container paginates. */
+  stickyHeader?: boolean
+  /** Hide the "N rows" footer (the page shows its own pagination bar). */
+  hideFooter?: boolean
+}
+
+/** Column order: declared `columns` metadata first, else keys of row 0. */
+function resolveColumns(
+  columns: ColumnMeta[] | undefined,
+  rows: Record<string, unknown>[],
+): ColumnMeta[] {
+  if (columns && columns.length > 0) return columns
+  if (rows.length === 0) return []
+  return Object.keys(rows[0]).map((name) => ({ name }))
+}
+
+function jsonPreview(value: unknown): string {
+  let text: string
+  try {
+    text = JSON.stringify(value)
+  } catch {
+    text = String(value)
+  }
+  if (text.length <= JSON_PREVIEW) return text
+  return `${text.slice(0, JSON_PREVIEW)}…`
+}
+
+function CellValue({
+  value,
+  category,
+}: {
+  value: unknown
+  category: ReturnType<typeof typeCategory>
+}) {
+  if (value === null || value === undefined) {
+    return <span className="db-cell-null">NULL</span>
+  }
+  if (typeof value === 'boolean') {
+    return (
+      <span className={value ? 'db-cell-bool-true' : 'db-cell-bool-false'}>
+        {String(value)}
+      </span>
+    )
+  }
+  if (typeof value === 'number') {
+    return <span className="db-cell-num">{String(value)}</span>
+  }
+  if (typeof value === 'object') {
+    const preview = jsonPreview(value)
+    return (
+      <span className="db-cell-json" title={preview}>
+        {preview}
+      </span>
+    )
+  }
+  const text = String(value)
+  const cls =
+    category === 'date'
+      ? 'db-cell-date'
+      : category === 'numeric'
+        ? 'db-cell-num'
+        : 'db-cell-str'
+  if (text.length > STRING_TRUNCATE) {
+    return (
+      <span className={cls} title={text}>
+        {text.slice(0, STRING_TRUNCATE)}…
+      </span>
+    )
+  }
+  return <span className={cls}>{text}</span>
+}
+
+function nextSort(current: TableSort | null | undefined, column: string) {
+  if (!current || current.column !== column) {
+    return { column, dir: 'asc' as const }
+  }
+  if (current.dir === 'asc') return { column, dir: 'desc' as const }
+  return null
+}
+
+export function ResultGrid({
+  columns,
+  rows,
+  rowCount,
+  primaryKeys,
+  sort,
+  onSort,
+  onRowClick,
+  selectedRow,
+  stickyHeader,
+  hideFooter,
+}: ResultGridProps) {
+  const [expanded, setExpanded] = useState(false)
+  const [copied, setCopied] = useState<string | null>(null)
+  const cols = resolveColumns(columns, rows)
+  const total = rowCount ?? rows.length
+  const clamped = !stickyHeader && !expanded && rows.length > CLAMP_ROWS
+  const visible = clamped ? rows.slice(0, CLAMP_ROWS) : rows
+  const pkSet = new Set(primaryKeys ?? [])
+
+  if (total === 0 || cols.length === 0) {
+    return <div className="db-grid-empty">· 0 rows</div>
+  }
+
+  const copyCell = (key: string, value: unknown) => {
+    copyText(cellText(value))
+    setCopied(key)
+    window.setTimeout(() => {
+      setCopied((cur) => (cur === key ? null : cur))
+    }, 1200)
+  }
+
+  return (
+    <div>
+      <div className="db-grid-wrap">
+        <table className="db-grid">
+          <thead className={stickyHeader ? 'sticky' : undefined}>
+            <tr>
+              {cols.map((col) => {
+                const category = typeCategory(col.type)
+                const isNum = category === 'numeric'
+                const sorted = sort?.column === col.name ? sort.dir : null
+                const label = (
+                  <>
+                    {pkSet.has(col.name) ? (
+                      <KeyRound
+                        size={10}
+                        aria-label="primary key"
+                        style={{ color: 'var(--color-accent)' }}
+                      />
+                    ) : null}
+                    <span className="colname">{col.name}</span>
+                    {col.type ? (
+                      <span className="coltype">{col.type}</span>
+                    ) : null}
+                    {sorted === 'asc' ? (
+                      <ArrowUp
+                        size={10}
+                        style={{ color: 'var(--color-accent)' }}
+                      />
+                    ) : sorted === 'desc' ? (
+                      <ArrowDown
+                        size={10}
+                        style={{ color: 'var(--color-accent)' }}
+                      />
+                    ) : null}
+                  </>
+                )
+                return (
+                  <th
+                    key={col.name}
+                    className={isNum ? 'num' : undefined}
+                    aria-sort={
+                      onSort
+                        ? sorted === 'asc'
+                          ? 'ascending'
+                          : sorted === 'desc'
+                            ? 'descending'
+                            : 'none'
+                        : undefined
+                    }
+                  >
+                    {onSort ? (
+                      <button
+                        type="button"
+                        className="sorter"
+                        onClick={() => onSort(nextSort(sort, col.name))}
+                        title={`sort by ${col.name}`}
+                      >
+                        {label}
+                      </button>
+                    ) : (
+                      <span className="static">{label}</span>
+                    )}
+                  </th>
+                )
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {visible.map((row, i) => {
+              const rowClass = [
+                onRowClick ? 'clickable' : '',
+                selectedRow === i ? 'selected' : '',
+              ]
+                .filter(Boolean)
+                .join(' ')
+              return (
+                <tr
+                  key={i}
+                  onClick={onRowClick ? () => onRowClick(i) : undefined}
+                  className={rowClass || undefined}
+                >
+                  {cols.map((col) => {
+                    const category = typeCategory(col.type)
+                    const isNum = category === 'numeric'
+                    const key = `${i}:${col.name}`
+                    const content =
+                      copied === key ? (
+                        <span className="db-copied">
+                          <Check size={12} /> copied
+                        </span>
+                      ) : (
+                        <CellValue value={row[col.name]} category={category} />
+                      )
+                    return (
+                      <td key={col.name} className={isNum ? 'num' : undefined}>
+                        {onRowClick ? (
+                          content
+                        ) : (
+                          <button
+                            type="button"
+                            className="copycell"
+                            onClick={() => copyCell(key, row[col.name])}
+                            title="click to copy"
+                          >
+                            {content}
+                          </button>
+                        )}
+                      </td>
+                    )
+                  })}
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+      {hideFooter ? null : (
+        <div className="db-grid-foot">
+          <span>
+            {total} row{total === 1 ? '' : 's'}
+          </span>
+          {clamped ? (
+            <button
+              type="button"
+              className="db-linkish"
+              onClick={() => setExpanded(true)}
+            >
+              show all · {rows.length} rows
+            </button>
+          ) : null}
+          {expanded && rows.length > CLAMP_ROWS ? (
+            <button
+              type="button"
+              className="db-linkish"
+              onClick={() => setExpanded(false)}
+            >
+              collapse
+            </button>
+          ) : null}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/database/ui/src/page/result-grid.tsx
+++ b/database/ui/src/page/result-grid.tsx
@@ -3,7 +3,9 @@
  * (`{ rows, row_count, columns }`). Cells render by value type: NULL is a
  * ghost literal, booleans and numbers are monospace (numbers right-aligned),
  * JSON values collapse to a compact preview, long strings truncate with the
- * full value on hover. Every cell copies its value on click.
+ * full value on hover. Two interaction modes: without `onRowClick` every cell
+ * copies its value on click; with it, the click (or Enter/Space on the focused
+ * row) selects the row and the inspector carries the per-field copy.
  *
  * Ported from the console's chat `ResultGrid` for the injected page: the
  * source already rendered a real `<table>`, so the port keeps the markup and
@@ -11,7 +13,7 @@
  */
 
 import { useState } from 'react'
-import { cellText, copyText } from './cells'
+import { useCopyFeedback } from './cells'
 import { type ColumnMeta, type TableSort, typeCategory } from './db-data'
 import { ArrowDown, ArrowUp, Check, KeyRound } from './icons'
 
@@ -125,7 +127,7 @@ export function ResultGrid({
   hideFooter,
 }: ResultGridProps) {
   const [expanded, setExpanded] = useState(false)
-  const [copied, setCopied] = useState<string | null>(null)
+  const { copied, copy } = useCopyFeedback()
   const cols = resolveColumns(columns, rows)
   const total = rowCount ?? rows.length
   const clamped = !stickyHeader && !expanded && rows.length > CLAMP_ROWS
@@ -134,14 +136,6 @@ export function ResultGrid({
 
   if (total === 0 || cols.length === 0) {
     return <div className="db-grid-empty">· 0 rows</div>
-  }
-
-  const copyCell = (key: string, value: unknown) => {
-    copyText(cellText(value))
-    setCopied(key)
-    window.setTimeout(() => {
-      setCopied((cur) => (cur === key ? null : cur))
-    }, 1200)
   }
 
   return (
@@ -223,6 +217,19 @@ export function ResultGrid({
                 <tr
                   key={i}
                   onClick={onRowClick ? () => onRowClick(i) : undefined}
+                  // Selectable rows are their own control: reachable by tab,
+                  // activated by Enter/Space like the click path.
+                  onKeyDown={
+                    onRowClick
+                      ? (e) => {
+                          if (e.key !== 'Enter' && e.key !== ' ') return
+                          e.preventDefault()
+                          onRowClick(i)
+                        }
+                      : undefined
+                  }
+                  tabIndex={onRowClick ? 0 : undefined}
+                  aria-selected={onRowClick ? selectedRow === i : undefined}
                   className={rowClass || undefined}
                 >
                   {cols.map((col) => {
@@ -245,7 +252,7 @@ export function ResultGrid({
                           <button
                             type="button"
                             className="copycell"
-                            onClick={() => copyCell(key, row[col.name])}
+                            onClick={() => copy(key, row[col.name])}
                             title="click to copy"
                           >
                             {content}

--- a/database/ui/src/page/useDatabaseRead.ts
+++ b/database/ui/src/page/useDatabaseRead.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from 'react'
+
+/**
+ * One in-flight database read: run `fetcher` while `enabled`, re-run when
+ * the fetcher identity changes (callers memo it on db/table/page deps) or on
+ * `refresh`. No polling and no live trigger bindings on purpose — the worker
+ * emits no change events yet (`database::row-change` is not functional), so
+ * the page refreshes on demand instead of guessing.
+ */
+
+export interface DatabaseRead<T> {
+  data: T | null
+  loading: boolean
+  error: string | null
+  refresh: () => void
+}
+
+export function useDatabaseRead<T>(
+  enabled: boolean,
+  fetcher: () => Promise<T>,
+): DatabaseRead<T> {
+  const [data, setData] = useState<T | null>(null)
+  const [loading, setLoading] = useState(enabled)
+  const [error, setError] = useState<string | null>(null)
+  const [token, setToken] = useState(0)
+
+  const refresh = useCallback(() => setToken((t) => t + 1), [])
+
+  // `token` is a re-run token (bumped by manual refresh), not read by the
+  // effect body — it only needs to be in the dependency list.
+  useEffect(() => {
+    if (!enabled) {
+      setData(null)
+      setLoading(false)
+      setError(null)
+      return
+    }
+    setLoading(true)
+    let cancelled = false
+    void (async () => {
+      try {
+        const next = await fetcher()
+        if (cancelled) return
+        setData(next)
+        setError(null)
+      } catch (err) {
+        if (cancelled) return
+        setError(err instanceof Error ? err.message : String(err))
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [enabled, fetcher, token])
+
+  return { data, loading, error, refresh }
+}

--- a/packages/console-ui/index.d.ts
+++ b/packages/console-ui/index.d.ts
@@ -373,6 +373,10 @@ export interface CodeEditorProps {
   /** Observes keys bubbling out of the editor (shortcuts like ⌘S) — keys
       the editor consumes for editing never reach it. */
   onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>
+  /** Domain identifiers to autocomplete (e.g. SQL table/column names +
+      keywords). Non-empty turns on the as-you-type suggest popup and
+      registers a completion provider for the current `language`. */
+  completions?: readonly string[]
 }
 /** The console's Monaco-backed code editor — the one editor for every code
     or long-text editing surface, themed by the console's design tokens in

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       '@iii-dev/console-ui':
         specifier: workspace:*
         version: link:../../packages/console-ui
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.3
     devDependencies:
       '@types/react':
         specifier: ^19.2.14


### PR DESCRIPTION
Adds an opt-in `completions?: readonly string[]` prop to the shared CodeEditor (#579). Non-empty turns on the as-you-type suggest popup (the default stays prose-quiet, so markdown/json/yaml behaviour is byte-for-byte unchanged) and registers a Monaco completion provider for the editor's language offering those words, disposed on unmount.

First consumer is the database worker's SQL panel, which feeds it the live table names plus SQL keywords for schema-aware autocomplete.

## Test
tsc + biome clean. Verified live in the console SQL editor: typing a keyword or table prefix pops the suggest list, and Ctrl+Space triggers it explicitly. Prose editors (markdown/json) are unaffected since they pass no completions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional as-you-type autocomplete suggestions to the code editor, configurable via a public completions list.
  * Introduced a new read-only database extension page with a schema sidebar, table viewer (sorting, pagination, row details), and an SQL panel with query history and EXPLAIN support.
* **Bug Fixes**
  * Improved safe clipboard copy behavior for values.
* **Chores**
  * Added database page styling, UI building blocks (schema tree, pagination, results grid), and read-only SQL safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->