### PR TITLE
docs(release): registry channel is release order, not a stability rating

### DIFF
--- a/docs/sops/new-worker.md
+++ b/docs/sops/new-worker.md
@@ -166,9 +166,11 @@ Ship `skills/SKILL.md` when agents should discover **when** to use the worker
 
 ## 9. First release
 
-Follow [`release.md`](release.md). For a brand-new worker, prefer
-**registry tag `next`** on the first publish so `iii worker add` users on
-`latest` are not surprised.
+Follow [`release.md`](release.md). A first release goes to **`latest`** —
+the channel is release order, not a stability rating, and a worker with one
+version has nothing newer for `next` to point at. Check **experimental** in
+Create Tag instead: that is the signal that says "new, expect changes", and it
+shows as a badge without touching resolution.
 
 Recommended preflight:
 

--- a/docs/sops/release.md
+++ b/docs/sops/release.md
@@ -94,10 +94,19 @@ Workers with `interface_smoke: false` skip the entire publish job.
 
 ### 4. Registry tag semantics
 
-| Channel | Typical use |
+The channel says **where a version sits in the release order**, nothing else.
+It is not a stability rating: that is the separate `experimental` flag, which
+rides the same tag.
+
+| Channel | What it means |
 |---|---|
-| `latest` | Default; what most `iii worker add` installs resolve |
-| `next` | Pre-release / risky channel; safer for first publish |
+| `latest` | The newest released version. What `iii worker add` resolves by default |
+| `next` | A version ahead of `latest` — a preview of what is coming |
+
+So a worker's first release is `latest`, even when it is brand new and
+experimental: there is nothing newer for `next` to point at. Reach for `next`
+only when `latest` already holds the version people should be getting and you
+are staging the one after it.
 
 The channel is stored in the **annotated tag message** (`registry-tag:`).
 `release.yml` refetches the annotated tag for this reason. Lightweight tags
@@ -226,7 +235,9 @@ There is **no unpublish**. Recovery:
 
 1. Fix the issue on `main`.
 2. Cut a new patch via Create Tag (registry `latest` moves forward).
-3. Use `registry-tag: next` when uncertain before promoting to `latest`.
+3. Staging a fix you are unsure of? Publish it on `next` so `latest` keeps
+   serving the version people already have, then cut the same fix to `latest`
+   once it holds up.
 
 GitHub Release assets for the bad version remain (immutable history).
 


### PR DESCRIPTION
Both release SOPs described the registry channel as a risk level rather than a position in the release order, and that reading has been costing us releases published to the wrong channel.

`latest` is the newest released version — what `iii worker add` resolves. `next` is a version ahead of it, a preview of what is coming. That is all the words mean. Whether a worker is new, rough, or still moving is the `experimental` flag, which rides the same annotated tag and shows as a badge without touching resolution.

## What changed

- `docs/sops/new-worker.md` §9 said "for a brand-new worker, prefer registry tag `next` on the first publish". A first release has nothing newer for `next` to sit ahead of, so it goes to `latest` with `experimental` checked.
- `docs/sops/release.md` §4 called `next` the "pre-release / risky channel; safer for first publish". Replaced with what each channel points at, and a note that the first release is `latest` regardless of how experimental it is.
- The rollback step used `next` as a synonym for "when uncertain". Rewritten as what it actually buys you: `latest` keeps serving the version people already have while the fix is staged.

No workflow or script changes; the annotation format and the `experimental` flag are untouched.

Ticketless docs correction, so no Linear prefix — labelling `no-ticket`.
