### PR TITLE
perf(demo): reach the first tool call sooner

### DIFF
--- a/console/web/src/demo/LandingDemo.tsx
+++ b/console/web/src/demo/LandingDemo.tsx
@@ -408,17 +408,16 @@ function DemoChrome({
         replay
       </button>
       {/* Embedded only: the host page listens for iii-demo-close and scrolls
-          the console away. Alert red on black, the loudest thing in the frame,
-          because a reader who wants out should not have to look for it. Black
-          rather than cream on the red: it is a 10px label and needs the
-          contrast. */}
+          the console away. Red, the loudest thing in the frame, because a
+          reader who wants out should not have to look for it. The exact red
+          and its text color are in demo.css. */}
       {window.self !== window.top && (
         <button
           type="button"
           onClick={() =>
             window.parent?.postMessage({ type: 'iii-demo-close' }, '*')
           }
-          className="flex items-center gap-1.5 bg-alert px-2.5 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-black transition-opacity hover:opacity-80"
+          className="demo-close flex items-center gap-1.5 px-2.5 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.14em] transition-opacity hover:opacity-80"
         >
           close <span className="opacity-70">esc</span>
         </button>

--- a/console/web/src/demo/LandingDemo.tsx
+++ b/console/web/src/demo/LandingDemo.tsx
@@ -408,16 +408,19 @@ function DemoChrome({
         replay
       </button>
       {/* Embedded only: the host page listens for iii-demo-close and scrolls
-          the console away. Inverted so the way out is unmissable. */}
+          the console away. Alert red on black, the loudest thing in the frame,
+          because a reader who wants out should not have to look for it. Black
+          rather than cream on the red: it is a 10px label and needs the
+          contrast. */}
       {window.self !== window.top && (
         <button
           type="button"
           onClick={() =>
             window.parent?.postMessage({ type: 'iii-demo-close' }, '*')
           }
-          className="flex items-center gap-1.5 bg-ink px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-bg transition-opacity hover:opacity-80"
+          className="flex items-center gap-1.5 bg-alert px-2.5 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-black transition-opacity hover:opacity-80"
         >
-          close <span className="opacity-60">esc</span>
+          close <span className="opacity-70">esc</span>
         </button>
       )}
     </div>

--- a/console/web/src/demo/demo.css
+++ b/console/web/src/demo/demo.css
@@ -62,3 +62,12 @@
     transform: none;
   }
 }
+
+/* The way out of the embedded console. Taken down from the raw alert red, so
+   it reads as an exit rather than as something having gone wrong, and dark
+   enough that white holds AA at the 10px the chrome bar uses. Derived from the
+   token, identical in both themes: the button means the same thing in each. */
+.demo-close {
+  background: color-mix(in oklab, var(--color-alert) 72%, #1a0206);
+  color: #fff;
+}

--- a/console/web/src/demo/scenario.ts
+++ b/console/web/src/demo/scenario.ts
@@ -132,6 +132,11 @@ function readingDwellMs(body: string): number {
   return Math.min(2800, Math.max(600, tokenize(body).length * 10))
 }
 
+/** Mean per-token delay that streams `body` in about `totalMs`. */
+function paceOver(body: string, totalMs: number): number {
+  return totalMs / tokenize(body).length
+}
+
 async function* thought(
   body: string,
   signal?: AbortSignal,
@@ -1139,6 +1144,10 @@ would have resumed from the last completed step, into the same trace.`
 
 /* ── the script ───────────────────────────────────────────────────────── */
 
+/** Streamed on a 1.1s budget: the reader is waiting on the first tool call. */
+const OPENING_THOUGHT =
+  'The user wants a payments ledger with durable storage. Before I write a line of it I should look at what is already connected to this engine. iii keeps a live catalog of every running worker, so a durable database may already be here. If it is, there is nothing to scaffold and nothing to deploy alongside.'
+
 export async function* runScenario(
   opts: ScenarioOptions,
 ): AsyncGenerator<DemoEvent> {
@@ -1153,10 +1162,7 @@ export async function* runScenario(
   /* step 1 — look at what is already running */
   yield* step(
     1,
-    thought(
-      'The user wants a payments ledger with durable storage. Before I write a line of it I should look at what is already connected to this engine. iii keeps a live catalog of every running worker, so a durable database may already be here. If it is, there is nothing to scaffold and nothing to deploy alongside.',
-      signal,
-    ),
+    thought(OPENING_THOUGHT, signal, paceOver(OPENING_THOUGHT, 1100)),
     signal,
     (stepSpan) =>
       call({

--- a/console/web/src/demo/usePlayer.ts
+++ b/console/web/src/demo/usePlayer.ts
@@ -41,7 +41,8 @@ export type Phase = 'idle' | 'typing' | 'streaming' | 'done'
 
 /** How long the finished turn stays up before the loop restarts. */
 const HOLD_MS = 14000
-const TYPE_MS_PER_CHAR = 42
+/** Fast: the prompt is the preamble, the run is what the reader came for. */
+const TYPE_MS_PER_CHAR = 18
 /** Repaint cadence while a span is still open, so its bar grows. */
 const PENDING_TICK_MS = 120
 /** The gate releases itself if nobody clicks approve. */


### PR DESCRIPTION
The landing demo spent over two seconds typing the prompt and another two on
the opening thought before anything happened. Both are preamble; the run is
what the reader came for.

- Prompt types at 18ms/char instead of 42.
- The opening thought streams on a 1.1s total budget, via a small
  `paceOver(body, totalMs)` helper, instead of a per-token cadence whose
  length decided the duration.

Measured on the built demo, from page load: prompt fully typed at 1.6s, the
opening thought streams in 1.09s, `engine::workers::list` on screen at 5.1s.

The website vendors this build, so it ships alongside
https://github.com/iii-hq/iii/pull/2029 there.

MOT-4440

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved the introductory thought-streaming animation for a smoother, more consistent presentation.
  * Increased prompt typing speed to make demo interactions feel more responsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->