### PR TITLE
fix(release): trigger alpha publish pipeline

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -80,10 +80,21 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      # Tags pushed with GITHUB_TOKEN do not trigger the Release workflow.
+      # Use the CI GitHub App token so the annotated alpha tag starts the
+      # build-and-publish pipeline after this workflow completes.
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.III_CI_APP_ID }}
+          private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
+
       - name: Checkout selected branch
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Refuse to release main
         env:


### PR DESCRIPTION
## What changed

- Generate a GitHub App token in the Alpha Release workflow.
- Use that token when checking out and pushing the annotated alpha tag.

## Why

The workflow previously pushed tags with `GITHUB_TOKEN`. GitHub does not start a second workflow from events created by that token, so the tag existed but the Release workflow never built or published it to the registry.

## Impact

Future alpha tags trigger Release, which builds the worker and publishes it to the `experimental` channel.

## Validation

- `actionlint .github/workflows/alpha-release.yml`
- `git diff --check`