### PR TITLE
(MOT-4277) fix(harness): bootstrap benchmark history branch

### DIFF
--- a/.github/scripts/bootstrap_benchmark_history.py
+++ b/.github/scripts/bootstrap_benchmark_history.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Create an empty remote benchmark-history branch when it does not exist."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+
+class BootstrapError(RuntimeError):
+    """Raised when the benchmark history branch cannot be inspected or created."""
+
+
+def run_git(
+    repository: Path,
+    *args: str,
+    input_text: str | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repository,
+        input=input_text,
+        text=True,
+        capture_output=True,
+    )
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise BootstrapError(f"git {' '.join(args)} failed: {detail}")
+    return result
+
+
+def remote_branch_exists(repository: Path, remote: str, branch: str) -> bool:
+    ref = f"refs/heads/{branch}"
+    run_git(repository, "check-ref-format", ref)
+    result = run_git(
+        repository,
+        "ls-remote",
+        "--exit-code",
+        "--heads",
+        remote,
+        ref,
+        check=False,
+    )
+    if result.returncode == 0:
+        return True
+    if result.returncode == 2:
+        return False
+    detail = result.stderr.strip() or result.stdout.strip()
+    raise BootstrapError(f"cannot inspect {remote}/{branch}: {detail}")
+
+
+def ensure_history_branch(
+    repository: Path,
+    *,
+    remote: str = "origin",
+    branch: str = "gh-pages",
+    message: str = "Initialize benchmark history",
+) -> bool:
+    """Ensure the remote branch exists, returning true only when it was created."""
+    if remote_branch_exists(repository, remote, branch):
+        return False
+
+    empty_tree = run_git(repository, "mktree", input_text="").stdout.strip()
+    commit = run_git(
+        repository,
+        "-c",
+        "user.name=github-actions",
+        "-c",
+        "user.email=github-actions@github.com",
+        "commit-tree",
+        empty_tree,
+        input_text=f"{message}\n",
+    ).stdout.strip()
+    push = run_git(
+        repository,
+        "push",
+        remote,
+        f"{commit}:refs/heads/{branch}",
+        check=False,
+    )
+    if push.returncode == 0:
+        return True
+
+    # Another publisher may have won the race after the initial lookup.
+    if remote_branch_exists(repository, remote, branch):
+        return False
+    detail = push.stderr.strip() or push.stdout.strip()
+    raise BootstrapError(f"cannot create {remote}/{branch}: {detail}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", type=Path, default=Path("."))
+    parser.add_argument("--remote", default="origin")
+    parser.add_argument("--branch", default="gh-pages")
+    parser.add_argument("--message", default="Initialize benchmark history")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    created = ensure_history_branch(
+        args.repository.resolve(),
+        remote=args.remote,
+        branch=args.branch,
+        message=args.message,
+    )
+    state = "created" if created else "already exists"
+    print(f"{args.remote}/{args.branch} {state}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_bootstrap_benchmark_history.py
+++ b/.github/scripts/tests/test_bootstrap_benchmark_history.py
@@ -1,0 +1,58 @@
+"""Tests for first-run benchmark history branch creation."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from _test_helpers import GIT_HERMETIC_ENV
+from bootstrap_benchmark_history import (
+    BootstrapError,
+    ensure_history_branch,
+)
+
+
+def git(repository: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repository,
+        check=True,
+        env=GIT_HERMETIC_ENV,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def repository_with_bare_remote(tmp_path: Path) -> tuple[Path, Path]:
+    remote = tmp_path / "remote.git"
+    checkout = tmp_path / "checkout"
+    git(tmp_path, "init", "--bare", "-q", str(remote))
+    git(tmp_path, "init", "-q", "-b", "main", str(checkout))
+    git(checkout, "config", "user.email", "test@example.com")
+    git(checkout, "config", "user.name", "Test")
+    (checkout / "README.md").write_text("main\n")
+    git(checkout, "add", "README.md")
+    git(checkout, "commit", "-q", "-m", "Initial main")
+    git(checkout, "remote", "add", "origin", str(remote))
+    git(checkout, "push", "-q", "-u", "origin", "main")
+    return checkout, remote
+
+
+def test_creates_empty_remote_history_branch_idempotently(tmp_path: Path) -> None:
+    checkout, remote = repository_with_bare_remote(tmp_path)
+
+    assert ensure_history_branch(checkout) is True
+    first_head = git(remote, "rev-parse", "refs/heads/gh-pages")
+    assert git(remote, "ls-tree", "--name-only", first_head) == ""
+
+    assert ensure_history_branch(checkout) is False
+    assert git(remote, "rev-parse", "refs/heads/gh-pages") == first_head
+
+
+def test_rejects_an_invalid_history_branch_name(tmp_path: Path) -> None:
+    checkout, _ = repository_with_bare_remote(tmp_path)
+
+    with pytest.raises(BootstrapError, match="check-ref-format"):
+        ensure_history_branch(checkout, branch="../invalid")

--- a/.github/workflows/harness-e2e-benchmark.yml
+++ b/.github/workflows/harness-e2e-benchmark.yml
@@ -76,6 +76,9 @@ jobs:
           }
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
 
+      - name: Bootstrap benchmark history
+        run: python3 .github/scripts/bootstrap_benchmark_history.py
+
       - name: Store quality history
         if: steps.compact.outcome == 'success'
         uses: benchmark-action/github-action-benchmark@v1
@@ -106,19 +109,10 @@ jobs:
           auto-push: true
           summary-always: true
 
-      - name: Resolve benchmark history branch
-        id: history
-        run: |
-          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Checkout benchmark history
         uses: actions/checkout@v5
         with:
-          ref: ${{ steps.history.outputs.exists == 'true' && 'gh-pages' || github.event.workflow_run.head_sha }}
+          ref: gh-pages
           path: pages-source
           fetch-depth: 0
 
@@ -136,13 +130,8 @@ jobs:
           CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          HISTORY_EXISTS: ${{ steps.history.outputs.exists }}
         run: |
           set -euo pipefail
-          if [[ "$HISTORY_EXISTS" != "true" ]]; then
-            git -C pages-source checkout --orphan gh-pages
-            git -C pages-source rm -rf .
-          fi
           mkdir -p pages-source/dev/harness-e2e
           cp -R "$SITE_DIR"/. pages-source/dev/harness-e2e/
           touch pages-source/.nojekyll


### PR DESCRIPTION
Refs MOT-4277

## Summary

- create the remote `gh-pages` branch before `benchmark-action` stores the first metrics
- use an empty Git commit so initialization does not modify or switch the workflow checkout
- make branch creation idempotent and safe when another publisher wins the creation race
- remove the late bootstrap path that could never run after the first benchmark action failed

## Root cause

The first publisher run successfully downloaded the compact metrics and full execution artifacts, but `benchmark-action` tried to fetch `gh-pages` before that branch existed. The job stopped before reaching the workflow's existing orphan-branch fallback, so no history or Pages artifact was published.

## Validation

- exercised branch creation and idempotence against a temporary bare Git remote
- verified invalid branch names are rejected
- `python3 -m py_compile .github/scripts/bootstrap_benchmark_history.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated benchmark history initialization now creates the publishing history when it is missing.
  * Benchmark publishing can reuse existing history without recreating or overwriting it.

* **Bug Fixes**
  * Improved reliability when multiple publishing processes attempt initialization simultaneously.
  * Invalid history branch names are rejected with a clear error.

* **Tests**
  * Added coverage for branch creation, idempotent behavior, and input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->