### PR TITLE
chore: make Harness E2E score advisory

### DIFF
--- a/.github/workflows/_harness-e2e.yml
+++ b/.github/workflows/_harness-e2e.yml
@@ -13,16 +13,6 @@ on:
         required: false
         type: number
         default: 2
-      quality_advisory:
-        description: Only fail degraded results below the CI score floor
-        required: false
-        type: boolean
-        default: false
-      ci_score_floor:
-        description: Minimum median score allowed by the advisory CI policy
-        required: false
-        type: number
-        default: 50
       subjects:
         description: JSON array of subject entries with id, model, and provider
         required: false
@@ -387,8 +377,6 @@ jobs:
           HARNESS_E2E_PROVIDER: ${{ matrix.subject.provider }}
           HARNESS_E2E_JUDGE_MODEL: ${{ inputs.judge_model }}
           HARNESS_E2E_JUDGE_PROVIDER: ${{ inputs.judge_provider }}
-          HARNESS_E2E_QUALITY_ADVISORY: ${{ inputs.quality_advisory }}
-          HARNESS_E2E_CI_SCORE_FLOOR: ${{ inputs.ci_score_floor }}
           HARNESS_E2E_ENGINE_REVISION: ${{ needs.build.outputs.engine_revision }}
           # run-ci.sh spawns every worker with cwd inside the artifacts dir, so
           # the profile path must be absolute; %c keeps profiles flushing after
@@ -416,8 +404,6 @@ jobs:
           HARNESS_E2E_PROVIDER: ${{ matrix.subject.provider }}
           HARNESS_E2E_JUDGE_MODEL: ${{ inputs.judge_model }}
           HARNESS_E2E_JUDGE_PROVIDER: ${{ inputs.judge_provider }}
-          HARNESS_E2E_QUALITY_ADVISORY: ${{ inputs.quality_advisory }}
-          HARNESS_E2E_CI_SCORE_FLOOR: ${{ inputs.ci_score_floor }}
         run: harness/tests/e2e/run-deployed-ci.sh
 
       - name: Write benchmark context
@@ -445,17 +431,11 @@ jobs:
         env:
           SCENARIO: ${{ matrix.scenario }}
           SUBJECT: ${{ matrix.subject.id }}
-          QUALITY_ADVISORY: ${{ inputs.quality_advisory }}
-          CI_SCORE_FLOOR: ${{ inputs.ci_score_floor }}
         run: |
           {
             echo "### Harness E2E · $SUBJECT · $SCENARIO"
             echo
-            if [[ "$QUALITY_ADVISORY" == "true" ]]; then
-              echo "CI gate: scores below ${CI_SCORE_FLOOR}% and technical failures are blocking. Higher-scoring quality and hard-gate failures remain visible but do not fail the workflow."
-            else
-              echo "Quality score gate: enforced."
-            fi
+            echo "CI gate: scores are advisory; hard-gate and technical failures are blocking."
             echo
             results=target/harness-e2e/results/results.json
             if [[ -f "$results" ]]; then

--- a/.github/workflows/_harness-e2e.yml
+++ b/.github/workflows/_harness-e2e.yml
@@ -435,7 +435,7 @@ jobs:
           {
             echo "### Harness E2E · $SUBJECT · $SCENARIO"
             echo
-            echo "CI gate: scores are advisory; hard-gate and technical failures are blocking."
+            echo "CI gate: scores are advisory; empty reports, hard-gate failures, and technical failures are blocking."
             echo
             results=target/harness-e2e/results/results.json
             if [[ -f "$results" ]]; then

--- a/.github/workflows/harness-e2e-daily.yml
+++ b/.github/workflows/harness-e2e-daily.yml
@@ -69,8 +69,6 @@ jobs:
     with:
       runs: 3
       max_parallel: 2
-      quality_advisory: true
-      ci_score_floor: 50
       source_ref: ${{ needs.context.outputs.source_sha }}
       benchmark_lane: daily
       release_tag: daily/${{ needs.context.outputs.benchmark_day }}

--- a/.github/workflows/harness-e2e-deployed.yml
+++ b/.github/workflows/harness-e2e-deployed.yml
@@ -61,8 +61,6 @@ jobs:
       stack_mode: registry
       runs: ${{ inputs.runs }}
       max_parallel: 2
-      quality_advisory: false
-      ci_score_floor: 50
       benchmark_lane: deployed
       registry_tag: ${{ inputs.channel }}
       release_tag: ${{ inputs.release_tag }}

--- a/.github/workflows/harness-e2e-main.yml
+++ b/.github/workflows/harness-e2e-main.yml
@@ -43,8 +43,6 @@ jobs:
     with:
       runs: 1
       max_parallel: 2
-      quality_advisory: true
-      ci_score_floor: 50
       benchmark_lane: main
       subjects: ${{ vars.HARNESS_E2E_SUBJECTS || '[{"id":"anthropic-sonnet","model":"claude-sonnet-4-6","provider":"anthropic"}]' }}
       judge_model: ${{ vars.HARNESS_E2E_JUDGE_MODEL || 'claude-sonnet-4-6' }}

--- a/harness/tests/e2e/README.md
+++ b/harness/tests/e2e/README.md
@@ -113,11 +113,9 @@ cargo run -p harness-e2e -- run \
 `HARNESS_E2E_OUTPUT` are accepted as environment variables. `--runs` accepts
 values from 1 through 20.
 
-`--quality-advisory` or `HARNESS_E2E_QUALITY_ADVISORY=true` keeps degraded
-quality and hard-gate results visible without failing CI when the median score
-is at least 50. Scores below that floor and technical failures remain blocking.
-Override the floor with `--ci-score-floor` or
-`HARNESS_E2E_CI_SCORE_FLOOR`.
+Scores are quality data and never determine the CI exit status. Quality
+failures remain visible in the report, while hard-gate and technical failures
+remain blocking.
 
 The runner emits a progress heartbeat every 15 seconds with the active turn,
 step, pending function count, child-session count, and descendant-tree size.
@@ -151,7 +149,8 @@ Scenarios without one award every criterion objectively in code. Mechanical
 effects remain hard gates in both cases. Judge-backed scenarios use a 50-point
 pass floor so a mediocre but usable answer remains a passing execution while
 its full score still exposes the quality gap in reports and historical trends.
-Scores below 50 continue to fail as semantically inadequate. The
+Scores below 50 continue to be reported as semantically inadequate, but do not
+fail CI by themselves. The
 `shell_coder_sandbox` scenario also uses a 50-point floor because its required
 effects remain hard gates; an error-free execution earns 45 additional quality
 points, while a recovered function error stays visible without failing an
@@ -209,9 +208,9 @@ zero.
 | Workflow | Trigger | Live-model runs | Gate |
 | --- | --- | ---: | --- |
 | Pull-request CI | Relevant pull-request changes | 0 | Deterministic integration only |
-| Harness E2E Main | Relevant push to `main` | 1 per subject/scenario | Score advisory; technical failures blocking |
-| Harness E2E Daily | Daily at 06:00 UTC, or manual dispatch on `main` | 3 per subject/scenario | Median score and reliability gates are evaluated; history is published on failure |
-| Harness E2E deployed | Successful post-release smoke for Harness or a mandatory dependency | 1 per subject/scenario | Exact registry artifact, hard gates, and technical failures blocking |
+| Harness E2E Main | Relevant push to `main` | 1 per subject/scenario | Score advisory; hard-gate and technical failures blocking |
+| Harness E2E Daily | Daily at 06:00 UTC, or manual dispatch on `main` | 3 per subject/scenario | Score is advisory; hard-gate and technical failures are blocking; history is always published |
+| Harness E2E deployed | Successful post-release smoke for Harness or a mandatory dependency | 1 per subject/scenario | Score advisory; hard-gate and technical failures blocking |
 
 The reusable workflow supports source and registry stack modes. Source runs
 install the latest stable `iii` release with its companion binaries, then build
@@ -314,9 +313,9 @@ Each matrix job publishes its result for 14 days; failed jobs also publish
 diagnostics for 14 days. The workflow summary shows subject, judge, and total
 cost per scenario and consolidated by subject. The daily dashboard retains the
 latest 100 comparable points and summaries, plus complete reports for the latest
-30 workflow attempts. Fixed code-defined thresholds remain the CI gate;
-historical deltas are a team-facing signal and do not add a second implicit
-threshold.
+30 workflow attempts. Fixed code-defined thresholds remain evaluation criteria;
+they do not determine CI success. Historical deltas are a team-facing signal
+and do not add an implicit threshold.
 
 The source launcher performs a clean first boot with isolated configuration,
 session, queue, state, and log directories. It starts the provider workers

--- a/harness/tests/e2e/README.md
+++ b/harness/tests/e2e/README.md
@@ -114,8 +114,8 @@ cargo run -p harness-e2e -- run \
 values from 1 through 20.
 
 Scores are quality data and never determine the CI exit status. Quality
-failures remain visible in the report, while hard-gate and technical failures
-remain blocking.
+failures remain visible in the report, while empty reports, hard-gate
+failures, and technical failures remain blocking.
 
 The runner emits a progress heartbeat every 15 seconds with the active turn,
 step, pending function count, child-session count, and descendant-tree size.
@@ -208,9 +208,9 @@ zero.
 | Workflow | Trigger | Live-model runs | Gate |
 | --- | --- | ---: | --- |
 | Pull-request CI | Relevant pull-request changes | 0 | Deterministic integration only |
-| Harness E2E Main | Relevant push to `main` | 1 per subject/scenario | Score advisory; hard-gate and technical failures blocking |
-| Harness E2E Daily | Daily at 06:00 UTC, or manual dispatch on `main` | 3 per subject/scenario | Score is advisory; hard-gate and technical failures are blocking; history is always published |
-| Harness E2E deployed | Successful post-release smoke for Harness or a mandatory dependency | 1 per subject/scenario | Score advisory; hard-gate and technical failures blocking |
+| Harness E2E Main | Relevant push to `main` | 1 per subject/scenario | Score advisory; empty reports, hard-gate and technical failures blocking |
+| Harness E2E Daily | Daily at 06:00 UTC, or manual dispatch on `main` | 3 per subject/scenario | Score is advisory; empty reports, hard-gate and technical failures are blocking; history is always published |
+| Harness E2E deployed | Successful post-release smoke for Harness or a mandatory dependency | 1 per subject/scenario | Score advisory; empty reports, hard-gate and technical failures blocking |
 
 The reusable workflow supports source and registry stack modes. Source runs
 install the latest stable `iii` release with its companion binaries, then build

--- a/harness/tests/e2e/src/main.rs
+++ b/harness/tests/e2e/src/main.rs
@@ -80,19 +80,6 @@ struct RunArgs {
     )]
     progress_interval_seconds: u64,
 
-    /// Keep degraded results above the CI score floor advisory; technical errors still fail.
-    #[arg(long, env = "HARNESS_E2E_QUALITY_ADVISORY", default_value_t = false)]
-    quality_advisory: bool,
-
-    /// Minimum median score allowed when the CI quality policy is advisory.
-    #[arg(
-        long,
-        env = "HARNESS_E2E_CI_SCORE_FLOOR",
-        default_value_t = 50,
-        value_parser = clap::value_parser!(u8).range(1..=100)
-    )]
-    ci_score_floor: u8,
-
     /// Run only the selected scenario. Repeat to select more than one.
     #[arg(long, value_enum)]
     scenario: Vec<ScenarioId>,
@@ -150,8 +137,6 @@ fn report(args: ReportArgs) -> Result<()> {
 }
 
 async fn run(args: RunArgs) -> Result<()> {
-    let quality_advisory = args.quality_advisory;
-    let ci_score_floor = args.ci_score_floor;
     let selected_scenarios = scenarios::selected(&args.scenario);
     let subject = SubjectConfig {
         model: args.model,
@@ -181,16 +166,13 @@ async fn run(args: RunArgs) -> Result<()> {
 
     print!("{}", outcome.report.summary(false));
     println!("report: {}", outcome.report_path.display());
-    if !outcome.report.passed
-        && !(quality_advisory && !outcome.report.fails_ci_gate(ci_score_floor))
-    {
+    if !outcome.report.passed && outcome.report.has_ci_blocking_failure() {
         bail!("E2E suite failed");
     }
     if !outcome.report.passed {
         tracing::warn!(
             path = %outcome.report_path.display(),
-            ci_score_floor,
-            "E2E result is degraded but remains above the advisory CI score floor"
+            "E2E quality score is below the scenario threshold but remains advisory"
         );
         return Ok(());
     }

--- a/harness/tests/e2e/src/report.rs
+++ b/harness/tests/e2e/src/report.rs
@@ -404,14 +404,11 @@ impl E2eReport {
         Ok((report, path))
     }
 
-    pub fn fails_ci_gate(&self, score_floor: u8) -> bool {
+    pub fn has_ci_blocking_failure(&self) -> bool {
         self.scenarios.is_empty()
             || self.scenarios.iter().any(|scenario| {
-                scenario.aggregate.technical_failures > 0
-                    || scenario
-                        .aggregate
-                        .median_score
-                        .is_none_or(|score| score < f64::from(score_floor))
+                scenario.aggregate.hard_gate_failures > 0
+                    || scenario.aggregate.technical_failures > 0
             })
     }
 }
@@ -632,37 +629,38 @@ mod tests {
     }
 
     #[test]
-    fn advisory_ci_gate_uses_the_score_floor_for_quality_and_hard_gate_failures() {
-        let quality = E2eReport::new(
-            model(),
-            None,
-            None,
-            None,
-            vec![aggregate(vec![run(70, false)])],
-        );
-        assert!(!quality.fails_ci_gate(50));
-
-        let below_floor = E2eReport::new(
+    fn quality_score_failure_does_not_block_ci() {
+        let report = E2eReport::new(
             model(),
             None,
             None,
             None,
             vec![aggregate(vec![run(49, false)])],
         );
-        assert!(below_floor.fails_ci_gate(50));
-
-        let mut hard_gate = run(80, true);
-        hard_gate.status = RunStatus::HardGateFailed;
-        let hard_gate = E2eReport::new(model(), None, None, None, vec![aggregate(vec![hard_gate])]);
-        assert!(!hard_gate.fails_ci_gate(50));
+        assert!(!report.passed);
+        assert!(!report.has_ci_blocking_failure());
     }
 
     #[test]
-    fn advisory_ci_gate_keeps_technical_failures_blocking() {
+    fn hard_gate_failure_blocks_ci_even_with_a_score() {
+        let mut hard_gate = run(80, true);
+        hard_gate.status = RunStatus::HardGateFailed;
+        let report = E2eReport::new(model(), None, None, None, vec![aggregate(vec![hard_gate])]);
+        assert!(report.has_ci_blocking_failure());
+    }
+
+    #[test]
+    fn technical_failure_blocks_ci() {
         let mut technical = run(80, true);
         technical.status = RunStatus::InfrastructureError;
         let report = E2eReport::new(model(), None, None, None, vec![aggregate(vec![technical])]);
-        assert!(report.fails_ci_gate(50));
+        assert!(report.has_ci_blocking_failure());
+    }
+
+    #[test]
+    fn an_empty_report_blocks_ci() {
+        let report = E2eReport::new(model(), None, None, None, vec![]);
+        assert!(report.has_ci_blocking_failure());
     }
 
     fn model() -> ModelArtifact {


### PR DESCRIPTION
## Summary

- keep Harness E2E scores as reported quality data without using them as a CI exit gate
- keep hard-gate, technical, and empty-report failures blocking
- remove the obsolete score-advisory and score-floor configuration from the runner and workflows
- document the updated CI behavior

## Why

Model scores are probabilistic quality signals. A low score should remain visible for evaluation and trend analysis without independently failing CI.

## Validation

- `cargo fmt --manifest-path harness/Cargo.toml --all -- --check`
- `cargo test --locked --manifest-path harness/Cargo.toml -p harness-e2e` — 62 passed
- `cargo clippy --locked --manifest-path harness/Cargo.toml -p harness-e2e --all-targets -- -D warnings`
- YAML parsing for the affected workflows


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated end-to-end test gating so quality scores are advisory and do not independently fail CI.
  * Hard-gate failures, technical failures, and empty test scenarios remain blocking.
  * Removed configurable score thresholds from E2E execution and reporting.

* **Documentation**
  * Clarified score interpretation, CI gate behavior, and dashboard thresholds in the E2E documentation.

* **Tests**
  * Expanded coverage for advisory quality failures and blocking failure conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->