### PR TITLE
ci: use Node 22 for shell E2E

### DIFF
--- a/.github/workflows/shell-e2e.yml
+++ b/.github/workflows/shell-e2e.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: shell/tests/e2e/workers/harness/package-lock.json
 


### PR DESCRIPTION
## What changed

- run the Shell E2E workflow with Node.js 22
- keep the workflow compatible with the repository's `pnpm@11.13.1` toolchain

## Root cause

The workflow installed Node.js 20 before resolving pnpm from the root `packageManager` field. pnpm 11 requires Node.js 22.13 or newer and failed while importing `node:sqlite`, causing the Shell UI build to panic before either Harness mode could run.

## Impact

The default and jailed Shell Harness jobs can install the UI dependencies and proceed to the actual E2E scenarios.

## Validation

- `git diff --check`
- verified the PR contains only the Node.js version change in `.github/workflows/shell-e2e.yml`
