### PR TITLE
(MOT-3748) fix(harness): preserve registrations across engine reloads

### DIFF
--- a/.github/workflows/harness-quickstart.yml
+++ b/.github/workflows/harness-quickstart.yml
@@ -1,6 +1,18 @@
 name: Harness quickstart
 
 on:
+  workflow_call:
+    inputs:
+      channel:
+        description: Installer channel to validate
+        required: false
+        type: string
+        default: latest
+    secrets:
+      SLACK_BOT_TOKEN:
+        required: false
+      ZAI_API_KEY:
+        required: true
   schedule:
     - cron: "17 5 * * *"
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,6 +241,25 @@ jobs:
       experimental: ${{ needs.setup.outputs.experimental }}
     secrets: inherit
 
+  # Run the published Harness quickstart immediately after the registry
+  # deployment. The validator supports the stable release channels only.
+  quickstart:
+    name: Harness quickstart
+    needs: [setup, publish]
+    if: >-
+      ${{
+        !failure() &&
+        !cancelled() &&
+        needs.setup.outputs.worker == 'harness' &&
+        needs.setup.outputs.dry_run != 'true' &&
+        needs.publish.result == 'success' &&
+        (needs.setup.outputs.registry_tag == 'latest' || needs.setup.outputs.registry_tag == 'next')
+      }}
+    uses: ./.github/workflows/harness-quickstart.yml
+    with:
+      channel: ${{ needs.setup.outputs.registry_tag }}
+    secrets: inherit
+
   # ──────────────────────────────────────────────────────────────
   # Announce the release in Slack (#worker-releases). Terminal job:
   # nothing depends on it, but a bad token or channel fails red

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,7 @@ jobs:
       experimental: ${{ steps.meta.outputs.experimental }}
       web_bundle: ${{ steps.web.outputs.needed }}
       interface_smoke: ${{ steps.smoke.outputs.interface_smoke }}
+      harness_smoke: ${{ steps.harness_smoke.outputs.enabled }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -149,6 +150,29 @@ jobs:
           if [[ "$val" == "false" ]]; then
             echo "::notice::$WORKER opts out of interface collection; registry publish will be skipped"
           fi
+
+      # The published Harness quickstart also covers every worker declared as
+      # a mandatory Harness dependency. Keep this derived from the manifest so
+      # the post-deploy smoke follows dependency changes automatically.
+      - name: Detect Harness quickstart smoke target
+        id: harness_smoke
+        env:
+          WORKER: ${{ steps.meta.outputs.worker }}
+        run: |
+          set -euo pipefail
+          enabled=$(WORKER="$WORKER" python3 - <<'PY'
+          import os
+          from pathlib import Path
+          import yaml
+
+          worker = os.environ["WORKER"]
+          manifest = yaml.safe_load(Path("harness/iii.worker.yaml").read_text())
+          dependencies = manifest.get("dependencies", {}) or {}
+          print("true" if worker == "harness" or worker in dependencies else "false")
+          PY
+          )
+          echo "enabled=$enabled" >> "$GITHUB_OUTPUT"
+          echo "::notice::Harness quickstart smoke target=$enabled worker=$WORKER"
 
   # ──────────────────────────────────────────────────────────────
   # Create the GitHub Release shell (skipped on dry runs).
@@ -242,7 +266,8 @@ jobs:
     secrets: inherit
 
   # Run the published Harness quickstart immediately after the registry
-  # deployment. The validator supports the stable release channels only.
+  # deployment of Harness or one of its mandatory dependencies. The validator
+  # supports the stable release channels only.
   quickstart:
     name: Harness quickstart
     needs: [setup, publish]
@@ -250,7 +275,7 @@ jobs:
       ${{
         !failure() &&
         !cancelled() &&
-        needs.setup.outputs.worker == 'harness' &&
+        needs.setup.outputs.harness_smoke == 'true' &&
         needs.setup.outputs.dry_run != 'true' &&
         needs.publish.result == 'success' &&
         (needs.setup.outputs.registry_tag == 'latest' || needs.setup.outputs.registry_tag == 'next')

--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "1.6.6"
+version = "1.6.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -804,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.21.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "84bdc7bbc3abfde934a62cdc5d3045adf52914dfc1ed6c20f8af691fc561dc55"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -825,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.21.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "4dd563a1d2f55f893d9a433b747f0bf9bc426656413b136b6ed3a699f3c757b2"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "harness"
-version = "1.6.5"
+version = "1.6.6"
 edition = "2021"
 publish = false
 

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "harness"
-version = "1.6.6"
+version = "1.6.7"
 edition = "2021"
 publish = false
 

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "harness"
-version = "1.6.4"
+version = "1.6.5"
 edition = "2021"
 publish = false
 
@@ -17,12 +17,14 @@ name = "harness"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+# 0.21.8 adds the reconnect reattach handshake. Older SDKs can lose this
+# worker's registrations when the engine reloads another worker.
+iii-sdk = "=0.21.8"
 # Re-exports the same `opentelemetry` the SDK uses, so we can carry the active
 # OTel context across `tokio::spawn` boundaries (shared `Context` global).
 # 0.21.5 adds the live span-start push (`LiveSpanStartProcessor`), so the
 # console renders `harness::turn step` while it runs instead of on close.
-iii-helpers = "=0.21.6"
+iii-helpers = "=0.21.8"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -9,7 +9,7 @@ description: Thin durable turn loop that wires session-manager, context-manager,
 
 dependencies:
   state: "^0.21.3"
-  queue: "^0.2.0"
+  queue: "^0.21.2"
   cron: "^0.21.0"
   configuration: "^0.21.6"
   iii-observability: "^0.21.6"

--- a/harness/src/queue.rs
+++ b/harness/src/queue.rs
@@ -23,7 +23,8 @@ const DEFINE_RETRY_BACKOFF_MS: u64 = 250;
 /// Exhaustion is fatal to harness startup: accepting sends without this queue
 /// would acknowledge work that cannot run durably.
 pub async fn ensure_turn_queue(iii: &IIIClient) -> Result<(), String> {
-    let payload = turn_queue_definition();
+    let mut payload = turn_queue_definition();
+    let mut restart_redelivery_requested = true;
     let mut last_error = String::new();
 
     for attempt in 1..=DEFINE_ATTEMPTS {
@@ -42,6 +43,16 @@ pub async fn ensure_turn_queue(iii: &IIIClient) -> Result<(), String> {
             }
             Err(error) => {
                 last_error = error.to_string();
+                if restart_redelivery_requested && is_legacy_queue_schema_error(&last_error) {
+                    tracing::warn!(
+                        queue = TURN_QUEUE,
+                        error = %last_error,
+                        "queue worker does not support restart redelivery; retrying with the legacy queue schema"
+                    );
+                    payload = legacy_turn_queue_definition();
+                    restart_redelivery_requested = false;
+                    continue;
+                }
                 if attempt < DEFINE_ATTEMPTS {
                     tracing::warn!(
                         queue = TURN_QUEUE,
@@ -60,6 +71,10 @@ pub async fn ensure_turn_queue(iii: &IIIClient) -> Result<(), String> {
     ))
 }
 
+fn is_legacy_queue_schema_error(error: &str) -> bool {
+    error.contains("unknown field `redeliver_on_engine_restart`")
+}
+
 fn turn_queue_definition() -> Value {
     json!({
         "queue": TURN_QUEUE,
@@ -71,6 +86,20 @@ fn turn_queue_definition() -> Value {
             "backoff_ms": 1_000,
             "poll_interval_ms": 100,
             "redeliver_on_engine_restart": true
+        }
+    })
+}
+
+fn legacy_turn_queue_definition() -> Value {
+    json!({
+        "queue": TURN_QUEUE,
+        "config": {
+            "type": "fifo",
+            "message_group_field": "session_id",
+            "concurrency": 10,
+            "max_retries": 3,
+            "backoff_ms": 1_000,
+            "poll_interval_ms": 100
         }
     })
 }
@@ -99,5 +128,36 @@ mod tests {
         assert!(turn_queue_definition()["config"]
             .get("timeout_ms")
             .is_none());
+    }
+
+    #[test]
+    fn legacy_turn_queue_definition_omits_restart_redelivery() {
+        assert_eq!(
+            legacy_turn_queue_definition(),
+            json!({
+                "queue": "harness-turn",
+                "config": {
+                    "type": "fifo",
+                    "message_group_field": "session_id",
+                    "concurrency": 10,
+                    "max_retries": 3,
+                    "backoff_ms": 1_000,
+                    "poll_interval_ms": 100
+                }
+            })
+        );
+        assert!(legacy_turn_queue_definition()["config"]
+            .get("redeliver_on_engine_restart")
+            .is_none());
+    }
+
+    #[test]
+    fn only_the_unsupported_restart_redelivery_field_triggers_fallback() {
+        assert!(is_legacy_queue_schema_error(
+            "serialization error: unknown field `redeliver_on_engine_restart`"
+        ));
+        assert!(!is_legacy_queue_schema_error(
+            "serialization error: unknown field `message_group_field`"
+        ));
     }
 }

--- a/harness/tests/e2e/Cargo.toml
+++ b/harness/tests/e2e/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 harness = { path = "../.." }
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.21.8"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/harness/tests/integration/Cargo.toml
+++ b/harness/tests/integration/Cargo.toml
@@ -13,7 +13,7 @@ name = "harness_integration"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.21.8"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "signal", "net", "io-util"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/harness/tests/manifest.rs
+++ b/harness/tests/manifest.rs
@@ -54,7 +54,7 @@ fn worker_manifest_uses_the_standalone_queue_worker() {
 
     assert_eq!(
         dependencies.get(serde_yaml::Value::String("queue".into())),
-        Some(&serde_yaml::Value::String("^0.2.0".into()))
+        Some(&serde_yaml::Value::String("^0.21.2".into()))
     );
     assert!(!dependencies.contains_key(serde_yaml::Value::String("iii-queue".into())));
 }


### PR DESCRIPTION
Published Harness workers can lose their registered functions when the engine reloads another worker, causing calls to fail with `function_not_found`. The same release also had a startup incompatibility: its queue recovery option was sent to older published queue workers, so Harness exited during installation.

## Technical details

- Pin Harness and its workspace test crates to the reconnect-capable `iii-sdk`/`iii-helpers` `0.21.8` release.
- Align the manifest with `queue ^0.21.2`.
- Retry queue provisioning without `redeliver_on_engine_restart` when an older queue worker rejects that field, preserving startup compatibility while the queue upgrade is rolled out.
- Prepare the patch release as Harness `1.6.7`.
- Validation: locked check, release build, 298 unit tests, and a local install smoke using the local Harness binary with published latest dependencies, including provider reload.

Fixes MOT-3748


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated Harness quickstart validation for eligible latest and next releases.
  - Added reusable workflow support with configurable release channels and required API authentication.

- **Bug Fixes**
  - Improved queue setup compatibility by retrying with a legacy configuration when advanced settings are unsupported.
  - Updated Harness and queue components for reconnect and live span-start support.

- **Chores**
  - Updated package and dependency versions across Harness components and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->