### PR TITLE
(MOT-4299) feat(e2e): pilot stateless daily scenario shards

### DIFF
--- a/.github/scripts/collect_harness_e2e_benchmarks.py
+++ b/.github/scripts/collect_harness_e2e_benchmarks.py
@@ -165,15 +165,29 @@ def discover_contexts(root: Path) -> dict[tuple[str, str], Path]:
         if not isinstance(context, dict):
             raise CollectionError(f"{path} must contain an object")
         subject_id = require_string(context.get("subject_id"), f"{path}: subject_id")
-        scenario_id = require_string(
-            context.get("scenario_id"), f"{path}: scenario_id"
-        )
-        key = (subject_id, scenario_id)
-        if key in contexts:
-            raise CollectionError(
-                f"duplicate benchmark context for {subject_id}/{scenario_id}"
-            )
-        contexts[key] = path
+        scenario_ids = context.get("scenario_ids")
+        if scenario_ids is None:
+            scenario_ids = [
+                require_string(context.get("scenario_id"), f"{path}: scenario_id")
+            ]
+        else:
+            if context.get("schema_version") != 2:
+                raise CollectionError(f"{path}: sharded context must use schema_version 2")
+            require_string(context.get("shard_id"), f"{path}: shard_id")
+        if (
+            not isinstance(scenario_ids, list)
+            or not scenario_ids
+            or not all(isinstance(value, str) and value for value in scenario_ids)
+            or len(set(scenario_ids)) != len(scenario_ids)
+        ):
+            raise CollectionError(f"{path}: scenario_ids must be unique and non-empty")
+        for scenario_id in scenario_ids:
+            key = (subject_id, scenario_id)
+            if key in contexts:
+                raise CollectionError(
+                    f"duplicate benchmark context for {subject_id}/{scenario_id}"
+                )
+            contexts[key] = path
     return contexts
 
 
@@ -288,12 +302,19 @@ def validate_report(
             f"{path}: report subject does not match {subject['id']}"
         )
     scenarios = report.get("scenarios")
-    if not isinstance(scenarios, list) or len(scenarios) != 1:
-        raise CollectionError(f"{path}: expected exactly one scenario")
-    scenario = scenarios[0]
-    if not isinstance(scenario, dict) or scenario.get("scenario_id") != scenario_id:
+    if not isinstance(scenarios, list) or not scenarios:
+        raise CollectionError(f"{path}: expected at least one scenario")
+    matches = [
+        scenario
+        for scenario in scenarios
+        if isinstance(scenario, dict) and scenario.get("scenario_id") == scenario_id
+    ]
+    if len(matches) != 1:
         raise CollectionError(f"{path}: scenario id does not match {scenario_id}")
-    return report, scenario
+    normalized_report = dict(report)
+    normalized_report["scenarios"] = [matches[0]]
+    normalized_report["passed"] = bool(matches[0].get("passed"))
+    return normalized_report, matches[0]
 
 
 def collect(

--- a/.github/scripts/harness_e2e_shards.py
+++ b/.github/scripts/harness_e2e_shards.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Create deterministic Harness E2E execution shards."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from typing import Any
+
+
+PILOT_SCENARIOS = (
+    "direct_answer",
+    "security_review",
+    "design_tradeoff",
+    "security_triage",
+    "custom_validator",
+)
+VALID_PROFILES = {"isolated", "stateless-pilot"}
+SCENARIO_ID = re.compile(r"^[a-z0-9][a-z0-9_]*$")
+
+
+def parse_scenarios(raw: str) -> list[str]:
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"scenarios are not valid JSON: {error}") from error
+    if not isinstance(value, list) or not value:
+        raise ValueError("scenarios must be a non-empty array")
+    scenarios: list[str] = []
+    for scenario in value:
+        if not isinstance(scenario, str) or not SCENARIO_ID.fullmatch(scenario):
+            raise ValueError(f"invalid scenario id: {scenario!r}")
+        if scenario in scenarios:
+            raise ValueError(f"scenario repeats: {scenario}")
+        scenarios.append(scenario)
+    return scenarios
+
+
+def execution_shards(scenarios: list[str], profile: str) -> list[dict[str, Any]]:
+    if profile not in VALID_PROFILES:
+        raise ValueError(f"sharding profile must be one of {sorted(VALID_PROFILES)}")
+    if not scenarios or len(scenarios) != len(set(scenarios)):
+        raise ValueError("scenarios must be non-empty and unique")
+
+    grouped: list[str] = []
+    if profile == "stateless-pilot":
+        grouped = [scenario for scenario in PILOT_SCENARIOS if scenario in scenarios]
+
+    shards: list[dict[str, Any]] = []
+    if len(grouped) > 1:
+        shards.append(
+            {
+                "id": "stateless-core",
+                "scenario_ids": grouped,
+                "requires_kvm": False,
+            }
+        )
+    else:
+        grouped = []
+
+    grouped_set = set(grouped)
+    shards.extend(
+        {
+            "id": scenario,
+            "scenario_ids": [scenario],
+            "requires_kvm": scenario == "shell_coder_sandbox",
+        }
+        for scenario in scenarios
+        if scenario not in grouped_set
+    )
+
+    flattened = [scenario for shard in shards for scenario in shard["scenario_ids"]]
+    if set(flattened) != set(scenarios) or len(flattened) != len(scenarios):
+        raise ValueError("shards must contain every scenario exactly once")
+    return shards
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scenarios-json", required=True)
+    parser.add_argument("--profile", default="isolated")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        shards = execution_shards(parse_scenarios(args.scenarios_json), args.profile)
+    except ValueError as error:
+        raise SystemExit(f"invalid_shards: {error}") from error
+    print(json.dumps(shards, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/tests/test_collect_harness_e2e_benchmarks.py
+++ b/.github/scripts/tests/test_collect_harness_e2e_benchmarks.py
@@ -426,6 +426,83 @@ def test_preflight_failure_explains_all_unstarted_scenarios(tmp_path: Path) -> N
     ]["value"] == 2
 
 
+def test_collects_each_scenario_from_a_sharded_report(tmp_path: Path) -> None:
+    write_report(tmp_path, subject_id="glm", scenario_id="direct_answer")
+    directory = tmp_path / "harness-e2e-glm-direct_answer-results"
+    context = directory / "benchmark-context.json"
+    context.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "subject_id": "glm",
+                "shard_id": "stateless-core",
+                "scenario_ids": ["direct_answer", "security_review"],
+                "requested_runs": 3,
+            }
+        )
+    )
+    report_path = directory / "results.json"
+    report = json.loads(report_path.read_text())
+    second = json.loads(json.dumps(report["scenarios"][0]))
+    second["scenario_id"] = "security_review"
+    report["scenarios"].append(second)
+    report_path.write_text(json.dumps(report))
+
+    quality, _, snapshot, execution = collect(
+        config(tmp_path, ["direct_answer", "security_review"])
+    )
+
+    assert snapshot["subjects"][0]["received_reports"] == 2
+    assert {scenario["id"] for scenario in snapshot["subjects"][0]["scenarios"]} == {
+        "direct_answer",
+        "security_review",
+    }
+    assert {
+        metric["name"]
+        for metric in quality
+        if metric["name"].endswith("median_score")
+    } >= {
+        "quality::glm::direct_answer::median_score",
+        "quality::glm::security_review::median_score",
+    }
+    assert len(execution["reports"]) == 2
+    assert [
+        record["report"]["scenarios"][0]["scenario_id"]
+        for record in execution["reports"]
+    ] == ["direct_answer", "security_review"]
+
+
+def test_missing_shard_report_marks_every_scenario_as_infra_failed(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "harness-e2e-glm-stateless-core-results"
+    directory.mkdir()
+    (directory / "benchmark-context.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "subject_id": "glm",
+                "shard_id": "stateless-core",
+                "scenario_ids": ["direct_answer", "security_review"],
+                "requested_runs": 3,
+            }
+        )
+    )
+    (directory / "deployment.json").write_text(
+        json.dumps({"status": "infra_failed", "failure_phase": "registry"})
+    )
+
+    _, _, snapshot, _ = collect(
+        config(tmp_path, ["direct_answer", "security_review"])
+    )
+
+    scenarios = snapshot["subjects"][0]["scenarios"]
+    assert [scenario["status"] for scenario in scenarios] == [
+        "infra_failed",
+        "infra_failed",
+    ]
+
+
 def test_unknown_cost_is_omitted_instead_of_recorded_as_zero(
     tmp_path: Path,
 ) -> None:

--- a/.github/scripts/tests/test_harness_e2e_shards.py
+++ b/.github/scripts/tests/test_harness_e2e_shards.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+
+from harness_e2e_shards import PILOT_SCENARIOS, execution_shards, parse_scenarios
+
+
+ALL_SCENARIOS = [
+    "direct_answer",
+    "persistent_state",
+    "security_review",
+    "reactive_automation",
+    "shell_coder_sandbox",
+    "design_tradeoff",
+    "security_triage",
+    "research_pipeline",
+    "mechanical_reaction",
+    "timer_wake",
+    "receiving_operation",
+    "validation_loop",
+    "subagent_validation",
+    "multi_subagent_validation",
+    "subagent_validation_failure",
+    "custom_validator",
+    "validation_self_repair",
+    "validation_scope_enforcement",
+    "validation_chain",
+]
+
+
+def test_stateless_pilot_reduces_full_suite_to_fifteen_shards() -> None:
+    shards = execution_shards(ALL_SCENARIOS, "stateless-pilot")
+
+    assert len(shards) == 15
+    assert shards[0] == {
+        "id": "stateless-core",
+        "scenario_ids": list(PILOT_SCENARIOS),
+        "requires_kvm": False,
+    }
+    assert [
+        scenario for shard in shards for scenario in shard["scenario_ids"]
+    ] == [*PILOT_SCENARIOS] + [
+        scenario for scenario in ALL_SCENARIOS if scenario not in PILOT_SCENARIOS
+    ]
+
+
+def test_isolated_profile_keeps_one_scenario_per_shard() -> None:
+    shards = execution_shards(ALL_SCENARIOS, "isolated")
+
+    assert len(shards) == 19
+    assert all(len(shard["scenario_ids"]) == 1 for shard in shards)
+    sandbox = next(shard for shard in shards if shard["id"] == "shell_coder_sandbox")
+    assert sandbox["requires_kvm"] is True
+
+
+def test_custom_subset_groups_only_selected_pilot_scenarios() -> None:
+    shards = execution_shards(
+        ["security_review", "timer_wake", "direct_answer"], "stateless-pilot"
+    )
+
+    assert shards == [
+        {
+            "id": "stateless-core",
+            "scenario_ids": ["direct_answer", "security_review"],
+            "requires_kvm": False,
+        },
+        {
+            "id": "timer_wake",
+            "scenario_ids": ["timer_wake"],
+            "requires_kvm": False,
+        },
+    ]
+
+
+@pytest.mark.parametrize("raw", ['[]', '["direct_answer","direct_answer"]'])
+def test_rejects_empty_or_duplicate_scenarios(raw: str) -> None:
+    with pytest.raises(ValueError):
+        parse_scenarios(raw)

--- a/.github/workflows/_harness-e2e.yml
+++ b/.github/workflows/_harness-e2e.yml
@@ -108,6 +108,11 @@ on:
         required: false
         type: number
         default: 1
+      sharding_profile:
+        description: Execution grouping profile for the resolved scenarios
+        required: false
+        type: string
+        default: isolated
       validation_profile:
         description: Scenario profile resolved for this execution
         required: false
@@ -140,6 +145,9 @@ on:
       scenarios_json:
         description: Resolved scenario ids
         value: ${{ jobs.build.outputs.scenarios }}
+      shards_json:
+        description: Resolved scenario execution shards
+        value: ${{ jobs.build.outputs.shards }}
       required_scenarios_json:
         description: Canonical promotion gate
         value: ${{ jobs.build.outputs.required_scenarios }}
@@ -177,6 +185,7 @@ jobs:
     timeout-minutes: ${{ inputs.coverage && 60 || 45 }}
     outputs:
       scenarios: ${{ steps.scenarios.outputs.json }}
+      shards: ${{ steps.shards.outputs.json }}
       required_scenarios: ${{ steps.scenarios.outputs.required }}
       validation_profile: ${{ steps.scenarios.outputs.profile }}
       profile_digest: ${{ steps.scenarios.outputs.profile_digest }}
@@ -228,6 +237,7 @@ jobs:
           RESOLVE_STACK: ${{ inputs.resolve_stack }}
           PREBUILT_RUNNER: ${{ inputs.prebuilt_runner }}
           PROVISIONING_ATTEMPTS: ${{ inputs.provisioning_attempts }}
+          SHARDING_PROFILE: ${{ inputs.sharding_profile }}
           COVERAGE: ${{ inputs.coverage }}
         run: |
           set -euo pipefail
@@ -243,6 +253,7 @@ jobs:
           [[ -n "$JUDGE_MODEL" ]]
           [[ "$JUDGE_PROVIDER" =~ ^[A-Za-z0-9_-]+$ ]]
           [[ "$PROVISIONING_ATTEMPTS" =~ ^[12]$ ]]
+          [[ "$SHARDING_PROFILE" == isolated || "$SHARDING_PROFILE" == stateless-pilot ]]
           case "$STACK_MODE" in
             source) ;;
             registry)
@@ -460,6 +471,18 @@ jobs:
             echo "catalog_sha=$(jq -r .catalog_sha <<<"$resolved")"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Resolve execution shards
+        id: shards
+        env:
+          SCENARIOS: ${{ steps.scenarios.outputs.json }}
+          SHARDING_PROFILE: ${{ inputs.sharding_profile }}
+        run: |
+          set -euo pipefail
+          shards=$(python3 .github/scripts/harness_e2e_shards.py \
+            --scenarios-json "$SCENARIOS" \
+            --profile "$SHARDING_PROFILE")
+          echo "json=$shards" >> "$GITHUB_OUTPUT"
+
       - name: Package E2E binaries
         if: inputs.stack_mode == 'source'
         env:
@@ -622,19 +645,19 @@ jobs:
           if-no-files-found: error
 
   e2e:
-    name: harness e2e / ${{ matrix.subject.id }} / ${{ matrix.scenario }}
+    name: harness e2e / ${{ matrix.subject.id }} / ${{ matrix.shard.id }}
     needs: [build, resolve-registry-stack]
     if: >-
       always() && needs.build.result == 'success' &&
       (needs.resolve-registry-stack.result == 'success' ||
       needs.resolve-registry-stack.result == 'skipped')
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ inputs.provisioning_attempts == 2 && 70 || 35 }}
+    timeout-minutes: ${{ matrix.shard.id == 'stateless-core' && 90 || (inputs.provisioning_attempts == 2 && 70 || 35) }}
     strategy:
       fail-fast: false
       max-parallel: ${{ inputs.max_parallel }}
       matrix:
-        scenario: ${{ fromJSON(needs.build.outputs.scenarios) }}
+        shard: ${{ fromJSON(needs.build.outputs.shards) }}
         subject: ${{ fromJSON(inputs.subjects) }}
     steps:
       - uses: actions/checkout@v5
@@ -666,7 +689,7 @@ jobs:
         run: python3 -m pip install --quiet pyyaml
 
       - name: Prepare KVM for sandbox scenario
-        if: matrix.scenario == 'shell_coder_sandbox'
+        if: matrix.shard.requires_kvm
         run: |
           test -c /dev/kvm
           sudo chmod 0666 /dev/kvm
@@ -685,7 +708,7 @@ jobs:
           III_BIN: ${{ github.workspace }}/${{ needs.build.outputs.engine_binary }}
           HARNESS_E2E_BIN: ${{ github.workspace }}/harness/target/release/harness-e2e
           HARNESS_E2E_ARTIFACTS_DIR: ${{ github.workspace }}/target/harness-e2e
-          HARNESS_E2E_SCENARIO: ${{ matrix.scenario }}
+          HARNESS_E2E_SCENARIOS_JSON: ${{ toJSON(matrix.shard.scenario_ids) }}
           HARNESS_E2E_RUNS: ${{ inputs.runs }}
           HARNESS_E2E_MODEL: ${{ matrix.subject.model }}
           HARNESS_E2E_PROVIDER: ${{ matrix.subject.provider }}
@@ -718,7 +741,7 @@ jobs:
           HARNESS_E2E_PROVISIONING_ATTEMPTS: ${{ inputs.provisioning_attempts }}
           HARNESS_E2E_BIN: ${{ github.workspace }}/target/runner/harness-e2e
           HARNESS_E2E_ARTIFACTS_DIR: ${{ github.workspace }}/target/harness-e2e
-          HARNESS_E2E_SCENARIO: ${{ matrix.scenario }}
+          HARNESS_E2E_SCENARIOS_JSON: ${{ toJSON(matrix.shard.scenario_ids) }}
           HARNESS_E2E_RUNS: ${{ inputs.runs }}
           HARNESS_E2E_MODEL: ${{ matrix.subject.model }}
           HARNESS_E2E_PROVIDER: ${{ matrix.subject.provider }}
@@ -730,37 +753,42 @@ jobs:
         if: always()
         env:
           SUBJECT_ID: ${{ matrix.subject.id }}
-          SCENARIO_ID: ${{ matrix.scenario }}
+          SHARD_ID: ${{ matrix.shard.id }}
+          SCENARIO_IDS: ${{ toJSON(matrix.shard.scenario_ids) }}
           REQUESTED_RUNS: ${{ inputs.runs }}
         run: |
           set -euo pipefail
           mkdir -p target/harness-e2e/results
           jq -n \
             --arg subject_id "$SUBJECT_ID" \
-            --arg scenario_id "$SCENARIO_ID" \
+            --arg shard_id "$SHARD_ID" \
+            --argjson scenario_ids "$SCENARIO_IDS" \
             --argjson requested_runs "$REQUESTED_RUNS" \
             '{
-              schema_version: 1,
+              schema_version: 2,
               subject_id: $subject_id,
-              scenario_id: $scenario_id,
+              shard_id: $shard_id,
+              scenario_ids: $scenario_ids,
               requested_runs: $requested_runs
             }' > target/harness-e2e/results/benchmark-context.json
 
       - name: Write E2E summary
         if: always()
         env:
-          SCENARIO: ${{ matrix.scenario }}
+          SHARD: ${{ matrix.shard.id }}
           SUBJECT: ${{ matrix.subject.id }}
         run: |
           {
-            echo "### Harness E2E · $SUBJECT · $SCENARIO"
+            echo "### Harness E2E · $SUBJECT · $SHARD"
             echo
             echo "CI gate: scores are advisory; empty reports, hard-gate failures, and technical failures are blocking."
             echo
             results=target/harness-e2e/results/results.json
             if [[ -f "$results" ]]; then
               jq -r '
-                .scenarios[0] |
+                .scenarios[] |
+                "#### \(.scenario_id)",
+                "",
                 "| Score median | Threshold | Pass rate | Hard-gate failures | Technical failures | Subject cost (USD) | Judge cost (USD) | Total cost (USD) | Status |",
                 "| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
                 "| \(.aggregate.median_score // "n/a") | \(.threshold) | \((.aggregate.pass_rate * 100) | round)% | \(.aggregate.hard_gate_failures) | \(.aggregate.technical_failures) | \(.aggregate.cost.subject_usd // "n/a") | \(.aggregate.cost.judge_usd // "n/a") | \(.aggregate.cost.total_usd // "n/a") | \(if .passed then "pass" else "fail" end) |",
@@ -779,7 +807,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: harness-e2e-${{ matrix.subject.id }}-${{ matrix.scenario }}-results
+          name: harness-e2e-${{ matrix.subject.id }}-${{ matrix.shard.id }}-results
           path: |
             target/harness-e2e/results/
             target/harness-e2e/deployment.json
@@ -793,7 +821,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v6
         with:
-          name: harness-e2e-${{ matrix.subject.id }}-${{ matrix.scenario }}-diagnostics
+          name: harness-e2e-${{ matrix.subject.id }}-${{ matrix.shard.id }}-diagnostics
           path: |
             target/harness-e2e/logs/
             target/harness-e2e/stack/
@@ -804,7 +832,7 @@ jobs:
         if: always() && inputs.coverage
         uses: actions/upload-artifact@v6
         with:
-          name: harness-e2e-${{ matrix.subject.id }}-${{ matrix.scenario }}-profraw
+          name: harness-e2e-${{ matrix.subject.id }}-${{ matrix.shard.id }}-profraw
           path: target/harness-e2e/profraw/
           retention-days: 1
           if-no-files-found: ignore

--- a/.github/workflows/harness-e2e-daily.yml
+++ b/.github/workflows/harness-e2e-daily.yml
@@ -83,6 +83,7 @@ jobs:
       resolve_stack: true
       prebuilt_runner: true
       provisioning_attempts: 2
+      sharding_profile: stateless-pilot
       benchmark_lane: daily
       release_tag: daily/${{ needs.context.outputs.benchmark_day }}
       release_worker: harness

--- a/harness/tests/e2e/README.md
+++ b/harness/tests/e2e/README.md
@@ -224,19 +224,26 @@ zero.
 
 The reusable workflow supports source and registry stack modes. Source runs
 install the latest stable `iii` release with its companion binaries, then build
-the runtime workers from the selected commit. Registry runs build only the E2E
-runner and install every runtime worker through `iii worker add`. Scenario ids
-come directly from `harness-e2e list`. Each subject/scenario pair receives a
-fresh stack, and repetitions run sequentially inside that job with unique table,
-session, and state namespaces. At most two matrix jobs make live-model calls
-concurrently.
+the runtime workers from the selected commit. Registry runs install every
+runtime worker through `iii worker add`; they may compile the E2E runner or use
+an immutable runner artifact produced for the selected commit. Scenario ids
+come directly from `harness-e2e list`. Each subject/shard pair receives a fresh
+stack, and repetitions run sequentially inside that job with unique table,
+session, and state namespaces. The default shard profile keeps one scenario per
+job. At most two matrix jobs make live-model calls concurrently.
 
 The daily lane uses the registry mode to measure the currently published live
-stack. It resolves `latest` once per matrix job, records the exact versions and
-SHA-256 digest of the resulting `iii.lock`, and treats Registry resolution
-failures as `infra_failed`; it does not fall back to a source build. The main
-lane keeps the source build and LLVM coverage so operational daily metrics stay
-separate from checkout regression coverage.
+stack. It resolves `latest` once for the workflow, records the exact versions
+and SHA-256 digest of the resulting `iii.lock`, and gives that immutable lock to
+every shard. It downloads the runner artifact for the exact source SHA and
+never compiles a fallback. Bootstrap and Registry failures may receive one
+clean provisioning retry; scenario and gate failures are never retried by the
+launcher. The daily stateless pilot runs `direct_answer`, `security_review`,
+`design_tradeoff`, `security_triage`, and `custom_validator` sequentially in one
+shard while the remaining scenarios stay isolated. Metrics and history remain
+separate per subject/scenario. The main lane keeps the source build and LLVM
+coverage so operational daily metrics stay separate from checkout regression
+coverage.
 
 The deployed lane is a separate workflow run dispatched by the release smoke
 workflow. The release publishes first, the smoke validates the published
@@ -326,16 +333,17 @@ credentials remain in access-controlled workflow artifacts. Missing reports are
 stored as reliability events; unknown cost is omitted instead of recorded as
 zero.
 
-The daily lane evaluates repository binaries built from the resolved default
-branch commit. It does not install registry artifacts; registry installation
-remains the responsibility of the quickstart validator.
+The daily lane evaluates the immutable E2E runner built from the resolved
+default-branch commit against the once-resolved Registry stack. Missing,
+expired, mismatched, or tampered runner artifacts fail before scenario
+execution rather than triggering an unverified local build.
 
 Repository administration has one manual prerequisite: under **Settings →
 Pages**, select **GitHub Actions** as the Pages source. The benchmark workflow
 maintains the `gh-pages` data history and deploys that history through the
 official Pages artifact flow.
 
-Each matrix job publishes its result for 14 days; failed jobs also publish
+Each shard job publishes its result for 14 days; failed jobs also publish
 diagnostics for 14 days. The workflow summary shows subject, judge, and total
 cost per scenario and consolidated by subject. The daily dashboard retains the
 latest 100 comparable points and summaries, plus complete reports for the latest

--- a/harness/tests/e2e/run-ci.sh
+++ b/harness/tests/e2e/run-ci.sh
@@ -2,7 +2,6 @@
 set -Eeuo pipefail
 
 : "${III_BIN:?III_BIN must point to the pinned iii engine binary}"
-: "${HARNESS_E2E_SCENARIO:?HARNESS_E2E_SCENARIO is required}"
 : "${HARNESS_E2E_MODEL:?HARNESS_E2E_MODEL is required}"
 : "${HARNESS_E2E_PROVIDER:?HARNESS_E2E_PROVIDER is required}"
 : "${HARNESS_E2E_JUDGE_MODEL:?HARNESS_E2E_JUDGE_MODEL is required}"
@@ -22,6 +21,20 @@ export PATH="$iii_bin_dir:$PATH"
 artifacts_dir=${HARNESS_E2E_ARTIFACTS_DIR:-"$repo_root/target/harness-e2e"}
 e2e_bin=${HARNESS_E2E_BIN:-"$harness_root/target/release/harness-e2e"}
 runs=${HARNESS_E2E_RUNS:-1}
+scenarios_json=${HARNESS_E2E_SCENARIOS_JSON:-}
+if [[ -z "$scenarios_json" ]]; then
+  : "${HARNESS_E2E_SCENARIO:?HARNESS_E2E_SCENARIO or HARNESS_E2E_SCENARIOS_JSON is required}"
+  scenarios_json=$(jq -cn --arg scenario "$HARNESS_E2E_SCENARIO" '[$scenario]')
+fi
+jq -e '
+  type == "array" and length > 0 and
+  all(.[]; type == "string" and test("^[a-z0-9][a-z0-9_]*$")) and
+  (unique | length) == length
+' <<<"$scenarios_json" >/dev/null || {
+  echo "HARNESS_E2E_SCENARIOS_JSON must contain unique scenario ids" >&2
+  exit 2
+}
+mapfile -t scenarios < <(jq -r '.[]' <<<"$scenarios_json")
 run_dir="$artifacts_dir/stack"
 logs_dir="$artifacts_dir/logs"
 iii_port=${HARNESS_E2E_PORT:-49134}
@@ -223,12 +236,17 @@ start_process harness \
   --url "$iii_url"
 wait_for_function harness::send
 
-if [[ "$HARNESS_E2E_SCENARIO" == "research_pipeline" ]]; then
+if jq -e 'index("research_pipeline") != null' <<<"$scenarios_json" >/dev/null; then
   start_process web \
     "$repo_root/web/target/release/web" \
     --url "$iii_url"
   wait_for_function web::fetch
 fi
+
+scenario_args=()
+for scenario in "${scenarios[@]}"; do
+  scenario_args+=(--scenario "$scenario")
+done
 
 "$e2e_bin" run \
   --url "$iii_url" \
@@ -237,5 +255,5 @@ fi
   --judge-model "$HARNESS_E2E_JUDGE_MODEL" \
   --judge-provider "$HARNESS_E2E_JUDGE_PROVIDER" \
   --output "$artifacts_dir/results" \
-  --scenario "$HARNESS_E2E_SCENARIO" \
+  "${scenario_args[@]}" \
   --runs "$runs"

--- a/harness/tests/e2e/run-deployed-ci.sh
+++ b/harness/tests/e2e/run-deployed-ci.sh
@@ -9,7 +9,6 @@ set -Eeuo pipefail
 : "${HARNESS_E2E_PROVIDER:?HARNESS_E2E_PROVIDER is required}"
 : "${HARNESS_E2E_JUDGE_MODEL:?HARNESS_E2E_JUDGE_MODEL is required}"
 : "${HARNESS_E2E_JUDGE_PROVIDER:?HARNESS_E2E_JUDGE_PROVIDER is required}"
-: "${HARNESS_E2E_SCENARIO:?HARNESS_E2E_SCENARIO is required}"
 
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 harness_root=$(cd -- "$script_dir/../.." && pwd)
@@ -24,6 +23,20 @@ resolve_stack=${HARNESS_E2E_RESOLVE_STACK:-false}
 resolve_only=${HARNESS_E2E_RESOLVE_ONLY:-false}
 expected_stack_digest=${HARNESS_E2E_STACK_DIGEST:-}
 runs=${HARNESS_E2E_RUNS:-1}
+scenarios_json=${HARNESS_E2E_SCENARIOS_JSON:-}
+if [[ -z "$scenarios_json" ]]; then
+  : "${HARNESS_E2E_SCENARIO:?HARNESS_E2E_SCENARIO or HARNESS_E2E_SCENARIOS_JSON is required}"
+  scenarios_json=$(jq -cn --arg scenario "$HARNESS_E2E_SCENARIO" '[$scenario]')
+fi
+jq -e '
+  type == "array" and length > 0 and
+  all(.[]; type == "string" and test("^[a-z0-9][a-z0-9_]*$")) and
+  (unique | length) == length
+' <<<"$scenarios_json" >/dev/null || {
+  echo "HARNESS_E2E_SCENARIOS_JSON must contain unique scenario ids" >&2
+  exit 2
+}
+mapfile -t scenarios < <(jq -r '.[]' <<<"$scenarios_json")
 engine_port=49134
 wait_seconds=180
 add_timeout_seconds=600
@@ -482,6 +495,10 @@ fi
 failure_phase=e2e
 export HARNESS_E2E_RUN_DIR="$project_dir"
 export HARNESS_E2E_ENGINE_REVISION="$cli_version"
+scenario_args=()
+for scenario in "${scenarios[@]}"; do
+  scenario_args+=(--scenario "$scenario")
+done
 "$e2e_bin" run \
   --url "ws://127.0.0.1:$engine_port" \
   --model "$HARNESS_E2E_MODEL" \
@@ -489,5 +506,5 @@ export HARNESS_E2E_ENGINE_REVISION="$cli_version"
   --judge-model "$HARNESS_E2E_JUDGE_MODEL" \
   --judge-provider "$HARNESS_E2E_JUDGE_PROVIDER" \
   --output "$artifact_dir/results" \
-  --scenario "$HARNESS_E2E_SCENARIO" \
+  "${scenario_args[@]}" \
   --runs "$runs"


### PR DESCRIPTION
## What changed

- add the conservative `stateless-pilot` sharding profile
- run five stateless scenarios sequentially in `stateless-core`
- keep the remaining fourteen scenarios isolated
- extend launchers, benchmark contexts, collector, summaries, and artifacts for multi-scenario reports
- preserve one dashboard/history entry per subject and scenario

## Why

Every scenario currently provisions an identical stack. Reusing one stack for the lowest-risk scenarios reduces repeated setup without changing the metric identity or merging stateful scenarios.

## Impact

The daily matrix moves from 19 to 15 shards per subject. Source, release, and deployed callers remain isolated unless they explicitly select another sharding profile.

## Validation

- shard completeness, uniqueness, ordering, and KVM tests
- collector compatibility tests for legacy and schema-v2 contexts
- missing-shard infrastructure failure tests
- 275 Python tests and 33 dashboard tests
- `actionlint` and shell syntax validation

## Stack

Merge in order:

1. #750 — Registry stack lock
2. #751 — immutable runner artifact
3. #752 — infrastructure-only retry
4. **#753 — conservative scenario sharding (this PR)**

Fixes MOT-4299
