### PR TITLE
fix(release): take the bundle pnpm version from packageManager

### DIFF
--- a/.github/workflows/_bundle.yml
+++ b/.github/workflows/_bundle.yml
@@ -80,10 +80,10 @@ jobs:
       # file with all npm deps + JSON assets inlined. Only Node built-ins
       # and `fsevents` (macOS-only optional native dep used by chokidar)
       # are external. See `<worker>/scripts/build-bundle.mjs`.
+      # The pnpm version comes from the repo-root package.json
+      # `packageManager` field (the UI pnpm workspace root).
       - uses: pnpm/action-setup@v5
         if: inputs.language == 'node' || inputs.language == 'javascript'
-        with:
-          version: 10
 
       - uses: actions/setup-node@v5
         if: inputs.language == 'node' || inputs.language == 'javascript'


### PR DESCRIPTION
## What

Removes the `version: 10` input from `pnpm/action-setup` in `_bundle.yml` so the pnpm version comes from the repo-root `package.json` `packageManager` field, matching `ci.yml` and `_rust-binary.yml`.

## Why

Every `deploy: bundle` worker release currently fails in the Bundle build job:

```
Error: Multiple versions of pnpm specified:
  - version 10 in the GitHub Action config with the key "version"
  - version pnpm@11.13.1 in the package.json with the key "packageManager"
```

PR #570 bumped the root `packageManager` to `pnpm@11.13.1` and removed the `version: 10` pin from `ci.yml` and `_rust-binary.yml`, but `_bundle.yml` kept its pin, and `pnpm/action-setup` refuses to run when both are set.

Failed release runs: pi/v0.1.12, opencode/v0.1.8, claude-code/v0.1.11. The tags exist with the correct annotated messages, so Release can be re-dispatched for them once this lands.

## Testing

CI-only change. The three failed tags will be re-run through the Release workflow via workflow_dispatch after merge to verify the bundle path end to end.
