### PR TITLE
(MOT-4279) fix(harness): install published iii for e2e

### DIFF
--- a/.github/workflows/_harness-e2e.yml
+++ b/.github/workflows/_harness-e2e.yml
@@ -49,8 +49,8 @@ jobs:
     timeout-minutes: 45
     outputs:
       scenarios: ${{ steps.scenarios.outputs.json }}
-      engine_binary: ${{ steps.lock.outputs.binary }}
-      engine_revision: ${{ steps.lock.outputs.revision }}
+      engine_binary: ${{ steps.engine.outputs.binary }}
+      engine_revision: ${{ steps.engine.outputs.version }}
     steps:
       - uses: actions/checkout@v5
 
@@ -86,77 +86,33 @@ jobs:
           [[ -n "$JUDGE_MODEL" ]]
           [[ "$JUDGE_PROVIDER" =~ ^[A-Za-z0-9_-]+$ ]]
 
-      - name: Read and validate engine.lock
-        id: lock
+      - name: Install published iii release
+        id: engine
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          III_INSTALL_URL: https://install.iii.dev/iii/main/install.sh
+          III_INSTALL_BIN_DIR: ${{ github.workspace }}/target/iii/bin
         run: |
           set -euo pipefail
-          lock=harness/tests/integration/engine.lock
-          read_field() {
-            local field=$1 values
-            values=$(sed -n "s/^${field} = \"\\([^\"]*\\)\"$/\\1/p" "$lock")
-            [[ $(printf '%s\n' "$values" | sed '/^$/d' | wc -l) -eq 1 ]] || {
-              echo "engine.lock: $field must appear exactly once"
-              exit 3
-            }
-            printf '%s' "$values"
-          }
-          invalid=$(sed \
-            -e '/^[[:space:]]*$/d' \
-            -e '/^[[:space:]]*#/d' \
-            -e '/^\(repository\|revision\|package\|binary\) = "[^"]*"$/d' \
-            "$lock")
-          [[ -z "$invalid" ]] || {
-            echo "engine.lock: unsupported or malformed entry"
-            printf '%s\n' "$invalid"
-            exit 3
-          }
-          repository=$(read_field repository)
-          revision=$(read_field revision)
-          package=$(read_field package)
-          binary=$(read_field binary)
-          [[ "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || {
-            echo "engine.lock: repository must be an owner/name slug"
-            exit 3
-          }
-          [[ "$revision" =~ ^[0-9a-f]{40}$ ]] || {
-            echo "engine.lock: revision must be 40-hex"
-            exit 3
-          }
-          [[ "$package" =~ ^[A-Za-z0-9_-]+$ ]] || {
-            echo "engine.lock: package contains unsupported characters"
-            exit 3
-          }
-          [[ "$binary" =~ ^target/(debug|release)/[A-Za-z0-9_.-]+$ ]] || {
-            echo "engine.lock: binary must be a target profile path"
-            exit 3
-          }
-          {
-            echo "repository=$repository"
-            echo "revision=$revision"
-            echo "package=$package"
-            echo "binary=$binary"
-          } >> "$GITHUB_OUTPUT"
+          installer="$RUNNER_TEMP/install-iii.sh"
+          curl -fsSL --retry 3 --retry-all-errors \
+            "$III_INSTALL_URL" \
+            -o "$installer"
+          BIN_DIR="$III_INSTALL_BIN_DIR" sh "$installer"
 
-      - name: Checkout pinned engine source
-        uses: actions/checkout@v5
-        with:
-          repository: ${{ steps.lock.outputs.repository }}
-          ref: ${{ steps.lock.outputs.revision }}
-          path: target/integration-engine-src
+          for binary in iii iii-init iii-worker; do
+            test -x "$III_INSTALL_BIN_DIR/$binary"
+          done
+          version=$("$III_INSTALL_BIN_DIR/iii" --version | awk '{print $NF}')
+          test -n "$version"
+          {
+            echo "binary=target/iii/bin/iii"
+            echo "version=$version"
+          } >> "$GITHUB_OUTPUT"
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-
-      - name: Restore engine build
-        uses: actions/cache/restore@v4
-        with:
-          path: target/integration-engine-src/target
-          key: integration-engine-${{ runner.os }}-${{ runner.arch }}-${{ steps.lock.outputs.revision }}-${{ hashFiles('target/integration-engine-src/Cargo.lock') }}
-
-      - name: Build pinned engine
-        working-directory: target/integration-engine-src
-        run: cargo build --locked --release -p ${{ steps.lock.outputs.package }}
 
       - name: Restore E2E Rust cache
         uses: Swatinem/rust-cache@v2
@@ -226,7 +182,9 @@ jobs:
         run: |
           set -euo pipefail
           paths=(
-            "target/integration-engine-src/${{ steps.lock.outputs.binary }}"
+            target/iii/bin/iii
+            target/iii/bin/iii-init
+            target/iii/bin/iii-worker
             database/target/release/database
             state/target/release/state
             queue/target/release/queue
@@ -294,7 +252,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.anthropic_api_key }}
           OPENAI_API_KEY: ${{ secrets.openai_api_key }}
           ZAI_API_KEY: ${{ secrets.zai_api_key }}
-          III_BIN: ${{ github.workspace }}/target/integration-engine-src/${{ needs.build.outputs.engine_binary }}
+          III_BIN: ${{ github.workspace }}/${{ needs.build.outputs.engine_binary }}
           HARNESS_E2E_BIN: ${{ github.workspace }}/harness/target/release/harness-e2e
           HARNESS_E2E_ARTIFACTS_DIR: ${{ github.workspace }}/target/harness-e2e
           HARNESS_E2E_SCENARIO: ${{ matrix.scenario }}

--- a/harness/tests/e2e/README.md
+++ b/harness/tests/e2e/README.md
@@ -158,7 +158,7 @@ The runner writes `results.json` with:
 
 - exact catalog-resolved subject and judge model identity and capabilities;
 - effective scenario execution policy;
-- judge protocol and pinned engine revision when CI supplies it;
+- judge protocol and installed engine version when CI supplies it;
 - prompt, transcript, and `harness::metrics` for every run;
 - hard-gate results and per-criterion points;
 - judge attempts, token usage, and failures grouped by phase;
@@ -180,12 +180,14 @@ zero.
 | Harness E2E Main | Relevant push to `main` | 1 per subject/scenario | Score advisory; hard gates and technical failures blocking |
 | Harness E2E Nightly | New `main` revision on schedule, or manual dispatch on `main` | 3 per subject/scenario | Median score, two-of-three pass policy, hard gates and technical failures blocking |
 
-The reusable workflow itself is guarded to run only from `main`. It builds the
-pinned engine, the SQLite-backed database worker, and only the provider workers
-required by the subject matrix and fixed judge. Scenario ids come directly from
-`harness-e2e list`. Each subject/scenario pair receives a fresh stack, and
-repetitions run sequentially inside that job with unique table, session, and
-state namespaces. At most two matrix jobs make live-model calls concurrently.
+The reusable workflow itself is guarded to run only from `main`. It installs
+the latest published stable `iii` release with its `iii-init` and `iii-worker`
+companions, then builds the SQLite-backed database worker and only the provider
+workers required by the subject matrix and fixed judge. Scenario ids come
+directly from `harness-e2e list`. Each subject/scenario pair receives a fresh
+stack, and repetitions run sequentially inside that job with unique table,
+session, and state namespaces. At most two matrix jobs make live-model calls
+concurrently.
 
 The scheduled nightly skips the live suite when the current `main` SHA already
 has a successful full nightly result. A manual dispatch bypasses this

--- a/harness/tests/e2e/run-ci.sh
+++ b/harness/tests/e2e/run-ci.sh
@@ -11,6 +11,14 @@ set -Eeuo pipefail
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 harness_root=$(cd -- "$script_dir/../.." && pwd)
 repo_root=$(cd -- "$harness_root/.." && pwd)
+iii_bin_dir=$(cd -- "$(dirname -- "$III_BIN")" && pwd)
+for binary in iii iii-init iii-worker; do
+  [[ -x "$iii_bin_dir/$binary" ]] || {
+    echo "installed iii companion is not executable: $iii_bin_dir/$binary" >&2
+    exit 2
+  }
+done
+export PATH="$iii_bin_dir:$PATH"
 artifacts_dir=${HARNESS_E2E_ARTIFACTS_DIR:-"$repo_root/target/harness-e2e"}
 e2e_bin=${HARNESS_E2E_BIN:-"$harness_root/target/release/harness-e2e"}
 runs=${HARNESS_E2E_RUNS:-1}

--- a/harness/tests/e2e/stack-config/engine.yaml
+++ b/harness/tests/e2e/stack-config/engine.yaml
@@ -1,4 +1,5 @@
 workers:
+  - name: iii-worker-ops
   - name: iii-worker-manager
     config:
       host: 127.0.0.1


### PR DESCRIPTION
## Summary

- install the latest stable published `iii` release instead of checking out and compiling the engine source
- package `iii`, `iii-init`, and `iii-worker` for each E2E matrix job
- add the installed binary directory to `PATH` and start `iii-worker-ops`

## Root cause

The E2E stack compiled and packaged only the `iii` binary. The external worker lifecycle daemon lives in `iii-worker`, so `worker::add` was never registered and every live scenario timed out during preflight.

## Impact

The E2E stack now uses the same published release distribution as users and includes the companion binaries required by worker installation and sandbox execution.

## Validation

- `cargo test --locked --manifest-path harness/Cargo.toml -p harness-e2e` (55 passed)
- installed the current stable release (`iii 0.22.0`) with the official installer
- booted the E2E engine config and confirmed `iii-worker-ops` registered `worker::add`
- `bash -n harness/tests/e2e/run-ci.sh`
- YAML parse and `git diff --check`

Refs MOT-4279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - End-to-end testing now uses installed stable `iii` releases and their companion tools.
  - Added support for the operations worker in E2E stack configurations.
  - E2E runs now validate and consistently use the required engine companion binaries.

- **Documentation**
  - Updated CI guidance and result descriptions to reflect installed engine versions, judge protocols, worker selection, and concurrency limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->