### PR TITLE
(MOT-4277) feat(harness): treat judged scores as quality signal

### DIFF
--- a/harness/tests/e2e/README.md
+++ b/harness/tests/e2e/README.md
@@ -134,7 +134,10 @@ the two-of-three tolerance used by the daily benchmark.
 
 Scenarios with a judge reference delegate every criterion score to the judge.
 Scenarios without one award every criterion objectively in code. Mechanical
-effects remain hard gates in both cases.
+effects remain hard gates in both cases. Judge-backed scenarios use a 50-point
+pass floor so a mediocre but usable answer remains a passing execution while
+its full score still exposes the quality gap in reports and historical trends.
+Scores below 50 continue to fail as semantically inadequate.
 
 Every run has one explicit status:
 

--- a/harness/tests/e2e/src/scenarios/direct_answer.rs
+++ b/harness/tests/e2e/src/scenarios/direct_answer.rs
@@ -1,7 +1,7 @@
 use serde_json::json;
 
 use super::common;
-use super::{CriterionSpec, ExecutionPolicy, ScenarioSpec};
+use super::{CriterionSpec, ExecutionPolicy, ScenarioSpec, JUDGE_BACKED_PASS_THRESHOLD};
 
 pub const ID: &str = "direct_answer";
 
@@ -16,7 +16,7 @@ pub fn scenario(_run_id: &str) -> ScenarioSpec {
             max_total_tokens: 32_768,
             stuck_timeout_seconds: 120,
         },
-        threshold: 80,
+        threshold: JUDGE_BACKED_PASS_THRESHOLD,
         criteria: vec![
             CriterionSpec {
                 id: "correctness",

--- a/harness/tests/e2e/src/scenarios/mod.rs
+++ b/harness/tests/e2e/src/scenarios/mod.rs
@@ -19,6 +19,10 @@ pub mod reactive_automation;
 pub mod security_review;
 pub mod shell_coder_sandbox;
 
+/// Judge-backed scenarios keep a low semantic floor while exposing the full
+/// score as a quality signal. Objective contract violations remain hard gates.
+pub(super) const JUDGE_BACKED_PASS_THRESHOLD: u8 = 50;
+
 pub type EvaluationFuture<'a> =
     Pin<Box<dyn Future<Output = Result<ObjectiveEvaluation>> + Send + 'a>>;
 pub type CleanupFuture<'a> = Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
@@ -86,6 +90,12 @@ impl ScenarioSpec {
         self.execution.validate(self.id)?;
         if !(1..=100).contains(&self.threshold) {
             bail!("scenario {} threshold must be between 1 and 100", self.id);
+        }
+        if self.needs_judge() && self.threshold != JUDGE_BACKED_PASS_THRESHOLD {
+            bail!(
+                "judge-backed scenario {} threshold must be {JUDGE_BACKED_PASS_THRESHOLD}",
+                self.id
+            );
         }
         let total: u16 = self
             .criteria
@@ -221,6 +231,26 @@ mod tests {
                 .execution
                 .max_output_tokens,
             None
+        );
+    }
+
+    #[test]
+    fn judge_backed_scenarios_use_the_quality_signal_floor() {
+        for scenario in [ScenarioId::DirectAnswer, ScenarioId::SecurityReview] {
+            let spec = scenario.spec("run");
+            assert!(spec.needs_judge());
+            assert_eq!(spec.threshold, JUDGE_BACKED_PASS_THRESHOLD);
+        }
+    }
+
+    #[test]
+    fn validation_rejects_a_different_judge_backed_threshold() {
+        let mut spec = ScenarioId::DirectAnswer.spec("run");
+        spec.threshold = JUDGE_BACKED_PASS_THRESHOLD + 1;
+
+        assert_eq!(
+            spec.validate().unwrap_err().to_string(),
+            "judge-backed scenario direct_answer threshold must be 50"
         );
     }
 }

--- a/harness/tests/e2e/src/scenarios/security_review.rs
+++ b/harness/tests/e2e/src/scenarios/security_review.rs
@@ -1,7 +1,7 @@
 use serde_json::json;
 
 use super::common;
-use super::{CriterionSpec, ExecutionPolicy, ScenarioSpec};
+use super::{CriterionSpec, ExecutionPolicy, ScenarioSpec, JUDGE_BACKED_PASS_THRESHOLD};
 
 pub const ID: &str = "security_review";
 
@@ -23,7 +23,7 @@ For each snippet, identify the vulnerability, explain its impact, and recommend 
             max_total_tokens: 49_152,
             stuck_timeout_seconds: 120,
         },
-        threshold: 80,
+        threshold: JUDGE_BACKED_PASS_THRESHOLD,
         criteria: vec![
             CriterionSpec {
                 id: "coverage",


### PR DESCRIPTION
Refs MOT-4277

## Summary

- lower the pass floor for judge-backed E2E scenarios from 80 to 50
- enforce the shared floor for every scenario with a judge reference
- preserve the full score in reports and benchmark trends while hard gates and technical failures remain blocking
- keep objective scenario thresholds unchanged

## Why

A mediocre but usable judged response should remain visible as a low quality score without turning an otherwise valid execution into an operational failure. Scores below 50 still fail as semantically inadequate.

## Validation

- `cargo test --locked --manifest-path harness/Cargo.toml -p harness-e2e scenarios::tests`
- `cargo fmt --manifest-path harness/Cargo.toml --all -- --check`
- `git diff --check`