### PR TITLE
(MOT-4290) fix: harden worker presence and diagnostics

### DIFF
--- a/console/web/e2e/harness-stack.ts
+++ b/console/web/e2e/harness-stack.ts
@@ -20,6 +20,10 @@ interface ReadyManifest {
   model: { id: string; provider: string }
   message: string
   functions: Record<string, string>
+  controls: {
+    gate_status: string
+    gate_release: string
+  }
   send: Record<string, unknown>
 }
 
@@ -67,6 +71,9 @@ export interface HarnessStack {
   ready: ReadyManifest
   consoleUrl: string
   trigger(): Promise<unknown>
+  waitForRouterGate(name: string, count?: number): Promise<void>
+  waitForQueuedMessage(text: string): Promise<void>
+  releaseRouterGate(name: string): Promise<void>
   waitForTurnCompleted(): Promise<TurnCompletedEvent>
   finish(): Promise<PlaygroundResult>
 }
@@ -274,6 +281,52 @@ export const test = base.extend<FixtureValues, FixtureOptions>({
             function_id: 'harness::send',
             payload: manifest.send,
           }),
+        waitForRouterGate: async (name, count = 1) => {
+          const deadline = Date.now() + 15_000
+          while (Date.now() < deadline) {
+            const status = (await connectedSdk.trigger({
+              function_id: manifest.controls.gate_status,
+              payload: { name },
+            })) as { arrivals?: number }
+            if ((status.arrivals ?? 0) >= count) return
+            await delay(25)
+          }
+          throw new Error(
+            `timed out waiting for scripted router gate ${name} (${count} arrivals)`,
+          )
+        },
+        waitForQueuedMessage: async (text) => {
+          const deadline = Date.now() + 15_000
+          while (Date.now() < deadline) {
+            const status = (await connectedSdk.trigger({
+              function_id: 'harness::status',
+              payload: { session_id: manifest.session.id },
+            })) as {
+              queued?: Array<{
+                message?: { content?: Array<{ type?: string; text?: string }> }
+              }>
+            } | null
+            const queued = status?.queued?.some((row) =>
+              row.message?.content?.some(
+                (block) => block.type === 'text' && block.text === text,
+              ),
+            )
+            if (queued) return
+            await delay(25)
+          }
+          throw new Error(
+            `timed out waiting for queued harness message ${JSON.stringify(text)}`,
+          )
+        },
+        releaseRouterGate: async (name) => {
+          const response = (await connectedSdk.trigger({
+            function_id: manifest.controls.gate_release,
+            payload: { name },
+          })) as { released?: boolean }
+          if (response.released !== true) {
+            throw new Error(`scripted router gate ${name} was not released`)
+          }
+        },
         waitForTurnCompleted: () => armCompletion(connectedSdk, manifest),
         finish,
       }

--- a/console/web/e2e/harness-stack.ts
+++ b/console/web/e2e/harness-stack.ts
@@ -21,7 +21,6 @@ interface ReadyManifest {
   message: string
   functions: Record<string, string>
   controls: {
-    gate_status: string
     gate_release: string
   }
   send: Record<string, unknown>
@@ -64,6 +63,20 @@ interface TurnCompletedEvent {
   session_id: string
   turn_id: string
   status: 'completed' | 'cancelled' | 'failed'
+  terminal: boolean
+  timestamp: number
+}
+
+interface TurnStartedEvent {
+  session_id: string
+  turn_id: string
+  timestamp: number
+}
+
+interface MessageQueuedEvent {
+  session_id: string
+  entry_id: string
+  queued_at: number
   timestamp: number
 }
 
@@ -71,7 +84,7 @@ export interface HarnessStack {
   ready: ReadyManifest
   consoleUrl: string
   trigger(): Promise<unknown>
-  waitForRouterGate(name: string, count?: number): Promise<void>
+  waitForTurnStarted(): Promise<TurnStartedEvent>
   waitForQueuedMessage(text: string): Promise<void>
   releaseRouterGate(name: string): Promise<void>
   waitForTurnCompleted(): Promise<TurnCompletedEvent>
@@ -151,16 +164,22 @@ async function waitForReady(
   }
 }
 
-function armCompletion(
+let eventSubscriptionSequence = 0
+
+function armTriggerEvent<T>(
   sdk: ISdk,
   ready: ReadyManifest,
-): Promise<TurnCompletedEvent> {
-  const functionId = `console-e2e::turn-completed::${ready.run_id}`
+  triggerType: string,
+  label: string,
+  config: Record<string, unknown>,
+  select: (payload: unknown) => T | undefined,
+): Promise<T> {
+  eventSubscriptionSequence += 1
+  const functionId = `console-e2e::${label}::${ready.run_id}::${eventSubscriptionSequence}`
   let functionRef: ReturnType<ISdk['registerFunction']> | undefined
   let triggerRef: ReturnType<ISdk['registerTrigger']> | undefined
-  let timer: NodeJS.Timeout | undefined
+  let settled = false
   const cleanup = () => {
-    if (timer) clearTimeout(timer)
     try {
       triggerRef?.unregister()
       functionRef?.unregister()
@@ -168,27 +187,108 @@ function armCompletion(
       // The isolated stack may already be shutting down.
     }
   }
-  return new Promise<TurnCompletedEvent>((resolve, reject) => {
+  return new Promise<T>((resolve, reject) => {
     functionRef = sdk.registerFunction(
       functionId,
       async (payload) => {
-        const event = payload as TurnCompletedEvent
-        if (event.session_id !== ready.session.id) return null
-        cleanup()
-        resolve(event)
+        try {
+          const selected = select(payload)
+          if (selected === undefined) return null
+          settled = true
+          cleanup()
+          resolve(selected)
+        } catch (error) {
+          settled = true
+          cleanup()
+          reject(error)
+        }
         return null
       },
       { metadata: { internal: true } },
     )
     triggerRef = sdk.registerTrigger({
-      type: 'harness::turn-completed',
+      type: triggerType,
       function_id: functionId,
-      config: { session_id: ready.session.id },
+      config,
     })
-    timer = setTimeout(() => {
-      cleanup()
-      reject(new Error('harness::turn-completed was not delivered'))
-    }, 60_000)
+    // A state-backed trigger may catch up while registerTrigger is still
+    // returning its handle. Complete teardown once the handle is available.
+    if (settled) cleanup()
+  })
+}
+
+function armCompletion(
+  sdk: ISdk,
+  ready: ReadyManifest,
+): Promise<TurnCompletedEvent> {
+  return armTriggerEvent(
+    sdk,
+    ready,
+    'harness::turn-completed',
+    'turn-completed',
+    { session_id: ready.session.id },
+    (payload) => {
+      const event = payload as TurnCompletedEvent
+      if (event.session_id !== ready.session.id || event.terminal !== true)
+        return undefined
+      return event
+    },
+  )
+}
+
+function armTurnStarted(
+  sdk: ISdk,
+  ready: ReadyManifest,
+): Promise<TurnStartedEvent> {
+  return armTriggerEvent(
+    sdk,
+    ready,
+    'harness::turn-started',
+    'turn-started',
+    { session_id: ready.session.id },
+    (payload) => {
+      const event = payload as TurnStartedEvent
+      return event.session_id === ready.session.id ? event : undefined
+    },
+  )
+}
+
+function armQueuedMessage(
+  sdk: ISdk,
+  ready: ReadyManifest,
+  text: string,
+): Promise<void> {
+  return armTriggerEvent<MessageQueuedEvent>(
+    sdk,
+    ready,
+    'harness::message-queued',
+    'message-queued',
+    { session_id: ready.session.id },
+    (payload) => {
+      const event = payload as MessageQueuedEvent
+      return event.session_id === ready.session.id ? event : undefined
+    },
+  ).then(async (event) => {
+    const status = (await sdk.trigger({
+      function_id: 'harness::status',
+      payload: { session_id: ready.session.id },
+    })) as {
+      queued?: Array<{
+        entry_id?: string
+        message?: { content?: Array<{ type?: string; text?: string }> }
+      }>
+    } | null
+    const row = status?.queued?.find(
+      (queued) => queued.entry_id === event.entry_id,
+    )
+    const matches = row?.message?.content?.some(
+      (block) => block.type === 'text' && block.text === text,
+    )
+    if (!matches) {
+      throw new Error(
+        `harness::message-queued ${event.entry_id} did not reference ${JSON.stringify(text)}`,
+      )
+    }
   })
 }
 
@@ -281,43 +381,9 @@ export const test = base.extend<FixtureValues, FixtureOptions>({
             function_id: 'harness::send',
             payload: manifest.send,
           }),
-        waitForRouterGate: async (name, count = 1) => {
-          const deadline = Date.now() + 15_000
-          while (Date.now() < deadline) {
-            const status = (await connectedSdk.trigger({
-              function_id: manifest.controls.gate_status,
-              payload: { name },
-            })) as { arrivals?: number }
-            if ((status.arrivals ?? 0) >= count) return
-            await delay(25)
-          }
-          throw new Error(
-            `timed out waiting for scripted router gate ${name} (${count} arrivals)`,
-          )
-        },
-        waitForQueuedMessage: async (text) => {
-          const deadline = Date.now() + 15_000
-          while (Date.now() < deadline) {
-            const status = (await connectedSdk.trigger({
-              function_id: 'harness::status',
-              payload: { session_id: manifest.session.id },
-            })) as {
-              queued?: Array<{
-                message?: { content?: Array<{ type?: string; text?: string }> }
-              }>
-            } | null
-            const queued = status?.queued?.some((row) =>
-              row.message?.content?.some(
-                (block) => block.type === 'text' && block.text === text,
-              ),
-            )
-            if (queued) return
-            await delay(25)
-          }
-          throw new Error(
-            `timed out waiting for queued harness message ${JSON.stringify(text)}`,
-          )
-        },
+        waitForTurnStarted: () => armTurnStarted(connectedSdk, manifest),
+        waitForQueuedMessage: (text) =>
+          armQueuedMessage(connectedSdk, manifest, text),
         releaseRouterGate: async (name) => {
           const response = (await connectedSdk.trigger({
             function_id: manifest.controls.gate_release,

--- a/console/web/e2e/queued-message-streaming.spec.ts
+++ b/console/web/e2e/queued-message-streaming.spec.ts
@@ -1,0 +1,55 @@
+import { expect, expectPassingResult, openSession, test } from './harness-stack'
+
+const GATE = 'console-queued-message-streaming-in-flight'
+const QUEUED_MESSAGE = 'Queue this while the first response is streaming.'
+
+test.use({ scenario: 'console-queued-message-streaming' })
+
+test('keeps the composer editable and queues a message while streaming', async ({
+  page,
+  stack,
+}) => {
+  const completed = stack.waitForTurnCompleted()
+  await openSession(page, stack)
+
+  const composer = page.getByLabel('message composer')
+  await composer.pressSequentially(stack.ready.message)
+  await page.getByRole('button', { name: 'send message' }).click()
+
+  await stack.waitForRouterGate(GATE)
+  await expect(
+    page.getByRole('button', { name: 'stop generating' }),
+  ).toBeVisible()
+  await expect(composer).toBeEditable()
+  await expect(composer).toHaveAttribute('aria-placeholder', 'queue a message…')
+
+  await composer.pressSequentially(QUEUED_MESSAGE)
+  await expect(composer).toHaveText(QUEUED_MESSAGE)
+  await page.getByRole('button', { name: 'queue message' }).click()
+
+  const queued = page.getByRole('region', { name: 'queued messages' })
+  await expect(queued).toContainText(QUEUED_MESSAGE)
+  await stack.waitForQueuedMessage(QUEUED_MESSAGE)
+  await stack.releaseRouterGate(GATE)
+
+  expect(await completed).toMatchObject({
+    session_id: stack.ready.session.id,
+    status: 'completed',
+  })
+  await expect(
+    page.locator('[data-message-role="user"]', { hasText: QUEUED_MESSAGE }),
+  ).toHaveCount(1)
+  await expect(
+    page.locator('[data-message-role="assistant"]', {
+      hasText: 'first Console response complete',
+    }),
+  ).toHaveCount(1)
+  await expect(
+    page.locator('[data-message-role="assistant"]', {
+      hasText: 'queued Console message complete',
+    }),
+  ).toHaveCount(1)
+  await expect(queued).toHaveCount(0)
+
+  expectPassingResult(await stack.finish())
+})

--- a/console/web/e2e/queued-message-streaming.spec.ts
+++ b/console/web/e2e/queued-message-streaming.spec.ts
@@ -10,13 +10,14 @@ test('keeps the composer editable and queues a message while streaming', async (
   stack,
 }) => {
   const completed = stack.waitForTurnCompleted()
+  const turnStarted = stack.waitForTurnStarted()
   await openSession(page, stack)
 
   const composer = page.getByLabel('message composer')
   await composer.pressSequentially(stack.ready.message)
   await page.getByRole('button', { name: 'send message' }).click()
 
-  await stack.waitForRouterGate(GATE)
+  await turnStarted
   await expect(
     page.getByRole('button', { name: 'stop generating' }),
   ).toBeVisible()
@@ -25,16 +26,18 @@ test('keeps the composer editable and queues a message while streaming', async (
 
   await composer.pressSequentially(QUEUED_MESSAGE)
   await expect(composer).toHaveText(QUEUED_MESSAGE)
+  const queuedOnHarness = stack.waitForQueuedMessage(QUEUED_MESSAGE)
   await page.getByRole('button', { name: 'queue message' }).click()
 
   const queued = page.getByRole('region', { name: 'queued messages' })
   await expect(queued).toContainText(QUEUED_MESSAGE)
-  await stack.waitForQueuedMessage(QUEUED_MESSAGE)
+  await queuedOnHarness
   await stack.releaseRouterGate(GATE)
 
   expect(await completed).toMatchObject({
     session_id: stack.ready.session.id,
     status: 'completed',
+    terminal: true,
   })
   await expect(
     page.locator('[data-message-role="user"]', { hasText: QUEUED_MESSAGE }),

--- a/console/web/src/components/chat/EmptyState.tsx
+++ b/console/web/src/components/chat/EmptyState.tsx
@@ -4,6 +4,7 @@ import { Terminal } from '@/components/chat/sandbox/terminal/Terminal'
 import { Button } from '@/components/ui/Button'
 import { Prompt } from '@/components/ui/Prompt'
 import type { InstallStage } from '@/hooks/use-harness-status'
+import type { WorkerPresenceState } from '@/hooks/use-worker-presence'
 import { normalizeErrorMessage } from '@/lib/providers'
 import { cn } from '@/lib/utils'
 
@@ -12,7 +13,7 @@ import { cn } from '@/lib/utils'
  *
  *   - `ready`          — harness present + a model available (the hero copy)
  *   - `no-provider`    — harness present, no model configured -> configure CTA
- *   - `no-harness`     — harness worker missing -> install CTA + cli hint
+ *   - `no-harness`     — harness absent/starting/stopped -> state-aware CTA
  *   - `installing`     — `worker::add` in flight -> live console
  *   - `install-failed` — add failed -> console + retry
  *
@@ -38,6 +39,8 @@ export interface EmptyStateProps {
   errorMessage?: string | null
   /** `no-harness` primary CTA. */
   onInstallHarness?: () => void
+  /** Reconciled harness state, used to distinguish stopped/starting from absent. */
+  harnessState?: WorkerPresenceState
   /** `install-failed` retry CTA. */
   onRetryInstall?: () => void
   /** `no-provider` CTA (defaults to opening the harness configuration). */
@@ -57,6 +60,7 @@ export function EmptyState({
   stages = [],
   errorMessage,
   onInstallHarness,
+  harnessState = 'absent',
   onRetryInstall,
   onConfigureProvider,
 }: EmptyStateProps) {
@@ -76,7 +80,10 @@ export function EmptyState({
           <NoProviderBody onConfigureProvider={onConfigureProvider} />
         ) : null}
         {variant === 'no-harness' ? (
-          <NoHarnessBody onInstallHarness={onInstallHarness} />
+          <NoHarnessBody
+            onInstallHarness={onInstallHarness}
+            harnessState={harnessState}
+          />
         ) : null}
         {variant === 'installing' || variant === 'install-failed' ? (
           <InstallingBody
@@ -105,8 +112,8 @@ function ReadyBody() {
       <h1 className={HEADING_CLASS}>welcome to iii! 👋</h1>
       <div className="flex flex-col gap-2">
         <p className={BODY_CLASS}>
-          You're in an agent-oriented workspace where you can
-          leverage the power of a full-featured agentic system:
+          You're in an agent-oriented workspace where you can leverage the power
+          of a full-featured agentic system:
         </p>
         <ul className="font-mono text-[13px] leading-[1.7] text-ink-faint flex flex-col gap-1">
           <li>· trigger functions via the function registry</li>
@@ -161,20 +168,55 @@ function NoProviderBody({
 
 function NoHarnessBody({
   onInstallHarness,
+  harnessState,
 }: {
   onInstallHarness?: () => void
+  harnessState: WorkerPresenceState
 }) {
+  const isInstalled =
+    harnessState === 'starting' ||
+    harnessState === 'provisioning' ||
+    harnessState === 'stopped'
+  const isStopped = harnessState === 'stopped'
+  const isUnknown = harnessState === 'unknown'
   return (
     <>
-      <h1 className={HEADING_CLASS}>install the harness worker.</h1>
+      <h1 className={HEADING_CLASS}>
+        {isStopped
+          ? 'the harness worker is stopped.'
+          : isUnknown
+            ? "couldn't verify the harness worker."
+            : isInstalled
+              ? 'starting the harness worker…'
+              : 'install the harness worker.'}
+      </h1>
       <p className={BODY_CLASS}>
-        chat runs on the <span className="text-ink">harness</span> worker, and
-        it isn't connected yet. add it to start a session.
+        {isStopped ? (
+          <>
+            the <span className="text-ink">harness</span> worker is installed
+            but not connected. retry to start it, or inspect the worker logs.
+          </>
+        ) : isUnknown ? (
+          <>
+            the engine or worker manager did not answer the presence check.
+            retry before installing anything.
+          </>
+        ) : isInstalled ? (
+          <>
+            the <span className="text-ink">harness</span> worker is installed;
+            waiting for it to connect before starting a session.
+          </>
+        ) : (
+          <>
+            chat runs on the <span className="text-ink">harness</span> worker,
+            and it isn't connected yet. add it to start a session.
+          </>
+        )}
       </p>
       <div className="flex flex-col gap-4">
         <div>
           <Button variant="primary" onClick={onInstallHarness}>
-            add harness
+            {isInstalled || isUnknown ? 'retry harness' : 'add harness'}
           </Button>
         </div>
         <div className="flex flex-col gap-1.5">

--- a/console/web/src/components/chat/MessageList.tsx
+++ b/console/web/src/components/chat/MessageList.tsx
@@ -258,6 +258,7 @@ function resolveEmptyState(
     density,
     stages: harnessStatus.stages,
     errorMessage: harnessStatus.error,
+    harnessState: harnessStatus.state,
     onInstallHarness: harnessStatus.install,
     onRetryInstall: harnessStatus.retry,
     onConfigureProvider: () => {

--- a/console/web/src/hooks/use-harness-status.ts
+++ b/console/web/src/hooks/use-harness-status.ts
@@ -1,19 +1,23 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { z } from 'zod'
-import { getIiiClient, type IiiClient } from '@/lib/iii-client'
+import { getIiiClient } from '@/lib/iii-client'
 import { normalizeErrorMessage } from '@/lib/providers'
 import { useWorkerLifecycle } from './use-worker-lifecycle'
+import {
+  readWorkerPresence,
+  type WorkerPresenceState,
+} from './use-worker-presence'
 
 /**
  * Watches the engine for the `harness` worker and drives an in-app install of
  * it via `worker::add`, surfacing live progress.
  *
- * Two signals feed `present`:
- *   1. An initial `engine::workers::list` read on mount.
- *   2. A real-time `worker` lifecycle trigger (operations: ['add']) so the UI
- *      reacts the instant harness is added — whether from the in-app CTA or a
- *      `iii worker add harness` run in the operator's own terminal (this is the
- *      educational, "you can do this in the CLI too" angle).
+ * Presence reconciles two runtime signals:
+ *   1. `engine::workers::list` says whether the worker is callable now.
+ *   2. `worker::status` explains installed, starting, provisioning, and stopped
+ *      states when the worker is not connected.
+ * A real-time `worker` lifecycle trigger keeps the UI responsive to an add
+ * started from the in-app CTA or from `iii worker add harness` in a terminal.
  *
  * `install()` triggers `worker::add` for the registry `harness` source. It
  * resolves with a terminal outcome, but the per-stage progress
@@ -48,6 +52,10 @@ export interface HarnessStatus {
   present: boolean
   /** Initial presence probe in flight. */
   loading: boolean
+  /** Reconciled engine/worker-manager state for the harness process. */
+  state: WorkerPresenceState
+  /** Optional worker-manager detail when the process is not connected. */
+  detail: string | null
   /** An add is in progress (in-app or detected from the CLI). */
   installing: boolean
   /** Ordered console lines for the current/last add. */
@@ -117,15 +125,6 @@ function toStage(evt: WorkerEvent): InstallStage {
   }
 }
 
-async function checkHarnessPresent(client: IiiClient): Promise<boolean> {
-  const res = await client.trigger<{ workers?: Array<{ name?: unknown }> }>(
-    'engine::workers::list',
-    {},
-  )
-  const workers = Array.isArray(res?.workers) ? res.workers : []
-  return workers.some((w) => w?.name === HARNESS_WORKER_NAME)
-}
-
 /**
  * @param enabled - only run against the real backend; pass `false` for the
  *   mock/Storybook backend (treats harness as present so the normal empty
@@ -134,9 +133,14 @@ async function checkHarnessPresent(client: IiiClient): Promise<boolean> {
 export function useHarnessStatus(enabled: boolean): HarnessStatus {
   const [present, setPresent] = useState<boolean>(!enabled)
   const [loading, setLoading] = useState<boolean>(enabled)
+  const [state, setState] = useState<WorkerPresenceState>(
+    enabled ? 'unknown' : 'connected',
+  )
+  const [detail, setDetail] = useState<string | null>(null)
   const [installing, setInstalling] = useState<boolean>(false)
   const [stages, setStages] = useState<InstallStage[]>([])
   const [error, setError] = useState<string | null>(null)
+  const [probeNonce, setProbeNonce] = useState(0)
 
   // Process a single inbound `worker` lifecycle event. Uses functional
   // setState only so the handler has no reactive deps and stays stable.
@@ -148,6 +152,11 @@ export function useHarnessStatus(enabled: boolean): HarnessStatus {
     setStages((prev) => [...prev, toStage(evt)])
 
     if (evt.stage === 'failed') {
+      setPresent(false)
+      setState('stopped')
+      setDetail(
+        evt.error?.message ?? 'worker manager failed to start the harness',
+      )
       setError(
         evt.error?.message
           ? normalizeErrorMessage(evt.error)
@@ -155,8 +164,14 @@ export function useHarnessStatus(enabled: boolean): HarnessStatus {
       )
       setInstalling(false)
     } else if (evt.stage === 'done') {
-      setPresent(true)
+      // A completed manager operation does not guarantee that the process has
+      // registered with the engine yet. Reconcile both signals immediately.
+      setPresent(false)
+      setState('starting')
+      setDetail(null)
+      setError(null)
       setInstalling(false)
+      setProbeNonce((nonce) => nonce + 1)
     } else {
       // started / downloading / downloaded — make sure the console is shown
       // even when the add was kicked off from the CLI rather than the CTA.
@@ -175,23 +190,36 @@ export function useHarnessStatus(enabled: boolean): HarnessStatus {
     onEvent: handleEvent,
   })
 
-  // One-time presence probe on mount. Live changes — the in-app CTA or a CLI
-  // `iii worker add harness` — arrive purely through the `worker` add trigger
-  // above (the engine's push channel). No polling, no focus re-checks.
+  // Presence probe on mount and after a completed add. Reconcile the engine
+  // catalogue with worker-manager status so an installed-but-stopped worker
+  // does not masquerade as an absent worker.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: probeNonce is an explicit re-probe trigger after worker::add completes.
   useEffect(() => {
     if (!enabled) {
       setLoading(false)
       setPresent(true)
+      setState('connected')
+      setDetail(null)
       return
     }
     let cancelled = false
+    setLoading(true)
     void (async () => {
-      const client = await getIiiClient()
       try {
-        const found = await checkHarnessPresent(client)
-        if (!cancelled) setPresent(found)
+        const client = await getIiiClient()
+        const snapshot = await readWorkerPresence(client, HARNESS_WORKER_NAME)
+        if (!cancelled) {
+          setPresent(snapshot.present)
+          setState(snapshot.state)
+          setDetail(snapshot.detail)
+          if (snapshot.present) setError(null)
+        }
       } catch {
-        if (!cancelled) setPresent(false)
+        if (!cancelled) {
+          setPresent(false)
+          setState('unknown')
+          setDetail('could not read worker presence')
+        }
       } finally {
         if (!cancelled) setLoading(false)
       }
@@ -199,7 +227,7 @@ export function useHarnessStatus(enabled: boolean): HarnessStatus {
     return () => {
       cancelled = true
     }
-  }, [enabled])
+  }, [enabled, probeNonce])
 
   const install = useCallback(() => {
     if (!enabled) return
@@ -207,23 +235,33 @@ export function useHarnessStatus(enabled: boolean): HarnessStatus {
     setStages([])
     setInstalling(true)
     void (async () => {
-      const client = await getIiiClient()
+      let client: Awaited<ReturnType<typeof getIiiClient>> | undefined
       try {
+        client = await getIiiClient()
         await client.trigger('worker::add', {
           source: { kind: 'registry', name: HARNESS_WORKER_NAME },
           wait: true,
         })
         // Terminal success. Trigger events may have already flipped these, but
-        // setting them again is harmless and covers the no-events fallback.
-        setPresent(true)
+        // reconcile again for the no-events fallback and for the short window
+        // between manager completion and engine registration.
+        const snapshot = await readWorkerPresence(client, HARNESS_WORKER_NAME)
+        setPresent(snapshot.present)
+        setState(snapshot.state)
+        setDetail(snapshot.detail)
         setInstalling(false)
+        if (snapshot.present) setError(null)
       } catch (err) {
         setInstalling(false)
         // The add may have actually landed even though the call rejected
         // (e.g. a late timeout) — re-check before surfacing the error.
         try {
-          if (await checkHarnessPresent(client)) {
-            setPresent(true)
+          if (!client) throw new Error('iii client unavailable')
+          const snapshot = await readWorkerPresence(client, HARNESS_WORKER_NAME)
+          setPresent(snapshot.present)
+          setState(snapshot.state)
+          setDetail(snapshot.detail)
+          if (snapshot.present) {
             setError(null)
             return
           }
@@ -239,13 +277,15 @@ export function useHarnessStatus(enabled: boolean): HarnessStatus {
     () => ({
       present,
       loading,
+      state,
+      detail,
       installing,
       stages,
       error,
       install,
       retry: install,
     }),
-    [present, loading, installing, stages, error, install],
+    [present, loading, state, detail, installing, stages, error, install],
   )
 }
 
@@ -278,5 +318,9 @@ export function isChatBlockedByHarness(status: HarnessStatus): boolean {
 /** Composer placeholder copy while the harness gate is closed. */
 export function harnessComposerPlaceholder(status: HarnessStatus): string {
   if (status.installing) return 'installing harness…'
+  if (status.state === 'starting') return 'starting harness…'
+  if (status.state === 'provisioning') return 'preparing harness…'
+  if (status.state === 'stopped') return 'harness is stopped…'
+  if (status.state === 'unknown') return 'checking harness…'
   return 'install the harness worker to send a message…'
 }

--- a/console/web/src/hooks/use-worker-presence.test.ts
+++ b/console/web/src/hooks/use-worker-presence.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { IiiClient } from '@/lib/iii-client'
+import { readWorkerPresence } from './use-worker-presence'
+
+function fakeClient(
+  values: Record<string, unknown | (() => never)>,
+): IiiClient {
+  const trigger = vi.fn(async (functionId: string) => {
+    const value = values[functionId]
+    if (typeof value === 'function') return value()
+    return value
+  })
+  return { trigger } as unknown as IiiClient
+}
+
+const connectedEngine = {
+  workers: [{ name: 'harness', status: 'connected' }],
+}
+
+describe('readWorkerPresence', () => {
+  it('requires an engine connection before reporting the worker present', async () => {
+    const client = fakeClient({
+      'engine::workers::list': connectedEngine,
+      'worker::status': {
+        installed: true,
+        running: true,
+        stderr_tail: [],
+        stdout_tail: [],
+      },
+    })
+
+    await expect(readWorkerPresence(client, 'harness')).resolves.toEqual({
+      present: true,
+      state: 'connected',
+      detail: null,
+    })
+  })
+
+  it('reports a running manager process that has not registered as starting', async () => {
+    const client = fakeClient({
+      'engine::workers::list': { workers: [] },
+      'worker::status': {
+        installed: true,
+        running: true,
+        stderr_tail: [],
+        stdout_tail: ['booting'],
+      },
+    })
+
+    await expect(readWorkerPresence(client, 'harness')).resolves.toMatchObject({
+      present: false,
+      state: 'starting',
+    })
+  })
+
+  it('surfaces a stopped worker and prefers stderr diagnostics', async () => {
+    const client = fakeClient({
+      'engine::workers::list': { workers: [] },
+      'worker::status': {
+        installed: true,
+        running: false,
+        stderr_tail: ['boot failed'],
+        stdout_tail: ['last normal line'],
+      },
+    })
+
+    await expect(readWorkerPresence(client, 'harness')).resolves.toEqual({
+      present: false,
+      state: 'stopped',
+      detail: 'boot failed',
+    })
+  })
+
+  it('keeps an explicitly absent worker distinct from an unreadable backend', async () => {
+    const absent = fakeClient({
+      'engine::workers::list': { workers: [] },
+      'worker::status': {
+        installed: false,
+        running: false,
+        stderr_tail: [],
+        stdout_tail: [],
+      },
+    })
+    await expect(readWorkerPresence(absent, 'harness')).resolves.toMatchObject({
+      state: 'absent',
+    })
+
+    const unreadable = fakeClient({
+      'engine::workers::list': () => {
+        throw new Error('engine offline')
+      },
+      'worker::status': () => {
+        throw new Error('manager offline')
+      },
+    })
+    await expect(
+      readWorkerPresence(unreadable, 'harness'),
+    ).resolves.toMatchObject({
+      present: false,
+      state: 'unknown',
+    })
+
+    const managerUnavailable = fakeClient({
+      'engine::workers::list': { workers: [] },
+      'worker::status': () => {
+        throw new Error('worker manager restarting')
+      },
+    })
+    await expect(
+      readWorkerPresence(managerUnavailable, 'harness'),
+    ).resolves.toMatchObject({
+      state: 'unknown',
+      detail: 'could not read worker-manager presence',
+    })
+  })
+})

--- a/console/web/src/hooks/use-worker-presence.ts
+++ b/console/web/src/hooks/use-worker-presence.ts
@@ -1,29 +1,33 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { z } from 'zod'
+import { unwrapEnvelope } from '@/components/chat/sandbox/parsers'
 import { getIiiClient, type IiiClient } from '@/lib/iii-client'
 import { useWorkerLifecycle } from './use-worker-lifecycle'
 
 /**
- * Generic presence probe for an OPTIONAL standalone engine worker. Answers a
- * single question — "is worker `workerName` connected right now?" — so callers
- * can gate worker-specific UI + RPC on it and never trigger "function not
- * found".
- *
- * Presence is fed by two signals, mirroring the harness probe:
- *   1. An initial `engine::workers::list` read on mount.
- *   2. A real-time `worker` add/remove lifecycle trigger, so the UI reacts the
- *      instant the worker is added or removed — whether from the CLI
- *      (`iii worker add <name>`) or another surface.
- *
- * Each consumer MUST pass a unique `watchFnId` so its browser-local handler for
- * the `worker` trigger does not collide with another presence probe's.
+ * Generic presence probe for an OPTIONAL standalone engine worker. The
+ * engine catalogue answers "connected now" while worker-manager status
+ * answers "installed/running"; both are required to explain a worker that is
+ * installed but stopped or still booting.
  */
 
+export type WorkerPresenceState =
+  | 'connected'
+  | 'starting'
+  | 'provisioning'
+  | 'stopped'
+  | 'absent'
+  | 'unknown'
+
 export interface WorkerPresence {
-  /** Whether the worker is currently connected. */
+  /** Whether the worker is currently connected and safe to call. */
   present: boolean
   /** Initial presence probe in flight. */
   loading: boolean
+  /** Distinguishes absent, installed-but-stopped, and booting workers. */
+  state: WorkerPresenceState
+  /** Optional operator-facing detail, usually the latest worker error. */
+  detail: string | null
 }
 
 const workerEventSchema = z.object({
@@ -58,16 +62,99 @@ function eventMatchesWorker(evt: WorkerEvent, workerName: string): boolean {
   return false
 }
 
-async function checkWorkerPresent(
+const engineWorkersSchema = z.object({
+  workers: z.array(
+    z.object({
+      name: z.string().nullable().optional(),
+      status: z.string().optional(),
+    }),
+  ),
+})
+
+const workerStatusSchema = z.object({
+  installed: z.boolean(),
+  running: z.boolean(),
+  stderr_tail: z.array(z.string()).optional().default([]),
+  stdout_tail: z.array(z.string()).optional().default([]),
+  hint: z.string().optional(),
+})
+
+export interface WorkerPresenceSnapshot {
+  present: boolean
+  state: WorkerPresenceState
+  detail: string | null
+}
+
+function latestWorkerDetail(
+  status: z.infer<typeof workerStatusSchema>,
+): string | null {
+  // stderr is the failure signal for a stopped worker. Prefer it when both
+  // tails are populated so a benign stdout line cannot hide the boot error.
+  const lines =
+    status.stderr_tail.length > 0 ? status.stderr_tail : status.stdout_tail
+  return lines.length > 0
+    ? (lines[lines.length - 1] ?? null)
+    : (status.hint ?? null)
+}
+
+/**
+ * Reconcile the engine catalogue with worker-manager status. A successful
+ * manager read is intentionally not treated as connected: a managed process
+ * can be alive while its registration is still missing or has crashed.
+ */
+export async function readWorkerPresence(
   client: IiiClient,
   name: string,
-): Promise<boolean> {
-  const res = await client.trigger<{ workers?: Array<{ name?: unknown }> }>(
-    'engine::workers::list',
-    {},
-  )
-  const workers = Array.isArray(res?.workers) ? res.workers : []
-  return workers.some((w) => w?.name === name)
+): Promise<WorkerPresenceSnapshot> {
+  const [engineResult, managerResult] = await Promise.allSettled([
+    client.trigger<unknown>('engine::workers::list', {}),
+    client.trigger<unknown>('worker::status', { name }),
+  ])
+
+  const engine =
+    engineResult.status === 'fulfilled'
+      ? engineWorkersSchema.safeParse(unwrapEnvelope(engineResult.value)).data
+      : null
+  const manager =
+    managerResult.status === 'fulfilled'
+      ? workerStatusSchema.safeParse(unwrapEnvelope(managerResult.value)).data
+      : null
+  const connected =
+    engine?.workers.some(
+      (worker) =>
+        worker.name === name && worker.status?.toLowerCase() === 'connected',
+    ) ?? false
+
+  if (connected) {
+    return { present: true, state: 'connected', detail: null }
+  }
+
+  if (manager) {
+    if (!manager.installed) {
+      return { present: false, state: 'absent', detail: null }
+    }
+    if (manager.running) {
+      return {
+        present: false,
+        state: 'starting',
+        detail: 'worker process is running but has not connected to the engine',
+      }
+    }
+    const detail = latestWorkerDetail(manager)
+    return {
+      present: false,
+      state: detail ? 'stopped' : 'provisioning',
+      detail,
+    }
+  }
+
+  // A rejected or malformed manager response is not proof that the worker is
+  // absent. Keep the UI honest when an older/restarting manager cannot answer.
+  return {
+    present: false,
+    state: 'unknown',
+    detail: 'could not read worker-manager presence',
+  }
 }
 
 export interface UseWorkerPresenceOptions {
@@ -89,22 +176,41 @@ export function useWorkerPresence({
 }: UseWorkerPresenceOptions): WorkerPresence {
   const [present, setPresent] = useState<boolean>(!enabled)
   const [loading, setLoading] = useState<boolean>(enabled)
+  const [state, setState] = useState<WorkerPresenceState>(
+    enabled ? 'unknown' : 'connected',
+  )
+  const [detail, setDetail] = useState<string | null>(null)
+  const [probeNonce, setProbeNonce] = useState(0)
 
   // Live add/remove so installing or dropping the worker mid-session flips the
-  // UI without a reload. `workerName` is a stable literal per consumer, so this
-  // callback's identity does not churn the lifecycle subscription.
+  // UI without a reload. `workerName` is a stable literal per consumer, so
+  // this callback's identity does not churn the lifecycle subscription.
   const handleEvent = useCallback(
     (payload: unknown) => {
       const evt = parseWorkerEvent(payload)
       if (
         !evt ||
         !eventMatchesWorker(evt, workerName) ||
-        evt.stage !== 'done'
+        (evt.stage !== 'done' && evt.stage !== 'failed')
       ) {
         return
       }
-      if (evt.operation === 'add') setPresent(true)
-      else if (evt.operation === 'remove') setPresent(false)
+      if (evt.operation === 'remove') {
+        setPresent(false)
+        setState('absent')
+        setDetail(null)
+      } else if (evt.stage === 'failed') {
+        setPresent(false)
+        setState('stopped')
+        setDetail('worker manager failed to start the worker')
+      } else {
+        // `worker::add` done means the manager finished its operation, not
+        // necessarily that the process has registered with the engine yet.
+        setPresent(false)
+        setState('starting')
+        setDetail(null)
+        setProbeNonce((nonce) => nonce + 1)
+      }
     },
     [workerName],
   )
@@ -116,22 +222,34 @@ export function useWorkerPresence({
     onEvent: handleEvent,
   })
 
-  // One-time presence probe on mount. Live changes arrive through the `worker`
-  // trigger above; no polling.
+  // Initial presence probe plus a re-probe after lifecycle completion. Live
+  // changes arrive through the `worker` trigger above; no blind polling.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: probeNonce is an explicit re-probe trigger after lifecycle completion.
   useEffect(() => {
     if (!enabled) {
       setLoading(false)
       setPresent(true)
+      setState('connected')
+      setDetail(null)
       return
     }
     let cancelled = false
+    setLoading(true)
     void (async () => {
-      const client = await getIiiClient()
       try {
-        const found = await checkWorkerPresent(client, workerName)
-        if (!cancelled) setPresent(found)
+        const client = await getIiiClient()
+        const snapshot = await readWorkerPresence(client, workerName)
+        if (!cancelled) {
+          setPresent(snapshot.present)
+          setState(snapshot.state)
+          setDetail(snapshot.detail)
+        }
       } catch {
-        if (!cancelled) setPresent(false)
+        if (!cancelled) {
+          setPresent(false)
+          setState('unknown')
+          setDetail('could not read worker presence')
+        }
       } finally {
         if (!cancelled) setLoading(false)
       }
@@ -139,9 +257,12 @@ export function useWorkerPresence({
     return () => {
       cancelled = true
     }
-  }, [enabled, workerName])
+  }, [enabled, workerName, probeNonce])
 
-  return useMemo(() => ({ present, loading }), [present, loading])
+  return useMemo(
+    () => ({ present, loading, state, detail }),
+    [present, loading, state, detail],
+  )
 }
 
 /**

--- a/console/web/src/hooks/use-worktree-status.test.ts
+++ b/console/web/src/hooks/use-worktree-status.test.ts
@@ -14,8 +14,29 @@ describe('worktree presence probe wiring', () => {
   })
 
   it('gates on both presence and the initial probe settling', () => {
-    expect(isWorktreeAvailable({ present: true, loading: false })).toBe(true)
-    expect(isWorktreeAvailable({ present: true, loading: true })).toBe(false)
-    expect(isWorktreeAvailable({ present: false, loading: false })).toBe(false)
+    expect(
+      isWorktreeAvailable({
+        present: true,
+        loading: false,
+        state: 'connected',
+        detail: null,
+      }),
+    ).toBe(true)
+    expect(
+      isWorktreeAvailable({
+        present: true,
+        loading: true,
+        state: 'unknown',
+        detail: null,
+      }),
+    ).toBe(false)
+    expect(
+      isWorktreeAvailable({
+        present: false,
+        loading: false,
+        state: 'absent',
+        detail: null,
+      }),
+    ).toBe(false)
   })
 })

--- a/console/web/src/pages/TracesV2/index.tsx
+++ b/console/web/src/pages/TracesV2/index.tsx
@@ -82,6 +82,7 @@ import {
 } from './lib/traceTransform'
 
 const PAGE_SIZES = [25, 50, 100]
+const TRACE_STALL_TIMEOUT_MS = 10_000
 
 export interface TracesV2Props {
   /** mount with a trace's detail already expanded (stories/deep links) */
@@ -328,12 +329,14 @@ export function TracesV2({ initialTraceId }: TracesV2Props) {
   // waterfall via `toWaterfallData`. Accumulated by `span_id` so re-delivered
   // spans dedupe. Frozen while paused.
   const detailSpansRef = useRef<Map<string, StoredSpan>>(new Map())
+  const detailLastActivityRef = useRef<number | null>(null)
   const isPausedRef = useRef(isPaused)
   useEffect(() => {
     isPausedRef.current = isPaused
   }, [isPaused])
 
   const [hasPendingSpans, setHasPendingSpans] = useState(false)
+  const [detailStalled, setDetailStalled] = useState(false)
 
   const rebuildDetail = useCallback((traceId: string): WaterfallData | null => {
     const wf = toWaterfallData([...detailSpansRef.current.values()], traceId)
@@ -346,8 +349,18 @@ export function TracesV2({ initialTraceId }: TracesV2Props) {
   // waterfall every second so live bars and elapsed durations keep growing
   // between stream frames (the transform measures pendings against "now").
   useEffect(() => {
-    if (!hasPendingSpans || !selectedTraceId || isPaused) return
-    const timer = setInterval(() => rebuildDetail(selectedTraceId), 1000)
+    if (!hasPendingSpans || !selectedTraceId || isPaused) {
+      setDetailStalled(false)
+      return
+    }
+    const timer = setInterval(() => {
+      rebuildDetail(selectedTraceId)
+      const lastActivity = detailLastActivityRef.current
+      setDetailStalled(
+        lastActivity !== null &&
+          Date.now() - lastActivity >= TRACE_STALL_TIMEOUT_MS,
+      )
+    }, 1000)
     return () => clearInterval(timer)
   }, [hasPendingSpans, selectedTraceId, isPaused, rebuildDetail])
 
@@ -358,6 +371,8 @@ export function TracesV2({ initialTraceId }: TracesV2Props) {
         setIsLoadingSpans(true)
         setSpansError(null)
         setWaterfallData(null)
+        detailLastActivityRef.current = null
+        setDetailStalled(false)
       }
       try {
         const { spans } = await fetchTraces({
@@ -368,6 +383,10 @@ export function TracesV2({ initialTraceId }: TracesV2Props) {
         })
         detailSpansRef.current = new Map(spans.map((s) => [s.span_id, s]))
         const wf = rebuildDetail(traceId)
+        detailLastActivityRef.current = wf?.spans.some((s) => s.pending)
+          ? Date.now()
+          : null
+        setDetailStalled(false)
         if (!wf && !silent) {
           setSpansError('no span data available for this trace')
         }
@@ -388,6 +407,8 @@ export function TracesV2({ initialTraceId }: TracesV2Props) {
     (traceId: string, spans: StoredSpan[]) => {
       if (spans.length === 0) return
       for (const s of spans) mergeDetailSpan(detailSpansRef.current, s)
+      detailLastActivityRef.current = Date.now()
+      setDetailStalled(false)
       rebuildDetail(traceId)
     },
     [rebuildDetail],
@@ -468,6 +489,9 @@ export function TracesV2({ initialTraceId }: TracesV2Props) {
       setSelectedSpan(null)
       setWaterfallData(null)
       setSpansError(null)
+      setHasPendingSpans(false)
+      setDetailStalled(false)
+      detailLastActivityRef.current = null
       detailSpansRef.current = new Map()
       if (traceId) {
         loadTraceSpans(traceId)
@@ -552,6 +576,25 @@ export function TracesV2({ initialTraceId }: TracesV2Props) {
         )}
         {!isLoadingSpans && !spansError && waterfallData && (
           <>
+            {detailStalled ? (
+              <div className="border-b border-rule p-3 flex items-start gap-3">
+                <StatusPanel
+                  variant="warn"
+                  icon={<AlertCircle className="w-full h-full" />}
+                  headline="trace stream stalled"
+                  detail="this trace is still marked running, but no span updates arrived for 10 seconds. retry to resync it."
+                  className="min-w-0 flex-1"
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => loadTraceSpans(selectedTraceId)}
+                >
+                  <RefreshCw className="w-3 h-3" />
+                  retry
+                </Button>
+              </div>
+            ) : null}
             <TraceHeader
               data={waterfallData}
               traceId={selectedTraceId}

--- a/console/web/src/pages/Workers/components/WorkersTable.tsx
+++ b/console/web/src/pages/Workers/components/WorkersTable.tsx
@@ -38,6 +38,12 @@ const MANAGEMENT_VARIANT: Record<
   internal: 'default',
 }
 
+const STATUS_LABEL: Record<WorkerRow['status'], string> = {
+  connected: 'connected',
+  disconnected: 'not connected',
+  stopped: 'stopped',
+}
+
 function statusTone(
   status: WorkerRow['status'],
 ): 'accent' | 'alert' | 'warn' | 'ink' {
@@ -178,6 +184,9 @@ function WorkerTableRow({
           />
           <span className="font-mono text-[13px] text-ink lowercase">
             {row.name}
+          </span>
+          <span className="font-mono text-[11px] text-ink-ghost lowercase">
+            {STATUS_LABEL[row.status]}
           </span>
         </div>
       </td>

--- a/console/web/src/pages/Workers/lib/merge-workers.test.ts
+++ b/console/web/src/pages/Workers/lib/merge-workers.test.ts
@@ -133,6 +133,35 @@ describe('mergeWorkers', () => {
     expect(rows[0]?.stopEnabled).toBe(true)
   })
 
+  it('does not call a running but disconnected engine worker connected', () => {
+    const rows = mergeWorkers(
+      snapshot({
+        engineWorkers: [
+          {
+            id: 'w-booting',
+            name: 'harness',
+            runtime: 'rust',
+            status: 'starting',
+            function_count: 0,
+            connected_at_ms: 0,
+            active_invocations: 0,
+          },
+        ],
+        supervisorWorkers: [
+          {
+            name: 'harness',
+            running: true,
+            pid: 250,
+          },
+        ],
+      }),
+    )
+
+    expect(rows[0]?.status).toBe('disconnected')
+    expect(rows[0]?.stopEnabled).toBe(false)
+    expect(rows[0]?.stopDisabledReason).toContain('not connected')
+  })
+
   it('classifies standalone workers without stop', () => {
     const rows = mergeWorkers(
       snapshot({

--- a/console/web/src/pages/Workers/lib/merge-workers.ts
+++ b/console/web/src/pages/Workers/lib/merge-workers.ts
@@ -14,6 +14,7 @@ const STOP_REASON = {
   standalone:
     'standalone workers must be stopped from the process that started them',
   notRunning: 'worker is not running',
+  notConnected: 'worker process is running but not connected to the engine',
 } as const
 
 interface ConfigurationLookup {
@@ -63,7 +64,14 @@ function deriveConnectionStatus(
   engineStatus: string | undefined,
   supervisor: WorkerEntry | undefined,
 ): WorkerConnectionStatus {
-  if (engineStatus?.toLowerCase() === 'connected') return 'connected'
+  // An engine row with a non-connected status is a real, registered worker
+  // that is not callable yet. A running supervisor process alone must not
+  // turn that row green — it may still be booting or have lost registration.
+  if (engineStatus !== undefined) {
+    return engineStatus.toLowerCase() === 'connected'
+      ? 'connected'
+      : 'disconnected'
+  }
   if (supervisor?.running) return 'connected'
   if (supervisor && !supervisor.running) return 'stopped'
   return 'disconnected'
@@ -74,6 +82,9 @@ function deriveStopState(
   status: WorkerConnectionStatus,
   supervisor: WorkerEntry | undefined,
 ): Pick<WorkerRow, 'stopEnabled' | 'stopDisabledReason'> {
+  if (kind === 'supervisor' && supervisor?.running && status !== 'connected') {
+    return { stopEnabled: false, stopDisabledReason: STOP_REASON.notConnected }
+  }
   if (kind === 'supervisor' && status === 'connected' && supervisor?.running) {
     return { stopEnabled: true, stopDisabledReason: null }
   }

--- a/harness/prompts/default.txt
+++ b/harness/prompts/default.txt
@@ -94,8 +94,13 @@ assistant: The payload was a JSON-encoded string. Re-issuing the SAME function w
 
 - `engine::workers::list` — workers connected right now.
 - `engine::workers::info { name }` — one worker's functions, trigger types, and triggers.
-- `worker::list` — installed + running workers, including daemon-managed builtins. To check
-  a worker is running, merge `engine::workers::list` with `worker::list` by name.
+- `worker::list` — installed + running workers, including daemon-managed builtins.
+- `worker::status { name }` — installed/running state plus the latest stdout/stderr tails;
+  use it when a worker is installed but not connected so you can distinguish provisioning
+  from a stopped process with a boot error.
+- A worker-manager process can be running before it registers with the engine: treat
+  `engine::workers::list` status `connected` as the callable signal, not the manager's
+  `running` flag alone.
 - Lifecycle ops: `worker::add` (install from registry or OCI), `worker::start`,
   `worker::stop`, `worker::update`, `worker::remove`, `worker::clear`. The ops
   `remove`, `stop`, and `clear` require exactly `yes: true` — the boolean, not a

--- a/harness/skills/browser-frontend.md
+++ b/harness/skills/browser-frontend.md
@@ -1,0 +1,46 @@
+---
+name: browser-frontend
+description: >-
+  Build and verify browser-facing React interfaces on iii. Use the browser
+  worker for real page interaction, the browser SDK for browser-connected
+  workers, and the console UI surface for native iii extensions.
+---
+
+# Browser and frontend architecture
+
+Use the browser worker as the agent's browser boundary. A frontend is a real
+web application or a console extension; it is not an HTTP-shaped substitute
+for browser interaction.
+
+## Choose the right boundary
+
+- Use `browser::sessions::*`, `browser::navigate`, `browser::snapshot`, and
+  `browser::act` to inspect and drive a running web page.
+- Use the browser SDK when writing a browser-connected worker or client. Read
+  the current reference at `https://iii.dev/docs/reference/sdk-browser.md`
+  before writing the first SDK call.
+- Use React for the UI itself. For an iii console extension, use the
+  `@iii-dev/console-ui` components and the injectable console UI contract;
+  keep React and the console package external in the asset build.
+- Use a normal HTTP API only when the product explicitly needs an API. Do not
+  turn the browser UI into a hand-built HTTP bridge just because browser
+  functions were not visible in the current skill index.
+
+## Build and verify
+
+1. Discover the installed browser and console surfaces with
+   `engine::functions::list` and fetch each contract with
+   `engine::functions::info` before calling it.
+2. Keep browser sessions explicit and short-lived: start one, navigate, act,
+   inspect console/network evidence when something fails, and stop it when the
+   check is complete.
+3. Verify the UI through the browser worker against the running page. A
+   successful HTTP response alone does not prove that the React application
+   rendered or that its interactions work.
+4. For a console extension, register a `console:script` or `console:style`
+   asset through the worker and use the shared React components rather than
+   bundling a second UI system.
+
+The browser worker's full function and troubleshooting reference is available
+as `browser/index`; this page exists so frontend architecture remains
+available even before an optional browser worker is connected.

--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -20,7 +20,9 @@
 //!      the fully-built snapshot cell + the cron handle.
 //!  10. Emit `harness::ready`, then sleep on Ctrl+C and shut down cleanly.
 
+use std::future::Future;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -64,38 +66,114 @@ async fn load_config_with_retries(
     iii: &iii_sdk::IIIClient,
     seed: Option<&config::WorkerConfig>,
 ) -> Result<config::WorkerConfig> {
-    let mut last_error = String::new();
-
-    for attempt in 1..=BOOT_CONFIG_ATTEMPTS {
-        let result = async {
+    retry_boot_dependency(
+        BOOT_CONFIG_ATTEMPTS,
+        Duration::from_millis(BOOT_CONFIG_RETRY_BACKOFF_MS),
+        || async {
             configuration::register_config(iii, seed).await?;
             configuration::fetch_config(iii).await
-        }
-        .await;
+        },
+    )
+    .await
+    .map_err(|last_error| {
+        anyhow::Error::msg(format!(
+            "harness boot dependency initialization failed after {BOOT_CONFIG_ATTEMPTS} attempts: {last_error}"
+        ))
+    })
+}
 
-        match result {
-            Ok(cfg) => return Ok(cfg),
+async fn retry_boot_dependency<T, F, Fut>(
+    max_attempts: u32,
+    backoff: Duration,
+    mut operation: F,
+) -> Result<T, String>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, String>>,
+{
+    if max_attempts == 0 {
+        return Err("retry attempt count must be greater than zero".to_string());
+    }
+
+    let mut last_error = String::new();
+
+    for attempt in 1..=max_attempts {
+        match operation().await {
+            Ok(value) => return Ok(value),
             Err(error) => {
                 last_error = error;
-                if attempt < BOOT_CONFIG_ATTEMPTS {
+                if attempt < max_attempts {
                     tracing::warn!(
                         attempt,
-                        max_attempts = BOOT_CONFIG_ATTEMPTS,
+                        max_attempts,
                         error = %last_error,
                         "harness boot dependency unavailable; retrying"
                     );
-                    tokio::time::sleep(std::time::Duration::from_millis(
-                        BOOT_CONFIG_RETRY_BACKOFF_MS,
-                    ))
-                    .await;
+                    tokio::time::sleep(backoff).await;
                 }
             }
         }
     }
 
-    Err(anyhow::Error::msg(format!(
-        "harness boot dependency initialization failed after {BOOT_CONFIG_ATTEMPTS} attempts: {last_error}"
-    )))
+    Err(last_error)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn boot_dependency_retries_transient_failures() {
+        let attempts = Arc::new(AtomicU32::new(0));
+
+        let result = retry_boot_dependency(4, Duration::ZERO, || {
+            let attempts = attempts.clone();
+            async move {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+                if attempt < 3 {
+                    Err(format!("not ready on attempt {attempt}"))
+                } else {
+                    Ok("ready")
+                }
+            }
+        })
+        .await;
+
+        assert_eq!(result, Ok("ready"));
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn boot_dependency_returns_last_error_after_attempt_budget() {
+        let attempts = Arc::new(AtomicU32::new(0));
+
+        let result = retry_boot_dependency(3, Duration::ZERO, || {
+            let attempts = attempts.clone();
+            async move {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+                Err::<(), _>(format!("failure {attempt}"))
+            }
+        })
+        .await;
+
+        assert_eq!(result, Err("failure 3".to_string()));
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn boot_dependency_rejects_an_empty_attempt_budget() {
+        let result = retry_boot_dependency(0, Duration::ZERO, || async {
+            Ok::<_, String>("must not run")
+        })
+        .await;
+
+        assert_eq!(
+            result,
+            Err("retry attempt count must be greater than zero".to_string())
+        );
+    }
 }
 
 #[tokio::main]

--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -118,64 +118,6 @@ where
     Err(last_error)
 }
 
-#[cfg(test)]
-mod tests {
-    use std::sync::atomic::{AtomicU32, Ordering};
-
-    use super::*;
-
-    #[tokio::test]
-    async fn boot_dependency_retries_transient_failures() {
-        let attempts = Arc::new(AtomicU32::new(0));
-
-        let result = retry_boot_dependency(4, Duration::ZERO, || {
-            let attempts = attempts.clone();
-            async move {
-                let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
-                if attempt < 3 {
-                    Err(format!("not ready on attempt {attempt}"))
-                } else {
-                    Ok("ready")
-                }
-            }
-        })
-        .await;
-
-        assert_eq!(result, Ok("ready"));
-        assert_eq!(attempts.load(Ordering::SeqCst), 3);
-    }
-
-    #[tokio::test]
-    async fn boot_dependency_returns_last_error_after_attempt_budget() {
-        let attempts = Arc::new(AtomicU32::new(0));
-
-        let result = retry_boot_dependency(3, Duration::ZERO, || {
-            let attempts = attempts.clone();
-            async move {
-                let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
-                Err::<(), _>(format!("failure {attempt}"))
-            }
-        })
-        .await;
-
-        assert_eq!(result, Err("failure 3".to_string()));
-        assert_eq!(attempts.load(Ordering::SeqCst), 3);
-    }
-
-    #[tokio::test]
-    async fn boot_dependency_rejects_an_empty_attempt_budget() {
-        let result = retry_boot_dependency(0, Duration::ZERO, || async {
-            Ok::<_, String>("must not run")
-        })
-        .await;
-
-        assert_eq!(
-            result,
-            Err("retry attempt count must be greater than zero".to_string())
-        );
-    }
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
@@ -289,4 +231,62 @@ async fn main() -> Result<()> {
     tracing::info!("harness shutting down");
     iii.shutdown_async().await;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn boot_dependency_retries_transient_failures() {
+        let attempts = Arc::new(AtomicU32::new(0));
+
+        let result = retry_boot_dependency(4, Duration::ZERO, || {
+            let attempts = attempts.clone();
+            async move {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+                if attempt < 3 {
+                    Err(format!("not ready on attempt {attempt}"))
+                } else {
+                    Ok("ready")
+                }
+            }
+        })
+        .await;
+
+        assert_eq!(result, Ok("ready"));
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn boot_dependency_returns_last_error_after_attempt_budget() {
+        let attempts = Arc::new(AtomicU32::new(0));
+
+        let result = retry_boot_dependency(3, Duration::ZERO, || {
+            let attempts = attempts.clone();
+            async move {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+                Err::<(), _>(format!("failure {attempt}"))
+            }
+        })
+        .await;
+
+        assert_eq!(result, Err("failure 3".to_string()));
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn boot_dependency_rejects_an_empty_attempt_budget() {
+        let result = retry_boot_dependency(0, Duration::ZERO, || async {
+            Ok::<_, String>("must not run")
+        })
+        .await;
+
+        assert_eq!(
+            result,
+            Err("retry attempt count must be greater than zero".to_string())
+        );
+    }
 }

--- a/harness/src/main.rs
+++ b/harness/src/main.rs
@@ -34,6 +34,9 @@ use harness::events::TurnEvents;
 use harness::hooks::HookRegistry;
 use harness::{config, discovery, functions, manifest, queue, subscriptions};
 
+const BOOT_CONFIG_ATTEMPTS: u32 = 8;
+const BOOT_CONFIG_RETRY_BACKOFF_MS: u64 = 500;
+
 #[derive(Parser, Debug)]
 #[command(
     name = "harness",
@@ -50,6 +53,49 @@ struct Cli {
 
     #[arg(long)]
     manifest: bool,
+}
+
+/// Configuration is the first external boot dependency. A worker-manager
+/// restart can bring the harness up before `configuration` has registered its
+/// functions, so a single failed RPC must not turn a transient startup race
+/// into a permanently dead harness process. Registration is idempotent and
+/// the stored value remains authoritative, making this safe across retries.
+async fn load_config_with_retries(
+    iii: &iii_sdk::IIIClient,
+    seed: Option<&config::WorkerConfig>,
+) -> Result<config::WorkerConfig> {
+    let mut last_error = String::new();
+
+    for attempt in 1..=BOOT_CONFIG_ATTEMPTS {
+        let result = async {
+            configuration::register_config(iii, seed).await?;
+            configuration::fetch_config(iii).await
+        }
+        .await;
+
+        match result {
+            Ok(cfg) => return Ok(cfg),
+            Err(error) => {
+                last_error = error;
+                if attempt < BOOT_CONFIG_ATTEMPTS {
+                    tracing::warn!(
+                        attempt,
+                        max_attempts = BOOT_CONFIG_ATTEMPTS,
+                        error = %last_error,
+                        "harness boot dependency unavailable; retrying"
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(
+                        BOOT_CONFIG_RETRY_BACKOFF_MS,
+                    ))
+                    .await;
+                }
+            }
+        }
+    }
+
+    Err(anyhow::Error::msg(format!(
+        "harness boot dependency initialization failed after {BOOT_CONFIG_ATTEMPTS} attempts: {last_error}"
+    )))
 }
 
 #[tokio::main]
@@ -102,13 +148,8 @@ async fn main() -> Result<()> {
         None => None,
     };
 
-    configuration::register_config(&iii, seed.as_ref())
+    let cfg = load_config_with_retries(&iii, seed.as_ref())
         .await
-        .map_err(anyhow::Error::msg)
-        .context("registering harness configuration schema")?;
-    let cfg = configuration::fetch_config(&iii)
-        .await
-        .map_err(anyhow::Error::msg)
         .context("loading harness configuration")?;
 
     // Trigger types first: the handlers capture the subscriber sets.

--- a/harness/tests/e2e/run-ci.sh
+++ b/harness/tests/e2e/run-ci.sh
@@ -48,6 +48,44 @@ export HARNESS_E2E_PORT="$iii_port"
 export III_ENGINE_URL="$iii_url"
 
 pids=()
+declare -A process_pids=()
+
+assert_engine_port_available() {
+  # The worker manager owns the configured port. Starting an E2E stack on an
+  # occupied port can make the manager tear down an otherwise healthy engine;
+  # fail before spawning anything and make the conflicting port explicit.
+  if (exec 3<>"/dev/tcp/127.0.0.1/$iii_port"; exec 3>&-) 2>/dev/null; then
+    echo "HARNESS_E2E_PORT=$iii_port is already in use; choose a free port" >&2
+    return 1
+  fi
+}
+
+report_process_failure() {
+  local name=$1
+  local pid=${process_pids[$name]:-}
+  [[ -n "$pid" ]] || return 0
+
+  local state
+  state=$(ps -o stat= -p "$pid" 2>/dev/null | tr -d '[:space:]' || true)
+  if kill -0 "$pid" 2>/dev/null && [[ "$state" != Z* ]]; then
+    return 0
+  fi
+
+  echo "$name exited before its function surface became ready (pid $pid)" >&2
+  if [[ -f "$logs_dir/$name.log" ]]; then
+    echo "--- $name.log (last 80 lines) ---" >&2
+    tail -n 80 "$logs_dir/$name.log" >&2 || true
+    echo "--- end $name.log ---" >&2
+  fi
+  return 1
+}
+
+check_started_processes() {
+  local name
+  for name in "${!process_pids[@]}"; do
+    report_process_failure "$name" || return 1
+  done
+}
 
 cleanup() {
   local status=$?
@@ -68,6 +106,7 @@ start_process() {
     exec "$@"
   ) >"$logs_dir/$name.log" 2>&1 &
   pids+=("$!")
+  process_pids["$name"]=$!
 }
 
 wait_for_function() {
@@ -75,6 +114,7 @@ wait_for_function() {
   local attempts=120
   local response
   for ((attempt = 1; attempt <= attempts; attempt++)); do
+    check_started_processes
     response=$(
       "$III_BIN" trigger engine::functions::list \
         --port "$iii_port" \
@@ -88,6 +128,7 @@ wait_for_function() {
     sleep 0.5
   done
   echo "timed out waiting for function $function_id" >&2
+  check_started_processes || true
   return 1
 }
 
@@ -96,6 +137,7 @@ wait_for_trigger_type() {
   local attempts=120
   local response
   for ((attempt = 1; attempt <= attempts; attempt++)); do
+    check_started_processes
     response=$(
       "$III_BIN" trigger engine::triggers::list \
         --port "$iii_port" \
@@ -109,6 +151,7 @@ wait_for_trigger_type() {
     sleep 0.5
   done
   echo "timed out waiting for trigger type $trigger_type" >&2
+  check_started_processes || true
   return 1
 }
 
@@ -121,6 +164,7 @@ wait_for_model() {
   request=$(jq -cn --arg provider "$provider" --arg id "$model" \
     '{provider:$provider,id:$id}')
   for ((attempt = 1; attempt <= attempts; attempt++)); do
+    check_started_processes
     response=$(
       "$III_BIN" trigger router::models::get \
         --port "$iii_port" \
@@ -132,6 +176,7 @@ wait_for_model() {
     sleep 0.5
   done
   echo "timed out waiting for E2E model $provider/$model" >&2
+  check_started_processes || true
   return 1
 }
 
@@ -151,6 +196,7 @@ start_provider() {
   wait_for_function "provider::$provider::stream"
 }
 
+assert_engine_port_available
 start_process engine "$III_BIN" -c "$engine_config"
 wait_for_function engine::workers::list
 wait_for_function worker::add

--- a/harness/tests/integration/README.md
+++ b/harness/tests/integration/README.md
@@ -25,6 +25,7 @@ No provider key or network access is required.
 | INT-012 | `queued-message-edit-unqueue` | direct | edit one queued message in place and unqueue another while the first turn is streaming; only the edited and untouched rows drain in order |
 | UI-001 | `console-streamed-text` | playground | a message sent by the Console streams to durable completion |
 | UI-002 | `multi-turn-traces` | playground | a native function turn and a Console turn expose distinct traces and function-call events |
+| UI-003 | `console-queued-message-streaming` | playground | the Console composer remains editable during streaming and queues a second message that drains in order |
 
 Each fixture is defined end to end in its own `src/scenarios/*.rs` file with a
 small typed DSL. The scenario keeps its send policy, router request matchers,

--- a/harness/tests/integration/src/fixtures/tests.rs
+++ b/harness/tests/integration/src/fixtures/tests.rs
@@ -11,7 +11,7 @@ fn all_selection_returns_the_checked_in_fixtures() {
         ids,
         std::collections::BTreeSet::from([
             "INT-001", "INT-002", "INT-003", "INT-004", "INT-005", "INT-006", "INT-007", "INT-008",
-            "INT-009", "INT-010", "INT-011", "INT-012", "UI-001", "UI-002"
+            "INT-009", "INT-010", "INT-011", "INT-012", "UI-001", "UI-002", "UI-003"
         ])
     );
     assert_eq!(

--- a/harness/tests/integration/src/scenario/playground.rs
+++ b/harness/tests/integration/src/scenario/playground.rs
@@ -15,7 +15,7 @@ use crate::deadline::Deadline;
 use crate::fixtures::ScenarioFixture;
 use crate::runtime::{RunError, RunErrorKind, RunPhase};
 use crate::scenarios::ScenarioDriver;
-use crate::scripted_router::{GATE_RELEASE_FUNCTION_ID, GATE_STATUS_FUNCTION_ID};
+use crate::scripted_router::GATE_RELEASE_FUNCTION_ID;
 use crate::stack::{Stack, StackBins};
 use crate::types::scenario::{Classification, CompiledSendV1};
 use crate::types::script::SchemaVersion1;
@@ -49,7 +49,6 @@ pub struct PlaygroundReadyV1 {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PlaygroundControlsV1 {
-    pub gate_status: String,
     pub gate_release: String,
 }
 
@@ -371,7 +370,6 @@ fn build_ready_manifest(
         message: prepared.scenario.send.message.clone(),
         functions,
         controls: PlaygroundControlsV1 {
-            gate_status: GATE_STATUS_FUNCTION_ID.to_string(),
             gate_release: GATE_RELEASE_FUNCTION_ID.to_string(),
         },
         send: prepared.scenario.send.clone(),

--- a/harness/tests/integration/src/scenario/playground.rs
+++ b/harness/tests/integration/src/scenario/playground.rs
@@ -15,6 +15,7 @@ use crate::deadline::Deadline;
 use crate::fixtures::ScenarioFixture;
 use crate::runtime::{RunError, RunErrorKind, RunPhase};
 use crate::scenarios::ScenarioDriver;
+use crate::scripted_router::{GATE_RELEASE_FUNCTION_ID, GATE_STATUS_FUNCTION_ID};
 use crate::stack::{Stack, StackBins};
 use crate::types::scenario::{Classification, CompiledSendV1};
 use crate::types::script::SchemaVersion1;
@@ -41,7 +42,15 @@ pub struct PlaygroundReadyV1 {
     pub model: PlaygroundModelV1,
     pub message: String,
     pub functions: BTreeMap<String, String>,
+    pub controls: PlaygroundControlsV1,
     pub send: CompiledSendV1,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlaygroundControlsV1 {
+    pub gate_status: String,
+    pub gate_release: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -361,6 +370,10 @@ fn build_ready_manifest(
         },
         message: prepared.scenario.send.message.clone(),
         functions,
+        controls: PlaygroundControlsV1 {
+            gate_status: GATE_STATUS_FUNCTION_ID.to_string(),
+            gate_release: GATE_RELEASE_FUNCTION_ID.to_string(),
+        },
         send: prepared.scenario.send.clone(),
     }
 }

--- a/harness/tests/integration/src/scenarios/console_queued_message_streaming.rs
+++ b/harness/tests/integration/src/scenarios/console_queued_message_streaming.rs
@@ -1,0 +1,101 @@
+//! UI-003 — the production Console keeps its composer editable while a turn is
+//! streaming and queues a second message through the public harness surface.
+
+use super::dsl::{Generation, Message, Model, Request, Response, Scenario, Send, Tool};
+use super::ScenarioDriver;
+use crate::fixtures::ScenarioFixture;
+
+pub(super) const GATE: &str = "console-queued-message-streaming-in-flight";
+pub(super) const QUEUED_MESSAGE: &str = "Queue this while the first response is streaming.";
+
+pub(super) fn scenario() -> ScenarioFixture {
+    const ID: &str = "UI-003";
+    const INITIAL_MESSAGE: &str = "Start the Console queueing fixture.";
+    const FIRST_TEXT: &str = "first Console response complete";
+    const FINAL_TEXT: &str = "queued Console message complete";
+
+    let model = Model::scripted("fixture-model");
+
+    Scenario::new(
+        ID,
+        "console-queued-message-streaming",
+        "The Console composer stays editable during streaming and queues a second message in order.",
+        ScenarioDriver::Playground,
+        model.clone(),
+    )
+    .send(
+        Send::message(INITIAL_MESSAGE)
+            .idempotency_key("{{run_id}}:ui-003")
+            .without_functions(),
+    )
+    .generation(
+        Generation::new(1)
+            .expect(
+                Request::new()
+                    .turn_request()
+                    .system_prompt_regex("agent_trigger")
+                    .messages_exact([Message::user(INITIAL_MESSAGE)])
+                    .tools_subset([Tool::named("agent_trigger")]),
+            )
+            .gate(GATE)
+            .respond(Response::streamed_text(
+                FIRST_TEXT,
+                ["first Console ", "response complete"],
+                12,
+                3,
+            )),
+    )
+    .generation(
+        Generation::new(2)
+            .expect(
+                Request::new()
+                    .turn_request_step(1)
+                    .system_prompt_regex("agent_trigger")
+                    .messages_exact([
+                        Message::user(INITIAL_MESSAGE),
+                        Message::assistant_text(FIRST_TEXT, &model, 12, 3),
+                        Message::user(QUEUED_MESSAGE),
+                    ])
+                    .tools_subset([Tool::named("agent_trigger")]),
+            )
+            .respond(Response::streamed_text(
+                FINAL_TEXT,
+                ["queued Console ", "message complete"],
+                10,
+                3,
+            )),
+    )
+    .verify(|run| {
+        run.expect_assistant_texts([FIRST_TEXT, FINAL_TEXT])?;
+        run.expect_message_counts(2, 2, 0)?;
+        run.expect_no_duplicate_messages()
+    })
+    .scenario_timeout_ms(60_000)
+    .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_generation_is_gated_and_second_consumes_the_queued_message() {
+        let fixture = scenario();
+        assert_eq!(fixture.script.generations.len(), 2);
+        assert_eq!(
+            fixture.script.generations[0]
+                .gate
+                .as_ref()
+                .map(|gate| gate.name.as_str()),
+            Some(GATE)
+        );
+        assert!(serde_json::to_string(&fixture.script.generations[1])
+            .unwrap()
+            .contains(QUEUED_MESSAGE));
+        assert!(
+            serde_json::to_string(&fixture.script.generations[1].match_.request_id)
+                .unwrap()
+                .contains(":1$")
+        );
+    }
+}

--- a/harness/tests/integration/src/scenarios/mod.rs
+++ b/harness/tests/integration/src/scenarios/mod.rs
@@ -1,6 +1,7 @@
 //! The checked-in integration fixtures.
 
 mod coalesced_fire;
+mod console_queued_message_streaming;
 mod console_streamed_text;
 mod dsl;
 mod engine_restart_recovery;
@@ -32,6 +33,7 @@ pub enum ScenarioDriver {
 pub fn all() -> Vec<ScenarioFixture> {
     vec![
         coalesced_fire::scenario(),
+        console_queued_message_streaming::scenario(),
         console_streamed_text::scenario(),
         engine_restart_recovery::scenario(),
         exactly_once_function::scenario(),
@@ -55,7 +57,7 @@ mod tests {
     #[test]
     fn every_fixture_is_unique_and_valid() {
         let fixtures = all();
-        assert_eq!(fixtures.len(), 14);
+        assert_eq!(fixtures.len(), 15);
         let mut slugs = std::collections::BTreeSet::new();
         let mut ids = std::collections::BTreeSet::new();
         for fixture in fixtures {

--- a/harness/tests/integration/src/scripted_router.rs
+++ b/harness/tests/integration/src/scripted_router.rs
@@ -29,6 +29,9 @@ use crate::types::script::{
     ModelFixtureV1, RouterDispatchV1, RouterScriptV1, ScriptedGenerationV1, ServeEffectV1,
 };
 
+pub const GATE_STATUS_FUNCTION_ID: &str = "integration-scripted-router::gate::status";
+pub const GATE_RELEASE_FUNCTION_ID: &str = "integration-scripted-router::gate::release";
+
 /// One `router::chat` call's evidence, stored raw (never normalized).
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct RouterCallEvidence {
@@ -254,6 +257,42 @@ impl ScriptedRouter {
                 "router::system_prompt::get",
             ),
         );
+        {
+            let state = self.state.clone();
+            iii.register_function(
+                GATE_STATUS_FUNCTION_ID,
+                RegisterFunction::new_async(move |input: Value| {
+                    let state = state.clone();
+                    async move {
+                        let name = required_gate_name(&input)?;
+                        let (arrivals, released) = gate_status(&state, name);
+                        Ok::<Value, Error>(json!({
+                            "name": name,
+                            "arrivals": arrivals,
+                            "released": released,
+                        }))
+                    }
+                })
+                .metadata(json!({ "internal": true })),
+            );
+        }
+        {
+            let state = self.state.clone();
+            iii.register_function(
+                GATE_RELEASE_FUNCTION_ID,
+                RegisterFunction::new_async(move |input: Value| {
+                    let state = state.clone();
+                    async move {
+                        let name = required_gate_name(&input)?;
+                        release_gate_state(&state, name).map_err(|error| {
+                            Error::Handler(format!("integration/gate_release: {error}"))
+                        })?;
+                        Ok::<Value, Error>(json!({ "name": name, "released": true }))
+                    }
+                })
+                .metadata(json!({ "internal": true })),
+            );
+        }
     }
 
     /// Number of generations consumed so far.
@@ -295,16 +334,7 @@ impl ScriptedRouter {
     /// would turn a fixture typo into a test that proceeds without its hard
     /// synchronization point.
     pub fn release_gate(&self, name: &str) -> anyhow::Result<()> {
-        let notify = {
-            let mut state = self.state.lock().expect("router state");
-            let gate = state.gates.get_mut(name).ok_or_else(|| {
-                anyhow::anyhow!("scripted router gate {name:?} was never entered")
-            })?;
-            gate.released = true;
-            Arc::clone(&state.gate_notify)
-        };
-        notify.notify_waiters();
-        Ok(())
+        release_gate_state(&self.state, name)
     }
 
     /// Unblock all gates during teardown, including after an intervention
@@ -433,6 +463,36 @@ fn model_supports(model: &ModelFixtureV1, capability: &str) -> bool {
         "thinking:xhigh" => model.supports_xhigh == Some(true),
         _ => false,
     }
+}
+
+fn required_gate_name(input: &Value) -> Result<&str, Error> {
+    input
+        .get("name")
+        .and_then(Value::as_str)
+        .filter(|name| !name.trim().is_empty())
+        .ok_or_else(|| Error::Handler("integration/gate_name: non-empty name is required".into()))
+}
+
+fn gate_status(state: &Arc<Mutex<State>>, name: &str) -> (usize, bool) {
+    let state = state.lock().expect("router state");
+    state
+        .gates
+        .get(name)
+        .map_or((0, false), |gate| (gate.arrivals, gate.released))
+}
+
+fn release_gate_state(state: &Arc<Mutex<State>>, name: &str) -> anyhow::Result<()> {
+    let notify = {
+        let mut state = state.lock().expect("router state");
+        let gate = state
+            .gates
+            .get_mut(name)
+            .ok_or_else(|| anyhow::anyhow!("scripted router gate {name:?} was never entered"))?;
+        gate.released = true;
+        Arc::clone(&state.gate_notify)
+    };
+    notify.notify_waiters();
+    Ok(())
 }
 
 async fn wait_for_gate_state(

--- a/harness/tests/integration/src/scripted_router.rs
+++ b/harness/tests/integration/src/scripted_router.rs
@@ -29,7 +29,6 @@ use crate::types::script::{
     ModelFixtureV1, RouterDispatchV1, RouterScriptV1, ScriptedGenerationV1, ServeEffectV1,
 };
 
-pub const GATE_STATUS_FUNCTION_ID: &str = "integration-scripted-router::gate::status";
 pub const GATE_RELEASE_FUNCTION_ID: &str = "integration-scripted-router::gate::release";
 
 /// One `router::chat` call's evidence, stored raw (never normalized).
@@ -260,33 +259,12 @@ impl ScriptedRouter {
         {
             let state = self.state.clone();
             iii.register_function(
-                GATE_STATUS_FUNCTION_ID,
-                RegisterFunction::new_async(move |input: Value| {
-                    let state = state.clone();
-                    async move {
-                        let name = required_gate_name(&input)?;
-                        let (arrivals, released) = gate_status(&state, name);
-                        Ok::<Value, Error>(json!({
-                            "name": name,
-                            "arrivals": arrivals,
-                            "released": released,
-                        }))
-                    }
-                })
-                .metadata(json!({ "internal": true })),
-            );
-        }
-        {
-            let state = self.state.clone();
-            iii.register_function(
                 GATE_RELEASE_FUNCTION_ID,
                 RegisterFunction::new_async(move |input: Value| {
                     let state = state.clone();
                     async move {
                         let name = required_gate_name(&input)?;
-                        release_gate_state(&state, name).map_err(|error| {
-                            Error::Handler(format!("integration/gate_release: {error}"))
-                        })?;
+                        latch_gate_release(&state, name);
                         Ok::<Value, Error>(json!({ "name": name, "released": true }))
                     }
                 })
@@ -473,12 +451,24 @@ fn required_gate_name(input: &Value) -> Result<&str, Error> {
         .ok_or_else(|| Error::Handler("integration/gate_name: non-empty name is required".into()))
 }
 
-fn gate_status(state: &Arc<Mutex<State>>, name: &str) -> (usize, bool) {
-    let state = state.lock().expect("router state");
-    state
-        .gates
-        .get(name)
-        .map_or((0, false), |gate| (gate.arrivals, gate.released))
+/// Arm a release even when the router has not reached the gate yet. This is
+/// the Console playground's event-driven control seam: the queued-message
+/// lifecycle event authorizes progress, and an early release is remembered
+/// instead of turning ordering into another wait.
+fn latch_gate_release(state: &Arc<Mutex<State>>, name: &str) {
+    let notify = {
+        let mut state = state.lock().expect("router state");
+        state
+            .gates
+            .entry(name.to_string())
+            .or_insert(GateState {
+                arrivals: 0,
+                released: false,
+            })
+            .released = true;
+        Arc::clone(&state.gate_notify)
+    };
+    notify.notify_waiters();
 }
 
 fn release_gate_state(state: &Arc<Mutex<State>>, name: &str) -> anyhow::Result<()> {
@@ -895,5 +885,20 @@ mod tests {
             .await
             .expect("gate release should wake the router")
             .expect("router gate task should finish");
+    }
+
+    #[tokio::test]
+    async fn latched_release_does_not_wait_for_gate_arrival() {
+        let state = state();
+
+        latch_gate_release(&state, "test-gate");
+        tokio::time::timeout(Duration::from_secs(1), await_gate(&state, "test-gate"))
+            .await
+            .expect("an early release should let a later arrival pass");
+
+        let state = state.lock().expect("router state");
+        let gate = state.gates.get("test-gate").expect("gate should exist");
+        assert_eq!(gate.arrivals, 1);
+        assert!(gate.released);
     }
 }

--- a/iii-directory/README.md
+++ b/iii-directory/README.md
@@ -99,7 +99,7 @@ auto_download: true                   # subscribe to worker-add + run the boot r
 registry_url: https://api.workers.iii.dev   # workers registry base URL
 download_timeout_ms: 60000                   # per git-clone / HTTP request timeout (ms)
 registry_cache_ttl_ms: 60000                 # in-process TTL for registry::workers::* responses
-filter_unregistered: true                    # hide skills whose namespace isn't an installed worker
+filter_unregistered: false                   # opt in to hiding skills whose namespace isn't installed
 ```
 
 The `skills_folder` is created on first download if it doesn't exist.

--- a/iii-directory/config.yaml.example
+++ b/iii-directory/config.yaml.example
@@ -32,3 +32,7 @@ registry_url: https://api.workers.iii.dev
 
 # Timeout for a single download (`git clone` or HTTP request) in ms.
 download_timeout_ms: 60000
+
+# Keep explicitly downloaded skills visible even before their worker connects.
+# Set true only when the directory should hide uninstalled namespaces.
+filter_unregistered: false

--- a/iii-directory/src/config.rs
+++ b/iii-directory/src/config.rs
@@ -54,7 +54,10 @@ fn default_registry_cache_ttl_ms() -> u64 {
 }
 
 fn default_filter_unregistered() -> bool {
-    true
+    // Downloaded skills are explicit operator content. Keep them visible even
+    // when their namespace is not currently connected to the engine; callers
+    // can opt into the stricter installed-worker filter when they need it.
+    false
 }
 
 fn default_auto_download() -> bool {
@@ -100,10 +103,10 @@ pub struct SkillsConfig {
     #[serde(default = "default_registry_cache_ttl_ms")]
     pub registry_cache_ttl_ms: u64,
 
-    /// When `true` (default), read functions hide skills whose top
-    /// namespace segment doesn't match a registered (installed) worker
-    /// name. Orphan namespaces are hidden. When `false`, all scanned
-    /// skills are returned regardless of installed workers.
+    /// When `true`, read functions hide skills whose top namespace segment
+    /// doesn't match a registered (installed) worker name. When `false`
+    /// (the default), all scanned skills are returned. Explicitly downloaded
+    /// skills remain visible even before their worker is connected.
     #[serde(default = "default_filter_unregistered")]
     pub filter_unregistered: bool,
 
@@ -271,7 +274,7 @@ mod tests {
         assert_eq!(cfg.registry_url, DEFAULT_REGISTRY_URL);
         assert_eq!(cfg.download_timeout_ms, 60_000);
         assert_eq!(cfg.registry_cache_ttl_ms, 60_000);
-        assert!(cfg.filter_unregistered);
+        assert!(!cfg.filter_unregistered);
         assert!(cfg.auto_download);
     }
 

--- a/iii-directory/src/functions/skills.rs
+++ b/iii-directory/src/functions/skills.rs
@@ -376,10 +376,10 @@ fn parse_worker_names(val: &serde_json::Value) -> HashSet<String> {
 
 /// Resolve the visible set of skills given config and engine handle.
 ///
-/// When `cfg.filter_unregistered` is true, only skills whose top
-/// namespace segment matches a registered (installed) worker name are
-/// returned. On daemon-down or first-boot-no-cache, falls back to
-/// the unfiltered set.
+/// When `cfg.filter_unregistered` is true, only skills whose top namespace
+/// segment matches a registered (installed) worker name are returned. The
+/// default is false so explicitly downloaded skills are not silently hidden.
+/// On daemon-down or first-boot-no-cache, falls back to the unfiltered set.
 pub async fn resolve_visible_skills(
     cfg: &SkillsConfig,
     cache: &RegisteredWorkersCache,

--- a/iii-directory/src/manifest.rs
+++ b/iii-directory/src/manifest.rs
@@ -26,7 +26,7 @@ pub fn build_manifest() -> ModuleManifest {
             "registry_url": DEFAULT_REGISTRY_URL,
             "download_timeout_ms": 60_000,
             "registry_cache_ttl_ms": 60_000,
-            "filter_unregistered": true,
+            "filter_unregistered": false,
             "auto_download": true,
         }),
         supported_targets: vec![env!("TARGET").to_string()],
@@ -58,6 +58,7 @@ mod tests {
         );
         assert_eq!(parsed["default_config"]["download_timeout_ms"], 60_000);
         assert_eq!(parsed["default_config"]["registry_cache_ttl_ms"], 60_000);
+        assert_eq!(parsed["default_config"]["filter_unregistered"], false);
         assert!(!parsed["supported_targets"].as_array().unwrap().is_empty());
     }
 }

--- a/iii-directory/ui/src/configuration/index.tsx
+++ b/iii-directory/ui/src/configuration/index.tsx
@@ -127,8 +127,8 @@ export function DirectoryConfigForm(props: ConfigFormProps) {
       <CheckField
         field="filter_unregistered"
         label="hide skills of uninstalled workers"
-        hint="reads only show namespaces matching a registered worker; off = everything on disk"
-        checked={value.filter_unregistered !== false}
+        hint="off by default: downloaded skills stay visible; on = only registered-worker namespaces"
+        checked={value.filter_unregistered === true}
         onChange={setBool}
         errors={props.errors}
       />


### PR DESCRIPTION
## Summary

- Reconcile engine and worker-manager state so the Console distinguishes connected, starting, stopped, absent, and unknown workers.
- Show actionable Harness empty states, worker connection status, and trace-stream stall diagnostics.
- Add UI-003, a real Console + Harness + scripted-router Playwright scenario proving the composer remains editable and a persisted queued message drains exactly once during streaming.
- Synchronize UI-003 through the native `harness::turn-started`, `harness::message-queued`, and terminal `harness::turn-completed` triggers; the scripted gate uses an early-release latch, with no status/gate polling or synchronization sleeps.
- Harden Harness startup/config registration retries and E2E port/process diagnostics, with focused retry and occupied-port validation.
- Keep explicitly downloaded skills visible by default, add browser frontend guidance, and refresh stale documentation links.

## Context

The recording exposed several misleading states: a running manager process could be shown as a healthy worker without a registered connection, stopped workers could collapse into an empty state without diagnostics, the chat composer could appear unusable during a running turn, and a stalled trace had no actionable feedback.

The backend stop and queued-message scenarios (INT-011/INT-012) are now on `main`; this branch builds on them with UI-003 through the production Console surface. The worker-manager port collision remains an external runtime/environment issue, so the E2E launcher now fails before boot on an occupied port and reports early child-process exits with log tails.

Lifecycle hooks were intentionally not used as test observers: they are synchronous execution boundaries that can veto or mutate a turn. The async lifecycle trigger types expose the exact facts this scenario needs without inserting test behavior into the production turn path.

## Validation

- Console: app/E2E TypeScript checks, Biome, and 15 focused Vitest tests passed.
- Console Playwright UI-003: 3 consecutive real-stack runs passed, plus a focused run with the event-driven latched gate.
- Harness: 306 crate tests and 90 integration harness tests passed; rustfmt and E2E shell syntax passed.
- Integration runner: scripted-router unit tests and clippy with warnings denied passed.
- iii-directory: UI typecheck/build, 261 Rust tests, and 44 BDD scenarios passed.
- Occupied-port fail-fast probe and `git diff --check` passed.

Fixes MOT-4290
