### PR TITLE
feat(ci): add worker alpha release

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -1,0 +1,216 @@
+name: Alpha Release
+
+# Publishes a worker prerelease from a feature branch without changing that
+# branch or main. The versioned commit is reachable only through the annotated
+# alpha tag, and the registry channel is intentionally fixed to `next`.
+#
+# Run from Actions -> Alpha Release -> "Use workflow from: <feature-branch>".
+
+on:
+  workflow_dispatch:
+    inputs:
+      worker:
+        description: 'Worker module to publish as an alpha prerelease'
+        required: true
+        type: choice
+        options:
+          - acp
+          - approval-gate
+          - bridge
+          - browser
+          - claude-code
+          - codex
+          - devin
+          - console
+          - grok
+          - context-manager
+          - cron
+          - database
+          - editor
+          - email
+          - eval
+          - harness
+          - hermes
+          - http
+          - iii-directory
+          - lsp
+          - image-resize
+          - llm-router
+          - fp
+          - github
+          - mcp
+          - memory
+          - memory-consolidate
+          - opencode
+          - openwiki
+          - pi
+          - provider-anthropic
+          - provider-claude-code
+          - provider-kimi
+          - provider-llamacpp
+          - provider-openai
+          - provider-openai-codex
+          - provider-xai
+          - provider-zai
+          - pubsub
+          - queue
+          - rbac-proxy
+          - session-manager
+          - slack
+          - telegram-bot
+          - shell
+          - state
+          - worktree
+          - storage
+          - scrapling
+          - web
+
+permissions:
+  contents: write
+
+concurrency:
+  # Alpha counters are global per worker, so serialise branches for the same
+  # worker and prevent two runs from creating the same -alpha.N tag.
+  group: alpha-release-${{ inputs.worker }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Bump and tag alpha
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.III_CI_APP_ID }}
+          private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
+
+      - name: Checkout selected branch
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Refuse main
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ "$BRANCH" == "main" ]]; then
+            echo "::error::Alpha releases must run from a feature branch; use Create Tag for main releases"
+            exit 1
+          fi
+          echo "::notice::Publishing alpha from branch: $BRANCH"
+
+      - name: Discover manifest
+        id: meta
+        env:
+          WORKER: ${{ inputs.worker }}
+        run: |
+          set -euo pipefail
+          if [[ ! -f "$WORKER/iii.worker.yaml" ]]; then
+            echo "::error::$WORKER/iii.worker.yaml is missing"
+            exit 1
+          fi
+          manifest=$(awk '/^manifest:/ { print $2; exit }' "$WORKER/iii.worker.yaml")
+          if [[ -z "$manifest" ]]; then
+            echo "::error::$WORKER/iii.worker.yaml has no 'manifest' key"
+            exit 1
+          fi
+          if [[ ! -f "$WORKER/$manifest" ]]; then
+            echo "::error::Manifest does not exist: $WORKER/$manifest"
+            exit 1
+          fi
+          echo "manifest=$manifest" >> "$GITHUB_OUTPUT"
+
+      - name: Calculate next alpha version
+        id: version
+        env:
+          WORKER: ${{ inputs.worker }}
+          MANIFEST: ${{ steps.meta.outputs.manifest }}
+        run: |
+          set -euo pipefail
+          current=$(python3 .github/scripts/manifest_version.py read "$WORKER/$MANIFEST")
+          core=${current%%-*}
+          if [[ ! "$core" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Manifest version must be semver MAJOR.MINOR.PATCH (got $current)"
+            exit 1
+          fi
+
+          counter=0
+          while IFS= read -r tag; do
+            suffix=${tag##*-alpha.}
+            if [[ "$suffix" =~ ^[0-9]+$ ]] && (( suffix > counter )); then
+              counter=$suffix
+            fi
+          done < <(git tag --list "${WORKER}/v${core}-alpha.*")
+
+          version="${core}-alpha.$((counter + 1))"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=${WORKER}/v${version}" >> "$GITHUB_OUTPUT"
+          echo "::notice::$WORKER: $current -> $version"
+
+      - name: Write alpha version to manifest
+        env:
+          WORKER: ${{ inputs.worker }}
+          MANIFEST: ${{ steps.meta.outputs.manifest }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          python3 - "$WORKER/$MANIFEST" "$VERSION" <<'PY'
+          import sys
+          from pathlib import Path
+
+          sys.path.insert(0, ".github/scripts")
+          import _lib
+
+          _lib.write_version(Path(sys.argv[1]), sys.argv[2])
+          PY
+          python3 .github/scripts/manifest_version.py verify \
+            "$WORKER/$MANIFEST" --expected "$VERSION"
+
+      - name: Sync Cargo.lock to alpha version
+        env:
+          WORKER: ${{ inputs.worker }}
+          MANIFEST: ${{ steps.meta.outputs.manifest }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/manifest_version.py sync-lock "$WORKER/$MANIFEST"
+
+      - name: Ensure alpha tag is available
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null; then
+            echo "::error::Tag already exists: $TAG"
+            exit 1
+          fi
+
+      - name: Configure git identity
+        run: |
+          git config user.name "workers-ci[bot]"
+          git config user.email "workers-ci[bot]@users.noreply.github.com"
+
+      - name: Commit version bump and push alpha tag only
+        env:
+          WORKER: ${{ inputs.worker }}
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git add -A
+          git commit -m "chore(${WORKER}): alpha ${VERSION} [skip ci]"
+          git tag -a "$TAG" -m "Alpha release $TAG
+
+          worker: $WORKER
+          version: $VERSION
+          registry-tag: next
+          "
+          # Do not push the selected branch or main. The ephemeral alpha
+          # commit is reachable exclusively through this annotated tag.
+          git push origin "$TAG"
+          echo "::notice::Created $TAG (registry-tag=next)"

--- a/docs/sops/release.md
+++ b/docs/sops/release.md
@@ -144,6 +144,18 @@ Create Tag cannot produce prerelease suffixes. Push a manual **annotated** tag:
 With tag message including `registry-tag: next`. Marks the GitHub Release as
 prerelease; still builds and publishes (unless `interface_smoke: false`).
 
+### Alpha release from a feature branch
+
+Actions → **Alpha Release** → choose the worker and select the feature branch
+in **Use workflow from**. The workflow refuses `main`, derives the next
+`<worker>/vX.Y.Z-alpha.N` version from the branch manifest and existing alpha
+tags, then creates an ephemeral commit reachable only from that annotated tag.
+It never pushes the selected branch or `main`.
+
+The tag annotation always contains `registry-tag: next`; alpha releases cannot
+publish to `latest`. The regular **Release** workflow runs from that tag and
+creates a GitHub prerelease, release assets, and the registry entry on `next`.
+
 ### Dry run
 
 Tag shape: `<worker>/vX.Y.Z-dry-run.1` (parsed by `parse_release_tag.py`).


### PR DESCRIPTION
## Summary

Adds a manual Alpha Release workflow for workers from feature branches. It produces annotated `-alpha.N` tags, creates release prereleases, and always publishes registry artifacts to `next`.

The workflow never pushes the selected feature branch or `main`; its version bump is reachable only through the alpha tag.

## Validation

- `git diff --check`
- YAML parsed successfully in a temporary container
- 31 manifest-version and release-tag tests passed in a temporary container


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered alpha-release workflow with worker selection and validation.
  * Alpha releases now generate sequential prerelease versions and publish through the fixed `next` channel.
  * Release operations are serialized per worker to prevent conflicts.
* **Documentation**
  * Added guidance for creating alpha releases from feature branches without pushing branch or main-branch changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->