### PR TITLE
(MOT-4299) fix(ci): fit harness-e2e-deployed dispatch inputs under GitHub's cap

### DIFF
--- a/.github/workflows/harness-e2e-deployed.yml
+++ b/.github/workflows/harness-e2e-deployed.yml
@@ -39,14 +39,6 @@ on:
         description: Optional JSON subject matrix
         type: string
         default: ''
-      judge_model:
-        description: Optional fixed judge model id
-        type: string
-        default: ''
-      judge_provider:
-        description: Optional fixed judge provider id
-        type: string
-        default: ''
       runs:
         description: Number of executions per scenario
         type: number
@@ -76,8 +68,8 @@ jobs:
       release_run_id: ${{ inputs.release_run_id }}
       smoke_run_id: ${{ inputs.smoke_run_id }}
       subjects: ${{ inputs.subjects || vars.HARNESS_E2E_SUBJECTS || '[{"id":"anthropic-sonnet","model":"claude-sonnet-4-6","provider":"anthropic"}]' }}
-      judge_model: ${{ inputs.judge_model || vars.HARNESS_E2E_JUDGE_MODEL || 'claude-sonnet-4-6' }}
-      judge_provider: ${{ inputs.judge_provider || vars.HARNESS_E2E_JUDGE_PROVIDER || 'anthropic' }}
+      judge_model: ${{ vars.HARNESS_E2E_JUDGE_MODEL || 'claude-sonnet-4-6' }}
+      judge_provider: ${{ vars.HARNESS_E2E_JUDGE_PROVIDER || 'anthropic' }}
     secrets:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
       openai_api_key: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
Every manual dispatch of `harness-e2e-deployed.yml` failed at startup with the opaque *"This run likely failed because of a workflow file issue"* and zero jobs ([30965720679](https://github.com/iii-hq/workers/actions/runs/30965720679), [30966132857](https://github.com/iii-hq/workers/actions/runs/30966132857)). GitHub's API exposes no error detail; **actionlint** pinpointed it instantly:

```
maximum number of inputs for "workflow_dispatch" event is 10 but 11 inputs are provided
```

Push-triggered reusable-workflow callers don't traverse this validation, so the release pipeline path never surfaced it — the wrapper (new in #692/#694) had simply never been dispatched.

Fix: drop the `judge_model`/`judge_provider` dispatch overrides (10→9 inputs would be 11→9). Both already fall back to `HARNESS_E2E_JUDGE_MODEL`/`HARNESS_E2E_JUDGE_PROVIDER` repo vars, which remain the operator control surface; `subjects` stays for one-off model tests.

Worth considering as follow-up: an actionlint job in CI — it also validates reusable-workflow contracts that GitHub only checks at dispatch time.