### PR TITLE
(MOT-4269) test(harness): harden reactive automation validation

### DIFF
--- a/harness/tests/e2e/src/scenarios/reactive_automation/evaluate.rs
+++ b/harness/tests/e2e/src/scenarios/reactive_automation/evaluate.rs
@@ -59,12 +59,11 @@ pub(super) fn score(evidence: &Evidence, names: &ScenarioNames) -> ObjectiveEval
     .iter()
     .all(|name| evidence.existing_tables.contains(*name));
 
-    let orders_complete = evidence.order_summary.as_ref().is_some_and(|summary| {
-        summary.rows_written == Some(EXPECTED_ORDERS)
-            && summary.distinct_ids == Some(EXPECTED_ORDERS)
-            && summary.writer_count == Some(EXPECTED_WRITERS as i64)
-            && summary.missing_created_at == Some(0)
-    });
+    let orders_complete = order_summary_complete(evidence.order_summary.as_ref());
+    let invalid_amounts = evidence
+        .order_summary
+        .as_ref()
+        .and_then(|summary| summary.invalid_amounts);
     let writers_done = evidence.writers.len() == EXPECTED_WRITERS
         && evidence.writers.iter().all(|row| {
             row.writer
@@ -138,7 +137,8 @@ pub(super) fn score(evidence: &Evidence, names: &ScenarioNames) -> ObjectiveEval
                 workload_passed,
                 format!(
                     "tables={all_tables_exist}, parallel_writers={parallel_writers}, \
-                     orders_complete={orders_complete}, writers_done={writers_done}"
+                     orders_complete={orders_complete}, invalid_amounts={invalid_amounts:?}, \
+                     writers_done={writers_done}"
                 ),
             ),
             common::gate(
@@ -190,6 +190,16 @@ pub(super) fn score(evidence: &Evidence, names: &ScenarioNames) -> ObjectiveEval
             ),
         ],
     }
+}
+
+fn order_summary_complete(summary: Option<&super::evidence::OrderSummary>) -> bool {
+    summary.is_some_and(|summary| {
+        summary.rows_written == Some(EXPECTED_ORDERS)
+            && summary.distinct_ids == Some(EXPECTED_ORDERS)
+            && summary.writer_count == Some(EXPECTED_WRITERS as i64)
+            && summary.invalid_amounts == Some(0)
+            && summary.missing_created_at == Some(0)
+    })
 }
 
 fn single_report(reports: &[FinalReport]) -> Option<&FinalReport> {
@@ -262,6 +272,7 @@ mod tests {
                 rows_written: Some(15),
                 distinct_ids: Some(15),
                 writer_count: Some(3),
+                invalid_amounts: Some(0),
                 missing_created_at: Some(0),
             }),
             writers: (1..=3)
@@ -304,6 +315,32 @@ mod tests {
                 .sum::<u16>(),
             100
         );
+    }
+
+    #[test]
+    fn numeric_order_amounts_satisfy_the_order_summary() {
+        let summary = OrderSummary {
+            rows_written: Some(15),
+            distinct_ids: Some(15),
+            writer_count: Some(3),
+            invalid_amounts: Some(0),
+            missing_created_at: Some(0),
+        };
+
+        assert!(order_summary_complete(Some(&summary)));
+    }
+
+    #[test]
+    fn invalid_order_amounts_fail_the_order_summary() {
+        let summary = OrderSummary {
+            rows_written: Some(15),
+            distinct_ids: Some(15),
+            writer_count: Some(3),
+            invalid_amounts: Some(1),
+            missing_created_at: Some(0),
+        };
+
+        assert!(!order_summary_complete(Some(&summary)));
     }
 
     #[test]

--- a/harness/tests/e2e/src/scenarios/reactive_automation/evidence.rs
+++ b/harness/tests/e2e/src/scenarios/reactive_automation/evidence.rs
@@ -41,6 +41,7 @@ pub(super) struct OrderSummary {
     pub(super) rows_written: Option<i64>,
     pub(super) distinct_ids: Option<i64>,
     pub(super) writer_count: Option<i64>,
+    pub(super) invalid_amounts: Option<i64>,
     pub(super) missing_created_at: Option<i64>,
 }
 
@@ -74,6 +75,7 @@ impl OrderSummary {
             rows_written: integer_field(value, "rows_written"),
             distinct_ids: integer_field(value, "distinct_ids"),
             writer_count: integer_field(value, "writer_count"),
+            invalid_amounts: integer_field(value, "invalid_amounts"),
             missing_created_at: integer_field(value, "missing_created_at"),
         }
     }

--- a/harness/tests/e2e/src/scenarios/reactive_automation/prompt.rs
+++ b/harness/tests/e2e/src/scenarios/reactive_automation/prompt.rs
@@ -63,16 +63,17 @@ Required execution:
 
 6. After the trigger-spawned finalizer writes the report, wake the existing root session
    explicitly. Set the wake reaction's `metadata.session_id` to the current root session id;
-   setting only `parent_session_id` spawns a new unnamed child and does not wake the root. In the
-   resumed root turn, unregister every trigger and subscription created for this run, then list
-   the registered triggers and verify that none contains `{run_label}` or `{namespace}`. Do not
-   give the final response before the root has resumed and this cleanup check has passed.
+   setting only `parent_session_id` spawns a new unnamed child and does not wake the root. Set
+   that reaction's `metadata.options.functions.allow` to `["*"]`; a narrower policy can prevent
+   the resumed root from listing and unregistering triggers. In the resumed root turn, unregister
+   every trigger and subscription created for this run, then list the registered triggers and
+   verify that none contains `{run_label}` or `{namespace}`. Do not give the final response before
+   the root has resumed and this cleanup check has passed.
 
-This is a deliberately large execution. A deadline is only a stuck-execution watchdog, not a
-normal completion deadline. If you register a watchdog, use at least {watchdog_seconds} seconds
-after the writers start and fire it only when there has been no progress; never use a 120-second
-deadline to interrupt normal work. Do not write the report from the root as a substitute for the
-trigger-spawned finalizer: wait for `{finalizer}` to run and write it.
+This is a deliberately large execution. The harness already applies a {watchdog_seconds}-second
+stuck-execution watchdog, so do not register a cron or deadline watchdog for this run. Do not
+write the report from the root as a substitute for the trigger-spawned finalizer: wait for
+`{finalizer}` to run and write it.
 
 Success requires exact equality between `{totals}` and a direct `GROUP BY` over `{orders}`, no
 lost or duplicated orders, trigger provenance for reactor and finalizer sessions, no inline
@@ -90,4 +91,18 @@ Report progress briefly and keep the final response factual."#,
         writer_3 = names.writer_sessions[2],
         finalizer = names.finalizer_session,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn root_wake_preserves_cleanup_access_without_a_competing_watchdog() {
+        let prompt = build(&ScenarioNames::new("abcd-rest"), 600);
+
+        assert!(prompt.contains("reaction's `metadata.options.functions.allow` to `[\"*\"]`"));
+        assert!(prompt.contains("harness already applies a 600-second\nstuck-execution watchdog"));
+        assert!(prompt.contains("do not register a cron or deadline watchdog for this run"));
+    }
 }

--- a/harness/tests/e2e/src/scenarios/reactive_automation/queries.rs
+++ b/harness/tests/e2e/src/scenarios/reactive_automation/queries.rs
@@ -78,6 +78,8 @@ pub(super) async fn collect(
                 &format!(
                     "SELECT COUNT(*) AS rows_written, COUNT(DISTINCT id) AS distinct_ids, \
                          COUNT(DISTINCT writer) AS writer_count, \
+                         SUM(CASE WHEN typeof(amount) IN ('integer', 'real') \
+                             THEN 0 ELSE 1 END) AS invalid_amounts, \
                          SUM(CASE WHEN created_at IS NULL THEN 1 ELSE 0 END) AS missing_created_at \
                          FROM {}",
                     names.orders


### PR DESCRIPTION
## Summary

- reject non-numeric order amounts using persisted SQLite type evidence
- require the root wake reaction to retain trigger cleanup permissions
- use the harness inactivity watchdog instead of registering a competing cron watchdog
- add focused coverage for numeric amounts and root cleanup instructions

## Root cause

The scenario verified order counts, uniqueness, writers, timestamps, and aggregate equality, but did not verify the persisted type of `amount`. SQLite can coerce textual values during aggregation, allowing invalid rows to satisfy the existing gates.

Cleanup could also become nondeterministic when a scenario-created cron watchdog resumed the root session with a restricted function policy. That prevented the resumed root from listing and unregistering run triggers even though the final report was valid.

## Impact

Reactive automation runs now fail when any order amount is not stored as an integer or real value. The cleanup path retains access to all functions required to remove and verify run triggers, without a competing scenario-owned watchdog.

## Validation

- `cargo test --locked --manifest-path harness/Cargo.toml -p harness-e2e` — 50 passed
- `cargo clippy --locked --manifest-path harness/Cargo.toml -p harness -p harness-e2e -p harness-integration --all-targets -- -D warnings`
- `make -C harness integration-validate` — 11 fixtures valid
- `cargo fmt --manifest-path harness/Cargo.toml --all -- --check`
- `git diff --check`
- reactive automation smoke with `zai/glm-5.2` — 1/1 passed, score 100
- reactive automation confidence run with `zai/glm-5.2` — 3/3 passed, median score 100, zero hard-gate or cleanup failures

Refs MOT-4269


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved order validation to detect and reject records with invalid numeric amounts.
  - Enhanced completion checks and diagnostic reporting for automated order-processing scenarios.

- **Tests**
  - Added coverage for valid and invalid order amount scenarios.
  - Updated automation guidance to support reliable wake-up, cleanup verification, and watchdog behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->