### PR TITLE
feat(release): add an experimental flag to Create Tag

### DIFF
--- a/.github/scripts/build_publish_payload.py
+++ b/.github/scripts/build_publish_payload.py
@@ -329,6 +329,7 @@ def build_payload(
     binaries: dict[str, Any],
     image_tag: str,
     bundle: dict[str, Any] | None = None,
+    experimental: bool = False,
 ) -> dict[str, Any]:
     root = repo_root / worker
     meta = _read_yaml(root / "iii.worker.yaml") or {}
@@ -364,6 +365,11 @@ def build_payload(
             _normalize_registry_trigger(trigger)
             for trigger in interface.get("triggers") or []
         ],
+        # Always sent, never omitted: the registry treats a missing flag as
+        # "not experimental" and clears the badge, so leaving it out on a
+        # still-experimental release would silently promote the worker. The
+        # registry rejects a string here, hence the explicit bool.
+        "experimental": bool(experimental),
     }
 
     tags = normalize_tags(meta.get("tags"))
@@ -410,6 +416,14 @@ def main() -> int:
     parser.add_argument("--image-tag", default="")
     parser.add_argument("--repo-root", default=".")
     parser.add_argument("--out", default="payload.json")
+    # Workflow inputs arrive as strings; anything but a literal `true` is
+    # false, so a missing or malformed value publishes as stable rather than
+    # marking a worker experimental by accident.
+    parser.add_argument(
+        "--experimental",
+        default="false",
+        help="'true' marks the published worker experimental in the registry",
+    )
     args = parser.parse_args()
 
     interface = json.loads(pathlib.Path(args.interface_json).read_text(encoding="utf-8"))
@@ -431,6 +445,7 @@ def main() -> int:
         binaries=binaries,
         image_tag=args.image_tag,
         bundle=bundle,
+        experimental=args.experimental.strip().lower() == "true",
     )
     pathlib.Path(args.out).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     print(json.dumps({k: v for k, v in payload.items() if k != "readme"}, indent=2))

--- a/.github/scripts/parse_release_tag.py
+++ b/.github/scripts/parse_release_tag.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Parse a release tag and emit setup outputs for release.yml.
 
-Writes 10 keys to $GITHUB_OUTPUT:
-    tag, worker, version, deploy, language,
-    bin, manifest, registry_tag, is_prerelease, dry_run
+Writes 12 keys to $GITHUB_OUTPUT:
+    tag, worker, version, deploy, language, bin, manifest,
+    registry_tag, is_prerelease, dry_run, targets, experimental
 """
 from __future__ import annotations
 
@@ -55,7 +55,13 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    registry_tag = _lib.read_tag_annotation(raw).get("registry-tag", "latest") or "latest"
+    annotation = _lib.read_tag_annotation(raw)
+    registry_tag = annotation.get("registry-tag", "latest") or "latest"
+
+    # Anything but a literal `true` is false: a lightweight tag, a missing
+    # line, or a typo publishes as stable. Marking a worker experimental is
+    # the deliberate choice, so it takes the exact word.
+    experimental = "true" if annotation.get("experimental", "").strip().lower() == "true" else "false"
 
     # `targets` is an optional iii.worker.yaml field that can be either a
     # list (`- aarch64-apple-darwin\n- x86_64-unknown-linux-gnu`) or a comma
@@ -80,6 +86,7 @@ def main(argv: list[str] | None = None) -> int:
         ("is_prerelease", is_pre),
         ("dry_run", dry_run),
         ("targets", targets),
+        ("experimental", experimental),
     ]
 
     gh_out = os.environ.get("GITHUB_OUTPUT")
@@ -90,7 +97,7 @@ def main(argv: list[str] | None = None) -> int:
 
     print(
         f"::notice::release {worker} v{version} deploy={wm.deploy} "
-        f"registry-tag={registry_tag}"
+        f"registry-tag={registry_tag} experimental={experimental}"
     )
     return 0
 

--- a/.github/scripts/tests/test_build_publish_payload.py
+++ b/.github/scripts/tests/test_build_publish_payload.py
@@ -5,7 +5,7 @@ import pytest
 from build_publish_payload import build_payload
 
 
-def build_binary_payload(tmp_path: Path, manifest: str) -> dict[str, object]:
+def build_binary_payload(tmp_path: Path, manifest: str, **kwargs) -> dict[str, object]:
     worker_dir = tmp_path / "smoke"
     worker_dir.mkdir(parents=True)
     (worker_dir / "iii.worker.yaml").write_text(manifest)
@@ -20,6 +20,7 @@ def build_binary_payload(tmp_path: Path, manifest: str) -> dict[str, object]:
         interface={"functions": [], "triggers": []},
         binaries={"x86_64-unknown-linux-gnu": {"url": "https://example.test/smoke.tgz"}},
         image_tag="",
+        **kwargs,
     )
 
 
@@ -53,3 +54,13 @@ def test_manifest_tags_are_normalized_validated_and_optional(tmp_path: Path) -> 
     invalid = tmp_path / "invalid"
     with pytest.raises(ValueError, match="tags entries must be strings"):
         build_binary_payload(invalid, "name: smoke\ntags:\n  - sql\n  - 7\n")
+
+
+def test_experimental_is_always_sent_as_a_bool(tmp_path: Path) -> None:
+    # The registry clears the badge when the key is missing and 422s on a
+    # string, so the payload must always carry a real boolean.
+    default = build_binary_payload(tmp_path / "default", "name: smoke\n")
+    assert default["experimental"] is False
+
+    marked = build_binary_payload(tmp_path / "marked", "name: smoke\n", experimental=True)
+    assert marked["experimental"] is True

--- a/.github/scripts/tests/test_parse_release_tag.py
+++ b/.github/scripts/tests/test_parse_release_tag.py
@@ -114,3 +114,40 @@ class TestParseReleaseTag:
         out_path.touch()
         r = run_script(repo, "missing/v1.0.0", out_path)
         assert r.returncode != 0
+
+
+class TestExperimentalAnnotation:
+    """`experimental:` rides the annotated tag message next to `registry-tag:`."""
+
+    def _run(self, tmp_path, registry_tag_line):
+        repo = make_repo_with_tagged_worker(
+            tmp_path, "smoke/v1.0.0", "1.0.0", registry_tag_line=registry_tag_line
+        )
+        out_path = tmp_path / "gh_output"
+        out_path.touch()
+        r = run_script(repo, "smoke/v1.0.0", out_path)
+        assert r.returncode == 0, r.stderr
+        return parse_outputs(out_path)
+
+    def test_absent_line_is_false(self, tmp_path):
+        out = self._run(tmp_path, "registry-tag: latest")
+        assert out["experimental"] == "false"
+
+    def test_true_marks_experimental(self, tmp_path):
+        out = self._run(tmp_path, "registry-tag: latest\nexperimental: true")
+        assert out["experimental"] == "true"
+        assert out["registry_tag"] == "latest"
+
+    def test_false_stays_false(self, tmp_path):
+        out = self._run(tmp_path, "registry-tag: latest\nexperimental: false")
+        assert out["experimental"] == "false"
+
+    def test_casing_and_padding_tolerated(self, tmp_path):
+        out = self._run(tmp_path, "registry-tag: latest\nexperimental:   TRUE  ")
+        assert out["experimental"] == "true"
+
+    # A typo must not mark a stable worker experimental — anything but the
+    # exact word is false, and the release still publishes.
+    def test_typo_falls_back_to_false(self, tmp_path):
+        out = self._run(tmp_path, "registry-tag: latest\nexperimental: yes")
+        assert out["experimental"] == "false"

--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -39,6 +39,11 @@ on:
         required: false
         type: string
         default: 'https://api.workers.iii.dev'
+      experimental:
+        description: "'true' marks the worker experimental in the registry (badge only)"
+        required: false
+        type: string
+        default: 'false'
 
 jobs:
   publish:
@@ -322,11 +327,13 @@ jobs:
           REGISTRY_TAG: ${{ inputs.registry_tag }}
           IMAGE_TAG: ${{ inputs.image_tag }}
           REPO_URL: ${{ format('https://github.com/{0}', github.repository) }}
+          EXPERIMENTAL: ${{ inputs.experimental }}
         run: |
           python3 .github/scripts/build_publish_payload.py \
             --worker "$WORKER" \
             --version "$VERSION" \
             --registry-tag "$REGISTRY_TAG" \
+            --experimental "$EXPERIMENTAL" \
             --deploy "$DEPLOY" \
             --repo-url "$REPO_URL" \
             --interface-json worker-interface.json \

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -77,6 +77,11 @@ on:
           - latest
           - next
         default: latest
+      experimental:
+        description: 'Mark the worker experimental in the registry (badge only — it still installs and resolves normally). Leave unchecked once it is stable: releasing without this clears the badge.'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -213,12 +218,17 @@ jobs:
           REGISTRY_TAG: ${{ inputs.tag }}
           WORKER: ${{ inputs.worker }}
           NEW_VERSION: ${{ steps.versions.outputs.version }}
+          EXPERIMENTAL: ${{ inputs.experimental }}
         run: |
+          # `experimental` rides the annotation like `registry-tag`: the tag is
+          # the only thing the Release workflow receives, so anything the
+          # publish needs has to be written here.
           git tag -a "$TAG" -m "Release $TAG
 
           worker: $WORKER
           version: $NEW_VERSION
           registry-tag: $REGISTRY_TAG
+          experimental: $EXPERIMENTAL
           "
           git push origin "$TAG"
-          echo "::notice::Created tag: $TAG (registry-tag=$REGISTRY_TAG)"
+          echo "::notice::Created tag: $TAG (registry-tag=$REGISTRY_TAG, experimental=$EXPERIMENTAL)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,7 @@ jobs:
       is_prerelease: ${{ steps.meta.outputs.is_prerelease }}
       dry_run: ${{ steps.meta.outputs.dry_run }}
       targets: ${{ steps.meta.outputs.targets }}
+      experimental: ${{ steps.meta.outputs.experimental }}
       web_bundle: ${{ steps.web.outputs.needed }}
       interface_smoke: ${{ steps.smoke.outputs.interface_smoke }}
     steps:
@@ -236,6 +237,7 @@ jobs:
       tag: ${{ needs.setup.outputs.tag }}
       bin: ${{ needs.setup.outputs.bin }}
       image_tag: ${{ needs.container-build.outputs.image_tag }}
+      experimental: ${{ needs.setup.outputs.experimental }}
     secrets: inherit
 
   # ──────────────────────────────────────────────────────────────

--- a/docs/sops/release.md
+++ b/docs/sops/release.md
@@ -36,13 +36,15 @@ Actions → **Create Tag**:
 | Worker | Folder name (must be in workflow options) |
 | Bump | `patch` / `minor` / `major` |
 | Registry tag | `latest` or `next` — channel for `iii worker add` resolution |
+| Experimental | Checkbox. Marks the worker experimental in the registry — see [Experimental releases](#experimental-releases) |
 
 The workflow:
 
 1. Bumps version in the worker manifest (`Cargo.toml`, `package.json`, …).
 2. Commits `chore(<worker>): bump to vX.Y.Z` to `main`.
 3. Creates and pushes an **annotated** tag `<worker>/vX.Y.Z` with
-   `registry-tag: <latest|next>` in the tag message.
+   `registry-tag: <latest|next>` and `experimental: <true|false>` in the tag
+   message.
 
 ### 2. Release pipeline
 
@@ -100,6 +102,28 @@ Workers with `interface_smoke: false` skip the entire publish job.
 The channel is stored in the **annotated tag message** (`registry-tag:`).
 `release.yml` refetches the annotated tag for this reason. Lightweight tags
 lose the channel and default to `latest`.
+
+## Experimental releases
+
+Tick **Experimental** on Create Tag to mark the worker unstable in the
+registry. It is a badge and nothing else — the version publishes to the
+channel you picked, installs normally, and resolves normally. Nobody has to
+opt in to see it, and nothing has to be promoted later.
+
+It travels the same way the channel does: `experimental: true` in the
+annotated tag message, read by `parse_release_tag.py`, forwarded through
+`release.yml` to the publish payload. Anything but the literal `true` — a
+missing line, a lightweight tag, a typo — publishes as stable.
+
+**Leave it unticked once the worker settles.** The registry treats a release
+without the flag as the promotion signal and drops the badge, so there is no
+separate "make it stable" step. Re-releasing while still experimental keeps
+the original mark, so the badge records when the worker first shipped
+experimental.
+
+For what the registry does with the flag, see
+[`EXPERIMENTAL_WORKERS.md`](https://github.com/iii-hq/registry/blob/main/docs/EXPERIMENTAL_WORKERS.md)
+in the registry repo.
 
 ## Variants
 


### PR DESCRIPTION
Adds an **Experimental** checkbox to Create Tag. Ticking it marks the worker
experimental in the registry — a badge, nothing more: the version publishes
to the channel you picked, installs normally, and resolves normally.

This is the replacement for the `experimental` channel reverted in #643. That
one needed resolver support the registry never had, and isolating a release
from `latest` is not what "this is unstable" should mean.

**Depends on iii-hq/registry#81** (the column + the badge). Merging this
first would 422 every publish: the registry's publish payload is a strict
object, so it rejects the unknown field.

## The path the flag takes

```
Create Tag input  →  annotated tag message (`experimental: true`)
                  →  parse_release_tag.py  (output `experimental`)
                  →  release.yml  (setup job output)
                  →  _publish-registry.yml
                  →  build_publish_payload.py  →  POST /publish
```

It rides the tag annotation next to `registry-tag:` because the tag is all
the Release workflow receives — anything the publish needs has to be written
there.

## Two rules worth knowing

**Anything but the literal `true` is false.** A lightweight tag, a missing
line, a typo (`experimental: yes`) — all publish as stable. Marking a worker
experimental is the deliberate choice, so it takes the exact word.

**Leaving the box unticked is the promotion.** The registry treats a release
without the flag as the signal that the worker stabilised and drops the
badge, so there is no separate promote step. Re-releasing while still
experimental keeps the original mark.

The payload always carries the key, always as a real boolean — the registry
422s a stringly-typed value, and a workflow input is a string.

## Verification

- `.github/scripts/tests/`: **157 passed** (7 new — 5 on the annotation
  parsing incl. typo/casing/absent, 2 on the payload's boolean)
- End-to-end dry run on a scratch repo, both directions: an annotated tag
  carrying `experimental: true` produced `"experimental": true` (JSON bool)
  in the payload; the same tag without the line produced `false`
- All three edited workflows parse as YAML


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for marking releases as experimental during tag creation and registry publishing.
  * Experimental status is propagated through release workflows and included in registry metadata.
  * Added documentation describing experimental releases and promotion to stable status.

* **Bug Fixes**
  * Ensured the experimental registry field is always recorded as a boolean, defaulting to `false`.
  * Invalid or missing experimental tag values now safely fall back to `false`.

* **Tests**
  * Added coverage for experimental release parsing and payload generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->