### PR TITLE
(MOT-3554) feat(console): landing-page demo build of the console for the website

### DIFF
--- a/console/web/.gitignore
+++ b/console/web/.gitignore
@@ -6,3 +6,4 @@ storybook-static
 *.log
 .vite
 *.tsbuildinfo
+dist-demo

--- a/console/web/demo.html
+++ b/console/web/demo.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en" class="antialiased">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
+    <title>iii console — recorded session</title>
+    <script>
+      /* Theme before first paint so the embed never flashes the wrong one. */
+      try {
+        const t = new URLSearchParams(location.search).get('theme');
+        document.documentElement.dataset.theme = t === 'dark' ? 'dark' : 'light';
+      } catch (_) {
+        document.documentElement.dataset.theme = 'light';
+      }
+    </script>
+  </head>
+  <body class="bg-bg text-ink font-sans">
+    <div id="root"></div>
+    <script type="module" src="/src/demo/main.tsx"></script>
+  </body>
+</html>

--- a/console/web/package.json
+++ b/console/web/package.json
@@ -18,7 +18,8 @@
     "test:e2e": "playwright test",
     "test:e2e:install": "playwright install chromium",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "build:demo": "vite build --config vite.demo.config.ts"
   },
   "dependencies": {
     "@fontsource/chivo-mono": "^5.2.8",

--- a/console/web/src/components/chat/FunctionTriggerGroup.tsx
+++ b/console/web/src/components/chat/FunctionTriggerGroup.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/components/function-trigger/FunctionTriggerCard'
 import type { FilesystemAccessAction } from '@/components/permissions/FilesystemAccessPrompt'
 import { StatusDot } from '@/components/ui/StatusDot'
+import { formatCallDuration } from '@/lib/format-call-duration'
 import { cn } from '@/lib/utils'
 import type { FunctionTriggerMessage as FunctionTriggerMessageType } from '@/types/chat'
 
@@ -117,7 +118,7 @@ function deriveStatus(messages: FunctionTriggerMessageType[]): GroupStatus {
     label: (
       <>
         <span className="tabular-nums">{total}</span> functions for{' '}
-        <span className="tabular-nums">{sum}</span>ms
+        <span className="tabular-nums">{formatCallDuration(sum)}</span>
       </>
     ),
   }

--- a/console/web/src/components/chat/Message.tsx
+++ b/console/web/src/components/chat/Message.tsx
@@ -38,6 +38,8 @@ interface MessageProps {
   /** Copy payload for an assistant turn (prose + its function calls). Lazy so
       the string is built on click, not on every streaming re-render. */
   copyText?: string | (() => string)
+  /** Render function-call cards already expanded (showcase surfaces). */
+  defaultOpenCalls?: boolean
 }
 
 export function Message({
@@ -48,6 +50,7 @@ export function Message({
   onManageFilesystemAccess,
   workingDir,
   copyText,
+  defaultOpenCalls,
 }: MessageProps) {
   switch (message.role) {
     case 'user':
@@ -89,6 +92,7 @@ export function Message({
       return (
         <FunctionTriggerCard
           message={message}
+          defaultOpen={defaultOpenCalls}
           onApprove={onApprove}
           onDeny={onDeny}
           onAlwaysAllow={onAlwaysAllowHandler}

--- a/console/web/src/components/chat/MessageList.tsx
+++ b/console/web/src/components/chat/MessageList.tsx
@@ -42,6 +42,12 @@ interface MessageListProps {
   ) => Promise<void>
   onManageFilesystemAccess?: () => void
   workingDir?: string | null
+  /**
+   * Render every function-call card (and group) already expanded. Off in the
+   * product, where a turn's calls collapse to one line each; on for showcase
+   * surfaces whose whole point is the result renderers.
+   */
+  defaultOpenCalls?: boolean
 }
 
 type RenderItem =
@@ -99,6 +105,7 @@ export function MessageList({
   onResolveFilesystemAccess,
   onManageFilesystemAccess,
   workingDir,
+  defaultOpenCalls,
 }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -181,6 +188,7 @@ export function MessageList({
               <FunctionTriggerGroup
                 key={item.key}
                 messages={item.messages}
+                defaultOpen={defaultOpenCalls}
                 onResolveApproval={onResolveApproval}
                 onAlwaysAllow={onAlwaysAllow}
                 onResolveFilesystemAccess={onResolveFilesystemAccess}
@@ -205,6 +213,7 @@ export function MessageList({
               key={item.key}
               message={m}
               copyText={copyText}
+              defaultOpenCalls={defaultOpenCalls}
               onResolveApproval={onResolveApproval}
               onAlwaysAllow={onAlwaysAllow}
               onResolveFilesystemAccess={onResolveFilesystemAccess}

--- a/console/web/src/components/chat/MessageList.tsx
+++ b/console/web/src/components/chat/MessageList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { type ReactNode, useEffect, useMemo, useRef } from 'react'
 import type { FilesystemAccessAction } from '@/components/permissions/FilesystemAccessPrompt'
 import { useConversationsCtxOptional } from '@/lib/conversations-context'
 import {
@@ -25,6 +25,10 @@ interface MessageListProps {
       when absent. */
   thinkingDetail?: string
   density?: 'route' | 'dock'
+  /** Rendered at the top of the transcript scroller, above the messages, so
+      it scrolls away with them instead of unmounting. When set it replaces
+      the `EmptyState` on an empty transcript (landing demo). */
+  header?: ReactNode
   onResolveApproval?: (
     sessionId: string,
     functionTriggerId: string,
@@ -42,12 +46,6 @@ interface MessageListProps {
   ) => Promise<void>
   onManageFilesystemAccess?: () => void
   workingDir?: string | null
-  /**
-   * Render every function-call card (and group) already expanded. Off in the
-   * product, where a turn's calls collapse to one line each; on for showcase
-   * surfaces whose whole point is the result renderers.
-   */
-  defaultOpenCalls?: boolean
 }
 
 type RenderItem =
@@ -100,12 +98,12 @@ export function MessageList({
   isThinking,
   thinkingDetail,
   density = 'route',
+  header,
   onResolveApproval,
   onAlwaysAllow,
   onResolveFilesystemAccess,
   onManageFilesystemAccess,
   workingDir,
-  defaultOpenCalls,
 }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -173,7 +171,7 @@ export function MessageList({
     })
   }, [messages])
 
-  if (messages.length === 0) {
+  if (messages.length === 0 && !header) {
     return <EmptyState {...resolveEmptyState(ctx, density)} />
   }
 
@@ -182,13 +180,13 @@ export function MessageList({
   return (
     <div ref={containerRef} className={cn('flex-1 overflow-y-auto', listPad)}>
       <div className="mx-auto max-w-[760px] flex flex-col gap-y-8">
+        {header}
         {items.map((item) => {
           if (item.kind === 'fcall-group') {
             return (
               <FunctionTriggerGroup
                 key={item.key}
                 messages={item.messages}
-                defaultOpen={defaultOpenCalls}
                 onResolveApproval={onResolveApproval}
                 onAlwaysAllow={onAlwaysAllow}
                 onResolveFilesystemAccess={onResolveFilesystemAccess}
@@ -213,7 +211,6 @@ export function MessageList({
               key={item.key}
               message={m}
               copyText={copyText}
-              defaultOpenCalls={defaultOpenCalls}
               onResolveApproval={onResolveApproval}
               onAlwaysAllow={onAlwaysAllow}
               onResolveFilesystemAccess={onResolveFilesystemAccess}

--- a/console/web/src/components/chat/MessageList.tsx
+++ b/console/web/src/components/chat/MessageList.tsx
@@ -46,6 +46,12 @@ interface MessageListProps {
   ) => Promise<void>
   onManageFilesystemAccess?: () => void
   workingDir?: string | null
+  /**
+   * Render every function-call card (and group) already expanded. Off in the
+   * product, where a turn's calls collapse to one line each; on for showcase
+   * surfaces whose whole point is the result renderers.
+   */
+  defaultOpenCalls?: boolean
 }
 
 type RenderItem =
@@ -104,6 +110,7 @@ export function MessageList({
   onResolveFilesystemAccess,
   onManageFilesystemAccess,
   workingDir,
+  defaultOpenCalls,
 }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -187,6 +194,7 @@ export function MessageList({
               <FunctionTriggerGroup
                 key={item.key}
                 messages={item.messages}
+                defaultOpen={defaultOpenCalls}
                 onResolveApproval={onResolveApproval}
                 onAlwaysAllow={onAlwaysAllow}
                 onResolveFilesystemAccess={onResolveFilesystemAccess}
@@ -211,6 +219,7 @@ export function MessageList({
               key={item.key}
               message={m}
               copyText={copyText}
+              defaultOpenCalls={defaultOpenCalls}
               onResolveApproval={onResolveApproval}
               onAlwaysAllow={onAlwaysAllow}
               onResolveFilesystemAccess={onResolveFilesystemAccess}

--- a/console/web/src/components/function-trigger/FunctionTriggerCard.tsx
+++ b/console/web/src/components/function-trigger/FunctionTriggerCard.tsx
@@ -14,6 +14,7 @@ import { Button } from '@/components/ui/Button'
 import { StatusDot } from '@/components/ui/StatusDot'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/Tabs'
 import { copyTextToClipboard } from '@/lib/clipboard'
+import { formatCallDuration } from '@/lib/format-call-duration'
 import { JsonHighlight } from '@/lib/syntax'
 import { cn } from '@/lib/utils'
 import type { FunctionTriggerMessage as FunctionTriggerMessageType } from '@/types/chat'
@@ -365,8 +366,10 @@ export function FunctionTriggerCard({
               typeof message.durationMs === 'number' ? (
                 <span className="text-ink-faint">
                   {' '}
-                  for <span className="tabular-nums">{message.durationMs}</span>
-                  ms
+                  for{' '}
+                  <span className="tabular-nums">
+                    {formatCallDuration(message.durationMs)}
+                  </span>
                 </span>
               ) : null}
             </span>

--- a/console/web/src/demo/EmptyState.tsx
+++ b/console/web/src/demo/EmptyState.tsx
@@ -23,7 +23,7 @@ export function DemoEmptyState() {
         </p>
         <ul className="font-mono text-[13px] leading-[1.7] text-ink-faint flex flex-col gap-1">
           <li>· trigger functions via the function registry</li>
-          <li>· spawn sub-agents for parallel/async work</li>
+          <li>· spawn subagents for parallel/async work</li>
           <li>· register triggers for loop and graph control</li>
           <li>
             · query state, publish to queues, and do everything production

--- a/console/web/src/demo/EmptyState.tsx
+++ b/console/web/src/demo/EmptyState.tsx
@@ -1,0 +1,36 @@
+/**
+ * Demo-local copy of the chat empty state's hero. The product's `EmptyState`
+ * keeps its own words; the landing demo wants this greeting, rendered inside
+ * the transcript scroller (via `MessageList`'s `header` slot) so the replay
+ * scrolls it away instead of unmounting it.
+ */
+
+import { Prompt } from '@/components/ui/Prompt'
+
+export function DemoEmptyState() {
+  return (
+    <div className="flex max-w-[520px] flex-col gap-6">
+      <div className="font-mono text-[11px] uppercase tracking-[0.06em] text-ink-faint">
+        <Prompt symbol="$">new session</Prompt>
+      </div>
+      <h1 className="font-mono text-[28px] font-medium tracking-[-0.01em] text-ink lowercase">
+        welcome to iii! 👋
+      </h1>
+      <div className="flex flex-col gap-2">
+        <p className="font-mono text-[14px] leading-[1.7] text-ink-faint lowercase">
+          You're in a 1:1 reproduction of our agent-oriented workspace where
+          you can leverage the power of a full-featured agentic system:
+        </p>
+        <ul className="font-mono text-[13px] leading-[1.7] text-ink-faint flex flex-col gap-1">
+          <li>· trigger functions via the function registry</li>
+          <li>· spawn sub-agents for parallel/async work</li>
+          <li>· register triggers for loop and graph control</li>
+          <li>
+            · query state, publish to queues, and do everything production
+            systems do
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/console/web/src/demo/EmptyState.tsx
+++ b/console/web/src/demo/EmptyState.tsx
@@ -18,8 +18,8 @@ export function DemoEmptyState() {
       </h1>
       <div className="flex flex-col gap-2">
         <p className="font-mono text-[14px] leading-[1.7] text-ink-faint lowercase">
-          You're in a 1:1 reproduction of our agent-oriented workspace where
-          you can leverage the power of a full-featured agentic system:
+          You're in a 1:1 reproduction of our agent-oriented workspace where you
+          can leverage the power of a full-featured agentic system:
         </p>
         <ul className="font-mono text-[13px] leading-[1.7] text-ink-faint flex flex-col gap-1">
           <li>· trigger functions via the function registry</li>

--- a/console/web/src/demo/LandingDemo.tsx
+++ b/console/web/src/demo/LandingDemo.tsx
@@ -183,7 +183,7 @@ export function LandingDemo({ active = true, loop = false }: LandingDemoProps) {
                 <>
                   <span className="flex-shrink-0 text-ink-ghost">·</span>
                   <span className="flex-shrink-0 text-accent">
-                    sub-agent · depth 1
+                    subagent · depth 1
                   </span>
                 </>
               ) : null}

--- a/console/web/src/demo/LandingDemo.tsx
+++ b/console/web/src/demo/LandingDemo.tsx
@@ -166,6 +166,7 @@ export function LandingDemo({ active = true, loop = false }: LandingDemoProps) {
 
         {/* ── transcript ─────────────────────────────────────────────── */}
         <section className="relative flex min-h-0 flex-1 flex-col lg:flex-none lg:w-[46%]">
+          <MobileNotice />
           <header className="flex items-center justify-between gap-3 whitespace-nowrap border-b border-rule px-5 py-3 lg:px-9">
             <div className="flex min-w-0 flex-1 items-center gap-2 font-mono text-[11px] uppercase tracking-[0.06em] text-ink-faint">
               <span className="flex-shrink-0 text-accent" aria-hidden>
@@ -376,6 +377,28 @@ function DemoChrome({
           close <span className="opacity-60">esc</span>
         </button>
       )}
+    </div>
+  )
+}
+
+/** Phone-width only: drops in from the top, over the transcript header. */
+function MobileNotice() {
+  const [shown, setShown] = useState(false)
+  useEffect(() => {
+    const t = setTimeout(() => setShown(true), 400)
+    return () => clearTimeout(t)
+  }, [])
+  return (
+    <div
+      className={cn(
+        'pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center transition-all duration-500 lg:hidden',
+        shown ? 'translate-y-0 opacity-100' : '-translate-y-3 opacity-0',
+      )}
+    >
+      <div className="border-x border-b border-rule bg-panel px-3 py-2 text-center font-mono text-[10px] uppercase tracking-[0.08em] text-ink-faint">
+        this is a simplified view. the iii console is best viewed on larger
+        screens.
+      </div>
     </div>
   )
 }

--- a/console/web/src/demo/LandingDemo.tsx
+++ b/console/web/src/demo/LandingDemo.tsx
@@ -10,7 +10,7 @@
  */
 
 import { ArrowUp, Paperclip } from 'lucide-react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { type RefObject, useCallback, useEffect, useRef, useState } from 'react'
 import { ContextUsage } from '@/components/chat/ContextUsage'
 import { MessageList } from '@/components/chat/MessageList'
 import { ConversationSidebar } from '@/components/sidebar/ConversationSidebar'
@@ -27,13 +27,73 @@ const CONTEXT_WINDOW = 1_000_000
 /** The sidebar's write actions are wired to nothing: this is a recording. */
 const noop = () => {}
 
+/** Back within this many px of the bottom counts as "following again". */
+const FOLLOW_SLACK_PX = 120
+
+/**
+ * Keep a pane's scroll on the newest row while the turn plays, and stop the
+ * moment the reader takes the scrollbar.
+ *
+ * The demo has to pin: `MessageList` only follows when the viewport is
+ * already near the bottom, and its scroll-the-approval-into-view pass parks
+ * it mid-transcript for the rest of the turn, while the waterfall never
+ * follows at all. But pinning must lose to a person — scrolling up to reread
+ * a card should not be yanked back by the next token.
+ *
+ * Following is released on real input (wheel, touch) rather than on any
+ * scroll, because the programmatic scrolls are indistinguishable from a
+ * user's by position alone. It re-arms when a scroll lands back at the
+ * bottom, so scrolling down to catch up resumes the follow.
+ */
+function useTailFollow(wrapRef: RefObject<HTMLElement | null>) {
+  const followRef = useRef(true)
+
+  useEffect(() => {
+    const wrap = wrapRef.current
+    if (!wrap) return
+    const release = () => {
+      followRef.current = false
+    }
+    const onScroll = (event: Event) => {
+      const el = event.target as HTMLElement | null
+      if (!el || typeof el.scrollHeight !== 'number') return
+      const fromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+      if (fromBottom <= FOLLOW_SLACK_PX) followRef.current = true
+    }
+    wrap.addEventListener('wheel', release, { passive: true })
+    wrap.addEventListener('touchmove', release, { passive: true })
+    // Scroll does not bubble; capture catches whichever child is scrolling.
+    wrap.addEventListener('scroll', onScroll, { capture: true, passive: true })
+    return () => {
+      wrap.removeEventListener('wheel', release)
+      wrap.removeEventListener('touchmove', release)
+      wrap.removeEventListener('scroll', onScroll, { capture: true })
+    }
+  }, [wrapRef])
+
+  return useCallback(() => {
+    if (!followRef.current) return
+    const el = wrapRef.current?.querySelector<HTMLElement>('.overflow-y-auto')
+    if (!el) return
+    const id = requestAnimationFrame(() => {
+      el.scrollTop = el.scrollHeight
+    })
+    return () => cancelAnimationFrame(id)
+  }, [wrapRef])
+}
+
 export interface LandingDemoProps {
   /** Pause the whole thing when the overlay is closed. */
   active?: boolean
+  /**
+   * Replay forever. Off by default: the turn ends holding a finished
+   * transcript, a full trace and three child sessions, and that is the state
+   * worth clicking around in. Restarting on top of someone reading it is not.
+   */
   loop?: boolean
 }
 
-export function LandingDemo({ active = true, loop = true }: LandingDemoProps) {
+export function LandingDemo({ active = true, loop = false }: LandingDemoProps) {
   const player = usePlayer(active, loop)
   const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null)
   const listWrapRef = useRef<HTMLDivElement>(null)
@@ -43,34 +103,13 @@ export function LandingDemo({ active = true, loop = true }: LandingDemoProps) {
     setSelectedSpanId((prev) => (prev === span.span_id ? null : span.span_id))
   }, [])
 
-  /**
-   * Nobody is driving the scrollbar here. `MessageList` only follows the tail
-   * when the reader is already near it, and its scroll-the-approval-into-view
-   * pass parks the viewport mid-transcript for the rest of the turn; the
-   * waterfall never follows at all (a reader inspecting a trace would hate
-   * that). Both panes are pinned to the tail so the demo keeps showing the
-   * thing that just happened.
-   */
-  // biome-ignore lint/correctness/useExhaustiveDependencies: the transcript is the trigger, not a value read here.
-  useEffect(() => {
-    const el = listWrapRef.current?.firstElementChild as HTMLElement | null
-    if (!el) return
-    const id = requestAnimationFrame(() => {
-      el.scrollTop = el.scrollHeight
-    })
-    return () => cancelAnimationFrame(id)
-  }, [player.messages, player.callout])
+  const pinTranscript = useTailFollow(listWrapRef)
+  const pinTrace = useTailFollow(traceWrapRef)
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the transcript is the trigger, not a value read here.
+  useEffect(pinTranscript, [pinTranscript, player.messages, player.callout])
   // biome-ignore lint/correctness/useExhaustiveDependencies: the span count is the trigger, not a value read here.
-  useEffect(() => {
-    const el =
-      traceWrapRef.current?.querySelector<HTMLElement>('.overflow-y-auto')
-    if (!el) return
-    const id = requestAnimationFrame(() => {
-      el.scrollTop = el.scrollHeight
-    })
-    return () => cancelAnimationFrame(id)
-  }, [player.spanCount, player.callout])
+  useEffect(pinTrace, [pinTrace, player.spanCount, player.callout])
 
   const working = player.phase === 'streaming'
   /* The header follows whichever session the sidebar has selected. */

--- a/console/web/src/demo/LandingDemo.tsx
+++ b/console/web/src/demo/LandingDemo.tsx
@@ -147,12 +147,11 @@ export function LandingDemo({ active = true, loop = false }: LandingDemoProps) {
 
       {/*
         Sidebar, transcript, traces — the console's own three columns, once
-        there is room for them. Narrower than that the sidebar drops (a
-        session tree is not worth a phone's width) and the two panes stack,
-        each with a height of its own and the pair scrolling: a 58/42 split
-        of a phone screen leaves the transcript with no room to be one.
+        there is room for them. Narrower than that only the chat survives:
+        the sidebar and the traces pane hide, and the transcript takes the
+        whole frame.
       */}
-      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto lg:flex-row lg:overflow-hidden">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden lg:flex-row">
         <div className="hidden lg:flex">
           <ConversationSidebar
             conversations={player.conversations}
@@ -166,7 +165,7 @@ export function LandingDemo({ active = true, loop = false }: LandingDemoProps) {
         </div>
 
         {/* ── transcript ─────────────────────────────────────────────── */}
-        <section className="relative flex h-[72vh] shrink-0 flex-col lg:h-auto lg:min-h-0 lg:w-[46%]">
+        <section className="relative flex min-h-0 flex-1 flex-col lg:flex-none lg:w-[46%]">
           <header className="flex items-center justify-between gap-3 whitespace-nowrap border-b border-rule px-5 py-3 lg:px-9">
             <div className="flex min-w-0 flex-1 items-center gap-2 font-mono text-[11px] uppercase tracking-[0.06em] text-ink-faint">
               <span className="flex-shrink-0 text-accent" aria-hidden>
@@ -240,7 +239,7 @@ export function LandingDemo({ active = true, loop = false }: LandingDemoProps) {
         </section>
 
         {/* ── traces ─────────────────────────────────────────────────── */}
-        <aside className="relative flex h-[68vh] shrink-0 flex-col border-t border-rule bg-panel lg:h-auto lg:min-h-0 lg:flex-1 lg:border-l lg:border-t-0">
+        <aside className="relative hidden min-h-0 flex-1 flex-col border-l border-rule bg-panel lg:flex">
           <header className="flex items-center justify-between gap-3 border-b border-rule px-5 py-3">
             <div className="flex min-w-0 items-center gap-2 font-mono text-[11px] uppercase tracking-[0.06em]">
               <span className="text-ink">traces</span>

--- a/console/web/src/demo/LandingDemo.tsx
+++ b/console/web/src/demo/LandingDemo.tsx
@@ -1,12 +1,16 @@
 /**
  * The landing-page demo surface: the console's real chat transcript and real
- * trace waterfall, side by side, replaying a scripted turn.
+ * traces surface, side by side, replaying a scripted turn.
  *
  * Everything below the chrome is the shipped product code — `MessageList`
- * (and through it every per-worker result renderer) and `WaterfallChart` over
- * `toWaterfallData`. Only three things are demo-local: the composer is a
- * lookalike that types instead of a Lexical editor, the events come from
- * `scenario.ts` instead of the engine, and the callout chips are new.
+ * (and through it every per-worker result renderer), and on the traces side
+ * the page's own stack: the live `TimelineStrip` masthead, `TraceFilters`,
+ * the `timeline`/`waterfall` switcher over `TraceTimeline` / `WaterfallChart`,
+ * and the `WorkerBreakdown` footer: same components, same defaults (the
+ * hierarchical timeline, not the waterfall). Only three things are demo-local:
+ * the composer is a lookalike that types instead of a Lexical editor, the
+ * events come from `scenario.ts` instead of the engine, and the callout chips
+ * are new.
  */
 
 import { ArrowUp, Paperclip } from 'lucide-react'
@@ -16,7 +20,16 @@ import { MessageList } from '@/components/chat/MessageList'
 import { ConversationSidebar } from '@/components/sidebar/ConversationSidebar'
 import { StatusDot } from '@/components/ui/StatusDot'
 import { cn } from '@/lib/utils'
+import { TimelineStrip } from '@/pages/TracesV2/components/timeline/TimelineStrip'
+import { TraceTimeline } from '@/pages/TracesV2/components/timeline/TraceTimeline'
+import { TraceFilters } from '@/pages/TracesV2/components/TraceFilters'
+import {
+  ViewSwitcher,
+  type ViewType,
+} from '@/pages/TracesV2/components/ViewSwitcher'
 import { WaterfallChart } from '@/pages/TracesV2/components/WaterfallChart'
+import { WorkerBreakdown } from '@/pages/TracesV2/components/WorkerBreakdown'
+import { useTraceFilters } from '@/pages/TracesV2/hooks/useTraceFilters'
 import type { VisualizationSpan } from '@/pages/TracesV2/lib/traceTransform'
 import { MODEL_ID, SESSION_ID, TRACE_ID } from './scenario'
 import { usePlayer } from './usePlayer'
@@ -96,6 +109,11 @@ export interface LandingDemoProps {
 export function LandingDemo({ active = true, loop = false }: LandingDemoProps) {
   const player = usePlayer(active, loop)
   const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null)
+  // The page's default view, and the page's own filter state. The filters
+  // control a single recorded trace, so narrowing has nothing to narrow;
+  // they are here because the surface is not the surface without them.
+  const [view, setView] = useState<ViewType>('timeline')
+  const traceFilters = useTraceFilters()
   const listWrapRef = useRef<HTMLDivElement>(null)
   const traceWrapRef = useRef<HTMLDivElement>(null)
 
@@ -230,20 +248,67 @@ export function LandingDemo({ active = true, loop = false }: LandingDemoProps) {
             </div>
           </header>
 
-          <div ref={traceWrapRef} className="flex min-h-0 flex-1 flex-col">
+          {/* The masthead and filter bar the real page carries above its
+              trace list; the strip runs live off the same span feed the
+              detail below is built from. */}
+          <TimelineStrip spans={player.spans} isPaused={!active} />
+          <div className="border-b border-rule px-4 py-2.5">
+            <TraceFilters
+              filters={traceFilters.filters}
+              onFilterChange={traceFilters.updateFilter}
+              onClear={traceFilters.resetFilters}
+              validationWarnings={traceFilters.validationWarnings}
+              onClearWarnings={traceFilters.clearValidationWarnings}
+              stats={{
+                totalTraces: 1,
+                errorCount: player.waterfall
+                  ? player.waterfall.spans.filter((s) => s.status === 'error')
+                      .length
+                  : 0,
+                avgDuration: player.waterfall?.total_duration_ms ?? 0,
+              }}
+            />
+          </div>
+
+          <div className="border-b border-rule px-4 py-2.5">
+            <ViewSwitcher currentView={view} onViewChange={setView} />
+          </div>
+
+          <div
+            ref={traceWrapRef}
+            className="flex min-h-0 flex-1 flex-col overflow-y-auto"
+          >
             {player.waterfall ? (
-              <WaterfallChart
-                data={player.waterfall}
-                onSpanClick={handleSpanClick}
-                selectedSpanId={selectedSpanId}
-                showExpandControls={false}
-              />
+              view === 'timeline' ? (
+                <TraceTimeline
+                  data={player.waterfall}
+                  onSpanClick={handleSpanClick}
+                  selectedSpanId={selectedSpanId ?? undefined}
+                  fitContent
+                />
+              ) : (
+                <div className="min-h-0 flex-1">
+                  {/* The real console boxes the chart at 420px; the demo pane is the whole column, so it takes all of it. */}
+                  <WaterfallChart
+                    data={player.waterfall}
+                    onSpanClick={handleSpanClick}
+                    selectedSpanId={selectedSpanId}
+                    showExpandControls={false}
+                  />
+                </div>
+              )
             ) : (
               <div className="flex h-full items-center justify-center px-6 text-center font-mono text-[12px] text-ink-ghost">
                 waiting for the first span…
               </div>
             )}
           </div>
+
+          {player.waterfall ? (
+            <div className="shrink-0 border-t border-rule">
+              <WorkerBreakdown data={player.waterfall} />
+            </div>
+          ) : null}
 
           <CalloutStrip
             callout={

--- a/console/web/src/demo/LandingDemo.tsx
+++ b/console/web/src/demo/LandingDemo.tsx
@@ -31,6 +31,7 @@ import { WaterfallChart } from '@/pages/TracesV2/components/WaterfallChart'
 import { WorkerBreakdown } from '@/pages/TracesV2/components/WorkerBreakdown'
 import { useTraceFilters } from '@/pages/TracesV2/hooks/useTraceFilters'
 import type { VisualizationSpan } from '@/pages/TracesV2/lib/traceTransform'
+import { DemoEmptyState } from './EmptyState'
 import { MODEL_ID, SESSION_ID, TRACE_ID } from './scenario'
 import { usePlayer } from './usePlayer'
 
@@ -137,7 +138,12 @@ export function LandingDemo({ active = true, loop = false }: LandingDemoProps) {
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-bg text-ink">
-      <DemoChrome working={working} />
+      <DemoChrome
+        working={working}
+        paused={player.paused}
+        onTogglePause={player.togglePause}
+        onReplay={player.replay}
+      />
 
       {/*
         Sidebar, transcript, traces — the console's own three columns, once
@@ -210,6 +216,7 @@ export function LandingDemo({ active = true, loop = false }: LandingDemoProps) {
           <div ref={listWrapRef} className="flex min-h-0 flex-1 flex-col">
             <MessageList
               messages={player.messages}
+              header={<DemoEmptyState />}
               isThinking={player.isThinking}
               thinkingDetail={
                 player.thinkingDetail ?? `dispatching ${MODEL_LABEL}`
@@ -325,7 +332,19 @@ export function LandingDemo({ active = true, loop = false }: LandingDemoProps) {
  * The window frame. The real console is a full app with a sidebar and route
  * tabs; the demo keeps just enough of it to read as the same product.
  */
-function DemoChrome({ working }: { working: boolean }) {
+function DemoChrome({
+  working,
+  paused,
+  onTogglePause,
+  onReplay,
+}: {
+  working: boolean
+  paused: boolean
+  onTogglePause: () => void
+  onReplay: () => void
+}) {
+  const controlClass =
+    'flex items-center gap-1.5 border border-rule px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-ink-faint transition-colors hover:text-ink'
   return (
     <div className="flex items-center gap-3 border-b border-rule bg-panel px-5 py-2">
       <span className="font-mono text-[12px] lowercase tracking-[0.06em] text-ink">
@@ -337,8 +356,14 @@ function DemoChrome({ working }: { working: boolean }) {
       </span>
       <span className="ml-auto flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.14em] text-ink-ghost">
         <span className="hidden sm:inline">recorded session</span>
-        <StatusDot tone={working ? 'accent' : 'ink'} pulse={working} />
+        <StatusDot tone={working ? 'accent' : 'ink'} pulse={working && !paused} />
       </span>
+      <button type="button" onClick={onTogglePause} className={controlClass}>
+        {paused ? 'play' : 'pause'}
+      </button>
+      <button type="button" onClick={onReplay} className={controlClass}>
+        replay
+      </button>
       {/* Embedded only: the host page listens for iii-demo-close and scrolls
           the console away. Inverted so the way out is unmissable. */}
       {window.self !== window.top && (

--- a/console/web/src/demo/LandingDemo.tsx
+++ b/console/web/src/demo/LandingDemo.tsx
@@ -1,0 +1,294 @@
+/**
+ * The landing-page demo surface: the console's real chat transcript and real
+ * trace waterfall, side by side, replaying a scripted turn.
+ *
+ * Everything below the chrome is the shipped product code — `MessageList`
+ * (and through it every per-worker result renderer) and `WaterfallChart` over
+ * `toWaterfallData`. Only three things are demo-local: the composer is a
+ * lookalike that types instead of a Lexical editor, the events come from
+ * `scenario.ts` instead of the engine, and the callout chips are new.
+ */
+
+import { ArrowUp, Paperclip } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ContextUsage } from '@/components/chat/ContextUsage'
+import { MessageList } from '@/components/chat/MessageList'
+import { StatusDot } from '@/components/ui/StatusDot'
+import { cn } from '@/lib/utils'
+import { WaterfallChart } from '@/pages/TracesV2/components/WaterfallChart'
+import type { VisualizationSpan } from '@/pages/TracesV2/lib/traceTransform'
+import { MODEL_ID, SESSION_ID, TRACE_ID } from './scenario'
+import { usePlayer } from './usePlayer'
+
+const MODEL_LABEL = 'claude opus 4.7'
+const CONTEXT_WINDOW = 1_000_000
+
+export interface LandingDemoProps {
+  /** Pause the whole thing when the overlay is closed. */
+  active?: boolean
+  loop?: boolean
+}
+
+export function LandingDemo({ active = true, loop = true }: LandingDemoProps) {
+  const player = usePlayer(active, loop)
+  const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null)
+  const listWrapRef = useRef<HTMLDivElement>(null)
+  const traceWrapRef = useRef<HTMLDivElement>(null)
+
+  const handleSpanClick = useCallback((span: VisualizationSpan) => {
+    setSelectedSpanId((prev) => (prev === span.span_id ? null : span.span_id))
+  }, [])
+
+  /**
+   * Nobody is driving the scrollbar here. `MessageList` only follows the tail
+   * when the reader is already near it, and its scroll-the-approval-into-view
+   * pass parks the viewport mid-transcript for the rest of the turn; the
+   * waterfall never follows at all (a reader inspecting a trace would hate
+   * that). Both panes are pinned to the tail so the demo keeps showing the
+   * thing that just happened.
+   */
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the transcript is the trigger, not a value read here.
+  useEffect(() => {
+    const el = listWrapRef.current?.firstElementChild as HTMLElement | null
+    if (!el) return
+    const id = requestAnimationFrame(() => {
+      el.scrollTop = el.scrollHeight
+    })
+    return () => cancelAnimationFrame(id)
+  }, [player.messages, player.callout])
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the span count is the trigger, not a value read here.
+  useEffect(() => {
+    const el =
+      traceWrapRef.current?.querySelector<HTMLElement>('.overflow-y-auto')
+    if (!el) return
+    const id = requestAnimationFrame(() => {
+      el.scrollTop = el.scrollHeight
+    })
+    return () => cancelAnimationFrame(id)
+  }, [player.spanCount, player.callout])
+
+  const working = player.phase === 'streaming'
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-bg text-ink">
+      <DemoChrome working={working} />
+
+      {/*
+        Two panes side by side once there is room for both. Narrower than
+        that they stack, each with a height of its own and the pair
+        scrolling: a 58/42 split of a phone screen leaves the transcript
+        with no room to be a transcript.
+      */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto lg:flex-row lg:overflow-hidden">
+        {/* ── transcript ─────────────────────────────────────────────── */}
+        <section className="relative flex h-[72vh] shrink-0 flex-col lg:h-auto lg:min-h-0 lg:w-[58%]">
+          <header className="flex items-center justify-between gap-3 whitespace-nowrap border-b border-rule px-5 py-3 lg:px-9">
+            <div className="flex min-w-0 flex-1 items-center gap-2 font-mono text-[11px] uppercase tracking-[0.06em] text-ink-faint">
+              <span className="flex-shrink-0 text-accent" aria-hidden>
+                $
+              </span>
+              <span className="hidden min-w-0 truncate text-ink sm:inline">
+                {MODEL_LABEL}
+              </span>
+              <span className="hidden flex-shrink-0 text-ink-ghost sm:inline">
+                ·
+              </span>
+              <span className="flex-shrink-0 text-ink-faint">agent</span>
+              <span className="hidden flex-shrink-0 text-ink-ghost md:inline">
+                ·
+              </span>
+              <span className="hidden min-w-0 truncate font-mono text-[11px] normal-case tracking-normal tabular-nums text-ink-faint md:inline">
+                {SESSION_ID}
+              </span>
+            </div>
+            <div className="flex flex-shrink-0 items-center gap-3 font-mono text-[11px] uppercase tracking-[0.06em]">
+              <span className="hidden sm:inline-flex">
+                <ContextUsage
+                  messages={player.messages}
+                  contextWindow={CONTEXT_WINDOW}
+                />
+              </span>
+              <div className="flex items-center gap-2">
+                <StatusDot tone={working ? 'accent' : 'ink'} pulse={working} />
+                <span className="text-ink-faint">
+                  {working ? 'working' : 'ready'}
+                </span>
+              </div>
+            </div>
+          </header>
+
+          <div ref={listWrapRef} className="flex min-h-0 flex-1 flex-col">
+            <MessageList
+              messages={player.messages}
+              isThinking={player.isThinking}
+              thinkingDetail={
+                player.thinkingDetail ?? `dispatching ${MODEL_LABEL}`
+              }
+              defaultOpenCalls
+              onResolveApproval={player.resolveApproval}
+            />
+          </div>
+
+          <CalloutStrip
+            callout={
+              player.callout?.anchor === 'transcript' ? player.callout : null
+            }
+          />
+
+          <footer className="px-5 pb-6 pt-2 lg:px-9">
+            <div className="mx-auto max-w-[760px]">
+              <FakeComposer typed={player.typed} streaming={working} />
+            </div>
+          </footer>
+        </section>
+
+        {/* ── traces ─────────────────────────────────────────────────── */}
+        <aside className="relative flex h-[68vh] shrink-0 flex-col border-t border-rule bg-panel lg:h-auto lg:min-h-0 lg:flex-1 lg:border-l lg:border-t-0">
+          <header className="flex items-center justify-between gap-3 border-b border-rule px-5 py-3">
+            <div className="flex min-w-0 items-center gap-2 font-mono text-[11px] uppercase tracking-[0.06em]">
+              <span className="text-ink">traces</span>
+              <span className="text-ink-ghost">·</span>
+              <span className="min-w-0 truncate normal-case tracking-normal text-ink-faint">
+                {TRACE_ID}
+              </span>
+            </div>
+            <div className="flex flex-shrink-0 items-center gap-2 font-mono text-[11px] uppercase tracking-[0.06em] text-ink-faint">
+              <StatusDot tone={working ? 'accent' : 'ink'} pulse={working} />
+              <span className="tabular-nums">{player.spanCount} spans</span>
+            </div>
+          </header>
+
+          <div ref={traceWrapRef} className="flex min-h-0 flex-1 flex-col">
+            {player.waterfall ? (
+              <WaterfallChart
+                data={player.waterfall}
+                onSpanClick={handleSpanClick}
+                selectedSpanId={selectedSpanId}
+              />
+            ) : (
+              <div className="flex h-full items-center justify-center px-6 text-center font-mono text-[12px] text-ink-ghost">
+                waiting for the first span…
+              </div>
+            )}
+          </div>
+
+          <CalloutStrip
+            callout={
+              player.callout?.anchor === 'waterfall' ? player.callout : null
+            }
+          />
+        </aside>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * The window frame. The real console is a full app with a sidebar and route
+ * tabs; the demo keeps just enough of it to read as the same product.
+ */
+function DemoChrome({ working }: { working: boolean }) {
+  return (
+    <div className="flex items-center gap-3 border-b border-rule bg-panel px-5 py-2">
+      <span className="font-mono text-[12px] lowercase tracking-[0.06em] text-ink">
+        iii console
+      </span>
+      <span className="text-ink-ghost">·</span>
+      <span className="min-w-0 truncate font-mono text-[12px] text-ink-faint">
+        payments ledger
+      </span>
+      <span className="ml-auto flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.14em] text-ink-ghost">
+        <span className="hidden sm:inline">recorded session</span>
+        <StatusDot tone={working ? 'accent' : 'ink'} pulse={working} />
+      </span>
+    </div>
+  )
+}
+
+/** Composer lookalike: same frame as `Composer`, types instead of editing. */
+function FakeComposer({
+  typed,
+  streaming,
+}: {
+  typed: string
+  streaming: boolean
+}) {
+  const showPlaceholder = typed.length === 0
+  return (
+    <div className="border border-rule bg-panel">
+      <div className="px-1 pt-1">
+        <div className="composer-editor min-h-[2.5rem] px-3 py-2 text-[14px] leading-[1.5]">
+          {showPlaceholder ? (
+            <span className="text-ink-ghost">
+              {streaming ? 'streaming response…' : 'send a message…'}
+            </span>
+          ) : (
+            <span className="whitespace-pre-wrap break-words">
+              {typed}
+              <span className="ml-px inline-block h-[1.05em] w-[1px] translate-y-[3px] animate-pulse bg-ink" />
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="flex min-w-0 items-center gap-2 border-t border-rule-2 px-3 py-2">
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+          <span className="inline-flex h-9 items-center gap-2 border border-rule bg-bg px-3 font-mono text-[13px] lowercase text-ink">
+            agent
+          </span>
+          <span className="inline-flex h-9 min-w-0 items-center gap-2 border border-rule bg-bg px-3 font-mono text-[13px] lowercase text-ink">
+            <span className="truncate">{MODEL_LABEL}</span>
+          </span>
+          <span className="hidden font-mono text-[11px] uppercase tracking-[0.06em] text-ink-ghost sm:inline">
+            {MODEL_ID.split('::')[0]}
+          </span>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <span className="inline-flex size-9 items-center justify-center text-ink-ghost">
+            <Paperclip size={16} aria-hidden />
+          </span>
+          <span
+            className={cn(
+              'inline-flex size-9 items-center justify-center rounded-full bg-bg text-ink',
+              '[html[data-theme=dark]_&]:bg-white [html[data-theme=dark]_&]:text-[#0a0a0a]',
+              typed.length === 0 && 'opacity-40',
+            )}
+          >
+            <ArrowUp size={20} aria-hidden />
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * The annotation strip. One at a time, replaced as the turn moves on. In
+ * flow rather than floating: both panes pin to their newest row, and a
+ * floating chip would sit exactly on top of it.
+ */
+function CalloutStrip({
+  callout,
+}: {
+  callout: { title: string; text: string } | null
+}) {
+  if (!callout) return null
+  return (
+    <div
+      className="shrink-0 border-t border-accent bg-accent/[0.06] px-5 py-3 lg:px-9"
+      aria-live="polite"
+    >
+      {callout ? (
+        <div className="mx-auto max-w-[760px]">
+          <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent">
+            {callout.title}
+          </div>
+          <p className="mt-1.5 text-[13px] leading-[1.5] text-ink">
+            {callout.text}
+          </p>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/console/web/src/demo/LandingDemo.tsx
+++ b/console/web/src/demo/LandingDemo.tsx
@@ -127,11 +127,15 @@ export function LandingDemo({ active = true, loop = false }: LandingDemoProps) {
   /* ~8s into the replay the composer types out an invitation to run the
      harness yourself — the type-out is the attention cue, and the typed text
      is a live link. Hidden whenever the player owns the composer (the loop
-     retyping the scenario prompt). */
+     retyping the scenario prompt). Keyed on the run, so a replay types it out
+     again instead of revealing the finished line the moment the composer
+     frees up. */
   const started = player.phase !== 'idle'
   const [ctaChars, setCtaChars] = useState(0)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: runKey is the restart trigger, not a value read here.
   useEffect(() => {
     if (!started) return
+    setCtaChars(0)
     let interval: ReturnType<typeof setInterval> | undefined
     const delay = setTimeout(() => {
       interval = setInterval(() => {
@@ -148,7 +152,7 @@ export function LandingDemo({ active = true, loop = false }: LandingDemoProps) {
       clearTimeout(delay)
       clearInterval(interval)
     }
-  }, [started])
+  }, [started, player.runKey])
   const cta = player.typed ? '' : CTA_TEXT.slice(0, ctaChars)
 
   const pinTranscript = useTailFollow(listWrapRef)

--- a/console/web/src/demo/LandingDemo.tsx
+++ b/console/web/src/demo/LandingDemo.tsx
@@ -236,6 +236,7 @@ export function LandingDemo({ active = true, loop = false }: LandingDemoProps) {
                 data={player.waterfall}
                 onSpanClick={handleSpanClick}
                 selectedSpanId={selectedSpanId}
+                showExpandControls={false}
               />
             ) : (
               <div className="flex h-full items-center justify-center px-6 text-center font-mono text-[12px] text-ink-ghost">

--- a/console/web/src/demo/LandingDemo.tsx
+++ b/console/web/src/demo/LandingDemo.tsx
@@ -339,6 +339,19 @@ function DemoChrome({ working }: { working: boolean }) {
         <span className="hidden sm:inline">recorded session</span>
         <StatusDot tone={working ? 'accent' : 'ink'} pulse={working} />
       </span>
+      {/* Embedded only: the host page listens for iii-demo-close and scrolls
+          the console away. Inverted so the way out is unmissable. */}
+      {window.self !== window.top && (
+        <button
+          type="button"
+          onClick={() =>
+            window.parent?.postMessage({ type: 'iii-demo-close' }, '*')
+          }
+          className="flex items-center gap-1.5 bg-ink px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-bg transition-opacity hover:opacity-80"
+        >
+          close <span className="opacity-60">esc</span>
+        </button>
+      )}
     </div>
   )
 }

--- a/console/web/src/demo/LandingDemo.tsx
+++ b/console/web/src/demo/LandingDemo.tsx
@@ -35,7 +35,9 @@ import { DemoEmptyState } from './EmptyState'
 import { MODEL_ID, SESSION_ID, TRACE_ID } from './scenario'
 import { usePlayer } from './usePlayer'
 
-const MODEL_LABEL = 'claude opus 4.7'
+const MODEL_LABEL = 'claude sonnet 5'
+const CTA_TEXT = 'click here to try the harness for yourself'
+const CTA_HREF = 'https://workers.iii.dev/workers/harness#quickstart'
 const CONTEXT_WINDOW = 1_000_000
 
 /** The sidebar's write actions are wired to nothing: this is a recording. */
@@ -122,6 +124,33 @@ export function LandingDemo({ active = true, loop = false }: LandingDemoProps) {
     setSelectedSpanId((prev) => (prev === span.span_id ? null : span.span_id))
   }, [])
 
+  /* ~8s into the replay the composer types out an invitation to run the
+     harness yourself — the type-out is the attention cue, and the typed text
+     is a live link. Hidden whenever the player owns the composer (the loop
+     retyping the scenario prompt). */
+  const started = player.phase !== 'idle'
+  const [ctaChars, setCtaChars] = useState(0)
+  useEffect(() => {
+    if (!started) return
+    let interval: ReturnType<typeof setInterval> | undefined
+    const delay = setTimeout(() => {
+      interval = setInterval(() => {
+        setCtaChars((c) => {
+          if (c >= CTA_TEXT.length) {
+            clearInterval(interval)
+            return c
+          }
+          return c + 1
+        })
+      }, 55)
+    }, 8000)
+    return () => {
+      clearTimeout(delay)
+      clearInterval(interval)
+    }
+  }, [started])
+  const cta = player.typed ? '' : CTA_TEXT.slice(0, ctaChars)
+
   const pinTranscript = useTailFollow(listWrapRef)
   const pinTrace = useTailFollow(traceWrapRef)
 
@@ -166,7 +195,9 @@ export function LandingDemo({ active = true, loop = false }: LandingDemoProps) {
 
         {/* ── transcript ─────────────────────────────────────────────── */}
         <section className="relative flex min-h-0 flex-1 flex-col lg:flex-none lg:w-[46%]">
-          <MobileNotice />
+          <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex flex-col items-center">
+            <MobileNotice />
+          </div>
           <header className="flex items-center justify-between gap-3 whitespace-nowrap border-b border-rule px-5 py-3 lg:px-9">
             <div className="flex min-w-0 flex-1 items-center gap-2 font-mono text-[11px] uppercase tracking-[0.06em] text-ink-faint">
               <span className="flex-shrink-0 text-accent" aria-hidden>
@@ -234,7 +265,7 @@ export function LandingDemo({ active = true, loop = false }: LandingDemoProps) {
 
           <footer className="px-5 pb-6 pt-2 lg:px-9">
             <div className="mx-auto max-w-[760px]">
-              <FakeComposer typed={player.typed} streaming={working} />
+              <FakeComposer typed={player.typed} streaming={working} cta={cta} />
             </div>
           </footer>
         </section>
@@ -391,39 +422,56 @@ function MobileNotice() {
   return (
     <div
       className={cn(
-        'pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center transition-all duration-500 lg:hidden',
+        'border-x border-b border-rule bg-panel px-3 py-2 text-center font-mono text-[10px] uppercase tracking-[0.08em] text-ink-faint transition-all duration-500 lg:hidden',
         shown ? 'translate-y-0 opacity-100' : '-translate-y-3 opacity-0',
       )}
     >
-      <div className="border-x border-b border-rule bg-panel px-3 py-2 text-center font-mono text-[10px] uppercase tracking-[0.08em] text-ink-faint">
-        this is a simplified view. the iii console is best viewed on larger
-        screens.
-      </div>
+      this is a simplified view. the iii console is best viewed on larger
+      screens.
     </div>
   )
 }
 
-/** Composer lookalike: same frame as `Composer`, types instead of editing. */
+/** Composer lookalike: same frame as `Composer`, types instead of editing.
+    `cta` types out an invitation in the editor when the player isn't using
+    it; the typed text is a live link and the frame glows accent while it
+    has something to say. */
 function FakeComposer({
   typed,
   streaming,
+  cta = '',
 }: {
   typed: string
   streaming: boolean
+  cta?: string
 }) {
-  const showPlaceholder = typed.length === 0
   return (
-    <div className="border border-rule bg-panel">
+    <div
+      className={cn(
+        'border bg-panel transition-colors duration-700',
+        cta ? 'border-accent' : 'border-rule',
+      )}
+    >
       <div className="px-1 pt-1">
         <div className="composer-editor min-h-[2.5rem] px-3 py-2 text-[14px] leading-[1.5]">
-          {showPlaceholder ? (
-            <span className="text-ink-ghost">
-              {streaming ? 'streaming response…' : 'send a message…'}
-            </span>
-          ) : (
+          {typed.length > 0 ? (
             <span className="whitespace-pre-wrap break-words">
               {typed}
               <span className="ml-px inline-block h-[1.05em] w-[1px] translate-y-[3px] animate-pulse bg-ink" />
+            </span>
+          ) : cta ? (
+            <a
+              href={CTA_HREF}
+              target="_blank"
+              rel="noreferrer"
+              className="whitespace-pre-wrap break-words text-accent underline decoration-accent/50 underline-offset-4 hover:decoration-accent"
+            >
+              {cta}
+              <span className="ml-px inline-block h-[1.05em] w-[1px] translate-y-[3px] animate-pulse bg-accent" />
+            </a>
+          ) : (
+            <span className="text-ink-ghost">
+              {streaming ? 'streaming response…' : 'send a message…'}
             </span>
           )}
         </div>

--- a/console/web/src/demo/LandingDemo.tsx
+++ b/console/web/src/demo/LandingDemo.tsx
@@ -13,6 +13,7 @@ import { ArrowUp, Paperclip } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ContextUsage } from '@/components/chat/ContextUsage'
 import { MessageList } from '@/components/chat/MessageList'
+import { ConversationSidebar } from '@/components/sidebar/ConversationSidebar'
 import { StatusDot } from '@/components/ui/StatusDot'
 import { cn } from '@/lib/utils'
 import { WaterfallChart } from '@/pages/TracesV2/components/WaterfallChart'
@@ -22,6 +23,9 @@ import { usePlayer } from './usePlayer'
 
 const MODEL_LABEL = 'claude opus 4.7'
 const CONTEXT_WINDOW = 1_000_000
+
+/** The sidebar's write actions are wired to nothing: this is a recording. */
+const noop = () => {}
 
 export interface LandingDemoProps {
   /** Pause the whole thing when the overlay is closed. */
@@ -69,20 +73,37 @@ export function LandingDemo({ active = true, loop = true }: LandingDemoProps) {
   }, [player.spanCount, player.callout])
 
   const working = player.phase === 'streaming'
+  /* The header follows whichever session the sidebar has selected. */
+  const paneWorking = player.activeChild
+    ? player.activeChild.status === 'working'
+    : working
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-bg text-ink">
       <DemoChrome working={working} />
 
       {/*
-        Two panes side by side once there is room for both. Narrower than
-        that they stack, each with a height of its own and the pair
-        scrolling: a 58/42 split of a phone screen leaves the transcript
-        with no room to be a transcript.
+        Sidebar, transcript, traces — the console's own three columns, once
+        there is room for them. Narrower than that the sidebar drops (a
+        session tree is not worth a phone's width) and the two panes stack,
+        each with a height of its own and the pair scrolling: a 58/42 split
+        of a phone screen leaves the transcript with no room to be one.
       */}
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto lg:flex-row lg:overflow-hidden">
+        <div className="hidden lg:flex">
+          <ConversationSidebar
+            conversations={player.conversations}
+            activeId={player.activeId}
+            width={260}
+            onSelect={player.select}
+            onCreate={noop}
+            onRename={noop}
+            onRemove={noop}
+          />
+        </div>
+
         {/* ── transcript ─────────────────────────────────────────────── */}
-        <section className="relative flex h-[72vh] shrink-0 flex-col lg:h-auto lg:min-h-0 lg:w-[58%]">
+        <section className="relative flex h-[72vh] shrink-0 flex-col lg:h-auto lg:min-h-0 lg:w-[46%]">
           <header className="flex items-center justify-between gap-3 whitespace-nowrap border-b border-rule px-5 py-3 lg:px-9">
             <div className="flex min-w-0 flex-1 items-center gap-2 font-mono text-[11px] uppercase tracking-[0.06em] text-ink-faint">
               <span className="flex-shrink-0 text-accent" aria-hidden>
@@ -95,11 +116,19 @@ export function LandingDemo({ active = true, loop = true }: LandingDemoProps) {
                 ·
               </span>
               <span className="flex-shrink-0 text-ink-faint">agent</span>
+              {player.activeChild ? (
+                <>
+                  <span className="flex-shrink-0 text-ink-ghost">·</span>
+                  <span className="flex-shrink-0 text-accent">
+                    sub-agent · depth 1
+                  </span>
+                </>
+              ) : null}
               <span className="hidden flex-shrink-0 text-ink-ghost md:inline">
                 ·
               </span>
               <span className="hidden min-w-0 truncate font-mono text-[11px] normal-case tracking-normal tabular-nums text-ink-faint md:inline">
-                {SESSION_ID}
+                {player.activeChild ? player.activeChild.id : SESSION_ID}
               </span>
             </div>
             <div className="flex flex-shrink-0 items-center gap-3 font-mono text-[11px] uppercase tracking-[0.06em]">
@@ -110,9 +139,12 @@ export function LandingDemo({ active = true, loop = true }: LandingDemoProps) {
                 />
               </span>
               <div className="flex items-center gap-2">
-                <StatusDot tone={working ? 'accent' : 'ink'} pulse={working} />
+                <StatusDot
+                  tone={paneWorking ? 'accent' : 'ink'}
+                  pulse={paneWorking}
+                />
                 <span className="text-ink-faint">
-                  {working ? 'working' : 'ready'}
+                  {paneWorking ? 'working' : 'ready'}
                 </span>
               </div>
             </div>

--- a/console/web/src/demo/LandingDemo.tsx
+++ b/console/web/src/demo/LandingDemo.tsx
@@ -20,9 +20,9 @@ import { MessageList } from '@/components/chat/MessageList'
 import { ConversationSidebar } from '@/components/sidebar/ConversationSidebar'
 import { StatusDot } from '@/components/ui/StatusDot'
 import { cn } from '@/lib/utils'
+import { TraceFilters } from '@/pages/TracesV2/components/TraceFilters'
 import { TimelineStrip } from '@/pages/TracesV2/components/timeline/TimelineStrip'
 import { TraceTimeline } from '@/pages/TracesV2/components/timeline/TraceTimeline'
-import { TraceFilters } from '@/pages/TracesV2/components/TraceFilters'
 import {
   ViewSwitcher,
   type ViewType,
@@ -265,7 +265,11 @@ export function LandingDemo({ active = true, loop = false }: LandingDemoProps) {
 
           <footer className="px-5 pb-6 pt-2 lg:px-9">
             <div className="mx-auto max-w-[760px]">
-              <FakeComposer typed={player.typed} streaming={working} cta={cta} />
+              <FakeComposer
+                typed={player.typed}
+                streaming={working}
+                cta={cta}
+              />
             </div>
           </footer>
         </section>
@@ -377,17 +381,21 @@ function DemoChrome({
   const controlClass =
     'flex items-center gap-1.5 border border-rule px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-ink-faint transition-colors hover:text-ink'
   return (
-    <div className="flex items-center gap-3 border-b border-rule bg-panel px-5 py-2">
+    <div className="relative flex items-center gap-3 border-b border-rule bg-panel px-5 py-2">
       <span className="font-mono text-[12px] lowercase tracking-[0.06em] text-ink">
         iii console
       </span>
+      <TryItCta />
       <span className="text-ink-ghost">·</span>
       <span className="min-w-0 truncate font-mono text-[12px] text-ink-faint">
         payments ledger
       </span>
       <span className="ml-auto flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.14em] text-ink-ghost">
         <span className="hidden sm:inline">recorded session</span>
-        <StatusDot tone={working ? 'accent' : 'ink'} pulse={working && !paused} />
+        <StatusDot
+          tone={working ? 'accent' : 'ink'}
+          pulse={working && !paused}
+        />
       </span>
       <button type="button" onClick={onTogglePause} className={controlClass}>
         {paused ? 'play' : 'pause'}
@@ -409,6 +417,37 @@ function DemoChrome({
         </button>
       )}
     </div>
+  )
+}
+
+/**
+ * Centered in the window chrome: the one thing in the frame that leads out of
+ * the recording and into the reader's own terminal. A shine sweep and a slow
+ * 3D tilt carry the attention; the colors are the page's accent tokens, so it
+ * reads as part of whichever theme the host is in. Centered absolutely so it
+ * stays mid-bar regardless of what the controls on either side measure, and
+ * dropped below `md` where there is no room between them.
+ */
+function TryItCta() {
+  return (
+    <span className="demo-3d absolute left-1/2 hidden -translate-x-1/2 md:block">
+      <a
+        href={CTA_HREF}
+        target="_blank"
+        rel="noreferrer"
+        className={cn(
+          'demo-shine demo-tilt flex items-center gap-1.5 overflow-hidden',
+          'border border-accent bg-accent/10 px-3 py-1 font-mono text-[10px]',
+          'uppercase tracking-[0.14em] text-accent transition-colors',
+          'hover:bg-accent hover:text-accent-fg',
+        )}
+      >
+        try it for yourself
+        <span aria-hidden className="text-[11px]">
+          👩‍💻
+        </span>
+      </a>
+    </span>
   )
 }
 

--- a/console/web/src/demo/demo.css
+++ b/console/web/src/demo/demo.css
@@ -1,0 +1,64 @@
+/* Demo-only decoration. Kept out of the console's index.css so the product
+   stylesheet stays the product's. Colors come from the theme tokens; only
+   the motion lives here. */
+
+/* Shine sweeping across the CTA pill, in the pill's own text color. */
+.demo-shine::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    100deg,
+    transparent 30%,
+    currentColor 50%,
+    transparent 70%
+  );
+  background-size: 250% 100%;
+  background-repeat: no-repeat;
+  opacity: 0.35;
+  animation: demo-shine 3.2s ease-in-out infinite;
+  pointer-events: none;
+}
+@keyframes demo-shine {
+  0%,
+  20% {
+    background-position: 200% 0;
+  }
+  60%,
+  100% {
+    background-position: -100% 0;
+  }
+}
+
+/* The pill as a physical chip: a lip and a cast shadow in its own text color,
+   tumbling slowly through a shallow perspective. Rotation lives on the inner
+   element so the wrapper keeps owning the centering transform. */
+.demo-3d {
+  perspective: 420px;
+}
+.demo-tilt {
+  box-shadow:
+    0 2px 0 color-mix(in srgb, currentColor 40%, transparent),
+    0 6px 14px color-mix(in srgb, currentColor 22%, transparent);
+  animation: demo-tilt 7s ease-in-out infinite;
+}
+@keyframes demo-tilt {
+  0%,
+  100% {
+    transform: rotateX(7deg) rotateZ(-1.4deg);
+  }
+  50% {
+    transform: rotateX(-7deg) rotateZ(1.4deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .demo-shine::after {
+    animation: none;
+    opacity: 0;
+  }
+  .demo-tilt {
+    animation: none;
+    transform: none;
+  }
+}

--- a/console/web/src/demo/demo.css
+++ b/console/web/src/demo/demo.css
@@ -10,7 +10,7 @@
   background: linear-gradient(
     100deg,
     transparent 30%,
-    currentColor 50%,
+    currentcolor 50%,
     transparent 70%
   );
   background-size: 250% 100%;
@@ -38,8 +38,8 @@
 }
 .demo-tilt {
   box-shadow:
-    0 2px 0 color-mix(in srgb, currentColor 40%, transparent),
-    0 6px 14px color-mix(in srgb, currentColor 22%, transparent);
+    0 2px 0 color-mix(in srgb, currentcolor 40%, transparent),
+    0 6px 14px color-mix(in srgb, currentcolor 22%, transparent);
   animation: demo-tilt 7s ease-in-out infinite;
 }
 @keyframes demo-tilt {

--- a/console/web/src/demo/main.tsx
+++ b/console/web/src/demo/main.tsx
@@ -51,7 +51,14 @@ function mount() {
 
   window.addEventListener('message', (event: MessageEvent) => {
     const data = event.data
-    if (!data || typeof data !== 'object' || data.type !== 'iii-demo') return
+    if (!data || typeof data !== 'object') return
+    if (data.type === 'iii-demo-theme') {
+      /* The host's theme button flipped while the overlay is open. */
+      document.documentElement.dataset.theme =
+        data.theme === 'dark' ? 'dark' : 'light'
+      return
+    }
+    if (data.type !== 'iii-demo') return
     const next = !!data.active
     if (next === active) return
     active = next

--- a/console/web/src/demo/main.tsx
+++ b/console/web/src/demo/main.tsx
@@ -9,6 +9,8 @@
  * URL params:
  *   ?theme=dark|light   follow the host page's theme (default light)
  *   ?loop=0             play once instead of looping
+ *   ?paused=1           mount paused; the host posts `{type:'iii-demo',
+ *                       active:true}` when the frame is actually on screen
  */
 
 import { StrictMode } from 'react'
@@ -94,7 +96,7 @@ if (!root) throw new Error('missing #root container')
  */
 function mount() {
   const reactRoot = createRoot(root as HTMLElement)
-  let active = true
+  let active = params.get('paused') !== '1'
   /* Bumped to replay: a fresh key remounts the player from the top. */
   let runKey = 0
 

--- a/console/web/src/demo/main.tsx
+++ b/console/web/src/demo/main.tsx
@@ -39,12 +39,18 @@ if (!root) throw new Error('missing #root container')
 function mount() {
   const reactRoot = createRoot(root as HTMLElement)
   let active = true
+  /* Bumped to replay: a fresh key remounts the player from the top. */
+  let runKey = 0
 
   const render = () =>
     reactRoot.render(
       <StrictMode>
         <TooltipProvider delayDuration={150}>
-          <LandingDemo active={active} loop={params.get('loop') !== '0'} />
+          <LandingDemo
+            key={runKey}
+            active={active}
+            loop={params.get('loop') === '1'}
+          />
         </TooltipProvider>
       </StrictMode>,
     )
@@ -56,6 +62,11 @@ function mount() {
       /* The host's theme button flipped while the overlay is open. */
       document.documentElement.dataset.theme =
         data.theme === 'dark' ? 'dark' : 'light'
+      return
+    }
+    if (data.type === 'iii-demo-replay') {
+      runKey += 1
+      render()
       return
     }
     if (data.type !== 'iii-demo') return

--- a/console/web/src/demo/main.tsx
+++ b/console/web/src/demo/main.tsx
@@ -1,0 +1,73 @@
+/**
+ * Entry for the landing-page demo build (`npm run build:demo`).
+ *
+ * Standalone page, not part of the console SPA: no engine client, no
+ * injectable-UI loader, no router. It renders one component over a scripted
+ * turn and is embedded by the marketing site in an iframe, which is what
+ * keeps the console's Tailwind reset from touching the host page.
+ *
+ * URL params:
+ *   ?theme=dark|light   follow the host page's theme (default light)
+ *   ?loop=0             play once instead of looping
+ */
+
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { TooltipProvider } from '@/components/ui/Tooltip'
+import { LandingDemo } from './LandingDemo'
+import { setScenarioSpeed } from './scenario'
+import '../index.css'
+
+const params = new URLSearchParams(window.location.search)
+document.documentElement.dataset.theme =
+  params.get('theme') === 'dark' ? 'dark' : 'light'
+
+/* Reduced motion: fill the turn in at once and hold it, rather than
+   animating a minute of typing at someone who asked for less of that. */
+if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+  setScenarioSpeed(0.02)
+}
+
+const root = document.getElementById('root')
+if (!root) throw new Error('missing #root container')
+
+/**
+ * The host page pauses the demo by posting `{ type: 'iii-demo', active }`
+ * when the overlay opens and closes, so a hidden iframe is not burning a
+ * timer loop. Without a host it just plays.
+ */
+function mount() {
+  const reactRoot = createRoot(root as HTMLElement)
+  let active = true
+
+  const render = () =>
+    reactRoot.render(
+      <StrictMode>
+        <TooltipProvider delayDuration={150}>
+          <LandingDemo active={active} loop={params.get('loop') !== '0'} />
+        </TooltipProvider>
+      </StrictMode>,
+    )
+
+  window.addEventListener('message', (event: MessageEvent) => {
+    const data = event.data
+    if (!data || typeof data !== 'object' || data.type !== 'iii-demo') return
+    const next = !!data.active
+    if (next === active) return
+    active = next
+    render()
+  })
+
+  /* Once the viewer clicks inside the frame (the approval buttons are real),
+     keystrokes land here, not on the host page — forward the one the host
+     cares about so Escape keeps closing the overlay. */
+  window.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      window.parent?.postMessage({ type: 'iii-demo-close' }, '*')
+    }
+  })
+
+  render()
+}
+
+mount()

--- a/console/web/src/demo/main.tsx
+++ b/console/web/src/demo/main.tsx
@@ -8,7 +8,7 @@
  *
  * URL params:
  *   ?theme=dark|light   follow the host page's theme (default light)
- *   ?loop=0             play once instead of looping
+ *   ?loop=1             replay forever instead of holding the finished turn
  *   ?paused=1           mount paused; the host posts `{type:'iii-demo',
  *                       active:true}` when the frame is actually on screen
  */

--- a/console/web/src/demo/main.tsx
+++ b/console/web/src/demo/main.tsx
@@ -28,6 +28,62 @@ if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
   setScenarioSpeed(0.02)
 }
 
+/**
+ * Keep every scroll inside this document.
+ *
+ * `scrollIntoView` walks the ancestor scroll chain past the iframe and into
+ * the EMBEDDER's viewport, so the transcript's auto-follow (`MessageList`
+ * pins the newest row, and pulls a fresh approval into view) drags the host
+ * page around while the session plays inline on it. The replacement does the
+ * same alignment in the nearest scrollport and stops there; it is the whole
+ * behavior the demo needs, and the product code stays untouched.
+ */
+Element.prototype.scrollIntoView = function scrollWithinFrame(
+  this: Element,
+  arg?: boolean | ScrollIntoViewOptions,
+) {
+  const opts: ScrollIntoViewOptions =
+    typeof arg === 'object' ? arg : { block: arg === false ? 'end' : 'start' }
+  let port: HTMLElement | null = null
+  for (let p = this.parentElement; p; p = p.parentElement) {
+    const overflowY = getComputedStyle(p).overflowY
+    if (
+      (overflowY === 'auto' || overflowY === 'scroll') &&
+      p.scrollHeight > p.clientHeight
+    ) {
+      port = p
+      break
+    }
+  }
+  if (!port) return
+  const offset =
+    this.getBoundingClientRect().top -
+    port.getBoundingClientRect().top +
+    port.scrollTop
+  const height = this.getBoundingClientRect().height
+  const top =
+    opts.block === 'center'
+      ? offset - (port.clientHeight - height) / 2
+      : opts.block === 'end' || opts.block === 'nearest'
+        ? offset - port.clientHeight + height
+        : offset
+  port.scrollTo({ top, behavior: opts.behavior ?? 'auto' })
+}
+
+/**
+ * Inner scrollports keep the wheel they catch: when the transcript or the
+ * trace list bottoms out, the scroll ends there. Surface with nothing of its
+ * own to scroll still chains out to the embedding page (html and body keep
+ * the default), and that chain is what un-pins the marketing site's
+ * scroll-zoom. Below the lg breakpoint the whole demo is one scroller, so
+ * containing it would trap the reader; the rule only covers the two-pane
+ * layout.
+ */
+const contain = document.createElement('style')
+contain.textContent =
+  '@media (min-width: 1024px) { body * { overscroll-behavior: contain; } }'
+document.head.appendChild(contain)
+
 const root = document.getElementById('root')
 if (!root) throw new Error('missing #root container')
 

--- a/console/web/src/demo/main.tsx
+++ b/console/web/src/demo/main.tsx
@@ -19,6 +19,7 @@ import { TooltipProvider } from '@/components/ui/Tooltip'
 import { LandingDemo } from './LandingDemo'
 import { setScenarioSpeed } from './scenario'
 import '../index.css'
+import './demo.css'
 
 const params = new URLSearchParams(window.location.search)
 document.documentElement.dataset.theme =

--- a/console/web/src/demo/scenario.ts
+++ b/console/web/src/demo/scenario.ts
@@ -17,48 +17,48 @@
  * generation, and `execute <fn>` for each dispatched call.
  */
 
-import type { StreamEvent } from '@/lib/backend'
-import { sleep, tokenize } from '@/stories/playground/scenarios/helpers'
+import type { StreamEvent } from "@/lib/backend";
+import { sleep, tokenize } from "@/stories/playground/scenarios/helpers";
 
-export const PROMPT = 'build a payments ledger service with a durable db'
+export const PROMPT = "build a payments ledger service with a durable db";
 
-export const MODEL_ID = 'anthropic::claude-opus-4-7'
-export const SESSION_ID = 'console-payments-ledger-demo'
-export const TRACE_ID = 'trace-payments-ledger-0000000001'
+export const MODEL_ID = "anthropic::claude-opus-4-7";
+export const SESSION_ID = "console-payments-ledger-demo";
+export const TRACE_ID = "trace-payments-ledger-0000000001";
 
 /**
  * Global playback rate. `prefers-reduced-motion` sets it near zero so the
  * turn fills in at once and holds, instead of animating for a minute.
  */
-let SPEED = 1
+let SPEED = 1;
 export function setScenarioSpeed(multiplier: number) {
-  SPEED = multiplier
+  SPEED = multiplier;
 }
-const nap = (ms: number, signal?: AbortSignal) => sleep(ms * SPEED, signal)
+const nap = (ms: number, signal?: AbortSignal) => sleep(ms * SPEED, signal);
 
-export type CalloutAnchor = 'transcript' | 'waterfall' | 'composer'
+export type CalloutAnchor = "transcript" | "waterfall" | "composer";
 
 export interface Callout {
-  title: string
-  text: string
-  anchor: CalloutAnchor
+  title: string;
+  text: string;
+  anchor: CalloutAnchor;
 }
 
 export interface DemoSpanInit {
-  id: string
-  parent?: string
-  name: string
-  service: string
-  kind?: string
-  attributes?: Array<[string, unknown]>
+  id: string;
+  parent?: string;
+  name: string;
+  service: string;
+  kind?: string;
+  attributes?: Array<[string, unknown]>;
 }
 
 /** A child session `harness::spawn` created, as the sidebar shows it. */
 export interface DemoSession {
-  id: string
-  title: string
+  id: string;
+  title: string;
   /** The task the parent handed down: the child's seeding user message. */
-  task: string
+  task: string;
 }
 
 /**
@@ -67,58 +67,58 @@ export interface DemoSession {
  * and the three off-screen ones would be animating at nobody.
  */
 export type ChildEntry =
-  | { role: 'thought'; content: string; durationMs: number }
-  | { role: 'assistant'; content: string }
+  | { role: "thought"; content: string; durationMs: number }
+  | { role: "assistant"; content: string }
   | {
-      role: 'function-trigger'
-      functionId: string
+      role: "function-trigger";
+      functionId: string;
       /** Worker that runs it — the child's `execute` span's service name. */
-      worker: string
-      input: unknown
-      output: unknown
-      durationMs: number
-    }
+      worker: string;
+      input: unknown;
+      output: unknown;
+      durationMs: number;
+    };
 
 export type DemoEvent =
   | StreamEvent
-  | { kind: 'demo-span-open'; span: DemoSpanInit }
+  | { kind: "demo-span-open"; span: DemoSpanInit }
   | {
-      kind: 'demo-span-close'
-      id: string
-      status?: 'OK' | 'ERROR'
+      kind: "demo-span-close";
+      id: string;
+      status?: "OK" | "ERROR";
       /** Close the span this long after it opened, rather than now. */
-      durationMs?: number
+      durationMs?: number;
     }
-  | { kind: 'demo-callout'; callout: Callout }
-  | { kind: 'demo-session-open'; session: DemoSession }
-  | { kind: 'demo-session-msg'; id: string; entry: ChildEntry }
-  | { kind: 'demo-session-done'; id: string; result: string }
+  | { kind: "demo-callout"; callout: Callout }
+  | { kind: "demo-session-open"; session: DemoSession }
+  | { kind: "demo-session-msg"; id: string; entry: ChildEntry }
+  | { kind: "demo-session-done"; id: string; result: string };
 
 export interface ScenarioOptions {
-  signal?: AbortSignal
+  signal?: AbortSignal;
   /**
    * Resolves when the gated call is released — by the viewer clicking
    * approve/deny on the real card, or by the demo's own timeout. The demo
    * never denies; a deny resolves the same way so the card can't hang.
    */
-  gate: (functionTriggerId: string) => Promise<void>
+  gate: (functionTriggerId: string) => Promise<void>;
 }
 
 /* ── span bookkeeping ─────────────────────────────────────────────────── */
 
-let spanSeq = 0
+let spanSeq = 0;
 function spanId(prefix: string): string {
-  spanSeq += 1
-  return `${prefix}-${String(spanSeq).padStart(3, '0')}`
+  spanSeq += 1;
+  return `${prefix}-${String(spanSeq).padStart(3, "0")}`;
 }
 
 /** Turn-identity baggage the harness stamps on every span of a step. */
 const TURN_TAGS: Array<[string, unknown]> = [
-  ['iii.session.id', SESSION_ID],
-  ['iii.message.id', 'turn-01'],
-  ['iii.tag.kind', 'harness.turn'],
-  ['iii.tag.message', PROMPT],
-]
+  ["iii.session.id", SESSION_ID],
+  ["iii.message.id", "turn-01"],
+  ["iii.tag.kind", "harness.turn"],
+  ["iii.tag.message", PROMPT],
+];
 
 /* ── stream fragments ─────────────────────────────────────────────────── */
 
@@ -129,7 +129,7 @@ const TURN_TAGS: Array<[string, unknown]> = [
  * read of the closing answer.
  */
 function readingDwellMs(body: string): number {
-  return Math.min(2800, Math.max(600, tokenize(body).length * 10))
+  return Math.min(2800, Math.max(600, tokenize(body).length * 10));
 }
 
 async function* thought(
@@ -137,15 +137,15 @@ async function* thought(
   signal?: AbortSignal,
   meanDelayMs = 38,
 ): AsyncGenerator<DemoEvent> {
-  const startedAt = Date.now()
-  yield { kind: 'thought-start' }
+  const startedAt = Date.now();
+  yield { kind: "thought-start" };
   for (const token of tokenize(body)) {
-    if (signal?.aborted) return
-    if (token) yield { kind: 'thought-token', token }
-    await nap(meanDelayMs * (0.6 + Math.random() * 0.8), signal)
+    if (signal?.aborted) return;
+    if (token) yield { kind: "thought-token", token };
+    await nap(meanDelayMs * (0.6 + Math.random() * 0.8), signal);
   }
-  yield { kind: 'thought-end', durationMs: Date.now() - startedAt }
-  await nap(readingDwellMs(body), signal)
+  yield { kind: "thought-end", durationMs: Date.now() - startedAt };
+  await nap(readingDwellMs(body), signal);
 }
 
 async function* assistant(
@@ -154,12 +154,12 @@ async function* assistant(
   meanDelayMs = 38,
 ): AsyncGenerator<DemoEvent> {
   for (const token of tokenize(body)) {
-    if (signal?.aborted) return
-    if (token) yield { kind: 'assistant-token', token }
-    await nap(meanDelayMs * (0.5 + Math.random()), signal)
+    if (signal?.aborted) return;
+    if (token) yield { kind: "assistant-token", token };
+    await nap(meanDelayMs * (0.5 + Math.random()), signal);
   }
-  yield { kind: 'assistant-end' }
-  await nap(readingDwellMs(body), signal)
+  yield { kind: "assistant-end" };
+  await nap(readingDwellMs(body), signal);
 }
 
 /**
@@ -172,41 +172,41 @@ async function* readPause(
   signal: AbortSignal | undefined,
   holdMs = 2800,
 ): AsyncGenerator<DemoEvent> {
-  const startedAt = Date.now()
-  yield { kind: 'thought-start' }
-  for (const token of tokenize('letting the user read…')) {
-    if (signal?.aborted) return
-    if (token) yield { kind: 'thought-token', token }
-    await nap(55, signal)
+  const startedAt = Date.now();
+  yield { kind: "thought-start" };
+  for (const token of tokenize("letting the user read…")) {
+    if (signal?.aborted) return;
+    if (token) yield { kind: "thought-token", token };
+    await nap(55, signal);
   }
-  await nap(holdMs, signal)
-  if (signal?.aborted) return
-  yield { kind: 'thought-end', durationMs: Date.now() - startedAt }
+  await nap(holdMs, signal);
+  if (signal?.aborted) return;
+  yield { kind: "thought-end", durationMs: Date.now() - startedAt };
 }
 
 interface CallOptions {
-  fn: string
+  fn: string;
   /** Worker that runs it — the `execute` span's service name. */
-  worker: string
-  input: unknown
-  output: unknown
+  worker: string;
+  input: unknown;
+  output: unknown;
   /** How long the demo lingers on the call, so a viewer can see it happen. */
-  runMs: number
+  runMs: number;
   /**
    * What the card and the span report, when that differs from how long the
    * demo dwells. An engine-local call really does finish in microseconds;
    * animating it that fast would make it invisible, and reporting the dwell
    * instead would claim a trigger registration costs a third of a second.
    */
-  reportedMs?: number
-  parentSpan: string
-  signal?: AbortSignal
+  reportedMs?: number;
+  parentSpan: string;
+  signal?: AbortSignal;
   /** Nested spans opened inside the call, as [name, service, share-of-runMs]. */
-  inner?: Array<[string, string, number]>
+  inner?: Array<[string, string, number]>;
   /** Hold the call in the approval gate before it executes. */
-  gate?: (functionTriggerId: string) => Promise<void>
-  functionTriggerId?: string
-  callout?: Callout
+  gate?: (functionTriggerId: string) => Promise<void>;
+  functionTriggerId?: string;
+  callout?: Callout;
 }
 
 async function* call(opts: CallOptions): AsyncGenerator<DemoEvent> {
@@ -223,11 +223,11 @@ async function* call(opts: CallOptions): AsyncGenerator<DemoEvent> {
     gate,
     functionTriggerId,
     callout,
-  } = opts
-  const startedAt = Date.now()
+  } = opts;
+  const startedAt = Date.now();
 
   yield {
-    kind: 'fcall-start',
+    kind: "fcall-start",
     functionId: fn,
     input,
     ...(gate
@@ -237,72 +237,72 @@ async function* call(opts: CallOptions): AsyncGenerator<DemoEvent> {
           sessionId: SESSION_ID,
         }
       : {}),
-  }
-  if (callout) yield { kind: 'demo-callout', callout }
+  };
+  if (callout) yield { kind: "demo-callout", callout };
 
   if (gate && functionTriggerId) {
-    await gate(functionTriggerId)
-    if (signal?.aborted) return
-    yield { kind: 'fcall-approval-cleared', functionTriggerId, running: true }
+    await gate(functionTriggerId);
+    if (signal?.aborted) return;
+    yield { kind: "fcall-approval-cleared", functionTriggerId, running: true };
   }
 
-  const execSpan = spanId('exec')
+  const execSpan = spanId("exec");
   yield {
-    kind: 'demo-span-open',
+    kind: "demo-span-open",
     span: {
       id: execSpan,
       parent: parentSpan,
       name: `execute ${fn}`,
       service: worker,
-      kind: 'internal',
-      attributes: [...TURN_TAGS, ['iii.function.id', fn]],
+      kind: "internal",
+      attributes: [...TURN_TAGS, ["iii.function.id", fn]],
     },
-  }
+  };
 
   if (inner?.length) {
-    let elapsed = 0
+    let elapsed = 0;
     for (const [name, service, share] of inner) {
-      const childSpan = spanId('inner')
+      const childSpan = spanId("inner");
       yield {
-        kind: 'demo-span-open',
+        kind: "demo-span-open",
         span: {
           id: childSpan,
           parent: execSpan,
           name,
           service,
-          kind: 'internal',
+          kind: "internal",
           attributes: TURN_TAGS,
         },
-      }
-      const slice = runMs * share
-      await nap(slice, signal)
-      elapsed += slice
-      if (signal?.aborted) return
+      };
+      const slice = runMs * share;
+      await nap(slice, signal);
+      elapsed += slice;
+      if (signal?.aborted) return;
       yield {
-        kind: 'demo-span-close',
+        kind: "demo-span-close",
         id: childSpan,
         /* Inner work takes its share of the REPORTED time, so a child can
            never outlast the call it happened inside. */
         ...(reportedMs === undefined ? {} : { durationMs: reportedMs * share }),
-      }
+      };
     }
-    await nap(Math.max(0, runMs - elapsed), signal)
+    await nap(Math.max(0, runMs - elapsed), signal);
   } else {
-    await nap(runMs, signal)
+    await nap(runMs, signal);
   }
-  if (signal?.aborted) return
+  if (signal?.aborted) return;
 
   yield {
-    kind: 'demo-span-close',
+    kind: "demo-span-close",
     id: execSpan,
     ...(reportedMs === undefined ? {} : { durationMs: reportedMs }),
-  }
+  };
   yield {
-    kind: 'fcall-end',
+    kind: "fcall-end",
     output,
     durationMs: reportedMs ?? Date.now() - startedAt,
     ...(functionTriggerId ? { functionTriggerId } : {}),
-  }
+  };
 }
 
 /**
@@ -316,53 +316,53 @@ async function* step(
   signal: AbortSignal | undefined,
   after: (stepSpan: string) => AsyncGenerator<DemoEvent>,
 ): AsyncGenerator<DemoEvent> {
-  const stepSpan = spanId('step')
-  const routerSpan = spanId('router')
-  const providerSpan = spanId('provider')
+  const stepSpan = spanId("step");
+  const routerSpan = spanId("router");
+  const providerSpan = spanId("provider");
 
   yield {
-    kind: 'demo-span-open',
+    kind: "demo-span-open",
     span: {
       id: stepSpan,
-      name: 'harness::turn step',
-      service: 'harness',
-      kind: 'internal',
-      attributes: [...TURN_TAGS, ['iii.turn.step', index]],
+      name: "harness::turn step",
+      service: "harness",
+      kind: "internal",
+      attributes: [...TURN_TAGS, ["iii.turn.step", index]],
     },
-  }
+  };
   yield {
-    kind: 'demo-span-open',
+    kind: "demo-span-open",
     span: {
       id: routerSpan,
       parent: stepSpan,
-      name: 'execute router::chat',
-      service: 'llm-router',
-      kind: 'internal',
-      attributes: [...TURN_TAGS, ['gen_ai.request.model', 'claude-opus-4-7']],
+      name: "execute router::chat",
+      service: "llm-router",
+      kind: "internal",
+      attributes: [...TURN_TAGS, ["gen_ai.request.model", "claude-opus-4-7"]],
     },
-  }
+  };
   yield {
-    kind: 'demo-span-open',
+    kind: "demo-span-open",
     span: {
       id: providerSpan,
       parent: routerSpan,
-      name: 'execute provider::anthropic::stream',
-      service: 'llm-provider-anthropic',
-      kind: 'client',
+      name: "execute provider::anthropic::stream",
+      service: "llm-provider-anthropic",
+      kind: "client",
       attributes: TURN_TAGS,
     },
-  }
+  };
 
-  yield* body
-  if (signal?.aborted) return
+  yield* body;
+  if (signal?.aborted) return;
 
-  yield { kind: 'demo-span-close', id: providerSpan }
-  yield { kind: 'demo-span-close', id: routerSpan }
+  yield { kind: "demo-span-close", id: providerSpan };
+  yield { kind: "demo-span-close", id: routerSpan };
 
-  yield* after(stepSpan)
-  if (signal?.aborted) return
+  yield* after(stepSpan);
+  if (signal?.aborted) return;
 
-  yield { kind: 'demo-span-close', id: stepSpan }
+  yield { kind: "demo-span-close", id: stepSpan };
 }
 
 /**
@@ -382,51 +382,51 @@ async function* step(
  */
 async function* spawnFanOut(
   stepSpan: string,
-  gate: ScenarioOptions['gate'],
+  gate: ScenarioOptions["gate"],
   signal: AbortSignal | undefined,
 ): AsyncGenerator<DemoEvent> {
-  const startedAt = Date.now()
-  const spans = new Map<string, string>()
+  const startedAt = Date.now();
+  const spans = new Map<string, string>();
 
   /** Open the child's span pair and its session — it is running now. */
   function* launch(child: ChildSpec): Generator<DemoEvent> {
-    const execSpan = spanId('exec')
-    const childStep = spanId('child')
-    spans.set(child.callId, execSpan)
+    const execSpan = spanId("exec");
+    const childStep = spanId("child");
+    spans.set(child.callId, execSpan);
     yield {
-      kind: 'demo-span-open',
+      kind: "demo-span-open",
       span: {
         id: execSpan,
         parent: stepSpan,
-        name: 'execute harness::spawn',
-        service: 'harness',
-        kind: 'internal',
-        attributes: [...TURN_TAGS, ['iii.child.session_id', child.sessionId]],
+        name: "execute harness::spawn",
+        service: "harness",
+        kind: "internal",
+        attributes: [...TURN_TAGS, ["iii.child.session_id", child.sessionId]],
       },
-    }
+    };
     yield {
-      kind: 'demo-span-open',
+      kind: "demo-span-open",
       span: {
         id: childStep,
         parent: execSpan,
-        name: 'harness::turn step',
-        service: 'harness',
-        kind: 'internal',
+        name: "harness::turn step",
+        service: "harness",
+        kind: "internal",
         attributes: [
-          ['iii.session.id', child.sessionId],
-          ['iii.tag.kind', 'harness.subagent'],
-          ['iii.tag.display_name', `Sub-agent · ${child.title}`],
+          ["iii.session.id", child.sessionId],
+          ["iii.tag.kind", "harness.subagent"],
+          ["iii.tag.display_name", `Sub-agent · ${child.title}`],
         ],
       },
-    }
-    spans.set(`${child.callId}:step`, childStep)
+    };
+    spans.set(`${child.callId}:step`, childStep);
     yield {
-      kind: 'demo-session-open',
+      kind: "demo-session-open",
       session: { id: child.sessionId, title: child.title, task: child.task },
-    }
+    };
     /* Whatever the child has to say the moment it wakes up. */
     for (const beat of child.work) {
-      if (beat.at === 0) yield* childBeat(child, beat.entry)
+      if (beat.at === 0) yield* childBeat(child, beat.entry);
     }
   }
 
@@ -435,76 +435,76 @@ async function* spawnFanOut(
     child: ChildSpec,
     entry: ChildEntry,
   ): Generator<DemoEvent> {
-    yield { kind: 'demo-session-msg', id: child.sessionId, entry }
-    if (entry.role !== 'function-trigger') return
-    const callSpan = spanId('childcall')
+    yield { kind: "demo-session-msg", id: child.sessionId, entry };
+    if (entry.role !== "function-trigger") return;
+    const callSpan = spanId("childcall");
     yield {
-      kind: 'demo-span-open',
+      kind: "demo-span-open",
       span: {
         id: callSpan,
         parent: spans.get(`${child.callId}:step`),
         name: `execute ${entry.functionId}`,
         service: entry.worker,
-        kind: 'internal',
+        kind: "internal",
         attributes: [
-          ['iii.session.id', child.sessionId],
-          ['iii.function.id', entry.functionId],
+          ["iii.session.id", child.sessionId],
+          ["iii.function.id", entry.functionId],
         ],
       },
-    }
+    };
     /* Closed at what the call really costs, like every other call here: the
        child's turn span is the wide one, its dispatches are hairlines. */
     yield {
-      kind: 'demo-span-close',
+      kind: "demo-span-close",
       id: callSpan,
       durationMs: entry.durationMs,
-    }
+    };
   }
 
   /* Every card at once — a parallel tool-call batch is one assistant turn. */
   for (const child of CHILDREN) {
     yield {
-      kind: 'fcall-start',
-      functionId: 'harness::spawn',
+      kind: "fcall-start",
+      functionId: "harness::spawn",
       input: spawnInput(child),
       functionTriggerId: child.callId,
       sessionId: SESSION_ID,
       ...(child.gated ? { pendingApproval: true } : {}),
-    }
+    };
   }
   for (const child of CHILDREN) {
-    if (!child.gated) yield* launch(child)
+    if (!child.gated) yield* launch(child);
   }
 
   yield {
-    kind: 'demo-callout',
+    kind: "demo-callout",
     callout: {
-      anchor: 'transcript',
-      title: 'three sub-agents, one held at the gate',
-      text: 'Each child is its own session with its own budget and its own function policy, listed under this chat as it starts and readable on its own. Only `ledger core` asked for `database::*`, a write scope this session does not hold, so only that one waits for a human. Click approve to release it.',
+      anchor: "transcript",
+      title: "three sub-agents, one held at the gate",
+      text: "Each child is its own session with its own budget and its own function policy, listed under this chat as it starts and readable on its own. Only `ledger core` asked for `database::*`, a write scope this session does not hold, so only that one waits for a human. Click approve to release it.",
     },
-  }
+  };
 
   for (const child of CHILDREN) {
-    if (!child.gated) continue
-    await gate(child.callId)
-    if (signal?.aborted) return
+    if (!child.gated) continue;
+    await gate(child.callId);
+    if (signal?.aborted) return;
     yield {
-      kind: 'fcall-approval-cleared',
+      kind: "fcall-approval-cleared",
       functionTriggerId: child.callId,
       running: true,
-    }
-    yield* launch(child)
+    };
+    yield* launch(child);
   }
 
   yield {
-    kind: 'demo-callout',
+    kind: "demo-callout",
     callout: {
-      anchor: 'transcript',
-      title: 'three sessions, running at once',
-      text: 'Every child is a session of its own, listed in the sidebar. Click one to watch it think and call while the others keep going; whatever it dispatches lands in this same trace, under its own `harness::turn step`.',
+      anchor: "transcript",
+      title: "three sessions, running at once",
+      text: "Every child is a session of its own, listed in the sidebar. Click one to watch it think and call while the others keep going; whatever it dispatches lands in this same trace, under its own `harness::turn step`.",
     },
-  }
+  };
 
   /* One clock over all three: the children interleave, and each reports when
      it is done rather than in dispatch order. */
@@ -519,166 +519,166 @@ async function* spawnFanOut(
       child,
       entry: undefined,
     })),
-  ].sort((a, b) => a.at - b.at)
+  ].sort((a, b) => a.at - b.at);
 
-  let waited = 0
+  let waited = 0;
   for (const beat of beats) {
-    await nap(beat.at - waited, signal)
-    if (signal?.aborted) return
-    waited = beat.at
+    await nap(beat.at - waited, signal);
+    if (signal?.aborted) return;
+    waited = beat.at;
 
     if (beat.entry) {
-      yield* childBeat(beat.child, beat.entry)
-      continue
+      yield* childBeat(beat.child, beat.entry);
+      continue;
     }
 
-    const child = beat.child
-    const childStep = spans.get(`${child.callId}:step`)
-    const execSpan = spans.get(child.callId)
-    if (childStep) yield { kind: 'demo-span-close', id: childStep }
-    if (execSpan) yield { kind: 'demo-span-close', id: execSpan }
+    const child = beat.child;
+    const childStep = spans.get(`${child.callId}:step`);
+    const execSpan = spans.get(child.callId);
+    if (childStep) yield { kind: "demo-span-close", id: childStep };
+    if (execSpan) yield { kind: "demo-span-close", id: execSpan };
     yield {
-      kind: 'demo-session-done',
+      kind: "demo-session-done",
       id: child.sessionId,
       result: child.resultText,
-    }
+    };
     yield {
-      kind: 'fcall-end',
+      kind: "fcall-end",
       output: spawnResult(child),
       durationMs: Date.now() - startedAt,
       functionTriggerId: child.callId,
-    }
+    };
   }
 }
 
 /* ── outputs ──────────────────────────────────────────────────────────── */
 
-const CONNECTED_AT = () => Date.now() - 4 * 60 * 60 * 1000
+const CONNECTED_AT = () => Date.now() - 4 * 60 * 60 * 1000;
 
 const WORKERS_LIST = () => ({
   workers: [
     {
-      id: 'wrk_01hq4m8database',
-      name: 'database',
-      description: 'Durable postgres: tables, queries, migrations.',
-      version: '0.21.0',
-      runtime: 'rust',
-      os: 'linux',
-      status: 'connected',
+      id: "wrk_01hq4m8database",
+      name: "database",
+      description: "Durable postgres: tables, queries, migrations.",
+      version: "0.21.0",
+      runtime: "rust",
+      os: "linux",
+      status: "connected",
       function_count: 9,
       connected_at_ms: CONNECTED_AT(),
       active_invocations: 0,
-      isolation: 'container',
-      tag: 'core',
+      isolation: "container",
+      tag: "core",
     },
     {
-      id: 'wrk_01hq4m8shell00',
-      name: 'shell',
-      description: 'Scoped command execution and filesystem access.',
-      version: '0.21.0',
-      runtime: 'rust',
-      os: 'linux',
-      status: 'connected',
+      id: "wrk_01hq4m8shell00",
+      name: "shell",
+      description: "Scoped command execution and filesystem access.",
+      version: "0.21.0",
+      runtime: "rust",
+      os: "linux",
+      status: "connected",
       function_count: 16,
       connected_at_ms: CONNECTED_AT(),
       active_invocations: 0,
-      isolation: 'container',
+      isolation: "container",
     },
     {
-      id: 'wrk_01hq4m8coder000',
-      name: 'coder',
-      description: 'Reads, writes and patches files in a scoped workspace.',
-      version: '0.21.0',
-      runtime: 'node',
-      os: 'linux',
-      status: 'connected',
+      id: "wrk_01hq4m8coder000",
+      name: "coder",
+      description: "Reads, writes and patches files in a scoped workspace.",
+      version: "0.21.0",
+      runtime: "node",
+      os: "linux",
+      status: "connected",
       function_count: 12,
       connected_at_ms: CONNECTED_AT(),
       active_invocations: 0,
-      isolation: 'container',
+      isolation: "container",
     },
     {
-      id: 'wrk_01hq4m8harness0',
-      name: 'harness',
-      description: 'The durable agent turn loop.',
-      version: '0.21.0',
-      runtime: 'rust',
-      os: 'linux',
-      status: 'connected',
+      id: "wrk_01hq4m8harness0",
+      name: "harness",
+      description: "The durable agent turn loop.",
+      version: "0.21.0",
+      runtime: "rust",
+      os: "linux",
+      status: "connected",
       function_count: 14,
       connected_at_ms: CONNECTED_AT(),
       active_invocations: 1,
-      isolation: 'container',
+      isolation: "container",
     },
     {
-      id: 'wrk_01hq4m8observ00',
-      name: 'observability',
-      description: 'OTel collector: traces, logs and metrics for the engine.',
-      version: '0.21.0',
-      runtime: 'rust',
-      os: 'linux',
-      status: 'connected',
+      id: "wrk_01hq4m8observ00",
+      name: "observability",
+      description: "OTel collector: traces, logs and metrics for the engine.",
+      version: "0.21.0",
+      runtime: "rust",
+      os: "linux",
+      status: "connected",
       function_count: 6,
       connected_at_ms: CONNECTED_AT(),
       active_invocations: 0,
-      isolation: 'container',
+      isolation: "container",
     },
   ],
-})
+});
 
 const DATABASE_INFO = () => ({
   worker: {
-    id: 'wrk_01hq4m8database',
-    name: 'database',
-    description: 'Durable postgres: tables, queries, migrations.',
-    version: '0.21.0',
-    runtime: 'rust',
-    os: 'linux',
-    status: 'connected',
+    id: "wrk_01hq4m8database",
+    name: "database",
+    description: "Durable postgres: tables, queries, migrations.",
+    version: "0.21.0",
+    runtime: "rust",
+    os: "linux",
+    status: "connected",
     function_count: 9,
     connected_at_ms: CONNECTED_AT(),
     active_invocations: 0,
-    isolation: 'container',
+    isolation: "container",
     internal: false,
     pid: 1421,
     latest_metrics: null,
   },
   functions: [
     {
-      function_id: 'database::create_table',
-      worker_name: 'database',
-      description: 'Create a table from a column spec.',
+      function_id: "database::create_table",
+      worker_name: "database",
+      description: "Create a table from a column spec.",
     },
     {
-      function_id: 'database::query',
-      worker_name: 'database',
-      description: 'Run a parameterised read query.',
+      function_id: "database::query",
+      worker_name: "database",
+      description: "Run a parameterised read query.",
     },
     {
-      function_id: 'database::execute',
-      worker_name: 'database',
-      description: 'Run a parameterised write statement.',
+      function_id: "database::execute",
+      worker_name: "database",
+      description: "Run a parameterised write statement.",
     },
     {
-      function_id: 'database::transaction',
-      worker_name: 'database',
-      description: 'Run several statements atomically.',
+      function_id: "database::transaction",
+      worker_name: "database",
+      description: "Run several statements atomically.",
     },
     {
-      function_id: 'database::migrate',
-      worker_name: 'database',
-      description: 'Apply pending migrations.',
+      function_id: "database::migrate",
+      worker_name: "database",
+      description: "Apply pending migrations.",
     },
   ],
   trigger_types: [
     {
-      id: 'database.row_changed',
-      worker_name: 'database',
-      description: 'Fires when a watched table changes.',
+      id: "database.row_changed",
+      worker_name: "database",
+      description: "Fires when a watched table changes.",
     },
   ],
   registered_triggers: [],
-})
+});
 
 /**
  * The fan-out. Three children, dispatched in one step, each its own session
@@ -688,25 +688,25 @@ const DATABASE_INFO = () => ({
  */
 interface ChildSpec {
   /** iii function_call_id, and the key the approval resolves against. */
-  callId: string
-  sessionId: string
-  title: string
-  task: string
-  allow: string[]
+  callId: string;
+  sessionId: string;
+  title: string;
+  task: string;
+  allow: string[];
   /** Held at the gate before it may run. */
-  gated?: boolean
+  gated?: boolean;
   /** The child's own transcript, played out while the parent waits. */
-  work: ChildBeat[]
-  resultText: string
-  resultDetails: Record<string, unknown>
+  work: ChildBeat[];
+  resultText: string;
+  resultDetails: Record<string, unknown>;
   /** Delay after the gate clears before this child reports, in ms. */
-  finishAfterMs: number
+  finishAfterMs: number;
 }
 
 interface ChildBeat {
   /** ms after the gate clears; 0 lands the moment the child starts. */
-  at: number
-  entry: ChildEntry
+  at: number;
+  entry: ChildEntry;
 }
 
 /* The source the children write, shown by the coder card as they write it. */
@@ -740,7 +740,7 @@ pub fn register(iii: &IIIClient) {
         })
         .description("Post a charge to the ledger as a balanced double entry."),
     );
-}`
+}`;
 
 const CHARGE_REFUND_RS = `use crate::types::{Entry, Refund};
 use iii_sdk::{Error, IIIClient, RegisterFunction, TriggerRequest};
@@ -769,7 +769,7 @@ pub fn register(iii: &IIIClient) {
         })
         .description("Reverse a posted charge, in part or in full."),
     );
-}`
+}`;
 
 const WEBHOOK_STRIPE_RS = `use crate::types::{StripeEvent, WebhookAck};
 use iii_sdk::{Error, IIIClient, RegisterFunction, TriggerRequest};
@@ -800,7 +800,7 @@ pub fn register(iii: &IIIClient) {
         })
         .description("Post a Stripe charge event to the ledger, exactly once."),
     );
-}`
+}`;
 
 const RECONCILE_RS = `use crate::types::{ReconcileReport, Window};
 use iii_sdk::{Error, IIIClient, RegisterFunction, TriggerRequest};
@@ -828,7 +828,7 @@ pub fn register(iii: &IIIClient) {
         })
         .description("Check the ledger balances and flag orphaned entries."),
     );
-}`
+}`;
 
 const TESTS_RS = `use crate::support::{ledger, TestEngine};
 
@@ -865,7 +865,7 @@ async fn refund_rejects_over_refund() {
 }
 
 // 8 more: reversal maths, unknown event kinds, orphaned entries, reads of
-// uncommitted rows, concurrent charges on one account, schema drift.`
+// uncommitted rows, concurrent charges on one account, schema drift.`;
 
 /** A `coder::create-file` exchange, as the batch card renders it. */
 function writeFiles(
@@ -873,9 +873,9 @@ function writeFiles(
   durationMs: number,
 ): ChildEntry {
   return {
-    role: 'function-trigger',
-    functionId: 'coder::create-file',
-    worker: 'coder',
+    role: "function-trigger",
+    functionId: "coder::create-file",
+    worker: "coder",
     input: {
       files: files.map(([path, content]) => ({ path, content, parents: true })),
     },
@@ -887,7 +887,7 @@ function writeFiles(
       })),
     },
     durationMs,
-  }
+  };
 }
 
 /** A `database::create_table` exchange. */
@@ -897,9 +897,9 @@ function createTable(
   durationMs: number,
 ): ChildEntry {
   return {
-    role: 'function-trigger',
-    functionId: 'database::create_table',
-    worker: 'database',
+    role: "function-trigger",
+    functionId: "database::create_table",
+    worker: "database",
     input: {
       table,
       if_not_exists: true,
@@ -907,39 +907,39 @@ function createTable(
     },
     output: { table, created: true, columns: columns.length },
     durationMs,
-  }
+  };
 }
 
 const CHILDREN: ChildSpec[] = [
   {
-    callId: 'fc_spawn_ledger_core',
-    sessionId: 'console-sub-ledger-core',
-    title: 'ledger core',
+    callId: "fc_spawn_ledger_core",
+    sessionId: "console-sub-ledger-core",
+    title: "ledger core",
     task: `Write the payments-ledger worker's core against the existing \`database\` worker.
 
 \`payments::charge::record\` and \`payments::charge::refund\`, double-entry rows,
 \`database::transaction\` for anything that writes two rows. Create the
 \`ledger_entries\` and \`ledger_accounts\` tables.`,
-    allow: ['coder::*', 'database::*'],
+    allow: ["coder::*", "database::*"],
     gated: true,
     work: [
       {
         at: 0,
         entry: {
-          role: 'assistant',
+          role: "assistant",
           content:
-            'Double-entry, so a charge is never one row: debit the customer account, credit the house account, both inside one `database::transaction` or neither. That also gives the tests their invariant, every account summing to zero across its entries. Tables first, then the two writers.',
+            "Double-entry, so a charge is never one row: debit the customer account, credit the house account, both inside one `database::transaction` or neither. That also gives the tests their invariant, every account summing to zero across its entries. Tables first, then the two writers.",
         },
       },
       {
         at: 1300,
         entry: createTable(
-          'ledger_accounts',
+          "ledger_accounts",
           [
-            ['id', 'text primary key'],
-            ['owner', 'text not null'],
-            ['currency', 'text not null'],
-            ['balance_minor', 'bigint not null default 0'],
+            ["id", "text primary key"],
+            ["owner", "text not null"],
+            ["currency", "text not null"],
+            ["balance_minor", "bigint not null default 0"],
           ],
           18.7,
         ),
@@ -947,13 +947,13 @@ const CHILDREN: ChildSpec[] = [
       {
         at: 2500,
         entry: createTable(
-          'ledger_entries',
+          "ledger_entries",
           [
-            ['id', 'text primary key'],
-            ['account_id', 'text not null references ledger_accounts(id)'],
-            ['amount_minor', 'bigint not null'],
-            ['provider_event_id', 'text unique'],
-            ['posted_at', 'timestamptz not null default now()'],
+            ["id", "text primary key"],
+            ["account_id", "text not null references ledger_accounts(id)"],
+            ["amount_minor", "bigint not null"],
+            ["provider_event_id", "text unique"],
+            ["posted_at", "timestamptz not null default now()"],
           ],
           22.4,
         ),
@@ -961,9 +961,9 @@ const CHILDREN: ChildSpec[] = [
       {
         at: 3500,
         entry: {
-          role: 'thought',
+          role: "thought",
           content:
-            'Both tables are up, and the foreign key ties every entry to an account. Now the writers. Refund is the one with a rule attached: it reverses a posted entry and can never take out more than is left in it.',
+            "Both tables are up, and the foreign key ties every entry to an account. Now the writers. Refund is the one with a rule attached: it reverses a posted entry and can never take out more than is left in it.",
           durationMs: 2400,
         },
       },
@@ -971,115 +971,115 @@ const CHILDREN: ChildSpec[] = [
         at: 4400,
         entry: writeFiles(
           [
-            ['src/functions/charge_record.rs', CHARGE_RECORD_RS],
-            ['src/functions/charge_refund.rs', CHARGE_REFUND_RS],
+            ["src/functions/charge_record.rs", CHARGE_RECORD_RS],
+            ["src/functions/charge_refund.rs", CHARGE_REFUND_RS],
           ],
           61.5,
         ),
       },
     ],
     resultText:
-      'ledger core done: charge::record + charge::refund over a double-entry schema, 2 tables created.',
+      "ledger core done: charge::record + charge::refund over a double-entry schema, 2 tables created.",
     resultDetails: {
-      functions: ['payments::charge::record', 'payments::charge::refund'],
-      tables: ['ledger_entries', 'ledger_accounts'],
+      functions: ["payments::charge::record", "payments::charge::refund"],
+      tables: ["ledger_entries", "ledger_accounts"],
       turns_used: 7,
     },
     finishAfterMs: 7400,
   },
   {
-    callId: 'fc_spawn_ledger_webhook',
-    sessionId: 'console-sub-ledger-webhook',
-    title: 'stripe webhook',
+    callId: "fc_spawn_ledger_webhook",
+    sessionId: "console-sub-ledger-webhook",
+    title: "stripe webhook",
     task: `Write \`payments::webhook::stripe\` and \`payments::ledger::reconcile\` for the
 payments-ledger worker. Idempotent on the provider event id: a replayed event
 must post nothing and return the original entry.`,
-    allow: ['coder::*', 'web::search'],
+    allow: ["coder::*", "web::search"],
     work: [
       {
         at: 0,
         entry: {
-          role: 'assistant',
+          role: "assistant",
           content:
-            'Stripe retries on any non-2xx, so this has to be idempotent at the ledger rather than at the HTTP layer. The provider event id is the natural key and `charge::record` is already unique on it, so the webhook stays thin: map the event, hand it over, return whatever comes back.',
+            "Stripe retries on any non-2xx, so this has to be idempotent at the ledger rather than at the HTTP layer. The provider event id is the natural key and `charge::record` is already unique on it, so the webhook stays thin: map the event, hand it over, return whatever comes back.",
         },
       },
       {
         at: 1500,
         entry: writeFiles(
-          [['src/functions/webhook_stripe.rs', WEBHOOK_STRIPE_RS]],
+          [["src/functions/webhook_stripe.rs", WEBHOOK_STRIPE_RS]],
           44.6,
         ),
       },
       {
         at: 2500,
         entry: {
-          role: 'thought',
+          role: "thought",
           content:
-            'Reconcile is the other half of trusting the ledger: read-only, so it can run on a cron without taking a lock, and it reports drift rather than repairing it. Silently fixing a payments discrepancy is how you lose the audit trail that made it findable.',
+            "Reconcile is the other half of trusting the ledger: read-only, so it can run on a cron without taking a lock, and it reports drift rather than repairing it. Silently fixing a payments discrepancy is how you lose the audit trail that made it findable.",
           durationMs: 1900,
         },
       },
       {
         at: 3300,
-        entry: writeFiles([['src/functions/reconcile.rs', RECONCILE_RS]], 31.9),
+        entry: writeFiles([["src/functions/reconcile.rs", RECONCILE_RS]], 31.9),
       },
     ],
     resultText:
-      'webhook + reconcile done: dedupe keyed on provider_event_id, replays return the original entry.',
+      "webhook + reconcile done: dedupe keyed on provider_event_id, replays return the original entry.",
     resultDetails: {
-      functions: ['payments::webhook::stripe', 'payments::ledger::reconcile'],
-      idempotency_key: 'provider_event_id',
+      functions: ["payments::webhook::stripe", "payments::ledger::reconcile"],
+      idempotency_key: "provider_event_id",
       turns_used: 5,
     },
     finishAfterMs: 4600,
   },
   {
-    callId: 'fc_spawn_ledger_tests',
-    sessionId: 'console-sub-ledger-tests',
-    title: 'test suite',
+    callId: "fc_spawn_ledger_tests",
+    sessionId: "console-sub-ledger-tests",
+    title: "test suite",
     task: `Write the payments-ledger test suite. Cover double-entry balance, refunds
 over the original amount, webhook replay, concurrent charges on one account,
 and that the schema matches the migration.`,
-    allow: ['coder::*', 'shell::exec'],
+    allow: ["coder::*", "shell::exec"],
     work: [
       {
         at: 0,
         entry: {
-          role: 'assistant',
+          role: "assistant",
           content:
-            'The other two are still writing, so I will test the contract rather than their implementation: call every function through the engine the way a caller would. The suite is then ready the moment the worker installs, and it fails for the same reasons production would.',
+            "The other two are still writing, so I will test the contract rather than their implementation: call every function through the engine the way a caller would. The suite is then ready the moment the worker installs, and it fails for the same reasons production would.",
         },
       },
-      { at: 1100, entry: writeFiles([['tests/ledger.rs', TESTS_RS]], 38.2) },
+      { at: 1100, entry: writeFiles([["tests/ledger.rs", TESTS_RS]], 38.2) },
     ],
     resultText:
-      'test suite done: 11 tests over the ledger, webhook and schema.',
-    resultDetails: { tests: 11, files: ['tests/ledger.rs'], turns_used: 4 },
+      "test suite done: 11 tests over the ledger, webhook and schema.",
+    resultDetails: { tests: 11, files: ["tests/ledger.rs"], turns_used: 4 },
     finishAfterMs: 2600,
   },
-]
+];
 
 function spawnInput(child: ChildSpec) {
   return {
     task: child.task,
-    model: 'claude-opus-4-7',
+    model: "claude-opus-4-7",
     session_id: child.sessionId,
     parent_session_id: SESSION_ID,
     options: {
-      mode: 'agent',
+      mode: "agent",
       max_turns: 12,
-      output: { type: 'text' },
-      functions: { allow: child.allow, deny: ['compose::*', 'worker::remove'] },
+      output: { type: "text" },
+      functions: { allow: child.allow, deny: ["compose::*", "worker::remove"] },
     },
-  }
+  };
 }
 
 function spawnResult(child: ChildSpec) {
   return {
-    content: [{ type: 'text' as const, text: child.resultText }],
+    content: [{ type: "text" as const, text: child.resultText }],
     details: { session_id: child.sessionId, ...child.resultDetails },
-  }
+  };
 }
 
 const TEST_STDOUT = `   Compiling payments-ledger v0.1.0
@@ -1098,14 +1098,14 @@ test balance_reads_committed_only ........ ok
 test concurrent_charges_serialize ........ ok
 test schema_matches_migration ............ ok
 
-test result: ok. 11 passed; 0 failed; finished in 1.83s`
+test result: ok. 11 passed; 0 failed; finished in 1.83s`;
 
 const HTTP_TRIGGERS = [
-  ['payments::charge::record', 'POST', '/payments/charges'],
-  ['payments::charge::refund', 'POST', '/payments/refunds'],
-  ['payments::webhook::stripe', 'POST', '/payments/webhooks/stripe'],
-  ['payments::ledger::reconcile', 'POST', '/payments/reconcile'],
-] as const
+  ["payments::charge::record", "POST", "/payments/charges"],
+  ["payments::charge::refund", "POST", "/payments/refunds"],
+  ["payments::webhook::stripe", "POST", "/payments/webhooks/stripe"],
+  ["payments::ledger::reconcile", "POST", "/payments/reconcile"],
+] as const;
 
 const FINAL_ANSWER = `\`payments-ledger\` is live on the engine and answering.
 
@@ -1116,159 +1116,160 @@ const FINAL_ANSWER = `\`payments-ledger\` is live on the engine and answering.
 | \`payments::webhook::stripe\` | \`POST /payments/webhooks/stripe\` | \`database::execute\` |
 | \`payments::ledger::reconcile\` | \`POST /payments/reconcile\` | \`database::query\` |
 
-Nothing here was scaffolded from a template. The \`database\` worker was already
-connected, so the ledger tables went straight onto it and the new worker joined
+Nothing here needed to be integrated. The \`database\` worker was available on the registry,
+so I installed it like a library. Unlike a library it was immediately ready to use. It joined
 the same engine the rest of your workers are on.
 
-**About those three children.** \`ledger core\`, \`stripe webhook\` and
-\`test suite\` are still listed under this chat. They are real sessions, not log
-lines: each one had its own transcript, its own turn budget and its own
-function policy, and you can open any of them to read what it did. Only
-\`ledger core\` needed a scope this session lacks, so only that one waited on
-you.
+**About those three subagents.** \`ledger core\`, \`stripe webhook\` and
+\`test suite\` are still listed under this chat. They are real sessions
+started in iii's native way: the sandbox worker. Each one had its own transcript,
+its own turn budget and its own function policy, and you can open any of
+them to read what it did. 
 
-**About the pane on the right.** That is not a replay of this chat, it is the
-trace the engine recorded while it happened. Every row above opened a span:
-each \`harness::turn step\` is one durable step of my loop off the queue, the
-three \`harness::spawn\` branches are the children running at the same time, and
+**About the pane on the right.** That is the
+trace the observability worker recorded while the harness worker did its work.
+There was no separate setup, as with any worker if it's added to the iii engine
+it's immediately and completely observable. Every row above opened a span:
+each \`harness::turn step\` is one durable step of my loop running on top of the queue worker, the
+three \`harness::spawn\` branches are the subagents running at the same time, and
 \`execute payments::charge::record\` near the bottom is the function they built
 answering a live request. In the console you would click any bar for its
 arguments, its result, and its logs. If this turn had crashed halfway, the loop
-would have resumed from the last completed step, into the same trace.`
+would have resumed from the last completed step, into the same trace.`;
 
 /* ── the script ───────────────────────────────────────────────────────── */
 
 export async function* runScenario(
   opts: ScenarioOptions,
 ): AsyncGenerator<DemoEvent> {
-  const { signal, gate } = opts
-  spanSeq = 0
+  const { signal, gate } = opts;
+  spanSeq = 0;
 
-  yield { kind: 'turn-status', phase: 'accepted' }
-  await nap(420, signal)
-  yield { kind: 'turn-status', phase: 'started' }
-  await nap(260, signal)
+  yield { kind: "turn-status", phase: "accepted" };
+  await nap(420, signal);
+  yield { kind: "turn-status", phase: "started" };
+  await nap(260, signal);
 
   /* step 1 — look at what is already running */
   yield* step(
     1,
     thought(
-      'The user wants a payments ledger with durable storage. Before I write a line of it I should look at what is already connected to this engine. iii keeps a live catalog of every running worker, so a durable database may already be here. If it is, there is nothing to scaffold and nothing to deploy alongside.',
+      "The user wants a payments ledger with durable storage. Before I write a line of it I should look at what is already connected to this engine. iii keeps a live catalog of every running worker, so a durable database may already be here. If it is, there is nothing to scaffold and nothing to deploy alongside.",
       signal,
     ),
     signal,
     (stepSpan) =>
       call({
-        fn: 'engine::workers::list',
-        worker: 'iii',
-        input: { status: 'connected' },
+        fn: "engine::workers::list",
+        worker: "iii",
+        input: { status: "connected" },
         output: WORKERS_LIST(),
         runMs: 900,
         reportedMs: 2.1,
         parentSpan: stepSpan,
         signal,
         callout: {
-          anchor: 'transcript',
-          title: 'discovery, not scaffolding',
-          text: 'The agent reads the engine’s live worker catalog. Whatever is already running is already callable: no boilerplate, no glue service.',
+          anchor: "transcript",
+          title: "discovery",
+          text: "The agent reads the engine’s live worker catalog. Whatever is already running is already integrated and callable.",
         },
       }),
-  )
-  if (signal?.aborted) return
-  yield* readPause(signal)
+  );
+  if (signal?.aborted) return;
+  yield* readPause(signal);
 
   /* step 2 — read the database worker's contract */
   yield* step(
     2,
     thought(
-      '`database` is right there: durable postgres, nine functions. Let me read its contract so the ledger is written against the real signatures instead of guesses.',
+      "`database` is available: durable postgres, nine functions. Let me read its contract so the ledger is written against the real signatures instead of guesses.",
       signal,
     ),
     signal,
     (stepSpan) =>
       call({
-        fn: 'engine::workers::info',
-        worker: 'iii',
-        input: { name: 'database' },
+        fn: "engine::workers::info",
+        worker: "iii",
+        input: { name: "database" },
         output: DATABASE_INFO(),
         runMs: 700,
         reportedMs: 1.4,
         parentSpan: stepSpan,
         signal,
         callout: {
-          anchor: 'waterfall',
-          title: 'the trace is building itself',
-          text: 'Every call opens a span. This is the console’s own trace view, filling in live. The observability comes with the runtime; nothing here was instrumented by hand.',
+          anchor: "waterfall",
+          title: "every operation is traced",
+          text: "Every call opens a span. This is the console’s own trace view, filling in live. The observability comes with the runtime and is OTel compatible.",
         },
       }),
-  )
-  if (signal?.aborted) return
-  yield* readPause(signal)
+  );
+  if (signal?.aborted) return;
+  yield* readPause(signal);
 
   /* step 3 — fan out to three sub-agents; one of them stops at the gate */
   yield* step(
     3,
     assistant(
-      '`database` gives me durable postgres with transactions, so the ledger can be double-entry without a second datastore. Three pieces here are independent, so I’ll run them as three sub-agents and stay on the wiring myself.',
+      "`database` gives me durable postgres with transactions, so the ledger can be double-entry without a second datastore. Three pieces here are independent, so I’ll run them as three sub-agents and stay on the wiring myself.",
       signal,
     ),
     signal,
     (stepSpan) => spawnFanOut(stepSpan, gate, signal),
-  )
-  if (signal?.aborted) return
-  yield* readPause(signal)
+  );
+  if (signal?.aborted) return;
+  yield* readPause(signal);
 
   /* step 4 — install the worker the children wrote */
   yield* step(
     4,
     thought(
-      'All three children are back: core, webhook and tests. Install the worker so the engine can route to it.',
+      "All three children are back: core, webhook and tests. Install the worker so the engine can route to it.",
       signal,
     ),
     signal,
     (stepSpan) =>
       call({
-        fn: 'worker::add',
-        worker: 'worker-manager',
+        fn: "worker::add",
+        worker: "worker-manager",
         input: {
-          source: { kind: 'local', path: './payments-ledger' },
+          source: { kind: "local", path: "./payments-ledger" },
           wait: true,
         },
         output: {
-          name: 'payments-ledger',
-          version: '0.1.0',
-          status: 'installed',
+          name: "payments-ledger",
+          version: "0.1.0",
+          status: "installed",
           awaited_ready: true,
-          config_path: './config.yaml',
+          config_path: "./config.yaml",
         },
         runMs: 1600,
         parentSpan: stepSpan,
         signal,
       }),
-  )
-  if (signal?.aborted) return
+  );
+  if (signal?.aborted) return;
 
   /* step 5 — one HTTP trigger per function, dispatched in a single step */
   yield* step(
     5,
     thought(
-      'Now the entry points. Each function gets an HTTP trigger; the engine owns the routing, so there is no gateway to write.',
+      "Now the entry points. I can use the http worker and each function gets an HTTP trigger.",
       signal,
     ),
     signal,
     async function* (stepSpan) {
       for (const [fn, method, path] of HTTP_TRIGGERS) {
         yield* call({
-          fn: 'engine::register_trigger',
-          worker: 'iii',
+          fn: "engine::register_trigger",
+          worker: "iii",
           input: {
-            trigger_type: 'http',
+            trigger_type: "http",
             function_id: fn,
             config: { method, path },
           },
           output: {
-            id: `trg_${path.replace(/\W+/g, '_')}`,
-            trigger_type: 'http',
+            id: `trg_${path.replace(/\W+/g, "_")}`,
+            trigger_type: "http",
             function_id: fn,
             registered: true,
           },
@@ -1276,34 +1277,34 @@ export async function* runScenario(
           reportedMs: 0.31,
           parentSpan: stepSpan,
           signal,
-        })
-        if (signal?.aborted) return
+        });
+        if (signal?.aborted) return;
       }
     },
-  )
-  if (signal?.aborted) return
+  );
+  if (signal?.aborted) return;
 
   /* step 6 — run the child's tests against the live worker */
   yield* step(
     6,
     thought(
-      'Run the tests the child wrote against the installed worker.',
+      "Run the tests the subagent wrote against the installed worker.",
       signal,
     ),
     signal,
     (stepSpan) =>
       call({
-        fn: 'shell::exec',
-        worker: 'shell',
+        fn: "shell::exec",
+        worker: "shell",
         input: {
-          command: 'iii test payments-ledger',
-          cwd: '/workspace/payments-ledger',
+          command: "iii test payments-ledger",
+          cwd: "/workspace/payments-ledger",
           timeout_ms: 120000,
         },
         output: {
           exit_code: 0,
           stdout: TEST_STDOUT,
-          stderr: '',
+          stderr: "",
           duration_ms: 6041,
           timed_out: false,
           stdout_truncated: false,
@@ -1314,33 +1315,30 @@ export async function* runScenario(
         parentSpan: stepSpan,
         signal,
       }),
-  )
-  if (signal?.aborted) return
-  yield* readPause(signal)
+  );
+  if (signal?.aborted) return;
+  yield* readPause(signal);
 
   /* step 7 — call the thing it just built */
   yield* step(
     7,
-    thought(
-      'Tests pass. Last check: call the function for real, through the engine, the same way the HTTP trigger will.',
-      signal,
-    ),
+    thought("Tests pass. Last check: call the function for real.", signal),
     signal,
     (stepSpan) =>
       call({
-        fn: 'payments::charge::record',
-        worker: 'payments-ledger',
+        fn: "payments::charge::record",
+        worker: "payments-ledger",
         input: {
           amount: 4200,
-          currency: 'usd',
-          customer_id: 'cus_8Kd2Qw',
-          provider_event_id: 'evt_3PfL2m',
+          currency: "usd",
+          customer_id: "cus_8Kd2Qw",
+          provider_event_id: "evt_3PfL2m",
         },
         output: {
-          entry_id: 'led_01hq5r7t9m',
-          account: 'cus_8Kd2Qw',
+          entry_id: "led_01hq5r7t9m",
+          account: "cus_8Kd2Qw",
           amount: 4200,
-          currency: 'usd',
+          currency: "usd",
           balance: 4200,
           posted_at: new Date().toISOString(),
           idempotent_replay: false,
@@ -1349,16 +1347,16 @@ export async function* runScenario(
         reportedMs: 12.4,
         parentSpan: stepSpan,
         signal,
-        inner: [['execute database::transaction', 'database', 0.6]],
+        inner: [["execute database::transaction", "database", 0.6]],
         callout: {
-          anchor: 'waterfall',
-          title: 'a worker that did not exist a minute ago',
-          text: 'The new worker’s span lands under the same trace, next to the `database` call it makes. Nothing was re-instrumented to get it there.',
+          anchor: "waterfall",
+          title: "a new payments worker, just added to the system",
+          text: "The new worker’s span lands under the same trace, next to the `database` call it makes. Nothing was re-instrumented to get it there.",
         },
       }),
-  )
-  if (signal?.aborted) return
-  yield* readPause(signal)
+  );
+  if (signal?.aborted) return;
+  yield* readPause(signal);
 
   /* step 8 — the answer, and a tour of the pane on the right */
   yield* step(
@@ -1367,13 +1365,13 @@ export async function* runScenario(
     signal,
     async function* () {
       yield {
-        kind: 'demo-callout',
+        kind: "demo-callout",
         callout: {
-          anchor: 'waterfall',
-          title: 'one trace, eight durable steps',
-          text: 'Each `harness::turn step` row is one queue item. A crash mid-turn resumes from the last completed step instead of starting the conversation over.',
+          anchor: "waterfall",
+          title: "one trace, eight durable steps",
+          text: "Each `harness::turn step` row is one queue item. A crash mid-turn resumes from the last completed step. Agentic loops are a normal engineering pattern in iii. They work the same as any programmatic loop would in iii.",
         },
-      }
+      };
     },
-  )
+  );
 }

--- a/console/web/src/demo/scenario.ts
+++ b/console/web/src/demo/scenario.ts
@@ -61,6 +61,24 @@ export interface DemoSession {
   task: string
 }
 
+/**
+ * A line a child wrote in its own transcript. Children are replayed a whole
+ * entry at a time rather than token by token: only one session is on screen,
+ * and the three off-screen ones would be animating at nobody.
+ */
+export type ChildEntry =
+  | { role: 'thought'; content: string; durationMs: number }
+  | { role: 'assistant'; content: string }
+  | {
+      role: 'function-trigger'
+      functionId: string
+      /** Worker that runs it — the child's `execute` span's service name. */
+      worker: string
+      input: unknown
+      output: unknown
+      durationMs: number
+    }
+
 export type DemoEvent =
   | StreamEvent
   | { kind: 'demo-span-open'; span: DemoSpanInit }
@@ -73,6 +91,7 @@ export type DemoEvent =
     }
   | { kind: 'demo-callout'; callout: Callout }
   | { kind: 'demo-session-open'; session: DemoSession }
+  | { kind: 'demo-session-msg'; id: string; entry: ChildEntry }
   | { kind: 'demo-session-done'; id: string; result: string }
 
 export interface ScenarioOptions {
@@ -355,6 +374,11 @@ async function* step(
  * own `execute harness::spawn` span with the child's own `harness::turn step`
  * nested inside, so the fan-out shows up as three branches of one trace, and
  * its own session, so it shows up as three rows in the sidebar.
+ *
+ * Each child then works out loud: its `work` beats append to its own
+ * transcript and open their own `execute` spans under its turn step, so a
+ * viewer who clicks a sidebar row watches that child reason and call, and
+ * sees those calls in the same trace as the parent's.
  */
 async function* spawnFanOut(
   stepSpan: string,
@@ -400,6 +424,41 @@ async function* spawnFanOut(
       kind: 'demo-session-open',
       session: { id: child.sessionId, title: child.title, task: child.task },
     }
+    /* Whatever the child has to say the moment it wakes up. */
+    for (const beat of child.work) {
+      if (beat.at === 0) yield* childBeat(child, beat.entry)
+    }
+  }
+
+  /** One line of a child's own work: its transcript entry, and its span. */
+  function* childBeat(
+    child: ChildSpec,
+    entry: ChildEntry,
+  ): Generator<DemoEvent> {
+    yield { kind: 'demo-session-msg', id: child.sessionId, entry }
+    if (entry.role !== 'function-trigger') return
+    const callSpan = spanId('childcall')
+    yield {
+      kind: 'demo-span-open',
+      span: {
+        id: callSpan,
+        parent: spans.get(`${child.callId}:step`),
+        name: `execute ${entry.functionId}`,
+        service: entry.worker,
+        kind: 'internal',
+        attributes: [
+          ['iii.session.id', child.sessionId],
+          ['iii.function.id', entry.functionId],
+        ],
+      },
+    }
+    /* Closed at what the call really costs, like every other call here: the
+       child's turn span is the wide one, its dispatches are hairlines. */
+    yield {
+      kind: 'demo-span-close',
+      id: callSpan,
+      durationMs: entry.durationMs,
+    }
   }
 
   /* Every card at once — a parallel tool-call batch is one assistant turn. */
@@ -438,15 +497,42 @@ async function* spawnFanOut(
     yield* launch(child)
   }
 
-  /* Children report as they finish, not in dispatch order. */
-  const finishing = [...CHILDREN].sort(
-    (a, b) => a.finishAfterMs - b.finishAfterMs,
-  )
+  yield {
+    kind: 'demo-callout',
+    callout: {
+      anchor: 'transcript',
+      title: 'three sessions, running at once',
+      text: 'Every child is a session of its own, listed in the sidebar. Click one to watch it think and call while the others keep going; whatever it dispatches lands in this same trace, under its own `harness::turn step`.',
+    },
+  }
+
+  /* One clock over all three: the children interleave, and each reports when
+     it is done rather than in dispatch order. */
+  const beats = [
+    ...CHILDREN.flatMap((child) =>
+      child.work
+        .filter((beat) => beat.at > 0)
+        .map((beat) => ({ at: beat.at, child, entry: beat.entry })),
+    ),
+    ...CHILDREN.map((child) => ({
+      at: child.finishAfterMs,
+      child,
+      entry: undefined,
+    })),
+  ].sort((a, b) => a.at - b.at)
+
   let waited = 0
-  for (const child of finishing) {
-    await nap(child.finishAfterMs - waited, signal)
+  for (const beat of beats) {
+    await nap(beat.at - waited, signal)
     if (signal?.aborted) return
-    waited = child.finishAfterMs
+    waited = beat.at
+
+    if (beat.entry) {
+      yield* childBeat(beat.child, beat.entry)
+      continue
+    }
+
+    const child = beat.child
     const childStep = spans.get(`${child.callId}:step`)
     const execSpan = spans.get(child.callId)
     if (childStep) yield { kind: 'demo-span-close', id: childStep }
@@ -609,10 +695,219 @@ interface ChildSpec {
   allow: string[]
   /** Held at the gate before it may run. */
   gated?: boolean
+  /** The child's own transcript, played out while the parent waits. */
+  work: ChildBeat[]
   resultText: string
   resultDetails: Record<string, unknown>
   /** Delay after the gate clears before this child reports, in ms. */
   finishAfterMs: number
+}
+
+interface ChildBeat {
+  /** ms after the gate clears; 0 lands the moment the child starts. */
+  at: number
+  entry: ChildEntry
+}
+
+/* The source the children write, shown by the coder card as they write it. */
+
+const CHARGE_RECORD_RS = `use crate::types::{Charge, Entry};
+use iii_sdk::{Error, IIIClient, RegisterFunction, TriggerRequest};
+use serde_json::json;
+
+/// A charge is two rows: debit the customer, credit the house account.
+/// Both land in one \`database::transaction\`, or neither does.
+pub fn register(iii: &IIIClient) {
+    let db = iii.clone();
+    iii.register_function(
+        "payments::charge::record",
+        RegisterFunction::new_async(move |charge: Charge| {
+            let db = db.clone();
+            async move {
+                if let Some(posted) = replay_of(&db, &charge.provider_event_id).await? {
+                    return Ok::<Entry, Error>(posted);
+                }
+                let rows = db
+                    .trigger(TriggerRequest {
+                        function_id: "database::transaction".into(),
+                        payload: json!({ "statements": double_entry(&charge) }),
+                        action: None,
+                        timeout_ms: Some(5_000),
+                    })
+                    .await?;
+                Ok(Entry::from_rows(&charge, rows)?)
+            }
+        })
+        .description("Post a charge to the ledger as a balanced double entry."),
+    );
+}`
+
+const CHARGE_REFUND_RS = `use crate::types::{Entry, Refund};
+use iii_sdk::{Error, IIIClient, RegisterFunction, TriggerRequest};
+use serde_json::json;
+
+/// A refund reverses a posted entry and can never exceed what is left of it.
+pub fn register(iii: &IIIClient) {
+    let db = iii.clone();
+    iii.register_function(
+        "payments::charge::refund",
+        RegisterFunction::new_async(move |refund: Refund| {
+            let db = db.clone();
+            async move {
+                let original = fetch_entry(&db, &refund.entry_id).await?;
+                guard_refundable(&original, &refund)?;
+                let rows = db
+                    .trigger(TriggerRequest {
+                        function_id: "database::transaction".into(),
+                        payload: json!({ "statements": reversal(&original, &refund) }),
+                        action: None,
+                        timeout_ms: Some(5_000),
+                    })
+                    .await?;
+                Ok::<Entry, Error>(Entry::from_reversal(&original, rows)?)
+            }
+        })
+        .description("Reverse a posted charge, in part or in full."),
+    );
+}`
+
+const WEBHOOK_STRIPE_RS = `use crate::types::{StripeEvent, WebhookAck};
+use iii_sdk::{Error, IIIClient, RegisterFunction, TriggerRequest};
+use serde_json::json;
+
+/// Stripe retries. \`charge::record\` already dedupes on the provider event
+/// id, so a replayed delivery posts nothing and returns the first entry.
+pub fn register(iii: &IIIClient) {
+    let engine = iii.clone();
+    iii.register_function(
+        "payments::webhook::stripe",
+        RegisterFunction::new_async(move |event: StripeEvent| {
+            let engine = engine.clone();
+            async move {
+                let Some(charge) = charge_from(&event) else {
+                    return Ok::<WebhookAck, Error>(WebhookAck::ignored(&event.kind));
+                };
+                let entry = engine
+                    .trigger(TriggerRequest {
+                        function_id: "payments::charge::record".into(),
+                        payload: json!(charge),
+                        action: None,
+                        timeout_ms: Some(10_000),
+                    })
+                    .await?;
+                Ok(WebhookAck::posted(entry))
+            }
+        })
+        .description("Post a Stripe charge event to the ledger, exactly once."),
+    );
+}`
+
+const RECONCILE_RS = `use crate::types::{ReconcileReport, Window};
+use iii_sdk::{Error, IIIClient, RegisterFunction, TriggerRequest};
+use serde_json::json;
+
+/// Every account's entries must sum to its balance and every entry must have
+/// a counterpart. Anything else is reported, never silently repaired.
+pub fn register(iii: &IIIClient) {
+    let db = iii.clone();
+    iii.register_function(
+        "payments::ledger::reconcile",
+        RegisterFunction::new_async(move |window: Window| {
+            let db = db.clone();
+            async move {
+                let rows = db
+                    .trigger(TriggerRequest {
+                        function_id: "database::query".into(),
+                        payload: json!({ "sql": UNBALANCED, "params": [window.since] }),
+                        action: None,
+                        timeout_ms: Some(30_000),
+                    })
+                    .await?;
+                Ok::<ReconcileReport, Error>(ReconcileReport::from_rows(rows)?)
+            }
+        })
+        .description("Check the ledger balances and flag orphaned entries."),
+    );
+}`
+
+const TESTS_RS = `use crate::support::{ledger, TestEngine};
+
+// The suite runs through the engine, against the contract, so it passes and
+// fails the same way a caller does.
+
+#[tokio::test]
+async fn charge_record_writes_double_entry() {
+    let engine = TestEngine::start().await;
+    let entry = ledger::record(&engine, 4_200, "cus_8Kd2Qw", "evt_3PfL2m").await;
+
+    assert_eq!(entry.balance, 4_200);
+    assert_eq!(ledger::rows_for(&engine, &entry.entry_id).await.len(), 2);
+    assert_eq!(ledger::sum_of(&engine, &entry.account).await, 0);
+}
+
+#[tokio::test]
+async fn stripe_webhook_dedupes_by_event_id() {
+    let engine = TestEngine::start().await;
+    let first = ledger::webhook(&engine, "evt_3PfL2m").await;
+    let replay = ledger::webhook(&engine, "evt_3PfL2m").await;
+
+    assert_eq!(first.entry_id, replay.entry_id);
+    assert!(replay.idempotent_replay);
+}
+
+#[tokio::test]
+async fn refund_rejects_over_refund() {
+    let engine = TestEngine::start().await;
+    let entry = ledger::record(&engine, 4_200, "cus_8Kd2Qw", "evt_9Qm1Zx").await;
+    let err = ledger::try_refund(&engine, &entry.entry_id, 5_000).await.unwrap_err();
+
+    assert!(err.to_string().contains("exceeds"));
+}
+
+// 8 more: reversal maths, unknown event kinds, orphaned entries, reads of
+// uncommitted rows, concurrent charges on one account, schema drift.`
+
+/** A `coder::create-file` exchange, as the batch card renders it. */
+function writeFiles(
+  files: Array<[path: string, content: string]>,
+  durationMs: number,
+): ChildEntry {
+  return {
+    role: 'function-trigger',
+    functionId: 'coder::create-file',
+    worker: 'coder',
+    input: {
+      files: files.map(([path, content]) => ({ path, content, parents: true })),
+    },
+    output: {
+      results: files.map(([path, content]) => ({
+        path: `/workspace/payments-ledger/${path}`,
+        success: true,
+        bytes_written: content.length,
+      })),
+    },
+    durationMs,
+  }
+}
+
+/** A `database::create_table` exchange. */
+function createTable(
+  table: string,
+  columns: Array<[name: string, type: string]>,
+  durationMs: number,
+): ChildEntry {
+  return {
+    role: 'function-trigger',
+    functionId: 'database::create_table',
+    worker: 'database',
+    input: {
+      table,
+      if_not_exists: true,
+      columns: columns.map(([name, type]) => ({ name, type })),
+    },
+    output: { table, created: true, columns: columns.length },
+    durationMs,
+  }
 }
 
 const CHILDREN: ChildSpec[] = [
@@ -627,6 +922,62 @@ const CHILDREN: ChildSpec[] = [
 \`ledger_entries\` and \`ledger_accounts\` tables.`,
     allow: ['coder::*', 'database::*'],
     gated: true,
+    work: [
+      {
+        at: 0,
+        entry: {
+          role: 'assistant',
+          content:
+            'Double-entry, so a charge is never one row: debit the customer account, credit the house account, both inside one `database::transaction` or neither. That also gives the tests their invariant, every account summing to zero across its entries. Tables first, then the two writers.',
+        },
+      },
+      {
+        at: 1300,
+        entry: createTable(
+          'ledger_accounts',
+          [
+            ['id', 'text primary key'],
+            ['owner', 'text not null'],
+            ['currency', 'text not null'],
+            ['balance_minor', 'bigint not null default 0'],
+          ],
+          18.7,
+        ),
+      },
+      {
+        at: 2500,
+        entry: createTable(
+          'ledger_entries',
+          [
+            ['id', 'text primary key'],
+            ['account_id', 'text not null references ledger_accounts(id)'],
+            ['amount_minor', 'bigint not null'],
+            ['provider_event_id', 'text unique'],
+            ['posted_at', 'timestamptz not null default now()'],
+          ],
+          22.4,
+        ),
+      },
+      {
+        at: 3500,
+        entry: {
+          role: 'thought',
+          content:
+            'Both tables are up, and the foreign key ties every entry to an account. Now the writers. Refund is the one with a rule attached: it reverses a posted entry and can never take out more than is left in it.',
+          durationMs: 2400,
+        },
+      },
+      {
+        at: 4400,
+        entry: writeFiles(
+          [
+            ['src/functions/charge_record.rs', CHARGE_RECORD_RS],
+            ['src/functions/charge_refund.rs', CHARGE_REFUND_RS],
+          ],
+          61.5,
+        ),
+      },
+    ],
     resultText:
       'ledger core done: charge::record + charge::refund over a double-entry schema, 2 tables created.',
     resultDetails: {
@@ -634,7 +985,7 @@ const CHILDREN: ChildSpec[] = [
       tables: ['ledger_entries', 'ledger_accounts'],
       turns_used: 7,
     },
-    finishAfterMs: 3400,
+    finishAfterMs: 7400,
   },
   {
     callId: 'fc_spawn_ledger_webhook',
@@ -644,6 +995,36 @@ const CHILDREN: ChildSpec[] = [
 payments-ledger worker. Idempotent on the provider event id: a replayed event
 must post nothing and return the original entry.`,
     allow: ['coder::*', 'web::search'],
+    work: [
+      {
+        at: 0,
+        entry: {
+          role: 'assistant',
+          content:
+            'Stripe retries on any non-2xx, so this has to be idempotent at the ledger rather than at the HTTP layer. The provider event id is the natural key and `charge::record` is already unique on it, so the webhook stays thin: map the event, hand it over, return whatever comes back.',
+        },
+      },
+      {
+        at: 1500,
+        entry: writeFiles(
+          [['src/functions/webhook_stripe.rs', WEBHOOK_STRIPE_RS]],
+          44.6,
+        ),
+      },
+      {
+        at: 2500,
+        entry: {
+          role: 'thought',
+          content:
+            'Reconcile is the other half of trusting the ledger: read-only, so it can run on a cron without taking a lock, and it reports drift rather than repairing it. Silently fixing a payments discrepancy is how you lose the audit trail that made it findable.',
+          durationMs: 1900,
+        },
+      },
+      {
+        at: 3300,
+        entry: writeFiles([['src/functions/reconcile.rs', RECONCILE_RS]], 31.9),
+      },
+    ],
     resultText:
       'webhook + reconcile done: dedupe keyed on provider_event_id, replays return the original entry.',
     resultDetails: {
@@ -651,7 +1032,7 @@ must post nothing and return the original entry.`,
       idempotency_key: 'provider_event_id',
       turns_used: 5,
     },
-    finishAfterMs: 1100,
+    finishAfterMs: 4600,
   },
   {
     callId: 'fc_spawn_ledger_tests',
@@ -661,10 +1042,21 @@ must post nothing and return the original entry.`,
 over the original amount, webhook replay, concurrent charges on one account,
 and that the schema matches the migration.`,
     allow: ['coder::*', 'shell::exec'],
+    work: [
+      {
+        at: 0,
+        entry: {
+          role: 'assistant',
+          content:
+            'The other two are still writing, so I will test the contract rather than their implementation: call every function through the engine the way a caller would. The suite is then ready the moment the worker installs, and it fails for the same reasons production would.',
+        },
+      },
+      { at: 1100, entry: writeFiles([['tests/ledger.rs', TESTS_RS]], 38.2) },
+    ],
     resultText:
       'test suite done: 11 tests over the ledger, webhook and schema.',
     resultDetails: { tests: 11, files: ['tests/ledger.rs'], turns_used: 4 },
-    finishAfterMs: 400,
+    finishAfterMs: 2600,
   },
 ]
 

--- a/console/web/src/demo/scenario.ts
+++ b/console/web/src/demo/scenario.ts
@@ -22,7 +22,7 @@ import { sleep, tokenize } from "@/stories/playground/scenarios/helpers";
 
 export const PROMPT = "build a payments ledger service with a durable db";
 
-export const MODEL_ID = "anthropic::claude-opus-4-7";
+export const MODEL_ID = "anthropic::claude-sonnet-5";
 export const SESSION_ID = "console-payments-ledger-demo";
 export const TRACE_ID = "trace-payments-ledger-0000000001";
 
@@ -338,7 +338,7 @@ async function* step(
       name: "execute router::chat",
       service: "llm-router",
       kind: "internal",
-      attributes: [...TURN_TAGS, ["gen_ai.request.model", "claude-opus-4-7"]],
+      attributes: [...TURN_TAGS, ["gen_ai.request.model", "claude-sonnet-5"]],
     },
   };
   yield {
@@ -1063,7 +1063,7 @@ and that the schema matches the migration.`,
 function spawnInput(child: ChildSpec) {
   return {
     task: child.task,
-    model: "claude-opus-4-7",
+    model: "claude-sonnet-5",
     session_id: child.sessionId,
     parent_session_id: SESSION_ID,
     options: {

--- a/console/web/src/demo/scenario.ts
+++ b/console/web/src/demo/scenario.ts
@@ -415,7 +415,7 @@ async function* spawnFanOut(
         attributes: [
           ["iii.session.id", child.sessionId],
           ["iii.tag.kind", "harness.subagent"],
-          ["iii.tag.display_name", `Sub-agent · ${child.title}`],
+          ["iii.tag.display_name", `Subagent · ${child.title}`],
         ],
       },
     };
@@ -480,8 +480,8 @@ async function* spawnFanOut(
     kind: "demo-callout",
     callout: {
       anchor: "transcript",
-      title: "three sub-agents, one held at the gate",
-      text: "Each child is its own session with its own budget and its own function policy, listed under this chat as it starts and readable on its own. Only `ledger core` asked for `database::*`, a write scope this session does not hold, so only that one waits for a human. Click approve to release it.",
+      title: "three subagents, one held at the gate",
+      text: "Each subagent is a real session started in iii's native way, the sandbox worker, with its own transcript, its own turn budget and its own function policy, listed under this chat as it starts. Only `ledger core` asked for `database::*`, a write scope this session does not hold, so only that one waits for a human. Click approve to release it.",
     },
   };
 
@@ -502,7 +502,7 @@ async function* spawnFanOut(
     callout: {
       anchor: "transcript",
       title: "three sessions, running at once",
-      text: "Every child is a session of its own, listed in the sidebar. Click one to watch it think and call while the others keep going; whatever it dispatches lands in this same trace, under its own `harness::turn step`.",
+      text: "Every subagent is a session of its own, listed in the sidebar. Click one to watch it think and call while the others keep going; whatever it dispatches lands in this same trace, under its own `harness::turn step`.",
     },
   };
 
@@ -1199,18 +1199,18 @@ export async function* runScenario(
         callout: {
           anchor: "waterfall",
           title: "every operation is traced",
-          text: "Every call opens a span. This is the console’s own trace view, filling in live. The observability comes with the runtime and is OTel compatible.",
+          text: "Every call opens a span. This is the console’s own trace view, filling in live, recorded by the observability worker. Any worker added to the engine is immediately observable, no separate setup, and it is OTel compatible.",
         },
       }),
   );
   if (signal?.aborted) return;
   yield* readPause(signal);
 
-  /* step 3 — fan out to three sub-agents; one of them stops at the gate */
+  /* step 3 — fan out to three subagents; one of them stops at the gate */
   yield* step(
     3,
     assistant(
-      "`database` gives me durable postgres with transactions, so the ledger can be double-entry without a second datastore. Three pieces here are independent, so I’ll run them as three sub-agents and stay on the wiring myself.",
+      "`database` gives me durable postgres with transactions, so the ledger can be double-entry without a second datastore. Three pieces here are independent, so I’ll run them as three subagents and stay on the wiring myself.",
       signal,
     ),
     signal,
@@ -1219,11 +1219,11 @@ export async function* runScenario(
   if (signal?.aborted) return;
   yield* readPause(signal);
 
-  /* step 4 — install the worker the children wrote */
+  /* step 4 — install the worker the subagents wrote */
   yield* step(
     4,
     thought(
-      "All three children are back: core, webhook and tests. Install the worker so the engine can route to it.",
+      "All three subagents are back: core, webhook and tests. Install the worker so the engine can route to it.",
       signal,
     ),
     signal,
@@ -1284,7 +1284,7 @@ export async function* runScenario(
   );
   if (signal?.aborted) return;
 
-  /* step 6 — run the child's tests against the live worker */
+  /* step 6 — run the subagent's tests against the live worker */
   yield* step(
     6,
     thought(
@@ -1369,7 +1369,7 @@ export async function* runScenario(
         callout: {
           anchor: "waterfall",
           title: "one trace, eight durable steps",
-          text: "Each `harness::turn step` row is one queue item. A crash mid-turn resumes from the last completed step. Agentic loops are a normal engineering pattern in iii. They work the same as any programmatic loop would in iii.",
+          text: "Each `harness::turn step` row is one durable step of the loop, running on top of the queue worker. A crash mid-turn resumes from the last completed step, into the same trace. Agentic loops are a normal engineering pattern in iii. They work the same as any programmatic loop would in iii.",
         },
       };
     },

--- a/console/web/src/demo/scenario.ts
+++ b/console/web/src/demo/scenario.ts
@@ -143,6 +143,28 @@ async function* assistant(
   await nap(readingDwellMs(body), signal)
 }
 
+/**
+ * A held beat after a result worth reading: the worker catalogue, a worker's
+ * contract, a test run's output. Rendered as a thought so the pause is a
+ * visible line in the transcript rather than the demo appearing to stall,
+ * and placed BETWEEN durable steps so it never inflates a step's span.
+ */
+async function* readPause(
+  signal: AbortSignal | undefined,
+  holdMs = 2800,
+): AsyncGenerator<DemoEvent> {
+  const startedAt = Date.now()
+  yield { kind: 'thought-start' }
+  for (const token of tokenize('letting the user read…')) {
+    if (signal?.aborted) return
+    if (token) yield { kind: 'thought-token', token }
+    await nap(55, signal)
+  }
+  await nap(holdMs, signal)
+  if (signal?.aborted) return
+  yield { kind: 'thought-end', durationMs: Date.now() - startedAt }
+}
+
 interface CallOptions {
   fn: string
   /** Worker that runs it — the `execute` span's service name. */
@@ -761,6 +783,7 @@ export async function* runScenario(
       }),
   )
   if (signal?.aborted) return
+  yield* readPause(signal)
 
   /* step 2 — read the database worker's contract */
   yield* step(
@@ -788,6 +811,7 @@ export async function* runScenario(
       }),
   )
   if (signal?.aborted) return
+  yield* readPause(signal)
 
   /* step 3 — fan out to three sub-agents; one of them stops at the gate */
   yield* step(
@@ -800,6 +824,7 @@ export async function* runScenario(
     (stepSpan) => spawnFanOut(stepSpan, gate, signal),
   )
   if (signal?.aborted) return
+  yield* readPause(signal)
 
   /* step 4 — install the worker the children wrote */
   yield* step(
@@ -899,6 +924,7 @@ export async function* runScenario(
       }),
   )
   if (signal?.aborted) return
+  yield* readPause(signal)
 
   /* step 7 — call the thing it just built */
   yield* step(
@@ -940,6 +966,7 @@ export async function* runScenario(
       }),
   )
   if (signal?.aborted) return
+  yield* readPause(signal)
 
   /* step 8 — the answer, and a tour of the pane on the right */
   yield* step(

--- a/console/web/src/demo/scenario.ts
+++ b/console/web/src/demo/scenario.ts
@@ -64,7 +64,13 @@ export interface DemoSession {
 export type DemoEvent =
   | StreamEvent
   | { kind: 'demo-span-open'; span: DemoSpanInit }
-  | { kind: 'demo-span-close'; id: string; status?: 'OK' | 'ERROR' }
+  | {
+      kind: 'demo-span-close'
+      id: string
+      status?: 'OK' | 'ERROR'
+      /** Close the span this long after it opened, rather than now. */
+      durationMs?: number
+    }
   | { kind: 'demo-callout'; callout: Callout }
   | { kind: 'demo-session-open'; session: DemoSession }
   | { kind: 'demo-session-done'; id: string; result: string }
@@ -97,10 +103,20 @@ const TURN_TAGS: Array<[string, unknown]> = [
 
 /* ── stream fragments ─────────────────────────────────────────────────── */
 
+/**
+ * Time to leave a finished block of prose on screen before the next thing
+ * lands on top of it. Scaled by length and capped: the point is that the
+ * reader gets to finish the sentence, not that the demo waits out a full
+ * read of the closing answer.
+ */
+function readingDwellMs(body: string): number {
+  return Math.min(2800, Math.max(600, tokenize(body).length * 10))
+}
+
 async function* thought(
   body: string,
   signal?: AbortSignal,
-  meanDelayMs = 26,
+  meanDelayMs = 38,
 ): AsyncGenerator<DemoEvent> {
   const startedAt = Date.now()
   yield { kind: 'thought-start' }
@@ -110,12 +126,13 @@ async function* thought(
     await nap(meanDelayMs * (0.6 + Math.random() * 0.8), signal)
   }
   yield { kind: 'thought-end', durationMs: Date.now() - startedAt }
+  await nap(readingDwellMs(body), signal)
 }
 
 async function* assistant(
   body: string,
   signal?: AbortSignal,
-  meanDelayMs = 26,
+  meanDelayMs = 38,
 ): AsyncGenerator<DemoEvent> {
   for (const token of tokenize(body)) {
     if (signal?.aborted) return
@@ -123,6 +140,7 @@ async function* assistant(
     await nap(meanDelayMs * (0.5 + Math.random()), signal)
   }
   yield { kind: 'assistant-end' }
+  await nap(readingDwellMs(body), signal)
 }
 
 interface CallOptions {
@@ -131,7 +149,15 @@ interface CallOptions {
   worker: string
   input: unknown
   output: unknown
+  /** How long the demo lingers on the call, so a viewer can see it happen. */
   runMs: number
+  /**
+   * What the card and the span report, when that differs from how long the
+   * demo dwells. An engine-local call really does finish in microseconds;
+   * animating it that fast would make it invisible, and reporting the dwell
+   * instead would claim a trigger registration costs a third of a second.
+   */
+  reportedMs?: number
   parentSpan: string
   signal?: AbortSignal
   /** Nested spans opened inside the call, as [name, service, share-of-runMs]. */
@@ -149,6 +175,7 @@ async function* call(opts: CallOptions): AsyncGenerator<DemoEvent> {
     input,
     output,
     runMs,
+    reportedMs,
     parentSpan,
     signal,
     inner,
@@ -210,7 +237,13 @@ async function* call(opts: CallOptions): AsyncGenerator<DemoEvent> {
       await nap(slice, signal)
       elapsed += slice
       if (signal?.aborted) return
-      yield { kind: 'demo-span-close', id: childSpan }
+      yield {
+        kind: 'demo-span-close',
+        id: childSpan,
+        /* Inner work takes its share of the REPORTED time, so a child can
+           never outlast the call it happened inside. */
+        ...(reportedMs === undefined ? {} : { durationMs: reportedMs * share }),
+      }
     }
     await nap(Math.max(0, runMs - elapsed), signal)
   } else {
@@ -218,11 +251,15 @@ async function* call(opts: CallOptions): AsyncGenerator<DemoEvent> {
   }
   if (signal?.aborted) return
 
-  yield { kind: 'demo-span-close', id: execSpan }
+  yield {
+    kind: 'demo-span-close',
+    id: execSpan,
+    ...(reportedMs === undefined ? {} : { durationMs: reportedMs }),
+  }
   yield {
     kind: 'fcall-end',
     output,
-    durationMs: Date.now() - startedAt,
+    durationMs: reportedMs ?? Date.now() - startedAt,
     ...(functionTriggerId ? { functionTriggerId } : {}),
   }
 }
@@ -713,6 +750,7 @@ export async function* runScenario(
         input: { status: 'connected' },
         output: WORKERS_LIST(),
         runMs: 900,
+        reportedMs: 2.1,
         parentSpan: stepSpan,
         signal,
         callout: {
@@ -739,6 +777,7 @@ export async function* runScenario(
         input: { name: 'database' },
         output: DATABASE_INFO(),
         runMs: 700,
+        reportedMs: 1.4,
         parentSpan: stepSpan,
         signal,
         callout: {
@@ -817,6 +856,7 @@ export async function* runScenario(
             registered: true,
           },
           runMs: 320,
+          reportedMs: 0.31,
           parentSpan: stepSpan,
           signal,
         })
@@ -853,6 +893,7 @@ export async function* runScenario(
           stderr_truncated: false,
         },
         runMs: 2600,
+        reportedMs: 6041,
         parentSpan: stepSpan,
         signal,
       }),
@@ -887,6 +928,7 @@ export async function* runScenario(
           idempotent_replay: false,
         },
         runMs: 900,
+        reportedMs: 12.4,
         parentSpan: stepSpan,
         signal,
         inner: [['execute database::transaction', 'database', 0.6]],
@@ -902,7 +944,7 @@ export async function* runScenario(
   /* step 8 — the answer, and a tour of the pane on the right */
   yield* step(
     8,
-    assistant(FINAL_ANSWER, signal, 17),
+    assistant(FINAL_ANSWER, signal, 22),
     signal,
     async function* () {
       yield {

--- a/console/web/src/demo/scenario.ts
+++ b/console/web/src/demo/scenario.ts
@@ -17,48 +17,48 @@
  * generation, and `execute <fn>` for each dispatched call.
  */
 
-import type { StreamEvent } from "@/lib/backend";
-import { sleep, tokenize } from "@/stories/playground/scenarios/helpers";
+import type { StreamEvent } from '@/lib/backend'
+import { sleep, tokenize } from '@/stories/playground/scenarios/helpers'
 
-export const PROMPT = "build a payments ledger service with a durable db";
+export const PROMPT = 'build a payments ledger service with a durable db'
 
-export const MODEL_ID = "anthropic::claude-sonnet-5";
-export const SESSION_ID = "console-payments-ledger-demo";
-export const TRACE_ID = "trace-payments-ledger-0000000001";
+export const MODEL_ID = 'anthropic::claude-sonnet-5'
+export const SESSION_ID = 'console-payments-ledger-demo'
+export const TRACE_ID = 'trace-payments-ledger-0000000001'
 
 /**
  * Global playback rate. `prefers-reduced-motion` sets it near zero so the
  * turn fills in at once and holds, instead of animating for a minute.
  */
-let SPEED = 1;
+let SPEED = 1
 export function setScenarioSpeed(multiplier: number) {
-  SPEED = multiplier;
+  SPEED = multiplier
 }
-const nap = (ms: number, signal?: AbortSignal) => sleep(ms * SPEED, signal);
+const nap = (ms: number, signal?: AbortSignal) => sleep(ms * SPEED, signal)
 
-export type CalloutAnchor = "transcript" | "waterfall" | "composer";
+export type CalloutAnchor = 'transcript' | 'waterfall' | 'composer'
 
 export interface Callout {
-  title: string;
-  text: string;
-  anchor: CalloutAnchor;
+  title: string
+  text: string
+  anchor: CalloutAnchor
 }
 
 export interface DemoSpanInit {
-  id: string;
-  parent?: string;
-  name: string;
-  service: string;
-  kind?: string;
-  attributes?: Array<[string, unknown]>;
+  id: string
+  parent?: string
+  name: string
+  service: string
+  kind?: string
+  attributes?: Array<[string, unknown]>
 }
 
 /** A child session `harness::spawn` created, as the sidebar shows it. */
 export interface DemoSession {
-  id: string;
-  title: string;
+  id: string
+  title: string
   /** The task the parent handed down: the child's seeding user message. */
-  task: string;
+  task: string
 }
 
 /**
@@ -67,58 +67,58 @@ export interface DemoSession {
  * and the three off-screen ones would be animating at nobody.
  */
 export type ChildEntry =
-  | { role: "thought"; content: string; durationMs: number }
-  | { role: "assistant"; content: string }
+  | { role: 'thought'; content: string; durationMs: number }
+  | { role: 'assistant'; content: string }
   | {
-      role: "function-trigger";
-      functionId: string;
+      role: 'function-trigger'
+      functionId: string
       /** Worker that runs it — the child's `execute` span's service name. */
-      worker: string;
-      input: unknown;
-      output: unknown;
-      durationMs: number;
-    };
+      worker: string
+      input: unknown
+      output: unknown
+      durationMs: number
+    }
 
 export type DemoEvent =
   | StreamEvent
-  | { kind: "demo-span-open"; span: DemoSpanInit }
+  | { kind: 'demo-span-open'; span: DemoSpanInit }
   | {
-      kind: "demo-span-close";
-      id: string;
-      status?: "OK" | "ERROR";
+      kind: 'demo-span-close'
+      id: string
+      status?: 'OK' | 'ERROR'
       /** Close the span this long after it opened, rather than now. */
-      durationMs?: number;
+      durationMs?: number
     }
-  | { kind: "demo-callout"; callout: Callout }
-  | { kind: "demo-session-open"; session: DemoSession }
-  | { kind: "demo-session-msg"; id: string; entry: ChildEntry }
-  | { kind: "demo-session-done"; id: string; result: string };
+  | { kind: 'demo-callout'; callout: Callout }
+  | { kind: 'demo-session-open'; session: DemoSession }
+  | { kind: 'demo-session-msg'; id: string; entry: ChildEntry }
+  | { kind: 'demo-session-done'; id: string; result: string }
 
 export interface ScenarioOptions {
-  signal?: AbortSignal;
+  signal?: AbortSignal
   /**
    * Resolves when the gated call is released — by the viewer clicking
    * approve/deny on the real card, or by the demo's own timeout. The demo
    * never denies; a deny resolves the same way so the card can't hang.
    */
-  gate: (functionTriggerId: string) => Promise<void>;
+  gate: (functionTriggerId: string) => Promise<void>
 }
 
 /* ── span bookkeeping ─────────────────────────────────────────────────── */
 
-let spanSeq = 0;
+let spanSeq = 0
 function spanId(prefix: string): string {
-  spanSeq += 1;
-  return `${prefix}-${String(spanSeq).padStart(3, "0")}`;
+  spanSeq += 1
+  return `${prefix}-${String(spanSeq).padStart(3, '0')}`
 }
 
 /** Turn-identity baggage the harness stamps on every span of a step. */
 const TURN_TAGS: Array<[string, unknown]> = [
-  ["iii.session.id", SESSION_ID],
-  ["iii.message.id", "turn-01"],
-  ["iii.tag.kind", "harness.turn"],
-  ["iii.tag.message", PROMPT],
-];
+  ['iii.session.id', SESSION_ID],
+  ['iii.message.id', 'turn-01'],
+  ['iii.tag.kind', 'harness.turn'],
+  ['iii.tag.message', PROMPT],
+]
 
 /* ── stream fragments ─────────────────────────────────────────────────── */
 
@@ -129,7 +129,7 @@ const TURN_TAGS: Array<[string, unknown]> = [
  * read of the closing answer.
  */
 function readingDwellMs(body: string): number {
-  return Math.min(2800, Math.max(600, tokenize(body).length * 10));
+  return Math.min(2800, Math.max(600, tokenize(body).length * 10))
 }
 
 async function* thought(
@@ -137,15 +137,15 @@ async function* thought(
   signal?: AbortSignal,
   meanDelayMs = 38,
 ): AsyncGenerator<DemoEvent> {
-  const startedAt = Date.now();
-  yield { kind: "thought-start" };
+  const startedAt = Date.now()
+  yield { kind: 'thought-start' }
   for (const token of tokenize(body)) {
-    if (signal?.aborted) return;
-    if (token) yield { kind: "thought-token", token };
-    await nap(meanDelayMs * (0.6 + Math.random() * 0.8), signal);
+    if (signal?.aborted) return
+    if (token) yield { kind: 'thought-token', token }
+    await nap(meanDelayMs * (0.6 + Math.random() * 0.8), signal)
   }
-  yield { kind: "thought-end", durationMs: Date.now() - startedAt };
-  await nap(readingDwellMs(body), signal);
+  yield { kind: 'thought-end', durationMs: Date.now() - startedAt }
+  await nap(readingDwellMs(body), signal)
 }
 
 async function* assistant(
@@ -154,12 +154,12 @@ async function* assistant(
   meanDelayMs = 38,
 ): AsyncGenerator<DemoEvent> {
   for (const token of tokenize(body)) {
-    if (signal?.aborted) return;
-    if (token) yield { kind: "assistant-token", token };
-    await nap(meanDelayMs * (0.5 + Math.random()), signal);
+    if (signal?.aborted) return
+    if (token) yield { kind: 'assistant-token', token }
+    await nap(meanDelayMs * (0.5 + Math.random()), signal)
   }
-  yield { kind: "assistant-end" };
-  await nap(readingDwellMs(body), signal);
+  yield { kind: 'assistant-end' }
+  await nap(readingDwellMs(body), signal)
 }
 
 /**
@@ -172,41 +172,41 @@ async function* readPause(
   signal: AbortSignal | undefined,
   holdMs = 2800,
 ): AsyncGenerator<DemoEvent> {
-  const startedAt = Date.now();
-  yield { kind: "thought-start" };
-  for (const token of tokenize("letting the user read…")) {
-    if (signal?.aborted) return;
-    if (token) yield { kind: "thought-token", token };
-    await nap(55, signal);
+  const startedAt = Date.now()
+  yield { kind: 'thought-start' }
+  for (const token of tokenize('letting the user read…')) {
+    if (signal?.aborted) return
+    if (token) yield { kind: 'thought-token', token }
+    await nap(55, signal)
   }
-  await nap(holdMs, signal);
-  if (signal?.aborted) return;
-  yield { kind: "thought-end", durationMs: Date.now() - startedAt };
+  await nap(holdMs, signal)
+  if (signal?.aborted) return
+  yield { kind: 'thought-end', durationMs: Date.now() - startedAt }
 }
 
 interface CallOptions {
-  fn: string;
+  fn: string
   /** Worker that runs it — the `execute` span's service name. */
-  worker: string;
-  input: unknown;
-  output: unknown;
+  worker: string
+  input: unknown
+  output: unknown
   /** How long the demo lingers on the call, so a viewer can see it happen. */
-  runMs: number;
+  runMs: number
   /**
    * What the card and the span report, when that differs from how long the
    * demo dwells. An engine-local call really does finish in microseconds;
    * animating it that fast would make it invisible, and reporting the dwell
    * instead would claim a trigger registration costs a third of a second.
    */
-  reportedMs?: number;
-  parentSpan: string;
-  signal?: AbortSignal;
+  reportedMs?: number
+  parentSpan: string
+  signal?: AbortSignal
   /** Nested spans opened inside the call, as [name, service, share-of-runMs]. */
-  inner?: Array<[string, string, number]>;
+  inner?: Array<[string, string, number]>
   /** Hold the call in the approval gate before it executes. */
-  gate?: (functionTriggerId: string) => Promise<void>;
-  functionTriggerId?: string;
-  callout?: Callout;
+  gate?: (functionTriggerId: string) => Promise<void>
+  functionTriggerId?: string
+  callout?: Callout
 }
 
 async function* call(opts: CallOptions): AsyncGenerator<DemoEvent> {
@@ -223,11 +223,11 @@ async function* call(opts: CallOptions): AsyncGenerator<DemoEvent> {
     gate,
     functionTriggerId,
     callout,
-  } = opts;
-  const startedAt = Date.now();
+  } = opts
+  const startedAt = Date.now()
 
   yield {
-    kind: "fcall-start",
+    kind: 'fcall-start',
     functionId: fn,
     input,
     ...(gate
@@ -237,72 +237,72 @@ async function* call(opts: CallOptions): AsyncGenerator<DemoEvent> {
           sessionId: SESSION_ID,
         }
       : {}),
-  };
-  if (callout) yield { kind: "demo-callout", callout };
+  }
+  if (callout) yield { kind: 'demo-callout', callout }
 
   if (gate && functionTriggerId) {
-    await gate(functionTriggerId);
-    if (signal?.aborted) return;
-    yield { kind: "fcall-approval-cleared", functionTriggerId, running: true };
+    await gate(functionTriggerId)
+    if (signal?.aborted) return
+    yield { kind: 'fcall-approval-cleared', functionTriggerId, running: true }
   }
 
-  const execSpan = spanId("exec");
+  const execSpan = spanId('exec')
   yield {
-    kind: "demo-span-open",
+    kind: 'demo-span-open',
     span: {
       id: execSpan,
       parent: parentSpan,
       name: `execute ${fn}`,
       service: worker,
-      kind: "internal",
-      attributes: [...TURN_TAGS, ["iii.function.id", fn]],
+      kind: 'internal',
+      attributes: [...TURN_TAGS, ['iii.function.id', fn]],
     },
-  };
+  }
 
   if (inner?.length) {
-    let elapsed = 0;
+    let elapsed = 0
     for (const [name, service, share] of inner) {
-      const childSpan = spanId("inner");
+      const childSpan = spanId('inner')
       yield {
-        kind: "demo-span-open",
+        kind: 'demo-span-open',
         span: {
           id: childSpan,
           parent: execSpan,
           name,
           service,
-          kind: "internal",
+          kind: 'internal',
           attributes: TURN_TAGS,
         },
-      };
-      const slice = runMs * share;
-      await nap(slice, signal);
-      elapsed += slice;
-      if (signal?.aborted) return;
+      }
+      const slice = runMs * share
+      await nap(slice, signal)
+      elapsed += slice
+      if (signal?.aborted) return
       yield {
-        kind: "demo-span-close",
+        kind: 'demo-span-close',
         id: childSpan,
         /* Inner work takes its share of the REPORTED time, so a child can
            never outlast the call it happened inside. */
         ...(reportedMs === undefined ? {} : { durationMs: reportedMs * share }),
-      };
+      }
     }
-    await nap(Math.max(0, runMs - elapsed), signal);
+    await nap(Math.max(0, runMs - elapsed), signal)
   } else {
-    await nap(runMs, signal);
+    await nap(runMs, signal)
   }
-  if (signal?.aborted) return;
+  if (signal?.aborted) return
 
   yield {
-    kind: "demo-span-close",
+    kind: 'demo-span-close',
     id: execSpan,
     ...(reportedMs === undefined ? {} : { durationMs: reportedMs }),
-  };
+  }
   yield {
-    kind: "fcall-end",
+    kind: 'fcall-end',
     output,
     durationMs: reportedMs ?? Date.now() - startedAt,
     ...(functionTriggerId ? { functionTriggerId } : {}),
-  };
+  }
 }
 
 /**
@@ -316,53 +316,53 @@ async function* step(
   signal: AbortSignal | undefined,
   after: (stepSpan: string) => AsyncGenerator<DemoEvent>,
 ): AsyncGenerator<DemoEvent> {
-  const stepSpan = spanId("step");
-  const routerSpan = spanId("router");
-  const providerSpan = spanId("provider");
+  const stepSpan = spanId('step')
+  const routerSpan = spanId('router')
+  const providerSpan = spanId('provider')
 
   yield {
-    kind: "demo-span-open",
+    kind: 'demo-span-open',
     span: {
       id: stepSpan,
-      name: "harness::turn step",
-      service: "harness",
-      kind: "internal",
-      attributes: [...TURN_TAGS, ["iii.turn.step", index]],
+      name: 'harness::turn step',
+      service: 'harness',
+      kind: 'internal',
+      attributes: [...TURN_TAGS, ['iii.turn.step', index]],
     },
-  };
+  }
   yield {
-    kind: "demo-span-open",
+    kind: 'demo-span-open',
     span: {
       id: routerSpan,
       parent: stepSpan,
-      name: "execute router::chat",
-      service: "llm-router",
-      kind: "internal",
-      attributes: [...TURN_TAGS, ["gen_ai.request.model", "claude-sonnet-5"]],
+      name: 'execute router::chat',
+      service: 'llm-router',
+      kind: 'internal',
+      attributes: [...TURN_TAGS, ['gen_ai.request.model', 'claude-sonnet-5']],
     },
-  };
+  }
   yield {
-    kind: "demo-span-open",
+    kind: 'demo-span-open',
     span: {
       id: providerSpan,
       parent: routerSpan,
-      name: "execute provider::anthropic::stream",
-      service: "llm-provider-anthropic",
-      kind: "client",
+      name: 'execute provider::anthropic::stream',
+      service: 'llm-provider-anthropic',
+      kind: 'client',
       attributes: TURN_TAGS,
     },
-  };
+  }
 
-  yield* body;
-  if (signal?.aborted) return;
+  yield* body
+  if (signal?.aborted) return
 
-  yield { kind: "demo-span-close", id: providerSpan };
-  yield { kind: "demo-span-close", id: routerSpan };
+  yield { kind: 'demo-span-close', id: providerSpan }
+  yield { kind: 'demo-span-close', id: routerSpan }
 
-  yield* after(stepSpan);
-  if (signal?.aborted) return;
+  yield* after(stepSpan)
+  if (signal?.aborted) return
 
-  yield { kind: "demo-span-close", id: stepSpan };
+  yield { kind: 'demo-span-close', id: stepSpan }
 }
 
 /**
@@ -382,51 +382,51 @@ async function* step(
  */
 async function* spawnFanOut(
   stepSpan: string,
-  gate: ScenarioOptions["gate"],
+  gate: ScenarioOptions['gate'],
   signal: AbortSignal | undefined,
 ): AsyncGenerator<DemoEvent> {
-  const startedAt = Date.now();
-  const spans = new Map<string, string>();
+  const startedAt = Date.now()
+  const spans = new Map<string, string>()
 
   /** Open the child's span pair and its session — it is running now. */
   function* launch(child: ChildSpec): Generator<DemoEvent> {
-    const execSpan = spanId("exec");
-    const childStep = spanId("child");
-    spans.set(child.callId, execSpan);
+    const execSpan = spanId('exec')
+    const childStep = spanId('child')
+    spans.set(child.callId, execSpan)
     yield {
-      kind: "demo-span-open",
+      kind: 'demo-span-open',
       span: {
         id: execSpan,
         parent: stepSpan,
-        name: "execute harness::spawn",
-        service: "harness",
-        kind: "internal",
-        attributes: [...TURN_TAGS, ["iii.child.session_id", child.sessionId]],
+        name: 'execute harness::spawn',
+        service: 'harness',
+        kind: 'internal',
+        attributes: [...TURN_TAGS, ['iii.child.session_id', child.sessionId]],
       },
-    };
+    }
     yield {
-      kind: "demo-span-open",
+      kind: 'demo-span-open',
       span: {
         id: childStep,
         parent: execSpan,
-        name: "harness::turn step",
-        service: "harness",
-        kind: "internal",
+        name: 'harness::turn step',
+        service: 'harness',
+        kind: 'internal',
         attributes: [
-          ["iii.session.id", child.sessionId],
-          ["iii.tag.kind", "harness.subagent"],
-          ["iii.tag.display_name", `Subagent · ${child.title}`],
+          ['iii.session.id', child.sessionId],
+          ['iii.tag.kind', 'harness.subagent'],
+          ['iii.tag.display_name', `Subagent · ${child.title}`],
         ],
       },
-    };
-    spans.set(`${child.callId}:step`, childStep);
+    }
+    spans.set(`${child.callId}:step`, childStep)
     yield {
-      kind: "demo-session-open",
+      kind: 'demo-session-open',
       session: { id: child.sessionId, title: child.title, task: child.task },
-    };
+    }
     /* Whatever the child has to say the moment it wakes up. */
     for (const beat of child.work) {
-      if (beat.at === 0) yield* childBeat(child, beat.entry);
+      if (beat.at === 0) yield* childBeat(child, beat.entry)
     }
   }
 
@@ -435,76 +435,76 @@ async function* spawnFanOut(
     child: ChildSpec,
     entry: ChildEntry,
   ): Generator<DemoEvent> {
-    yield { kind: "demo-session-msg", id: child.sessionId, entry };
-    if (entry.role !== "function-trigger") return;
-    const callSpan = spanId("childcall");
+    yield { kind: 'demo-session-msg', id: child.sessionId, entry }
+    if (entry.role !== 'function-trigger') return
+    const callSpan = spanId('childcall')
     yield {
-      kind: "demo-span-open",
+      kind: 'demo-span-open',
       span: {
         id: callSpan,
         parent: spans.get(`${child.callId}:step`),
         name: `execute ${entry.functionId}`,
         service: entry.worker,
-        kind: "internal",
+        kind: 'internal',
         attributes: [
-          ["iii.session.id", child.sessionId],
-          ["iii.function.id", entry.functionId],
+          ['iii.session.id', child.sessionId],
+          ['iii.function.id', entry.functionId],
         ],
       },
-    };
+    }
     /* Closed at what the call really costs, like every other call here: the
        child's turn span is the wide one, its dispatches are hairlines. */
     yield {
-      kind: "demo-span-close",
+      kind: 'demo-span-close',
       id: callSpan,
       durationMs: entry.durationMs,
-    };
+    }
   }
 
   /* Every card at once — a parallel tool-call batch is one assistant turn. */
   for (const child of CHILDREN) {
     yield {
-      kind: "fcall-start",
-      functionId: "harness::spawn",
+      kind: 'fcall-start',
+      functionId: 'harness::spawn',
       input: spawnInput(child),
       functionTriggerId: child.callId,
       sessionId: SESSION_ID,
       ...(child.gated ? { pendingApproval: true } : {}),
-    };
+    }
   }
   for (const child of CHILDREN) {
-    if (!child.gated) yield* launch(child);
+    if (!child.gated) yield* launch(child)
   }
 
   yield {
-    kind: "demo-callout",
+    kind: 'demo-callout',
     callout: {
-      anchor: "transcript",
-      title: "three subagents, one held at the gate",
+      anchor: 'transcript',
+      title: 'three subagents, one held at the gate',
       text: "Each subagent is a real session started in iii's native way, the sandbox worker, with its own transcript, its own turn budget and its own function policy, listed under this chat as it starts. Only `ledger core` asked for `database::*`, a write scope this session does not hold, so only that one waits for a human. Click approve to release it.",
     },
-  };
+  }
 
   for (const child of CHILDREN) {
-    if (!child.gated) continue;
-    await gate(child.callId);
-    if (signal?.aborted) return;
+    if (!child.gated) continue
+    await gate(child.callId)
+    if (signal?.aborted) return
     yield {
-      kind: "fcall-approval-cleared",
+      kind: 'fcall-approval-cleared',
       functionTriggerId: child.callId,
       running: true,
-    };
-    yield* launch(child);
+    }
+    yield* launch(child)
   }
 
   yield {
-    kind: "demo-callout",
+    kind: 'demo-callout',
     callout: {
-      anchor: "transcript",
-      title: "three sessions, running at once",
-      text: "Every subagent is a session of its own, listed in the sidebar. Click one to watch it think and call while the others keep going; whatever it dispatches lands in this same trace, under its own `harness::turn step`.",
+      anchor: 'transcript',
+      title: 'three sessions, running at once',
+      text: 'Every subagent is a session of its own, listed in the sidebar. Click one to watch it think and call while the others keep going; whatever it dispatches lands in this same trace, under its own `harness::turn step`.',
     },
-  };
+  }
 
   /* One clock over all three: the children interleave, and each reports when
      it is done rather than in dispatch order. */
@@ -519,166 +519,166 @@ async function* spawnFanOut(
       child,
       entry: undefined,
     })),
-  ].sort((a, b) => a.at - b.at);
+  ].sort((a, b) => a.at - b.at)
 
-  let waited = 0;
+  let waited = 0
   for (const beat of beats) {
-    await nap(beat.at - waited, signal);
-    if (signal?.aborted) return;
-    waited = beat.at;
+    await nap(beat.at - waited, signal)
+    if (signal?.aborted) return
+    waited = beat.at
 
     if (beat.entry) {
-      yield* childBeat(beat.child, beat.entry);
-      continue;
+      yield* childBeat(beat.child, beat.entry)
+      continue
     }
 
-    const child = beat.child;
-    const childStep = spans.get(`${child.callId}:step`);
-    const execSpan = spans.get(child.callId);
-    if (childStep) yield { kind: "demo-span-close", id: childStep };
-    if (execSpan) yield { kind: "demo-span-close", id: execSpan };
+    const child = beat.child
+    const childStep = spans.get(`${child.callId}:step`)
+    const execSpan = spans.get(child.callId)
+    if (childStep) yield { kind: 'demo-span-close', id: childStep }
+    if (execSpan) yield { kind: 'demo-span-close', id: execSpan }
     yield {
-      kind: "demo-session-done",
+      kind: 'demo-session-done',
       id: child.sessionId,
       result: child.resultText,
-    };
+    }
     yield {
-      kind: "fcall-end",
+      kind: 'fcall-end',
       output: spawnResult(child),
       durationMs: Date.now() - startedAt,
       functionTriggerId: child.callId,
-    };
+    }
   }
 }
 
 /* ── outputs ──────────────────────────────────────────────────────────── */
 
-const CONNECTED_AT = () => Date.now() - 4 * 60 * 60 * 1000;
+const CONNECTED_AT = () => Date.now() - 4 * 60 * 60 * 1000
 
 const WORKERS_LIST = () => ({
   workers: [
     {
-      id: "wrk_01hq4m8database",
-      name: "database",
-      description: "Durable postgres: tables, queries, migrations.",
-      version: "0.21.0",
-      runtime: "rust",
-      os: "linux",
-      status: "connected",
+      id: 'wrk_01hq4m8database',
+      name: 'database',
+      description: 'Durable postgres: tables, queries, migrations.',
+      version: '0.21.0',
+      runtime: 'rust',
+      os: 'linux',
+      status: 'connected',
       function_count: 9,
       connected_at_ms: CONNECTED_AT(),
       active_invocations: 0,
-      isolation: "container",
-      tag: "core",
+      isolation: 'container',
+      tag: 'core',
     },
     {
-      id: "wrk_01hq4m8shell00",
-      name: "shell",
-      description: "Scoped command execution and filesystem access.",
-      version: "0.21.0",
-      runtime: "rust",
-      os: "linux",
-      status: "connected",
+      id: 'wrk_01hq4m8shell00',
+      name: 'shell',
+      description: 'Scoped command execution and filesystem access.',
+      version: '0.21.0',
+      runtime: 'rust',
+      os: 'linux',
+      status: 'connected',
       function_count: 16,
       connected_at_ms: CONNECTED_AT(),
       active_invocations: 0,
-      isolation: "container",
+      isolation: 'container',
     },
     {
-      id: "wrk_01hq4m8coder000",
-      name: "coder",
-      description: "Reads, writes and patches files in a scoped workspace.",
-      version: "0.21.0",
-      runtime: "node",
-      os: "linux",
-      status: "connected",
+      id: 'wrk_01hq4m8coder000',
+      name: 'coder',
+      description: 'Reads, writes and patches files in a scoped workspace.',
+      version: '0.21.0',
+      runtime: 'node',
+      os: 'linux',
+      status: 'connected',
       function_count: 12,
       connected_at_ms: CONNECTED_AT(),
       active_invocations: 0,
-      isolation: "container",
+      isolation: 'container',
     },
     {
-      id: "wrk_01hq4m8harness0",
-      name: "harness",
-      description: "The durable agent turn loop.",
-      version: "0.21.0",
-      runtime: "rust",
-      os: "linux",
-      status: "connected",
+      id: 'wrk_01hq4m8harness0',
+      name: 'harness',
+      description: 'The durable agent turn loop.',
+      version: '0.21.0',
+      runtime: 'rust',
+      os: 'linux',
+      status: 'connected',
       function_count: 14,
       connected_at_ms: CONNECTED_AT(),
       active_invocations: 1,
-      isolation: "container",
+      isolation: 'container',
     },
     {
-      id: "wrk_01hq4m8observ00",
-      name: "observability",
-      description: "OTel collector: traces, logs and metrics for the engine.",
-      version: "0.21.0",
-      runtime: "rust",
-      os: "linux",
-      status: "connected",
+      id: 'wrk_01hq4m8observ00',
+      name: 'observability',
+      description: 'OTel collector: traces, logs and metrics for the engine.',
+      version: '0.21.0',
+      runtime: 'rust',
+      os: 'linux',
+      status: 'connected',
       function_count: 6,
       connected_at_ms: CONNECTED_AT(),
       active_invocations: 0,
-      isolation: "container",
+      isolation: 'container',
     },
   ],
-});
+})
 
 const DATABASE_INFO = () => ({
   worker: {
-    id: "wrk_01hq4m8database",
-    name: "database",
-    description: "Durable postgres: tables, queries, migrations.",
-    version: "0.21.0",
-    runtime: "rust",
-    os: "linux",
-    status: "connected",
+    id: 'wrk_01hq4m8database',
+    name: 'database',
+    description: 'Durable postgres: tables, queries, migrations.',
+    version: '0.21.0',
+    runtime: 'rust',
+    os: 'linux',
+    status: 'connected',
     function_count: 9,
     connected_at_ms: CONNECTED_AT(),
     active_invocations: 0,
-    isolation: "container",
+    isolation: 'container',
     internal: false,
     pid: 1421,
     latest_metrics: null,
   },
   functions: [
     {
-      function_id: "database::create_table",
-      worker_name: "database",
-      description: "Create a table from a column spec.",
+      function_id: 'database::create_table',
+      worker_name: 'database',
+      description: 'Create a table from a column spec.',
     },
     {
-      function_id: "database::query",
-      worker_name: "database",
-      description: "Run a parameterised read query.",
+      function_id: 'database::query',
+      worker_name: 'database',
+      description: 'Run a parameterised read query.',
     },
     {
-      function_id: "database::execute",
-      worker_name: "database",
-      description: "Run a parameterised write statement.",
+      function_id: 'database::execute',
+      worker_name: 'database',
+      description: 'Run a parameterised write statement.',
     },
     {
-      function_id: "database::transaction",
-      worker_name: "database",
-      description: "Run several statements atomically.",
+      function_id: 'database::transaction',
+      worker_name: 'database',
+      description: 'Run several statements atomically.',
     },
     {
-      function_id: "database::migrate",
-      worker_name: "database",
-      description: "Apply pending migrations.",
+      function_id: 'database::migrate',
+      worker_name: 'database',
+      description: 'Apply pending migrations.',
     },
   ],
   trigger_types: [
     {
-      id: "database.row_changed",
-      worker_name: "database",
-      description: "Fires when a watched table changes.",
+      id: 'database.row_changed',
+      worker_name: 'database',
+      description: 'Fires when a watched table changes.',
     },
   ],
   registered_triggers: [],
-});
+})
 
 /**
  * The fan-out. Three children, dispatched in one step, each its own session
@@ -688,25 +688,25 @@ const DATABASE_INFO = () => ({
  */
 interface ChildSpec {
   /** iii function_call_id, and the key the approval resolves against. */
-  callId: string;
-  sessionId: string;
-  title: string;
-  task: string;
-  allow: string[];
+  callId: string
+  sessionId: string
+  title: string
+  task: string
+  allow: string[]
   /** Held at the gate before it may run. */
-  gated?: boolean;
+  gated?: boolean
   /** The child's own transcript, played out while the parent waits. */
-  work: ChildBeat[];
-  resultText: string;
-  resultDetails: Record<string, unknown>;
+  work: ChildBeat[]
+  resultText: string
+  resultDetails: Record<string, unknown>
   /** Delay after the gate clears before this child reports, in ms. */
-  finishAfterMs: number;
+  finishAfterMs: number
 }
 
 interface ChildBeat {
   /** ms after the gate clears; 0 lands the moment the child starts. */
-  at: number;
-  entry: ChildEntry;
+  at: number
+  entry: ChildEntry
 }
 
 /* The source the children write, shown by the coder card as they write it. */
@@ -740,7 +740,7 @@ pub fn register(iii: &IIIClient) {
         })
         .description("Post a charge to the ledger as a balanced double entry."),
     );
-}`;
+}`
 
 const CHARGE_REFUND_RS = `use crate::types::{Entry, Refund};
 use iii_sdk::{Error, IIIClient, RegisterFunction, TriggerRequest};
@@ -769,7 +769,7 @@ pub fn register(iii: &IIIClient) {
         })
         .description("Reverse a posted charge, in part or in full."),
     );
-}`;
+}`
 
 const WEBHOOK_STRIPE_RS = `use crate::types::{StripeEvent, WebhookAck};
 use iii_sdk::{Error, IIIClient, RegisterFunction, TriggerRequest};
@@ -800,7 +800,7 @@ pub fn register(iii: &IIIClient) {
         })
         .description("Post a Stripe charge event to the ledger, exactly once."),
     );
-}`;
+}`
 
 const RECONCILE_RS = `use crate::types::{ReconcileReport, Window};
 use iii_sdk::{Error, IIIClient, RegisterFunction, TriggerRequest};
@@ -828,7 +828,7 @@ pub fn register(iii: &IIIClient) {
         })
         .description("Check the ledger balances and flag orphaned entries."),
     );
-}`;
+}`
 
 const TESTS_RS = `use crate::support::{ledger, TestEngine};
 
@@ -865,7 +865,7 @@ async fn refund_rejects_over_refund() {
 }
 
 // 8 more: reversal maths, unknown event kinds, orphaned entries, reads of
-// uncommitted rows, concurrent charges on one account, schema drift.`;
+// uncommitted rows, concurrent charges on one account, schema drift.`
 
 /** A `coder::create-file` exchange, as the batch card renders it. */
 function writeFiles(
@@ -873,9 +873,9 @@ function writeFiles(
   durationMs: number,
 ): ChildEntry {
   return {
-    role: "function-trigger",
-    functionId: "coder::create-file",
-    worker: "coder",
+    role: 'function-trigger',
+    functionId: 'coder::create-file',
+    worker: 'coder',
     input: {
       files: files.map(([path, content]) => ({ path, content, parents: true })),
     },
@@ -887,7 +887,7 @@ function writeFiles(
       })),
     },
     durationMs,
-  };
+  }
 }
 
 /** A `database::create_table` exchange. */
@@ -897,9 +897,9 @@ function createTable(
   durationMs: number,
 ): ChildEntry {
   return {
-    role: "function-trigger",
-    functionId: "database::create_table",
-    worker: "database",
+    role: 'function-trigger',
+    functionId: 'database::create_table',
+    worker: 'database',
     input: {
       table,
       if_not_exists: true,
@@ -907,39 +907,39 @@ function createTable(
     },
     output: { table, created: true, columns: columns.length },
     durationMs,
-  };
+  }
 }
 
 const CHILDREN: ChildSpec[] = [
   {
-    callId: "fc_spawn_ledger_core",
-    sessionId: "console-sub-ledger-core",
-    title: "ledger core",
+    callId: 'fc_spawn_ledger_core',
+    sessionId: 'console-sub-ledger-core',
+    title: 'ledger core',
     task: `Write the payments-ledger worker's core against the existing \`database\` worker.
 
 \`payments::charge::record\` and \`payments::charge::refund\`, double-entry rows,
 \`database::transaction\` for anything that writes two rows. Create the
 \`ledger_entries\` and \`ledger_accounts\` tables.`,
-    allow: ["coder::*", "database::*"],
+    allow: ['coder::*', 'database::*'],
     gated: true,
     work: [
       {
         at: 0,
         entry: {
-          role: "assistant",
+          role: 'assistant',
           content:
-            "Double-entry, so a charge is never one row: debit the customer account, credit the house account, both inside one `database::transaction` or neither. That also gives the tests their invariant, every account summing to zero across its entries. Tables first, then the two writers.",
+            'Double-entry, so a charge is never one row: debit the customer account, credit the house account, both inside one `database::transaction` or neither. That also gives the tests their invariant, every account summing to zero across its entries. Tables first, then the two writers.',
         },
       },
       {
         at: 1300,
         entry: createTable(
-          "ledger_accounts",
+          'ledger_accounts',
           [
-            ["id", "text primary key"],
-            ["owner", "text not null"],
-            ["currency", "text not null"],
-            ["balance_minor", "bigint not null default 0"],
+            ['id', 'text primary key'],
+            ['owner', 'text not null'],
+            ['currency', 'text not null'],
+            ['balance_minor', 'bigint not null default 0'],
           ],
           18.7,
         ),
@@ -947,13 +947,13 @@ const CHILDREN: ChildSpec[] = [
       {
         at: 2500,
         entry: createTable(
-          "ledger_entries",
+          'ledger_entries',
           [
-            ["id", "text primary key"],
-            ["account_id", "text not null references ledger_accounts(id)"],
-            ["amount_minor", "bigint not null"],
-            ["provider_event_id", "text unique"],
-            ["posted_at", "timestamptz not null default now()"],
+            ['id', 'text primary key'],
+            ['account_id', 'text not null references ledger_accounts(id)'],
+            ['amount_minor', 'bigint not null'],
+            ['provider_event_id', 'text unique'],
+            ['posted_at', 'timestamptz not null default now()'],
           ],
           22.4,
         ),
@@ -961,9 +961,9 @@ const CHILDREN: ChildSpec[] = [
       {
         at: 3500,
         entry: {
-          role: "thought",
+          role: 'thought',
           content:
-            "Both tables are up, and the foreign key ties every entry to an account. Now the writers. Refund is the one with a rule attached: it reverses a posted entry and can never take out more than is left in it.",
+            'Both tables are up, and the foreign key ties every entry to an account. Now the writers. Refund is the one with a rule attached: it reverses a posted entry and can never take out more than is left in it.',
           durationMs: 2400,
         },
       },
@@ -971,115 +971,115 @@ const CHILDREN: ChildSpec[] = [
         at: 4400,
         entry: writeFiles(
           [
-            ["src/functions/charge_record.rs", CHARGE_RECORD_RS],
-            ["src/functions/charge_refund.rs", CHARGE_REFUND_RS],
+            ['src/functions/charge_record.rs', CHARGE_RECORD_RS],
+            ['src/functions/charge_refund.rs', CHARGE_REFUND_RS],
           ],
           61.5,
         ),
       },
     ],
     resultText:
-      "ledger core done: charge::record + charge::refund over a double-entry schema, 2 tables created.",
+      'ledger core done: charge::record + charge::refund over a double-entry schema, 2 tables created.',
     resultDetails: {
-      functions: ["payments::charge::record", "payments::charge::refund"],
-      tables: ["ledger_entries", "ledger_accounts"],
+      functions: ['payments::charge::record', 'payments::charge::refund'],
+      tables: ['ledger_entries', 'ledger_accounts'],
       turns_used: 7,
     },
     finishAfterMs: 7400,
   },
   {
-    callId: "fc_spawn_ledger_webhook",
-    sessionId: "console-sub-ledger-webhook",
-    title: "stripe webhook",
+    callId: 'fc_spawn_ledger_webhook',
+    sessionId: 'console-sub-ledger-webhook',
+    title: 'stripe webhook',
     task: `Write \`payments::webhook::stripe\` and \`payments::ledger::reconcile\` for the
 payments-ledger worker. Idempotent on the provider event id: a replayed event
 must post nothing and return the original entry.`,
-    allow: ["coder::*", "web::search"],
+    allow: ['coder::*', 'web::search'],
     work: [
       {
         at: 0,
         entry: {
-          role: "assistant",
+          role: 'assistant',
           content:
-            "Stripe retries on any non-2xx, so this has to be idempotent at the ledger rather than at the HTTP layer. The provider event id is the natural key and `charge::record` is already unique on it, so the webhook stays thin: map the event, hand it over, return whatever comes back.",
+            'Stripe retries on any non-2xx, so this has to be idempotent at the ledger rather than at the HTTP layer. The provider event id is the natural key and `charge::record` is already unique on it, so the webhook stays thin: map the event, hand it over, return whatever comes back.',
         },
       },
       {
         at: 1500,
         entry: writeFiles(
-          [["src/functions/webhook_stripe.rs", WEBHOOK_STRIPE_RS]],
+          [['src/functions/webhook_stripe.rs', WEBHOOK_STRIPE_RS]],
           44.6,
         ),
       },
       {
         at: 2500,
         entry: {
-          role: "thought",
+          role: 'thought',
           content:
-            "Reconcile is the other half of trusting the ledger: read-only, so it can run on a cron without taking a lock, and it reports drift rather than repairing it. Silently fixing a payments discrepancy is how you lose the audit trail that made it findable.",
+            'Reconcile is the other half of trusting the ledger: read-only, so it can run on a cron without taking a lock, and it reports drift rather than repairing it. Silently fixing a payments discrepancy is how you lose the audit trail that made it findable.',
           durationMs: 1900,
         },
       },
       {
         at: 3300,
-        entry: writeFiles([["src/functions/reconcile.rs", RECONCILE_RS]], 31.9),
+        entry: writeFiles([['src/functions/reconcile.rs', RECONCILE_RS]], 31.9),
       },
     ],
     resultText:
-      "webhook + reconcile done: dedupe keyed on provider_event_id, replays return the original entry.",
+      'webhook + reconcile done: dedupe keyed on provider_event_id, replays return the original entry.',
     resultDetails: {
-      functions: ["payments::webhook::stripe", "payments::ledger::reconcile"],
-      idempotency_key: "provider_event_id",
+      functions: ['payments::webhook::stripe', 'payments::ledger::reconcile'],
+      idempotency_key: 'provider_event_id',
       turns_used: 5,
     },
     finishAfterMs: 4600,
   },
   {
-    callId: "fc_spawn_ledger_tests",
-    sessionId: "console-sub-ledger-tests",
-    title: "test suite",
+    callId: 'fc_spawn_ledger_tests',
+    sessionId: 'console-sub-ledger-tests',
+    title: 'test suite',
     task: `Write the payments-ledger test suite. Cover double-entry balance, refunds
 over the original amount, webhook replay, concurrent charges on one account,
 and that the schema matches the migration.`,
-    allow: ["coder::*", "shell::exec"],
+    allow: ['coder::*', 'shell::exec'],
     work: [
       {
         at: 0,
         entry: {
-          role: "assistant",
+          role: 'assistant',
           content:
-            "The other two are still writing, so I will test the contract rather than their implementation: call every function through the engine the way a caller would. The suite is then ready the moment the worker installs, and it fails for the same reasons production would.",
+            'The other two are still writing, so I will test the contract rather than their implementation: call every function through the engine the way a caller would. The suite is then ready the moment the worker installs, and it fails for the same reasons production would.',
         },
       },
-      { at: 1100, entry: writeFiles([["tests/ledger.rs", TESTS_RS]], 38.2) },
+      { at: 1100, entry: writeFiles([['tests/ledger.rs', TESTS_RS]], 38.2) },
     ],
     resultText:
-      "test suite done: 11 tests over the ledger, webhook and schema.",
-    resultDetails: { tests: 11, files: ["tests/ledger.rs"], turns_used: 4 },
+      'test suite done: 11 tests over the ledger, webhook and schema.',
+    resultDetails: { tests: 11, files: ['tests/ledger.rs'], turns_used: 4 },
     finishAfterMs: 2600,
   },
-];
+]
 
 function spawnInput(child: ChildSpec) {
   return {
     task: child.task,
-    model: "claude-sonnet-5",
+    model: 'claude-sonnet-5',
     session_id: child.sessionId,
     parent_session_id: SESSION_ID,
     options: {
-      mode: "agent",
+      mode: 'agent',
       max_turns: 12,
-      output: { type: "text" },
-      functions: { allow: child.allow, deny: ["compose::*", "worker::remove"] },
+      output: { type: 'text' },
+      functions: { allow: child.allow, deny: ['compose::*', 'worker::remove'] },
     },
-  };
+  }
 }
 
 function spawnResult(child: ChildSpec) {
   return {
-    content: [{ type: "text" as const, text: child.resultText }],
+    content: [{ type: 'text' as const, text: child.resultText }],
     details: { session_id: child.sessionId, ...child.resultDetails },
-  };
+  }
 }
 
 const TEST_STDOUT = `   Compiling payments-ledger v0.1.0
@@ -1098,14 +1098,14 @@ test balance_reads_committed_only ........ ok
 test concurrent_charges_serialize ........ ok
 test schema_matches_migration ............ ok
 
-test result: ok. 11 passed; 0 failed; finished in 1.83s`;
+test result: ok. 11 passed; 0 failed; finished in 1.83s`
 
 const HTTP_TRIGGERS = [
-  ["payments::charge::record", "POST", "/payments/charges"],
-  ["payments::charge::refund", "POST", "/payments/refunds"],
-  ["payments::webhook::stripe", "POST", "/payments/webhooks/stripe"],
-  ["payments::ledger::reconcile", "POST", "/payments/reconcile"],
-] as const;
+  ['payments::charge::record', 'POST', '/payments/charges'],
+  ['payments::charge::refund', 'POST', '/payments/refunds'],
+  ['payments::webhook::stripe', 'POST', '/payments/webhooks/stripe'],
+  ['payments::ledger::reconcile', 'POST', '/payments/reconcile'],
+] as const
 
 const FINAL_ANSWER = `\`payments-ledger\` is live on the engine and answering.
 
@@ -1135,141 +1135,141 @@ three \`harness::spawn\` branches are the subagents running at the same time, an
 \`execute payments::charge::record\` near the bottom is the function they built
 answering a live request. In the console you would click any bar for its
 arguments, its result, and its logs. If this turn had crashed halfway, the loop
-would have resumed from the last completed step, into the same trace.`;
+would have resumed from the last completed step, into the same trace.`
 
 /* ── the script ───────────────────────────────────────────────────────── */
 
 export async function* runScenario(
   opts: ScenarioOptions,
 ): AsyncGenerator<DemoEvent> {
-  const { signal, gate } = opts;
-  spanSeq = 0;
+  const { signal, gate } = opts
+  spanSeq = 0
 
-  yield { kind: "turn-status", phase: "accepted" };
-  await nap(420, signal);
-  yield { kind: "turn-status", phase: "started" };
-  await nap(260, signal);
+  yield { kind: 'turn-status', phase: 'accepted' }
+  await nap(420, signal)
+  yield { kind: 'turn-status', phase: 'started' }
+  await nap(260, signal)
 
   /* step 1 — look at what is already running */
   yield* step(
     1,
     thought(
-      "The user wants a payments ledger with durable storage. Before I write a line of it I should look at what is already connected to this engine. iii keeps a live catalog of every running worker, so a durable database may already be here. If it is, there is nothing to scaffold and nothing to deploy alongside.",
+      'The user wants a payments ledger with durable storage. Before I write a line of it I should look at what is already connected to this engine. iii keeps a live catalog of every running worker, so a durable database may already be here. If it is, there is nothing to scaffold and nothing to deploy alongside.',
       signal,
     ),
     signal,
     (stepSpan) =>
       call({
-        fn: "engine::workers::list",
-        worker: "iii",
-        input: { status: "connected" },
+        fn: 'engine::workers::list',
+        worker: 'iii',
+        input: { status: 'connected' },
         output: WORKERS_LIST(),
         runMs: 900,
         reportedMs: 2.1,
         parentSpan: stepSpan,
         signal,
         callout: {
-          anchor: "transcript",
-          title: "discovery",
-          text: "The agent reads the engine’s live worker catalog. Whatever is already running is already integrated and callable.",
+          anchor: 'transcript',
+          title: 'discovery',
+          text: 'The agent reads the engine’s live worker catalog. Whatever is already running is already integrated and callable.',
         },
       }),
-  );
-  if (signal?.aborted) return;
-  yield* readPause(signal);
+  )
+  if (signal?.aborted) return
+  yield* readPause(signal)
 
   /* step 2 — read the database worker's contract */
   yield* step(
     2,
     thought(
-      "`database` is available: durable postgres, nine functions. Let me read its contract so the ledger is written against the real signatures instead of guesses.",
+      '`database` is available: durable postgres, nine functions. Let me read its contract so the ledger is written against the real signatures instead of guesses.',
       signal,
     ),
     signal,
     (stepSpan) =>
       call({
-        fn: "engine::workers::info",
-        worker: "iii",
-        input: { name: "database" },
+        fn: 'engine::workers::info',
+        worker: 'iii',
+        input: { name: 'database' },
         output: DATABASE_INFO(),
         runMs: 700,
         reportedMs: 1.4,
         parentSpan: stepSpan,
         signal,
         callout: {
-          anchor: "waterfall",
-          title: "every operation is traced",
-          text: "Every call opens a span. This is the console’s own trace view, filling in live, recorded by the observability worker. Any worker added to the engine is immediately observable, no separate setup, and it is OTel compatible.",
+          anchor: 'waterfall',
+          title: 'every operation is traced',
+          text: 'Every call opens a span. This is the console’s own trace view, filling in live, recorded by the observability worker. Any worker added to the engine is immediately observable, no separate setup, and it is OTel compatible.',
         },
       }),
-  );
-  if (signal?.aborted) return;
-  yield* readPause(signal);
+  )
+  if (signal?.aborted) return
+  yield* readPause(signal)
 
   /* step 3 — fan out to three subagents; one of them stops at the gate */
   yield* step(
     3,
     assistant(
-      "`database` gives me durable postgres with transactions, so the ledger can be double-entry without a second datastore. Three pieces here are independent, so I’ll run them as three subagents and stay on the wiring myself.",
+      '`database` gives me durable postgres with transactions, so the ledger can be double-entry without a second datastore. Three pieces here are independent, so I’ll run them as three subagents and stay on the wiring myself.',
       signal,
     ),
     signal,
     (stepSpan) => spawnFanOut(stepSpan, gate, signal),
-  );
-  if (signal?.aborted) return;
-  yield* readPause(signal);
+  )
+  if (signal?.aborted) return
+  yield* readPause(signal)
 
   /* step 4 — install the worker the subagents wrote */
   yield* step(
     4,
     thought(
-      "All three subagents are back: core, webhook and tests. Install the worker so the engine can route to it.",
+      'All three subagents are back: core, webhook and tests. Install the worker so the engine can route to it.',
       signal,
     ),
     signal,
     (stepSpan) =>
       call({
-        fn: "worker::add",
-        worker: "worker-manager",
+        fn: 'worker::add',
+        worker: 'worker-manager',
         input: {
-          source: { kind: "local", path: "./payments-ledger" },
+          source: { kind: 'local', path: './payments-ledger' },
           wait: true,
         },
         output: {
-          name: "payments-ledger",
-          version: "0.1.0",
-          status: "installed",
+          name: 'payments-ledger',
+          version: '0.1.0',
+          status: 'installed',
           awaited_ready: true,
-          config_path: "./config.yaml",
+          config_path: './config.yaml',
         },
         runMs: 1600,
         parentSpan: stepSpan,
         signal,
       }),
-  );
-  if (signal?.aborted) return;
+  )
+  if (signal?.aborted) return
 
   /* step 5 — one HTTP trigger per function, dispatched in a single step */
   yield* step(
     5,
     thought(
-      "Now the entry points. I can use the http worker and each function gets an HTTP trigger.",
+      'Now the entry points. I can use the http worker and each function gets an HTTP trigger.',
       signal,
     ),
     signal,
     async function* (stepSpan) {
       for (const [fn, method, path] of HTTP_TRIGGERS) {
         yield* call({
-          fn: "engine::register_trigger",
-          worker: "iii",
+          fn: 'engine::register_trigger',
+          worker: 'iii',
           input: {
-            trigger_type: "http",
+            trigger_type: 'http',
             function_id: fn,
             config: { method, path },
           },
           output: {
-            id: `trg_${path.replace(/\W+/g, "_")}`,
-            trigger_type: "http",
+            id: `trg_${path.replace(/\W+/g, '_')}`,
+            trigger_type: 'http',
             function_id: fn,
             registered: true,
           },
@@ -1277,34 +1277,34 @@ export async function* runScenario(
           reportedMs: 0.31,
           parentSpan: stepSpan,
           signal,
-        });
-        if (signal?.aborted) return;
+        })
+        if (signal?.aborted) return
       }
     },
-  );
-  if (signal?.aborted) return;
+  )
+  if (signal?.aborted) return
 
   /* step 6 — run the subagent's tests against the live worker */
   yield* step(
     6,
     thought(
-      "Run the tests the subagent wrote against the installed worker.",
+      'Run the tests the subagent wrote against the installed worker.',
       signal,
     ),
     signal,
     (stepSpan) =>
       call({
-        fn: "shell::exec",
-        worker: "shell",
+        fn: 'shell::exec',
+        worker: 'shell',
         input: {
-          command: "iii test payments-ledger",
-          cwd: "/workspace/payments-ledger",
+          command: 'iii test payments-ledger',
+          cwd: '/workspace/payments-ledger',
           timeout_ms: 120000,
         },
         output: {
           exit_code: 0,
           stdout: TEST_STDOUT,
-          stderr: "",
+          stderr: '',
           duration_ms: 6041,
           timed_out: false,
           stdout_truncated: false,
@@ -1315,30 +1315,30 @@ export async function* runScenario(
         parentSpan: stepSpan,
         signal,
       }),
-  );
-  if (signal?.aborted) return;
-  yield* readPause(signal);
+  )
+  if (signal?.aborted) return
+  yield* readPause(signal)
 
   /* step 7 — call the thing it just built */
   yield* step(
     7,
-    thought("Tests pass. Last check: call the function for real.", signal),
+    thought('Tests pass. Last check: call the function for real.', signal),
     signal,
     (stepSpan) =>
       call({
-        fn: "payments::charge::record",
-        worker: "payments-ledger",
+        fn: 'payments::charge::record',
+        worker: 'payments-ledger',
         input: {
           amount: 4200,
-          currency: "usd",
-          customer_id: "cus_8Kd2Qw",
-          provider_event_id: "evt_3PfL2m",
+          currency: 'usd',
+          customer_id: 'cus_8Kd2Qw',
+          provider_event_id: 'evt_3PfL2m',
         },
         output: {
-          entry_id: "led_01hq5r7t9m",
-          account: "cus_8Kd2Qw",
+          entry_id: 'led_01hq5r7t9m',
+          account: 'cus_8Kd2Qw',
           amount: 4200,
-          currency: "usd",
+          currency: 'usd',
           balance: 4200,
           posted_at: new Date().toISOString(),
           idempotent_replay: false,
@@ -1347,16 +1347,16 @@ export async function* runScenario(
         reportedMs: 12.4,
         parentSpan: stepSpan,
         signal,
-        inner: [["execute database::transaction", "database", 0.6]],
+        inner: [['execute database::transaction', 'database', 0.6]],
         callout: {
-          anchor: "waterfall",
-          title: "a new payments worker, just added to the system",
-          text: "The new worker’s span lands under the same trace, next to the `database` call it makes. Nothing was re-instrumented to get it there.",
+          anchor: 'waterfall',
+          title: 'a new payments worker, just added to the system',
+          text: 'The new worker’s span lands under the same trace, next to the `database` call it makes. Nothing was re-instrumented to get it there.',
         },
       }),
-  );
-  if (signal?.aborted) return;
-  yield* readPause(signal);
+  )
+  if (signal?.aborted) return
+  yield* readPause(signal)
 
   /* step 8 — the answer, and a tour of the pane on the right */
   yield* step(
@@ -1365,13 +1365,13 @@ export async function* runScenario(
     signal,
     async function* () {
       yield {
-        kind: "demo-callout",
+        kind: 'demo-callout',
         callout: {
-          anchor: "waterfall",
-          title: "one trace, eight durable steps",
-          text: "Each `harness::turn step` row is one durable step of the loop, running on top of the queue worker. A crash mid-turn resumes from the last completed step, into the same trace. Agentic loops are a normal engineering pattern in iii. They work the same as any programmatic loop would in iii.",
+          anchor: 'waterfall',
+          title: 'one trace, eight durable steps',
+          text: 'Each `harness::turn step` row is one durable step of the loop, running on top of the queue worker. A crash mid-turn resumes from the last completed step, into the same trace. Agentic loops are a normal engineering pattern in iii. They work the same as any programmatic loop would in iii.',
         },
-      };
+      }
     },
-  );
+  )
 }

--- a/console/web/src/demo/scenario.ts
+++ b/console/web/src/demo/scenario.ts
@@ -53,11 +53,21 @@ export interface DemoSpanInit {
   attributes?: Array<[string, unknown]>
 }
 
+/** A child session `harness::spawn` created, as the sidebar shows it. */
+export interface DemoSession {
+  id: string
+  title: string
+  /** The task the parent handed down: the child's seeding user message. */
+  task: string
+}
+
 export type DemoEvent =
   | StreamEvent
   | { kind: 'demo-span-open'; span: DemoSpanInit }
   | { kind: 'demo-span-close'; id: string; status?: 'OK' | 'ERROR' }
   | { kind: 'demo-callout'; callout: Callout }
+  | { kind: 'demo-session-open'; session: DemoSession }
+  | { kind: 'demo-session-done'; id: string; result: string }
 
 export interface ScenarioOptions {
   signal?: AbortSignal
@@ -277,6 +287,125 @@ async function* step(
   yield { kind: 'demo-span-close', id: stepSpan }
 }
 
+/**
+ * One step that dispatches every child in `CHILDREN` as a parallel batch.
+ *
+ * All three cards land together; the gated one holds while the other two are
+ * already running, which is what the batch actually looks like when a
+ * deny-by-default policy only objects to one call in it. Each child opens its
+ * own `execute harness::spawn` span with the child's own `harness::turn step`
+ * nested inside, so the fan-out shows up as three branches of one trace, and
+ * its own session, so it shows up as three rows in the sidebar.
+ */
+async function* spawnFanOut(
+  stepSpan: string,
+  gate: ScenarioOptions['gate'],
+  signal: AbortSignal | undefined,
+): AsyncGenerator<DemoEvent> {
+  const startedAt = Date.now()
+  const spans = new Map<string, string>()
+
+  /** Open the child's span pair and its session — it is running now. */
+  function* launch(child: ChildSpec): Generator<DemoEvent> {
+    const execSpan = spanId('exec')
+    const childStep = spanId('child')
+    spans.set(child.callId, execSpan)
+    yield {
+      kind: 'demo-span-open',
+      span: {
+        id: execSpan,
+        parent: stepSpan,
+        name: 'execute harness::spawn',
+        service: 'harness',
+        kind: 'internal',
+        attributes: [...TURN_TAGS, ['iii.child.session_id', child.sessionId]],
+      },
+    }
+    yield {
+      kind: 'demo-span-open',
+      span: {
+        id: childStep,
+        parent: execSpan,
+        name: 'harness::turn step',
+        service: 'harness',
+        kind: 'internal',
+        attributes: [
+          ['iii.session.id', child.sessionId],
+          ['iii.tag.kind', 'harness.subagent'],
+          ['iii.tag.display_name', `Sub-agent · ${child.title}`],
+        ],
+      },
+    }
+    spans.set(`${child.callId}:step`, childStep)
+    yield {
+      kind: 'demo-session-open',
+      session: { id: child.sessionId, title: child.title, task: child.task },
+    }
+  }
+
+  /* Every card at once — a parallel tool-call batch is one assistant turn. */
+  for (const child of CHILDREN) {
+    yield {
+      kind: 'fcall-start',
+      functionId: 'harness::spawn',
+      input: spawnInput(child),
+      functionTriggerId: child.callId,
+      sessionId: SESSION_ID,
+      ...(child.gated ? { pendingApproval: true } : {}),
+    }
+  }
+  for (const child of CHILDREN) {
+    if (!child.gated) yield* launch(child)
+  }
+
+  yield {
+    kind: 'demo-callout',
+    callout: {
+      anchor: 'transcript',
+      title: 'three sub-agents, one held at the gate',
+      text: 'Each child is its own session with its own budget and its own function policy, listed under this chat as it starts and readable on its own. Only `ledger core` asked for `database::*`, a write scope this session does not hold, so only that one waits for a human. Click approve to release it.',
+    },
+  }
+
+  for (const child of CHILDREN) {
+    if (!child.gated) continue
+    await gate(child.callId)
+    if (signal?.aborted) return
+    yield {
+      kind: 'fcall-approval-cleared',
+      functionTriggerId: child.callId,
+      running: true,
+    }
+    yield* launch(child)
+  }
+
+  /* Children report as they finish, not in dispatch order. */
+  const finishing = [...CHILDREN].sort(
+    (a, b) => a.finishAfterMs - b.finishAfterMs,
+  )
+  let waited = 0
+  for (const child of finishing) {
+    await nap(child.finishAfterMs - waited, signal)
+    if (signal?.aborted) return
+    waited = child.finishAfterMs
+    const childStep = spans.get(`${child.callId}:step`)
+    const execSpan = spans.get(child.callId)
+    if (childStep) yield { kind: 'demo-span-close', id: childStep }
+    if (execSpan) yield { kind: 'demo-span-close', id: execSpan }
+    yield {
+      kind: 'demo-session-done',
+      id: child.sessionId,
+      result: child.resultText,
+    }
+    yield {
+      kind: 'fcall-end',
+      output: spawnResult(child),
+      durationMs: Date.now() - startedAt,
+      functionTriggerId: child.callId,
+    }
+  }
+}
+
 /* ── outputs ──────────────────────────────────────────────────────────── */
 
 const CONNECTED_AT = () => Date.now() - 4 * 60 * 60 * 1000
@@ -406,31 +535,100 @@ const DATABASE_INFO = () => ({
   registered_triggers: [],
 })
 
-const SPAWN_TASK = `Write a payments-ledger worker against the existing \`database\` worker.
+/**
+ * The fan-out. Three children, dispatched in one step, each its own session
+ * with its own budget and its own function policy. Only the first asks for
+ * `database::*` — the write scope this session does not hold — so only the
+ * first stops at the approval gate; the other two dispatch immediately.
+ */
+interface ChildSpec {
+  /** iii function_call_id, and the key the approval resolves against. */
+  callId: string
+  sessionId: string
+  title: string
+  task: string
+  allow: string[]
+  /** Held at the gate before it may run. */
+  gated?: boolean
+  resultText: string
+  resultDetails: Record<string, unknown>
+  /** Delay after the gate clears before this child reports, in ms. */
+  finishAfterMs: number
+}
 
-Four functions: charge::record, charge::refund, webhook::stripe, ledger::reconcile.
-Double-entry rows, idempotent on the provider event id. Use database::transaction
-for anything that writes two rows. Ship tests.`
+const CHILDREN: ChildSpec[] = [
+  {
+    callId: 'fc_spawn_ledger_core',
+    sessionId: 'console-sub-ledger-core',
+    title: 'ledger core',
+    task: `Write the payments-ledger worker's core against the existing \`database\` worker.
 
-const SPAWN_RESULT = {
-  content: [
-    {
-      type: 'text' as const,
-      text: 'payments-ledger scaffolded: 4 functions, 11 tests, ledger schema applied.',
+\`payments::charge::record\` and \`payments::charge::refund\`, double-entry rows,
+\`database::transaction\` for anything that writes two rows. Create the
+\`ledger_entries\` and \`ledger_accounts\` tables.`,
+    allow: ['coder::*', 'database::*'],
+    gated: true,
+    resultText:
+      'ledger core done: charge::record + charge::refund over a double-entry schema, 2 tables created.',
+    resultDetails: {
+      functions: ['payments::charge::record', 'payments::charge::refund'],
+      tables: ['ledger_entries', 'ledger_accounts'],
+      turns_used: 7,
     },
-  ],
-  details: {
-    worker: 'payments-ledger',
-    functions: [
-      'payments::charge::record',
-      'payments::charge::refund',
-      'payments::webhook::stripe',
-      'payments::ledger::reconcile',
-    ],
-    tables: ['ledger_entries', 'ledger_accounts'],
-    tests: 11,
-    turns_used: 6,
+    finishAfterMs: 3400,
   },
+  {
+    callId: 'fc_spawn_ledger_webhook',
+    sessionId: 'console-sub-ledger-webhook',
+    title: 'stripe webhook',
+    task: `Write \`payments::webhook::stripe\` and \`payments::ledger::reconcile\` for the
+payments-ledger worker. Idempotent on the provider event id: a replayed event
+must post nothing and return the original entry.`,
+    allow: ['coder::*', 'web::search'],
+    resultText:
+      'webhook + reconcile done: dedupe keyed on provider_event_id, replays return the original entry.',
+    resultDetails: {
+      functions: ['payments::webhook::stripe', 'payments::ledger::reconcile'],
+      idempotency_key: 'provider_event_id',
+      turns_used: 5,
+    },
+    finishAfterMs: 1100,
+  },
+  {
+    callId: 'fc_spawn_ledger_tests',
+    sessionId: 'console-sub-ledger-tests',
+    title: 'test suite',
+    task: `Write the payments-ledger test suite. Cover double-entry balance, refunds
+over the original amount, webhook replay, concurrent charges on one account,
+and that the schema matches the migration.`,
+    allow: ['coder::*', 'shell::exec'],
+    resultText:
+      'test suite done: 11 tests over the ledger, webhook and schema.',
+    resultDetails: { tests: 11, files: ['tests/ledger.rs'], turns_used: 4 },
+    finishAfterMs: 400,
+  },
+]
+
+function spawnInput(child: ChildSpec) {
+  return {
+    task: child.task,
+    model: 'claude-opus-4-7',
+    session_id: child.sessionId,
+    parent_session_id: SESSION_ID,
+    options: {
+      mode: 'agent',
+      max_turns: 12,
+      output: { type: 'text' },
+      functions: { allow: child.allow, deny: ['compose::*', 'worker::remove'] },
+    },
+  }
+}
+
+function spawnResult(child: ChildSpec) {
+  return {
+    content: [{ type: 'text' as const, text: child.resultText }],
+    details: { session_id: child.sessionId, ...child.resultDetails },
+  }
 }
 
 const TEST_STDOUT = `   Compiling payments-ledger v0.1.0
@@ -471,14 +669,21 @@ Nothing here was scaffolded from a template. The \`database\` worker was already
 connected, so the ledger tables went straight onto it and the new worker joined
 the same engine the rest of your workers are on.
 
+**About those three children.** \`ledger core\`, \`stripe webhook\` and
+\`test suite\` are still listed under this chat. They are real sessions, not log
+lines: each one had its own transcript, its own turn budget and its own
+function policy, and you can open any of them to read what it did. Only
+\`ledger core\` needed a scope this session lacks, so only that one waited on
+you.
+
 **About the pane on the right.** That is not a replay of this chat, it is the
 trace the engine recorded while it happened. Every row above opened a span:
 each \`harness::turn step\` is one durable step of my loop off the queue, the
-\`router::chat\` spans are the model calls, and \`execute payments::charge::record\`
-at the bottom is the function I just built answering a live request. In the
-console you would click any bar for its arguments, its result, and its logs.
-If this turn had crashed halfway, the loop would have resumed from the last
-completed step, into the same trace.`
+three \`harness::spawn\` branches are the children running at the same time, and
+\`execute payments::charge::record\` near the bottom is the function they built
+answering a live request. In the console you would click any bar for its
+arguments, its result, and its logs. If this turn had crashed halfway, the loop
+would have resumed from the last completed step, into the same trace.`
 
 /* ── the script ───────────────────────────────────────────────────────── */
 
@@ -545,52 +750,23 @@ export async function* runScenario(
   )
   if (signal?.aborted) return
 
-  /* step 3 — hand the writing to a sub-agent, behind the approval gate */
+  /* step 3 — fan out to three sub-agents; one of them stops at the gate */
   yield* step(
     3,
     assistant(
-      '`database` gives me durable postgres with transactions, so the ledger can be double-entry without a second datastore. I’ll hand the code to a sub-agent while I stay on the wiring.',
+      '`database` gives me durable postgres with transactions, so the ledger can be double-entry without a second datastore. Three pieces here are independent, so I’ll run them as three sub-agents and stay on the wiring myself.',
       signal,
     ),
     signal,
-    (stepSpan) =>
-      call({
-        fn: 'harness::spawn',
-        worker: 'harness',
-        input: {
-          task: SPAWN_TASK,
-          model: 'claude-opus-4-7',
-          options: {
-            mode: 'agent',
-            max_turns: 12,
-            output: { type: 'text' },
-            functions: {
-              allow: ['coder::*', 'shell::exec', 'database::*'],
-              deny: ['compose::*', 'worker::remove'],
-            },
-          },
-        },
-        output: SPAWN_RESULT,
-        runMs: 4200,
-        parentSpan: stepSpan,
-        signal,
-        gate,
-        functionTriggerId: 'fc_spawn_payments_ledger',
-        inner: [['harness::turn step', 'harness', 0.8]],
-        callout: {
-          anchor: 'transcript',
-          title: 'held at the gate',
-          text: 'Dispatch is deny-by-default. A call outside the allowed set stops here until a human approves it, or a policy does. Click approve to release it.',
-        },
-      }),
+    (stepSpan) => spawnFanOut(stepSpan, gate, signal),
   )
   if (signal?.aborted) return
 
-  /* step 4 — install the worker the child wrote */
+  /* step 4 — install the worker the children wrote */
   yield* step(
     4,
     thought(
-      'Child is done: four functions, eleven tests, schema applied. Install the worker so the engine can route to it.',
+      'All three children are back: core, webhook and tests. Install the worker so the engine can route to it.',
       signal,
     ),
     signal,

--- a/console/web/src/demo/scenario.ts
+++ b/console/web/src/demo/scenario.ts
@@ -1,0 +1,742 @@
+/**
+ * The canned turn the landing-page demo replays.
+ *
+ * The chat half of the stream is the real `ChatBackend.stream()` contract
+ * (`@/lib/backend/types`) — the same `StreamEvent`s the live harness backend
+ * emits, in the same order, consumed by the same reducer the console's
+ * `ChatView` uses. Three demo-only markers ride alongside it so the trace
+ * pane and the callout layer stay in lockstep with the transcript without a
+ * second timeline to keep in sync:
+ *
+ *   demo-span-open / demo-span-close   the waterfall's spans
+ *   demo-callout                       the annotation chip
+ *
+ * Span shapes mirror what a real turn produces: one `harness::turn step`
+ * root per durable loop step (`workers/harness/src/functions/turn.rs`),
+ * `execute router::chat` → `execute provider::anthropic::stream` for the
+ * generation, and `execute <fn>` for each dispatched call.
+ */
+
+import type { StreamEvent } from '@/lib/backend'
+import { sleep, tokenize } from '@/stories/playground/scenarios/helpers'
+
+export const PROMPT = 'build a payments ledger service with a durable db'
+
+export const MODEL_ID = 'anthropic::claude-opus-4-7'
+export const SESSION_ID = 'console-payments-ledger-demo'
+export const TRACE_ID = 'trace-payments-ledger-0000000001'
+
+/**
+ * Global playback rate. `prefers-reduced-motion` sets it near zero so the
+ * turn fills in at once and holds, instead of animating for a minute.
+ */
+let SPEED = 1
+export function setScenarioSpeed(multiplier: number) {
+  SPEED = multiplier
+}
+const nap = (ms: number, signal?: AbortSignal) => sleep(ms * SPEED, signal)
+
+export type CalloutAnchor = 'transcript' | 'waterfall' | 'composer'
+
+export interface Callout {
+  title: string
+  text: string
+  anchor: CalloutAnchor
+}
+
+export interface DemoSpanInit {
+  id: string
+  parent?: string
+  name: string
+  service: string
+  kind?: string
+  attributes?: Array<[string, unknown]>
+}
+
+export type DemoEvent =
+  | StreamEvent
+  | { kind: 'demo-span-open'; span: DemoSpanInit }
+  | { kind: 'demo-span-close'; id: string; status?: 'OK' | 'ERROR' }
+  | { kind: 'demo-callout'; callout: Callout }
+
+export interface ScenarioOptions {
+  signal?: AbortSignal
+  /**
+   * Resolves when the gated call is released — by the viewer clicking
+   * approve/deny on the real card, or by the demo's own timeout. The demo
+   * never denies; a deny resolves the same way so the card can't hang.
+   */
+  gate: (functionTriggerId: string) => Promise<void>
+}
+
+/* ── span bookkeeping ─────────────────────────────────────────────────── */
+
+let spanSeq = 0
+function spanId(prefix: string): string {
+  spanSeq += 1
+  return `${prefix}-${String(spanSeq).padStart(3, '0')}`
+}
+
+/** Turn-identity baggage the harness stamps on every span of a step. */
+const TURN_TAGS: Array<[string, unknown]> = [
+  ['iii.session.id', SESSION_ID],
+  ['iii.message.id', 'turn-01'],
+  ['iii.tag.kind', 'harness.turn'],
+  ['iii.tag.message', PROMPT],
+]
+
+/* ── stream fragments ─────────────────────────────────────────────────── */
+
+async function* thought(
+  body: string,
+  signal?: AbortSignal,
+  meanDelayMs = 26,
+): AsyncGenerator<DemoEvent> {
+  const startedAt = Date.now()
+  yield { kind: 'thought-start' }
+  for (const token of tokenize(body)) {
+    if (signal?.aborted) return
+    if (token) yield { kind: 'thought-token', token }
+    await nap(meanDelayMs * (0.6 + Math.random() * 0.8), signal)
+  }
+  yield { kind: 'thought-end', durationMs: Date.now() - startedAt }
+}
+
+async function* assistant(
+  body: string,
+  signal?: AbortSignal,
+  meanDelayMs = 26,
+): AsyncGenerator<DemoEvent> {
+  for (const token of tokenize(body)) {
+    if (signal?.aborted) return
+    if (token) yield { kind: 'assistant-token', token }
+    await nap(meanDelayMs * (0.5 + Math.random()), signal)
+  }
+  yield { kind: 'assistant-end' }
+}
+
+interface CallOptions {
+  fn: string
+  /** Worker that runs it — the `execute` span's service name. */
+  worker: string
+  input: unknown
+  output: unknown
+  runMs: number
+  parentSpan: string
+  signal?: AbortSignal
+  /** Nested spans opened inside the call, as [name, service, share-of-runMs]. */
+  inner?: Array<[string, string, number]>
+  /** Hold the call in the approval gate before it executes. */
+  gate?: (functionTriggerId: string) => Promise<void>
+  functionTriggerId?: string
+  callout?: Callout
+}
+
+async function* call(opts: CallOptions): AsyncGenerator<DemoEvent> {
+  const {
+    fn,
+    worker,
+    input,
+    output,
+    runMs,
+    parentSpan,
+    signal,
+    inner,
+    gate,
+    functionTriggerId,
+    callout,
+  } = opts
+  const startedAt = Date.now()
+
+  yield {
+    kind: 'fcall-start',
+    functionId: fn,
+    input,
+    ...(gate
+      ? {
+          pendingApproval: true,
+          functionTriggerId,
+          sessionId: SESSION_ID,
+        }
+      : {}),
+  }
+  if (callout) yield { kind: 'demo-callout', callout }
+
+  if (gate && functionTriggerId) {
+    await gate(functionTriggerId)
+    if (signal?.aborted) return
+    yield { kind: 'fcall-approval-cleared', functionTriggerId, running: true }
+  }
+
+  const execSpan = spanId('exec')
+  yield {
+    kind: 'demo-span-open',
+    span: {
+      id: execSpan,
+      parent: parentSpan,
+      name: `execute ${fn}`,
+      service: worker,
+      kind: 'internal',
+      attributes: [...TURN_TAGS, ['iii.function.id', fn]],
+    },
+  }
+
+  if (inner?.length) {
+    let elapsed = 0
+    for (const [name, service, share] of inner) {
+      const childSpan = spanId('inner')
+      yield {
+        kind: 'demo-span-open',
+        span: {
+          id: childSpan,
+          parent: execSpan,
+          name,
+          service,
+          kind: 'internal',
+          attributes: TURN_TAGS,
+        },
+      }
+      const slice = runMs * share
+      await nap(slice, signal)
+      elapsed += slice
+      if (signal?.aborted) return
+      yield { kind: 'demo-span-close', id: childSpan }
+    }
+    await nap(Math.max(0, runMs - elapsed), signal)
+  } else {
+    await nap(runMs, signal)
+  }
+  if (signal?.aborted) return
+
+  yield { kind: 'demo-span-close', id: execSpan }
+  yield {
+    kind: 'fcall-end',
+    output,
+    durationMs: Date.now() - startedAt,
+    ...(functionTriggerId ? { functionTriggerId } : {}),
+  }
+}
+
+/**
+ * One durable loop step: the harness dequeues, asks the router for a
+ * completion, then dispatches whatever the model asked for. `body` streams
+ * the model's visible output; the router/provider spans close when it ends.
+ */
+async function* step(
+  index: number,
+  body: AsyncGenerator<DemoEvent>,
+  signal: AbortSignal | undefined,
+  after: (stepSpan: string) => AsyncGenerator<DemoEvent>,
+): AsyncGenerator<DemoEvent> {
+  const stepSpan = spanId('step')
+  const routerSpan = spanId('router')
+  const providerSpan = spanId('provider')
+
+  yield {
+    kind: 'demo-span-open',
+    span: {
+      id: stepSpan,
+      name: 'harness::turn step',
+      service: 'harness',
+      kind: 'internal',
+      attributes: [...TURN_TAGS, ['iii.turn.step', index]],
+    },
+  }
+  yield {
+    kind: 'demo-span-open',
+    span: {
+      id: routerSpan,
+      parent: stepSpan,
+      name: 'execute router::chat',
+      service: 'llm-router',
+      kind: 'internal',
+      attributes: [...TURN_TAGS, ['gen_ai.request.model', 'claude-opus-4-7']],
+    },
+  }
+  yield {
+    kind: 'demo-span-open',
+    span: {
+      id: providerSpan,
+      parent: routerSpan,
+      name: 'execute provider::anthropic::stream',
+      service: 'llm-provider-anthropic',
+      kind: 'client',
+      attributes: TURN_TAGS,
+    },
+  }
+
+  yield* body
+  if (signal?.aborted) return
+
+  yield { kind: 'demo-span-close', id: providerSpan }
+  yield { kind: 'demo-span-close', id: routerSpan }
+
+  yield* after(stepSpan)
+  if (signal?.aborted) return
+
+  yield { kind: 'demo-span-close', id: stepSpan }
+}
+
+/* ── outputs ──────────────────────────────────────────────────────────── */
+
+const CONNECTED_AT = () => Date.now() - 4 * 60 * 60 * 1000
+
+const WORKERS_LIST = () => ({
+  workers: [
+    {
+      id: 'wrk_01hq4m8database',
+      name: 'database',
+      description: 'Durable postgres: tables, queries, migrations.',
+      version: '0.21.0',
+      runtime: 'rust',
+      os: 'linux',
+      status: 'connected',
+      function_count: 9,
+      connected_at_ms: CONNECTED_AT(),
+      active_invocations: 0,
+      isolation: 'container',
+      tag: 'core',
+    },
+    {
+      id: 'wrk_01hq4m8shell00',
+      name: 'shell',
+      description: 'Scoped command execution and filesystem access.',
+      version: '0.21.0',
+      runtime: 'rust',
+      os: 'linux',
+      status: 'connected',
+      function_count: 16,
+      connected_at_ms: CONNECTED_AT(),
+      active_invocations: 0,
+      isolation: 'container',
+    },
+    {
+      id: 'wrk_01hq4m8coder000',
+      name: 'coder',
+      description: 'Reads, writes and patches files in a scoped workspace.',
+      version: '0.21.0',
+      runtime: 'node',
+      os: 'linux',
+      status: 'connected',
+      function_count: 12,
+      connected_at_ms: CONNECTED_AT(),
+      active_invocations: 0,
+      isolation: 'container',
+    },
+    {
+      id: 'wrk_01hq4m8harness0',
+      name: 'harness',
+      description: 'The durable agent turn loop.',
+      version: '0.21.0',
+      runtime: 'rust',
+      os: 'linux',
+      status: 'connected',
+      function_count: 14,
+      connected_at_ms: CONNECTED_AT(),
+      active_invocations: 1,
+      isolation: 'container',
+    },
+    {
+      id: 'wrk_01hq4m8observ00',
+      name: 'observability',
+      description: 'OTel collector: traces, logs and metrics for the engine.',
+      version: '0.21.0',
+      runtime: 'rust',
+      os: 'linux',
+      status: 'connected',
+      function_count: 6,
+      connected_at_ms: CONNECTED_AT(),
+      active_invocations: 0,
+      isolation: 'container',
+    },
+  ],
+})
+
+const DATABASE_INFO = () => ({
+  worker: {
+    id: 'wrk_01hq4m8database',
+    name: 'database',
+    description: 'Durable postgres: tables, queries, migrations.',
+    version: '0.21.0',
+    runtime: 'rust',
+    os: 'linux',
+    status: 'connected',
+    function_count: 9,
+    connected_at_ms: CONNECTED_AT(),
+    active_invocations: 0,
+    isolation: 'container',
+    internal: false,
+    pid: 1421,
+    latest_metrics: null,
+  },
+  functions: [
+    {
+      function_id: 'database::create_table',
+      worker_name: 'database',
+      description: 'Create a table from a column spec.',
+    },
+    {
+      function_id: 'database::query',
+      worker_name: 'database',
+      description: 'Run a parameterised read query.',
+    },
+    {
+      function_id: 'database::execute',
+      worker_name: 'database',
+      description: 'Run a parameterised write statement.',
+    },
+    {
+      function_id: 'database::transaction',
+      worker_name: 'database',
+      description: 'Run several statements atomically.',
+    },
+    {
+      function_id: 'database::migrate',
+      worker_name: 'database',
+      description: 'Apply pending migrations.',
+    },
+  ],
+  trigger_types: [
+    {
+      id: 'database.row_changed',
+      worker_name: 'database',
+      description: 'Fires when a watched table changes.',
+    },
+  ],
+  registered_triggers: [],
+})
+
+const SPAWN_TASK = `Write a payments-ledger worker against the existing \`database\` worker.
+
+Four functions: charge::record, charge::refund, webhook::stripe, ledger::reconcile.
+Double-entry rows, idempotent on the provider event id. Use database::transaction
+for anything that writes two rows. Ship tests.`
+
+const SPAWN_RESULT = {
+  content: [
+    {
+      type: 'text' as const,
+      text: 'payments-ledger scaffolded: 4 functions, 11 tests, ledger schema applied.',
+    },
+  ],
+  details: {
+    worker: 'payments-ledger',
+    functions: [
+      'payments::charge::record',
+      'payments::charge::refund',
+      'payments::webhook::stripe',
+      'payments::ledger::reconcile',
+    ],
+    tables: ['ledger_entries', 'ledger_accounts'],
+    tests: 11,
+    turns_used: 6,
+  },
+}
+
+const TEST_STDOUT = `   Compiling payments-ledger v0.1.0
+    Finished test profile in 4.21s
+     Running tests/ledger.rs
+
+test charge_record_writes_double_entry ... ok
+test charge_record_is_idempotent ......... ok
+test refund_reverses_original_entry ...... ok
+test refund_rejects_over_refund .......... ok
+test stripe_webhook_dedupes_by_event_id .. ok
+test stripe_webhook_ignores_unknown_type . ok
+test reconcile_balances_to_zero .......... ok
+test reconcile_flags_orphan_entries ...... ok
+test balance_reads_committed_only ........ ok
+test concurrent_charges_serialize ........ ok
+test schema_matches_migration ............ ok
+
+test result: ok. 11 passed; 0 failed; finished in 1.83s`
+
+const HTTP_TRIGGERS = [
+  ['payments::charge::record', 'POST', '/payments/charges'],
+  ['payments::charge::refund', 'POST', '/payments/refunds'],
+  ['payments::webhook::stripe', 'POST', '/payments/webhooks/stripe'],
+  ['payments::ledger::reconcile', 'POST', '/payments/reconcile'],
+] as const
+
+const FINAL_ANSWER = `\`payments-ledger\` is live on the engine and answering.
+
+| function | trigger | backed by |
+| --- | --- | --- |
+| \`payments::charge::record\` | \`POST /payments/charges\` | \`database::transaction\` |
+| \`payments::charge::refund\` | \`POST /payments/refunds\` | \`database::transaction\` |
+| \`payments::webhook::stripe\` | \`POST /payments/webhooks/stripe\` | \`database::execute\` |
+| \`payments::ledger::reconcile\` | \`POST /payments/reconcile\` | \`database::query\` |
+
+Nothing here was scaffolded from a template. The \`database\` worker was already
+connected, so the ledger tables went straight onto it and the new worker joined
+the same engine the rest of your workers are on.
+
+**About the pane on the right.** That is not a replay of this chat, it is the
+trace the engine recorded while it happened. Every row above opened a span:
+each \`harness::turn step\` is one durable step of my loop off the queue, the
+\`router::chat\` spans are the model calls, and \`execute payments::charge::record\`
+at the bottom is the function I just built answering a live request. In the
+console you would click any bar for its arguments, its result, and its logs.
+If this turn had crashed halfway, the loop would have resumed from the last
+completed step, into the same trace.`
+
+/* ── the script ───────────────────────────────────────────────────────── */
+
+export async function* runScenario(
+  opts: ScenarioOptions,
+): AsyncGenerator<DemoEvent> {
+  const { signal, gate } = opts
+  spanSeq = 0
+
+  yield { kind: 'turn-status', phase: 'accepted' }
+  await nap(420, signal)
+  yield { kind: 'turn-status', phase: 'started' }
+  await nap(260, signal)
+
+  /* step 1 — look at what is already running */
+  yield* step(
+    1,
+    thought(
+      'The user wants a payments ledger with durable storage. Before I write a line of it I should look at what is already connected to this engine. iii keeps a live catalog of every running worker, so a durable database may already be here. If it is, there is nothing to scaffold and nothing to deploy alongside.',
+      signal,
+    ),
+    signal,
+    (stepSpan) =>
+      call({
+        fn: 'engine::workers::list',
+        worker: 'iii',
+        input: { status: 'connected' },
+        output: WORKERS_LIST(),
+        runMs: 900,
+        parentSpan: stepSpan,
+        signal,
+        callout: {
+          anchor: 'transcript',
+          title: 'discovery, not scaffolding',
+          text: 'The agent reads the engine’s live worker catalog. Whatever is already running is already callable: no boilerplate, no glue service.',
+        },
+      }),
+  )
+  if (signal?.aborted) return
+
+  /* step 2 — read the database worker's contract */
+  yield* step(
+    2,
+    thought(
+      '`database` is right there: durable postgres, nine functions. Let me read its contract so the ledger is written against the real signatures instead of guesses.',
+      signal,
+    ),
+    signal,
+    (stepSpan) =>
+      call({
+        fn: 'engine::workers::info',
+        worker: 'iii',
+        input: { name: 'database' },
+        output: DATABASE_INFO(),
+        runMs: 700,
+        parentSpan: stepSpan,
+        signal,
+        callout: {
+          anchor: 'waterfall',
+          title: 'the trace is building itself',
+          text: 'Every call opens a span. This is the console’s own trace view, filling in live. The observability comes with the runtime; nothing here was instrumented by hand.',
+        },
+      }),
+  )
+  if (signal?.aborted) return
+
+  /* step 3 — hand the writing to a sub-agent, behind the approval gate */
+  yield* step(
+    3,
+    assistant(
+      '`database` gives me durable postgres with transactions, so the ledger can be double-entry without a second datastore. I’ll hand the code to a sub-agent while I stay on the wiring.',
+      signal,
+    ),
+    signal,
+    (stepSpan) =>
+      call({
+        fn: 'harness::spawn',
+        worker: 'harness',
+        input: {
+          task: SPAWN_TASK,
+          model: 'claude-opus-4-7',
+          options: {
+            mode: 'agent',
+            max_turns: 12,
+            output: { type: 'text' },
+            functions: {
+              allow: ['coder::*', 'shell::exec', 'database::*'],
+              deny: ['compose::*', 'worker::remove'],
+            },
+          },
+        },
+        output: SPAWN_RESULT,
+        runMs: 4200,
+        parentSpan: stepSpan,
+        signal,
+        gate,
+        functionTriggerId: 'fc_spawn_payments_ledger',
+        inner: [['harness::turn step', 'harness', 0.8]],
+        callout: {
+          anchor: 'transcript',
+          title: 'held at the gate',
+          text: 'Dispatch is deny-by-default. A call outside the allowed set stops here until a human approves it, or a policy does. Click approve to release it.',
+        },
+      }),
+  )
+  if (signal?.aborted) return
+
+  /* step 4 — install the worker the child wrote */
+  yield* step(
+    4,
+    thought(
+      'Child is done: four functions, eleven tests, schema applied. Install the worker so the engine can route to it.',
+      signal,
+    ),
+    signal,
+    (stepSpan) =>
+      call({
+        fn: 'worker::add',
+        worker: 'worker-manager',
+        input: {
+          source: { kind: 'local', path: './payments-ledger' },
+          wait: true,
+        },
+        output: {
+          name: 'payments-ledger',
+          version: '0.1.0',
+          status: 'installed',
+          awaited_ready: true,
+          config_path: './config.yaml',
+        },
+        runMs: 1600,
+        parentSpan: stepSpan,
+        signal,
+      }),
+  )
+  if (signal?.aborted) return
+
+  /* step 5 — one HTTP trigger per function, dispatched in a single step */
+  yield* step(
+    5,
+    thought(
+      'Now the entry points. Each function gets an HTTP trigger; the engine owns the routing, so there is no gateway to write.',
+      signal,
+    ),
+    signal,
+    async function* (stepSpan) {
+      for (const [fn, method, path] of HTTP_TRIGGERS) {
+        yield* call({
+          fn: 'engine::register_trigger',
+          worker: 'iii',
+          input: {
+            trigger_type: 'http',
+            function_id: fn,
+            config: { method, path },
+          },
+          output: {
+            id: `trg_${path.replace(/\W+/g, '_')}`,
+            trigger_type: 'http',
+            function_id: fn,
+            registered: true,
+          },
+          runMs: 320,
+          parentSpan: stepSpan,
+          signal,
+        })
+        if (signal?.aborted) return
+      }
+    },
+  )
+  if (signal?.aborted) return
+
+  /* step 6 — run the child's tests against the live worker */
+  yield* step(
+    6,
+    thought(
+      'Run the tests the child wrote against the installed worker.',
+      signal,
+    ),
+    signal,
+    (stepSpan) =>
+      call({
+        fn: 'shell::exec',
+        worker: 'shell',
+        input: {
+          command: 'iii test payments-ledger',
+          cwd: '/workspace/payments-ledger',
+          timeout_ms: 120000,
+        },
+        output: {
+          exit_code: 0,
+          stdout: TEST_STDOUT,
+          stderr: '',
+          duration_ms: 6041,
+          timed_out: false,
+          stdout_truncated: false,
+          stderr_truncated: false,
+        },
+        runMs: 2600,
+        parentSpan: stepSpan,
+        signal,
+      }),
+  )
+  if (signal?.aborted) return
+
+  /* step 7 — call the thing it just built */
+  yield* step(
+    7,
+    thought(
+      'Tests pass. Last check: call the function for real, through the engine, the same way the HTTP trigger will.',
+      signal,
+    ),
+    signal,
+    (stepSpan) =>
+      call({
+        fn: 'payments::charge::record',
+        worker: 'payments-ledger',
+        input: {
+          amount: 4200,
+          currency: 'usd',
+          customer_id: 'cus_8Kd2Qw',
+          provider_event_id: 'evt_3PfL2m',
+        },
+        output: {
+          entry_id: 'led_01hq5r7t9m',
+          account: 'cus_8Kd2Qw',
+          amount: 4200,
+          currency: 'usd',
+          balance: 4200,
+          posted_at: new Date().toISOString(),
+          idempotent_replay: false,
+        },
+        runMs: 900,
+        parentSpan: stepSpan,
+        signal,
+        inner: [['execute database::transaction', 'database', 0.6]],
+        callout: {
+          anchor: 'waterfall',
+          title: 'a worker that did not exist a minute ago',
+          text: 'The new worker’s span lands under the same trace, next to the `database` call it makes. Nothing was re-instrumented to get it there.',
+        },
+      }),
+  )
+  if (signal?.aborted) return
+
+  /* step 8 — the answer, and a tour of the pane on the right */
+  yield* step(
+    8,
+    assistant(FINAL_ANSWER, signal, 17),
+    signal,
+    async function* () {
+      yield {
+        kind: 'demo-callout',
+        callout: {
+          anchor: 'waterfall',
+          title: 'one trace, eight durable steps',
+          text: 'Each `harness::turn step` row is one queue item. A crash mid-turn resumes from the last completed step instead of starting the conversation over.',
+        },
+      }
+    },
+  )
+}

--- a/console/web/src/demo/stubs/pierre-diffs.tsx
+++ b/console/web/src/demo/stubs/pierre-diffs.tsx
@@ -1,0 +1,31 @@
+/**
+ * Build stub for `@pierre/diffs` (and `/react`), aliased in only by
+ * `vite.demo.config.ts`.
+ *
+ * The package pulls all of shiki's grammars, which lands ~13MB of language
+ * chunks in the output directory. The landing demo's scenario dispatches no
+ * `coder::*` calls, so the diff views are unreachable — but the renderer
+ * registry imports the family statically, so the specifier still has to
+ * resolve. This keeps the graph honest and degrades to a plain notice if a
+ * future scenario ever does render one.
+ */
+
+export const DEFAULT_THEMES = { light: 'github-light', dark: 'github-dark' }
+
+export interface FileContents {
+  name: string
+  contents: string
+}
+
+function DiffUnavailable() {
+  return (
+    <div className="px-3 py-3 font-mono text-[12.5px] text-ink-ghost">
+      · diff rendering is not bundled in this demo
+    </div>
+  )
+}
+
+export const File = DiffUnavailable
+export const MultiFileDiff = DiffUnavailable
+
+export default { DEFAULT_THEMES, File, MultiFileDiff }

--- a/console/web/src/demo/stubs/pierre-diffs.tsx
+++ b/console/web/src/demo/stubs/pierre-diffs.tsx
@@ -3,11 +3,9 @@
  * `vite.demo.config.ts`.
  *
  * The package pulls all of shiki's grammars, which lands ~13MB of language
- * chunks in the output directory. The landing demo's scenario dispatches no
- * `coder::*` calls, so the diff views are unreachable — but the renderer
- * registry imports the family statically, so the specifier still has to
- * resolve. This keeps the graph honest and degrades to a plain notice if a
- * future scenario ever does render one.
+ * chunks in the output directory. The demo's sub-agents do write files, so
+ * the coder card is reachable — it just renders the body unhighlighted here.
+ * Everything around it (batch chips, paths, byte counts) is the real view.
  */
 
 export const DEFAULT_THEMES = { light: 'github-light', dark: 'github-dark' }
@@ -17,15 +15,22 @@ export interface FileContents {
   contents: string
 }
 
-function DiffUnavailable() {
+/** The body, monospaced and scrollable, with no tokenizer behind it. */
+function PlainFile({ contents }: { contents: string }) {
   return (
-    <div className="px-3 py-3 font-mono text-[12.5px] text-ink-ghost">
-      · diff rendering is not bundled in this demo
-    </div>
+    <pre className="max-h-[280px] overflow-auto whitespace-pre px-3 py-2 font-mono text-[12px] leading-[1.55] text-ink">
+      {contents}
+    </pre>
   )
 }
 
-export const File = DiffUnavailable
-export const MultiFileDiff = DiffUnavailable
+export function File({ file }: { file: FileContents }) {
+  return <PlainFile contents={file.contents} />
+}
+
+/** New-file diffs are all the demo produces: show the new side. */
+export function MultiFileDiff({ newFile }: { newFile: FileContents }) {
+  return <PlainFile contents={newFile.contents} />
+}
 
 export default { DEFAULT_THEMES, File, MultiFileDiff }

--- a/console/web/src/demo/usePlayer.ts
+++ b/console/web/src/demo/usePlayer.ts
@@ -121,6 +121,8 @@ export interface PlayerState {
   /** Characters of the prompt typed so far, for the composer. */
   typed: string
   waterfall: WaterfallData | null
+  /** The raw feed, for the live TimelineStrip masthead. */
+  spans: readonly StoredSpan[]
   spanCount: number
   callout: Callout | null
   /** The turn is between visible outputs — drives the thinking shimmer. */
@@ -155,6 +157,9 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
   // waterfall needs to repaint, and the pending tick owns the cadence.
   const spansRef = useRef<StoredSpan[]>([])
   const [waterfall, setWaterfall] = useState<WaterfallData | null>(null)
+  // The strip masthead reads spans directly (it does its own layout), so the
+  // repaint publishes the array alongside the derived waterfall.
+  const [spans, setSpans] = useState<readonly StoredSpan[]>([])
   const [spanCount, setSpanCount] = useState(0)
 
   const gateResolveRef = useRef<(() => void) | null>(null)
@@ -260,6 +265,7 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
 
   const repaintSpans = useCallback(() => {
     const spans = spansRef.current
+    setSpans(spans)
     setSpanCount(spans.length)
     setWaterfall(spans.length ? toWaterfallData(spans, TRACE_ID) : null)
   }, [])
@@ -325,6 +331,7 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
       setTyped('')
       showCallout(null)
       setWaterfall(null)
+      setSpans([])
       setSpanCount(0)
       setIsStreaming(false)
       setTurnPhase(null)
@@ -606,6 +613,7 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
     messages: activeChild ? activeChild.messages : messages,
     typed,
     waterfall,
+    spans,
     spanCount,
     callout,
     isThinking: activeChild ? activeChild.status === 'working' : rootThinking,

--- a/console/web/src/demo/usePlayer.ts
+++ b/console/web/src/demo/usePlayer.ts
@@ -39,7 +39,7 @@ import {
 export type Phase = 'idle' | 'typing' | 'streaming' | 'done'
 
 /** How long the finished turn stays up before the loop restarts. */
-const HOLD_MS = 9000
+const HOLD_MS = 14000
 const TYPE_MS_PER_CHAR = 42
 /** Repaint cadence while a span is still open, so its bar grows. */
 const PENDING_TICK_MS = 120
@@ -441,7 +441,12 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
               s.span_id === ev.id
                 ? {
                     ...s,
-                    end_time_unix_nano: now,
+                    /* An explicit duration is what the call really costs;
+                       the demo dwelt longer only so it could be seen. */
+                    end_time_unix_nano:
+                      ev.durationMs === undefined
+                        ? now
+                        : s.start_time_unix_nano + ev.durationMs,
                     status: ev.status ?? 'OK',
                     pending: false,
                   }

--- a/console/web/src/demo/usePlayer.ts
+++ b/console/web/src/demo/usePlayer.ts
@@ -647,7 +647,7 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
     callout,
     isThinking: activeChild ? activeChild.status === 'working' : rootThinking,
     thinkingDetail: activeChild
-      ? 'sub-agent working…'
+      ? 'subagent working…'
       : turnPhase === 'accepted'
         ? 'turn accepted, step queued…'
         : turnPhase === 'started'

--- a/console/web/src/demo/usePlayer.ts
+++ b/console/web/src/demo/usePlayer.ts
@@ -28,6 +28,7 @@ import type {
 } from '@/types/chat'
 import {
   type Callout,
+  type ChildEntry,
   type DemoEvent,
   MODEL_ID,
   PROMPT,
@@ -56,6 +57,47 @@ function uid(): string {
 
 /** Root chat title, shown in the sidebar. */
 const ROOT_TITLE = 'payments ledger'
+
+/** One replayed child entry, as the `Message` the transcript renders. */
+function childMessage(
+  sessionId: string,
+  index: number,
+  entry: ChildEntry,
+  now: number,
+): Message {
+  const id = `${sessionId}-${index}`
+  switch (entry.role) {
+    case 'thought':
+      return {
+        id,
+        role: 'thought',
+        content: entry.content,
+        durationMs: entry.durationMs,
+        createdAt: now,
+      }
+    case 'assistant':
+      return {
+        id,
+        role: 'assistant',
+        content: entry.content,
+        model: MODEL_ID,
+        mode: 'agent',
+        createdAt: now,
+      }
+    case 'function-trigger':
+      return {
+        id,
+        role: 'function-trigger',
+        functionId: entry.functionId,
+        input: entry.input,
+        output: entry.output,
+        durationMs: entry.durationMs,
+        running: false,
+        sessionId,
+        createdAt: now,
+      }
+  }
+}
 
 function rootConversation(status: Conversation['status']): Conversation {
   const now = Date.now()
@@ -159,6 +201,24 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
               updatedAt: now,
             },
           ],
+    )
+  }, [])
+
+  const appendChild = useCallback((id: string, entry: ChildEntry) => {
+    const now = Date.now()
+    setChildren((prev) =>
+      prev.map((c) =>
+        c.id === id
+          ? {
+              ...c,
+              updatedAt: now,
+              messages: [
+                ...c.messages,
+                childMessage(id, c.messages.length, entry, now),
+              ],
+            }
+          : c,
+      ),
     )
   }, [])
 
@@ -463,6 +523,10 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
             openChild(ev.session.id, ev.session.title, ev.session.task)
             break
           }
+          case 'demo-session-msg': {
+            appendChild(ev.id, ev.entry)
+            break
+          }
           case 'demo-session-done': {
             finishChild(ev.id, ev.result)
             break
@@ -505,6 +569,7 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
     repaintSpans,
     showCallout,
     openChild,
+    appendChild,
     finishChild,
   ])
 

--- a/console/web/src/demo/usePlayer.ts
+++ b/console/web/src/demo/usePlayer.ts
@@ -11,7 +11,7 @@
  * Lifecycle: idle → typing the prompt → streaming → done → (hold) → reset.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { StoredSpan } from '@/pages/TracesV2/api/traces'
 import {
   toWaterfallData,
@@ -19,6 +19,7 @@ import {
 } from '@/pages/TracesV2/lib/traceTransform'
 import type {
   AssistantMessage,
+  Conversation,
   FunctionTriggerMessage,
   Message,
   MessagePatch,
@@ -53,8 +54,27 @@ function uid(): string {
   return `demo-${seq}`
 }
 
+/** Root chat title, shown in the sidebar. */
+const ROOT_TITLE = 'payments ledger'
+
+function rootConversation(status: Conversation['status']): Conversation {
+  const now = Date.now()
+  return {
+    id: SESSION_ID,
+    title: ROOT_TITLE,
+    model: MODEL_ID,
+    mode: 'agent',
+    messages: [],
+    depth: 0,
+    status,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
 export interface PlayerState {
   phase: Phase
+  /** The selected session's transcript: the root turn, or a child's. */
   messages: Message[]
   /** Characters of the prompt typed so far, for the composer. */
   typed: string
@@ -70,6 +90,12 @@ export interface PlayerState {
     functionTriggerId: string,
     decision: 'allow' | 'deny',
   ) => Promise<void>
+  /** Root chat plus every session `harness::spawn` created, for the sidebar. */
+  conversations: Conversation[]
+  activeId: string
+  select: (id: string) => void
+  /** The selected session, when it is one of the children. */
+  activeChild: Conversation | null
 }
 
 export function usePlayer(active: boolean, loop = true): PlayerState {
@@ -79,6 +105,9 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
   const [callout, setCallout] = useState<Callout | null>(null)
   const [turnPhase, setTurnPhase] = useState<string | null>(null)
   const [isStreaming, setIsStreaming] = useState(false)
+  /* Child sessions, in spawn order, each carrying its own little transcript. */
+  const [children, setChildren] = useState<Conversation[]>([])
+  const [activeId, setActiveId] = useState<string>(SESSION_ID)
 
   // Spans live in a ref: the scenario mutates them far more often than the
   // waterfall needs to repaint, and the pending tick owns the cadence.
@@ -99,6 +128,64 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
     if (next) {
       calloutTimerRef.current = setTimeout(() => setCallout(null), CALLOUT_MS)
     }
+  }, [])
+
+  const openChild = useCallback((id: string, title: string, task: string) => {
+    const now = Date.now()
+    setChildren((prev) =>
+      prev.some((c) => c.id === id)
+        ? prev
+        : [
+            ...prev,
+            {
+              id,
+              title,
+              model: MODEL_ID,
+              mode: 'agent',
+              parentId: SESSION_ID,
+              depth: 1,
+              spawnedBy: 'agent',
+              status: 'working',
+              messages: [
+                {
+                  id: `${id}-task`,
+                  role: 'user',
+                  content: task,
+                  spawn: true,
+                  createdAt: now,
+                },
+              ],
+              createdAt: now,
+              updatedAt: now,
+            },
+          ],
+    )
+  }, [])
+
+  const finishChild = useCallback((id: string, result: string) => {
+    const now = Date.now()
+    setChildren((prev) =>
+      prev.map((c) =>
+        c.id === id
+          ? {
+              ...c,
+              status: 'done',
+              updatedAt: now,
+              messages: [
+                ...c.messages,
+                {
+                  id: `${id}-result`,
+                  role: 'assistant',
+                  content: result,
+                  model: MODEL_ID,
+                  mode: 'agent',
+                  createdAt: now,
+                },
+              ],
+            }
+          : c,
+      ),
+    )
   }, [])
 
   const append = useCallback((message: Message) => {
@@ -173,6 +260,8 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
       /* reset */
       spansRef.current = []
       setMessages([])
+      setChildren([])
+      setActiveId(SESSION_ID)
       setTyped('')
       showCallout(null)
       setWaterfall(null)
@@ -365,6 +454,14 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
             showCallout(ev.callout)
             break
           }
+          case 'demo-session-open': {
+            openChild(ev.session.id, ev.session.title, ev.session.task)
+            break
+          }
+          case 'demo-session-done': {
+            finishChild(ev.id, ev.result)
+            break
+          }
         }
 
         if (
@@ -395,12 +492,21 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
       clearTimeout(calloutTimerRef.current)
       gateResolveRef.current = null
     }
-  }, [active, loop, append, patch, repaintSpans, showCallout])
+  }, [
+    active,
+    loop,
+    append,
+    patch,
+    repaintSpans,
+    showCallout,
+    openChild,
+    finishChild,
+  ])
 
   const lastRole = messages.length
     ? messages[messages.length - 1].role
     : undefined
-  const isThinking =
+  const rootThinking =
     isStreaming &&
     (lastRole === 'user' ||
       (lastRole === 'function-trigger' &&
@@ -408,21 +514,43 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
         !(messages[messages.length - 1] as FunctionTriggerMessage)
           .pendingApproval))
 
+  /* Rebuilt only when a child or the root's status changes — not per token,
+     which is what the transcript re-renders on. */
+  const conversations = useMemo(
+    () => [
+      rootConversation(
+        phase === 'streaming' ? 'working' : phase === 'done' ? 'done' : 'idle',
+      ),
+      ...children,
+    ],
+    [children, phase],
+  )
+
+  const activeChild =
+    activeId === SESSION_ID
+      ? null
+      : (children.find((c) => c.id === activeId) ?? null)
+
   return {
     phase,
-    messages,
+    messages: activeChild ? activeChild.messages : messages,
     typed,
     waterfall,
     spanCount,
     callout,
-    isThinking,
-    thinkingDetail:
-      turnPhase === 'accepted'
+    isThinking: activeChild ? activeChild.status === 'working' : rootThinking,
+    thinkingDetail: activeChild
+      ? 'sub-agent working…'
+      : turnPhase === 'accepted'
         ? 'turn accepted, step queued…'
         : turnPhase === 'started'
           ? 'harness::turn started…'
           : undefined,
     resolveApproval,
+    conversations,
+    activeId,
+    select: setActiveId,
+    activeChild,
   }
 }
 

--- a/console/web/src/demo/usePlayer.ts
+++ b/console/web/src/demo/usePlayer.ts
@@ -145,6 +145,8 @@ export interface PlayerState {
   togglePause: () => void
   /** Restart the turn from the top, whatever state it is in. */
   replay: () => void
+  /** Bumped by every restart, for anything outside that plays along. */
+  runKey: number
 }
 
 export function usePlayer(active: boolean, loop = true): PlayerState {
@@ -315,17 +317,18 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
 
     const stale = () => signal.aborted || runIdRef.current !== runId
 
+    /* The listener is dropped when the timer wins too: one controller serves a
+       whole looping run, and the paused-hold polls every 150ms, so leaving
+       them attached grows the list for as long as the demo is on screen. */
     const wait = (ms: number) =>
       new Promise<void>((resolve) => {
-        const t = setTimeout(resolve, ms)
-        signal.addEventListener(
-          'abort',
-          () => {
-            clearTimeout(t)
-            resolve()
-          },
-          { once: true },
-        )
+        const done = () => {
+          clearTimeout(t)
+          signal.removeEventListener('abort', done)
+          resolve()
+        }
+        const t = setTimeout(done, ms)
+        signal.addEventListener('abort', done, { once: true })
       })
 
     const holdWhilePaused = async () => {
@@ -661,6 +664,7 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
     paused,
     togglePause,
     replay,
+    runKey,
   }
 }
 

--- a/console/web/src/demo/usePlayer.ts
+++ b/console/web/src/demo/usePlayer.ts
@@ -1,0 +1,429 @@
+/**
+ * Drives the landing demo: walks `runScenario()` and folds its events into
+ * the three pieces of state the surface renders.
+ *
+ * The `StreamEvent` half of the switch below is the reducer from
+ * `ChatView`'s stream loop (`components/chat/ChatView.tsx`), trimmed to the
+ * cases a scripted turn can produce. Keeping the same reducer is the point:
+ * the transcript is built the way the real console builds it, so
+ * `MessageList` renders exactly what it renders in the product.
+ *
+ * Lifecycle: idle → typing the prompt → streaming → done → (hold) → reset.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { StoredSpan } from '@/pages/TracesV2/api/traces'
+import {
+  toWaterfallData,
+  type WaterfallData,
+} from '@/pages/TracesV2/lib/traceTransform'
+import type {
+  AssistantMessage,
+  FunctionTriggerMessage,
+  Message,
+  MessagePatch,
+  ThoughtMessage,
+  UserMessage,
+} from '@/types/chat'
+import {
+  type Callout,
+  type DemoEvent,
+  MODEL_ID,
+  PROMPT,
+  runScenario,
+  SESSION_ID,
+  TRACE_ID,
+} from './scenario'
+
+export type Phase = 'idle' | 'typing' | 'streaming' | 'done'
+
+/** How long the finished turn stays up before the loop restarts. */
+const HOLD_MS = 9000
+const TYPE_MS_PER_CHAR = 42
+/** Repaint cadence while a span is still open, so its bar grows. */
+const PENDING_TICK_MS = 120
+/** The gate releases itself if nobody clicks approve. */
+const GATE_TIMEOUT_MS = 5200
+/** A callout clears itself so a stale one never annotates the wrong beat. */
+const CALLOUT_MS = 11000
+
+let seq = 0
+function uid(): string {
+  seq += 1
+  return `demo-${seq}`
+}
+
+export interface PlayerState {
+  phase: Phase
+  messages: Message[]
+  /** Characters of the prompt typed so far, for the composer. */
+  typed: string
+  waterfall: WaterfallData | null
+  spanCount: number
+  callout: Callout | null
+  /** The turn is between visible outputs — drives the thinking shimmer. */
+  isThinking: boolean
+  thinkingDetail?: string
+  /** Set while a call sits in the approval gate. */
+  resolveApproval: (
+    sessionId: string,
+    functionTriggerId: string,
+    decision: 'allow' | 'deny',
+  ) => Promise<void>
+}
+
+export function usePlayer(active: boolean, loop = true): PlayerState {
+  const [phase, setPhase] = useState<Phase>('idle')
+  const [messages, setMessages] = useState<Message[]>([])
+  const [typed, setTyped] = useState('')
+  const [callout, setCallout] = useState<Callout | null>(null)
+  const [turnPhase, setTurnPhase] = useState<string | null>(null)
+  const [isStreaming, setIsStreaming] = useState(false)
+
+  // Spans live in a ref: the scenario mutates them far more often than the
+  // waterfall needs to repaint, and the pending tick owns the cadence.
+  const spansRef = useRef<StoredSpan[]>([])
+  const [waterfall, setWaterfall] = useState<WaterfallData | null>(null)
+  const [spanCount, setSpanCount] = useState(0)
+
+  const gateResolveRef = useRef<(() => void) | null>(null)
+  const calloutTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  )
+  const runIdRef = useRef(0)
+
+  /** Show a callout, and retire it on its own so it never outlives its beat. */
+  const showCallout = useCallback((next: Callout | null) => {
+    clearTimeout(calloutTimerRef.current)
+    setCallout(next)
+    if (next) {
+      calloutTimerRef.current = setTimeout(() => setCallout(null), CALLOUT_MS)
+    }
+  }, [])
+
+  const append = useCallback((message: Message) => {
+    setMessages((prev) => [...prev, message])
+  }, [])
+
+  const patch = useCallback((id: string, p: MessagePatch) => {
+    setMessages((prev) =>
+      prev.map((m) => (m.id === id ? ({ ...m, ...p } as Message) : m)),
+    )
+  }, [])
+
+  const repaintSpans = useCallback(() => {
+    const spans = spansRef.current
+    setSpanCount(spans.length)
+    setWaterfall(spans.length ? toWaterfallData(spans, TRACE_ID) : null)
+  }, [])
+
+  const resolveApproval = useCallback(async () => {
+    gateResolveRef.current?.()
+    gateResolveRef.current = null
+  }, [])
+
+  /* Repaint while anything is still open so pending bars grow. */
+  useEffect(() => {
+    if (phase !== 'streaming') return
+    const t = setInterval(() => {
+      if (spansRef.current.some((s) => s.pending)) repaintSpans()
+    }, PENDING_TICK_MS)
+    return () => clearInterval(t)
+  }, [phase, repaintSpans])
+
+  useEffect(() => {
+    if (!active) return
+    runIdRef.current += 1
+    const runId = runIdRef.current
+    const controller = new AbortController()
+    const { signal } = controller
+    let holdTimer: ReturnType<typeof setTimeout> | undefined
+
+    const stale = () => signal.aborted || runIdRef.current !== runId
+
+    const wait = (ms: number) =>
+      new Promise<void>((resolve) => {
+        const t = setTimeout(resolve, ms)
+        signal.addEventListener(
+          'abort',
+          () => {
+            clearTimeout(t)
+            resolve()
+          },
+          { once: true },
+        )
+      })
+
+    const gate = (_functionTriggerId: string) =>
+      new Promise<void>((resolve) => {
+        let done = false
+        const finish = () => {
+          if (done) return
+          done = true
+          gateResolveRef.current = null
+          clearTimeout(timer)
+          resolve()
+        }
+        const timer = setTimeout(finish, GATE_TIMEOUT_MS)
+        gateResolveRef.current = finish
+        signal.addEventListener('abort', finish, { once: true })
+      })
+
+    async function play() {
+      /* reset */
+      spansRef.current = []
+      setMessages([])
+      setTyped('')
+      showCallout(null)
+      setWaterfall(null)
+      setSpanCount(0)
+      setIsStreaming(false)
+      setTurnPhase(null)
+      setPhase('typing')
+
+      /* type the prompt into the composer */
+      await wait(700)
+      for (let i = 1; i <= PROMPT.length; i++) {
+        if (stale()) return
+        setTyped(PROMPT.slice(0, i))
+        await wait(TYPE_MS_PER_CHAR * (0.55 + Math.random() * 0.9))
+      }
+      if (stale()) return
+      await wait(520)
+
+      /* submit */
+      const userMsg: UserMessage = {
+        id: uid(),
+        role: 'user',
+        content: PROMPT,
+        createdAt: Date.now(),
+      }
+      setTyped('')
+      append(userMsg)
+      setPhase('streaming')
+      setIsStreaming(true)
+
+      /* ── the ChatView stream reducer ─────────────────────────────── */
+      let thoughtId: string | null = null
+      let thoughtBuffer = ''
+      let fcallId: string | null = null
+      const fcallMap = new Map<string, string>()
+      let assistantId: string | null = null
+      let assistantBuffer = ''
+
+      for await (const event of runScenario({ signal, gate })) {
+        if (stale()) return
+        const ev = event as DemoEvent
+        switch (ev.kind) {
+          case 'thought-start': {
+            const msg: ThoughtMessage = {
+              id: uid(),
+              role: 'thought',
+              content: '',
+              durationMs: 0,
+              streaming: true,
+              createdAt: Date.now(),
+            }
+            thoughtId = msg.id
+            thoughtBuffer = ''
+            append(msg)
+            break
+          }
+          case 'thought-token': {
+            if (!thoughtId) break
+            thoughtBuffer += ev.token
+            patch(thoughtId, { content: thoughtBuffer })
+            break
+          }
+          case 'thought-end': {
+            if (!thoughtId) break
+            patch(thoughtId, { streaming: false, durationMs: ev.durationMs })
+            thoughtId = null
+            break
+          }
+          case 'fcall-start': {
+            if (assistantId) {
+              patch(assistantId, { streaming: false })
+              assistantId = null
+              assistantBuffer = ''
+            }
+            const msg: FunctionTriggerMessage = {
+              id: uid(),
+              role: 'function-trigger',
+              functionId: ev.functionId,
+              input: ev.input,
+              running: !ev.pendingApproval,
+              pendingApproval: ev.pendingApproval,
+              functionTriggerId: ev.functionTriggerId,
+              sessionId: ev.sessionId,
+              createdAt: Date.now(),
+            }
+            fcallId = msg.id
+            if (ev.functionTriggerId) fcallMap.set(msg.id, ev.functionTriggerId)
+            append(msg)
+            break
+          }
+          case 'fcall-approval-cleared': {
+            const clearedId = [...fcallMap.entries()].find(
+              ([, fcid]) => fcid === ev.functionTriggerId,
+            )?.[0]
+            if (clearedId) {
+              patch(clearedId, {
+                pendingApproval: false,
+                ...(ev.running ? { running: true } : {}),
+              })
+            }
+            break
+          }
+          case 'fcall-end': {
+            const targetId: string | null = ev.functionTriggerId
+              ? ([...fcallMap.entries()].find(
+                  ([, fcid]) => fcid === ev.functionTriggerId,
+                )?.[0] ?? fcallId)
+              : fcallId
+            if (!targetId) break
+            patch(targetId, {
+              output: ev.output,
+              durationMs: ev.durationMs,
+              running: false,
+              pendingApproval: false,
+            })
+            fcallMap.delete(targetId)
+            if (targetId === fcallId) fcallId = null
+            break
+          }
+          case 'assistant-token': {
+            if (!assistantId) {
+              const msg: AssistantMessage = {
+                id: uid(),
+                role: 'assistant',
+                content: '',
+                model: MODEL_ID,
+                mode: 'agent',
+                streaming: true,
+                createdAt: Date.now(),
+              }
+              assistantId = msg.id
+              assistantBuffer = ''
+              append(msg)
+            }
+            assistantBuffer += ev.token
+            patch(assistantId, { content: assistantBuffer })
+            break
+          }
+          case 'assistant-end': {
+            if (assistantId) patch(assistantId, { streaming: false })
+            assistantId = null
+            assistantBuffer = ''
+            break
+          }
+          case 'turn-status': {
+            setTurnPhase(ev.phase)
+            break
+          }
+
+          /* ── demo-only markers ─────────────────────────────────── */
+          case 'demo-span-open': {
+            const now = Date.now()
+            spansRef.current = [
+              ...spansRef.current,
+              {
+                trace_id: TRACE_ID,
+                span_id: ev.span.id,
+                parent_span_id: ev.span.parent,
+                name: ev.span.name,
+                kind: ev.span.kind,
+                service_name: ev.span.service,
+                start_time_unix_nano: now,
+                end_time_unix_nano: 0,
+                status: 'UNSET',
+                attributes: ev.span.attributes ?? [],
+                events: [],
+                links: [],
+                pending: true,
+              },
+            ]
+            repaintSpans()
+            break
+          }
+          case 'demo-span-close': {
+            const now = Date.now()
+            spansRef.current = spansRef.current.map((s) =>
+              s.span_id === ev.id
+                ? {
+                    ...s,
+                    end_time_unix_nano: now,
+                    status: ev.status ?? 'OK',
+                    pending: false,
+                  }
+                : s,
+            )
+            repaintSpans()
+            break
+          }
+          case 'demo-callout': {
+            showCallout(ev.callout)
+            break
+          }
+        }
+
+        if (
+          ev.kind === 'fcall-start' ||
+          ev.kind === 'assistant-token' ||
+          ev.kind === 'thought-start'
+        ) {
+          setTurnPhase(null)
+        }
+      }
+
+      if (stale()) return
+      setIsStreaming(false)
+      setPhase('done')
+
+      if (loop) {
+        holdTimer = setTimeout(() => {
+          if (!stale()) play()
+        }, HOLD_MS)
+      }
+    }
+
+    play()
+
+    return () => {
+      controller.abort()
+      clearTimeout(holdTimer)
+      clearTimeout(calloutTimerRef.current)
+      gateResolveRef.current = null
+    }
+  }, [active, loop, append, patch, repaintSpans, showCallout])
+
+  const lastRole = messages.length
+    ? messages[messages.length - 1].role
+    : undefined
+  const isThinking =
+    isStreaming &&
+    (lastRole === 'user' ||
+      (lastRole === 'function-trigger' &&
+        !(messages[messages.length - 1] as FunctionTriggerMessage).running &&
+        !(messages[messages.length - 1] as FunctionTriggerMessage)
+          .pendingApproval))
+
+  return {
+    phase,
+    messages,
+    typed,
+    waterfall,
+    spanCount,
+    callout,
+    isThinking,
+    thinkingDetail:
+      turnPhase === 'accepted'
+        ? 'turn accepted, step queued…'
+        : turnPhase === 'started'
+          ? 'harness::turn started…'
+          : undefined,
+    resolveApproval,
+  }
+}
+
+export { SESSION_ID }

--- a/console/web/src/demo/usePlayer.ts
+++ b/console/web/src/demo/usePlayer.ts
@@ -140,6 +140,11 @@ export interface PlayerState {
   select: (id: string) => void
   /** The selected session, when it is one of the children. */
   activeChild: Conversation | null
+  /** Reader-controlled freeze: the run holds between events until resumed. */
+  paused: boolean
+  togglePause: () => void
+  /** Restart the turn from the top, whatever state it is in. */
+  replay: () => void
 }
 
 export function usePlayer(active: boolean, loop = true): PlayerState {
@@ -161,6 +166,21 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
   // repaint publishes the array alongside the derived waterfall.
   const [spans, setSpans] = useState<readonly StoredSpan[]>([])
   const [spanCount, setSpanCount] = useState(0)
+
+  /* Pause is a ref the running loop polls (state alone would be stale inside
+     the closure) plus state for the button label. */
+  const [paused, setPaused] = useState(false)
+  const pausedRef = useRef(false)
+  const togglePause = useCallback(() => {
+    pausedRef.current = !pausedRef.current
+    setPaused(pausedRef.current)
+  }, [])
+  const [runKey, setRunKey] = useState(0)
+  const replay = useCallback(() => {
+    pausedRef.current = false
+    setPaused(false)
+    setRunKey((k) => k + 1)
+  }, [])
 
   const gateResolveRef = useRef<(() => void) | null>(null)
   const calloutTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
@@ -279,7 +299,8 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
   useEffect(() => {
     if (phase !== 'streaming') return
     const t = setInterval(() => {
-      if (spansRef.current.some((s) => s.pending)) repaintSpans()
+      if (!pausedRef.current && spansRef.current.some((s) => s.pending))
+        repaintSpans()
     }, PENDING_TICK_MS)
     return () => clearInterval(t)
   }, [phase, repaintSpans])
@@ -306,6 +327,10 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
           { once: true },
         )
       })
+
+    const holdWhilePaused = async () => {
+      while (pausedRef.current && !stale()) await wait(150)
+    }
 
     const gate = (_functionTriggerId: string) =>
       new Promise<void>((resolve) => {
@@ -340,6 +365,7 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
       /* type the prompt into the composer */
       await wait(700)
       for (let i = 1; i <= PROMPT.length; i++) {
+        await holdWhilePaused()
         if (stale()) return
         setTyped(PROMPT.slice(0, i))
         await wait(TYPE_MS_PER_CHAR * (0.55 + Math.random() * 0.9))
@@ -368,6 +394,8 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
       let assistantBuffer = ''
 
       for await (const event of runScenario({ signal, gate })) {
+        /* The generator is pull-based: holding here suspends the scenario. */
+        await holdWhilePaused()
         if (stale()) return
         const ev = event as DemoEvent
         switch (ev.kind) {
@@ -571,6 +599,7 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
   }, [
     active,
     loop,
+    runKey,
     append,
     patch,
     repaintSpans,
@@ -629,6 +658,9 @@ export function usePlayer(active: boolean, loop = true): PlayerState {
     activeId,
     select: setActiveId,
     activeChild,
+    paused,
+    togglePause,
+    replay,
   }
 }
 

--- a/console/web/src/index.css
+++ b/console/web/src/index.css
@@ -331,9 +331,25 @@
   animation: timeline-enter 240ms ease-out both;
 }
 
+/* live-timeline re-packs — geometry changes glide instead of teleporting.
+   Composes with timeline-enter: the entrance animates transform/opacity,
+   this transitions the box, so a new bar mounts in place and only later
+   moves smoothly. */
+@utility timeline-glide {
+  transition:
+    left 300ms ease,
+    top 300ms ease,
+    width 300ms ease,
+    height 300ms ease,
+    max-width 300ms ease;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .timeline-enter {
     animation: none;
+  }
+  .timeline-glide {
+    transition: none;
   }
 }
 

--- a/console/web/src/lib/format-call-duration.ts
+++ b/console/web/src/lib/format-call-duration.ts
@@ -1,0 +1,14 @@
+/**
+ * How long a function call took, for the chat surface's card header.
+ *
+ * Milliseconds above a millisecond, exactly as before. Below one, the same
+ * `μs` the traces surface uses (`pages/TracesV2/lib/traceUtils.ts`): a lot of
+ * what an agent dispatches is engine-local — a trigger registration, a state
+ * read — and finishes in microseconds, where rounding to `0ms` reads like the
+ * call never happened.
+ */
+export function formatCallDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '0μs'
+  if (ms < 1) return `${Math.max(1, Math.round(ms * 1000))}μs`
+  return `${Math.round(ms)}ms`
+}

--- a/console/web/src/pages/TracesV2/components/WaterfallChart.tsx
+++ b/console/web/src/pages/TracesV2/components/WaterfallChart.tsx
@@ -108,6 +108,12 @@ interface WaterfallChartProps {
    * only when BOTH this and `spanGroupKey` are provided.
    */
   spanFilter?: SpanFilterControls
+  /**
+   * Show expand-all / collapse-all. Pass `false` when the trace is still
+   * arriving: every change to `data.spans` re-expands the tree, so a
+   * collapse taken mid-stream is undone by the next span to land.
+   */
+  showExpandControls?: boolean
 }
 
 interface WaterfallRowProps {
@@ -338,6 +344,12 @@ function indentKeys(spanId: string, depth: number): string[] {
 interface ToolbarProps {
   expandAll: () => void
   collapseAll: () => void
+  /**
+   * Expand-all / collapse-all. Off for a trace that is still arriving: the
+   * effect below re-expands everything whenever `data.spans` changes, so a
+   * collapse taken mid-stream is undone by the next span.
+   */
+  showExpandControls: boolean
   spanGroups: readonly SpanGroup[]
   workerGroups: readonly SpanGroup[]
   internalGroups: readonly SpanGroup[]
@@ -351,6 +363,7 @@ function Toolbar(props: ToolbarProps) {
   const {
     expandAll,
     collapseAll,
+    showExpandControls,
     spanGroups,
     workerGroups,
     internalGroups,
@@ -362,32 +375,36 @@ function Toolbar(props: ToolbarProps) {
   return (
     <div className="flex items-center justify-between px-3 py-2 border-b border-rule bg-panel">
       <div className="flex items-center gap-1.5">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={expandAll}
-              aria-label="expand all spans"
-              className="inline-flex items-center justify-center w-7 h-7 border bg-bg text-ink-faint border-rule hover:text-ink hover:border-ink transition-colors"
-            >
-              <ChevronsDown className="w-3.5 h-3.5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">expand all</TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={collapseAll}
-              aria-label="collapse all spans"
-              className="inline-flex items-center justify-center w-7 h-7 border bg-bg text-ink-faint border-rule hover:text-ink hover:border-ink transition-colors"
-            >
-              <ChevronsUp className="w-3.5 h-3.5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">collapse all</TooltipContent>
-        </Tooltip>
+        {showExpandControls ? (
+          <>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={expandAll}
+                  aria-label="expand all spans"
+                  className="inline-flex items-center justify-center w-7 h-7 border bg-bg text-ink-faint border-rule hover:text-ink hover:border-ink transition-colors"
+                >
+                  <ChevronsDown className="w-3.5 h-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">expand all</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={collapseAll}
+                  aria-label="collapse all spans"
+                  className="inline-flex items-center justify-center w-7 h-7 border bg-bg text-ink-faint border-rule hover:text-ink hover:border-ink transition-colors"
+                >
+                  <ChevronsUp className="w-3.5 h-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">collapse all</TooltipContent>
+            </Tooltip>
+          </>
+        ) : null}
         {spanFilter &&
           (spanGroups.length > 0 ||
             workerGroups.length > 0 ||
@@ -427,6 +444,7 @@ export function WaterfallChart({
   selectedSpanId,
   spanGroupKey,
   spanFilter,
+  showExpandControls = true,
 }: WaterfallChartProps) {
   const [displayState, dispatch] = useReducer(
     displayReducer,
@@ -707,6 +725,7 @@ export function WaterfallChart({
   const toolbarProps: ToolbarProps = {
     expandAll,
     collapseAll,
+    showExpandControls,
     spanGroups,
     workerGroups,
     internalGroups,

--- a/console/web/src/pages/TracesV2/components/timeline/TraceTimeline.tsx
+++ b/console/web/src/pages/TracesV2/components/timeline/TraceTimeline.tsx
@@ -124,6 +124,9 @@ interface PlacedSpan {
 interface TraceLayout {
   placed: PlacedSpan[]
   lineCount: number
+  /** each span's packed offset relative to its parent — fed back into the
+   *  next `buildLayout` so a streaming re-pack keeps bars on their lines */
+  offsets: ReadonlyMap<string, number>
 }
 
 /** A subtree's footprint: the lines it spans and its full time extent. */
@@ -170,6 +173,12 @@ function rowTop(line: number): number {
  * stack further down. Rectangles never interleave, which keeps every
  * subtree a contiguous visual block.
  *
+ * Sticky re-packs: when `prev` holds a span's offset from the previous
+ * layout and the subtree still fits there, it stays — a streaming trace
+ * re-packs on every span, and without the preference a growing sibling
+ * reshuffles lines that were already settled. Only spans whose remembered
+ * spot now collides fall back to first-fit.
+ *
  * Mutates each child's `info.offset`; returns the deepest occupied
  * offset+height (i.e. lines consumed), or `firstOffset` when empty.
  */
@@ -177,25 +186,41 @@ function packSubtrees(
   children: readonly VisualizationSpan[],
   info: ReadonlyMap<string, SubtreeInfo>,
   firstOffset: number,
+  prev?: ReadonlyMap<string, number>,
 ): number {
   const placed: SubtreeInfo[] = []
   let deepest = firstOffset
+  const collides = (rect: SubtreeInfo, offset: number): boolean => {
+    for (const other of placed) {
+      const timeOverlap =
+        rect.minStart < other.maxEnd && other.minStart < rect.maxEnd
+      const lineOverlap =
+        offset < other.offset + other.height &&
+        other.offset < offset + rect.height
+      if (timeOverlap && lineOverlap) return true
+    }
+    return false
+  }
   for (const child of children) {
     const rect = info.get(child.span_id)
     if (!rect) continue
-    let offset = firstOffset
-    let moved = true
-    while (moved) {
-      moved = false
-      for (const other of placed) {
-        const timeOverlap =
-          rect.minStart < other.maxEnd && other.minStart < rect.maxEnd
-        const lineOverlap =
-          offset < other.offset + other.height &&
-          other.offset < offset + rect.height
-        if (timeOverlap && lineOverlap) {
-          offset = other.offset + other.height
-          moved = true
+    const kept = prev?.get(child.span_id)
+    let offset: number
+    if (kept != null && kept >= firstOffset && !collides(rect, kept)) {
+      // ponytail: holes a departed subtree leaves behind persist until the
+      // remembered spot collides; re-compact from scratch if sparse layouts
+      // ever matter more than stability.
+      offset = kept
+    } else {
+      offset = firstOffset
+      while (collides(rect, offset)) {
+        for (const other of placed) {
+          const timeOverlap =
+            rect.minStart < other.maxEnd && other.minStart < rect.maxEnd
+          const lineOverlap =
+            offset < other.offset + other.height &&
+            other.offset < offset + rect.height
+          if (timeOverlap && lineOverlap) offset = other.offset + other.height
         }
       }
     }
@@ -223,6 +248,7 @@ function packSubtrees(
 function buildLayout(
   source: readonly VisualizationSpan[],
   spans: readonly TimelineSpan[],
+  prev?: ReadonlyMap<string, number>,
 ): TraceLayout {
   const byId = new Map(spans.map((s) => [s.id, s]))
   const childrenOf = new Map<string, VisualizationSpan[]>()
@@ -281,11 +307,11 @@ function buildLayout(
         if (ki.maxEnd > maxEnd) maxEnd = ki.maxEnd
       }
     }
-    const height = kids ? Math.max(1, packSubtrees(kids, info, 1)) : 1
+    const height = kids ? Math.max(1, packSubtrees(kids, info, 1, prev)) : 1
     info.set(id, { height, minStart, maxEnd, offset: 0 })
   }
 
-  let lineCount = packSubtrees(roots, info, 0)
+  let lineCount = packSubtrees(roots, info, 0, prev)
 
   // Pre-order: absolute lines, parents emitted before their children.
   const placed: PlacedSpan[] = []
@@ -326,7 +352,10 @@ function buildLayout(
       if (span) placed.push({ span, line: lineCount++, parentIndex: null })
     }
   }
-  return { placed, lineCount }
+
+  const offsets = new Map<string, number>()
+  for (const [id, i] of info) offsets.set(id, i.offset)
+  return { placed, lineCount, offsets }
 }
 
 export function TraceTimeline({
@@ -414,10 +443,14 @@ export function TraceTimeline({
   )
   const total = Math.max(detail.totalDurationMs, 1)
 
+  // A cache, never a dependency: each layout prefers the lines the previous
+  // one assigned, so a streaming re-pack moves as few bars as possible.
+  const stickyOffsets = useRef<ReadonlyMap<string, number>>(new Map())
   const layout = useMemo(
-    () => buildLayout(visibleData.spans, detail.spans),
+    () => buildLayout(visibleData.spans, detail.spans, stickyOffsets.current),
     [visibleData.spans, detail.spans],
   )
+  stickyOffsets.current = layout.offsets
 
   const innerWidth = Math.max(stage.width - PADDING_X * 2, 0)
   const pxPerMs = innerWidth > 0 ? innerWidth / total : 0
@@ -680,7 +713,7 @@ export function TraceTimeline({
                   <div
                     key={rail.id}
                     aria-hidden
-                    className="absolute w-px bg-rule"
+                    className="timeline-glide absolute w-px bg-rule"
                     style={{
                       left: rail.left,
                       top: rail.top,
@@ -692,7 +725,7 @@ export function TraceTimeline({
                   <div
                     key={stub.id}
                     aria-hidden
-                    className="absolute h-px bg-rule"
+                    className="timeline-glide absolute h-px bg-rule"
                     style={{
                       left: stub.left,
                       top: stub.top,
@@ -744,7 +777,7 @@ export function TraceTimeline({
                           onSpanClick ? () => handleClick(span) : undefined
                         }
                         className={cn(
-                          'timeline-enter absolute flex items-center gap-1 overflow-hidden rounded-[4px] px-[3px]',
+                          'timeline-enter timeline-glide absolute flex items-center gap-1 overflow-hidden rounded-[4px] px-[3px]',
                           'focus-visible:outline-1 focus-visible:outline-accent',
                           onSpanClick ? 'cursor-pointer' : 'cursor-default',
                         )}
@@ -773,7 +806,7 @@ export function TraceTimeline({
                       {spillLabel && (
                         <span
                           aria-hidden
-                          className="pointer-events-none absolute overflow-hidden font-mono text-[10px] leading-none lowercase whitespace-nowrap text-ellipsis text-ink-faint"
+                          className="timeline-glide pointer-events-none absolute overflow-hidden font-mono text-[10px] leading-none lowercase whitespace-nowrap text-ellipsis text-ink-faint"
                           style={{
                             left: spillLeft,
                             top: top + BAR_HEIGHT / 2 - 5,

--- a/console/web/vite.demo.config.ts
+++ b/console/web/vite.demo.config.ts
@@ -19,8 +19,11 @@ const pierreStub = fileURLToPath(
 )
 
 export default defineConfig({
-  // Relative asset paths: the site serves this from an arbitrary subpath.
-  base: './',
+  // Absolute asset paths at the site's mount point. Relative ('./') paths
+  // break behind Vercel's cleanUrls, which 308s /console-demo/index.html to
+  // /console-demo (no trailing slash), making ./assets/* resolve to the
+  // domain root. The marketing site vendors this build at /console-demo/.
+  base: '/console-demo/',
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: [

--- a/console/web/vite.demo.config.ts
+++ b/console/web/vite.demo.config.ts
@@ -1,0 +1,42 @@
+/**
+ * Build config for the landing-page demo (`npm run build:demo`).
+ *
+ * Produces a standalone page in `dist-demo/` that the marketing site vendors
+ * and embeds in an iframe. Separate from the console build on purpose: no
+ * engine client, no injectable-UI import map, and two heavy specifiers the
+ * demo can never reach are aliased to stubs so their chunks stay out of the
+ * committed artifact.
+ */
+
+import { fileURLToPath, URL } from 'node:url'
+import tailwindcss from '@tailwindcss/vite'
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+
+const src = fileURLToPath(new URL('./src', import.meta.url))
+const pierreStub = fileURLToPath(
+  new URL('./src/demo/stubs/pierre-diffs.tsx', import.meta.url),
+)
+
+export default defineConfig({
+  // Relative asset paths: the site serves this from an arbitrary subpath.
+  base: './',
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: [
+      // `@pierre/diffs` drags in every shiki grammar (~13MB of chunks) for
+      // coder diff views the demo never renders. Order matters: the
+      // `/react` entry must match before the bare specifier.
+      { find: '@pierre/diffs/react', replacement: pierreStub },
+      { find: '@pierre/diffs', replacement: pierreStub },
+      { find: '@', replacement: src },
+    ],
+  },
+  build: {
+    outDir: 'dist-demo',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: fileURLToPath(new URL('./demo.html', import.meta.url)),
+    },
+  },
+})


### PR DESCRIPTION
## What

A separate vite build (`pnpm build:demo` / `vite.demo.config.ts`) that renders the console's real chat transcript and traces surface replaying a scripted turn (`web/src/demo/`). The iii.dev website vendors the output of this build at `/console-demo/` and embeds it in the landing page's scroll-pinned console section, so this processing and bundling exists for the website: it gets the real product UI without depending on the console's toolchain, and the website CI stays standalone (see `website/scripts/sync-console-demo.sh` in iii-hq/iii).

The demo entry is its own `demo.html` with no engine client and no injectable-UI import map; `@pierre/diffs` is stubbed so ~13MB of shiki grammars stay out of the vendored artifact, and assets build with absolute `/console-demo/` paths to survive Vercel's cleanUrls.

## Demo-local surface (`web/src/demo/`, not in the console bundle)

- `LandingDemo.tsx` — chrome, transcript + traces panes, pause/replay controls, chat-only layout and a simplified-view notice on phone widths
- `scenario.ts` / `usePlayer.ts` — the scripted turn, folded through the same stream reducer `ChatView` uses
- `EmptyState.tsx` — demo-local greeting that scrolls away with the transcript

## Product changes (deliberate, small)

- `MessageList` gains an optional `header` slot (renders nothing when unset — the real console is unchanged)
- `Message`/`FunctionTriggerCard` gain optional `defaultOpen` props (off by default)
- `WaterfallChart` expand controls become suppressible (`showExpandControls`, default `true`)
- sub-millisecond call durations render as `Nμs` instead of `0ms` in chat call cards
- live trace timeline re-packs glide instead of teleporting (`timeline-glide`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standalone landing-page demo with replayable conversations, traces, waterfall views, approvals, callouts, and responsive layout.
  * Introduced demo build support and a dedicated HTML entrypoint with light/dark theme query handling.
  * Function-call cards/groups can render expanded by default; message lists can include an optional header.
* **Bug Fixes**
  * Improved timeline stability with sticky re-packing and glide transitions; reduced-motion mode further limits timeline motion.
  * Waterfall expand/collapse controls can now be hidden.
* **Enhancements**
  * Call durations are now formatted more readably with microsecond precision and edge-case handling.
* **Chores**
  * Updated demo build output ignoring for generated `dist-demo`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->