### PR TITLE
(MOT-4376) fix(provider-openrouter): drop batch-endpoint-only model variants

### DIFF
--- a/provider-openrouter/Cargo.lock
+++ b/provider-openrouter/Cargo.lock
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "provider-openrouter"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "futures",

--- a/provider-openrouter/Cargo.toml
+++ b/provider-openrouter/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "provider-openrouter"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/provider-openrouter/README.md
+++ b/provider-openrouter/README.md
@@ -22,10 +22,12 @@ rows mapped to full catalog records → `router::models::reconcile`).
   (`anthropic/claude-sonnet-4.5`), which unprefixed would read as belonging
   to the sibling single-vendor providers. Catalog ids are therefore
   `openrouter/vendor/model`; the prefix is stripped on every upstream call.
-- **Admission:** a model must support function `tools` and emit `text` to be
-  reconciled. The agent loop is unusable without tool calling, and image or
-  audio generators would be dead rows in the picker; everything else in the
-  listing (several hundred models) lands in the catalog with live metadata.
+- **Admission:** a model must support function `tools`, emit `text`, and be
+  reachable over Chat Completions to be reconciled. The agent loop is
+  unusable without tool calling; image or audio generators and
+  batch-endpoint-only `:batch` variants (chat calls to them 404) would be
+  dead rows in the picker. Everything else in the listing (several hundred
+  models) lands in the catalog with live metadata.
 - **Registration:** self-declares via `router::provider::register` with
   backoff until acked, and re-declares on the `router::ready` trigger type.
   The declaration carries no static `models` slice — the live listing is the

--- a/provider-openrouter/src/discovery.rs
+++ b/provider-openrouter/src/discovery.rs
@@ -32,14 +32,21 @@ fn str_array(v: Option<&Value>) -> impl Iterator<Item = &str> {
         .filter_map(Value::as_str)
 }
 
-/// Harness-usable models only: function tools + text output. OpenRouter lists
+/// Harness-usable models only: function tools + text output, reachable over
+/// the Chat Completions endpoint this provider speaks. OpenRouter lists
 /// hundreds of models; the ones that cannot drive an agent loop (no `tools`
-/// support) or produce no text (image/audio generators, embedders) would be
-/// dead rows in the picker.
+/// support), produce no text (image/audio generators, embedders), or are
+/// batch-endpoint-only would be dead rows in the picker. `:batch` variants
+/// carry chat-identical metadata — the id suffix is the only signal — and a
+/// chat call to one returns 404 "only available through the Batch API".
 pub fn admit(row: &Value) -> bool {
+    let batch_only = row
+        .get("id")
+        .and_then(Value::as_str)
+        .is_some_and(|id| id.ends_with(":batch"));
     let has_tools = str_array(row.get("supported_parameters")).any(|p| p == "tools");
     let text_out = str_array(row.pointer("/architecture/output_modalities")).any(|m| m == "text");
-    has_tools && text_out
+    !batch_only && has_tools && text_out
 }
 
 pub fn parse_live_models(json: &Value) -> Vec<Model> {
@@ -178,6 +185,18 @@ mod tests {
         assert!(!admit(&row("vendor/painter", &["tools"], &["image"])));
         // missing metadata → not admitted
         assert!(!admit(&json!({ "id": "vendor/bare" })));
+        // batch-endpoint-only variant → 404 on chat completions, dead row
+        assert!(!admit(&row(
+            "anthropic/claude-x:batch",
+            &["tools"],
+            &["text"]
+        )));
+        // other variant suffixes stay admitted
+        assert!(admit(&row(
+            "meta-llama/llama-x:free",
+            &["tools"],
+            &["text"]
+        )));
     }
 
     #[test]


### PR DESCRIPTION
Picking a `:batch` model in the console failed with `404 "This model is only available through the Batch API"`. OpenRouter lists 60 such variants and their metadata is chat-identical (tools, text output) — the id suffix is the only signal — so admission let them into the catalog as dead picker rows.

## What

- `discovery::admit` now rejects `:batch` ids alongside tool-less models and non-text generators; other variant suffixes (`:free`, `:thinking`) stay admitted.
- README admission section updated; version bumped to 0.1.2.

## Testing

- Admission unit tests cover the `:batch` rejection and confirm `:free` stays admitted.
- `cargo fmt --check`, `clippy --all-targets --all-features -D warnings`, full suite green (84 tests).
- Live listing probe: 60 of the 333 previously admitted rows are `:batch`; post-fix catalog is ~273 chat-reachable models.

Refs MOT-4376


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved OpenRouter model discovery by verifying Chat Completions availability.
  - Batch-only model variants are no longer listed when they cannot be reached through Chat Completions.
  - Models that support tools, text output, and Chat Completions continue to be cataloged with live metadata.
- **Bug Fixes**
  - Prevented unavailable batch variants from appearing as supported models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->