### PR TITLE
chore: regenerate provider lock files for llm-router 1.4.1

### DIFF
--- a/provider-anthropic/Cargo.lock
+++ b/provider-anthropic/Cargo.lock
@@ -668,6 +668,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-console-ui"
+version = "0.1.0"
+dependencies = [
+ "iii-sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,11 +788,12 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-claude-code/Cargo.lock
+++ b/provider-claude-code/Cargo.lock
@@ -648,6 +648,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-console-ui"
+version = "0.1.0"
+dependencies = [
+ "iii-sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,11 +750,12 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-deepseek/Cargo.lock
+++ b/provider-deepseek/Cargo.lock
@@ -648,6 +648,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-console-ui"
+version = "0.1.0"
+dependencies = [
+ "iii-sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,11 +750,12 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-kimi/Cargo.lock
+++ b/provider-kimi/Cargo.lock
@@ -627,6 +627,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-console-ui"
+version = "0.1.0"
+dependencies = [
+ "iii-sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,11 +729,12 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-llamacpp/Cargo.lock
+++ b/provider-llamacpp/Cargo.lock
@@ -648,6 +648,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-console-ui"
+version = "0.1.0"
+dependencies = [
+ "iii-sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,11 +750,12 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.3.2"
+version = "1.4.1"
 dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-openai-codex/Cargo.lock
+++ b/provider-openai-codex/Cargo.lock
@@ -668,6 +668,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-console-ui"
+version = "0.1.0"
+dependencies = [
+ "iii-sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,11 +788,12 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-openai/Cargo.lock
+++ b/provider-openai/Cargo.lock
@@ -668,6 +668,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-console-ui"
+version = "0.1.0"
+dependencies = [
+ "iii-sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,11 +788,12 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-xai/Cargo.lock
+++ b/provider-xai/Cargo.lock
@@ -668,6 +668,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-console-ui"
+version = "0.1.0"
+dependencies = [
+ "iii-sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,11 +788,12 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.3.2"
+version = "1.4.1"
 dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-zai/Cargo.lock
+++ b/provider-zai/Cargo.lock
@@ -668,6 +668,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-console-ui"
+version = "0.1.0"
+dependencies = [
+ "iii-sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,11 +788,12 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",


### PR DESCRIPTION
## Summary
Sync all nine provider workers' `Cargo.lock` files to the llm-router **1.4.1** bump (531b1407), which updated only the router's own manifest. Every provider pins llm-router as a path dependency, so their stale locks (1.4.0; `llamacpp`/`xai` still at **1.3.2**) break any `--locked` build.

## Impact
First Harness E2E run on main after the bump ([30955188907](https://github.com/iii-hq/workers/actions/runs/30955188907)) failed in the **build** job before any scenario started:

```
error: cannot update the lock file .../provider-deepseek/Cargo.lock because --locked was passed
```

Every provider in the E2E matrix (subject `deepseek`, judge `zai`) is affected — deepseek just failed first. All nine locks now resolve cleanly under `--locked` (`cargo tree --locked`).

## Follow-up worth considering
The `llamacpp`/`xai` locks were stale across *two* bumps — the worker-bump tooling never regenerates dependent providers' locks. A bump-time hook (or CI check) that runs `cargo update -p llm-router` across `provider-*/` would prevent recurrence.