### PR TITLE
(MOT-4299) feat(e2e): reuse immutable daily runner artifact

### DIFF
--- a/.github/scripts/find_harness_e2e_runner.py
+++ b/.github/scripts/find_harness_e2e_runner.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Find the non-expired Harness E2E runner artifact for an exact commit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+
+class LookupError(RuntimeError):
+    """Raised when the runner cannot be resolved safely."""
+
+
+def api_json(url: str, token: str) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            value = json.load(response)
+    except (urllib.error.URLError, json.JSONDecodeError) as error:
+        raise LookupError(f"GitHub API request failed for {url}: {error}") from error
+    if not isinstance(value, dict):
+        raise LookupError(f"GitHub API returned a non-object for {url}")
+    return value
+
+
+def find_runner(
+    *,
+    api_url: str,
+    repository: str,
+    workflow: str,
+    source_sha: str,
+    token: str,
+) -> dict[str, Any]:
+    artifact_name = f"harness-e2e-runner-{source_sha}"
+    query = urllib.parse.urlencode(
+        {"head_sha": source_sha, "event": "push", "per_page": 100}
+    )
+    runs_url = (
+        f"{api_url}/repos/{repository}/actions/workflows/{workflow}/runs?{query}"
+    )
+    runs = api_json(runs_url, token).get("workflow_runs")
+    if not isinstance(runs, list):
+        raise LookupError("GitHub API response did not contain workflow_runs")
+
+    ordered_runs = sorted(
+        (run for run in runs if isinstance(run, dict) and run.get("id")),
+        key=lambda run: str(run.get("created_at", "")),
+        reverse=True,
+    )
+    for run in ordered_runs:
+        run_id = int(run["id"])
+        artifacts_url = (
+            f"{api_url}/repos/{repository}/actions/runs/{run_id}/artifacts?per_page=100"
+        )
+        artifacts = api_json(artifacts_url, token).get("artifacts")
+        if not isinstance(artifacts, list):
+            continue
+        for artifact in artifacts:
+            if (
+                isinstance(artifact, dict)
+                and artifact.get("name") == artifact_name
+                and artifact.get("expired") is False
+            ):
+                return {
+                    "run_id": run_id,
+                    "artifact_id": artifact.get("id"),
+                    "artifact_name": artifact_name,
+                }
+
+    raise LookupError(
+        f"no non-expired {artifact_name} artifact was found; "
+        "the daily workflow will not compile a fallback"
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--api-url", default="https://api.github.com")
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--workflow", default="harness-e2e-main.yml")
+    parser.add_argument("--source-sha", required=True)
+    parser.add_argument("--token", required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        runner = find_runner(
+            api_url=args.api_url.rstrip("/"),
+            repository=args.repository,
+            workflow=args.workflow,
+            source_sha=args.source_sha,
+            token=args.token,
+        )
+    except LookupError as error:
+        raise SystemExit(f"runner_not_found: {error}") from error
+    print(json.dumps(runner, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/tests/test_find_harness_e2e_runner.py
+++ b/.github/scripts/tests/test_find_harness_e2e_runner.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pytest
+
+import find_harness_e2e_runner as runner_lookup
+
+
+def test_finds_exact_non_expired_artifact(monkeypatch: pytest.MonkeyPatch) -> None:
+    source_sha = "a" * 40
+
+    def fake_api(url: str, _token: str) -> dict:
+        if "/workflows/" in url:
+            return {
+                "workflow_runs": [
+                    {"id": 41, "created_at": "2026-08-07T10:00:00Z"}
+                ]
+            }
+        return {
+            "artifacts": [
+                {
+                    "id": 99,
+                    "name": f"harness-e2e-runner-{source_sha}",
+                    "expired": False,
+                }
+            ]
+        }
+
+    monkeypatch.setattr(runner_lookup, "api_json", fake_api)
+
+    result = runner_lookup.find_runner(
+        api_url="https://api.github.test",
+        repository="iii-hq/workers",
+        workflow="harness-e2e-main.yml",
+        source_sha=source_sha,
+        token="secret",
+    )
+
+    assert result == {
+        "run_id": 41,
+        "artifact_id": 99,
+        "artifact_name": f"harness-e2e-runner-{source_sha}",
+    }
+
+
+def test_rejects_expired_or_different_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_sha = "b" * 40
+
+    def fake_api(url: str, _token: str) -> dict:
+        if "/workflows/" in url:
+            return {"workflow_runs": [{"id": 42, "created_at": "now"}]}
+        return {
+            "artifacts": [
+                {
+                    "id": 100,
+                    "name": f"harness-e2e-runner-{source_sha}",
+                    "expired": True,
+                },
+                {"id": 101, "name": "different", "expired": False},
+            ]
+        }
+
+    monkeypatch.setattr(runner_lookup, "api_json", fake_api)
+
+    with pytest.raises(runner_lookup.LookupError, match="will not compile"):
+        runner_lookup.find_runner(
+            api_url="https://api.github.test",
+            repository="iii-hq/workers",
+            workflow="harness-e2e-main.yml",
+            source_sha=source_sha,
+            token="secret",
+        )

--- a/.github/scripts/tests/test_verify_harness_e2e_runner.py
+++ b/.github/scripts/tests/test_verify_harness_e2e_runner.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from verify_harness_e2e_runner import VerificationError, verify_runner
+
+
+def bundle(tmp_path: Path, *, source_sha: str = "a" * 40) -> tuple[Path, Path]:
+    archive = tmp_path / "harness-e2e-runner.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        contents = b"runner"
+        member = tarfile.TarInfo("harness-e2e")
+        member.mode = 0o755
+        member.size = len(contents)
+        tar.addfile(member, io.BytesIO(contents))
+    metadata = tmp_path / "harness-e2e-runner.json"
+    metadata.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "source_sha": source_sha,
+                "sha256": hashlib.sha256(archive.read_bytes()).hexdigest(),
+                "runner_version": "1.8.0",
+                "scenario_ids": ["direct_answer"],
+            }
+        )
+    )
+    return metadata, archive
+
+
+def test_accepts_exact_runner_bundle(tmp_path: Path) -> None:
+    metadata, archive = bundle(tmp_path)
+
+    result = verify_runner(
+        metadata_path=metadata, archive_path=archive, source_sha="a" * 40
+    )
+
+    assert result["runner_version"] == "1.8.0"
+
+
+def test_rejects_wrong_source_sha(tmp_path: Path) -> None:
+    metadata, archive = bundle(tmp_path)
+
+    with pytest.raises(VerificationError, match="source SHA"):
+        verify_runner(
+            metadata_path=metadata, archive_path=archive, source_sha="b" * 40
+        )
+
+
+def test_rejects_tampered_archive(tmp_path: Path) -> None:
+    metadata, archive = bundle(tmp_path)
+    archive.write_bytes(archive.read_bytes() + b"tampered")
+
+    with pytest.raises(VerificationError, match="checksum"):
+        verify_runner(
+            metadata_path=metadata, archive_path=archive, source_sha="a" * 40
+        )

--- a/.github/scripts/verify_harness_e2e_runner.py
+++ b/.github/scripts/verify_harness_e2e_runner.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Verify an immutable Harness E2E runner bundle before execution."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import tarfile
+from pathlib import Path
+from typing import Any
+
+
+class VerificationError(ValueError):
+    """Raised when runner evidence is missing or contradictory."""
+
+
+def verify_runner(
+    *, metadata_path: Path, archive_path: Path, source_sha: str
+) -> dict[str, Any]:
+    try:
+        metadata = json.loads(metadata_path.read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise VerificationError(f"cannot read runner metadata: {error}") from error
+    if not isinstance(metadata, dict):
+        raise VerificationError("runner metadata must be an object")
+    if metadata.get("schema_version") != 1:
+        raise VerificationError("unsupported runner metadata schema")
+    if metadata.get("source_sha") != source_sha:
+        raise VerificationError("runner source SHA does not match the requested source")
+
+    try:
+        digest = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+    except OSError as error:
+        raise VerificationError(f"cannot read runner archive: {error}") from error
+    if metadata.get("sha256") != digest:
+        raise VerificationError("runner archive checksum does not match metadata")
+
+    scenarios = metadata.get("scenario_ids")
+    if (
+        not isinstance(scenarios, list)
+        or not scenarios
+        or not all(isinstance(item, str) and item for item in scenarios)
+        or len(set(scenarios)) != len(scenarios)
+    ):
+        raise VerificationError("runner scenario catalog must be unique and non-empty")
+    if not isinstance(metadata.get("runner_version"), str) or not metadata[
+        "runner_version"
+    ]:
+        raise VerificationError("runner version is required")
+
+    try:
+        with tarfile.open(archive_path, "r:gz") as archive:
+            members = archive.getnames()
+    except (OSError, tarfile.TarError) as error:
+        raise VerificationError(f"cannot inspect runner archive: {error}") from error
+    if members != ["harness-e2e"]:
+        raise VerificationError("runner archive must contain only harness-e2e")
+    return metadata
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--metadata", type=Path, required=True)
+    parser.add_argument("--archive", type=Path, required=True)
+    parser.add_argument("--source-sha", required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        metadata = verify_runner(
+            metadata_path=args.metadata,
+            archive_path=args.archive,
+            source_sha=args.source_sha,
+        )
+    except VerificationError as error:
+        raise SystemExit(f"invalid_runner: {error}") from error
+    print(json.dumps(metadata, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/_harness-e2e.yml
+++ b/.github/workflows/_harness-e2e.yml
@@ -98,6 +98,11 @@ on:
         required: false
         type: boolean
         default: false
+      prebuilt_runner:
+        description: Download the immutable runner for source_ref instead of compiling it
+        required: false
+        type: boolean
+        default: false
       validation_profile:
         description: Scenario profile resolved for this execution
         required: false
@@ -193,9 +198,11 @@ jobs:
       # stack mode (Test/Lint E2E crate), so both lanes need the same
       # Node/pnpm toolchain as the regular CI worker builds.
       - name: Setup pnpm
+        if: inputs.stack_mode == 'source' || !inputs.prebuilt_runner
         uses: pnpm/action-setup@v5
 
       - name: Setup Node
+        if: inputs.stack_mode == 'source' || !inputs.prebuilt_runner
         uses: actions/setup-node@v5
         with:
           node-version: 22
@@ -214,6 +221,7 @@ jobs:
           RELEASE_VERSION: ${{ inputs.release_version }}
           STACK_VERSIONS: ${{ inputs.stack_versions }}
           RESOLVE_STACK: ${{ inputs.resolve_stack }}
+          PREBUILT_RUNNER: ${{ inputs.prebuilt_runner }}
           COVERAGE: ${{ inputs.coverage }}
         run: |
           set -euo pipefail
@@ -235,6 +243,9 @@ jobs:
               [[ "$REGISTRY_TAG" =~ ^[A-Za-z0-9._-]+$ ]]
               [[ "$RELEASE_WORKER" =~ ^[A-Za-z0-9_-]+$ ]]
               [[ "$COVERAGE" == "false" ]]
+              if [[ "$PREBUILT_RUNNER" == "true" ]]; then
+                [[ "${{ inputs.source_ref }}" =~ ^[0-9a-f]{40}$ ]]
+              fi
               if [[ "$RESOLVE_STACK" == "true" ]]; then
                 [[ "$RELEASE_WORKER" == "harness" ]]
                 [[ "$RELEASE_VERSION" == "latest" ]]
@@ -258,6 +269,7 @@ jobs:
           esac
 
       - uses: dtolnay/rust-toolchain@stable
+        if: inputs.stack_mode == 'source' || !inputs.prebuilt_runner
         with:
           components: ${{ inputs.coverage && 'clippy,llvm-tools' || 'clippy' }}
 
@@ -299,6 +311,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Restore E2E Rust cache
+        if: inputs.stack_mode == 'source' || !inputs.prebuilt_runner
         uses: Swatinem/rust-cache@v2
         with:
           # Instrumented builds have different fingerprints; keep them on their
@@ -326,9 +339,11 @@ jobs:
             web -> target
 
       - name: Test E2E crate
+        if: inputs.stack_mode == 'source' || !inputs.prebuilt_runner
         run: cargo test --locked --manifest-path harness/Cargo.toml -p harness-e2e
 
       - name: Lint E2E crate
+        if: inputs.stack_mode == 'source' || !inputs.prebuilt_runner
         run: cargo clippy --locked --manifest-path harness/Cargo.toml -p harness-e2e --all-targets -- -D warnings
 
       - name: Build source E2E stack
@@ -363,8 +378,53 @@ jobs:
             -p harness-e2e
 
       - name: Build registry E2E runner
-        if: inputs.stack_mode == 'registry'
+        if: inputs.stack_mode == 'registry' && !inputs.prebuilt_runner
         run: cargo build --locked --release --manifest-path harness/Cargo.toml -p harness-e2e
+
+      - name: Find immutable E2E runner
+        if: inputs.stack_mode == 'registry' && inputs.prebuilt_runner
+        id: prebuilt-runner
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ inputs.source_ref }}
+        run: |
+          set -euo pipefail
+          runner=$(python3 .github/scripts/find_harness_e2e_runner.py \
+            --api-url "$GITHUB_API_URL" \
+            --repository "$GITHUB_REPOSITORY" \
+            --workflow harness-e2e-main.yml \
+            --source-sha "$SOURCE_SHA" \
+            --token "$GITHUB_TOKEN")
+          {
+            echo "run_id=$(jq -r .run_id <<<"$runner")"
+            echo "artifact_name=$(jq -r .artifact_name <<<"$runner")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download immutable E2E runner
+        if: inputs.stack_mode == 'registry' && inputs.prebuilt_runner
+        uses: actions/download-artifact@v7
+        with:
+          name: ${{ steps.prebuilt-runner.outputs.artifact_name }}
+          path: target/prebuilt-runner
+          github-token: ${{ github.token }}
+          run-id: ${{ steps.prebuilt-runner.outputs.run_id }}
+
+      - name: Verify immutable E2E runner
+        if: inputs.stack_mode == 'registry' && inputs.prebuilt_runner
+        env:
+          SOURCE_SHA: ${{ inputs.source_ref }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/verify_harness_e2e_runner.py \
+            --metadata target/prebuilt-runner/harness-e2e-runner.json \
+            --archive target/prebuilt-runner/harness-e2e-runner.tar.gz \
+            --source-sha "$SOURCE_SHA"
+          mkdir -p harness/target/release target
+          tar -xzf target/prebuilt-runner/harness-e2e-runner.tar.gz \
+            -C harness/target/release
+          cp target/prebuilt-runner/harness-e2e-runner.tar.gz \
+            target/harness-e2e-stack.tar.gz
+          test -x harness/target/release/harness-e2e
 
       - name: Read code-defined scenarios
         id: scenarios
@@ -432,7 +492,7 @@ jobs:
           tar -czf target/harness-e2e-stack.tar.gz "${paths[@]}"
 
       - name: Package registry E2E runner
-        if: inputs.stack_mode == 'registry'
+        if: inputs.stack_mode == 'registry' && !inputs.prebuilt_runner
         # Registry mode builds only the runner (harness/target/release), so the
         # repo-root target/ this writes into does not exist yet — source mode
         # gets it from the engine install. Both harness release attempts died

--- a/.github/workflows/harness-e2e-daily.yml
+++ b/.github/workflows/harness-e2e-daily.yml
@@ -81,6 +81,7 @@ jobs:
       source_ref: ${{ needs.context.outputs.source_sha }}
       stack_mode: registry
       resolve_stack: true
+      prebuilt_runner: true
       benchmark_lane: daily
       release_tag: daily/${{ needs.context.outputs.benchmark_day }}
       release_worker: harness

--- a/.github/workflows/harness-e2e-main.yml
+++ b/.github/workflows/harness-e2e-main.yml
@@ -13,6 +13,90 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  runner:
+    name: Build immutable E2E runner
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Free runner disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune -af >/dev/null 2>&1 || true
+
+      - uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: '**/pnpm-lock.yaml'
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Restore E2E Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: harness-e2e-runner
+          save-if: true
+          workspaces: harness -> target
+
+      - name: Test E2E crate
+        run: cargo test --locked --manifest-path harness/Cargo.toml -p harness-e2e
+
+      - name: Lint E2E crate
+        run: cargo clippy --locked --manifest-path harness/Cargo.toml -p harness-e2e --all-targets -- -D warnings
+
+      - name: Build E2E runner
+        run: cargo build --locked --release --manifest-path harness/Cargo.toml -p harness-e2e
+
+      - name: Package immutable runner
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          output=target/harness-e2e-runner
+          mkdir -p "$output"
+          tar -czf "$output/harness-e2e-runner.tar.gz" \
+            -C harness/target/release harness-e2e
+          checksum=$(sha256sum "$output/harness-e2e-runner.tar.gz" | awk '{print $1}')
+          scenarios=$(harness/target/release/harness-e2e list)
+          runner_version=$(python3 - <<'PY'
+          import tomllib
+          from pathlib import Path
+          print(tomllib.loads(Path("harness/Cargo.toml").read_text())["package"]["version"])
+          PY
+          )
+          jq -n \
+            --arg source_sha "$SOURCE_SHA" \
+            --arg sha256 "$checksum" \
+            --arg runner_version "$runner_version" \
+            --argjson scenario_ids "$scenarios" '
+              {
+                schema_version: 1,
+                source_sha: $source_sha,
+                sha256: $sha256,
+                runner_version: $runner_version,
+                scenario_ids: $scenario_ids
+              }
+            ' >"$output/harness-e2e-runner.json"
+          printf '%s  %s\n' "$checksum" harness-e2e-runner.tar.gz \
+            >"$output/harness-e2e-runner.sha256"
+
+      - name: Upload immutable runner
+        uses: actions/upload-artifact@v6
+        with:
+          name: harness-e2e-runner-${{ github.sha }}
+          path: target/harness-e2e-runner/
+          retention-days: 14
+          if-no-files-found: error
+
   changes:
     name: Discover E2E changes
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What changed

- build and retain an immutable Harness E2E runner artifact for every push to `main`
- identify artifacts by the exact source SHA
- verify runner metadata, scenario catalog, archive contents, and checksum before use
- make the daily workflow fail before the matrix when the exact artifact is unavailable

## Why

The daily benchmark spent time installing build toolchains and compiling the E2E crate before any scenario ran. Builds also introduced unrelated pnpm, Rust, test, and lint failure modes into an operational benchmark.

## Impact

Daily executions no longer compile or lint the runner and never build a fallback. Main/source coverage continues to use the existing source build path.

## Validation

- exact, expired, mismatched-SHA, and tampered-artifact tests
- full Python workflow test suite
- `actionlint`
- dashboard Node tests

## Stack

Merge in order:

1. #750 — Registry stack lock
2. **#751 — immutable runner artifact (this PR)**
3. #752 — infrastructure-only retry
4. #753 — conservative scenario sharding

Refs MOT-4299
