### PR TITLE
fix(ci): simplify Alpha Release inputs

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -6,16 +6,12 @@ name: Alpha Release
 #
 # The regular release workflow handles this tag normally, producing a GitHub
 # prerelease and publishing the worker to the isolated `experimental` channel.
-# Run this workflow from main and provide the feature branch or pull-request
-# ref to release. That lets it test PRs created before this workflow existed.
+# Run this workflow from the feature branch to release. GitHub Actions' branch
+# selector chooses the source; the only workflow input is the worker to publish.
 
 on:
   workflow_dispatch:
     inputs:
-      source_ref:
-        description: 'Feature branch or pull-request ref (e.g. feat/my-worker or refs/pull/123/head)'
-        required: true
-        type: string
       worker:
         description: 'Worker module to publish from this branch'
         required: true
@@ -69,16 +65,6 @@ on:
           - scrapling
           - web
           - worktree
-      bump:
-        description: 'Base version for the alpha (none = use the manifest version as its base)'
-        required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
-          - none
-        default: patch
 
 permissions:
   contents: write
@@ -94,17 +80,21 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Checkout source ref
+      - name: Checkout selected branch
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          ref: ${{ inputs.source_ref }}
 
       - name: Refuse to release main
         env:
-          SOURCE_REF: ${{ inputs.source_ref }}
+          REF_TYPE: ${{ github.ref_type }}
+          SOURCE_BRANCH: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+          if [[ "$REF_TYPE" != "branch" ]]; then
+            echo "::error::Alpha Release must run from a feature branch"
+            exit 1
+          fi
           git fetch origin main
           source_sha=$(git rev-parse HEAD)
           main_sha=$(git rev-parse origin/main)
@@ -112,7 +102,7 @@ jobs:
             echo "::error::Alpha Release is for feature branches; use Create Tag for main releases"
             exit 1
           fi
-          echo "::notice::Preparing alpha release from $SOURCE_REF at $source_sha"
+          echo "::notice::Preparing alpha release from $SOURCE_BRANCH at $source_sha"
 
       - name: Discover manifest
         id: meta
@@ -135,12 +125,11 @@ jobs:
         id: version
         env:
           WORKER: ${{ inputs.worker }}
-          BUMP: ${{ inputs.bump }}
           MANIFEST: ${{ steps.meta.outputs.manifest }}
         run: |
           set -euo pipefail
           version=$(python3 .github/scripts/manifest_version.py bump "$WORKER/$MANIFEST" \
-            --kind "$BUMP" --suffix alpha --worker "$WORKER")
+            --kind none --suffix alpha --worker "$WORKER")
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=${WORKER}/v${version}" >> "$GITHUB_OUTPUT"
           echo "::notice::${WORKER}: alpha ${version}@experimental"

--- a/docs/sops/release.md
+++ b/docs/sops/release.md
@@ -175,10 +175,9 @@ counter — `parse_release_tag.py` detects prereleases as `-<word>.<number>`.
 
 ### Alpha release from a pull request branch
 
-To publish a worker from an unmerged pull request for integration testing, use
-**Actions → Alpha Release** from `main`. Set **Source ref** to the pull request
-branch (or `refs/pull/<number>/head`), then choose the worker and the intended
-base-version bump. The workflow creates an ephemeral commit with an
+To publish a worker from an unmerged pull request for integration testing, open
+**Actions → Alpha Release**, select the pull request branch in **Use workflow
+from**, then choose the worker. The workflow creates an ephemeral commit with an
 `-alpha.N` manifest version, then pushes only its annotated tag, for example
 `browser/v1.4.0-alpha.1`.
 
@@ -187,8 +186,8 @@ the `experimental` registry channel (`browser@experimental`). Neither the
 selected branch nor `main` is pushed or changed. The channel is shared: a new
 alpha release for the same worker moves `experimental` to that version.
 
-**Source ref** must not resolve to `main`; use **Create Tag** for a release
-that should move `latest` or `next`.
+The selected branch must not be `main`; use **Create Tag** for a release that
+should move `latest` or `next`.
 
 ### Dry run
 


### PR DESCRIPTION
## Summary

Simplifies the Alpha Release workflow so the GitHub Actions branch selector chooses the feature branch and the only workflow input is the worker to publish.

## Changes

- Removes the manual source-ref input and pull-request-ref support.
- Removes the version-bump selector; alpha versions now continue from the worker manifest version.
- Checks out the branch selected in the Actions UI and rejects non-branch refs and `main`.
- Updates the release guide with the new run flow.

## Validation

- `actionlint .github/workflows/alpha-release.yml`
- YAML parse validation
- `python -m pytest .github/scripts/tests -q`