### PR TITLE
fix(ci): dispatch release after alpha tag

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -86,6 +86,8 @@ jobs:
         with:
           app-id: ${{ secrets.III_CI_APP_ID }}
           private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
+          permission-actions: write
+          permission-contents: write
 
       - name: Checkout selected branch
         uses: actions/checkout@v5
@@ -214,3 +216,12 @@ jobs:
           # commit is reachable exclusively through this annotated tag.
           git push origin "$TAG"
           echo "::notice::Created $TAG (registry-tag=next)"
+
+      - name: Dispatch release workflow
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh workflow run release.yml --ref main -f tag="$TAG"
+          echo "::notice::Dispatched Release for $TAG"


### PR DESCRIPTION
## Summary

Dispatch the Release workflow explicitly after Alpha Release creates and pushes its tag.

## Root cause

The alpha workflow stopped after the tag push. The expected tag-push trigger did not start the Release workflow, so no GitHub Release or registry publication followed.

## Validation

- `git diff --check`
- Container-based YAML parsing was attempted but the image pull timed out during the TLS handshake.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the alpha release workflow to automatically start the release process after an alpha version is tagged.
  - Enhanced release automation reliability, reducing manual steps required to publish alpha versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->