### PR TITLE
(MOT-4299) fix(ci): coerce the deployed E2E dispatch runs input to a number

### DIFF
--- a/.github/workflows/harness-e2e-deployed.yml
+++ b/.github/workflows/harness-e2e-deployed.yml
@@ -57,7 +57,7 @@ jobs:
     uses: ./.github/workflows/_harness-e2e.yml
     with:
       stack_mode: registry
-      runs: ${{ inputs.runs }}
+      runs: ${{ fromJSON(format('{0}', inputs.runs || 1)) }}
       max_parallel: 2
       benchmark_lane: deployed
       cli_channel: ${{ inputs.cli_channel }}


### PR DESCRIPTION
Second startup killer in `harness-e2e-deployed.yml` dispatch, surfaced immediately after #702 cleared the input-count cap ([30966815754](https://github.com/iii-hq/workers/actions/runs/30966815754), zero jobs, same opaque banner, head_sha already on fixed main).

workflow_dispatch delivers `type: number` inputs **as strings** in the `inputs` context; forwarding `inputs.runs` into `_harness-e2e.yml`'s `runs` (`type: number`) fails the callee's startup type check. Push-triggered callers pass literals, so only manual dispatch dies — and this wrapper had never been dispatched before tonight. actionlint cannot catch this one (runtime evaluation, not schema).

Fix: `runs: ${{ fromJSON(format('{0}', inputs.runs || 1)) }}` — coerces both the explicit-string and untouched-default shapes.