### PR TITLE
(MOT-4299) feat(e2e): retry clean Registry provisioning failures

### DIFF
--- a/.github/scripts/harness_e2e_infra_retry.py
+++ b/.github/scripts/harness_e2e_infra_retry.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Decide whether a deployed Harness E2E provisioning attempt may be retried."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+RETRYABLE_PHASES = {"bootstrap", "registry"}
+INTERRUPTED_EXIT_CODES = {124, 130, 137, 143}
+
+
+def load_deployment(path: Path) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def retry_eligible(
+    *,
+    deployment: dict[str, Any] | None,
+    exit_code: int,
+    results_exist: bool,
+) -> bool:
+    if exit_code == 0 or exit_code in INTERRUPTED_EXIT_CODES or results_exist:
+        return False
+    return bool(
+        deployment
+        and deployment.get("status") == "infra_failed"
+        and deployment.get("failure_phase") in RETRYABLE_PHASES
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--deployment", type=Path, required=True)
+    parser.add_argument("--results", type=Path, required=True)
+    parser.add_argument("--exit-code", type=int, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    eligible = retry_eligible(
+        deployment=load_deployment(args.deployment),
+        exit_code=args.exit_code,
+        results_exist=args.results.is_file(),
+    )
+    print(json.dumps({"retry_eligible": eligible}))
+    return 0 if eligible else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_harness_e2e_infra_retry.py
+++ b/.github/scripts/tests/test_harness_e2e_infra_retry.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+from harness_e2e_infra_retry import retry_eligible
+
+
+@pytest.mark.parametrize("phase", ["bootstrap", "registry"])
+def test_retries_only_pre_execution_infrastructure_failures(phase: str) -> None:
+    assert retry_eligible(
+        deployment={"status": "infra_failed", "failure_phase": phase},
+        exit_code=1,
+        results_exist=False,
+    )
+
+
+@pytest.mark.parametrize("phase", ["preflight", "e2e", "quality", "hard_gate"])
+def test_does_not_retry_scenario_or_gate_failures(phase: str) -> None:
+    assert not retry_eligible(
+        deployment={"status": "failed", "failure_phase": phase},
+        exit_code=1,
+        results_exist=False,
+    )
+
+
+@pytest.mark.parametrize("exit_code", [0, 124, 130, 137, 143])
+def test_does_not_retry_success_timeout_or_interruption(exit_code: int) -> None:
+    assert not retry_eligible(
+        deployment={"status": "infra_failed", "failure_phase": "registry"},
+        exit_code=exit_code,
+        results_exist=False,
+    )
+
+
+def test_does_not_retry_after_results_exist() -> None:
+    assert not retry_eligible(
+        deployment={"status": "infra_failed", "failure_phase": "registry"},
+        exit_code=1,
+        results_exist=True,
+    )
+
+
+def test_requires_structured_deployment_evidence() -> None:
+    assert not retry_eligible(deployment=None, exit_code=1, results_exist=False)

--- a/.github/scripts/tests/test_run_deployed_with_infra_retry.py
+++ b/.github/scripts/tests/test_run_deployed_with_infra_retry.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+REPOSITORY = Path(__file__).parents[3]
+WRAPPER = REPOSITORY / "harness/tests/e2e/run-deployed-with-infra-retry.sh"
+
+
+def write_launcher(path: Path, first_phase: str) -> None:
+    path.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p "$HARNESS_E2E_ARTIFACTS_DIR/results"
+if [[ "$HARNESS_E2E_ARTIFACTS_DIR" == *attempt-1 ]]; then
+  jq -n '{{
+    status: "infra_failed",
+    failure_phase: "{first_phase}",
+    failure_reason: "first failed",
+    elapsed_ms: 10
+  }}' >"$HARNESS_E2E_ARTIFACTS_DIR/deployment.json"
+  exit 1
+fi
+jq -n '{{
+  status: "passed",
+  failure_phase: "e2e",
+  failure_reason: "",
+  elapsed_ms: 20
+}}' >"$HARNESS_E2E_ARTIFACTS_DIR/deployment.json"
+printf '{{"scenarios":[]}}\n' >"$HARNESS_E2E_ARTIFACTS_DIR/results/results.json"
+"""
+    )
+    path.chmod(0o755)
+
+
+def run_wrapper(tmp_path: Path, phase: str) -> subprocess.CompletedProcess[str]:
+    launcher = tmp_path / "launcher.sh"
+    write_launcher(launcher, phase)
+    env = {
+        **os.environ,
+        "HARNESS_E2E_ARTIFACTS_DIR": str(tmp_path / "artifacts"),
+        "HARNESS_E2E_PROVISIONING_ATTEMPTS": "2",
+        "HARNESS_E2E_DEPLOYED_LAUNCHER": str(launcher),
+    }
+    return subprocess.run(
+        ["bash", str(WRAPPER)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_retries_registry_failure_and_preserves_both_attempts(tmp_path: Path) -> None:
+    result = run_wrapper(tmp_path, "registry")
+
+    assert result.returncode == 0, result.stderr
+    artifacts = tmp_path / "artifacts"
+    deployment = json.loads((artifacts / "deployment.json").read_text())
+    assert deployment["provisioning_attempts"] == 2
+    assert [
+        item["status"] for item in deployment["provisioning_attempt_history"]
+    ] == ["infra_failed", "passed"]
+    assert (artifacts / "attempts/attempt-1/deployment.json").is_file()
+    assert (artifacts / "attempts/attempt-2/deployment.json").is_file()
+    assert (artifacts / "results/results.json").is_file()
+
+
+def test_does_not_retry_e2e_failure(tmp_path: Path) -> None:
+    result = run_wrapper(tmp_path, "e2e")
+
+    assert result.returncode == 1
+    deployment = json.loads(
+        (tmp_path / "artifacts/deployment.json").read_text()
+    )
+    assert deployment["provisioning_attempts"] == 1
+    assert not (tmp_path / "artifacts/attempts/attempt-2").exists()

--- a/.github/workflows/_harness-e2e.yml
+++ b/.github/workflows/_harness-e2e.yml
@@ -103,6 +103,11 @@ on:
         required: false
         type: boolean
         default: false
+      provisioning_attempts:
+        description: Full attempts allowed for bootstrap or Registry failures
+        required: false
+        type: number
+        default: 1
       validation_profile:
         description: Scenario profile resolved for this execution
         required: false
@@ -222,6 +227,7 @@ jobs:
           STACK_VERSIONS: ${{ inputs.stack_versions }}
           RESOLVE_STACK: ${{ inputs.resolve_stack }}
           PREBUILT_RUNNER: ${{ inputs.prebuilt_runner }}
+          PROVISIONING_ATTEMPTS: ${{ inputs.provisioning_attempts }}
           COVERAGE: ${{ inputs.coverage }}
         run: |
           set -euo pipefail
@@ -236,6 +242,7 @@ jobs:
           ' <<<"$SUBJECTS" >/dev/null
           [[ -n "$JUDGE_MODEL" ]]
           [[ "$JUDGE_PROVIDER" =~ ^[A-Za-z0-9_-]+$ ]]
+          [[ "$PROVISIONING_ATTEMPTS" =~ ^[12]$ ]]
           case "$STACK_MODE" in
             source) ;;
             registry)
@@ -514,7 +521,7 @@ jobs:
     needs: build
     if: inputs.stack_mode == 'registry' && inputs.resolve_stack
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: ${{ inputs.provisioning_attempts == 2 && 70 || 20 }}
     outputs:
       stack_versions: ${{ steps.identity.outputs.stack_versions }}
       stack_digest: ${{ steps.identity.outputs.stack_digest }}
@@ -581,6 +588,7 @@ jobs:
           HARNESS_E2E_STACK_DIGEST: ${{ inputs.stack_digest }}
           HARNESS_E2E_RESOLVE_STACK: 'true'
           HARNESS_E2E_RESOLVE_ONLY: 'true'
+          HARNESS_E2E_PROVISIONING_ATTEMPTS: ${{ inputs.provisioning_attempts }}
           HARNESS_E2E_MODEL_SPECS: ${{ steps.models.outputs.json }}
           HARNESS_E2E_BIN: ${{ github.workspace }}/target/runner/harness-e2e
           HARNESS_E2E_ARTIFACTS_DIR: ${{ github.workspace }}/target/harness-e2e-resolution
@@ -590,7 +598,7 @@ jobs:
           HARNESS_E2E_PROVIDER: ${{ steps.models.outputs.first_provider }}
           HARNESS_E2E_JUDGE_MODEL: ${{ inputs.judge_model }}
           HARNESS_E2E_JUDGE_PROVIDER: ${{ inputs.judge_provider }}
-        run: harness/tests/e2e/run-deployed-ci.sh
+        run: harness/tests/e2e/run-deployed-with-infra-retry.sh
 
       - name: Export resolved Registry identity
         id: identity
@@ -621,7 +629,7 @@ jobs:
       (needs.resolve-registry-stack.result == 'success' ||
       needs.resolve-registry-stack.result == 'skipped')
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: ${{ inputs.provisioning_attempts == 2 && 70 || 35 }}
     strategy:
       fail-fast: false
       max-parallel: ${{ inputs.max_parallel }}
@@ -707,6 +715,7 @@ jobs:
           HARNESS_E2E_STACK_VERSIONS: ${{ inputs.resolve_stack && needs.resolve-registry-stack.outputs.stack_versions || inputs.stack_versions }}
           HARNESS_E2E_STACK_DIGEST: ${{ inputs.resolve_stack && needs.resolve-registry-stack.outputs.stack_digest || inputs.stack_digest }}
           HARNESS_E2E_RESOLVE_STACK: 'false'
+          HARNESS_E2E_PROVISIONING_ATTEMPTS: ${{ inputs.provisioning_attempts }}
           HARNESS_E2E_BIN: ${{ github.workspace }}/target/runner/harness-e2e
           HARNESS_E2E_ARTIFACTS_DIR: ${{ github.workspace }}/target/harness-e2e
           HARNESS_E2E_SCENARIO: ${{ matrix.scenario }}
@@ -715,7 +724,7 @@ jobs:
           HARNESS_E2E_PROVIDER: ${{ matrix.subject.provider }}
           HARNESS_E2E_JUDGE_MODEL: ${{ inputs.judge_model }}
           HARNESS_E2E_JUDGE_PROVIDER: ${{ inputs.judge_provider }}
-        run: harness/tests/e2e/run-deployed-ci.sh
+        run: harness/tests/e2e/run-deployed-with-infra-retry.sh
 
       - name: Write benchmark context
         if: always()
@@ -776,6 +785,7 @@ jobs:
             target/harness-e2e/deployment.json
             target/harness-e2e/cli-version.txt
             target/harness-e2e/stack/
+            target/harness-e2e/attempts/
           retention-days: 14
           if-no-files-found: error
 

--- a/.github/workflows/harness-e2e-daily.yml
+++ b/.github/workflows/harness-e2e-daily.yml
@@ -82,6 +82,7 @@ jobs:
       stack_mode: registry
       resolve_stack: true
       prebuilt_runner: true
+      provisioning_attempts: 2
       benchmark_lane: daily
       release_tag: daily/${{ needs.context.outputs.benchmark_day }}
       release_worker: harness

--- a/harness/tests/e2e/run-deployed-with-infra-retry.sh
+++ b/harness/tests/e2e/run-deployed-with-infra-retry.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Retry only cleanly classified provisioning failures. The scenario runner and
+# quality gates are never repeated here.
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+harness_root=$(cd -- "$script_dir/../.." && pwd)
+repo_root=$(cd -- "$harness_root/.." && pwd)
+base_artifact_dir=${HARNESS_E2E_ARTIFACTS_DIR:-"$repo_root/target/harness-e2e"}
+max_attempts=${HARNESS_E2E_PROVISIONING_ATTEMPTS:-1}
+launcher=${HARNESS_E2E_DEPLOYED_LAUNCHER:-"$script_dir/run-deployed-ci.sh"}
+
+[[ "$max_attempts" =~ ^[12]$ ]] || {
+  echo "HARNESS_E2E_PROVISIONING_ATTEMPTS must be 1 or 2" >&2
+  exit 2
+}
+
+mkdir -p "$base_artifact_dir/attempts"
+base_artifact_dir=$(cd "$base_artifact_dir" && pwd)
+history_file="$base_artifact_dir/attempts/history.jsonl"
+: >"$history_file"
+
+final_attempt=1
+final_status=1
+for attempt in $(seq 1 "$max_attempts"); do
+  attempt_dir="$base_artifact_dir/attempts/attempt-$attempt"
+  mkdir -p "$attempt_dir"
+
+  set +e
+  HARNESS_E2E_ARTIFACTS_DIR="$attempt_dir" \
+    "$launcher"
+  status=$?
+  set -e
+
+  deployment="$attempt_dir/deployment.json"
+  if [[ -f "$deployment" ]]; then
+    jq -c --argjson attempt "$attempt" '{
+      attempt: $attempt,
+      status,
+      failure_phase,
+      failure_reason,
+      elapsed_ms
+    }' "$deployment" >>"$history_file"
+  else
+    jq -cn \
+      --argjson attempt "$attempt" \
+      --argjson exit_code "$status" \
+      '{
+        attempt: $attempt,
+        status: "missing_deployment",
+        failure_phase: "unknown",
+        failure_reason: ("launcher exited with " + ($exit_code | tostring)),
+        elapsed_ms: null
+      }' >>"$history_file"
+  fi
+
+  final_attempt=$attempt
+  final_status=$status
+  if ((status == 0 || attempt == max_attempts)); then
+    break
+  fi
+  if ! python3 "$repo_root/.github/scripts/harness_e2e_infra_retry.py" \
+    --deployment "$deployment" \
+    --results "$attempt_dir/results/results.json" \
+    --exit-code "$status"; then
+    break
+  fi
+  printf '\nRetrying clean provisioning after attempt %s\n' "$attempt" >&2
+done
+
+final_dir="$base_artifact_dir/attempts/attempt-$final_attempt"
+for name in logs stack results; do
+  [[ -d "$final_dir/$name" ]] && cp -a "$final_dir/$name" "$base_artifact_dir/$name"
+done
+[[ -f "$final_dir/cli-version.txt" ]] && \
+  cp "$final_dir/cli-version.txt" "$base_artifact_dir/cli-version.txt"
+
+if [[ -f "$final_dir/deployment.json" ]]; then
+  history=$(jq -s . "$history_file")
+  jq \
+    --argjson attempts "$final_attempt" \
+    --argjson history "$history" '
+      . + {
+        provisioning_attempts: $attempts,
+        provisioning_attempt_history: $history
+      }
+    ' "$final_dir/deployment.json" >"$base_artifact_dir/deployment.json"
+  if [[ -d "$base_artifact_dir/results" ]]; then
+    cp "$base_artifact_dir/deployment.json" \
+      "$base_artifact_dir/results/deployment.json"
+  fi
+fi
+
+exit "$final_status"


### PR DESCRIPTION
## What changed

- allow one clean provisioning retry for `bootstrap` and `registry` failures
- reject retries after scenario execution, for gate/quality failures, timeouts, or cancellation
- isolate retry attempts and retain both logs and deployment evidence
- record `provisioning_attempts` and the attempt history in `deployment.json`

## Why

Transient Registry/bootstrap failures currently discard an entire daily observation, while retrying model or quality failures would distort the benchmark. The retry boundary now follows structured lifecycle evidence.

## Impact

The daily lane uses two provisioning attempts at most. Other reusable-workflow callers keep the one-attempt default.

## Validation

- retry eligibility unit tests
- wrapper integration tests for successful retry and non-retryable E2E failure
- full Python workflow test suite
- `actionlint` and shell syntax validation

## Stack

Merge in order:

1. #750 — Registry stack lock
2. #751 — immutable runner artifact
3. **#752 — infrastructure-only retry (this PR)**
4. #753 — conservative scenario sharding

Refs MOT-4299
