### PR TITLE
(MOT-4299) fix(e2e): install fp and web in the deployed registry stack

### DIFF
--- a/harness/tests/e2e/run-deployed-ci.sh
+++ b/harness/tests/e2e/run-deployed-ci.sh
@@ -268,7 +268,7 @@ printf 'workers: []\n' >"$project_dir/config.yaml"
 engine_pid=$!
 wait_for_engine
 
-workers=("harness@$worker_tag" "database@$worker_tag")
+workers=("harness@$worker_tag" "database@$worker_tag" "fp@$worker_tag" "web@$worker_tag")
 declare -A providers=()
 for provider in "$HARNESS_E2E_PROVIDER" "$HARNESS_E2E_JUDGE_PROVIDER"; do
   if [[ -z "${providers[$provider]:-}" ]]; then


### PR DESCRIPTION
Root cause of the 8-scenario failure split in the deployed candidate validation ([30969507041](https://github.com/iii-hq/workers/actions/runs/30969507041)): the registry-mode stack installs only harness's dependency graph + database. `fp` (post-turn validation control plane — source mode starts it unconditionally: *"cheap enough to run for every scenario"*) and `web` (research_pipeline) are not harness dependencies, so they were never installed. Deployed lock had **no fp/web entries** while every installed worker matched main's versions exactly.

Result: single-turn scenarios (direct_answer, security_review, design_tradeoff…) passed; every wake/binding multi-turn scenario wedged to `resource_limit` with the stack fully healthy — timer registered, wake never delivered.

Both workers resolve at `latest` in the registry. After merge, the proof needs a **fresh dispatch** (a failed-jobs rerun reuses the pre-fix snapshot).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded deployed end-to-end test coverage to include fingerprint and web workers alongside existing harness and database workers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->