### PR TITLE
(MOT-4367) feat(ci): expose manual test pipelines

### DIFF
--- a/.github/workflows/database-e2e.yml
+++ b/.github/workflows/database-e2e.yml
@@ -1,4 +1,5 @@
 name: database E2E
+run-name: Test · database_e2e · ${{ inputs.operation_id || github.event_name }}
 
 on:
   pull_request:
@@ -6,9 +7,22 @@ on:
       - 'database/**'
       - '.github/workflows/database-e2e.yml'
   workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Optional full source commit SHA
+        type: string
+        default: ''
+      operation_id:
+        description: Release Control operation UUID
+        type: string
+        default: ''
+      step_id:
+        description: Release Control operation step UUID
+        type: string
+        default: ''
 
 concurrency:
-  group: database-e2e-${{ github.ref }}
+  group: database-e2e-${{ inputs.operation_id || inputs.source_sha || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -21,6 +35,8 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.source_sha || github.sha }}
 
       - name: Rewrite SSH to HTTPS for public deps
         run: git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"

--- a/.github/workflows/harness-e2e-daily.yml
+++ b/.github/workflows/harness-e2e-daily.yml
@@ -1,4 +1,5 @@
 name: Harness E2E Daily
+run-name: Test · harness_source · ${{ inputs.operation_id || github.event_name }}
 
 on:
   schedule:
@@ -22,13 +23,21 @@ on:
         description: Optional judge provider id
         required: false
         type: string
+      operation_id:
+        description: Release Control operation UUID
+        required: false
+        type: string
+      step_id:
+        description: Release Control operation step UUID
+        required: false
+        type: string
 
 permissions:
   actions: read
   contents: read
 
 concurrency:
-  group: harness-e2e-daily-benchmark
+  group: harness-e2e-daily-${{ inputs.operation_id || 'benchmark' }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/harness-quickstart.yml
+++ b/.github/workflows/harness-quickstart.yml
@@ -1,4 +1,5 @@
 name: Harness quickstart
+run-name: Test · harness_quickstart · ${{ inputs.operation_id || github.event_name }}
 
 on:
   schedule:
@@ -33,6 +34,18 @@ on:
         description: Dispatch deployed E2E after quickstart
         type: boolean
         default: false
+      source_sha:
+        description: Optional full source commit SHA
+        type: string
+        default: ''
+      operation_id:
+        description: Release Control operation UUID
+        type: string
+        default: ''
+      step_id:
+        description: Release Control operation step UUID
+        type: string
+        default: ''
   workflow_dispatch:
     inputs:
       cli_channel:
@@ -65,12 +78,24 @@ on:
         description: Dispatch the deployed E2E workflow after a successful smoke
         type: boolean
         default: false
+      source_sha:
+        description: Optional full source commit SHA
+        type: string
+        default: ''
+      operation_id:
+        description: Release Control operation UUID
+        type: string
+        default: ''
+      step_id:
+        description: Release Control operation step UUID
+        type: string
+        default: ''
 
 permissions:
   contents: read
 
 concurrency:
-  group: harness-quickstart-${{ inputs.cli_channel || github.event_name }}-${{ inputs.registry_tag || github.event_name }}-${{ inputs.release_version || 'rolling' }}
+  group: harness-quickstart-${{ inputs.operation_id || inputs.release_version || github.event_name }}-${{ inputs.cli_channel || github.event_name }}-${{ inputs.registry_tag || github.event_name }}
   cancel-in-progress: ${{ inputs.release_version == '' }}
 
 jobs:
@@ -89,6 +114,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.source_sha || github.sha }}
 
       - name: Run quickstart validator
         id: quickstart

--- a/.github/workflows/rbac-proxy-e2e.yml
+++ b/.github/workflows/rbac-proxy-e2e.yml
@@ -1,4 +1,5 @@
 name: rbac-proxy E2E
+run-name: Test · rbac_proxy_e2e · ${{ inputs.operation_id || github.event_name }}
 
 on:
   pull_request:
@@ -6,9 +7,22 @@ on:
       - 'rbac-proxy/**'
       - '.github/workflows/rbac-proxy-e2e.yml'
   workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Optional full source commit SHA
+        type: string
+        default: ''
+      operation_id:
+        description: Release Control operation UUID
+        type: string
+        default: ''
+      step_id:
+        description: Release Control operation step UUID
+        type: string
+        default: ''
 
 concurrency:
-  group: rbac-proxy-e2e-${{ github.ref }}
+  group: rbac-proxy-e2e-${{ inputs.operation_id || inputs.source_sha || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -21,6 +35,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.source_sha || github.sha }}
 
       - name: Rewrite SSH to HTTPS for public deps
         run: git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"

--- a/.github/workflows/shell-e2e.yml
+++ b/.github/workflows/shell-e2e.yml
@@ -1,4 +1,5 @@
 name: shell E2E
+run-name: Test · shell_e2e · ${{ inputs.operation_id || github.event_name }}
 
 on:
   pull_request:
@@ -6,9 +7,22 @@ on:
       - 'shell/**'
       - '.github/workflows/shell-e2e.yml'
   workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Optional full source commit SHA
+        type: string
+        default: ''
+      operation_id:
+        description: Release Control operation UUID
+        type: string
+        default: ''
+      step_id:
+        description: Release Control operation step UUID
+        type: string
+        default: ''
 
 concurrency:
-  group: shell-e2e-${{ github.ref }}
+  group: shell-e2e-${{ inputs.operation_id || inputs.source_sha || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -21,6 +35,8 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.source_sha || github.sha }}
 
       - name: Rewrite SSH to HTTPS for public deps
         run: git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"

--- a/.github/workflows/storage-e2e.yml
+++ b/.github/workflows/storage-e2e.yml
@@ -1,4 +1,5 @@
 name: storage E2E
+run-name: Test · storage_e2e · ${{ inputs.operation_id || github.event_name }}
 
 on:
   pull_request:
@@ -6,9 +7,22 @@ on:
       - 'storage/**'
       - '.github/workflows/storage-e2e.yml'
   workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Optional full source commit SHA
+        type: string
+        default: ''
+      operation_id:
+        description: Release Control operation UUID
+        type: string
+        default: ''
+      step_id:
+        description: Release Control operation step UUID
+        type: string
+        default: ''
 
 concurrency:
-  group: storage-e2e-${{ github.ref }}
+  group: storage-e2e-${{ inputs.operation_id || inputs.source_sha || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -21,6 +35,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.source_sha || github.sha }}
 
       - name: Rewrite SSH to HTTPS for public deps
         run: git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"


### PR DESCRIPTION
## What changed

- add deterministic run titles and Release Control identity inputs to approved E2E workflows
- allow manual runs to check out an immutable source commit
- isolate concurrency by operation or source identity
- extend Harness source and quickstart workflows with operation and step correlation

## Why

Release Control needs a safe, allowlisted way to dispatch tests without exposing release or promotion workflows and without correlating runs by timing.

## Impact

Existing pull request, scheduled, and reusable workflow behavior remains unchanged. Manual executions can now be tracked deterministically by Release Control.

## Validation

- parsed all six changed workflow files as YAML
- `actionlint` on all six changed workflows
- `git diff --check`

Refs MOT-4367


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added optional source revision, operation, and step inputs to supported manually triggered test workflows.
  * Workflow runs now display clearer operation-based names.
  * Improved concurrency handling to isolate runs by operation or source revision.
  * Workflows can now test a specified source revision when provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->