### PR TITLE
chore: update iii dependencies to 0.22.0

### DIFF
--- a/acp/Cargo.lock
+++ b/acp/Cargo.lock
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -706,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/acp/Cargo.toml
+++ b/acp/Cargo.toml
@@ -23,7 +23,7 @@ name = "iii-acp"
 path = "src/main.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util", "sync", "time", "signal"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/approval-gate/Cargo.lock
+++ b/approval-gate/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "1.6.1"
+version = "1.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -806,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -827,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/approval-gate/Cargo.toml
+++ b/approval-gate/Cargo.toml
@@ -15,7 +15,7 @@ name = "approval_gate"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/bridge/Cargo.lock
+++ b/bridge/Cargo.lock
@@ -660,9 +660,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -681,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -18,7 +18,7 @@ name = "bridge"
 path = "src/main.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }

--- a/browser/Cargo.lock
+++ b/browser/Cargo.lock
@@ -822,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -843,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/browser/Cargo.toml
+++ b/browser/Cargo.toml
@@ -15,7 +15,7 @@ name = "browser"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 iii-console-ui = { path = "../crates/console-ui" }
 arc-swap = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time", "process"] }

--- a/claude-code/package.json
+++ b/claude-code/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.173",
-    "iii-sdk": "^0.21.6",
+    "iii-sdk": "0.22.0",
     "yaml": "^2.6.0",
     "zod": "^4.0.0"
   },

--- a/claude-code/pnpm-lock.yaml
+++ b/claude-code/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.3.173
         version: 0.3.173(@anthropic-ai/sdk@0.104.1(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       iii-sdk:
-        specifier: ^0.21.6
-        version: 0.21.6
+        specifier: 0.22.0
+        version: 0.22.0
       yaml:
         specifier: ^2.6.0
         version: 2.9.0
@@ -630,8 +630,8 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@iii-dev/helpers@0.21.6':
-    resolution: {integrity: sha512-UkiIqC5Ob41xc9uYx1SRt4LXLKrzAMzOCq6Kwo4hCak7Qj4Q1tP0GW0nYP7UpgYHsQnzf+2sspb2yD/DVa2ePA==}
+  '@iii-dev/helpers@0.22.0':
+    resolution: {integrity: sha512-GYmAFmGoRcHIggvtPOIjQ3/ZzpMe0uGkj1FpXnOEpr1WFalzbs5T50WmhUOaZZ73UjfSiya0hv+oFm1+Rg4Pkw==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -1178,8 +1178,8 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
-  iii-sdk@0.21.6:
-    resolution: {integrity: sha512-D9NGtcGWdY8tqXRIjvRDqNqKRI2qJcQguSDWuUEPXaYyIHSn1jp3PIVF34cCY6C+f3Bby8fjptxpfzWYQUOg2A==}
+  iii-sdk@0.22.0:
+    resolution: {integrity: sha512-ia6iW/RrhslKz01KflGRRRUv1i98ZEeYgyT+CR4WG6zBiUg2XmSB97NCJCp4HYlrYGRENyYV5qYsIUzC8DjWdQ==}
 
   import-in-the-middle@1.15.0:
     resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
@@ -1919,7 +1919,7 @@ snapshots:
     dependencies:
       hono: 4.12.25
 
-  '@iii-dev/helpers@0.21.6':
+  '@iii-dev/helpers@0.22.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.57.2
@@ -2530,9 +2530,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  iii-sdk@0.21.6:
+  iii-sdk@0.22.0:
     dependencies:
-      '@iii-dev/helpers': 0.21.6
+      '@iii-dev/helpers': 0.22.0
       '@opentelemetry/api': 1.9.1
       ws: 8.21.0
     transitivePeerDependencies:

--- a/codex/Cargo.lock
+++ b/codex/Cargo.lock
@@ -672,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/codex/Cargo.toml
+++ b/codex/Cargo.toml
@@ -15,8 +15,8 @@ name = "codex"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
-iii-helpers = "=0.21.6"
+iii-sdk = "=0.22.0"
+iii-helpers = "=0.22.0"
 schemars = { version = "0.8", features = ["uuid1"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "process", "time", "io-util"] }
 serde = { version = "1", features = ["derive"] }

--- a/console/Cargo.lock
+++ b/console/Cargo.lock
@@ -778,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -799,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 # Worker-side injectable console UI (content function + console:script/style
 # triggers + hot-reload watcher) — the console dogfoods its own protocol to
 # ship the injectable-UI toggle form. Direct link, never published.

--- a/console/web/package.json
+++ b/console/web/package.json
@@ -37,7 +37,7 @@
     "@tanstack/react-virtual": "^3.13.24",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "iii-browser-sdk": "^0.21.6",
+    "iii-browser-sdk": "0.22.0",
     "lexical": "^0.44.0",
     "lucide-react": "^1.16.0",
     "monaco-editor": "^0.56.0",

--- a/context-manager/Cargo.lock
+++ b/context-manager/Cargo.lock
@@ -939,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -960,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/context-manager/Cargo.toml
+++ b/context-manager/Cargo.toml
@@ -15,7 +15,7 @@ name = "context_manager"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/console-ui/Cargo.lock
+++ b/crates/console-ui/Cargo.lock
@@ -515,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.8"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84bdc7bbc3abfde934a62cdc5d3045adf52914dfc1ed6c20f8af691fc561dc55"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -536,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/crates/console-ui/Cargo.toml
+++ b/crates/console-ui/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 [dependencies]
 # Same exact pin the workers carry — path-linking this crate must never be
 # what drags a worker onto a different SDK build.
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 tokio = { version = "1", features = ["rt", "sync", "time", "fs"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/cron/Cargo.lock
+++ b/cron/Cargo.lock
@@ -773,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -794,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/cron/Cargo.toml
+++ b/cron/Cargo.toml
@@ -18,7 +18,7 @@ name = "cron"
 path = "src/main.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }

--- a/database/Cargo.lock
+++ b/database/Cargo.lock
@@ -1282,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -1303,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
-iii-helpers = "=0.21.6"
+iii-sdk = "=0.22.0"
+iii-helpers = "=0.22.0"
 iii-console-ui = { path = "../crates/console-ui" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }

--- a/devin/Cargo.lock
+++ b/devin/Cargo.lock
@@ -670,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -691,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/devin/Cargo.toml
+++ b/devin/Cargo.toml
@@ -15,8 +15,8 @@ name = "devin"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
-iii-helpers = "=0.21.6"
+iii-sdk = "=0.22.0"
+iii-helpers = "=0.22.0"
 schemars = { version = "0.8", features = ["uuid1"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "process", "time", "io-util"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/editor/Cargo.lock
+++ b/editor/Cargo.lock
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/editor/Cargo.toml
+++ b/editor/Cargo.toml
@@ -17,11 +17,11 @@ path = "src/lib.rs"
 # Lockstep with every other worker and with `crates/console-ui`, which this
 # binary links: two iii-sdk versions in one process means two incompatible
 # `IIIClient` types.
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 iii-console-ui = { path = "../crates/console-ui" }
 # Shared observability: the observer fires inside a harness turn, so its span
 # has to hang off that turn rather than dangle as its own trace root.
-iii-helpers = "=0.21.6"
+iii-helpers = "=0.22.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/email/Cargo.lock
+++ b/email/Cargo.lock
@@ -1204,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -1225,9 +1225,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/email/Cargo.toml
+++ b/email/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time", "io-util", "net"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/eval/Cargo.lock
+++ b/eval/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "1.6.1"
+version = "1.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -811,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/eval/Cargo.toml
+++ b/eval/Cargo.toml
@@ -16,8 +16,8 @@ path = "src/lib.rs"
 
 [dependencies]
 harness = { path = "../harness" }
-iii-sdk = "=0.21.6"
-iii-helpers = "=0.21.6"
+iii-sdk = "=0.22.0"
+iii-helpers = "=0.22.0"
 iii-console-ui = { path = "../crates/console-ui" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }

--- a/fp/Cargo.lock
+++ b/fp/Cargo.lock
@@ -645,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -666,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/fp/Cargo.toml
+++ b/fp/Cargo.toml
@@ -17,7 +17,7 @@ name = "fp"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 # Must stay on the same schemars major as iii-sdk so the derived schemas line up.
 schemars = "0.8"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal"] }

--- a/github/Cargo.lock
+++ b/github/Cargo.lock
@@ -680,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -701,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/github/Cargo.toml
+++ b/github/Cargo.toml
@@ -17,7 +17,7 @@ name = "github"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 iii-console-ui = { path = "../crates/console-ui" }
 # Must stay on the same schemars major as iii-sdk so the derived schemas line up.
 schemars = "0.8"

--- a/grok/Cargo.lock
+++ b/grok/Cargo.lock
@@ -671,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -692,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/grok/Cargo.toml
+++ b/grok/Cargo.toml
@@ -15,8 +15,8 @@ name = "grok"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
-iii-helpers = "=0.21.6"
+iii-sdk = "=0.22.0"
+iii-helpers = "=0.22.0"
 schemars = { version = "0.8", features = ["uuid1"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "process", "time", "io-util"] }
 serde = { version = "1", features = ["derive"] }

--- a/harness/Cargo.lock
+++ b/harness/Cargo.lock
@@ -804,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.8"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84bdc7bbc3abfde934a62cdc5d3045adf52914dfc1ed6c20f8af691fc561dc55"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -825,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.8"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd563a1d2f55f893d9a433b747f0bf9bc426656413b136b6ed3a699f3c757b2"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -19,12 +19,12 @@ path = "src/lib.rs"
 [dependencies]
 # 0.21.8 adds the reconnect reattach handshake. Older SDKs can lose this
 # worker's registrations when the engine reloads another worker.
-iii-sdk = "=0.21.8"
+iii-sdk = "=0.22.0"
 # Re-exports the same `opentelemetry` the SDK uses, so we can carry the active
 # OTel context across `tokio::spawn` boundaries (shared `Context` global).
 # 0.21.5 adds the live span-start push (`LiveSpanStartProcessor`), so the
 # console renders `harness::turn step` while it runs instead of on close.
-iii-helpers = "=0.21.8"
+iii-helpers = "=0.22.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/harness/tests/e2e/Cargo.toml
+++ b/harness/tests/e2e/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 harness = { path = "../.." }
-iii-sdk = "=0.21.8"
+iii-sdk = "=0.22.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/harness/tests/integration/Cargo.toml
+++ b/harness/tests/integration/Cargo.toml
@@ -13,7 +13,7 @@ name = "harness_integration"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.8"
+iii-sdk = "=0.22.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "signal", "net", "io-util"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/hermes/pyproject.toml
+++ b/hermes/pyproject.toml
@@ -10,8 +10,8 @@ authors = [{ name = "iii" }]
 license = "Apache-2.0"
 requires-python = ">=3.11"
 dependencies = [
-    "iii-sdk==0.21.6",
-    "iii-helpers==0.21.6",
+    "iii-sdk==0.22.0",
+    "iii-helpers==0.22.0",
     "opentelemetry-api",
     "opentelemetry-sdk",
     "pyyaml",

--- a/http/Cargo.lock
+++ b/http/Cargo.lock
@@ -795,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -847,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -18,12 +18,12 @@ name = "http"
 path = "src/main.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 # Direct dep for W3C trace-context propagation helpers
 # (`observability::extract_context` + the re-exported `opentelemetry` crate).
 # Pinned to the version `iii-sdk` already resolves so the `opentelemetry` types
 # line up across both crates.
-iii-helpers = "=0.21.6"
+iii-helpers = "=0.22.0"
 # W3C trace-context parent propagation on `tracing::Span` (`OpenTelemetrySpanExt`).
 # 0.32 pairs with opentelemetry 0.31 (same as the engine).
 tracing-opentelemetry = "0.32"

--- a/iii-directory/Cargo.lock
+++ b/iii-directory/Cargo.lock
@@ -1090,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -1111,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/iii-directory/Cargo.toml
+++ b/iii-directory/Cargo.toml
@@ -15,7 +15,7 @@ name = "iii_directory"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 arc-swap = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time", "fs", "process"] }
 serde = { version = "1", features = ["derive"] }

--- a/image-resize/Cargo.lock
+++ b/image-resize/Cargo.lock
@@ -697,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -718,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/image-resize/Cargo.toml
+++ b/image-resize/Cargo.toml
@@ -11,7 +11,7 @@ name = "image-resize"
 path = "src/main.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
 kamadak-exif = "0.6"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal"] }

--- a/llm-router/Cargo.lock
+++ b/llm-router/Cargo.lock
@@ -669,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/llm-router/Cargo.toml
+++ b/llm-router/Cargo.toml
@@ -18,12 +18,12 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 # Re-exports the same `opentelemetry` the SDK uses, so we can carry the active
 # OTel context across `tokio::spawn` boundaries (shared `Context` global).
 # 0.21.5 adds the live span-start push, so `router::chat` renders in the
 # console while it streams instead of on close.
-iii-helpers = "=0.21.6"
+iii-helpers = "=0.22.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Must stay on the same schemars major as iii-sdk so the derived

--- a/lsp/Cargo.lock
+++ b/lsp/Cargo.lock
@@ -712,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -733,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/lsp/Cargo.toml
+++ b/lsp/Cargo.toml
@@ -13,7 +13,7 @@ name = "lsp"
 path = "src/main.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 tower-lsp-server = "0.23"
 tree-sitter = "0.24"
 tree-sitter-typescript = "0.23"

--- a/mcp/Cargo.lock
+++ b/mcp/Cargo.lock
@@ -887,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -908,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -15,8 +15,8 @@ name = "iii_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
-iii-helpers = "=0.21.6"
+iii-sdk = "=0.22.0"
+iii-helpers = "=0.22.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/memory-consolidate/Cargo.lock
+++ b/memory-consolidate/Cargo.lock
@@ -642,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.3"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6455e06a9357696d8aa7cf7ba6d6b30ce8803036d85ea53a51de76178b867ec"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/memory-consolidate/Cargo.toml
+++ b/memory-consolidate/Cargo.toml
@@ -15,7 +15,7 @@ name = "memory_consolidate"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.3"
+iii-sdk = "=0.22.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/memory/Cargo.lock
+++ b/memory/Cargo.lock
@@ -660,9 +660,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.8"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84bdc7bbc3abfde934a62cdc5d3045adf52914dfc1ed6c20f8af691fc561dc55"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -681,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 # Bumped from =0.21.3 to match the `iii-console-ui` crate's exact pin: both are
 # `=` requirements so they must resolve to a single version, and the injectable
 # UI helper must never drag a worker onto a different SDK build.
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 # Worker-side injectable console UI (content function + console:script/style
 # triggers + hot-reload watcher) — direct path link, never published.
 iii-console-ui = { path = "../crates/console-ui" }

--- a/opencode/package.json
+++ b/opencode/package.json
@@ -23,7 +23,7 @@
     "opencode-worker": "./dist/index.js"
   },
   "dependencies": {
-    "iii-sdk": "^0.21.6",
+    "iii-sdk": "0.22.0",
     "yaml": "^2.6.0",
     "zod": "^4.0.0"
   },

--- a/opencode/pnpm-lock.yaml
+++ b/opencode/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       iii-sdk:
-        specifier: ^0.21.6
-        version: 0.21.6
+        specifier: 0.22.0
+        version: 0.22.0
       yaml:
         specifier: ^2.6.0
         version: 2.9.0
@@ -560,8 +560,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@iii-dev/helpers@0.21.6':
-    resolution: {integrity: sha512-UkiIqC5Ob41xc9uYx1SRt4LXLKrzAMzOCq6Kwo4hCak7Qj4Q1tP0GW0nYP7UpgYHsQnzf+2sspb2yD/DVa2ePA==}
+  '@iii-dev/helpers@0.22.0':
+    resolution: {integrity: sha512-GYmAFmGoRcHIggvtPOIjQ3/ZzpMe0uGkj1FpXnOEpr1WFalzbs5T50WmhUOaZZ73UjfSiya0hv+oFm1+Rg4Pkw==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -936,8 +936,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  iii-sdk@0.21.6:
-    resolution: {integrity: sha512-D9NGtcGWdY8tqXRIjvRDqNqKRI2qJcQguSDWuUEPXaYyIHSn1jp3PIVF34cCY6C+f3Bby8fjptxpfzWYQUOg2A==}
+  iii-sdk@0.22.0:
+    resolution: {integrity: sha512-ia6iW/RrhslKz01KflGRRRUv1i98ZEeYgyT+CR4WG6zBiUg2XmSB97NCJCp4HYlrYGRENyYV5qYsIUzC8DjWdQ==}
 
   import-in-the-middle@1.15.0:
     resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
@@ -1440,7 +1440,7 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@iii-dev/helpers@0.21.6':
+  '@iii-dev/helpers@0.22.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.57.2
@@ -1839,9 +1839,9 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  iii-sdk@0.21.6:
+  iii-sdk@0.22.0:
     dependencies:
-      '@iii-dev/helpers': 0.21.6
+      '@iii-dev/helpers': 0.22.0
       '@opentelemetry/api': 1.9.1
       ws: 8.21.0
     transitivePeerDependencies:

--- a/openwiki/package.json
+++ b/openwiki/package.json
@@ -18,7 +18,7 @@
     "start": "node src/index.mjs"
   },
   "dependencies": {
-    "iii-sdk": "^0.21.6"
+    "iii-sdk": "0.22.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.10",

--- a/openwiki/pnpm-lock.yaml
+++ b/openwiki/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       iii-sdk:
-        specifier: ^0.21.6
-        version: 0.21.8
+        specifier: 0.22.0
+        version: 0.22.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.10
@@ -230,8 +230,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@iii-dev/helpers@0.21.8':
-    resolution: {integrity: sha512-lLXVvhsX7nuMrGRAcLdAkHmKDmerziYQeyvexQg5lDEmY4lL4fRI5p57+z4oWCvDuGj+245rNN9F0ivDbm7LQg==}
+  '@iii-dev/helpers@0.22.0':
+    resolution: {integrity: sha512-GYmAFmGoRcHIggvtPOIjQ3/ZzpMe0uGkj1FpXnOEpr1WFalzbs5T50WmhUOaZZ73UjfSiya0hv+oFm1+Rg4Pkw==}
 
   '@opentelemetry/api-logs@0.57.2':
     resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
@@ -386,8 +386,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  iii-sdk@0.21.8:
-    resolution: {integrity: sha512-fb41PSiMv0XGJ2hwgc7x2Mh062ueh1ccoTg1Z6y5XEWzBo5+KSzNMuHYDR5o7m2J7PE1TMiBN6e/fSY5vNb59A==}
+  iii-sdk@0.22.0:
+    resolution: {integrity: sha512-ia6iW/RrhslKz01KflGRRRUv1i98ZEeYgyT+CR4WG6zBiUg2XmSB97NCJCp4HYlrYGRENyYV5qYsIUzC8DjWdQ==}
 
   import-in-the-middle@1.15.0:
     resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
@@ -563,7 +563,7 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
-  '@iii-dev/helpers@0.21.8':
+  '@iii-dev/helpers@0.22.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.57.2
@@ -745,9 +745,9 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  iii-sdk@0.21.8:
+  iii-sdk@0.22.0:
     dependencies:
-      '@iii-dev/helpers': 0.21.8
+      '@iii-dev/helpers': 0.22.0
       '@opentelemetry/api': 1.9.1
       ws: 8.21.1
     transitivePeerDependencies:

--- a/pi/package.json
+++ b/pi/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@earendil-works/pi-coding-agent": "^0.79.0",
-    "iii-sdk": "^0.21.6",
+    "iii-sdk": "0.22.0",
     "yaml": "^2.6.0",
     "zod": "^4.0.0"
   },

--- a/pi/pnpm-lock.yaml
+++ b/pi/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.79.0
         version: 0.79.10(ws@8.21.0)(zod@4.4.3)
       iii-sdk:
-        specifier: ^0.21.6
-        version: 0.21.6
+        specifier: 0.22.0
+        version: 0.22.0
       yaml:
         specifier: ^2.6.0
         version: 2.9.0
@@ -704,8 +704,8 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
-  '@iii-dev/helpers@0.21.6':
-    resolution: {integrity: sha512-UkiIqC5Ob41xc9uYx1SRt4LXLKrzAMzOCq6Kwo4hCak7Qj4Q1tP0GW0nYP7UpgYHsQnzf+2sspb2yD/DVa2ePA==}
+  '@iii-dev/helpers@0.22.0':
+    resolution: {integrity: sha512-GYmAFmGoRcHIggvtPOIjQ3/ZzpMe0uGkj1FpXnOEpr1WFalzbs5T50WmhUOaZZ73UjfSiya0hv+oFm1+Rg4Pkw==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -1301,8 +1301,8 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
-  iii-sdk@0.21.6:
-    resolution: {integrity: sha512-D9NGtcGWdY8tqXRIjvRDqNqKRI2qJcQguSDWuUEPXaYyIHSn1jp3PIVF34cCY6C+f3Bby8fjptxpfzWYQUOg2A==}
+  iii-sdk@0.22.0:
+    resolution: {integrity: sha512-ia6iW/RrhslKz01KflGRRRUv1i98ZEeYgyT+CR4WG6zBiUg2XmSB97NCJCp4HYlrYGRENyYV5qYsIUzC8DjWdQ==}
 
   import-in-the-middle@1.15.0:
     resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
@@ -2246,7 +2246,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@iii-dev/helpers@0.21.6':
+  '@iii-dev/helpers@0.22.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.57.2
@@ -2865,9 +2865,9 @@ snapshots:
 
   ignore@7.0.5: {}
 
-  iii-sdk@0.21.6:
+  iii-sdk@0.22.0:
     dependencies:
-      '@iii-dev/helpers': 0.21.6
+      '@iii-dev/helpers': 0.22.0
       '@opentelemetry/api': 1.9.1
       ws: 8.21.0
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       iii-browser-sdk:
-        specifier: ^0.21.6
-        version: 0.21.6
+        specifier: 0.22.0
+        version: 0.22.0
       lexical:
         specifier: ^0.44.0
         version: 0.44.0
@@ -2209,8 +2209,8 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
-  iii-browser-sdk@0.21.6:
-    resolution: {integrity: sha512-ZyVvWAG3ar6P6Xi+OTKpVwWeoFPjsCH3AtFfV7UCva/pMj7fo5u1DzxZ7Kz7Vc/g9KBCn9dy3KOo5fBpmirYDA==}
+  iii-browser-sdk@0.22.0:
+    resolution: {integrity: sha512-E/x116r19QATon73K74+ddAGLBYwH6jy9NXrHJcUPi1irZO+LPOsXhVAacmDDu8bC4cErqv9TsyvAp6jIBE5Zg==}
 
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
@@ -4911,7 +4911,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  iii-browser-sdk@0.21.6: {}
+  iii-browser-sdk@0.22.0: {}
 
   indent-string@4.0.0: {}
 

--- a/provider-anthropic/Cargo.lock
+++ b/provider-anthropic/Cargo.lock
@@ -669,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/provider-anthropic/Cargo.toml
+++ b/provider-anthropic/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/lib.rs"
 llm-router = { path = "../llm-router" }
 # Must match llm-router's pin (one iii-sdk per graph). 0.21.5 brings the
 # live span-start push: `provider::anthropic::stream` renders while streaming.
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Must stay on the same schemars major as iii-sdk so the derived

--- a/provider-claude-code/Cargo.lock
+++ b/provider-claude-code/Cargo.lock
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -670,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/provider-claude-code/Cargo.toml
+++ b/provider-claude-code/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 llm-router = { path = "../llm-router" }
 # Must match llm-router's pin (one iii-sdk per graph). 0.21.5 brings the
 # live span-start push: `provider::claude-code::stream` renders while streaming.
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Must stay on the same schemars major as iii-sdk so the derived

--- a/provider-kimi/Cargo.lock
+++ b/provider-kimi/Cargo.lock
@@ -628,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -717,7 +717,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-kimi/Cargo.toml
+++ b/provider-kimi/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 [dependencies]
 llm-router = { path = "../llm-router" }
 # Must match llm-router's pin so the provider and router share one IIIClient type.
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Must stay on the same schemars major as iii-sdk so the derived

--- a/provider-llamacpp/Cargo.lock
+++ b/provider-llamacpp/Cargo.lock
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -670,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -738,7 +738,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-llamacpp/Cargo.toml
+++ b/provider-llamacpp/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 llm-router = { path = "../llm-router" }
 # Must match llm-router's pin (one iii-sdk per graph). 0.21.5 brings the
 # live span-start push: `provider::llamacpp::stream` renders while streaming.
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Must stay on the same schemars major as iii-sdk so the derived

--- a/provider-openai-codex/Cargo.lock
+++ b/provider-openai-codex/Cargo.lock
@@ -669,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/provider-openai-codex/Cargo.toml
+++ b/provider-openai-codex/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 llm-router = { path = "../llm-router" }
 # Must match llm-router's pin (one iii-sdk per graph). 0.21.5 brings the
 # live span-start push: `provider::openai-codex::stream` renders while streaming.
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Must stay on the same schemars major as iii-sdk so the derived

--- a/provider-openai/Cargo.lock
+++ b/provider-openai/Cargo.lock
@@ -669,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/provider-openai/Cargo.toml
+++ b/provider-openai/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/lib.rs"
 llm-router = { path = "../llm-router" }
 # Must match llm-router's pin (one iii-sdk per graph). 0.21.5 brings the
 # live span-start push: `provider::openai::stream` renders while streaming.
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Must stay on the same schemars major as iii-sdk so the derived

--- a/provider-xai/Cargo.lock
+++ b/provider-xai/Cargo.lock
@@ -669,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -776,7 +776,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-xai/Cargo.toml
+++ b/provider-xai/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/lib.rs"
 llm-router = { path = "../llm-router" }
 # Must match llm-router's pin (one iii-sdk per graph). 0.21.5 brings the
 # live span-start push: `provider::xai::stream` renders while streaming.
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Must stay on the same schemars major as iii-sdk so the derived

--- a/provider-zai/Cargo.lock
+++ b/provider-zai/Cargo.lock
@@ -669,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/provider-zai/Cargo.toml
+++ b/provider-zai/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 llm-router = { path = "../llm-router" }
 # Must match llm-router's pin (one iii-sdk per graph). 0.21.5 brings the
 # live span-start push: `provider::zai::stream` renders while streaming.
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Must stay on the same schemars major as iii-sdk so the derived

--- a/pubsub/Cargo.lock
+++ b/pubsub/Cargo.lock
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -737,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/pubsub/Cargo.toml
+++ b/pubsub/Cargo.toml
@@ -18,7 +18,7 @@ name = "pubsub"
 path = "src/main.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }

--- a/queue/Cargo.lock
+++ b/queue/Cargo.lock
@@ -1217,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -1263,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/queue/Cargo.toml
+++ b/queue/Cargo.toml
@@ -27,8 +27,8 @@ rabbitmq = ["dep:lapin"]
 test-adapters = []
 
 [dependencies]
-iii-sdk = "=0.21.6"
-iii-helpers = "=0.21.6"
+iii-sdk = "=0.22.0"
+iii-helpers = "=0.22.0"
 async-trait = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }

--- a/rbac-proxy/Cargo.lock
+++ b/rbac-proxy/Cargo.lock
@@ -692,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -713,9 +713,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/rbac-proxy/Cargo.toml
+++ b/rbac-proxy/Cargo.toml
@@ -15,7 +15,7 @@ name = "rbac_proxy"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "net", "io-util", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/scrapling/pyproject.toml
+++ b/scrapling/pyproject.toml
@@ -13,7 +13,7 @@ authors = [{ name = "iii" }]
 license = "Apache-2.0"
 requires-python = ">=3.11"
 dependencies = [
-    "iii-sdk==0.21.6",
+    "iii-sdk==0.22.0",
     "scrapling[fetchers]==0.4.9",
     "markdownify",  # scrapling's HTML→Markdown backend (only in its [shell]/[ai] extras)
     "pillow",  # screenshot downscale/tiling so images fit model input limits

--- a/session-manager/Cargo.lock
+++ b/session-manager/Cargo.lock
@@ -914,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -935,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -2592,7 +2592,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/session-manager/Cargo.toml
+++ b/session-manager/Cargo.toml
@@ -15,10 +15,10 @@ name = "session_manager"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 # `run_with_baggage` for call-site span hiding (`iii.tag.hidden` on the
 # session-event fan-out — see src/events.rs `IiiDeliverer`).
-iii-helpers = "=0.21.6"
+iii-helpers = "=0.22.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/shell/Cargo.lock
+++ b/shell/Cargo.lock
@@ -893,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -914,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -11,8 +11,8 @@ name = "shell"
 path = "src/main.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
-iii-helpers = "=0.21.6"
+iii-sdk = "=0.22.0"
+iii-helpers = "=0.22.0"
 schemars = { version = "0.8", features = ["uuid1"] }
 libc = "0.2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "process", "time", "io-util", "fs"] }

--- a/slack/Cargo.lock
+++ b/slack/Cargo.lock
@@ -657,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -678,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/slack/Cargo.toml
+++ b/slack/Cargo.toml
@@ -15,7 +15,7 @@ name = "slack"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/state/Cargo.lock
+++ b/state/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -752,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -773,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -1173,7 +1173,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror",
  "tokio",
  "tracing",
@@ -1211,7 +1211,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -18,10 +18,10 @@ name = "state"
 path = "src/main.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 # UpdateOp / StreamSetResult / StreamUpdateResult / UpdateOpError / MergePath —
 # the exact types the builtin used; pinned to the version iii-sdk resolves.
-iii-helpers = "=0.21.6"
+iii-helpers = "=0.22.0"
 # Worker-side injectable console UI (content function + console:script/style
 # triggers + hot-reload watcher) — direct link, never published.
 iii-console-ui = { path = "../crates/console-ui" }

--- a/storage/Cargo.lock
+++ b/storage/Cargo.lock
@@ -1781,7 +1781,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1922,9 +1922,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -1943,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -2567,7 +2567,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2605,7 +2605,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time", "process", "io-util", "net"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/telegram-bot/Cargo.lock
+++ b/telegram-bot/Cargo.lock
@@ -679,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/telegram-bot/Cargo.toml
+++ b/telegram-bot/Cargo.toml
@@ -15,8 +15,8 @@ name = "telegram_bot"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
-iii-helpers = "=0.21.6"
+iii-sdk = "=0.22.0"
+iii-helpers = "=0.22.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/web/Cargo.lock
+++ b/web/Cargo.lock
@@ -758,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -779,9 +779,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -15,7 +15,7 @@ name = "web"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 arc-swap = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time", "net"] }
 serde = { version = "1", features = ["derive"] }

--- a/workers-dev/Cargo.lock
+++ b/workers-dev/Cargo.lock
@@ -741,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -762,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/workers-dev/Cargo.toml
+++ b/workers-dev/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 crossterm = "0.28"
 libc = "0.2"
 ratatui = "0.29"

--- a/workflow/Cargo.lock
+++ b/workflow/Cargo.lock
@@ -621,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -642,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/workflow/Cargo.toml
+++ b/workflow/Cargo.toml
@@ -15,8 +15,8 @@ name = "workflow"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
-iii-helpers = "=0.21.6"
+iii-sdk = "=0.22.0"
+iii-helpers = "=0.22.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/worktree/Cargo.lock
+++ b/worktree/Cargo.lock
@@ -683,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "iii-helpers"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d84d5c149ae4404365a79feca28aa66f6a7dbed56423b4b8c4e2421e0b5add"
+checksum = "d990b866c3ef708290e1160f5640721130a8ebc28afa65b387551ee358f0a616"
 dependencies = [
  "futures-util",
  "opentelemetry",
@@ -704,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "iii-sdk"
-version = "0.21.6"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dd060fddcc9153b0dd07c038a14cf172ce15ce1d4edb98155563ed55b2caba"
+checksum = "19734770ea4561a5a40c389410c96704ca8fa46bcd76eaf091f965c819ed8ca3"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/worktree/Cargo.toml
+++ b/worktree/Cargo.toml
@@ -15,7 +15,7 @@ name = "worktree"
 path = "src/lib.rs"
 
 [dependencies]
-iii-sdk = "=0.21.6"
+iii-sdk = "=0.22.0"
 # Worker-side injectable console UI (content function + console:script/style
 # triggers + hot-reload watcher) — direct path link, never published.
 iii-console-ui = { path = "../crates/console-ui" }


### PR DESCRIPTION
## Summary

Updates the workers and shared UI package to iii dependencies 0.22.0, with regenerated Rust and pnpm lockfiles.

## Validation

- `cargo metadata --locked` for 47 Rust manifests
- `cargo check --locked` for state and harness
- pnpm lockfile validation in containers
- Python manifest parsing
