### PR TITLE
(MOT-4304) feat(console): editor workspace follows the chat working directory

### DIFF
--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -30,6 +30,7 @@ import type {
   QueuedMessagePreview,
 } from '@/lib/backend/types'
 import { useConversationsCtxOptional } from '@/lib/conversations-context'
+import { syncEditorWorkspace } from '@/lib/editor-sync'
 import { expandFileMentions, parseFileMentions } from '@/lib/file-mentions'
 import { formatStopReason } from '@/lib/format-stop-reason'
 import { newMessageId } from '@/lib/session-id'
@@ -710,6 +711,11 @@ export function ChatView({
     if (!workingDirEnabled || conversation.draft) return
     const dir = conversation.workingDir
     if (!dir) return
+    // Switching to a conversation brings its working directory with it: the
+    // editor page follows the active chat, not the last folder ever opened.
+    // Best-effort with its own consecutive-root dedupe, so re-activations
+    // and already-validated dirs stay cheap.
+    void syncEditorWorkspace(dir)
     const key = `${conversation.id}:${dir}`
     if (validatedWorkingDirs.has(key)) return
     let cancelled = false
@@ -1473,6 +1479,9 @@ export function ChatView({
       setWorkingDirError(null)
       validatedWorkingDirs.add(`${id}:${next}`)
       onUpdateWorkingDir(id, next)
+      // The editor follows the chat: picking a folder here repoints the
+      // shared editor workspace so the editor page shows this project.
+      void syncEditorWorkspace(next)
       if (!conversation.draft && next !== prev) {
         onAppendMessage(
           id,

--- a/console/web/src/lib/editor-sync.test.ts
+++ b/console/web/src/lib/editor-sync.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resetEditorSyncForTests, syncEditorWorkspace } from './editor-sync'
+
+describe('syncEditorWorkspace', () => {
+  beforeEach(() => {
+    resetEditorSyncForTests()
+  })
+
+  it('opens the editor workspace at the given root', async () => {
+    const trigger = vi.fn().mockResolvedValue({})
+    await expect(syncEditorWorkspace('/repo', trigger)).resolves.toBe(true)
+    expect(trigger).toHaveBeenCalledWith('editor::workspace::open', {
+      root: '/repo',
+    })
+  })
+
+  it('dedupes consecutive calls for the same root', async () => {
+    const trigger = vi.fn().mockResolvedValue({})
+    await syncEditorWorkspace('/repo', trigger)
+    await syncEditorWorkspace('/repo', trigger)
+    expect(trigger).toHaveBeenCalledTimes(1)
+    await syncEditorWorkspace('/other', trigger)
+    expect(trigger).toHaveBeenCalledTimes(2)
+  })
+
+  it('swallows failures and retries on the next call', async () => {
+    const trigger = vi.fn().mockRejectedValue(new Error('function_not_found'))
+    await expect(syncEditorWorkspace('/repo', trigger)).resolves.toBe(false)
+    // The failed root was not recorded, so the same root retries.
+    await syncEditorWorkspace('/repo', trigger)
+    expect(trigger).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores empty roots', async () => {
+    const trigger = vi.fn()
+    await expect(syncEditorWorkspace('', trigger)).resolves.toBe(false)
+    expect(trigger).not.toHaveBeenCalled()
+  })
+})

--- a/console/web/src/lib/editor-sync.ts
+++ b/console/web/src/lib/editor-sync.ts
@@ -1,0 +1,52 @@
+/**
+ * Keep the shared editor workspace pointed at the chat's working directory.
+ *
+ * The editor worker holds one active root (the workspace every surface sees);
+ * chat holds a per-conversation working directory. Without this bridge the
+ * editor page keeps showing whatever was opened last — usually the engine's
+ * own folder — while the conversation works somewhere else entirely.
+ *
+ * Best-effort on purpose: the editor keeps per-root sessions, so repointing
+ * is lossless, and when the editor worker is not installed the call fails
+ * quietly and chat behaves exactly as before.
+ */
+import { getIiiClient } from './iii-client'
+
+const OPEN_FUNCTION_ID = 'editor::workspace::open'
+
+type TriggerFn = (
+  functionId: string,
+  payload: Record<string, unknown>,
+) => Promise<unknown>
+
+/**
+ * Consecutive-call dedupe: activating the same conversation (or re-validating
+ * the same folder) must not re-open the workspace it already points at.
+ */
+let lastSyncedRoot: string | null = null
+
+export async function syncEditorWorkspace(
+  root: string,
+  trigger?: TriggerFn,
+): Promise<boolean> {
+  if (!root || root === lastSyncedRoot) return false
+  const call =
+    trigger ??
+    (async (functionId: string, payload: Record<string, unknown>) => {
+      const client = await getIiiClient()
+      return client.trigger(functionId, payload, { timeoutMs: 15_000 })
+    })
+  try {
+    await call(OPEN_FUNCTION_ID, { root })
+    lastSyncedRoot = root
+    return true
+  } catch {
+    // Editor worker absent, or the folder is not reachable from it. The
+    // conversation is unaffected either way; the next root change retries.
+    return false
+  }
+}
+
+export function resetEditorSyncForTests(): void {
+  lastSyncedRoot = null
+}


### PR DESCRIPTION
Chat holds a per-conversation working directory; the editor worker holds one shared workspace root. Nothing connected them, so the editor page kept showing whatever was opened last (usually the engine's own folder) while the conversation worked somewhere else.

The chat surface now repoints the editor whenever a working directory becomes active:

- picking a folder in the composer fires editor::workspace::open with the chosen root
- switching to a conversation that carries a working directory does the same on activation

Best-effort by design: consecutive-root dedupe keeps re-activations cheap, a missing editor worker fails quietly with chat unaffected, and the editor's per-root sessions make repointing lossless (each project keeps its own tabs and expanded folders).

New lib module with unit tests (payload shape, dedupe, failure tolerance, empty root). Typecheck, full vitest suite (1089), and build pass.

Refs MOT-4304