### PR TITLE
fix(ci): build the tag being released, not the dispatch branch

### DIFF
--- a/.github/workflows/_bundle.yml
+++ b/.github/workflows/_bundle.yml
@@ -13,6 +13,11 @@ name: Bundle Release
 on:
   workflow_call:
     inputs:
+      ref:
+        description: 'Git ref to build (the tag being released). Empty checks out the calling workflow ref, which on a manual dispatch is the branch it was started from, not the tag.'
+        required: false
+        type: string
+        default: ''
       worker:
         description: 'Worker name (folder), e.g. harness'
         required: true
@@ -54,6 +59,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         if: inputs.skip_create_release != true && inputs.dry_run != true
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Create GitHub Release
         if: inputs.skip_create_release != true && inputs.dry_run != true
@@ -74,6 +81,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
 
       # ── Node bundle path ─────────────────────────────────────────────
       # esbuild produces `<worker>/dist/bundle/index.mjs`, a single ESM

--- a/.github/workflows/_container.yml
+++ b/.github/workflows/_container.yml
@@ -3,6 +3,11 @@ name: Container Release
 on:
   workflow_call:
     inputs:
+      ref:
+        description: 'Git ref to build (the tag being released). Empty checks out the calling workflow ref, which on a manual dispatch is the branch it was started from, not the tag.'
+        required: false
+        type: string
+        default: ''
       worker:
         description: 'Worker name (folder)'
         required: true
@@ -43,6 +48,8 @@ jobs:
       image_tag: ${{ steps.refs.outputs.image_tag }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Compute image refs
         id: refs

--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -3,6 +3,11 @@ name: Publish to workers registry
 on:
   workflow_call:
     inputs:
+      ref:
+        description: 'Git ref to build (the tag being released). Empty checks out the calling workflow ref, which on a manual dispatch is the branch it was started from, not the tag.'
+        required: false
+        type: string
+        default: ''
       worker:
         description: 'Worker name (folder)'
         required: true
@@ -53,6 +58,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Install pyyaml
         run: pip install --quiet pyyaml

--- a/.github/workflows/_rust-binary.yml
+++ b/.github/workflows/_rust-binary.yml
@@ -3,6 +3,11 @@ name: Rust Binary Release
 on:
   workflow_call:
     inputs:
+      ref:
+        description: 'Git ref to build (the tag being released). Empty checks out the calling workflow ref, which on a manual dispatch is the branch it was started from, not the tag.'
+        required: false
+        type: string
+        default: ''
       bin_name:
         description: 'Binary name (e.g., image-resize)'
         required: true
@@ -60,6 +65,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         if: inputs.skip_create_release != true && inputs.dry_run != true
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Create GitHub Release
         if: inputs.skip_create_release != true && inputs.dry_run != true
@@ -127,6 +134,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Resolve worker dir
         id: dirs
@@ -229,6 +238,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Rewrite SSH to HTTPS for public deps
         run: git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -186,6 +187,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag || github.ref }}
       - uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.setup.outputs.tag }}
@@ -203,6 +206,7 @@ jobs:
     if: ${{ !failure() && !cancelled() && needs.setup.outputs.deploy == 'binary' }}
     uses: ./.github/workflows/_rust-binary.yml
     with:
+      ref: ${{ inputs.tag || github.ref }}
       bin_name: ${{ needs.setup.outputs.bin }}
       manifest_path: ${{ needs.setup.outputs.worker }}/${{ needs.setup.outputs.manifest }}
       tag_name: ${{ needs.setup.outputs.tag }}
@@ -222,6 +226,7 @@ jobs:
     if: ${{ !failure() && !cancelled() && needs.setup.outputs.deploy == 'image' }}
     uses: ./.github/workflows/_container.yml
     with:
+      ref: ${{ inputs.tag || github.ref }}
       worker: ${{ needs.setup.outputs.worker }}
       version: ${{ needs.setup.outputs.version }}
       registry_tag: ${{ needs.setup.outputs.registry_tag }}
@@ -238,6 +243,7 @@ jobs:
     if: ${{ !failure() && !cancelled() && needs.setup.outputs.deploy == 'bundle' }}
     uses: ./.github/workflows/_bundle.yml
     with:
+      ref: ${{ inputs.tag || github.ref }}
       worker: ${{ needs.setup.outputs.worker }}
       version: ${{ needs.setup.outputs.version }}
       language: ${{ needs.setup.outputs.language }}
@@ -255,6 +261,7 @@ jobs:
     if: ${{ !failure() && !cancelled() && needs.setup.outputs.dry_run != 'true' && needs.setup.outputs.interface_smoke != 'false' }}
     uses: ./.github/workflows/_publish-registry.yml
     with:
+      ref: ${{ inputs.tag || github.ref }}
       worker: ${{ needs.setup.outputs.worker }}
       version: ${{ needs.setup.outputs.version }}
       deploy: ${{ needs.setup.outputs.deploy }}


### PR DESCRIPTION
## The problem

`actions/checkout` with no `ref` resolves the ref that started the run. On a `push: tags:` trigger that is the tag itself, so the release path was correct by accident. On a `workflow_dispatch` it is the branch the dispatch was started from — and `alpha-release.yml:225` dispatches with `gh workflow run release.yml --ref main -f tag="$TAG"`, so that branch is always main.

The tag reaches the jobs only as metadata: `parse_release_tag.py` reads the version out of its **name**, and `tag_name` goes to `create-release`. Nothing there decides what gets compiled.

The result is a release that **compiles one commit and labels the artifacts with another commit's version**, with no signal that it happened.

## How it surfaced

`state/v0.21.4-alpha.2` shipped this way:

- [Alpha Release](https://github.com/iii-hq/workers/actions/runs/30753342327) ran on `feat/new-sdk-migration` and created the tag. It points at `bd119851`, whose `state/Cargo.toml` has `version = "0.21.4-alpha.2"` and `iii-sdk = "=0.22.0-alpha.3"`.
- [Release](https://github.com/iii-hq/workers/actions/runs/30753354878) — the run that compiles and uploads the assets — was a `workflow_dispatch` from main (`d5bfaf1f`), which pins `iii-sdk = "=0.21.6"`.

The published binary (`sha256 ec31dd33…`) embeds `iii-sdk-0.21.6` and `iii-helpers-0.21.6`, and contains no occurrence of `0.22.0`. Captured on the wire against a live engine, its `engine::workers::register` call carries no `namespace` field, while a control worker built from the new SDK does. The artifact carries the prerelease version number and none of the code that number names, so no worker published through this path can join a namespaced project.

## The change

Every `actions/checkout` in the release path now takes the ref being released:

- `release.yml` uses `${{ inputs.tag || github.ref }}` in its own two jobs and passes the same value down to the four reusable workflows.
- `_rust-binary.yml`, `_bundle.yml`, `_container.yml` and `_publish-registry.yml` gain an optional `ref` input defaulting to `''` — which is `actions/checkout`'s own default. Nothing changes for a tag push.

Nine checkouts in total. `release.yml` is the only caller of all four reusable workflows, so the change is self-contained.

The dispatch keeps using `--ref main` on purpose: the pipeline definition should come from main, and only the source it compiles should follow the tag. Those two were conflated; this separates them.

## Verification

All five files still parse, and a structural check over the parsed YAML confirms no checkout in the release path was left without a `ref`.

## Suggested follow-up (not in this PR)

Nothing today compares the tag's version against the version declared in the worker's manifest — which is why the mismatch stayed silent. `_lib.read_version()` already reads `Cargo.toml` and `package.json` uniformly; comparing the two in `parse_release_tag.py` (skipping dry runs, whose tags carry their own suffix) would turn a wrong build into a job that fails loudly. Left out to keep this PR to the fix itself, but worth having as a net.