### PR TITLE
(MOT-4184) feat(eval): lead the comparison picker with system prompt

### DIFF
--- a/eval/ui/src/form.ts
+++ b/eval/ui/src/form.ts
@@ -41,7 +41,9 @@ export interface EvalFormState {
 }
 
 export const DEFAULT_FORM: EvalFormState = {
-  dimension: 'prompt',
+  // Matches the first tab in NewEvaluationForm — the leading option is the
+  // one that opens selected.
+  dimension: 'system_prompt',
   model: '',
   provider: '',
   runs: '1',

--- a/eval/ui/src/page/NewEvaluationForm.tsx
+++ b/eval/ui/src/page/NewEvaluationForm.tsx
@@ -203,8 +203,8 @@ export function NewEvaluationForm({
           }}
         >
           <TabsList>
-            <TabsTrigger value="prompt">prompt text</TabsTrigger>
             <TabsTrigger value="system_prompt">system prompt</TabsTrigger>
+            <TabsTrigger value="prompt">prompt text</TabsTrigger>
           </TabsList>
         </Tabs>
         <div className="eval-ui-comparison-rule">


### PR DESCRIPTION
System prompt comparison is the more common starting point, so it now comes first in the "choose what changes" tabs and is the dimension a new evaluation opens on.

Reordering the tabs alone would have left the second tab selected on load, so `DEFAULT_FORM.dimension` moves to `system_prompt` to match.

Labels stay lowercase (`system prompt`) because the panel CSS already uppercases them, so the tab renders as SYSTEM PROMPT alongside PROMPT TEXT.

Verified against the local dev stack: the eval page opens on the system prompt tab, the heading reads "new system prompt comparison", and the variant editors show the system prompt fields.

Refs MOT-4184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New evaluation forms now default to the system prompt dimension.
  * Reordered evaluation dimension tabs so the system prompt option appears first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->