### PR TITLE
fix(ci): retain exact Harness dependency pins

### DIFF
--- a/harness/tests/e2e/run-deployed-ci.sh
+++ b/harness/tests/e2e/run-deployed-ci.sh
@@ -344,16 +344,17 @@ add_with_retry() {
 log "Installing stable E2E support stack: ${workers[*]}"
 add_with_retry worker-add "${workers[@]}"
 
-# Bring the exact dependencies up first and the released worker last. For a
-# Harness candidate this prevents Harness from briefly booting against the
-# stable dependency graph before its candidate dependencies replace it.
+# Install the released worker first, then apply its exact candidate dependency
+# overrides. Resolving Harness necessarily selects the stable versions allowed
+# by its semver ranges; installing Harness last would overwrite the exact
+# dependency pins that Release Control supplied.
 while IFS=$'\t' read -r candidate_worker candidate_version; do
   log "Installing exact stack candidate: ${candidate_worker}@${candidate_version}"
   add_with_retry "candidate-${candidate_worker}" \
     "${candidate_worker}@${candidate_version}" --force
 done < <(jq -r --arg release_worker "$HARNESS_E2E_RELEASE_WORKER" '
   to_entries
-  | sort_by([if .key == $release_worker then 1 else 0 end, .key])[]
+  | sort_by([if .key == $release_worker then 0 else 1 end, .key])[]
   | [.key, .value]
   | @tsv
 ' <<<"$stack_versions")


### PR DESCRIPTION
## What changed

- install the exact Harness candidate before its exact dependency overrides
- leave the candidate dependency versions as the final entries in `iii.lock`

## Why

Resolving `harness@1.7.4` also resolves its semver dependency graph. Installing Harness after the dependency candidates replaced `iii-directory@1.1.2`, `llm-router@1.4.2`, and `shell@0.10.4` with their stable `latest` versions.

Installing Harness first and then applying the exact dependency map preserves the Release Control stack identity verified by `verify_registry_lock.py`.

## Validation

- reproduced the mismatch in deployed E2E run `31062606179`
- asserted the order `harness`, `iii-directory`, `llm-router`, `shell`
- `bash -n harness/tests/e2e/run-deployed-ci.sh`
- `git diff --check`
