### PR TITLE
(MOT-4235) fix(harness): use row-changed trigger name

### DIFF
--- a/harness/tests/e2e/README.md
+++ b/harness/tests/e2e/README.md
@@ -44,7 +44,7 @@ scenario through one global `allow: ["*"]` policy:
   accuracy, remediation, and clarity.
 - `reactive_automation`: orchestrates three parallel database writers,
   trigger-spawned aggregate reactors, and a single finalizer. The CI stack uses
-  SQLite, so the scenario proves bounded `database::row-change` discovery and
+  SQLite, so the scenario proves bounded `database::row-changed` discovery and
   the namespaced `state`-trigger fallback. The evaluator queries the resulting
   tables, verifies trigger provenance from session metadata, and checks that all
   run-owned triggers were removed.

--- a/harness/tests/e2e/run-ci.sh
+++ b/harness/tests/e2e/run-ci.sh
@@ -137,7 +137,7 @@ start_process database \
   --url "$iii_url" \
   --config "$database_config"
 wait_for_function database::query
-wait_for_trigger_type database::row-change
+wait_for_trigger_type database::row-changed
 
 start_process state \
   "$repo_root/state/target/release/state" \

--- a/harness/tests/e2e/src/scenarios/reactive_automation/prompt.rs
+++ b/harness/tests/e2e/src/scenarios/reactive_automation/prompt.rs
@@ -21,7 +21,7 @@ Namespace every other resource and session with `{run_label}`.
 Required execution:
 
 1. Before spawning writers, list the available trigger types and probe
-   `database::row-change` against `{orders}`. Allow at most 30 seconds for the probe, remove its
+   `database::row-changed` against `{orders}`. Allow at most 30 seconds for the probe, remove its
    test row afterward, and record the result.
 
 2. Before spawning writers, register a namespaced `state` trigger targeting `harness::react`.

--- a/harness/tests/e2e/src/scenarios/reactive_automation/queries.rs
+++ b/harness/tests/e2e/src/scenarios/reactive_automation/queries.rs
@@ -56,7 +56,7 @@ pub(super) async fn collect(
         row_change_probe: calls.iter().position(|call| {
             call.function_id == "engine::register_trigger"
                 && call.arguments.get("trigger_type").and_then(Value::as_str)
-                    == Some("database::row-change")
+                    == Some("database::row-changed")
         }),
         state_reaction: calls.iter().position(|call| {
             call.function_id == "engine::register_trigger"


### PR DESCRIPTION
## Summary

- align the Harness E2E stack readiness check with `database::row-changed`
- update the reactive automation prompt, evidence matcher, and documentation to use the registered trigger name

## Root cause

The database worker changed its trigger type from `database::row-change` to `database::row-changed` in #614, but the separate Harness E2E suite retained the old name. Its shared startup check waited 60 seconds for a trigger that would never register, so every scenario failed before execution.

## Validation

- `cargo test -p harness-e2e` — 41 passed
- `cargo fmt --all -- --check`
- `bash -n harness/tests/e2e/run-ci.sh`
- `git diff --check`

Refs MOT-4235


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected database trigger event handling in the reactive automation scenario.
  * Improved synchronization and trigger discovery during end-to-end test execution.

* **Documentation**
  * Updated scenario documentation and prompts to reflect the correct database trigger event name.

* **Tests**
  * Ensured evidence collection and service startup checks recognize the updated trigger event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->