### PR TITLE
(MOT-4295) feat(ci): publish harness integration and e2e coverage to the metrics site

### DIFF
--- a/.github/benchmark-site/coverage/index.html
+++ b/.github/benchmark-site/coverage/index.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="LLVM line coverage for the harness integration and E2E suites."
+    >
+    <meta name="color-scheme" content="dark light">
+    <title>Harness stack coverage</title>
+    <link rel="stylesheet" href="../styles.css">
+    <style>
+      .coverage-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+        gap: 1.25rem;
+      }
+      .coverage-card {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 1.5rem;
+      }
+      .coverage-card h2 {
+        margin: 0;
+      }
+      .coverage-percent {
+        font-size: 2.5rem;
+        font-weight: 700;
+        font-variant-numeric: tabular-nums;
+      }
+      .coverage-meta {
+        opacity: 0.75;
+        font-size: 0.875rem;
+      }
+      .coverage-links {
+        display: flex;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to coverage reports</a>
+    <div class="ambient ambient-one" aria-hidden="true"></div>
+    <div class="ambient ambient-two" aria-hidden="true"></div>
+
+    <header class="topbar">
+      <a class="brand" href="https://github.com/iii-hq/workers" aria-label="iii workers">
+        <span class="brand-copy">
+          <strong>iii</strong>
+          <span>Harness benchmarks</span>
+        </span>
+      </a>
+      <nav class="topbar-actions" aria-label="Dashboard actions">
+        <a class="button button-secondary" href="../index.html">Executions</a>
+        <a class="button button-secondary" href="../coverage-trend/">Trend</a>
+      </nav>
+    </header>
+
+    <main id="main" class="page-shell overview-shell">
+      <section class="page-heading" aria-labelledby="page-title">
+        <div>
+          <div class="eyebrow">
+            <span class="live-dot" aria-hidden="true"></span>
+            Harness stack
+          </div>
+          <h1 id="page-title">Code coverage</h1>
+          <p>LLVM line coverage of the instrumented stack, refreshed by the daily E2E cycle.</p>
+        </div>
+        <div class="sync-block">
+          <span id="sync-label">Last published</span>
+          <time id="last-update" datetime="">Waiting for data</time>
+        </div>
+      </section>
+
+      <section id="empty-state" class="empty-state" hidden>
+        <div class="empty-icon" aria-hidden="true">⌁</div>
+        <h2>No coverage published yet</h2>
+        <p>The next scheduled Harness E2E Daily workflow will publish the first reports here.</p>
+      </section>
+
+      <section id="coverage-content" class="coverage-grid" hidden>
+        <article class="panel coverage-card" id="card-integration">
+          <h2>Integration suite</h2>
+          <div class="coverage-percent" data-percent>–</div>
+          <div class="coverage-meta" data-meta>Not published yet.</div>
+          <div class="coverage-links">
+            <a class="button button-secondary" href="./integration/index.html" data-report hidden>
+              Browse report
+            </a>
+          </div>
+        </article>
+        <article class="panel coverage-card" id="card-e2e">
+          <h2>E2E suite</h2>
+          <div class="coverage-percent" data-percent>–</div>
+          <div class="coverage-meta" data-meta>Not published yet.</div>
+          <div class="coverage-links">
+            <a class="button button-secondary" href="./e2e/index.html" data-report hidden>
+              Browse report
+            </a>
+          </div>
+        </article>
+      </section>
+    </main>
+
+    <script>
+      window.HARNESS_COVERAGE = null;
+    </script>
+    <script src="./summary.js"></script>
+    <script>
+      (function () {
+        var data = window.HARNESS_COVERAGE;
+        var empty = document.getElementById("empty-state");
+        var content = document.getElementById("coverage-content");
+        var suites = data && data.suites ? data.suites : {};
+        var hasAny = Boolean(suites.e2e || suites.integration);
+        if (!hasAny) {
+          empty.hidden = false;
+          return;
+        }
+        content.hidden = false;
+
+        if (data.updated_at) {
+          var time = document.getElementById("last-update");
+          time.dateTime = data.updated_at;
+          time.textContent = new Date(data.updated_at).toLocaleString();
+        }
+
+        function render(cardId, summary) {
+          var card = document.getElementById(cardId);
+          if (!summary || !summary.totals || !summary.totals.lines) return;
+          var lines = summary.totals.lines;
+          card.querySelector("[data-percent]").textContent =
+            lines.percent.toFixed(1) + "%";
+          card.querySelector("[data-meta]").textContent =
+            (lines.covered != null ? lines.covered.toLocaleString() : "?") +
+            " of " + (lines.count != null ? lines.count.toLocaleString() : "?") +
+            " lines covered · " + (summary.generated_at || "");
+          card.querySelector("[data-report]").hidden = false;
+        }
+        render("card-integration", suites.integration);
+        render("card-e2e", suites.e2e);
+      })();
+    </script>
+  </body>
+</html>

--- a/.github/benchmark-site/execution-data.js
+++ b/.github/benchmark-site/execution-data.js
@@ -852,6 +852,42 @@
     return history?.executions?.find((execution) => execution.id === id) || null;
   }
 
+  function groupRunFailures(reports) {
+    const groups = [];
+    (Array.isArray(reports) ? reports : []).forEach((record) => {
+      (record?.report?.scenarios || []).forEach((scenario) => {
+        (scenario.runs || []).forEach((run, runIndex) => {
+          const items = [];
+          (run.failures || []).forEach((failure) => {
+            items.push({
+              kind: "failure",
+              phase: failure.phase || "failure",
+              message: failure.message || "No failure message",
+            });
+          });
+          (run.hard_gates || [])
+            .filter((gate) => gate && gate.passed === false)
+            .forEach((gate) => {
+              items.push({
+                kind: "gate",
+                gateId: gate.id,
+                message: gate.reason || "Hard gate failed",
+              });
+            });
+          if (items.length) {
+            groups.push({
+              subjectId: record.subject_id,
+              scenarioId: scenario.scenario_id,
+              runIndex,
+              items,
+            });
+          }
+        });
+      });
+    });
+    return groups;
+  }
+
   return {
     buildEfficiencyOverview,
     contractFingerprint,
@@ -859,6 +895,7 @@
     executionsWithinDays,
     filterExecutions,
     findExecution,
+    groupRunFailures,
     legacyExecution,
     matrixCell,
     matrixCellLabel,

--- a/.github/benchmark-site/execution-data.test.cjs
+++ b/.github/benchmark-site/execution-data.test.cjs
@@ -8,6 +8,7 @@ const {
   executionsWithinDays,
   filterExecutions,
   findExecution,
+  groupRunFailures,
   matrixCell,
   matrixCellLabel,
   matrixRows,
@@ -513,4 +514,65 @@ test("compares efficiency only within the same scenario contract", () => {
   assert.equal(overview.metrics.tokens.comparableCurrent, 90);
   assert.equal(overview.metrics.tokens.comparableBaseline, 100);
   assert.equal(overview.metrics.tokens.delta, -10);
+});
+
+test("groupRunFailures returns empty for missing or empty reports", () => {
+  assert.deepEqual(groupRunFailures(undefined), []);
+  assert.deepEqual(groupRunFailures([]), []);
+  assert.deepEqual(
+    groupRunFailures([
+      {
+        subject_id: "s",
+        report: {
+          scenarios: [
+            {
+              scenario_id: "clean",
+              runs: [{ failures: [], hard_gates: [{ id: "g", passed: true }] }],
+            },
+          ],
+        },
+      },
+    ]),
+    [],
+  );
+});
+
+test("groupRunFailures groups failures and failed gates per run", () => {
+  const groups = groupRunFailures([
+    {
+      subject_id: "anthropic-sonnet",
+      report: {
+        scenarios: [
+          {
+            scenario_id: "security_review",
+            runs: [
+              {
+                failures: [{ phase: "execute", message: "boom" }],
+                hard_gates: [
+                  { id: "no_secrets", passed: false, reason: "leaked" },
+                  { id: "compiles", passed: true },
+                ],
+              },
+              { failures: [], hard_gates: [] },
+              { failures: [{ message: "" }] },
+            ],
+          },
+        ],
+      },
+    },
+  ]);
+  assert.equal(groups.length, 2);
+  assert.deepEqual(groups[0], {
+    subjectId: "anthropic-sonnet",
+    scenarioId: "security_review",
+    runIndex: 0,
+    items: [
+      { kind: "failure", phase: "execute", message: "boom" },
+      { kind: "gate", gateId: "no_secrets", message: "leaked" },
+    ],
+  });
+  assert.equal(groups[1].runIndex, 2);
+  assert.deepEqual(groups[1].items, [
+    { kind: "failure", phase: "failure", message: "No failure message" },
+  ]);
 });

--- a/.github/benchmark-site/execution.html
+++ b/.github/benchmark-site/execution.html
@@ -92,16 +92,12 @@
             <div id="detail-runtime" class="kpi-value">—</div>
             <div id="workflow-runtime" class="kpi-delta">—</div>
           </article>
-          <article class="kpi-card">
-            <div class="kpi-label">Reliability events</div>
-            <div id="detail-reliability" class="kpi-value">—</div>
-            <div class="kpi-delta">Blocking failures and missing reports</div>
-          </article>
         </section>
 
         <div class="detail-layout">
           <aside class="detail-index" aria-label="Execution detail sections">
             <span>On this page</span>
+            <a href="#detail-failures">Failures</a>
             <a href="#overview">Overview</a>
             <a href="#configuration">Configuration</a>
             <a href="#scenarios">Scenarios and runs</a>
@@ -112,13 +108,25 @@
             <section id="overview" class="detail-section" aria-labelledby="overview-heading">
               <div class="section-kicker">Execution context</div>
               <h2 id="overview-heading">Overview</h2>
-              <div id="metadata-grid" class="metadata-grid"></div>
+              <details class="section-disclosure">
+                <summary>
+                  <span id="overview-digest" class="section-digest">Loading…</span>
+                  <span class="section-chevron" aria-hidden="true">⌄</span>
+                </summary>
+                <div id="metadata-grid" class="metadata-grid"></div>
+              </details>
             </section>
 
             <section id="configuration" class="detail-section" aria-labelledby="configuration-heading">
               <div class="section-kicker">Resolved stack</div>
               <h2 id="configuration-heading">Configuration</h2>
-              <div id="configuration-content"></div>
+              <details class="section-disclosure">
+                <summary>
+                  <span id="configuration-digest" class="section-digest">Loading…</span>
+                  <span class="section-chevron" aria-hidden="true">⌄</span>
+                </summary>
+                <div id="configuration-content"></div>
+              </details>
             </section>
 
             <section id="scenarios" class="detail-section" aria-labelledby="scenarios-heading">

--- a/.github/benchmark-site/execution.js
+++ b/.github/benchmark-site/execution.js
@@ -17,6 +17,7 @@
     availability: document.querySelector("#availability-badge"),
     breadcrumb: document.querySelector("#breadcrumb-run"),
     configuration: document.querySelector("#configuration-content"),
+    configurationDigest: document.querySelector("#configuration-digest"),
     content: document.querySelector("#detail-content"),
     cost: document.querySelector("#detail-cost"),
     coverage: document.querySelector("#detail-coverage"),
@@ -24,12 +25,14 @@
     errorMessage: document.querySelector("#detail-error-message"),
     failureBox: document.querySelector("#detail-failures"),
     failureSummary: document.querySelector("#failure-summary"),
+    failureTitle: document.querySelector("#failures-title"),
     loading: document.querySelector("#detail-loading"),
     metadata: document.querySelector("#metadata-grid"),
+    overviewDigest: document.querySelector("#overview-digest"),
     passRate: document.querySelector("#detail-pass-rate"),
     rawActions: document.querySelector("#raw-actions"),
     rawJson: document.querySelector("#raw-json"),
-    reliability: document.querySelector("#detail-reliability"),
+    rawPreview: document.querySelector("#raw-preview"),
     runtime: document.querySelector("#detail-runtime"),
     scenarioDetails: document.querySelector("#scenario-details"),
     scenarioIntro: document.querySelector("#scenario-intro"),
@@ -202,12 +205,16 @@
     elements.runtime.textContent = formatDuration(totals.wall_time_seconds);
     elements.workflowRuntime.textContent =
       `${formatDuration(execution.workflow_duration_seconds)} workflow elapsed`;
-    elements.reliability.textContent = compactNumber(blockingFailures(), 0);
   }
 
   function renderMetadata() {
     const source = execution.source || {};
     const release = execution.release || {};
+    elements.overviewDigest.textContent = [
+      source.sha ? source.sha.slice(0, 7) : "unknown commit",
+      titleCase(execution.event || "unknown trigger"),
+      execution.actor || "unknown actor",
+    ].join(" · ");
     elements.metadata.innerHTML = [
       metadataItem("Workflow run", execution.run_id || "Unknown", { mono: true }),
       metadataItem("Attempt", execution.attempt),
@@ -299,6 +306,20 @@
     const protocols = [
       ...new Set(reports.map((report) => report.judge_protocol).filter(Boolean)),
     ];
+    const digestSubject =
+      [...fullSubjects.values()][0] || execution.subjects[0] || null;
+    const digestJudge = [...judges.values()][0] || null;
+    elements.configurationDigest.textContent = [
+      digestSubject
+        ? `${digestSubject.provider}/${digestSubject.model}`
+        : "unknown subject",
+      digestJudge ? `judge ${digestJudge.provider}/${digestJudge.model}` : "",
+      execution.requested_runs != null
+        ? `${execution.requested_runs} runs requested`
+        : "",
+    ]
+      .filter(Boolean)
+      .join(" · ");
     elements.configuration.innerHTML = `
       <div class="config-grid">${subjectCards}${judgeCards}</div>
       <div class="config-facts">
@@ -310,7 +331,32 @@
     `;
   }
 
-  function renderAggregateScenario(subject, scenario) {
+  function scenarioSummaryRow(options) {
+    return `
+      <summary class="scenario-summary-row">
+        <span class="scenario-summary-copy">
+          <strong>${escapeHtml(options.title)}</strong>
+          <small>${escapeHtml(options.subjectLabel)}</small>
+        </span>
+        <span class="scenario-summary-stat">
+          <small>Median</small>
+          <strong>${escapeHtml(options.median)}</strong>
+        </span>
+        <span class="scenario-summary-stat">
+          <small>Pass rate</small>
+          <strong>${escapeHtml(options.passRate)}</strong>
+        </span>
+        <span class="scenario-summary-stat">
+          <small>Cost</small>
+          <strong>${escapeHtml(options.cost)}</strong>
+        </span>
+        <span class="table-status status-${options.statusCss}">${options.statusLabel}</span>
+        <span class="scenario-chevron" aria-hidden="true">⌄</span>
+      </summary>
+    `;
+  }
+
+  function renderAggregateScenario(subject, scenario, options = {}) {
     const meta = statusMeta(
       scenario.status === "missing_report"
         ? "incomplete"
@@ -319,29 +365,36 @@
           : "failed",
     );
     const anchor = scenarioAnchor(subject.id, scenario.id);
+    const open = scenario.passed === false || options.soleScenario;
     return `
-      <article id="${escapeHtml(anchor)}" class="scenario-detail-card">
-        <header>
-          <div>
-            <span>${escapeHtml(subject.provider)}/${escapeHtml(subject.model)}</span>
-            <h3>${escapeHtml(titleCase(scenario.id))}</h3>
+      <details id="${escapeHtml(anchor)}" class="scenario-detail-card" ${open ? "open" : ""}>
+        ${scenarioSummaryRow({
+          title: titleCase(scenario.id),
+          subjectLabel: `${subject.provider}/${subject.model}`,
+          median: `${compactNumber(scenario.median_score, 1)} / ${compactNumber(scenario.threshold, 0)}`,
+          passRate: formatPercent(
+            typeof scenario.pass_rate === "number" ? scenario.pass_rate * 100 : null,
+          ),
+          cost: formatCurrency(scenario.total_cost_usd),
+          statusCss: meta.css,
+          statusLabel: meta.label,
+        })}
+        <div class="scenario-detail-body">
+          <div class="scenario-detail-metrics">
+            ${metricBlock("Median score", compactNumber(scenario.median_score, 1), `target ${compactNumber(scenario.threshold, 0)}`)}
+            ${metricBlock("Pass rate", formatPercent(typeof scenario.pass_rate === "number" ? scenario.pass_rate * 100 : null))}
+            ${metricBlock("Cost", formatCurrency(scenario.total_cost_usd))}
+            ${metricBlock("Runtime", formatDuration(scenario.wall_time_seconds))}
+            ${metricBlock("Hard gates", compactNumber(scenario.hard_gate_failures, 0))}
+            ${metricBlock("Technical", compactNumber(scenario.technical_failures, 0))}
+            ${metricBlock("Retries", compactNumber(scenario.retries, 0))}
+            ${metricBlock("Runs", compactNumber(scenario.runs, 0))}
           </div>
-          <span class="table-status status-${meta.css}">${meta.label}</span>
-        </header>
-        <div class="scenario-detail-metrics">
-          ${metricBlock("Median score", compactNumber(scenario.median_score, 1), `target ${compactNumber(scenario.threshold, 0)}`)}
-          ${metricBlock("Pass rate", formatPercent(typeof scenario.pass_rate === "number" ? scenario.pass_rate * 100 : null))}
-          ${metricBlock("Cost", formatCurrency(scenario.total_cost_usd))}
-          ${metricBlock("Runtime", formatDuration(scenario.wall_time_seconds))}
-          ${metricBlock("Hard gates", compactNumber(scenario.hard_gate_failures, 0))}
-          ${metricBlock("Technical", compactNumber(scenario.technical_failures, 0))}
-          ${metricBlock("Retries", compactNumber(scenario.retries, 0))}
-          ${metricBlock("Runs", compactNumber(scenario.runs, 0))}
+          <div class="aggregate-expired">
+            Per-run prompts, transcripts, criteria, and traces are not retained for this execution.
+          </div>
         </div>
-        <div class="aggregate-expired">
-          Per-run prompts, transcripts, criteria, and traces are not retained for this execution.
-        </div>
-      </article>
+      </details>
     `;
   }
 
@@ -741,9 +794,9 @@
             </div>`
           : ""
       }
-      <details class="nested-raw">
+      <details class="nested-raw" data-trace="true">
         <summary>Trace summary</summary>
-        <pre>${escapeHtml(JSON.stringify(traces, null, 2))}</pre>
+        <pre></pre>
       </details>
     `;
   }
@@ -756,6 +809,71 @@
       </section>
     `;
   }
+
+  const PROMPT_CLAMP_THRESHOLD = 1200;
+
+  function renderEvaluationTab(panel, run) {
+    panel.innerHTML = `
+      ${runSection("Failures", renderFailureList(run.failures))}
+      ${runSection("Hard gates", renderGateTable(run.hard_gates), { wide: true })}
+      ${runSection("Scored criteria", renderCriteriaTable(run.criteria), { wide: true })}
+      ${runSection("Retry attempts", renderRetries(run.retry_attempts), { wide: true })}
+    `;
+  }
+
+  function renderUsageTab(panel, run) {
+    panel.innerHTML = runSection("Usage and cost", usageBlocks(run), { wide: true });
+  }
+
+  function renderPromptTab(panel, run) {
+    const prompt = run.prompt || "No prompt recorded.";
+    const clamp = prompt.length > PROMPT_CLAMP_THRESHOLD;
+    panel.innerHTML = runSection(
+      "Prompt",
+      `
+        <pre class="prompt-block${clamp ? " is-clamped" : ""}">${escapeHtml(prompt)}</pre>
+        ${clamp ? '<button type="button" class="prompt-expand">Show full prompt</button>' : ""}
+      `,
+      { wide: true },
+    );
+    panel.querySelector(".prompt-expand")?.addEventListener("click", (event) => {
+      panel.querySelector(".prompt-block").classList.remove("is-clamped");
+      event.target.remove();
+    });
+  }
+
+  function renderSessionsTab(panel, run) {
+    panel.innerHTML = runSection("Sessions and traces", sessionTable(run.metrics), {
+      wide: true,
+    });
+    const trace = panel.querySelector('details[data-trace="true"]');
+    trace?.addEventListener("toggle", () => {
+      if (!trace.open || trace.dataset.rendered) return;
+      trace.dataset.rendered = "true";
+      trace.querySelector("pre").textContent = JSON.stringify(
+        run.metrics?.traces || {},
+        null,
+        2,
+      );
+    });
+  }
+
+  function renderRawTab(panel, run) {
+    panel.innerHTML = runSection(
+      "Complete run record",
+      '<pre class="prompt-block"></pre>',
+      { wide: true },
+    );
+    panel.querySelector("pre").textContent = JSON.stringify(run, null, 2);
+  }
+
+  const RUN_TABS = [
+    { id: "evaluation", label: "Evaluation", render: renderEvaluationTab },
+    { id: "usage", label: "Usage", render: renderUsageTab },
+    { id: "prompt", label: "Prompt", render: renderPromptTab },
+    { id: "sessions", label: "Sessions", render: renderSessionsTab },
+    { id: "raw", label: "Raw", render: renderRawTab },
+  ];
 
   function renderRunContent(container, run, context) {
     const messages = Array.isArray(run.transcript?.messages)
@@ -771,29 +889,44 @@
         ${metricBlock("Session", run.session_id || "Unknown")}
       </div>
       ${renderConversationLaunch(messages, run)}
-      <div class="run-sections">
-        ${runSection("Failures", renderFailureList(run.failures))}
-        ${runSection("Hard gates", renderGateTable(run.hard_gates), { wide: true })}
-        ${runSection("Scored criteria", renderCriteriaTable(run.criteria), { wide: true })}
-        ${runSection("Usage and cost", usageBlocks(run), { wide: true })}
-        ${runSection("Retry attempts", renderRetries(run.retry_attempts), { wide: true })}
-        ${runSection("Prompt", `<pre class="prompt-block">${escapeHtml(run.prompt || "No prompt recorded.")}</pre>`, { wide: true })}
-        ${runSection("Sessions and traces", sessionTable(run.metrics), { wide: true })}
-        ${runSection(
-          "Complete run record",
-          `<details class="nested-raw"><summary>Show JSON</summary><pre>${escapeHtml(
-            JSON.stringify(run, null, 2),
-          )}</pre></details>`,
-          { wide: true },
-        )}
+      <div class="run-tabs" role="tablist" aria-label="Run diagnostics">
+        ${RUN_TABS.map(
+          (tab) =>
+            `<button type="button" role="tab" data-tab="${tab.id}" aria-selected="false">${tab.label}</button>`,
+        ).join("")}
       </div>
+      ${RUN_TABS.map(
+        (tab) =>
+          `<div class="run-sections" role="tabpanel" data-panel="${tab.id}" hidden></div>`,
+      ).join("")}
     `;
     container.querySelector(".conversation-open")?.addEventListener("click", () => {
       openConversationDialog(run, context);
     });
+    const buttons = [...container.querySelectorAll(".run-tabs button")];
+    const activateRunTab = (tabId) => {
+      RUN_TABS.forEach((tab) => {
+        const panel = container.querySelector(`[data-panel="${tab.id}"]`);
+        const active = tab.id === tabId;
+        if (active && !panel.dataset.rendered) {
+          panel.dataset.rendered = "true";
+          tab.render(panel, run);
+        }
+        panel.hidden = !active;
+      });
+      buttons.forEach((button) => {
+        const active = button.dataset.tab === tabId;
+        button.classList.toggle("active", active);
+        button.setAttribute("aria-selected", String(active));
+      });
+    };
+    buttons.forEach((button) => {
+      button.addEventListener("click", () => activateRunTab(button.dataset.tab));
+    });
+    activateRunTab("evaluation");
   }
 
-  function renderFullScenario(record) {
+  function renderFullScenario(record, options = {}) {
     const report = record.report;
     const scenario = report.scenarios?.find(
       (item) => item.scenario_id === record.scenario_id,
@@ -804,15 +937,26 @@
     const aggregate = scenario.aggregate || {};
     const policy = scenario.execution_policy || {};
     const anchor = scenarioAnchor(subjectId, scenario.scenario_id);
+    const failingRun = (scenario.runs || []).some(
+      (run) =>
+        (run.failures || []).length ||
+        (run.hard_gates || []).some((gate) => gate && gate.passed === false),
+    );
+    const open = !scenario.passed || failingRun || options.soleScenario;
     return `
-      <article id="${escapeHtml(anchor)}" class="scenario-detail-card">
-        <header>
-          <div>
-            <span>${escapeHtml(report.subject.provider)}/${escapeHtml(report.subject.model)}</span>
-            <h3>${escapeHtml(titleCase(scenario.scenario_id))}</h3>
-          </div>
-          <span class="table-status status-${meta.css}">${meta.label}</span>
-        </header>
+      <details id="${escapeHtml(anchor)}" class="scenario-detail-card" ${open ? "open" : ""}>
+        ${scenarioSummaryRow({
+          title: titleCase(scenario.scenario_id),
+          subjectLabel: `${report.subject.provider}/${report.subject.model}`,
+          median: `${compactNumber(aggregate.median_score, 1)} / ${compactNumber(scenario.threshold, 0)}`,
+          passRate: formatPercent(
+            typeof aggregate.pass_rate === "number" ? aggregate.pass_rate * 100 : null,
+          ),
+          cost: formatCurrency(aggregate.cost?.total_usd),
+          statusCss: meta.css,
+          statusLabel: meta.label,
+        })}
+        <div class="scenario-detail-body">
         <div class="scenario-detail-metrics">
           ${metricBlock("Median score", compactNumber(aggregate.median_score, 1), `target ${compactNumber(scenario.threshold, 0)}`)}
           ${metricBlock("Pass rate", formatPercent(
@@ -860,7 +1004,8 @@
             })
             .join("")}
         </div>
-      </article>
+        </div>
+      </details>
     `;
   }
 
@@ -910,9 +1055,11 @@
       );
       elements.scenarioIntro.textContent =
         `${availableReports.length} scenario reports and ${runCount} individual runs. ` +
-        "Expand a run to render its complete diagnostics.";
+        "Select a scenario to expand its runs.";
       elements.scenarioDetails.innerHTML = availableReports
-        .map(renderFullScenario)
+        .map((record) =>
+          renderFullScenario(record, { soleScenario: availableReports.length === 1 }),
+        )
         .join("");
       attachRunRenderers();
       return;
@@ -921,10 +1068,16 @@
       execution.availability === "aggregate"
         ? "The complete report expired after 30 executions. Historical aggregate metrics remain available."
         : "This workflow did not produce a complete benchmark report.";
+    const aggregateCount = execution.subjects.reduce(
+      (total, subject) => total + (subject.scenarios || []).length,
+      0,
+    );
     elements.scenarioDetails.innerHTML = execution.subjects
       .flatMap((subject) =>
         (subject.scenarios || []).map((scenario) =>
-          renderAggregateScenario(subject, scenario),
+          renderAggregateScenario(subject, scenario, {
+            soleScenario: aggregateCount === 1,
+          }),
         ),
       )
       .join("");
@@ -934,58 +1087,54 @@
     }
   }
 
-  function collectDetailedFailures() {
-    const failures = [];
-    (detail?.reports || []).forEach((record) => {
-      (record?.report?.scenarios || []).forEach((scenario) => {
-        (scenario.runs || []).forEach((run, index) => {
-          const anchor = runAnchor(record.subject_id, scenario.scenario_id, index);
-          (run.failures || []).forEach((failure) => {
-            failures.push({
-              anchor,
-              label: `${titleCase(scenario.scenario_id)} · run ${index + 1}`,
-              message: `${titleCase(failure.phase)}: ${failure.message}`,
-            });
-          });
-          (run.hard_gates || [])
-            .filter((gate) => !gate.passed)
-            .forEach((gate) => {
-              failures.push({
-                anchor,
-                label: `${titleCase(scenario.scenario_id)} · ${gate.id}`,
-                message: gate.reason,
-              });
-            });
-        });
-      });
-    });
-    return failures;
+  const MAX_FAILURE_CHIPS = 5;
+
+  function truncateText(value, limit) {
+    const text = String(value || "");
+    return text.length > limit ? `${text.slice(0, limit - 1)}…` : text;
+  }
+
+  function failureChip(group) {
+    const anchor = runAnchor(group.subjectId, group.scenarioId, group.runIndex);
+    const first = group.items[0];
+    const preview =
+      first.kind === "gate"
+        ? `${first.gateId}: ${first.message}`
+        : `${titleCase(first.phase)}: ${first.message}`;
+    return `
+      <a class="failure-chip" href="#${escapeHtml(anchor)}">
+        <span class="table-status status-fail">${group.items.length} issue${group.items.length === 1 ? "" : "s"}</span>
+        <strong>${escapeHtml(titleCase(group.scenarioId))} · run ${group.runIndex + 1}</strong>
+        <span class="failure-chip-message">${escapeHtml(truncateText(preview, 140))}</span>
+      </a>
+    `;
   }
 
   function renderFailures() {
-    const failures = collectDetailedFailures();
+    const groups = window.HarnessExecutionData.groupRunFailures(detail?.reports);
     const count = blockingFailures();
-    if (!failures.length && count === 0 && execution.status === "passed") {
+    if (!groups.length && count === 0 && execution.status === "passed") {
       elements.failureBox.hidden = true;
       return;
     }
     elements.failureBox.hidden = false;
-    if (failures.length) {
+    elements.failureTitle.textContent = count
+      ? `Execution failures · ${count} blocking event${count === 1 ? "" : "s"}`
+      : "Execution failures";
+    if (groups.length) {
+      const sorted = [...groups].sort((a, b) => b.items.length - a.items.length);
+      const visible = sorted.slice(0, MAX_FAILURE_CHIPS);
+      const overflow = sorted.slice(MAX_FAILURE_CHIPS);
       elements.failureSummary.innerHTML = `
-        <ul>
-          ${failures
-            .map(
-              (failure) => `
-                <li>
-                  <a href="#${escapeHtml(failure.anchor)}">${escapeHtml(
-                    failure.label,
-                  )}</a>
-                  <span>${escapeHtml(failure.message)}</span>
-                </li>
-              `,
-            )
-            .join("")}
-        </ul>
+        <div class="failure-groups">${visible.map(failureChip).join("")}</div>
+        ${
+          overflow.length
+            ? `<details class="failure-overflow">
+                <summary>Show all ${sorted.length} failing runs</summary>
+                <div class="failure-groups">${overflow.map(failureChip).join("")}</div>
+              </details>`
+            : ""
+        }
       `;
       return;
     }
@@ -1001,8 +1150,13 @@
   }
 
   function renderRawData() {
-    const raw = detail || execution;
-    elements.rawJson.textContent = JSON.stringify(raw, null, 2);
+    // The detail JSON can be multi-megabyte: serialize only when the preview
+    // is opened or the fallback download is clicked, never at page load.
+    elements.rawPreview.addEventListener("toggle", () => {
+      if (!elements.rawPreview.open || elements.rawPreview.dataset.rendered) return;
+      elements.rawPreview.dataset.rendered = "true";
+      elements.rawJson.textContent = JSON.stringify(detail || execution, null, 2);
+    });
     elements.rawActions.replaceChildren();
     if (detail && execution.detail_path && !window.HARNESS_BENCHMARK_PREVIEW) {
       const link = document.createElement("a");
@@ -1013,14 +1167,19 @@
       elements.rawActions.append(link);
       return;
     }
-    const blob = new Blob([JSON.stringify(raw, null, 2)], {
-      type: "application/json",
-    });
     const link = document.createElement("a");
     link.className = "button";
-    link.href = URL.createObjectURL(blob);
+    link.href = "#raw-data";
     link.download = `${execution.id}.json`;
     link.textContent = "Download available JSON";
+    link.addEventListener("click", () => {
+      if (link.dataset.blobUrl) return;
+      const blob = new Blob([JSON.stringify(detail || execution, null, 2)], {
+        type: "application/json",
+      });
+      link.dataset.blobUrl = URL.createObjectURL(blob);
+      link.href = link.dataset.blobUrl;
+    });
     elements.rawActions.append(link);
   }
 
@@ -1049,20 +1208,42 @@
     return value;
   }
 
+  function revealAnchor(anchorId) {
+    if (!anchorId) return;
+    const target = document.getElementById(anchorId);
+    if (!target) return;
+    // Open the target and every collapsed ancestor so deep links land on
+    // rendered content; opening fires toggle, which drives the lazy renderers.
+    let node = target.closest("details");
+    while (node) {
+      node.open = true;
+      node = node.parentElement?.closest("details");
+    }
+    const disclosure = target.querySelector?.("details.section-disclosure");
+    if (disclosure) disclosure.open = true;
+    requestAnimationFrame(() => target.scrollIntoView());
+  }
+
+  function attachAnchorNavigation() {
+    window.addEventListener("hashchange", () => {
+      revealAnchor(window.location.hash.slice(1));
+    });
+    // Same-hash re-clicks do not fire hashchange; handle triage links directly.
+    elements.failureSummary.addEventListener("click", (event) => {
+      const link = event.target.closest('a[href^="#"]');
+      if (link) revealAnchor(link.getAttribute("href").slice(1));
+    });
+  }
+
   function reveal() {
     elements.loading.hidden = true;
     elements.content.hidden = false;
-    requestAnimationFrame(() => {
-      const anchor = window.location.hash.slice(1);
-      if (!anchor) return;
-      const target = document.getElementById(anchor);
-      if (target?.tagName === "DETAILS") target.open = true;
-      requestAnimationFrame(() => target?.scrollIntoView());
-    });
+    requestAnimationFrame(() => revealAnchor(window.location.hash.slice(1)));
   }
 
   async function initialize() {
     attachTranscriptDialogControls();
+    attachAnchorNavigation();
     if (!execution) {
       elements.loading.hidden = true;
       elements.error.hidden = false;

--- a/.github/benchmark-site/index.html
+++ b/.github/benchmark-site/index.html
@@ -161,41 +161,6 @@
           </article>
         </section>
 
-        <div id="coverage-divider" class="section-divider-heading" hidden>
-          <div>
-            <div class="section-kicker">Stack instrumentation</div>
-            <h2>Code coverage</h2>
-          </div>
-          <p>LLVM line coverage of the instrumented stack from the latest daily cycle.</p>
-        </div>
-
-        <section
-          id="coverage-kpis"
-          class="kpi-grid"
-          aria-label="Stack code coverage"
-          hidden
-        >
-          <article class="kpi-card">
-            <div class="kpi-label">Integration suite</div>
-            <div id="coverage-integration" class="kpi-value">—</div>
-            <div id="coverage-integration-caption" class="kpi-delta">Not published yet</div>
-          </article>
-          <article class="kpi-card">
-            <div class="kpi-label">E2E suite</div>
-            <div id="coverage-e2e" class="kpi-value">—</div>
-            <div id="coverage-e2e-caption" class="kpi-delta">Not published yet</div>
-          </article>
-          <article class="kpi-card">
-            <div class="kpi-label">Reports</div>
-            <div class="kpi-value kpi-status-value">
-              <a href="./coverage/">Browse <span aria-hidden="true">→</span></a>
-            </div>
-            <div class="kpi-delta">
-              <a href="./coverage-trend/">Line coverage trend</a>
-            </div>
-          </article>
-        </section>
-
         <section class="panel health-panel" aria-labelledby="health-heading">
           <div class="panel-heading">
             <div>
@@ -360,29 +325,6 @@
     <script>
       window.BENCHMARK_DATA = window.BENCHMARK_DATA || null;
       window.HARNESS_EXECUTIONS = window.HARNESS_EXECUTIONS || null;
-      window.HARNESS_COVERAGE = window.HARNESS_COVERAGE || null;
-    </script>
-    <script src="./coverage/summary.js"></script>
-    <script>
-      (function () {
-        var coverage = window.HARNESS_COVERAGE;
-        var suites = coverage && coverage.suites ? coverage.suites : null;
-        if (!suites || (!suites.integration && !suites.e2e)) return;
-        document.getElementById("coverage-divider").hidden = false;
-        document.getElementById("coverage-kpis").hidden = false;
-        function apply(valueId, captionId, summary) {
-          if (!summary || !summary.totals || !summary.totals.lines) return;
-          var lines = summary.totals.lines;
-          document.getElementById(valueId).textContent =
-            lines.percent.toFixed(1) + "%";
-          document.getElementById(captionId).textContent =
-            (lines.covered != null ? lines.covered.toLocaleString() : "?") +
-            " of " + (lines.count != null ? lines.count.toLocaleString() : "?") +
-            " lines covered";
-        }
-        apply("coverage-integration", "coverage-integration-caption", suites.integration);
-        apply("coverage-e2e", "coverage-e2e-caption", suites.e2e);
-      })();
     </script>
     <script src="./data.js"></script>
     <script>

--- a/.github/benchmark-site/index.html
+++ b/.github/benchmark-site/index.html
@@ -25,6 +25,7 @@
       </a>
       <nav class="topbar-actions" aria-label="Dashboard actions">
         <span id="preview-badge" class="badge badge-preview" hidden>Preview data</span>
+        <a class="button button-secondary" href="./coverage/">Coverage</a>
         <a id="actions-link" class="button button-secondary" href="https://github.com/iii-hq/workers/actions">
           View Actions <span aria-hidden="true">↗</span>
         </a>
@@ -157,6 +158,41 @@
             <div class="kpi-label">Model cost</div>
             <div id="kpi-cost" class="kpi-value">—</div>
             <div id="kpi-runtime" class="kpi-delta">—</div>
+          </article>
+        </section>
+
+        <div id="coverage-divider" class="section-divider-heading" hidden>
+          <div>
+            <div class="section-kicker">Stack instrumentation</div>
+            <h2>Code coverage</h2>
+          </div>
+          <p>LLVM line coverage of the instrumented stack from the latest daily cycle.</p>
+        </div>
+
+        <section
+          id="coverage-kpis"
+          class="kpi-grid"
+          aria-label="Stack code coverage"
+          hidden
+        >
+          <article class="kpi-card">
+            <div class="kpi-label">Integration suite</div>
+            <div id="coverage-integration" class="kpi-value">—</div>
+            <div id="coverage-integration-caption" class="kpi-delta">Not published yet</div>
+          </article>
+          <article class="kpi-card">
+            <div class="kpi-label">E2E suite</div>
+            <div id="coverage-e2e" class="kpi-value">—</div>
+            <div id="coverage-e2e-caption" class="kpi-delta">Not published yet</div>
+          </article>
+          <article class="kpi-card">
+            <div class="kpi-label">Reports</div>
+            <div class="kpi-value kpi-status-value">
+              <a href="./coverage/">Browse <span aria-hidden="true">→</span></a>
+            </div>
+            <div class="kpi-delta">
+              <a href="./coverage-trend/">Line coverage trend</a>
+            </div>
           </article>
         </section>
 
@@ -324,6 +360,29 @@
     <script>
       window.BENCHMARK_DATA = window.BENCHMARK_DATA || null;
       window.HARNESS_EXECUTIONS = window.HARNESS_EXECUTIONS || null;
+      window.HARNESS_COVERAGE = window.HARNESS_COVERAGE || null;
+    </script>
+    <script src="./coverage/summary.js"></script>
+    <script>
+      (function () {
+        var coverage = window.HARNESS_COVERAGE;
+        var suites = coverage && coverage.suites ? coverage.suites : null;
+        if (!suites || (!suites.integration && !suites.e2e)) return;
+        document.getElementById("coverage-divider").hidden = false;
+        document.getElementById("coverage-kpis").hidden = false;
+        function apply(valueId, captionId, summary) {
+          if (!summary || !summary.totals || !summary.totals.lines) return;
+          var lines = summary.totals.lines;
+          document.getElementById(valueId).textContent =
+            lines.percent.toFixed(1) + "%";
+          document.getElementById(captionId).textContent =
+            (lines.covered != null ? lines.covered.toLocaleString() : "?") +
+            " of " + (lines.count != null ? lines.count.toLocaleString() : "?") +
+            " lines covered";
+        }
+        apply("coverage-integration", "coverage-integration-caption", suites.integration);
+        apply("coverage-e2e", "coverage-e2e-caption", suites.e2e);
+      })();
     </script>
     <script src="./data.js"></script>
     <script>

--- a/.github/benchmark-site/styles.css
+++ b/.github/benchmark-site/styles.css
@@ -1448,14 +1448,16 @@ footer {
   line-height: 1;
 }
 
-.scenario-history-tabs {
+.scenario-history-tabs,
+.run-tabs {
   display: flex;
   flex-wrap: wrap;
   gap: 7px;
   margin-top: 24px;
 }
 
-.scenario-history-tabs button {
+.scenario-history-tabs button,
+.run-tabs button {
   min-height: 32px;
   padding: 0 11px;
   border: 1px solid var(--line);
@@ -1468,7 +1470,9 @@ footer {
 }
 
 .scenario-history-tabs button:hover,
-.scenario-history-tabs button.active {
+.scenario-history-tabs button.active,
+.run-tabs button:hover,
+.run-tabs button.active {
   border-color: rgba(199, 255, 74, 0.28);
   background: var(--accent-soft);
   color: var(--text);
@@ -2068,6 +2072,104 @@ footer {
   line-height: 1.45;
 }
 
+#detail-failures {
+  scroll-margin-top: 24px;
+}
+
+.failure-groups {
+  display: grid;
+  gap: 8px;
+}
+
+.failure-chip {
+  display: grid;
+  grid-template-columns: auto minmax(140px, auto) minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  padding: 9px 12px;
+  border: 1px solid rgba(255, 120, 111, 0.2);
+  border-radius: 9px;
+  background: rgba(255, 120, 111, 0.04);
+  color: var(--text);
+  font-size: 0.7rem;
+  text-decoration: none;
+}
+
+.failure-chip:hover {
+  border-color: rgba(255, 120, 111, 0.45);
+}
+
+.failure-chip strong {
+  font-size: 0.72rem;
+  font-weight: 650;
+}
+
+.failure-chip-message {
+  overflow: hidden;
+  color: var(--text-soft);
+  font-size: 0.66rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.failure-overflow {
+  margin-top: 10px;
+}
+
+.failure-overflow > summary {
+  cursor: pointer;
+  color: var(--text-soft);
+  font-size: 0.68rem;
+  font-weight: 650;
+}
+
+.failure-overflow[open] > summary {
+  margin-bottom: 10px;
+}
+
+.section-disclosure {
+  margin-top: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+}
+
+.section-disclosure > summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 18px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.section-disclosure > summary::-webkit-details-marker {
+  display: none;
+}
+
+.section-digest {
+  color: var(--text-soft);
+  font-size: 0.71rem;
+}
+
+.section-chevron,
+.scenario-chevron {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  transition: transform 0.15s ease;
+}
+
+.section-disclosure[open] .section-chevron,
+.scenario-detail-card[open] .scenario-chevron {
+  transform: rotate(180deg);
+}
+
+.section-disclosure > .metadata-grid,
+.section-disclosure > #configuration-content {
+  padding: 0 18px 18px;
+}
+
 .detail-kpis {
   margin-bottom: 34px;
 }
@@ -2246,22 +2348,70 @@ footer {
 
 .scenario-detail-card {
   scroll-margin-top: 24px;
-  padding: 22px;
   border: 1px solid var(--line);
   border-radius: var(--radius-md);
   background: var(--surface);
+  content-visibility: auto;
+  contain-intrinsic-size: auto 64px;
 }
 
-.scenario-detail-card > header {
-  display: flex;
+.scenario-detail-card[open] {
+  border-color: var(--line-strong);
+}
+
+.scenario-summary-row {
+  display: grid;
+  grid-template-columns: minmax(200px, 1fr) auto auto auto auto auto;
   align-items: center;
-  justify-content: space-between;
   gap: 18px;
+  min-height: 64px;
+  padding: 12px 22px;
+  cursor: pointer;
+  list-style: none;
 }
 
-.scenario-detail-card > header span:first-child {
+.scenario-summary-row::-webkit-details-marker {
+  display: none;
+}
+
+.scenario-summary-copy {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.scenario-summary-copy strong {
+  font-size: 0.94rem;
+  font-weight: 590;
+}
+
+.scenario-summary-copy small {
   color: var(--text-muted);
-  font-size: 0.63rem;
+  font-size: 0.62rem;
+}
+
+.scenario-summary-stat {
+  display: grid;
+  gap: 2px;
+  text-align: right;
+}
+
+.scenario-summary-stat small {
+  color: var(--text-muted);
+  font-size: 0.56rem;
+  font-weight: 680;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.scenario-summary-stat strong {
+  font-size: 0.74rem;
+  font-weight: 600;
+}
+
+.scenario-detail-body {
+  padding: 0 22px 22px;
+  border-top: 1px solid var(--line);
 }
 
 .scenario-detail-card h3 {
@@ -2334,6 +2484,8 @@ footer {
   border: 1px solid var(--line);
   border-radius: 11px;
   background: var(--bg);
+  content-visibility: auto;
+  contain-intrinsic-size: auto 64px;
 }
 
 .run-detail[open] {
@@ -2416,6 +2568,12 @@ footer {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 9px;
   margin-top: 14px;
+}
+
+/* The authored display would otherwise override the UA [hidden] rule and
+   show every tab panel at once. */
+.run-sections[hidden] {
+  display: none;
 }
 
 .run-section {
@@ -2544,6 +2702,31 @@ footer {
   line-height: 1.55;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+.prompt-block.is-clamped {
+  max-height: 260px;
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(to bottom, black 72%, transparent);
+  mask-image: linear-gradient(to bottom, black 72%, transparent);
+}
+
+.prompt-expand {
+  min-height: 32px;
+  margin-top: 10px;
+  padding: 0 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--text-soft);
+  cursor: pointer;
+  font-size: 0.67rem;
+  font-weight: 650;
+}
+
+.prompt-expand:hover {
+  border-color: var(--line-strong);
+  color: var(--text);
 }
 
 .conversation-launch {
@@ -3456,6 +3639,22 @@ footer {
 
   .run-detail > summary > span:nth-child(3),
   .run-detail > summary > span:nth-child(4) {
+    display: none;
+  }
+
+  .scenario-summary-row {
+    grid-template-columns: minmax(0, 1fr) auto auto;
+  }
+
+  .scenario-summary-row > .scenario-summary-stat {
+    display: none;
+  }
+
+  .failure-chip {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .failure-chip-message {
     display: none;
   }
 

--- a/.github/scripts/coverage_report.sh
+++ b/.github/scripts/coverage_report.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Merge LLVM coverage profiles from a dedicated profraw directory and emit a
+# combined multi-binary report: html/, summary.json, and report.txt.
+#
+# Usage:
+#   coverage_report.sh --profraw-dir DIR --output-dir DIR --title NAME \
+#     --object BIN [--object BIN ...]
+#
+# Binaries must be built with:
+#   RUSTFLAGS="-Cinstrument-coverage -Cllvm-args=-runtime-counter-relocation"
+# and run with LLVM_PROFILE_FILE containing %c (continuous mode) so profiles
+# survive SIGTERM/SIGKILL teardown. Requires the rustup llvm-tools component.
+set -euo pipefail
+
+IGNORE_REGEX='\.cargo/(registry|git)|/rustc/|harness/tests/'
+
+profraw_dir=""
+output_dir=""
+title="coverage"
+objects=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profraw-dir) profraw_dir="$2"; shift 2 ;;
+    --output-dir) output_dir="$2"; shift 2 ;;
+    --title) title="$2"; shift 2 ;;
+    --object) objects+=("$2"); shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$profraw_dir" && -n "$output_dir" ]] || {
+  echo "usage: $0 --profraw-dir DIR --output-dir DIR --title NAME --object BIN [--object BIN ...]" >&2
+  exit 2
+}
+
+tool_dir="$(dirname "$(rustc --print target-libdir)")/bin"
+for tool in llvm-profdata llvm-cov; do
+  [[ -x "$tool_dir/$tool" ]] || {
+    echo "missing $tool_dir/$tool; install with: rustup component add llvm-tools" >&2
+    exit 2
+  }
+done
+
+mkdir -p "$output_dir"
+
+mapfile -t profraws < <(find "$profraw_dir" -name '*.profraw' -type f 2>/dev/null | sort)
+if [[ ${#profraws[@]} -eq 0 ]]; then
+  echo "no .profraw files under $profraw_dir; skipping report" >&2
+  exit 0
+fi
+
+object_args=()
+for object in "${objects[@]}"; do
+  if [[ -x "$object" ]]; then
+    object_args+=(-object "$object")
+  else
+    echo "warning: skipping missing object $object" >&2
+  fi
+done
+[[ ${#object_args[@]} -gt 0 ]] || { echo "no usable --object binaries" >&2; exit 2; }
+
+demangler_args=()
+if command -v rustfilt >/dev/null 2>&1; then
+  demangler_args=(-Xdemangler=rustfilt)
+fi
+
+"$tool_dir/llvm-profdata" merge -sparse "${profraws[@]}" -o "$output_dir/merged.profdata"
+
+"$tool_dir/llvm-cov" show --format=html --output-dir="$output_dir/html" \
+  -instr-profile="$output_dir/merged.profdata" \
+  --ignore-filename-regex="$IGNORE_REGEX" \
+  "${demangler_args[@]}" \
+  "${object_args[@]}"
+
+"$tool_dir/llvm-cov" report \
+  -instr-profile="$output_dir/merged.profdata" \
+  --ignore-filename-regex="$IGNORE_REGEX" \
+  "${object_args[@]}" > "$output_dir/report.txt"
+
+"$tool_dir/llvm-cov" export -summary-only \
+  -instr-profile="$output_dir/merged.profdata" \
+  --ignore-filename-regex="$IGNORE_REGEX" \
+  "${object_args[@]}" \
+  | jq --arg title "$title" --arg at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{title: $title, generated_at: $at, totals: .data[0].totals}' \
+  > "$output_dir/summary.json"
+
+echo "coverage report written to $output_dir"
+tail -1 "$output_dir/report.txt"

--- a/.github/workflows/_harness-e2e.yml
+++ b/.github/workflows/_harness-e2e.yml
@@ -73,6 +73,11 @@ on:
         required: false
         type: string
         default: ''
+      coverage:
+        description: Instrument the E2E stack and produce an LLVM coverage report
+        required: false
+        type: boolean
+        default: false
     secrets:
       anthropic_api_key:
         required: false
@@ -86,7 +91,8 @@ jobs:
     name: harness e2e build
     if: github.ref == 'refs/heads/main' || inputs.source_ref != ''
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Instrumented cold builds are slower than regular ones.
+    timeout-minutes: ${{ inputs.coverage && 60 || 45 }}
     outputs:
       scenarios: ${{ steps.scenarios.outputs.json }}
       engine_binary: ${{ steps.engine.outputs.binary }}
@@ -154,13 +160,15 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: ${{ inputs.coverage && 'clippy,llvm-tools' || 'clippy' }}
 
       - name: Restore E2E Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: harness-e2e
-          save-if: false
+          # Instrumented builds have different fingerprints; keep them on their
+          # own key so coverage runs never poison the normal cache.
+          shared-key: ${{ inputs.coverage && 'harness-e2e-coverage' || 'harness-e2e' }}
+          save-if: ${{ inputs.coverage }}
           workspaces: |
             harness -> target
             database -> target
@@ -187,8 +195,13 @@ jobs:
         env:
           SUBJECTS: ${{ inputs.subjects }}
           JUDGE_PROVIDER: ${{ inputs.judge_provider }}
+          RUSTFLAGS: ${{ inputs.coverage && '-Cinstrument-coverage -Cllvm-args=-runtime-counter-relocation' || '' }}
+          # Scratch profile path so instrumented build scripts don't drop
+          # default.profraw files inside the crate directories.
+          LLVM_PROFILE_FILE: ${{ inputs.coverage && format('{0}/target/coverage/build-profraw/%m_%p.profraw', github.workspace) || '' }}
         run: |
           set -euo pipefail
+          mkdir -p target/coverage/build-profraw
           for worker in database state queue session-manager llm-router context-manager iii-directory cron; do
             cargo build --locked --release --manifest-path "$worker/Cargo.toml"
           done
@@ -210,6 +223,9 @@ jobs:
 
       - name: Read code-defined scenarios
         id: scenarios
+        env:
+          # The instrumented binary would otherwise drop default.profraw in cwd.
+          LLVM_PROFILE_FILE: ${{ inputs.coverage && format('{0}/target/coverage/build-profraw/%m_%p.profraw', github.workspace) || '' }}
         run: |
           set -euo pipefail
           scenarios=$(harness/target/release/harness-e2e list)
@@ -291,6 +307,10 @@ jobs:
           test -c /dev/kvm
           sudo chmod 0666 /dev/kvm
 
+      - name: Prepare coverage profile directory
+        if: inputs.coverage
+        run: mkdir -p target/harness-e2e/profraw
+
       - name: Run real-stack quality scenario
         env:
           ANTHROPIC_API_KEY: ${{ secrets.anthropic_api_key }}
@@ -308,6 +328,10 @@ jobs:
           HARNESS_E2E_QUALITY_ADVISORY: ${{ inputs.quality_advisory }}
           HARNESS_E2E_CI_SCORE_FLOOR: ${{ inputs.ci_score_floor }}
           HARNESS_E2E_ENGINE_REVISION: ${{ needs.build.outputs.engine_revision }}
+          # run-ci.sh spawns every worker with cwd inside the artifacts dir, so
+          # the profile path must be absolute; %c keeps profiles flushing after
+          # the SIGTERM teardown. Inert when the stack is not instrumented.
+          LLVM_PROFILE_FILE: ${{ inputs.coverage && format('{0}/target/harness-e2e/profraw/%m_%p%c.profraw', github.workspace) || '' }}
         run: harness/tests/e2e/run-ci.sh
 
       - name: Write benchmark context
@@ -383,6 +407,15 @@ jobs:
             target/harness-e2e/logs/
             target/harness-e2e/stack/
           retention-days: 14
+          if-no-files-found: ignore
+
+      - name: Upload coverage profiles
+        if: always() && inputs.coverage
+        uses: actions/upload-artifact@v6
+        with:
+          name: harness-e2e-${{ matrix.subject.id }}-${{ matrix.scenario }}-profraw
+          path: target/harness-e2e/profraw/
+          retention-days: 1
           if-no-files-found: ignore
 
   summary:
@@ -512,3 +545,84 @@ jobs:
           path: target/harness-e2e-benchmark/execution.json
           retention-days: 30
           if-no-files-found: error
+
+  coverage:
+    name: harness e2e coverage
+    needs: [build, e2e]
+    if: always() && inputs.coverage && needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # Sources must match the binaries built from the same ref for llvm-cov.
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.source_ref }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools
+
+      - name: Download E2E binaries
+        uses: actions/download-artifact@v7
+        with:
+          name: harness-e2e-stack
+          path: target
+
+      - name: Extract E2E binaries
+        run: tar -xzf target/harness-e2e-stack.tar.gz
+
+      - name: Download coverage profiles
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          pattern: harness-e2e-*-profraw
+          merge-multiple: true
+          path: target/coverage/profraw
+
+      - name: Generate coverage report
+        env:
+          SUBJECTS: ${{ inputs.subjects }}
+          JUDGE_PROVIDER: ${{ inputs.judge_provider }}
+        run: |
+          set -euo pipefail
+          objects=(
+            database/target/release/database
+            state/target/release/state
+            queue/target/release/queue
+            session-manager/target/release/session-manager
+            llm-router/target/release/llm-router
+            context-manager/target/release/context-manager
+            iii-directory/target/release/iii-directory
+            cron/target/release/cron
+            harness/target/release/harness
+            harness/target/release/harness-e2e
+          )
+          mapfile -t providers < <(
+            {
+              jq -r '.[].provider' <<<"$SUBJECTS"
+              printf '%s\n' "$JUDGE_PROVIDER"
+            } | sort -u
+          )
+          for provider in "${providers[@]}"; do
+            objects+=("provider-$provider/target/release/provider-$provider")
+          done
+          object_args=()
+          for object in "${objects[@]}"; do
+            object_args+=(--object "$object")
+          done
+          .github/scripts/coverage_report.sh \
+            --profraw-dir target/coverage/profraw \
+            --output-dir target/coverage/e2e \
+            --title harness-e2e \
+            "${object_args[@]}"
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v6
+        with:
+          name: harness-e2e-coverage
+          path: |
+            target/coverage/e2e/html/
+            target/coverage/e2e/summary.json
+            target/coverage/e2e/report.txt
+          retention-days: 14
+          if-no-files-found: ignore

--- a/.github/workflows/_harness-integration.yml
+++ b/.github/workflows/_harness-integration.yml
@@ -8,6 +8,16 @@ on:
         type: boolean
         required: false
         default: false
+      coverage:
+        description: Instrument the harness stack and produce an LLVM coverage report
+        type: boolean
+        required: false
+        default: false
+      source_ref:
+        description: Git ref to check out (empty uses the caller revision)
+        type: string
+        required: false
+        default: ''
 
 jobs:
   integration:
@@ -15,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.source_ref }}
 
       - name: Read and validate engine.lock
         id: lock
@@ -72,6 +84,8 @@ jobs:
           path: target/integration-engine-src
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: ${{ inputs.coverage && 'llvm-tools' || '' }}
 
       - uses: pnpm/action-setup@v5
         with:
@@ -115,8 +129,10 @@ jobs:
         id: stack-cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: harness-integration
-          save-if: ${{ inputs.save-cache }}
+          # Instrumented builds have different fingerprints; keep them on their
+          # own key so coverage runs never poison the normal cache.
+          shared-key: ${{ inputs.coverage && 'harness-integration-coverage' || 'harness-integration' }}
+          save-if: ${{ inputs.save-cache || inputs.coverage }}
           workspaces: |
             harness -> target
             queue -> target
@@ -132,7 +148,14 @@ jobs:
       - name: Validate integration scenarios
         run: make -C harness integration-validate
 
+      - name: Prepare coverage directories
+        if: inputs.coverage
+        run: mkdir -p target/coverage/profraw
+
       - name: Run integration scenarios
+        env:
+          RUSTFLAGS: ${{ inputs.coverage && '-Cinstrument-coverage -Cllvm-args=-runtime-counter-relocation' || '' }}
+          LLVM_PROFILE_FILE: ${{ inputs.coverage && format('{0}/target/coverage/profraw/%m_%p%c.profraw', github.workspace) || '' }}
         run: make -C harness integration-test III_BIN="${{ steps.engine.outputs.bin }}"
 
       - name: Install Console web dependencies
@@ -144,6 +167,9 @@ jobs:
         run: pnpm build
 
       - name: Build Console worker
+        env:
+          RUSTFLAGS: ${{ inputs.coverage && '-Cinstrument-coverage -Cllvm-args=-runtime-counter-relocation' || '' }}
+          LLVM_PROFILE_FILE: ${{ inputs.coverage && format('{0}/target/coverage/profraw/%m_%p%c.profraw', github.workspace) || '' }}
         run: cargo build --release --manifest-path console/Cargo.toml
 
       - name: Install Playwright Chromium
@@ -167,6 +193,7 @@ jobs:
           CONTEXT_MANAGER_BIN: ${{ github.workspace }}/context-manager/target/release/context-manager
           STATE_BIN: ${{ github.workspace }}/state/target/release/state
           CONSOLE_E2E_ARTIFACTS_DIR: ${{ github.workspace }}/target/console-e2e
+          LLVM_PROFILE_FILE: ${{ inputs.coverage && format('{0}/target/coverage/profraw/%m_%p%c.profraw', github.workspace) || '' }}
         run: pnpm test:e2e
 
       - name: Verify integration report links
@@ -189,6 +216,34 @@ jobs:
               exit 3
             }
           done
+
+      - name: Generate coverage report
+        if: always() && inputs.coverage
+        run: |
+          .github/scripts/coverage_report.sh \
+            --profraw-dir target/coverage/profraw \
+            --output-dir target/coverage/integration \
+            --title harness-integration \
+            --object queue/target/release/queue \
+            --object iii-directory/target/release/iii-directory \
+            --object session-manager/target/release/session-manager \
+            --object context-manager/target/release/context-manager \
+            --object state/target/release/state \
+            --object harness/target/release/harness \
+            --object harness/target/release/harness-integration \
+            --object console/target/release/console
+
+      - name: Upload coverage report
+        if: always() && inputs.coverage
+        uses: actions/upload-artifact@v6
+        with:
+          name: harness-integration-coverage
+          path: |
+            target/coverage/integration/html/
+            target/coverage/integration/summary.json
+            target/coverage/integration/report.txt
+          retention-days: 14
+          if-no-files-found: ignore
 
       - name: Write cache summary
         if: always()

--- a/.github/workflows/harness-e2e-benchmark.yml
+++ b/.github/workflows/harness-e2e-benchmark.yml
@@ -61,6 +61,26 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
 
+      - name: Download E2E coverage report
+        id: e2e-coverage
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          name: harness-e2e-coverage
+          path: target/coverage/e2e
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Download integration coverage report
+        id: integration-coverage
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          name: harness-integration-coverage
+          path: target/coverage/integration
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
       - name: Resolve benchmark source
         id: benchmark
         if: steps.compact.outcome == 'success'
@@ -109,12 +129,103 @@ jobs:
           auto-push: true
           summary-always: true
 
+      - name: Collect coverage trend metrics
+        id: coverage-metrics
+        if: steps.benchmark.outputs.source_sha != ''
+        run: |
+          set -euo pipefail
+          entries='[]'
+          add_entry() {
+            local name=$1 summary=$2
+            [[ -f "$summary" ]] || return 0
+            entries=$(
+              jq --arg name "$name" --slurpfile summary "$summary" \
+                '. + [{
+                  name: $name,
+                  unit: "%",
+                  value: (($summary[0].totals.lines.percent * 100 | round) / 100)
+                }]' <<<"$entries"
+            )
+          }
+          add_entry "E2E line coverage" target/coverage/e2e/summary.json
+          add_entry "Integration line coverage" target/coverage/integration/summary.json
+          if [[ $(jq 'length' <<<"$entries") -eq 0 ]]; then
+            echo "No coverage summaries in this run; skipping trend history."
+            echo "has_metrics=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf '%s\n' "$entries" > target/coverage/coverage-metrics.json
+          echo "has_metrics=true" >> "$GITHUB_OUTPUT"
+
+      - name: Store coverage history
+        if: steps.coverage-metrics.outputs.has_metrics == 'true'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Harness Stack Coverage
+          tool: customBiggerIsBetter
+          output-file-path: target/coverage/coverage-metrics.json
+          ref: ${{ steps.benchmark.outputs.source_sha }}
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/harness-e2e/coverage-trend
+          max-items-in-chart: 100
+          github-token: ${{ github.token }}
+          auto-push: true
+          summary-always: true
+
       - name: Checkout benchmark history
         uses: actions/checkout@v5
         with:
           ref: gh-pages
           path: pages-source
           fetch-depth: 0
+
+      - name: Install coverage reports
+        env:
+          WORKFLOW_URL: ${{ github.event.workflow_run.html_url }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          COMPLETED_AT: ${{ github.event.workflow_run.updated_at }}
+        run: |
+          set -euo pipefail
+          coverage_root=pages-source/dev/harness-e2e/coverage
+          mkdir -p "$coverage_root"
+
+          # Replace-latest semantics: only swap a suite when this run produced
+          # a report, so a partial daily failure keeps yesterday's pages.
+          install_suite() {
+            local suite=$1 source=$2
+            [[ -d "$source/html" ]] || {
+              echo "no $suite coverage in this run; keeping the published report"
+              return 0
+            }
+            rm -rf "${coverage_root:?}/$suite"
+            mkdir -p "$coverage_root/$suite"
+            cp -R "$source/html/." "$coverage_root/$suite/"
+            cp "$source/summary.json" "$coverage_root/$suite.summary.json"
+          }
+          install_suite e2e target/coverage/e2e
+          install_suite integration target/coverage/integration
+
+          # Manifest consumed by the coverage landing page; built from the
+          # published per-suite summaries so it reflects the latest known
+          # report even when one suite was skipped this run.
+          read_summary() {
+            if [[ -f "$1" ]]; then cat "$1"; else echo null; fi
+          }
+          manifest=$(
+            jq -cn \
+              --argjson e2e "$(read_summary "$coverage_root/e2e.summary.json")" \
+              --argjson integration "$(read_summary "$coverage_root/integration.summary.json")" \
+              --arg updated_at "$COMPLETED_AT" \
+              --arg head_sha "$HEAD_SHA" \
+              --arg run_url "$WORKFLOW_URL" \
+              '{
+                updated_at: $updated_at,
+                head_sha: $head_sha,
+                run_url: $run_url,
+                suites: {e2e: $e2e, integration: $integration}
+              }'
+          )
+          printf 'window.HARNESS_COVERAGE = %s;\n' "$manifest" > "$coverage_root/summary.js"
 
       - name: Install dashboard and execution history
         env:

--- a/.github/workflows/harness-e2e-daily.yml
+++ b/.github/workflows/harness-e2e-daily.yml
@@ -78,6 +78,7 @@ jobs:
       release_version: ${{ needs.context.outputs.benchmark_day }}
       release_url: ${{ needs.context.outputs.source_url }}
       registry_tag: daily
+      coverage: true
       subjects: ${{ inputs.subjects || vars.HARNESS_E2E_SUBJECTS || '[{"id":"anthropic-sonnet","model":"claude-sonnet-4-6","provider":"anthropic"}]' }}
       judge_model: ${{ inputs.judge_model || vars.HARNESS_E2E_JUDGE_MODEL || 'claude-sonnet-4-6' }}
       judge_provider: ${{ inputs.judge_provider || vars.HARNESS_E2E_JUDGE_PROVIDER || 'anthropic' }}
@@ -85,3 +86,17 @@ jobs:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}
       zai_api_key: ${{ secrets.ZAI_API_KEY }}
+
+  integration:
+    needs: context
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      actions: read
+      contents: read
+    uses: ./.github/workflows/_harness-integration.yml
+    with:
+      coverage: true
+      # rust-cache saving is driven by the coverage input; the pinned engine
+      # cache key stays owned by cache-warm.
+      save-cache: false
+      source_ref: ${{ needs.context.outputs.source_sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ dist/
 .next/
 .vite/
 graphify-out
+*.profraw
+*.profdata
 
 # Dependencies
 node_modules

--- a/harness/Makefile
+++ b/harness/Makefile
@@ -30,7 +30,7 @@ RUST_WORKERS   := $(filter-out $(PYTHON_WORKERS),$(STACK))
 
 GOAL_ARGS        := $(filter-out help install-iii-next build install-local clean cargo-clean dev-run dev-up dev-down dev-restart \
                     engine wait-engine wait-base wait-stack restart restart-worker stop stop-worker stop-work stop-engine status smoke logs attach \
-                    ensure-session prepare-scrapling require-engine where integration-test integration-playground integration-validate quickstart-validate,$(MAKECMDGOALS))
+                    ensure-session prepare-scrapling require-engine where integration-test integration-coverage integration-playground integration-validate quickstart-validate,$(MAKECMDGOALS))
 SELECTED_WORKERS := $(strip $(GOAL_ARGS))
 ACTIVE_WORKERS   := $(if $(SELECTED_WORKERS),$(SELECTED_WORKERS),$(STACK))
 UNKNOWN_WORKERS  := $(filter-out $(STACK),$(SELECTED_WORKERS))
@@ -42,7 +42,7 @@ RUN_FLAG   := $(if $(filter release,$(RUN_PROFILE)),--release,)
 
 .PHONY: help install-iii-next build install-local clean cargo-clean dev-run dev-up dev-down dev-restart engine wait-engine wait-base wait-stack \
         restart restart-worker stop stop-worker stop-work stop-engine status smoke logs attach ensure-session prepare-scrapling \
-        require-engine where integration-test integration-playground integration-validate quickstart-validate $(STACK)
+        require-engine where integration-test integration-coverage integration-playground integration-validate quickstart-validate $(STACK)
 
 help:
 	@printf '%s\n' \
@@ -65,6 +65,7 @@ help:
 	  '  make cargo-clean [workers...]       cargo clean stack or selected workers' \
 	  '  make install-local [workers...]     build and symlink into ~/.iii/workers' \
 	  '  make integration-test III_BIN=<iii>  run the harness integration scenarios (tests/integration)' \
+	  '  make integration-coverage III_BIN=<iii>  run the scenarios instrumented and emit an LLVM coverage report' \
 	  '  make integration-playground III_BIN=<iii>  open the Console against an isolated integration stack' \
 	  '  make integration-validate           validate every integration scenario' \
 	  '  make quickstart-validate            validate the published harness quickstart'
@@ -402,6 +403,27 @@ integration-test:
 	  --worker-bin "state=$(REPO_ROOT)/state/target/$(INTEGRATION_PROFILE)/state" \
 	  --scenario "$(INTEGRATION_SCENARIO)" \
 	  --artifacts-dir "$(INTEGRATION_ARTIFACTS)"
+
+COVERAGE_RUSTFLAGS := -Cinstrument-coverage -Cllvm-args=-runtime-counter-relocation
+COVERAGE_PROFRAW   := $(REPO_ROOT)/target/coverage/profraw
+
+integration-coverage:
+	@mkdir -p "$(COVERAGE_PROFRAW)"
+	@RUSTFLAGS="$(COVERAGE_RUSTFLAGS)" \
+	  LLVM_PROFILE_FILE="$(COVERAGE_PROFRAW)/%m_%p%c.profraw" \
+	  $(MAKE) integration-test III_BIN="$(III_BIN)"
+	@"$(REPO_ROOT)/.github/scripts/coverage_report.sh" \
+	  --profraw-dir "$(COVERAGE_PROFRAW)" \
+	  --output-dir "$(REPO_ROOT)/target/coverage/integration" \
+	  --title harness-integration \
+	  --object "$(REPO_ROOT)/queue/target/$(INTEGRATION_PROFILE)/queue" \
+	  --object "$(REPO_ROOT)/iii-directory/target/$(INTEGRATION_PROFILE)/iii-directory" \
+	  --object "$(REPO_ROOT)/session-manager/target/$(INTEGRATION_PROFILE)/session-manager" \
+	  --object "$(REPO_ROOT)/context-manager/target/$(INTEGRATION_PROFILE)/context-manager" \
+	  --object "$(REPO_ROOT)/state/target/$(INTEGRATION_PROFILE)/state" \
+	  --object "$(REPO_ROOT)/harness/target/$(INTEGRATION_PROFILE)/harness" \
+	  --object "$(REPO_ROOT)/harness/target/$(INTEGRATION_PROFILE)/harness-integration"
+	@echo "open $(REPO_ROOT)/target/coverage/integration/html/index.html"
 
 integration-playground:
 	@if [ -z "$(III_BIN)" ]; then \

--- a/harness/tests/integration/src/process/spec.rs
+++ b/harness/tests/integration/src/process/spec.rs
@@ -74,6 +74,12 @@ impl ProcessSpec {
             // group ID. This runs between fork and exec without a closure.
             .process_group(0);
 
+        // Coverage runs need instrumented children to keep writing their
+        // profiles despite env_clear; inert otherwise.
+        if let Ok(profile_file) = std::env::var("LLVM_PROFILE_FILE") {
+            command.env("LLVM_PROFILE_FILE", profile_file);
+        }
+
         let child = command.spawn().with_context(|| {
             format!("spawning {} from {}", self.name, self.executable.display())
         })?;


### PR DESCRIPTION
Fixes MOT-4295

## Summary

Adds LLVM source-based code coverage for the harness **integration** and **E2E** suites and publishes browsable HTML reports plus a line-coverage trend to the gh-pages metrics site at `dev/harness-e2e/coverage/`, riding the daily E2E cycle.

- **`coverage` input (default `false`) on `_harness-integration.yml` and `_harness-e2e.yml`** — when on: `llvm-tools` component, per-step `RUSTFLAGS="-Cinstrument-coverage -Cllvm-args=-runtime-counter-relocation"`, absolute continuous-mode `LLVM_PROFILE_FILE` (`%c`) so profiles survive the SIGTERM/SIGKILL stack teardown, and `-coverage`-suffixed rust-cache keys so normal caches are never poisoned. PR CI and cache-warm are untouched.
- **E2E**: each matrix job uploads a `…-profraw` artifact; a new `coverage` job merges them against the packaged `harness-e2e-stack` binaries and uploads `harness-e2e-coverage`. The prebuilt `iii` engine and registry-installed workers stay uninstrumented.
- **Integration**: the make-driven builds and the Console Playwright stack run instrumented; the report (`harness-integration-coverage`) is generated in-job. The process supervisor now passes `LLVM_PROFILE_FILE` through `env_clear` (inert outside coverage runs).
- **Daily cycle**: `harness-e2e-daily.yml` enables coverage on the e2e call and adds an `integration` job, so both artifacts land on the same `workflow_run` the benchmark publisher consumes.
- **Publishing**: `harness-e2e-benchmark.yml` installs both HTML reports with replace-latest semantics (a partial daily failure keeps yesterday's report), writes a `summary.js` manifest, and records "E2E line coverage" / "Integration line coverage" as a `github-action-benchmark` time series under `dev/harness-e2e/coverage-trend/`.
- **Site**: new coverage landing page (per-suite cards + report/trend links + first-run empty state) and a "Coverage" topbar button.
- **Tooling**: shared `.github/scripts/coverage_report.sh` (llvm-profdata merge + llvm-cov show/report/export) reused by CI and the new local `make -C harness integration-coverage III_BIN=<engine>` target.

## Verification

- The coverage recipe was validated end to end locally: all 12 integration scenarios (INT-001…INT-012) pass with the instrumented stack and produce a combined multi-binary HTML report (44.1% line coverage across harness + 5 workers).
- `coverage_report.sh` smoke-tested against real profraw/binaries (missing objects degrade to warnings; empty profraw dir no-ops).
- Workflows YAML-parse; benchmark-site tests pass (21/21); `cargo check -p harness-integration` passes; `make -n integration-coverage` dry-runs.
- After merge, dry-run with `gh workflow run "Harness E2E Daily" -f source_sha=<sha>` and check `https://iii-hq.github.io/workers/dev/harness-e2e/coverage/`.

First daily run builds the `-coverage` caches cold (slower); subsequent runs reuse them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a coverage dashboard with integration and end-to-end coverage summaries, report links, timestamps, and responsive navigation.
  * Added an integration coverage command for generating HTML reports.
* **Improvements**
  * Automated integration and end-to-end coverage collection in scheduled workflows.
  * Added coverage trend reporting to the benchmark dashboard.
  * Enabled instrumented child processes to retain coverage data during testing.
* **Bug Fixes**
  * Improved handling of missing coverage reports while preserving previously published results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Also in this PR: execution detail page UX redesign

`refactor(benchmark-site)`: the execution detail page rendered everything eagerly (~40 tiles + 15 run accordions before any interaction, unbounded failure list, full prompt expanded, multi-MB `JSON.stringify` at load). It is now failure-first with progressive disclosure:

- grouped failure-triage chips (top 5 + "Show all") whose links auto-expand the target scenario/run onto the Evaluation tab (deep-link reveal now opens collapsed ancestors, incl. on `hashchange`)
- 4 KPIs (reliability count folded into the failure strip title); Overview/Configuration collapsed behind one-line digests; scenario cards become one-line accordions (open only when failed or sole scenario)
- run bodies split into five lazily-rendered tabs (Evaluation/Usage/Prompt/Sessions/Raw); prompt clamped with expand; all JSON serialization (trace, run, page preview, download blob) is on-demand
- new additive `HarnessExecutionData.groupRunFailures` helper with unit tests; no existing module APIs changed (23/23 site tests)

Verified live with a Playwright-driven Chromium against the static site: triage chip → auto-expanded run on Evaluation, lazy tab activation, prompt clamp, transcript dialog, aggregate/error states, fresh-load hash deep links; DOM pre-expansion dropped to ~550 nodes on the failing sample execution.
