### PR TITLE
fix(ci): dispatch alpha releases with workflow token

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -66,6 +66,7 @@ on:
           - web
 
 permissions:
+  actions: write
   contents: write
 
 concurrency:
@@ -86,8 +87,6 @@ jobs:
         with:
           app-id: ${{ secrets.III_CI_APP_ID }}
           private-key: ${{ secrets.III_CI_APP_PRIVATE_KEY }}
-          permission-actions: write
-          permission-contents: write
 
       - name: Checkout selected branch
         uses: actions/checkout@v5
@@ -219,7 +218,7 @@ jobs:
 
       - name: Dispatch release workflow
         env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

Use the workflow token, with Actions write permission, to dispatch Release after an alpha tag is created.

## Root cause

The GitHub App installation cannot request `actions: write`, which caused token generation to fail before the alpha tag could be created.

## Validation

- `git diff --check`
- Container-based YAML parsing was attempted but the image pull timed out during the TLS handshake.