### PR TITLE
fix(release): isolate alpha releases

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -80,7 +80,7 @@ on:
           - stable
         default: none
       tag:
-        description: 'Registry channel the version is published under (passed to POST /publish; not part of the git tag name)'
+        description: 'Registry channel (alpha releases are always published to experimental)'
         required: true
         type: choice
         options:
@@ -158,6 +158,7 @@ jobs:
           WORKER: ${{ inputs.worker }}
           BUMP: ${{ inputs.bump }}
           SUFFIX: ${{ inputs.suffix }}
+          REQUESTED_REGISTRY_TAG: ${{ inputs.tag }}
           MANIFEST: ${{ steps.meta.outputs.manifest }}
         run: |
           set -euo pipefail
@@ -166,10 +167,18 @@ jobs:
           # (checkout above is fetch-depth 0, so they are all present).
           new_ver=$(python3 .github/scripts/manifest_version.py bump "$WORKER/$MANIFEST" \
             --kind "$BUMP" --suffix "$SUFFIX" --worker "$WORKER")
-          echo "current=$current" >> "$GITHUB_OUTPUT"
-          echo "version=$new_ver" >> "$GITHUB_OUTPUT"
-          echo "tag=${WORKER}/v${new_ver}" >> "$GITHUB_OUTPUT"
-          echo "::notice::${WORKER}: ${current} -> ${new_ver} (channel: ${{ inputs.tag }})"
+          registry_tag="$REQUESTED_REGISTRY_TAG"
+          if [[ "$SUFFIX" == "alpha" ]]; then
+            registry_tag="experimental"
+            echo "::notice::alpha releases always publish to the experimental channel"
+          fi
+          {
+            echo "current=$current"
+            echo "version=$new_ver"
+            echo "tag=${WORKER}/v${new_ver}"
+            echo "registry_tag=$registry_tag"
+          } >> "$GITHUB_OUTPUT"
+          echo "::notice::${WORKER}: ${current} -> ${new_ver} (channel: $registry_tag)"
 
       - name: Validate manifest update
         env:
@@ -225,7 +234,7 @@ jobs:
       - name: Create and push annotated tag
         env:
           TAG: ${{ steps.versions.outputs.tag }}
-          REGISTRY_TAG: ${{ inputs.tag }}
+          REGISTRY_TAG: ${{ steps.versions.outputs.registry_tag }}
           WORKER: ${{ inputs.worker }}
           NEW_VERSION: ${{ steps.versions.outputs.version }}
         run: |

--- a/docs/sops/release.md
+++ b/docs/sops/release.md
@@ -36,13 +36,12 @@ Actions → **Create Tag**:
 | Worker | Folder name (must be in workflow options) |
 | Bump | `patch` / `minor` / `major` / `none` — picks the base version |
 | Suffix | `none` / `alpha` / `beta` / `rc` / `stable` — pre-release line on that base |
-| Registry tag | `latest` / `next` / `experimental` — channel the version publishes to |
+| Registry tag | `latest` / `next` / `experimental` — channel the version publishes to; alpha always resolves to `experimental` |
 
-**Suffix and Registry tag are independent axes.** The suffix lives in the
-version (`1.2.3-rc.1`); the channel is where that version is published
-(`@next`). Any combination is valid — a release is `<version>@<channel>`, e.g.
-`1.2.3-rc.1@next`. See [Version suffixes](#version-suffixes) and
-[Registry tag semantics](#4-registry-tag-semantics).
+The suffix lives in the version (`1.2.3-rc.1`); the channel is where that
+version is published (`@next`). They are independent except for `alpha`, which
+is always published as `@experimental` so it cannot advance `latest`. See
+[Version suffixes](#version-suffixes) and [Registry tag semantics](#4-registry-tag-semantics).
 
 The workflow:
 
@@ -124,13 +123,14 @@ a dead channel that nothing resolves.
 
 ### Version suffixes
 
-A suffix is *what the version is*, written into the version itself. It is
-orthogonal to the channel — pick both independently.
+A suffix is *what the version is*, written into the version itself. The
+channel is normally chosen independently, except that alpha releases are
+always isolated on `experimental`.
 
 | Suffix | Result from `1.2.3` | Meaning |
 |---|---|---|
 | `none` | `1.2.4` | Stable release (default) |
-| `alpha` | `1.2.4-alpha.1` | Earliest, expected to break |
+| `alpha` | `1.2.4-alpha.1` | Earliest, expected to break; always `@experimental` |
 | `beta` | `1.2.4-beta.1` | Feature-complete but unstable |
 | `rc` | `1.2.4-rc.1` | Release candidate |
 | `stable` | `1.2.3` | Promote a pre-release to its base, no bump |
@@ -142,6 +142,9 @@ colliding. Each suffix line advances independently at the same base.
 Bump and suffix compose: **Bump** picks the base version, **Suffix** decides
 whether that base ships as a pre-release. `Bump: none` keeps the current base,
 which is how you iterate a pre-release without walking the version forward.
+
+Create Tag overrides the selected registry channel to `experimental` for an
+`alpha` suffix, so a test build can never advance the stable `latest` pointer.
 
 A typical `rc` cycle, all on `@next`, then promoted:
 


### PR DESCRIPTION
## What changed

- Route `alpha` releases from Create Tag to the `experimental` registry channel.
- Preserve the selected `latest`, `next`, or `experimental` channel for stable, beta, and release-candidate releases.
- Document that alpha releases cannot advance `latest`.

## Why

An alpha release of `image-resize` was published with `latest`, replacing the stable install pointer. Alpha builds are intended for testing and must remain isolated from stable installs.

## Validation

- `actionlint .github/workflows/create-tag.yml`
- `git diff --check`
- Verified alpha routes to `experimental`, while beta and rc retain their selected channels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Alpha releases are now consistently published to the experimental channel, preventing them from advancing the stable latest channel.
  * Release publishing now honors the effective channel selected during version calculation.

* **Documentation**
  * Clarified how version suffixes and registry channels interact during releases.
  * Documented the special handling for alpha releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->