### PR TITLE
fix(release): trigger alpha tag publish

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -182,7 +182,10 @@ jobs:
           git config user.name "workers-ci[bot]"
           git config user.email "workers-ci[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "chore(${WORKER}): alpha v${VERSION} [skip ci]"
+          # This commit is the target of the tag push. Do not add `[skip ci]`:
+          # GitHub would then suppress the Release workflow that publishes the
+          # new alpha tag to the registry.
+          git commit -m "chore(${WORKER}): alpha v${VERSION}"
           git tag -a "$TAG" -m "Alpha release $TAG
 
           worker: $WORKER


### PR DESCRIPTION
## What changed

- Remove `[skip ci]` from the ephemeral commit created by Alpha Release.

## Why

The alpha tag points at that commit. Because its message included `[skip ci]`, GitHub suppressed the Release workflow after the tag push, so the worker was never published to the registry.

## Impact

Alpha tag pushes now start Release, which builds and publishes the worker to the `experimental` channel.

## Validation

- `actionlint .github/workflows/alpha-release.yml`
- Confirmed the alpha commit command contains no `[skip ci]` marker.
- `git diff --check`