### PR TITLE
(MOT-4252) fix(shell,harness): boot on fresh managed installs and heal null stored config

### DIFF
--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -20,5 +20,5 @@ dependencies:
   context-manager: "^1.0.0"
   provider-anthropic: "^1.0.0"
   provider-openai: "^1.0.0"
-  shell: "^0.9.0"
+  shell: "^0.10.3"
   scrapling: "^0.2.4"

--- a/shell/CHANGELOG.md
+++ b/shell/CHANGELOG.md
@@ -29,7 +29,9 @@
   sent `initial_value`, and `configuration::register` replaces the stored
   value when it is present — so a reboot with a seed file silently clobbered
   runtime `configuration::set` changes. The stored value now takes
-  precedence once it exists, matching the documented contract.
+  precedence once it exists, matching the documented contract. If a
+  deployment relied on file-wins-on-restart, apply file edits with
+  `configuration::set` (or clear the stored value) instead.
 
 ## 0.10.0
 

--- a/shell/CHANGELOG.md
+++ b/shell/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 0.10.3
+
+### Fixed
+
+- **Fresh managed installs no longer crash-loop with zero functions
+  registered (MOT-4252)** — managed workers run with cwd = the engine's
+  project directory, so the default `--config ./config.yaml` resolved to the
+  engine's own worker roster (`workers: [...]`). Serde tolerates unknown
+  top-level keys, so the roster parsed as an all-defaults shell config,
+  failed the fail-closed jail validation, left the stored value null, and
+  the engine's read-time schema validation then turned every
+  `configuration::get` into a fatal SCHEMA_INVALID — boot died before any
+  function registered, forever. Boot now classifies a seed file with no
+  shell keys (and no removed/renamed shell key) as *foreign* and treats it
+  like a missing file, so the zero-config path seeds the bootable
+  permissive default. Shell-shaped files that fail to parse still refuse to
+  boot, and un-migrated configs still get the loud migration hint.
+- The boot probe of the stored value uses `configuration::get { raw: true }`
+  so a stored null (the state a broken install is stuck in) is readable
+  instead of erroring, and the bootable default is re-seeded over it —
+  installs already caught in the crash loop self-heal on upgrade.
+
+### Changed
+
+- A `--config` seed (and the built-in default) is registered as
+  `initial_value` only when no value is stored yet. Previously every boot
+  sent `initial_value`, and `configuration::register` replaces the stored
+  value when it is present — so a reboot with a seed file silently clobbered
+  runtime `configuration::set` changes. The stored value now takes
+  precedence once it exists, matching the documented contract.
+
 ## 0.10.0
 
 ### Breaking

--- a/shell/Cargo.lock
+++ b/shell/Cargo.lock
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "shell"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "shell"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 publish = false
 

--- a/shell/src/config.rs
+++ b/shell/src/config.rs
@@ -596,6 +596,24 @@ impl ShellConfig {
     }
 }
 
+/// Outcome of loading the optional `--config` seed file at boot.
+#[derive(Debug)]
+pub enum SeedFile {
+    /// No file at the path — the zero-config path (stored value if present,
+    /// else the built-in seed default).
+    Missing,
+    /// The file exists and parses as a YAML mapping, but shares no top-level
+    /// key with the shell schema and carries no removed/renamed shell key: it
+    /// is some other tool's config (in managed installs, the engine's project
+    /// roster), not a shell seed. Treated exactly like [`SeedFile::Missing`];
+    /// `keys` is what was found, for the boot log.
+    Foreign { keys: Vec<String> },
+    /// A shell seed: at least one recognized top-level key. Parsed and
+    /// migration-checked (jail validation still runs in `build_runtime`).
+    /// Boxed: `ShellConfig` dwarfs the other variants.
+    Seed(Box<ShellConfig>),
+}
+
 impl ShellConfig {
     pub fn compile_denylist(&mut self) -> Result<()> {
         self.compiled_denylist = self
@@ -665,10 +683,55 @@ impl ShellConfig {
         serde_yaml::from_str(yaml).map_err(|e| format!("yaml parse: {e}"))
     }
 
-    /// Load a YAML seed file. Used only for the optional `--config` seed.
-    pub fn from_file(path: &str) -> Result<Self, String> {
-        let raw = std::fs::read_to_string(path).map_err(|e| format!("read {path}: {e}"))?;
-        Self::from_yaml(&raw)
+    /// Load and classify the optional `--config` seed file. Boot uses this
+    /// instead of a plain parse so a config file that belongs to some
+    /// OTHER tool is not misread as a shell policy: managed installs run the
+    /// worker with cwd = the engine's project directory, where the default
+    /// `./config.yaml` is the engine's own worker roster (`workers: [...]`).
+    /// Serde tolerates unknown top-level fields, so that roster used to parse
+    /// as an all-defaults ShellConfig, fail the fail-closed jail validation,
+    /// and leave the worker in a permanent boot loop with no functions
+    /// registered (MOT-4252).
+    pub fn load_seed_file(path: &str) -> Result<SeedFile, String> {
+        let raw = match std::fs::read_to_string(path) {
+            Ok(raw) => raw,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(SeedFile::Missing),
+            Err(e) => return Err(format!("read {path}: {e}")),
+        };
+        Self::seed_from_yaml(&raw)
+    }
+
+    /// Classification core of [`Self::load_seed_file`], split from the file
+    /// read so it is testable on plain strings.
+    fn seed_from_yaml(yaml: &str) -> Result<SeedFile, String> {
+        let parsed: serde_yaml::Value =
+            serde_yaml::from_str(yaml).map_err(|e| format!("yaml parse: {e}"))?;
+        let bridged =
+            serde_json::to_value(&parsed).map_err(|e| format!("yaml->json bridge: {e}"))?;
+        // Removed-key hints BEFORE the foreign check: an un-migrated shell
+        // config whose keys have all since been renamed must keep failing
+        // loudly with the migration hint — never be classified as foreign and
+        // silently replaced by the permissive built-in default.
+        check_removed_keys(&bridged)?;
+        if let Some(obj) = bridged.as_object() {
+            let known = Self::schema_property_names();
+            if !obj.keys().any(|k| known.contains(k)) {
+                return Ok(SeedFile::Foreign {
+                    keys: obj.keys().cloned().collect(),
+                });
+            }
+        }
+        Self::from_yaml(yaml).map(|cfg| SeedFile::Seed(Box::new(cfg)))
+    }
+
+    /// Top-level field names of the registered schema — the recognizer for
+    /// "is this file a shell config at all". Derived from the JSON Schema so
+    /// a new config field automatically counts.
+    fn schema_property_names() -> std::collections::BTreeSet<String> {
+        Self::json_schema()["properties"]
+            .as_object()
+            .map(|props| props.keys().cloned().collect())
+            .unwrap_or_default()
     }
 
     /// Deserialize the live value fetched from the configuration worker.
@@ -1268,6 +1331,66 @@ sandbox:
     fn from_yaml_parses_seed() {
         let c = ShellConfig::from_yaml("fs:\n  host_roots: [/tmp/x]\n").expect("seed yaml parses");
         assert_eq!(c.fs.host_roots, vec![std::path::PathBuf::from("/tmp/x")]);
+    }
+
+    /// The engine's project roster (`workers: [...]`) — what the default
+    /// `./config.yaml` resolves to in a managed install — must classify as
+    /// foreign, not parse as an all-defaults (and unbootable) shell config.
+    #[test]
+    fn seed_from_yaml_classifies_engine_roster_as_foreign() {
+        let out = ShellConfig::seed_from_yaml("workers:\n  - name: shell\n  - name: harness\n")
+            .expect("roster classifies");
+        match out {
+            SeedFile::Foreign { keys } => assert_eq!(keys, vec!["workers".to_string()]),
+            other => panic!("expected Foreign, got {other:?}"),
+        }
+    }
+
+    /// One recognized top-level key is enough to be a shell seed — even
+    /// alongside unknown keys, which serde tolerates.
+    #[test]
+    fn seed_from_yaml_accepts_shell_shaped_file() {
+        let out = ShellConfig::seed_from_yaml("fs:\n  allow_unjailed: true\n")
+            .expect("shell seed classifies");
+        match out {
+            SeedFile::Seed(cfg) => assert!(cfg.fs.allow_unjailed),
+            other => panic!("expected Seed, got {other:?}"),
+        }
+    }
+
+    /// An empty mapping expresses no policy — same as no file at all.
+    #[test]
+    fn seed_from_yaml_classifies_empty_mapping_as_foreign() {
+        let out = ShellConfig::seed_from_yaml("{}\n").expect("empty mapping classifies");
+        assert!(
+            matches!(out, SeedFile::Foreign { ref keys } if keys.is_empty()),
+            "got {out:?}"
+        );
+    }
+
+    /// Removed/renamed shell keys win over the foreign check: an un-migrated
+    /// config whose every key was since renamed must keep the loud migration
+    /// error, never be silently replaced by the permissive default.
+    #[test]
+    fn seed_from_yaml_prefers_removed_key_hint_over_foreign() {
+        let err =
+            ShellConfig::seed_from_yaml("allowlist: [ls]\n").expect_err("removed key must error");
+        assert!(err.contains("removed config keys"), "got: {err}");
+    }
+
+    /// Non-mapping YAML is neither a shell seed nor a recognizable foreign
+    /// config — keep the fail-closed parse error.
+    #[test]
+    fn seed_from_yaml_rejects_non_mapping() {
+        ShellConfig::seed_from_yaml("- just\n- a\n- list\n").expect_err("non-mapping must error");
+    }
+
+    #[test]
+    fn load_seed_file_missing_path_is_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("does-not-exist.yaml");
+        let out = ShellConfig::load_seed_file(path.to_str().unwrap()).expect("missing classifies");
+        assert!(matches!(out, SeedFile::Missing), "got {out:?}");
     }
 
     /// A 0.6.x seed still carrying the removed single-root alias must be

--- a/shell/src/configuration.rs
+++ b/shell/src/configuration.rs
@@ -163,13 +163,21 @@ pub fn build_runtime(cfg: &ShellConfig, iii: &IIIClient) -> Result<ShellRuntime,
 
 /// Register the `shell` configuration schema with the configuration worker.
 ///
-/// `initial_value` (used only on first registration; preserved afterwards) is
-/// taken from an explicit `--config` seed when given, otherwise from the
-/// built-in zero-config default when no value is stored yet — so the worker
-/// boots with no config file at all (database parity). Unlike database we
-/// cannot seed `ShellConfig::default()`: it is intentionally unjailed/invalid,
-/// so the built-in seed is `ShellConfig::seed_default()`, a bootable permissive
-/// dev default.
+/// `initial_value` is taken from an explicit `--config` seed when given,
+/// otherwise from the built-in zero-config default — so the worker boots with
+/// no config file at all (database parity). Unlike database we cannot seed
+/// `ShellConfig::default()`: it is intentionally unjailed/invalid, so the
+/// built-in seed is `ShellConfig::seed_default()`, a bootable permissive dev
+/// default.
+///
+/// Seeding is gated on the stored value being absent or null:
+/// `configuration::register` REPLACES the stored value whenever
+/// `initial_value` is present (not only on first registration), so an
+/// ungated seed would let every reboot with a `--config` file clobber
+/// runtime `configuration::set` changes — the documented contract is the
+/// opposite ("the live value takes precedence once an entry exists"). The
+/// null case is a boot that previously could not seed (MOT-4252): re-seeding
+/// over it repairs the entry instead of leaving the worker in a crash loop.
 pub async fn register_config(iii: &IIIClient, seed: Option<&ShellConfig>) -> Result<(), String> {
     let mut payload = json!({
         "id": CONFIG_ID,
@@ -177,20 +185,18 @@ pub async fn register_config(iii: &IIIClient, seed: Option<&ShellConfig>) -> Res
         "description": "Command denylist, timeout & output caps, and the fs jail.",
         "schema": ShellConfig::json_schema(),
     });
-    let candidate: Option<ShellConfig> = match seed {
-        Some(s) => Some(s.clone()),
-        None if should_seed_default_value(iii).await? => Some(ShellConfig::seed_default()),
-        None => None,
-    };
-    if let Some(cfg) = &candidate {
+    if stored_value_absent(iii).await? {
+        let candidate = match seed {
+            Some(s) => s.clone(),
+            None => ShellConfig::seed_default(),
+        };
         // Validate with the SAME checks build_runtime uses (denylist regex
         // compile, fs-jail rule, host_roots/denylist reachability) BEFORE
-        // persisting. configuration::register preserves the value after first
-        // registration, so a one-line typo in --config — or an unbootable
-        // built-in seed — would become a persistent outage. If invalid, register
-        // the schema only and let the worker fail closed with a clear error.
-        match build_runtime(cfg, iii) {
-            Ok(_) => payload["initial_value"] = cfg.to_json(),
+        // persisting: a one-line typo in --config — or an unbootable built-in
+        // seed — would become a persistent outage. If invalid, register the
+        // schema only and let the worker fail closed with a clear error.
+        match build_runtime(&candidate, iii) {
+            Ok(_) => payload["initial_value"] = candidate.to_json(),
             Err(e) => tracing::error!(
                 error = %e,
                 "ignoring invalid config seed; not registering it as initial_value"
@@ -201,13 +207,20 @@ pub async fn register_config(iii: &IIIClient, seed: Option<&ShellConfig>) -> Res
     Ok(())
 }
 
-/// Seed the built-in default only when nothing is stored yet — never overwrite
-/// an operator's persisted value.
-async fn should_seed_default_value(iii: &IIIClient) -> Result<bool, String> {
-    match try_get_config_value(iii).await? {
+/// True when no usable value is stored yet (entry missing or value null) —
+/// the only state in which a boot seed may be installed.
+///
+/// The probe uses `raw: true`: the engine validates the stored value against
+/// the registered schema on a plain `configuration::get`, so a stored null —
+/// exactly the state left behind by a boot that could not seed — surfaces as
+/// a SCHEMA_INVALID error instead of a readable null, and treating that error
+/// as fatal is what kept broken installs in a permanent crash loop
+/// (MOT-4252). `raw` skips validation (and env expansion, which is fine: only
+/// nullness is inspected here).
+async fn stored_value_absent(iii: &IIIClient) -> Result<bool, String> {
+    match try_get_config_value(iii, true).await? {
         None => Ok(true),
-        Some(value) if value.is_null() => Ok(true),
-        Some(_) => Ok(false),
+        Some(value) => Ok(value.is_null()),
     }
 }
 
@@ -243,13 +256,19 @@ fn parse_fetched_value(value: Value) -> Result<ShellConfig, String> {
 }
 
 async fn get_config_value(iii: &IIIClient) -> Result<Value, String> {
-    try_get_config_value(iii)
+    try_get_config_value(iii, false)
         .await?
         .ok_or_else(|| format!("configuration `{CONFIG_ID}` not found"))
 }
 
-async fn try_get_config_value(iii: &IIIClient) -> Result<Option<Value>, String> {
-    match trigger_with_retry(iii, "configuration::get", json!({ "id": CONFIG_ID })).await {
+async fn try_get_config_value(iii: &IIIClient, raw: bool) -> Result<Option<Value>, String> {
+    match trigger_with_retry(
+        iii,
+        "configuration::get",
+        json!({ "id": CONFIG_ID, "raw": raw }),
+    )
+    .await
+    {
         Ok(resp) => Ok(resp.get("value").cloned()),
         // `trigger_with_retry` flattens the structured `Error` to its
         // Display string, so we substring-match the recovered message rather
@@ -593,7 +612,8 @@ mod tests {
     #[test]
     fn build_runtime_accepts_shipped_collect_config() {
         let path = concat!(env!("CARGO_MANIFEST_DIR"), "/config.collect.yaml");
-        let cfg = ShellConfig::from_file(path).expect("config.collect.yaml parses");
+        let raw = std::fs::read_to_string(path).expect("config.collect.yaml reads");
+        let cfg = ShellConfig::from_yaml(&raw).expect("config.collect.yaml parses");
         let iii = iii_sdk::register_worker("ws://127.0.0.1:59598", iii_sdk::InitOptions::default());
         build_runtime(&cfg, &iii)
             .expect("config.collect.yaml must boot for CI interface collection");

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -146,19 +146,32 @@ async fn main() -> Result<()> {
     telemetry::init();
 
     // Seed policy: a MISSING file is the zero-config path (warn + fall through
-    // to the stored value or built-in seed). A file that EXISTS but fails to
-    // parse aborts boot: on first registration the fallback would silently
-    // replace the operator's intended policy with the permissive dev seed —
+    // to the stored value or built-in seed), and so is a FOREIGN file — one
+    // with no shell keys at all, like the engine's project roster that
+    // `./config.yaml` resolves to in a managed install (MOT-4252). A file
+    // that is shell-shaped but fails to parse (or carries removed keys)
+    // aborts boot: on first registration the fallback would silently replace
+    // the operator's intended policy with the permissive dev seed —
     // fail-open — and with 0.7.0's removed-key rejection every un-migrated
     // 0.6.x config file hits exactly this path. Mirrors the stored-value
     // story: reject loudly, never degrade to a wider policy.
-    let seed = match config::ShellConfig::from_file(&cli.config) {
-        Ok(cfg) => {
+    let seed = match config::ShellConfig::load_seed_file(&cli.config) {
+        Ok(config::SeedFile::Seed(cfg)) => {
             tracing::info!(path = %cli.config, "loaded seed config for initial registration");
-            Some(cfg)
+            Some(*cfg)
         }
-        Err(e) if !std::path::Path::new(&cli.config).exists() => {
-            tracing::warn!(path = %cli.config, error = %e, "no --config seed file; using the stored configuration value if present, else the built-in zero-config default");
+        Ok(config::SeedFile::Missing) => {
+            tracing::warn!(path = %cli.config, "no --config seed file; using the stored configuration value if present, else the built-in zero-config default");
+            None
+        }
+        Ok(config::SeedFile::Foreign { keys }) => {
+            tracing::warn!(
+                path = %cli.config,
+                keys = %keys.join(", "),
+                "--config file has no shell config keys (managed installs resolve \
+                 ./config.yaml to the engine's project roster); ignoring it — using the \
+                 stored configuration value if present, else the built-in zero-config default"
+            );
             None
         }
         Err(e) => {

--- a/shell/tests/e2e/run-tests-jailed.sh
+++ b/shell/tests/e2e/run-tests-jailed.sh
@@ -13,8 +13,11 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # --config <temp.yaml> derived from the `shell` config block in config-jailed.yaml.
 # The shell worker registers that as the SEED with the built-in `configuration`
 # worker (configuration::register) and then reads it back (configuration::get).
-# The configuration worker is fresh per engine process, so the config-jailed.yaml
-# block is authoritative each run — no separate seed step is needed.
+# The configuration worker persists registered configs in ./config (relative to
+# the engine cwd) and a stored value takes precedence over the boot seed, so a
+# permissive value left behind by a prior run-tests.sh engine in this same
+# directory would override the jailed seed and defeat the S-C1 repro. Clear the
+# generated state dir before each run, exactly like run-tests.sh does.
 
 WORKER_SRC="${WORKER_SRC:-$(cd "$ROOT_DIR/../.." && pwd)}"
 III_BIN="${III_BIN:-$(command -v iii 2>/dev/null || echo "$HOME/.local/bin/iii")}"
@@ -97,6 +100,11 @@ export HARNESS_TEST_VAR="harness-allowed-value"
 echo "[run-tests-jailed] starting iii engine (jailed config: host_roots=[$JAIL_ROOT])"
 : > "$ENGINE_LOG"
 : > "$HARNESS_LOG"
+
+# The persisted configuration store: stale values (e.g. the permissive shell
+# config from a run-tests.sh engine in this directory) take precedence over
+# the jailed seed and would silently un-jail this suite.
+rm -rf "$ROOT_DIR/config"
 
 ( cd "$ROOT_DIR" && "$III_BIN" --no-update-check -c ./config-jailed.yaml ) > "$ENGINE_LOG" 2>&1 &
 ENGINE_PID=$!


### PR DESCRIPTION
Fresh installs (`iii worker add harness`) had no working directory, no filesystem, and no `shell::*`/`coder::*` functions: the shell worker was in a permanent ~2s crash loop while `iii worker status` kept reporting it as running.

## Root cause

Managed workers run with cwd = the engine's project directory, so shell's default `--config ./config.yaml` resolved to the engine's own worker roster (`workers: [...]`). Serde tolerates unknown top-level keys, so the roster parsed as an all-defaults shell config, failed the fail-closed jail validation ("refusing to start unjailed"), and left the stored configuration value null — the bootable `seed_default()` is only seeded when no seed file is present. The engine's read-time schema validation then turned every `configuration::get` into a fatal `SCHEMA_INVALID: null is not of type \"object\"`, so boot died before any function registered, forever.

## Changes

**shell 0.10.3**
- Classify a `--config` file with no shell keys (and no removed/renamed shell key) as *foreign* and treat it like a missing file, so the zero-config path seeds the bootable permissive default. Shell-shaped files that fail to parse still refuse to boot, and un-migrated configs still get the loud migration hint (the removed-key check runs before the foreign check, so an old config can never be silently replaced by the permissive default).
- Probe the stored value with `configuration::get { raw: true }` (raw skips read-time schema validation) and re-seed the bootable default over a stored null — installs already caught in the crash loop self-heal on upgrade.
- Gate `initial_value` on the stored value being absent/null: `configuration::register` replaces the stored value whenever `initial_value` is present, so an ungated seed let every reboot with a `--config` file clobber runtime `configuration::set` changes. The live value now takes precedence once it exists, matching the documented contract.

**harness**
- Bump the shell dependency pin `^0.9.0` → `^0.10.3` (semver `^0.9` never matches 0.10.x, so fresh installs were stuck on shell 0.9.2).

## Validation

- 6 new unit tests for seed classification (roster → foreign, shell-shaped → seed, empty mapping → foreign, removed-key hint wins over foreign, non-mapping → error, missing file → missing); full shell suite green (608 unit + integration), clippy and rustfmt clean.
- Live end-to-end against a real engine with the built binary:
  - fresh-install scenario (roster `config.yaml` as cwd): boots, logs the foreign warning, registers 18 `shell::*` + 9 `coder::*` functions, stores the seed default;
  - broken-install scenario (null state created by the actual released shell 0.9.2 binary): the fixed binary re-seeds and boots;
  - stored operator value survives a reboot with a competing `--config` seed file.

Rollout note: fresh installs pick this up once shell 0.10.3 and a harness patch release are cut. Follow-up for the iii repo (separate issue): `configuration::get` returning `SCHEMA_INVALID` for an unset (null) value is hostile to every consumer.

Fixes MOT-4252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup handling for missing, invalid, or unrelated configuration files.
  * Prevented configuration seeds and built-in defaults from overwriting values changed at runtime.
  * Fixed boot failures when stored configuration values are explicitly empty.
  * Managed installs with no registered functions now receive the appropriate default configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->