### PR TITLE
(MOT-4299) fix(release): keep engine builtins out of the candidate interface gate

### DIFF
--- a/.github/scripts/build_publish_payload.py
+++ b/.github/scripts/build_publish_payload.py
@@ -124,6 +124,23 @@ def _baseline_worker_identities(baseline_workers_json: dict[str, Any] | None) ->
     }
 
 
+# Workers the engine itself hosts (enabled via the engine config, not
+# installed from the registry). A candidate install can flip one on mid-boot
+# (e.g. harness enables `iii-stream` for console streaming), which lands it in
+# the workers-baseline diff even though its interface is not part of the
+# released worker's surface — and its schemas are not this repo's to fix.
+ENGINE_BUILTIN_WORKERS = frozenset(
+    {
+        "configuration",
+        "iii-observability",
+        "iii-state",
+        "iii-stream",
+        "iii-worker-manager",
+        "iii-worker-ops",
+    }
+)
+
+
 def _resolve_target_worker_names(
     *,
     workers: list[dict[str, Any]],
@@ -137,7 +154,9 @@ def _resolve_target_worker_names(
         new_names = {
             identity
             for worker in workers
-            if (identity := _worker_identity(worker)) and identity not in baseline
+            if (identity := _worker_identity(worker))
+            and identity not in baseline
+            and identity not in ENGINE_BUILTIN_WORKERS
         }
         if new_names:
             return new_names

--- a/.github/scripts/tests/test_build_publish_payload.py
+++ b/.github/scripts/tests/test_build_publish_payload.py
@@ -64,3 +64,43 @@ def test_experimental_is_always_sent_as_a_bool(tmp_path: Path) -> None:
 
     marked = build_binary_payload(tmp_path / "marked", "name: smoke\n", experimental=True)
     assert marked["experimental"] is True
+
+
+def test_engine_builtins_are_not_release_targets() -> None:
+    """A candidate install can enable an engine-hosted worker mid-boot (harness
+    turns on `iii-stream`), which lands it in the workers-baseline diff. Its
+    interface is not part of the released worker's surface and must not reach
+    the typed-schema gate."""
+    from build_publish_payload import _resolve_target_worker_names
+
+    target = _resolve_target_worker_names(
+        workers=[
+            {"name": "iii-worker-ops"},
+            {"name": "harness"},
+            {"name": "iii-stream"},
+        ],
+        worker_name="harness",
+        functions=[],
+        baseline_workers_json={"workers": [{"name": "iii-worker-ops"}]},
+    )
+    assert target == {"harness"}
+
+
+def test_builtin_only_diff_falls_back_to_name_match() -> None:
+    """When the baseline diff contains nothing but engine builtins, resolution
+    falls through to matching the released worker by name."""
+    from build_publish_payload import _resolve_target_worker_names
+
+    target = _resolve_target_worker_names(
+        workers=[
+            {"name": "iii-worker-ops"},
+            {"name": "iii-stream"},
+            {"name": "harness", "functions": ["harness::send"]},
+        ],
+        worker_name="harness",
+        functions=[],
+        baseline_workers_json={
+            "workers": [{"name": "iii-worker-ops"}, {"name": "harness"}]
+        },
+    )
+    assert target == {"harness"}

--- a/.github/workflows/_candidate-smoke.yml
+++ b/.github/workflows/_candidate-smoke.yml
@@ -37,6 +37,14 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      # The interface gate must run with the pipeline's current validation
+      # logic, not the logic frozen into the release tag — a dispatched re-run
+      # of an already-published candidate (release SOP § re-run) picks up gate
+      # fixes from the calling ref this way. On tag pushes both refs coincide.
+      - uses: actions/checkout@v5
+        with:
+          path: pipeline-scripts
+
       - name: Install smoke dependencies
         run: python3 -m pip install --quiet pyyaml
 
@@ -109,13 +117,13 @@ jobs:
         env:
           WORKER: ${{ inputs.worker }}
         run: |
-          python3 .github/scripts/collect_worker_interface.py \
+          python3 pipeline-scripts/.github/scripts/collect_worker_interface.py \
             --worker "$WORKER" \
             --out "$SMOKE_DIR/worker-interface.json" \
             --wait-seconds 180 \
             --trigger-types-baseline "$SMOKE_DIR/trigger-types-baseline.json" \
             --workers-baseline "$SMOKE_DIR/workers-baseline.json"
-          python3 .github/scripts/collect_worker_interface.py \
+          python3 pipeline-scripts/.github/scripts/collect_worker_interface.py \
             --assert-non-empty \
             --assert-typed-schemas \
             --assert-file "$SMOKE_DIR/worker-interface.json"


### PR DESCRIPTION
## Problem
The **harness 1.7.0** staged release ([run 30955188088](https://github.com/iii-hq/workers/actions/runs/30955188088)) published to `harness@next` successfully but died in candidate validation:

```
untyped (AnyValue/empty) schemas in worker-interface.json:
iii-stream::on-config-change.*, stream::get/list/list_groups/send.response_schema
```

None of those belong to harness. `_resolve_target_worker_names` treats every worker that appears after the baseline snapshot as part of the released surface — and the harness install enables the engine's **`iii-stream` builtin** (console streaming) mid-boot, landing it in the diff. Earlier releases today (providers, llm-router, console) passed because their installs don't touch engine builtins. A builtin is not installable from the registry and its schemas are not this repo's to fix.

## Fix
1. `build_publish_payload.py`: exclude the engine-hosted worker set (`configuration`, `iii-observability`, `iii-state`, `iii-stream`, `iii-worker-manager`, `iii-worker-ops`) from baseline-diff target resolution, with tests for both the exclusion and the builtin-only-diff fallback.
2. `_candidate-smoke.yml`: run the interface-gate scripts from the **pipeline ref** (second checkout) instead of the release tag, so the SOP's dispatched re-run of an existing candidate picks up gate fixes without re-tagging. Tag-push runs are unchanged (both refs coincide).

## Unblocks
After merge: Actions → **Release** → `workflow_dispatch` with tag `harness/v1.7.0` re-validates the already-published candidate (publish is idempotent per the SOP), records evidence, and reopens the path to promotion.