### PR TITLE
chore(ci): wire DEEPSEEK_API_KEY through the Harness E2E workflows

### DIFF
--- a/.github/workflows/_harness-e2e.yml
+++ b/.github/workflows/_harness-e2e.yml
@@ -95,6 +95,8 @@ on:
         required: false
       zai_api_key:
         required: false
+      deepseek_api_key:
+        required: false
 
 jobs:
   build:
@@ -214,6 +216,7 @@ jobs:
             provider-openai-codex -> target
             provider-claude-code -> target
             provider-zai -> target
+            provider-deepseek -> target
             context-manager -> target
             iii-directory -> target
             cron -> target
@@ -378,6 +381,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.anthropic_api_key }}
           OPENAI_API_KEY: ${{ secrets.openai_api_key }}
           ZAI_API_KEY: ${{ secrets.zai_api_key }}
+          DEEPSEEK_API_KEY: ${{ secrets.deepseek_api_key }}
           III_BIN: ${{ github.workspace }}/${{ needs.build.outputs.engine_binary }}
           HARNESS_E2E_BIN: ${{ github.workspace }}/harness/target/release/harness-e2e
           HARNESS_E2E_ARTIFACTS_DIR: ${{ github.workspace }}/target/harness-e2e
@@ -400,6 +404,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.anthropic_api_key }}
           OPENAI_API_KEY: ${{ secrets.openai_api_key }}
           ZAI_API_KEY: ${{ secrets.zai_api_key }}
+          DEEPSEEK_API_KEY: ${{ secrets.deepseek_api_key }}
           III_CLI_CHANNEL: ${{ inputs.cli_channel }}
           III_WORKER_TAG: ${{ inputs.registry_tag }}
           HARNESS_E2E_RELEASE_WORKER: ${{ inputs.release_worker }}

--- a/.github/workflows/harness-e2e-daily.yml
+++ b/.github/workflows/harness-e2e-daily.yml
@@ -84,6 +84,7 @@ jobs:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}
       zai_api_key: ${{ secrets.ZAI_API_KEY }}
+      deepseek_api_key: ${{ secrets.DEEPSEEK_API_KEY }}
 
   integration:
     needs: context

--- a/.github/workflows/harness-e2e-deployed.yml
+++ b/.github/workflows/harness-e2e-deployed.yml
@@ -82,3 +82,4 @@ jobs:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}
       zai_api_key: ${{ secrets.ZAI_API_KEY }}
+      deepseek_api_key: ${{ secrets.DEEPSEEK_API_KEY }}

--- a/.github/workflows/harness-e2e-main.yml
+++ b/.github/workflows/harness-e2e-main.yml
@@ -51,3 +51,4 @@ jobs:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}
       zai_api_key: ${{ secrets.ZAI_API_KEY }}
+      deepseek_api_key: ${{ secrets.DEEPSEEK_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,6 +351,7 @@ jobs:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}
       zai_api_key: ${{ secrets.ZAI_API_KEY }}
+      deepseek_api_key: ${{ secrets.DEEPSEEK_API_KEY }}
 
   candidate-ready:
     name: Record candidate evidence


### PR DESCRIPTION
## Summary
- Declare the optional `deepseek_api_key` secret in the reusable `_harness-e2e.yml` and export it as `DEEPSEEK_API_KEY` in both run steps (source and registry stacks)
- Forward the repo secret from every caller (`harness-e2e-main`, `harness-e2e-daily`, `harness-e2e-deployed`)
- Add `provider-deepseek -> target` to the E2E Rust cache workspaces

## Context
`provider-deepseek` (#691) resolves its credential from `DEEPSEEK_API_KEY` on the router; without this wiring a deepseek subject or judge never discovers models in CI (`wait_for_model` times out). Prerequisite for switching `HARNESS_E2E_SUBJECTS` to `deepseek-v4-flash` (judge stays `zai/glm-5.2`).

Validated locally: `direct_answer` and `persistent_state` PASS with `deepseek-v4-pro`; full sweep with `deepseek-v4-flash` in progress.

Note: the DeepSeek API now serves only `deepseek-v4-flash`/`deepseek-v4-pro` — the `deepseek-chat`/`deepseek-reasoner` aliases were retired upstream. Discovery picks the new ids up automatically (curated-table misses land on conservative defaults).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added optional DeepSeek API key support for automated end-to-end testing.
  * Updated scheduled, deployed, main, and release workflows to securely pass the configured key when available.
  * Existing workflows remain compatible when no DeepSeek key is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->