### PR TITLE
(MOT-4299) fix(e2e): resolve worker logs from the project directory

### DIFF
--- a/harness/tests/e2e/run-deployed-ci.sh
+++ b/harness/tests/e2e/run-deployed-ci.sh
@@ -174,7 +174,7 @@ collect_worker_logs() {
   local name
   while IFS= read -r name; do
     [[ -n "$name" ]] || continue
-    timeout 20 "$iii_bin" worker logs "$name" --port "$engine_port" \
+    (cd "$project_dir" && timeout 20 "$iii_bin" worker logs "$name") \
       >"$log_dir/worker-$name.log" 2>&1 || true
   done < <(python3 - "$project_dir/config.yaml" <<'PY'
 import sys


### PR DESCRIPTION
Follow-up to #707: `iii worker logs` rejects `--port` — every worker log in the first instrumented run ([30990957869](https://github.com/iii-hq/workers/actions/runs/30990957869)) contains only the CLI usage error. Resolve the engine from the project directory instead, mirroring `stop_workers`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker log collection in deployed CI by using the configured project context, helping ensure logs are retrieved reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->