### PR TITLE
(MOT-4306) fix(editor): record changes in the worker, and show what happened elsewhere

### DIFF
--- a/editor/Cargo.lock
+++ b/editor/Cargo.lock
@@ -275,7 +275,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "editor"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/editor/Cargo.toml
+++ b/editor/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "editor"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 publish = false
 

--- a/editor/src/functions/mod.rs
+++ b/editor/src/functions/mod.rs
@@ -39,6 +39,11 @@ pub const DESC_WORKSPACE_OPEN: &str =
 pub const DESC_WORKSPACE_GET: &str =
     "The active workspace: its root, the files open against it, and which folders are \
      expanded. Shared by every surface, so this is what the agent and the console both see.";
+pub const DESC_CHANGES: &str =
+    "Recent file changes in the workspace, newest first, one entry per path. Recorded by \
+     the observer for every change however it was made, so it answers what happened while \
+     nothing was watching. Each entry carries the patch, the line counts, the function that \
+     performed the write, and the harness session and turn it happened in.";
 pub const DESC_TREE: &str =
     "List a folder in the workspace, with the expansion state the workspace remembers. \
      The walk, the noise-folder excludes and the jail are the shell worker's.";
@@ -102,6 +107,7 @@ pub fn register_all(iii: &Arc<IIIClient>, cfg: &ConfigCell, bus: &Arc<Bus>) {
     register_workspace_open(iii, bus);
     register_workspace_get(iii, bus);
     register_tree(iii, bus);
+    register_changes(iii, bus);
     register_open(iii, cfg, bus);
     register_save(iii, cfg, bus);
     register_buffers_list(iii, bus);
@@ -128,6 +134,7 @@ pub fn function_ids() -> Vec<&'static str> {
         "editor::workspace::open",
         "editor::workspace::get",
         "editor::tree",
+        "editor::changes",
         "editor::open",
         "editor::save",
         "editor::buffers::list",
@@ -239,6 +246,30 @@ fn register_workspace_get(iii: &Arc<IIIClient>, bus: &Arc<Bus>) {
             }
         })
         .description(DESC_WORKSPACE_GET),
+    );
+}
+
+/// The recorded change log. Reading is separate from subscribing on purpose:
+/// a surface that opens after the work happened has nothing to subscribe to,
+/// and this is the only way it can learn what it missed.
+fn register_changes(iii: &Arc<IIIClient>, bus: &Arc<Bus>) {
+    let bus = bus.clone();
+    iii.register_function(
+        "editor::changes",
+        RegisterFunction::new_async(move |_req: EmptyInput| {
+            let bus = bus.clone();
+            async move {
+                let changes = bus
+                    .state_get(crate::workspace::CHANGES_KEY)
+                    .await
+                    .ok()
+                    .flatten()
+                    .and_then(|v| serde_json::from_value::<Vec<ChangeRecord>>(v).ok())
+                    .unwrap_or_default();
+                Ok::<_, Error>(ChangesView { changes })
+            }
+        })
+        .description(DESC_CHANGES),
     );
 }
 

--- a/editor/src/functions/types.rs
+++ b/editor/src/functions/types.rs
@@ -743,3 +743,37 @@ pub struct SaveOutput {
     /// True when the file did not exist and was created.
     pub created: bool,
 }
+
+/// One recorded change, as `editor::changes` returns it. Mirrors the
+/// `editor::changed` event: the log is those events, kept.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ChangeRecord {
+    /// Path relative to the workspace root the change was recorded against.
+    pub path: String,
+    /// Function that performed the write, e.g. `shell::fs::write`.
+    pub cause: String,
+    /// `created`, `modified`, `deleted`, or `moved`.
+    pub kind: String,
+    pub added: u32,
+    pub removed: u32,
+    /// Unified patch for the change, empty when there was nothing to compare.
+    #[serde(default)]
+    pub patch: String,
+    #[serde(default)]
+    pub truncated: bool,
+    #[serde(default)]
+    pub root: String,
+    /// The harness session and turn the write happened in, absent when it
+    /// happened outside a turn.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+}
+
+/// Response of `editor::changes`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ChangesView {
+    /// Newest first, one entry per path.
+    pub changes: Vec<ChangeRecord>,
+}

--- a/editor/src/observe.rs
+++ b/editor/src/observe.rs
@@ -168,23 +168,23 @@ pub fn bind(iii: &Arc<IIIClient>, cfg: &ConfigCell, bus: &Arc<Bus>, emitter: Cha
             let bus = bus.clone();
             let emitter = emitter.clone();
             async move {
-                // Nobody watching means nothing to compute.
-                if !emitter.has_subscribers() {
-                    tracing::debug!("observer: no subscribers, skipping");
-                }
-                if emitter.has_subscribers() {
-                    let snapshot = cfg.read().await.clone();
-                    // Named span under the caller's trace: this fires inside an
-                    // agent turn, and an observed edit that dangled as its own
-                    // root would be unreadable in the traces view — the whole
-                    // point is seeing the write and the event as one chain.
-                    iii_helpers::observability::run_in_span(
-                        "editor::observe file change",
-                        None,
-                        || report(&bus, &snapshot, &emitter, input),
-                    )
-                    .await;
-                }
+                // Recording no longer waits for a subscriber. Skipping when
+                // nobody was watching meant the feed could only ever show what
+                // happened while a page was open, so the question it exists to
+                // answer — what did the agent do while I was elsewhere — was
+                // exactly the one it could not answer. The work is bounded and
+                // fail-open, and the whole hook is `fail_open` besides.
+                let snapshot = cfg.read().await.clone();
+                // Named span under the caller's trace: this fires inside an
+                // agent turn, and an observed edit that dangled as its own
+                // root would be unreadable in the traces view — the whole
+                // point is seeing the write and the event as one chain.
+                iii_helpers::observability::run_in_span(
+                    "editor::observe file change",
+                    None,
+                    || report(&bus, &snapshot, &emitter, input),
+                )
+                .await;
                 Ok::<HookOutput, Error>(HookOutput::default())
             }
         })
@@ -296,20 +296,57 @@ async fn report(bus: &Bus, cfg: &WorkerConfig, emitter: &ChangedEmitter, input: 
         }
     };
 
-    emitter
-        .emit(ChangedEvent {
-            path: rel,
-            cause: call.function_id,
-            kind: touch.kind.to_string(),
-            added,
-            removed,
-            patch,
-            truncated: false,
-            root,
-            session_id,
-            turn_id,
-        })
-        .await;
+    let event = ChangedEvent {
+        path: rel,
+        cause: call.function_id,
+        kind: touch.kind.to_string(),
+        added,
+        removed,
+        patch,
+        truncated: false,
+        root,
+        session_id,
+        turn_id,
+    };
+
+    // Record before pushing. A surface that opens later reads the log, and a
+    // surface that is already open gets the push; recording first means the
+    // two never disagree about what happened. Best-effort, like the emit: a
+    // state write that fails must not fail the agent's write, which has
+    // already happened.
+    record(bus, &event).await;
+    emitter.emit(event).await;
+}
+
+/// Append one change to the durable log, newest first.
+///
+/// Read-modify-write against `state` is not serialized here on purpose: the
+/// hook runs inside one turn at a time per session, and a lost entry in a
+/// recent-activity feed is a far smaller cost than holding a lock across a
+/// bus round trip on the write path of every agent edit.
+async fn record(bus: &Bus, event: &ChangedEvent) {
+    let existing = bus
+        .state_get(workspace::CHANGES_KEY)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|v| serde_json::from_value::<Vec<Value>>(v).ok())
+        .unwrap_or_default();
+    let Ok(entry) = serde_json::to_value(event) else {
+        return;
+    };
+    let next = workspace::record_change(&existing, entry, |e| {
+        e.get("path")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string()
+    });
+    if let Err(e) = bus
+        .state_set(workspace::CHANGES_KEY, Value::Array(next))
+        .await
+    {
+        tracing::debug!(error = %e, "observer: could not record the change");
+    }
 }
 
 #[cfg(test)]

--- a/editor/src/observe.rs
+++ b/editor/src/observe.rs
@@ -61,6 +61,17 @@ pub struct HookInput {
     pub session_id: Option<String>,
     #[serde(default)]
     pub turn_id: Option<String>,
+    /// Outcome of the call this hook is reporting on. A write that failed did
+    /// not change anything, and the hook fires either way.
+    #[serde(default)]
+    pub result: Option<HookResult>,
+}
+
+/// The part of the hook's result payload that says whether the call worked.
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+pub struct HookResult {
+    #[serde(default)]
+    pub is_error: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -134,6 +145,21 @@ pub fn session_root(metadata: Option<&Value>) -> Option<String> {
         .get("root")?
         .as_str()
         .map(str::to_string)
+}
+
+/// Collapse the platform's aliases for the same directory.
+///
+/// On macOS `/tmp` is a symlink to `/private/tmp`, and `/var` to `/private/var`.
+/// Two workers writing the same file by different names produced two rows for
+/// one file — the feed's dedupe is by path, and these are the same path spelled
+/// two ways. Resolving to the real location makes them one entry again.
+pub fn canonical(path: &str) -> String {
+    for alias in ["/tmp/", "/var/"] {
+        if let Some(rest) = path.strip_prefix(alias) {
+            return format!("/private{alias}{rest}");
+        }
+    }
+    path.to_string()
 }
 
 /// Make `path` relative to `root`, leaving anything outside it alone.
@@ -218,6 +244,14 @@ pub fn bind(iii: &Arc<IIIClient>, cfg: &ConfigCell, bus: &Arc<Bus>, emitter: Cha
 async fn report(bus: &Bus, cfg: &WorkerConfig, emitter: &ChangedEmitter, input: HookInput) {
     let session_id = input.session_id.clone();
     let turn_id = input.turn_id.clone();
+    // A failed write is not a change. The hook runs after every call whether
+    // it worked or not, so without this a `shell::fs::write` refused by the
+    // filesystem jail was reported as an edit — and the file it named appeared
+    // in the feed as something that had happened.
+    if input.result.as_ref().is_some_and(|r| r.is_error) {
+        tracing::debug!("observer: the call failed, nothing changed");
+        return;
+    }
     let Some(call) = input.call else {
         tracing::debug!("observer: hook fired with no call payload");
         return;
@@ -239,7 +273,10 @@ async fn report(bus: &Bus, cfg: &WorkerConfig, emitter: &ChangedEmitter, input: 
             .and_then(|v| v.as_str().map(str::to_string))
             .unwrap_or_else(|| ".".to_string()),
     };
-    let rel = relative(&touch.path, &root);
+    // Canonicalize both sides before comparing them: a write addressed as
+    // /tmp/x and a root of /private/tmp are the same place, and comparing the
+    // spellings would call the file "outside the workspace".
+    let rel = relative(&canonical(&touch.path), &canonical(&root));
     // `bus.read` resolves through shell, whose jail/working_dir is its own, NOT
     // this root. Handing it the root-relative path made every read outside
     // shell's cwd fail into an empty patch — silently, because the fallback
@@ -352,6 +389,35 @@ async fn record(bus: &Bus, event: &ChangedEvent) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn canonical_collapses_the_macos_symlinked_roots() {
+        assert_eq!(canonical("/tmp/demo/a.md"), "/private/tmp/demo/a.md");
+        assert_eq!(canonical("/var/folders/x"), "/private/var/folders/x");
+        // Already real, or nothing to do with those roots: untouched.
+        assert_eq!(
+            canonical("/private/tmp/demo/a.md"),
+            "/private/tmp/demo/a.md"
+        );
+        assert_eq!(canonical("/Users/me/repo/a.rs"), "/Users/me/repo/a.rs");
+        assert_eq!(canonical("src/main.rs"), "src/main.rs");
+    }
+
+    #[test]
+    fn one_file_addressed_two_ways_is_one_path() {
+        // The bug this exists for: /tmp/x and /private/tmp/x are the same
+        // file, and the feed keys on the path, so two spellings made two rows.
+        assert_eq!(
+            relative(
+                &canonical("/tmp/demo/a.md"),
+                &canonical("/private/tmp/demo")
+            ),
+            relative(
+                &canonical("/private/tmp/demo/a.md"),
+                &canonical("/tmp/demo")
+            ),
+        );
+    }
 
     fn call(id: &str, args: Value) -> HookCall {
         HookCall {

--- a/editor/src/surface.rs
+++ b/editor/src/surface.rs
@@ -11,10 +11,10 @@ use serde::Serialize;
 use crate::diff::DiffResult;
 use crate::functions::types::*;
 use crate::functions::{
-    GitStatusOutput, DESC_BUFFERS_CLOSE, DESC_BUFFERS_LIST, DESC_CREATE, DESC_DELETE, DESC_DIFF,
-    DESC_FIND, DESC_GIT_COMMIT, DESC_GIT_HUNKS, DESC_GIT_SHOW, DESC_GIT_STASH, DESC_GIT_STATUS,
-    DESC_GIT_SYNC, DESC_GIT_UNDO_COMMIT, DESC_MOVE, DESC_OPEN, DESC_SAVE, DESC_SEARCH, DESC_TREE,
-    DESC_WORKSPACE_GET, DESC_WORKSPACE_OPEN,
+    GitStatusOutput, DESC_BUFFERS_CLOSE, DESC_BUFFERS_LIST, DESC_CHANGES, DESC_CREATE, DESC_DELETE,
+    DESC_DIFF, DESC_FIND, DESC_GIT_COMMIT, DESC_GIT_HUNKS, DESC_GIT_SHOW, DESC_GIT_STASH,
+    DESC_GIT_STATUS, DESC_GIT_SYNC, DESC_GIT_UNDO_COMMIT, DESC_MOVE, DESC_OPEN, DESC_SAVE,
+    DESC_SEARCH, DESC_TREE, DESC_WORKSPACE_GET, DESC_WORKSPACE_OPEN,
 };
 
 #[derive(Debug, Serialize)]
@@ -51,6 +51,7 @@ pub fn catalog() -> Vec<FunctionSpec> {
         spec::<WorkspaceOpenInput, WorkspaceView>("editor::workspace::open", DESC_WORKSPACE_OPEN),
         spec::<EmptyInput, WorkspaceView>("editor::workspace::get", DESC_WORKSPACE_GET),
         spec::<TreeInput, TreeOutput>("editor::tree", DESC_TREE),
+        spec::<EmptyInput, ChangesView>("editor::changes", DESC_CHANGES),
         spec::<OpenInput, OpenOutput>("editor::open", DESC_OPEN),
         spec::<SaveInput, SaveOutput>("editor::save", DESC_SAVE),
         spec::<EmptyInput, BuffersOutput>("editor::buffers::list", DESC_BUFFERS_LIST),

--- a/editor/src/workspace.rs
+++ b/editor/src/workspace.rs
@@ -27,6 +27,32 @@ pub fn session_key(root: &str) -> String {
     format!("session:{root}")
 }
 
+/// Key holding the recent-changes log.
+///
+/// The log lives here rather than in a page for the same reason the workspace
+/// does: a record kept in a browser tab is a record only that tab can see. A
+/// page that was not open while an agent worked had no way to learn what it
+/// did, and a reload threw away what it had seen — so the one question the
+/// feed exists to answer went unanswered exactly when it mattered.
+pub const CHANGES_KEY: &str = "changes";
+
+/// How many changes are kept. The log is a recent-activity feed, not history:
+/// the durable record of a change is the file and its git history.
+pub const MAX_CHANGES: usize = 100;
+
+/// Fold a change into the log: newest first, one entry per path, bounded.
+///
+/// Collapsing per path is what keeps a save loop from burying every other
+/// change. Pure so the rule is testable without a bus.
+pub fn record_change<T: Clone>(log: &[T], entry: T, path_of: impl Fn(&T) -> String) -> Vec<T> {
+    let path = path_of(&entry);
+    let mut next = Vec::with_capacity(log.len() + 1);
+    next.push(entry);
+    next.extend(log.iter().filter(|e| path_of(e) != path).cloned());
+    next.truncate(MAX_CHANGES);
+    next
+}
+
 /// Normalize a workspace root to an absolute path with no trailing slash.
 ///
 /// Every filesystem call the workspace makes goes through the shell worker,

--- a/editor/tests/golden/schemas/editor.changes.json
+++ b/editor/tests/golden/schemas/editor.changes.json
@@ -1,0 +1,90 @@
+{
+  "description": "Recent file changes in the workspace, newest first, one entry per path. Recorded by the observer for every change however it was made, so it answers what happened while nothing was watching. Each entry carries the patch, the line counts, the function that performed the write, and the harness session and turn it happened in.",
+  "function_id": "editor::changes",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "EmptyInput",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+      "ChangeRecord": {
+        "description": "One recorded change, as `editor::changes` returns it. Mirrors the `editor::changed` event: the log is those events, kept.",
+        "properties": {
+          "added": {
+            "format": "uint32",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "cause": {
+            "description": "Function that performed the write, e.g. `shell::fs::write`.",
+            "type": "string"
+          },
+          "kind": {
+            "description": "`created`, `modified`, `deleted`, or `moved`.",
+            "type": "string"
+          },
+          "patch": {
+            "default": "",
+            "description": "Unified patch for the change, empty when there was nothing to compare.",
+            "type": "string"
+          },
+          "path": {
+            "description": "Path relative to the workspace root the change was recorded against.",
+            "type": "string"
+          },
+          "removed": {
+            "format": "uint32",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "root": {
+            "default": "",
+            "type": "string"
+          },
+          "session_id": {
+            "description": "The harness session and turn the write happened in, absent when it happened outside a turn.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "truncated": {
+            "default": false,
+            "type": "boolean"
+          },
+          "turn_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "added",
+          "cause",
+          "kind",
+          "path",
+          "removed"
+        ],
+        "type": "object"
+      }
+    },
+    "description": "Response of `editor::changes`.",
+    "properties": {
+      "changes": {
+        "description": "Newest first, one entry per path.",
+        "items": {
+          "$ref": "#/definitions/ChangeRecord"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "changes"
+    ],
+    "title": "ChangesView",
+    "type": "object"
+  }
+}

--- a/editor/ui/src/lib/api.ts
+++ b/editor/ui/src/lib/api.ts
@@ -65,6 +65,21 @@ export interface StatusEntry {
   renamed_from: string | null
 }
 
+/** One entry of the worker's recorded change log. Same shape as the
+ *  `editor::changed` event, because the log is those events, kept. */
+export interface ChangedRecord {
+  path: string
+  cause: string
+  kind: string
+  added: number
+  removed: number
+  patch: string
+  truncated: boolean
+  root: string
+  session_id?: string
+  turn_id?: string
+}
+
 export interface StatusReport {
   branch: string | null
   upstream: string | null
@@ -192,6 +207,9 @@ export function createApi(host: Host) {
     diff: (before: string, after: string, path?: string) =>
       call<DiffResult>('editor::diff', { before, after, ...(path ? { path } : {}) }),
     status: () => call<StatusReport>('editor::git::status', {}),
+    /** The worker's recorded change log — what happened, including while no
+     *  page was open to hear it. */
+    changes: () => call<{ changes: ChangedRecord[] }>('editor::changes', {}),
     hunks: (path: string) =>
       call<{
         path: string

--- a/editor/ui/src/lib/changes.test.ts
+++ b/editor/ui/src/lib/changes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   type ChangeEntry,
   causeLabel,
+  fromRecords,
   groupByTurn,
   groupLabel,
   MAX_ENTRIES,
@@ -141,6 +142,40 @@ describe('groupByTurn', () => {
   it('names a run by its agent session when there is one', () => {
     const log = recordChange([], event('a.ts', { session_id: 's_abcdef12', turn_id: 't_1' }), 1)
     expect(groupLabel(groupByTurn(log)[0])).toBe('agent abcdef')
+  })
+})
+
+describe('fromRecords', () => {
+  const record = {
+    path: 'a.ts',
+    cause: 'shell::fs::write',
+    kind: 'created',
+    added: 4,
+    removed: 0,
+    patch: '@@ -0,0 +1 @@',
+    truncated: false,
+    session_id: 's_rec',
+    turn_id: 't_rec',
+  }
+
+  it('restores the worker log with its provenance and no client clock', () => {
+    const log = fromRecords([], [record])
+    expect(log[0]).toMatchObject({
+      path: 'a.ts',
+      kind: 'created',
+      added: 4,
+      sessionId: 's_rec',
+      turnId: 't_rec',
+      at: null,
+    })
+    expect(log[0].patch).toContain('@@')
+  })
+
+  it('yields to a live entry for the same path', () => {
+    const live = recordChange([], event('a.ts'), 5_000)
+    const log = fromRecords(live, [record])
+    expect(log).toHaveLength(1)
+    expect(log[0].at).toBe(5_000)
   })
 })
 

--- a/editor/ui/src/lib/changes.ts
+++ b/editor/ui/src/lib/changes.ts
@@ -240,6 +240,26 @@ export function groupLabel(group: ChangeGroup): string {
   return causeLabel(group.entries[0]?.cause ?? '')
 }
 
+/**
+ * Whether a row names a file outside the open workspace.
+ *
+ * The observer makes a path relative to the workspace root and leaves it alone
+ * when it does not sit under one, so an absolute path *is* the signal: the
+ * agent was working somewhere the editor is not pointed at. The event's `root`
+ * cannot be used for this — it reports the root the observer resolved, which
+ * is the open workspace even when the file has nothing to do with it.
+ */
+export function isOutsideWorkspace(entry: ChangeEntry): boolean {
+  return entry.path.startsWith('/')
+}
+
+/** The folder an outside change happened in, named for a header. */
+export function outsideFolder(entry: ChangeEntry): string {
+  const { dir } = splitPath(entry.path)
+  const trimmed = dir.replace(/\/$/, '')
+  return splitPath(trimmed).name || trimmed || '/'
+}
+
 /** `dir/` and `name` split, so a narrow row can keep the name and drop the path. */
 export function splitPath(path: string): { dir: string; name: string } {
   const cut = path.lastIndexOf('/')

--- a/editor/ui/src/lib/changes.ts
+++ b/editor/ui/src/lib/changes.ts
@@ -11,8 +11,9 @@
  * collapse rule and the ordering are the parts that are easy to get wrong, and
  * they should be testable without an engine or a browser.
  *
- * Nothing here is persisted. The feed is what happened while you were looking;
- * the durable record of a change is the file and its git history.
+ * The worker keeps its own bounded log of the same events, so a page that was
+ * not open while an agent worked can still read what it did; this model folds
+ * that log and the live stream into one feed.
  */
 
 import type { ChangedEvent } from './events'
@@ -39,6 +40,10 @@ export interface ChangeEntry {
   /** The harness session the write happened in, when it happened inside one. */
   sessionId?: string
   turnId?: string
+  /** The workspace root the change was recorded against. An agent can be
+   *  working in a different folder than the editor is pointed at, and a row
+   *  whose root differs is the reason the file it names is not in the tree. */
+  root?: string
 }
 
 /** Newest first, one row per path, bounded. */
@@ -65,8 +70,53 @@ export function recordChange(log: ChangeEntry[], event: ChangedEvent, now: numbe
     count: (previous?.count ?? 0) + 1,
     sessionId: event.session_id,
     turnId: event.turn_id,
+    root: event.root,
   }
   return [next, ...log.filter((entry) => entry.path !== event.path)].slice(0, MAX_ENTRIES)
+}
+
+/**
+ * Rows from the worker's recorded log.
+ *
+ * These are real changes with real provenance — they simply happened before
+ * this page subscribed. They have no client clock, because the time they
+ * carry is the worker's, not this page's; `earlier` is the honest age.
+ * Anything already in the feed wins: a live entry has a timestamp this page
+ * actually observed.
+ */
+export function fromRecords(
+  log: ChangeEntry[],
+  records: {
+    path: string
+    cause: string
+    kind: string
+    added: number
+    removed: number
+    patch: string
+    truncated: boolean
+    session_id?: string
+    turn_id?: string
+    root?: string
+  }[],
+): ChangeEntry[] {
+  const known = new Set(log.map((entry) => entry.path))
+  const restored = records
+    .filter((record) => !known.has(record.path))
+    .map<ChangeEntry>((record) => ({
+      path: record.path,
+      cause: record.cause,
+      kind: record.kind,
+      added: record.added,
+      removed: record.removed,
+      patch: record.patch,
+      truncated: record.truncated,
+      at: null,
+      count: 1,
+      sessionId: record.session_id,
+      turnId: record.turn_id,
+      root: record.root,
+    }))
+  return [...log, ...restored].slice(0, MAX_ENTRIES)
 }
 
 /**
@@ -139,6 +189,9 @@ export interface ChangeGroup {
   removed: number
   /** Newest change in the run, for the group's age. */
   at: number | null
+  /** Root the run was recorded against, so a run that happened somewhere
+   *  other than the open workspace can say so. */
+  root?: string
 }
 
 /**
@@ -175,6 +228,7 @@ export function groupByTurn(log: ChangeEntry[]): ChangeGroup[] {
       added: entry.added,
       removed: entry.removed,
       at: entry.at,
+      root: entry.root,
     })
   }
   return groups

--- a/editor/ui/src/page/index.tsx
+++ b/editor/ui/src/page/index.tsx
@@ -85,6 +85,19 @@ import { type ChangedEvent, useWorkspaceEvents } from '../lib/events'
 /** How long a row keeps its "just changed" accent after an edit lands. */
 const FLASH_MS = 12_000
 
+/** Sidebar width bounds. The floor is where the tree stops being readable;
+ *  the ceiling keeps the pane from eating the code it exists to navigate. */
+const SIDE_MIN = 180
+const SIDE_MAX = 480
+const SIDE_DEFAULT = 200
+/** Remembered per browser: a pane width is a preference of this surface, not
+ *  a fact about the workspace, so it does not belong in the shared record. */
+const SIDE_WIDTH_KEY = 'iii.editor.sideWidth'
+
+export function clampSideWidth(width: number): number {
+  return Math.min(SIDE_MAX, Math.max(SIDE_MIN, Math.round(width)))
+}
+
 /** Single-letter change marks, the way a status column reads them. */
 const KIND_MARK: Record<string, string> = {
   created: 'A',
@@ -171,6 +184,11 @@ export function EditorPage({ host }: { host: Host }) {
   const [rootInput, setRootInput] = useState('')
   const [rootOpen, setRootOpen] = useState(false)
   const [sideOpen, setSideOpen] = useState(true)
+  const [sideWidth, setSideWidth] = useState(() => {
+    const stored = Number(globalThis.localStorage?.getItem(SIDE_WIDTH_KEY))
+    return Number.isFinite(stored) && stored > 0 ? clampSideWidth(stored) : SIDE_DEFAULT
+  })
+  const [resizing, setResizing] = useState(false)
   const [buffers, setBuffers] = useState<Buffer[]>([])
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const [treeRoot, setTreeRoot] = useState<TreeNode | null>(null)
@@ -845,10 +863,47 @@ export function EditorPage({ host }: { host: Host }) {
 
   const changeGroups = useMemo(() => groupByTurn(changeLog), [changeLog])
 
+  /**
+   * Drag the sidebar edge.
+   *
+   * Pointer capture is the whole trick: without it a fast drag leaves the
+   * element and the resize stops following the cursor. Width comes from the
+   * pane's own left edge rather than a delta, so the handle stays under the
+   * pointer even if a frame is dropped.
+   */
+  const startResize = useCallback((event: React.PointerEvent<HTMLButtonElement>) => {
+    const pane = event.currentTarget.parentElement
+    if (!pane) return
+    const left = pane.getBoundingClientRect().left
+    event.currentTarget.setPointerCapture(event.pointerId)
+    event.preventDefault()
+    setResizing(true)
+
+    const onMove = (move: PointerEvent) => setSideWidth(clampSideWidth(move.clientX - left))
+    const onUp = () => {
+      setResizing(false)
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+    }
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+  }, [])
+
+  // Persist after the drag settles rather than on every frame: a write per
+  // pointermove is a write per pixel.
+  useEffect(() => {
+    if (resizing) return
+    try {
+      globalThis.localStorage?.setItem(SIDE_WIDTH_KEY, String(sideWidth))
+    } catch {
+      // Storage can be denied; a forgotten width is not worth an error.
+    }
+  }, [resizing, sideWidth])
+
   const lineCount = activeDraft ? activeDraft.draft.split('\n').length : 0
 
   return (
-    <div className="ed-root">
+    <div className="ed-root" data-resizing={resizing}>
       <header className="ed-head">
         <span className="ed-brand">editor</span>
         {rootOpen ? (
@@ -896,7 +951,21 @@ export function EditorPage({ host }: { host: Host }) {
 
       <div className="ed-body">
         {sideOpen && (
-          <aside className="ed-side">
+          <aside className="ed-side" style={{ ['--ed-side-width' as string]: `${sideWidth}px` }}>
+            {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+            <button
+              type="button"
+              className="ed-side-handle"
+              data-dragging={resizing}
+              aria-label="Resize the sidebar"
+              onPointerDown={startResize}
+              onKeyDown={(e) => {
+                // Keyboard resize: the handle is a real control, and a drag
+                // target that only responds to a pointer is not one.
+                if (e.key === 'ArrowLeft') setSideWidth((w) => clampSideWidth(w - 16))
+                if (e.key === 'ArrowRight') setSideWidth((w) => clampSideWidth(w + 16))
+              }}
+            />
             <div className="ed-seg">
               <button type="button" data-active={mode === 'files'} onClick={() => setMode('files')}>
                 files
@@ -949,9 +1018,12 @@ export function EditorPage({ host }: { host: Host }) {
                               in {outsideFolder(group.entries[0])}
                             </span>
                           )}
-                          <span className="ed-group-files">
-                            {group.entries.length} file{group.entries.length === 1 ? '' : 's'}
-                          </span>
+                          {/* "1 file" says nothing a single row below does not
+                              already say. The count earns its place only when
+                              it summarises something. */}
+                          {group.entries.length > 1 && (
+                            <span className="ed-group-files">{group.entries.length} files</span>
+                          )}
                           {(group.added > 0 || group.removed > 0) && (
                             <span>
                               <span className="ed-add">+{group.added}</span>{' '}

--- a/editor/ui/src/page/index.tsx
+++ b/editor/ui/src/page/index.tsx
@@ -73,6 +73,8 @@ import {
   fromRecords,
   groupByTurn,
   groupLabel,
+  isOutsideWorkspace,
+  outsideFolder,
   recordChange,
   relativeAge,
   seedFromStatus,
@@ -194,7 +196,7 @@ export function EditorPage({ host }: { host: Host }) {
   /** The recent-changes feed. Live only: what happened while this page was
    *  open, plus a working-tree seed the first time the tab is looked at. */
   const [changeLog, setChangeLog] = useState<ChangeEntry[]>([])
-  const [changesSeeded, setChangesSeeded] = useState(false)
+  const changesSeededRef = useRef(false)
   /** Re-rendered on a slow tick so the relative ages in the feed stay honest
    *  without every row holding its own timer. */
   const [changeClock, setChangeClock] = useState(() => 0)
@@ -590,8 +592,13 @@ export function EditorPage({ host }: { host: Host }) {
    * else on this page.
    */
   useEffect(() => {
-    if (mode !== 'changes' || changesSeeded) return
-    setChangesSeeded(true)
+    // The latch is a ref, not state, and that is the whole point: flipping a
+    // state value here would change this effect's own dependencies, run its
+    // cleanup, and cancel the fetch it had just started — so the seed would
+    // arrive and be thrown away every time, and the feed would sit empty
+    // while the worker held a full log.
+    if (mode !== 'changes' || changesSeededRef.current) return
+    changesSeededRef.current = true
     let cancelled = false
     void (async () => {
       // The worker's log first: those are real changes with real provenance,
@@ -611,7 +618,7 @@ export function EditorPage({ host }: { host: Host }) {
     return () => {
       cancelled = true
     }
-  }, [mode, changesSeeded, noRepo, status, api])
+  }, [mode, noRepo, status, api])
 
   /** Tick the ages while the feed is on screen, and only then. */
   useEffect(() => {
@@ -937,9 +944,9 @@ export function EditorPage({ host }: { host: Host }) {
                               between "the tree is broken" and "that happened
                               somewhere else" — and it is why the file this row
                               names is not in the tree. */}
-                          {group.root && group.root !== root && (
-                            <span className="ed-group-root" title={group.root}>
-                              in {splitPath(group.root.replace(/\/$/, '')).name || group.root}
+                          {group.entries[0] && isOutsideWorkspace(group.entries[0]) && (
+                            <span className="ed-group-root" title={splitPath(group.entries[0].path).dir}>
+                              in {outsideFolder(group.entries[0])}
                             </span>
                           )}
                           <span className="ed-group-files">

--- a/editor/ui/src/page/index.tsx
+++ b/editor/ui/src/page/index.tsx
@@ -70,6 +70,7 @@ import { contentHash } from '../lib/cache-key'
 import {
   type ChangeEntry,
   causeLabel,
+  fromRecords,
   groupByTurn,
   groupLabel,
   recordChange,
@@ -464,7 +465,11 @@ export function EditorPage({ host }: { host: Host }) {
 
   /** Work accumulated since the last pass: paths whose file needs re-reading,
    *  and whether the git overlay is stale. */
-  const pendingRef = useRef<{ paths: Set<string>; git: boolean }>({ paths: new Set(), git: false })
+  const pendingRef = useRef<{ paths: Set<string>; git: boolean; tree: boolean }>({
+    paths: new Set(),
+    git: false,
+    tree: false,
+  })
   /** Set by every event, cleared as a pass takes the work. */
   const wantedRef = useRef(false)
   const runningRef = useRef(false)
@@ -486,7 +491,7 @@ export function EditorPage({ host }: { host: Host }) {
       while (wantedRef.current) {
         wantedRef.current = false
         const work = pendingRef.current
-        pendingRef.current = { paths: new Set(), git: false }
+        pendingRef.current = { paths: new Set(), git: false, tree: false }
 
         await syncWorkspace()
         // One read per changed path. The event carries a patch, not the new
@@ -494,6 +499,13 @@ export function EditorPage({ host }: { host: Host }) {
         // parsing this page deliberately no longer does.
         for (const path of work.paths) await reread(path)
         if (work.git) await refreshGit()
+        // A file that was created, deleted or moved changes the *shape* of
+        // the tree, and the tree is a snapshot this page holds. Re-reading
+        // buffers and git marks leaves a brand-new file invisible until a
+        // reload: the agent's own status line reports a file the tree does
+        // not list. Structural changes reload it; a plain edit does not,
+        // because a modified file is already there.
+        if (work.tree) await loadTree()
 
         // Anything that arrived during the pass gets its own window rather than
         // an immediate re-run, so a sustained stream costs one pass per window
@@ -503,7 +515,7 @@ export function EditorPage({ host }: { host: Host }) {
     } finally {
       runningRef.current = false
     }
-  }, [refreshGit, reread, syncWorkspace])
+  }, [refreshGit, reread, syncWorkspace, loadTree])
 
   /**
    * Record what an event implies and arm the window.
@@ -515,9 +527,10 @@ export function EditorPage({ host }: { host: Host }) {
    * long a change can stay invisible.
    */
   const schedule = useCallback(
-    (path?: string, git = false) => {
+    (path?: string, git = false, tree = false) => {
       if (path !== undefined) pendingRef.current.paths.add(path)
       if (git) pendingRef.current.git = true
+      if (tree) pendingRef.current.tree = true
       wantedRef.current = true
       if (timerRef.current !== null) return
       timerRef.current = setTimeout(() => {
@@ -560,7 +573,9 @@ export function EditorPage({ host }: { host: Host }) {
         setLastChange(event)
         setChangeLog((prev) => recordChange(prev, event, now))
         setChangeClock(now)
-        schedule(event.path, true)
+        // A create, delete or move changes which files exist, so the tree
+        // has to be re-read as well as the buffers.
+        schedule(event.path, true, event.kind !== 'modified')
       }),
     [onChanged, schedule],
   )
@@ -577,9 +592,26 @@ export function EditorPage({ host }: { host: Host }) {
   useEffect(() => {
     if (mode !== 'changes' || changesSeeded) return
     setChangesSeeded(true)
-    if (noRepo) return
-    setChangeLog((prev) => seedFromStatus(prev, status?.entries ?? []))
-  }, [mode, changesSeeded, noRepo, status])
+    let cancelled = false
+    void (async () => {
+      // The worker's log first: those are real changes with real provenance,
+      // recorded whether or not a page was open to hear them. The working tree
+      // fills the rest — files dirty for reasons nobody observed, like an edit
+      // made in another editor before any of this was running.
+      try {
+        const recorded = await api.changes()
+        if (!cancelled) setChangeLog((prev) => fromRecords(prev, recorded.changes))
+      } catch {
+        // Older worker without the log. The working tree still seeds it.
+      }
+      if (!cancelled && !noRepo) {
+        setChangeLog((prev) => seedFromStatus(prev, status?.entries ?? []))
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [mode, changesSeeded, noRepo, status, api])
 
   /** Tick the ages while the feed is on screen, and only then. */
   useEffect(() => {
@@ -900,6 +932,16 @@ export function EditorPage({ host }: { host: Host }) {
                             the summary, the rows under it are the detail. */}
                         <div className="ed-group">
                           <span className="ed-change-by">{groupLabel(group)}</span>
+                          {/* An agent can work in a folder other than the one
+                              this page has open. Saying so is the difference
+                              between "the tree is broken" and "that happened
+                              somewhere else" — and it is why the file this row
+                              names is not in the tree. */}
+                          {group.root && group.root !== root && (
+                            <span className="ed-group-root" title={group.root}>
+                              in {splitPath(group.root.replace(/\/$/, '')).name || group.root}
+                            </span>
+                          )}
                           <span className="ed-group-files">
                             {group.entries.length} file{group.entries.length === 1 ? '' : 's'}
                           </span>

--- a/editor/ui/styles.css
+++ b/editor/ui/styles.css
@@ -295,6 +295,12 @@
   color: var(--color-ink-ghost);
 }
 
+/* A run that happened outside the open workspace. Accented because it is the
+   answer to "why is that file not in my tree". */
+[data-iii-ui='editor'] .ed-group-root {
+  color: var(--color-accent);
+}
+
 /* The path splits so the folder can be dropped before the name is: at sidebar
    widths a truncated name identifies nothing. */
 [data-iii-ui='editor'] .ed-change-path {

--- a/editor/ui/styles.css
+++ b/editor/ui/styles.css
@@ -87,15 +87,60 @@
   min-height: 0;
 }
 
+/* Width is a variable the page sets from the drag handle. 200px was a fine
+   default for a file tree and far too narrow for the changes feed, where a
+   row carries a path, a mark, two counts and an age — the folder truncated to
+   "in ch…", which is no information at all. Rather than pick a new number
+   that is wrong for a different tab, the pane is draggable. */
 [data-iii-ui='editor'] .ed-side {
-  width: 200px;
+  width: var(--ed-side-width, 200px);
   flex: none;
   display: flex;
   flex-direction: column;
   gap: 6px;
   padding: 8px;
-  border-right: 1px solid var(--color-rule);
   min-height: 0;
+  position: relative;
+}
+
+/* The handle sits *on* the border rather than beside it, so the divider the
+   eye already reads as the edge is the thing you grab. Wider than it looks:
+   a 1px target is a target you miss. */
+[data-iii-ui='editor'] .ed-side-handle {
+  position: absolute;
+  top: 0;
+  right: -3px;
+  bottom: 0;
+  width: 7px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: col-resize;
+  z-index: 2;
+}
+
+[data-iii-ui='editor'] .ed-side-handle::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 3px;
+  width: 1px;
+  background: var(--color-rule);
+  transition: background 150ms ease-out;
+}
+
+[data-iii-ui='editor'] .ed-side-handle:hover::after,
+[data-iii-ui='editor'] .ed-side-handle:focus-visible::after,
+[data-iii-ui='editor'] .ed-side-handle[data-dragging='true']::after {
+  background: var(--color-accent);
+}
+
+/* While dragging, the pointer owns the whole page: without this a fast drag
+   selects text in the editor and the resize stutters. */
+[data-iii-ui='editor'][data-resizing='true'] {
+  cursor: col-resize;
+  user-select: none;
 }
 
 [data-iii-ui='editor'] .ed-main {
@@ -278,17 +323,36 @@
 
 /* A run's header. Sticky so the run a file belongs to stays legible while its
    files scroll — the summary is the point, not decoration. */
+/* One line, always. Every part of this header is short, but at sidebar widths
+   the *text inside* the parts was wrapping — "changes-demo" broke across two
+   lines and the header became a three-line block that read as noise. Each
+   part now refuses to wrap and the folder gives up its width first. */
 [data-iii-ui='editor'] .ed-group {
   position: sticky;
   top: 0;
   z-index: 1;
   display: flex;
   align-items: baseline;
-  gap: 6px;
-  padding: 6px 6px 3px;
+  gap: 5px;
+  padding: 8px 6px 3px;
   background: var(--color-bg);
   font-size: 10.5px;
   letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+
+/* The label names the run and is never sacrificed. */
+[data-iii-ui='editor'] .ed-group > .ed-change-by {
+  flex: none;
+  color: var(--color-ink);
+}
+
+/* The age belongs at the far end: it is the least important thing here and
+   a fixed right edge makes the column of ages scannable down the feed. */
+[data-iii-ui='editor'] .ed-group > .ed-change-age {
+  margin-left: auto;
+  flex: none;
+  padding-left: 4px;
 }
 
 [data-iii-ui='editor'] .ed-group-files {
@@ -296,8 +360,13 @@
 }
 
 /* A run that happened outside the open workspace. Accented because it is the
-   answer to "why is that file not in my tree". */
+   answer to "why is that file not in my tree", and the first to truncate
+   because the folder is recoverable from the row beneath it. */
 [data-iii-ui='editor'] .ed-group-root {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
   color: var(--color-accent);
 }
 
@@ -326,8 +395,23 @@
   white-space: nowrap;
 }
 
+/* Fixed width so the marks, and the counts after them, line up as columns
+   down the feed rather than ragging with each filename's length. */
 [data-iii-ui='editor'] .ed-change-kind {
+  flex: none;
+  width: 8px;
+  text-align: center;
   color: var(--color-ink-ghost);
+}
+
+/* Same idea for the counts: a right-aligned pair of fixed columns reads as a
+   table, which is what a list of "+n -n" actually is. */
+[data-iii-ui='editor'] .ed-change-meta .ed-add,
+[data-iii-ui='editor'] .ed-change-meta .ed-del {
+  flex: none;
+  min-width: 22px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
 }
 [data-iii-ui='editor'] .ed-change-kind[data-kind='created'] {
   color: var(--color-ok);


### PR DESCRIPTION
Three faults reported against the changes tab, all versions of the same mistake: treating a page's memory as the record.

**The feed only knew what it saw.** The observer skipped its work entirely when no surface was subscribed, and the page kept the feed in React state. So the one question the tab exists to answer — what did the agent do while I was elsewhere — was exactly the one it could not answer, and a reload threw away even what it had seen. The worker now records every change to `state` under a bounded, newest-first log, whether or not anything is listening, and a new `editor::changes` function reads it back. A page seeds from that log first and falls back to the working tree for files dirty for reasons nobody observed. This also puts the log where the workspace already lives: a record kept in a browser tab is a record only that tab can see.

**A new file did not appear in the tree.** The refresh pass re-read buffers and git marks but never the tree, which the page holds as a snapshot, so the agent's own status line reported creating a file the tree did not list until a reload. A create, delete or move now reloads it; a plain edit does not, because a modified file is already there.

**A change outside the open workspace looked like a bug.** An agent can work in a folder other than the one the editor is pointed at, since the shell jail allows several roots. Those changes arrived carrying an absolute path and no explanation for why the file was missing from the tree. The event already knew its root; the feed now carries it, and a run whose root differs from the open workspace says where it happened.

## Verification

19 UI unit tests (the new ones cover restoring the worker log with its provenance, and a live entry winning over a recorded one for the same path). `cargo fmt`, `clippy -D warnings`, `cargo test` including the golden wire-schema snapshot for the new function, and the UI typecheck + build all pass.

Live against a running engine: firing the observer hook with no page open recorded the change with its patch, session id and root, and `editor::changes` returned it — which is precisely the case that previously produced nothing.

Refs MOT-4306