### PR TITLE
(MOT-4363) fix(harness): accept absolute workspace paths

### DIFF
--- a/harness/tests/e2e/src/scenarios/common.rs
+++ b/harness/tests/e2e/src/scenarios/common.rs
@@ -11,6 +11,12 @@ pub struct ObservedFunctionCall {
     pub arguments: Value,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct ObservedFunctionInvocation {
+    pub call_id: Option<String>,
+    pub call: ObservedFunctionCall,
+}
+
 pub fn final_response(transcript: &Value) -> String {
     transcript
         .get("messages")
@@ -35,6 +41,13 @@ pub fn final_response(transcript: &Value) -> String {
 }
 
 pub fn function_calls(transcript: &Value) -> Vec<ObservedFunctionCall> {
+    function_invocations(transcript)
+        .into_iter()
+        .map(|invocation| invocation.call)
+        .collect()
+}
+
+pub fn function_invocations(transcript: &Value) -> Vec<ObservedFunctionInvocation> {
     transcript
         .get("messages")
         .and_then(Value::as_array)
@@ -50,26 +63,53 @@ pub fn function_calls(transcript: &Value) -> Vec<ObservedFunctionCall> {
                 .flatten()
         })
         .filter(|block| block.get("type").and_then(Value::as_str) == Some("function_call"))
-        .filter_map(normalize_call)
+        .filter_map(normalize_invocation)
         .collect()
 }
 
-fn normalize_call(block: &Value) -> Option<ObservedFunctionCall> {
+fn normalize_invocation(block: &Value) -> Option<ObservedFunctionInvocation> {
+    let call_id = block.get("id").and_then(Value::as_str).map(str::to_owned);
     let function_id = block.get("function_id")?.as_str()?;
     let arguments = block.get("arguments").cloned().unwrap_or_else(|| json!({}));
     if function_id == "agent_trigger" {
-        return Some(ObservedFunctionCall {
-            function_id: arguments.get("function")?.as_str()?.to_string(),
-            arguments: arguments
-                .get("payload")
-                .cloned()
-                .unwrap_or_else(|| json!({})),
+        return Some(ObservedFunctionInvocation {
+            call_id,
+            call: ObservedFunctionCall {
+                function_id: arguments.get("function")?.as_str()?.to_string(),
+                arguments: arguments
+                    .get("payload")
+                    .cloned()
+                    .unwrap_or_else(|| json!({})),
+            },
         });
     }
-    Some(ObservedFunctionCall {
-        function_id: function_id.to_string(),
-        arguments,
+    Some(ObservedFunctionInvocation {
+        call_id,
+        call: ObservedFunctionCall {
+            function_id: function_id.to_string(),
+            arguments,
+        },
     })
+}
+
+pub fn function_result<'a>(
+    transcript: &'a Value,
+    invocation: &ObservedFunctionInvocation,
+) -> Option<&'a Value> {
+    let call_id = invocation.call_id.as_deref()?;
+    transcript
+        .get("messages")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| entry.get("message"))
+        .find(|message| {
+            message.get("role").and_then(Value::as_str) == Some("function_result")
+                && message.get("function_call_id").and_then(Value::as_str) == Some(call_id)
+                && message.get("function_id").and_then(Value::as_str)
+                    == Some(invocation.call.function_id.as_str())
+                && message.get("is_error").and_then(Value::as_bool) == Some(false)
+        })
 }
 
 pub fn gate(id: &str, passed: bool, reason: impl Into<String>) -> HardGateReport {
@@ -229,6 +269,7 @@ mod tests {
                     "content": [
                         {
                             "type": "function_call",
+                            "id": "call-state",
                             "function_id": "agent_trigger",
                             "arguments": {
                                 "function": "state::set",
@@ -237,6 +278,7 @@ mod tests {
                         },
                         {
                             "type": "function_call",
+                            "id": "call-native",
                             "function_id": "native::call",
                             "arguments": { "value": 2 }
                         }
@@ -248,6 +290,45 @@ mod tests {
         assert_eq!(calls[0].function_id, "state::set");
         assert_eq!(calls[0].arguments["key"], "k");
         assert_eq!(calls[1].function_id, "native::call");
+    }
+
+    #[test]
+    fn correlates_a_function_result_with_its_call_id() {
+        let transcript = json!({
+            "messages": [
+                {"message": {"role": "assistant", "content": [{
+                    "type": "function_call",
+                    "id": "call-match",
+                    "function_id": "agent_trigger",
+                    "arguments": {
+                        "function": "state::set",
+                        "payload": { "scope": "s", "key": "k", "value": 1 }
+                    }
+                }]}},
+                {"message": {
+                    "role": "function_result",
+                    "function_call_id": "call-other",
+                    "function_id": "state::set",
+                    "is_error": false,
+                    "details": { "ok": false }
+                }},
+                {"message": {
+                    "role": "function_result",
+                    "function_call_id": "call-match",
+                    "function_id": "state::set",
+                    "is_error": false,
+                    "details": { "ok": true }
+                }}
+            ]
+        });
+        let invocations = function_invocations(&transcript);
+        let result = function_result(&transcript, &invocations[0]).expect("matching result");
+
+        assert_eq!(invocations[0].call_id.as_deref(), Some("call-match"));
+        assert_eq!(
+            result.pointer("/details/ok").and_then(Value::as_bool),
+            Some(true)
+        );
     }
 
     #[test]

--- a/harness/tests/e2e/src/scenarios/shell_coder_sandbox.rs
+++ b/harness/tests/e2e/src/scenarios/shell_coder_sandbox.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use anyhow::bail;
 use serde_json::{json, Value};
@@ -113,7 +113,11 @@ fn evaluate<'a>(
     run_id: &'a str,
 ) -> EvaluationFuture<'a> {
     Box::pin(async move {
-        let calls = common::function_calls(&observation.transcript);
+        let invocations = common::function_invocations(&observation.transcript);
+        let calls = invocations
+            .iter()
+            .map(|invocation| invocation.call.clone())
+            .collect::<Vec<_>>();
         let installed_shell = calls.iter().any(|call| is_registry_install(call, "shell"));
         let installed_sandbox = calls
             .iter()
@@ -125,11 +129,12 @@ fn evaluate<'a>(
         let surfaces_ready = shell_surface_ready && coder_surface_ready && sandbox_surface_ready;
         let worker_setup = installed_shell && installed_sandbox && surfaces_ready;
 
+        let root = workspace_root(run_id);
         let coder_info = calls.iter().any(|call| call.function_id == "coder::info");
-        let coder_create = calls.iter().any(is_exact_create);
-        let coder_update = calls.iter().any(is_exact_update);
-        let coder_move = calls.iter().any(is_exact_move);
-        let coder_read = calls.iter().any(is_exact_read);
+        let coder_create = calls.iter().any(|call| is_exact_create(call, &root));
+        let coder_update = calls.iter().any(|call| is_exact_update(call, &root));
+        let coder_move = calls.iter().any(|call| is_exact_move(call, &root));
+        let coder_read = calls.iter().any(|call| is_exact_read(call, &root));
         let coder_ordered = calls_are_ordered(
             &calls,
             &[
@@ -140,13 +145,33 @@ fn evaluate<'a>(
                 "coder::read-file",
             ],
         );
-        let coder_results_succeeded =
-            batch_result_succeeded(&observation.transcript, "coder::create-file")
-                && batch_result_succeeded(&observation.transcript, "coder::update-file")
-                && batch_result_succeeded(&observation.transcript, "coder::move")
-                && successful_coder_read(&observation.transcript);
+        let coder_results_succeeded = correlated_call_succeeded(
+            &observation.transcript,
+            &invocations,
+            |call| call.function_id == "coder::info",
+            |_| true,
+        ) && correlated_call_succeeded(
+            &observation.transcript,
+            &invocations,
+            |call| is_exact_create(call, &root),
+            batch_result_succeeded,
+        ) && correlated_call_succeeded(
+            &observation.transcript,
+            &invocations,
+            |call| is_exact_update(call, &root),
+            batch_result_succeeded,
+        ) && correlated_call_succeeded(
+            &observation.transcript,
+            &invocations,
+            |call| is_exact_move(call, &root),
+            batch_result_succeeded,
+        ) && correlated_call_succeeded(
+            &observation.transcript,
+            &invocations,
+            |call| is_exact_read(call, &root),
+            successful_coder_read,
+        );
 
-        let root = workspace_root(run_id);
         let draft_path = root.join(DRAFT_NAME);
         let final_path = root.join(FINAL_NAME);
         let final_read = std::fs::read_to_string(&final_path);
@@ -164,8 +189,13 @@ fn evaluate<'a>(
             && final_matches
             && draft_removed;
 
-        let host_exec = calls.iter().any(is_exact_host_exec);
-        let host_output = successful_output(&observation.transcript, "shell::exec", HOST_STDOUT);
+        let host_exec = calls.iter().any(|call| is_exact_host_exec(call, &root));
+        let host_output = correlated_call_succeeded(
+            &observation.transcript,
+            &invocations,
+            |call| is_exact_host_exec(call, &root),
+            |result| successful_output_result(result, HOST_STDOUT),
+        );
         let host_execution = host_exec && host_output;
 
         let expected_sandbox_name = sandbox_name(run_id);
@@ -302,13 +332,15 @@ fn is_registry_install(call: &common::ObservedFunctionCall, worker: &str) -> boo
             == Some(worker)
 }
 
-fn is_exact_create(call: &common::ObservedFunctionCall) -> bool {
+fn is_exact_create(call: &common::ObservedFunctionCall, root: &Path) -> bool {
     call.function_id == "coder::create-file"
-        && call
-            .arguments
-            .pointer("/files/0/path")
-            .and_then(Value::as_str)
-            == Some(DRAFT_NAME)
+        && workspace_path_matches(
+            call.arguments
+                .pointer("/files/0/path")
+                .and_then(Value::as_str),
+            root,
+            DRAFT_NAME,
+        )
         && call
             .arguments
             .pointer("/files/0/content")
@@ -321,13 +353,15 @@ fn is_exact_create(call: &common::ObservedFunctionCall) -> bool {
             .is_some_and(|files| files.len() == 1)
 }
 
-fn is_exact_update(call: &common::ObservedFunctionCall) -> bool {
+fn is_exact_update(call: &common::ObservedFunctionCall, root: &Path) -> bool {
     call.function_id == "coder::update-file"
-        && call
-            .arguments
-            .pointer("/files/0/path")
-            .and_then(Value::as_str)
-            == Some(DRAFT_NAME)
+        && workspace_path_matches(
+            call.arguments
+                .pointer("/files/0/path")
+                .and_then(Value::as_str),
+            root,
+            DRAFT_NAME,
+        )
         && call
             .arguments
             .pointer("/files/0/ops")
@@ -340,18 +374,22 @@ fn is_exact_update(call: &common::ObservedFunctionCall) -> bool {
             .is_some_and(|files| files.len() == 1)
 }
 
-fn is_exact_move(call: &common::ObservedFunctionCall) -> bool {
+fn is_exact_move(call: &common::ObservedFunctionCall, root: &Path) -> bool {
     call.function_id == "coder::move"
-        && call
-            .arguments
-            .pointer("/files/0/from")
-            .and_then(Value::as_str)
-            == Some(DRAFT_NAME)
-        && call
-            .arguments
-            .pointer("/files/0/to")
-            .and_then(Value::as_str)
-            == Some(FINAL_NAME)
+        && workspace_path_matches(
+            call.arguments
+                .pointer("/files/0/from")
+                .and_then(Value::as_str),
+            root,
+            DRAFT_NAME,
+        )
+        && workspace_path_matches(
+            call.arguments
+                .pointer("/files/0/to")
+                .and_then(Value::as_str),
+            root,
+            FINAL_NAME,
+        )
         && call
             .arguments
             .get("files")
@@ -359,13 +397,17 @@ fn is_exact_move(call: &common::ObservedFunctionCall) -> bool {
             .is_some_and(|files| files.len() == 1)
 }
 
-fn is_exact_read(call: &common::ObservedFunctionCall) -> bool {
+fn is_exact_read(call: &common::ObservedFunctionCall, root: &Path) -> bool {
     call.function_id == "coder::read-file"
-        && call.arguments.get("path").and_then(Value::as_str) == Some(FINAL_NAME)
+        && workspace_path_matches(
+            call.arguments.get("path").and_then(Value::as_str),
+            root,
+            FINAL_NAME,
+        )
         && call.arguments.get("paths").is_none()
 }
 
-fn is_exact_host_exec(call: &common::ObservedFunctionCall) -> bool {
+fn is_exact_host_exec(call: &common::ObservedFunctionCall, root: &Path) -> bool {
     let host_target = call.arguments.get("target").is_none()
         || call
             .arguments
@@ -381,8 +423,45 @@ fn is_exact_host_exec(call: &common::ObservedFunctionCall) -> bool {
         .arguments
         .get("args")
         .and_then(Value::as_array)
-        .is_some_and(|args| args.iter().any(|arg| arg.as_str() == Some(FINAL_NAME)));
+        .is_some_and(|args| {
+            args.iter()
+                .any(|arg| workspace_path_matches(arg.as_str(), root, FINAL_NAME))
+        });
     call.function_id == "shell::exec" && host_target && python && final_arg
+}
+
+fn workspace_path_matches(value: Option<&str>, root: &Path, expected: &str) -> bool {
+    let Some(value) = value else {
+        return false;
+    };
+    let path = Path::new(value);
+    let resolved = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    };
+
+    let Some(resolved) = normalize_workspace_path(&resolved) else {
+        return false;
+    };
+    let Some(expected) = normalize_workspace_path(&root.join(expected)) else {
+        return false;
+    };
+    resolved == expected
+}
+
+fn normalize_workspace_path(path: &Path) -> Option<PathBuf> {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => return None,
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+    Some(normalized)
 }
 
 fn calls_are_ordered(calls: &[common::ObservedFunctionCall], required: &[&str]) -> bool {
@@ -397,6 +476,20 @@ fn calls_are_ordered(calls: &[common::ObservedFunctionCall], required: &[&str]) 
         next += offset + 1;
     }
     true
+}
+
+fn correlated_call_succeeded(
+    transcript: &Value,
+    invocations: &[common::ObservedFunctionInvocation],
+    call_matches: impl Fn(&common::ObservedFunctionCall) -> bool,
+    result_matches: impl Fn(&Value) -> bool,
+) -> bool {
+    invocations
+        .iter()
+        .filter(|invocation| call_matches(&invocation.call))
+        .any(|invocation| {
+            common::function_result(transcript, invocation).is_some_and(&result_matches)
+        })
 }
 
 fn function_results<'a>(transcript: &'a Value, function_id: &'a str) -> Vec<&'a Value> {
@@ -414,51 +507,45 @@ fn function_results<'a>(transcript: &'a Value, function_id: &'a str) -> Vec<&'a 
         .collect()
 }
 
-fn batch_result_succeeded(transcript: &Value, function_id: &str) -> bool {
-    function_results(transcript, function_id)
-        .into_iter()
-        .any(|message| {
-            message
-                .pointer("/details/results")
-                .and_then(Value::as_array)
-                .is_some_and(|results| {
-                    !results.is_empty()
-                        && results.iter().all(|result| {
-                            result.get("success").and_then(Value::as_bool) == Some(true)
-                        })
-                })
+fn batch_result_succeeded(message: &Value) -> bool {
+    message
+        .pointer("/details/results")
+        .and_then(Value::as_array)
+        .is_some_and(|results| {
+            !results.is_empty()
+                && results
+                    .iter()
+                    .all(|result| result.get("success").and_then(Value::as_bool) == Some(true))
         })
 }
 
-fn successful_coder_read(transcript: &Value) -> bool {
-    function_results(transcript, "coder::read-file")
-        .into_iter()
-        .any(|message| {
-            message.pointer("/details/content").and_then(Value::as_str) == Some(FINAL_SCRIPT)
-        })
+fn successful_coder_read(message: &Value) -> bool {
+    message.pointer("/details/content").and_then(Value::as_str) == Some(FINAL_SCRIPT)
 }
 
 fn successful_output(transcript: &Value, function_id: &str, expected: &str) -> bool {
     function_results(transcript, function_id)
         .into_iter()
-        .any(|message| {
-            message
-                .pointer("/details/exit_code")
-                .and_then(Value::as_i64)
-                == Some(0)
-                && message
-                    .pointer("/details/stdout")
-                    .and_then(Value::as_str)
-                    .is_some_and(|stdout| stdout.trim() == expected)
-                && message
-                    .pointer("/details/stderr")
-                    .and_then(Value::as_str)
-                    .is_some_and(|stderr| stderr.trim().is_empty())
-                && message
-                    .pointer("/details/timed_out")
-                    .and_then(Value::as_bool)
-                    != Some(true)
-        })
+        .any(|message| successful_output_result(message, expected))
+}
+
+fn successful_output_result(message: &Value, expected: &str) -> bool {
+    message
+        .pointer("/details/exit_code")
+        .and_then(Value::as_i64)
+        == Some(0)
+        && message
+            .pointer("/details/stdout")
+            .and_then(Value::as_str)
+            .is_some_and(|stdout| stdout.trim() == expected)
+        && message
+            .pointer("/details/stderr")
+            .and_then(Value::as_str)
+            .is_some_and(|stderr| stderr.trim().is_empty())
+        && message
+            .pointer("/details/timed_out")
+            .and_then(Value::as_bool)
+            != Some(true)
 }
 
 #[derive(Debug, Default)]
@@ -741,6 +828,145 @@ mod tests {
     }
 
     #[test]
+    fn workspace_paths_accept_relative_and_absolute_equivalents() {
+        let root = Path::new("/tmp/e2e-shell-coder/workspace");
+
+        assert!(workspace_path_matches(Some(DRAFT_NAME), root, DRAFT_NAME));
+        assert!(workspace_path_matches(
+            Some("./draft_check.py"),
+            root,
+            DRAFT_NAME
+        ));
+        assert!(workspace_path_matches(
+            root.join(DRAFT_NAME).to_str(),
+            root,
+            DRAFT_NAME
+        ));
+        assert!(workspace_path_matches(
+            root.join(FINAL_NAME).to_str(),
+            root,
+            FINAL_NAME
+        ));
+    }
+
+    #[test]
+    fn workspace_paths_reject_other_targets_and_parent_traversal() {
+        let root = Path::new("/tmp/e2e-shell-coder/workspace");
+
+        assert!(!workspace_path_matches(
+            Some("other/draft_check.py"),
+            root,
+            DRAFT_NAME
+        ));
+        assert!(!workspace_path_matches(
+            Some("checks/../checks/check.py"),
+            root,
+            FINAL_NAME
+        ));
+        assert!(!workspace_path_matches(
+            Some("../workspace/draft_check.py"),
+            root,
+            DRAFT_NAME
+        ));
+        assert!(!workspace_path_matches(
+            Some("/tmp/e2e-shell-coder/outside/draft_check.py"),
+            root,
+            DRAFT_NAME
+        ));
+        assert!(!workspace_path_matches(None, root, DRAFT_NAME));
+    }
+
+    #[test]
+    fn exact_operations_accept_absolute_workspace_paths() {
+        let root = Path::new("/tmp/e2e-shell-coder/workspace");
+        let draft = root.join(DRAFT_NAME).to_string_lossy().into_owned();
+        let final_path = root.join(FINAL_NAME).to_string_lossy().into_owned();
+        let create = observed_call(
+            "coder::create-file",
+            json!({ "files": [{ "path": draft.clone(), "content": DRAFT_SCRIPT }] }),
+        );
+        let update = observed_call(
+            "coder::update-file",
+            json!({ "files": [{ "path": draft.clone(), "ops": [{ "op": "update_lines" }] }] }),
+        );
+        let move_call = observed_call(
+            "coder::move",
+            json!({ "files": [{ "from": draft, "to": final_path.clone() }] }),
+        );
+        let read = observed_call("coder::read-file", json!({ "path": final_path.clone() }));
+        let host = observed_call(
+            "shell::exec",
+            json!({ "command": "python3", "args": [final_path] }),
+        );
+
+        assert!(is_exact_create(&create, root));
+        assert!(is_exact_update(&update, root));
+        assert!(is_exact_move(&move_call, root));
+        assert!(is_exact_read(&read, root));
+        assert!(is_exact_host_exec(&host, root));
+    }
+
+    #[test]
+    fn exact_call_requires_its_own_successful_result() {
+        let root = Path::new("/tmp/e2e-shell-coder/workspace");
+        let transcript = json!({
+            "messages": [
+                invocation(
+                    "call-create",
+                    "coder::create-file",
+                    json!({ "files": [{
+                        "path": root.join(DRAFT_NAME).to_string_lossy(),
+                        "content": DRAFT_SCRIPT
+                    }] }),
+                ),
+                correlated_result(
+                    "call-other",
+                    "coder::create-file",
+                    false,
+                    json!({ "results": [{ "success": true }] }),
+                )
+            ]
+        });
+        let invocations = common::function_invocations(&transcript);
+
+        assert!(invocations
+            .iter()
+            .any(|invocation| is_exact_create(&invocation.call, root)));
+        assert!(!correlated_call_succeeded(
+            &transcript,
+            &invocations,
+            |call| is_exact_create(call, root),
+            batch_result_succeeded,
+        ));
+
+        let transcript = json!({
+            "messages": [
+                invocation(
+                    "call-create",
+                    "coder::create-file",
+                    json!({ "files": [{
+                        "path": root.join(DRAFT_NAME).to_string_lossy(),
+                        "content": DRAFT_SCRIPT
+                    }] }),
+                ),
+                correlated_result(
+                    "call-create",
+                    "coder::create-file",
+                    false,
+                    json!({ "results": [{ "success": true }] }),
+                )
+            ]
+        });
+        let invocations = common::function_invocations(&transcript);
+        assert!(correlated_call_succeeded(
+            &transcript,
+            &invocations,
+            |call| is_exact_create(call, root),
+            batch_result_succeeded,
+        ));
+    }
+
+    #[test]
     fn recognizes_successful_sandbox_lifecycle() {
         let name = "e2e-shell-coder-1234567890ab";
         let id = "sandbox-1";
@@ -821,6 +1047,48 @@ mod tests {
                 "role": "function_result",
                 "function_id": function_id,
                 "is_error": false,
+                "details": details,
+                "content": []
+            }
+        })
+    }
+
+    fn observed_call(function_id: &str, arguments: Value) -> common::ObservedFunctionCall {
+        common::ObservedFunctionCall {
+            function_id: function_id.into(),
+            arguments,
+        }
+    }
+
+    fn invocation(call_id: &str, function_id: &str, payload: Value) -> Value {
+        json!({
+            "message": {
+                "role": "assistant",
+                "content": [{
+                    "type": "function_call",
+                    "id": call_id,
+                    "function_id": "agent_trigger",
+                    "arguments": {
+                        "function": function_id,
+                        "payload": payload
+                    }
+                }]
+            }
+        })
+    }
+
+    fn correlated_result(
+        call_id: &str,
+        function_id: &str,
+        is_error: bool,
+        details: Value,
+    ) -> Value {
+        json!({
+            "message": {
+                "role": "function_result",
+                "function_call_id": call_id,
+                "function_id": function_id,
+                "is_error": is_error,
                 "details": details,
                 "content": []
             }


### PR DESCRIPTION
## Summary

- treat relative and absolute paths inside the scenario workspace as equivalent for exact Coder and host execution gates
- reject parent traversal and paths outside the run-owned workspace
- correlate matched Coder and host calls with their own results through `function_call_id`
- add regression coverage for absolute paths, traversal, outside targets, and mismatched results

## Why

The `shell_coder_sandbox` evaluator compared raw path strings with relative filenames. The DeepSeek V4 Flash daily execution completed the required file workflow with absolute in-workspace paths, but the evaluator reported a hard-gate failure despite the exact final file and successful outputs.

## Impact

Valid workflows no longer fail solely because they use an absolute workspace path. A successful result from an unrelated invocation can no longer satisfy the affected Coder or host gate. The scenario prompt, score weights, threshold, and hard-gate policy remain unchanged.

## Validation

- `cargo fmt --manifest-path harness/Cargo.toml --all -- --check`
- `cargo test --locked --manifest-path harness/Cargo.toml -p harness-e2e` (91 passed)
- `cargo clippy --locked --manifest-path harness/Cargo.toml -p harness-e2e -- -D warnings`
- confirmed all six affected calls in each retained failing run have a result with the same call ID and function ID

Fixes MOT-4363
Refs MOT-4279


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved function-call result matching for more reliable operation tracking.
  * Added validation for relative and absolute workspace paths while rejecting unsafe traversal and unrelated targets.
  * Strengthened checks for successful batch operations, exact file reads, and non-timeout command output.

* **Tests**
  * Expanded end-to-end coverage for path normalization, result correlation, and transcript handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->