### PR TITLE
fix(llm-router): gate the console UI behind a default-on feature; sync stale worker locks

### DIFF
--- a/approval-gate/Cargo.lock
+++ b/approval-gate/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "1.6.7"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/llm-router/Cargo.toml
+++ b/llm-router/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 
 [dependencies]
 iii-sdk = "=0.21.6"
-iii-console-ui = { path = "../crates/console-ui" }
+iii-console-ui = { path = "../crates/console-ui", optional = true }
 # Re-exports the same `opentelemetry` the SDK uses, so we can carry the active
 # OTel context across `tokio::spawn` boundaries (shared `Context` global).
 # 0.21.5 adds the live span-start push, so `router::chat` renders in the
@@ -43,3 +43,10 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["test-util"] }
+
+[features]
+# The injectable console UI (ui.rs + the pnpm bundle in build.rs). Path
+# dependents that only consume the library types disable default features to
+# drop the Node toolchain from their build graph.
+default = ["console-ui"]
+console-ui = ["dep:iii-console-ui"]

--- a/llm-router/build.rs
+++ b/llm-router/build.rs
@@ -18,6 +18,13 @@ fn main() {
         std::env::var("TARGET").expect("TARGET must be set by Cargo build scripts")
     );
 
+    // Everything below builds/validates the injectable console UI bundle.
+    // Skip it when the `console-ui` feature is off (lib-only path dependents)
+    // so their builds never need a Node toolchain.
+    if std::env::var_os("CARGO_FEATURE_CONSOLE_UI").is_none() {
+        return;
+    }
+
     // `dist/` itself is not listed: include_str! reads it directly, and
     // listing it would rebuild-loop on our own output.
     println!("cargo:rerun-if-changed=ui/page.tsx");

--- a/llm-router/src/lib.rs
+++ b/llm-router/src/lib.rs
@@ -18,4 +18,5 @@ pub mod system_prompt;
 pub mod testkit;
 pub mod triggers;
 pub mod types;
+#[cfg(feature = "console-ui")]
 pub mod ui;

--- a/llm-router/src/main.rs
+++ b/llm-router/src/main.rs
@@ -86,6 +86,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     register_router(iii.clone()).await?;
+    #[cfg(feature = "console-ui")]
     llm_router::ui::register(&iii);
     tracing::info!(url = %cli.url, "llm-router registered");
 

--- a/provider-anthropic/Cargo.lock
+++ b/provider-anthropic/Cargo.lock
@@ -668,6 +668,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-console-ui"
+version = "0.1.0"
+dependencies = [
+ "iii-sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,11 +788,12 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-anthropic/Cargo.lock
+++ b/provider-anthropic/Cargo.lock
@@ -668,18 +668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-console-ui"
-version = "0.1.0"
-dependencies = [
- "iii-sdk",
- "schemars",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,7 +781,6 @@ dependencies = [
  "async-trait",
  "clap",
  "futures",
- "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-anthropic/Cargo.toml
+++ b/provider-anthropic/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-llm-router = { path = "../llm-router" }
+llm-router = { path = "../llm-router", default-features = false }
 # Must match llm-router's pin (one iii-sdk per graph). 0.21.5 brings the
 # live span-start push: `provider::anthropic::stream` renders while streaming.
 iii-sdk = "=0.21.6"

--- a/provider-claude-code/Cargo.lock
+++ b/provider-claude-code/Cargo.lock
@@ -648,6 +648,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-console-ui"
+version = "0.1.0"
+dependencies = [
+ "iii-sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,11 +750,12 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-claude-code/Cargo.lock
+++ b/provider-claude-code/Cargo.lock
@@ -648,18 +648,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-console-ui"
-version = "0.1.0"
-dependencies = [
- "iii-sdk",
- "schemars",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,7 +743,6 @@ dependencies = [
  "async-trait",
  "clap",
  "futures",
- "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-claude-code/Cargo.toml
+++ b/provider-claude-code/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-llm-router = { path = "../llm-router" }
+llm-router = { path = "../llm-router", default-features = false }
 # Must match llm-router's pin (one iii-sdk per graph). 0.21.5 brings the
 # live span-start push: `provider::claude-code::stream` renders while streaming.
 iii-sdk = "=0.21.6"

--- a/provider-deepseek/Cargo.lock
+++ b/provider-deepseek/Cargo.lock
@@ -648,6 +648,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-console-ui"
+version = "0.1.0"
+dependencies = [
+ "iii-sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,11 +750,12 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-deepseek/Cargo.lock
+++ b/provider-deepseek/Cargo.lock
@@ -648,18 +648,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-console-ui"
-version = "0.1.0"
-dependencies = [
- "iii-sdk",
- "schemars",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,7 +743,6 @@ dependencies = [
  "async-trait",
  "clap",
  "futures",
- "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-deepseek/Cargo.toml
+++ b/provider-deepseek/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-llm-router = { path = "../llm-router" }
+llm-router = { path = "../llm-router", default-features = false }
 # Must match llm-router's pin (one iii-sdk per graph).
 iii-sdk = "=0.21.6"
 serde = { version = "1", features = ["derive"] }

--- a/provider-kimi/Cargo.lock
+++ b/provider-kimi/Cargo.lock
@@ -627,6 +627,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-console-ui"
+version = "0.1.0"
+dependencies = [
+ "iii-sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,11 +729,12 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-kimi/Cargo.lock
+++ b/provider-kimi/Cargo.lock
@@ -627,18 +627,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-console-ui"
-version = "0.1.0"
-dependencies = [
- "iii-sdk",
- "schemars",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,7 +722,6 @@ dependencies = [
  "async-trait",
  "clap",
  "futures",
- "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-kimi/Cargo.toml
+++ b/provider-kimi/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-llm-router = { path = "../llm-router" }
+llm-router = { path = "../llm-router", default-features = false }
 # Must match llm-router's pin so the provider and router share one IIIClient type.
 iii-sdk = "=0.21.6"
 serde = { version = "1", features = ["derive"] }

--- a/provider-llamacpp/Cargo.lock
+++ b/provider-llamacpp/Cargo.lock
@@ -648,6 +648,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-console-ui"
+version = "0.1.0"
+dependencies = [
+ "iii-sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,11 +750,12 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.3.2"
+version = "1.4.1"
 dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-llamacpp/Cargo.lock
+++ b/provider-llamacpp/Cargo.lock
@@ -648,18 +648,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-console-ui"
-version = "0.1.0"
-dependencies = [
- "iii-sdk",
- "schemars",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,7 +743,6 @@ dependencies = [
  "async-trait",
  "clap",
  "futures",
- "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-llamacpp/Cargo.toml
+++ b/provider-llamacpp/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-llm-router = { path = "../llm-router" }
+llm-router = { path = "../llm-router", default-features = false }
 # Must match llm-router's pin (one iii-sdk per graph). 0.21.5 brings the
 # live span-start push: `provider::llamacpp::stream` renders while streaming.
 iii-sdk = "=0.21.6"

--- a/provider-openai-codex/Cargo.lock
+++ b/provider-openai-codex/Cargo.lock
@@ -668,6 +668,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-console-ui"
+version = "0.1.0"
+dependencies = [
+ "iii-sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,11 +788,12 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-openai-codex/Cargo.lock
+++ b/provider-openai-codex/Cargo.lock
@@ -668,18 +668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-console-ui"
-version = "0.1.0"
-dependencies = [
- "iii-sdk",
- "schemars",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,7 +781,6 @@ dependencies = [
  "async-trait",
  "clap",
  "futures",
- "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-openai-codex/Cargo.toml
+++ b/provider-openai-codex/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-llm-router = { path = "../llm-router" }
+llm-router = { path = "../llm-router", default-features = false }
 # Must match llm-router's pin (one iii-sdk per graph). 0.21.5 brings the
 # live span-start push: `provider::openai-codex::stream` renders while streaming.
 iii-sdk = "=0.21.6"

--- a/provider-openai/Cargo.lock
+++ b/provider-openai/Cargo.lock
@@ -668,6 +668,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-console-ui"
+version = "0.1.0"
+dependencies = [
+ "iii-sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,11 +788,12 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-openai/Cargo.lock
+++ b/provider-openai/Cargo.lock
@@ -668,18 +668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-console-ui"
-version = "0.1.0"
-dependencies = [
- "iii-sdk",
- "schemars",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,7 +781,6 @@ dependencies = [
  "async-trait",
  "clap",
  "futures",
- "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-openai/Cargo.toml
+++ b/provider-openai/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-llm-router = { path = "../llm-router" }
+llm-router = { path = "../llm-router", default-features = false }
 # Must match llm-router's pin (one iii-sdk per graph). 0.21.5 brings the
 # live span-start push: `provider::openai::stream` renders while streaming.
 iii-sdk = "=0.21.6"

--- a/provider-xai/Cargo.lock
+++ b/provider-xai/Cargo.lock
@@ -668,6 +668,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-console-ui"
+version = "0.1.0"
+dependencies = [
+ "iii-sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,11 +788,12 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.3.2"
+version = "1.4.1"
 dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-xai/Cargo.lock
+++ b/provider-xai/Cargo.lock
@@ -668,18 +668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-console-ui"
-version = "0.1.0"
-dependencies = [
- "iii-sdk",
- "schemars",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,7 +781,6 @@ dependencies = [
  "async-trait",
  "clap",
  "futures",
- "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-xai/Cargo.toml
+++ b/provider-xai/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-llm-router = { path = "../llm-router" }
+llm-router = { path = "../llm-router", default-features = false }
 # Must match llm-router's pin (one iii-sdk per graph). 0.21.5 brings the
 # live span-start push: `provider::xai::stream` renders while streaming.
 iii-sdk = "=0.21.6"

--- a/provider-zai/Cargo.lock
+++ b/provider-zai/Cargo.lock
@@ -668,6 +668,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "iii-console-ui"
+version = "0.1.0"
+dependencies = [
+ "iii-sdk",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,11 +788,12 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "async-trait",
  "clap",
  "futures",
+ "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-zai/Cargo.lock
+++ b/provider-zai/Cargo.lock
@@ -668,18 +668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iii-console-ui"
-version = "0.1.0"
-dependencies = [
- "iii-sdk",
- "schemars",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "iii-helpers"
 version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,7 +781,6 @@ dependencies = [
  "async-trait",
  "clap",
  "futures",
- "iii-console-ui",
  "iii-helpers",
  "iii-sdk",
  "regex",

--- a/provider-zai/Cargo.toml
+++ b/provider-zai/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 path = "src/lib.rs"
 
 [dependencies]
-llm-router = { path = "../llm-router" }
+llm-router = { path = "../llm-router", default-features = false }
 # Must match llm-router's pin (one iii-sdk per graph). 0.21.5 brings the
 # live span-start push: `provider::zai::stream` renders while streaming.
 iii-sdk = "=0.21.6"


### PR DESCRIPTION
Supersedes #696 (the lock regeneration alone exposed a deeper break).

## Problem
llm-router 1.4.1's `build.rs` shells out to **pnpm** to bundle the injectable console UI. Every provider worker path-depends on the router for `llm_router::types`, so compiling any provider now demands a Node toolchain — breaking all nine providers' `rust lint + test` and `interface boot smoke` jobs (their runners only carry Rust, by design):

```
pnpm not found on PATH — install Node + pnpm, or set SKIP_UI_BUILD=1 ...
```

`SKIP_UI_BUILD=1` is no escape: it requires a prebuilt `ui/dist/`, which is not committed.

## Fix
Default-on `console-ui` feature on llm-router carrying `ui.rs`, the `iii-console-ui` dependency, and the build.rs bundle step; the nine providers depend on the router with `default-features = false`. Their builds no longer touch Node anywhere — CI, local, or user machines. The router's own binary keeps the UI (default features).

Validated locally: `provider-deepseek` compiles with **no pnpm on PATH and no ui/dist**; llm-router compiles both with default features (UI bundled) and with `--no-default-features`.

## Lock sync (versions deployed today)
- Nine provider `Cargo.lock`s → llm-router **1.4.1** (were 1.4.0; llamacpp/xai at 1.3.2)
- `approval-gate/Cargo.lock` → harness **1.7.0**

## Known pre-existing break (out of scope)
`eval` cannot resolve at all on main since the harness 1.7.0 bump: harness pins `iii-sdk =0.21.8` while `crates/console-ui` (also in eval's graph) pins `=0.21.6` — and the rest of the repo is on 0.21.6. Aligning it means propagating the 0.21.8 migration beyond harness; left untouched here so this PR stays green and scoped. Its CI job only fires when `eval/` changes.

## Follow-up worth considering
Bump tooling never regenerates dependents' lock files (llamacpp/xai were stale across two bumps). A bump-time `cargo update -p <worker>` across path dependents would prevent recurrence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional console UI feature, enabled by default.
  * Applications can now disable the console UI and its build tools when using library-only functionality.

* **Improvements**
  * Library-only builds now skip unnecessary UI asset validation and frontend build steps.
  * Provider integrations use a leaner configuration by disabling the console UI by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->