### PR TITLE
(MOT-4299) fix(ci): unbreak cold registry-lane harness e2e builds

### DIFF
--- a/.github/workflows/_harness-e2e.yml
+++ b/.github/workflows/_harness-e2e.yml
@@ -294,9 +294,11 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           # Instrumented builds have different fingerprints; keep them on their
-          # own key so coverage runs never poison the normal cache.
+          # own key so coverage runs never poison the normal cache. Both lanes
+          # save their own key: with coverage-only saving, the plain key was
+          # never written and every registry-lane build compiled from scratch.
           shared-key: ${{ inputs.coverage && 'harness-e2e-coverage' || 'harness-e2e' }}
-          save-if: ${{ inputs.coverage }}
+          save-if: true
           workspaces: |
             harness -> target
             database -> target

--- a/.github/workflows/_harness-e2e.yml
+++ b/.github/workflows/_harness-e2e.yml
@@ -179,15 +179,14 @@ jobs:
         with:
           ref: ${{ inputs.source_ref }}
 
-      # state/build.rs builds its embedded UI when the checked-out assets are
-      # stale, so the isolated E2E build needs the same Node/pnpm toolchain as
-      # the regular CI worker builds.
+      # state/build.rs and harness/build.rs build their embedded UIs when the
+      # checked-out assets are stale, and the harness crate compiles in every
+      # stack mode (Test/Lint E2E crate), so both lanes need the same
+      # Node/pnpm toolchain as the regular CI worker builds.
       - name: Setup pnpm
-        if: inputs.stack_mode == 'source'
         uses: pnpm/action-setup@v5
 
       - name: Setup Node
-        if: inputs.stack_mode == 'source'
         uses: actions/setup-node@v5
         with:
           node-version: 22


### PR DESCRIPTION
Today's daily ([run 31153706659](https://github.com/iii-hq/workers/actions/runs/31153706659)) failed "Test E2E crate" — reproducibly, including on re-run. Two defects compounded:

1. **`harness/build.rs` needs pnpm, but registry mode never sets it up.** Since #686 embedded the console UI, compiling `harness` from scratch runs the UI build. `Test E2E crate` / `Lint E2E crate` compile `harness` (dep of `harness-e2e`) in every stack mode, but `Setup pnpm`/`Setup Node` were gated to `stack_mode == 'source'` → `pnpm not found on PATH` panic on the first cold registry-lane build after #686. Fixed by making both steps unconditional.

2. **The plain `harness-e2e` cache key was never saved.** `save-if: ${{ inputs.coverage }}` meant only coverage runs saved, and since #735 moved the daily to `coverage: false`, every registry-lane build compiled and downloaded everything from scratch (which is what exposed defect 1). Fixed with `save-if: true`.

The e2e crate itself is healthy: 91/91 tests pass warm and cold on stable 1.97.1 (with pnpm on PATH). `_harness-integration.yml` is not affected — `harness-integration` has no path dep on `harness`.

After merge, the next scheduled daily (or a `workflow_dispatch`) picks this up.