### PR TITLE
(MOT-4361) feat(database,console): writable sql panel, driver decode fixes, page-wide consistency, shared config dialog

### DIFF
--- a/console/web/public/vendor/console-ui.js
+++ b/console/web/public/vendor/console-ui.js
@@ -40,5 +40,6 @@ export const {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
+  WorkerConfigurationDialog,
 } = api.components
 export default api

--- a/console/web/src/components/ui/CodeEditor.tsx
+++ b/console/web/src/components/ui/CodeEditor.tsx
@@ -210,12 +210,15 @@ export const CodeEditor = React.forwardRef<CodeEditorHandle, CodeEditorProps>(
     // popup (the default stays prose-quiet) and registers a provider for the
     // current language offering those words. The joined key keeps the effect
     // from churning when the parent passes a fresh array of the same words.
-    const completionsKey = (completions ?? []).join('')
+    // '\n' as separator: identifiers can't contain it, and unlike the
+    // invisible control character it replaced, it can't masquerade as an
+    // empty string in an editor or a grep.
+    const completionsKey = (completions ?? []).join('\n')
     React.useEffect(() => {
       const editor = editorRef.current
       if (!ready || !editor) return
       const words = completionsKey
-        ? completionsKey.split('').filter(Boolean)
+        ? completionsKey.split('\n').filter(Boolean)
         : []
       if (words.length === 0) return
       editor.updateOptions({

--- a/console/web/src/lib/console-api.ts
+++ b/console/web/src/lib/console-api.ts
@@ -47,6 +47,7 @@ import { useTheme } from '@/hooks/use-theme'
 import type { IiiClient } from '@/lib/iii-client'
 import { Markdown } from '@/lib/markdown'
 import { CodeHighlight, JsonHighlight } from '@/lib/syntax'
+import { WorkerConfigurationDialog } from '@/pages/Workers/components/WorkerConfigurationDialog'
 import type { ConsoleApi, ExtensionIii } from '@/types/injectable-ui'
 
 /**
@@ -89,6 +90,10 @@ export const components: ConsoleApi['components'] = {
   JsonHighlight,
   Markdown,
   MarkdownPreview,
+  // The one page-level composite in the kit: worker pages offer "configure"
+  // in place instead of navigating to the workers tab and stranding the
+  // operator there when the editor closes.
+  WorkerConfigurationDialog,
 }
 
 /** Token names mirroring `index.css`'s `@theme` block (documentation aid). */

--- a/console/web/src/lib/console-ui-conformance.test.ts
+++ b/console/web/src/lib/console-ui-conformance.test.ts
@@ -55,6 +55,7 @@ import {
 import { components } from '@/lib/console-api'
 import { Markdown } from '@/lib/markdown'
 import { CodeHighlight, JsonHighlight } from '@/lib/syntax'
+import { WorkerConfigurationDialog } from '@/pages/Workers/components/WorkerConfigurationDialog'
 
 /**
  * The type-level check: assigning each real component to the package's
@@ -95,6 +96,7 @@ const conformance: {
   Tooltip: typeof ConsoleUi.Tooltip
   TooltipContent: typeof ConsoleUi.TooltipContent
   TooltipTrigger: typeof ConsoleUi.TooltipTrigger
+  WorkerConfigurationDialog: typeof ConsoleUi.WorkerConfigurationDialog
 } = {
   Badge,
   Button,
@@ -129,6 +131,7 @@ const conformance: {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
+  WorkerConfigurationDialog,
 }
 
 describe('@iii-dev/console-ui surface', () => {

--- a/database/src/driver/mysql.rs
+++ b/database/src/driver/mysql.rs
@@ -40,7 +40,7 @@ pub async fn query(
             .iter()
             .map(|c| ColumnMeta {
                 name: c.name_str().to_string(),
-                ty: format!("{:?}", c.column_type()),
+                ty: sql_type_name(c),
             })
             .collect();
         let raw_rows: Vec<mysql_async::Row> = result.collect().await.map_err(map_err)?;
@@ -62,6 +62,89 @@ pub async fn query(
         columns: cols,
         rows: out_rows,
     })
+}
+
+/// MySQL's binary charset. Wire metadata reuses one protocol type for a text
+/// column and its binary twin (`TEXT`/`BLOB`, `VARCHAR`/`VARBINARY`); the
+/// charset is the only thing that separates them.
+const BINARY_CHARSET: u16 = 63;
+
+/// The SQL type name for a result column, as a caller would write it.
+///
+/// The protocol hands back an internal enum, and `{:?}` on it produced
+/// `MYSQL_TYPE_VAR_STRING` — leaked into the console's grid header and into
+/// every agent reading `columns[].type`. Postgres reports `text` and SQLite
+/// reports the declared type, so MySQL was the odd one out; this restores
+/// parity. Length and precision are not on the wire, so `varchar` here where
+/// `describeTable` (which reads the catalog) says `varchar(50)`.
+fn sql_type_name(col: &mysql_async::Column) -> String {
+    use mysql_async::consts::{ColumnFlags, ColumnType::*};
+
+    let binary = col.character_set() == BINARY_CHARSET;
+    let name = match col.column_type() {
+        MYSQL_TYPE_TINY => "tinyint",
+        MYSQL_TYPE_SHORT => "smallint",
+        MYSQL_TYPE_INT24 => "mediumint",
+        MYSQL_TYPE_LONG => "int",
+        MYSQL_TYPE_LONGLONG => "bigint",
+        MYSQL_TYPE_FLOAT => "float",
+        MYSQL_TYPE_DOUBLE => "double",
+        MYSQL_TYPE_DECIMAL | MYSQL_TYPE_NEWDECIMAL => "decimal",
+        MYSQL_TYPE_BIT => "bit",
+        MYSQL_TYPE_DATE | MYSQL_TYPE_NEWDATE => "date",
+        MYSQL_TYPE_TIME | MYSQL_TYPE_TIME2 => "time",
+        MYSQL_TYPE_DATETIME | MYSQL_TYPE_DATETIME2 => "datetime",
+        MYSQL_TYPE_TIMESTAMP | MYSQL_TYPE_TIMESTAMP2 => "timestamp",
+        MYSQL_TYPE_YEAR => "year",
+        MYSQL_TYPE_JSON => "json",
+        MYSQL_TYPE_ENUM => "enum",
+        MYSQL_TYPE_SET => "set",
+        MYSQL_TYPE_GEOMETRY => "geometry",
+        MYSQL_TYPE_NULL => "null",
+        MYSQL_TYPE_TINY_BLOB => return blob_or_text(binary, "tiny"),
+        MYSQL_TYPE_MEDIUM_BLOB => return blob_or_text(binary, "medium"),
+        MYSQL_TYPE_LONG_BLOB => return blob_or_text(binary, "long"),
+        MYSQL_TYPE_BLOB => return blob_or_text(binary, ""),
+        MYSQL_TYPE_VARCHAR | MYSQL_TYPE_VAR_STRING => {
+            if binary {
+                "varbinary"
+            } else {
+                "varchar"
+            }
+        }
+        MYSQL_TYPE_STRING => {
+            if binary {
+                "binary"
+            } else {
+                "char"
+            }
+        }
+        // `MYSQL_TYPE_UNKNOWN` and anything a future server adds. Better a
+        // lowercase debug name than a wrong guess at a SQL type.
+        other => return format!("{other:?}").to_ascii_lowercase(),
+    };
+
+    if col.flags().contains(ColumnFlags::UNSIGNED_FLAG) && is_integer(col.column_type()) {
+        format!("{name} unsigned")
+    } else {
+        name.to_string()
+    }
+}
+
+fn blob_or_text(binary: bool, size: &str) -> String {
+    format!("{size}{}", if binary { "blob" } else { "text" })
+}
+
+fn is_integer(ty: mysql_async::consts::ColumnType) -> bool {
+    use mysql_async::consts::ColumnType::*;
+    matches!(
+        ty,
+        MYSQL_TYPE_TINY
+            | MYSQL_TYPE_SHORT
+            | MYSQL_TYPE_INT24
+            | MYSQL_TYPE_LONG
+            | MYSQL_TYPE_LONGLONG
+    )
 }
 
 fn bind_params(params: &[JsonParam]) -> Params {
@@ -210,7 +293,7 @@ pub async fn transaction(
                         .iter()
                         .map(|col| ColumnMeta {
                             name: col.name_str().to_string(),
-                            ty: format!("{:?}", col.column_type()),
+                            ty: sql_type_name(col),
                         })
                         .collect();
                     let raw: Result<Vec<mysql_async::Row>, _> = iter.collect().await;
@@ -337,7 +420,7 @@ pub async fn run_prepared(
         .iter()
         .map(|c| ColumnMeta {
             name: c.name_str().to_string(),
-            ty: format!("{:?}", c.column_type()),
+            ty: sql_type_name(c),
         })
         .collect();
     let raw_rows: Vec<mysql_async::Row> = iter.collect().await.map_err(map_err)?;

--- a/database/src/driver/postgres.rs
+++ b/database/src/driver/postgres.rs
@@ -193,6 +193,14 @@ fn pg_cell_to_row_value(
             Some(s) => RowValue::Text(s),
             None => RowValue::Null,
         },
+        // The internal one-byte "char" (OID 18) — what pg_catalog uses for
+        // relkind/contype/attidentity. It is NOT text-family: `String`'s
+        // FromSql rejects it (so the `_` fallback below fails with "error
+        // deserializing column N"), and tokio-postgres decodes it as i8.
+        T::CHAR => match get!(i8) {
+            Some(c) => RowValue::Text(((c as u8) as char).to_string()),
+            None => RowValue::Null,
+        },
         T::BYTEA => match get!(Vec<u8>) {
             Some(b) => RowValue::Bytes(b),
             None => RowValue::Null,

--- a/database/src/ui.rs
+++ b/database/src/ui.rs
@@ -8,7 +8,8 @@
 //!   every `database::*` call (SQL with highlighting, request chips, result
 //!   tables, batch/transaction step lists; errors fall through to the
 //!   console's built-in error card) plus the `#/ext/database` page: schema
-//!   tree, paged row grid, row inspector, read-only SQL panel.
+//!   tree, paged row grid, row inspector, SQL panel (reads via
+//!   `database::query`, writes via `database::execute`).
 //! - `database/styles.css` (`console:style`) — the stylesheet for both, every
 //!   rule scoped under `[data-iii-ui="database"]`; the console mounts it as a
 //!   `<link>` and link-swaps it on change, styles-before-scripts on boot.

--- a/database/ui/src/configuration/index.tsx
+++ b/database/ui/src/configuration/index.tsx
@@ -12,6 +12,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import type { ConfigFormProps, Host, JsonValue } from '@iii-dev/console-ui'
+import { errText } from '../lib/errors'
 
 type JsonObject = { [key: string]: JsonValue }
 
@@ -111,7 +112,7 @@ export function DatabaseConfigForm(props: ConfigFormProps & { host: Host }) {
           : resp.message ?? 'connection failed',
       }
     } catch (e) {
-      result = { status: 'done', ok: false, text: e instanceof Error ? e.message : String(e) }
+      result = { status: 'done', ok: false, text: errText(e) }
     }
     if (testTokens.current[name] !== token) return // superseded by an edit
     setTestResults((r) => ({ ...r, [name]: result }))

--- a/database/ui/src/lib/errors.test.ts
+++ b/database/ui/src/lib/errors.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { errText } from './errors'
+
+describe('errText', () => {
+  it('unwraps the real driver error out of the transport envelope', () => {
+    // Exactly what `database::query` rejects with for a missing table.
+    const wire = {
+      code: 'invocation_failed',
+      message:
+        'handler error: {"code":"DRIVER_ERROR","driver":"mysql","inner_code":"1146","message":"Server error: `ERROR 42S02 (1146): Table \'iii.no_such_table\' doesn\'t exist\'"}',
+      stacktrace: 'a very long rust backtrace',
+    }
+    expect(errText(wire)).toBe(
+      "DRIVER_ERROR (1146): Server error: `ERROR 42S02 (1146): Table 'iii.no_such_table' doesn't exist'",
+    )
+  })
+
+  it('never renders [object Object]', () => {
+    for (const value of [{}, { a: 1 }, [], null, undefined, 42]) {
+      expect(errText(value)).not.toContain('object Object')
+    }
+  })
+
+  it('passes Errors and strings straight through', () => {
+    expect(errText(new Error('boom'))).toBe('boom')
+    expect(errText('boom')).toBe('boom')
+  })
+
+  it('drops the transport code when there is nothing better', () => {
+    expect(errText({ code: 'invocation_failed', message: 'worker not connected' })).toBe('worker not connected')
+  })
+
+  it('keeps a handler code that carries meaning', () => {
+    expect(errText({ code: 'POOL_TIMEOUT', message: 'pool acquire exceeded 5000ms' })).toBe(
+      'POOL_TIMEOUT: pool acquire exceeded 5000ms',
+    )
+  })
+
+  it('stops rather than spins on a self-referential wrapper', () => {
+    const nested = { code: 'A', message: 'handler error: {"code":"B","message":"handler error: {"}' }
+    expect(errText(nested)).toContain('B')
+  })
+})

--- a/database/ui/src/lib/errors.ts
+++ b/database/ui/src/lib/errors.ts
@@ -1,0 +1,82 @@
+/**
+ * One readable string out of whatever a rejected `host.iii.trigger` throws.
+ *
+ * The browser SDK rejects with the wire error *object*, not an `Error`, so the
+ * usual `err instanceof Error ? err.message : String(err)` rendered every
+ * failed read as `[object Object]` — lowercased by the page's own CSS into
+ * `[object object]`. The whole point of a SQL panel is to iterate on errors.
+ *
+ * The envelope nests: the transport says `invocation_failed` and hides the
+ * useful part inside `message` as `handler error: {"code":…,"message":…}`.
+ * Unwrap to the innermost message and prefix the handler's own code, so a
+ * missing table reads `DRIVER_ERROR (1146): Table 'x' doesn't exist` rather
+ * than the transport's generic failure.
+ */
+
+/** Codes that only say "the call failed" — never worth showing. */
+const TRANSPORT_CODES = new Set(['invocation_failed', 'handler_error'])
+
+interface ErrorBody {
+  code?: string
+  inner_code?: string
+  message?: string
+}
+
+function bodyOf(value: unknown): ErrorBody | null {
+  if (typeof value !== 'object' || value === null) return null
+  const { code, inner_code, message } = value as Record<string, unknown>
+  return {
+    code: typeof code === 'string' ? code : undefined,
+    inner_code: typeof inner_code === 'string' ? inner_code : undefined,
+    message: typeof message === 'string' ? message : undefined,
+  }
+}
+
+/**
+ * Peel `handler error: {json}` wrappers until the message stops being one.
+ * Bounded, because a malformed payload must not spin.
+ */
+function unwrap(body: ErrorBody): ErrorBody {
+  let current = body
+  for (let depth = 0; depth < 4; depth++) {
+    const text = current.message
+    if (!text) return current
+    const brace = text.indexOf('{')
+    if (brace === -1) return current
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(text.slice(brace))
+    } catch {
+      return current
+    }
+    const inner = bodyOf(parsed)
+    if (!inner?.message) return current
+    current = inner
+  }
+  return current
+}
+
+export function errText(err: unknown): string {
+  if (err instanceof Error) return err.message
+  if (typeof err === 'string') return err
+
+  const body = bodyOf(err)
+  if (body?.message) {
+    const { code, inner_code, message } = unwrap(body)
+    const label = code && !TRANSPORT_CODES.has(code) ? code : null
+    if (!label) return message ?? String(err)
+    return `${label}${inner_code ? ` (${inner_code})` : ''}: ${message}`
+  }
+
+  // Last resort: something unrecognised. Anything beats `[object Object]`,
+  // which is what `String()` gives for every object — the bug this exists to
+  // stop. Only non-objects are safe to stringify that way.
+  if (typeof err === 'object' && err !== null) {
+    try {
+      return JSON.stringify(err) ?? 'unknown error'
+    } catch {
+      return 'unknown error'
+    }
+  }
+  return String(err)
+}

--- a/database/ui/src/lib/rpc.ts
+++ b/database/ui/src/lib/rpc.ts
@@ -18,6 +18,7 @@ import { z } from 'zod'
 
 export const DB = {
   listDatabases: 'database::listDatabases',
+  execute: 'database::execute',
   listTables: 'database::listTables',
   describeTable: 'database::describeTable',
   describeSchema: 'database::describeSchema',
@@ -365,9 +366,25 @@ export async function browseTable(
   )
 }
 
-/** Ad-hoc SQL from the editor. Still goes through `database::query`. */
+/** Ad-hoc read SQL from the editor. Goes through `database::query`. */
 export async function runSql(host: Host, db: string, sql: string): Promise<QueryResponse> {
   return call(host, DB.query, { db, sql }, queryResponseSchema)
+}
+
+const executeResponseSchema = z.object({
+  affected_rows: z.number(),
+  // The worker sends the id as a string: SQLite/MySQL rowids exceed what a
+  // JS number holds exactly.
+  last_insert_id: z.string().nullish(),
+  returned_rows: z.array(z.record(z.string(), z.unknown())).nullish(),
+})
+export type ExecuteResponse = z.infer<typeof executeResponseSchema>
+
+/** Ad-hoc write SQL from the editor. Goes through `database::execute` — the
+    same surface agents use, so policy and `database::row-changed` both see
+    it. */
+export async function execSql(host: Host, db: string, sql: string): Promise<ExecuteResponse> {
+  return call(host, DB.execute, { db, sql }, executeResponseSchema)
 }
 
 export const planNodeSchema: z.ZodType<PlanNode> = z.lazy(() =>

--- a/database/ui/src/page/ChangesPanel.tsx
+++ b/database/ui/src/page/ChangesPanel.tsx
@@ -29,6 +29,15 @@ const OP_LABEL: Record<string, string> = {
   other: 'other',
 }
 
+/**
+ * The capture-mode caveat, shown on demand. It used to live only in a title
+ * attribute the idle copy told you to hover — unreachable by keyboard, touch,
+ * or a screen reader. The badge is a real disclosure button now; the tooltip
+ * stays for mouse users.
+ */
+const CAPTURE_NOTE =
+  'following committed writes to this table. a connection using statement capture reports only writes made through this worker; one using native capture reports every client. delivery is best effort — reload to be certain.'
+
 export function ChangesPanel({
   host,
   db,
@@ -43,6 +52,7 @@ export function ChangesPanel({
   kind?: string
   onRefresh?: () => void
 }) {
+  const [capOpen, setCapOpen] = useState(false)
   // A view is never the target of a write. The worker keys every change on the
   // table the statement actually touched, so a binding on a view matches
   // nothing and would sit at "following" forever while rows visibly change
@@ -90,10 +100,15 @@ export function ChangesPanel({
 
   return (
     <div className="db-changes">
-      <div className="db-changes-bar">
-        <FreshnessBadge status={feed.status} lastAt={feed.lastAt} />
+      <div className="db-changes-bar db-toolbar">
+        <FreshnessBadge
+          status={feed.status}
+          lastAt={feed.lastAt}
+          expanded={capOpen}
+          onToggle={() => setCapOpen((v) => !v)}
+        />
         <span className="db-changes-target">{table}</span>
-        <div className="db-erd-spacer" />
+        <div className="db-toolbar-spacer" />
         {feed.pending > 0 && onRefresh ? (
           <Button
             variant="ghost"
@@ -104,23 +119,25 @@ export function ChangesPanel({
             }}
           >
             <RefreshCw size={13} aria-hidden />
-            reload rows ({feed.pending})
+            reload rows · {feed.pending}
           </Button>
         ) : null}
       </div>
 
+      {capOpen ? <p className="db-changes-capnote">{CAPTURE_NOTE}</p> : null}
+
       {feed.changes.length === 0 ? (
-        <div className="db-changes-idle">
-          <p>nothing yet.</p>
-          <p className="db-changes-hint">
-            writes to <code>{table}</code> appear here as they commit. what counts as a write depends on this
-            connection's capture mode — hover the indicator above.
-          </p>
-        </div>
+        <EmptyState
+          icon={HistoryIcon}
+          title="nothing yet"
+          description={`writes to ${table} appear here as they commit. what counts as a write depends on this connection's capture mode — the "following" indicator above explains it.`}
+        />
       ) : (
-        <ol className="db-changes-list">
-          {feed.changes.map((c, i) => (
-            <ChangeRow key={`${c.seen}-${i}`} change={c} />
+        // role="log": arrivals are announced politely without stealing focus —
+        // the whole point of a feed whose job is telling you about writes.
+        <ol className="db-changes-list" role="log" aria-label={`writes to ${table}`}>
+          {feed.changes.map((c) => (
+            <ChangeRow key={c.seq} change={c} />
           ))}
         </ol>
       )}
@@ -155,22 +172,31 @@ function ChangeRow({ change }: { change: RowChange }) {
  * carries the caveat rather than a word in the badge implying more than is
  * true.
  */
-function FreshnessBadge({ status, lastAt }: { status: string; lastAt: number | null }) {
+function FreshnessBadge({
+  status,
+  lastAt,
+  expanded,
+  onToggle,
+}: {
+  status: string
+  lastAt: number | null
+  expanded: boolean
+  onToggle: () => void
+}) {
   const bound = status === 'bound'
   const recent = lastAt != null && Date.now() - lastAt < 10_000
   return (
-    <span
+    <button
+      type="button"
       className="db-freshness"
-      title={
-        bound
-          ? 'following committed writes to this table. a connection using statement capture reports only writes made through this worker; one using native capture reports every client. delivery is best effort — reload to be certain.'
-          : 'not following this table.'
-      }
+      onClick={onToggle}
+      aria-expanded={expanded}
+      title={bound ? CAPTURE_NOTE : 'not following this table.'}
     >
       <StatusDot tone={bound ? 'accent' : 'ink'} pulse={bound && recent} />
       <span>{bound ? 'following' : 'not following'}</span>
       {lastAt != null ? <span className="db-freshness-at">· last {relative(Date.now() - lastAt)}</span> : null}
-    </span>
+    </button>
   )
 }
 

--- a/database/ui/src/page/ErdPanel.tsx
+++ b/database/ui/src/page/ErdPanel.tsx
@@ -16,7 +16,7 @@
 import { Badge, Button, EmptyState, type Host, Input, Select, StatusPanel } from '@iii-dev/console-ui'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { schemaDiagram } from '../lib/rpc'
-import { AlertCircle, KeyRound, Link2, RefreshCw, Table2 } from './icons'
+import { AlertCircle, KeyRound, Link2, Maximize, Table2 } from './icons'
 import { useDatabaseRead } from './useDatabaseRead'
 
 const MIN_ZOOM = 0.15
@@ -269,9 +269,10 @@ export function ErdPanel({
 
   return (
     <div className="db-erd">
-      <div className="db-erd-bar">
+      <div className="db-erd-bar db-toolbar">
         <span className="db-erd-stat">
-          {diagram.nodes.length} tables · {diagram.edges.length} relations
+          {diagram.nodes.length} table{diagram.nodes.length === 1 ? '' : 's'} · {diagram.edges.length} relation
+          {diagram.edges.length === 1 ? '' : 's'}
         </span>
         {related === 0 ? (
           <span className="db-erd-stat quiet">no foreign keys — nothing to connect</span>
@@ -281,7 +282,7 @@ export function ErdPanel({
           </span>
         )}
         {diagram.truncated ? <Badge variant="warn">truncated</Badge> : null}
-        <div className="db-erd-spacer" />
+        <div className="db-toolbar-spacer" />
         {focus ? (
           <>
             <span className="db-erd-focus">
@@ -316,8 +317,10 @@ export function ErdPanel({
             reset positions
           </Button>
         ) : null}
+        {/* A frame icon, not the refresh arrows: fit re-frames the view, the
+            header's refresh re-reads data — same glyph implied same verb. */}
         <Button variant="ghost" size="sm" onClick={fitToFrame}>
-          <RefreshCw size={13} aria-hidden />
+          <Maximize size={13} aria-hidden />
           fit
         </Button>
       </div>
@@ -451,7 +454,16 @@ export function ErdPanel({
                     setFocus(n.table)
                     setSelected(null)
                   }}
-                  title={`${n.table} · ${n.degree} relation${n.degree === 1 ? '' : 's'} · drag to move, double-click to focus`}
+                  // Double-click has no keyboard equivalent — F is it.
+                  onKeyDown={(e) => {
+                    if (e.key === 'f' || e.key === 'F') {
+                      e.preventDefault()
+                      setFocus(n.table)
+                      setSelected(null)
+                    }
+                  }}
+                  aria-keyshortcuts="F"
+                  title={`${n.table} · ${n.degree} relation${n.degree === 1 ? '' : 's'} · drag to move, double-click or F to focus`}
                 >
                   <span className="db-erd-node-name">{n.table}</span>
                   {n.degree > 0 ? <span className="db-erd-node-deg">{n.degree}</span> : null}

--- a/database/ui/src/page/HealthPanel.tsx
+++ b/database/ui/src/page/HealthPanel.tsx
@@ -26,14 +26,51 @@ const INTERVALS = [
   { value: '60', label: 'every 60s' },
 ]
 
-export function HealthPanel({ host, db }: { host: Host; db: string }) {
+function intervalKey(db: string): string {
+  return `iii-console:database:health-interval:${db}`
+}
+
+export function HealthPanel({
+  host,
+  db,
+  refreshToken,
+}: {
+  host: Host
+  db: string
+  /** Bumped by the page's refresh — the header button must reach this tab
+      too, not silently no-op on it. */
+  refreshToken?: number
+}) {
   const [nonce, setNonce] = useState(0)
-  const [every, setEvery] = useState('0')
+  // The cadence you picked survives leaving the tab (the panel itself
+  // remounts by design — it is a fresh-read view).
+  const [every, setEveryState] = useState(() => {
+    try {
+      const stored = window.localStorage.getItem(intervalKey(db))
+      return stored && INTERVALS.some((i) => i.value === stored) ? stored : '0'
+    } catch {
+      return '0'
+    }
+  })
+  const setEvery = (next: string) => {
+    setEveryState(next)
+    try {
+      window.localStorage.setItem(intervalKey(db), next)
+    } catch {
+      // the cadence is a convenience, not state
+    }
+  }
   const fetcher = useCallback(() => {
     void nonce
+    void refreshToken
     return health(host, db)
-  }, [host, db, nonce])
+  }, [host, db, nonce, refreshToken])
   const read = useDatabaseRead(true, fetcher)
+  // When the report was read, so a stale card never poses as current.
+  const [asOf, setAsOf] = useState<Date | null>(null)
+  useEffect(() => {
+    if (read.data) setAsOf(new Date())
+  }, [read.data])
 
   const refresh = useCallback(() => setNonce((n) => n + 1), [])
 
@@ -64,10 +101,15 @@ export function HealthPanel({ host, db }: { host: Host; db: string }) {
 
   return (
     <div className="db-health">
-      <div className="db-health-bar">
+      <div className="db-health-bar db-toolbar">
         <span className="db-health-driver">{h.driver}</span>
         <span className="db-health-ver">worker {h.worker_version}</span>
-        <div className="db-erd-spacer" />
+        {asOf ? (
+          <span className="db-health-asof">
+            as of {asOf.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
+          </span>
+        ) : null}
+        <div className="db-toolbar-spacer" />
         <Select value={every} onChange={setEvery} options={INTERVALS} aria-label="refresh interval" />
         <Button variant="ghost" size="sm" onClick={refresh} disabled={read.loading}>
           <RefreshCw size={13} aria-hidden />
@@ -75,7 +117,7 @@ export function HealthPanel({ host, db }: { host: Host; db: string }) {
         </Button>
       </div>
 
-      <div className="db-health-cards">
+      <div className={`db-health-cards${read.loading ? ' stale' : ''}`}>
         <Card title="pool">
           <dl className="db-kv">
             <Stat label="max" value={pool.max} />
@@ -95,23 +137,32 @@ export function HealthPanel({ host, db }: { host: Host; db: string }) {
           <ProbeBody
             probe={h.active_queries as Probe<HealthQuery[]>}
             empty="no queries are running."
-            render={(rows: HealthQuery[]) => (
-              <ul className="db-health-list">
-                {rows.map((q) => (
-                  <li key={q.id} className="db-health-query">
-                    <div className="db-health-query-head">
-                      <span className="db-health-id">{q.id}</span>
-                      {q.state ? <span className="db-health-state">{q.state}</span> : null}
-                      {q.duration_ms != null ? <span className="db-num">{formatMs(q.duration_ms)}</span> : null}
-                      {q.user ? <span className="db-health-user">{q.user}</span> : null}
-                    </div>
-                    <code className="db-health-sql" title={q.sql}>
-                      {q.sql}
-                    </code>
-                  </li>
-                ))}
-              </ul>
-            )}
+            render={(rows: HealthQuery[]) => {
+              // MySQL's processlist includes replication daemons that sit
+              // "running" for the server's whole uptime. Billing them as
+              // active queries reads as an alarm — show them (honest), but
+              // name them and sort them after the real work.
+              const daemons = rows.filter(isReplication)
+              const real = rows.filter((q) => !isReplication(q))
+              return (
+                <ul className="db-health-list">
+                  {[...real, ...daemons].map((q) => (
+                    <li key={q.id} className={`db-health-query${isReplication(q) ? ' daemon' : ''}`}>
+                      <div className="db-health-query-head">
+                        <span className="db-health-id">{q.id}</span>
+                        {isReplication(q) ? <span className="db-health-daemon">replication</span> : null}
+                        {q.state ? <span className="db-health-state">{q.state}</span> : null}
+                        {q.duration_ms != null ? <span className="db-num">{formatMs(q.duration_ms)}</span> : null}
+                        {q.user ? <span className="db-health-user">{q.user}</span> : null}
+                      </div>
+                      <code className="db-health-sql" title={q.sql}>
+                        {q.sql}
+                      </code>
+                    </li>
+                  ))}
+                </ul>
+              )
+            }}
           />
         </Card>
 
@@ -207,6 +258,11 @@ type HealthQuery = {
   duration_ms?: number | null
   user?: string | null
 }
+
+/** A replication/binlog daemon connection, not a query anyone ran. */
+function isReplication(q: HealthQuery): boolean {
+  return /binlog|replic/i.test(q.state ?? '') || /binlog dump/i.test(q.sql ?? '')
+}
 type HealthLock = { blocked_id: string; blocked_sql: string; blocking_id: string; relation?: string | null }
 type HealthCache = { hit_ratio: number; blocks_hit: number; blocks_read: number }
 type HealthTableSize = {
@@ -291,5 +347,12 @@ function formatCount(n: number | null | undefined): string {
 
 function formatMs(ms: number): string {
   if (ms < 1000) return `${Math.round(ms)}ms`
-  return `${(ms / 1000).toFixed(1)}s`
+  const s = ms / 1000
+  // Roll up: "13233.0s" is a number you have to do arithmetic on; "3h 40m"
+  // is a fact.
+  if (s < 120) return `${s.toFixed(1)}s`
+  const m = Math.floor(s / 60)
+  if (m < 120) return `${m}m ${Math.round(s % 60)}s`
+  const h = Math.floor(m / 60)
+  return `${h}h ${m % 60}m`
 }

--- a/database/ui/src/page/PlanTree.tsx
+++ b/database/ui/src/page/PlanTree.tsx
@@ -98,6 +98,7 @@ function Node({
           className={`db-plan-twist${hasChildren ? '' : ' leaf'}${isCollapsed ? '' : ' open'}`}
           onClick={() => hasChildren && onToggle(node.id)}
           aria-label={isCollapsed ? 'expand' : 'collapse'}
+          aria-expanded={hasChildren ? !isCollapsed : undefined}
           tabIndex={hasChildren ? 0 : -1}
         >
           {hasChildren ? <ChevronRight size={11} aria-hidden /> : null}

--- a/database/ui/src/page/SchemaTree.tsx
+++ b/database/ui/src/page/SchemaTree.tsx
@@ -6,24 +6,18 @@
  * the cache-invalidation point.
  */
 
-import { type Host, Skeleton } from '@iii-dev/console-ui'
+import { type Host, Input, Skeleton } from '@iii-dev/console-ui'
 import { type ComponentType, useState } from 'react'
 import {
   type ColumnInfo,
+  commonSchema,
   type DbDriver,
   type DbTable,
   type IndexInfo,
   tableColumns,
   tableIndexes,
 } from './db-data'
-import {
-  ChevronRight,
-  Eye,
-  type IconProps,
-  KeyRound,
-  Link2,
-  Table2,
-} from './icons'
+import { ChevronRight, Eye, type IconProps, KeyRound, Link2, Table2 } from './icons'
 
 interface SchemaTreeProps {
   host: Host
@@ -39,18 +33,23 @@ interface TableSchema {
   indexes: IndexInfo[]
 }
 
-export function SchemaTree({
-  host,
-  db,
-  driver,
-  tables,
-  selectedTable,
-  onSelectTable,
-}: SchemaTreeProps) {
+export function SchemaTree({ host, db, driver, tables, selectedTable, onSelectTable }: SchemaTreeProps) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
-  const [schemaByTable, setSchemaByTable] = useState<
-    Record<string, TableSchema | 'loading' | 'error'>
-  >({})
+  const [schemaByTable, setSchemaByTable] = useState<Record<string, TableSchema | 'loading' | 'error'>>({})
+
+  // Fourteen `public.` prefixes ate the width the actual names needed.
+  // Display strips a universal schema; selection, fetches and titles keep
+  // the qualified name.
+  const prefix = commonSchema(tables.map((t) => t.name))
+  const display = (name: string) => (prefix && name.startsWith(`${prefix}.`) ? name.slice(prefix.length + 1) : name)
+
+  // Type-to-filter beats walking two tab stops per row. Matches the
+  // displayed name and the qualified one; Escape clears.
+  const [query, setQuery] = useState('')
+  const needle = query.trim().toLowerCase()
+  const matches = (t: DbTable) =>
+    needle === '' || display(t.name).toLowerCase().includes(needle) || t.name.toLowerCase().includes(needle)
+  const anyMatch = tables.some(matches)
 
   const toggle = (table: DbTable) => {
     setExpanded((cur) => {
@@ -68,9 +67,7 @@ export function SchemaTree({
       setSchemaByTable((cur) => ({ ...cur, [table.name]: 'loading' }))
       void Promise.all([
         tableColumns(host, db, driver, table.name),
-        table.kind === 'table'
-          ? tableIndexes(host, db, driver, table.name).catch(() => [])
-          : Promise.resolve([]),
+        table.kind === 'table' ? tableIndexes(host, db, driver, table.name).catch(() => []) : Promise.resolve([]),
       ])
         .then(([columns, indexes]) => {
           setSchemaByTable((cur) => ({
@@ -95,14 +92,24 @@ export function SchemaTree({
 
   return (
     <div className="db-tree">
+      <div className="db-tree-filter">
+        <Input
+          value={query}
+          onChange={setQuery}
+          placeholder="filter tables"
+          aria-label="filter tables"
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') setQuery('')
+          }}
+        />
+      </div>
+      {!anyMatch && needle !== '' ? <p className="db-tree-msg">no tables match "{needle}"</p> : null}
       {groups.map((group) => {
-        const entries = tables.filter((t) => t.kind === group.kind)
+        const entries = tables.filter((t) => t.kind === group.kind && matches(t))
         if (entries.length === 0) return null
         return (
           <div key={group.kind}>
-            {group.kind === 'view' ? (
-              <div className="db-tree-grouphead">views · {entries.length}</div>
-            ) : null}
+            {group.kind === 'view' ? <div className="db-tree-grouphead">views · {entries.length}</div> : null}
             <ul>
               {entries.map((table) => {
                 const isOpen = expanded.has(table.name)
@@ -111,18 +118,13 @@ export function SchemaTree({
                 const Icon = group.icon
                 return (
                   <li key={table.name}>
-                    <div
-                      className={`db-tree-row${isSelected ? ' active' : ''}`}
-                    >
+                    <div className={`db-tree-row${isSelected ? ' active' : ''}`}>
                       <button
                         type="button"
                         className="db-tree-toggle"
                         onClick={() => toggle(table)}
-                        aria-label={
-                          isOpen
-                            ? `collapse ${table.name} columns`
-                            : `expand ${table.name} columns`
-                        }
+                        aria-expanded={isOpen}
+                        aria-label={isOpen ? `collapse ${table.name} columns` : `expand ${table.name} columns`}
                       >
                         <ChevronRight
                           size={12}
@@ -138,11 +140,8 @@ export function SchemaTree({
                         onClick={() => onSelectTable(table.name)}
                         title={table.name}
                       >
-                        <Icon
-                          size={12}
-                          style={{ color: 'var(--color-ink-ghost)' }}
-                        />
-                        <span className="db-trunc">{table.name}</span>
+                        <Icon size={12} style={{ color: 'var(--color-ink-ghost)' }} />
+                        <span className="db-trunc">{display(table.name)}</span>
                       </button>
                     </div>
                     {isOpen ? <TableSchemaRows schema={schema} /> : null}
@@ -157,11 +156,7 @@ export function SchemaTree({
   )
 }
 
-function TableSchemaRows({
-  schema,
-}: {
-  schema: TableSchema | 'loading' | 'error' | undefined
-}) {
+function TableSchemaRows({ schema }: { schema: TableSchema | 'loading' | 'error' | undefined }) {
   if (schema === 'loading' || schema === undefined) {
     return (
       <div style={{ padding: '4px 12px 4px 36px' }}>
@@ -209,15 +204,11 @@ function TableSchemaRows({
             <li
               key={idx.name}
               className="db-idx"
-              title={[idx.unique ? 'unique' : null, idx.detail]
-                .filter(Boolean)
-                .join(' · ')}
+              title={[idx.unique ? 'unique' : null, idx.detail].filter(Boolean).join(' · ')}
             >
               <span style={{ width: 10, flexShrink: 0 }} />
               <span className="db-idx-name">{idx.name}</span>
-              {idx.unique ? (
-                <span className="db-idx-unique">unique</span>
-              ) : null}
+              {idx.unique ? <span className="db-idx-unique">unique</span> : null}
             </li>
           ))}
         </>

--- a/database/ui/src/page/SqlPanel.tsx
+++ b/database/ui/src/page/SqlPanel.tsx
@@ -1,8 +1,9 @@
 /**
- * Ad-hoc read-only SQL: the shared Monaco `CodeEditor` (⌘⏎ runs), an explain
- * action, per-database history in localStorage, and results in the shared grid
- * with duration. Write verbs never leave the browser — `runReadOnlySql`
- * rejects them.
+ * Ad-hoc SQL: the shared Monaco `CodeEditor` (⌘⏎ runs), an explain action,
+ * per-database history in localStorage, and results in the shared grid with
+ * duration. Reads run through `database::query`, writes through
+ * `database::execute` — a "write" note appears by the actions before a
+ * mutating statement runs, and the result line reports affected rows.
  *
  * Explain goes through `database::explain`, which parses the dialect's own
  * plan format into one tree. The panel no longer knows which driver it is
@@ -11,8 +12,9 @@
 
 import { Button, CodeEditor, type CodeEditorHandle, type Host, StatusPanel } from '@iii-dev/console-ui'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { errText } from '../lib/errors'
 import { type ExplainResult, explain } from '../lib/rpc'
-import { type AdhocResult, isReadOnlySql, runReadOnlySql } from './db-data'
+import { type AdhocResult, ddlInfo, isReadOnlySql, runAdhocSql } from './db-data'
 import { AlertCircle, History, Play, X } from './icons'
 import { PlanTree } from './PlanTree'
 import { ResultGrid } from './result-grid'
@@ -25,9 +27,25 @@ interface SqlPanelProps {
   /** Table names in the active database — fed to the editor's autocomplete
       alongside the SQL keywords. */
   tables?: readonly string[]
+  /**
+   * A statement that actually runs against *this* database, offered as the
+   * first thing to try. Quoted by the caller, which is the only place that
+   * knows the driver. Absent when the database has no tables.
+   */
+  starterSql?: string
+  /**
+   * Called after a write commits, so the page can refresh schema-derived
+   * state — otherwise the table list keeps showing a dropped table and
+   * disconfirms what just happened.
+   */
+  onWrite?: () => void
 }
 
 const HISTORY_LIMIT = 20
+
+/** The run chord, written the way this keyboard has it. */
+const RUN_CHORD =
+  typeof navigator !== 'undefined' && /mac/i.test(navigator.platform || navigator.userAgent) ? '⌘⏎' : 'ctrl+⏎'
 
 /** The keyword slice offered as-you-type; the table names ride alongside. */
 const SQL_KEYWORDS = [
@@ -85,7 +103,7 @@ function saveHistory(db: string, entries: string[]) {
   }
 }
 
-export function SqlPanel({ host, db, seedSql, tables }: SqlPanelProps) {
+export function SqlPanel({ host, db, seedSql, tables, starterSql, onWrite }: SqlPanelProps) {
   const [sql, setSql] = useState(seedSql ?? '')
   const completions = useMemo(() => Array.from(new Set([...(tables ?? []), ...SQL_KEYWORDS])), [tables])
   const [running, setRunning] = useState(false)
@@ -94,7 +112,35 @@ export function SqlPanel({ host, db, seedSql, tables }: SqlPanelProps) {
   const [history, setHistory] = useState<string[]>(() => loadHistory(db))
   const [historyOpen, setHistoryOpen] = useState(false)
   const [plan, setPlan] = useState<ExplainResult | null>(null)
+  // The statement the current outcome belongs to — once the editor moves on,
+  // the result line dims rather than passing off old numbers as current.
+  const [ranSql, setRanSql] = useState<string | null>(null)
   const editorRef = useRef<CodeEditorHandle>(null)
+  const actionsRef = useRef<HTMLDivElement>(null)
+  const historyRef = useRef<HTMLDivElement>(null)
+  const historyBtnRef = useRef<HTMLSpanElement>(null)
+
+  // Dropdown manners: Escape and clicking elsewhere both dismiss. The
+  // trigger is excluded from "elsewhere" so its own toggle doesn't
+  // close-then-reopen in one click.
+  useEffect(() => {
+    if (!historyOpen) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setHistoryOpen(false)
+    }
+    const onDown = (e: MouseEvent) => {
+      const t = e.target
+      if (!(t instanceof Node)) return
+      if (historyRef.current?.contains(t) || historyBtnRef.current?.contains(t)) return
+      setHistoryOpen(false)
+    }
+    document.addEventListener('keydown', onKey)
+    document.addEventListener('mousedown', onDown)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.removeEventListener('mousedown', onDown)
+    }
+  }, [historyOpen])
 
   useEffect(() => {
     if (seedSql) setSql(seedSql)
@@ -108,8 +154,10 @@ export function SqlPanel({ host, db, seedSql, tables }: SqlPanelProps) {
       setError(null)
       setPlan(null)
       try {
-        const next = await runReadOnlySql(host, db, trimmed)
+        const next = await runAdhocSql(host, db, trimmed)
         setOutcome(next)
+        setRanSql(trimmed)
+        if (next.write) onWrite?.()
         setHistory((cur) => {
           const updated = [trimmed, ...cur.filter((s) => s !== trimmed)].slice(0, HISTORY_LIMIT)
           saveHistory(db, updated)
@@ -117,12 +165,12 @@ export function SqlPanel({ host, db, seedSql, tables }: SqlPanelProps) {
         })
       } catch (err) {
         setOutcome(null)
-        setError(err instanceof Error ? err.message : String(err))
+        setError(errText(err))
       } finally {
         setRunning(false)
       }
     },
-    [host, db, running],
+    [host, db, running, onWrite],
   )
 
   /**
@@ -140,13 +188,15 @@ export function SqlPanel({ host, db, seedSql, tables }: SqlPanelProps) {
       setPlan(await explain(host, db, trimmed))
     } catch (err) {
       setPlan(null)
-      setError(err instanceof Error ? err.message : String(err))
+      setError(errText(err))
     } finally {
       setRunning(false)
     }
   }, [host, db, sql, running])
 
-  const readOnly = sql.trim() === '' || isReadOnlySql(sql)
+  const isWrite = sql.trim() !== '' && !isReadOnlySql(sql)
+  const ddl = useMemo(() => (isWrite ? ddlInfo(sql) : null), [isWrite, sql])
+  const stale = outcome !== null && ranSql !== null && sql.trim() !== ranSql
 
   return (
     <div className="db-sql">
@@ -157,7 +207,7 @@ export function SqlPanel({ host, db, seedSql, tables }: SqlPanelProps) {
             onChange={setSql}
             language="sql"
             className="db-sql-code"
-            placeholder={`select * from … — read-only, ⌘⏎ runs against ${db}`}
+            placeholder={`select * from … — ${RUN_CHORD} runs against ${db}`}
             aria-label="sql statement"
             completions={completions}
             ref={editorRef}
@@ -166,10 +216,19 @@ export function SqlPanel({ host, db, seedSql, tables }: SqlPanelProps) {
                 e.preventDefault()
                 void run(sql)
               }
+              // Monaco keeps Tab for indentation, so Escape is the keyboard
+              // exit: land on the first usable action, or just release focus
+              // when they're all disabled. (Monaco consumes Escape while a
+              // widget is open — closing it — so this fires on the second.)
+              if (e.key === 'Escape') {
+                const next = actionsRef.current?.querySelector<HTMLButtonElement>('button:not(:disabled)')
+                if (next) next.focus()
+                else if (document.activeElement instanceof HTMLElement) document.activeElement.blur()
+              }
             }}
           />
         </div>
-        <div className="db-sql-actions">
+        <div className="db-sql-actions" ref={actionsRef}>
           <Button variant="ghost" size="sm" onClick={() => void run(sql)} disabled={running || sql.trim() === ''}>
             <Play size={12} aria-hidden />
             {running ? 'running…' : 'run'}
@@ -177,23 +236,60 @@ export function SqlPanel({ host, db, seedSql, tables }: SqlPanelProps) {
           <Button variant="ghost" size="sm" onClick={() => void explainNow()} disabled={running || sql.trim() === ''}>
             explain
           </Button>
-          <Button variant="ghost" size="sm" onClick={() => setHistoryOpen((v) => !v)} disabled={history.length === 0}>
-            <History size={12} aria-hidden />
-            history · {history.length}
-          </Button>
-          {!readOnly ? (
-            <span className="db-sql-warn">write statements are rejected — this panel is read-only</span>
+          <span ref={historyBtnRef} style={{ display: 'contents' }}>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setHistoryOpen((v) => !v)}
+              disabled={history.length === 0}
+              aria-expanded={historyOpen}
+            >
+              <History size={12} aria-hidden />
+              history · {history.length}
+            </Button>
+          </span>
+          {isWrite ? (
+            // A heads-up, not a gate: this statement will mutate and commit.
+            // Schema changes get the louder ink and name what they do.
+            <span className={`db-sql-warn${ddl ? ' ddl' : ''}`}>
+              {ddl ? `${ddl.present} — commits on ${db}` : `write — runs and commits on ${db}`}
+            </span>
           ) : null}
           {outcome ? (
-            <span className="db-sql-meta">
-              {outcome.result.row_count} row
-              {outcome.result.row_count === 1 ? '' : 's'} · {outcome.durationMs}
+            <span className={`db-sql-meta${stale ? ' stale' : ''}`}>
+              {outcome.write
+                ? (outcome.write.echo ??
+                  `${outcome.write.affectedRows} affected${
+                    outcome.write.lastInsertId !== null ? ` · id ${outcome.write.lastInsertId}` : ''
+                  }`)
+                : `${outcome.result.row_count} row${outcome.result.row_count === 1 ? '' : 's'}`}{' '}
+              · {outcome.durationMs}
               ms
             </span>
           ) : null}
+          {/* The audible twin of the visual states: one polite live region
+              voices running/result/failure and the write heads-up. The armed
+              message is static on purpose — including the typed table name
+              would re-announce on every keystroke. */}
+          <span className="db-sr-only" role="status">
+            {running
+              ? 'running'
+              : error
+                ? `query failed: ${error}`
+                : outcome
+                  ? outcome.write
+                    ? `${outcome.write.echo ?? `${outcome.write.affectedRows} rows affected`} in ${outcome.durationMs}ms`
+                    : `${outcome.result.row_count} rows in ${outcome.durationMs}ms`
+                  : isWrite
+                    ? `write statement — runs and commits on ${db}`
+                    : ''}
+          </span>
         </div>
         {historyOpen && history.length > 0 ? (
-          <div className="db-sql-history">
+          <div className="db-sql-history" ref={historyRef}>
+            {/* Where these live is worth one line: they never leave this
+                browser, and eviction is silent at the cap. */}
+            <div className="db-sql-history-note">recent statements · saved in this browser · newest first</div>
             {history.map((entry) => (
               <div key={entry} className="db-sql-history-row">
                 <button
@@ -227,7 +323,7 @@ export function SqlPanel({ host, db, seedSql, tables }: SqlPanelProps) {
           </div>
         ) : null}
       </div>
-      <div className="db-sql-results">
+      <div className={`db-sql-results${running ? ' running' : ''}`}>
         {error ? (
           <div className="db-pad">
             <StatusPanel variant="alert" icon={<AlertCircle size={18} />} headline="query failed" detail={error} />
@@ -235,15 +331,47 @@ export function SqlPanel({ host, db, seedSql, tables }: SqlPanelProps) {
         ) : plan ? (
           <PlanTree plan={plan} />
         ) : outcome ? (
-          <ResultGrid
-            columns={outcome.result.columns}
-            rows={outcome.result.rows}
-            rowCount={outcome.result.row_count}
-            stickyHeader
-          />
+          outcome.write && outcome.result.rows.length === 0 ? (
+            // A write without RETURNING has no grid to draw; an empty one
+            // reads as "nothing happened", which is the opposite of the truth.
+            <p className="db-sql-placeholder">
+              statement ran —{' '}
+              {outcome.write.echo ??
+                `${outcome.write.affectedRows} row${outcome.write.affectedRows === 1 ? '' : 's'} affected`}
+            </p>
+          ) : (
+            <ResultGrid
+              columns={outcome.result.columns}
+              rows={outcome.result.rows}
+              rowCount={outcome.result.row_count}
+              stickyHeader
+            />
+          )
         ) : (
           <p className={`db-sql-placeholder${running ? ' db-pulse' : ''}`}>
-            {running ? 'running…' : 'results appear here. try: select name from sqlite_master limit 10'}
+            {running ? (
+              'running…'
+            ) : starterSql ? (
+              <>
+                results appear here. try{' '}
+                {/* The old copy suggested `select name from sqlite_master`
+                    whatever the driver was — an error on two of the three.
+                    A statement from the schema in front of you runs, and one
+                    click beats retyping it. */}
+                <button
+                  type="button"
+                  className="db-linkish"
+                  onClick={() => {
+                    setSql(starterSql)
+                    void run(starterSql)
+                  }}
+                >
+                  {starterSql}
+                </button>
+              </>
+            ) : (
+              'results appear here.'
+            )}
           </p>
         )}
       </div>

--- a/database/ui/src/page/TableDataPanel.tsx
+++ b/database/ui/src/page/TableDataPanel.tsx
@@ -27,7 +27,7 @@ import { CellInspector } from './CellInspector'
 import { ColumnStatsPanel } from './ColumnStatsPanel'
 import { browseTableRef, type DbDriver, type TableSort, tableColumns } from './db-data'
 import { FilterBar } from './FilterBar'
-import { AlertCircle, type IconProps, Table2 } from './icons'
+import { AlertCircle, type IconProps, Table2, X } from './icons'
 import { Pagination } from './pagination'
 import { RowDetail } from './RowDetail'
 import { ResultGrid } from './result-grid'
@@ -51,9 +51,18 @@ interface TableDataPanelProps {
    * there.
    */
   initialFilters?: FilterSpec[]
+  /**
+   * Bumped by the page's refresh. Re-reads the page and columns in place —
+   * a refresh must not remount the panel, because a remount wipes filters,
+   * sort, and the cursor.
+   */
+  refreshToken?: number
 }
 
 const TableIcon = (p: IconProps) => <Table2 size={28} {...p} />
+
+/** The modifier key, written the way this keyboard has it. */
+const MOD = typeof navigator !== 'undefined' && /mac/i.test(navigator.platform || navigator.userAgent) ? '⌘' : 'ctrl+'
 
 export function TableDataPanel({
   host,
@@ -64,6 +73,7 @@ export function TableDataPanel({
   onOpenInSql,
   onFollow,
   initialFilters,
+  refreshToken,
 }: TableDataPanelProps) {
   const [page, setPage] = useState(0)
   const [pageSize, setPageSize] = useState(PAGE_SIZE)
@@ -85,17 +95,20 @@ export function TableDataPanel({
     setSelectedRow(null)
   }, [])
 
-  const pageFetcher = useCallback(
-    () =>
-      browseTableRef(host, db, table, {
-        page,
-        pageSize,
-        sort: sort ? [{ column: sort.column, direction: sort.dir }] : [],
-        filters: JSON.parse(appliedKey) as FilterSpec[],
-      }),
-    [host, db, table, page, pageSize, sort, appliedKey],
-  )
-  const columnsFetcher = useCallback(() => tableColumns(host, db, driver, table), [host, db, driver, table])
+  // `refreshToken` re-creates the fetchers so the reads re-run in place.
+  const pageFetcher = useCallback(() => {
+    void refreshToken
+    return browseTableRef(host, db, table, {
+      page,
+      pageSize,
+      sort: sort ? [{ column: sort.column, direction: sort.dir }] : [],
+      filters: JSON.parse(appliedKey) as FilterSpec[],
+    })
+  }, [host, db, table, page, pageSize, sort, appliedKey, refreshToken])
+  const columnsFetcher = useCallback(() => {
+    void refreshToken
+    return tableColumns(host, db, driver, table)
+  }, [host, db, driver, table, refreshToken])
   const pageRead = useDatabaseRead(enabled, pageFetcher)
   const columnsRead = useDatabaseRead(enabled, columnsFetcher)
 
@@ -154,13 +167,22 @@ export function TableDataPanel({
   }, [total, hasMore, page, pageSize])
 
   if (pageRead.error) {
+    // The filter bar stays: when a filter itself caused the failure, hiding
+    // it traps the user with no way to edit or remove the offending chip.
     return (
-      <StatusPanel
-        variant="alert"
-        icon={<AlertCircle size={18} />}
-        headline="database read failed"
-        detail={pageRead.error}
-      />
+      <div className="db-data">
+        <div className="db-data-main">
+          <FilterBar columns={columnInfo} filters={filters} onChange={changeFilters} />
+          <div className="db-pad">
+            <StatusPanel
+              variant="alert"
+              icon={<AlertCircle size={18} />}
+              headline="database read failed"
+              detail={pageRead.error}
+            />
+          </div>
+        </div>
+      </div>
     )
   }
 
@@ -187,7 +209,7 @@ export function TableDataPanel({
             title={filtering ? 'no matching rows' : 'empty table'}
             description={
               filtering
-                ? `no rows in ${table} match the ${applied.length} filter${applied.length === 1 ? '' : 's'} above.`
+                ? `no rows in ${table} match the ${applied.length} filter${applied.length === 1 ? '' : 's'} above`
                 : `${table} has no rows`
             }
           />
@@ -203,15 +225,27 @@ export function TableDataPanel({
     <div className="db-data">
       <div className="db-data-main">
         <FilterBar columns={columnInfo} filters={filters} onChange={changeFilters} />
-        <div className="db-data-bar">
+        <div className="db-data-bar db-toolbar">
           <span className="name">{table}</span>
-          <span>{result.columns?.length ?? Object.keys(rows[0] ?? {}).length} columns</span>
+          <span>
+            {(() => {
+              const n = result.columns?.length ?? Object.keys(rows[0] ?? {}).length
+              return `${n} column${n === 1 ? '' : 's'}`
+            })()}
+          </span>
           {/* A count is only trustworthy when it is described: "12,443 rows"
               beside three active filters reads as the table's size. The
               worker counts with the same filters applied, so say so. */}
-          <span>
-            {total !== null ? `${total.toLocaleString()} rows` : '… rows'}
+          <span className={total === null ? 'db-pulse' : undefined}>
+            {total !== null ? `${total.toLocaleString()} row${total === 1 ? '' : 's'}` : '… rows'}
             {filtering ? ' matching' : ''}
+          </span>
+          {/* The audible twin of the counts: rows and page after each load,
+              silence while loading. */}
+          <span className="db-sr-only" role="status">
+            {pageRead.loading
+              ? ''
+              : `${(total ?? rows.length).toLocaleString()} rows, page ${page + 1} of ${totalPages}`}
           </span>
           {sort ? (
             <button
@@ -226,8 +260,8 @@ export function TableDataPanel({
             </button>
           ) : null}
           {pageRead.loading ? (
-            <span className="db-pulse" style={{ color: 'var(--color-ink-ghost)' }}>
-              refreshing…
+            <span className="db-pulse" style={{ color: 'var(--color-ink-faint)' }}>
+              · refreshing…
             </span>
           ) : null}
           {view.view.hidden.length > 0 ? (
@@ -273,6 +307,11 @@ export function TableDataPanel({
           />
         </div>
         <div className="db-data-foot">
+          {/* Advertised nowhere else — without this line the roving-cursor
+              grid reads as mouse-only. */}
+          <span className="db-kbd-hint">
+            arrows move · pgup/pgdn turn pages · {MOD}c copies a cell · {MOD}⇧c the row
+          </span>
           <Pagination
             currentPage={page + 1}
             totalPages={totalPages}
@@ -295,17 +334,34 @@ export function TableDataPanel({
       {detailRow || keyboard.cursor ? (
         <div className="db-rowdetail">
           <Tabs defaultValue={detailRow ? 'row' : 'cell'}>
-            <TabsList>
-              <TabsTrigger value="row" disabled={!detailRow}>
-                row
-              </TabsTrigger>
-              <TabsTrigger value="cell" disabled={!keyboard.cursor}>
-                cell
-              </TabsTrigger>
-              <TabsTrigger value="stats" disabled={!cursorColumn}>
-                stats
-              </TabsTrigger>
-            </TabsList>
+            {/* The inspector opens implicitly (row click, cell cursor) — so
+                it must close explicitly too: without this button, a cell
+                cursor pinned the panel open with no way out. */}
+            <div className="db-inspector-head">
+              <TabsList>
+                <TabsTrigger value="row" disabled={!detailRow}>
+                  row
+                </TabsTrigger>
+                <TabsTrigger value="cell" disabled={!keyboard.cursor}>
+                  cell
+                </TabsTrigger>
+                <TabsTrigger value="stats" disabled={!cursorColumn}>
+                  stats
+                </TabsTrigger>
+              </TabsList>
+              <button
+                type="button"
+                className="db-icon-btn"
+                onClick={() => {
+                  setSelectedRow(null)
+                  keyboard.setCursor(null)
+                }}
+                aria-label="close inspector"
+                title="close inspector"
+              >
+                <X size={12} />
+              </button>
+            </div>
             <TabsContent value="row">
               {detailRow ? (
                 <RowDetail

--- a/database/ui/src/page/db-data.ts
+++ b/database/ui/src/page/db-data.ts
@@ -10,9 +10,9 @@
  * callable by any agent rather than only by this page.
  *
  * What remains is shape translation for the existing components, plus the two
- * client-side SQL affordances (`isReadOnlySql`, `explainPrefix`) that exist to
- * grey out a button before a round trip. The worker enforces both for real;
- * neither is trusted.
+ * client-side SQL affordances (`isReadOnlySql` picks the query vs execute
+ * surface for a statement, `explainPrefix`). The worker enforces read-only on
+ * `query` for real; nothing here is trusted.
  */
 
 import type { Host } from '@iii-dev/console-ui'
@@ -77,8 +77,15 @@ export interface TablePage {
 }
 
 export interface AdhocResult {
+  /** Grid to draw. For writes, synthesized from the RETURNING rows. */
   result: QueryResponse
   durationMs: number
+  /**
+   * Present when the statement ran through `database::execute`. `echo` is the
+   * human account of a schema change ("dropped table x") — the row count is
+   * the wrong summary for DDL, which MySQL reports as `0 affected`.
+   */
+  write?: { affectedRows: number; lastInsertId: string | null; echo: string | null }
 }
 
 /** Split a schema-qualified name for the worker, which takes them apart. */
@@ -193,15 +200,18 @@ const WRITE_ANYWHERE =
   /\b(insert|update|delete|replace|merge|upsert|drop|create|alter|truncate|grant|revoke|attach|detach|reindex|vacuum)\b/i
 
 /**
- * Best-effort read check, used only to grey out the run button before a round
- * trip. The worker re-checks every statement and is the actual authority —
- * this is a UX affordance, not a security boundary.
+ * Best-effort read check. It routes: reads go to `database::query`, anything
+ * else to `database::execute`. Misclassifying a read as a write is harmless —
+ * `execute` runs SELECTs too, it just reports them as `0 affected` — and the
+ * worker's own read-only enforcement on `query` catches the other direction.
+ * A routing hint, not a security boundary.
  */
+function stripSqlComments(sql: string): string {
+  return sql.replace(/--[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '')
+}
+
 export function isReadOnlySql(sql: string): boolean {
-  const stripped = sql
-    .replace(/--[^\n]*/g, '')
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .trim()
+  const stripped = stripSqlComments(sql).trim()
   if (!stripped) return false
   if (stripped.replace(/;+\s*$/, '').includes(';')) return false
   if (!READ_ONLY_LEAD.test(stripped)) return false
@@ -209,13 +219,63 @@ export function isReadOnlySql(sql: string): boolean {
   return !WRITE_ANYWHERE.test(stripped)
 }
 
-export async function runReadOnlySql(host: Host, db: string, sql: string): Promise<AdhocResult> {
-  if (!isReadOnlySql(sql)) {
-    throw new Error('only read-only statements can be run from this panel')
-  }
+/**
+ * Run a statement from the editor: reads through `database::query`, writes
+ * through `database::execute`. Both are the worker's own functions, so an
+ * engine policy that narrows an agent to reads narrows this panel the same
+ * way, and writes land in the `database::row-changed` feed like any other.
+ */
+export async function runAdhocSql(host: Host, db: string, sql: string): Promise<AdhocResult> {
+  // People type SQL with a trailing `;`; the drivers' prepared paths don't
+  // all accept one. Strip it here instead of teaching that per driver.
+  const statement = sql.trim().replace(/;+\s*$/, '')
   const started = performance.now()
-  const result = await rpc.runSql(host, db, sql)
-  return { result, durationMs: Math.round(performance.now() - started) }
+  if (isReadOnlySql(statement)) {
+    const result = await rpc.runSql(host, db, statement)
+    return { result, durationMs: Math.round(performance.now() - started) }
+  }
+  const res = await rpc.execSql(host, db, statement)
+  const rows = res.returned_rows ?? []
+  const ddl = ddlInfo(statement)
+  return {
+    result: {
+      rows,
+      row_count: rows.length,
+      columns: Object.keys(rows[0] ?? {}).map((name) => ({ name })),
+    },
+    durationMs: Math.round(performance.now() - started),
+    write: {
+      affectedRows: res.affected_rows,
+      lastInsertId: res.last_insert_id ?? null,
+      echo: ddl ? ddl.past : null,
+    },
+  }
+}
+
+/** Verb pairs for the statements that reshape the schema itself. */
+const DDL_VERBS: Record<string, [string, string]> = {
+  drop: ['drops', 'dropped'],
+  truncate: ['truncates', 'truncated'],
+  alter: ['alters', 'altered'],
+}
+
+const DDL_RE =
+  /^(drop|truncate|alter)\b(?:\s+(table|view|index|database|schema|trigger))?(?:\s+if\s+(?:not\s+)?exists)?(?:\s+([`"']?[\w.$]+[`"']?))?/i
+
+/**
+ * The statements that reshape the schema, named in both tenses: the armed
+ * note says what is about to happen ("drops table x"), the result line says
+ * what did ("dropped table x"). Display-only — routing does not depend on it.
+ */
+export function ddlInfo(sql: string): { present: string; past: string } | null {
+  const m = DDL_RE.exec(stripSqlComments(sql).trim())
+  if (!m) return null
+  const [present, past] = DDL_VERBS[m[1].toLowerCase()]
+  const object = [m[2]?.toLowerCase(), m[3]?.replace(/[`"']/g, '')].filter(Boolean).join(' ')
+  return {
+    present: object ? `${present} ${object}` : present,
+    past: object ? `${past} ${object}` : past,
+  }
 }
 
 /**
@@ -224,6 +284,16 @@ export async function runReadOnlySql(host: Host, db: string, sql: string): Promi
  */
 export function explainPrefix(driver: DbDriver): string {
   return driver === 'sqlite' ? 'EXPLAIN QUERY PLAN ' : 'EXPLAIN '
+}
+
+/**
+ * The schema qualifying every listed table, or '' when there isn't exactly
+ * one. A universal prefix (postgres's `public.` on every row) is repetition,
+ * not information — display strips it; identity keeps the qualified name.
+ */
+export function commonSchema(names: readonly string[]): string {
+  const schemas = new Set(names.map((n) => (n.includes('.') ? n.slice(0, n.indexOf('.')) : '')))
+  return schemas.size === 1 ? [...schemas][0] : ''
 }
 
 /* ---- identifier quoting, for display only ---- */

--- a/database/ui/src/page/icons.tsx
+++ b/database/ui/src/page/icons.tsx
@@ -185,6 +185,26 @@ export function History(props: IconProps) {
   )
 }
 
+export function Settings(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+      <circle cx="12" cy="12" r="3" />
+    </Svg>
+  )
+}
+
+export function Maximize(props: IconProps) {
+  return (
+    <Svg {...props}>
+      <path d="M8 3H5a2 2 0 0 0-2 2v3" />
+      <path d="M21 8V5a2 2 0 0 0-2-2h-3" />
+      <path d="M3 16v3a2 2 0 0 0 2 2h3" />
+      <path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+    </Svg>
+  )
+}
+
 export function RefreshCw(props: IconProps) {
   return (
     <Svg {...props}>

--- a/database/ui/src/page/index.tsx
+++ b/database/ui/src/page/index.tsx
@@ -1,16 +1,17 @@
 /**
- * The database page (#/ext/database): the database worker's read surface —
+ * The database page (#/ext/database): the database worker's console surface —
  * configured databases, their schema, paged and sortable table contents with a
- * row inspector, an ad-hoc read-only SQL panel, a schema diagram, connection
- * health, and the writes landing in the selected table as they commit.
+ * row inspector, an ad-hoc SQL panel, a schema diagram, connection health, and
+ * the writes landing in the selected table as they commit.
  *
  * Nothing here computes what the worker can compute. The catalog, the filter
  * compiler, the plan parser and the diagram layout all live in `handlers/`,
  * which is why an agent can ask the same questions this page answers. The page
  * fetches and draws.
  *
- * Read-only on purpose: INSERT/UPDATE/DDL stay in agent flows behind the
- * approval gate.
+ * The grid and its affordances stay read-only; the SQL panel runs writes,
+ * routed through `database::execute` — the same function agents call, so
+ * engine policy and the `database::row-changed` feed treat both alike.
  *
  * The host only mounts this page when the database worker is connected, so
  * there is no presence gate here; a failed `listDatabases` surfaces as the
@@ -18,14 +19,14 @@
  */
 
 import { Badge, Button, EmptyState, type Host, Select, Skeleton, StatusPanel } from '@iii-dev/console-ui'
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { ALL, type Capabilities, probe } from '../lib/capabilities'
+import { type ComponentType, useCallback, useEffect, useMemo, useState } from 'react'
+import { ALL, type Capabilities, MIN_VERSION_HINT, probe } from '../lib/capabilities'
 import { DB } from '../lib/rpc'
 import { ChangesPanel } from './ChangesPanel'
 import { type DbInfo, listDbs, listTables, PAGE_SIZE, quoteTableRef } from './db-data'
 import { ErdPanel } from './ErdPanel'
 import { HealthPanel } from './HealthPanel'
-import { AlertCircle, Database, type IconProps, RefreshCw, Table2 } from './icons'
+import { AlertCircle, ChevronLeft, ChevronRight, Database, type IconProps, RefreshCw, Settings, Table2 } from './icons'
 import { SchemaTree } from './SchemaTree'
 import { SqlPanel } from './SqlPanel'
 import { TableDataPanel } from './TableDataPanel'
@@ -45,6 +46,16 @@ const MODE_REQUIRES: Partial<Record<PanelMode, string>> = {
 
 const ALWAYS: PanelMode[] = ['data', 'sql']
 
+/** Collapsed state of the table rail, remembered per browser. */
+const ASIDE_KEY = 'iii-console:database:aside'
+
+/**
+ * Fallback route for consoles that predate the shared configuration dialog:
+ * the workers-tab editor deep-link. It navigates away from this page — the
+ * lesser experience, kept only as the degradation path.
+ */
+const CONFIG_HASH = '#/workers/configuration/database'
+
 /** One step of following a foreign key. */
 interface Hop {
   table: string
@@ -61,10 +72,44 @@ export function DatabasePage({ host }: { host: Host }) {
   const [mode, setMode] = useState<PanelMode>('data')
   const [seedSql, setSeedSql] = useState<string | undefined>(undefined)
   const [bump, setBump] = useState(0)
+  // Configuration opens HERE, in the console's own editor dialog — schema
+  // fetch, custom-form resolution, dirty guard and save are all host-owned,
+  // shared with the workers tab rather than duplicated. Read off
+  // `host.components` at runtime, never imported: a console predating the
+  // export degrades to navigation instead of failing the module load.
+  const [configOpen, setConfigOpen] = useState(false)
+  const HostConfigDialog = host.components.WorkerConfigurationDialog as
+    | ComponentType<{ configurationId: string | null; onClose: () => void }>
+    | undefined
+  const openConfiguration = () => {
+    if (HostConfigDialog) setConfigOpen(true)
+    else window.location.hash = CONFIG_HASH
+  }
   const [caps, setCaps] = useState<Capabilities>(ALL)
   // Where following foreign keys has taken you. The last entry supplies the
   // filter the current table opens with.
   const [trail, setTrail] = useState<Hop[]>([])
+  // At dock widths the table rail costs every tab its first screenful, and
+  // two of the five modes barely use it — so it collapses, and stays where
+  // you left it.
+  const [asideOpen, setAsideOpen] = useState(() => {
+    try {
+      return window.localStorage.getItem(ASIDE_KEY) !== 'closed'
+    } catch {
+      return true
+    }
+  })
+
+  const toggleAside = () => {
+    setAsideOpen((open) => {
+      try {
+        window.localStorage.setItem(ASIDE_KEY, open ? 'closed' : 'open')
+      } catch {
+        // remembering the rail is a convenience, not state
+      }
+      return !open
+    })
+  }
 
   const follow = useCallback((table: string, column: string, value: unknown) => {
     setTrail((prev) => [...prev, { table, column, value }])
@@ -120,6 +165,13 @@ export function DatabasePage({ host }: { host: Host }) {
     return [...ALWAYS, ...optional] as PanelMode[]
   }, [caps])
 
+  // Hidden-not-broken leaves a trace: an older worker's page looks smaller,
+  // and this one line says why (MIN_VERSION_HINT exists for exactly this).
+  const hiddenModes = useMemo(
+    () => (['diagram', 'health', 'changes'] as const).filter((m) => !modes.includes(m)),
+    [modes],
+  )
+
   // Never leave the page on a mode that just disappeared.
   useEffect(() => {
     if (!modes.includes(mode)) setMode('data')
@@ -130,12 +182,25 @@ export function DatabasePage({ host }: { host: Host }) {
   const dbs = dbsRead.data ?? []
   const activeDb: DbInfo | undefined = dbs.find((db) => db.name === selectedDb) ?? dbs[0]
 
+  // The list travels with the name of the database it came from. The read
+  // hook keeps its previous data while a switch's fetch is in flight or
+  // failed — untagged, mysql's tables kept rendering under a postgres
+  // header, down to a stale "14 tables in postgres" count beside the
+  // postgres error.
   const tablesFetcher = useCallback(() => {
-    if (!activeDb) return Promise.resolve([])
-    return listTables(host, activeDb.name, activeDb.driver)
+    if (!activeDb) return Promise.resolve(null)
+    const db = activeDb.name
+    return listTables(host, db, activeDb.driver).then((list) => ({ db, list }))
   }, [host, activeDb])
   const tablesRead = useDatabaseRead(!!activeDb, tablesFetcher)
-  const tables = tablesRead.data ?? []
+  const tables = tablesRead.data && tablesRead.data.db === activeDb?.name ? tablesRead.data.list : []
+  const tableCount = tables.filter((t) => t.kind === 'table').length
+  const viewCount = tables.length - tableCount
+
+  // Selection means "open these rows" on data, a focus on the diagram, a
+  // binding on changes — sql and health barely use it, and the rail says so
+  // rather than letting the highlight imply navigation everywhere.
+  const passiveAside = mode === 'sql' || mode === 'health'
 
   // Keep the selected table valid when the db or its table list changes.
   useEffect(() => {
@@ -143,6 +208,20 @@ export function DatabasePage({ host }: { host: Host }) {
       setSelectedTable(null)
     }
   }, [tables, selectedTable])
+
+  /**
+   * A statement the SQL panel can offer that runs here. Prefers the selected
+   * table, falls back to the first one — the point is that it is real, not
+   * that it is interesting.
+   */
+  const starterSql = useMemo(() => {
+    if (!activeDb) return undefined
+    const target = tables.find((t) => t.name === selectedTable) ?? tables[0]
+    if (!target) return undefined
+    // Lowercase like every other string on the page — the panel speaks one
+    // case.
+    return `select * from ${quoteTableRef(activeDb.driver, target.name)} limit ${PAGE_SIZE}`
+  }, [activeDb, tables, selectedTable])
 
   const refresh = () => {
     dbsRead.refresh()
@@ -204,8 +283,30 @@ export function DatabasePage({ host }: { host: Host }) {
             <RefreshCw size={14} aria-hidden />
             refresh
           </Button>
+          <Button variant="ghost" size="sm" onClick={openConfiguration}>
+            <Settings size={14} aria-hidden />
+            configure
+          </Button>
         </div>
       </div>
+
+      {HostConfigDialog ? (
+        <HostConfigDialog
+          configurationId={configOpen ? 'database' : null}
+          onClose={() => {
+            setConfigOpen(false)
+            // A save may have happened in there: the worker hot-reloads its
+            // pools, and this page re-reads what it derived from them.
+            refresh()
+          }}
+        />
+      ) : null}
+
+      {dbs.length > 0 && hiddenModes.length > 0 ? (
+        <p className="db-modes-hint">
+          {hiddenModes.join(' · ')} hidden: {MIN_VERSION_HINT}
+        </p>
+      ) : null}
 
       {dbsRead.error ? (
         <div style={{ marginTop: 16 }}>
@@ -225,47 +326,81 @@ export function DatabasePage({ host }: { host: Host }) {
           <EmptyState
             icon={DatabaseIcon}
             title="no databases configured"
-            description="configure a database in the worker's config (databases: { name: { url } }) and it appears here."
+            description="databases are defined in the worker's configuration (databases: { name: { url } }) and appear here as soon as one connects."
+            action={{
+              label: 'open configuration',
+              onClick: openConfiguration,
+            }}
           />
         </div>
       ) : (
-        <div className="db-body">
-          <aside className="db-aside">
-            <div className="db-aside-head">
-              tables
-              {tables.length > 0 ? ` · ${tables.filter((t) => t.kind === 'table').length}` : ''}
-            </div>
-            <div className="db-aside-body">
-              {tablesRead.error ? (
-                <p className="db-tree-msg alert" style={{ padding: '8px 12px' }}>
-                  {tablesRead.error}
+        <div className={`db-body${asideOpen ? '' : ' aside-collapsed'}`}>
+          {!asideOpen ? (
+            <aside className="db-aside collapsed">
+              <button
+                type="button"
+                className="db-aside-reopen"
+                onClick={toggleAside}
+                aria-label="show the table list"
+                title="show the table list"
+              >
+                <ChevronRight size={12} aria-hidden />
+              </button>
+            </aside>
+          ) : (
+            <aside className={`db-aside${passiveAside ? ' passive' : ''}`}>
+              <div className="db-aside-head">
+                <span>
+                  tables
+                  {tableCount > 0 ? ` · ${tableCount}` : ''}
+                </span>
+                <button
+                  type="button"
+                  className="db-aside-toggle"
+                  onClick={toggleAside}
+                  aria-label="hide the table list"
+                  title="hide the table list"
+                >
+                  <ChevronLeft size={12} aria-hidden />
+                </button>
+              </div>
+              {passiveAside ? (
+                <p className="db-aside-note">
+                  {mode === 'health' ? 'selection is not used on health' : 'selection only seeds the sql starter'}
                 </p>
-              ) : tablesRead.loading && tables.length === 0 ? (
-                <div className="db-skel">
-                  <Skeleton style={{ display: 'block', height: 20, width: '100%' }} />
-                  <Skeleton style={{ display: 'block', height: 20, width: '75%' }} />
-                  <Skeleton style={{ display: 'block', height: 20, width: '83%' }} />
-                </div>
-              ) : tables.length === 0 ? (
-                <p className="db-msg">no tables</p>
-              ) : activeDb ? (
-                // Remount on db/refresh so lazily-cached columns re-read.
-                <SchemaTree
-                  key={`${activeDb.name}:${bump}`}
-                  host={host}
-                  db={activeDb.name}
-                  driver={activeDb.driver}
-                  tables={tables}
-                  selectedTable={selectedTable}
-                  onSelectTable={(t) => {
-                    // Choosing from the tree is a fresh start, not another hop.
-                    setTrail([])
-                    setSelectedTable(t)
-                  }}
-                />
               ) : null}
-            </div>
-          </aside>
+              <div className="db-aside-body">
+                {tablesRead.error ? (
+                  <p className="db-tree-msg alert" style={{ padding: '8px 12px' }}>
+                    {tablesRead.error}
+                  </p>
+                ) : tablesRead.loading && tables.length === 0 ? (
+                  <div className="db-skel">
+                    <Skeleton style={{ display: 'block', height: 20, width: '100%' }} />
+                    <Skeleton style={{ display: 'block', height: 20, width: '75%' }} />
+                    <Skeleton style={{ display: 'block', height: 20, width: '83%' }} />
+                  </div>
+                ) : tables.length === 0 ? (
+                  <p className="db-msg">no tables</p>
+                ) : activeDb ? (
+                  // Remount on db/refresh so lazily-cached columns re-read.
+                  <SchemaTree
+                    key={`${activeDb.name}:${bump}`}
+                    host={host}
+                    db={activeDb.name}
+                    driver={activeDb.driver}
+                    tables={tables}
+                    selectedTable={selectedTable}
+                    onSelectTable={(t) => {
+                      // Choosing from the tree is a fresh start, not another hop.
+                      setTrail([])
+                      setSelectedTable(t)
+                    }}
+                  />
+                ) : null}
+              </div>
+            </aside>
+          )}
           <div className="db-panel">
             {trail.length > 0 && mode === 'data' ? (
               <nav className="db-trail" aria-label="foreign key trail">
@@ -287,69 +422,98 @@ export function DatabasePage({ host }: { host: Host }) {
               </nav>
             ) : null}
             {activeDb ? (
-              mode === 'sql' ? (
-                // Keyed by db only: a refresh reloads metadata, it must not
-                // wipe an in-progress statement or its results.
-                <SqlPanel
-                  key={activeDb.name}
-                  host={host}
-                  db={activeDb.name}
-                  seedSql={seedSql}
-                  tables={tables.map((t) => t.name)}
-                />
-              ) : mode === 'diagram' ? (
-                <ErdPanel
-                  // Keyed by the selected table so switching in the tree opens
-                  // the diagram around it rather than leaving the old focus.
-                  key={`${activeDb.name}:${bump}:${selectedTable ?? ''}`}
-                  host={host}
-                  db={activeDb.name}
-                  focusTable={selectedTable}
-                />
-              ) : mode === 'health' ? (
-                <HealthPanel key={activeDb.name} host={host} db={activeDb.name} />
-              ) : mode === 'changes' ? (
-                // Keyed by table: the feed is per-binding, and a switch must
-                // not carry the previous table's events across.
-                <ChangesPanel
-                  key={`${activeDb.name}:${selectedTable ?? ''}`}
-                  host={host}
-                  db={activeDb.name}
-                  table={selectedTable}
-                  kind={tables.find((t) => t.name === selectedTable)?.kind}
-                  onRefresh={refresh}
-                />
-              ) : !selectedTable ? (
-                <div className="db-pad">
-                  <EmptyState
-                    icon={TableIcon}
-                    title="select a table"
-                    description={
-                      tables.length > 0
-                        ? `${tables.length} table${tables.length === 1 ? '' : 's'} in ${activeDb.name} — pick one to browse its rows, sort columns, and inspect values.`
-                        : `no tables in ${activeDb.name} yet`
-                    }
+              <>
+                {/* Every panel that accumulates user work stays mounted and
+                    hides (`.db-keep`) instead of unmounting: a peek at another
+                    tab must not destroy a sql draft, the data tab's filters,
+                    the changes feed, or a hand-arranged diagram. Health alone
+                    remounts — it is a fresh-read tab, and kept mounted its
+                    auto-refresh would keep polling while hidden. */}
+                <div className="db-keep" hidden={mode !== 'sql'}>
+                  {/* Keyed by db only: a refresh reloads metadata without
+                      wiping the draft. After a write commits, the page
+                      refreshes so the table list, completions and starter SQL
+                      can't disconfirm what just happened. */}
+                  <SqlPanel
+                    key={activeDb.name}
+                    host={host}
+                    db={activeDb.name}
+                    seedSql={seedSql}
+                    tables={tables.map((t) => t.name)}
+                    starterSql={starterSql}
+                    onWrite={refresh}
                   />
                 </div>
-              ) : (
-                // Remount on db/table/refresh so every fetch hook restarts clean.
-                <TableDataPanel
-                  // Keyed by the arrival filter too: following a key is a
-                  // navigation, and the panel must restart with it applied.
-                  key={`${activeDb.name}:${selectedTable}:${bump}:${arrivalKey}`}
-                  host={host}
-                  db={activeDb.name}
-                  driver={activeDb.driver}
-                  table={selectedTable}
-                  initialFilters={arrival}
-                  onFollow={follow}
-                  enabled
-                  onOpenInSql={(table) => {
-                    setSeedSql(`SELECT * FROM ${quoteTableRef(activeDb.driver, table)} LIMIT ${PAGE_SIZE}`)
-                    setMode('sql')
-                  }}
-                />
-              )
+                <div className="db-keep" hidden={mode !== 'data'}>
+                  {!selectedTable ? (
+                    <div className="db-pad">
+                      <EmptyState
+                        icon={TableIcon}
+                        title="select a table"
+                        description={
+                          tableCount > 0
+                            ? `${tableCount} table${tableCount === 1 ? '' : 's'}${
+                                viewCount > 0 ? ` and ${viewCount} view${viewCount === 1 ? '' : 's'}` : ''
+                              } in ${activeDb.name} — pick one to browse its rows, sort columns, and inspect values.`
+                            : `no tables in ${activeDb.name} yet`
+                        }
+                      />
+                    </div>
+                  ) : (
+                    // Keyed by db/table/arrival — navigation restarts the
+                    // panel clean. A header refresh re-reads through
+                    // `refreshToken` instead of a key bump, so it can no
+                    // longer wipe half-built filters.
+                    <TableDataPanel
+                      key={`${activeDb.name}:${selectedTable}:${arrivalKey}`}
+                      host={host}
+                      db={activeDb.name}
+                      driver={activeDb.driver}
+                      table={selectedTable}
+                      initialFilters={arrival}
+                      onFollow={follow}
+                      enabled
+                      refreshToken={bump}
+                      onOpenInSql={(table) => {
+                        setSeedSql(`select * from ${quoteTableRef(activeDb.driver, table)} limit ${PAGE_SIZE}`)
+                        setMode('sql')
+                      }}
+                    />
+                  )}
+                </div>
+                {modes.includes('diagram') ? (
+                  <div className="db-keep" hidden={mode !== 'diagram'}>
+                    <ErdPanel
+                      // Keyed by the selected table so switching in the tree
+                      // opens the diagram around it. A mode switch no longer
+                      // remounts, so zoom and dragged nodes survive a peek at
+                      // the rows.
+                      key={`${activeDb.name}:${bump}:${selectedTable ?? ''}`}
+                      host={host}
+                      db={activeDb.name}
+                      focusTable={selectedTable}
+                    />
+                  </div>
+                ) : null}
+                {modes.includes('changes') ? (
+                  <div className="db-keep" hidden={mode !== 'changes'}>
+                    {/* Keyed by table: the feed is per-binding. Kept mounted,
+                        it keeps listening while you look at the rows it is
+                        telling you about. */}
+                    <ChangesPanel
+                      key={`${activeDb.name}:${selectedTable ?? ''}`}
+                      host={host}
+                      db={activeDb.name}
+                      table={selectedTable}
+                      kind={tables.find((t) => t.name === selectedTable)?.kind}
+                      onRefresh={refresh}
+                    />
+                  </div>
+                ) : null}
+                {mode === 'health' ? (
+                  <HealthPanel key={activeDb.name} host={host} db={activeDb.name} refreshToken={bump} />
+                ) : null}
+              </>
             ) : null}
           </div>
         </div>

--- a/database/ui/src/page/pagination.tsx
+++ b/database/ui/src/page/pagination.tsx
@@ -32,11 +32,7 @@ export function Pagination({
     <div className="db-pager">
       <div className="db-pager-group">
         <span className="db-pager-cap">show</span>
-        <select
-          value={pageSize}
-          onChange={(e) => onPageSizeChange(Number(e.target.value))}
-          aria-label="rows per page"
-        >
+        <select value={pageSize} onChange={(e) => onPageSizeChange(Number(e.target.value))} aria-label="rows per page">
           {pageSizeOptions.map((opt) => (
             <option key={opt} value={opt}>
               {opt}
@@ -57,7 +53,9 @@ export function Pagination({
         >
           <ChevronLeft size={14} />
         </Button>
-        <span className="db-pager-cap">
+        {/* A value phrase, not a label — it stays in the pager's lowercase
+            voice ("show" above is a label and keeps the caps). */}
+        <span>
           page {currentPage} of {totalPages}
         </span>
         <Button

--- a/database/ui/src/page/result-grid.tsx
+++ b/database/ui/src/page/result-grid.tsx
@@ -200,7 +200,9 @@ export function ResultGrid({
   return (
     <div>
       <div className="db-grid-wrap">
-        <table className="db-grid">
+        {/* With the roving cursor the table is a grid for real — the role
+            makes the per-cell `gridcell`s valid instead of orphaned. */}
+        <table className="db-grid" role={keyboard ? 'grid' : undefined}>
           <thead className={stickyHeader ? 'sticky' : undefined}>
             <tr>
               {cols.map((col) => {

--- a/database/ui/src/page/run-sql.test.ts
+++ b/database/ui/src/page/run-sql.test.ts
@@ -1,0 +1,94 @@
+import type { Host } from '@iii-dev/console-ui'
+import { describe, expect, it } from 'vitest'
+import { commonSchema, ddlInfo, runAdhocSql } from './db-data'
+
+/** Host stub that records the one call the dispatcher makes. */
+function fakeHost(respond: (fn: string) => unknown) {
+  const calls: Array<{ fn: string; payload: Record<string, unknown> }> = []
+  const host = {
+    iii: {
+      trigger: async (fn: string, payload: Record<string, unknown>) => {
+        calls.push({ fn, payload })
+        return respond(fn)
+      },
+    },
+  } as unknown as Host
+  return { host, calls }
+}
+
+const EMPTY_QUERY = { rows: [], row_count: 0, columns: [] }
+
+describe('runAdhocSql', () => {
+  it('routes reads through database::query', async () => {
+    const { host, calls } = fakeHost(() => EMPTY_QUERY)
+    const out = await runAdhocSql(host, 'mysql', 'SELECT * FROM shipments')
+    expect(calls.map((c) => c.fn)).toEqual(['database::query'])
+    expect(out.write).toBeUndefined()
+  })
+
+  it('routes writes through database::execute and strips the trailing semicolon', async () => {
+    const { host, calls } = fakeHost(() => ({
+      affected_rows: 1,
+      last_insert_id: null,
+      returned_rows: [],
+    }))
+    // The exact statement from the screenshot that used to be rejected.
+    const out = await runAdhocSql(host, 'mysql', 'drop table completion_log;')
+    expect(calls.map((c) => c.fn)).toEqual(['database::execute'])
+    expect(calls[0].payload.sql).toBe('drop table completion_log')
+    expect(out.write).toEqual({ affectedRows: 1, lastInsertId: null, echo: 'dropped table completion_log' })
+    expect(out.result.rows).toEqual([])
+  })
+
+  it('turns RETURNING rows into a drawable grid', async () => {
+    const { host } = fakeHost(() => ({
+      affected_rows: 1,
+      last_insert_id: '7',
+      returned_rows: [{ id: 7, email: 'a@x' }],
+    }))
+    const out = await runAdhocSql(host, 'pg', "INSERT INTO users (email) VALUES ('a@x') RETURNING id, email")
+    expect(out.write).toEqual({ affectedRows: 1, lastInsertId: '7', echo: null })
+    expect(out.result.rows).toEqual([{ id: 7, email: 'a@x' }])
+    expect(out.result.columns.map((c) => c.name)).toEqual(['id', 'email'])
+  })
+})
+
+describe('ddlInfo', () => {
+  it('names the schema change in both tenses', () => {
+    expect(ddlInfo('drop table completion_log')).toEqual({
+      present: 'drops table completion_log',
+      past: 'dropped table completion_log',
+    })
+    expect(ddlInfo('DROP TABLE IF EXISTS `completion_log`')).toEqual({
+      present: 'drops table completion_log',
+      past: 'dropped table completion_log',
+    })
+    expect(ddlInfo('truncate shipments')).toEqual({
+      present: 'truncates shipments',
+      past: 'truncated shipments',
+    })
+    expect(ddlInfo('alter table orders add column note text')).toEqual({
+      present: 'alters table orders',
+      past: 'altered table orders',
+    })
+  })
+
+  it('leaves row writes and reads alone', () => {
+    expect(ddlInfo('update t set a = 1')).toBeNull()
+    expect(ddlInfo('insert into t values (1)')).toBeNull()
+    expect(ddlInfo("select * from t where note like '%drop table%'")).toBeNull()
+  })
+})
+
+describe('commonSchema', () => {
+  it('finds the one schema qualifying every table', () => {
+    expect(commonSchema(['public.a', 'public.b', 'public.c'])).toBe('public')
+  })
+
+  it('returns nothing when schemas are mixed or absent', () => {
+    expect(commonSchema(['public.a', 'audit.b'])).toBe('')
+    expect(commonSchema(['public.a', 'plain'])).toBe('')
+    expect(commonSchema(['shipments', 'ledger'])).toBe('')
+    expect(commonSchema([])).toBe('')
+  })
+})

--- a/database/ui/src/page/useDatabaseRead.ts
+++ b/database/ui/src/page/useDatabaseRead.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
+import { errText } from '../lib/errors'
 
 /**
  * One in-flight database read: run `fetcher` while `enabled`, re-run when
@@ -45,7 +46,7 @@ export function useDatabaseRead<T>(
         setError(null)
       } catch (err) {
         if (cancelled) return
-        setError(err instanceof Error ? err.message : String(err))
+        setError(errText(err))
       } finally {
         if (!cancelled) setLoading(false)
       }

--- a/database/ui/src/page/useRowChanges.ts
+++ b/database/ui/src/page/useRowChanges.ts
@@ -38,6 +38,9 @@ export interface RowChange extends RowChangedEvent {
   /** Local receipt time. Ordering and the recency fade both use this, because
    *  `at` comes from the database clock and may skew against the browser's. */
   seen: number
+  /** Monotonic arrival number — the collision-free list key (`seen` repeats
+   *  for two events landing in the same millisecond). */
+  seq: number
 }
 
 export interface RowChangeFeed {
@@ -51,6 +54,9 @@ export interface RowChangeFeed {
 }
 
 const MAX_KEPT = 60
+
+/** Shared across feeds on purpose: any two changes anywhere differ. */
+let feedSeq = 0
 
 export function useRowChanges(host: Host, db: string | undefined, table: string | null | undefined): RowChangeFeed {
   const [changes, setChanges] = useState<RowChange[]>([])
@@ -84,6 +90,7 @@ export function useRowChanges(host: Host, db: string | undefined, table: string 
         returning: event?.returning,
         at: Number.isFinite(at) ? at : Date.now(),
         seen: Date.now(),
+        seq: feedSeq++,
       }
       setChanges((prev) => [change, ...prev].slice(0, MAX_KEPT))
       setPending((n) => n + 1)

--- a/database/ui/styles.css
+++ b/database/ui/styles.css
@@ -225,14 +225,44 @@
 [data-iii-ui="database"] .db-aside-head {
   position: sticky;
   top: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
   background: var(--color-bg);
   padding: 8px 12px;
   border-bottom: 1px solid var(--color-rule-2);
-  font-size: 10px;
+  /* 11px + faint, not 10px ghost: a functional label, not decoration. */
+  font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  color: var(--color-ink-ghost);
+  color: var(--color-ink-faint);
 }
+[data-iii-ui="database"] .db-aside-toggle,
+[data-iii-ui="database"] .db-aside-reopen {
+  display: inline-flex;
+  padding: 2px;
+  border: 0;
+  background: transparent;
+  color: var(--color-ink-faint);
+  cursor: pointer;
+}
+[data-iii-ui="database"] .db-aside-toggle:hover { color: var(--color-ink); }
+[data-iii-ui="database"] .db-aside-reopen:hover { color: var(--color-ink); }
+[data-iii-ui="database"] .db-aside.collapsed {
+  align-items: stretch;
+  padding: 4px 0;
+}
+[data-iii-ui="database"] .db-body.aside-collapsed { grid-template-columns: max-content minmax(0, 1fr); }
+/* Selection is dimmed, not hidden, on modes that barely use it. */
+[data-iii-ui="database"] .db-aside-note {
+  margin: 0;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--color-rule-2);
+  font-size: 11px;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="database"] .db-aside.passive .db-tree-row.active { opacity: 0.55; }
 [data-iii-ui="database"] .db-aside-body { flex: 1; padding: 4px 0; }
 
 [data-iii-ui="database"] .db-panel {
@@ -247,23 +277,60 @@
 [data-iii-ui="database"] .db-msg {
   padding: 10px 12px;
   font-size: 12px;
-  color: var(--color-ink-ghost);
+  /* faint, not ghost: these are answers ("no tables", "· probing…"), and
+     ghost measures 2.3:1 on this paper. */
+  color: var(--color-ink-faint);
   text-transform: lowercase;
 }
-[data-iii-ui="database"] .db-msg.alert { color: var(--color-alert); text-transform: none; word-break: break-all; }
+[data-iii-ui="database"] .db-msg.alert { color: #c60021; text-transform: none; word-break: break-all; }
 [data-iii-ui="database"] .db-pulse { animation: db-page-pulse 1.6s ease-in-out infinite; }
 @keyframes db-page-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }
 
 [data-iii-ui="database"] .db-pad { padding: 16px; }
 [data-iii-ui="database"] .db-skel { display: flex; flex-direction: column; gap: 8px; padding: 12px; }
 
+/* ---- shared panel toolbar -------------------------------------------- */
+/* One bar grammar for every tab's top strip. The bars grew by copy-paste
+   (the erd spacer was living inside the health and changes bars); this is
+   the base they were all reaching for. Per-tab rules keep only what is
+   genuinely theirs. */
+[data-iii-ui="database"] .db-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--color-rule);
+  font-size: 11.5px;
+}
+[data-iii-ui="database"] .db-toolbar-spacer { flex: 1 1 0; }
+
+/* One focus vocabulary: every button gets the hairline ink outline — the
+   shared component ring is a 5%-alpha halo, invisible on paper. Grid cells
+   keep their inset accent ring (they are not buttons). */
+[data-iii-ui="database"] button:focus-visible {
+  outline: 1px solid var(--color-ink);
+  outline-offset: 2px;
+}
+
+/* The trace capability-hiding leaves: which modes this worker can't serve. */
+[data-iii-ui="database"] .db-modes-hint {
+  margin: 8px 0 0;
+  font-size: 11px;
+  color: var(--color-ink-faint);
+}
+
 /* ---- schema tree ---- */
+[data-iii-ui="database"] .db-tree-filter {
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--color-rule-2);
+}
 [data-iii-ui="database"] .db-tree-grouphead {
   padding: 12px 12px 4px;
-  font-size: 10px;
+  font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  color: var(--color-ink-ghost);
+  color: var(--color-ink-faint);
 }
 [data-iii-ui="database"] .db-tree ul { list-style: none; margin: 0; padding: 0; }
 [data-iii-ui="database"] .db-tree-row {
@@ -305,10 +372,17 @@
 [data-iii-ui="database"] .db-idx-name { color: var(--color-ink-faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 [data-iii-ui="database"] .db-idx-unique { color: var(--color-accent); font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.06em; }
 [data-iii-ui="database"] .db-tree-msg { padding: 4px 12px 4px 36px; font-size: 11px; color: var(--color-ink-ghost); }
-[data-iii-ui="database"] .db-tree-msg.alert { color: var(--color-alert); }
+[data-iii-ui="database"] .db-tree-msg.alert { color: #c60021; }
 
 /* ---- result grid ---- */
 [data-iii-ui="database"] .db-grid-wrap { overflow-x: auto; }
+/* Inside the panels' own scroll panes the wrap must NOT be a second scroll
+   container: nested x-scroll drew a phantom scrollbar strip under short
+   tables, and any overflow ancestor between thead.sticky and the real
+   scroller breaks sticky headers. The bare wrap rule above stays for the
+   chat-card contexts, which have no scroll pane of their own. */
+[data-iii-ui="database"] .db-data-scroll .db-grid-wrap { overflow-x: visible; }
+[data-iii-ui="database"] .db-sql-results .db-grid-wrap { overflow-x: visible; }
 [data-iii-ui="database"] .db-grid { width: 100%; border-collapse: collapse; }
 [data-iii-ui="database"] .db-grid thead.sticky th { position: sticky; top: 0; z-index: 10; }
 [data-iii-ui="database"] .db-grid th {
@@ -318,7 +392,7 @@
 }
 [data-iii-ui="database"] .db-grid th.num { text-align: right; }
 [data-iii-ui="database"] .db-grid th .colname { color: var(--color-ink-faint); font-weight: 500; }
-[data-iii-ui="database"] .db-grid th .coltype { color: var(--color-ink-ghost); font-weight: 400; text-transform: lowercase; }
+[data-iii-ui="database"] .db-grid th .coltype { color: var(--color-ink-faint); font-weight: 400; text-transform: lowercase; }
 [data-iii-ui="database"] .db-grid th .sorter {
   appearance: none; background: transparent; border: 0; cursor: pointer;
   display: inline-flex; align-items: center; gap: 6px; font: inherit; color: inherit;
@@ -343,7 +417,9 @@
 }
 [data-iii-ui="database"] .db-cell-null { color: var(--color-ink-ghost); font-style: italic; }
 [data-iii-ui="database"] .db-cell-bool-true { color: var(--color-accent); }
-[data-iii-ui="database"] .db-cell-bool-false { color: var(--color-warn); }
+/* Booleans are data, not judgments — warn ink turned a flag column full of
+   `false` into a wall of caution. */
+[data-iii-ui="database"] .db-cell-bool-false { color: var(--color-ink-faint); }
 [data-iii-ui="database"] .db-cell-num { color: var(--color-ink); font-variant-numeric: tabular-nums; }
 [data-iii-ui="database"] .db-cell-json { color: var(--color-ink-faint); }
 [data-iii-ui="database"] .db-cell-str { color: var(--color-ink); }
@@ -363,24 +439,47 @@
 [data-iii-ui="database"] .db-grid-empty { padding: 12px; font-size: 12.5px; color: var(--color-ink-ghost); }
 
 /* ---- table data panel ---- */
-[data-iii-ui="database"] .db-data { display: flex; min-height: 0; min-width: 0; width: 100%; }
+/* flex: 1 fills the panel so the pager sits at its bottom edge instead of
+   stranding mid-air over a void when the table is short. */
+[data-iii-ui="database"] .db-data { display: flex; flex: 1; min-height: 0; min-width: 0; width: 100%; }
 [data-iii-ui="database"] .db-data-main { flex: 1; display: flex; flex-direction: column; min-width: 0; }
-[data-iii-ui="database"] .db-data-bar {
-  display: flex; flex-wrap: wrap; align-items: center; gap: 12px;
-  padding: 8px 16px; border-bottom: 1px solid var(--color-rule);
-  font-size: 11px; color: var(--color-ink-faint);
+/* Extends .db-toolbar; only the ink is its own. */
+[data-iii-ui="database"] .db-data-bar { color: var(--color-ink-faint); }
+/* Its own container: the row inspector takes 320px from this column, so the
+   page-level container query cannot see how narrow the data area really is —
+   the footer must respond to THIS width, not the page's. */
+[data-iii-ui="database"] .db-data-main {
+  container-name: db-data-main;
+  container-type: inline-size;
 }
 [data-iii-ui="database"] .db-data-bar .name { color: var(--color-ink); font-weight: 500; }
 [data-iii-ui="database"] .db-data-bar .spacer { margin-left: auto; }
-[data-iii-ui="database"] .db-data-scroll { overflow: auto; max-height: 60vh; }
-[data-iii-ui="database"] .db-data-foot { border-top: 1px solid var(--color-rule); padding: 8px 16px; }
+[data-iii-ui="database"] .db-data-scroll { overflow: auto; flex: 1; max-height: 60vh; }
+[data-iii-ui="database"] .db-data-foot {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  border-top: 1px solid var(--color-rule);
+  padding: 8px 16px;
+}
+[data-iii-ui="database"] .db-data-foot .db-pager { flex: 1; }
+[data-iii-ui="database"] .db-kbd-hint { font-size: 11px; color: var(--color-ink-faint); white-space: nowrap; }
 
 /* ---- pagination ---- */
 [data-iii-ui="database"] .db-pager {
   display: flex; align-items: center; justify-content: space-between; gap: 16px;
   font-size: 12px; color: var(--color-ink-faint); text-transform: lowercase;
 }
-[data-iii-ui="database"] .db-pager-group { display: flex; align-items: center; gap: 8px; font-variant-numeric: tabular-nums; }
+/* Phrases wrap as units or not at all — "page 1 of 1" must never shred into
+   three lines when the inspector squeezes the column. */
+[data-iii-ui="database"] .db-pager { flex-wrap: wrap; row-gap: 4px; }
+[data-iii-ui="database"] .db-pager-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
 [data-iii-ui="database"] .db-pager-cap { text-transform: uppercase; letter-spacing: 0.06em; font-size: 11px; }
 [data-iii-ui="database"] .db-pager select {
   border: 1px solid var(--color-rule); background: var(--color-bg); color: var(--color-ink);
@@ -392,6 +491,25 @@
 [data-iii-ui="database"] .db-rowdetail {
   width: 320px; flex-shrink: 0; border-left: 1px solid var(--color-rule);
   overflow-y: auto; max-height: 60vh;
+}
+/* The inspector's tab strip (NOT `.db-rowdetail-head`, which is RowDetail's
+   own standalone header further down — reusing that name let its rule win
+   the cascade and break this bar's height). Sticky, so close and the tabs
+   survive scrolling a long row; min-height pins its bottom rule to the
+   filter bar's beside it (8px padding + 32px button + 8px + 1px border = 49):
+   one continuous line across both columns. */
+[data-iii-ui="database"] .db-inspector-head {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 49px;
+  padding: 0 8px 0 12px;
+  background: var(--color-bg);
+  border-bottom: 1px solid var(--color-rule);
 }
 [data-iii-ui="database"] .db-rowdetail-head {
   position: sticky; top: 0; background: var(--color-paper-2);
@@ -428,8 +546,45 @@
   display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
   padding: 8px 16px; border-top: 1px solid var(--color-rule-2); background: var(--color-paper-2);
 }
-[data-iii-ui="database"] .db-sql-warn { font-size: 11px; color: var(--color-warn); }
+/* Derived inks, not the raw tokens: --color-warn (#a87a00) and --color-alert
+   (#ff0026) sit near 3:1 on the actions band — below AA for 11px functional
+   text. Same families, pushed to ≥4.5:1 per theme (the console shell darkened
+   its accent token for the identical reason). */
+[data-iii-ui="database"] .db-sql-warn { font-size: 11px; color: #7a5700; }
+[data-iii-ui="database"] .db-sql-warn.ddl { color: #c60021; }
+/* :where keeps the scope prefix first without adding specificity, so source
+   order settles light vs dark. One rule per surface — the build's scope
+   checker splits grouped selectors on commas. These are every user of the
+   derived warn/alert inks page-wide. */
+[data-iii-ui="database"] .db-sql-warn:where([data-theme="dark"] *) { color: #d49b00; }
+[data-iii-ui="database"] .db-health-note.warn:where([data-theme="dark"] *) { color: #d49b00; }
+[data-iii-ui="database"] .db-health-blocked:where([data-theme="dark"] *) { color: #d49b00; }
+[data-iii-ui="database"] .db-plan-warncount:where([data-theme="dark"] *) { color: #d49b00; }
+[data-iii-ui="database"] .db-erd-req:where([data-theme="dark"] *) { color: #d49b00; }
+[data-iii-ui="database"] .db-sql-warn.ddl:where([data-theme="dark"] *) { color: #ff4d63; }
+[data-iii-ui="database"] .db-tree-msg.alert:where([data-theme="dark"] *) { color: #ff4d63; }
+[data-iii-ui="database"] .db-msg.alert:where([data-theme="dark"] *) { color: #ff4d63; }
+[data-iii-ui="database"] .db-change-op.op-delete:where([data-theme="dark"] *) { color: #ff4d63; }
 [data-iii-ui="database"] .db-sql-meta { margin-left: auto; font-size: 11px; color: var(--color-ink-faint); font-variant-numeric: tabular-nums; }
+/* Numbers describing a statement the editor has moved past. */
+[data-iii-ui="database"] .db-sql-meta.stale { opacity: 0.45; }
+/* Visually hidden, present to assistive tech (the panels' live regions). */
+[data-iii-ui="database"] .db-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+/* Keeps a panel mounted while other modes show: `contents` removes the
+   wrapper from layout when visible, `none` hides the kept panel. Every tab
+   that accumulates user work sits in one of these. */
+[data-iii-ui="database"] .db-keep { display: contents; }
+[data-iii-ui="database"] .db-keep[hidden] { display: none; }
 [data-iii-ui="database"] .db-sql-history { border-top: 1px solid var(--color-rule-2); max-height: 160px; overflow-y: auto; }
 [data-iii-ui="database"] .db-sql-history-row {
   display: flex; align-items: center; gap: 8px; padding: 4px 16px;
@@ -443,8 +598,19 @@
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 [data-iii-ui="database"] .db-sql-history-pick:hover { color: var(--color-ink); }
-[data-iii-ui="database"] .db-sql-results { flex: 1; overflow: auto; max-height: 55vh; min-height: 0; }
-[data-iii-ui="database"] .db-sql-placeholder { padding: 16px; font-size: 12px; color: var(--color-ink-ghost); text-transform: lowercase; }
+[data-iii-ui="database"] .db-sql-history-note {
+  padding: 4px 8px 6px;
+  border-bottom: 1px solid var(--color-rule-2);
+  font-size: 11px;
+  color: var(--color-ink-faint);
+}
+[data-iii-ui="database"] .db-sql-results { flex: 1; overflow: auto; max-height: 55vh; min-height: 0; transition: opacity 120ms ease-out; }
+/* A re-run over a previous result: the old grid dims instead of posing as
+   the answer to the statement in flight. */
+[data-iii-ui="database"] .db-sql-results.running { opacity: 0.55; }
+/* ink-faint, not ghost: "statement ran — dropped table x" is a result, and
+   ghost measures 2.3:1 here — decoration ink for content text. */
+[data-iii-ui="database"] .db-sql-placeholder { padding: 16px; font-size: 12px; color: var(--color-ink-faint); text-transform: lowercase; }
 
 /* This page is a panel inside the console shell, so its own width is the
    signal — the viewport is not, and reads visibly wrong with the chat dock
@@ -453,9 +619,19 @@
   [data-iii-ui="database"] .db-body { grid-template-columns: minmax(0, 1fr); }
   [data-iii-ui="database"] .db-data { flex-direction: column; }
   [data-iii-ui="database"] .db-rowdetail { width: auto; border-left: 0; border-top: 1px solid var(--color-rule); }
+  /* Stacked, the table list sits *above* the data, so its 74vh cap pushed the
+     grid below the fold — you picked a table and saw nothing happen. Scroll
+     the list instead of the page. */
+  [data-iii-ui="database"] .db-aside { max-height: 34vh; }
 }
 
-/* --- configuration form (Workers tab, `database` entry) --------------- */
+/* The pager needs the row to itself when the data column tightens — whether
+   the page is narrow or the inspector took 320px of it. */
+@container db-data-main (max-width: 760px) {
+  [data-iii-ui="database"] .db-kbd-hint { display: none; }
+}
+
+/* --- configuration form (Workers tab + shared config dialog) ---------- */
 [data-iii-ui="database"] .db-cfg {
   display: flex;
   flex-direction: column;
@@ -653,7 +829,6 @@
   display: block;
   height: 100%;
   background: var(--color-accent);
-  transition: width 180ms ease-out;
 }
 [data-iii-ui="database"] .db-kv {
   display: grid;
@@ -672,22 +847,17 @@
   padding: 3px 0;
 }
 [data-iii-ui="database"] .db-bar-label { color: var(--color-ink-ghost); min-width: 72px; }
-[data-iii-ui="database"] .db-erd-spacer { flex: 1; }
 
 /* --- schema diagram --------------------------------------------------- */
 [data-iii-ui="database"] .db-erd { display: flex; flex-direction: column; height: 100%; min-height: 0; }
-[data-iii-ui="database"] .db-erd-bar {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--color-rule);
-  font-size: 11.5px;
-}
-[data-iii-ui="database"] .db-erd-stat { color: var(--color-ink-faint); font-variant-numeric: tabular-nums; }
-[data-iii-ui="database"] .db-erd-stat.quiet { color: var(--color-ink-ghost); }
-[data-iii-ui="database"] .db-erd-zoom { color: var(--color-ink-ghost); font-variant-numeric: tabular-nums; min-width: 40px; text-align: right; }
-[data-iii-ui="database"] .db-erd-search { max-width: 180px; }
+/* Extends .db-toolbar (which wraps rather than shrinks — unwrapped, a narrow
+   panel clipped the search to "find a ta"). Controls keep their size; the
+   search alone flexes. */
+[data-iii-ui="database"] .db-erd-bar > * { flex: 0 0 auto; }
+[data-iii-ui="database"] .db-erd-stat { color: var(--color-ink-faint); font-variant-numeric: tabular-nums; white-space: nowrap; }
+[data-iii-ui="database"] .db-erd-stat.quiet { color: var(--color-ink-faint); }
+[data-iii-ui="database"] .db-erd-zoom { color: var(--color-ink-faint); font-variant-numeric: tabular-nums; min-width: 40px; text-align: right; }
+[data-iii-ui="database"] .db-erd-bar > .db-erd-search { flex: 1 1 120px; min-width: 100px; max-width: 220px; }
 [data-iii-ui="database"] .db-erd-focus { color: var(--color-ink-faint); }
 [data-iii-ui="database"] .db-erd-focus strong { color: var(--color-ink); font-weight: 500; }
 [data-iii-ui="database"] .db-erd-frontier {
@@ -841,8 +1011,8 @@
 [data-iii-ui="database"] .db-erd-glyph { width: 11px; flex: none; color: var(--color-ink-ghost); }
 [data-iii-ui="database"] .db-erd-glyph.pk { color: var(--color-accent); }
 [data-iii-ui="database"] .db-erd-col-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-[data-iii-ui="database"] .db-erd-col-type { color: var(--color-ink-ghost); font-size: 10px; }
-[data-iii-ui="database"] .db-erd-req { color: var(--color-warn); font-size: 10px; flex: none; }
+[data-iii-ui="database"] .db-erd-col-type { color: var(--color-ink-faint); font-size: 11px; }
+[data-iii-ui="database"] .db-erd-req { color: #7a5700; font-size: 10px; flex: none; }
 /* Below 0.5 zoom the column text is unreadable anyway; dropping the bodies
    turns 200 nodes x 12 rows into 200 headers. This class is the whole
    performance story for a wide schema. */
@@ -851,16 +1021,21 @@
 
 /* --- health ----------------------------------------------------------- */
 [data-iii-ui="database"] .db-health { display: flex; flex-direction: column; height: 100%; min-height: 0; }
-[data-iii-ui="database"] .db-health-bar {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--color-rule);
-  font-size: 11.5px;
-}
+/* Extends .db-toolbar. */
 [data-iii-ui="database"] .db-health-driver { color: var(--color-ink); text-transform: lowercase; }
 [data-iii-ui="database"] .db-health-ver { color: var(--color-ink-ghost); }
+[data-iii-ui="database"] .db-health-asof { color: var(--color-ink-faint); font-variant-numeric: tabular-nums; }
+/* Cards describing the previous read while a new one is in flight. */
+[data-iii-ui="database"] .db-health-cards.stale { opacity: 0.55; transition: opacity 120ms ease-out; }
+/* Replication daemons: shown (honest), named, and visually demoted. */
+[data-iii-ui="database"] .db-health-query.daemon { opacity: 0.6; }
+[data-iii-ui="database"] .db-health-daemon {
+  font-size: 9.5px;
+  letter-spacing: 0.08em;
+  color: var(--color-ink-faint);
+  border: 1px solid var(--color-rule);
+  padding: 0 4px;
+}
 [data-iii-ui="database"] .db-health-cards {
   flex: 1;
   overflow: auto;
@@ -882,7 +1057,7 @@
 }
 [data-iii-ui="database"] .db-health-note { margin: 0; font-size: 11.5px; color: var(--color-ink-faint); }
 [data-iii-ui="database"] .db-health-note.quiet { color: var(--color-ink-ghost); font-style: italic; }
-[data-iii-ui="database"] .db-health-note.warn { color: var(--color-warn); }
+[data-iii-ui="database"] .db-health-note.warn { color: #7a5700; }
 [data-iii-ui="database"] .db-health-list { list-style: none; margin: 0; padding: 0; }
 [data-iii-ui="database"] .db-health-list > li {
   padding: 5px 0;
@@ -900,7 +1075,7 @@
 [data-iii-ui="database"] .db-health-state,
 [data-iii-ui="database"] .db-health-user,
 [data-iii-ui="database"] .db-health-rel { color: var(--color-ink-ghost); }
-[data-iii-ui="database"] .db-health-blocked { color: var(--color-warn); }
+[data-iii-ui="database"] .db-health-blocked { color: #7a5700; }
 [data-iii-ui="database"] .db-health-sql {
   display: block;
   margin-top: 2px;
@@ -939,7 +1114,7 @@
   font-size: 11px;
 }
 [data-iii-ui="database"] .db-plan-format { color: var(--color-ink-ghost); text-transform: lowercase; }
-[data-iii-ui="database"] .db-plan-warncount { color: var(--color-warn); }
+[data-iii-ui="database"] .db-plan-warncount { color: #7a5700; }
 [data-iii-ui="database"] .db-plan-tree,
 [data-iii-ui="database"] .db-plan-tree ul { list-style: none; margin: 0; padding: 0; }
 [data-iii-ui="database"] .db-plan-node {
@@ -1066,7 +1241,11 @@
   transition: opacity 120ms ease-out;
   z-index: 1;
 }
-[data-iii-ui="database"] .db-grid th:hover .db-col-hide { opacity: 1; }
+/* :focus-within beside :hover — a keyboard user must never focus an
+   invisible control. */
+[data-iii-ui="database"] .db-grid th:hover .db-col-hide,
+[data-iii-ui="database"] .db-grid th:focus-within .db-col-hide,
+[data-iii-ui="database"] .db-col-hide:focus-visible { opacity: 1; }
 [data-iii-ui="database"] .db-col-hide:hover { color: var(--color-alert); }
 /* Where a dragged column would land. */
 [data-iii-ui="database"] .db-grid th.dropping { box-shadow: inset 2px 0 0 var(--color-accent); }
@@ -1163,7 +1342,9 @@
   opacity: 0;
   transition: opacity 120ms ease-out;
 }
-[data-iii-ui="database"] .db-json-row:hover .db-json-copy { opacity: 1; }
+[data-iii-ui="database"] .db-json-row:hover .db-json-copy,
+[data-iii-ui="database"] .db-json-row:focus-within .db-json-copy,
+[data-iii-ui="database"] .db-json-copy:focus-visible { opacity: 1; }
 [data-iii-ui="database"] .db-json-copy:hover { color: var(--color-accent); }
 
 [data-iii-ui="database"] .db-rowdetail-body { padding: 0 12px 12px; }
@@ -1294,26 +1475,31 @@
 
 /* --- row changes ------------------------------------------------------ */
 [data-iii-ui="database"] .db-changes { display: flex; flex-direction: column; height: 100%; min-height: 0; }
-[data-iii-ui="database"] .db-changes-bar {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--color-rule);
-  font-size: 11.5px;
-}
+/* Extends .db-toolbar. */
 [data-iii-ui="database"] .db-changes-target { color: var(--color-ink); }
+/* A real disclosure button now, not a hover-only span — the capture-mode
+   caveat it carries must be reachable by keyboard and touch. */
 [data-iii-ui="database"] .db-freshness {
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font: inherit;
   color: var(--color-ink-faint);
-  cursor: help;
+  cursor: pointer;
 }
 [data-iii-ui="database"] .db-freshness-at { color: var(--color-ink-ghost); font-variant-numeric: tabular-nums; }
-[data-iii-ui="database"] .db-changes-idle { padding: 16px; font-size: 11.5px; color: var(--color-ink-faint); }
-[data-iii-ui="database"] .db-changes-idle p { margin: 0 0 6px; }
-[data-iii-ui="database"] .db-changes-hint { color: var(--color-ink-ghost); max-width: 52ch; line-height: 1.5; }
+[data-iii-ui="database"] .db-changes-capnote {
+  margin: 0;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--color-rule-2);
+  font-size: 11.5px;
+  line-height: 1.5;
+  max-width: 62ch;
+  color: var(--color-ink-faint);
+}
 [data-iii-ui="database"] .db-changes-list { list-style: none; margin: 0; padding: 0; flex: 1; overflow: auto; }
 [data-iii-ui="database"] .db-change {
   display: flex;
@@ -1345,7 +1531,9 @@
   text-align: center;
 }
 [data-iii-ui="database"] .db-change-op.op-insert { color: var(--color-ok); }
-[data-iii-ui="database"] .db-change-op.op-delete { color: var(--color-alert); }
-[data-iii-ui="database"] .db-change-op.op-update { color: var(--color-accent); }
+[data-iii-ui="database"] .db-change-op.op-delete { color: #c60021; }
+/* update stays ink: accent means "selected/active" everywhere else on the
+   page, and delete borrows the derived alert ink AA-safe at badge size. */
+[data-iii-ui="database"] .db-change-op.op-update { color: var(--color-ink); }
 [data-iii-ui="database"] .db-change-rows { color: var(--color-ink-faint); font-variant-numeric: tabular-nums; }
 [data-iii-ui="database"] .db-change-at { margin-left: auto; color: var(--color-ink-ghost); font-variant-numeric: tabular-nums; }

--- a/packages/console-ui/component-names.mjs
+++ b/packages/console-ui/component-names.mjs
@@ -44,6 +44,7 @@ export const componentNames = [
   'Tooltip',
   'TooltipContent',
   'TooltipTrigger',
+  'WorkerConfigurationDialog',
 ]
 
 export default componentNames

--- a/packages/console-ui/index.d.ts
+++ b/packages/console-ui/index.d.ts
@@ -417,3 +417,18 @@ export interface MarkdownPreviewProps {
 /** `Markdown` inside the standard `bg-bg` pane chrome — the preview
     counterpart to `CodeEditor` for markdown-editing UIs. */
 export declare const MarkdownPreview: React.ComponentType<MarkdownPreviewProps>
+
+export interface WorkerConfigurationDialogProps {
+  /** Which worker's configuration to edit; `null` renders the dialog closed. */
+  configurationId: string | null
+  onClose: () => void
+}
+/**
+ * The console's worker-configuration editor in a dialog — schema fetch,
+ * custom `configForms` resolution, dirty guard, save/reset and error
+ * mapping all host-owned. Lets a worker page offer "configure" without
+ * navigating to the workers tab. Prefer reading it off `host.components`
+ * at runtime rather than importing the name: a console predating this
+ * export then degrades to navigation instead of failing the module load.
+ */
+export declare const WorkerConfigurationDialog: React.ComponentType<WorkerConfigurationDialogProps>


### PR DESCRIPTION
Fixes MOT-4361

The database console page overhaul from the 2026-08-04/05 live review sessions: two driver-level bugs, the sql panel gaining sanctioned writes, a page-wide consistency migration, and the console sharing its worker-configuration dialog with injected pages.

## Worker (Rust)

- **MySQL type names**: result columns reported the protocol enum's debug names (`MYSQL_TYPE_VAR_STRING`) instead of SQL names (`varchar`) — leaked into grid headers and every agent reading `columns[].type`, and silently broke the UI's type-category logic. New `sql_type_name()` maps the wire type (charset 63 splits text/binary twins, UNSIGNED honoured). Verified against the live mysql.
- **Postgres `"char"` decode**: the row decoder had no arm for the internal one-byte `"char"` type (OID 18) and the unknown-type fallback's `String` FromSql rejects it — so `listTables` (which reads `pg_class.relkind`) failed on **every** postgres server with `error deserializing column 2`. New arm decodes i8→text. Verified against live postgres 18.4 and via ad-hoc `SELECT relkind`.

## SQL panel

- **Writes allowed** (owner decision): `isReadOnlySql` routes instead of gates — reads → `database::query`, writes → `database::execute`, the same surfaces agents use, so engine policy and `database::row-changed` treat both alike. Trailing `;` stripped for the prepared paths.
- **DDL severity + honest account**: drop/truncate/alter get an alert-ink note naming the change before ⌘⏎ ("drops table x — commits on mysql") and a past-tense echo after ("dropped table x") replacing MySQL's misleading `0 affected`.
- **`errText`**: unwraps the SDK's wire-error envelope to the driver's own code+message — every failure used to render `[object Object]`.

## Page-wide consistency (impeccable critiques: sql 27/40, page 25/40)

- **Keep-mounted panels**: sql drafts, data filters/sort/cursor, the changes feed, and diagram zoom/drag all survive mode switches; header refresh threads `refreshToken` into fetchers instead of remount keys (and now actually reaches health, where it was a silent no-op).
- **One visual system**: shared `.db-toolbar` bar grammar, derived AA warn/alert inks in both themes (raw tokens sit ~3:1 at 11px), page-wide `:focus-visible` hairline, ghost→faint on functional text, `:focus-within` beside hover-only reveals.
- **A11y**: live regions (sql status, changes `role="log"`, data rows/page), freshness badge became a real disclosure button (its caveat was hover-only `title` text), `aria-expanded` on tree/plan twists, `role="grid"` legitimizing the roving-cursor gridcells, keyboard hints in the data footer, Escape exits the Monaco tab-trap, ERD nodes take F to focus.
- **Table rail**: collapsible (remembered per browser), type-to-filter, universal schema prefix stripped from display (`public.` ×14 was eating the name width), passive-mode notes on sql/health, list tagged by source db — a failed database switch can no longer render the previous database's tables under the new header.
- **Health**: replication daemons labeled + demoted instead of billed as active queries at `13233.0s`; durations roll up (`3h 40m`); as-of stamp; stale-dim while refetching.
- **Inspector**: header in the shared bar grammar with an explicit close — a cell cursor used to pin the panel open with no way out — and its bottom rule aligns with the filter bar (fixing a class collision with RowDetail's standalone header).
- **Copy voice**: plural guards ("1 tables"), interpunct idiom, pager caps, empty states with real actions.

## Console: shared configuration dialog

`WorkerConfigurationDialog` joins the curated component registry, the package manifest, and the regenerated vendor shim (conformance-test pinned). The database page opens the console's own config editor **in place** via a `host.components` runtime lookup — dialog chrome, dirty guard, custom-form resolution and save all stay host-owned. Consoles predating the export degrade to the workers-tab navigation; the runtime lookup (never a static import) is what keeps an old console from failing the page's module load. Also: CodeEditor's completions separator is a visible `'\n'` now, replacing an invisible U+0001 that read as `join('')` in every editor and grep.

## Verification

- `cargo fmt` / `clippy --all-features` / `cargo test` green (347+28+3+1); driver fixes proven with throwaway integration tests against the live mysql and postgres 18.4
- database/ui: `tsc` clean, 32/32 vitest (routing, ddlInfo, errText, commonSchema), biome clean per touched file
- console: `tsc -b` clean, conformance test 3/3 (registry ↔ manifest ↔ types), shim regenerated (34 components)
- Live-verified in the running console throughout: contrast/focus probes, keep-mounted behavior, footer alignment measured to the pixel

## Notes for reviewers

- The sql-panel write capability is deliberate ("a heads-up, not a gate") — no confirmation step; DDL gets the louder treatment described above.
- `.impeccable/critique/` snapshots and the provider `Cargo.lock` drift are intentionally not part of this PR.
- Version skew is handled on both axes: older worker → console page hides missing modes with a hint; older console → configure falls back to navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added worker configuration access from the database console.
  * SQL panels now support write and DDL statements, with affected-row, insert-ID, and result reporting.
  * Added schema/table filtering, starter SQL, refresh controls, persisted navigation, and improved panel state retention.
  * Added keyboard shortcuts and accessibility enhancements across database views.
* **Bug Fixes**
  * Improved database error messages and handling of MySQL, PostgreSQL, and autocomplete results.
  * Corrected stale data, refresh behavior, type metadata, and active-query display.
* **Style**
  * Refined responsive layouts, toolbars, colors, focus states, and loading indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->