### PR TITLE
fix(providers): sync deepseek and zai locks with llm-router 1.4.2

### DIFF
--- a/provider-deepseek/Cargo.lock
+++ b/provider-deepseek/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-zai/Cargo.lock
+++ b/provider-zai/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "async-trait",
  "clap",


### PR DESCRIPTION
The standalone provider lockfiles still pinned `llm-router 1.4.1` after the path dependency was bumped to 1.4.2, so every `--locked` build of `provider-deepseek` and `provider-zai` fails with:

```
error: cannot update the lock file .../provider-deepseek/Cargo.lock because --locked was passed to prevent this
```

This is what broke last night's **Harness E2E Daily** (run 31078732959) at the *Build source E2E stack* step — the daily builds `provider-$provider` for every subject/judge provider with `--locked`, and the current matrix is deepseek subject + zai judge.

Regenerated both locks with `cargo metadata`; the only change is `llm-router 1.4.1 → 1.4.2` in each. Verified locally: `cargo metadata --locked` passes for both, and `cargo check --locked` compiles provider-deepseek clean. Same drift class previously fixed in 8d053c22.

Note: the Aug 4/5 daily failures are unrelated (`shell_coder_sandbox` hard-gate failures, already being addressed on `fix/harness-shell-coder-e2e-improvement`).