### PR TITLE
(MOT-4299) fix(ci): free runner disk before the Harness E2E stack build

### DIFF
--- a/.github/workflows/_harness-e2e.yml
+++ b/.github/workflows/_harness-e2e.yml
@@ -110,6 +110,16 @@ jobs:
       engine_binary: ${{ steps.engine.outputs.binary }}
       engine_revision: ${{ steps.engine.outputs.version }}
     steps:
+      # The registry-mode stack build filled a standard runner's disk (the
+      # harness 1.7.1 release died packaging harness-e2e-stack.tar.gz with
+      # ENOSPC). Preinstalled toolchains this job never touches hold ~30GB;
+      # drop them before building.
+      - name: Free runner disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune -af >/dev/null 2>&1 || true
+          df -h /
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.source_ref }}


### PR DESCRIPTION
The harness **1.7.1** release ([run 30963283418](https://github.com/iii-hq/workers/actions/runs/30963283418)) cleared the fixed candidate gate (#698) and quickstart, then died in **Validate candidate in deployed Harness E2E / harness e2e build**:

```
tar: target/harness-e2e-stack.tar.gz: Wrote only 4096 of 10240 bytes
```

ENOSPC — the registry-mode stack build fills the standard runner's ~14GB free disk. Reproduced identically on a failed-jobs rerun, so it's structural, not runner variance (this is the first harness staged release to reach this stage).

Fix: drop preinstalled toolchains the job never uses (~30GB: dotnet, Android SDK, GHC/ghcup, CodeQL, docker images) as the first step of the shared `build` job, with a `df -h` for observability. Benefits both source and registry modes.

**Evidence gating context**: `release_candidate.py` requires `harness_e2e == success` in the *same run*, and a release rerun uses the tag's workflow snapshot — so this fix can only take effect through a **new tag (1.7.2)** after merge. Ref #699 for the broader re-run idempotency issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build workflow preparation by freeing disk space before checkout.
  * Added disk capacity reporting to help monitor build environment availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->