### PR TITLE
(MOT-4299) feat(e2e): freeze Registry stack per execution

### DIFF
--- a/.github/scripts/collect_harness_e2e_benchmarks.py
+++ b/.github/scripts/collect_harness_e2e_benchmarks.py
@@ -45,6 +45,7 @@ class CollectionConfig:
     stack_mode: str = "source"
     stack_versions: dict[str, str] = field(default_factory=dict)
     stack_digest: str = ""
+    preflight_deployment: Path | None = None
 
 
 def load_json(path: Path) -> Any:
@@ -304,6 +305,14 @@ def collect(
     dict[str, Any],
 ]:
     contexts = discover_contexts(config.reports_root)
+    preflight_deployment = None
+    if config.preflight_deployment is not None and config.preflight_deployment.is_file():
+        value = load_json(config.preflight_deployment)
+        if not isinstance(value, dict):
+            raise CollectionError(
+                f"{config.preflight_deployment} must contain an object"
+            )
+        preflight_deployment = value
     quality: list[dict[str, Any]] = []
     efficiency: list[dict[str, Any]] = []
     snapshot_subjects: list[dict[str, Any]] = []
@@ -335,7 +344,7 @@ def collect(
 
         for scenario_id in config.scenarios:
             context_path = contexts.get((subject["id"], scenario_id))
-            deployment = load_deployment(context_path)
+            deployment = load_deployment(context_path) or preflight_deployment
             report_path = (
                 context_path.parent / "results.json" if context_path is not None else None
             )
@@ -869,6 +878,8 @@ def collect(
         "requested_runs": config.requested_runs,
         "subjects": snapshot_subjects,
     }
+    if preflight_deployment is not None:
+        snapshot["preflight_deployment"] = preflight_deployment
     execution_detail = {
         **snapshot,
         "reports": execution_reports,
@@ -915,6 +926,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--stack-mode", default="source")
     parser.add_argument("--stack-versions", default="{}")
     parser.add_argument("--stack-digest", default="")
+    parser.add_argument("--preflight-deployment", type=Path)
     parser.add_argument("--judge-model", required=True)
     parser.add_argument("--judge-provider", required=True)
     parser.add_argument("--execution-run-id", required=True)
@@ -958,6 +970,7 @@ def main(argv: list[str] | None = None) -> int:
         stack_mode=require_string(args.stack_mode, "stack mode"),
         stack_versions=parse_stack_versions(args.stack_versions),
         stack_digest=args.stack_digest,
+        preflight_deployment=args.preflight_deployment,
     )
     quality, efficiency, snapshot, execution = collect(config)
     write_outputs(args.output_dir, quality, efficiency, snapshot, execution)

--- a/.github/scripts/tests/test_collect_harness_e2e_benchmarks.py
+++ b/.github/scripts/tests/test_collect_harness_e2e_benchmarks.py
@@ -393,6 +393,39 @@ def test_registry_identity_is_recorded_and_registry_failure_is_infra_failed(
     assert execution["reports"][1]["deployment"]["status"] == "infra_failed"
 
 
+def test_preflight_failure_explains_all_unstarted_scenarios(tmp_path: Path) -> None:
+    preflight = tmp_path / "preflight-deployment.json"
+    preflight.write_text(
+        json.dumps(
+            {
+                "status": "infra_failed",
+                "failure_phase": "registry",
+                "failure_reason": "Registry resolution failed",
+                "stack_versions": {},
+                "stack_lock_digest": "",
+            }
+        )
+    )
+
+    _, efficiency, snapshot, execution = collect(
+        replace(
+            config(tmp_path, ["direct_answer", "security_review"]),
+            stack_mode="registry",
+            preflight_deployment=preflight,
+        )
+    )
+
+    assert snapshot["preflight_deployment"]["failure_phase"] == "registry"
+    assert snapshot["subjects"][0]["infra_failures"] == 2
+    assert all(
+        report["deployment"]["failure_reason"] == "Registry resolution failed"
+        for report in execution["reports"]
+    )
+    assert by_name(efficiency)[
+        "reliability::glm::suite::infra_failed"
+    ]["value"] == 2
+
+
 def test_unknown_cost_is_omitted_instead_of_recorded_as_zero(
     tmp_path: Path,
 ) -> None:

--- a/.github/workflows/_harness-e2e.yml
+++ b/.github/workflows/_harness-e2e.yml
@@ -139,6 +139,15 @@ on:
       catalog_sha:
         description: Catalog commit used by the suite
         value: ${{ jobs.build.outputs.catalog_sha }}
+      stack_versions:
+        description: Exact Registry versions resolved for the execution
+        value: ${{ jobs.resolve-registry-stack.outputs.stack_versions }}
+      stack_digest:
+        description: SHA-256 digest of the resolved Registry lock
+        value: ${{ jobs.resolve-registry-stack.outputs.stack_digest }}
+      resolved_release_version:
+        description: Exact released worker version used by the execution
+        value: ${{ jobs.resolve-registry-stack.outputs.release_version }}
     secrets:
       anthropic_api_key:
         required: false
@@ -440,9 +449,117 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  resolve-registry-stack:
+    name: resolve Registry stack
+    needs: build
+    if: inputs.stack_mode == 'registry' && inputs.resolve_stack
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      stack_versions: ${{ steps.identity.outputs.stack_versions }}
+      stack_digest: ${{ steps.identity.outputs.stack_digest }}
+      release_version: ${{ steps.identity.outputs.release_version }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.source_ref }}
+
+      - name: Download E2E runner
+        uses: actions/download-artifact@v7
+        with:
+          name: harness-e2e-stack
+          path: target
+
+      - name: Extract E2E runner
+        run: |
+          mkdir -p target/runner
+          tar -xzf target/harness-e2e-stack.tar.gz -C target/runner
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install Registry helper dependency
+        run: python3 -m pip install --quiet pyyaml
+
+      - name: Resolve requested models
+        id: models
+        env:
+          SUBJECTS: ${{ inputs.subjects }}
+          JUDGE_MODEL: ${{ inputs.judge_model }}
+          JUDGE_PROVIDER: ${{ inputs.judge_provider }}
+        run: |
+          set -euo pipefail
+          models=$(jq -c \
+            --arg judge_model "$JUDGE_MODEL" \
+            --arg judge_provider "$JUDGE_PROVIDER" '
+              [(.[] | {provider, model}), {provider: $judge_provider, model: $judge_model}]
+              | unique_by([.provider, .model])
+            ' <<<"$SUBJECTS")
+          first_provider=$(jq -r '.[0].provider' <<<"$models")
+          first_model=$(jq -r '.[0].model' <<<"$models")
+          {
+            echo "json=$models"
+            echo "first_provider=$first_provider"
+            echo "first_model=$first_model"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Resolve and verify Registry stack
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.anthropic_api_key }}
+          OPENAI_API_KEY: ${{ secrets.openai_api_key }}
+          ZAI_API_KEY: ${{ secrets.zai_api_key }}
+          DEEPSEEK_API_KEY: ${{ secrets.deepseek_api_key }}
+          III_CLI_CHANNEL: ${{ inputs.cli_channel }}
+          III_WORKER_TAG: ${{ inputs.registry_tag }}
+          HARNESS_E2E_RELEASE_WORKER: ${{ inputs.release_worker }}
+          HARNESS_E2E_RELEASE_VERSION: ${{ inputs.release_version }}
+          HARNESS_E2E_RELEASE_TAG: ${{ inputs.release_tag }}
+          HARNESS_E2E_RELEASE_RUN_ID: ${{ inputs.release_run_id }}
+          HARNESS_E2E_SMOKE_RUN_ID: ${{ inputs.smoke_run_id }}
+          HARNESS_E2E_STACK_VERSIONS: ${{ inputs.stack_versions }}
+          HARNESS_E2E_STACK_DIGEST: ${{ inputs.stack_digest }}
+          HARNESS_E2E_RESOLVE_STACK: 'true'
+          HARNESS_E2E_RESOLVE_ONLY: 'true'
+          HARNESS_E2E_MODEL_SPECS: ${{ steps.models.outputs.json }}
+          HARNESS_E2E_BIN: ${{ github.workspace }}/target/runner/harness-e2e
+          HARNESS_E2E_ARTIFACTS_DIR: ${{ github.workspace }}/target/harness-e2e-resolution
+          HARNESS_E2E_SCENARIO: registry_stack_resolution
+          HARNESS_E2E_RUNS: 1
+          HARNESS_E2E_MODEL: ${{ steps.models.outputs.first_model }}
+          HARNESS_E2E_PROVIDER: ${{ steps.models.outputs.first_provider }}
+          HARNESS_E2E_JUDGE_MODEL: ${{ inputs.judge_model }}
+          HARNESS_E2E_JUDGE_PROVIDER: ${{ inputs.judge_provider }}
+        run: harness/tests/e2e/run-deployed-ci.sh
+
+      - name: Export resolved Registry identity
+        id: identity
+        run: |
+          set -euo pipefail
+          deployment=target/harness-e2e-resolution/deployment.json
+          test "$(jq -r .status "$deployment")" = passed
+          {
+            echo "stack_versions=$(jq -c .stack_versions "$deployment")"
+            echo "stack_digest=$(jq -r .stack_lock_digest "$deployment")"
+            echo "release_version=$(jq -r .actual_release_version "$deployment")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload Registry resolution evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: harness-e2e-registry-stack-resolution
+          path: target/harness-e2e-resolution/
+          retention-days: 14
+          if-no-files-found: error
+
   e2e:
     name: harness e2e / ${{ matrix.subject.id }} / ${{ matrix.scenario }}
-    needs: build
+    needs: [build, resolve-registry-stack]
+    if: >-
+      always() && needs.build.result == 'success' &&
+      (needs.resolve-registry-stack.result == 'success' ||
+      needs.resolve-registry-stack.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 35
     strategy:
@@ -523,13 +640,13 @@ jobs:
           III_CLI_CHANNEL: ${{ inputs.cli_channel }}
           III_WORKER_TAG: ${{ inputs.registry_tag }}
           HARNESS_E2E_RELEASE_WORKER: ${{ inputs.release_worker }}
-          HARNESS_E2E_RELEASE_VERSION: ${{ inputs.release_version }}
+          HARNESS_E2E_RELEASE_VERSION: ${{ inputs.resolve_stack && needs.resolve-registry-stack.outputs.release_version || inputs.release_version }}
           HARNESS_E2E_RELEASE_TAG: ${{ inputs.release_tag }}
           HARNESS_E2E_RELEASE_RUN_ID: ${{ inputs.release_run_id }}
           HARNESS_E2E_SMOKE_RUN_ID: ${{ inputs.smoke_run_id }}
-          HARNESS_E2E_STACK_VERSIONS: ${{ inputs.stack_versions }}
-          HARNESS_E2E_STACK_DIGEST: ${{ inputs.stack_digest }}
-          HARNESS_E2E_RESOLVE_STACK: ${{ inputs.resolve_stack }}
+          HARNESS_E2E_STACK_VERSIONS: ${{ inputs.resolve_stack && needs.resolve-registry-stack.outputs.stack_versions || inputs.stack_versions }}
+          HARNESS_E2E_STACK_DIGEST: ${{ inputs.resolve_stack && needs.resolve-registry-stack.outputs.stack_digest || inputs.stack_digest }}
+          HARNESS_E2E_RESOLVE_STACK: 'false'
           HARNESS_E2E_BIN: ${{ github.workspace }}/target/runner/harness-e2e
           HARNESS_E2E_ARTIFACTS_DIR: ${{ github.workspace }}/target/harness-e2e
           HARNESS_E2E_SCENARIO: ${{ matrix.scenario }}
@@ -624,7 +741,7 @@ jobs:
 
   summary:
     name: harness e2e summary
-    needs: [build, e2e]
+    needs: [build, resolve-registry-stack, e2e]
     if: always() && needs.build.result == 'success'
     runs-on: ubuntu-latest
     steps:
@@ -638,6 +755,14 @@ jobs:
         with:
           pattern: harness-e2e-*-results
           path: target/harness-e2e-results
+
+      - name: Download Registry resolution evidence
+        if: always() && needs.resolve-registry-stack.result != 'skipped'
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          name: harness-e2e-registry-stack-resolution
+          path: target/harness-e2e-preflight
 
       - name: Write suite cost summary
         run: |
@@ -697,12 +822,12 @@ jobs:
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           RELEASE_TAG: ${{ inputs.release_tag }}
           RELEASE_WORKER: ${{ inputs.release_worker }}
-          RELEASE_VERSION: ${{ inputs.release_version }}
+          RELEASE_VERSION: ${{ inputs.resolve_stack && needs.resolve-registry-stack.outputs.release_version || inputs.release_version }}
           RELEASE_URL: ${{ inputs.release_url }}
           REGISTRY_TAG: ${{ inputs.registry_tag }}
           STACK_MODE: ${{ inputs.stack_mode }}
-          STACK_VERSIONS: ${{ inputs.stack_versions }}
-          STACK_DIGEST: ${{ inputs.stack_digest }}
+          STACK_VERSIONS: ${{ inputs.resolve_stack && needs.resolve-registry-stack.outputs.stack_versions || inputs.stack_versions }}
+          STACK_DIGEST: ${{ inputs.resolve_stack && needs.resolve-registry-stack.outputs.stack_digest || inputs.stack_digest }}
           JUDGE_MODEL: ${{ inputs.judge_model }}
           JUDGE_PROVIDER: ${{ inputs.judge_provider }}
           EXECUTION_RUN_ID: ${{ github.run_id }}
@@ -730,6 +855,7 @@ jobs:
             --stack-mode "$STACK_MODE" \
             --stack-versions "$STACK_VERSIONS" \
             --stack-digest "$STACK_DIGEST" \
+            --preflight-deployment target/harness-e2e-preflight/deployment.json \
             --judge-model "$JUDGE_MODEL" \
             --judge-provider "$JUDGE_PROVIDER" \
             --execution-run-id "$EXECUTION_RUN_ID" \

--- a/harness/tests/e2e/run-deployed-ci.sh
+++ b/harness/tests/e2e/run-deployed-ci.sh
@@ -21,6 +21,7 @@ cli_channel=${III_CLI_CHANNEL:-latest}
 worker_tag=${III_WORKER_TAG:-latest}
 stack_versions=${HARNESS_E2E_STACK_VERSIONS:-'{}'}
 resolve_stack=${HARNESS_E2E_RESOLVE_STACK:-false}
+resolve_only=${HARNESS_E2E_RESOLVE_ONLY:-false}
 expected_stack_digest=${HARNESS_E2E_STACK_DIGEST:-}
 runs=${HARNESS_E2E_RUNS:-1}
 engine_port=49134
@@ -53,6 +54,32 @@ case "$resolve_stack" in
     exit 2
     ;;
 esac
+case "$resolve_only" in
+  true | false) ;;
+  *)
+    echo "HARNESS_E2E_RESOLVE_ONLY must be true or false" >&2
+    exit 2
+    ;;
+esac
+model_specs=${HARNESS_E2E_MODEL_SPECS:-$(jq -cn \
+  --arg subject_provider "$HARNESS_E2E_PROVIDER" \
+  --arg subject_model "$HARNESS_E2E_MODEL" \
+  --arg judge_provider "$HARNESS_E2E_JUDGE_PROVIDER" \
+  --arg judge_model "$HARNESS_E2E_JUDGE_MODEL" \
+  '[
+    {provider: $subject_provider, model: $subject_model},
+    {provider: $judge_provider, model: $judge_model}
+  ] | unique_by([.provider, .model])')}
+jq -e '
+  type == "array" and length > 0 and
+  all(.[];
+    (.provider | type == "string" and test("^[A-Za-z0-9_-]+$")) and
+    (.model | type == "string" and length > 0)
+  )
+' <<<"$model_specs" >/dev/null || {
+  echo "HARNESS_E2E_MODEL_SPECS must contain provider/model objects" >&2
+  exit 2
+}
 if [[ "$resolve_stack" == true ]]; then
   [[ "$release_worker" == harness ]] || {
     echo "dynamic Registry stack resolution requires release_worker=harness" >&2
@@ -130,7 +157,7 @@ die() {
 write_deployment_result() {
   local outcome=$1
   local result_status=$outcome
-  if [[ "$outcome" != passed && "$failure_phase" == registry ]]; then
+  if [[ "$outcome" != passed && "$failure_phase" =~ ^(bootstrap|registry|preflight)$ ]]; then
     result_status=infra_failed
   fi
   jq -n \
@@ -355,12 +382,12 @@ wait_for_engine
 support_worker_tag=latest
 workers=("database@$support_worker_tag" "fp@$support_worker_tag" "web@$support_worker_tag")
 declare -A providers=()
-for provider in "$HARNESS_E2E_PROVIDER" "$HARNESS_E2E_JUDGE_PROVIDER"; do
+while IFS= read -r provider; do
   if [[ -z "${providers[$provider]:-}" ]]; then
     workers+=("provider-$provider@$support_worker_tag")
     providers[$provider]=1
   fi
-done
+done < <(jq -r 'map(.provider) | unique[]' <<<"$model_specs")
 
 # The registry's /resolve sits at ~7s per call and a stack install issues
 # dozens of them; one transient network blip fails the whole add. Retry the
@@ -384,7 +411,8 @@ if [[ "$resolve_stack" == true ]]; then
   log "Resolving the live Registry stack from latest: harness@latest ${workers[*]}"
   identity=$(add_with_retry live-stack "harness@latest" "${workers[@]}" >/dev/null && \
     python3 "$repo_root/.github/scripts/registry_stack_identity.py" \
-      --lock "$project_dir/iii.lock")
+      --lock "$project_dir/iii.lock" \
+      --output "$stack_dir/registry-stack.json")
   stack_versions=$(jq -c '.stack_versions' <<<"$identity")
   release_version=$(jq -er '.stack_versions.harness' <<<"$identity")
   lock_digest=$(jq -er '.lock_digest' <<<"$identity")
@@ -416,14 +444,15 @@ else
   fi
 fi
 
-failure_phase=e2e
+failure_phase=preflight
 wait_for_functions \
   harness::send harness::status worker::add database::query state::get \
   queue::define session::messages context::assemble router::models::get \
   directory::skills::list
 wait_for_triggers cron
-wait_for_model "$HARNESS_E2E_PROVIDER" "$HARNESS_E2E_MODEL"
-wait_for_model "$HARNESS_E2E_JUDGE_PROVIDER" "$HARNESS_E2E_JUDGE_MODEL"
+while IFS=$'\t' read -r provider model; do
+  wait_for_model "$provider" "$model"
+done < <(jq -r '.[] | [.provider, .model] | @tsv' <<<"$model_specs")
 
 "$iii_bin" trigger engine::workers::list --port "$engine_port" \
   --json '{}' >"$project_dir/workers.json"
@@ -444,6 +473,11 @@ done
 failure_phase=registry
 verification=$(python3 "$repo_root/.github/scripts/verify_registry_lock.py" "${verify_args[@]}")
 actual_release_version=$(jq -r '.actual_version' <<<"$verification")
+
+if [[ "$resolve_only" == true ]]; then
+  log "Registry stack resolved and verified; skipping scenario execution"
+  exit 0
+fi
 
 failure_phase=e2e
 export HARNESS_E2E_RUN_DIR="$project_dir"


### PR DESCRIPTION
## What changed

- resolve the daily Registry stack once before the scenario matrix
- freeze exact worker versions and the `iii.lock` digest for every job
- preflight all requested subject and judge models
- retain structured preflight evidence when scenarios cannot start

## Why

Resolving `latest` independently in every matrix job allowed one daily execution to observe different Registry states and multiplied transient resolution failures. A workflow-level immutable lock makes scenario comparisons reproducible.

## Impact

Existing source and deployed callers remain compatible. Dynamic Registry callers receive the resolved versions and digest as workflow outputs; scenario jobs install and verify only those exact versions.

## Validation

- `pytest .github/scripts/tests/`
- `actionlint`
- `bash -n harness/tests/e2e/run-deployed-ci.sh`
- `node --test .github/benchmark-site/*.test.cjs`

## Stack

Merge in order:

1. **#750 — Registry stack lock (this PR)**
2. #751 — immutable runner artifact
3. #752 — infrastructure-only retry
4. #753 — conservative scenario sharding

Refs MOT-4299
