### PR TITLE
(MOT-4299) fix(ci): create target/ before packaging the registry E2E runner

### DIFF
--- a/.github/workflows/_harness-e2e.yml
+++ b/.github/workflows/_harness-e2e.yml
@@ -325,7 +325,13 @@ jobs:
 
       - name: Package registry E2E runner
         if: inputs.stack_mode == 'registry'
-        run: tar -czf target/harness-e2e-stack.tar.gz -C harness/target/release harness-e2e
+        # Registry mode builds only the runner (harness/target/release), so the
+        # repo-root target/ this writes into does not exist yet — source mode
+        # gets it from the engine install. Both harness release attempts died
+        # here (1.7.1 masked as ENOSPC, 1.7.2 as ENOENT).
+        run: |
+          mkdir -p target
+          tar -czf target/harness-e2e-stack.tar.gz -C harness/target/release harness-e2e
 
       - name: Upload E2E binaries
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
Third and hopefully last first-run bug in the registry-mode E2E path — which has **never executed past this step**:

- **1.7.1**: `Package registry E2E runner` failed with `Wrote only 4096 of 10240 bytes` — read as ENOSPC, fixed disk headroom in #700 (still a real improvement).
- **1.7.2** (attempt 2, after quickstart's transient registry blip passed on rerun): same step, now a clean `Cannot open: No such file or directory` — the actual latent bug. Registry mode builds only `harness/target/release/harness-e2e`; nothing creates the **repo-root `target/`** the tarball is written into. Source mode gets it from the engine install step (`stack_mode == 'source'` only).

Fix: `mkdir -p target` before the tar.

**De-risking the next tag**: instead of cutting 1.7.3 blind, after this merges the plan is to dispatch `harness-e2e-deployed.yml` from main against the already-published `harness@next` (1.7.2, registry state is valid) to prove the whole registry-mode path end-to-end — then tag. Evidence gating still requires the same-run success (`release_candidate.py`), so the tag is still needed for promotion; the dispatch just guarantees it passes. Ref #699.