### PR TITLE
(MOT-4096) feat(eval): compare live session metrics

### DIFF
--- a/eval/Cargo.lock
+++ b/eval/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "1.6.7"
+version = "1.7.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/eval/README.md
+++ b/eval/README.md
@@ -1,9 +1,11 @@
 # eval
 
-`eval` compares two prompt or system-prompt variants under the same model and
-execution settings. It runs control and treatment through the iii harness,
-evaluates each result with an iii function, and reports correctness together
-with tokens, cost, latency, function-call, trace, and span metrics.
+`eval` primarily compares 2–5 existing root sessions live. It reads the
+current session lifecycle and `harness::metrics` values, then displays
+objective deltas against a user-selected reference. The user decides whether
+the sessions are comparable; `eval` does not score, rank, validate equivalence,
+or persist a comparison. Prompt and system-prompt experiments remain available
+as an advanced surface.
 
 ## Start an evaluation
 
@@ -39,13 +41,15 @@ immediately. Use `eval::status` for occasional progress checks and
 `eval::result` for the terminal report, or bind to the `eval::completed`
 trigger type.
 
-Three runs per variant are scheduled by default. Their order alternates by
+One run per variant is scheduled by default. Their order alternates by
 pair to reduce order bias. A candidate is eligible only when every treatment
 run passes and its pass count does not regress against control. Efficiency
 metrics are descriptive and never select a winner automatically.
 
 ## Public functions
 
+- `eval::compare-sessions` — read 2–5 root sessions concurrently and return
+  objective metrics plus arithmetic deltas against the selected reference.
 - `eval::start` — validate, persist, and enqueue an evaluation.
 - `eval::list` — list recent evaluations as lightweight summaries.
 - `eval::status` — inspect progress without loading the full report.
@@ -62,9 +66,10 @@ at-least-once.
 ## Console UI
 
 When the console worker is running, `eval` injects an **eval** page at
-`#/ext/eval-benchmarks`. The page creates prompt or system-prompt comparisons,
-tracks durable progress, restores recent reports after reload, and compares
-correctness, token, cost, latency, function-call, trace, and span metrics.
+`#/ext/eval-benchmarks`. The default **Sessions** tab lists visible root
+sessions, accepts active sessions, and renders a live matrix grouped by
+efficiency, reliability, orchestration, and context. **Prompt experiments**
+keeps the durable prompt/system-prompt workflow for advanced use.
 
 The model picker reads the live `router::models::list` catalog and falls back
 to manual model/provider entry when the catalog is unavailable. Exact-value

--- a/eval/iii.worker.yaml
+++ b/eval/iii.worker.yaml
@@ -5,8 +5,8 @@ deploy: binary
 manifest: Cargo.toml
 license: Apache-2.0
 bin: eval
-tags: [evaluation, benchmark, prompt, system-prompt, ab-test]
-description: Compare prompt or system-prompt variants on the same model using durable harness runs and correctness-first reports.
+tags: [evaluation, benchmark, sessions, metrics, prompt, system-prompt]
+description: Compare live objective metrics for 2-5 root sessions; retain durable prompt experiments as an advanced surface.
 
 dependencies:
   state: "^0.21.3"

--- a/eval/src/comparison.rs
+++ b/eval/src/comparison.rs
@@ -1,0 +1,658 @@
+//! Live, read-only comparison of existing root sessions.
+//!
+//! This module deliberately has no state or queue integration. Every request
+//! reads the current session metadata, lifecycle and Harness metrics, then
+//! derives mathematical summaries and deltas for the caller to interpret.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use harness::functions::metrics::{SessionMetricsRequestV1, SessionMetricsResponseV1};
+use harness::functions::status::{StatusReport, StatusRequest};
+use harness::types::turn::TurnStatus;
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
+use schemars::JsonSchema;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::{json, Value};
+use tokio::task::JoinSet;
+
+use crate::error::EvalError;
+use crate::ids;
+use crate::runtime::Deps;
+
+pub const SCHEMA_VERSION: &str = "1";
+const COLLECTION_TIMEOUT_MS: u64 = 30_000;
+
+/// The only input needed to compare sessions. The caller is responsible for
+/// choosing sessions that are meaningful to compare; the worker only checks
+/// shape and root identity.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CompareSessionsRequestV1 {
+    #[schemars(length(min = 2, max = 5))]
+    pub session_ids: Vec<String>,
+    pub baseline_session_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SessionComparisonResponseV1 {
+    pub schema_version: String,
+    pub captured_at: i64,
+    pub baseline_session_id: String,
+    pub sessions: Vec<SessionComparisonItemV1>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SessionComparisonItemV1 {
+    pub session: SessionMetaProjectionV1,
+    pub lifecycle: SessionLifecycleV1,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metrics: Option<SessionMetricsResponseV1>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<ObjectiveSummaryV1>,
+    /// One entry per objective numeric metric. A missing value is represented
+    /// by null in either delta field, never by zero.
+    #[serde(default)]
+    pub deltas: BTreeMap<String, MetricDeltaV1>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub errors: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SessionLifecycleV1 {
+    pub session_status: SessionStatusV1,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_status: Option<TurnStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_error: Option<String>,
+    /// Null means `harness::status` did not provide a turn record.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal: Option<bool>,
+    /// Null means the status read was unavailable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expects_wake: Option<bool>,
+    /// Null means the metrics read was unavailable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub complete: Option<bool>,
+    pub partial: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionStatusV1 {
+    #[default]
+    Idle,
+    Working,
+    Done,
+    Error,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct SessionMetaProjectionV1 {
+    pub session_id: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub description: String,
+    pub status: SessionStatusV1,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub forked_from: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub draft: Option<String>,
+    #[serde(default)]
+    pub created_at: i64,
+    #[serde(default)]
+    pub updated_at: i64,
+    #[serde(default)]
+    pub message_count: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct ObjectiveSummaryV1 {
+    pub total_tokens: Option<u64>,
+    pub generations: Option<u64>,
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub cache_read_tokens: Option<u64>,
+    pub cache_write_tokens: Option<u64>,
+    pub reasoning_tokens: Option<u64>,
+    pub subject_cost_usd: Option<f64>,
+    pub tokens_per_generation: Option<f64>,
+    pub cost_per_generation_usd: Option<f64>,
+    pub function_calls: Option<u64>,
+    pub function_call_errors: Option<u64>,
+    pub function_error_rate: Option<f64>,
+    pub trace_duration_ms: Option<u64>,
+    pub trace_count: Option<u64>,
+    pub span_count: Option<u64>,
+    pub error_span_count: Option<u64>,
+    pub sessions: Option<u64>,
+    pub descendants: Option<u64>,
+    pub max_depth: Option<u32>,
+    pub compacted_sessions: Option<u64>,
+    pub context_total_tokens: Option<u64>,
+    pub context_usable_tokens: Option<u64>,
+    pub context_free_tokens: Option<u64>,
+    pub context_occupancy: Option<f64>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct MetricDeltaV1 {
+    pub absolute: Option<f64>,
+    pub percent: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SessionGetResponseV1 {
+    meta: SessionMetaProjectionV1,
+}
+
+#[derive(Debug)]
+struct SessionObservation {
+    meta: SessionMetaProjectionV1,
+    status: Result<Option<StatusReport>, EvalError>,
+    metrics: Result<SessionMetricsResponseV1, EvalError>,
+}
+
+/// Collect all three live sources concurrently for each requested session and
+/// all requested sessions concurrently. Metadata is validated before the
+/// response is returned, while later status/metrics failures stay local.
+pub async fn compare(
+    deps: &Deps,
+    request: CompareSessionsRequestV1,
+) -> Result<SessionComparisonResponseV1, EvalError> {
+    validate_request(&request)?;
+
+    let mut jobs = JoinSet::new();
+    for (index, session_id) in request.session_ids.iter().cloned().enumerate() {
+        let iii = deps.iii.clone();
+        jobs.spawn(async move {
+            let (meta, status, metrics) = tokio::join!(
+                trigger::<_, Option<SessionGetResponseV1>>(
+                    &iii,
+                    "session::get",
+                    json!({ "session_id": session_id.clone() }),
+                ),
+                trigger::<_, Option<StatusReport>>(
+                    &iii,
+                    "harness::status",
+                    StatusRequest {
+                        session_id: session_id.clone(),
+                    },
+                ),
+                trigger::<_, SessionMetricsResponseV1>(
+                    &iii,
+                    "harness::metrics",
+                    SessionMetricsRequestV1 {
+                        root_session_id: session_id.clone(),
+                    },
+                ),
+            );
+            let meta = meta?.ok_or_else(|| EvalError::SessionNotFound(session_id.clone()))?;
+            Ok::<_, EvalError>((
+                index,
+                SessionObservation {
+                    meta: meta.meta,
+                    status,
+                    metrics,
+                },
+            ))
+        });
+    }
+
+    let mut observations: Vec<Option<SessionObservation>> = std::iter::repeat_with(|| None)
+        .take(request.session_ids.len())
+        .collect();
+    while let Some(joined) = jobs.join_next().await {
+        let (index, observation) = joined.map_err(|error| {
+            EvalError::Dependency(format!("session collection task failed: {error}"))
+        })??;
+        observations[index] = Some(observation);
+    }
+    let observations = observations
+        .into_iter()
+        .map(|observation| {
+            observation.ok_or_else(|| {
+                EvalError::Dependency("session collection returned no result".into())
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    for observation in &observations {
+        if let Some(parent) = metadata_parent_key(&observation.meta) {
+            return Err(EvalError::InvalidRequest(format!(
+                "session {} is a descendant (metadata.{parent}) and only root sessions can be compared",
+                observation.meta.session_id
+            )));
+        }
+    }
+
+    let baseline_summary = observations
+        .iter()
+        .find(|observation| observation.meta.session_id == request.baseline_session_id)
+        .and_then(|observation| observation.metrics.as_ref().ok())
+        .map(ObjectiveSummaryV1::from_metrics);
+
+    let mut sessions = observations
+        .into_iter()
+        .map(|observation| item_from_observation(observation, baseline_summary.as_ref()))
+        .collect::<Vec<_>>();
+    // Preserve the user's explicit order, with the reference first only when
+    // they sent it first; selection order remains meaningful in the matrix.
+    sessions.shrink_to_fit();
+
+    Ok(SessionComparisonResponseV1 {
+        schema_version: SCHEMA_VERSION.into(),
+        captured_at: ids::now_ms(),
+        baseline_session_id: request.baseline_session_id,
+        sessions,
+    })
+}
+
+fn validate_request(request: &CompareSessionsRequestV1) -> Result<(), EvalError> {
+    if !(2..=5).contains(&request.session_ids.len()) {
+        return Err(EvalError::InvalidRequest(
+            "session_ids must contain between 2 and 5 sessions".into(),
+        ));
+    }
+    if request
+        .session_ids
+        .iter()
+        .any(|session_id| session_id.trim().is_empty())
+    {
+        return Err(EvalError::InvalidRequest(
+            "session_ids cannot contain empty values".into(),
+        ));
+    }
+    let unique = request
+        .session_ids
+        .iter()
+        .collect::<std::collections::BTreeSet<_>>();
+    if unique.len() != request.session_ids.len() {
+        return Err(EvalError::InvalidRequest(
+            "session_ids must be unique".into(),
+        ));
+    }
+    if !request
+        .session_ids
+        .iter()
+        .any(|session_id| session_id == &request.baseline_session_id)
+    {
+        return Err(EvalError::InvalidRequest(
+            "baseline_session_id must belong to session_ids".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn metadata_parent_key(meta: &SessionMetaProjectionV1) -> Option<&'static str> {
+    meta.metadata
+        .as_ref()
+        .and_then(Value::as_object)
+        .and_then(|metadata| {
+            metadata
+                .contains_key("parent_session_id")
+                .then_some("parent_session_id")
+        })
+}
+
+fn item_from_observation(
+    observation: SessionObservation,
+    baseline: Option<&ObjectiveSummaryV1>,
+) -> SessionComparisonItemV1 {
+    let status_error = observation.status.as_ref().err().map(ToString::to_string);
+    let status_report = observation
+        .status
+        .as_ref()
+        .ok()
+        .and_then(|status| status.as_ref());
+    let metrics_error = observation.metrics.as_ref().err().map(ToString::to_string);
+    let metrics = observation.metrics.ok();
+    let mut errors = Vec::new();
+    if let Some(error) = status_error {
+        errors.push(format!("harness::status: {error}"));
+    }
+    if let Some(error) = metrics_error {
+        errors.push(format!("harness::metrics: {error}"));
+    }
+
+    let summary = metrics.as_ref().map(ObjectiveSummaryV1::from_metrics);
+    let lifecycle = lifecycle_from(
+        observation.meta.status,
+        status_report,
+        metrics.as_ref().map(|metrics| metrics.complete),
+    );
+    let deltas = summary
+        .as_ref()
+        .map(|summary| metric_deltas(summary, baseline))
+        .unwrap_or_else(null_metric_deltas);
+
+    SessionComparisonItemV1 {
+        session: observation.meta,
+        lifecycle,
+        metrics,
+        summary,
+        deltas,
+        errors,
+    }
+}
+
+fn lifecycle_from(
+    session_status: SessionStatusV1,
+    status: Option<&StatusReport>,
+    complete: Option<bool>,
+) -> SessionLifecycleV1 {
+    let turn_status = status.map(|status| status.status);
+    SessionLifecycleV1 {
+        session_status,
+        turn_id: status.and_then(|status| status.turn_id.clone()),
+        terminal: status.map(|status| status.status.is_terminal() && !status.expects_wake),
+        turn_status,
+        result_error: status.and_then(|status| status.result_error.clone()),
+        expects_wake: status.map(|status| status.expects_wake),
+        partial: complete != Some(true),
+        complete,
+    }
+}
+
+impl ObjectiveSummaryV1 {
+    fn from_metrics(metrics: &SessionMetricsResponseV1) -> Self {
+        let totals = &metrics.totals;
+        let total_tokens = totals
+            .input_tokens
+            .zip(totals.output_tokens)
+            .map(|(input, output)| input.saturating_add(output));
+        let generations = totals.turns;
+        let function_error_rate = (totals.function_calls > 0)
+            .then(|| totals.function_call_errors as f64 / totals.function_calls as f64);
+        let tokens_per_generation = (generations > 0)
+            .then(|| total_tokens.map(|tokens| tokens as f64 / generations as f64))
+            .flatten();
+        let cost_per_generation_usd = (generations > 0)
+            .then(|| totals.cost_usd.map(|cost| cost / generations as f64))
+            .flatten();
+        let max_depth = metrics.by_session.iter().map(|session| session.depth).max();
+        let root_context = metrics
+            .by_session
+            .iter()
+            .find(|session| session.session_id == metrics.root_session_id)
+            .and_then(|session| session.context.as_ref());
+        let compacted_sessions = metrics
+            .by_session
+            .iter()
+            .filter(|session| {
+                session
+                    .context
+                    .as_ref()
+                    .is_some_and(|context| context.compacted)
+            })
+            .count() as u64;
+        let context_sessions = metrics
+            .by_session
+            .iter()
+            .filter(|session| session.context.is_some())
+            .count();
+
+        Self {
+            total_tokens,
+            generations: Some(generations),
+            input_tokens: totals.input_tokens,
+            output_tokens: totals.output_tokens,
+            cache_read_tokens: totals.cache_read_tokens,
+            cache_write_tokens: totals.cache_write_tokens,
+            reasoning_tokens: totals.reasoning_tokens,
+            subject_cost_usd: totals.cost_usd,
+            tokens_per_generation,
+            cost_per_generation_usd,
+            function_calls: Some(totals.function_calls),
+            function_call_errors: Some(totals.function_call_errors),
+            function_error_rate,
+            trace_duration_ms: metrics.traces.as_ref().map(|traces| traces.duration_ms),
+            trace_count: metrics.traces.as_ref().map(|traces| traces.trace_count),
+            span_count: metrics.traces.as_ref().map(|traces| traces.span_count),
+            error_span_count: metrics
+                .traces
+                .as_ref()
+                .map(|traces| traces.error_span_count),
+            sessions: Some(totals.sessions),
+            descendants: Some(totals.sessions.saturating_sub(1)),
+            max_depth,
+            compacted_sessions: (context_sessions > 0).then_some(compacted_sessions),
+            context_total_tokens: root_context.map(|context| context.total),
+            context_usable_tokens: root_context.map(|context| context.usable),
+            context_free_tokens: root_context.map(|context| context.free),
+            context_occupancy: root_context.and_then(|context| {
+                (context.usable > 0).then(|| context.total as f64 / context.usable as f64)
+            }),
+        }
+    }
+
+    fn values(&self) -> BTreeMap<String, Option<f64>> {
+        BTreeMap::from([
+            ("total_tokens".into(), self.total_tokens.map(|v| v as f64)),
+            ("generations".into(), self.generations.map(|v| v as f64)),
+            ("input_tokens".into(), self.input_tokens.map(|v| v as f64)),
+            ("output_tokens".into(), self.output_tokens.map(|v| v as f64)),
+            (
+                "cache_read_tokens".into(),
+                self.cache_read_tokens.map(|v| v as f64),
+            ),
+            (
+                "cache_write_tokens".into(),
+                self.cache_write_tokens.map(|v| v as f64),
+            ),
+            (
+                "reasoning_tokens".into(),
+                self.reasoning_tokens.map(|v| v as f64),
+            ),
+            ("subject_cost_usd".into(), self.subject_cost_usd),
+            ("tokens_per_generation".into(), self.tokens_per_generation),
+            (
+                "cost_per_generation_usd".into(),
+                self.cost_per_generation_usd,
+            ),
+            (
+                "function_calls".into(),
+                self.function_calls.map(|v| v as f64),
+            ),
+            (
+                "function_call_errors".into(),
+                self.function_call_errors.map(|v| v as f64),
+            ),
+            ("function_error_rate".into(), self.function_error_rate),
+            (
+                "trace_duration_ms".into(),
+                self.trace_duration_ms.map(|v| v as f64),
+            ),
+            ("trace_count".into(), self.trace_count.map(|v| v as f64)),
+            ("span_count".into(), self.span_count.map(|v| v as f64)),
+            (
+                "error_span_count".into(),
+                self.error_span_count.map(|v| v as f64),
+            ),
+            ("sessions".into(), self.sessions.map(|v| v as f64)),
+            ("descendants".into(), self.descendants.map(|v| v as f64)),
+            ("max_depth".into(), self.max_depth.map(|v| v as f64)),
+            (
+                "compacted_sessions".into(),
+                self.compacted_sessions.map(|v| v as f64),
+            ),
+            (
+                "context_total_tokens".into(),
+                self.context_total_tokens.map(|v| v as f64),
+            ),
+            (
+                "context_usable_tokens".into(),
+                self.context_usable_tokens.map(|v| v as f64),
+            ),
+            (
+                "context_free_tokens".into(),
+                self.context_free_tokens.map(|v| v as f64),
+            ),
+            ("context_occupancy".into(), self.context_occupancy),
+        ])
+    }
+}
+
+fn metric_deltas(
+    summary: &ObjectiveSummaryV1,
+    baseline: Option<&ObjectiveSummaryV1>,
+) -> BTreeMap<String, MetricDeltaV1> {
+    let current = summary.values();
+    let baseline = baseline.map(ObjectiveSummaryV1::values);
+    current
+        .into_iter()
+        .map(|(name, value)| {
+            let baseline_value = baseline
+                .as_ref()
+                .and_then(|values| values.get(&name).copied())
+                .flatten();
+            let absolute = value
+                .zip(baseline_value)
+                .map(|(value, baseline)| value - baseline);
+            let percent = absolute
+                .zip(baseline_value)
+                .filter(|(_, baseline)| *baseline != 0.0)
+                .map(|(absolute, baseline)| absolute / baseline * 100.0);
+            (name, MetricDeltaV1 { absolute, percent })
+        })
+        .collect()
+}
+
+fn null_metric_deltas() -> BTreeMap<String, MetricDeltaV1> {
+    ObjectiveSummaryV1::default()
+        .values()
+        .into_keys()
+        .map(|name| (name, MetricDeltaV1::default()))
+        .collect()
+}
+
+async fn trigger<I, O>(iii: &Arc<IIIClient>, function_id: &str, input: I) -> Result<O, EvalError>
+where
+    I: Serialize,
+    O: DeserializeOwned,
+{
+    let request = TriggerRequest {
+        function_id: function_id.into(),
+        payload: serde_json::to_value(input)?,
+        action: None,
+        timeout_ms: Some(COLLECTION_TIMEOUT_MS),
+    };
+    let value = iii
+        .trigger(request)
+        .await
+        .map_err(|error| EvalError::Dependency(format!("{function_id} failed: {error}")))?;
+    serde_json::from_value(value)
+        .map_err(|error| EvalError::Serialization(format!("{function_id} response: {error}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harness::functions::metrics::{
+        SessionMetricsResponseV1, SessionUsageTotalsV1, SessionUsageV1,
+    };
+
+    fn metrics(input: Option<u64>, output: Option<u64>, turns: u64) -> SessionMetricsResponseV1 {
+        SessionMetricsResponseV1 {
+            root_session_id: "root".into(),
+            complete: true,
+            totals: SessionUsageTotalsV1 {
+                sessions: 1,
+                turns,
+                input_tokens: input,
+                output_tokens: output,
+                ..SessionUsageTotalsV1::default()
+            },
+            by_session: vec![SessionUsageV1 {
+                session_id: "root".into(),
+                parent_session_id: None,
+                depth: 0,
+                turns,
+                function_calls: 0,
+                function_call_errors: 0,
+                input_tokens: input,
+                output_tokens: output,
+                cache_read_tokens: None,
+                cache_write_tokens: None,
+                reasoning_tokens: None,
+                cost_usd: None,
+                context: None,
+            }],
+            traces: None,
+        }
+    }
+
+    #[test]
+    fn validates_shape_and_baseline() {
+        let base = CompareSessionsRequestV1 {
+            session_ids: vec!["a".into(), "a".into()],
+            baseline_session_id: "a".into(),
+        };
+        assert!(validate_request(&base).is_err());
+        let base = CompareSessionsRequestV1 {
+            session_ids: vec!["a".into(), "b".into()],
+            baseline_session_id: "c".into(),
+        };
+        assert!(validate_request(&base).is_err());
+        for count in [0, 1, 6] {
+            let request = CompareSessionsRequestV1 {
+                session_ids: (0..count).map(|index| format!("session-{index}")).collect(),
+                baseline_session_id: "session-0".into(),
+            };
+            assert!(validate_request(&request).is_err());
+        }
+    }
+
+    #[test]
+    fn identifies_descendants_by_metadata_without_rejecting_forks() {
+        let root = SessionMetaProjectionV1 {
+            session_id: "root".into(),
+            metadata: Some(json!({ "forked": true })),
+            ..SessionMetaProjectionV1::default()
+        };
+        let child = SessionMetaProjectionV1 {
+            session_id: "child".into(),
+            metadata: Some(json!({ "parent_session_id": "root" })),
+            ..SessionMetaProjectionV1::default()
+        };
+        assert_eq!(metadata_parent_key(&root), None);
+        assert_eq!(metadata_parent_key(&child), Some("parent_session_id"));
+    }
+
+    #[test]
+    fn derives_totals_and_nulls_missing_usage() {
+        let complete = ObjectiveSummaryV1::from_metrics(&metrics(Some(10), Some(2), 2));
+        assert_eq!(complete.total_tokens, Some(12));
+        assert_eq!(complete.tokens_per_generation, Some(6.0));
+        let partial = ObjectiveSummaryV1::from_metrics(&metrics(Some(10), None, 2));
+        assert_eq!(partial.total_tokens, None);
+        assert_eq!(partial.tokens_per_generation, None);
+    }
+
+    #[test]
+    fn percentage_delta_is_null_for_missing_or_zero_baseline() {
+        let current = ObjectiveSummaryV1 {
+            total_tokens: Some(12),
+            ..ObjectiveSummaryV1::default()
+        };
+        let zero = ObjectiveSummaryV1 {
+            total_tokens: Some(0),
+            ..ObjectiveSummaryV1::default()
+        };
+        let delta = metric_deltas(&current, Some(&zero));
+        assert_eq!(delta["total_tokens"].absolute, Some(12.0));
+        assert_eq!(delta["total_tokens"].percent, None);
+        let missing = metric_deltas(&current, None);
+        assert_eq!(missing["total_tokens"].absolute, None);
+        assert_eq!(missing["total_tokens"].percent, None);
+        assert_eq!(null_metric_deltas().len(), current.values().len());
+    }
+}

--- a/eval/src/error.rs
+++ b/eval/src/error.rs
@@ -55,6 +55,8 @@ pub enum EvalError {
     InvalidRequest(String),
     #[error("evaluation not found: {0}")]
     NotFound(String),
+    #[error("session not found: {0}")]
+    SessionNotFound(String),
     #[error("evaluation conflict: {0}")]
     Conflict(String),
     #[error("dependency error: {0}")]

--- a/eval/src/functions.rs
+++ b/eval/src/functions.rs
@@ -4,6 +4,7 @@ use iii_sdk::errors::Error;
 use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::json;
 
+use crate::comparison::CompareSessionsRequestV1;
 use crate::contract::{
     EvalListRequestV1, EvalRerunRequestV1, EvalStartRequestV1, EvaluationIdRequestV1,
     EvaluatorInputV1, StepRequestV1, SweepEventV1, WakeEventV1,
@@ -22,8 +23,27 @@ pub const NORMALIZED_TEXT_ID: &str = "eval::assert::normalized_text";
 pub const STEP_ID: &str = "eval::step";
 pub const WAKE_ID: &str = "eval::on-turn-completed";
 pub const SWEEP_ID: &str = "eval::sweep";
+pub const COMPARE_SESSIONS_ID: &str = "eval::compare-sessions";
 
 pub fn register_all(iii: &Arc<IIIClient>, deps: &Deps) {
+    let current = deps.clone();
+    iii.register_function(
+        COMPARE_SESSIONS_ID,
+        RegisterFunction::new_async(move |request: CompareSessionsRequestV1| {
+            let deps = current.clone();
+            async move {
+                crate::comparison::compare(&deps, request)
+                    .await
+                    .map_err(Error::from)
+            }
+        })
+        .description(
+            "Compare 2–5 existing root sessions from live session, lifecycle, and Harness metrics. \
+             The response contains objective values and arithmetic deltas against the chosen \
+             baseline; it does not score, rank, validate equivalence, or persist a snapshot.",
+        ),
+    );
+
     let current = deps.clone();
     iii.register_function(
         START_ID,

--- a/eval/src/lib.rs
+++ b/eval/src/lib.rs
@@ -1,5 +1,7 @@
-//! Durable A/B evaluation of prompts and system prompts over harness turns.
+//! Live session comparison, with durable prompt experiments kept as an
+//! advanced surface.
 
+pub mod comparison;
 pub mod contract;
 pub mod error;
 pub mod events;

--- a/eval/src/main.rs
+++ b/eval/src/main.rs
@@ -17,7 +17,7 @@ use eval::{functions, manifest, queue, state, ui};
 #[derive(Parser, Debug)]
 #[command(
     name = "eval",
-    about = "Durable same-model A/B prompt evaluation over harness turns."
+    about = "Live comparison of Harness session metrics, with prompt experiments as an advanced surface."
 )]
 struct Cli {
     #[arg(long, env = "III_URL", default_value = "ws://127.0.0.1:49134")]

--- a/eval/src/manifest.rs
+++ b/eval/src/manifest.rs
@@ -13,9 +13,7 @@ pub fn build_manifest() -> ModuleManifest {
     ModuleManifest {
         name: env!("CARGO_PKG_NAME").to_string(),
         version: env!("CARGO_PKG_VERSION").to_string(),
-        description:
-            "Durable same-model A/B evaluation for prompts and system prompts over harness turns."
-                .to_string(),
+        description: "Live comparison of 2–5 root session metrics, with durable prompt and system-prompt experiments retained as an advanced surface.".to_string(),
         default_config: serde_json::json!({}),
         supported_targets: vec![env!("TARGET").to_string()],
     }

--- a/eval/src/surface.rs
+++ b/eval/src/surface.rs
@@ -1,5 +1,6 @@
 use schemars::JsonSchema;
 
+use crate::comparison::{CompareSessionsRequestV1, SessionComparisonResponseV1};
 use crate::contract::{
     EvalCancelResponseV1, EvalDeleteResponseV1, EvalListRequestV1, EvalListResponseV1,
     EvalRerunRequestV1, EvalResultResponseV1, EvalStartRequestV1, EvalStartResponseV1,
@@ -7,8 +8,8 @@ use crate::contract::{
     StepRequestV1, StepResponseV1, SweepEventV1, SweepResponseV1, WakeEventV1, WakeResponseV1,
 };
 use crate::functions::{
-    CANCEL_ID, DELETE_ID, EXACT_ID, LIST_ID, NORMALIZED_TEXT_ID, RERUN_ID, RESULT_ID, START_ID,
-    STATUS_ID, STEP_ID, SWEEP_ID, WAKE_ID,
+    CANCEL_ID, COMPARE_SESSIONS_ID, DELETE_ID, EXACT_ID, LIST_ID, NORMALIZED_TEXT_ID, RERUN_ID,
+    RESULT_ID, START_ID, STATUS_ID, STEP_ID, SWEEP_ID, WAKE_ID,
 };
 
 pub struct FunctionSpec {
@@ -33,6 +34,7 @@ fn spec<Req: JsonSchema, Resp: JsonSchema>(function_id: &'static str) -> Functio
 
 pub fn catalog() -> Vec<FunctionSpec> {
     vec![
+        spec::<CompareSessionsRequestV1, SessionComparisonResponseV1>(COMPARE_SESSIONS_ID),
         spec::<EvalStartRequestV1, EvalStartResponseV1>(START_ID),
         spec::<EvalRerunRequestV1, EvalStartResponseV1>(RERUN_ID),
         spec::<EvalListRequestV1, EvalListResponseV1>(LIST_ID),

--- a/eval/tests/golden/schemas/eval.compare-sessions.json
+++ b/eval/tests/golden/schemas/eval.compare-sessions.json
@@ -1,0 +1,990 @@
+{
+  "function_id": "eval::compare-sessions",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "description": "The only input needed to compare sessions. The caller is responsible for choosing sessions that are meaningful to compare; the worker only checks shape and root identity.",
+    "properties": {
+      "baseline_session_id": {
+        "type": "string"
+      },
+      "session_ids": {
+        "items": {
+          "type": "string"
+        },
+        "maxItems": 5,
+        "minItems": 2,
+        "type": "array"
+      }
+    },
+    "required": [
+      "baseline_session_id",
+      "session_ids"
+    ],
+    "title": "CompareSessionsRequestV1",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+      "ContextSnapshotV1": {
+        "description": "One generation's context accounting. `free = usable - total`, floored at zero: once provider usage lands, `total` is what was billed, which can exceed the `usable` budget the window was fit into — that budget was derived before the generation from an estimate.",
+        "properties": {
+          "categories": {
+            "$ref": "#/definitions/SnapshotCategoriesV1"
+          },
+          "compacted": {
+            "type": "boolean"
+          },
+          "effective_max_output_tokens": {
+            "description": "Output allocation `usable` was derived against.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "estimator": {
+            "description": "Which estimator produced the numbers (`heuristic` until the context-manager resolves a real tokenizer). Absent when the context-manager predates the breakdown response.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "free": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "model": {
+            "type": "string"
+          },
+          "provider": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "step": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "summarized_head_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "timestamp": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "total": {
+            "description": "Final request estimate: categories plus post-assembly growth.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "turn_id": {
+            "type": "string"
+          },
+          "usable": {
+            "description": "The input budget the window was fit into.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "usage": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Usage"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Actual provider usage for this generation, stamped after the terminal frame; absent when the provider returned none (or the generation never completed)."
+          }
+        },
+        "required": [
+          "categories",
+          "compacted",
+          "effective_max_output_tokens",
+          "free",
+          "model",
+          "session_id",
+          "step",
+          "timestamp",
+          "total",
+          "turn_id",
+          "usable"
+        ],
+        "type": "object"
+      },
+      "MetricDeltaV1": {
+        "properties": {
+          "absolute": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "percent": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "ObjectiveSummaryV1": {
+        "properties": {
+          "cache_read_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "cache_write_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "compacted_sessions": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "context_free_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "context_occupancy": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "context_total_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "context_usable_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "cost_per_generation_usd": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "descendants": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "error_span_count": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "function_call_errors": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "function_calls": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "function_error_rate": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "generations": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "input_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "max_depth": {
+            "format": "uint32",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "output_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "reasoning_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "sessions": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "span_count": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "subject_cost_usd": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "tokens_per_generation": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "total_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "trace_count": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "trace_duration_ms": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "SessionComparisonItemV1": {
+        "properties": {
+          "deltas": {
+            "additionalProperties": {
+              "$ref": "#/definitions/MetricDeltaV1"
+            },
+            "default": {},
+            "description": "One entry per objective numeric metric. A missing value is represented by null in either delta field, never by zero.",
+            "type": "object"
+          },
+          "errors": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "lifecycle": {
+            "$ref": "#/definitions/SessionLifecycleV1"
+          },
+          "metrics": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SessionMetricsResponseV1"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "session": {
+            "$ref": "#/definitions/SessionMetaProjectionV1"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/ObjectiveSummaryV1"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "lifecycle",
+          "session"
+        ],
+        "type": "object"
+      },
+      "SessionLifecycleV1": {
+        "properties": {
+          "complete": {
+            "description": "Null means the metrics read was unavailable.",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "expects_wake": {
+            "description": "Null means the status read was unavailable.",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "partial": {
+            "type": "boolean"
+          },
+          "result_error": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "session_status": {
+            "$ref": "#/definitions/SessionStatusV1"
+          },
+          "terminal": {
+            "description": "Null means `harness::status` did not provide a turn record.",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "turn_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "turn_status": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/TurnStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "partial",
+          "session_status"
+        ],
+        "type": "object"
+      },
+      "SessionMetaProjectionV1": {
+        "properties": {
+          "created_at": {
+            "default": 0,
+            "format": "int64",
+            "type": "integer"
+          },
+          "description": {
+            "default": "",
+            "type": "string"
+          },
+          "draft": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "forked_from": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "message_count": {
+            "default": 0,
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "metadata": true,
+          "session_id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/definitions/SessionStatusV1"
+          },
+          "status_reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "title": {
+            "default": "",
+            "type": "string"
+          },
+          "updated_at": {
+            "default": 0,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "session_id",
+          "status"
+        ],
+        "type": "object"
+      },
+      "SessionMetricsResponseV1": {
+        "additionalProperties": false,
+        "properties": {
+          "by_session": {
+            "items": {
+              "$ref": "#/definitions/SessionUsageV1"
+            },
+            "type": "array"
+          },
+          "complete": {
+            "type": "boolean"
+          },
+          "root_session_id": {
+            "type": "string"
+          },
+          "totals": {
+            "$ref": "#/definitions/SessionUsageTotalsV1"
+          },
+          "traces": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/SessionTraceMetricsV1"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Trace/span aggregates when the engine's in-memory observability exporter is available. Usage metrics remain available when it is not."
+          }
+        },
+        "required": [
+          "by_session",
+          "complete",
+          "root_session_id",
+          "totals"
+        ],
+        "type": "object"
+      },
+      "SessionStatusV1": {
+        "enum": [
+          "idle",
+          "working",
+          "done",
+          "error"
+        ],
+        "type": "string"
+      },
+      "SessionTraceMetricsV1": {
+        "additionalProperties": false,
+        "properties": {
+          "by_session": {
+            "items": {
+              "$ref": "#/definitions/SessionTraceUsageV1"
+            },
+            "type": "array"
+          },
+          "duration_ms": {
+            "description": "Elapsed window from the first observed span to the last observed span.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "error_span_count": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "span_count": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "trace_count": {
+            "description": "Distinct traces across the root session and all descendants.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "by_session",
+          "duration_ms",
+          "error_span_count",
+          "span_count",
+          "trace_count"
+        ],
+        "type": "object"
+      },
+      "SessionTraceUsageV1": {
+        "additionalProperties": false,
+        "properties": {
+          "depth": {
+            "format": "uint32",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "duration_ms": {
+            "description": "Elapsed window from the session's first observed span to its last.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "error_span_count": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "parent_session_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "span_count": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "trace_count": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "depth",
+          "duration_ms",
+          "error_span_count",
+          "session_id",
+          "span_count",
+          "trace_count"
+        ],
+        "type": "object"
+      },
+      "SessionUsageTotalsV1": {
+        "additionalProperties": false,
+        "properties": {
+          "cache_read_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "cache_write_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "cost_usd": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "function_call_errors": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "function_calls": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "input_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "output_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "reasoning_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "sessions": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "turns": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "function_call_errors",
+          "function_calls",
+          "sessions",
+          "turns"
+        ],
+        "type": "object"
+      },
+      "SessionUsageV1": {
+        "additionalProperties": false,
+        "properties": {
+          "cache_read_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "cache_write_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "context": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/ContextSnapshotV1"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The session's latest per-generation context snapshot (categories, budget, usage) — absent for sessions that have not generated since snapshots landed."
+          },
+          "cost_usd": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "depth": {
+            "format": "uint32",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "function_call_errors": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "function_calls": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "input_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "output_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "parent_session_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "reasoning_tokens": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "turns": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "depth",
+          "function_call_errors",
+          "function_calls",
+          "session_id",
+          "turns"
+        ],
+        "type": "object"
+      },
+      "SnapshotCategoriesV1": {
+        "description": "Where the request's tokens sit. Categories are assembly-time estimates; `hook_guidance` is the measured growth after assembly (pre-generate hook appends and orphan-repair patches), 0 when the request left assembly unchanged.",
+        "properties": {
+          "hook_guidance": {
+            "default": 0,
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "messages": {
+            "$ref": "#/definitions/SnapshotMessagesV1"
+          },
+          "overhead": {
+            "description": "Provider framing plus response_format / provider_options fields.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "system_prompt": {
+            "description": "Final assembled system prompt: mode paragraph, identity, per-step aids, and any compaction summary section.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "tools": {
+            "description": "Function schemas exposed to the model.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "messages",
+          "overhead",
+          "system_prompt",
+          "tools"
+        ],
+        "type": "object"
+      },
+      "SnapshotMessagesV1": {
+        "description": "Estimated tokens of the assembled window's messages, by role.",
+        "properties": {
+          "assistant": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "custom": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "function_result": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          },
+          "user": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "assistant",
+          "custom",
+          "function_result",
+          "user"
+        ],
+        "type": "object"
+      },
+      "TurnStatus": {
+        "description": "The coarse, harness-internal turn lifecycle (harness.md § API Reference). Finer-grained than the session's `status`, which the loop derives from it.",
+        "enum": [
+          "running",
+          "awaiting_functions",
+          "completed",
+          "cancelled",
+          "failed"
+        ],
+        "type": "string"
+      },
+      "Usage": {
+        "properties": {
+          "cache_read": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "cache_write": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "cost_usd": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "input": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "output": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "reasoning": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      }
+    },
+    "properties": {
+      "baseline_session_id": {
+        "type": "string"
+      },
+      "captured_at": {
+        "format": "int64",
+        "type": "integer"
+      },
+      "schema_version": {
+        "type": "string"
+      },
+      "sessions": {
+        "items": {
+          "$ref": "#/definitions/SessionComparisonItemV1"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "baseline_session_id",
+      "captured_at",
+      "schema_version",
+      "sessions"
+    ],
+    "title": "SessionComparisonResponseV1",
+    "type": "object"
+  }
+}

--- a/eval/tests/schemas.rs
+++ b/eval/tests/schemas.rs
@@ -12,6 +12,7 @@ fn catalog_matches_the_registered_surface() {
     assert_eq!(
         ids,
         [
+            "eval::compare-sessions",
             "eval::start",
             "eval::rerun",
             "eval::list",

--- a/eval/ui/package.json
+++ b/eval/ui/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && node build.mjs",
-    "watch": "node build.mjs --watch"
+    "watch": "node build.mjs --watch",
+    "test": "vitest run"
   },
   "dependencies": {
     "@iii-dev/console-ui": "workspace:*"
@@ -13,6 +14,7 @@
   "devDependencies": {
     "@types/react": "^19.2.14",
     "esbuild": "^0.25.0",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "vitest": "^4.1.6"
   }
 }

--- a/eval/ui/src/api.ts
+++ b/eval/ui/src/api.ts
@@ -6,11 +6,15 @@ import type {
   EvalStatus,
   EvalStatusResponse,
   EvalSummary,
+  SessionComparisonResponse,
+  SessionMeta,
 } from './types'
 
 const TIMEOUT_MS = 30_000
 
 export interface EvalApi {
+  sessions(): Promise<SessionMeta[]>
+  compareSessions(sessionIds: string[], baselineSessionId: string): Promise<SessionComparisonResponse>
   list(): Promise<EvalSummary[]>
   start(request: EvalRequest): Promise<{
     evaluation_id: string
@@ -33,6 +37,19 @@ export function createEvalApi(host: Host): EvalApi {
     host.iii.trigger<T>(functionId, payload, { timeoutMs: TIMEOUT_MS })
 
   return {
+    async sessions() {
+      const response = await trigger<{ sessions: SessionMeta[] }>('session::list', {
+        limit: 200,
+        order: 'updated_desc',
+      })
+      return response.sessions
+    },
+    compareSessions(sessionIds, baselineSessionId) {
+      return trigger('eval::compare-sessions', {
+        session_ids: sessionIds,
+        baseline_session_id: baselineSessionId,
+      })
+    },
     async list() {
       const response = await trigger<{ evaluations: EvalSummary[] }>(
         'eval::list',

--- a/eval/ui/src/page/SessionComparison.tsx
+++ b/eval/ui/src/page/SessionComparison.tsx
@@ -1,0 +1,274 @@
+import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react'
+import { EmptyState, Skeleton, StatusPanel, type Host } from '@iii-dev/console-ui'
+import { createEvalApi, errorMessage } from '../api'
+import {
+  formatDate,
+  formatDelta,
+  formatMetricValue,
+  metricGroups,
+  rootSessions,
+  toggleSession,
+  type ComparisonMetric,
+} from '../sessionComparison'
+import type {
+  ContextSnapshot,
+  SessionComparisonItem,
+  SessionComparisonResponse,
+  SessionMeta,
+} from '../types'
+
+function sessionLabel(session: SessionMeta): string {
+  return session.title.trim() || session.session_id
+}
+
+function statusLabel(session: SessionMeta): string {
+  return session.status === 'working' ? 'active' : session.status
+}
+
+function valueFor(item: SessionComparisonItem, key: string): number | null | undefined {
+  return item.summary?.[key]
+}
+
+function metricValue(item: SessionComparisonItem, metric: ComparisonMetric): string {
+  return formatMetricValue(valueFor(item, metric.key), metric.format)
+}
+
+function contextFor(item: SessionComparisonItem): ContextSnapshot | undefined {
+  return item.metrics?.by_session.find(
+    (session) => session.session_id === item.session.session_id,
+  )?.context
+}
+
+function gridStyle(count: number): CSSProperties {
+  return {
+    gridTemplateColumns: `minmax(170px, 1.2fr) repeat(${count}, minmax(150px, 1fr))`,
+  }
+}
+
+function ContextDetails({ item }: { item: SessionComparisonItem }) {
+  const context = contextFor(item)
+  if (!context) {
+    return <span className="eval-ui-comparison-unavailable">—</span>
+  }
+  const categories = context.categories
+  return (
+    <div className="eval-ui-context-details">
+      <div>
+        <strong>{context.compacted ? 'latest snapshot · compacted' : 'latest snapshot'}</strong>
+        <span>{formatDate(context.timestamp)}</span>
+      </div>
+      <div className="eval-ui-context-categories">
+        <span>system {formatMetricValue(categories.system_prompt)}</span>
+        <span>tools {formatMetricValue(categories.tools)}</span>
+        <span>messages {formatMetricValue(categories.messages.user + categories.messages.assistant + categories.messages.function_result + categories.messages.custom)}</span>
+        <span>overhead {formatMetricValue(categories.overhead)}</span>
+        <span>hook {formatMetricValue(categories.hook_guidance)}</span>
+      </div>
+    </div>
+  )
+}
+
+function LifecycleTable({ items }: { items: SessionComparisonItem[] }) {
+  return (
+    <div className="eval-ui-comparison-table eval-ui-comparison-lifecycle">
+      <div className="eval-ui-comparison-row header" style={gridStyle(items.length)}>
+        <span>lifecycle</span>
+        {items.map((item) => (
+          <span key={item.session.session_id}>{sessionLabel(item.session)}</span>
+        ))}
+      </div>
+      {[
+        ['session status', (item: SessionComparisonItem) => statusLabel(item.session)],
+        ['turn status', (item: SessionComparisonItem) => item.lifecycle.turn_status ?? '—'],
+        ['result error', (item: SessionComparisonItem) => item.lifecycle.result_error ?? '—'],
+        ['complete', (item: SessionComparisonItem) => item.lifecycle.complete === undefined ? '—' : item.lifecycle.complete ? 'yes' : 'no'],
+        ['partial snapshot', (item: SessionComparisonItem) => item.lifecycle.partial ? 'yes' : 'no'],
+        ['terminal', (item: SessionComparisonItem) => item.lifecycle.terminal === undefined ? '—' : item.lifecycle.terminal ? 'yes' : 'no'],
+        ['wake armed', (item: SessionComparisonItem) => item.lifecycle.expects_wake === undefined ? '—' : item.lifecycle.expects_wake ? 'yes' : 'no'],
+      ].map(([label, read]) => (
+        <div className="eval-ui-comparison-row" key={label as string} style={gridStyle(items.length)}>
+          <span>{label as string}</span>
+          {items.map((item) => <span key={item.session.session_id}>{(read as (item: SessionComparisonItem) => string)(item)}</span>)}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function ComparisonMatrix({ comparison }: { comparison: SessionComparisonResponse }) {
+  const baseline = comparison.baseline_session_id
+  return (
+    <div className="eval-ui-comparison-result">
+      <div className="eval-ui-comparison-capture">
+        <span>live capture {formatDate(comparison.captured_at)}</span>
+        <span>reference: {comparison.sessions.find((item) => item.session.session_id === baseline)?.session.title || baseline}</span>
+      </div>
+      <LifecycleTable items={comparison.sessions} />
+      {metricGroups.map((group) => (
+        <section className="eval-ui-comparison-group" key={group.label}>
+          <h2>{group.label}</h2>
+          <div className="eval-ui-comparison-table">
+            <div className="eval-ui-comparison-row header" style={gridStyle(comparison.sessions.length)}>
+              <span>metric</span>
+              {comparison.sessions.map((item) => (
+                <span key={item.session.session_id}>
+                  {sessionLabel(item.session)}{item.session.session_id === baseline ? ' · reference' : ''}
+                </span>
+              ))}
+            </div>
+            {group.metrics.map((metric) => (
+              <div className="eval-ui-comparison-row" key={metric.key} style={gridStyle(comparison.sessions.length)}>
+                <span>{metric.label}</span>
+                {comparison.sessions.map((item) => (
+                  <span className="eval-ui-comparison-value" key={item.session.session_id}>
+                    <strong>{metricValue(item, metric)}</strong>
+                    {item.session.session_id === baseline ? null : (
+                      <small>{formatDelta(item.deltas[metric.key], metric.format)}</small>
+                    )}
+                  </span>
+                ))}
+              </div>
+            ))}
+          </div>
+          {group.label === 'Context' ? (
+            <div className="eval-ui-context-grid">
+              {comparison.sessions.map((item) => (
+                <div className="eval-ui-context-card" key={item.session.session_id}>
+                  <strong>{sessionLabel(item.session)}</strong>
+                  <ContextDetails item={item} />
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </section>
+      ))}
+      {comparison.sessions.some((item) => item.errors.length > 0) ? (
+        <div className="eval-ui-comparison-errors">
+          {comparison.sessions.filter((item) => item.errors.length > 0).map((item) => (
+            <div key={item.session.session_id}>
+              <strong>{sessionLabel(item.session)}</strong>
+              <span>{item.errors.join(' · ')}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export function SessionComparison({ host }: { host: Host }) {
+  const api = useMemo(() => createEvalApi(host), [host])
+  const [sessions, setSessions] = useState<SessionMeta[]>([])
+  const [selected, setSelected] = useState<string[]>([])
+  const [baseline, setBaseline] = useState<string | null>(null)
+  const [query, setQuery] = useState('')
+  const [comparison, setComparison] = useState<SessionComparisonResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [comparing, setComparing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadSessions = useCallback(async (quiet = false) => {
+    if (quiet) setRefreshing(true)
+    else setLoading(true)
+    try {
+      const next = rootSessions(await api.sessions())
+      setSessions(next)
+      setSelected((current) => current.filter((id) => next.some((session) => session.session_id === id)))
+      setBaseline((current) => current && next.some((session) => session.session_id === current) ? current : null)
+      setError(null)
+    } catch (loadError) {
+      setError(errorMessage(loadError))
+    } finally {
+      setLoading(false)
+      setRefreshing(false)
+    }
+  }, [api])
+
+  useEffect(() => { void loadSessions() }, [loadSessions])
+
+  const filteredSessions = sessions.filter((session) => {
+    const needle = query.trim().toLowerCase()
+    return !needle || `${sessionLabel(session)} ${session.session_id}`.toLowerCase().includes(needle)
+  })
+
+  const choose = (sessionId: string) => {
+    setSelected((current) => {
+      const next = toggleSession(current, sessionId)
+      if (!next.includes(baseline ?? '')) setBaseline(next[0] ?? null)
+      return next
+    })
+    setComparison(null)
+  }
+
+  const compare = async () => {
+    if (selected.length < 2 || !baseline) return
+    setComparing(true)
+    try {
+      setComparison(await api.compareSessions(selected, baseline))
+      setError(null)
+    } catch (compareError) {
+      setError(errorMessage(compareError))
+    } finally {
+      setComparing(false)
+    }
+  }
+
+  return (
+    <div className="eval-ui-sessions">
+      <div className="eval-ui-section-head">
+        <div>
+          <h1>Compare sessions</h1>
+          <p>Choose 2–5 visible root sessions. You decide whether they are comparable; this view only shows current facts and deltas.</p>
+        </div>
+        <button className="eval-ui-button" type="button" onClick={() => void loadSessions(true)} disabled={refreshing}>
+          {refreshing ? 'refreshing…' : 'refresh sessions'}
+        </button>
+      </div>
+      <div className="eval-ui-comparison-rule">
+        <strong>Live, descriptive comparison.</strong>
+        <span>No snapshots, polling, score, ranking, or equivalence check are created.</span>
+      </div>
+      {error ? <StatusPanel variant="alert" headline="session comparison unavailable" detail={error} /> : null}
+      {loading ? (
+        <div className="eval-ui-loading"><Skeleton /><Skeleton /><Skeleton /></div>
+      ) : sessions.length === 0 ? (
+        <EmptyState title="no root sessions" description="Create or run a session in Console, then return here to compare its live metrics." />
+      ) : (
+        <>
+          <section className="eval-ui-panel eval-ui-session-picker">
+            <div className="eval-ui-panel-title">sessions · {selected.length}/5 selected</div>
+            <input className="eval-ui-input" type="search" value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search title or session id" />
+            <div className="eval-ui-session-list">
+              {filteredSessions.map((session) => {
+                const checked = selected.includes(session.session_id)
+                return (
+                  <div className={`eval-ui-session-option${checked ? ' selected' : ''}`} key={session.session_id}>
+                    <label>
+                      <input type="checkbox" checked={checked} onChange={() => choose(session.session_id)} />
+                      <span>
+                        <strong>{sessionLabel(session)}</strong>
+                        <small>{statusLabel(session)} · {formatDate(session.updated_at)} · {session.session_id}</small>
+                      </span>
+                    </label>
+                    <label className="eval-ui-baseline-choice">
+                      <input type="radio" name="eval-baseline" checked={baseline === session.session_id} disabled={!checked} onChange={() => setBaseline(session.session_id)} />
+                      reference
+                    </label>
+                  </div>
+                )
+              })}
+            </div>
+            <div className="eval-ui-comparison-actions">
+              <span>{selected.length < 2 ? 'Select at least two sessions.' : baseline ? 'Reference is explicit and can be changed.' : 'Choose a reference session.'}</span>
+              <button className="eval-ui-button primary" type="button" onClick={() => void compare()} disabled={selected.length < 2 || !baseline || comparing}>
+                {comparing ? 'collecting…' : 'compare live metrics'}
+              </button>
+            </div>
+          </section>
+          {comparison ? <ComparisonMatrix comparison={comparison} /> : null}
+        </>
+      )}
+    </div>
+  )
+}

--- a/eval/ui/src/page/index.tsx
+++ b/eval/ui/src/page/index.tsx
@@ -6,13 +6,15 @@ import type { CatalogModel, EvalRequest, EvalResultResponse, EvalStatusResponse,
 import { EvaluationDetail } from './EvaluationDetail'
 import { History } from './History'
 import { NewEvaluationForm } from './NewEvaluationForm'
+import { SessionComparison } from './SessionComparison'
 
 export function EvalPage({ host }: { host: Host }) {
   const api = useMemo(() => createEvalApi(host), [host])
+  const [surface, setSurface] = useState<'sessions' | 'experiments'>('sessions')
   const [evaluations, setEvaluations] = useState<EvalSummary[]>([])
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [creating, setCreating] = useState(false)
-  const [historyLoading, setHistoryLoading] = useState(true)
+  const [historyLoading, setHistoryLoading] = useState(false)
   const [historyError, setHistoryError] = useState<string | null>(null)
   const [models, setModels] = useState<CatalogModel[]>([])
   const [modelCatalogError, setModelCatalogError] = useState<string | null>(null)
@@ -80,6 +82,7 @@ export function EvalPage({ host }: { host: Host }) {
   )
 
   useEffect(() => {
+    if (surface !== 'experiments') return
     void loadHistory()
     api
       .models()
@@ -91,33 +94,36 @@ export function EvalPage({ host }: { host: Host }) {
         setModels([])
         setModelCatalogError(errorMessage(error))
       })
-  }, [api, loadHistory])
+  }, [api, loadHistory, surface])
 
   useEffect(() => {
+    if (surface !== 'experiments') return
     if (!selectedId || creating) {
       setStatus(null)
       setResult(null)
       return
     }
     void loadDetail(selectedId)
-  }, [creating, loadDetail, selectedId])
+  }, [creating, loadDetail, selectedId, surface])
 
   useEffect(() => {
+    if (surface !== 'experiments') return
     if (!selectedId || creating || !status || isTerminal(status.status)) return
     const timer = window.setInterval(() => {
       void loadDetail(selectedId, true)
     }, 2_000)
     return () => window.clearInterval(timer)
-  }, [creating, loadDetail, selectedId, status])
+  }, [creating, loadDetail, selectedId, status, surface])
 
   const onCompleted = useCallback(
     (event: { evaluation_id: string }) => {
+      if (surface !== 'experiments') return
       void loadHistory()
       if (event.evaluation_id === selectedId) {
         void loadDetail(event.evaluation_id, true)
       }
     },
-    [loadDetail, loadHistory, selectedId],
+    [loadDetail, loadHistory, selectedId, surface],
   )
   useEvalCompleted(host, onCompleted)
 
@@ -181,8 +187,12 @@ export function EvalPage({ host }: { host: Host }) {
 
   return (
     <div className="eval-ui-container">
-      <div className={`eval-ui${creating ? ' creating' : ''}`}>
-        <History
+      <div className="eval-ui-tabs" role="tablist" aria-label="Eval views">
+        <button className={surface === 'sessions' ? 'active' : ''} type="button" role="tab" aria-selected={surface === 'sessions'} onClick={() => setSurface('sessions')}>Sessions</button>
+        <button className={surface === 'experiments' ? 'active' : ''} type="button" role="tab" aria-selected={surface === 'experiments'} onClick={() => setSurface('experiments')}>Prompt experiments</button>
+      </div>
+      <div className={`eval-ui${creating && surface === 'experiments' ? ' creating' : ''}${surface === 'sessions' ? ' sessions-mode' : ''}`}>
+        {surface === 'experiments' ? <History
           evaluations={evaluations}
           selectedId={creating ? null : selectedId}
           loading={historyLoading}
@@ -192,19 +202,20 @@ export function EvalPage({ host }: { host: Host }) {
           }}
           onNew={() => setCreating(true)}
           onRefresh={() => void loadHistory()}
-        />
+        /> : null}
         <main className="eval-ui-main">
-          {historyError ? (
+          {surface === 'sessions' ? <SessionComparison host={host} /> : null}
+          {surface === 'experiments' && historyError ? (
             <StatusPanel variant="alert" headline="evaluation history unavailable" detail={historyError} />
           ) : null}
-          {creating ? (
+          {surface === 'experiments' && creating ? (
             <NewEvaluationForm
               models={models}
               modelCatalogError={modelCatalogError}
               onLoadDefaultSystemPrompt={(provider) => api.systemPrompt(provider)}
               onCreate={create}
             />
-          ) : selected ? (
+          ) : surface === 'experiments' && selected ? (
             <EvaluationDetail
               summary={selected}
               status={status}
@@ -216,19 +227,19 @@ export function EvalPage({ host }: { host: Host }) {
               onDelete={() => void remove()}
               onRerun={(reverseOrder) => void rerun(reverseOrder)}
             />
-          ) : historyLoading ? (
+          ) : surface === 'experiments' && historyLoading ? (
             <div className="eval-ui-loading">
               <Skeleton />
               <Skeleton />
               <Skeleton />
             </div>
-          ) : (
+          ) : surface === 'experiments' ? (
             <EmptyState
               title="select an evaluation"
               description="choose a recent report or start a new prompt comparison."
               action={{ label: 'new evaluation', onClick: () => setCreating(true) }}
             />
-          )}
+          ) : null}
         </main>
       </div>
     </div>

--- a/eval/ui/src/sessionComparison.test.ts
+++ b/eval/ui/src/sessionComparison.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatDelta,
+  formatMetricValue,
+  rootSessions,
+  toggleSession,
+} from './sessionComparison'
+import type { JsonValue, SessionMeta } from './types'
+
+function session(sessionId: string, metadata?: Record<string, JsonValue>): SessionMeta {
+  return {
+    session_id: sessionId,
+    title: sessionId,
+    description: '',
+    status: 'idle',
+    metadata,
+    created_at: 1,
+    updated_at: 1,
+    message_count: 0,
+  }
+}
+
+describe('session comparison selection', () => {
+  it('keeps only roots and includes every lifecycle status', () => {
+    expect(rootSessions([
+      session('root'),
+      session('child', { parent_session_id: 'root' }),
+      session('active'),
+    ]).map((item) => item.session_id)).toEqual(['root', 'active'])
+  })
+
+  it('enforces the five-session selection limit and supports deselection', () => {
+    const five = ['a', 'b', 'c', 'd', 'e']
+    expect(toggleSession(five, 'f')).toEqual(five)
+    expect(toggleSession(five, 'c')).toEqual(['a', 'b', 'd', 'e'])
+  })
+})
+
+describe('session comparison presentation', () => {
+  it('renders unavailable and partial values without inventing zero', () => {
+    expect(formatMetricValue(null)).toBe('—')
+    expect(formatMetricValue(undefined)).toBe('—')
+    expect(formatMetricValue(0)).toBe('0')
+    expect(formatDelta({ absolute: null, percent: null })).toBe('—')
+  })
+
+  it('formats objective ratios and deltas without direction colors', () => {
+    expect(formatMetricValue(0.25, 'ratio')).toBe('25.0%')
+    expect(formatDelta({ absolute: 10, percent: 25 }, 'number')).toBe('Δ +10 · +25.0%')
+    expect(formatDelta({ absolute: -0.5, percent: null }, 'cost')).toBe('Δ $-0.500000 · —')
+  })
+})

--- a/eval/ui/src/sessionComparison.ts
+++ b/eval/ui/src/sessionComparison.ts
@@ -1,0 +1,130 @@
+import type { SessionMeta } from './types'
+
+export type ComparisonMetricKey =
+  | 'total_tokens'
+  | 'input_tokens'
+  | 'output_tokens'
+  | 'cache_read_tokens'
+  | 'cache_write_tokens'
+  | 'reasoning_tokens'
+  | 'subject_cost_usd'
+  | 'trace_duration_ms'
+  | 'tokens_per_generation'
+  | 'cost_per_generation_usd'
+  | 'function_calls'
+  | 'function_call_errors'
+  | 'function_error_rate'
+  | 'error_span_count'
+  | 'sessions'
+  | 'descendants'
+  | 'max_depth'
+  | 'generations'
+  | 'trace_count'
+  | 'span_count'
+  | 'compacted_sessions'
+  | 'context_total_tokens'
+  | 'context_usable_tokens'
+  | 'context_free_tokens'
+  | 'context_occupancy'
+
+export interface ComparisonMetric {
+  key: ComparisonMetricKey
+  label: string
+  format?: 'number' | 'cost' | 'duration' | 'ratio'
+}
+
+export const metricGroups: Array<{ label: string; metrics: ComparisonMetric[] }> = [
+  {
+    label: 'Efficiency',
+    metrics: [
+      { key: 'total_tokens', label: 'total tokens' },
+      { key: 'input_tokens', label: 'input tokens' },
+      { key: 'output_tokens', label: 'output tokens' },
+      { key: 'cache_read_tokens', label: 'cache read tokens' },
+      { key: 'cache_write_tokens', label: 'cache write tokens' },
+      { key: 'reasoning_tokens', label: 'reasoning tokens' },
+      { key: 'subject_cost_usd', label: 'subject cost', format: 'cost' },
+      { key: 'trace_duration_ms', label: 'observed trace duration', format: 'duration' },
+      { key: 'tokens_per_generation', label: 'tokens / generation', format: 'number' },
+      { key: 'cost_per_generation_usd', label: 'subject cost / generation', format: 'cost' },
+    ],
+  },
+  {
+    label: 'Reliability',
+    metrics: [
+      { key: 'function_call_errors', label: 'function-call errors' },
+      { key: 'function_error_rate', label: 'function errors / call', format: 'ratio' },
+      { key: 'error_span_count', label: 'error spans' },
+    ],
+  },
+  {
+    label: 'Orchestration',
+    metrics: [
+      { key: 'sessions', label: 'sessions' },
+      { key: 'descendants', label: 'descendants' },
+      { key: 'max_depth', label: 'maximum depth' },
+      { key: 'generations', label: 'generations' },
+      { key: 'function_calls', label: 'function calls' },
+      { key: 'trace_count', label: 'traces' },
+      { key: 'span_count', label: 'spans' },
+    ],
+  },
+  {
+    label: 'Context',
+    metrics: [
+      { key: 'context_total_tokens', label: 'latest snapshot total' },
+      { key: 'context_usable_tokens', label: 'latest snapshot usable' },
+      { key: 'context_free_tokens', label: 'latest snapshot free' },
+      { key: 'context_occupancy', label: 'latest snapshot occupancy', format: 'ratio' },
+      { key: 'compacted_sessions', label: 'sessions with compaction' },
+    ],
+  },
+]
+
+export function rootSessions(sessions: SessionMeta[]): SessionMeta[] {
+  return sessions.filter((session) => {
+    const metadata = session.metadata
+    return !metadata || !Object.prototype.hasOwnProperty.call(metadata, 'parent_session_id')
+  })
+}
+
+export function toggleSession(
+  selected: string[],
+  sessionId: string,
+  max = 5,
+): string[] {
+  if (selected.includes(sessionId)) return selected.filter((id) => id !== sessionId)
+  if (selected.length >= max) return selected
+  return [...selected, sessionId]
+}
+
+export function formatMetricValue(
+  value: number | null | undefined,
+  format: ComparisonMetric['format'] = 'number',
+): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) return '—'
+  if (format === 'cost') return `$${value.toFixed(6)}`
+  if (format === 'duration') {
+    return value >= 1000 ? `${(value / 1000).toFixed(2)} s` : `${Math.round(value)} ms`
+  }
+  if (format === 'ratio') return `${(value * 100).toFixed(1)}%`
+  return Number.isInteger(value) ? value.toLocaleString() : value.toFixed(2)
+}
+
+export function formatDelta(
+  delta: { absolute: number | null; percent: number | null } | undefined,
+  format: ComparisonMetric['format'] = 'number',
+): string {
+  if (!delta || delta.absolute === null || delta.absolute === undefined) return '—'
+  const absolute = formatMetricValue(delta.absolute, format)
+  const signedAbsolute = delta.absolute > 0 ? `+${absolute}` : absolute
+  const percent =
+    delta.percent === null || delta.percent === undefined
+      ? '—'
+      : `${delta.percent > 0 ? '+' : ''}${delta.percent.toFixed(1)}%`
+  return `Δ ${signedAbsolute} · ${percent}`
+}
+
+export function formatDate(value: number): string {
+  return new Date(value).toLocaleString()
+}

--- a/eval/ui/src/types.ts
+++ b/eval/ui/src/types.ts
@@ -6,6 +6,130 @@ export type JsonValue =
   | JsonValue[]
   | { [key: string]: JsonValue }
 
+export type SessionStatus = 'idle' | 'working' | 'done' | 'error'
+
+export interface SessionMeta {
+  session_id: string
+  title: string
+  description: string
+  status: SessionStatus
+  status_reason?: string
+  metadata?: Record<string, JsonValue>
+  forked_from?: string
+  draft?: string
+  created_at: number
+  updated_at: number
+  message_count: number
+}
+
+export interface ContextSnapshot {
+  session_id: string
+  turn_id: string
+  step: number
+  model: string
+  provider?: string
+  estimator?: string
+  usable: number
+  effective_max_output_tokens: number
+  total: number
+  free: number
+  categories: {
+    system_prompt: number
+    tools: number
+    messages: {
+      user: number
+      assistant: number
+      function_result: number
+      custom: number
+    }
+    overhead: number
+    hook_guidance: number
+  }
+  compacted: boolean
+  summarized_head_tokens?: number
+  usage?: JsonValue
+  timestamp: number
+}
+
+export interface SessionMetrics {
+  root_session_id: string
+  complete: boolean
+  totals: {
+    sessions: number
+    turns: number
+    function_calls: number
+    function_call_errors: number
+    input_tokens?: number
+    output_tokens?: number
+    cache_read_tokens?: number
+    cache_write_tokens?: number
+    reasoning_tokens?: number
+    cost_usd?: number
+  }
+  by_session: Array<{
+    session_id: string
+    parent_session_id?: string
+    depth: number
+    turns: number
+    function_calls: number
+    function_call_errors: number
+    input_tokens?: number
+    output_tokens?: number
+    cache_read_tokens?: number
+    cache_write_tokens?: number
+    reasoning_tokens?: number
+    cost_usd?: number
+    context?: ContextSnapshot
+  }>
+  traces?: {
+    trace_count: number
+    span_count: number
+    error_span_count: number
+    duration_ms: number
+    by_session: Array<{
+      session_id: string
+      parent_session_id?: string
+      depth: number
+      trace_count: number
+      span_count: number
+      error_span_count: number
+      duration_ms: number
+    }>
+  }
+}
+
+export type TurnStatus =
+  | 'running'
+  | 'awaiting_functions'
+  | 'completed'
+  | 'cancelled'
+  | 'failed'
+
+export interface SessionComparisonItem {
+  session: SessionMeta
+  lifecycle: {
+    session_status: SessionStatus
+    turn_id?: string
+    turn_status?: TurnStatus
+    result_error?: string
+    terminal?: boolean
+    expects_wake?: boolean
+    complete?: boolean
+    partial: boolean
+  }
+  metrics?: SessionMetrics
+  summary?: Record<string, number | null>
+  deltas: Record<string, { absolute: number | null; percent: number | null }>
+  errors: string[]
+}
+
+export interface SessionComparisonResponse {
+  schema_version: string
+  captured_at: number
+  baseline_session_id: string
+  sessions: SessionComparisonItem[]
+}
+
 export type EvalStatus =
   | 'queued'
   | 'running'

--- a/eval/ui/styles.css
+++ b/eval/ui/styles.css
@@ -638,6 +638,298 @@
   text-transform: uppercase;
 }
 
+[data-iii-ui="eval"] .eval-ui-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 12px 24px 0;
+  border-bottom: 1px solid var(--color-rule);
+  background: var(--color-panel);
+}
+
+[data-iii-ui="eval"] .eval-ui-tabs button,
+[data-iii-ui="eval"] .eval-ui-button {
+  padding: 8px 11px;
+  border: 1px solid var(--color-rule);
+  border-radius: 0;
+  background: var(--color-bg);
+  color: var(--color-ink-faint);
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+[data-iii-ui="eval"] .eval-ui-tabs button {
+  border-bottom: 0;
+  background: transparent;
+  letter-spacing: 0.04em;
+}
+
+[data-iii-ui="eval"] .eval-ui-tabs button.active,
+[data-iii-ui="eval"] .eval-ui-button.primary {
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  color: var(--color-bg);
+}
+
+[data-iii-ui="eval"] .eval-ui-tabs button:hover,
+[data-iii-ui="eval"] .eval-ui-button:hover {
+  border-color: var(--color-accent);
+}
+
+[data-iii-ui="eval"] .eval-ui-button:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+[data-iii-ui="eval"] .eval-ui.sessions-mode {
+  display: block;
+}
+
+[data-iii-ui="eval"] .eval-ui-sessions {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  width: min(100%, 1280px);
+  margin: 0 auto;
+}
+
+[data-iii-ui="eval"] .eval-ui-session-picker {
+  gap: 12px;
+}
+
+[data-iii-ui="eval"] .eval-ui-input {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 9px 10px;
+  border: 1px solid var(--color-rule);
+  border-radius: 0;
+  outline: none;
+  background: var(--color-bg);
+  color: var(--color-ink);
+  font: inherit;
+  font-size: 11.5px;
+}
+
+[data-iii-ui="eval"] .eval-ui-input:focus {
+  border-color: var(--color-accent);
+}
+
+[data-iii-ui="eval"] .eval-ui-session-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 330px;
+  overflow-y: auto;
+}
+
+[data-iii-ui="eval"] .eval-ui-session-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 9px 10px;
+  border: 1px solid var(--color-rule-2);
+  background: var(--color-bg);
+}
+
+[data-iii-ui="eval"] .eval-ui-session-option.selected {
+  border-color: var(--color-accent);
+}
+
+[data-iii-ui="eval"] .eval-ui-session-option label:first-child {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  min-width: 0;
+}
+
+[data-iii-ui="eval"] .eval-ui-session-option label:first-child span {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+[data-iii-ui="eval"] .eval-ui-session-option strong {
+  overflow: hidden;
+  color: var(--color-ink);
+  font-size: 11.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-iii-ui="eval"] .eval-ui-session-option small,
+[data-iii-ui="eval"] .eval-ui-baseline-choice,
+[data-iii-ui="eval"] .eval-ui-comparison-actions,
+[data-iii-ui="eval"] .eval-ui-comparison-capture {
+  color: var(--color-ink-ghost);
+  font-size: 10.5px;
+}
+
+[data-iii-ui="eval"] .eval-ui-session-option small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-iii-ui="eval"] .eval-ui-baseline-choice {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 5px;
+  cursor: pointer;
+}
+
+[data-iii-ui="eval"] .eval-ui-comparison-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 4px;
+}
+
+[data-iii-ui="eval"] .eval-ui-comparison-result {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+[data-iii-ui="eval"] .eval-ui-comparison-capture {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 2px;
+}
+
+[data-iii-ui="eval"] .eval-ui-comparison-group {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+
+[data-iii-ui="eval"] .eval-ui-comparison-group h2 {
+  margin: 0;
+  color: var(--color-ink-faint);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+[data-iii-ui="eval"] .eval-ui-comparison-table {
+  overflow-x: auto;
+  border: 1px solid var(--color-rule-2);
+  background: var(--color-bg);
+}
+
+[data-iii-ui="eval"] .eval-ui-comparison-row {
+  display: grid;
+  grid-template-columns: minmax(170px, 1.2fr) repeat(var(--comparison-columns, 2), minmax(150px, 1fr));
+  min-width: 500px;
+  border-bottom: 1px solid var(--color-rule-2);
+}
+
+[data-iii-ui="eval"] .eval-ui-comparison-row:last-child {
+  border-bottom: 0;
+}
+
+[data-iii-ui="eval"] .eval-ui-comparison-row > span {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+  padding: 8px 10px;
+  color: var(--color-ink);
+  font-size: 11px;
+  text-align: right;
+}
+
+[data-iii-ui="eval"] .eval-ui-comparison-row > span:first-child {
+  color: var(--color-ink-faint);
+  text-align: left;
+}
+
+[data-iii-ui="eval"] .eval-ui-comparison-row.header {
+  background: var(--color-paper-2);
+}
+
+[data-iii-ui="eval"] .eval-ui-comparison-row.header > span {
+  color: var(--color-ink-ghost);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+[data-iii-ui="eval"] .eval-ui-comparison-value small {
+  color: var(--color-ink-ghost);
+  font-size: 9.5px;
+  font-weight: 400;
+  white-space: nowrap;
+}
+
+[data-iii-ui="eval"] .eval-ui-comparison-unavailable {
+  color: var(--color-ink-ghost);
+}
+
+[data-iii-ui="eval"] .eval-ui-context-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 8px;
+}
+
+[data-iii-ui="eval"] .eval-ui-context-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid var(--color-rule-2);
+  background: var(--color-panel);
+  color: var(--color-ink);
+  font-size: 10.5px;
+}
+
+[data-iii-ui="eval"] .eval-ui-context-details {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--color-ink-ghost);
+}
+
+[data-iii-ui="eval"] .eval-ui-context-details > div:first-child {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+[data-iii-ui="eval"] .eval-ui-context-details strong {
+  color: var(--color-ink-faint);
+  font-size: 10.5px;
+}
+
+[data-iii-ui="eval"] .eval-ui-context-categories {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px 9px;
+  line-height: 1.4;
+}
+
+[data-iii-ui="eval"] .eval-ui-comparison-errors {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
+  border: 1px solid var(--color-alert);
+  color: var(--color-alert);
+  font-size: 10.5px;
+}
+
+[data-iii-ui="eval"] .eval-ui-comparison-errors div {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 [data-iii-ui="eval"] .eval-ui-metric .positive {
   color: var(--color-ok);
 }

--- a/harness/src/functions/metrics.rs
+++ b/harness/src/functions/metrics.rs
@@ -143,13 +143,24 @@ pub async fn handle(
             complete = false;
             continue;
         }
-        let Some(turn) =
+        let mut context = None;
+        if let Some(turn) =
             crate::state::get_turn(&deps.iii, &node.session_id, cfg.session_timeout_ms).await?
-        else {
-            complete = false;
-            continue;
-        };
-        if !terminal_status(Some(turn.status)) {
+        {
+            context = turn.context_snapshot.clone();
+            if context.is_none() {
+                missing_context.push(by_session.len());
+            }
+            if !terminal_snapshot(
+                Some(turn.status),
+                crate::bindings::session_expects_wake(deps, &node.session_id).await,
+            ) {
+                complete = false;
+            }
+        } else {
+            // The transcript is durable independently of the latest harness
+            // turn record. Keep aggregating it, but make the snapshot partial
+            // and leave lifecycle/context data unavailable.
             complete = false;
         }
         let entries = session.messages_strict(&node.session_id).await?;
@@ -164,10 +175,6 @@ pub async fn handle(
         // free. A freshly seeded turn has not generated yet, so its record has
         // none and the durable `harness_context` row is the fallback — noted
         // here, read after the walk.
-        let context = turn.context_snapshot.clone();
-        if context.is_none() {
-            missing_context.push(by_session.len());
-        }
         by_session.push(current.finish_session(node, context));
     }
     // One state read per session whose record carried no snapshot — collected
@@ -203,6 +210,10 @@ pub async fn handle(
 
 fn terminal_status(status: Option<crate::types::turn::TurnStatus>) -> bool {
     status.is_some_and(crate::types::turn::TurnStatus::is_terminal)
+}
+
+fn terminal_snapshot(status: Option<crate::types::turn::TurnStatus>, expects_wake: bool) -> bool {
+    terminal_status(status) && !expects_wake
 }
 
 async fn collect_trace_metrics(
@@ -553,6 +564,8 @@ mod tests {
         assert!(terminal_status(Some(TurnStatus::Completed)));
         assert!(terminal_status(Some(TurnStatus::Cancelled)));
         assert!(terminal_status(Some(TurnStatus::Failed)));
+        assert!(!terminal_snapshot(Some(TurnStatus::Completed), true));
+        assert!(terminal_snapshot(Some(TurnStatus::Completed), false));
     }
 
     #[test]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,9 @@ importers:
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0))
 
   github/ui:
     dependencies:


### PR DESCRIPTION
## Summary

- Add live comparison of 2–5 root sessions using objective Harness metrics
- Add the `eval::compare-sessions` API with isolated per-session collection failures and null-safe deltas
- Add the Sessions UI while keeping prompt experiments available as an advanced tab
- Preserve partial/active Harness metric semantics and add schema/UI coverage

The comparison is read-only and does not persist snapshots, create jobs, rank sessions, or apply scores/judges.

## Validation

- `cargo test --manifest-path eval/Cargo.toml`
- `cargo test --manifest-path harness/Cargo.toml`
- Clippy with `-D warnings` for eval and harness
- Eval UI TypeScript check, build, and Vitest tests

Fixes MOT-4096