### PR TITLE
fix: allow prereleases to publish directly to latest

### DIFF
--- a/.github/scripts/parse_release_tag.py
+++ b/.github/scripts/parse_release_tag.py
@@ -107,9 +107,6 @@ def main(argv: list[str] | None = None) -> int:
     if registry_tag not in {"next", "latest"}:
         print(f"::error::registry-tag must be next|latest (got {registry_tag!r})", file=sys.stderr)
         return 1
-    if is_pre == "true" and dry_run != "true" and registry_tag != "next":
-        print(f"::error::prerelease {version} must publish to next", file=sys.stderr)
-        return 1
     if registry_tag == "latest" and not worker_config["allow_direct_latest"]:
         print(f"::error::{worker} cannot publish directly to latest", file=sys.stderr)
         return 1

--- a/.github/scripts/tests/test_parse_release_tag.py
+++ b/.github/scripts/tests/test_parse_release_tag.py
@@ -15,7 +15,8 @@ SCRIPT = Path(__file__).resolve().parents[1] / "parse_release_tag.py"
 
 
 def make_repo_with_tagged_worker(tmp_path, tag, version, deploy="binary",
-                                  registry_tag_line="registry-tag: latest"):
+                                  registry_tag_line="registry-tag: latest",
+                                  allow_direct_latest=True):
     """Init a tmp repo with one worker + an annotated tag matching `tag`."""
     def run(*args):
         return subprocess.run(args, cwd=tmp_path, check=True, env=GIT_HERMETIC_ENV)
@@ -47,7 +48,7 @@ def make_repo_with_tagged_worker(tmp_path, tag, version, deploy="binary",
                 },
                 "defaults": {
                     "release_workflow": "release.yml",
-                    "allow_direct_latest": True,
+                    "allow_direct_latest": allow_direct_latest,
                     "required_validation": "smoke",
                     "release_control_enabled": True,
                 },
@@ -153,7 +154,38 @@ class TestParseReleaseTag:
         assert output["maturity"] == "alpha"
         assert output["operation_id"] == "11111111-1111-1111-1111-111111111111"
 
-    def test_v2_prerelease_cannot_publish_latest(self, tmp_path):
+    @pytest.mark.parametrize("maturity", ["experimental", "alpha", "beta"])
+    def test_v2_prerelease_can_publish_latest(self, tmp_path, maturity):
+        version = f"1.2.3-{maturity}"
+        metadata = "\n".join(
+            [
+                "release-contract: 2",
+                "worker: smoke",
+                f"version: {version}",
+                f"maturity: {maturity}",
+                "registry-tag: latest",
+                "experimental: false",
+                "operation-id: op",
+                "step-id: step",
+                "source-sha: unknown",
+            ]
+        )
+        repo = make_repo_with_tagged_worker(
+            tmp_path,
+            f"smoke/v{version}",
+            version,
+            registry_tag_line=metadata,
+        )
+        out_path = tmp_path / "gh_output"
+        out_path.touch()
+        result = run_script(repo, f"smoke/v{version}", out_path)
+        assert result.returncode == 0, result.stderr
+        output = parse_outputs(out_path)
+        assert output["registry_tag"] == "latest"
+        assert output["is_prerelease"] == "true"
+        assert output["maturity"] == maturity
+
+    def test_v2_prerelease_latest_still_requires_worker_permission(self, tmp_path):
         metadata = "\n".join(
             [
                 "release-contract: 2",
@@ -172,12 +204,13 @@ class TestParseReleaseTag:
             "smoke/v1.2.3-beta",
             "1.2.3-beta",
             registry_tag_line=metadata,
+            allow_direct_latest=False,
         )
         out_path = tmp_path / "gh_output"
         out_path.touch()
         result = run_script(repo, "smoke/v1.2.3-beta", out_path)
         assert result.returncode != 0
-        assert "must publish to next" in result.stderr
+        assert "cannot publish directly to latest" in result.stderr
 
     def test_missing_channel_fails_closed_to_next(self, tmp_path):
         repo = make_repo_with_tagged_worker(

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -175,10 +175,6 @@ jobs:
             "$WORKER/$MANIFEST" --kind "$BUMP" --suffix "$SUFFIX" --target "$TARGET_VERSION")
           maturity=$(python3 .github/scripts/manifest_version.py maturity "$new_ver")
           python3 .github/scripts/manifest_version.py check-history "$WORKER" "$new_ver"
-          if [[ "$maturity" != stable && "$REGISTRY_TAG" != next ]]; then
-            echo "::error::prerelease $new_ver must publish to next"
-            exit 2
-          fi
           {
             echo "current=$current"
             echo "version=$new_ver"

--- a/.github/workflows/repair-worker-release.yml
+++ b/.github/workflows/repair-worker-release.yml
@@ -107,16 +107,11 @@ jobs:
         env:
           CHANNEL_INPUT: ${{ inputs.channel }}
           ORIGINAL_CHANNEL: ${{ steps.meta.outputs.registry_tag }}
-          MATURITY: ${{ steps.meta.outputs.maturity }}
         run: |
           set -euo pipefail
           channel="$CHANNEL_INPUT"
           if [[ "$channel" == original ]]; then channel="$ORIGINAL_CHANNEL"; fi
           [[ "$channel" == next || "$channel" == latest ]]
-          if [[ "$channel" == latest && "$MATURITY" != stable ]]; then
-            echo "::error::prereleases cannot repair latest"
-            exit 2
-          fi
           if [[ "${{ inputs.action }}" == candidate-smoke && "$channel" != next ]]; then
             echo "::error::candidate-smoke repairs require channel next"
             exit 2

--- a/docs/sops/release.md
+++ b/docs/sops/release.md
@@ -72,7 +72,7 @@ Actions -> **Create Tag** accepts:
 | `bump` | `patch`, `minor`, `major`, or `none` |
 | `target_version` | Optional exact version; overrides `bump` and `suffix` |
 | `suffix` | `none`, `experimental`, `alpha`, or `beta` |
-| `registry_tag` | `next` for a candidate, `latest` for a direct stable release |
+| `registry_tag` | `next` for a candidate, `latest` for a direct release |
 | `experimental` | Independent Registry badge |
 | `operation_id`, `step_id` | Optional Release Control correlation IDs |
 | `expected_current_version` | Optional compare-and-swap guard for the manifest |
@@ -98,9 +98,10 @@ needed, pushes the version commit to `main`, then creates the annotated
 selected worker did not change. A matching existing tag is treated as an
 idempotent result.
 
-Prereleases always publish to `next`. Harness also cannot publish directly to
-`latest`; it must pass the candidate and deployed-E2E gates before promotion.
-Other stable workers may use either channel.
+Experimental, alpha, beta, and stable versions may publish directly to `latest`
+when the worker allows it. Harness cannot publish directly to `latest`; it must
+pass the candidate and deployed-E2E gates before promotion. Any worker may use
+`next` for candidate validation.
 
 ## Release pipeline
 


### PR DESCRIPTION
## Summary

- allow `experimental`, `alpha`, and `beta` releases to publish directly to `latest` when the worker catalog enables `allow_direct_latest`
- apply the same policy in create-tag validation and release repair
- preserve `next` as the default for workers that do not opt in and retain exact supported release-version validation

Prerelease candidate promotion is handled separately in the follow-up PR from `fix/allow-prerelease-promotion`.

## Validation

- release script tests
- `actionlint` on all workflows
- benchmark site tests
- Python compile checks for the changed release scripts
- `git diff --check`
