### PR TITLE
ci: surface cache budget consumers and cap the E2E await deadline

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -218,6 +218,27 @@ jobs:
             echo "- Target: at most 8 GiB"
             echo "- Hard budget: 10 GiB"
           } >> "$GITHUB_STEP_SUMMARY"
+          # Going over budget evicts by last-access, so the entries that every
+          # PR depends on lose to bulk written by rarely-run workflows. Name the
+          # biggest consumers so the trade-off is visible instead of implicit.
+          {
+            echo
+            echo "<details><summary>Largest cache entries</summary>"
+            echo
+            echo "| Size (GiB) | Last accessed | Key | Ref |"
+            echo "| ---: | --- | --- | --- |"
+            # `head` would close sort's stdout early and SIGPIPE it under
+            # pipefail, so cap the row count inside the same awk pass.
+            gh api --method GET "repos/$REPOSITORY/actions/caches" \
+              -F per_page=100 --paginate \
+              --jq '.actions_caches[] | [.size_in_bytes, .last_accessed_at, .key, .ref] | @tsv' \
+              | sort -rn \
+              | awk -F"$(printf '\t')" 'NR <= 15 \
+                  { printf "| %.2f | %s | `%s` | `%s` |\n", \
+                      $1 / 1073741824, substr($2, 1, 10), $3, $4 }'
+            echo
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
           if (( bytes > 10737418240 )); then
             echo "::error::Actions cache usage is above the 10 GiB budget ($gib GiB)"
             exit 1

--- a/harness/tests/e2e/src/types/scenario.rs
+++ b/harness/tests/e2e/src/types/scenario.rs
@@ -14,7 +14,10 @@ mod tests {
     fn deadline_defaults_are_safe() {
         let timeouts = DeadlinesV1::default();
         assert_eq!(timeouts.readiness_ms, 60_000);
-        assert_eq!(timeouts.scenario_ms, 60_000);
+        assert_eq!(timeouts.scenario_ms, 25_000);
         assert_eq!(timeouts.teardown_ms, 15_000);
+        // The await deadline must stay well clear of the slowest passing
+        // scenario (~4s in CI) so a slow runner does not read as a failure.
+        assert!(timeouts.scenario_ms >= 5 * 4_000);
     }
 }

--- a/harness/tests/e2e/src/types/scenario/compiled.rs
+++ b/harness/tests/e2e/src/types/scenario/compiled.rs
@@ -80,7 +80,12 @@ impl Default for DeadlinesV1 {
     fn default() -> Self {
         Self {
             readiness_ms: 60_000,
-            scenario_ms: 60_000,
+            // Stack boot is budgeted by `readiness_ms`; this covers only the
+            // await phase, where the slowest passing scenario observed in CI
+            // takes ~4s. 25s keeps ~6x headroom while capping what a wedged
+            // scenario costs — at 60s, a red run spent more time waiting on
+            // deadlines than doing work.
+            scenario_ms: 25_000,
             teardown_ms: 15_000,
         }
     }


### PR DESCRIPTION
> **Correction (after CodeRabbit review):** this PR originally added a step that deleted "duplicate" caches. That was wrong and has been removed — see [On pruning](#on-pruning) below. What remains is diagnosis plus one deadline change.

The `harness-integration` job takes **10m31s**. Measured breakdown of that run:

| Step | Time | Share |
| --- | ---: | ---: |
| Build pinned engine | 308s | 49% |
| Run integration scenarios | 257s | 41% |
| Restore Rust cache | 28s | 4% |
| everything else | 35s | 6% |

## 1. Cache budget visibility (`cache-warm.yml`)

The 308s is a **cache miss on every PR run** — there is no `integration-engine-*` entry in the repository at all. The caching architecture is correct (PRs run with `save-cache: false`; `cache-warm.yml` saves with `true`), and the warm job does succeed. The entry simply doesn't survive: the repository sits at **10.42 GiB against a 10 GiB hard budget**, so GitHub evicts by last access and the engine cache loses.

The budget report gave a total with no way to see what was consuming the space, which made the eviction look arbitrary. It now lists the 15 largest entries with their key and **ref**.

On current data that immediately shows **4.01 GiB — 38% of the budget — is Windows release-build caches** from `_rust-binary.yml`, written on tag pushes by `release.yml` and read only by the next release of the same worker. Every PR pays for that by having the engine cache evicted instead.

Pruning those is a judgement call about release build times, so this PR does not make it — it only stops it being invisible. Reclaiming that 4 GiB, or raising the cache limit (configurable since Nov 2025, billed above 10 GiB), is what actually removes the 308s.

## 2. E2E await deadline (`scenario_ms`)

`scenario_ms` was 60s. It covers only the await phase — stack boot is budgeted separately by `readiness_ms`, left unchanged — and the slowest *passing* scenario observed in CI takes 3.9s. In the run measured above, two wedged scenarios burned **122s of the 257s** scenario step purely waiting on deadlines.

Lowered to 25s: roughly 6x headroom over the slowest observed pass, and a wedged scenario now costs 25s instead of 60s. The default-deadline test additionally asserts that headroom, so a future reduction can't quietly creep toward real runtime.

## On pruning

The first version of this PR deleted entries sharing the same `key`, on the assumption that only the newest is ever restored. **CodeRabbit pointed out that entries are scoped by `(key, ref, version)`, and it was right.** Checked against live data:

- the 4 "duplicates" the step would have deleted have the **same version, different refs** — `refs/pull/{592,594,597,598}/merge`;
- all four PRs are **open**;
- caches are ref-scoped: PR 598 cannot restore PR 592's cache. These were never duplicates — they were per-PR caches working as designed. The step would have caused cache misses on four open PRs;
- and there are **zero** true duplicates on `(key, ref, version)` — GitHub enforces uniqueness on that tuple, so the corrected grouping would be dead code.

So the step was removed rather than regrouped. Caches from closed PRs are already handled by the existing `prune-closed-prs` job. The honest conclusion: **there is no safe automatic pruning to add here** — the real waste is the 4 GiB of Windows release caches, which is a human decision.

## Expected effect

This PR saves 35s per wedged scenario on red runs, and unblocks the budget check once the space question is settled. The large win (308s) depends on the decision in §1.

## Validation

- `cargo test --manifest-path harness/Cargo.toml -p harness-integration` — 84 passed, 0 failed.
- `cache-warm.yml` parses; the edited `run:` block passes `bash -n`.
- The report table was simulated against the live listing (47 entries) with `pipefail` enabled, exit 0 — row capping lives inside the `awk` pass precisely because `head` would close sort's stdout early and SIGPIPE it under `pipefail`.

No write or DELETE path against the GitHub API remains in this PR.

CI-only, so no Linear ticket; labelled `no-ticket` per `pr-linear-check.yml`.
