### PR TITLE
(MOT-4214) feat(queue): per-binding queue subscriptions with metadata delivery

### DIFF
--- a/queue/src/adapter.rs
+++ b/queue/src/adapter.rs
@@ -202,6 +202,7 @@ pub trait QueueAdapter: Send + Sync + 'static {
         topic: &str,
         id: &str,
         function_id: &str,
+        metadata: Option<Value>,
         condition_function_id: Option<String>,
         queue_config: Option<SubscriberQueueConfig>,
     );
@@ -389,12 +390,20 @@ impl QueueAdapter for SwappableAdapter {
         topic: &str,
         id: &str,
         function_id: &str,
+        metadata: Option<Value>,
         condition_function_id: Option<String>,
         queue_config: Option<SubscriberQueueConfig>,
     ) {
         self.current()
             .await
-            .subscribe(topic, id, function_id, condition_function_id, queue_config)
+            .subscribe(
+                topic,
+                id,
+                function_id,
+                metadata,
+                condition_function_id,
+                queue_config,
+            )
             .await;
     }
 
@@ -554,6 +563,7 @@ mod tests {
             _topic: &str,
             _id: &str,
             _function_id: &str,
+            _metadata: Option<Value>,
             _condition_function_id: Option<String>,
             _queue_config: Option<SubscriberQueueConfig>,
         ) {

--- a/queue/src/adapters/builtin.rs
+++ b/queue/src/adapters/builtin.rs
@@ -310,16 +310,20 @@ impl QueueAdapter for BuiltinAdapter {
             }
         }
 
-        // Stop consuming, then wait for the in-flight delivery to finish and
-        // ack. The store state stays untouched: the backlog, DLQ, and stats
-        // are the durable data a later same-id resubscribe reattaches to —
+        // Stop consuming and DETACH the poller instead of awaiting it: the
+        // in-flight delivery still runs to completion and acks (dropping a
+        // JoinHandle detaches the task; aborting it would risk duplicate
+        // execution on redelivery), but callers — the trigger handler holds
+        // its registrations lock across this call — return after the map
+        // updates instead of blocking for up to one whole invocation. The
+        // store state stays untouched: the backlog, DLQ, and stats are the
+        // durable data a later same-id resubscribe reattaches to —
         // unsubscribe fires on every routine subscriber disconnect, so
         // destroying them here would wipe exactly what `durable:subscriber`
-        // exists to keep. Both locks are already released: a drain can take
-        // as long as one invocation, and a concurrent same-id resubscribe is
-        // safe (two pollers on one store queue still deliver each job once).
+        // exists to keep. A same-id resubscribe racing the detached drain is
+        // safe: two pollers on one store queue still deliver each job once.
         let _ = sub.cancel.send(());
-        let _ = sub.task.await;
+        drop(sub.task);
         tracing::debug!(topic = %topic, id = %id, "Unsubscribed from queue");
     }
 
@@ -1804,7 +1808,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unsubscribe_drains_the_inflight_delivery_before_returning() {
+    async fn unsubscribe_detaches_while_the_inflight_delivery_completes() {
         let store: Arc<dyn QueueStore> = Arc::new(InMemoryStore::new());
         let invoker = Arc::new(GatedInvoker::default());
         let adapter = Arc::new(BuiltinAdapter::with_poll_interval_ms(
@@ -1821,31 +1825,29 @@ mod tests {
             .await
             .expect("delivery should start");
 
-        let unsubscribing = {
-            let adapter = adapter.clone();
-            tokio::spawn(async move {
-                adapter.unsubscribe("demo", "sub1").await;
-            })
-        };
-        sleep(Duration::from_millis(50)).await;
-        assert!(
-            !unsubscribing.is_finished(),
-            "unsubscribe must wait for the in-flight invocation, not abort it"
-        );
-
-        invoker.release.notify_one();
-        tokio::time::timeout(Duration::from_secs(1), unsubscribing)
+        // Returns promptly even though a delivery is parked mid-invocation:
+        // unsubscribe must never stall the control plane (the trigger
+        // handler holds its registrations lock across this call) behind one
+        // slow job.
+        tokio::time::timeout(Duration::from_secs(1), adapter.unsubscribe("demo", "sub1"))
             .await
-            .expect("unsubscribe should return once the delivery completes")
-            .unwrap();
-        assert_eq!(
-            invoker.completed.lock().await.as_slice(),
-            [json!("inflight")],
-            "the invocation ran to completion"
-        );
-        // Completed and acked: nothing is left behind to redeliver.
+            .expect("unsubscribe must not wait for the in-flight invocation");
+
+        // The detached delivery still runs to completion and acks — it is
+        // never aborted, so redelivery can't double-execute its side effects.
+        invoker.release.notify_one();
+        wait_until(|| {
+            let invoker = invoker.clone();
+            async move { invoker.completed.lock().await.as_slice() == [json!("inflight")] }
+        })
+        .await;
         let queue_name = internal_queue_name("demo", "sub1");
-        assert_eq!(store.topic_stats(&queue_name).await.depth, 0);
+        wait_until(|| {
+            let store = store.clone();
+            let queue_name = queue_name.clone();
+            async move { store.topic_stats(&queue_name).await.delivered == 1 }
+        })
+        .await;
         adapter.shutdown().await;
     }
 

--- a/queue/src/adapters/builtin.rs
+++ b/queue/src/adapters/builtin.rs
@@ -11,10 +11,10 @@
 //! Fan-out model (matches the engine exactly — see
 //! `engine/src/workers/queue/adapters/builtin/adapter.rs:196-337`):
 //! - Each `(topic, id)` subscription gets its own internal queue named
-//!   `format!("{topic}::{function_id}")` (`adapter.rs:206,229`); `topic_functions`
-//!   tracks which function ids are currently subscribed to a topic.
+//!   `format!("{topic}::{id}")`; `topic_subscriptions` tracks which
+//!   subscription ids are currently attached to a topic.
 //! - `enqueue` pushes a **separate copy** of the message onto every
-//!   subscribed function's internal queue when the topic has subscribers
+//!   subscription's internal queue when the topic has subscribers
 //!   (`adapter.rs:203-215`, broadcast — N subscribers each receive every
 //!   message, they do not compete for one shared queue); with no
 //!   subscribers it enqueues straight onto the bare topic name
@@ -28,7 +28,7 @@
 //!   functions and operators keep passing the bare topic name for these
 //!   ops regardless of how many subscribers exist.
 //! - `list_topics` mirrors `adapter.rs:558-584`: topics are enumerated
-//!   from the subscription registry (`topic_functions`), not by scanning
+//!   from the subscription registry (`topic_subscriptions`), not by scanning
 //!   every key the store happens to hold — a topic that only ever had a
 //!   bare, subscriber-less `enqueue` does not appear (same as the engine).
 //!
@@ -64,8 +64,9 @@ use std::time::Duration;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tokio::sync::{mpsc, Mutex, OwnedSemaphorePermit, RwLock, Semaphore};
-use tokio::task::JoinHandle;
+use tokio::sync::oneshot::error::TryRecvError;
+use tokio::sync::{mpsc, oneshot, Mutex, OwnedSemaphorePermit, RwLock, Semaphore};
+use tokio::task::{JoinHandle, JoinSet};
 
 use crate::adapter::{FunctionQueueConfig, QueueAdapter, QueueMessage, TopicInfo};
 use crate::store::{Job, QueueStore, TopicStats};
@@ -91,25 +92,23 @@ enum Mode {
 /// shared (read-only) across a subscription's polling task(s).
 struct PollerConfig {
     /// The internal queue this subscription's poller reads from —
-    /// `format!("{topic}::{function_id}")`, not the bare topic name (see
+    /// `format!("{topic}::{id}")`, not the bare topic name (see
     /// the module doc's fan-out model).
     queue_name: String,
     function_id: String,
+    /// The trigger's stored metadata, delivered with every message (the
+    /// harness's `__binding` pointer — see `trigger.rs::RegisteredSubscriber`).
+    metadata: Option<Value>,
     condition_function_id: Option<String>,
     max_retries: u32,
     backoff_ms: u64,
     poll_interval_ms: u64,
 }
 
-/// A tracked `(topic, id)` subscription: its polling task plus the
-/// function id it targets, so `unsubscribe` can decide whether any other
-/// subscription still needs that function's entry in `topic_functions`
-/// (mirrors the engine's `trigger_function_map`, `adapter.rs:50,273-308` —
-/// folded into `subscriptions` here since the two maps always share the
-/// same `(topic, id)` key set).
+/// A tracked `(topic, id)` subscription and its polling task.
 struct Subscription {
+    cancel: oneshot::Sender<()>,
     task: JoinHandle<()>,
-    function_id: String,
 }
 
 /// Builtin transport adapter: subscriptions are backed by pure in-process
@@ -118,12 +117,10 @@ pub struct BuiltinAdapter {
     store: Arc<dyn QueueStore>,
     invoker: Arc<dyn Invoker>,
     subscriptions: Mutex<HashMap<(String, String), Subscription>>,
-    /// topic -> set of function ids currently subscribed to it. Resolves a
+    /// topic -> set of subscription ids currently attached to it. Resolves a
     /// bare topic name to its subscribers' internal queue names
-    /// (`format!("{topic}::{function_id}")`) for fan-out enqueue and all
-    /// DLQ/stat ops — mirrors the engine's `topic_functions`
-    /// (`adapter.rs:49`).
-    topic_functions: Mutex<HashMap<String, HashSet<String>>>,
+    /// (`format!("{topic}::{id}")`) for fan-out enqueue and all DLQ/stat ops.
+    topic_subscriptions: Mutex<HashMap<String, HashSet<String>>>,
     poll_interval_ms: u64,
     function_queue_configs: RwLock<HashMap<String, FunctionQueueConfig>>,
     function_deliveries: Arc<Mutex<HashMap<u64, Arc<FunctionDelivery>>>>,
@@ -162,11 +159,10 @@ struct FunctionQueueEnvelope {
     priority: Option<u8>,
 }
 
-/// `format!("{topic}::{function_id}")` — the internal queue name a
-/// subscription's messages, acks/nacks, and DLQ entries live under.
-/// Mirrors the engine's internal-queue naming (`adapter.rs:206,229`).
-fn internal_queue_name(topic: &str, function_id: &str) -> String {
-    format!("{topic}::{function_id}")
+/// The internal queue name a subscription's messages, acks/nacks, and DLQ
+/// entries live under.
+fn internal_queue_name(topic: &str, subscription_id: &str) -> String {
+    format!("{topic}::{subscription_id}")
 }
 
 impl BuiltinAdapter {
@@ -186,7 +182,7 @@ impl BuiltinAdapter {
             store,
             invoker,
             subscriptions: Mutex::new(HashMap::new()),
-            topic_functions: Mutex::new(HashMap::new()),
+            topic_subscriptions: Mutex::new(HashMap::new()),
             poll_interval_ms,
             function_queue_configs: RwLock::new(HashMap::new()),
             function_deliveries: Arc::new(Mutex::new(HashMap::new())),
@@ -213,11 +209,15 @@ impl QueueAdapter for BuiltinAdapter {
         // gets a separate copy pushed onto EACH subscriber's own internal
         // queue (broadcast); a topic with none enqueues straight onto the
         // bare topic name.
-        let function_ids = self.topic_functions.lock().await.get(topic).cloned();
-        match function_ids {
-            Some(function_ids) if !function_ids.is_empty() => {
-                for function_id in &function_ids {
-                    let queue_name = internal_queue_name(topic, function_id);
+        // Snapshot the routing set and release the adapter-wide lock BEFORE
+        // touching the store: a FileStore enqueue is blocking file I/O, and
+        // one slow disk write must delay this topic only, not every publish
+        // and un/subscribe on the worker.
+        let subscription_ids = self.topic_subscriptions.lock().await.get(topic).cloned();
+        match subscription_ids {
+            Some(subscription_ids) if !subscription_ids.is_empty() => {
+                for subscription_id in &subscription_ids {
+                    let queue_name = internal_queue_name(topic, subscription_id);
                     let _ = self.store.enqueue(&queue_name, data.clone()).await;
                 }
             }
@@ -232,6 +232,7 @@ impl QueueAdapter for BuiltinAdapter {
         topic: &str,
         id: &str,
         function_id: &str,
+        metadata: Option<Value>,
         condition_function_id: Option<String>,
         queue_config: Option<SubscriberQueueConfig>,
     ) {
@@ -261,38 +262,33 @@ impl QueueAdapter for BuiltinAdapter {
             _ => Mode::Concurrent,
         };
 
-        let queue_name = internal_queue_name(topic, function_id);
+        let queue_name = internal_queue_name(topic, id);
 
-        self.topic_functions
+        self.topic_subscriptions
             .lock()
             .await
             .entry(topic.to_string())
             .or_default()
-            .insert(function_id.to_string());
+            .insert(id.to_string());
 
         let cfg = PollerConfig {
             queue_name,
             function_id: function_id.to_string(),
+            metadata,
             condition_function_id,
             max_retries,
             backoff_ms,
             poll_interval_ms: self.poll_interval_ms,
         };
 
-        let task = spawn_poller(
+        let sub = spawn_poller(
             Arc::clone(&self.store),
             Arc::clone(&self.invoker),
             cfg,
             mode,
             concurrency,
         );
-        subs.insert(
-            key,
-            Subscription {
-                task,
-                function_id: function_id.to_string(),
-            },
-        );
+        subs.insert(key, sub);
 
         tracing::debug!(topic = %topic, id = %id, function_id = %function_id, ?mode, "Subscribed to queue via BuiltinAdapter");
     }
@@ -300,42 +296,40 @@ impl QueueAdapter for BuiltinAdapter {
     async fn unsubscribe(&self, topic: &str, id: &str) {
         let key = (topic.to_string(), id.to_string());
         let removed = self.subscriptions.lock().await.remove(&key);
-
         let Some(sub) = removed else {
             tracing::warn!(topic = %topic, id = %id, "No subscription found to unsubscribe");
             return;
         };
-        sub.task.abort();
-        tracing::debug!(topic = %topic, id = %id, "Unsubscribed from queue");
-
-        // Only drop `function_id` from `topic_functions[topic]` once no
-        // other subscription on this topic still targets it — mirrors the
-        // engine's ref-counted cleanup (`adapter.rs:291-307`).
-        let still_targeted = self
-            .subscriptions
-            .lock()
-            .await
-            .iter()
-            .any(|((t, _), s)| t == topic && s.function_id == sub.function_id);
-
-        if !still_targeted {
-            let mut tf = self.topic_functions.lock().await;
-            if let Some(function_ids) = tf.get_mut(topic) {
-                function_ids.remove(&sub.function_id);
-                if function_ids.is_empty() {
-                    tf.remove(topic);
+        {
+            let mut topic_subscriptions = self.topic_subscriptions.lock().await;
+            if let Some(subscription_ids) = topic_subscriptions.get_mut(topic) {
+                subscription_ids.remove(id);
+                if subscription_ids.is_empty() {
+                    topic_subscriptions.remove(topic);
                 }
             }
         }
+
+        // Stop consuming, then wait for the in-flight delivery to finish and
+        // ack. The store state stays untouched: the backlog, DLQ, and stats
+        // are the durable data a later same-id resubscribe reattaches to —
+        // unsubscribe fires on every routine subscriber disconnect, so
+        // destroying them here would wipe exactly what `durable:subscriber`
+        // exists to keep. Both locks are already released: a drain can take
+        // as long as one invocation, and a concurrent same-id resubscribe is
+        // safe (two pollers on one store queue still deliver each job once).
+        let _ = sub.cancel.send(());
+        let _ = sub.task.await;
+        tracing::debug!(topic = %topic, id = %id, "Unsubscribed from queue");
     }
 
     async fn redrive_dlq(&self, topic: &str) -> anyhow::Result<u64> {
-        let function_ids = self.topic_functions.lock().await.get(topic).cloned();
-        match function_ids {
-            Some(function_ids) if !function_ids.is_empty() => {
+        let subscription_ids = self.topic_subscriptions.lock().await.get(topic).cloned();
+        match subscription_ids {
+            Some(subscription_ids) if !subscription_ids.is_empty() => {
                 let mut total = 0u64;
-                for function_id in &function_ids {
-                    let queue_name = internal_queue_name(topic, function_id);
+                for subscription_id in &subscription_ids {
+                    let queue_name = internal_queue_name(topic, subscription_id);
                     total += self.store.redrive_dlq(&queue_name).await;
                 }
                 Ok(total)
@@ -345,11 +339,11 @@ impl QueueAdapter for BuiltinAdapter {
     }
 
     async fn redrive_dlq_message(&self, topic: &str, message_id: &str) -> anyhow::Result<bool> {
-        let function_ids = self.topic_functions.lock().await.get(topic).cloned();
-        match function_ids {
-            Some(function_ids) if !function_ids.is_empty() => {
-                for function_id in &function_ids {
-                    let queue_name = internal_queue_name(topic, function_id);
+        let subscription_ids = self.topic_subscriptions.lock().await.get(topic).cloned();
+        match subscription_ids {
+            Some(subscription_ids) if !subscription_ids.is_empty() => {
+                for subscription_id in &subscription_ids {
+                    let queue_name = internal_queue_name(topic, subscription_id);
                     if self
                         .store
                         .redrive_dlq_message(&queue_name, message_id)
@@ -365,11 +359,11 @@ impl QueueAdapter for BuiltinAdapter {
     }
 
     async fn discard_dlq_message(&self, topic: &str, message_id: &str) -> anyhow::Result<bool> {
-        let function_ids = self.topic_functions.lock().await.get(topic).cloned();
-        match function_ids {
-            Some(function_ids) if !function_ids.is_empty() => {
-                for function_id in &function_ids {
-                    let queue_name = internal_queue_name(topic, function_id);
+        let subscription_ids = self.topic_subscriptions.lock().await.get(topic).cloned();
+        match subscription_ids {
+            Some(subscription_ids) if !subscription_ids.is_empty() => {
+                for subscription_id in &subscription_ids {
+                    let queue_name = internal_queue_name(topic, subscription_id);
                     if self
                         .store
                         .discard_dlq_message(&queue_name, message_id)
@@ -385,12 +379,12 @@ impl QueueAdapter for BuiltinAdapter {
     }
 
     async fn dlq_count(&self, topic: &str) -> anyhow::Result<u64> {
-        let function_ids = self.topic_functions.lock().await.get(topic).cloned();
-        match function_ids {
-            Some(function_ids) if !function_ids.is_empty() => {
+        let subscription_ids = self.topic_subscriptions.lock().await.get(topic).cloned();
+        match subscription_ids {
+            Some(subscription_ids) if !subscription_ids.is_empty() => {
                 let mut total = 0u64;
-                for function_id in &function_ids {
-                    let queue_name = internal_queue_name(topic, function_id);
+                for subscription_id in &subscription_ids {
+                    let queue_name = internal_queue_name(topic, subscription_id);
                     total += self.store.topic_stats(&queue_name).await.dlq_depth;
                 }
                 Ok(total)
@@ -400,12 +394,12 @@ impl QueueAdapter for BuiltinAdapter {
     }
 
     async fn dlq_peek(&self, topic: &str, offset: u64, limit: u64) -> anyhow::Result<Vec<Value>> {
-        let function_ids = self.topic_functions.lock().await.get(topic).cloned();
-        let jobs: Vec<Job> = match function_ids {
-            Some(function_ids) if !function_ids.is_empty() => {
+        let subscription_ids = self.topic_subscriptions.lock().await.get(topic).cloned();
+        let jobs: Vec<Job> = match subscription_ids {
+            Some(subscription_ids) if !subscription_ids.is_empty() => {
                 let mut all = Vec::new();
-                for function_id in &function_ids {
-                    let queue_name = internal_queue_name(topic, function_id);
+                for subscription_id in &subscription_ids {
+                    let queue_name = internal_queue_name(topic, subscription_id);
                     all.extend(
                         self.store
                             .dlq_messages(&queue_name, offset.saturating_add(limit))
@@ -431,12 +425,12 @@ impl QueueAdapter for BuiltinAdapter {
     async fn list_topics(&self) -> anyhow::Result<Vec<TopicInfo>> {
         // Enumerated from the subscription registry, not by scanning every
         // key the store happens to hold — mirrors `adapter.rs:558-584`.
-        let topic_functions = self.topic_functions.lock().await.clone();
-        let mut infos = Vec::with_capacity(topic_functions.len());
-        for (topic, function_ids) in &topic_functions {
+        let topic_subscriptions = self.topic_subscriptions.lock().await.clone();
+        let mut infos = Vec::with_capacity(topic_subscriptions.len());
+        for (topic, subscription_ids) in &topic_subscriptions {
             let mut depth = 0u64;
-            for function_id in function_ids {
-                let queue_name = internal_queue_name(topic, function_id);
+            for subscription_id in subscription_ids {
+                let queue_name = internal_queue_name(topic, subscription_id);
                 depth += self.store.topic_stats(&queue_name).await.depth;
             }
             infos.push(TopicInfo {
@@ -468,12 +462,12 @@ impl QueueAdapter for BuiltinAdapter {
     }
 
     async fn topic_stats(&self, topic: &str) -> anyhow::Result<TopicStats> {
-        let function_ids = self.topic_functions.lock().await.get(topic).cloned();
-        match function_ids {
-            Some(function_ids) if !function_ids.is_empty() => {
+        let subscription_ids = self.topic_subscriptions.lock().await.get(topic).cloned();
+        match subscription_ids {
+            Some(subscription_ids) if !subscription_ids.is_empty() => {
                 let mut aggregate = TopicStats::default();
-                for function_id in &function_ids {
-                    let queue_name = internal_queue_name(topic, function_id);
+                for subscription_id in &subscription_ids {
+                    let queue_name = internal_queue_name(topic, subscription_id);
                     let stats = self.store.topic_stats(&queue_name).await;
                     aggregate.depth += stats.depth;
                     aggregate.dlq_depth += stats.dlq_depth;
@@ -487,9 +481,23 @@ impl QueueAdapter for BuiltinAdapter {
     }
 
     async fn shutdown(&self) {
+        // Shutdown is process exit: pollers are aborted, and any in-flight
+        // delivery is abandoned mid-invocation ON PURPOSE — its job is
+        // already recorded in-flight in the store, and recovery on the next
+        // open redelivers it (at-least-once). Draining here instead could
+        // hang exit behind one blocked invocation. Contrast `unsubscribe`,
+        // where the process keeps running and the drain preserves acks.
         let subs = self.subscriptions.lock().await.drain().collect::<Vec<_>>();
-        for (_, sub) in subs {
-            sub.task.abort();
+        let tasks = subs
+            .into_iter()
+            .map(|(_, sub)| {
+                let _ = sub.cancel.send(());
+                sub.task.abort();
+                sub.task
+            })
+            .collect::<Vec<_>>();
+        for task in tasks {
+            let _ = task.await;
         }
 
         let consumers = self
@@ -844,23 +852,43 @@ fn spawn_poller(
     cfg: PollerConfig,
     mode: Mode,
     concurrency: u32,
-) -> JoinHandle<()> {
-    tokio::spawn(async move {
+) -> Subscription {
+    let (cancel, cancelled) = oneshot::channel();
+    let task = tokio::spawn(async move {
         match mode {
-            Mode::Fifo => run_fifo(store, invoker, cfg).await,
-            Mode::Concurrent => run_concurrent(store, invoker, cfg, concurrency).await,
+            Mode::Fifo => run_fifo(store, invoker, cfg, cancelled).await,
+            Mode::Concurrent => run_concurrent(store, invoker, cfg, concurrency, cancelled).await,
         }
-    })
+    });
+    Subscription { cancel, task }
 }
 
 /// Strictly one in-flight invocation, processed in dequeue order. Mirrors
 /// the engine's `FifoWorker` (`concurrency <= 1` case) without the inline
 /// retry-in-place behavior — see the module doc's "Deliberate deviations".
-async fn run_fifo(store: Arc<dyn QueueStore>, invoker: Arc<dyn Invoker>, cfg: PollerConfig) {
+async fn run_fifo(
+    store: Arc<dyn QueueStore>,
+    invoker: Arc<dyn Invoker>,
+    cfg: PollerConfig,
+    mut cancelled: oneshot::Receiver<()>,
+) {
     loop {
+        // Cancellation is honored only between jobs: an in-flight invocation
+        // runs to completion and acks/nacks (killing it mid-call risks a
+        // duplicate execution on redelivery), and a dequeue is never dropped
+        // mid-await (it mutates store state across await points).
+        if !matches!(cancelled.try_recv(), Err(TryRecvError::Empty)) {
+            return;
+        }
         match store.dequeue(&cfg.queue_name).await {
             Some(job) => process_job(&store, &invoker, &cfg, job).await,
-            None => tokio::time::sleep(Duration::from_millis(cfg.poll_interval_ms)).await,
+            None => {
+                tokio::select! {
+                    biased;
+                    _ = &mut cancelled => return,
+                    _ = tokio::time::sleep(Duration::from_millis(cfg.poll_interval_ms)) => {}
+                }
+            }
         }
     }
 }
@@ -873,14 +901,24 @@ async fn run_concurrent(
     invoker: Arc<dyn Invoker>,
     cfg: PollerConfig,
     concurrency: u32,
+    mut cancelled: oneshot::Receiver<()>,
 ) {
     let semaphore = Arc::new(Semaphore::new(concurrency as usize));
     let cfg = Arc::new(cfg);
+    let mut tasks = JoinSet::new();
 
     loop {
-        let permit = match Arc::clone(&semaphore).acquire_owned().await {
-            Ok(permit) => permit,
-            Err(_) => return, // semaphore closed; subscription is being torn down
+        while tasks.try_join_next().is_some() {}
+        // The permit wait is the one cancellable await (`concurrency: 0`
+        // parks here forever); a dequeue is never dropped mid-await, and
+        // spawned invocations run to completion — see the drain below.
+        let permit = tokio::select! {
+            biased;
+            _ = &mut cancelled => break,
+            permit = Arc::clone(&semaphore).acquire_owned() => match permit {
+                Ok(permit) => permit,
+                Err(_) => break, // semaphore closed; subscription is being torn down
+            },
         };
 
         match store.dequeue(&cfg.queue_name).await {
@@ -888,17 +926,27 @@ async fn run_concurrent(
                 let store = Arc::clone(&store);
                 let invoker = Arc::clone(&invoker);
                 let cfg = Arc::clone(&cfg);
-                tokio::spawn(async move {
+                tasks.spawn(async move {
                     process_job(&store, &invoker, &cfg, job).await;
                     drop(permit);
                 });
             }
             None => {
                 drop(permit);
-                tokio::time::sleep(Duration::from_millis(cfg.poll_interval_ms)).await;
+                tokio::select! {
+                    biased;
+                    _ = &mut cancelled => break,
+                    _ = tokio::time::sleep(Duration::from_millis(cfg.poll_interval_ms)) => {}
+                }
             }
         }
     }
+
+    // Drain: every in-flight delivery finishes its invocation and acks or
+    // nacks. Aborting here would kill invocations whose side effects may
+    // already have applied, turning teardown into duplicate executions on
+    // redelivery.
+    while tasks.join_next().await.is_some() {}
 }
 
 async fn process_job(
@@ -910,6 +958,7 @@ async fn process_job(
     let result = invoke(
         invoker.as_ref(),
         &cfg.function_id,
+        cfg.metadata.clone(),
         cfg.condition_function_id.as_deref(),
         job.payload.clone(),
     )
@@ -933,6 +982,7 @@ async fn process_job(
 async fn invoke(
     invoker: &dyn Invoker,
     function_id: &str,
+    metadata: Option<Value>,
     condition_function_id: Option<&str>,
     payload: Value,
 ) -> Result<(), String> {
@@ -943,7 +993,10 @@ async fn invoke(
             Err(err) => return Err(err),
         }
     }
-    invoker.call(function_id, payload).await.map(|_| ())
+    invoker
+        .call_delivery(function_id, payload, metadata)
+        .await
+        .map(|_| ())
 }
 
 #[cfg(test)]
@@ -953,6 +1006,7 @@ mod tests {
     use serde_json::json;
     use std::future::Future;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use tokio::sync::Notify;
     use tokio::time::{sleep, Instant};
 
     async fn wait_until<F, Fut>(mut pred: F)
@@ -1198,6 +1252,7 @@ mod tests {
     #[derive(Default)]
     struct FakeInvoker {
         calls: Mutex<Vec<(String, Value)>>,
+        delivery_metadata: Mutex<Vec<Option<Value>>>,
         fail_backend: AtomicBool,
         condition_value: Mutex<Option<Value>>,
     }
@@ -1205,6 +1260,10 @@ mod tests {
     impl FakeInvoker {
         async fn calls(&self) -> Vec<(String, Value)> {
             self.calls.lock().await.clone()
+        }
+
+        async fn delivery_metadata(&self) -> Vec<Option<Value>> {
+            self.delivery_metadata.lock().await.clone()
         }
     }
 
@@ -1223,6 +1282,97 @@ mod tests {
             } else {
                 Ok(Some(json!({"ok": true})))
             }
+        }
+
+        async fn call_delivery(
+            &self,
+            function_id: &str,
+            payload: Value,
+            metadata: Option<Value>,
+        ) -> Result<Option<Value>, String> {
+            self.delivery_metadata.lock().await.push(metadata);
+            self.call(function_id, payload).await
+        }
+    }
+
+    /// Signals when an invocation starts, then parks it until `release` —
+    /// for pinning what teardown does with an in-flight delivery.
+    #[derive(Default)]
+    struct GatedInvoker {
+        started: Notify,
+        release: Notify,
+        completed: Mutex<Vec<Value>>,
+    }
+
+    #[async_trait]
+    impl Invoker for GatedInvoker {
+        async fn call(&self, _function_id: &str, payload: Value) -> Result<Option<Value>, String> {
+            self.started.notify_one();
+            self.release.notified().await;
+            self.completed.lock().await.push(payload);
+            Ok(None)
+        }
+    }
+
+    #[derive(Default)]
+    struct GatedEnqueueStore {
+        inner: InMemoryStore,
+        entered: Notify,
+        release: Notify,
+    }
+
+    #[async_trait]
+    impl QueueStore for GatedEnqueueStore {
+        async fn enqueue(&self, topic: &str, payload: Value) -> anyhow::Result<String> {
+            if payload == json!("racing") {
+                self.entered.notify_one();
+                self.release.notified().await;
+            }
+            self.inner.enqueue(topic, payload).await
+        }
+
+        async fn dequeue(&self, topic: &str) -> Option<Job> {
+            self.inner.dequeue(topic).await
+        }
+
+        async fn ack(&self, topic: &str, job_id: &str) {
+            self.inner.ack(topic, job_id).await;
+        }
+
+        async fn nack(&self, topic: &str, job: Job, max_retries: u32, backoff_ms: u64) {
+            self.inner.nack(topic, job, max_retries, backoff_ms).await;
+        }
+
+        async fn requeue(&self, topic: &str, job: Job) -> anyhow::Result<()> {
+            self.inner.requeue(topic, job).await
+        }
+
+        async fn list_topics(&self) -> Vec<String> {
+            self.inner.list_topics().await
+        }
+
+        async fn topic_stats(&self, topic: &str) -> TopicStats {
+            self.inner.topic_stats(topic).await
+        }
+
+        async fn dlq_topics(&self) -> Vec<(String, u64)> {
+            self.inner.dlq_topics().await
+        }
+
+        async fn dlq_messages(&self, topic: &str, limit: u64) -> Vec<Job> {
+            self.inner.dlq_messages(topic, limit).await
+        }
+
+        async fn redrive_dlq(&self, topic: &str) -> u64 {
+            self.inner.redrive_dlq(topic).await
+        }
+
+        async fn redrive_dlq_message(&self, topic: &str, job_id: &str) -> bool {
+            self.inner.redrive_dlq_message(topic, job_id).await
+        }
+
+        async fn discard_dlq_message(&self, topic: &str, job_id: &str) -> bool {
+            self.inner.discard_dlq_message(topic, job_id).await
         }
     }
 
@@ -1295,7 +1445,7 @@ mod tests {
         let adapter = BuiltinAdapter::with_poll_interval_ms(store.clone(), invoker.clone(), 5);
 
         adapter
-            .subscribe("demo", "sub1", "backend", None, None)
+            .subscribe("demo", "sub1", "backend", None, None, None)
             .await;
         adapter
             .enqueue("demo", json!({"hello": "world"}), None, None)
@@ -1319,8 +1469,12 @@ mod tests {
         let invoker = Arc::new(FakeInvoker::default());
         let adapter = BuiltinAdapter::with_poll_interval_ms(store.clone(), invoker.clone(), 5);
 
-        adapter.subscribe("demo", "sub-a", "fn-a", None, None).await;
-        adapter.subscribe("demo", "sub-b", "fn-b", None, None).await;
+        adapter
+            .subscribe("demo", "sub-a", "fn-a", None, None, None)
+            .await;
+        adapter
+            .subscribe("demo", "sub-b", "fn-b", None, None, None)
+            .await;
 
         for i in 0..3 {
             adapter.enqueue("demo", json!(i), None, None).await;
@@ -1337,6 +1491,54 @@ mod tests {
         let fn_b_calls = calls.iter().filter(|(f, _)| f == "fn-b").count();
         assert_eq!(fn_a_calls, 3, "fn-a should receive every enqueued message");
         assert_eq!(fn_b_calls, 3, "fn-b should receive every enqueued message");
+        adapter.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn same_function_subscriptions_each_receive_their_metadata() {
+        let store: Arc<dyn QueueStore> = Arc::new(InMemoryStore::new());
+        let invoker = Arc::new(FakeInvoker::default());
+        let adapter = BuiltinAdapter::with_poll_interval_ms(store, invoker.clone(), 5);
+
+        adapter
+            .subscribe(
+                "demo",
+                "sub-a",
+                "backend",
+                Some(json!({"binding": "a"})),
+                None,
+                None,
+            )
+            .await;
+        adapter
+            .subscribe(
+                "demo",
+                "sub-b",
+                "backend",
+                Some(json!({"binding": "b"})),
+                None,
+                None,
+            )
+            .await;
+        adapter
+            .enqueue("demo", json!({"event": 1}), None, None)
+            .await;
+
+        wait_until(|| {
+            let invoker = invoker.clone();
+            async move { invoker.calls().await.len() == 2 }
+        })
+        .await;
+
+        let calls = invoker.calls().await;
+        assert!(calls
+            .iter()
+            .all(|(function_id, payload)| function_id == "backend"
+                && payload == &json!({"event": 1})));
+        let metadata = invoker.delivery_metadata().await;
+        assert_eq!(metadata.len(), 2);
+        assert!(metadata.contains(&Some(json!({"binding": "a"}))));
+        assert!(metadata.contains(&Some(json!({"binding": "b"}))));
         adapter.shutdown().await;
     }
 
@@ -1375,6 +1577,7 @@ mod tests {
                 "sub1",
                 "backend",
                 None,
+                None,
                 config(SubscriberQueueConfig {
                     concurrency: Some(0),
                     ..Default::default()
@@ -1405,6 +1608,7 @@ mod tests {
                 "demo",
                 "sub1",
                 "backend",
+                None,
                 None,
                 config(SubscriberQueueConfig {
                     concurrency: Some(3),
@@ -1439,6 +1643,7 @@ mod tests {
                 "demo",
                 "sub1",
                 "backend",
+                None,
                 None,
                 config(SubscriberQueueConfig {
                     queue_mode: Some("fifo".to_string()),
@@ -1481,6 +1686,7 @@ mod tests {
                 "sub1",
                 "backend",
                 None,
+                None,
                 config(SubscriberQueueConfig {
                     max_retries: Some(2),
                     backoff_delay_ms: Some(1),
@@ -1517,10 +1723,10 @@ mod tests {
             })
         };
         adapter
-            .subscribe("demo", "sub-a", "fn-a", None, retry_cfg())
+            .subscribe("demo", "sub-a", "fn-a", None, None, retry_cfg())
             .await;
         adapter
-            .subscribe("demo", "sub-b", "fn-b", None, retry_cfg())
+            .subscribe("demo", "sub-b", "fn-b", None, None, retry_cfg())
             .await;
 
         adapter.enqueue("demo", json!("job"), None, None).await;
@@ -1544,20 +1750,168 @@ mod tests {
         adapter.shutdown().await;
     }
 
-    // (e) unsubscribe stops delivery.
+    // (e) unsubscribe stops delivery but keeps the durable backlog: the
+    // buffered messages survive for a later same-id resubscribe to drain.
     #[tokio::test]
-    async fn unsubscribe_stops_delivery() {
+    async fn unsubscribe_stops_delivery_and_keeps_backlog_for_rearm() {
         let store: Arc<dyn QueueStore> = Arc::new(InMemoryStore::new());
         let invoker = Arc::new(FakeInvoker::default());
         let adapter = BuiltinAdapter::with_poll_interval_ms(store.clone(), invoker.clone(), 3);
 
         adapter
-            .subscribe("demo", "sub1", "backend", None, None)
+            .subscribe(
+                "demo",
+                "sub1",
+                "backend",
+                None,
+                None,
+                Some(SubscriberQueueConfig {
+                    concurrency: Some(0),
+                    ..Default::default()
+                }),
+            )
             .await;
+        adapter.enqueue("demo", json!("queued"), None, None).await;
+        let queue_name = internal_queue_name("demo", "sub1");
+        assert_eq!(store.topic_stats(&queue_name).await.depth, 1);
+
         adapter.unsubscribe("demo", "sub1").await;
+        assert_eq!(
+            store.topic_stats(&queue_name).await.depth,
+            1,
+            "the backlog is durable state and must survive unsubscribe"
+        );
+
         store.enqueue("demo", json!("after")).await.unwrap();
         sleep(Duration::from_millis(120)).await;
         assert!(invoker.calls().await.is_empty());
+
+        // Re-arming under the same id resumes exactly where it left off.
+        adapter
+            .subscribe("demo", "sub1", "backend", None, None, None)
+            .await;
+        wait_until(|| {
+            let invoker = invoker.clone();
+            async move { !invoker.calls().await.is_empty() }
+        })
+        .await;
+        assert_eq!(
+            invoker.calls().await,
+            vec![("backend".to_string(), json!("queued"))],
+            "the kept backlog drains; the bare-topic publish stays buffered"
+        );
+        adapter.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_drains_the_inflight_delivery_before_returning() {
+        let store: Arc<dyn QueueStore> = Arc::new(InMemoryStore::new());
+        let invoker = Arc::new(GatedInvoker::default());
+        let adapter = Arc::new(BuiltinAdapter::with_poll_interval_ms(
+            store.clone(),
+            invoker.clone(),
+            3,
+        ));
+
+        adapter
+            .subscribe("demo", "sub1", "backend", None, None, None)
+            .await;
+        adapter.enqueue("demo", json!("inflight"), None, None).await;
+        tokio::time::timeout(Duration::from_secs(1), invoker.started.notified())
+            .await
+            .expect("delivery should start");
+
+        let unsubscribing = {
+            let adapter = adapter.clone();
+            tokio::spawn(async move {
+                adapter.unsubscribe("demo", "sub1").await;
+            })
+        };
+        sleep(Duration::from_millis(50)).await;
+        assert!(
+            !unsubscribing.is_finished(),
+            "unsubscribe must wait for the in-flight invocation, not abort it"
+        );
+
+        invoker.release.notify_one();
+        tokio::time::timeout(Duration::from_secs(1), unsubscribing)
+            .await
+            .expect("unsubscribe should return once the delivery completes")
+            .unwrap();
+        assert_eq!(
+            invoker.completed.lock().await.as_slice(),
+            [json!("inflight")],
+            "the invocation ran to completion"
+        );
+        // Completed and acked: nothing is left behind to redeliver.
+        let queue_name = internal_queue_name("demo", "sub1");
+        assert_eq!(store.topic_stats(&queue_name).await.depth, 0);
+        adapter.shutdown().await;
+    }
+
+    // The routing lock is released before store I/O: one parked write delays
+    // its own topic only, never the whole worker.
+    #[tokio::test]
+    async fn publish_blocked_on_store_io_does_not_block_other_topics() {
+        let store = Arc::new(GatedEnqueueStore::default());
+        let invoker = Arc::new(FakeInvoker::default());
+        let adapter = Arc::new(BuiltinAdapter::with_poll_interval_ms(
+            store.clone(),
+            invoker.clone(),
+            3,
+        ));
+
+        let paused = Some(SubscriberQueueConfig {
+            concurrency: Some(0),
+            ..Default::default()
+        });
+        adapter
+            .subscribe("demo", "sub1", "backend", None, None, paused.clone())
+            .await;
+        adapter
+            .subscribe("other", "sub2", "backend", None, None, paused)
+            .await;
+
+        let entered = store.entered.notified();
+        let publishing = {
+            let adapter = adapter.clone();
+            tokio::spawn(async move {
+                adapter.enqueue("demo", json!("racing"), None, None).await;
+            })
+        };
+        tokio::time::timeout(Duration::from_secs(1), entered)
+            .await
+            .expect("publish should reach the store");
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            adapter.enqueue("other", json!("free"), None, None),
+        )
+        .await
+        .expect("an unrelated topic's publish must not wait on demo's store write");
+        assert_eq!(
+            store
+                .inner
+                .topic_stats(&internal_queue_name("other", "sub2"))
+                .await
+                .depth,
+            1
+        );
+
+        store.release.notify_one();
+        tokio::time::timeout(Duration::from_secs(1), publishing)
+            .await
+            .expect("the gated publish should finish once released")
+            .unwrap();
+        assert_eq!(
+            store
+                .inner
+                .topic_stats(&internal_queue_name("demo", "sub1"))
+                .await
+                .depth,
+            1
+        );
+        adapter.shutdown().await;
     }
 
     // (f) condition=false skips + acks without invoking the target function.
@@ -1573,6 +1927,7 @@ mod tests {
                 "demo",
                 "sub1",
                 "backend",
+                None,
                 Some("condition".to_string()),
                 None,
             )
@@ -1599,10 +1954,10 @@ mod tests {
         let adapter = BuiltinAdapter::with_poll_interval_ms(store.clone(), invoker.clone(), 3);
 
         adapter
-            .subscribe("demo", "sub1", "backend", None, None)
+            .subscribe("demo", "sub1", "backend", None, None, None)
             .await;
         adapter
-            .subscribe("demo", "sub1", "other-backend", None, None)
+            .subscribe("demo", "sub1", "other-backend", None, None, None)
             .await;
         assert_eq!(adapter.subscriptions.lock().await.len(), 1);
         adapter.shutdown().await;

--- a/queue/src/adapters/memory.rs
+++ b/queue/src/adapters/memory.rs
@@ -60,11 +60,19 @@ impl QueueAdapter for MemoryAdapter {
         topic: &str,
         id: &str,
         function_id: &str,
+        metadata: Option<Value>,
         condition_function_id: Option<String>,
         queue_config: Option<SubscriberQueueConfig>,
     ) {
         self.inner
-            .subscribe(topic, id, function_id, condition_function_id, queue_config)
+            .subscribe(
+                topic,
+                id,
+                function_id,
+                metadata,
+                condition_function_id,
+                queue_config,
+            )
             .await;
     }
 
@@ -209,7 +217,9 @@ mod tests {
         let invoker = Arc::new(RecordingInvoker::default());
         let adapter = MemoryAdapter::new(invoker.clone());
 
-        adapter.subscribe("demo", "sub-1", "fn-1", None, None).await;
+        adapter
+            .subscribe("demo", "sub-1", "fn-1", None, None, None)
+            .await;
         adapter
             .enqueue("demo", json!({"hello": "world"}), None, None)
             .await;

--- a/queue/src/adapters/rabbitmq/adapter.rs
+++ b/queue/src/adapters/rabbitmq/adapter.rs
@@ -1,6 +1,6 @@
 //! RabbitMQ transport adapter: implements
 //! [`crate::adapter::QueueAdapter`] on top of the fanout-exchange +
-//! per-function-queue topology (`topology.rs`), the job envelope
+//! per-subscription queue topology (`topology.rs`), the job envelope
 //! (`types.rs`), and the retry/DLQ decision table (`retry.rs`).
 //!
 //! Port of `engine/src/workers/queue/adapters/rabbitmq/adapter.rs`. Seams
@@ -58,7 +58,7 @@ use async_trait::async_trait;
 use lapin::{message::Delivery, options::*, Channel, Connection, ConnectionProperties};
 use serde_json::Value;
 use tokio::{
-    sync::{Mutex, RwLock},
+    sync::{oneshot, Mutex, RwLock},
     task::JoinHandle,
 };
 use uuid::Uuid;
@@ -81,7 +81,7 @@ pub struct RabbitMQAdapter {
     retry_handler: Arc<RetryHandler>,
     topology: Arc<TopologyManager>,
     channel: Arc<Channel>,
-    subscriptions: Arc<RwLock<HashMap<String, SubscriptionInfo>>>,
+    subscriptions: Arc<RwLock<HashMap<(String, String), SubscriptionInfo>>>,
     invoker: Arc<dyn Invoker>,
     config: RabbitMQConfig,
     delivery_map: Arc<RwLock<HashMap<u64, Arc<FunctionQueueDelivery>>>>,
@@ -109,8 +109,8 @@ struct FunctionConsumerHandle {
 }
 
 struct SubscriptionInfo {
-    id: String,
     consumer_tag: String,
+    cancel: oneshot::Sender<()>,
     task_handle: JoinHandle<()>,
 }
 
@@ -375,6 +375,7 @@ impl QueueAdapter for RabbitMQAdapter {
         topic: &str,
         id: &str,
         function_id: &str,
+        metadata: Option<Value>,
         condition_function_id: Option<String>,
         queue_config: Option<SubscriberQueueConfig>,
     ) {
@@ -383,12 +384,14 @@ impl QueueAdapter for RabbitMQAdapter {
         let function_id = function_id.to_string();
         let subscriptions = Arc::clone(&self.subscriptions);
 
-        let already_subscribed = {
-            let subs = subscriptions.read().await;
-            subs.contains_key(&format!("{}:{}", topic, id))
-        };
-
-        if already_subscribed {
+        // Hold the write lock from the duplicate check through the insert:
+        // two racing same-key subscribes would otherwise both pass the check
+        // and the loser's consumer task would be silently overwritten and
+        // leak (delivering every message a second time, unstoppable by
+        // unsubscribe). Subscribes are rare control-plane work, so lock
+        // duration is not a concern.
+        let mut subs = subscriptions.write().await;
+        if subs.contains_key(&(topic.clone(), id.clone())) {
             tracing::warn!(topic = %topic, id = %id, "Already subscribed to topic");
             return;
         }
@@ -405,20 +408,20 @@ impl QueueAdapter for RabbitMQAdapter {
         let subscriber_max_priority = queue_config.as_ref().and_then(|c| c.max_priority);
         if let Err(e) = self
             .topology
-            .setup_subscriber_queue(&topic, &function_id, subscriber_max_priority)
+            .setup_subscriber_queue(&topic, &id, subscriber_max_priority)
             .await
         {
             tracing::error!(
                 error = ?e,
                 topic = %topic,
-                function_id = %function_id,
-                "Failed to setup RabbitMQ per-function queue"
+                subscription_id = %id,
+                "Failed to setup RabbitMQ per-subscription queue"
             );
             return;
         }
 
         let names = RabbitNames::new(&topic);
-        let per_function_queue = names.function_queue(&function_id);
+        let subscriber_queue = names.subscriber_queue(&id);
         let consumer_tag = format!("consumer-{}", Uuid::new_v4());
 
         let effective_queue_mode = queue_config
@@ -442,28 +445,32 @@ impl QueueAdapter for RabbitMQAdapter {
         ));
 
         let topic_clone = topic.clone();
+        let id_clone = id.clone();
         let function_id_clone = function_id.clone();
         let consumer_tag_clone = consumer_tag.clone();
-        let queue_name_clone = per_function_queue.clone();
+        let queue_name_clone = subscriber_queue.clone();
+        let (cancel, cancelled) = oneshot::channel();
 
         let task_handle = tokio::spawn(async move {
             worker
                 .run(
                     topic_clone,
+                    id_clone,
                     function_id_clone,
+                    metadata,
                     condition_function_id,
                     consumer_tag_clone,
                     queue_name_clone,
+                    cancelled,
                 )
                 .await;
         });
 
-        let mut subs = subscriptions.write().await;
         subs.insert(
-            format!("{}:{}", topic, id),
+            (topic.clone(), id),
             SubscriptionInfo {
-                id,
                 consumer_tag,
+                cancel,
                 task_handle,
             },
         );
@@ -471,47 +478,44 @@ impl QueueAdapter for RabbitMQAdapter {
         tracing::debug!(
             topic = %topic,
             function_id = %function_id,
-            queue = %per_function_queue,
-            "Subscribed to RabbitMQ per-function queue"
+            queue = %subscriber_queue,
+            "Subscribed to RabbitMQ per-subscription queue"
         );
     }
 
     async fn unsubscribe(&self, topic: &str, id: &str) {
         let subscriptions = Arc::clone(&self.subscriptions);
-        let key = format!("{}:{}", topic, id);
+        let key = (topic.to_string(), id.to_string());
 
-        let mut subs = subscriptions.write().await;
+        let sub_info = subscriptions.write().await.remove(&key);
+        if let Some(sub_info) = sub_info {
+            tracing::debug!(
+                topic = %topic,
+                id = %id,
+                "Unsubscribing from RabbitMQ queue"
+            );
 
-        if let Some(sub_info) = subs.remove(&key) {
-            if sub_info.id == id {
-                tracing::debug!(
+            let _ = sub_info.cancel.send(());
+            if let Err(e) = self
+                .channel
+                .basic_cancel(&sub_info.consumer_tag, BasicCancelOptions::default())
+                .await
+            {
+                tracing::error!(
+                    error = ?e,
                     topic = %topic,
-                    id = %id,
-                    "Unsubscribing from RabbitMQ queue"
+                    consumer_tag = %sub_info.consumer_tag,
+                    "Failed to cancel consumer"
                 );
-
-                if let Err(e) = self
-                    .channel
-                    .basic_cancel(&sub_info.consumer_tag, BasicCancelOptions::default())
-                    .await
-                {
-                    tracing::error!(
-                        error = ?e,
-                        topic = %topic,
-                        consumer_tag = %sub_info.consumer_tag,
-                        "Failed to cancel consumer"
-                    );
-                }
-
-                sub_info.task_handle.abort();
-            } else {
-                tracing::warn!(
-                    topic = %topic,
-                    id = %id,
-                    "Subscription ID mismatch, not unsubscribing"
-                );
-                subs.insert(key, sub_info);
             }
+
+            // Wait for in-flight deliveries to finish, then leave the queue
+            // and DLQ declared and bound: they hold the subscription's
+            // durable backlog and dead letters, and unsubscribe fires on
+            // every routine subscriber disconnect — deleting them here would
+            // destroy exactly the data a later same-id resubscribe exists to
+            // drain.
+            let _ = sub_info.task_handle.await;
         } else {
             tracing::warn!(
                 topic = %topic,
@@ -1354,6 +1358,13 @@ impl QueueAdapter for RabbitMQAdapter {
     /// dropped (no field for it in this worker's `TopicStats`);
     /// `delivered`/`failed` are always `0` (not tracked by this adapter).
     ///
+    /// Inherits one engine quirk verbatim: the "main queue depth" is looked
+    /// up via `RabbitNames::new(topic).queue()` (`iii.{topic}.queue`), a
+    /// queue name that topic-fanout subscriptions never actually declare
+    /// (`subscribe` declares per-subscription queues via
+    /// `RabbitNames::subscriber_queue`, never the bare `.queue()` name) -- so
+    /// for topic-based (non-`__fn_queue::`) topics this always resolves to
+    /// depth `0` in both the engine and this port.
     async fn topic_stats(&self, topic: &str) -> anyhow::Result<TopicStats> {
         let is_configured_function_queue =
             self.function_queue_configs.read().await.contains_key(topic);
@@ -1386,11 +1397,8 @@ impl QueueAdapter for RabbitMQAdapter {
     async fn list_topics(&self) -> anyhow::Result<Vec<TopicInfo>> {
         let subs = self.subscriptions.read().await;
         let mut topics: HashMap<String, u64> = HashMap::new();
-        for key in subs.keys() {
-            // subscription key format is "topic:id"
-            if let Some(topic) = key.split(':').next() {
-                *topics.entry(topic.to_string()).or_insert(0u64) += 1;
-            }
+        for (topic, _) in subs.keys() {
+            *topics.entry(topic.clone()).or_insert(0u64) += 1;
         }
         drop(subs);
         let function_queues = self
@@ -1418,15 +1426,31 @@ impl QueueAdapter for RabbitMQAdapter {
     }
 
     async fn shutdown(&self) {
-        let mut subs = self.subscriptions.write().await;
-        for (_, sub) in subs.drain() {
+        let subs = self
+            .subscriptions
+            .write()
+            .await
+            .drain()
+            .map(|(_, sub)| {
+                let _ = sub.cancel.send(());
+                (sub.consumer_tag, sub.task_handle)
+            })
+            .collect::<Vec<_>>();
+        for (consumer_tag, _) in &subs {
             let _ = self
                 .channel
-                .basic_cancel(&sub.consumer_tag, BasicCancelOptions::default())
+                .basic_cancel(consumer_tag, BasicCancelOptions::default())
                 .await;
-            sub.task_handle.abort();
         }
-        drop(subs);
+        // Shutdown is process exit: abandon in-flight deliveries mid-
+        // invocation ON PURPOSE — they are unacked, so the broker redelivers
+        // them (at-least-once). Draining here could hang exit behind one
+        // blocked invocation. Contrast `unsubscribe`, where the process
+        // keeps running and the drain preserves acks.
+        for (_, task) in subs {
+            task.abort();
+            let _ = task.await;
+        }
 
         let tasks = self
             .function_consumer_tasks

--- a/queue/src/adapters/rabbitmq/adapter.rs
+++ b/queue/src/adapters/rabbitmq/adapter.rs
@@ -509,13 +509,17 @@ impl QueueAdapter for RabbitMQAdapter {
                 );
             }
 
-            // Wait for in-flight deliveries to finish, then leave the queue
-            // and DLQ declared and bound: they hold the subscription's
-            // durable backlog and dead letters, and unsubscribe fires on
-            // every routine subscriber disconnect — deleting them here would
-            // destroy exactly the data a later same-id resubscribe exists to
-            // drain.
-            let _ = sub_info.task_handle.await;
+            // Leave the queue and DLQ declared and bound: they hold the
+            // subscription's durable backlog and dead letters, and
+            // unsubscribe fires on every routine subscriber disconnect —
+            // deleting them here would destroy exactly the data a later
+            // same-id resubscribe exists to drain. The worker task is
+            // DETACHED, not awaited: it finishes its in-flight deliveries
+            // (acking or republishing) and exits on its own, while the
+            // caller — which may hold the trigger handler's registrations
+            // lock — returns after the broker-side consumer cancel instead
+            // of blocking for up to one whole invocation.
+            drop(sub_info.task_handle);
         } else {
             tracing::warn!(
                 topic = %topic,

--- a/queue/src/adapters/rabbitmq/naming.rs
+++ b/queue/src/adapters/rabbitmq/naming.rs
@@ -26,12 +26,15 @@ impl RabbitNames {
         format!("{}.{}.queue", EXCHANGE_PREFIX, self.topic)
     }
 
-    pub fn function_queue(&self, function_id: &str) -> String {
-        format!("{}.{}.{}.queue", EXCHANGE_PREFIX, self.topic, function_id)
+    pub fn subscriber_queue(&self, subscription_id: &str) -> String {
+        format!(
+            "{}.{}.{}.queue",
+            EXCHANGE_PREFIX, self.topic, subscription_id
+        )
     }
 
-    pub fn function_dlq(&self, function_id: &str) -> String {
-        format!("{}.{}.{}.dlq", EXCHANGE_PREFIX, self.topic, function_id)
+    pub fn subscriber_dlq(&self, subscription_id: &str) -> String {
+        format!("{}.{}.{}.dlq", EXCHANGE_PREFIX, self.topic, subscription_id)
     }
 
     pub fn dlq(&self) -> String {

--- a/queue/src/adapters/rabbitmq/publisher.rs
+++ b/queue/src/adapters/rabbitmq/publisher.rs
@@ -1,4 +1,4 @@
-//! Publishes `Job`s to fanout exchanges, per-function subscriber queues, and
+//! Publishes `Job`s to fanout exchanges, per-subscription queues, and
 //! DLQs.
 //!
 //! 1:1 port of `engine/src/workers/queue/adapters/rabbitmq/publisher.rs` — no
@@ -64,12 +64,17 @@ impl Publisher {
             .await
     }
 
-    pub async fn requeue(&self, topic: &str, job: &Job, function_id: Option<&str>) -> Result<()> {
-        if let Some(fid) = function_id {
-            // Per-function subscriber queue: publish directly to the function's
+    pub async fn requeue(
+        &self,
+        topic: &str,
+        job: &Job,
+        subscription_id: Option<&str>,
+    ) -> Result<()> {
+        if let Some(id) = subscription_id {
+            // Per-subscription queue: publish directly to the binding's
             // queue (default exchange) to avoid re-fanning out to all subscribers.
             let names = RabbitNames::new(topic);
-            let queue_name = names.function_queue(fid);
+            let queue_name = names.subscriber_queue(id);
             let headers = self.build_headers(job);
             self.publish_to_exchange("", &queue_name, job, Some(headers))
                 .await
@@ -83,11 +88,11 @@ impl Publisher {
         topic: &str,
         job: &Job,
         error: &str,
-        function_id: Option<&str>,
+        subscription_id: Option<&str>,
     ) -> Result<()> {
         let names = RabbitNames::new(topic);
-        let dlq_name = if let Some(fid) = function_id {
-            names.function_dlq(fid)
+        let dlq_name = if let Some(id) = subscription_id {
+            names.subscriber_dlq(id)
         } else {
             names.dlq()
         };

--- a/queue/src/adapters/rabbitmq/retry.rs
+++ b/queue/src/adapters/rabbitmq/retry.rs
@@ -57,13 +57,13 @@ impl RetryHandler {
         topic: &str,
         job: &mut Job,
         error: &str,
-        function_id: Option<&str>,
+        subscription_id: Option<&str>,
     ) -> Result<()> {
         job.increment_attempts();
 
         if job.is_exhausted() {
             self.publisher
-                .publish_to_dlq(topic, job, error, function_id)
+                .publish_to_dlq(topic, job, error, subscription_id)
                 .await?;
 
             tracing::warn!(
@@ -73,7 +73,7 @@ impl RetryHandler {
                 "Job exhausted retries, moved to DLQ"
             );
         } else {
-            self.publisher.requeue(topic, job, function_id).await?;
+            self.publisher.requeue(topic, job, subscription_id).await?;
 
             tracing::debug!(
                 job_id = %job.id,

--- a/queue/src/adapters/rabbitmq/topology.rs
+++ b/queue/src/adapters/rabbitmq/topology.rs
@@ -1,4 +1,4 @@
-//! RabbitMQ topology setup: fanout exchanges, per-function subscriber
+//! RabbitMQ topology setup: fanout exchanges, per-subscription subscriber
 //! queues, and the retry/DLX topology for function queues.
 //!
 //! 1:1 port of `engine/src/workers/queue/adapters/rabbitmq/topology.rs` — no
@@ -70,13 +70,13 @@ impl TopologyManager {
     pub async fn setup_subscriber_queue(
         &self,
         topic: &str,
-        function_id: &str,
+        subscription_id: &str,
         max_priority: Option<u8>,
     ) -> Result<()> {
         let names = RabbitNames::new(topic);
 
-        let queue_name = names.function_queue(function_id);
-        let dlq_name = names.function_dlq(function_id);
+        let queue_name = names.subscriber_queue(subscription_id);
+        let dlq_name = names.subscriber_dlq(subscription_id);
 
         self.channel
             .queue_declare(
@@ -115,9 +115,9 @@ impl TopologyManager {
 
         tracing::debug!(
             topic = %topic,
-            function_id = %function_id,
+            subscription_id = %subscription_id,
             queue = %queue_name,
-            "RabbitMQ per-function queue setup complete"
+            "RabbitMQ per-subscription queue setup complete"
         );
         Ok(())
     }

--- a/queue/src/adapters/rabbitmq/worker.rs
+++ b/queue/src/adapters/rabbitmq/worker.rs
@@ -22,7 +22,10 @@ use std::sync::Arc;
 use futures::StreamExt;
 use lapin::{message::Delivery, options::*, Channel};
 use serde_json::Value;
-use tokio::sync::Semaphore;
+use tokio::{
+    sync::{oneshot, Semaphore},
+    task::JoinSet,
+};
 
 use crate::trigger::Invoker;
 
@@ -85,13 +88,17 @@ impl Worker {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn run(
         self: Arc<Self>,
         topic: String,
+        subscription_id: String,
         function_id: String,
+        metadata: Option<Value>,
         condition_function_id: Option<String>,
         consumer_tag: String,
         queue_name: String,
+        mut cancelled: oneshot::Receiver<()>,
     ) {
         // Apply per-consumer prefetch (QoS) so the broker keeps a backlog in the
         // queue instead of shipping everything to this consumer at once. Without
@@ -128,35 +135,53 @@ impl Worker {
             }
         };
 
-        while let Some(delivery_result) = consumer.next().await {
+        let mut tasks = JoinSet::new();
+        let explicitly_cancelled = loop {
+            while tasks.try_join_next().is_some() {}
+            let delivery_result = tokio::select! {
+                biased;
+                _ = &mut cancelled => break true,
+                delivery = consumer.next() => match delivery {
+                    Some(delivery) => delivery,
+                    None => break false,
+                },
+            };
+
             match delivery_result {
                 Ok(delivery) => {
-                    let worker = Arc::clone(&self);
-                    let topic_clone = topic.clone();
-                    let function_id_clone = function_id.clone();
-                    let condition_function_id_clone = condition_function_id.clone();
-
                     match self.queue_mode {
                         QueueMode::Fifo => {
-                            if let Err(e) = worker
+                            // Processed inline and to completion: cancellation
+                            // is honored at the next loop head, never
+                            // mid-invocation — an aborted invocation's side
+                            // effects would apply again on redelivery.
+                            if let Err(e) = self
                                 .process_delivery(
                                     delivery,
-                                    &topic_clone,
-                                    &function_id_clone,
-                                    condition_function_id_clone.as_deref(),
+                                    &topic,
+                                    &subscription_id,
+                                    &function_id,
+                                    metadata.as_ref(),
+                                    condition_function_id.as_deref(),
                                 )
                                 .await
                             {
                                 tracing::error!(
-                                    topic = %topic_clone,
+                                    topic = %topic,
                                     error = ?e,
                                     "Failed to process delivery"
                                 );
                             }
                         }
                         QueueMode::Standard => {
+                            let worker = Arc::clone(&self);
+                            let topic_clone = topic.clone();
+                            let subscription_id_clone = subscription_id.clone();
+                            let function_id_clone = function_id.clone();
+                            let metadata_clone = metadata.clone();
+                            let condition_function_id_clone = condition_function_id.clone();
                             let semaphore = self.semaphore.as_ref().map(Arc::clone);
-                            tokio::spawn(async move {
+                            tasks.spawn(async move {
                                 let _permit = if let Some(ref sem) = semaphore {
                                     Some(sem.acquire().await.unwrap())
                                 } else {
@@ -167,7 +192,9 @@ impl Worker {
                                     .process_delivery(
                                         delivery,
                                         &topic_clone,
+                                        &subscription_id_clone,
                                         &function_id_clone,
+                                        metadata_clone.as_ref(),
                                         condition_function_id_clone.as_deref(),
                                     )
                                     .await
@@ -190,22 +217,34 @@ impl Worker {
                     );
                 }
             }
-        }
+        };
 
-        tracing::warn!(topic = %topic, "Consumer stream ended");
+        // Drain: every in-flight delivery completes its invocation and acks,
+        // nacks, or republishes. Aborting here would kill invocations whose
+        // side effects may already have applied server-side, so the broker's
+        // redelivery would execute them a second time.
+        while tasks.join_next().await.is_some() {}
+
+        if explicitly_cancelled {
+            tracing::debug!(topic = %topic, "Consumer cancelled");
+        } else {
+            tracing::warn!(topic = %topic, "Consumer stream ended");
+        }
     }
 
     async fn process_delivery(
         &self,
         delivery: Delivery,
         topic: &str,
+        subscription_id: &str,
         function_id: &str,
+        metadata: Option<&Value>,
         condition_function_id: Option<&str>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let mut job = JobParser::parse_from_delivery(&delivery)?;
 
         match self
-            .process_job(&job, function_id, condition_function_id)
+            .process_job(&job, function_id, metadata, condition_function_id)
             .await
         {
             Ok(_) => {
@@ -229,7 +268,7 @@ impl Worker {
                     .map_err(|e| format!("Failed to nack message: {}", e))?;
 
                 self.retry_handler
-                    .handle_failure(topic, &mut job, &format!("{:?}", e), Some(function_id))
+                    .handle_failure(topic, &mut job, &format!("{:?}", e), Some(subscription_id))
                     .await
                     .map_err(|e| format!("Failed to handle failure: {}", e))?;
             }
@@ -242,6 +281,7 @@ impl Worker {
         &self,
         job: &Job,
         function_id: &str,
+        metadata: Option<&Value>,
         condition_function_id: Option<&str>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let invoker = Arc::clone(&self.invoker);
@@ -272,7 +312,10 @@ impl Worker {
             }
         }
 
-        match invoker.call(function_id, data).await {
+        match invoker
+            .call_delivery(function_id, data, metadata.cloned())
+            .await
+        {
             Ok(_) => {
                 tracing::debug!(job_id = %job.id, "Job processed successfully");
                 Ok(())

--- a/queue/src/adapters/redis.rs
+++ b/queue/src/adapters/redis.rs
@@ -3,9 +3,9 @@
 //! 1:1 port of the engine builtin's `RedisAdapter`
 //! (`engine/src/workers/queue/adapters/redis_adapter.rs`, whole file),
 //! including its limitations: this transport is pub/sub only — it has no
-//! DLQ, no retries, no message durability, and delivers each published
-//! message to at most one subscriber connection per topic. Seams applied
-//! for the standalone worker:
+//! DLQ, retries, or message durability. Each `(topic, id)` subscription uses
+//! its own subscriber connection so Redis fans a copy out to every binding.
+//! Seams applied for the standalone worker:
 //! - `Arc<Engine>` + `engine.call(...)` inside the pubsub task ->
 //!   `Arc<dyn crate::trigger::Invoker>` + `invoker.call(function_id, payload)`.
 //! - The engine's `check_condition` helper (`engine/src/condition.rs`) is
@@ -24,11 +24,9 @@
 //!
 //! Testability note: [`RedisAdapter::new`]/[`RedisAdapter::from_config`]
 //! connect to Redis eagerly (engine parity), so unit tests can't construct
-//! a live instance without a running Redis. Two pieces of pure logic are
-//! therefore extracted so they're covered without a connection:
-//! - [`RedisAdapter::resolve_redis_url`] — config parsing.
-//! - [`unsubscribe_locked`] — the unsubscribe decision table, taking the
-//!   already-locked map directly.
+//! a live instance without a running Redis. The one piece of pure logic is
+//! extracted so it's covered without a connection:
+//! [`RedisAdapter::resolve_redis_url`] — config parsing.
 //!
 //! The DLQ methods need no such extraction: they return a constant error
 //! ([`DLQ_NOT_SUPPORTED`]) without touching `self` at all, so the constant
@@ -61,12 +59,11 @@ const DLQ_NOT_SUPPORTED: &str = "RedisAdapter does not support DLQ operations (p
 pub struct RedisAdapter {
     publisher: Arc<Mutex<ConnectionManager>>,
     subscriber: Arc<Client>,
-    subscriptions: Arc<RwLock<HashMap<String, SubscriptionInfo>>>,
+    subscriptions: Arc<RwLock<HashMap<(String, String), SubscriptionInfo>>>,
     invoker: Arc<dyn Invoker>,
 }
 
 struct SubscriptionInfo {
-    id: String,
     task_handle: JoinHandle<()>,
 }
 
@@ -145,24 +142,6 @@ async fn check_condition(
     }
 }
 
-/// The unsubscribe decision table, given the already write-locked map.
-/// Extracted so it's unit-testable without a live Redis connection (a
-/// `RedisAdapter` can't be constructed without one). Mirrors
-/// `engine/src/workers/queue/adapters/redis_adapter.rs:314-334`.
-fn unsubscribe_locked(subs: &mut HashMap<String, SubscriptionInfo>, topic: &str, id: &str) {
-    if let Some(sub_info) = subs.remove(topic) {
-        if sub_info.id == id {
-            tracing::debug!(topic = %topic, id = %id, "Unsubscribing from Redis channel");
-            sub_info.task_handle.abort();
-        } else {
-            tracing::warn!(topic = %topic, id = %id, "Subscription ID mismatch, not unsubscribing");
-            subs.insert(topic.to_string(), sub_info);
-        }
-    } else {
-        tracing::warn!(topic = %topic, id = %id, "No active subscription found for topic");
-    }
-}
-
 #[async_trait]
 impl QueueAdapter for RedisAdapter {
     async fn enqueue(
@@ -210,6 +189,7 @@ impl QueueAdapter for RedisAdapter {
         topic: &str,
         id: &str,
         function_id: &str,
+        metadata: Option<Value>,
         condition_function_id: Option<String>,
         _queue_config: Option<SubscriberQueueConfig>,
     ) {
@@ -219,15 +199,16 @@ impl QueueAdapter for RedisAdapter {
         let subscriber = Arc::clone(&self.subscriber);
         let invoker = Arc::clone(&self.invoker);
         let subscriptions = Arc::clone(&self.subscriptions);
+        let key = (topic.clone(), id.clone());
 
-        // Check if already subscribed — one subscription per topic per
-        // adapter instance, same guard as the engine.
-        let already_subscribed = {
-            let subs = subscriptions.read().await;
-            subs.contains_key(&topic)
-        };
-
-        if already_subscribed {
+        // Ignore duplicate ids on one topic. Distinct ids each get their own
+        // pub/sub connection and therefore their own message copy. The write
+        // lock is held from this check through the insert below: two racing
+        // same-key subscribes would otherwise both spawn a pubsub task, and
+        // the overwritten one would keep delivering forever (dropping a
+        // JoinHandle detaches the task, it does not abort it).
+        let mut subs = subscriptions.write().await;
+        if subs.contains_key(&key) {
             tracing::warn!(topic = %topic, id = %id, "Already subscribed to topic");
             return;
         }
@@ -235,6 +216,7 @@ impl QueueAdapter for RedisAdapter {
         let topic_for_task = topic.clone();
         let id_for_task = id.clone();
         let function_id_for_task = function_id.clone();
+        let metadata_for_task = metadata.clone();
         let condition_function_id_for_task = condition_function_id.clone();
 
         tracing::debug!(topic = %topic_for_task, id = %id_for_task, function_id = %function_id_for_task, "Subscribing to Redis channel");
@@ -337,10 +319,11 @@ impl QueueAdapter for RedisAdapter {
 
                 let invoker = Arc::clone(&invoker);
                 let function_id = function_id_for_task.clone();
+                let metadata = metadata_for_task.clone();
                 let topic_for_call = topic_for_task.clone();
 
                 tokio::spawn(async move {
-                    if let Err(e) = invoker.call(&function_id, data).await {
+                    if let Err(e) = invoker.call_delivery(&function_id, data, metadata).await {
                         tracing::error!(
                             error = %e,
                             function_id = %function_id,
@@ -356,15 +339,19 @@ impl QueueAdapter for RedisAdapter {
 
         tracing::debug!("Subscription task spawned");
 
-        // Store the subscription.
-        let mut subs = subscriptions.write().await;
-        subs.insert(topic, SubscriptionInfo { id, task_handle });
+        subs.insert(key, SubscriptionInfo { task_handle });
     }
 
     async fn unsubscribe(&self, topic: &str, id: &str) {
-        tracing::debug!(topic = %topic, id = %id, "Unsubscribing from Redis channel");
         let mut subs = self.subscriptions.write().await;
-        unsubscribe_locked(&mut subs, topic, id);
+        if let Some(sub_info) = subs.remove(&(topic.to_string(), id.to_string())) {
+            tracing::debug!(topic = %topic, id = %id, "Unsubscribing from Redis channel");
+            // Abort is safe here: per-message invocations run in their own
+            // detached tasks, and a pub/sub loop holds no durable state.
+            sub_info.task_handle.abort();
+        } else {
+            tracing::warn!(topic = %topic, id = %id, "No active subscription found");
+        }
     }
 
     async fn redrive_dlq(&self, _topic: &str) -> anyhow::Result<u64> {
@@ -451,20 +438,18 @@ impl QueueAdapter for RedisAdapter {
     }
 
     async fn list_topics(&self) -> anyhow::Result<Vec<TopicInfo>> {
-        // Redis adapter keys subscriptions by topic name directly, and only
-        // ever allows one subscription per topic (the guard in
-        // `subscribe`), so each present topic contributes exactly one to
-        // its own count. This worker's `TopicInfo` has no
+        // This worker's `TopicInfo` has no
         // `broker_type`/`subscriber_count` fields (unlike the engine's), so
         // the subscriber count is carried in `depth` — the closest
         // available field — for lack of a better one.
         let subs = self.subscriptions.read().await;
-        Ok(subs
-            .keys()
-            .map(|topic| TopicInfo {
-                name: topic.clone(),
-                depth: 1,
-            })
+        let mut topics = HashMap::<String, u64>::new();
+        for (topic, _) in subs.keys() {
+            *topics.entry(topic.clone()).or_default() += 1;
+        }
+        Ok(topics
+            .into_iter()
+            .map(|(name, depth)| TopicInfo { name, depth })
             .collect())
     }
 
@@ -512,48 +497,5 @@ mod tests {
             DLQ_NOT_SUPPORTED,
             "RedisAdapter does not support DLQ operations (pub/sub only)"
         );
-    }
-
-    #[tokio::test]
-    async fn unsubscribe_unknown_topic_is_a_noop() {
-        let mut subs: HashMap<String, SubscriptionInfo> = HashMap::new();
-        unsubscribe_locked(&mut subs, "missing-topic", "some-id");
-        assert!(subs.is_empty());
-    }
-
-    #[tokio::test]
-    async fn unsubscribe_mismatched_id_keeps_subscription() {
-        let mut subs: HashMap<String, SubscriptionInfo> = HashMap::new();
-        subs.insert(
-            "demo".to_string(),
-            SubscriptionInfo {
-                id: "owner".to_string(),
-                task_handle: tokio::spawn(async {
-                    std::future::pending::<()>().await;
-                }),
-            },
-        );
-        unsubscribe_locked(&mut subs, "demo", "someone-else");
-        assert!(
-            subs.contains_key("demo"),
-            "mismatched id must not remove the subscription"
-        );
-        subs.remove("demo").unwrap().task_handle.abort();
-    }
-
-    #[tokio::test]
-    async fn unsubscribe_matching_id_removes_and_aborts() {
-        let mut subs: HashMap<String, SubscriptionInfo> = HashMap::new();
-        subs.insert(
-            "demo".to_string(),
-            SubscriptionInfo {
-                id: "owner".to_string(),
-                task_handle: tokio::spawn(async {
-                    std::future::pending::<()>().await;
-                }),
-            },
-        );
-        unsubscribe_locked(&mut subs, "demo", "owner");
-        assert!(!subs.contains_key("demo"));
     }
 }

--- a/queue/src/configuration.rs
+++ b/queue/src/configuration.rs
@@ -242,6 +242,7 @@ mod tests {
             _topic: &str,
             _id: &str,
             _function_id: &str,
+            _metadata: Option<serde_json::Value>,
             _condition_function_id: Option<String>,
             _queue_config: Option<crate::subscriber_config::SubscriberQueueConfig>,
         ) {
@@ -310,6 +311,7 @@ mod tests {
             .register_subscriber(RegisteredSubscriber {
                 trigger_id: "t1".to_string(),
                 function_id: "backend".to_string(),
+                metadata: None,
                 spec: SubscriberSpec {
                     queue: "demo".to_string(),
                     max_retries: None,
@@ -353,6 +355,7 @@ mod tests {
             .register_subscriber(RegisteredSubscriber {
                 trigger_id: "t1".to_string(),
                 function_id: "backend".to_string(),
+                metadata: None,
                 spec: SubscriberSpec {
                     queue: "demo".to_string(),
                     max_retries: None,

--- a/queue/src/functions.rs
+++ b/queue/src/functions.rs
@@ -480,6 +480,7 @@ mod tests {
             _topic: &str,
             _id: &str,
             _function_id: &str,
+            _metadata: Option<serde_json::Value>,
             _condition_function_id: Option<String>,
             _queue_config: Option<SubscriberQueueConfig>,
         ) {

--- a/queue/src/runtime.rs
+++ b/queue/src/runtime.rs
@@ -1307,6 +1307,7 @@ mod tests {
             _topic: &str,
             _id: &str,
             _function_id: &str,
+            _metadata: Option<serde_json::Value>,
             _condition_function_id: Option<String>,
             _queue_config: Option<crate::subscriber_config::SubscriberQueueConfig>,
         ) {

--- a/queue/src/trigger.rs
+++ b/queue/src/trigger.rs
@@ -386,6 +386,14 @@ impl QueueTriggerHandler {
     /// Unregister by bare trigger id -- the queue/topic name is recovered
     /// from the stored registration, since an unregister `TriggerConfig`
     /// carries only the id.
+    ///
+    /// The registrations lock is deliberately held across `unsubscribe`:
+    /// releasing it first opens a window where a same-key register sees no
+    /// registration, calls subscribe while the adapter still holds the old
+    /// entry, no-ops on the adapter's duplicate check, and ends up
+    /// registered with no live consumer. Adapter unsubscribes are prompt
+    /// (they detach their drain rather than await it), so holding the lock
+    /// costs a broker round-trip, not an invocation.
     pub async fn unregister(&self, trigger_id: &str) {
         let mut registrations = self.registrations.lock().await;
         let Some(registration) = registrations.remove(trigger_id) else {

--- a/queue/src/trigger.rs
+++ b/queue/src/trigger.rs
@@ -654,6 +654,46 @@ mod tests {
         );
     }
 
+    /// A hot-swap resubscribe collapses registrations sharing a subscription
+    /// key to ONE subscribe against the new adapter, mirroring
+    /// `register_subscriber`'s dedup — otherwise the swap would stack
+    /// duplicate consumers that each deliver every message again.
+    #[tokio::test]
+    async fn resubscribe_all_subscribes_shared_keys_once() {
+        let (handler, _old_mock) = handler_with_mock();
+        handler
+            .register_trigger(trigger_config(
+                "uuid-1",
+                "backend",
+                json!({"queue": "demo"}),
+            ))
+            .await
+            .unwrap();
+        handler
+            .register_trigger(trigger_config(
+                "uuid-2",
+                "backend",
+                json!({"queue": "demo"}),
+            ))
+            .await
+            .unwrap();
+
+        let new_mock = Arc::new(MockAdapter::default());
+        let new_adapter: Arc<dyn QueueAdapter> = new_mock.clone();
+        handler.adapter.replace(new_adapter, "new-mock").await;
+        handler.resubscribe_all().await;
+
+        assert_eq!(
+            new_mock.calls().len(),
+            1,
+            "shared-key registrations must resubscribe once"
+        );
+        let Call::Subscribe { id, .. } = &new_mock.calls()[0] else {
+            panic!("expected a Subscribe call");
+        };
+        assert_eq!(id, "backend");
+    }
+
     /// Leftover duplicate registrations for the same function (e.g. persisted
     /// triggers re-delivered across app restarts) share one subscription
     /// instead of each delivering every message again.

--- a/queue/src/trigger.rs
+++ b/queue/src/trigger.rs
@@ -6,7 +6,7 @@
 //! (possibly hot-swapped) [`SwappableAdapter`]. All delivery, retry, and DLQ
 //! behavior lives in the adapter (e.g. [`crate::adapters::builtin::BuiltinAdapter`]).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -72,6 +72,24 @@ pub trait Invoker: Send + Sync + 'static {
         self.call(function_id, payload).await
     }
 
+    /// Dispatch one SUBSCRIPTION DELIVERY: the payload plus the trigger's
+    /// stored metadata, which the target may need to know which binding this
+    /// is (for a harness-managed binding it is the `__binding` pointer the
+    /// delivery hop resolves — without it every delivery is an unresolvable
+    /// fire, dropped on arrival; discovery run 4 lost all 18 messages to
+    /// exactly that). Condition checks and infrastructure calls stay on
+    /// [`Self::call`]. The default ignores metadata so bare test invokers
+    /// keep working; the iii-backed invoker overrides it.
+    async fn call_delivery(
+        &self,
+        function_id: &str,
+        payload: Value,
+        metadata: Option<Value>,
+    ) -> Result<Option<Value>, String> {
+        let _ = metadata;
+        self.call(function_id, payload).await
+    }
+
     /// Whether the target is currently registered with the engine.
     ///
     /// Adapters used in unit tests and embedded deployments can keep the
@@ -108,16 +126,7 @@ impl IiiInvoker {
 #[async_trait]
 impl Invoker for IiiInvoker {
     async fn call(&self, function_id: &str, payload: Value) -> Result<Option<Value>, String> {
-        self.iii
-            .trigger(TriggerRequest {
-                function_id: function_id.to_string(),
-                payload,
-                action: None,
-                timeout_ms: Some(FUNCTION_QUEUE_INVOCATION_TIMEOUT_MS),
-            })
-            .await
-            .map(Some)
-            .map_err(|e| e.to_string())
+        self.call_delivery(function_id, payload, None).await
     }
 
     async fn call_with_timeout(
@@ -136,6 +145,26 @@ impl Invoker for IiiInvoker {
             .await
             .map(Some)
             .map_err(|e| e.to_string())
+    }
+
+    async fn call_delivery(
+        &self,
+        function_id: &str,
+        payload: Value,
+        metadata: Option<Value>,
+    ) -> Result<Option<Value>, String> {
+        let request = TriggerRequest {
+            function_id: function_id.to_string(),
+            payload,
+            action: None,
+            timeout_ms: Some(FUNCTION_QUEUE_INVOCATION_TIMEOUT_MS),
+        };
+        match metadata {
+            Some(m) => self.iii.trigger(request.metadata(m)).await,
+            None => self.iii.trigger(request).await,
+        }
+        .map(Some)
+        .map_err(|e| e.to_string())
     }
 
     async fn function_available(&self, function_id: &str) -> Result<bool, String> {
@@ -210,7 +239,34 @@ pub struct SubscriberSpec {
 pub struct RegisteredSubscriber {
     pub trigger_id: String,
     pub function_id: String,
+    /// The trigger's stored metadata, delivered verbatim with every message.
+    /// For a harness-managed binding this carries `{"__binding": <id>}` — the
+    /// pointer the delivery hop resolves; dropping it makes every delivery an
+    /// unresolvable fire.
+    pub metadata: Option<Value>,
     pub spec: SubscriberSpec,
+}
+
+impl RegisteredSubscriber {
+    /// The durable identity the adapter keys this subscription's queue by.
+    ///
+    /// It must survive re-registration, or the replacement subscriber gets a
+    /// fresh empty queue and the old one sits bound to the exchange collecting
+    /// a copy of every publish forever (the SDK mints a new trigger id per
+    /// `register_trigger` call, so `trigger_id` itself cannot be the key).
+    /// A harness binding's `__binding` id is that identity; a plain SDK
+    /// subscriber falls back to its target function id — the pre-binding queue
+    /// naming, which also keeps existing deployments attached to their
+    /// backlogs across the upgrade. Distinct same-function subscribers without
+    /// a binding id therefore share one subscription (first registration's
+    /// config wins), exactly as they shared one function queue before.
+    fn subscription_key(&self) -> &str {
+        self.metadata
+            .as_ref()
+            .and_then(|m| m.get("__binding"))
+            .and_then(Value::as_str)
+            .unwrap_or(&self.function_id)
+    }
 }
 
 /// Merge the spec's legacy top-level `max_retries`/`backoff_ms` into its
@@ -265,13 +321,19 @@ impl QueueTriggerHandler {
     /// the newly built transport, so these `subscribe` calls attach
     /// consumers to the new adapter rather than the one being retired.
     pub async fn resubscribe_all(&self) {
+        let mut seen = HashSet::new();
         for registration in self.registrations().await {
+            let key = registration.subscription_key().to_string();
+            if !seen.insert((registration.spec.queue.clone(), key.clone())) {
+                continue; // registrations sharing a key share one subscription
+            }
             let queue_config = merged_queue_config(&registration.spec);
             self.adapter
                 .subscribe(
                     &registration.spec.queue,
-                    &registration.trigger_id,
+                    &key,
                     &registration.function_id,
+                    registration.metadata.clone(),
                     registration.spec.condition_function_id.clone(),
                     Some(queue_config),
                 )
@@ -295,16 +357,27 @@ impl QueueTriggerHandler {
             ));
         }
 
-        let queue_config = merged_queue_config(&registration.spec);
-        self.adapter
-            .subscribe(
-                &registration.spec.queue,
-                &registration.trigger_id,
-                &registration.function_id,
-                registration.spec.condition_function_id.clone(),
-                Some(queue_config),
-            )
-            .await;
+        // Registrations sharing a subscription key (e.g. a re-registered SDK
+        // subscriber whose previous trigger was never unregistered) share the
+        // one live subscription instead of stacking duplicate consumers that
+        // would each deliver every message again.
+        let key = registration.subscription_key().to_string();
+        let already_live = registrations
+            .values()
+            .any(|r| r.spec.queue == registration.spec.queue && r.subscription_key() == key);
+        if !already_live {
+            let queue_config = merged_queue_config(&registration.spec);
+            self.adapter
+                .subscribe(
+                    &registration.spec.queue,
+                    &key,
+                    &registration.function_id,
+                    registration.metadata.clone(),
+                    registration.spec.condition_function_id.clone(),
+                    Some(queue_config),
+                )
+                .await;
+        }
 
         registrations.insert(registration.trigger_id.clone(), registration);
         Ok(())
@@ -314,10 +387,17 @@ impl QueueTriggerHandler {
     /// from the stored registration, since an unregister `TriggerConfig`
     /// carries only the id.
     pub async fn unregister(&self, trigger_id: &str) {
-        let registration = self.registrations.lock().await.remove(trigger_id);
-        if let Some(registration) = registration {
+        let mut registrations = self.registrations.lock().await;
+        let Some(registration) = registrations.remove(trigger_id) else {
+            return;
+        };
+        let key = registration.subscription_key();
+        let still_shared = registrations
+            .values()
+            .any(|r| r.spec.queue == registration.spec.queue && r.subscription_key() == key);
+        if !still_shared {
             self.adapter
-                .unsubscribe(&registration.spec.queue, trigger_id)
+                .unsubscribe(&registration.spec.queue, key)
                 .await;
         }
     }
@@ -331,6 +411,7 @@ impl TriggerHandler for QueueTriggerHandler {
         self.register_subscriber(RegisteredSubscriber {
             trigger_id: config.id,
             function_id: config.function_id,
+            metadata: config.metadata,
             spec,
         })
         .await
@@ -357,6 +438,7 @@ mod tests {
             topic: String,
             id: String,
             function_id: String,
+            metadata: Option<Value>,
             condition_function_id: Option<String>,
             queue_config: Option<SubscriberQueueConfig>,
         },
@@ -393,6 +475,7 @@ mod tests {
             topic: &str,
             id: &str,
             function_id: &str,
+            metadata: Option<Value>,
             condition_function_id: Option<String>,
             queue_config: Option<SubscriberQueueConfig>,
         ) {
@@ -400,6 +483,7 @@ mod tests {
                 topic: topic.to_string(),
                 id: id.to_string(),
                 function_id: function_id.to_string(),
+                metadata,
                 condition_function_id,
                 queue_config,
             });
@@ -480,8 +564,11 @@ mod tests {
             mock.calls(),
             vec![Call::Subscribe {
                 topic: "demo".to_string(),
-                id: "t1".to_string(),
+                // No binding id in the metadata: the subscription is keyed by
+                // its stable function id, not the per-registration trigger id.
+                id: "backend".to_string(),
                 function_id: "backend".to_string(),
+                metadata: None,
                 condition_function_id: None,
                 queue_config: Some(SubscriberQueueConfig {
                     max_retries: Some(2),
@@ -489,6 +576,118 @@ mod tests {
                     ..Default::default()
                 }),
             }]
+        );
+    }
+
+    /// The discovery-run-4 regression: the harness's `__binding` pointer
+    /// arrives as trigger metadata and MUST reach the adapter — the delivery
+    /// hop cannot resolve a fire without it.
+    #[tokio::test]
+    async fn register_passes_trigger_metadata_to_the_adapter() {
+        let (handler, mock) = handler_with_mock();
+        let mut config = trigger_config("t1", "harness::trigger::deliver", json!({"queue": "q"}));
+        config.metadata = Some(json!({ "__binding": "sub_abc" }));
+        handler.register_trigger(config).await.unwrap();
+
+        let Call::Subscribe { id, metadata, .. } = &mock.calls()[0] else {
+            panic!("expected a Subscribe call");
+        };
+        assert_eq!(metadata, &Some(json!({ "__binding": "sub_abc" })));
+        // The binding id is the durable subscription identity — it, not the
+        // ephemeral trigger id, keys the adapter's queue.
+        assert_eq!(id, "sub_abc");
+
+        // And a hot-swap resubscribe carries it to the NEW adapter too.
+        let new_mock = Arc::new(MockAdapter::default());
+        let new_adapter: Arc<dyn QueueAdapter> = new_mock.clone();
+        handler.adapter.replace(new_adapter, "new-mock").await;
+        handler.resubscribe_all().await;
+        let Call::Subscribe { id, metadata, .. } = &new_mock.calls()[0] else {
+            panic!("expected a Subscribe call");
+        };
+        assert_eq!(metadata, &Some(json!({ "__binding": "sub_abc" })));
+        assert_eq!(id, "sub_abc");
+    }
+
+    /// The SDK mints a fresh trigger id per registration, so a restarted
+    /// subscriber re-registers under a new id. Its durable identity (here the
+    /// function-id fallback) must not change, or it would come back to a
+    /// fresh empty queue while the old one keeps collecting fanout copies
+    /// forever.
+    #[tokio::test]
+    async fn re_registration_under_a_new_trigger_id_keeps_the_subscription_key() {
+        let (handler, mock) = handler_with_mock();
+        handler
+            .register_trigger(trigger_config(
+                "uuid-1",
+                "backend",
+                json!({"queue": "demo"}),
+            ))
+            .await
+            .unwrap();
+        handler.unregister("uuid-1").await;
+        handler
+            .register_trigger(trigger_config(
+                "uuid-2",
+                "backend",
+                json!({"queue": "demo"}),
+            ))
+            .await
+            .unwrap();
+
+        let ids: Vec<_> = mock
+            .calls()
+            .iter()
+            .map(|call| match call {
+                Call::Subscribe { id, .. } => format!("subscribe:{id}"),
+                Call::Unsubscribe { id, .. } => format!("unsubscribe:{id}"),
+            })
+            .collect();
+        assert_eq!(
+            ids,
+            vec![
+                "subscribe:backend",
+                "unsubscribe:backend",
+                "subscribe:backend"
+            ],
+            "both registrations must attach to the same durable queue"
+        );
+    }
+
+    /// Leftover duplicate registrations for the same function (e.g. persisted
+    /// triggers re-delivered across app restarts) share one subscription
+    /// instead of each delivering every message again.
+    #[tokio::test]
+    async fn same_function_registrations_share_one_live_subscription() {
+        let (handler, mock) = handler_with_mock();
+        handler
+            .register_trigger(trigger_config(
+                "uuid-1",
+                "backend",
+                json!({"queue": "demo"}),
+            ))
+            .await
+            .unwrap();
+        handler
+            .register_trigger(trigger_config(
+                "uuid-2",
+                "backend",
+                json!({"queue": "demo"}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(mock.calls().len(), 1, "one shared subscription");
+
+        // The shared subscription stays live until the LAST registration goes.
+        handler.unregister("uuid-1").await;
+        assert_eq!(mock.calls().len(), 1, "still consumed by uuid-2");
+        handler.unregister("uuid-2").await;
+        assert_eq!(
+            mock.calls().last().unwrap(),
+            &Call::Unsubscribe {
+                topic: "demo".to_string(),
+                id: "backend".to_string(),
+            }
         );
     }
 
@@ -552,7 +751,7 @@ mod tests {
             mock.calls().last().unwrap(),
             &Call::Unsubscribe {
                 topic: "demo".to_string(),
-                id: "t1".to_string(),
+                id: "backend".to_string(),
             }
         );
         assert!(handler.registrations().await.is_empty());
@@ -594,8 +793,9 @@ mod tests {
         assert_eq!(new_calls.len(), 2);
         assert!(new_calls.contains(&Call::Subscribe {
             topic: "demo-1".to_string(),
-            id: "t1".to_string(),
+            id: "backend-1".to_string(),
             function_id: "backend-1".to_string(),
+            metadata: None,
             condition_function_id: None,
             queue_config: Some(SubscriberQueueConfig {
                 max_retries: Some(2),
@@ -604,8 +804,9 @@ mod tests {
         }));
         assert!(new_calls.contains(&Call::Subscribe {
             topic: "demo-2".to_string(),
-            id: "t2".to_string(),
+            id: "backend-2".to_string(),
             function_id: "backend-2".to_string(),
+            metadata: None,
             condition_function_id: None,
             queue_config: Some(SubscriberQueueConfig::default()),
         }));

--- a/queue/tests/e2e_durability.rs
+++ b/queue/tests/e2e_durability.rs
@@ -4,14 +4,20 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use async_trait::async_trait;
+use iii_queue::adapter::QueueAdapter;
+use iii_queue::adapters::builtin::BuiltinAdapter;
 use iii_queue::config::{AdapterEntry, QueueConfig};
 use iii_queue::functions::{DLQ_MESSAGES_FN_ID, PUBLISH_FN_ID, REDRIVE_FN_ID};
+use iii_queue::store::FileStore;
+use iii_queue::trigger::Invoker;
 use iii_queue::TRIGGER_TYPE;
 use iii_sdk::errors::Error;
 use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
 use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::{json, Value};
 use serial_test::serial;
+use tokio::sync::Notify;
 use tokio::time::Instant;
 use uuid::Uuid;
 
@@ -180,60 +186,59 @@ async fn delivery_dlq_and_redrive_connect_or_skip() {
     let _ = std::fs::remove_dir_all(dir);
 }
 
+struct RestartInvoker {
+    started: Notify,
+    resume: AtomicBool,
+    fires: AtomicUsize,
+}
+
+#[async_trait]
+impl Invoker for RestartInvoker {
+    async fn call(&self, _function_id: &str, _payload: Value) -> Result<Option<Value>, String> {
+        if self.resume.load(Ordering::SeqCst) {
+            self.fires.fetch_add(1, Ordering::SeqCst);
+            return Ok(None);
+        }
+        self.started.notify_one();
+        std::future::pending().await
+    }
+}
+
 #[tokio::test]
 #[serial]
-async fn file_based_pending_message_survives_worker_restart_connect_or_skip() {
-    let Some(iii) = engine::connect_fresh().await else {
-        return;
-    };
-
+async fn file_based_pending_message_survives_binding_restart() {
     let dir = temp_store_dir();
-    let boot = iii_queue::boot::start(iii.clone(), file_config(&dir))
-        .await
-        .expect("queue worker should boot");
-
-    // Engine-parity restart scenario: the message must be enqueued onto a
-    // SUBSCRIBED topic (fan-out routes it to the subscriber's internal
-    // queue, which is what the file store persists). A publish with no
-    // subscriber buffers on the bare topic and is never drained by a later
-    // subscribe — same as the engine builtin. `concurrency: 0` pauses
-    // consumption (engine semantics) so the message is still pending when
-    // the worker shuts down.
     let queue_name = format!("e2e-restart-{}", Uuid::new_v4());
     let function_id = format!("queue.restart.{queue_name}");
-    register_subscriber_with_config(
-        &iii,
-        &function_id,
-        &queue_name,
-        Some(json!({"concurrency": 0})),
-    );
-    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
-    trigger(
-        &iii,
-        PUBLISH_FN_ID,
-        json!({"queue": queue_name, "data": {"survives": true}}),
-    )
-    .await;
-    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
-    boot.shutdown().await;
-    iii.shutdown_async().await;
+    let subscription_id = "stable-binding";
+    let invoker = Arc::new(RestartInvoker {
+        started: Notify::new(),
+        resume: AtomicBool::new(false),
+        fires: AtomicUsize::new(0),
+    });
 
-    let Some(iii) = engine::connect_fresh().await else {
-        return;
-    };
-    let boot = iii_queue::boot::start(iii.clone(), file_config(&dir))
+    let store = Arc::new(FileStore::open(&dir, 5).await.unwrap());
+    let adapter = BuiltinAdapter::new(store, invoker.clone());
+    adapter
+        .subscribe(&queue_name, subscription_id, &function_id, None, None, None)
+        .await;
+    adapter
+        .enqueue(&queue_name, json!({"survives": true}), None, None)
+        .await;
+    tokio::time::timeout(Duration::from_secs(3), invoker.started.notified())
         .await
-        .expect("queue worker should reboot");
+        .expect("subscriber should start the blocked delivery");
+    adapter.shutdown().await;
+    drop(adapter);
 
-    let fires = Arc::new(AtomicUsize::new(0));
-    let fail = Arc::new(AtomicBool::new(false));
-    // Same function id as before the restart: the persisted job lives in
-    // the internal queue `{topic}::{function_id}`.
-    register_counting_function(&iii, &function_id, fires.clone(), fail);
-    register_subscriber(&iii, &function_id, &queue_name);
-    wait_for_fires(&fires, 1).await;
+    invoker.resume.store(true, Ordering::SeqCst);
+    let store = Arc::new(FileStore::open(&dir, 5).await.unwrap());
+    let adapter = BuiltinAdapter::new(store, invoker.clone());
+    adapter
+        .subscribe(&queue_name, subscription_id, &function_id, None, None, None)
+        .await;
+    wait_for_fires(&invoker.fires, 1).await;
 
-    boot.shutdown().await;
-    iii.shutdown_async().await;
+    adapter.shutdown().await;
     let _ = std::fs::remove_dir_all(dir);
 }

--- a/queue/tests/e2e_rabbitmq.rs
+++ b/queue/tests/e2e_rabbitmq.rs
@@ -61,7 +61,7 @@ fn subscriber_dlq_name(topic: &str, subscription_id: &str) -> String {
 /// via a raw `lapin` channel, so messages can be published into the queue
 /// BEFORE any adapter-owned consumer exists. All declarations use identical
 /// arguments to what `topology::TopologyManager` declares, so the later,
-/// real `subscribe()` call's redeclare is a idempotent no-op (AMQP rejects a
+/// real `subscribe()` call's redeclare is an idempotent no-op (AMQP rejects a
 /// redeclare with mismatched arguments).
 async fn predeclare_priority_subscriber_queue(
     channel: &Channel,

--- a/queue/tests/e2e_rabbitmq.rs
+++ b/queue/tests/e2e_rabbitmq.rs
@@ -132,6 +132,30 @@ impl Invoker for NoopInvoker {
     }
 }
 
+/// Records every delivery's payload — for adapter-direct tests that need a
+/// broker but no live engine.
+#[derive(Default)]
+struct RecordingInvoker {
+    deliveries: Mutex<Vec<Value>>,
+}
+
+#[async_trait]
+impl Invoker for RecordingInvoker {
+    async fn call(&self, _function_id: &str, _payload: Value) -> Result<Option<Value>, String> {
+        Ok(None)
+    }
+
+    async fn call_delivery(
+        &self,
+        _function_id: &str,
+        payload: Value,
+        _metadata: Option<Value>,
+    ) -> Result<Option<Value>, String> {
+        self.deliveries.lock().await.push(payload);
+        Ok(None)
+    }
+}
+
 /// (a) Basic delivery: subscribe, enqueue, the registered function receives
 /// the raw data.
 #[tokio::test]
@@ -441,6 +465,78 @@ async fn priority_ordering_connect_or_skip() {
     adapter.shutdown().await;
     let _ = raw_connection.close(200, "test done").await;
     iii.shutdown_async().await;
+}
+
+/// Unsubscribe detaches the consumer but keeps the durable queue bound to
+/// the fanout exchange: messages published while detached buffer on the
+/// broker, and a same-id resubscribe drains them. This is the contract that
+/// makes routine subscriber disconnects lossless — deleting the queue on
+/// unsubscribe destroyed exactly this backlog.
+#[tokio::test]
+#[serial]
+async fn unsubscribe_keeps_backlog_for_same_id_resubscribe_connect_or_skip() {
+    let Some(container) = docker::start_rabbitmq().await else {
+        return; // skip: docker not reachable
+    };
+
+    let invoker = Arc::new(RecordingInvoker::default());
+    let adapter = RabbitMQAdapter::from_config(
+        Some(&json!({"amqp_url": container.amqp_url()})),
+        invoker.clone(),
+    )
+    .await
+    .expect("rabbitmq adapter should connect");
+
+    let topic = format!("e2e-rmq-rearm-{}", Uuid::new_v4());
+    let sub_id = "sub-rearm-1";
+    adapter
+        .subscribe(&topic, sub_id, "rearm-fn", None, None, None)
+        .await;
+    // Give the consumer task a beat to attach before the first publish --
+    // same as basic_delivery.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    adapter.enqueue(&topic, json!({"n": 1}), None, None).await;
+    wait_until(
+        || {
+            let invoker = invoker.clone();
+            async move { invoker.deliveries.lock().await.len() == 1 }
+        },
+        Duration::from_secs(10),
+    )
+    .await;
+
+    adapter.unsubscribe(&topic, sub_id).await;
+    // Published while detached: both enqueues are broker-confirmed
+    // (`Publisher::publish` awaits the confirm), so they are already in the
+    // still-bound queue when we assert nothing got delivered.
+    adapter.enqueue(&topic, json!({"n": 2}), None, None).await;
+    adapter.enqueue(&topic, json!({"n": 3}), None, None).await;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert_eq!(
+        invoker.deliveries.lock().await.len(),
+        1,
+        "nothing may be delivered while detached"
+    );
+
+    adapter
+        .subscribe(&topic, sub_id, "rearm-fn", None, None, None)
+        .await;
+    wait_until(
+        || {
+            let invoker = invoker.clone();
+            async move { invoker.deliveries.lock().await.len() == 3 }
+        },
+        Duration::from_secs(10),
+    )
+    .await;
+    let deliveries = invoker.deliveries.lock().await.clone();
+    assert!(
+        deliveries.contains(&json!({"n": 2})) && deliveries.contains(&json!({"n": 3})),
+        "the detached-period backlog must drain on resubscribe, got: {deliveries:?}"
+    );
+
+    adapter.unsubscribe(&topic, sub_id).await;
+    adapter.shutdown().await;
 }
 
 /// (d) Fifo mode: 10 messages published in order are delivered in the same

--- a/queue/tests/e2e_rabbitmq.rs
+++ b/queue/tests/e2e_rabbitmq.rs
@@ -48,25 +48,25 @@ where
 fn exchange_name(topic: &str) -> String {
     format!("iii.{topic}.exchange")
 }
-fn function_queue_name(topic: &str, function_id: &str) -> String {
-    format!("iii.{topic}.{function_id}.queue")
+fn subscriber_queue_name(topic: &str, subscription_id: &str) -> String {
+    format!("iii.{topic}.{subscription_id}.queue")
 }
-fn function_dlq_name(topic: &str, function_id: &str) -> String {
-    format!("iii.{topic}.{function_id}.dlq")
+fn subscriber_dlq_name(topic: &str, subscription_id: &str) -> String {
+    format!("iii.{topic}.{subscription_id}.dlq")
 }
 
 /// Declares the exact same topology `RabbitMQAdapter::subscribe` would
-/// declare for `(topic, function_id)` -- fanout exchange, per-function DLQ,
-/// per-function priority queue (`x-max-priority`), and the binding -- via a
-/// raw `lapin` channel, so messages can be published into the queue BEFORE
-/// any adapter-owned consumer exists. All declarations use identical
+/// declare for `(topic, subscription_id)` -- fanout exchange, per-subscription
+/// DLQ, per-subscription priority queue (`x-max-priority`), and the binding --
+/// via a raw `lapin` channel, so messages can be published into the queue
+/// BEFORE any adapter-owned consumer exists. All declarations use identical
 /// arguments to what `topology::TopologyManager` declares, so the later,
 /// real `subscribe()` call's redeclare is a idempotent no-op (AMQP rejects a
 /// redeclare with mismatched arguments).
 async fn predeclare_priority_subscriber_queue(
     channel: &Channel,
     topic: &str,
-    function_id: &str,
+    subscription_id: &str,
     max_priority: i32,
 ) {
     channel
@@ -84,7 +84,7 @@ async fn predeclare_priority_subscriber_queue(
 
     channel
         .queue_declare(
-            &function_dlq_name(topic, function_id),
+            &subscriber_dlq_name(topic, subscription_id),
             QueueDeclareOptions {
                 durable: true,
                 ..Default::default()
@@ -98,7 +98,7 @@ async fn predeclare_priority_subscriber_queue(
     args.insert("x-max-priority".into(), AMQPValue::LongInt(max_priority));
     channel
         .queue_declare(
-            &function_queue_name(topic, function_id),
+            &subscriber_queue_name(topic, subscription_id),
             QueueDeclareOptions {
                 durable: true,
                 ..Default::default()
@@ -110,7 +110,7 @@ async fn predeclare_priority_subscriber_queue(
 
     channel
         .queue_bind(
-            &function_queue_name(topic, function_id),
+            &subscriber_queue_name(topic, subscription_id),
             &exchange_name(topic),
             "",
             QueueBindOptions::default(),
@@ -168,7 +168,7 @@ async fn basic_delivery_connect_or_skip() {
 
     let topic = format!("e2e-rmq-basic-{}", Uuid::new_v4());
     adapter
-        .subscribe(&topic, "sub-1", &function_id, None, None)
+        .subscribe(&topic, "sub-1", &function_id, None, None, None)
         .await;
     // Give the consumer task a beat to actually attach before the first
     // publish.
@@ -396,7 +396,7 @@ async fn priority_ordering_connect_or_skip() {
         .create_channel()
         .await
         .expect("raw amqp channel");
-    predeclare_priority_subscriber_queue(&raw_channel, &topic, &function_id, 10).await;
+    predeclare_priority_subscriber_queue(&raw_channel, &topic, sub_id, 10).await;
 
     for p in [1u64, 9, 5] {
         adapter
@@ -412,6 +412,7 @@ async fn priority_ordering_connect_or_skip() {
             &topic,
             sub_id,
             &function_id,
+            None,
             None,
             Some(SubscriberQueueConfig {
                 max_priority: Some(10),
@@ -488,6 +489,7 @@ async fn fifo_mode_preserves_order_connect_or_skip() {
             &topic,
             "sub-fifo-1",
             &function_id,
+            None,
             None,
             Some(SubscriberQueueConfig {
                 queue_mode: Some("fifo".to_string()),

--- a/queue/tests/e2e_redis.rs
+++ b/queue/tests/e2e_redis.rs
@@ -177,6 +177,11 @@ async fn same_function_subscriptions_each_receive_their_metadata_connect_or_skip
     wait_for_fires(&invoker.fires, 2).await;
 
     let deliveries = invoker.deliveries.lock().await;
+    assert_eq!(
+        deliveries.len(),
+        2,
+        "exactly one delivery per binding — a duplicate subscription would add more"
+    );
     assert!(deliveries
         .iter()
         .all(|(function_id, payload, _)| function_id == "same-function"

--- a/queue/tests/e2e_redis.rs
+++ b/queue/tests/e2e_redis.rs
@@ -4,9 +4,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use async_trait::async_trait;
 use iii_queue::adapter::QueueAdapter;
 use iii_queue::adapters::redis::RedisAdapter;
-use iii_queue::trigger::IiiInvoker;
+use iii_queue::trigger::{IiiInvoker, Invoker};
 use iii_sdk::errors::Error;
 use iii_sdk::RegisterFunction;
 use serde_json::{json, Value};
@@ -29,6 +30,33 @@ async fn wait_for_fires(fires: &AtomicUsize, expected: usize) {
         fires.load(Ordering::SeqCst) >= expected,
         "expected at least {expected} fires"
     );
+}
+
+#[derive(Default)]
+struct RecordingInvoker {
+    fires: AtomicUsize,
+    deliveries: tokio::sync::Mutex<Vec<(String, Value, Option<Value>)>>,
+}
+
+#[async_trait]
+impl Invoker for RecordingInvoker {
+    async fn call(&self, _function_id: &str, _payload: Value) -> Result<Option<Value>, String> {
+        Ok(None)
+    }
+
+    async fn call_delivery(
+        &self,
+        function_id: &str,
+        payload: Value,
+        metadata: Option<Value>,
+    ) -> Result<Option<Value>, String> {
+        self.deliveries
+            .lock()
+            .await
+            .push((function_id.to_string(), payload, metadata));
+        self.fires.fetch_add(1, Ordering::SeqCst);
+        Ok(None)
+    }
 }
 
 /// Boots a `RedisAdapter` directly against a live engine connection and a
@@ -75,7 +103,7 @@ async fn publish_delivers_unwrapped_payload_to_subscriber_connect_or_skip() {
 
     let topic = format!("e2e-redis-{}", Uuid::new_v4());
     adapter
-        .subscribe(&topic, "sub-1", &function_id, None, None)
+        .subscribe(&topic, "sub-1", &function_id, None, None, None)
         .await;
     // Give the subscription task a beat to actually SUBSCRIBE on the Redis
     // connection before the first publish — pub/sub has no buffering for a
@@ -103,6 +131,65 @@ async fn publish_delivers_unwrapped_payload_to_subscriber_connect_or_skip() {
     adapter.unsubscribe(&topic, "sub-1").await;
     adapter.shutdown().await;
     iii.shutdown_async().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn same_function_subscriptions_each_receive_their_metadata_connect_or_skip() {
+    let Some(container) = docker::start_redis() else {
+        return; // skip: docker not reachable
+    };
+
+    let invoker = Arc::new(RecordingInvoker::default());
+    let adapter = RedisAdapter::from_config(
+        Some(&json!({"redis_url": container.redis_url()})),
+        invoker.clone(),
+    )
+    .await
+    .expect("redis adapter should connect");
+    let topic = format!("e2e-redis-fanout-{}", Uuid::new_v4());
+
+    adapter
+        .subscribe(
+            &topic,
+            "sub-a",
+            "same-function",
+            Some(json!({"binding": "a"})),
+            None,
+            None,
+        )
+        .await;
+    adapter
+        .subscribe(
+            &topic,
+            "sub-b",
+            "same-function",
+            Some(json!({"binding": "b"})),
+            None,
+            None,
+        )
+        .await;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    adapter
+        .enqueue(&topic, json!({"event": 1}), None, None)
+        .await;
+
+    wait_for_fires(&invoker.fires, 2).await;
+
+    let deliveries = invoker.deliveries.lock().await;
+    assert!(deliveries
+        .iter()
+        .all(|(function_id, payload, _)| function_id == "same-function"
+            && payload == &json!({"event": 1})));
+    assert!(deliveries
+        .iter()
+        .any(|(_, _, metadata)| metadata == &Some(json!({"binding": "a"}))));
+    assert!(deliveries
+        .iter()
+        .any(|(_, _, metadata)| metadata == &Some(json!({"binding": "b"}))));
+    drop(deliveries);
+
+    adapter.shutdown().await;
 }
 
 /// The redis adapter is pub/sub only: every DLQ-family method must fail


### PR DESCRIPTION
## What

Each `durable:subscriber` registration now gets its own adapter subscription, and every delivery carries the trigger's stored metadata via the new `Invoker::call_delivery`. For harness-managed bindings that metadata is the `__binding` pointer the delivery hop resolves — without it every binding delivery is an unresolvable fire (discovery run 4 lost all 18 messages to exactly that). Two bindings on the same function each get their own queue, their own copy, and their own metadata.

## Durable identity

Subscription identity is derived at the trigger layer (`RegisteredSubscriber::subscription_key`):

- `metadata.__binding` when present (harness bindings) — stable across restarts by definition.
- the target `function_id` otherwise (plain SDK subscribers) — the pre-existing queue naming, so live deployments keep their queue names and backlogs across the upgrade.

SDK trigger ids are fresh UUIDs per `register_trigger` call and never key durable state. Duplicate registrations sharing a key share one live subscription (the adapter unsubscribes only when the last one goes), so leftover re-registrations don't multiply deliveries.

## Lifecycle semantics

- **unsubscribe** (process keeps running): cancel the consumer, drain the in-flight delivery to completion so it acks/nacks, and keep the queue/DLQ/store state — that backlog is exactly what a same-id resubscribe reattaches to. Unsubscribe fires on every routine subscriber disconnect, so it must never destroy data (`store.purge` is removed along with its only caller).
- **shutdown** (process exit): cancel and abort. In-flight jobs are owned by store inflight-recovery / broker redelivery (at-least-once); draining could hang exit behind one blocked invocation.

## Review hardening

A `/code-review max` pass over the branch produced 15 verified findings; all are fixed here. Highlights beyond the identity/lifecycle work above:

- rabbitmq/redis `subscribe` hold the write lock from duplicate-check through insert, closing a TOCTOU that leaked an unstoppable duplicate consumer; with queue deletion gone, the unsubscribe/resubscribe race that deleted a freshly re-created queue is dissolved.
- builtin `enqueue` snapshots the routing set before store I/O instead of holding the adapter-wide mutex across blocking FileStore writes; the race test asserts observable behavior instead of lock internals.
- rabbitmq worker drains its JoinSet instead of `abort_all`; FIFO deliveries borrow instead of deep-cloning metadata per message.
- `IiiInvoker::call` delegates to `call_delivery`; redis `unsubscribe_locked` and its HashMap-only tests are inlined/removed; the priority e2e predeclares the subscriber-id topology `subscribe` actually consumes.

## Compat

RabbitMQ topics consumed by **harness bindings** leave the old shared `iii.{topic}.{function_id}.queue`/`.dlq` bound to the fanout exchange with no consumer after upgrade — delete those queues manually or they keep accumulating fanout copies. Their backlog is messages the old code was already dropping as unresolvable. **Plain-SDK** subscriber queue names are unchanged, so their backlogs carry over untouched.

## Verification

- `cargo test --all-features`: 130 unit + durability/redis-shape tests pass. Docker-backed e2e skipped locally (no docker socket access); `missing_dlq_inspection_does_not_close_consumer_channel` hard-requires docker and fails on any docker-less machine — pre-existing behavior, gate untouched.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --check`: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional metadata to subscriptions and made it available to message handlers.
  * Multiple subscriptions can now share a topic and function while retaining separate metadata.
  * Improved subscription-specific queue and dead-letter handling across supported queue backends.

* **Bug Fixes**
  * Improved unsubscribe and shutdown behavior, including orderly cancellation and message redelivery.
  * Prevented duplicate subscriptions and preserved queued messages during subscription changes.

* **Tests**
  * Expanded coverage for metadata delivery, fan-out, durability, cancellation, and subscription lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Ticket

Queue-worker slice of MOT-4214 (trigger-owning workers dropping the fire-time metadata sidecar).