### PR TITLE
fix(release): use pipeline scripts for candidate lock verification

### DIFF
--- a/.github/workflows/_candidate-smoke.yml
+++ b/.github/workflows/_candidate-smoke.yml
@@ -106,7 +106,7 @@ jobs:
           WORKER: ${{ inputs.worker }}
           VERSION: ${{ inputs.version }}
         run: |
-          python3 .github/scripts/verify_registry_lock.py \
+          python3 pipeline-scripts/.github/scripts/verify_registry_lock.py \
             --lock "$SMOKE_DIR/project/iii.lock" \
             --required "$WORKER" \
             --worker "$WORKER" \


### PR DESCRIPTION
## Summary

Use the pipeline checkout when verifying the registry lock during candidate smoke tests.

## Root cause

Alpha releases dispatch the current release workflow from `main` while building the worker source from the release tag. The lock verifier was invoked from the tag checkout, so alpha tags created before that script was added failed with `No such file or directory`. The workflow already checks out the current pipeline sources under `pipeline-scripts`; this change uses that copy consistently with the interface collector.

## Impact

Candidate validation can verify alpha releases created from feature branches even when their tags do not contain the latest release validation scripts.

## Validation

- Parsed `.github/workflows/_candidate-smoke.yml` with the workspace YAML parser
- Ran `git diff --check`
- Confirmed the referenced script exists in the `pipeline-scripts` checkout on `main`

`actionlint` could not be run because the container image registry timed out during download.
