### PR TITLE
fix(release): install bundle worker deps outside the root UI workspace

### DIFF
--- a/.github/workflows/_bundle.yml
+++ b/.github/workflows/_bundle.yml
@@ -92,10 +92,14 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: ${{ inputs.worker }}/pnpm-lock.yaml
 
+      # Bundle workers are self-contained projects with their own lockfiles
+      # (see the note in the repo-root pnpm-workspace.yaml). Without
+      # --ignore-workspace, pnpm walks up to the root UI workspace and never
+      # installs the worker's own deps.
       - name: pnpm install
         if: inputs.language == 'node' || inputs.language == 'javascript'
         working-directory: ${{ inputs.worker }}
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-workspace
 
       - name: pnpm run build:bundle
         if: inputs.language == 'node' || inputs.language == 'javascript'


### PR DESCRIPTION
## What

Adds `--ignore-workspace` to the `pnpm install` step in `_bundle.yml` so bundle workers install their own dependencies from their own lockfiles.

## Why

After #650 unblocked pnpm setup, the re-dispatched bundle releases (pi/v0.1.12, opencode/v0.1.8, claude-code/v0.1.11) failed in `build:bundle` with `ERR_MODULE_NOT_FOUND` and "node_modules missing". The install log shows why:

```
Scope: all 13 workspace projects
```

`pnpm install` inside the worker directory walks up to the repo-root UI pnpm workspace and installs that instead, so the worker's own deps never land. The root `pnpm-workspace.yaml` note is explicit that Node bundle workers are self-contained projects with their own lockfiles, which is exactly what `--ignore-workspace` enforces. All three workers carry `lockfileVersion: '9.0'` lockfiles, compatible with the pinned pnpm@11.13.1.

## Testing

CI-only change. The three failed tags will be re-dispatched through Release after merge to verify the bundle path end to end.
