### PR TITLE
(MOT-4306) feat(editor): a changes tab that reads agent edits as diffs

### DIFF
--- a/editor/Cargo.lock
+++ b/editor/Cargo.lock
@@ -275,7 +275,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "editor"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/editor/Cargo.toml
+++ b/editor/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "editor"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 publish = false
 

--- a/editor/src/events.rs
+++ b/editor/src/events.rs
@@ -55,6 +55,14 @@ pub struct ChangedEvent {
     /// Workspace root the path is relative to, so a surface that follows the
     /// agent can notice the root moved.
     pub root: String,
+    /// The harness session and turn the write happened in, when it happened
+    /// inside one. This is the only part of the payload that says *who*: the
+    /// function id says which worker performed the write, not who asked for
+    /// it. Absent for a write made outside a turn.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
 }
 
 type Subscribers = Arc<Mutex<HashMap<String, String>>>;
@@ -260,6 +268,8 @@ mod tests {
             patch: String::new(),
             truncated: false,
             root: "/repo".into(),
+            session_id: Some("s_1".into()),
+            turn_id: Some("t_1".into()),
         }
     }
 

--- a/editor/src/observe.rs
+++ b/editor/src/observe.rs
@@ -44,12 +44,23 @@ const HOOK_TIMEOUT_MS: u64 = 3_000;
 const HOOK_ON_ERROR: &str = "fail_open";
 
 /// The subset of the harness hook payload this worker reads.
+///
+/// `session_id` and `turn_id` come from the hook envelope, which is the only
+/// place the identity of the writer exists: the call itself says a file was
+/// written, not who was writing. Carrying them onto the event is what lets a
+/// surface say *this* agent session made *this* change, rather than reporting
+/// an anonymous edit. Both stay optional — a hook fired outside a turn (or by
+/// an operator reproducing one) has no session, and that is not an error.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct HookInput {
     #[serde(default)]
     pub metadata: Option<Value>,
     #[serde(default)]
     pub call: Option<HookCall>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub turn_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -205,6 +216,8 @@ pub fn bind(iii: &Arc<IIIClient>, cfg: &ConfigCell, bus: &Arc<Bus>, emitter: Cha
 
 /// Build and emit the event for one observed call.
 async fn report(bus: &Bus, cfg: &WorkerConfig, emitter: &ChangedEmitter, input: HookInput) {
+    let session_id = input.session_id.clone();
+    let turn_id = input.turn_id.clone();
     let Some(call) = input.call else {
         tracing::debug!("observer: hook fired with no call payload");
         return;
@@ -293,6 +306,8 @@ async fn report(bus: &Bus, cfg: &WorkerConfig, emitter: &ChangedEmitter, input: 
             patch,
             truncated: false,
             root,
+            session_id,
+            turn_id,
         })
         .await;
 }

--- a/editor/ui/package.json
+++ b/editor/ui/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && node build.mjs",
-    "watch": "node build.mjs --watch"
+    "watch": "node build.mjs --watch",
+    "test": "vitest run"
   },
   "dependencies": {
     "@iii-dev/console-ui": "workspace:*",
@@ -14,6 +15,7 @@
   "devDependencies": {
     "@types/react": "^19.2.14",
     "esbuild": "^0.25.0",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "vitest": "^4.1.6"
   }
 }

--- a/editor/ui/src/lib/changes.test.ts
+++ b/editor/ui/src/lib/changes.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import { type ChangeEntry, causeLabel, MAX_ENTRIES, recordChange, relativeAge, seedFromStatus } from './changes'
+import type { ChangedEvent } from './events'
+
+function event(path: string, over: Partial<ChangedEvent> = {}): ChangedEvent {
+  return {
+    path,
+    cause: 'shell::fs::write',
+    kind: 'modified',
+    added: 3,
+    removed: 1,
+    patch: '@@ -1 +1 @@',
+    truncated: false,
+    root: '/repo',
+    ...over,
+  }
+}
+
+describe('recordChange', () => {
+  it('puts the newest change first', () => {
+    let log: ChangeEntry[] = []
+    log = recordChange(log, event('a.ts'), 1_000)
+    log = recordChange(log, event('b.ts'), 2_000)
+    expect(log.map((e) => e.path)).toEqual(['b.ts', 'a.ts'])
+  })
+
+  it('collapses repeats of one path and counts them', () => {
+    let log: ChangeEntry[] = []
+    log = recordChange(log, event('a.ts', { added: 1 }), 1_000)
+    log = recordChange(log, event('b.ts'), 2_000)
+    log = recordChange(log, event('a.ts', { added: 9 }), 3_000)
+    expect(log).toHaveLength(2)
+    expect(log[0]).toMatchObject({ path: 'a.ts', added: 9, count: 2, at: 3_000 })
+    expect(log[1].path).toBe('b.ts')
+  })
+
+  it('is bounded', () => {
+    let log: ChangeEntry[] = []
+    for (let i = 0; i < MAX_ENTRIES + 10; i++) log = recordChange(log, event(`f${i}.ts`), i)
+    expect(log).toHaveLength(MAX_ENTRIES)
+    expect(log[0].path).toBe(`f${MAX_ENTRIES + 9}.ts`)
+  })
+})
+
+describe('seedFromStatus', () => {
+  it('adds working-tree paths with no timestamp', () => {
+    const log = seedFromStatus([], [{ path: 'a.ts', index: ' ', worktree: 'M' }])
+    expect(log).toEqual([expect.objectContaining({ path: 'a.ts', kind: 'modified', at: null, count: 0, cause: 'git' })])
+  })
+
+  it('never overwrites a path that has a real event', () => {
+    const live = recordChange([], event('a.ts'), 1_000)
+    const log = seedFromStatus(live, [{ path: 'a.ts', index: ' ', worktree: 'M' }])
+    expect(log).toHaveLength(1)
+    expect(log[0].at).toBe(1_000)
+  })
+
+  it('maps status codes to change kinds', () => {
+    const rows = seedFromStatus(
+      [],
+      [
+        { path: 'new.ts', index: '?', worktree: '?' },
+        { path: 'gone.ts', index: ' ', worktree: 'D' },
+        { path: 'moved.ts', index: 'R', worktree: ' ' },
+      ],
+    )
+    expect(rows.map((r) => r.kind)).toEqual(['created', 'deleted', 'moved'])
+  })
+})
+
+describe('causeLabel', () => {
+  it('names the surface that performed the write', () => {
+    expect(causeLabel('shell::fs::write')).toBe('shell')
+    expect(causeLabel('editor::save')).toBe('editor')
+    expect(causeLabel('git')).toBe('working tree')
+    expect(causeLabel('')).toBe('unknown')
+  })
+})
+
+describe('relativeAge', () => {
+  it('reads as recency', () => {
+    expect(relativeAge(null, 10_000)).toBe('earlier')
+    expect(relativeAge(9_000, 10_000)).toBe('now')
+    expect(relativeAge(0, 30_000)).toBe('30s')
+    expect(relativeAge(0, 120_000)).toBe('2m')
+    expect(relativeAge(0, 7_200_000)).toBe('2h')
+  })
+})

--- a/editor/ui/src/lib/changes.test.ts
+++ b/editor/ui/src/lib/changes.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from 'vitest'
-import { type ChangeEntry, causeLabel, MAX_ENTRIES, recordChange, relativeAge, seedFromStatus } from './changes'
+import {
+  type ChangeEntry,
+  causeLabel,
+  groupByTurn,
+  groupLabel,
+  MAX_ENTRIES,
+  recordChange,
+  relativeAge,
+  seedFromStatus,
+  splitPath,
+} from './changes'
 import type { ChangedEvent } from './events'
 
 function event(path: string, over: Partial<ChangedEvent> = {}): ChangedEvent {
@@ -84,6 +94,60 @@ describe('relativeAge', () => {
     expect(relativeAge(0, 30_000)).toBe('30s')
     expect(relativeAge(0, 120_000)).toBe('2m')
     expect(relativeAge(0, 7_200_000)).toBe('2h')
+  })
+})
+
+describe('groupByTurn', () => {
+  it('folds one turn touching several files into one run', () => {
+    let log: ChangeEntry[] = []
+    log = recordChange(log, event('a.ts', { session_id: 's_1', turn_id: 't_1' }), 1)
+    log = recordChange(log, event('b.ts', { session_id: 's_1', turn_id: 't_1', added: 5 }), 2)
+    const groups = groupByTurn(log)
+    expect(groups).toHaveLength(1)
+    expect(groups[0].entries.map((e) => e.path)).toEqual(['b.ts', 'a.ts'])
+    expect(groups[0].added).toBe(8)
+    expect(groups[0].removed).toBe(2)
+  })
+
+  it('keeps separate turns apart', () => {
+    let log: ChangeEntry[] = []
+    log = recordChange(log, event('a.ts', { turn_id: 't_1' }), 1)
+    log = recordChange(log, event('b.ts', { turn_id: 't_2' }), 2)
+    expect(groupByTurn(log)).toHaveLength(2)
+  })
+
+  it('does not merge a turn with itself across an interruption', () => {
+    // The feed is a timeline: a turn that wrote, was interrupted, then wrote
+    // again really did happen twice, and collapsing that would claim an order
+    // that never occurred.
+    let log: ChangeEntry[] = []
+    log = recordChange(log, event('a.ts', { turn_id: 't_1' }), 1)
+    log = recordChange(log, event('b.ts', { turn_id: 't_2' }), 2)
+    log = recordChange(log, event('c.ts', { turn_id: 't_1' }), 3)
+    const groups = groupByTurn(log)
+    expect(groups).toHaveLength(3)
+    expect(groups.map((g) => g.key.split('#')[0])).toEqual(['t_1', 't_2', 't_1'])
+  })
+
+  it('groups turn-less changes by their cause', () => {
+    let log: ChangeEntry[] = []
+    log = recordChange(log, event('a.ts', { cause: 'editor::save' }), 1)
+    log = recordChange(log, event('b.ts', { cause: 'editor::save' }), 2)
+    const groups = groupByTurn(log)
+    expect(groups).toHaveLength(1)
+    expect(groupLabel(groups[0])).toBe('editor')
+  })
+
+  it('names a run by its agent session when there is one', () => {
+    const log = recordChange([], event('a.ts', { session_id: 's_abcdef12', turn_id: 't_1' }), 1)
+    expect(groupLabel(groupByTurn(log)[0])).toBe('agent abcdef')
+  })
+})
+
+describe('splitPath', () => {
+  it('separates the folder from the name', () => {
+    expect(splitPath('src/lib/api.ts')).toEqual({ dir: 'src/lib/', name: 'api.ts' })
+    expect(splitPath('README.md')).toEqual({ dir: '', name: 'README.md' })
   })
 })
 

--- a/editor/ui/src/lib/changes.test.ts
+++ b/editor/ui/src/lib/changes.test.ts
@@ -86,3 +86,20 @@ describe('relativeAge', () => {
     expect(relativeAge(0, 7_200_000)).toBe('2h')
   })
 })
+
+describe('session provenance', () => {
+  it('carries the session and turn from the event', () => {
+    const log = recordChange([], event('a.ts', { session_id: 's_abc', turn_id: 't_1' }), 1_000)
+    expect(log[0]).toMatchObject({ sessionId: 's_abc', turnId: 't_1' })
+  })
+
+  it('leaves them unset for a write made outside a turn', () => {
+    const log = recordChange([], event('a.ts'), 1_000)
+    expect(log[0].sessionId).toBeUndefined()
+  })
+
+  it('keeps the patch, which is what the diff view reads', () => {
+    const log = recordChange([], event('a.ts', { patch: '@@ -1 +1 @@\n-old\n+new' }), 1_000)
+    expect(log[0].patch).toContain('+new')
+  })
+})

--- a/editor/ui/src/lib/changes.ts
+++ b/editor/ui/src/lib/changes.ts
@@ -36,6 +36,9 @@ export interface ChangeEntry {
   /** How many events collapsed into this row. A save loop writes one file many
    *  times; showing that as forty rows buries every other change. */
   count: number
+  /** The harness session the write happened in, when it happened inside one. */
+  sessionId?: string
+  turnId?: string
 }
 
 /** Newest first, one row per path, bounded. */
@@ -60,6 +63,8 @@ export function recordChange(log: ChangeEntry[], event: ChangedEvent, now: numbe
     truncated: event.truncated,
     at: now,
     count: (previous?.count ?? 0) + 1,
+    sessionId: event.session_id,
+    turnId: event.turn_id,
   }
   return [next, ...log.filter((entry) => entry.path !== event.path)].slice(0, MAX_ENTRIES)
 }

--- a/editor/ui/src/lib/changes.ts
+++ b/editor/ui/src/lib/changes.ts
@@ -121,6 +121,78 @@ export function causeLabel(cause: string): string {
   return worker
 }
 
+/**
+ * A run of changes that belong together: one turn's work on several files.
+ *
+ * An agent turn that touches six files is one thing that happened, not six.
+ * Read as a flat list it buries whatever else changed; read as a group it says
+ * "this turn rewrote these six files, net +40 -12" at a glance, and the files
+ * are still one click away.
+ */
+export interface ChangeGroup {
+  /** Stable per run, so React keys survive a re-render. */
+  key: string
+  sessionId?: string
+  turnId?: string
+  entries: ChangeEntry[]
+  added: number
+  removed: number
+  /** Newest change in the run, for the group's age. */
+  at: number | null
+}
+
+/**
+ * Fold the feed into runs.
+ *
+ * Grouping is by *adjacency*, not by collecting every entry of a turn wherever
+ * it sits: the feed is a timeline, and a turn that writes, waits, then writes
+ * again really did happen twice. Pulling those together would claim an order
+ * that did not happen. Entries with no turn — a local edit, a working-tree
+ * seed — group by their cause instead, so hand edits do not merge into an
+ * agent's run.
+ */
+export function groupByTurn(log: ChangeEntry[]): ChangeGroup[] {
+  const groups: ChangeGroup[] = []
+  // Run identity and React key are different things: a turn that writes twice
+  // with something in between is two runs, so the key needs an index while the
+  // adjacency test must compare the bare run id.
+  let openRun: string | null = null
+  for (const entry of log) {
+    const run = entry.turnId ?? entry.sessionId ?? `cause:${entry.cause}`
+    const open = groups[groups.length - 1]
+    if (open && openRun === run) {
+      open.entries.push(entry)
+      open.added += entry.added
+      open.removed += entry.removed
+      continue
+    }
+    openRun = run
+    groups.push({
+      key: `${run}#${groups.length}`,
+      sessionId: entry.sessionId,
+      turnId: entry.turnId,
+      entries: [entry],
+      added: entry.added,
+      removed: entry.removed,
+      at: entry.at,
+    })
+  }
+  return groups
+}
+
+/** How a run of changes names itself: the agent's session, or the surface. */
+export function groupLabel(group: ChangeGroup): string {
+  if (group.sessionId) return `agent ${group.sessionId.replace(/^s_/, '').slice(0, 6)}`
+  return causeLabel(group.entries[0]?.cause ?? '')
+}
+
+/** `dir/` and `name` split, so a narrow row can keep the name and drop the path. */
+export function splitPath(path: string): { dir: string; name: string } {
+  const cut = path.lastIndexOf('/')
+  if (cut === -1) return { dir: '', name: path }
+  return { dir: path.slice(0, cut + 1), name: path.slice(cut + 1) }
+}
+
 /** Compact relative age: the feed is about recency, not timestamps. */
 export function relativeAge(at: number | null, now: number): string {
   if (at === null) return 'earlier'

--- a/editor/ui/src/lib/changes.ts
+++ b/editor/ui/src/lib/changes.ts
@@ -1,0 +1,128 @@
+/**
+ * The recent-changes feed.
+ *
+ * The worker already emits `editor::changed` for every file change however it
+ * was made — an agent writing through `shell`, a save through this worker, or
+ * an edit made by anything else the shell observer sees. The page was throwing
+ * those events away after flashing a tree row, so "what just changed, and what
+ * did it do" had no answer short of reading the tree and guessing.
+ *
+ * This is the model behind that answer, and it is deliberately pure: the
+ * collapse rule and the ordering are the parts that are easy to get wrong, and
+ * they should be testable without an engine or a browser.
+ *
+ * Nothing here is persisted. The feed is what happened while you were looking;
+ * the durable record of a change is the file and its git history.
+ */
+
+import type { ChangedEvent } from './events'
+
+/** One row of the feed: the latest change to one path. */
+export interface ChangeEntry {
+  path: string
+  /** Function id that produced the change, e.g. `shell::fs::write`. */
+  cause: string
+  kind: string
+  added: number
+  removed: number
+  /** Inline patch from the event, already truncated by the worker. Empty when
+   *  there was no previous content to compare against. */
+  patch: string
+  truncated: boolean
+  /** Client clock when the event arrived, or `null` for an entry seeded from
+   *  the working tree — that change happened before the page was watching and
+   *  claiming a time for it would be a lie. */
+  at: number | null
+  /** How many events collapsed into this row. A save loop writes one file many
+   *  times; showing that as forty rows buries every other change. */
+  count: number
+}
+
+/** Newest first, one row per path, bounded. */
+export const MAX_ENTRIES = 50
+
+/**
+ * Fold one event into the feed.
+ *
+ * Same path collapses: the row keeps its place at the front, takes the newest
+ * event's facts, and counts the repeat. A file touched twice is one thing that
+ * changed twice, not two things.
+ */
+export function recordChange(log: ChangeEntry[], event: ChangedEvent, now: number): ChangeEntry[] {
+  const previous = log.find((entry) => entry.path === event.path)
+  const next: ChangeEntry = {
+    path: event.path,
+    cause: event.cause,
+    kind: event.kind,
+    added: event.added,
+    removed: event.removed,
+    patch: event.patch,
+    truncated: event.truncated,
+    at: now,
+    count: (previous?.count ?? 0) + 1,
+  }
+  return [next, ...log.filter((entry) => entry.path !== event.path)].slice(0, MAX_ENTRIES)
+}
+
+/**
+ * Rows for the working tree, for changes that predate the page.
+ *
+ * Seeding only fills gaps: a path already in the feed has a real event behind
+ * it, which is strictly better information than a status code.
+ */
+export function seedFromStatus(
+  log: ChangeEntry[],
+  entries: { path: string; index: string; worktree: string }[],
+): ChangeEntry[] {
+  const known = new Set(log.map((entry) => entry.path))
+  const seeded = entries
+    .filter((entry) => !known.has(entry.path))
+    .map<ChangeEntry>((entry) => ({
+      path: entry.path,
+      cause: 'git',
+      kind: statusKind(entry),
+      added: 0,
+      removed: 0,
+      patch: '',
+      truncated: false,
+      at: null,
+      count: 0,
+    }))
+  return [...log, ...seeded].slice(0, MAX_ENTRIES)
+}
+
+/** The change kind a git status pair describes. */
+function statusKind(entry: { index: string; worktree: string }): string {
+  const codes = `${entry.index}${entry.worktree}`
+  if (codes.includes('?')) return 'created'
+  if (codes.includes('A')) return 'created'
+  if (codes.includes('D')) return 'deleted'
+  if (codes.includes('R')) return 'moved'
+  return 'modified'
+}
+
+/**
+ * Where a change came from, named by surface rather than by actor.
+ *
+ * The event carries a function id, which says which worker performed the
+ * write — not who asked for it. An agent turn and a person can both reach
+ * `editor::save`, so labelling one of them "agent" would be a guess presented
+ * as a fact. The surface is what the payload actually knows.
+ */
+export function causeLabel(cause: string): string {
+  const worker = String(cause || '').split('::')[0]
+  if (!worker) return 'unknown'
+  if (worker === 'git') return 'working tree'
+  return worker
+}
+
+/** Compact relative age: the feed is about recency, not timestamps. */
+export function relativeAge(at: number | null, now: number): string {
+  if (at === null) return 'earlier'
+  const seconds = Math.max(0, Math.round((now - at) / 1000))
+  if (seconds < 5) return 'now'
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return `${minutes}m`
+  return `${Math.round(minutes / 60)}h`
+}

--- a/editor/ui/src/lib/events.ts
+++ b/editor/ui/src/lib/events.ts
@@ -42,6 +42,11 @@ export interface ChangedEvent {
   patch: string
   truncated: boolean
   root: string
+  /** The harness session and turn the write happened in. Absent for a write
+   *  made outside a turn. This is the only part of the payload that says who
+   *  was writing; `cause` says which worker performed it. */
+  session_id?: string
+  turn_id?: string
 }
 
 type Listener<T> = (event: T) => void

--- a/editor/ui/src/page/index.tsx
+++ b/editor/ui/src/page/index.tsx
@@ -158,7 +158,7 @@ export function EditorPage({ host }: { host: Host }) {
   const [activePath, setActivePath] = useState<string | null>(null)
   // Reading is the default: opening a file should show you the file, not put
   // a cursor in it.
-  const [view, setView] = useState<'read' | 'edit' | 'preview' | 'diff' | 'git'>('read')
+  const [view, setView] = useState<'read' | 'edit' | 'preview' | 'diff' | 'git' | 'change'>('read')
   const [mode, setMode] = useState<'files' | 'search' | 'changes'>('files')
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<string[]>([])
@@ -180,6 +180,10 @@ export function EditorPage({ host }: { host: Host }) {
   /** Re-rendered on a slow tick so the relative ages in the feed stay honest
    *  without every row holding its own timer. */
   const [changeClock, setChangeClock] = useState(() => 0)
+  /** The feed row being read as a diff. The patch travels on the event, so
+   *  this renders without a round trip and keeps showing what that write did
+   *  even after the file moves on. */
+  const [openChangeEntry, setOpenChangeEntry] = useState<ChangeEntry | null>(null)
 
   // Read inside a refresh without making it a dependency — rebuilding the
   // refresh callbacks on every keystroke would re-run the effects that bind
@@ -577,6 +581,21 @@ export function EditorPage({ host }: { host: Host }) {
    */
   const openChange = useCallback(
     async (entry: ChangeEntry) => {
+      setOpenChangeEntry(entry)
+      // The patch the event carried is the diff of that write, so a change
+      // stays readable even after the file is committed, reverted or written
+      // again — which the working-tree diff cannot do. A seeded row has no
+      // patch of its own; for those the git view is the honest answer.
+      if (entry.patch.trim() !== '') {
+        // Opening the file alongside is what makes the tab a way into the
+        // workspace rather than a dead end, but a deleted file cannot be
+        // opened and its diff is the only thing left of it. The view is set
+        // *after* the open, because opening a file selects its reader — doing
+        // it first would have this land on the file rather than the diff.
+        if (entry.kind !== 'deleted') await openPath(entry.path)
+        setView('change')
+        return
+      }
       if (entry.kind === 'deleted') {
         setError(`${entry.path} was deleted`)
         return
@@ -837,10 +856,16 @@ export function EditorPage({ host }: { host: Host }) {
                         <button
                           type="button"
                           className="ed-row ed-change"
-                          data-active={entry.path === activePath}
+                          data-active={entry.path === openChangeEntry?.path}
                           data-fresh={flashed[entry.path] !== undefined}
                           onClick={() => void openChange(entry)}
-                          title={`${entry.kind} by ${entry.cause || 'unknown'}`}
+                          title={[
+                            `${entry.kind} via ${entry.cause || 'unknown'}`,
+                            entry.sessionId && `session ${entry.sessionId}`,
+                            entry.turnId && `turn ${entry.turnId}`,
+                          ]
+                            .filter(Boolean)
+                            .join('\n')}
                         >
                           <span className="ed-name">{entry.path}</span>
                           <span className="ed-change-meta">
@@ -850,7 +875,11 @@ export function EditorPage({ host }: { host: Host }) {
                                 <span className="ed-del">−{entry.removed}</span>{' '}
                               </>
                             )}
-                            <span className="ed-change-by">{causeLabel(entry.cause)}</span>{' '}
+                            <span className="ed-change-by">
+                              {entry.sessionId
+                                ? `agent ${entry.sessionId.replace(/^s_/, '').slice(0, 6)}`
+                                : causeLabel(entry.cause)}
+                            </span>{' '}
                             <span className="ed-change-age">{relativeAge(entry.at, changeClock)}</span>
                             {entry.count > 1 && <span className="ed-count">{entry.count}</span>}
                           </span>
@@ -943,7 +972,19 @@ export function EditorPage({ host }: { host: Host }) {
         )}
 
         <section className="ed-main">
-          {buffers.length === 0 ? (
+          {/* A change being read as a diff owns the pane: it can outlive the
+              file (a delete leaves no buffer to open) and it is the whole
+              point of selecting the row. */}
+          {view === 'change' && openChangeEntry ? (
+            <ChangeCard
+              entry={openChangeEntry}
+              themeType={themeType}
+              onClose={() => {
+                setOpenChangeEntry(null)
+                setView('read')
+              }}
+            />
+          ) : buffers.length === 0 ? (
             <EmptyState
               title="No file open"
               description="Pick a file from the tree, or search for one. Files an agent opens appear here too."
@@ -1225,6 +1266,58 @@ function FileView({ path, contents, themeType }: { path: string; contents: strin
  * from the prefix and its position, which is what keeps pierre from re-reading
  * an unchanged hunk on each render.
  */
+/**
+ * One change, read as the diff it was.
+ *
+ * The patch travels on the event, so this renders with no round trip and keeps
+ * showing what a write did after the file has moved on — committed, reverted,
+ * or written again. That is the difference between this and the git view,
+ * which can only ever show the working tree as it is now.
+ *
+ * The header is the provenance the payload actually knows: which worker
+ * performed the write, and the harness session and turn it happened in when it
+ * happened inside one.
+ */
+function ChangeCard({
+  entry,
+  themeType,
+  onClose,
+}: {
+  entry: ChangeEntry
+  themeType: 'light' | 'dark'
+  onClose: () => void
+}) {
+  return (
+    <>
+      <div className="ed-bar">
+        <span className="ed-change-title" title={entry.path}>
+          {entry.path}
+        </span>
+        <Badge variant={entry.kind === 'deleted' ? 'warn' : 'default'}>{entry.kind}</Badge>
+        {(entry.added > 0 || entry.removed > 0) && (
+          <span>
+            <span className="ed-add">+{entry.added}</span> <span className="ed-del">−{entry.removed}</span>
+          </span>
+        )}
+        <span className="ed-change-by">{causeLabel(entry.cause)}</span>
+        {entry.sessionId && (
+          <span className="ed-change-session" title={entry.turnId ? `turn ${entry.turnId}` : entry.sessionId}>
+            session {entry.sessionId.replace(/^s_/, '').slice(0, 8)}
+          </span>
+        )}
+        <span className="ed-bar-spacer" />
+        <Button onClick={onClose}>close</Button>
+      </div>
+      {entry.truncated && (
+        <div className="ed-warn">
+          The change was larger than the preview the event carries, so only its beginning is shown.
+        </div>
+      )}
+      <PatchView patch={entry.patch} themeType={themeType} />
+    </>
+  )
+}
+
 function PatchView({ patch, themeType }: { patch: string; themeType: 'light' | 'dark' }) {
   const files = useMemo(
     () => (patch.trim() === '' ? [] : parsePatchFiles(patch, `p${contentHash(patch)}`).flatMap((p) => p.files)),

--- a/editor/ui/src/page/index.tsx
+++ b/editor/ui/src/page/index.tsx
@@ -67,11 +67,28 @@ import {
   visibleRows,
 } from '../lib/api'
 import { contentHash } from '../lib/cache-key'
-import { type ChangeEntry, causeLabel, recordChange, relativeAge, seedFromStatus } from '../lib/changes'
+import {
+  type ChangeEntry,
+  causeLabel,
+  groupByTurn,
+  groupLabel,
+  recordChange,
+  relativeAge,
+  seedFromStatus,
+  splitPath,
+} from '../lib/changes'
 import { type ChangedEvent, useWorkspaceEvents } from '../lib/events'
 
 /** How long a row keeps its "just changed" accent after an edit lands. */
 const FLASH_MS = 12_000
+
+/** Single-letter change marks, the way a status column reads them. */
+const KIND_MARK: Record<string, string> = {
+  created: 'A',
+  deleted: 'D',
+  moved: 'R',
+  modified: 'M',
+}
 
 /**
  * Trailing-edge window for folding pushed events into one refresh, in ms.
@@ -579,31 +596,55 @@ export function EditorPage({ host }: { host: Host }) {
    * has unsaved edits. Without a repository there is nothing to diff against,
    * so the file itself is the answer.
    */
+  /**
+   * Find a patch to show for a row that arrived without one.
+   *
+   * A seeded row knows a file is dirty and nothing else. Falling through to
+   * the git view for those was the wrong answer twice over: an untracked file
+   * has no HEAD to diff against, so the pane said "no changes" about a file
+   * that is entirely new. Ask git first, and when git has nothing to say
+   * because the file is new, diff it against empty — the whole file *is* the
+   * change. This is the same ladder the worker's observer walks.
+   */
+  const resolvePatch = useCallback(
+    async (entry: ChangeEntry): Promise<string> => {
+      if (entry.patch.trim() !== '') return entry.patch
+      try {
+        const hunks = await api.hunks(entry.path)
+        if (hunks.patch.trim() !== '') return hunks.patch
+      } catch {
+        // Not a repo, or a path git does not track. The file itself is next.
+      }
+      try {
+        const file = await api.open(entry.path)
+        const whole = await api.diff('', file.content, entry.path)
+        return whole.patch
+      } catch {
+        return ''
+      }
+    },
+    [api],
+  )
+
   const openChange = useCallback(
     async (entry: ChangeEntry) => {
-      setOpenChangeEntry(entry)
       // The patch the event carried is the diff of that write, so a change
       // stays readable even after the file is committed, reverted or written
-      // again — which the working-tree diff cannot do. A seeded row has no
-      // patch of its own; for those the git view is the honest answer.
-      if (entry.patch.trim() !== '') {
-        // Opening the file alongside is what makes the tab a way into the
-        // workspace rather than a dead end, but a deleted file cannot be
-        // opened and its diff is the only thing left of it. The view is set
-        // *after* the open, because opening a file selects its reader — doing
-        // it first would have this land on the file rather than the diff.
-        if (entry.kind !== 'deleted') await openPath(entry.path)
-        setView('change')
-        return
+      // again — which the working-tree diff cannot do.
+      setOpenChangeEntry({ ...entry, patch: entry.patch })
+      // Opening the file alongside is what makes the feed a way into the
+      // workspace rather than a dead end. A deleted file cannot be opened and
+      // its diff is the only thing left of it. The view is set *after* the
+      // open, because opening a file selects its reader — doing it first would
+      // land on the file rather than the diff.
+      if (entry.kind !== 'deleted') await openPath(entry.path)
+      setView('change')
+      if (entry.patch.trim() === '') {
+        const patch = await resolvePatch(entry)
+        setOpenChangeEntry((current) => (current && current.path === entry.path ? { ...current, patch } : current))
       }
-      if (entry.kind === 'deleted') {
-        setError(`${entry.path} was deleted`)
-        return
-      }
-      await openPath(entry.path)
-      setView(noRepo ? 'read' : 'git')
     },
-    [openPath, noRepo],
+    [openPath, resolvePatch],
   )
 
   useEffect(() => {
@@ -763,6 +804,8 @@ export function EditorPage({ host }: { host: Host }) {
 
   const rows = useMemo(() => (treeRoot ? visibleRows(treeRoot, expanded) : []), [treeRoot, expanded])
 
+  const changeGroups = useMemo(() => groupByTurn(changeLog), [changeLog])
+
   const lineCount = activeDraft ? activeDraft.draft.split('\n').length : 0
 
   return (
@@ -851,39 +894,67 @@ export function EditorPage({ host }: { host: Host }) {
                   </div>
                 ) : (
                   <ul className="ed-list">
-                    {changeLog.map((entry) => (
-                      <li key={entry.path}>
-                        <button
-                          type="button"
-                          className="ed-row ed-change"
-                          data-active={entry.path === openChangeEntry?.path}
-                          data-fresh={flashed[entry.path] !== undefined}
-                          onClick={() => void openChange(entry)}
-                          title={[
-                            `${entry.kind} via ${entry.cause || 'unknown'}`,
-                            entry.sessionId && `session ${entry.sessionId}`,
-                            entry.turnId && `turn ${entry.turnId}`,
-                          ]
-                            .filter(Boolean)
-                            .join('\n')}
-                        >
-                          <span className="ed-name">{entry.path}</span>
-                          <span className="ed-change-meta">
-                            {(entry.added > 0 || entry.removed > 0) && (
-                              <>
-                                <span className="ed-add">+{entry.added}</span>{' '}
-                                <span className="ed-del">−{entry.removed}</span>{' '}
-                              </>
-                            )}
-                            <span className="ed-change-by">
-                              {entry.sessionId
-                                ? `agent ${entry.sessionId.replace(/^s_/, '').slice(0, 6)}`
-                                : causeLabel(entry.cause)}
-                            </span>{' '}
-                            <span className="ed-change-age">{relativeAge(entry.at, changeClock)}</span>
-                            {entry.count > 1 && <span className="ed-count">{entry.count}</span>}
+                    {changeGroups.map((group) => (
+                      <li key={group.key}>
+                        {/* One turn's work reads as one thing: the header is
+                            the summary, the rows under it are the detail. */}
+                        <div className="ed-group">
+                          <span className="ed-change-by">{groupLabel(group)}</span>
+                          <span className="ed-group-files">
+                            {group.entries.length} file{group.entries.length === 1 ? '' : 's'}
                           </span>
-                        </button>
+                          {(group.added > 0 || group.removed > 0) && (
+                            <span>
+                              <span className="ed-add">+{group.added}</span>{' '}
+                              <span className="ed-del">-{group.removed}</span>
+                            </span>
+                          )}
+                          <span className="ed-change-age">{relativeAge(group.at, changeClock)}</span>
+                        </div>
+                        <ul className="ed-list">
+                          {group.entries.map((entry) => {
+                            const split = splitPath(entry.path)
+                            return (
+                              <li key={entry.path}>
+                                <button
+                                  type="button"
+                                  className="ed-row ed-change"
+                                  data-active={entry.path === openChangeEntry?.path}
+                                  data-fresh={flashed[entry.path] !== undefined}
+                                  onClick={() => void openChange(entry)}
+                                  title={[
+                                    entry.path,
+                                    `${entry.kind} via ${entry.cause || 'unknown'}`,
+                                    entry.sessionId && `session ${entry.sessionId}`,
+                                    entry.turnId && `turn ${entry.turnId}`,
+                                  ]
+                                    .filter(Boolean)
+                                    .join('\n')}
+                                >
+                                  {/* The name identifies the row, so it is the
+                                      part that survives a narrow pane; the
+                                      folder gives way first. */}
+                                  <span className="ed-change-path">
+                                    {split.dir && <span className="ed-change-dir">{split.dir}</span>}
+                                    <span className="ed-change-name">{split.name}</span>
+                                  </span>
+                                  <span className="ed-change-meta">
+                                    <span className="ed-change-kind" data-kind={entry.kind}>
+                                      {KIND_MARK[entry.kind] ?? 'M'}
+                                    </span>
+                                    {(entry.added > 0 || entry.removed > 0) && (
+                                      <>
+                                        <span className="ed-add">+{entry.added}</span>
+                                        <span className="ed-del">-{entry.removed}</span>
+                                      </>
+                                    )}
+                                    {entry.count > 1 && <span className="ed-count">x{entry.count}</span>}
+                                  </span>
+                                </button>
+                              </li>
+                            )
+                          })}
+                        </ul>
                       </li>
                     ))}
                   </ul>

--- a/editor/ui/src/page/index.tsx
+++ b/editor/ui/src/page/index.tsx
@@ -67,6 +67,7 @@ import {
   visibleRows,
 } from '../lib/api'
 import { contentHash } from '../lib/cache-key'
+import { type ChangeEntry, causeLabel, recordChange, relativeAge, seedFromStatus } from '../lib/changes'
 import { type ChangedEvent, useWorkspaceEvents } from '../lib/events'
 
 /** How long a row keeps its "just changed" accent after an edit lands. */
@@ -158,7 +159,7 @@ export function EditorPage({ host }: { host: Host }) {
   // Reading is the default: opening a file should show you the file, not put
   // a cursor in it.
   const [view, setView] = useState<'read' | 'edit' | 'preview' | 'diff' | 'git'>('read')
-  const [mode, setMode] = useState<'files' | 'search'>('files')
+  const [mode, setMode] = useState<'files' | 'search' | 'changes'>('files')
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<string[]>([])
   const [searchResult, setSearchResult] = useState<SearchResult | null>(null)
@@ -172,6 +173,13 @@ export function EditorPage({ host }: { host: Host }) {
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [lastChange, setLastChange] = useState<ChangedEvent | null>(null)
+  /** The recent-changes feed. Live only: what happened while this page was
+   *  open, plus a working-tree seed the first time the tab is looked at. */
+  const [changeLog, setChangeLog] = useState<ChangeEntry[]>([])
+  const [changesSeeded, setChangesSeeded] = useState(false)
+  /** Re-rendered on a slow tick so the relative ages in the feed stay honest
+   *  without every row holding its own timer. */
+  const [changeClock, setChangeClock] = useState(() => 0)
 
   // Read inside a refresh without making it a dependency — rebuilding the
   // refresh callbacks on every keystroke would re-run the effects that bind
@@ -526,11 +534,57 @@ export function EditorPage({ host }: { host: Host }) {
   useEffect(
     () =>
       onChanged((event: ChangedEvent) => {
-        setFlashed((prev) => ({ ...prev, [event.path]: Date.now() }))
+        const now = Date.now()
+        setFlashed((prev) => ({ ...prev, [event.path]: now }))
         setLastChange(event)
+        setChangeLog((prev) => recordChange(prev, event, now))
+        setChangeClock(now)
         schedule(event.path, true)
       }),
     [onChanged, schedule],
+  )
+
+  /**
+   * Seed the feed from the working tree the first time it is looked at.
+   *
+   * Changes made before this page existed are still changes worth seeing, and
+   * asking git for them on mount would cost a status call for a tab most
+   * sessions never open. Outside a repository there is nothing to seed and the
+   * feed is simply live-only, which is what `noRepo` already means everywhere
+   * else on this page.
+   */
+  useEffect(() => {
+    if (mode !== 'changes' || changesSeeded) return
+    setChangesSeeded(true)
+    if (noRepo) return
+    setChangeLog((prev) => seedFromStatus(prev, status?.entries ?? []))
+  }, [mode, changesSeeded, noRepo, status])
+
+  /** Tick the ages while the feed is on screen, and only then. */
+  useEffect(() => {
+    if (mode !== 'changes') return
+    const id = setInterval(() => setChangeClock(Date.now()), 15_000)
+    return () => clearInterval(id)
+  }, [mode])
+
+  /**
+   * Open the file a feed row names, on the view that shows what changed.
+   *
+   * In a repository the git view is the honest answer — it diffs the working
+   * tree against HEAD, so it shows the agent's write whether or not this page
+   * has unsaved edits. Without a repository there is nothing to diff against,
+   * so the file itself is the answer.
+   */
+  const openChange = useCallback(
+    async (entry: ChangeEntry) => {
+      if (entry.kind === 'deleted') {
+        setError(`${entry.path} was deleted`)
+        return
+      }
+      await openPath(entry.path)
+      setView(noRepo ? 'read' : 'git')
+    },
+    [openPath, noRepo],
   )
 
   useEffect(() => {
@@ -749,21 +803,63 @@ export function EditorPage({ host }: { host: Host }) {
               <button type="button" data-active={mode === 'search'} onClick={() => setMode('search')}>
                 search
               </button>
+              <button type="button" data-active={mode === 'changes'} onClick={() => setMode('changes')}>
+                changes
+                {changeLog.length > 0 && <span className="ed-count">{changeLog.length}</span>}
+              </button>
             </div>
 
-            <Input
-              value={query}
-              onChange={setQuery}
-              placeholder={mode === 'files' ? 'find a file…' : 'search contents…'}
-              aria-label={mode === 'files' ? 'Find a file' : 'Search file contents'}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && mode === 'search') void runSearch()
-              }}
-              preserveCase
-            />
+            {/* The feed is not searched: it is short by construction, and a
+                box that filters two of three tabs is a box that lies. */}
+            {mode !== 'changes' && (
+              <Input
+                value={query}
+                onChange={setQuery}
+                placeholder={mode === 'files' ? 'find a file…' : 'search contents…'}
+                aria-label={mode === 'files' ? 'Find a file' : 'Search file contents'}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && mode === 'search') void runSearch()
+                }}
+                preserveCase
+              />
+            )}
 
             <div className="ed-scroll">
-              {mode === 'search' ? (
+              {mode === 'changes' ? (
+                changeLog.length === 0 ? (
+                  <div className="ed-hint">
+                    nothing yet — file changes appear here as they happen, whoever makes them
+                  </div>
+                ) : (
+                  <ul className="ed-list">
+                    {changeLog.map((entry) => (
+                      <li key={entry.path}>
+                        <button
+                          type="button"
+                          className="ed-row ed-change"
+                          data-active={entry.path === activePath}
+                          data-fresh={flashed[entry.path] !== undefined}
+                          onClick={() => void openChange(entry)}
+                          title={`${entry.kind} by ${entry.cause || 'unknown'}`}
+                        >
+                          <span className="ed-name">{entry.path}</span>
+                          <span className="ed-change-meta">
+                            {(entry.added > 0 || entry.removed > 0) && (
+                              <>
+                                <span className="ed-add">+{entry.added}</span>{' '}
+                                <span className="ed-del">−{entry.removed}</span>{' '}
+                              </>
+                            )}
+                            <span className="ed-change-by">{causeLabel(entry.cause)}</span>{' '}
+                            <span className="ed-change-age">{relativeAge(entry.at, changeClock)}</span>
+                            {entry.count > 1 && <span className="ed-count">{entry.count}</span>}
+                          </span>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )
+              ) : mode === 'search' ? (
                 searchResult === null ? (
                   <div className="ed-hint">enter to search contents</div>
                 ) : searchResult.files.length === 0 ? (

--- a/editor/ui/styles.css
+++ b/editor/ui/styles.css
@@ -280,6 +280,26 @@
   color: var(--color-ink-ghost);
 }
 
+/* The diff card's header: the path takes the room, provenance sits after it,
+   and the close button is pushed to the far end by the spacer. */
+[data-iii-ui='editor'] .ed-change-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+
+[data-iii-ui='editor'] .ed-change-session {
+  color: var(--color-ink-faint);
+  font-size: 10.5px;
+}
+
+[data-iii-ui='editor'] .ed-bar-spacer {
+  flex: 1;
+}
+
 /* ------------------------------------------------------------------ tabs */
 
 [data-iii-ui='editor'] .ed-tabs {

--- a/editor/ui/styles.css
+++ b/editor/ui/styles.css
@@ -276,6 +276,60 @@
   color: var(--color-ink-faint);
 }
 
+/* A run's header. Sticky so the run a file belongs to stays legible while its
+   files scroll — the summary is the point, not decoration. */
+[data-iii-ui='editor'] .ed-group {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 6px 6px 3px;
+  background: var(--color-bg);
+  font-size: 10.5px;
+  letter-spacing: 0.03em;
+}
+
+[data-iii-ui='editor'] .ed-group-files {
+  color: var(--color-ink-ghost);
+}
+
+/* The path splits so the folder can be dropped before the name is: at sidebar
+   widths a truncated name identifies nothing. */
+[data-iii-ui='editor'] .ed-change-path {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  overflow: hidden;
+}
+
+[data-iii-ui='editor'] .ed-change-dir {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-ink-ghost);
+  font-size: 11px;
+}
+
+[data-iii-ui='editor'] .ed-change-name {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+[data-iii-ui='editor'] .ed-change-kind {
+  color: var(--color-ink-ghost);
+}
+[data-iii-ui='editor'] .ed-change-kind[data-kind='created'] {
+  color: var(--color-ok);
+}
+[data-iii-ui='editor'] .ed-change-kind[data-kind='deleted'] {
+  color: var(--color-alert);
+}
+
 [data-iii-ui='editor'] .ed-change-age {
   color: var(--color-ink-ghost);
 }

--- a/editor/ui/styles.css
+++ b/editor/ui/styles.css
@@ -251,6 +251,35 @@
   font-size: 10.5px;
 }
 
+/* ------------------------------------------------------- the changes feed */
+
+/* A feed row carries more than a name, and the name is still the thing being
+   scanned: the metadata sits to the right at a smaller size and gives up its
+   space last, so a long path truncates before the counts disappear. */
+[data-iii-ui='editor'] .ed-change {
+  height: auto;
+  min-height: 22px;
+  padding-top: 3px;
+  padding-bottom: 3px;
+}
+
+[data-iii-ui='editor'] .ed-change-meta {
+  flex: none;
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  font-size: 10.5px;
+  white-space: nowrap;
+}
+
+[data-iii-ui='editor'] .ed-change-by {
+  color: var(--color-ink-faint);
+}
+
+[data-iii-ui='editor'] .ed-change-age {
+  color: var(--color-ink-ghost);
+}
+
 /* ------------------------------------------------------------------ tabs */
 
 [data-iii-ui='editor'] .ed-tabs {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.10(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0))
 
   eval/ui:
     dependencies:


### PR DESCRIPTION
When an agent is working, files change underneath you and the only signal was a row flashing in the file tree. There was no way to ask what changed recently, or what a change did.

The worker already emits `editor::changed` for every file change however it was made, and the page already subscribed to it. The handler flashed a row and then discarded the event. It now keeps them, and a third tab beside files and search reads them as an activity feed.

## What it does

- **Groups by turn.** An agent turn that touches six files is one thing that happened, not six. Runs of changes fold into a group with a summary header: who did it, how many files, the net line counts, and how long ago. Grouping is by adjacency rather than by collecting a turn's entries from wherever they sit, because the feed is a timeline: a turn that wrote, was interrupted, then wrote again really did happen twice.
- **Reads a change as its diff.** Selecting a row renders that change's patch, from the event itself. No round trip, and it keeps showing what a write did after the file has been committed, reverted or written again, which the working-tree diff cannot do.
- **Attributes to the session.** The observer now carries `session_id` and `turn_id` from the harness hook envelope onto `editor::changed`. They are the only part of the payload that says who was writing: the function id says which worker performed the write, not who asked for it. Both stay optional, because a write made outside a turn has no session and that is not an error.
- **Seeds from the working tree.** Opening the tab lists changes that predate the page. Outside a repository there is nothing to seed and the feed is live-only, which is what `noRepo` already means everywhere else on the page.
- **Never dead-ends a row.** A seeded row knows only that a file is dirty. Falling through to the git view was wrong twice over: an untracked file has no HEAD to diff against, so the pane said "no changes" about a file that is entirely new. Rows now resolve a patch on demand, asking git first and diffing against empty when git has nothing to say because the file is new. That is the same ladder the worker's observer walks.

Two smaller things the live testing turned up: the view has to be set after the file opens, because opening a file selects its reader and setting it first landed on the file rather than the diff; and at sidebar widths a path truncated to `alph…` identifies nothing, so the row splits the path and lets the folder give way before the name does.

## Verification

The feed model is a pure module with 17 unit tests covering collapse, ordering, the bound, status-code mapping, cause labelling, relative age, session provenance, turn grouping (including the interruption case) and path splitting. The `vitest` script follows the database and worktree UI precedent. `cargo fmt`, `clippy -D warnings`, `cargo test` and the UI typecheck + build all pass.

Live against a running engine, driving the observer hook the way the harness does:

- two simulated turns writing three files each rendered as grouped runs with `agent agentB · 3 files · +7 -1`
- selecting a row rendered its unified diff with the session in the card header
- selecting the untracked file that previously reported "no changes" rendered its contents as an addition

Fixes MOT-4306
