### PR TITLE
(MOT-4366) Publish worker license metadata

### DIFF
--- a/.github/scripts/build_publish_payload.py
+++ b/.github/scripts/build_publish_payload.py
@@ -374,6 +374,7 @@ def build_payload(
         "readme": readme,
         "repo": repo_url,
         "description": meta.get("description", ""),
+        "license": meta.get("license", ""),
         "dependencies": normalize_dependencies(meta.get("dependencies")),
         "config": config,
         "functions": [

--- a/.github/scripts/tests/test_build_publish_payload.py
+++ b/.github/scripts/tests/test_build_publish_payload.py
@@ -24,6 +24,14 @@ def build_binary_payload(tmp_path: Path, manifest: str, **kwargs) -> dict[str, o
     )
 
 
+def test_manifest_license_is_published(tmp_path: Path) -> None:
+    payload = build_binary_payload(
+        tmp_path,
+        "name: smoke\nlicense: Apache-2.0\n",
+    )
+    assert payload["license"] == "Apache-2.0"
+
+
 def test_manifest_tags_are_normalized_validated_and_optional(tmp_path: Path) -> None:
     payload = build_binary_payload(
         tmp_path,

--- a/acp/iii.worker.yaml
+++ b/acp/iii.worker.yaml
@@ -3,6 +3,7 @@ name: acp
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: iii-acp
 description: Agent Client Protocol surface — stdio JSON-RPC, exposes iii agents as ACP sessions
 # Opt out of the interface boot smoke: acp is a stdio JSON-RPC worker that exits

--- a/approval-gate/iii.worker.yaml
+++ b/approval-gate/iii.worker.yaml
@@ -3,6 +3,7 @@ name: approval-gate
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: approval-gate
 tags: [approval, human-in-the-loop, permissions, policy, security]
 description: Policy and decision surface for human-held function calls — pre_trigger gate, pending inbox, per-session permission settings, and two notification trigger types.

--- a/bridge/iii.worker.yaml
+++ b/bridge/iii.worker.yaml
@@ -3,6 +3,7 @@ name: bridge
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: bridge
 tags: [bridge, remote, websocket, federation, engine]
 description: Bridge two iii engines — expose local functions on a remote engine and invoke/forward remote functions locally.

--- a/browser/iii.worker.yaml
+++ b/browser/iii.worker.yaml
@@ -3,6 +3,7 @@ name: browser
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: browser
 tags: [browser, chromium, automation, web, cdp]
 description: Interactive Chromium sessions on the iii bus. Navigate, act, read the page console, pick elements.

--- a/claude-code/iii.worker.yaml
+++ b/claude-code/iii.worker.yaml
@@ -3,6 +3,7 @@ name: claude-code
 language: javascript
 deploy: bundle
 manifest: package.json
+license: Apache-2.0
 tags: [coding-agent, claude, anthropic, cli, headless]
 description: Claude Code as an iii worker — claude::* functions run headless Claude Code turns, mirror raw messages onto claude::events, and stream AgentEvent frames onto agent::events.
 

--- a/codex/iii.worker.yaml
+++ b/codex/iii.worker.yaml
@@ -3,6 +3,7 @@ name: codex
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: codex
 tags: [coding-agent, openai, codex-cli, headless, agent]
 description: OpenAI Codex as an iii worker; codex::run/start/stop/status/sessions::list spawn the codex CLI for headless turns, mirror raw thread events onto codex::events, and stream AgentEvent frames onto agent::events.

--- a/computer/iii.worker.yaml
+++ b/computer/iii.worker.yaml
@@ -3,6 +3,7 @@ name: computer
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: computer
 tags: [computer-use, desktop, screenshot, gui, automation]
 description: Drive a full desktop on the iii bus. Start a session on the local machine, a sandboxed desktop, or a remote one, screenshot it, click and type by coordinate, and stream the live screen.

--- a/console/iii.worker.yaml
+++ b/console/iii.worker.yaml
@@ -3,6 +3,7 @@ name: console
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: console
 tags: [console, dashboard, ui, web, admin]
 description: Web console for iii — bundles the React UI and proxies the engine WebSocket on a single port.

--- a/context-manager/iii.worker.yaml
+++ b/context-manager/iii.worker.yaml
@@ -3,6 +3,7 @@ name: context-manager
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: context-manager
 tags: [context, tokens, compaction, pruning, llm]
 description: Turns a raw conversation history plus a target model into a model-ready context — token counting, function-result pruning, and history compaction.

--- a/cron/iii.worker.yaml
+++ b/cron/iii.worker.yaml
@@ -3,6 +3,7 @@ name: cron
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: cron
 tags: [cron, schedule, timer, job]
 description: Schedule functions with cron expressions - registers the `cron` trigger type.

--- a/database/iii.worker.yaml
+++ b/database/iii.worker.yaml
@@ -3,6 +3,7 @@ name: database
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: database
 tags: [sql, sqlite, postgres, mysql, db]
 description: Talk to PostgreSQL, MySQL, and SQLite from iii — query, execute, transactions, prepared statements, and change feeds.

--- a/devin/iii.worker.yaml
+++ b/devin/iii.worker.yaml
@@ -3,6 +3,7 @@ name: devin
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: devin
 tags: [coding-agent, devin, cloud, pr-review, agent]
 description: Devin CLI + API as an iii worker; devin::run/start/stop/status/sessions::list follow the agent-worker family and stream AgentEvent frames onto agent::events, devin::session::* wrap the Devin cloud session lifecycle, devin::pr-review::* exposes Devin's review surface, and devin::api reaches any Devin v1/v3 endpoint.

--- a/editor/iii.worker.yaml
+++ b/editor/iii.worker.yaml
@@ -3,6 +3,7 @@ name: editor
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: editor
 tags: [editor, diff, git, code, review]
 description: A shared code workspace — open buffers, a file tree, unified diffs, fuzzy find and conflict-safe saves that an agent and a person see the same view of, plus a console editor page.

--- a/email/iii.worker.yaml
+++ b/email/iii.worker.yaml
@@ -3,6 +3,7 @@ name: email
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: email
 tags: [email, smtp, imap, inbox, messaging]
 description: Email worker — SMTP send and real-time IMAP read with IDLE push (email::*).

--- a/eval/iii.worker.yaml
+++ b/eval/iii.worker.yaml
@@ -3,6 +3,7 @@ name: eval
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: eval
 tags: [evaluation, benchmark, prompt, system-prompt, ab-test]
 description: Compare prompt or system-prompt variants on the same model using durable harness runs and correctness-first reports.

--- a/fp/iii.worker.yaml
+++ b/fp/iii.worker.yaml
@@ -3,6 +3,7 @@ name: fp
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: fp
 tags: [fp, functional, pipeline, transform, lodash]
 description: Lodash-style value transforms (fp::get/pick/take/…) and fp::pipe — worker-side pipelines that move big values function→function without routing them through the model.

--- a/github/iii.worker.yaml
+++ b/github/iii.worker.yaml
@@ -3,6 +3,7 @@ name: github
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: github
 tags: [github, gh, git, pull-requests, issues, actions, releases]
 description: GitHub CLI (gh) as an iii worker — typed github::pr/issue/repo/run/workflow/release/search functions, github::exec argv passthrough, and github::api for any GitHub REST endpoint.

--- a/grok/iii.worker.yaml
+++ b/grok/iii.worker.yaml
@@ -3,6 +3,7 @@ name: grok
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: grok
 tags: [coding-agent, grok, xai, cli, headless]
 description: xAI Grok CLI as an iii worker; grok::run/start/stop/status/sessions::list spawn the grok CLI for headless turns, mirror raw streaming-json events onto grok::events, and stream AgentEvent frames onto agent::events.

--- a/harness/iii.worker.yaml
+++ b/harness/iii.worker.yaml
@@ -3,6 +3,7 @@ name: harness
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: harness
 tags: [agent, harness, loop, autonomous]
 description: Thin durable turn loop that wires session-manager, context-manager, and llm-router into an agent loop; spawns sub-agents as child sessions.

--- a/hermes/iii.worker.yaml
+++ b/hermes/iii.worker.yaml
@@ -3,6 +3,7 @@ name: hermes
 language: python
 deploy: image
 manifest: pyproject.toml
+license: Apache-2.0
 tags: [agent, messaging, chat, webhook, multi-channel]
 description: Hermes agent as an iii worker — hermes::run runs headless Hermes turns with the iii runtime context, hermes::send delivers to 27+ messaging platforms, and inbound platform/webhook deliveries are republished onto hermes::events for iii workers to react to.
 

--- a/http/iii.worker.yaml
+++ b/http/iii.worker.yaml
@@ -3,6 +3,7 @@ name: http
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: http
 tags: [http, rest, api, endpoint]
 description: Expose functions as HTTP endpoints — registers the `http` trigger type and serves matched routes.

--- a/iii-directory/iii.worker.yaml
+++ b/iii-directory/iii.worker.yaml
@@ -3,6 +3,7 @@ name: iii-directory
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: iii-directory
 tags: [introspect, registry, skills, directory]
 description: Engine introspection (functions / triggers / workers), workers registry proxy, and filesystem-backed skill + prompt reader.

--- a/image-resize/iii.worker.yaml
+++ b/image-resize/iii.worker.yaml
@@ -3,6 +3,7 @@ name: image-resize
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: image-resize
 tags: [image, resize, jpeg, png, webp, media]
 description: III engine image resize worker (JPEG/PNG/WebP, EXIF orient, scale-to-fit / crop-to-fit)

--- a/llm-router/iii.worker.yaml
+++ b/llm-router/iii.worker.yaml
@@ -3,6 +3,7 @@ name: llm-router
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: llm-router
 tags: [llm, router, models, providers]
 description: One front door + provider protocol in front of every LLM provider.

--- a/lsp/iii.worker.yaml
+++ b/lsp/iii.worker.yaml
@@ -3,6 +3,7 @@ name: lsp
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: lsp
 description: III Language Server — autocompletion and hover for III engine functions and triggers
 # Opt out of the interface boot smoke. lsp is a stdio language server:

--- a/mcp/iii.worker.yaml
+++ b/mcp/iii.worker.yaml
@@ -3,6 +3,7 @@ name: mcp
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: mcp
 tags: [mcp, model-context-protocol, bridge, http, agents]
 description: MCP 2025-06-18 Streamable HTTP bridge for the iii engine.

--- a/memory-consolidate/iii.worker.yaml
+++ b/memory-consolidate/iii.worker.yaml
@@ -3,6 +3,7 @@ name: memory-consolidate
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: memory-consolidate
 tags: [memory, deduplication, cleanup, schedule, maintenance]
 description: Scheduled hygiene for the memory worker — deterministic dedup of near-duplicate memories, applied supersede-only through the public memory functions, pinned untouchable, with catch-up-on-boot scheduling. Install, stop, or remove it without touching stored memory.

--- a/memory/iii.worker.yaml
+++ b/memory/iii.worker.yaml
@@ -3,6 +3,7 @@ name: memory
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: memory
 tags: [memory, rag, bm25, recall, agent, context]
 description: Durable cross-session agent memory — named banks of always-injected markdown rules and auto-extracted memories, hybrid BM25 + entity recall, pinning, and supersede-never-delete history. Plain files on disk; every operation is a traced function.

--- a/opencode/iii.worker.yaml
+++ b/opencode/iii.worker.yaml
@@ -3,6 +3,7 @@ name: opencode
 language: javascript
 deploy: bundle
 manifest: package.json
+license: Apache-2.0
 tags: [coding-agent, opencode, cli, headless, agent]
 description: OpenCode as an iii worker — opencode::* functions run headless OpenCode turns, mirror raw JSON events onto opencode::events, and stream AgentEvent frames onto agent::events.
 

--- a/openwiki/iii.worker.yaml
+++ b/openwiki/iii.worker.yaml
@@ -3,6 +3,7 @@ name: openwiki
 language: javascript
 deploy: bundle
 manifest: package.json
+license: Apache-2.0
 tags: [wiki, documentation, docs, markdown, knowledge-base, repo]
 description: Source-grounded markdown wiki for any git repository — openwiki::* functions generate, search, and incrementally refresh categorized pages with pinned-commit line citations, and the engine serves a browser UI + JSON API under /openwiki.
 

--- a/pdf/iii.worker.yaml
+++ b/pdf/iii.worker.yaml
@@ -3,6 +3,7 @@ name: pdf
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: pdf
 tags: [pdf, document, markdown, text-extraction, ocr-routing, tables]
 description: Read PDFs locally — classify text-based vs scanned, convert to markdown, extract positioned text and tables, and report which pages still need OCR.

--- a/pi/iii.worker.yaml
+++ b/pi/iii.worker.yaml
@@ -3,6 +3,7 @@ name: pi
 language: javascript
 deploy: bundle
 manifest: package.json
+license: Apache-2.0
 tags: [coding-agent, pi, cli, headless, agent]
 description: Pi coding agent as an iii worker — pi::* functions run headless Pi turns, mirror raw events onto pi::events, and stream AgentEvent frames onto agent::events.
 

--- a/provider-anthropic/iii.worker.yaml
+++ b/provider-anthropic/iii.worker.yaml
@@ -3,6 +3,7 @@ name: provider-anthropic
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: provider-anthropic
 tags: [llm, anthropic, claude, messages, provider]
 description: Anthropic Messages API provider worker; implements provider::anthropic::stream and provider::anthropic::refresh_models behind llm-router.

--- a/provider-claude-code/iii.worker.yaml
+++ b/provider-claude-code/iii.worker.yaml
@@ -3,6 +3,7 @@ name: provider-claude-code
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: provider-claude-code
 tags: [llm, anthropic, claude, claude-code, subscription, provider]
 description: Claude Code (Pro/Max subscription) Messages API provider worker; implements provider::claude-code::stream and provider::claude-code::refresh_models behind llm-router, using OAuth credentials from the auth-credentials vault or ~/.claude/.credentials.json.

--- a/provider-deepseek/iii.worker.yaml
+++ b/provider-deepseek/iii.worker.yaml
@@ -3,6 +3,7 @@ name: provider-deepseek
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: provider-deepseek
 tags: [llm, deepseek, chat-completions, provider]
 description: DeepSeek Chat Completions provider worker; implements provider::deepseek::stream and provider::deepseek::refresh_models behind llm-router.

--- a/provider-kimi/iii.worker.yaml
+++ b/provider-kimi/iii.worker.yaml
@@ -3,6 +3,7 @@ name: provider-kimi
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: provider-kimi
 tags: [llm, kimi, moonshot, chat-completions, provider]
 description: Moonshot (Kimi) Chat Completions provider worker; implements provider::kimi::stream and provider::kimi::refresh_models behind llm-router.

--- a/provider-llamacpp/iii.worker.yaml
+++ b/provider-llamacpp/iii.worker.yaml
@@ -3,6 +3,7 @@ name: provider-llamacpp
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: provider-llamacpp
 tags: [llm, llama.cpp, local, open-source, provider]
 description: llama.cpp server (llama-server) Chat Completions provider worker; implements provider::llamacpp::stream and provider::llamacpp::refresh_models behind llm-router.

--- a/provider-openai-codex/iii.worker.yaml
+++ b/provider-openai-codex/iii.worker.yaml
@@ -3,6 +3,7 @@ name: provider-openai-codex
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: provider-openai-codex
 tags: [llm, openai, codex, chatgpt, subscription, provider]
 description: OpenAI Codex (ChatGPT subscription) provider; implements provider::openai-codex::stream and provider::openai-codex::refresh_models behind llm-router, sourcing credentials from the auth-credentials vault.

--- a/provider-openai/iii.worker.yaml
+++ b/provider-openai/iii.worker.yaml
@@ -3,6 +3,7 @@ name: provider-openai
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: provider-openai
 tags: [llm, openai, responses, chat-completions, provider]
 description: OpenAI Responses provider worker with Chat Completions compatibility; implements provider::openai::stream and provider::openai::refresh_models behind llm-router.

--- a/provider-xai/iii.worker.yaml
+++ b/provider-xai/iii.worker.yaml
@@ -3,6 +3,7 @@ name: provider-xai
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: provider-xai
 tags: [llm, xai, grok, chat-completions, provider]
 description: xAI Chat Completions provider worker; implements provider::xai::stream and provider::xai::refresh_models behind llm-router.

--- a/provider-zai/iii.worker.yaml
+++ b/provider-zai/iii.worker.yaml
@@ -3,6 +3,7 @@ name: provider-zai
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: provider-zai
 tags: [llm, zai, glm, chat-completions, provider]
 description: Z.AI Chat Completions provider worker; implements provider::zai::stream and provider::zai::refresh_models behind llm-router.

--- a/pubsub/iii.worker.yaml
+++ b/pubsub/iii.worker.yaml
@@ -3,6 +3,7 @@ name: pubsub
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: pubsub
 tags: [pubsub, messaging, events, topics]
 description: Topic-based publish/subscribe messaging — registers the `subscribe` trigger type and the `publish` function.

--- a/queue/iii.worker.yaml
+++ b/queue/iii.worker.yaml
@@ -3,6 +3,7 @@ name: queue
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: queue
 tags: [queue, async, jobs, retry, rabbitmq, redis]
 description: Durable function queues - registers the `durable:subscriber` trigger type and the queue/DLQ service functions.

--- a/rbac-proxy/iii.worker.yaml
+++ b/rbac-proxy/iii.worker.yaml
@@ -3,6 +3,7 @@ name: rbac-proxy
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: rbac-proxy
 tags: [rbac, authorization, security, proxy, middleware]
 description: "RBAC boundary proxy for the iii worker protocol — auth, gating, namespacing, middleware, and engine:: result filtering on its own port."

--- a/scrapling/iii.worker.yaml
+++ b/scrapling/iii.worker.yaml
@@ -9,6 +9,7 @@ name: scrapling
 language: python
 deploy: bundle
 manifest: pyproject.toml
+license: Apache-2.0
 tags: [scraping, browser, crawler, anti-bot, extraction, http]
 description: >-
   Scrapling as an iii worker — scrapling::* functions run HTTP / anti-bot /

--- a/session-manager/iii.worker.yaml
+++ b/session-manager/iii.worker.yaml
@@ -3,6 +3,7 @@ name: session-manager
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: session-manager
 tags: [session, conversation, chat, history]
 description: Durable, reactive, branching store of typed conversation entries with six emitted trigger types.

--- a/shell/iii.worker.yaml
+++ b/shell/iii.worker.yaml
@@ -3,6 +3,7 @@ name: shell
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: shell
 tags: [shell, exec, filesystem, bash, terminal]
 description: Unix shell + filesystem worker — exec with denylist/timeout/output caps and background jobs; fs::ls|stat|mkdir|rm|chmod|mv|grep|sed|read|write with host jail, denylist, size caps, and sandbox-target forwarding

--- a/slack/iii.worker.yaml
+++ b/slack/iii.worker.yaml
@@ -3,6 +3,7 @@ name: slack
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: slack
 tags: [slack, messaging, chat, bot, approvals]
 description: Slack as an iii worker — exposes the Slack Web API as slack::* functions, plus a harness bridge (inbound events → harness::send, native streaming, approvals). Configurable from the console.

--- a/state/iii.worker.yaml
+++ b/state/iii.worker.yaml
@@ -3,6 +3,7 @@ name: state
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: state
 tags: [key-value, kv, state, distributed, cache]
 description: Distributed key-value state management with reactive change triggers — registers the `state` trigger type and the `state::*` functions.

--- a/storage/iii.worker.yaml
+++ b/storage/iii.worker.yaml
@@ -3,6 +3,7 @@ name: storage
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: storage
 tags: [s3, object-storage, gcs, r2, blob]
 description: S3-compatible object storage across AWS S3, GCS, Cloudflare R2, and a managed local rustfs backend. Streamed uploads, presigned URLs, and object change triggers.

--- a/telegram-bot/iii.worker.yaml
+++ b/telegram-bot/iii.worker.yaml
@@ -3,6 +3,7 @@ name: telegram-bot
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: telegram-bot
 tags: [telegram, bot, messaging, chat, webhook]
 description: Telegram bridge to the harness stack — polling or webhook ingress, live message edits, approvals, and configurable verbosity.

--- a/web/iii.worker.yaml
+++ b/web/iii.worker.yaml
@@ -3,6 +3,7 @@ name: web
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: web
 tags: [http, client, fetch, rest, api]
 description: Outbound HTTP client on the iii bus (web::fetch).

--- a/workflow/iii.worker.yaml
+++ b/workflow/iii.worker.yaml
@@ -3,6 +3,7 @@ name: workflow
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: workflow
 tags: [workflow, orchestration, multi-agent, durable, automation]
 description: Deterministic, crash-resumable multi-agent workflow orchestrator over harness turns.

--- a/worktree/iii.worker.yaml
+++ b/worktree/iii.worker.yaml
@@ -3,6 +3,7 @@ name: worktree
 language: rust
 deploy: binary
 manifest: Cargo.toml
+license: Apache-2.0
 bin: worktree
 tags: [git, worktree, parallel, agents, branches, ci]
 description: Git worktree lifecycle for parallel agents — mint, claim, and track isolated worktrees per repo, emit lifecycle trigger types, and land branches back through a per-repo FIFO queue (rebase, test gate, ff-only merge).


### PR DESCRIPTION
## Summary

- add `license: Apache-2.0` to all 54 regular worker manifests
- require valid SPDX identifiers or expressions during worker PR checks
- forward the normalized, SPDX-validated license in registry publish payloads
- document the manifest requirement and add focused coverage

## Why

The repository license already covers these workers, but published registry metadata did not expose it. This gives the registry a reliable SPDX value to display as metadata and a label.

## Dependencies

- depends on iii-hq/registry#84 for registry schema, persistence, and UI support
- Linear: [MOT-4366](https://linear.app/motia/issue/MOT-4366/publish-worker-license-metadata-to-the-registry)

## Test plan

- `222 passed` across `.github/scripts/tests`
- all 54 worker manifests pass `.github/scripts/validate_worker.py`
- focused Ruff checks, workflow YAML parsing, and Python compilation pass