### PR TITLE
(MOT-4305) feat(harness): discriminative judge-backed scenarios and scored hard-gate failures

### DIFF
--- a/.github/scripts/collect_harness_e2e_benchmarks.py
+++ b/.github/scripts/collect_harness_e2e_benchmarks.py
@@ -543,7 +543,6 @@ def collect(
         suite_passed = (
             all_reports_present
             and subject_passed == expected_count
-            and hard_gate_failures == 0
             and technical_failures == 0
         )
         engine_revision = (

--- a/harness/tests/e2e/README.md
+++ b/harness/tests/e2e/README.md
@@ -55,6 +55,14 @@ scenario through one global `allow: ["*"]` policy:
   evaluator verifies every effect, exact stdout from both environments,
   operation ordering, shutdown, and scenario-owned cleanup. Recovered function
   errors reduce its quality score without overriding those validated effects.
+- `design_tradeoff`: recommends one side of a contested database-scaling
+  decision with facts that pull in opposite directions; a judge scores
+  commitment to a single pick, constraint-grounded reasoning, honest costs of
+  the chosen option, and concrete reversal conditions.
+- `security_triage`: classifies four snippets where two are subtly exploitable
+  and two only look vulnerable; a judge scores true positives, false-positive
+  control, remediation, and clarity.
+
 List the code-defined ids used by CI:
 
 ```bash

--- a/harness/tests/e2e/README.md
+++ b/harness/tests/e2e/README.md
@@ -55,7 +55,6 @@ scenario through one global `allow: ["*"]` policy:
   evaluator verifies every effect, exact stdout from both environments,
   operation ordering, shutdown, and scenario-owned cleanup. Recovered function
   errors reduce its quality score without overriding those validated effects.
-
 List the code-defined ids used by CI:
 
 ```bash
@@ -132,9 +131,12 @@ attempts; a third invalid response is a `judge_error`, not a zero quality score.
 Criterion weights total 100. A run passes when every hard gate passes and its
 score reaches the scenario threshold. For repeated runs, the aggregate requires
 at least two thirds of the runs to pass and the median score to reach the
-threshold. Hard-gate and technical failures stop further repetitions for that
-subject/scenario pair and always fail the aggregate. Score-only failures retain
-the two-of-three tolerance used by the daily benchmark.
+threshold. Technical failures stop further repetitions for that
+subject/scenario pair and always fail the aggregate. A hard-gate failure is a
+quality result, not an execution error: the run keeps its objective partial
+credit (zero when every criterion is judge-delegated), enters the aggregate as
+a poor score, and shares the two-of-three tolerance used by score-only
+failures.
 
 Scenarios with a judge reference delegate every criterion score to the judge.
 Scenarios without one award every criterion objectively in code. Mechanical
@@ -199,7 +201,7 @@ zero.
 | Workflow | Trigger | Live-model runs | Gate |
 | --- | --- | ---: | --- |
 | Pull-request CI | Relevant pull-request changes | 0 | Deterministic integration only |
-| Harness E2E Main | Relevant push to `main` | 1 per subject/scenario | Score advisory; hard gates and technical failures blocking |
+| Harness E2E Main | Relevant push to `main` | 1 per subject/scenario | Score advisory; technical failures blocking |
 | Harness E2E Daily | Daily at 06:00 UTC, or manual dispatch on `main` | 3 per subject/scenario | Median score and reliability gates are evaluated; history is published on failure |
 
 The reusable workflow normally runs from `main`; a manual daily benchmark may

--- a/harness/tests/e2e/src/report.rs
+++ b/harness/tests/e2e/src/report.rs
@@ -85,10 +85,6 @@ impl RunStatus {
         )
     }
 
-    pub fn is_blocking_failure(self) -> bool {
-        self == Self::HardGateFailed || self.is_technical_failure()
-    }
-
     fn label(self) -> &'static str {
         match self {
             Self::Passed => "PASS",
@@ -301,7 +297,6 @@ impl E2eScenarioReport {
             total_usd: sum_cost(runs.iter().map(|run| run.cost.total_usd)),
         };
         let passed = run_count > 0
-            && hard_gate_failures == 0
             && technical_failures == 0
             && passed_runs >= required_passes
             && median_score.is_some_and(|score| score >= f64::from(threshold));
@@ -547,12 +542,19 @@ mod tests {
     }
 
     #[test]
-    fn hard_gate_failures_cannot_be_outvoted() {
-        let mut hard_gate = run(100, true);
-        hard_gate.status = RunStatus::HardGateFailed;
-        let report = aggregate(vec![hard_gate, run(90, true), run(90, true)]);
-        assert!(!report.passed);
+    fn hard_gate_failures_count_as_scored_failed_runs() {
+        let mut outvoted = run(45, false);
+        outvoted.status = RunStatus::HardGateFailed;
+        let report = aggregate(vec![outvoted, run(90, true), run(90, true)]);
+        assert!(report.passed);
         assert_eq!(report.aggregate.hard_gate_failures, 1);
+        assert_eq!(report.aggregate.median_score, Some(90.0));
+
+        let mut decisive = run(45, false);
+        decisive.status = RunStatus::HardGateFailed;
+        let report = aggregate(vec![decisive, run(90, true)]);
+        assert!(!report.passed);
+        assert_eq!(report.aggregate.median_score, Some(67.5));
     }
 
     #[test]

--- a/harness/tests/e2e/src/scenarios/design_tradeoff.rs
+++ b/harness/tests/e2e/src/scenarios/design_tradeoff.rs
@@ -1,0 +1,84 @@
+use serde_json::json;
+
+use super::common;
+use super::{CriterionSpec, ExecutionPolicy, ScenarioSpec, JUDGE_BACKED_PASS_THRESHOLD};
+
+pub const ID: &str = "design_tradeoff";
+
+pub fn scenario(_run_id: &str) -> ScenarioSpec {
+    ScenarioSpec {
+        id: ID,
+        version: 1,
+        prompt: "You are advising a five-engineer team that operates a payments ledger \
+service on a single PostgreSQL instance. Facts: storage sits at 70% of the current \
+instance's capacity, and one larger instance size (double the capacity) is still \
+available from the cloud provider; data volume doubles roughly every eight months; \
+about 60% of stored rows are reconciliation records older than 18 months that are read \
+only during audits; regulators require strict transactional consistency for ledger \
+writes; nobody on the team has operated a sharded or distributed database; leadership \
+expects entry into two new markets within twelve months, which may double merchant \
+count.\n\n\
+The team must commit now to one of two plans: (A) shard PostgreSQL by merchant id over \
+the next two quarters, or (B) stay single-node, move audit-only records to cheaper \
+archival storage, take the instance upgrade when needed, and re-evaluate in twelve \
+months.\n\n\
+Recommend exactly one option. Justify it against the stated facts, state the real \
+costs and risks of the option you recommend, and give concrete conditions under which \
+the other option would become the right choice. Answer in a single reply and do not \
+perform any external action."
+            .into(),
+        filesystem_root: None,
+        execution: ExecutionPolicy {
+            max_turns: 2,
+            max_output_tokens: Some(4_096),
+            max_total_tokens: 49_152,
+            stuck_timeout_seconds: 120,
+        },
+        threshold: JUDGE_BACKED_PASS_THRESHOLD,
+        criteria: vec![
+            CriterionSpec {
+                id: "commitment",
+                weight: 30,
+                description: "Full credit: exactly one option clearly recommended, stated early \
+and never walked back. Half: a pick exists but is hedged, buried, or drowned in \
+both-sides framing. Zero: refuses to choose, recommends both, or answers 'it depends'.",
+            },
+            CriterionSpec {
+                id: "constraint_reasoning",
+                weight: 30,
+                description: "Full credit: argues from at least three stated facts with correct \
+implications, including the storage-runway arithmetic (archiving plus the remaining 2x \
+upgrade versus the eight-month doubling). Half: uses some facts but generically, or \
+skips the arithmetic. Zero: boilerplate pros and cons untethered from the stated facts.",
+            },
+            CriterionSpec {
+                id: "honest_costs",
+                weight: 20,
+                description: "Full credit: at least two concrete costs or risks of the \
+recommended option, stated plainly. Half: a single cost or only vague acknowledgement. \
+Zero: presents the recommended option as cost-free or lists costs only for the \
+rejected option.",
+            },
+            CriterionSpec {
+                id: "reversal_conditions",
+                weight: 20,
+                description: "Full credit: specific checkable triggers (metrics, thresholds, \
+dates, or events) under which the other option becomes right. Half: only vague 'if \
+circumstances change' conditions. Zero: no reversal conditions.",
+            },
+        ],
+        judge_reference: Some(json!({
+            "better_supported_option": "B: archive audit-only rows, use the remaining vertical upgrade, re-evaluate in twelve months",
+            "key_factors": {
+                "storage_runway": "archiving ~60% of rows drops usage to roughly 28% of current capacity, and one 2x upgrade remains; at an eight-month doubling rate that is roughly two years of runway, comfortably past the twelve-month re-evaluation point",
+                "team_capability": "five engineers with no distributed-database experience make a two-quarter sharding migration of a regulated ledger high risk",
+                "consistency": "strict transactional consistency is native on a single node; cross-shard ledger writes require two-phase commit or a redesign",
+                "growth_uncertainty": "market entry may double merchant count, but doubling data volume is already priced into the doubling-rate runway"
+            },
+            "reversal_examples": "storage growth outpacing archiving, single-writer throughput or vacuum saturation, per-market data-residency regulation forcing physical partitioning",
+            "grading_note": "an answer recommending A can still earn constraint_reasoning, honest_costs, and reversal_conditions credit if it honestly prices in team risk and consistency costs; commitment scores the clarity of the pick, not which pick"
+        })),
+        evaluate: common::evaluate_text_response,
+        cleanup: None,
+    }
+}

--- a/harness/tests/e2e/src/scenarios/direct_answer.rs
+++ b/harness/tests/e2e/src/scenarios/direct_answer.rs
@@ -22,17 +22,24 @@ pub fn scenario(_run_id: &str) -> ScenarioSpec {
             CriterionSpec {
                 id: "correctness",
                 weight: 50,
-                description: "Correctly distinguishes proving identity from deciding permissions.",
+                description: "Full credit: authentication framed as proving who you are and \
+authorization as what you may do, with no conflation. Half: both defined but the \
+contrast is muddled or partially wrong. Zero: definitions swapped, merged, or \
+incorrect.",
             },
             CriterionSpec {
                 id: "clarity",
                 weight: 30,
-                description: "Uses language a non-technical reader can understand.",
+                description: "Full credit: plain everyday language a non-technical reader \
+follows, any technical term immediately explained. Half: mostly clear but leans on \
+unexplained jargon. Zero: jargon-heavy or confusing.",
             },
             CriterionSpec {
                 id: "instruction_adherence",
                 weight: 20,
-                description: "Answers directly in no more than two sentences.",
+                description: "Full credit: a direct answer in one or two sentences with no \
+preamble or lists. Half: correct content but three sentences or noticeable padding. \
+Zero: far over length or the answer is buried.",
             },
         ],
         judge_reference: Some(json!({

--- a/harness/tests/e2e/src/scenarios/mod.rs
+++ b/harness/tests/e2e/src/scenarios/mod.rs
@@ -13,10 +13,12 @@ use crate::context::E2eContext;
 use crate::report::HardGateReport;
 
 pub mod common;
+pub mod design_tradeoff;
 pub mod direct_answer;
 pub mod persistent_state;
 pub mod reactive_automation;
 pub mod security_review;
+pub mod security_triage;
 pub mod shell_coder_sandbox;
 
 /// Judge-backed scenarios keep a low semantic floor while exposing the full
@@ -160,15 +162,21 @@ pub enum ScenarioId {
     ReactiveAutomation,
     #[value(name = "shell_coder_sandbox")]
     ShellCoderSandbox,
+    #[value(name = "design_tradeoff")]
+    DesignTradeoff,
+    #[value(name = "security_triage")]
+    SecurityTriage,
 }
 
 impl ScenarioId {
-    pub const ALL: [Self; 5] = [
+    pub const ALL: [Self; 7] = [
         Self::DirectAnswer,
         Self::PersistentState,
         Self::SecurityReview,
         Self::ReactiveAutomation,
         Self::ShellCoderSandbox,
+        Self::DesignTradeoff,
+        Self::SecurityTriage,
     ];
 
     pub fn as_str(self) -> &'static str {
@@ -178,6 +186,8 @@ impl ScenarioId {
             Self::SecurityReview => security_review::ID,
             Self::ReactiveAutomation => reactive_automation::ID,
             Self::ShellCoderSandbox => shell_coder_sandbox::ID,
+            Self::DesignTradeoff => design_tradeoff::ID,
+            Self::SecurityTriage => security_triage::ID,
         }
     }
 
@@ -188,6 +198,8 @@ impl ScenarioId {
             Self::SecurityReview => security_review::scenario(run_id),
             Self::ReactiveAutomation => reactive_automation::scenario(run_id),
             Self::ShellCoderSandbox => shell_coder_sandbox::scenario(run_id),
+            Self::DesignTradeoff => design_tradeoff::scenario(run_id),
+            Self::SecurityTriage => security_triage::scenario(run_id),
         }
     }
 }
@@ -208,13 +220,13 @@ pub fn selected(requested: &[ScenarioId]) -> Vec<ScenarioId> {
 mod tests {
     use super::*;
     #[test]
-    fn registry_contains_five_unique_valid_scenarios() {
+    fn registry_contains_seven_unique_valid_scenarios() {
         let mut ids = HashSet::new();
         for scenario in ScenarioId::ALL {
             assert!(ids.insert(scenario.as_str()));
             scenario.spec("run").validate().unwrap();
         }
-        assert_eq!(ids.len(), 5);
+        assert_eq!(ids.len(), 7);
     }
 
     #[test]
@@ -242,7 +254,12 @@ mod tests {
 
     #[test]
     fn judge_backed_scenarios_use_the_quality_signal_floor() {
-        for scenario in [ScenarioId::DirectAnswer, ScenarioId::SecurityReview] {
+        for scenario in [
+            ScenarioId::DirectAnswer,
+            ScenarioId::SecurityReview,
+            ScenarioId::DesignTradeoff,
+            ScenarioId::SecurityTriage,
+        ] {
             let spec = scenario.spec("run");
             assert!(spec.needs_judge());
             assert_eq!(spec.threshold, JUDGE_BACKED_PASS_THRESHOLD);

--- a/harness/tests/e2e/src/scenarios/security_review.rs
+++ b/harness/tests/e2e/src/scenarios/security_review.rs
@@ -29,22 +29,30 @@ For each snippet, identify the vulnerability, explain its impact, and recommend 
             CriterionSpec {
                 id: "coverage",
                 weight: 40,
-                description: "Identifies the relevant vulnerability in all three snippets.",
+                description: "Full credit: names the hardcoded secret, SQL injection, and open \
+redirect, each on its own snippet. Half: two of the three. Zero: one or none, or \
+findings mapped to the wrong snippets.",
             },
             CriterionSpec {
                 id: "accuracy",
                 weight: 30,
-                description: "Explains each risk accurately without invented findings.",
+                description: "Full credit: every stated impact is technically correct with no \
+invented vulnerabilities. Half: minor imprecision or one speculative extra finding. \
+Zero: materially wrong impacts or fabricated issues dominate.",
             },
             CriterionSpec {
                 id: "remediation",
                 weight: 20,
-                description: "Provides a practical mitigation for every finding.",
+                description: "Full credit: a concrete standard fix per finding (rotate plus \
+secret manager; parameterized queries; allowlisted or relative-path redirects). Half: \
+fixes for only some findings or vague advice. Zero: missing or incorrect fixes.",
             },
             CriterionSpec {
                 id: "clarity",
                 weight: 10,
-                description: "Presents a concise, easy-to-map review.",
+                description: "Full credit: concise snippet-by-snippet structure, findings \
+trivially mapped. Half: readable but disorganized or padded. Zero: unclear which \
+finding belongs to which snippet.",
             },
         ],
         judge_reference: Some(json!({

--- a/harness/tests/e2e/src/scenarios/security_triage.rs
+++ b/harness/tests/e2e/src/scenarios/security_triage.rs
@@ -1,0 +1,109 @@
+use serde_json::json;
+
+use super::common;
+use super::{CriterionSpec, ExecutionPolicy, ScenarioSpec, JUDGE_BACKED_PASS_THRESHOLD};
+
+pub const ID: &str = "security_triage";
+
+pub fn scenario(_run_id: &str) -> ScenarioSpec {
+    ScenarioSpec {
+        id: ID,
+        version: 1,
+        prompt: r#"Triage these four independent Python snippets. Not every snippet is vulnerable; classify each one.
+
+1.
+    import os
+    BASE = "/srv/exports"
+
+    def download(filename):
+        if ".." in filename:
+            raise ValueError("invalid path")
+        return open(os.path.join(BASE, filename), "rb").read()
+
+2.
+    SORT_COLUMNS = {"newest": "created_at", "name": "display_name"}
+
+    def list_users(db, sort):
+        column = SORT_COLUMNS[sort]
+        return db.execute(f"SELECT id, display_name FROM users ORDER BY {column}").fetchall()
+
+3.
+    import html
+
+    def greeting_fragment(name):
+        return "<p>Welcome back, " + html.escape(name) + "</p>"
+
+4.
+    import hmac, hashlib
+
+    def verify_webhook(secret: bytes, body: bytes, signature_header: str) -> bool:
+        expected = hmac.new(secret, body, hashlib.sha256).hexdigest()
+        return expected == signature_header
+
+The values filename, sort, name, body, and signature_header are attacker-controlled. For each snippet give a verdict (exploitable or safe), the concrete attack or the reason it is safe, and a fix for any exploitable snippet. Keep the triage concise and do not perform any external action."#
+            .into(),
+        filesystem_root: None,
+        execution: ExecutionPolicy {
+            max_turns: 2,
+            max_output_tokens: Some(4_096),
+            max_total_tokens: 49_152,
+            stuck_timeout_seconds: 120,
+        },
+        threshold: JUDGE_BACKED_PASS_THRESHOLD,
+        criteria: vec![
+            CriterionSpec {
+                id: "true_positives",
+                weight: 35,
+                description: "Full credit: flags snippet 1 (an absolute filename makes \
+os.path.join discard the base, bypassing the '..' check) and snippet 4 \
+(non-constant-time signature comparison) with correct mechanisms. Half: catches one of \
+the two, or the right snippet with the wrong mechanism. Zero: misses both.",
+            },
+            CriterionSpec {
+                id: "false_positive_control",
+                weight: 35,
+                description: "Full credit: explicitly declares snippets 2 and 3 safe with \
+correct reasoning (hardcoded whitelisted column literal; escaped output in element \
+content). Half: clears only one, or clears both without reasoning. Zero: reports \
+either safe snippet as exploitable.",
+            },
+            CriterionSpec {
+                id: "remediation",
+                weight: 20,
+                description: "Full credit: correct fixes for both real findings (canonicalize \
+and enforce the base-directory prefix or reject absolute paths before joining; use \
+hmac.compare_digest). Half: one correct fix. Zero: missing or incorrect fixes.",
+            },
+            CriterionSpec {
+                id: "clarity",
+                weight: 10,
+                description: "Full credit: four unambiguous per-snippet verdicts that are easy \
+to map. Half: verdicts present but disorganized. Zero: no clear verdict per snippet.",
+            },
+        ],
+        judge_reference: Some(json!({
+            "snippet_1": {
+                "verdict": "exploitable",
+                "finding": "path traversal: os.path.join discards BASE when filename is absolute (e.g. /etc/passwd), so the '..' substring check never fires",
+                "remediation": "canonicalize (realpath) and require the result to remain under BASE, or reject absolute paths and normalize before joining"
+            },
+            "snippet_2": {
+                "verdict": "safe",
+                "reason": "the f-string interpolates only one of two hardcoded column literals from SORT_COLUMNS; any other sort raises KeyError, so attacker data never reaches the SQL text",
+                "grading_note": "mentioning the unhandled KeyError as a robustness issue is acceptable; calling this SQL injection is a false positive"
+            },
+            "snippet_3": {
+                "verdict": "safe",
+                "reason": "html.escape neutralizes the attacker value and it lands in element content, so there is no XSS",
+                "grading_note": "flagging this as XSS is a false positive"
+            },
+            "snippet_4": {
+                "verdict": "exploitable",
+                "finding": "non-constant-time comparison of the HMAC hex digest (CWE-208) enables timing-based signature forgery",
+                "remediation": "compare with hmac.compare_digest"
+            }
+        })),
+        evaluate: common::evaluate_text_response,
+        cleanup: None,
+    }
+}

--- a/harness/tests/e2e/src/suite.rs
+++ b/harness/tests/e2e/src/suite.rs
@@ -87,12 +87,12 @@ pub async fn run_suite(config: SuiteRunConfig) -> Result<SuiteRunOutcome> {
                 config.progress_interval,
             )
             .await;
-            let stop = run.status.is_blocking_failure();
+            let stop = run.status.is_technical_failure();
             runs.push(run);
             if stop {
                 tracing::warn!(
                     scenario = scenario_id.as_str(),
-                    "stopping scenario after a blocking failure"
+                    "stopping scenario after a technical failure"
                 );
                 break;
             }
@@ -253,6 +253,9 @@ async fn run_once(
     report.wall_time_ms = started.elapsed().as_millis().min(u64::MAX as u128) as u64;
     if report.failures.is_empty() {
         if report.hard_gates.iter().any(|gate| !gate.passed) {
+            // Judge-backed scenarios skip the judge on a gate failure, leaving no
+            // criterion awards; the run must still enter the aggregate as a score.
+            report.score.get_or_insert(0);
             report.finish(RunStatus::HardGateFailed);
         } else if let Some(score) = report.score {
             report.finish(if score >= spec.threshold {


### PR DESCRIPTION
## Summary

Two related changes to the harness E2E quality suite:

### Hard-gate failures become scored quality results
A hard-gate failure no longer stops the scenario loop or fails the aggregate outright. The run keeps its objective partial credit (zero when every criterion is judge-delegated), enters the aggregate median as a poor score, and shares the two-of-three tolerance already used by score-only failures. Only technical failures (subject/judge/resource/infrastructure) still block further repetitions and fail the aggregate — in the runner and in the dashboard suite verdict (`collect_harness_e2e_benchmarks.py`).

Motivation: in execution [30736657213-1](https://iii-hq.github.io/workers/dev/harness-e2e/execution.html?id=30736657213-1), one hard-gate-failed run (score 45) stopped the scenario at 2 of 3 requested runs and forced the failure, even though there was no execution error. A poor score above an error, whenever no execution error occurred.

### Two new judge-backed scenarios + anchored rubrics
The existing subjective scenarios (`direct_answer`, `security_review`) pin at median 100 — trivial tasks, no discrimination. This adds:

- **`design_tradeoff`** — a contested database-scaling decision with facts pulling in opposite directions and verifiable runway arithmetic in the hidden judge reference. The rubric punishes non-committal "it depends" answers and rewards honest costs of the chosen option plus concrete reversal conditions.
- **`security_triage`** — four Python snippets: two subtly exploitable (absolute-path bypass of an `os.path.join` traversal check; non-constant-time HMAC comparison) and two safe decoys that pattern-match to SQLi/XSS. `false_positive_control` (35 pts) zeroes when a safe snippet is reported as vulnerable — measuring calibration, which the current suite cannot.

Every judge-backed criterion description (new and existing scenarios) now carries explicit full/half/zero score anchors, reducing judge variance.

No CI/workflow changes needed: the scenario matrix comes from `harness-e2e list` dynamically.

## Test plan
- [x] `cargo test -p harness-e2e` — 60/60, registry test validates all 7 specs
- [x] `cargo run -p harness-e2e -- list` includes `design_tradeoff` and `security_triage`
- [x] `cargo clippy -p harness-e2e` clean
- [ ] First daily run: confirm the new scenarios score in a discriminative range

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added design decision and security triage scenarios to end-to-end evaluations.
  * Expanded the scenario suite to seven scenarios.
  * Improved evaluation criteria for security reviews and direct answers.

* **Bug Fixes**
  * Hard-gate failures no longer automatically fail a suite when other scenarios pass.
  * Technical failures remain immediately blocking.
  * Updated scoring and pass-status handling for partial results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Fixes MOT-4305
