### PR TITLE
(MOT-4279) test(harness): validate shell coder and sandbox workflow

### DIFF
--- a/.github/workflows/_harness-e2e.yml
+++ b/.github/workflows/_harness-e2e.yml
@@ -283,6 +283,12 @@ jobs:
       - name: Extract E2E binaries
         run: tar -xzf target/harness-e2e-stack.tar.gz
 
+      - name: Prepare KVM for sandbox scenario
+        if: matrix.scenario == 'shell_coder_sandbox'
+        run: |
+          test -c /dev/kvm
+          sudo chmod 0666 /dev/kvm
+
       - name: Run real-stack quality scenario
         env:
           ANTHROPIC_API_KEY: ${{ secrets.anthropic_api_key }}

--- a/harness/tests/e2e/README.md
+++ b/harness/tests/e2e/README.md
@@ -48,6 +48,12 @@ scenario through one global `allow: ["*"]` policy:
   the namespaced `state`-trigger fallback. The evaluator queries the resulting
   tables, verifies trigger provenance from session metadata, and checks that all
   run-owned triggers were removed.
+- `shell_coder_sandbox`: performs 12 required operations across worker setup,
+  `coder`, `shell`, and `sandbox`. It adds both registry workers; inspects,
+  creates, updates, moves, and reads an exact Python file; executes it on the
+  host; then creates, executes in, lists, and stops an isolated microVM. The
+  evaluator verifies every effect, exact stdout from both environments,
+  operation ordering, shutdown, and scenario-owned cleanup.
 
 List the code-defined ids used by CI:
 
@@ -226,10 +232,11 @@ previous run.
 
 The launcher performs a clean first boot with isolated configuration, session,
 queue, state, and log directories. It starts the provider workers named by the
-subject and judge configuration. It executes repository binaries directly; it
-does not test registry installation or `iii worker add`. Those paths are covered
-by the nightly/manual [Harness quickstart validator](../quickstart/README.md),
-which runs without provider credentials or model calls.
+subject and judge configuration. It executes repository binaries directly. The
+`shell_coder_sandbox` scenario tests engine-side registry installation through
+`worker::add`; the `iii worker add` CLI path remains covered by the nightly/manual
+[Harness quickstart validator](../quickstart/README.md), which runs without
+provider credentials or model calls.
 
 ## Adding a scenario
 

--- a/harness/tests/e2e/run-ci.sh
+++ b/harness/tests/e2e/run-ci.sh
@@ -17,13 +17,27 @@ runs=${HARNESS_E2E_RUNS:-1}
 run_dir="$artifacts_dir/stack"
 logs_dir="$artifacts_dir/logs"
 iii_port=${HARNESS_E2E_PORT:-49134}
+[[ "$iii_port" =~ ^[0-9]+$ ]] && ((iii_port >= 1 && iii_port <= 65535)) || {
+  echo "HARNESS_E2E_PORT must be an integer from 1 through 65535" >&2
+  exit 1
+}
 iii_url="ws://127.0.0.1:$iii_port"
-engine_config=${HARNESS_E2E_ENGINE_CONFIG:-"$script_dir/stack-config/engine.yaml"}
+engine_config_template=${HARNESS_E2E_ENGINE_CONFIG:-"$script_dir/stack-config/engine.yaml"}
+# iii-worker's lifecycle helpers mutate config.yaml in their project root.
+# Use that same isolated path for the engine reload watcher.
+engine_config="$run_dir/config.yaml"
 database_config=${HARNESS_E2E_DATABASE_CONFIG:-"$script_dir/stack-config/database.yaml"}
 
 mkdir -p "$run_dir" "$logs_dir" "$run_dir/database"
+cp "$engine_config_template" "$engine_config"
+# The engine expands environment placeholders itself, but iii-worker reads the
+# same project file directly and expects the manager port to already be numeric.
+sed -i "s/\${HARNESS_E2E_PORT}/$iii_port/g" "$engine_config"
 export HARNESS_E2E_RUN_DIR="$run_dir"
 export HARNESS_E2E_PORT="$iii_port"
+# Built-in iii-worker daemons otherwise fall back to the fixed 49134 default,
+# which breaks isolated runs that select a different port.
+export III_ENGINE_URL="$iii_url"
 
 pids=()
 
@@ -131,6 +145,7 @@ start_provider() {
 
 start_process engine "$III_BIN" -c "$engine_config"
 wait_for_function engine::workers::list
+wait_for_function worker::add
 
 start_process database \
   "$repo_root/database/target/release/database" \

--- a/harness/tests/e2e/src/scenarios/direct_answer.rs
+++ b/harness/tests/e2e/src/scenarios/direct_answer.rs
@@ -9,6 +9,7 @@ pub fn scenario(_run_id: &str) -> ScenarioSpec {
     ScenarioSpec {
         id: ID,
         prompt: "Explain to a non-technical reader, in at most two sentences, the difference between authentication and authorization. Do not perform any external action.".into(),
+        filesystem_root: None,
         execution: ExecutionPolicy {
             max_turns: 2,
             max_output_tokens: Some(2_048),

--- a/harness/tests/e2e/src/scenarios/mod.rs
+++ b/harness/tests/e2e/src/scenarios/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::future::Future;
+use std::path::PathBuf;
 use std::pin::Pin;
 
 use anyhow::{bail, Result};
@@ -16,6 +17,7 @@ pub mod direct_answer;
 pub mod persistent_state;
 pub mod reactive_automation;
 pub mod security_review;
+pub mod shell_coder_sandbox;
 
 pub type EvaluationFuture<'a> =
     Pin<Box<dyn Future<Output = Result<ObjectiveEvaluation>> + Send + 'a>>;
@@ -67,6 +69,7 @@ impl ExecutionPolicy {
 pub struct ScenarioSpec {
     pub id: &'static str,
     pub prompt: String,
+    pub filesystem_root: Option<PathBuf>,
     pub execution: ExecutionPolicy,
     pub threshold: u8,
     pub criteria: Vec<CriterionSpec>,
@@ -139,14 +142,17 @@ pub enum ScenarioId {
     SecurityReview,
     #[value(name = "reactive_automation")]
     ReactiveAutomation,
+    #[value(name = "shell_coder_sandbox")]
+    ShellCoderSandbox,
 }
 
 impl ScenarioId {
-    pub const ALL: [Self; 4] = [
+    pub const ALL: [Self; 5] = [
         Self::DirectAnswer,
         Self::PersistentState,
         Self::SecurityReview,
         Self::ReactiveAutomation,
+        Self::ShellCoderSandbox,
     ];
 
     pub fn as_str(self) -> &'static str {
@@ -155,6 +161,7 @@ impl ScenarioId {
             Self::PersistentState => persistent_state::ID,
             Self::SecurityReview => security_review::ID,
             Self::ReactiveAutomation => reactive_automation::ID,
+            Self::ShellCoderSandbox => shell_coder_sandbox::ID,
         }
     }
 
@@ -164,6 +171,7 @@ impl ScenarioId {
             Self::PersistentState => persistent_state::scenario(run_id),
             Self::SecurityReview => security_review::scenario(run_id),
             Self::ReactiveAutomation => reactive_automation::scenario(run_id),
+            Self::ShellCoderSandbox => shell_coder_sandbox::scenario(run_id),
         }
     }
 }
@@ -184,13 +192,13 @@ pub fn selected(requested: &[ScenarioId]) -> Vec<ScenarioId> {
 mod tests {
     use super::*;
     #[test]
-    fn registry_contains_four_unique_valid_scenarios() {
+    fn registry_contains_five_unique_valid_scenarios() {
         let mut ids = HashSet::new();
         for scenario in ScenarioId::ALL {
             assert!(ids.insert(scenario.as_str()));
             scenario.spec("run").validate().unwrap();
         }
-        assert_eq!(ids.len(), 4);
+        assert_eq!(ids.len(), 5);
     }
 
     #[test]

--- a/harness/tests/e2e/src/scenarios/persistent_state.rs
+++ b/harness/tests/e2e/src/scenarios/persistent_state.rs
@@ -20,6 +20,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
             "Store this JSON value for later use in scope `{scope}` under key `{KEY}`: {}. Confirm briefly after it has been stored.",
             serde_json::to_string(&expected).expect("serialize static scenario value")
         ),
+        filesystem_root: None,
         execution: ExecutionPolicy {
             max_turns: 12,
             max_output_tokens: Some(8_192),

--- a/harness/tests/e2e/src/scenarios/reactive_automation/mod.rs
+++ b/harness/tests/e2e/src/scenarios/reactive_automation/mod.rs
@@ -27,6 +27,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
     ScenarioSpec {
         id: ID,
         prompt: prompt::build(&names, STUCK_WATCHDOG_SECONDS),
+        filesystem_root: None,
         execution: ExecutionPolicy {
             max_turns: 64,
             max_output_tokens: None,

--- a/harness/tests/e2e/src/scenarios/security_review.rs
+++ b/harness/tests/e2e/src/scenarios/security_review.rs
@@ -16,6 +16,7 @@ pub fn scenario(_run_id: &str) -> ScenarioSpec {
 
 For each snippet, identify the vulnerability, explain its impact, and recommend a practical remediation. Keep the review concise and do not perform any external action."#
             .into(),
+        filesystem_root: None,
         execution: ExecutionPolicy {
             max_turns: 2,
             max_output_tokens: Some(4_096),

--- a/harness/tests/e2e/src/scenarios/shell_coder_sandbox.rs
+++ b/harness/tests/e2e/src/scenarios/shell_coder_sandbox.rs
@@ -1,0 +1,782 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::bail;
+use serde_json::{json, Value};
+
+use crate::context::E2eContext;
+
+use super::common;
+use super::{
+    CleanupFuture, CriterionSpec, EvaluationFuture, ExecutionPolicy, ObjectiveEvaluation,
+    ScenarioObservation, ScenarioSpec,
+};
+
+pub const ID: &str = "shell_coder_sandbox";
+const DRAFT_NAME: &str = "draft_check.py";
+const FINAL_NAME: &str = "checks/check.py";
+const DRAFT_SCRIPT: &str = "values = [2, 3, 5, 7]\nprint(\"host-check:draft\")\n";
+const FINAL_SCRIPT: &str = "values = [2, 3, 5, 7]\nprint(f\"host-check:{sum(values)}\")\n";
+const HOST_STDOUT: &str = "host-check:17";
+const SANDBOX_STDOUT: &str = "sandbox-check:35";
+const EXPECTED_CORE_OPERATIONS: usize = 12;
+
+pub fn scenario(run_id: &str) -> ScenarioSpec {
+    let sandbox_name = sandbox_name(run_id);
+    ScenarioSpec {
+        id: ID,
+        prompt: format!(
+            "Perform this verification entirely in the current workspace and in the stated order.\n\n\
+             1. Add the `shell` worker from the public registry and wait for that add operation to \
+             finish. Only after it finishes, add the `iii-sandbox` worker from the public registry \
+             and wait for that operation too, even if either worker is already installed. Do not \
+             launch the two add operations in parallel.\n\
+             2. Invoke the dedicated code-file capability's own access-contract inspection \
+             operation. Generic engine function discovery does not satisfy this step.\n\
+             3. With dedicated code-file operations, create `{DRAFT_NAME}` with exactly:\n\n\
+             ```python\n{DRAFT_SCRIPT}```\n\n\
+             4. With the dedicated code-file update operation, change only the second line so the \
+             file content becomes exactly:\n\n\
+             ```python\n{FINAL_SCRIPT}```\n\n\
+             5. With the dedicated code-file move operation, move it to `{FINAL_NAME}`.\n\
+             6. Read `{FINAL_NAME}` back with the dedicated code-file read operation and verify \
+             the exact final content. Do not create, edit, move, or read this code file with a \
+             general shell filesystem operation or by running a command; these steps specifically \
+             validate the code-file capabilities.\n\
+             7. Run `{FINAL_NAME}` with Python 3 on the host workspace and verify stdout is exactly \
+             `{HOST_STDOUT}`.\n\
+             8. Create a short-lived isolated Python sandbox named `{sandbox_name}` with exactly \
+             1 CPU, 256 MB of memory, and networking disabled. Use the sandbox's own command \
+             execution capability to run Python inside it and produce stdout exactly \
+             `{SANDBOX_STDOUT}`. Do not use the shell's sandbox target for this step.\n\
+             9. List the sandboxes and confirm that named sandbox is present and active, then stop \
+             it and wait for shutdown.\n\n\
+             Only report completion after every operation succeeds. Include both exact output \
+             lines in your final response."
+        ),
+        filesystem_root: Some(workspace_root(run_id)),
+        execution: ExecutionPolicy {
+            max_turns: 40,
+            max_output_tokens: Some(8_192),
+            max_total_tokens: 1_638_400,
+            stuck_timeout_seconds: 600,
+        },
+        threshold: 95,
+        criteria: vec![
+            CriterionSpec {
+                id: "worker_setup",
+                weight: 15,
+                description: "Both registry workers are added and expose their required surfaces.",
+            },
+            CriterionSpec {
+                id: "coder_workflow",
+                weight: 35,
+                description:
+                    "Coder inspection, create, update, move, and read operations produce the exact file.",
+            },
+            CriterionSpec {
+                id: "host_execution",
+                weight: 15,
+                description: "The final file runs successfully on the host with exact stdout.",
+            },
+            CriterionSpec {
+                id: "sandbox_lifecycle",
+                weight: 30,
+                description:
+                    "A named isolated sandbox is created, executed in, listed, and stopped.",
+            },
+            CriterionSpec {
+                id: "completion_report",
+                weight: 5,
+                description: "The final response includes both exact observed outputs.",
+            },
+        ],
+        judge_reference: None,
+        evaluate,
+        cleanup: Some(cleanup),
+    }
+}
+
+fn evaluate<'a>(
+    context: &'a E2eContext,
+    observation: &'a ScenarioObservation,
+    run_id: &'a str,
+) -> EvaluationFuture<'a> {
+    Box::pin(async move {
+        let calls = common::function_calls(&observation.transcript);
+        let installed_shell = calls.iter().any(|call| is_registry_install(call, "shell"));
+        let installed_sandbox = calls
+            .iter()
+            .any(|call| is_registry_install(call, "iii-sandbox"));
+
+        let shell_surface_ready = context.function_exists("shell::exec").await?;
+        let coder_surface_ready = context.function_exists("coder::create-file").await?;
+        let sandbox_surface_ready = context.function_exists("sandbox::create").await?;
+        let surfaces_ready = shell_surface_ready && coder_surface_ready && sandbox_surface_ready;
+        let worker_setup = installed_shell && installed_sandbox && surfaces_ready;
+
+        let coder_info = calls.iter().any(|call| call.function_id == "coder::info");
+        let coder_create = calls.iter().any(is_exact_create);
+        let coder_update = calls.iter().any(is_exact_update);
+        let coder_move = calls.iter().any(is_exact_move);
+        let coder_read = calls.iter().any(is_exact_read);
+        let coder_ordered = calls_are_ordered(
+            &calls,
+            &[
+                "coder::info",
+                "coder::create-file",
+                "coder::update-file",
+                "coder::move",
+                "coder::read-file",
+            ],
+        );
+        let coder_results_succeeded =
+            batch_result_succeeded(&observation.transcript, "coder::create-file")
+                && batch_result_succeeded(&observation.transcript, "coder::update-file")
+                && batch_result_succeeded(&observation.transcript, "coder::move")
+                && successful_coder_read(&observation.transcript);
+
+        let root = workspace_root(run_id);
+        let draft_path = root.join(DRAFT_NAME);
+        let final_path = root.join(FINAL_NAME);
+        let final_read = std::fs::read_to_string(&final_path);
+        let final_matches = final_read
+            .as_deref()
+            .is_ok_and(|content| content == FINAL_SCRIPT);
+        let draft_removed = !draft_path.exists();
+        let coder_workflow = coder_info
+            && coder_create
+            && coder_update
+            && coder_move
+            && coder_read
+            && coder_ordered
+            && coder_results_succeeded
+            && final_matches
+            && draft_removed;
+
+        let host_exec = calls.iter().any(is_exact_host_exec);
+        let host_output = successful_output(&observation.transcript, "shell::exec", HOST_STDOUT);
+        let host_execution = host_exec && host_output;
+
+        let expected_sandbox_name = sandbox_name(run_id);
+        let sandbox = sandbox_evidence(&observation.transcript, &calls, &expected_sandbox_name);
+        let sandbox_lifecycle = sandbox.complete();
+
+        let core_operations = [
+            installed_shell,
+            installed_sandbox,
+            coder_info,
+            coder_create,
+            coder_update,
+            coder_move,
+            coder_read,
+            host_exec,
+            sandbox.created,
+            sandbox.executed,
+            sandbox.listed,
+            sandbox.stopped,
+        ]
+        .into_iter()
+        .filter(|observed| *observed)
+        .count();
+        let operation_volume = core_operations >= EXPECTED_CORE_OPERATIONS;
+        let no_errors = observation.metrics.totals.function_call_errors == 0;
+        let response_reports_outputs = observation.response.contains(HOST_STDOUT)
+            && observation.response.contains(SANDBOX_STDOUT);
+
+        Ok(ObjectiveEvaluation {
+            hard_gates: vec![
+                common::gate(
+                    "workers_added_and_ready",
+                    worker_setup,
+                    format!(
+                        "shell add={installed_shell}, iii-sandbox add={installed_sandbox}, \
+                         shell ready={shell_surface_ready}, coder ready={coder_surface_ready}, \
+                         sandbox ready={sandbox_surface_ready}"
+                    ),
+                ),
+                common::gate(
+                    "ordered_coder_workflow_completed",
+                    coder_workflow,
+                    match &final_read {
+                        Ok(_) => format!(
+                            "info={coder_info}, create={coder_create}, update={coder_update}, \
+                             move={coder_move}, read={coder_read}, ordered={coder_ordered}, \
+                             successful results={coder_results_succeeded}, exact final \
+                             content={final_matches}, draft removed={draft_removed}"
+                        ),
+                        Err(error) => format!(
+                            "coder operations info/create/update/move/read={coder_info}/{coder_create}/\
+                             {coder_update}/{coder_move}/{coder_read}; could not read {}: {error}",
+                            final_path.display()
+                        ),
+                    },
+                ),
+                common::gate(
+                    "host_execution_succeeded",
+                    host_execution,
+                    format!(
+                        "exact host execution call={host_exec}, exact successful stdout={host_output}"
+                    ),
+                ),
+                common::gate(
+                    "sandbox_lifecycle_completed",
+                    sandbox_lifecycle,
+                    sandbox.summary(),
+                ),
+                common::gate(
+                    "operation_volume_reached",
+                    operation_volume,
+                    format!(
+                        "observed {core_operations} of {EXPECTED_CORE_OPERATIONS} required core operations"
+                    ),
+                ),
+                common::gate(
+                    "no_function_errors",
+                    no_errors,
+                    format!(
+                        "observed {} function-call error(s)",
+                        observation.metrics.totals.function_call_errors
+                    ),
+                ),
+            ],
+            awards: vec![
+                common::award(
+                    "worker_setup",
+                    if worker_setup { 15 } else { 0 },
+                    "awarded for adding both registry workers and exposing all three surfaces",
+                ),
+                common::award(
+                    "coder_workflow",
+                    if coder_workflow { 35 } else { 0 },
+                    "awarded for the ordered inspect/create/update/move/read workflow and exact file",
+                ),
+                common::award(
+                    "host_execution",
+                    if host_execution && no_errors { 15 } else { 0 },
+                    "awarded for exact successful host stdout",
+                ),
+                common::award(
+                    "sandbox_lifecycle",
+                    if sandbox_lifecycle && no_errors { 30 } else { 0 },
+                    "awarded for creating, executing in, listing, and stopping the isolated sandbox",
+                ),
+                common::award(
+                    "completion_report",
+                    if response_reports_outputs { 5 } else { 0 },
+                    "awarded when the final response includes both exact outputs",
+                ),
+            ],
+        })
+    })
+}
+
+fn is_registry_install(call: &common::ObservedFunctionCall, worker: &str) -> bool {
+    call.function_id == "worker::add"
+        && call
+            .arguments
+            .pointer("/source/kind")
+            .and_then(Value::as_str)
+            == Some("registry")
+        && call
+            .arguments
+            .pointer("/source/name")
+            .and_then(Value::as_str)
+            == Some(worker)
+}
+
+fn is_exact_create(call: &common::ObservedFunctionCall) -> bool {
+    call.function_id == "coder::create-file"
+        && call
+            .arguments
+            .pointer("/files/0/path")
+            .and_then(Value::as_str)
+            == Some(DRAFT_NAME)
+        && call
+            .arguments
+            .pointer("/files/0/content")
+            .and_then(Value::as_str)
+            == Some(DRAFT_SCRIPT)
+        && call
+            .arguments
+            .get("files")
+            .and_then(Value::as_array)
+            .is_some_and(|files| files.len() == 1)
+}
+
+fn is_exact_update(call: &common::ObservedFunctionCall) -> bool {
+    call.function_id == "coder::update-file"
+        && call
+            .arguments
+            .pointer("/files/0/path")
+            .and_then(Value::as_str)
+            == Some(DRAFT_NAME)
+        && call
+            .arguments
+            .pointer("/files/0/ops")
+            .and_then(Value::as_array)
+            .is_some_and(|ops| !ops.is_empty())
+        && call
+            .arguments
+            .get("files")
+            .and_then(Value::as_array)
+            .is_some_and(|files| files.len() == 1)
+}
+
+fn is_exact_move(call: &common::ObservedFunctionCall) -> bool {
+    call.function_id == "coder::move"
+        && call
+            .arguments
+            .pointer("/files/0/from")
+            .and_then(Value::as_str)
+            == Some(DRAFT_NAME)
+        && call
+            .arguments
+            .pointer("/files/0/to")
+            .and_then(Value::as_str)
+            == Some(FINAL_NAME)
+        && call
+            .arguments
+            .get("files")
+            .and_then(Value::as_array)
+            .is_some_and(|files| files.len() == 1)
+}
+
+fn is_exact_read(call: &common::ObservedFunctionCall) -> bool {
+    call.function_id == "coder::read-file"
+        && call.arguments.get("path").and_then(Value::as_str) == Some(FINAL_NAME)
+        && call.arguments.get("paths").is_none()
+}
+
+fn is_exact_host_exec(call: &common::ObservedFunctionCall) -> bool {
+    let host_target = call.arguments.get("target").is_none()
+        || call
+            .arguments
+            .pointer("/target/kind")
+            .and_then(Value::as_str)
+            == Some("host");
+    let python = call
+        .arguments
+        .get("command")
+        .and_then(Value::as_str)
+        .is_some_and(|command| matches!(command, "python" | "python3"));
+    let final_arg = call
+        .arguments
+        .get("args")
+        .and_then(Value::as_array)
+        .is_some_and(|args| args.iter().any(|arg| arg.as_str() == Some(FINAL_NAME)));
+    call.function_id == "shell::exec" && host_target && python && final_arg
+}
+
+fn calls_are_ordered(calls: &[common::ObservedFunctionCall], required: &[&str]) -> bool {
+    let mut next = 0;
+    for required_id in required {
+        let Some(offset) = calls[next..]
+            .iter()
+            .position(|call| call.function_id == *required_id)
+        else {
+            return false;
+        };
+        next += offset + 1;
+    }
+    true
+}
+
+fn function_results<'a>(transcript: &'a Value, function_id: &'a str) -> Vec<&'a Value> {
+    transcript
+        .get("messages")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| entry.get("message"))
+        .filter(|message| {
+            message.get("role").and_then(Value::as_str) == Some("function_result")
+                && message.get("function_id").and_then(Value::as_str) == Some(function_id)
+                && message.get("is_error").and_then(Value::as_bool) == Some(false)
+        })
+        .collect()
+}
+
+fn batch_result_succeeded(transcript: &Value, function_id: &str) -> bool {
+    function_results(transcript, function_id)
+        .into_iter()
+        .any(|message| {
+            message
+                .pointer("/details/results")
+                .and_then(Value::as_array)
+                .is_some_and(|results| {
+                    !results.is_empty()
+                        && results.iter().all(|result| {
+                            result.get("success").and_then(Value::as_bool) == Some(true)
+                        })
+                })
+        })
+}
+
+fn successful_coder_read(transcript: &Value) -> bool {
+    function_results(transcript, "coder::read-file")
+        .into_iter()
+        .any(|message| {
+            message.pointer("/details/content").and_then(Value::as_str) == Some(FINAL_SCRIPT)
+        })
+}
+
+fn successful_output(transcript: &Value, function_id: &str, expected: &str) -> bool {
+    function_results(transcript, function_id)
+        .into_iter()
+        .any(|message| {
+            message
+                .pointer("/details/exit_code")
+                .and_then(Value::as_i64)
+                == Some(0)
+                && message
+                    .pointer("/details/stdout")
+                    .and_then(Value::as_str)
+                    .is_some_and(|stdout| stdout.trim() == expected)
+                && message
+                    .pointer("/details/stderr")
+                    .and_then(Value::as_str)
+                    .is_some_and(|stderr| stderr.trim().is_empty())
+                && message
+                    .pointer("/details/timed_out")
+                    .and_then(Value::as_bool)
+                    != Some(true)
+        })
+}
+
+#[derive(Debug, Default)]
+struct SandboxEvidence {
+    sandbox_id: Option<String>,
+    create_request: bool,
+    created: bool,
+    executed: bool,
+    listed: bool,
+    stopped: bool,
+    ordered: bool,
+}
+
+impl SandboxEvidence {
+    fn complete(&self) -> bool {
+        self.create_request
+            && self.created
+            && self.executed
+            && self.listed
+            && self.stopped
+            && self.ordered
+    }
+
+    fn summary(&self) -> String {
+        format!(
+            "sandbox id={}, exact create request={}, created={}, executed with exact stdout={}, \
+             listed active={}, stopped={}, lifecycle ordered={}",
+            self.sandbox_id.as_deref().unwrap_or("missing"),
+            self.create_request,
+            self.created,
+            self.executed,
+            self.listed,
+            self.stopped,
+            self.ordered
+        )
+    }
+}
+
+fn sandbox_evidence(
+    transcript: &Value,
+    calls: &[common::ObservedFunctionCall],
+    expected_name: &str,
+) -> SandboxEvidence {
+    let sandbox_id = function_results(transcript, "sandbox::create")
+        .into_iter()
+        .find_map(|message| {
+            (message.pointer("/details/image").and_then(Value::as_str) == Some("python"))
+                .then(|| {
+                    message
+                        .pointer("/details/sandbox_id")
+                        .and_then(Value::as_str)
+                        .map(str::to_owned)
+                })
+                .flatten()
+        });
+    let create_request = calls.iter().any(|call| {
+        call.function_id == "sandbox::create"
+            && call.arguments.get("image").and_then(Value::as_str) == Some("python")
+            && call.arguments.get("name").and_then(Value::as_str) == Some(expected_name)
+            && call.arguments.get("cpus").and_then(Value::as_u64) == Some(1)
+            && call.arguments.get("memory_mb").and_then(Value::as_u64) == Some(256)
+            && call.arguments.get("network").and_then(Value::as_bool) == Some(false)
+    });
+
+    let Some(id) = sandbox_id.as_deref() else {
+        return SandboxEvidence {
+            sandbox_id,
+            create_request,
+            ..SandboxEvidence::default()
+        };
+    };
+    let exec_call = calls.iter().any(|call| {
+        call.function_id == "sandbox::exec"
+            && call.arguments.get("sandbox_id").and_then(Value::as_str) == Some(id)
+    });
+    let executed = exec_call && successful_output(transcript, "sandbox::exec", SANDBOX_STDOUT);
+    let list_call = calls.iter().any(|call| call.function_id == "sandbox::list");
+    let listed = list_call
+        && function_results(transcript, "sandbox::list")
+            .into_iter()
+            .any(|message| {
+                message
+                    .pointer("/details/sandboxes")
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+                    .any(|sandbox| {
+                        sandbox.get("sandbox_id").and_then(Value::as_str) == Some(id)
+                            && sandbox.get("name").and_then(Value::as_str) == Some(expected_name)
+                            && sandbox.get("stopped").and_then(Value::as_bool) == Some(false)
+                    })
+            });
+    let stop_call = calls.iter().any(|call| {
+        call.function_id == "sandbox::stop"
+            && call.arguments.get("sandbox_id").and_then(Value::as_str) == Some(id)
+            && call.arguments.get("wait").and_then(Value::as_bool) == Some(true)
+    });
+    let stopped = stop_call
+        && function_results(transcript, "sandbox::stop")
+            .into_iter()
+            .any(|message| {
+                message
+                    .pointer("/details/sandbox_id")
+                    .and_then(Value::as_str)
+                    == Some(id)
+                    && message.pointer("/details/stopped").and_then(Value::as_bool) == Some(true)
+            });
+    let ordered = sandbox_calls_are_ordered(calls, expected_name, id);
+
+    SandboxEvidence {
+        sandbox_id,
+        create_request,
+        created: true,
+        executed,
+        listed,
+        stopped,
+        ordered,
+    }
+}
+
+fn sandbox_calls_are_ordered(
+    calls: &[common::ObservedFunctionCall],
+    expected_name: &str,
+    sandbox_id: &str,
+) -> bool {
+    let create = calls.iter().position(|call| {
+        call.function_id == "sandbox::create"
+            && call.arguments.get("name").and_then(Value::as_str) == Some(expected_name)
+    });
+    let exec = calls.iter().position(|call| {
+        call.function_id == "sandbox::exec"
+            && call.arguments.get("sandbox_id").and_then(Value::as_str) == Some(sandbox_id)
+    });
+    let list = calls
+        .iter()
+        .position(|call| call.function_id == "sandbox::list");
+    let stop = calls.iter().position(|call| {
+        call.function_id == "sandbox::stop"
+            && call.arguments.get("sandbox_id").and_then(Value::as_str) == Some(sandbox_id)
+    });
+    matches!(
+        (create, exec, list, stop),
+        (Some(create), Some(exec), Some(list), Some(stop))
+            if create < exec && exec < list && list < stop
+    )
+}
+
+fn cleanup<'a>(context: &'a E2eContext, run_id: &'a str) -> CleanupFuture<'a> {
+    Box::pin(async move {
+        let mut failures = Vec::new();
+        if let Err(error) = cleanup_owned_sandbox(context, &sandbox_name(run_id)).await {
+            failures.push(format!("sandbox cleanup: {error}"));
+        }
+        if let Err(error) = remove_workspace(&workspace_root(run_id)) {
+            failures.push(format!("workspace cleanup: {error}"));
+        }
+        if !failures.is_empty() {
+            bail!(failures.join("; "));
+        }
+        Ok(())
+    })
+}
+
+async fn cleanup_owned_sandbox(context: &E2eContext, expected_name: &str) -> anyhow::Result<()> {
+    if !context.function_exists("sandbox::list").await? {
+        return Ok(());
+    }
+    let listed = context.trigger_value("sandbox::list", json!({})).await?;
+    for sandbox_id in owned_running_sandbox_ids(&listed, expected_name) {
+        let _: Value = context
+            .trigger(
+                "sandbox::stop",
+                json!({ "sandbox_id": sandbox_id, "wait": true }),
+            )
+            .await?;
+    }
+    Ok(())
+}
+
+fn owned_running_sandbox_ids(listed: &Value, expected_name: &str) -> Vec<String> {
+    listed
+        .get("sandboxes")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|sandbox| sandbox.get("name").and_then(Value::as_str) == Some(expected_name))
+        .filter(|sandbox| sandbox.get("stopped").and_then(Value::as_bool) != Some(true))
+        .filter_map(|sandbox| sandbox.get("sandbox_id").and_then(Value::as_str))
+        .map(str::to_owned)
+        .collect()
+}
+
+fn remove_workspace(root: &Path) -> std::io::Result<()> {
+    match std::fs::remove_dir_all(root) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn sandbox_name(run_id: &str) -> String {
+    format!("e2e-shell-coder-{run_id}")
+}
+
+fn workspace_root(run_id: &str) -> PathBuf {
+    let base = std::env::var_os("HARNESS_E2E_RUN_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir);
+    let base = std::fs::canonicalize(&base).unwrap_or(base);
+    base.join("scenario-workspaces")
+        .join(format!("{ID}-{run_id}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn prompt_describes_all_operations_without_function_ids() {
+        let spec = scenario("1234567890abcdef");
+        assert!(!spec.prompt.contains("::"));
+        assert!(spec.prompt.contains("iii-sandbox"));
+        assert!(spec.prompt.contains(DRAFT_NAME));
+        assert!(spec.prompt.contains(FINAL_NAME));
+        assert!(spec.prompt.contains(HOST_STDOUT));
+        assert!(spec.prompt.contains(SANDBOX_STDOUT));
+        assert!(spec.prompt.contains("networking disabled"));
+        assert!(spec
+            .prompt
+            .contains("Generic engine function discovery does not satisfy this step"));
+        assert!(spec
+            .prompt
+            .contains("Do not create, edit, move, or read this code file with a general shell"));
+    }
+
+    #[test]
+    fn recognizes_both_registry_installs() {
+        let shell = common::ObservedFunctionCall {
+            function_id: "worker::add".into(),
+            arguments: json!({ "source": { "kind": "registry", "name": "shell" } }),
+        };
+        let sandbox = common::ObservedFunctionCall {
+            function_id: "worker::add".into(),
+            arguments: json!({ "source": { "kind": "registry", "name": "iii-sandbox" } }),
+        };
+        assert!(is_registry_install(&shell, "shell"));
+        assert!(is_registry_install(&sandbox, "iii-sandbox"));
+        assert!(!is_registry_install(&sandbox, "shell"));
+    }
+
+    #[test]
+    fn recognizes_successful_sandbox_lifecycle() {
+        let name = "e2e-shell-coder-1234567890ab";
+        let id = "sandbox-1";
+        let calls = vec![
+            common::ObservedFunctionCall {
+                function_id: "sandbox::create".into(),
+                arguments: json!({
+                    "image": "python",
+                    "name": name,
+                    "cpus": 1,
+                    "memory_mb": 256,
+                    "network": false
+                }),
+            },
+            common::ObservedFunctionCall {
+                function_id: "sandbox::exec".into(),
+                arguments: json!({ "sandbox_id": id, "cmd": "python3" }),
+            },
+            common::ObservedFunctionCall {
+                function_id: "sandbox::list".into(),
+                arguments: json!({}),
+            },
+            common::ObservedFunctionCall {
+                function_id: "sandbox::stop".into(),
+                arguments: json!({ "sandbox_id": id, "wait": true }),
+            },
+        ];
+        let transcript = json!({
+            "messages": [
+                result("sandbox::create", json!({ "sandbox_id": id, "image": "python" })),
+                result("sandbox::exec", json!({
+                    "stdout": "sandbox-check:35\n",
+                    "stderr": "",
+                    "exit_code": 0,
+                    "timed_out": false,
+                    "success": true
+                })),
+                result("sandbox::list", json!({ "sandboxes": [{
+                    "sandbox_id": id,
+                    "name": name,
+                    "image": "python",
+                    "stopped": false
+                }]})),
+                result("sandbox::stop", json!({ "sandbox_id": id, "stopped": true }))
+            ]
+        });
+        let evidence = sandbox_evidence(&transcript, &calls, name);
+        assert!(evidence.complete(), "{}", evidence.summary());
+    }
+
+    #[test]
+    fn cleanup_selects_only_owned_running_sandbox() {
+        let listed = json!({
+            "sandboxes": [
+                { "sandbox_id": "owned", "name": "mine", "stopped": false },
+                { "sandbox_id": "stopped", "name": "mine", "stopped": true },
+                { "sandbox_id": "foreign", "name": "other", "stopped": false }
+            ]
+        });
+        assert_eq!(
+            owned_running_sandbox_ids(&listed, "mine"),
+            vec!["owned".to_string()]
+        );
+    }
+
+    #[test]
+    fn workspace_root_and_sandbox_name_are_unique_per_run() {
+        let first = workspace_root("first");
+        let second = workspace_root("second");
+        assert!(first.is_absolute());
+        assert_ne!(first, second);
+        assert_ne!(sandbox_name("first"), sandbox_name("second"));
+    }
+
+    fn result(function_id: &str, details: Value) -> Value {
+        json!({
+            "message": {
+                "role": "function_result",
+                "function_id": function_id,
+                "is_error": false,
+                "details": details,
+                "content": []
+            }
+        })
+    }
+}

--- a/harness/tests/e2e/src/suite.rs
+++ b/harness/tests/e2e/src/suite.rs
@@ -351,6 +351,7 @@ async fn execute(
         progress_interval,
     } = request;
     let stuck_timeout = Duration::from_secs(spec.execution.stuck_timeout_seconds);
+    let filesystem_metadata = prepare_filesystem_root(spec)?;
     let response: SendResponse = context
         .trigger(
             "harness::send",
@@ -372,6 +373,7 @@ async fn execute(
                     max_output_tokens: spec.execution.max_output_tokens,
                     max_total_tokens: Some(spec.execution.max_total_tokens),
                     functions: Some(e2e_function_policy()),
+                    metadata: filesystem_metadata,
                     ..SendOptions::default()
                 }),
             },
@@ -474,6 +476,46 @@ async fn execute(
     report.criteria = criterion_reports(spec, awards);
     update_score(report);
     Ok(())
+}
+
+fn prepare_filesystem_root(spec: &ScenarioSpec) -> Result<Option<serde_json::Value>, RunFailure> {
+    let Some(root) = spec.filesystem_root.as_ref() else {
+        return Ok(None);
+    };
+    if !root.is_absolute() {
+        return Err(RunFailure::new(
+            RunStatus::InfrastructureError,
+            FailurePhase::Execute,
+            format!(
+                "scenario {} filesystem root must be absolute: {}",
+                spec.id,
+                root.display()
+            ),
+        ));
+    }
+    std::fs::create_dir_all(root).map_err(|error| {
+        RunFailure::new(
+            RunStatus::InfrastructureError,
+            FailurePhase::Execute,
+            format!(
+                "create scenario {} filesystem root {}: {error}",
+                spec.id,
+                root.display()
+            ),
+        )
+    })?;
+    let root = root.to_str().ok_or_else(|| {
+        RunFailure::new(
+            RunStatus::InfrastructureError,
+            FailurePhase::Execute,
+            format!(
+                "scenario {} filesystem root is not valid UTF-8: {}",
+                spec.id,
+                root.display()
+            ),
+        )
+    })?;
+    Ok(Some(json!({ "fs_scope": { "root": root } })))
 }
 
 async fn capture_partial_observation(
@@ -659,6 +701,7 @@ mod tests {
         ScenarioSpec {
             id: "case",
             prompt: "prompt".into(),
+            filesystem_root: None,
             execution: ExecutionPolicy {
                 max_turns: 1,
                 max_output_tokens: Some(1),


### PR DESCRIPTION
## Summary

- add the `shell_coder_sandbox` real-model E2E scenario
- validate 12 ordered operations across registry worker installation, Coder file handling, host Shell execution, and the Sandbox lifecycle
- grade exact filesystem effects, exact host and sandbox output, operation ordering, function-call failures, and cleanup
- give scenarios an isolated filesystem root and let dynamic worker installation update the isolated engine configuration
- prepare KVM only for the sandbox scenario in CI and document the added coverage

## Why

The quality suite did not exercise a full coding workflow across dynamically installed workers and an isolated microVM. This left worker readiness, cross-surface coordination, exact file mutations, and sandbox teardown without real-model regression coverage.

## Impact

The new scenario becomes part of the code-defined CI matrix. It fails when the model skips or reorders required operations, uses the wrong execution surface, produces unexpected output, leaves a sandbox running, or records any function-call error.

## Validation

- `cargo test -p harness-e2e` (55 passed)
- `bash -n tests/e2e/run-ci.sh`
- `git diff --check`

Fixes MOT-4279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end scenario covering worker setup, file operations, host execution, and isolated Python sandbox workflows.
  * Added scenario-specific filesystem configuration and workspace isolation.

* **Bug Fixes**
  * Improved CI reliability by validating ports, configuring isolated runs, and ensuring required services are ready before testing.
  * Added automatic preparation of virtualization support where required.

* **Documentation**
  * Documented the new scenario and clarified CI test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->