### PR TITLE
chore(ci): dispatchable Pages redeploy from gh-pages

### DIFF
--- a/.github/workflows/pages-redeploy.yml
+++ b/.github/workflows/pages-redeploy.yml
@@ -1,0 +1,40 @@
+# Redeploy the published GitHub Pages site from the current gh-pages branch
+# without waiting for the Harness E2E Daily cycle. The gh-pages branch is the
+# complete site (the benchmark publisher merges assets and data into it before
+# every deploy), so a faithful redeploy is checkout + upload + deploy.
+name: Redeploy Pages
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: harness-e2e-benchmark-publish
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Redeploy site from gh-pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: gh-pages
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: .
+
+      - name: Deploy GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The dashboard site (`build_type: workflow`) deploys only when **Harness E2E Daily** completes — any direct gh-pages content change (like today's history prune) waits a full cycle to go live. Since the publisher merges everything into gh-pages before each deploy, the branch is the complete site; this adds a minimal `workflow_dispatch` redeploy (checkout gh-pages → upload-pages-artifact → deploy-pages), sharing the publisher's concurrency group so they never race.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a manual option to redeploy the published website.
  * Redeployment now uses the existing published branch and reports the resulting site URL.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->