### PR TITLE
(MOT-4364) fix(shell): anchor coder::search matching at the session scope

### DIFF
--- a/shell/src/code/functions/info.rs
+++ b/shell/src/code/functions/info.rs
@@ -16,7 +16,14 @@ use crate::code::path::PathResolver;
 // examples are wire-contract; goldens pin them.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 #[schemars(example = "example_info_input")]
-pub struct InfoInput {}
+pub struct InfoInput {
+    /// Internal harness filesystem scope; omitted from published schema.
+    /// Echoed back as `session_root` so a caller whose path was rejected
+    /// learns the anchor its relative paths ACTUALLY resolve against.
+    #[serde(default)]
+    #[schemars(skip)]
+    pub fs_scope: Option<crate::fs::FsScope>,
+}
 
 // examples are wire-contract; goldens pin them.
 fn example_info_input() -> serde_json::Value {
@@ -52,8 +59,18 @@ pub struct InfoOutput {
     pub base_paths: Vec<String>,
 
     /// Convenience duplicate of `base_paths[0]` — the primary allowed root.
-    /// Relative paths resolve against this directory.
+    /// Relative paths resolve against this directory UNLESS `session_root`
+    /// is set, which takes precedence.
     pub primary_root: String,
+
+    /// The session's working directory when the caller runs under a
+    /// harness-stamped filesystem scope; `null` otherwise. When set, THIS
+    /// is what relative wire paths (and `coder::search` glob matching)
+    /// anchor against — not `primary_root`. In `unjailed` mode it may sit
+    /// outside every `base_paths` entry, so a relative path that looks
+    /// wrong against the allowed roots can still be correct here. Check it
+    /// first when a relative path was rejected.
+    pub session_root: Option<String>,
 
     /// Glob patterns matched per root (root-relative). Files whose
     /// root-relative path matches are listable but not
@@ -136,21 +153,28 @@ pub struct InfoOutput {
 pub async fn handle(
     resolver: Arc<PathResolver>,
     cfg: Arc<CoderConfig>,
+    req: InfoInput,
 ) -> Result<InfoOutput, String> {
     // info canonicalizes the configured roots (fs), so keep it off the executor
     // for consistency with the other read handlers.
-    tokio::task::spawn_blocking(move || Ok(inner(&resolver, &cfg)))
+    tokio::task::spawn_blocking(move || Ok(inner(&resolver, &cfg, &req)))
         .await
         .map_err(|e| format!("info task join failed: {e}"))?
 }
 
-fn inner(resolver: &PathResolver, cfg: &CoderConfig) -> InfoOutput {
+fn inner(resolver: &PathResolver, cfg: &CoderConfig, req: &InfoInput) -> InfoOutput {
     let base_paths: Vec<String> = resolver
         .roots()
         .iter()
         .map(|p| p.display().to_string())
         .collect();
     let primary_root = base_paths[0].clone();
+    // Canonicalized through the same gate the path resolution uses, so a
+    // scope this worker would reject is reported as absent rather than as a
+    // usable anchor.
+    let session_root = crate::fs::scope_anchor(req.fs_scope.as_ref())
+        .and_then(|root| resolver.session_root(root))
+        .map(|p| p.display().to_string());
 
     InfoOutput {
         mode: if resolver.unjailed() {
@@ -160,6 +184,7 @@ fn inner(resolver: &PathResolver, cfg: &CoderConfig) -> InfoOutput {
         },
         base_paths,
         primary_root,
+        session_root,
         non_accessible_globs: cfg.non_accessible_globs.clone(),
         default_exclude_globs: cfg.default_exclude_globs.clone(),
         max_read_bytes: cfg.max_read_bytes,
@@ -206,7 +231,7 @@ mod tests {
         let non_canon = tmp.path().join(".");
         let (resolver, cfg) = make_resolver_cfg(vec![non_canon], vec![]);
 
-        let out = inner(&resolver, &cfg);
+        let out = inner(&resolver, &cfg, &InfoInput::default());
 
         let expected_canon = std::fs::canonicalize(tmp.path())
             .unwrap()
@@ -248,7 +273,7 @@ mod tests {
         });
         let resolver = Arc::new(PathResolver::new(&cfg).unwrap());
 
-        let out = inner(&resolver, &cfg);
+        let out = inner(&resolver, &cfg, &InfoInput::default());
 
         // primary_root == base_paths[0]
         assert!(!out.base_paths.is_empty());
@@ -277,5 +302,45 @@ mod tests {
 
         // version
         assert_eq!(out.version, env!("CARGO_PKG_VERSION"));
+    }
+
+    /// The harness-stamped session scope is what relative paths anchor
+    /// against, and in unjailed mode it can sit outside every allowed root.
+    /// Reporting only `primary_root` sends a caller whose relative path was
+    /// rejected hunting in the wrong tree — the whole point of this call.
+    #[test]
+    fn reports_session_root_when_scoped() {
+        let roots = tempdir().unwrap();
+        let scope = tempdir().unwrap();
+        let cfg = Arc::new(CoderConfig {
+            base_paths: vec![roots.path().to_path_buf()],
+            unjailed: true,
+            ..CoderConfig::default()
+        });
+        let resolver = Arc::new(PathResolver::new(&cfg).unwrap());
+        let req = InfoInput {
+            fs_scope: Some(crate::fs::FsScope {
+                root: scope.path().display().to_string(),
+                grants: vec![],
+                boundary: crate::fs::FsBoundary::ConfiguredRoots,
+            }),
+        };
+
+        let out = inner(&resolver, &cfg, &req);
+
+        let expected = std::fs::canonicalize(scope.path())
+            .unwrap()
+            .display()
+            .to_string();
+        assert_eq!(out.session_root.as_deref(), Some(expected.as_str()));
+        assert_ne!(
+            out.session_root.as_deref(),
+            Some(out.primary_root.as_str()),
+            "the scope this test pins must differ from the configured anchor"
+        );
+
+        // Unscoped callers keep the old contract: null, anchor is primary_root.
+        let unscoped = inner(&resolver, &cfg, &InfoInput::default());
+        assert_eq!(unscoped.session_root, None);
     }
 }

--- a/shell/src/code/functions/mod.rs
+++ b/shell/src/code/functions/mod.rs
@@ -41,7 +41,10 @@ const INFO_ID: &str = "coder::info";
 const INFO_DESC: &str = "Report the coder access contract: the effective mode (jailed = \
      paths confined to the allowed roots; unjailed = deny-only, absolute \
      paths anywhere on the host, roots anchor relative paths only), \
-     canonical allowed roots (primary first), per-file size caps, \
+     canonical allowed roots (primary first), the session_root that \
+     relative paths actually anchor against when the session is scoped \
+     (it overrides primary_root and may sit outside every allowed root), \
+     per-file size caps, \
      response budgets (max_output_bytes, batch_read_budget_bytes, \
      search_response_budget_bytes), listing/search limits, the \
      non-accessible glob patterns, and the default_exclude_globs noise \
@@ -272,12 +275,12 @@ pub fn register_all(iii: &IIIClient, cells: CodeCells) {
 fn register_info(iii: &IIIClient, cells: CodeCells) {
     iii.register_function(
         INFO_ID,
-        RegisterFunction::new_async(move |_req: info::InfoInput| {
+        RegisterFunction::new_async(move |req: info::InfoInput| {
             let cells = cells.clone();
             async move {
                 let resolver = cells.resolver.read().await.clone();
                 let cfg = cells.config.read().await.clone();
-                info::handle(resolver, cfg).await.map_err(Error::from)
+                info::handle(resolver, cfg, req).await.map_err(Error::from)
             }
         })
         .description(INFO_DESC),

--- a/shell/src/code/functions/search.rs
+++ b/shell/src/code/functions/search.rs
@@ -49,8 +49,9 @@ pub struct SearchInput {
     #[serde(default)]
     pub ignore_case: bool,
     /// Glob patterns (matched against the path relative to its containing
-    /// root) that paths must match to be considered. Empty = include
-    /// everything.
+    /// root — or, for a walk root outside every configured root, relative
+    /// to the session directory `coder::info` reports as `session_root`)
+    /// that paths must match to be considered. Empty = include everything.
     #[serde(default)]
     pub include_globs: Vec<String>,
     /// Glob patterns (same relative-to-root matching) that exclude paths.
@@ -206,6 +207,18 @@ fn inner(
         )));
     }
 
+    // Glob/path matching runs on the form relative to the CONTAINING root.
+    // In unjailed mode the walk root can sit outside every configured root
+    // (the harness stamps a session scope anywhere on the host), where no
+    // root-relative form exists — every entry would be dropped and the
+    // search would return a false empty. Fall back to the same anchor that
+    // resolved the wire path: the session scope when it contains the walk
+    // root, else the walk root itself.
+    let match_anchor = crate::fs::scope_anchor(req.fs_scope.as_ref())
+        .and_then(|root| resolver.session_root(root))
+        .filter(|scope| walk_root.starts_with(scope))
+        .unwrap_or_else(|| walk_root.clone());
+
     let include = build_globset(&req.include_globs)?;
     let exclude = build_globset(&req.exclude_globs)?;
 
@@ -254,7 +267,10 @@ fn inner(
             continue;
         }
         let abs = entry.path();
-        let Some(rel) = resolver.relative(abs) else {
+        let Some(rel) = resolver
+            .relative(abs)
+            .or_else(|| relative_to(&match_anchor, abs))
+        else {
             continue;
         };
         if rel.is_empty() {
@@ -415,6 +431,17 @@ fn clip_line(line: &str, max_line_bytes: usize) -> &str {
         end -= 1;
     }
     &line[..end]
+}
+
+/// `abs` relative to `anchor` as a forward-slash string — the fallback
+/// matching form for entries that live outside every configured root, where
+/// `PathResolver::relative` has no root to strip. `None` when `abs` isn't
+/// under `anchor` (the entry has no expressible relative form and is
+/// skipped, as before).
+fn relative_to(anchor: &std::path::Path, abs: &std::path::Path) -> Option<String> {
+    abs.strip_prefix(anchor)
+        .ok()
+        .map(|p| p.to_string_lossy().replace('\\', "/"))
 }
 
 /// Charge `cost` wire bytes against the remaining response budget.
@@ -1423,5 +1450,122 @@ mod tests {
         assert_eq!(out.content_matches.len(), 1);
         assert_eq!(out.content_matches[0].text, "ab");
         assert!(!out.truncated);
+    }
+
+    /// Unjailed jail whose configured root is a SIBLING of the session
+    /// scope — the shape a console session gets when the harness stamps a
+    /// working directory outside the worker's own configured roots.
+    fn setup_scoped() -> (
+        tempfile::TempDir,
+        tempfile::TempDir,
+        Arc<PathResolver>,
+        Arc<CoderConfig>,
+    ) {
+        let roots = tempdir().unwrap();
+        let scope = tempdir().unwrap();
+        let cfg = Arc::new(CoderConfig {
+            base_paths: vec![roots.path().to_path_buf()],
+            non_accessible_globs: vec!["**/.env".to_string()],
+            unjailed: true,
+            max_read_bytes: 1024 * 1024,
+            search_default_max_matches: 1000,
+            search_default_max_line_bytes: 4096,
+            ..CoderConfig::default()
+        });
+        let resolver = Arc::new(PathResolver::new(&cfg).unwrap());
+        (roots, scope, resolver, cfg)
+    }
+
+    fn scoped_input(query: &str, scope: &tempfile::TempDir) -> SearchInput {
+        SearchInput {
+            fs_scope: Some(crate::fs::FsScope {
+                root: scope.path().display().to_string(),
+                grants: vec![],
+                boundary: crate::fs::FsBoundary::ConfiguredRoots,
+            }),
+            ..base_input(query)
+        }
+    }
+
+    /// REGRESSION: a session scoped outside every configured root walked
+    /// the right tree but had no root-relative form for any entry, so every
+    /// file was dropped — the search returned a FALSE EMPTY instead of
+    /// matches (and never an error, so the caller could not tell).
+    #[tokio::test]
+    async fn scope_outside_configured_roots_still_matches() {
+        let (_roots, scope, r, c) = setup_scoped();
+        std::fs::create_dir_all(scope.path().join("prompts")).unwrap();
+        std::fs::write(scope.path().join("prompts/subagent.txt"), "spawn agents\n").unwrap();
+        let out = handle(
+            r,
+            c,
+            SearchInput {
+                include_globs: vec!["**/*.txt".into()],
+                search_paths: true,
+                ..scoped_input("spawn", &scope)
+            },
+        )
+        .await
+        .unwrap();
+        let expected = std::fs::canonicalize(scope.path())
+            .unwrap()
+            .join("prompts/subagent.txt")
+            .display()
+            .to_string();
+        assert_eq!(out.content_matches.len(), 1, "content match dropped");
+        assert_eq!(out.content_matches[0].path, expected);
+        assert_eq!(out.path_matches.len(), 0);
+    }
+
+    /// The fallback anchor is the SESSION ROOT, not the walk root: an
+    /// include glob written relative to the session directory keeps working
+    /// when `path` narrows the walk to a subfolder — same semantics as a
+    /// root-relative glob inside a configured root (see the outline recipe).
+    #[tokio::test]
+    async fn scoped_include_globs_anchor_at_the_session_root() {
+        let (_roots, scope, r, c) = setup_scoped();
+        std::fs::create_dir_all(scope.path().join("src")).unwrap();
+        std::fs::write(scope.path().join("src/lib.rs"), "fn needle() {}\n").unwrap();
+        std::fs::write(scope.path().join("src/other.rs"), "fn needle() {}\n").unwrap();
+        let out = handle(
+            r,
+            c,
+            SearchInput {
+                path: "src".into(),
+                include_globs: vec!["src/lib.rs".into()],
+                ..scoped_input("needle", &scope)
+            },
+        )
+        .await
+        .unwrap();
+        let expected = std::fs::canonicalize(scope.path())
+            .unwrap()
+            .join("src/lib.rs")
+            .display()
+            .to_string();
+        assert_eq!(out.content_matches.len(), 1);
+        assert_eq!(out.content_matches[0].path, expected);
+    }
+
+    /// Non-accessible protection is unchanged by the fallback anchor:
+    /// secrets outside every configured root stay absent from both lists.
+    #[tokio::test]
+    async fn scoped_search_still_hides_non_accessible_files() {
+        let (_roots, scope, r, c) = setup_scoped();
+        std::fs::write(scope.path().join(".env"), "TOKEN=needle\n").unwrap();
+        std::fs::write(scope.path().join("ok.txt"), "needle\n").unwrap();
+        let out = handle(
+            r,
+            c,
+            SearchInput {
+                search_paths: true,
+                ..scoped_input("needle", &scope)
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.content_matches.len(), 1);
+        assert!(out.content_matches[0].path.ends_with("ok.txt"));
+        assert!(out.path_matches.is_empty());
     }
 }

--- a/shell/tests/common/world.rs
+++ b/shell/tests/common/world.rs
@@ -258,8 +258,10 @@ async fn call_direct(
 ) -> Result<Value, String> {
     match function_id {
         "coder::info" => {
-            let _input: info::InfoInput = decode_payload(payload)?;
-            serialize_result(info::handle(surface.resolver.clone(), surface.cfg.clone()).await)
+            let input: info::InfoInput = decode_payload(payload)?;
+            serialize_result(
+                info::handle(surface.resolver.clone(), surface.cfg.clone(), input).await,
+            )
         }
         "coder::create-file" => {
             let input = decode_payload(payload)?;

--- a/shell/tests/golden/schemas/coder.info.json
+++ b/shell/tests/golden/schemas/coder.info.json
@@ -1,5 +1,5 @@
 {
-  "description": "Report the coder access contract: the effective mode (jailed = paths confined to the allowed roots; unjailed = deny-only, absolute paths anywhere on the host, roots anchor relative paths only), canonical allowed roots (primary first), per-file size caps, response budgets (max_output_bytes, batch_read_budget_bytes, search_response_budget_bytes), listing/search limits, the non-accessible glob patterns, and the default_exclude_globs noise filter applied by tree/search. Call this FIRST when unsure where coder may read or write, or when a path was rejected — in jailed mode, paths outside every allowed root need the shell worker's shell::fs::* instead.",
+  "description": "Report the coder access contract: the effective mode (jailed = paths confined to the allowed roots; unjailed = deny-only, absolute paths anywhere on the host, roots anchor relative paths only), canonical allowed roots (primary first), the session_root that relative paths actually anchor against when the session is scoped (it overrides primary_root and may sit outside every allowed root), per-file size caps, response budgets (max_output_bytes, batch_read_budget_bytes, search_response_budget_bytes), listing/search limits, the non-accessible glob patterns, and the default_exclude_globs noise filter applied by tree/search. Call this FIRST when unsure where coder may read or write, or when a path was rejected — in jailed mode, paths outside every allowed root need the shell worker's shell::fs::* instead.",
   "function_id": "coder::info",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -100,7 +100,7 @@
         "type": "array"
       },
       "primary_root": {
-        "description": "Convenience duplicate of `base_paths[0]` — the primary allowed root. Relative paths resolve against this directory.",
+        "description": "Convenience duplicate of `base_paths[0]` — the primary allowed root. Relative paths resolve against this directory UNLESS `session_root` is set, which takes precedence.",
         "type": "string"
       },
       "search_default_max_line_bytes": {
@@ -120,6 +120,13 @@
         "format": "uint64",
         "minimum": 0.0,
         "type": "integer"
+      },
+      "session_root": {
+        "description": "The session's working directory when the caller runs under a harness-stamped filesystem scope; `null` otherwise. When set, THIS is what relative wire paths (and `coder::search` glob matching) anchor against — not `primary_root`. In `unjailed` mode it may sit outside every `base_paths` entry, so a relative path that looks wrong against the allowed roots can still be correct here. Check it first when a relative path was rejected.",
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "tree_default_depth": {
         "description": "Default `max_depth` used by `coder::tree` when the caller omits it.",

--- a/shell/tests/golden/schemas/coder.search.json
+++ b/shell/tests/golden/schemas/coder.search.json
@@ -51,7 +51,7 @@
       },
       "include_globs": {
         "default": [],
-        "description": "Glob patterns (matched against the path relative to its containing root) that paths must match to be considered. Empty = include everything.",
+        "description": "Glob patterns (matched against the path relative to its containing root — or, for a walk root outside every configured root, relative to the session directory `coder::info` reports as `session_root`) that paths must match to be considered. Empty = include everything.",
         "items": {
           "type": "string"
         },


### PR DESCRIPTION
Fixes MOT-4364.

## The bug

A session scoped outside every configured root — unjailed mode, harness `fs_scope` with boundary `configured_roots` — walked the right tree but dropped every entry. `coder::search` needs a root-relative form for glob and path matching and skips anything `PathResolver::relative` can't express:

```rust
let Some(rel) = resolver.relative(abs) else { continue };
```

`relative()` resolves through `containing_root()`, which only matches configured `base_paths`. The harness stamps `fs_scope` anywhere on the host, so under such a scope *every* file is skipped and the response is `{content_matches: [], path_matches: [], truncated: false}` — a false empty, never an error, so the caller can't tell.

Seen live in a console session scoped to `<worktree>/harness` with the worker rooted at `<worktree>/shell`: `coder::tree` returned the harness tree fine, while searches for `subagent` and `spawn` came back empty against files that plainly contain them.

## The fix

`search` falls back to the anchor that resolved the wire path — the session scope when it contains the walk root, else the walk root itself. Inside a configured root nothing changes. Access control is untouched: `is_non_accessible` already had its own unjailed fallback, so secrets outside the roots stay redacted (pinned by a test).

`coder::info` gains `session_root`, the anchor relative paths actually resolve against (`null` when unscoped). Reporting only `primary_root` sent a caller whose relative path was rejected hunting under the configured roots — the wrong tree whenever a scope is stamped, and that call is exactly what the rejection message tells you to make.

## Verification

- 3 new `search` tests (false empty, scope-anchored include globs, non-accessible redaction) + 1 `info` test. All 4 fail on the pre-fix code — confirmed by reverting the one-line guard and re-running.
- Full `shell` suite green: 15 test binaries, 0 failures. `cargo fmt --check` and `clippy --all-features --all-targets` clean.
- Golden schemas regenerated; `fs_scope` stays out of the published request schemas (`schemars(skip)`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added session-aware path information, including an optional canonical session root.
  - Search patterns now work correctly for paths outside configured roots while respecting access controls.

- **Documentation**
  - Updated command schemas to document session-root precedence and session-relative search patterns.

- **Tests**
  - Added coverage for scoped and unscoped session behavior, glob matching, and inaccessible file exclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->