### PR TITLE
(MOT-4304) fix(editor): resolve the workspace root to an absolute path

### DIFF
--- a/editor/Cargo.lock
+++ b/editor/Cargo.lock
@@ -275,7 +275,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "editor"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/editor/Cargo.toml
+++ b/editor/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "editor"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 

--- a/editor/src/functions/mod.rs
+++ b/editor/src/functions/mod.rs
@@ -28,7 +28,7 @@ use crate::config::WorkerConfig;
 use crate::configuration::ConfigCell;
 use crate::diff::DiffResult;
 use crate::git::{parse_hunk_headers, parse_status, StatusReport};
-use crate::workspace::{session_key, Buffer, Session, ACTIVE_ROOT_KEY};
+use crate::workspace::{normalize_root, session_key, Buffer, Session, ACTIVE_ROOT_KEY};
 use crate::{diff, fuzzy, lang, tree};
 
 use types::*;
@@ -153,16 +153,28 @@ pub type GitStatusOutput = StatusReport;
 
 // ---------------------------------------------------------------- workspace
 
-/// The active root, or `.` — shell's own working directory — when nothing has
-/// been opened yet. Defaulting rather than erroring means every function works
-/// on a fresh install without a setup step.
+/// The worker's own working directory, as the absolute fallback root.
+/// Defaulting rather than erroring means every function works on a fresh
+/// install without a setup step; it must be absolute because the shell fs
+/// jail rejects relative paths, so "." can never serve as a root.
+fn process_cwd() -> String {
+    std::env::current_dir()
+        .ok()
+        .and_then(|p| p.to_str().map(str::to_string))
+        .unwrap_or_else(|| "/".to_string())
+}
+
 async fn active_root(bus: &Bus) -> String {
-    bus.state_get(ACTIVE_ROOT_KEY)
+    let stored = bus
+        .state_get(ACTIVE_ROOT_KEY)
         .await
         .ok()
         .flatten()
-        .and_then(|v| v.as_str().map(str::to_string))
-        .unwrap_or_else(|| ".".to_string())
+        .and_then(|v| v.as_str().map(str::to_string));
+    // Normalize on read as well as on write: a rig that persisted the old
+    // "." default (or any relative root) heals on the next call instead of
+    // failing every open with the jail's "path must be absolute".
+    normalize_root(stored.as_deref().unwrap_or(""), &process_cwd())
 }
 
 /// A corrupt or absent session reads as an empty one. Losing the tab list is a
@@ -197,13 +209,17 @@ fn register_workspace_open(iii: &Arc<IIIClient>, bus: &Arc<Bus>) {
         RegisterFunction::new_async(move |req: WorkspaceOpenInput| {
             let bus = bus.clone();
             async move {
+                // Absolutize before anything else: the shell fs jail rejects
+                // relative paths, and the session key must be stable per
+                // project regardless of how the caller spelled the root.
+                let root = normalize_root(&req.root, &process_cwd());
                 // Prove the folder is reachable before recording it, so a typo
                 // fails here rather than as a confusing error on every later call.
-                bus.tree(&req.root, 1).await?;
-                bus.state_set(ACTIVE_ROOT_KEY, serde_json::json!(req.root))
+                bus.tree(&root, 1).await?;
+                bus.state_set(ACTIVE_ROOT_KEY, serde_json::json!(root))
                     .await?;
-                let session = load_session(&bus, &req.root).await;
-                Ok::<_, Error>(view(req.root, session))
+                let session = load_session(&bus, &root).await;
+                Ok::<_, Error>(view(root, session))
             }
         })
         .description(DESC_WORKSPACE_OPEN),
@@ -346,8 +362,10 @@ fn register_move(iii: &Arc<IIIClient>, bus: &Arc<Bus>) {
 }
 
 /// Join a root-relative path onto the root, leaving absolute paths alone.
+/// The root is always absolute (normalize_root guards both ends), so the
+/// result is always a path the shell fs jail accepts.
 fn joined(root: &str, rel: &str) -> String {
-    if rel.starts_with('/') || root == "." {
+    if rel.starts_with('/') {
         rel.to_string()
     } else {
         format!("{root}/{rel}")
@@ -821,8 +839,11 @@ mod tests {
     }
 
     #[test]
-    fn joined_uses_shell_cwd_when_no_root_is_set() {
-        assert_eq!(joined(".", "src/main.rs"), "src/main.rs");
+    fn joined_always_produces_an_absolute_path() {
+        // The old "." default passed bare relative paths through to the
+        // shell, whose fs jail rejects them. Roots are absolute now.
+        assert_eq!(joined("/repo", "src/main.rs"), "/repo/src/main.rs");
+        assert!(joined("/repo", "src/main.rs").starts_with('/'));
     }
 
     #[test]

--- a/editor/src/workspace.rs
+++ b/editor/src/workspace.rs
@@ -27,6 +27,32 @@ pub fn session_key(root: &str) -> String {
     format!("session:{root}")
 }
 
+/// Normalize a workspace root to an absolute path with no trailing slash.
+///
+/// Every filesystem call the workspace makes goes through the shell worker,
+/// whose fs jail rejects relative paths outright ("path must be absolute").
+/// A relative root — including the historical default of "." — therefore
+/// cannot work; resolve it against `cwd` at the door so the stored root, the
+/// per-project session key, and every joined path are absolute and stable.
+/// `cwd` is a parameter so this stays pure and testable.
+pub fn normalize_root(root: &str, cwd: &str) -> String {
+    let trimmed = root.trim();
+    let base = match trimmed {
+        "" | "." | "./" => cwd.to_string(),
+        rel if !rel.starts_with('/') => {
+            let rel = rel.strip_prefix("./").unwrap_or(rel);
+            format!("{}/{rel}", cwd.trim_end_matches('/'))
+        }
+        abs => abs.to_string(),
+    };
+    let out = base.trim_end_matches('/');
+    if out.is_empty() {
+        "/".to_string()
+    } else {
+        out.to_string()
+    }
+}
+
 /// One open file. `mtime` is what the conflict guard compares against, so it
 /// is part of the shared record rather than per-surface bookkeeping — two
 /// surfaces editing one file must agree on which version they started from.
@@ -146,6 +172,28 @@ mod tests {
             version: "1-0000000000000001".to_string(),
             language: "rust".to_string(),
         }
+    }
+
+    #[test]
+    fn normalize_root_resolves_the_relative_defaults() {
+        assert_eq!(normalize_root(".", "/home/me/rig"), "/home/me/rig");
+        assert_eq!(normalize_root("", "/home/me/rig"), "/home/me/rig");
+        assert_eq!(normalize_root("./", "/home/me/rig"), "/home/me/rig");
+    }
+
+    #[test]
+    fn normalize_root_absolutizes_relative_paths_against_cwd() {
+        assert_eq!(normalize_root("proj", "/home/me"), "/home/me/proj");
+        assert_eq!(normalize_root("./proj", "/home/me"), "/home/me/proj");
+        assert_eq!(normalize_root("proj", "/home/me/"), "/home/me/proj");
+    }
+
+    #[test]
+    fn normalize_root_keeps_absolute_paths_and_trims_trailing_slash() {
+        assert_eq!(normalize_root("/repo", "/elsewhere"), "/repo");
+        assert_eq!(normalize_root("/repo/", "/elsewhere"), "/repo");
+        assert_eq!(normalize_root(" /repo ", "/elsewhere"), "/repo");
+        assert_eq!(normalize_root("/", "/elsewhere"), "/");
     }
 
     #[test]

--- a/editor/ui/src/page/index.tsx
+++ b/editor/ui/src/page/index.tsx
@@ -197,7 +197,13 @@ export function EditorPage({ host }: { host: Host }) {
     if (view === 'preview' && !markdown) setView('read')
   }, [view, dirty, markdown])
 
+  /** The root the page currently renders, readable from stable callbacks.
+   *  `syncWorkspace` runs off push events and must notice the active root
+   *  moving underneath it without re-subscribing per render. */
+  const rootRef = useRef('')
+
   const applyWorkspace = useCallback((ws: { root: string; buffers: Buffer[]; expanded: string[] }) => {
+    rootRef.current = ws.root
     setRoot(ws.root)
     setBuffers(ws.buffers)
     setExpanded(new Set(ws.expanded))
@@ -208,6 +214,7 @@ export function EditorPage({ host }: { host: Host }) {
       try {
         const result = await api.tree(opts)
         setTreeRoot(result.tree.root)
+        rootRef.current = result.root
         setRoot(result.root)
         setExpanded(new Set(result.expanded))
         setError(null)
@@ -402,6 +409,19 @@ export function EditorPage({ host }: { host: Host }) {
   const syncWorkspace = useCallback(async () => {
     try {
       const ws = await api.workspace()
+      // The active root moved underneath the page: chat picked a working
+      // directory, or another surface opened a project. Follow it live —
+      // adopt the new root's remembered session exactly the way an explicit
+      // root change does, instead of leaving a stale tree until a reload.
+      if (ws.root && ws.root !== rootRef.current) {
+        applyWorkspace(ws)
+        setRootInput(ws.root)
+        setDrafts({})
+        setActivePath(ws.buffers[ws.buffers.length - 1]?.path ?? null)
+        await loadTree()
+        void refreshGit()
+        return
+      }
       setBuffers(ws.buffers)
       for (const buffer of ws.buffers) {
         const local = draftsRef.current[buffer.path]
@@ -411,7 +431,7 @@ export function EditorPage({ host }: { host: Host }) {
     } catch {
       // Transient; the next event tries again.
     }
-  }, [api, reread])
+  }, [api, reread, applyWorkspace, loadTree, refreshGit])
 
   /** Work accumulated since the last pass: paths whose file needs re-reading,
    *  and whether the git overlay is stale. */


### PR DESCRIPTION
On a fresh rig every editor::open failed with "path must be absolute: <file>" and the tree showed the engine's own directory. Root cause: the default workspace root was the literal ".", and joined() passed bare relative paths through for it on the assumption that the shell resolves them against its cwd. The shell fs jail rejects any non-absolute path, so the default workspace could render a tree but never open a file. Reported by Mike Piccolo, reproduced on a second rig.

- active_root() falls back to the worker's absolute cwd and normalizes whatever is stored, so a rig that persisted the old "." default heals on the next call
- editor::workspace::open absolutizes and trims the incoming root before the reachability check and the store, keeping per-project session keys stable regardless of how the caller spells the root
- joined() drops the "." passthrough; roots are always absolute
- normalize_root() is pure (cwd injected) and unit-tested

Verified against a live engine: editor::open on a relative path returned file content where the released binary fails with S210, and workspace::open repoints between projects with per-root sessions intact.

The console half of the ticket (editor follows the chat working directory) lands separately.

Fixes MOT-4304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace roots are now consistently resolved to absolute paths, including relative, empty, and whitespace-only inputs.
  * Workspace opening validates the resolved directory before saving and loading its session.
  * Path handling now works correctly for filesystem roots and relative files.

* **Chores**
  * Updated the editor package version to 0.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->