### PR TITLE
(MOT-4299) feat(e2e): collect per-worker logs in deployed diagnostics

### DIFF
--- a/harness/tests/e2e/run-deployed-ci.sh
+++ b/harness/tests/e2e/run-deployed-ci.sh
@@ -165,11 +165,36 @@ stop_owned_orphans() {
   kill -KILL "${pids[@]}" 2>/dev/null || true
 }
 
+# Worker-level logs are the only view into wake/binding delivery; the engine
+# log alone cannot explain a lost notification. Collected before teardown so
+# failed scenario jobs ship them in the diagnostics artifact.
+collect_worker_logs() {
+  [[ -n "$iii_bin" && -n "$engine_pid" ]] || return 0
+  kill -0 "$engine_pid" 2>/dev/null || return 0
+  local name
+  while IFS= read -r name; do
+    [[ -n "$name" ]] || continue
+    timeout 20 "$iii_bin" worker logs "$name" --port "$engine_port" \
+      >"$log_dir/worker-$name.log" 2>&1 || true
+  done < <(python3 - "$project_dir/config.yaml" <<'PY'
+import sys
+from pathlib import Path
+import yaml
+
+config = yaml.safe_load(Path(sys.argv[1]).read_text()) or {}
+for worker in config.get("workers") or []:
+    if isinstance(worker, dict) and worker.get("name"):
+        print(worker["name"])
+PY
+  )
+}
+
 cleanup() {
   local status=$?
   trap - EXIT INT TERM ERR
   set +e
   snapshot_stack
+  collect_worker_logs
   stop_workers
   stop_engine
   stop_owned_orphans


### PR DESCRIPTION
Instrumentation for the deployed wake-delivery investigation: the same 12 wake/binding scenarios fail every deployed validation run (now with correct stack composition — fp/web installed via #704, ecosystem released, install retries via #705, registry scaled) while single-turn scenarios pass. The diagnostics artifact only captures engine/install logs, which show a healthy stack and a lost wake.

Dump `iii worker logs <name>` for every worker in the project config during `cleanup`, before teardown, so every failed scenario job ships worker-level logs (harness binding registration, cron timer dispatch, session-manager wake delivery).

Local repro attempts were contaminated by the iii-cloud dev environment on the workstation (engine on the hardcoded 49134 + registry on 3111) — port isolation for the script is a small follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic artifact collection during deployed test runs by capturing individual worker logs before shutdown.
  * Log collection uses a timeout and does not interrupt cleanup if retrieval fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->