### PR TITLE
(MOT-4375) fix(harness,providers): session-total cost in the chip; stop double-billing cached tokens

### DIFF
--- a/harness/src/context_snapshot.rs
+++ b/harness/src/context_snapshot.rs
@@ -134,6 +134,12 @@ pub struct ContextSnapshotV1 {
     /// generation never completed).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub usage: Option<Usage>,
+    /// Running cost of the whole session in USD, accumulated across every
+    /// generation step. `usage.cost_usd` is one step's bill — on providers
+    /// with steep cache discounts the per-step number swings two orders of
+    /// magnitude, so a chip showing it alone reads as a bouncing total.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_cost_usd: Option<f64>,
     pub timestamp: i64,
 }
 
@@ -419,6 +425,7 @@ mod tests {
                 reasoning: None,
                 cost_usd: Some(0.42),
             }),
+            session_cost_usd: Some(1.37),
             timestamp: 1_722_700_000_000,
         };
         let mut value = serde_json::to_value(&snapshot).unwrap();

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -740,23 +740,38 @@ pub async fn run_step(
     if let Some(snapshot) = record.context_snapshot.as_mut() {
         snapshot.usage = outcome.message.usage.clone();
         // Accumulate the session's running cost on top of the stored
-        // snapshot's total: the loop is the only writer per session, so the
-        // read-back is race-free, and seeding from the store keeps the total
-        // honest across turns and harness restarts.
+        // snapshot's total: turns are serialized per session (the harness-turn
+        // queue is fifo grouped by session_id) and steps run sequentially
+        // within a turn, so the loop is the only writer and the read-back is
+        // race-free. Seeding from the store keeps the total honest across
+        // turns and harness restarts. A failed read leaves the total unknown
+        // rather than fabricating one that resets to the current step's cost.
         let step_cost = outcome
             .message
             .usage
             .as_ref()
             .and_then(|u| u.cost_usd)
             .unwrap_or(0.0);
-        let prior_cost =
-            crate::context_snapshot::get(&deps.iii, &record.session_id, cfg.session_timeout_ms)
-                .await
-                .ok()
-                .flatten()
-                .and_then(|prev| prev.session_cost_usd)
-                .unwrap_or(0.0);
-        snapshot.session_cost_usd = Some(prior_cost + step_cost);
+        snapshot.session_cost_usd = match crate::context_snapshot::get(
+            &deps.iii,
+            &record.session_id,
+            cfg.session_timeout_ms,
+        )
+        .await
+        {
+            Ok(prev) => {
+                let prior_cost = prev.and_then(|p| p.session_cost_usd).unwrap_or(0.0);
+                Some(prior_cost + step_cost)
+            }
+            Err(error) => {
+                tracing::warn!(
+                    session_id = %record.session_id,
+                    %error,
+                    "prior context snapshot read failed; session cost total unknown this step"
+                );
+                None
+            }
+        };
         crate::context_snapshot::exactify(snapshot, &router, gen_system_prompt.as_deref(), &tools)
             .await;
         if let Err(error) =

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -739,6 +739,24 @@ pub async fn run_step(
     // must never fail a turn that generated successfully.
     if let Some(snapshot) = record.context_snapshot.as_mut() {
         snapshot.usage = outcome.message.usage.clone();
+        // Accumulate the session's running cost on top of the stored
+        // snapshot's total: the loop is the only writer per session, so the
+        // read-back is race-free, and seeding from the store keeps the total
+        // honest across turns and harness restarts.
+        let step_cost = outcome
+            .message
+            .usage
+            .as_ref()
+            .and_then(|u| u.cost_usd)
+            .unwrap_or(0.0);
+        let prior_cost =
+            crate::context_snapshot::get(&deps.iii, &record.session_id, cfg.session_timeout_ms)
+                .await
+                .ok()
+                .flatten()
+                .and_then(|prev| prev.session_cost_usd)
+                .unwrap_or(0.0);
+        snapshot.session_cost_usd = Some(prior_cost + step_cost);
         crate::context_snapshot::exactify(snapshot, &router, gen_system_prompt.as_deref(), &tools)
             .await;
         if let Err(error) =
@@ -2217,6 +2235,7 @@ fn build_context_snapshot(
         model: record.options.model.clone(),
         provider: record.options.provider.clone(),
         estimator: b.estimator,
+        session_cost_usd: None,
         usable: assembled.usable,
         effective_max_output_tokens: assembled.effective_max_output_tokens,
         total: final_request_tokens,

--- a/harness/tests/golden/schemas/harness.metrics.json
+++ b/harness/tests/golden/schemas/harness.metrics.json
@@ -53,6 +53,14 @@
               "null"
             ]
           },
+          "session_cost_usd": {
+            "description": "Running cost of the whole session in USD, accumulated across every generation step. `usage.cost_usd` is one step's bill — on providers with steep cache discounts the per-step number swings two orders of magnitude, so a chip showing it alone reads as a bouncing total.",
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
           "session_id": {
             "type": "string"
           },

--- a/harness/ui/src/context-chip/index.tsx
+++ b/harness/ui/src/context-chip/index.tsx
@@ -282,6 +282,7 @@ function ContextPopover({
           <span>
             last step {formatTokens(usage?.input ?? 0)} in · output{' '}
             {formatTokens(usage?.output ?? 0)}
+            {usage?.cost_usd != null ? <> · {formatCost(usage.cost_usd)}</> : null}
           </span>
         ) : null}
         {cache ? (
@@ -298,8 +299,15 @@ function ContextPopover({
             </span>
           </span>
         ) : null}
-        {usage?.cost_usd != null ? (
-          <span>cost {formatCost(usage.cost_usd)}</span>
+        {snapshot.session_cost_usd != null ? (
+          <span
+            title={
+              'every generation step of this session summed. The per-step ' +
+              'cost on the line above swings with cache hits; this one only grows.'
+            }
+          >
+            session total {formatCost(snapshot.session_cost_usd)}
+          </span>
         ) : null}
       </div>
     </div>

--- a/harness/ui/src/lib/metrics.ts
+++ b/harness/ui/src/lib/metrics.ts
@@ -46,6 +46,8 @@ export interface ContextSnapshot {
   compacted: boolean
   summarized_head_tokens?: number
   usage?: SnapshotUsage
+  /** Running cost of the whole session, summed across generation steps. */
+  session_cost_usd?: number
   timestamp: number
 }
 

--- a/harness/ui/src/lib/metrics.ts
+++ b/harness/ui/src/lib/metrics.ts
@@ -47,7 +47,7 @@ export interface ContextSnapshot {
   summarized_head_tokens?: number
   usage?: SnapshotUsage
   /** Running cost of the whole session, summed across generation steps. */
-  session_cost_usd?: number
+  session_cost_usd?: number | null
   timestamp: number
 }
 

--- a/provider-kimi/Cargo.lock
+++ b/provider-kimi/Cargo.lock
@@ -943,7 +943,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-kimi/src/sse.rs
+++ b/provider-kimi/src/sse.rs
@@ -153,19 +153,27 @@ pub fn map_finish_reason(s: &str) -> StopReason {
 /// values — overwriting is correct for both, adding double-counts.
 pub fn merge_usage(raw: &Value, into: &mut Usage) {
     let num = |k: &str| raw.get(k).and_then(Value::as_u64);
-    if let Some(v) = num("prompt_tokens").or_else(|| num("input_tokens")) {
-        into.input = Some(v);
-    }
-    if let Some(v) = num("completion_tokens").or_else(|| num("output_tokens")) {
-        into.output = Some(v);
-    }
+    // `Usage.input` is the cache-MISS slice, disjoint from `cache_read`
+    // (pricing bills the splits additively). The wire's `prompt_tokens` is a
+    // TOTAL that includes the cached slice, so the miss slice is derived —
+    // mapping the total verbatim would bill the cached prefix twice.
+    let mut cached = None;
     for parent in ["prompt_tokens_details", "input_tokens_details"] {
         if let Some(v) = raw
             .pointer(&format!("/{parent}/cached_tokens"))
             .and_then(Value::as_u64)
         {
-            into.cache_read = Some(v);
+            cached = Some(v);
         }
+    }
+    if let Some(v) = cached {
+        into.cache_read = Some(v);
+    }
+    if let Some(v) = num("prompt_tokens").or_else(|| num("input_tokens")) {
+        into.input = Some(v.saturating_sub(cached.unwrap_or(0)));
+    }
+    if let Some(v) = num("completion_tokens").or_else(|| num("output_tokens")) {
+        into.output = Some(v);
     }
     if let Some(v) = raw
         .pointer("/completion_tokens_details/reasoning_tokens")
@@ -394,7 +402,7 @@ mod tests {
         assert_eq!(final_msg.stop_reason, StopReason::End);
         assert_eq!(final_msg.native_stop_reason.as_deref(), Some("stop"));
         let usage = final_msg.usage.unwrap();
-        assert_eq!(usage.input, Some(12));
+        assert_eq!(usage.input, Some(8));
         assert_eq!(usage.output, Some(2));
         assert_eq!(usage.cache_read, Some(4));
         assert_eq!(usage.reasoning, Some(0));

--- a/provider-kimi/src/upstream.rs
+++ b/provider-kimi/src/upstream.rs
@@ -214,7 +214,7 @@ mod tests {
         );
         match events.last() {
             Some(AssistantMessageEvent::Done { message }) => {
-                assert_eq!(message.usage.as_ref().unwrap().input, Some(12));
+                assert_eq!(message.usage.as_ref().unwrap().input, Some(8));
                 assert_eq!(message.usage.as_ref().unwrap().output, Some(2));
                 assert_eq!(message.usage.as_ref().unwrap().cache_read, Some(4));
                 assert_eq!(message.native_stop_reason.as_deref(), Some("stop"));

--- a/provider-llamacpp/Cargo.lock
+++ b/provider-llamacpp/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-llamacpp/src/sse.rs
+++ b/provider-llamacpp/src/sse.rs
@@ -154,19 +154,27 @@ pub fn map_finish_reason(s: &str) -> StopReason {
 /// correct whether it reports once at the end or cumulatively per chunk.
 pub fn merge_usage(raw: &Value, into: &mut Usage) {
     let num = |k: &str| raw.get(k).and_then(Value::as_u64);
-    if let Some(v) = num("prompt_tokens").or_else(|| num("input_tokens")) {
-        into.input = Some(v);
-    }
-    if let Some(v) = num("completion_tokens").or_else(|| num("output_tokens")) {
-        into.output = Some(v);
-    }
+    // `Usage.input` is the cache-MISS slice, disjoint from `cache_read`
+    // (pricing bills the splits additively). The wire's `prompt_tokens` is a
+    // TOTAL that includes the cached slice, so the miss slice is derived —
+    // mapping the total verbatim would bill the cached prefix twice.
+    let mut cached = None;
     for parent in ["prompt_tokens_details", "input_tokens_details"] {
         if let Some(v) = raw
             .pointer(&format!("/{parent}/cached_tokens"))
             .and_then(Value::as_u64)
         {
-            into.cache_read = Some(v);
+            cached = Some(v);
         }
+    }
+    if let Some(v) = cached {
+        into.cache_read = Some(v);
+    }
+    if let Some(v) = num("prompt_tokens").or_else(|| num("input_tokens")) {
+        into.input = Some(v.saturating_sub(cached.unwrap_or(0)));
+    }
+    if let Some(v) = num("completion_tokens").or_else(|| num("output_tokens")) {
+        into.output = Some(v);
     }
     if let Some(v) = raw
         .pointer("/completion_tokens_details/reasoning_tokens")
@@ -427,7 +435,7 @@ mod tests {
         assert_eq!(final_msg.stop_reason, StopReason::End);
         assert_eq!(final_msg.native_stop_reason.as_deref(), Some("stop"));
         let usage = final_msg.usage.unwrap();
-        assert_eq!(usage.input, Some(12));
+        assert_eq!(usage.input, Some(8));
         assert_eq!(usage.output, Some(2));
         assert_eq!(usage.cache_read, Some(4));
         assert_eq!(usage.reasoning, Some(0));

--- a/provider-llamacpp/src/upstream.rs
+++ b/provider-llamacpp/src/upstream.rs
@@ -221,7 +221,7 @@ mod tests {
         );
         match events.last() {
             Some(AssistantMessageEvent::Done { message }) => {
-                assert_eq!(message.usage.as_ref().unwrap().input, Some(12));
+                assert_eq!(message.usage.as_ref().unwrap().input, Some(8));
                 assert_eq!(message.usage.as_ref().unwrap().output, Some(2));
                 assert_eq!(message.usage.as_ref().unwrap().cache_read, Some(4));
                 assert_eq!(message.native_stop_reason.as_deref(), Some("stop"));

--- a/provider-openai-codex/Cargo.lock
+++ b/provider-openai-codex/Cargo.lock
@@ -3,6 +3,20 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +100,12 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -142,6 +162,15 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -212,6 +241,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +281,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,10 +316,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "daachorse"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f55d7153ba3b507595872a3874803f07a8a81d1e888abed8e5db7da0597d6e2"
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
 
 [[package]]
 name = "digest"
@@ -280,6 +430,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +450,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
 name = "fancy-regex"
@@ -311,6 +473,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -578,7 +746,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -684,6 +852,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +945,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,7 +996,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "async-trait",
  "clap",
@@ -821,12 +1004,14 @@ dependencies = [
  "iii-helpers",
  "iii-sdk",
  "regex",
+ "reqwest",
  "schemars",
  "serde",
  "serde_json",
  "sha2",
  "thiserror",
  "tiktoken-rs",
+ "tokenizers",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -846,6 +1031,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3ae8f6d608c795738406608304d30a2dfbdc8e58e44f7ba43236da5208ded3c"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "pastey",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +1062,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +1076,38 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -971,6 +1210,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,7 +1274,7 @@ dependencies = [
 name = "provider-openai-codex"
 version = "0.4.0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "clap",
  "futures",
  "iii-sdk",
@@ -1144,6 +1395,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools",
+ "rayon",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,7 +1460,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -1496,10 +1778,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1594,7 +1894,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac4a168cfc1d8ed65bf17a6ee0843ad9a68f863c63c0fb2fa7eab67838782ee"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bstr",
  "fancy-regex",
  "lazy_static",
@@ -1626,6 +1926,39 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44e5bea67576e04b6ff8564c5d9e09c2ef0cf476502245f2f120e497769d3112"
+dependencies = [
+ "ahash",
+ "compact_str",
+ "daachorse",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "fancy-regex",
+ "getrandom 0.3.4",
+ "itertools",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "paste",
+ "rand",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
 
 [[package]]
 name = "tokio"
@@ -1848,10 +2181,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "untrusted"

--- a/provider-openai-codex/src/sse.rs
+++ b/provider-openai-codex/src/sse.rs
@@ -152,18 +152,23 @@ pub fn merge_usage(data: &Value, into: &mut Usage) {
         return;
     };
     let num = |k: &str| u.get(k).and_then(Value::as_u64);
+    // `Usage.input` is the cache-MISS slice, disjoint from `cache_read`
+    // (pricing bills the splits additively). The Responses API's
+    // `input_tokens` is a TOTAL that includes the cached slice, so the miss
+    // slice is derived — mapping the total verbatim would bill the cached
+    // prefix twice.
+    let cached = u
+        .pointer("/input_tokens_details/cached_tokens")
+        .or_else(|| u.get("cached_tokens"))
+        .and_then(Value::as_u64);
+    if let Some(v) = cached {
+        into.cache_read = Some(v);
+    }
     if let Some(v) = num("input_tokens").or_else(|| num("prompt_tokens")) {
-        into.input = Some(v);
+        into.input = Some(v.saturating_sub(cached.unwrap_or(0)));
     }
     if let Some(v) = num("output_tokens").or_else(|| num("completion_tokens")) {
         into.output = Some(v);
-    }
-    if let Some(v) = u
-        .pointer("/input_tokens_details/cached_tokens")
-        .or_else(|| u.get("cached_tokens"))
-        .and_then(Value::as_u64)
-    {
-        into.cache_read = Some(v);
     }
     if let Some(v) = u
         .pointer("/output_tokens_details/reasoning_tokens")
@@ -446,6 +451,30 @@ mod tests {
         }
         assert_eq!(state.stop_reason, StopReason::End);
         assert_eq!(events.iter().filter(|e| e.is_terminal()).count(), 1);
+    }
+
+    #[test]
+    fn usage_input_excludes_the_cached_slice() {
+        // `input_tokens` on the wire is a TOTAL including the cached prefix;
+        // `Usage.input` is the disjoint miss slice pricing bills at the full
+        // input rate. 10 total with 4 cached reads as 6 in, 4 cache_read.
+        let (_state, events) = run(&[
+            json!({ "type": "response.created" }),
+            json!({ "type": "response.output_text.delta", "delta": "Hello" }),
+            json!({ "type": "response.completed", "response": { "usage": {
+                "input_tokens": 10,
+                "output_tokens": 2,
+                "input_tokens_details": { "cached_tokens": 4 }
+            } } }),
+        ]);
+        match events.last() {
+            Some(AssistantMessageEvent::Done { message }) => {
+                let usage = message.usage.as_ref().unwrap();
+                assert_eq!(usage.input, Some(6));
+                assert_eq!(usage.cache_read, Some(4));
+            }
+            other => panic!("want done, got {other:?}"),
+        }
     }
 
     #[test]

--- a/provider-openai-codex/src/upstream.rs
+++ b/provider-openai-codex/src/upstream.rs
@@ -232,7 +232,7 @@ mod tests {
         );
         match events.last() {
             Some(AssistantMessageEvent::Done { message }) => {
-                assert_eq!(message.usage.as_ref().unwrap().input, Some(12));
+                assert_eq!(message.usage.as_ref().unwrap().input, Some(8));
                 assert_eq!(message.usage.as_ref().unwrap().output, Some(2));
                 assert_eq!(message.usage.as_ref().unwrap().cache_read, Some(4));
             }

--- a/provider-openai/Cargo.lock
+++ b/provider-openai/Cargo.lock
@@ -3,6 +3,20 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +100,12 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -142,6 +162,15 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -212,6 +241,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +281,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,10 +316,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "daachorse"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f55d7153ba3b507595872a3874803f07a8a81d1e888abed8e5db7da0597d6e2"
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
 
 [[package]]
 name = "digest"
@@ -280,6 +430,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +450,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
 name = "fancy-regex"
@@ -311,6 +473,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -578,7 +746,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -684,6 +852,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +945,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,7 +996,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "async-trait",
  "clap",
@@ -821,12 +1004,14 @@ dependencies = [
  "iii-helpers",
  "iii-sdk",
  "regex",
+ "reqwest",
  "schemars",
  "serde",
  "serde_json",
  "sha2",
  "thiserror",
  "tiktoken-rs",
+ "tokenizers",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -846,6 +1031,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3ae8f6d608c795738406608304d30a2dfbdc8e58e44f7ba43236da5208ded3c"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "pastey",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +1062,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +1076,38 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -969,6 +1208,18 @@ dependencies = [
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -1143,6 +1394,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools",
+ "rayon",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,7 +1459,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -1495,10 +1777,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1593,7 +1893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac4a168cfc1d8ed65bf17a6ee0843ad9a68f863c63c0fb2fa7eab67838782ee"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bstr",
  "fancy-regex",
  "lazy_static",
@@ -1625,6 +1925,39 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44e5bea67576e04b6ff8564c5d9e09c2ef0cf476502245f2f120e497769d3112"
+dependencies = [
+ "ahash",
+ "compact_str",
+ "daachorse",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "fancy-regex",
+ "getrandom 0.3.4",
+ "itertools",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "paste",
+ "rand",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
 
 [[package]]
 name = "tokio"
@@ -1847,10 +2180,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "untrusted"

--- a/provider-openai/src/sse.rs
+++ b/provider-openai/src/sse.rs
@@ -155,19 +155,27 @@ pub fn map_finish_reason(s: &str) -> StopReason {
 /// values — overwriting is correct for both, adding double-counts.
 pub fn merge_usage(raw: &Value, into: &mut Usage) {
     let num = |k: &str| raw.get(k).and_then(Value::as_u64);
-    if let Some(v) = num("prompt_tokens").or_else(|| num("input_tokens")) {
-        into.input = Some(v);
-    }
-    if let Some(v) = num("completion_tokens").or_else(|| num("output_tokens")) {
-        into.output = Some(v);
-    }
+    // `Usage.input` is the cache-MISS slice, disjoint from `cache_read`
+    // (pricing bills the splits additively). The wire's `prompt_tokens` is a
+    // TOTAL that includes the cached slice, so the miss slice is derived —
+    // mapping the total verbatim would bill the cached prefix twice.
+    let mut cached = None;
     for parent in ["prompt_tokens_details", "input_tokens_details"] {
         if let Some(v) = raw
             .pointer(&format!("/{parent}/cached_tokens"))
             .and_then(Value::as_u64)
         {
-            into.cache_read = Some(v);
+            cached = Some(v);
         }
+    }
+    if let Some(v) = cached {
+        into.cache_read = Some(v);
+    }
+    if let Some(v) = num("prompt_tokens").or_else(|| num("input_tokens")) {
+        into.input = Some(v.saturating_sub(cached.unwrap_or(0)));
+    }
+    if let Some(v) = num("completion_tokens").or_else(|| num("output_tokens")) {
+        into.output = Some(v);
     }
     if let Some(v) = raw
         .pointer("/completion_tokens_details/reasoning_tokens")
@@ -589,7 +597,7 @@ mod tests {
         assert_eq!(final_msg.stop_reason, StopReason::End);
         assert_eq!(final_msg.native_stop_reason.as_deref(), Some("stop"));
         let usage = final_msg.usage.unwrap();
-        assert_eq!(usage.input, Some(12));
+        assert_eq!(usage.input, Some(8));
         assert_eq!(usage.output, Some(2));
         assert_eq!(usage.cache_read, Some(4));
         assert_eq!(usage.reasoning, Some(0));
@@ -781,7 +789,7 @@ mod tests {
             matches!(&final_message.content[0], ContentBlock::Text { text } if text == "Hello")
         );
         let usage = final_message.usage.unwrap();
-        assert_eq!(usage.input, Some(12));
+        assert_eq!(usage.input, Some(8));
         assert_eq!(usage.output, Some(2));
         assert_eq!(usage.cache_read, Some(4));
         assert_eq!(usage.reasoning, Some(1));

--- a/provider-openai/src/upstream.rs
+++ b/provider-openai/src/upstream.rs
@@ -232,7 +232,7 @@ mod tests {
         );
         match events.last() {
             Some(AssistantMessageEvent::Done { message }) => {
-                assert_eq!(message.usage.as_ref().unwrap().input, Some(12));
+                assert_eq!(message.usage.as_ref().unwrap().input, Some(8));
                 assert_eq!(message.usage.as_ref().unwrap().output, Some(2));
                 assert_eq!(message.usage.as_ref().unwrap().cache_read, Some(4));
                 assert_eq!(message.native_stop_reason.as_deref(), Some("stop"));

--- a/provider-xai/Cargo.lock
+++ b/provider-xai/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-xai/src/responses.rs
+++ b/provider-xai/src/responses.rs
@@ -229,17 +229,21 @@ pub fn handle_event(
 /// Map the Responses usage object onto the shared `Usage`.
 fn merge_usage(raw: &Value, into: &mut Usage) {
     let num = |k: &str| raw.get(k).and_then(Value::as_u64);
+    // `Usage.input` is the cache-MISS slice, disjoint from `cache_read`
+    // (pricing bills the splits additively). The wire's `input_tokens` is a
+    // TOTAL that includes the cached slice, so the miss slice is derived —
+    // mapping the total verbatim would bill the cached prefix twice.
+    let cached = raw
+        .pointer("/input_tokens_details/cached_tokens")
+        .and_then(Value::as_u64);
+    if let Some(v) = cached {
+        into.cache_read = Some(v);
+    }
     if let Some(v) = num("input_tokens") {
-        into.input = Some(v);
+        into.input = Some(v.saturating_sub(cached.unwrap_or(0)));
     }
     if let Some(v) = num("output_tokens") {
         into.output = Some(v);
-    }
-    if let Some(v) = raw
-        .pointer("/input_tokens_details/cached_tokens")
-        .and_then(Value::as_u64)
-    {
-        into.cache_read = Some(v);
     }
     if let Some(v) = raw
         .pointer("/output_tokens_details/reasoning_tokens")

--- a/provider-xai/src/sse.rs
+++ b/provider-xai/src/sse.rs
@@ -153,19 +153,27 @@ pub fn map_finish_reason(s: &str) -> StopReason {
 /// values — overwriting is correct for both, adding double-counts.
 pub fn merge_usage(raw: &Value, into: &mut Usage) {
     let num = |k: &str| raw.get(k).and_then(Value::as_u64);
-    if let Some(v) = num("prompt_tokens").or_else(|| num("input_tokens")) {
-        into.input = Some(v);
-    }
-    if let Some(v) = num("completion_tokens").or_else(|| num("output_tokens")) {
-        into.output = Some(v);
-    }
+    // `Usage.input` is the cache-MISS slice, disjoint from `cache_read`
+    // (pricing bills the splits additively). The wire's `prompt_tokens` is a
+    // TOTAL that includes the cached slice, so the miss slice is derived —
+    // mapping the total verbatim would bill the cached prefix twice.
+    let mut cached = None;
     for parent in ["prompt_tokens_details", "input_tokens_details"] {
         if let Some(v) = raw
             .pointer(&format!("/{parent}/cached_tokens"))
             .and_then(Value::as_u64)
         {
-            into.cache_read = Some(v);
+            cached = Some(v);
         }
+    }
+    if let Some(v) = cached {
+        into.cache_read = Some(v);
+    }
+    if let Some(v) = num("prompt_tokens").or_else(|| num("input_tokens")) {
+        into.input = Some(v.saturating_sub(cached.unwrap_or(0)));
+    }
+    if let Some(v) = num("completion_tokens").or_else(|| num("output_tokens")) {
+        into.output = Some(v);
     }
     if let Some(v) = raw
         .pointer("/completion_tokens_details/reasoning_tokens")
@@ -427,7 +435,7 @@ mod tests {
         assert_eq!(final_msg.stop_reason, StopReason::End);
         assert_eq!(final_msg.native_stop_reason.as_deref(), Some("stop"));
         let usage = final_msg.usage.unwrap();
-        assert_eq!(usage.input, Some(12));
+        assert_eq!(usage.input, Some(8));
         assert_eq!(usage.output, Some(2));
         assert_eq!(usage.cache_read, Some(4));
         assert_eq!(usage.reasoning, Some(0));

--- a/provider-xai/src/upstream.rs
+++ b/provider-xai/src/upstream.rs
@@ -218,7 +218,7 @@ mod tests {
         );
         match events.last() {
             Some(AssistantMessageEvent::Done { message }) => {
-                assert_eq!(message.usage.as_ref().unwrap().input, Some(12));
+                assert_eq!(message.usage.as_ref().unwrap().input, Some(8));
                 assert_eq!(message.usage.as_ref().unwrap().output, Some(2));
                 assert_eq!(message.usage.as_ref().unwrap().cache_read, Some(4));
                 assert_eq!(message.native_stop_reason.as_deref(), Some("stop"));

--- a/provider-xai/tests/integration.rs
+++ b/provider-xai/tests/integration.rs
@@ -373,7 +373,7 @@ async fn chat_streams_end_to_end_with_cost_fill() {
     assert_eq!(res["ok"], true, "chat response: {res}");
     assert_eq!(res["provider"], "xai");
     assert_eq!(res["stop_reason"], "end");
-    // the router filled cost_usd from the curated pricing (12 in + 2 out)
+    // the router filled cost_usd from the curated pricing (8 in + 4 cached + 2 out)
     assert!(
         res["usage"]["cost_usd"].as_f64().is_some_and(|c| c > 0.0),
         "cost filled: {res}"

--- a/provider-zai/src/sse.rs
+++ b/provider-zai/src/sse.rs
@@ -154,19 +154,27 @@ pub fn map_finish_reason(s: &str) -> StopReason {
 /// all of these, adding double-counts.
 pub fn merge_usage(raw: &Value, into: &mut Usage) {
     let num = |k: &str| raw.get(k).and_then(Value::as_u64);
-    if let Some(v) = num("prompt_tokens").or_else(|| num("input_tokens")) {
-        into.input = Some(v);
-    }
-    if let Some(v) = num("completion_tokens").or_else(|| num("output_tokens")) {
-        into.output = Some(v);
-    }
+    // `Usage.input` is the cache-MISS slice, disjoint from `cache_read`
+    // (pricing bills the splits additively). The wire's `prompt_tokens` is a
+    // TOTAL that includes the cached slice, so the miss slice is derived —
+    // mapping the total verbatim would bill the cached prefix twice.
+    let mut cached = None;
     for parent in ["prompt_tokens_details", "input_tokens_details"] {
         if let Some(v) = raw
             .pointer(&format!("/{parent}/cached_tokens"))
             .and_then(Value::as_u64)
         {
-            into.cache_read = Some(v);
+            cached = Some(v);
         }
+    }
+    if let Some(v) = cached {
+        into.cache_read = Some(v);
+    }
+    if let Some(v) = num("prompt_tokens").or_else(|| num("input_tokens")) {
+        into.input = Some(v.saturating_sub(cached.unwrap_or(0)));
+    }
+    if let Some(v) = num("completion_tokens").or_else(|| num("output_tokens")) {
+        into.output = Some(v);
     }
     if let Some(v) = raw
         .pointer("/completion_tokens_details/reasoning_tokens")
@@ -434,7 +442,7 @@ mod tests {
         assert_eq!(final_msg.stop_reason, StopReason::End);
         assert_eq!(final_msg.native_stop_reason.as_deref(), Some("stop"));
         let usage = final_msg.usage.unwrap();
-        assert_eq!(usage.input, Some(12));
+        assert_eq!(usage.input, Some(8));
         assert_eq!(usage.output, Some(2));
         assert_eq!(usage.cache_read, Some(4));
         assert_eq!(usage.reasoning, Some(0));

--- a/provider-zai/src/upstream.rs
+++ b/provider-zai/src/upstream.rs
@@ -220,7 +220,7 @@ mod tests {
         );
         match events.last() {
             Some(AssistantMessageEvent::Done { message }) => {
-                assert_eq!(message.usage.as_ref().unwrap().input, Some(12));
+                assert_eq!(message.usage.as_ref().unwrap().input, Some(8));
                 assert_eq!(message.usage.as_ref().unwrap().output, Some(2));
                 assert_eq!(message.usage.as_ref().unwrap().cache_read, Some(4));
                 assert_eq!(message.native_stop_reason.as_deref(), Some("stop"));


### PR DESCRIPTION
## What

Two defects found while chasing a "deepseek tokenizer counting seems wrong" report. The tokenizer was fine; the money was not.

## 1. Per-step cost read as a bouncing session total

The context chip's cost line showed the **last generation step's** bill. On providers with steep cache discounts the per-step number legitimately swings two orders of magnitude between cache-miss and cache-hit steps — so during a live turn the line bounced ($0.06 → $0.04 → $0.09 → $0.00014), and the final near-free cached step read as what the whole session cost.

- `ContextSnapshotV1` gains `session_cost_usd`, accumulated at the snapshot write site on top of the stored snapshot's total. The turn loop is the session's only writer, so the read-back is race-free; seeding from the store keeps the total honest across turns and harness restarts. Wire-schema golden regenerated.
- The chip moves per-step cost onto the line it describes — `last step 6 in · output 28 · $0.0127` — and renders `session total $0.1415` as its own only-grows line, with a tooltip explaining why the step number swings and this one does not.

## 2. Cached tokens double-billed on six providers

The `Usage` contract: `input` is the cache-**miss** slice, disjoint from `cache_read` — pricing bills the splits additively. deepseek, anthropic, and claude-code report disjoint splits natively and were correct. **openai, kimi, zai, llamacpp, openai-codex, and xai** (both its chat-completions and Responses merges) mapped the wire's `prompt_tokens` / `input_tokens` **total** (which includes the cached slice) straight into `input` while also setting `cache_read` — billing every cached token at the full input rate *plus* the cache rate. On an agent loop resending a large cached prefix every turn, reported cost read near-double, and exactified context totals inflated the same way.

Each provider's usage merge now derives the miss slice (`total − cached`), with the contract documented at the site. Fixtures that pinned the double-count as expected are corrected (12-token prompt with 4 cached asserts `8 in · 4 cache_read`); a new codex test pins the subtraction for the Responses API shape; the openai `responses` fixture has no cached slice, so its expectation correctly stays the full total.

That covers all nine providers on main; `provider-groq` is not on main yet (draft #712) and gets the same fix before it merges.

## Verification

Live on a rig: two turns in one session — step cost $0.1288 (cold) then $0.0127 (99% cache hit), session total accumulating to $0.1415, popover rendering both lines as designed. Per-step billed token sequence for the reporting deepseek session confirmed strictly monotonic (7.5k → 105k over 14 steps), ruling out the tokenizer. Gates on all six crates: `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, full test suites green.

## Follow-up (not in this PR)

The deepseek curated catalog claims a 1,000,000-token window for both v4 models. If v4-flash is a 128k-class model, context percentages understate ~8× and compaction fires late — needs a spec check (tracked in MOT-4375).

Linear: MOT-4375.
