### PR TITLE
(MOT-4299) fix(release): stage frontend bundles in a non-hidden directory

### DIFF
--- a/.github/workflows/_rust-binary.yml
+++ b/.github/workflows/_rust-binary.yml
@@ -215,7 +215,7 @@ jobs:
           # Repo-relative staging so the restore lands every dist/ exactly
           # where its crate's build.rs expects it — including dependency crates
           # outside the released worker's directory.
-          stage=".release-frontend-bundle"
+          stage="release-frontend-bundle"
           for bundle in "${bundles[@]}"; do
             test -d "$bundle/dist"
             mkdir -p "$stage/$bundle"
@@ -226,7 +226,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: frontend-bundles
-          path: .release-frontend-bundle/
+          path: release-frontend-bundle/
           if-no-files-found: error
           retention-days: 1
 


### PR DESCRIPTION
Follow-up to #747: [eval/v0.2.1-experimental](https://github.com/iii-hq/workers/actions/runs/31199140975) built every bundle correctly but uploaded an empty artifact — `upload-artifact` defaults to `include-hidden-files: false`, and pointing the path at `.release-frontend-bundle/` itself makes the dot-directory the glob root, excluding everything. The old layout only worked by accident (its search root was a child of the dot dir). Renamed the staging dir to `release-frontend-bundle` — no hidden semantics in a CI-only path.