### PR TITLE
(MOT-4338) fix(dashboard): make efficiency cards read one coherent population

### DIFF
--- a/.github/benchmark-site/execution-data.js
+++ b/.github/benchmark-site/execution-data.js
@@ -918,7 +918,11 @@
         total += value;
       }
       if (!complete) continue;
-      points.push({ executionId: execution.id, value: total });
+      points.push({
+        executionId: execution.id,
+        value: total,
+        timestamp: execution.completed_at || execution.started_at || "",
+      });
     }
     return points.reverse();
   }

--- a/.github/benchmark-site/execution-data.js
+++ b/.github/benchmark-site/execution-data.js
@@ -888,8 +888,44 @@
     return groups;
   }
 
+  function cohortMetricSparkline(executions, cohortRows, metricId, limit = 14) {
+    const basket = (cohortRows || [])
+      .filter((row) => row && row.scenarioId)
+      .map((row) => ({
+        key: `${row.subjectId || ""}::${row.scenarioId}`,
+        fingerprint: row.fingerprint || "",
+      }));
+    if (!basket.length) return [];
+    const points = [];
+    for (const execution of executions || []) {
+      if (points.length >= limit) break;
+      const metrics = execution?.scenario_metrics || [];
+      if (!metrics.length) continue;
+      let total = 0;
+      let complete = true;
+      for (const item of basket) {
+        const scenario = metrics.find(
+          (candidate) =>
+            `${candidate?.subject_id || ""}::${candidate?.scenario_id || ""}` ===
+              item.key &&
+            (candidate?.contract_fingerprint || "") === item.fingerprint,
+        );
+        const value = numberOrNull(scenario?.averages?.[metricId]);
+        if (value === null) {
+          complete = false;
+          break;
+        }
+        total += value;
+      }
+      if (!complete) continue;
+      points.push({ executionId: execution.id, value: total });
+    }
+    return points.reverse();
+  }
+
   return {
     buildEfficiencyOverview,
+    cohortMetricSparkline,
     contractFingerprint,
     executionEfficiencyTotalsFromDetail,
     executionsWithinDays,

--- a/.github/benchmark-site/execution-data.test.cjs
+++ b/.github/benchmark-site/execution-data.test.cjs
@@ -442,8 +442,8 @@ test("cohort sparkline sums matching contracts and skips partial executions", ()
   );
 
   assert.deepEqual(points, [
-    { executionId: "older", value: 100 },
-    { executionId: "newer", value: 300 },
+    { executionId: "older", value: 100, timestamp: "2026-07-29T06:10:00Z" },
+    { executionId: "newer", value: 300, timestamp: "2026-07-29T06:10:00Z" },
   ]);
   assert.deepEqual(cohortMetricSparkline([execution()], [], "tokens"), []);
 });

--- a/.github/benchmark-site/execution-data.test.cjs
+++ b/.github/benchmark-site/execution-data.test.cjs
@@ -3,6 +3,7 @@ const assert = require("node:assert/strict");
 
 const {
   buildEfficiencyOverview,
+  cohortMetricSparkline,
   contractFingerprint,
   executionEfficiencyTotalsFromDetail,
   executionsWithinDays,
@@ -412,6 +413,39 @@ test("keeps scenario metrics as one point per workflow execution", () => {
     ).length,
     0,
   );
+});
+
+test("cohort sparkline sums matching contracts and skips partial executions", () => {
+  const cohortRow = {
+    subjectId: "glm",
+    scenarioId: "direct_answer",
+    fingerprint: "fp1",
+    lifecycle: "comparable",
+  };
+  const metric = (fingerprint, tokens) => ({
+    subject_id: "glm",
+    scenario_id: "direct_answer",
+    contract_fingerprint: fingerprint,
+    averages: { tokens },
+  });
+
+  const points = cohortMetricSparkline(
+    [
+      execution({ id: "no-value", scenario_metrics: [metric("fp1", null)] }),
+      execution({ id: "newer", scenario_metrics: [metric("fp1", 300)] }),
+      execution({ id: "changed-contract", scenario_metrics: [metric("fp2", 999)] }),
+      execution({ id: "no-metrics", scenario_metrics: [] }),
+      execution({ id: "older", scenario_metrics: [metric("fp1", 100)] }),
+    ],
+    [cohortRow],
+    "tokens",
+  );
+
+  assert.deepEqual(points, [
+    { executionId: "older", value: 100 },
+    { executionId: "newer", value: 300 },
+  ]);
+  assert.deepEqual(cohortMetricSparkline([execution()], [], "tokens"), []);
 });
 
 test("compares efficiency only within the same scenario contract", () => {

--- a/.github/benchmark-site/index.html
+++ b/.github/benchmark-site/index.html
@@ -82,24 +82,28 @@
               <div class="efficiency-card-label">Cost</div>
               <strong id="efficiency-cost">—</strong>
               <span id="efficiency-cost-delta" class="efficiency-delta">—</span>
+              <small id="efficiency-cost-baseline" class="efficiency-baseline-value"></small>
               <div id="efficiency-cost-sparkline" class="efficiency-sparkline"></div>
             </article>
             <article class="efficiency-card" data-efficiency-metric="tokens">
               <div class="efficiency-card-label">Tokens</div>
               <strong id="efficiency-tokens">—</strong>
               <span id="efficiency-tokens-delta" class="efficiency-delta">—</span>
+              <small id="efficiency-tokens-baseline" class="efficiency-baseline-value"></small>
               <div id="efficiency-tokens-sparkline" class="efficiency-sparkline"></div>
             </article>
             <article class="efficiency-card" data-efficiency-metric="duration_seconds">
               <div class="efficiency-card-label">Scenario time</div>
               <strong id="efficiency-duration">—</strong>
               <span id="efficiency-duration-delta" class="efficiency-delta">—</span>
+              <small id="efficiency-duration-baseline" class="efficiency-baseline-value"></small>
               <div id="efficiency-duration-sparkline" class="efficiency-sparkline"></div>
             </article>
             <article class="efficiency-card" data-efficiency-metric="function_call_errors">
               <div class="efficiency-card-label">Function errors</div>
               <strong id="efficiency-errors">—</strong>
               <span id="efficiency-errors-delta" class="efficiency-delta">—</span>
+              <small id="efficiency-errors-baseline" class="efficiency-baseline-value"></small>
               <div id="efficiency-errors-sparkline" class="efficiency-sparkline"></div>
             </article>
           </div>

--- a/.github/benchmark-site/index.html
+++ b/.github/benchmark-site/index.html
@@ -64,8 +64,10 @@
               <div class="section-kicker">Primary view</div>
               <h2 id="efficiency-overview-heading">Efficiency overview</h2>
               <p class="trend-description">
-                Current suite workload with deltas calculated only from unchanged,
-                successful scenarios.
+                Every figure below — value, delta, and trend — reads the
+                comparable cohort: scenarios whose contract is unchanged and
+                whose latest run passed. New, changed, and missing scenarios
+                are counted in the guardrail and excluded here.
               </p>
             </div>
             <div class="efficiency-baseline">
@@ -75,9 +77,9 @@
             </div>
           </div>
 
-          <div class="efficiency-card-grid" aria-label="Latest efficiency totals">
+          <div class="efficiency-card-grid" aria-label="Comparable cohort totals">
             <article class="efficiency-card" data-efficiency-metric="cost_usd">
-              <div class="efficiency-card-label">Suite cost</div>
+              <div class="efficiency-card-label">Cost</div>
               <strong id="efficiency-cost">—</strong>
               <span id="efficiency-cost-delta" class="efficiency-delta">—</span>
               <div id="efficiency-cost-sparkline" class="efficiency-sparkline"></div>

--- a/.github/benchmark-site/overview.js
+++ b/.github/benchmark-site/overview.js
@@ -272,26 +272,34 @@
     }
     const absolute = Math.abs(value);
     if (absolute < 0.05) {
-      return { label: "No change in comparable cohort", css: "neutral" };
+      return { label: "No change vs baseline median", css: "neutral" };
     }
     return {
-      label: `${value < 0 ? "↓" : "↑"} ${compactNumber(absolute, 1)}% comparable cohort`,
+      label: `${value < 0 ? "↓" : "↑"} ${compactNumber(absolute, 1)}% vs baseline median`,
       css: value < 0 ? "improved" : "regressed",
     };
   }
 
-  function renderEfficiencySparkline(element, metricId, color, cohortRows) {
-    const values = executionApi
-      .cohortMetricSparkline(history.executions, cohortRows, metricId, 14)
-      .map((point) => point.value);
-    if (!values.length) {
+  function renderEfficiencySparkline(element, metricId, color, cohortRows, baseline) {
+    const points = executionApi.cohortMetricSparkline(
+      history.executions,
+      cohortRows,
+      metricId,
+      14,
+    );
+    if (!points.length) {
       element.replaceChildren();
       return;
     }
+    const definition = scenarioMetricDefinitions[metricId];
+    const values = points.map((point) => point.value);
+    const baselineValue = typeof baseline === "number" ? baseline : null;
+    const scaleValues =
+      baselineValue === null ? values : [...values, baselineValue];
     const width = 180;
     const height = 42;
-    const minimum = Math.min(...values);
-    const maximum = Math.max(...values);
+    const minimum = Math.min(...scaleValues);
+    const maximum = Math.max(...scaleValues);
     const range = maximum - minimum || 1;
     const x = (index) =>
       values.length === 1 ? width / 2 : (index / (values.length - 1)) * width;
@@ -299,7 +307,7 @@
     const svg = svgElement("svg", {
       viewBox: `0 0 ${width} ${height}`,
       role: "img",
-      "aria-label": `${scenarioMetricDefinitions[metricId].label} comparable cohort trend`,
+      "aria-label": `${definition.label} comparable cohort trend`,
     });
     const areaPoints = [
       `0,${height}`,
@@ -312,6 +320,19 @@
         fill: color,
         class: "efficiency-sparkline-area",
       }),
+    );
+    if (baselineValue !== null) {
+      svg.append(
+        svgElement("line", {
+          x1: 0,
+          x2: width,
+          y1: y(baselineValue),
+          y2: y(baselineValue),
+          class: "efficiency-sparkline-baseline",
+        }),
+      );
+    }
+    svg.append(
       svgElement("polyline", {
         points: values
           .map((value, index) => `${x(index)},${y(value)}`)
@@ -326,6 +347,20 @@
         fill: color,
       }),
     );
+    const slot = width / points.length;
+    points.forEach((point, index) => {
+      const hit = svgElement("rect", {
+        x: index * slot,
+        y: 0,
+        width: slot,
+        height,
+        class: "efficiency-sparkline-hit",
+      });
+      const title = svgElement("title", {});
+      title.textContent = `Run ${point.executionId}: ${definition.format(point.value)}`;
+      hit.append(title);
+      svg.append(hit);
+    });
     element.replaceChildren(svg);
   }
 
@@ -426,7 +461,11 @@
     );
     cards.forEach((card) => {
       const metric = overview.metrics[card.metricId];
-      card.value.textContent = card.format(metric?.operational);
+      // Value, delta, and sparkline must all read the same population; fall
+      // back to the full-suite total only while no cohort exists yet.
+      card.value.textContent = card.format(
+        cohortRows.length ? metric?.comparableCurrent : metric?.operational,
+      );
       const meta = deltaMeta(metric?.delta);
       card.delta.textContent = meta.label;
       card.delta.className = `efficiency-delta delta-${meta.css}`;
@@ -435,6 +474,7 @@
         card.metricId,
         card.color,
         cohortRows,
+        cohortRows.length ? metric?.comparableBaseline : null,
       );
     });
 

--- a/.github/benchmark-site/overview.js
+++ b/.github/benchmark-site/overview.js
@@ -280,18 +280,10 @@
     };
   }
 
-  function renderEfficiencySparkline(element, metricId, color) {
-    const values = history.executions
-      .filter((execution) => (execution.scenario_metrics || []).length)
-      .slice(0, 14)
-      .reverse()
-      .map((execution) =>
-        (execution.scenario_metrics || []).reduce(
-          (total, scenario) =>
-            total + (Number(scenario?.averages?.[metricId]) || 0),
-          0,
-        ),
-      );
+  function renderEfficiencySparkline(element, metricId, color, cohortRows) {
+    const values = executionApi
+      .cohortMetricSparkline(history.executions, cohortRows, metricId, 14)
+      .map((point) => point.value);
     if (!values.length) {
       element.replaceChildren();
       return;
@@ -307,7 +299,7 @@
     const svg = svgElement("svg", {
       viewBox: `0 0 ${width} ${height}`,
       role: "img",
-      "aria-label": `${scenarioMetricDefinitions[metricId].label} operational trend`,
+      "aria-label": `${scenarioMetricDefinitions[metricId].label} comparable cohort trend`,
     });
     const areaPoints = [
       `0,${height}`,
@@ -429,13 +421,21 @@
         color: palette[6],
       },
     ];
+    const cohortRows = overview.rows.filter(
+      (row) => row.lifecycle === "comparable" && row.outcome.passed,
+    );
     cards.forEach((card) => {
       const metric = overview.metrics[card.metricId];
       card.value.textContent = card.format(metric?.operational);
       const meta = deltaMeta(metric?.delta);
       card.delta.textContent = meta.label;
       card.delta.className = `efficiency-delta delta-${meta.css}`;
-      renderEfficiencySparkline(card.sparkline, card.metricId, card.color);
+      renderEfficiencySparkline(
+        card.sparkline,
+        card.metricId,
+        card.color,
+        cohortRows,
+      );
     });
 
     const passed = Number(overview.latest.totals?.passed_scenarios) || 0;

--- a/.github/benchmark-site/overview.js
+++ b/.github/benchmark-site/overview.js
@@ -84,14 +84,21 @@
     efficiencyBody: document.querySelector("#efficiency-body"),
     efficiencyCost: document.querySelector("#efficiency-cost"),
     efficiencyCostDelta: document.querySelector("#efficiency-cost-delta"),
+    efficiencyCostBaseline: document.querySelector("#efficiency-cost-baseline"),
     efficiencyCostSparkline: document.querySelector("#efficiency-cost-sparkline"),
     efficiencyDuration: document.querySelector("#efficiency-duration"),
     efficiencyDurationDelta: document.querySelector("#efficiency-duration-delta"),
+    efficiencyDurationBaseline: document.querySelector(
+      "#efficiency-duration-baseline",
+    ),
     efficiencyDurationSparkline: document.querySelector(
       "#efficiency-duration-sparkline",
     ),
     efficiencyErrors: document.querySelector("#efficiency-errors"),
     efficiencyErrorsDelta: document.querySelector("#efficiency-errors-delta"),
+    efficiencyErrorsBaseline: document.querySelector(
+      "#efficiency-errors-baseline",
+    ),
     efficiencyErrorsSparkline: document.querySelector(
       "#efficiency-errors-sparkline",
     ),
@@ -99,6 +106,9 @@
     efficiencyRunLabel: document.querySelector("#efficiency-run-label"),
     efficiencyTokens: document.querySelector("#efficiency-tokens"),
     efficiencyTokensDelta: document.querySelector("#efficiency-tokens-delta"),
+    efficiencyTokensBaseline: document.querySelector(
+      "#efficiency-tokens-baseline",
+    ),
     efficiencyTokensSparkline: document.querySelector(
       "#efficiency-tokens-sparkline",
     ),
@@ -322,15 +332,18 @@
       }),
     );
     if (baselineValue !== null) {
-      svg.append(
-        svgElement("line", {
-          x1: 0,
-          x2: width,
-          y1: y(baselineValue),
-          y2: y(baselineValue),
-          class: "efficiency-sparkline-baseline",
-        }),
-      );
+      const baselineLine = svgElement("line", {
+        x1: 0,
+        x2: width,
+        y1: y(baselineValue),
+        y2: y(baselineValue),
+        class: "efficiency-sparkline-baseline",
+      });
+      const baselineTitle = svgElement("title", {});
+      baselineTitle.textContent =
+        `Baseline ${definition.format(baselineValue)} — median of up to 7 prior comparable runs`;
+      baselineLine.append(baselineTitle);
+      svg.append(baselineLine);
     }
     svg.append(
       svgElement("polyline", {
@@ -356,8 +369,19 @@
         height,
         class: "efficiency-sparkline-hit",
       });
+      const parts = [
+        `Run ${point.executionId}`,
+        formatDate(point.timestamp),
+        definition.format(point.value),
+      ];
+      if (baselineValue !== null && baselineValue !== 0) {
+        const deltaPct = ((point.value - baselineValue) / Math.abs(baselineValue)) * 100;
+        parts.push(
+          `${deltaPct < 0 ? "↓" : "↑"} ${compactNumber(Math.abs(deltaPct), 1)}% vs baseline`,
+        );
+      }
       const title = svgElement("title", {});
-      title.textContent = `Run ${point.executionId}: ${definition.format(point.value)}`;
+      title.textContent = parts.join(" · ");
       hit.append(title);
       svg.append(hit);
     });
@@ -427,6 +451,7 @@
         metricId: "cost_usd",
         value: elements.efficiencyCost,
         delta: elements.efficiencyCostDelta,
+        baseline: elements.efficiencyCostBaseline,
         sparkline: elements.efficiencyCostSparkline,
         format: formatCurrency,
         color: palette[0],
@@ -435,6 +460,7 @@
         metricId: "tokens",
         value: elements.efficiencyTokens,
         delta: elements.efficiencyTokensDelta,
+        baseline: elements.efficiencyTokensBaseline,
         sparkline: elements.efficiencyTokensSparkline,
         format: (value) => compactNumber(value, 0),
         color: palette[1],
@@ -443,6 +469,7 @@
         metricId: "duration_seconds",
         value: elements.efficiencyDuration,
         delta: elements.efficiencyDurationDelta,
+        baseline: elements.efficiencyDurationBaseline,
         sparkline: elements.efficiencyDurationSparkline,
         format: formatDuration,
         color: palette[3],
@@ -451,6 +478,7 @@
         metricId: "function_call_errors",
         value: elements.efficiencyErrors,
         delta: elements.efficiencyErrorsDelta,
+        baseline: elements.efficiencyErrorsBaseline,
         sparkline: elements.efficiencyErrorsSparkline,
         format: (value) => compactNumber(value, 1),
         color: palette[6],
@@ -469,6 +497,12 @@
       const meta = deltaMeta(metric?.delta);
       card.delta.textContent = meta.label;
       card.delta.className = `efficiency-delta delta-${meta.css}`;
+      const baselineValue =
+        cohortRows.length && typeof metric?.comparableBaseline === "number"
+          ? metric.comparableBaseline
+          : null;
+      card.baseline.textContent =
+        baselineValue === null ? "" : `baseline ${card.format(baselineValue)}`;
       renderEfficiencySparkline(
         card.sparkline,
         card.metricId,

--- a/.github/benchmark-site/styles.css
+++ b/.github/benchmark-site/styles.css
@@ -1270,6 +1270,18 @@ footer {
   vector-effect: non-scaling-stroke;
 }
 
+.efficiency-sparkline-baseline {
+  stroke: var(--text-muted);
+  stroke-width: 1;
+  stroke-dasharray: 3 3;
+  opacity: 0.6;
+  vector-effect: non-scaling-stroke;
+}
+
+.efficiency-sparkline-hit {
+  fill: transparent;
+}
+
 .efficiency-guardrail {
   display: flex;
   flex-wrap: wrap;

--- a/.github/benchmark-site/styles.css
+++ b/.github/benchmark-site/styles.css
@@ -1270,6 +1270,14 @@ footer {
   vector-effect: non-scaling-stroke;
 }
 
+.efficiency-baseline-value {
+  display: block;
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
 .efficiency-sparkline-baseline {
   stroke: var(--text-muted);
   stroke-width: 1;


### PR DESCRIPTION
## Summary

The efficiency overview cards on the [harness E2E dashboard](https://iii-hq.github.io/workers/dev/harness-e2e/index.html) were unreadable because each card mixed **three different populations**:

- the headline value summed **every reported scenario** in the latest run,
- the delta chip compared only the **comparable cohort** against its baseline,
- the sparkline plotted **raw sums across history** — so a missing report produced a −79% visual cliff next to an honest −3% chip on the same card.

Two commits:

1. **Cherry-pick `83966dc6`** (orphaned from #672 — the PR was merged before this commit was pushed, so the cohort sparkline filter never reached main): `cohortMetricSparkline()` sums only the comparable-cohort contracts and skips executions missing any of them, with unit tests.
2. **Card coherence**: value, delta, and trend now all read the comparable cohort — the headline equals the sparkline's last point exactly (verified against live data on all four metrics). The sparkline gains a dashed baseline-median reference line and native per-point hover values (`Run <id>: <value>`), the delta chip names its baseline ("↓ 22% vs baseline median"), the section copy states the population once, and "Suite cost" is renamed "Cost" since the figure is no longer the full suite. While no cohort exists yet, cards fall back to full-suite totals with the existing "Collecting comparable baseline" chip.

## Test plan
- [x] `node --test .github/benchmark-site/*.test.cjs` — 24/24
- [x] Simulated against live published data: card value == last sparkline point on all four metrics; baseline within sparkline scale
- [ ] After merge + next daily publish: confirm cards read coherently on the live page

Fixes MOT-4338

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cohort-based efficiency comparisons using unchanged scenarios with passing runs.
  * Added baseline markers and run-specific hover details to efficiency sparklines.
  * Improved efficiency cards with comparable current and baseline values.

* **Improvements**
  * Clarified efficiency metric definitions and simplified cost labeling.
  * Updated accessibility labeling for the efficiency card grid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->