### PR TITLE
ci: move Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/_bundle.yml
+++ b/.github/workflows/_bundle.yml
@@ -52,12 +52,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: inputs.skip_create_release != true && inputs.dry_run != true
 
       - name: Create GitHub Release
         if: inputs.skip_create_release != true && inputs.dry_run != true
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.tag_name }}
           name: ${{ inputs.worker }} ${{ inputs.tag_name }}
@@ -73,19 +73,19 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # ── Node bundle path ─────────────────────────────────────────────
       # esbuild produces `<worker>/dist/bundle/index.mjs`, a single ESM
       # file with all npm deps + JSON assets inlined. Only Node built-ins
       # and `fsevents` (macOS-only optional native dep used by chokidar)
       # are external. See `<worker>/scripts/build-bundle.mjs`.
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         if: inputs.language == 'node' || inputs.language == 'javascript'
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         if: inputs.language == 'node' || inputs.language == 'javascript'
         with:
           node-version: 22
@@ -182,7 +182,7 @@ jobs:
 
       - name: Upload to GitHub Release
         if: inputs.dry_run != true
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.tag_name }}
           files: |

--- a/.github/workflows/_container.yml
+++ b/.github/workflows/_container.yml
@@ -42,7 +42,7 @@ jobs:
     outputs:
       image_tag: ${{ steps.refs.outputs.image_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Compute image refs
         id: refs
@@ -64,21 +64,21 @@ jobs:
           echo "::notice::image=${BASE}:${VERSION} (also :${REGISTRY_TAG})"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to ghcr.io
         if: inputs.dry_run != true
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.worker }}
           file: ${{ inputs.worker }}/${{ inputs.dockerfile }}

--- a/.github/workflows/_harness-integration.yml
+++ b/.github/workflows/_harness-integration.yml
@@ -14,7 +14,7 @@ jobs:
     name: harness integration e2e
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Read and validate engine.lock
         id: lock
@@ -65,7 +65,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Checkout pinned engine source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ steps.lock.outputs.repository }}
           ref: ${{ steps.lock.outputs.revision }}
@@ -73,12 +73,15 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 11.13.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
+          # setup-node v5 auto-caches when package.json declares packageManager.
+          # This step never cached; the repository is already over its cache budget.
+          package-manager-cache: false
           node-version: 22
 
       - name: Restore engine build
@@ -204,7 +207,7 @@ jobs:
 
       - name: Upload compact results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: integration-results
           path: |
@@ -215,7 +218,7 @@ jobs:
 
       - name: Upload full non-pass artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: integration-artifacts
           path: target/integration/
@@ -224,7 +227,7 @@ jobs:
 
       - name: Upload Console E2E artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: console-e2e-artifacts
           path: target/console-e2e/

--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -47,7 +47,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install pyyaml
         run: pip install --quiet pyyaml
@@ -57,8 +57,11 @@ jobs:
       # bundle. No-op for the binary / image paths.
       - name: Install Node (bundle deploy)
         if: inputs.deploy == 'bundle'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
+          # setup-node v5 auto-caches when package.json declares packageManager.
+          # This step never cached; the repository is already over its cache budget.
+          package-manager-cache: false
           node-version: 22
 
       - name: Install iii CLI

--- a/.github/workflows/_publish-worker-skills.yml
+++ b/.github/workflows/_publish-worker-skills.yml
@@ -27,7 +27,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build skills payload
         id: skills_payload

--- a/.github/workflows/_rust-binary.yml
+++ b/.github/workflows/_rust-binary.yml
@@ -58,12 +58,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: inputs.skip_create_release != true && inputs.dry_run != true
 
       - name: Create GitHub Release
         if: inputs.skip_create_release != true && inputs.dry_run != true
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.tag_name }}
           name: ${{ inputs.bin_name }} ${{ inputs.tag_name }}
@@ -126,7 +126,7 @@ jobs:
     if: inputs.web_bundle
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Resolve worker dir
         id: dirs
@@ -162,9 +162,9 @@ jobs:
       # `setup-node`'s `cache: 'pnpm'` finds the binary on PATH. The pnpm
       # version comes from the repo-root package.json `packageManager`
       # field (the UI pnpm workspace root).
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'pnpm'
@@ -203,7 +203,7 @@ jobs:
           done
 
       - name: Upload frontend bundles
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: frontend-bundles
           path: .release-frontend-bundle/${{ steps.dirs.outputs.worker }}/
@@ -228,7 +228,7 @@ jobs:
         include: ${{ fromJSON(needs.matrix.outputs.include) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Rewrite SSH to HTTPS for public deps
         run: git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
@@ -325,7 +325,7 @@ jobs:
 
       - name: Download frontend bundles
         if: inputs.web_bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: frontend-bundles
           path: ${{ steps.dirs.outputs.worker }}/

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -88,7 +88,7 @@ jobs:
     outputs:
       rust: ${{ steps.bucket.outputs.rust }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -140,7 +140,7 @@ jobs:
       run:
         working-directory: ${{ matrix.worker }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Rewrite SSH to HTTPS for public deps
         run: git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
@@ -159,13 +159,13 @@ jobs:
 
       - name: Setup pnpm for bundled web
         if: hashFiles(format('{0}/web/package.json', matrix.worker)) != ''
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Setup Node for bundled web
         if: hashFiles(format('{0}/web/package.json', matrix.worker)) != ''
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
     name: .github/scripts tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - run: pip install --quiet pytest pyyaml
@@ -41,7 +41,7 @@ jobs:
       vscode_changed: ${{ steps.bucket.outputs.vscode_changed }}
       any: ${{ steps.bucket.outputs.any }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -75,7 +75,7 @@ jobs:
       matrix:
         worker: ${{ fromJSON(needs.discover.outputs.all) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -113,7 +113,7 @@ jobs:
       run:
         working-directory: ${{ matrix.worker }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Rewrite SSH to HTTPS for public deps
         run: git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
@@ -136,13 +136,13 @@ jobs:
       # a `web/package.json` skip all three steps cleanly.
       - name: Setup pnpm (workers with bundled web/)
         if: hashFiles(format('{0}/web/package.json', matrix.worker), format('{0}/ui/package.json', matrix.worker)) != ''
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         # version comes from the repo-root package.json `packageManager`
         # field (the UI pnpm workspace root).
 
       - name: Setup Node (workers with bundled web/)
         if: hashFiles(format('{0}/web/package.json', matrix.worker), format('{0}/ui/package.json', matrix.worker)) != ''
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'pnpm'
@@ -191,7 +191,7 @@ jobs:
       run:
         working-directory: crates/${{ matrix.crate }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Rewrite SSH to HTTPS for public deps
         run: git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
@@ -237,9 +237,9 @@ jobs:
       matrix:
         worker: ${{ fromJSON(needs.discover.outputs.rust) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -281,13 +281,13 @@ jobs:
       # short-circuits it — mirrors the `rust` job above.
       - name: Setup pnpm (workers with bundled web/)
         if: hashFiles(format('{0}/web/package.json', matrix.worker), format('{0}/ui/package.json', matrix.worker)) != ''
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         # version comes from the repo-root package.json `packageManager`
         # field (the UI pnpm workspace root).
 
       - name: Setup Node (workers with bundled web/)
         if: hashFiles(format('{0}/web/package.json', matrix.worker), format('{0}/ui/package.json', matrix.worker)) != ''
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'pnpm'
@@ -471,10 +471,13 @@ jobs:
       matrix:
         worker: ${{ fromJSON(needs.discover.outputs.node) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
+          # setup-node v5 auto-caches when package.json declares packageManager.
+          # This step never cached; the repository is already over its cache budget.
+          package-manager-cache: false
           node-version: 22
 
       - name: Install dependencies
@@ -507,9 +510,9 @@ jobs:
       matrix:
         worker: ${{ fromJSON(needs.discover.outputs.python) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -543,10 +546,13 @@ jobs:
       run:
         working-directory: lsp-vscode
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
+          # setup-node v5 auto-caches when package.json declares packageManager.
+          # This step never cached; the repository is already over its cache budget.
+          package-manager-cache: false
           node-version: 20
 
       - name: Install dependencies

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -93,13 +93,13 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.III_CI_APP_ID }}
           private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/database-e2e.yml
+++ b/.github/workflows/database-e2e.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Rewrite SSH to HTTPS for public deps
         run: git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
@@ -38,10 +38,10 @@ jobs:
       # ci.yml rust job. Version comes from the repo-root package.json
       # `packageManager` field (the UI pnpm workspace root).
       - name: Setup pnpm (for build.rs UI build)
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           # 22, not 20: pnpm@11 requires the node:sqlite builtin (Node ≥22.5)
           # for its store, and ci.yml's pnpm jobs already standardize on 22.
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: database-e2e-report
           path: |

--- a/.github/workflows/publish-worker-skills.yml
+++ b/.github/workflows/publish-worker-skills.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       matrix: ${{ steps.parse.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build worker matrix
         id: parse

--- a/.github/workflows/rbac-proxy-e2e.yml
+++ b/.github/workflows/rbac-proxy-e2e.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Rewrite SSH to HTTPS for public deps
         run: git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
@@ -34,7 +34,7 @@ jobs:
           workspaces: rbac-proxy
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: rbac-proxy-e2e-report
           path: |

--- a/.github/workflows/release-lsp-vscode.yml
+++ b/.github/workflows/release-lsp-vscode.yml
@@ -83,12 +83,15 @@ jobs:
       run:
         working-directory: lsp-vscode
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.setup.outputs.tag }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
+          # setup-node v5 auto-caches when package.json declares packageManager.
+          # This step never cached; the repository is already over its cache budget.
+          package-manager-cache: false
           node-version: 20
 
       - name: Install dependencies
@@ -112,7 +115,7 @@ jobs:
         run: npx @vscode/vsce package --out iii-lsp-${{ needs.setup.outputs.version }}.vsix
 
       - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: iii-lsp-vsix-${{ needs.setup.outputs.version }}
           path: lsp-vscode/iii-lsp-${{ needs.setup.outputs.version }}.vsix
@@ -127,19 +130,22 @@ jobs:
       run:
         working-directory: lsp-vscode
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.setup.outputs.tag }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
+          # setup-node v5 auto-caches when package.json declares packageManager.
+          # This step never cached; the repository is already over its cache budget.
+          package-manager-cache: false
           node-version: 20
 
       - name: Install dependencies
         run: npm ci
 
       - name: Download VSIX artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: iii-lsp-vsix-${{ needs.setup.outputs.version }}
           path: lsp-vscode/dist
@@ -158,19 +164,22 @@ jobs:
       run:
         working-directory: lsp-vscode
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ needs.setup.outputs.tag }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
+          # setup-node v5 auto-caches when package.json declares packageManager.
+          # This step never cached; the repository is already over its cache budget.
+          package-manager-cache: false
           node-version: 20
 
       - name: Install dependencies
         run: npm ci
 
       - name: Download VSIX artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: iii-lsp-vsix-${{ needs.setup.outputs.version }}
           path: lsp-vscode/dist
@@ -187,13 +196,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download VSIX artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: iii-lsp-vsix-${{ needs.setup.outputs.version }}
           path: lsp-vscode/dist
 
       - name: Upload VSIX to GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.setup.outputs.tag }}
           name: lsp-vscode ${{ needs.setup.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
       web_bundle: ${{ steps.web.outputs.needed }}
       interface_smoke: ${{ steps.smoke.outputs.interface_smoke }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -158,8 +158,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: softprops/action-gh-release@v2
+      - uses: actions/checkout@v5
+      - uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.setup.outputs.tag }}
           name: ${{ needs.setup.outputs.worker }} ${{ needs.setup.outputs.version }}

--- a/.github/workflows/shell-e2e.yml
+++ b/.github/workflows/shell-e2e.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Rewrite SSH to HTTPS for public deps
         run: git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
@@ -34,7 +34,7 @@ jobs:
           workspaces: shell
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: shell-e2e-report
           path: |

--- a/.github/workflows/storage-e2e.yml
+++ b/.github/workflows/storage-e2e.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Rewrite SSH to HTTPS for public deps
         run: git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Rewrite SSH to HTTPS for public deps
         run: git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
@@ -65,8 +65,11 @@ jobs:
         with:
           workspaces: storage
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
+          # setup-node v5 auto-caches when package.json declares packageManager.
+          # This step never cached; the repository is already over its cache budget.
+          package-manager-cache: false
           node-version: '20'
           # No cache: harness has no committed package-lock.json (run-tests.sh
           # generates one via `npm install` at first run). setup-node@v4 with
@@ -95,7 +98,7 @@ jobs:
 
       - name: Upload reports on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: storage-e2e-reports
           path: |


### PR DESCRIPTION
Every job currently logs:

> Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` environment variable.

The runner already forces Node 24, so this is a warning about actions whose `action.yml` still declares `node20`. This moves each one to the **lowest** major that declares `node24`, so the change carries no more behavioural risk than the runtime demands.

| Action | From | To | Note |
| --- | --- | --- | --- |
| `actions/checkout` | v4 | v5 | |
| `actions/setup-node` | v4 | v5 | see caching note below |
| `actions/setup-python` | v5 | v6 | |
| `actions/upload-artifact` | v4 | **v6** | v5 is still node20 |
| `actions/download-artifact` | v4 | **v7** | v5 and v6 are still node20 |
| `pnpm/action-setup` | v4 | v5 | |
| `softprops/action-gh-release` | v2 | v3 | |
| `actions/create-github-app-token` | v2 | v3 | |
| `docker/setup-qemu-action` | v3 | v4 | |
| `docker/setup-buildx-action` | v3 | v4 | |
| `docker/login-action` | v3 | v4 | |
| `docker/build-push-action` | v6 | v7 | |

**Unchanged:** `Swatinem/rust-cache@v2` already declares node24. `dtolnay/rust-toolchain`, `taiki-e/upload-rust-binary-action` and `iii-hq/skills-and-validation` are composite actions with no Node runtime.

## Two things worth knowing

**The artifact actions skip majors.** `upload-artifact` v5.0.0 and `download-artifact` v6.0.0 both have release notes announcing Node 24 support, but `action.yml` at those tags still declares `node20`. Versions here were chosen by reading `runs.using` at each tag rather than trusting the notes — hence v6 and v7 respectively.

**`setup-node` v5 changes caching semantics.** It begins caching automatically when `package.json` declares `packageManager`, and this repository's root declares `pnpm@11.13.1`. Eight steps that have never cached would silently start — in a repository already **over its 10 GiB cache budget** (see #599), where added pressure evicts the pinned-engine cache that every PR run depends on. Those eight now pin `package-manager-cache: false` to preserve today's behaviour:

`_harness-integration.yml`, `_publish-registry.yml`, `ci.yml` (×2), `release-lsp-vscode.yml` (×3), `storage-e2e.yml`

The eight steps with an explicit `cache:` are untouched. Turning any of them on is a deliberate decision, not a side effect of a runtime bump.

## Validation

- Every workflow still parses (`yaml.safe_load` across `.github/workflows/*.yml`).
- Re-audited every `uses:` in the repository against the GitHub API: **no action still resolves to a node20 runtime**.
- Audited all 16 `setup-node` steps: the 8 with explicit `cache:` keep it, the 8 without now carry `package-manager-cache: false`. No step changes caching behaviour.
- `checkout` v5, `setup-python` v6 and the docker bumps require runner ≥ v2.327.1; all jobs run on GitHub-hosted `ubuntu-latest` or a hosted matrix, well past that.

Not validated: the release-only paths (`release.yml`, `release-lsp-vscode.yml`, docker publish) can't be exercised from a PR — they run on tag pushes. `softprops/action-gh-release@v3` and `docker/build-push-action@v7` land untested here and are worth watching on the first release after merge.

CI-only, so no Linear ticket; labelled `no-ticket` per `pr-linear-check.yml`.
