### PR TITLE
(MOT-4381) refactor(harness): migrate scored E2E assessments

### DIFF
--- a/harness/tests/e2e/README.md
+++ b/harness/tests/e2e/README.md
@@ -366,8 +366,10 @@ rules:
   while structural refactors that preserve the behavioral contract keep it;
 - for new code-defined objective evaluators, declare each check once as a static
   `AssessmentSpec`: use `required` for conditions that must emit a hard gate and
-  a binary award, and `signal` for non-blocking quality awards; existing
-  evaluators can migrate to this pattern incrementally;
+  `binary` when the gate controls a full-or-zero award, `required_points` when
+  the gate outcome and quality award are evaluated independently, and `signal`
+  for non-blocking quality awards; existing evaluators can migrate to this
+  pattern incrementally;
 - prompts describe user intent and never prescribe function ids;
 - declare a scenario-sized execution policy;
 - objective effects are hard gates, not judge opinions;

--- a/harness/tests/e2e/src/scenarios/assessment.rs
+++ b/harness/tests/e2e/src/scenarios/assessment.rs
@@ -53,10 +53,41 @@ impl AssessmentSpec {
     pub(super) fn points(self, awarded: u8, reason: impl Into<String>) -> Result<AssessmentResult> {
         if self.kind == AssessmentKind::Required {
             bail!(
-                "required assessment {} must be evaluated as pass or fail",
+                "required assessment {} cannot use signal-only points; use binary or required_points",
                 self.id
             );
         }
+        self.validate_points(awarded)?;
+        Ok(AssessmentResult {
+            spec: self,
+            awarded,
+            gate_passed: None,
+            reason: reason.into(),
+        })
+    }
+
+    pub(super) fn required_points(
+        self,
+        passed: bool,
+        awarded: u8,
+        reason: impl Into<String>,
+    ) -> Result<AssessmentResult> {
+        if self.kind == AssessmentKind::Signal {
+            bail!(
+                "signal assessment {} cannot produce a required gate",
+                self.id
+            );
+        }
+        self.validate_points(awarded)?;
+        Ok(AssessmentResult {
+            spec: self,
+            awarded,
+            gate_passed: Some(passed),
+            reason: reason.into(),
+        })
+    }
+
+    fn validate_points(self, awarded: u8) -> Result<()> {
         if awarded > self.weight {
             bail!(
                 "assessment {} awarded {awarded} points, exceeding its weight {}",
@@ -64,12 +95,7 @@ impl AssessmentSpec {
                 self.weight
             );
         }
-        Ok(AssessmentResult {
-            spec: self,
-            awarded,
-            gate_passed: None,
-            reason: reason.into(),
-        })
+        Ok(())
     }
 
     fn criterion(self) -> CriterionSpec {
@@ -200,10 +226,52 @@ mod tests {
     }
 
     #[test]
-    fn required_assessments_reject_partial_points() {
+    fn required_assessments_reject_the_signal_points_api() {
         assert_eq!(
             REQUIRED.points(35, "partial").unwrap_err().to_string(),
-            "required assessment required must be evaluated as pass or fail"
+            "required assessment required cannot use signal-only points; use binary or required_points"
+        );
+    }
+
+    #[test]
+    fn required_gate_can_award_partial_points_after_passing() {
+        let evaluation = objective([REQUIRED
+            .required_points(true, 35, "passed with partial quality")
+            .unwrap()]);
+
+        assert!(evaluation.hard_gates[0].passed);
+        assert_eq!(evaluation.awards[0].awarded, 35);
+    }
+
+    #[test]
+    fn failed_required_gate_can_retain_independent_quality_points() {
+        let evaluation = objective([REQUIRED
+            .required_points(false, 35, "failed with partial quality")
+            .unwrap()]);
+
+        assert!(!evaluation.hard_gates[0].passed);
+        assert_eq!(evaluation.awards[0].awarded, 35);
+    }
+
+    #[test]
+    fn required_gate_rejects_points_above_its_weight() {
+        assert_eq!(
+            REQUIRED
+                .required_points(true, 71, "too many")
+                .unwrap_err()
+                .to_string(),
+            "assessment required awarded 71 points, exceeding its weight 70"
+        );
+    }
+
+    #[test]
+    fn signal_rejects_a_required_gate() {
+        assert_eq!(
+            SIGNAL
+                .required_points(true, 30, "wrong kind")
+                .unwrap_err()
+                .to_string(),
+            "signal assessment signal cannot produce a required gate"
         );
     }
 }

--- a/harness/tests/e2e/src/scenarios/custom_validator.rs
+++ b/harness/tests/e2e/src/scenarios/custom_validator.rs
@@ -23,12 +23,10 @@ use serde_json::Value;
 
 use crate::context::E2eContext;
 
+use super::assessment::{self, AssessmentSpec};
 use super::common;
 use super::validation_loop::suffix;
-use super::{
-    CleanupFuture, CriterionSpec, EvaluationFuture, ExecutionPolicy, ObjectiveEvaluation,
-    ScenarioObservation, ScenarioSpec,
-};
+use super::{CleanupFuture, EvaluationFuture, ExecutionPolicy, ScenarioObservation, ScenarioSpec};
 
 pub const ID: &str = "custom_validator";
 
@@ -38,6 +36,26 @@ const HOOK_TYPE: &str = "harness::hook::post-turn";
 /// footgun for anyone writing a validator, so this scenario pins it.
 const HOOK_POINT: &str = "post_turn";
 const TOKENS: [&str; 3] = ["E2E-ACCEPT-1", "E2E-ACCEPT-2", "E2E-ACCEPT-3"];
+const ENVELOPE_REGISTRATION: AssessmentSpec = AssessmentSpec::required(
+    "envelope_registration",
+    30,
+    "Exactly one post-turn registration targeting the temporary function, envelope mode (no payload template).",
+);
+const CUSTOM_REASONS_DROVE_THE_LOOP: AssessmentSpec = AssessmentSpec::required(
+    "custom_reasons_drove_the_loop",
+    30,
+    "Both corrective prompts carry the validator's own reasons naming the next rung.",
+);
+const LADDER_CONVERGED: AssessmentSpec = AssessmentSpec::required(
+    "ladder_converged",
+    40,
+    "The final result carries the terminal token — reachable only by following two custom denials.",
+);
+const ASSESSMENTS: &[AssessmentSpec] = &[
+    LADDER_CONVERGED,
+    ENVELOPE_REGISTRATION,
+    CUSTOM_REASONS_DROVE_THE_LOOP,
+];
 
 /// Lenient view of the post-turn hook envelope (harness → validator).
 #[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
@@ -130,7 +148,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
     let validator = function_id(run_id);
     ScenarioSpec {
         id: ID,
-        version: 1,
+        version: 2,
         prompt: format!(
             "You are testing a validation loop driven by a custom validator function. Follow \
              these steps exactly.\n\n\
@@ -157,26 +175,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
         },
         denied_functions: &[],
         threshold: 90,
-        criteria: vec![
-            CriterionSpec {
-                id: "ladder_converged",
-                weight: 40,
-                description: "The final result carries the terminal token — reachable only by \
-                              following two custom denials.",
-            },
-            CriterionSpec {
-                id: "envelope_registration",
-                weight: 30,
-                description: "Exactly one post-turn registration targeting the temporary \
-                              function, envelope mode (no payload template).",
-            },
-            CriterionSpec {
-                id: "custom_reasons_drove_the_loop",
-                weight: 30,
-                description: "Both corrective prompts carry the validator's own reasons naming \
-                              the next rung.",
-            },
-        ],
+        criteria: assessment::criteria(ASSESSMENTS),
         judge_reference: None,
         setup: Some(setup),
         evaluate,
@@ -220,47 +219,32 @@ fn evaluate<'a>(
                 .all(|text| text.contains("custom validator"));
         let converged = observation.response.contains(TOKENS[2]);
         let no_errors = observation.metrics.totals.function_call_errors == 0;
+        let envelope_points = if envelope_mode && no_errors {
+            ENVELOPE_REGISTRATION.weight()
+        } else {
+            0
+        };
 
-        Ok(ObjectiveEvaluation {
-            hard_gates: vec![
-                common::gate(
-                    "envelope_registration",
-                    envelope_mode,
-                    format!(
-                        "observed {} post-turn registration(s); need exactly one targeting \
-                         {validator} with no payload",
-                        registrations.len()
-                    ),
+        Ok(assessment::objective([
+            LADDER_CONVERGED.binary(
+                converged,
+                format!("final response must contain {}", TOKENS[2]),
+            ),
+            ENVELOPE_REGISTRATION.required_points(
+                envelope_mode,
+                envelope_points,
+                format!(
+                    "observed {} post-turn registration(s); need exactly one targeting \
+                     {validator} with no payload; function_call_errors={}",
+                    registrations.len(),
+                    observation.metrics.totals.function_call_errors
                 ),
-                common::gate(
-                    "custom_reasons_delivered",
-                    laddered,
-                    format!("nudges: {nudge_texts:?} — expected the two ladder reasons in order"),
-                ),
-                common::gate(
-                    "ladder_converged",
-                    converged,
-                    format!("final response must contain {}", TOKENS[2]),
-                ),
-            ],
-            awards: vec![
-                common::award(
-                    "ladder_converged",
-                    if converged { 40 } else { 0 },
-                    "awarded when the terminal token is reached",
-                ),
-                common::award(
-                    "envelope_registration",
-                    if envelope_mode && no_errors { 30 } else { 0 },
-                    "awarded for one clean envelope-mode registration",
-                ),
-                common::award(
-                    "custom_reasons_drove_the_loop",
-                    if laddered { 30 } else { 0 },
-                    "awarded when both nudges carry the validator's own rung-naming reasons",
-                ),
-            ],
-        })
+            )?,
+            CUSTOM_REASONS_DROVE_THE_LOOP.binary(
+                laddered,
+                format!("nudges: {nudge_texts:?} — expected the two ladder reasons in order"),
+            ),
+        ]))
     })
 }
 
@@ -351,5 +335,17 @@ mod tests {
         assert!(spec.prompt.contains("e2etest::validate_aB19"));
         assert!(spec.setup.is_some());
         spec.validate().unwrap();
+        assert_eq!(spec.version, 2);
+        assert_eq!(
+            spec.criteria
+                .iter()
+                .map(|criterion| (criterion.id, criterion.weight))
+                .collect::<Vec<_>>(),
+            vec![
+                ("ladder_converged", 40),
+                ("envelope_registration", 30),
+                ("custom_reasons_drove_the_loop", 30),
+            ]
+        );
     }
 }

--- a/harness/tests/e2e/src/scenarios/multi_subagent_validation.rs
+++ b/harness/tests/e2e/src/scenarios/multi_subagent_validation.rs
@@ -14,12 +14,10 @@ use serde_json::{json, Value};
 
 use crate::context::E2eContext;
 
+use super::assessment::{self, AssessmentSpec};
 use super::common;
 use super::validation_loop::suffix;
-use super::{
-    CleanupFuture, CriterionSpec, EvaluationFuture, ExecutionPolicy, ObjectiveEvaluation,
-    ScenarioObservation, ScenarioSpec,
-};
+use super::{CleanupFuture, EvaluationFuture, ExecutionPolicy, ScenarioObservation, ScenarioSpec};
 
 pub const ID: &str = "multi_subagent_validation";
 
@@ -27,6 +25,22 @@ const HOOK_TYPE: &str = "harness::hook::post-turn";
 const THRESHOLD: u64 = 6;
 const EXPECTED_ROWS: u64 = 8;
 const WRITERS: [&str; 2] = ["w1", "w2"];
+const CHILDREN_GOAL: AssessmentSpec = AssessmentSpec::required(
+    "children_goal",
+    35,
+    "Both writers exceed the threshold and both verdict keys carry their accepted counts.",
+);
+const ORCHESTRATION_DISCIPLINE: AssessmentSpec = AssessmentSpec::required(
+    "orchestration_discipline",
+    35,
+    "Two child-scoped validators and two wakes registered before any spawn; both children looped under their own gate.",
+);
+const FAN_IN_REPORT: AssessmentSpec = AssessmentSpec::required(
+    "fan_in_report",
+    30,
+    "The parent tallies both verdicts and finishes with the exact report line.",
+);
+const ASSESSMENTS: &[AssessmentSpec] = &[CHILDREN_GOAL, ORCHESTRATION_DISCIPLINE, FAN_IN_REPORT];
 
 pub fn scenario(run_id: &str) -> ScenarioSpec {
     let table = table(run_id);
@@ -35,7 +49,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
     let child_2 = child_session(run_id, 2);
     ScenarioSpec {
         id: ID,
-        version: 1,
+        version: 2,
         prompt: format!(
             "You orchestrate TWO validated sub-agents in parallel. You never poll and never judge \
              work yourself: per-child validators gate every child reply, and verdict wakes drive \
@@ -90,26 +104,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
         },
         denied_functions: &[],
         threshold: 90,
-        criteria: vec![
-            CriterionSpec {
-                id: "children_goal",
-                weight: 35,
-                description: "Both writers exceed the threshold and both verdict keys carry \
-                              their accepted counts.",
-            },
-            CriterionSpec {
-                id: "orchestration_discipline",
-                weight: 35,
-                description: "Two child-scoped validators and two wakes registered before any \
-                              spawn; both children looped under their own gate.",
-            },
-            CriterionSpec {
-                id: "fan_in_report",
-                weight: 30,
-                description: "The parent tallies both verdicts and finishes with the exact \
-                              report line.",
-            },
-        ],
+        criteria: assessment::criteria(ASSESSMENTS),
         judge_reference: None,
         setup: None,
         evaluate,
@@ -180,65 +175,42 @@ fn evaluate<'a>(
         let goal = rows.iter().all(|count| *count > THRESHOLD)
             && verdicts.iter().all(|count| *count > THRESHOLD);
         let both_looped = child_nudges.iter().all(|nudges| *nudges >= 1);
-        let report = observation.response.contains("ALL CHILDREN VALIDATED")
+        let reported = observation.response.contains("ALL CHILDREN VALIDATED")
             && observation.response.contains("ORCHESTRATION DONE");
 
-        Ok(ObjectiveEvaluation {
-            hard_gates: vec![
-                common::gate(
-                    "children_goal_reached",
-                    goal,
-                    format!("rows={rows:?}, verdicts={verdicts:?}, all must exceed {THRESHOLD}"),
+        let orchestration_discipline = validator_count == 2 && ordered && both_looped;
+
+        Ok(assessment::objective([
+            CHILDREN_GOAL.required_points(
+                goal,
+                children_goal_points(goal, &rows),
+                format!(
+                    "rows={rows:?}, verdicts={verdicts:?}, all must exceed {THRESHOLD}; full \
+                     marks at exactly {EXPECTED_ROWS} rows each"
                 ),
-                common::gate(
-                    "two_scoped_validators",
-                    validator_count == 2,
-                    format!("observed {validator_count} post-turn registration(s), expected two"),
+            )?,
+            ORCHESTRATION_DISCIPLINE.binary(
+                orchestration_discipline,
+                format!(
+                    "observed {validator_count} post-turn registration(s), expected two; \
+                     observed {registrations_before_spawn} registration(s) before the first \
+                     spawn, expected at least four; child nudges {child_nudges:?}, each child \
+                     needs at least one"
                 ),
-                common::gate(
-                    "arm_before_spawn",
-                    ordered,
-                    format!(
-                        "observed {registrations_before_spawn} registration(s) before the first \
-                         spawn, expected at least four"
-                    ),
-                ),
-                common::gate(
-                    "both_children_looped",
-                    both_looped,
-                    format!("child nudges {child_nudges:?}, each child needs at least one"),
-                ),
-                common::gate("fan_in_report", report, "expected the exact report line"),
-            ],
-            awards: vec![
-                common::award(
-                    "children_goal",
-                    if goal && rows.iter().all(|count| *count == EXPECTED_ROWS) {
-                        35
-                    } else if goal {
-                        20
-                    } else {
-                        0
-                    },
-                    format!("rows={rows:?} (full marks at exactly {EXPECTED_ROWS} each)"),
-                ),
-                common::award(
-                    "orchestration_discipline",
-                    if validator_count == 2 && ordered && both_looped {
-                        35
-                    } else {
-                        0
-                    },
-                    "awarded for two scoped validators + wakes armed before the spawns",
-                ),
-                common::award(
-                    "fan_in_report",
-                    if report { 30 } else { 0 },
-                    "awarded for the exact tally report line",
-                ),
-            ],
-        })
+            ),
+            FAN_IN_REPORT.binary(reported, "expected the exact report line"),
+        ]))
     })
+}
+
+fn children_goal_points(goal: bool, rows: &[u64; 2]) -> u8 {
+    if goal && rows.iter().all(|count| *count == EXPECTED_ROWS) {
+        CHILDREN_GOAL.weight()
+    } else if goal {
+        20
+    } else {
+        0
+    }
 }
 
 fn cleanup<'a>(context: &'a E2eContext, run_id: &'a str) -> CleanupFuture<'a> {
@@ -285,5 +257,27 @@ mod tests {
         assert!(spec.prompt.contains("e2e_aB19-rest-child-2"));
         assert!(spec.prompt.contains("msubvtest_aB19"));
         spec.validate().unwrap();
+        assert_eq!(spec.version, 2);
+        assert_eq!(
+            spec.criteria
+                .iter()
+                .map(|criterion| (criterion.id, criterion.weight))
+                .collect::<Vec<_>>(),
+            vec![
+                ("children_goal", 35),
+                ("orchestration_discipline", 35),
+                ("fan_in_report", 30),
+            ]
+        );
+    }
+
+    #[test]
+    fn exact_rows_only_score_fully_after_both_verdicts_pass() {
+        assert_eq!(children_goal_points(false, &[EXPECTED_ROWS; 2]), 0);
+        assert_eq!(children_goal_points(true, &[EXPECTED_ROWS; 2]), 35);
+        assert_eq!(
+            children_goal_points(true, &[EXPECTED_ROWS, EXPECTED_ROWS + 1]),
+            20
+        );
     }
 }

--- a/harness/tests/e2e/src/scenarios/subagent_validation.rs
+++ b/harness/tests/e2e/src/scenarios/subagent_validation.rs
@@ -16,18 +16,32 @@ use serde_json::{json, Value};
 
 use crate::context::E2eContext;
 
+use super::assessment::{self, AssessmentSpec};
 use super::common;
 use super::validation_loop::suffix;
-use super::{
-    CleanupFuture, CriterionSpec, EvaluationFuture, ExecutionPolicy, ObjectiveEvaluation,
-    ScenarioObservation, ScenarioSpec,
-};
+use super::{CleanupFuture, EvaluationFuture, ExecutionPolicy, ScenarioObservation, ScenarioSpec};
 
 pub const ID: &str = "subagent_validation";
 
 const HOOK_TYPE: &str = "harness::hook::post-turn";
 const THRESHOLD: u64 = 6;
 const EXPECTED_ROWS: u64 = 8;
+const CHILD_GOAL: AssessmentSpec = AssessmentSpec::required(
+    "child_goal",
+    35,
+    "The child's table work exceeds the validator threshold and the verdict key carries the accepted count.",
+);
+const ORCHESTRATION_DISCIPLINE: AssessmentSpec = AssessmentSpec::required(
+    "orchestration_discipline",
+    35,
+    "Validator scoped to the child, wake armed before the spawn, and the child spawned with the named session.",
+);
+const WAKE_REPORT: AssessmentSpec = AssessmentSpec::required(
+    "wake_report",
+    30,
+    "The parent finishes from the verdict wake with the exact report line.",
+);
+const ASSESSMENTS: &[AssessmentSpec] = &[CHILD_GOAL, ORCHESTRATION_DISCIPLINE, WAKE_REPORT];
 
 pub fn scenario(run_id: &str) -> ScenarioSpec {
     let table = table(run_id);
@@ -35,7 +49,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
     let child = child_session(run_id);
     ScenarioSpec {
         id: ID,
-        version: 1,
+        version: 2,
         prompt: format!(
             "You orchestrate one validated sub-agent. You never poll and never judge its work \
              yourself: a validator gates every child reply and a verdict wake drives you. Follow \
@@ -83,26 +97,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
         },
         denied_functions: &[],
         threshold: 90,
-        criteria: vec![
-            CriterionSpec {
-                id: "child_goal",
-                weight: 35,
-                description: "The child's table work exceeds the validator threshold and the \
-                              verdict key carries the accepted count.",
-            },
-            CriterionSpec {
-                id: "orchestration_discipline",
-                weight: 35,
-                description: "Validator scoped to the child, wake armed before the spawn, and \
-                              the child spawned with the named session.",
-            },
-            CriterionSpec {
-                id: "wake_report",
-                weight: 30,
-                description: "The parent finishes from the verdict wake with the exact report \
-                              line.",
-            },
-        ],
+        criteria: assessment::criteria(ASSESSMENTS),
         judge_reference: None,
         setup: None,
         evaluate,
@@ -170,56 +165,53 @@ fn evaluate<'a>(
         };
 
         let goal = rows > THRESHOLD && verdict > THRESHOLD;
-        let report = observation.response.contains("CHILD VALIDATED")
+        let reported = observation.response.contains("CHILD VALIDATED")
             && observation.response.contains("PARENT DONE");
+        let (orchestration_passed, orchestration_points) =
+            orchestration_outcome(ordered, child_nudges);
 
-        Ok(ObjectiveEvaluation {
-            hard_gates: vec![
-                common::gate(
-                    "child_goal_reached",
-                    goal,
-                    format!("rows={rows}, verdict={verdict}, need both above {THRESHOLD}"),
+        Ok(assessment::objective([
+            CHILD_GOAL.required_points(
+                goal,
+                child_goal_points(goal, rows),
+                format!(
+                    "rows={rows}, verdict={verdict}, need both above {THRESHOLD}; full marks at \
+                     exactly {EXPECTED_ROWS} rows"
                 ),
-                common::gate(
-                    "arm_before_spawn",
-                    ordered,
-                    format!(
-                        "validator@{validator_index:?} wake@{wake_index:?} spawn@{spawn_index:?} \
-                         — validator and wake must precede the spawn"
-                    ),
+            )?,
+            ORCHESTRATION_DISCIPLINE.required_points(
+                orchestration_passed,
+                orchestration_points,
+                format!(
+                    "validator@{validator_index:?} wake@{wake_index:?} spawn@{spawn_index:?} — \
+                     validator and wake must precede the spawn; observed {child_nudges} nudge(s) \
+                     in the child transcript"
                 ),
-                common::gate(
-                    "child_loop_ran",
-                    child_nudges >= 1,
-                    format!("observed {child_nudges} nudge(s) in the child transcript"),
-                ),
-                common::gate("parent_report", report, "expected the exact report line"),
-            ],
-            awards: vec![
-                common::award(
-                    "child_goal",
-                    if goal && rows == EXPECTED_ROWS {
-                        35
-                    } else if goal {
-                        20
-                    } else {
-                        0
-                    },
-                    format!("rows={rows} (full marks at exactly {EXPECTED_ROWS})"),
-                ),
-                common::award(
-                    "orchestration_discipline",
-                    if ordered { 35 } else { 0 },
-                    "awarded for validator+wake registered before the spawn, all correctly named",
-                ),
-                common::award(
-                    "wake_report",
-                    if report { 30 } else { 0 },
-                    "awarded for the exact wake-driven report line",
-                ),
-            ],
-        })
+            )?,
+            WAKE_REPORT.binary(reported, "expected the exact report line"),
+        ]))
     })
+}
+
+fn child_goal_points(goal: bool, rows: u64) -> u8 {
+    if goal && rows == EXPECTED_ROWS {
+        CHILD_GOAL.weight()
+    } else if goal {
+        20
+    } else {
+        0
+    }
+}
+
+fn orchestration_outcome(ordered: bool, child_nudges: usize) -> (bool, u8) {
+    (
+        ordered && child_nudges >= 1,
+        if ordered {
+            ORCHESTRATION_DISCIPLINE.weight()
+        } else {
+            0
+        },
+    )
 }
 
 fn cleanup<'a>(context: &'a E2eContext, run_id: &'a str) -> CleanupFuture<'a> {
@@ -267,5 +259,28 @@ mod tests {
         assert!(spec.prompt.contains("e2e_aB19-rest-child-1"));
         assert!(spec.prompt.contains("subvtest_aB19"));
         spec.validate().unwrap();
+        assert_eq!(spec.version, 2);
+        assert_eq!(
+            spec.criteria
+                .iter()
+                .map(|criterion| (criterion.id, criterion.weight))
+                .collect::<Vec<_>>(),
+            vec![
+                ("child_goal", 35),
+                ("orchestration_discipline", 35),
+                ("wake_report", 30),
+            ]
+        );
+    }
+
+    #[test]
+    fn scoring_keeps_goal_and_orchestration_signals_independent() {
+        assert_eq!(child_goal_points(false, EXPECTED_ROWS), 0);
+        assert_eq!(child_goal_points(true, EXPECTED_ROWS), 35);
+        assert_eq!(child_goal_points(true, EXPECTED_ROWS + 1), 20);
+
+        assert_eq!(orchestration_outcome(true, 0), (false, 35));
+        assert_eq!(orchestration_outcome(true, 1), (true, 35));
+        assert_eq!(orchestration_outcome(false, 1), (false, 0));
     }
 }

--- a/harness/tests/e2e/src/scenarios/subagent_validation_failure.rs
+++ b/harness/tests/e2e/src/scenarios/subagent_validation_failure.rs
@@ -17,12 +17,10 @@ use serde_json::{json, Value};
 
 use crate::context::E2eContext;
 
+use super::assessment::{self, AssessmentSpec};
 use super::common;
 use super::validation_loop::suffix;
-use super::{
-    CleanupFuture, CriterionSpec, EvaluationFuture, ExecutionPolicy, ObjectiveEvaluation,
-    ScenarioObservation, ScenarioSpec,
-};
+use super::{CleanupFuture, EvaluationFuture, ExecutionPolicy, ScenarioObservation, ScenarioSpec};
 
 pub const ID: &str = "subagent_validation_failure";
 
@@ -35,6 +33,22 @@ const EXPECTED_NUDGES: usize = 2;
 /// Wake deadline: comfortably after the child fails (~1 min), well inside
 /// the stuck timeout.
 const EXPIRY_DELAY_MS: u64 = 150_000;
+const BOUNDED_FAILURE: AssessmentSpec = AssessmentSpec::required(
+    "bounded_failure",
+    40,
+    "The child fails after exactly the budgeted denials; the verdict key is never written.",
+);
+const ORCHESTRATION_DISCIPLINE: AssessmentSpec = AssessmentSpec::signal(
+    "orchestration_discipline",
+    30,
+    "Validator scoped to the child and the deadline wake armed before the spawn.",
+);
+const EXPIRY_REPORT: AssessmentSpec = AssessmentSpec::required(
+    "expiry_report",
+    30,
+    "The parent is woken by the expiry notice and reports the give-up with the exact line.",
+);
+const ASSESSMENTS: &[AssessmentSpec] = &[BOUNDED_FAILURE, ORCHESTRATION_DISCIPLINE, EXPIRY_REPORT];
 
 pub fn scenario(run_id: &str) -> ScenarioSpec {
     let table = table(run_id);
@@ -43,7 +57,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
     let expires_at = now_ms() + EXPIRY_DELAY_MS;
     ScenarioSpec {
         id: ID,
-        version: 1,
+        version: 2,
         prompt: format!(
             "You orchestrate one validated sub-agent whose goal may be unreachable; your job is \
              to bound the attempt and report honestly. You never poll; wakes drive you. Follow \
@@ -94,26 +108,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
         },
         denied_functions: &[],
         threshold: 90,
-        criteria: vec![
-            CriterionSpec {
-                id: "bounded_failure",
-                weight: 40,
-                description: "The child fails after exactly the budgeted denials; the verdict \
-                              key is never written.",
-            },
-            CriterionSpec {
-                id: "orchestration_discipline",
-                weight: 30,
-                description: "Validator scoped to the child and the deadline wake armed before \
-                              the spawn.",
-            },
-            CriterionSpec {
-                id: "expiry_report",
-                weight: 30,
-                description: "The parent is woken by the expiry notice and reports the give-up \
-                              with the exact line.",
-            },
-        ],
+        criteria: assessment::criteria(ASSESSMENTS),
         judge_reference: None,
         setup: None,
         evaluate,
@@ -178,60 +173,27 @@ fn evaluate<'a>(
         let child_failed = child_status == "failed";
         let verdict_absent = verdict.is_null();
         let bounded = child_nudges == EXPECTED_NUDGES;
-        let report = observation.response.contains("CHILD GAVE UP")
+        let reported = observation.response.contains("CHILD GAVE UP")
             && observation.response.contains("PARENT DONE");
 
-        Ok(ObjectiveEvaluation {
-            hard_gates: vec![
-                common::gate(
-                    "child_failed",
-                    child_failed,
-                    format!("child status `{child_status}`, expected `failed`"),
+        Ok(assessment::objective([
+            BOUNDED_FAILURE.binary(
+                child_failed && verdict_absent && bounded,
+                format!(
+                    "child status `{child_status}`, expected `failed`; verdict key holds \
+                     {verdict}, expected null; observed {child_nudges} nudge(s), expected exactly \
+                     {EXPECTED_NUDGES} (the child budget)"
                 ),
-                common::gate(
-                    "verdict_never_written",
-                    verdict_absent,
-                    format!("verdict key holds {verdict}, expected null"),
+            ),
+            ORCHESTRATION_DISCIPLINE.binary(
+                ordered,
+                format!(
+                    "validator@{validator_index:?} wake@{wake_index:?} \
+                     spawn@{spawn_index:?} — both must precede the spawn"
                 ),
-                common::gate(
-                    "budget_bounded",
-                    bounded,
-                    format!(
-                        "observed {child_nudges} nudge(s), expected exactly {EXPECTED_NUDGES} \
-                         (the child budget)"
-                    ),
-                ),
-                common::gate(
-                    "expiry_report",
-                    report,
-                    "expected the exact give-up report line",
-                ),
-            ],
-            awards: vec![
-                common::award(
-                    "bounded_failure",
-                    if child_failed && verdict_absent && bounded {
-                        40
-                    } else {
-                        0
-                    },
-                    "awarded when the child fails on budget with no verdict written",
-                ),
-                common::award(
-                    "orchestration_discipline",
-                    if ordered { 30 } else { 0 },
-                    format!(
-                        "validator@{validator_index:?} wake@{wake_index:?} \
-                         spawn@{spawn_index:?} — both must precede the spawn"
-                    ),
-                ),
-                common::award(
-                    "expiry_report",
-                    if report { 30 } else { 0 },
-                    "awarded for the exact expiry-driven give-up line",
-                ),
-            ],
-        })
+            ),
+            EXPIRY_REPORT.binary(reported, "expected the exact give-up report line"),
+        ]))
     })
 }
 
@@ -284,5 +246,17 @@ mod tests {
         assert!(spec.prompt.contains("\"expires_at\""));
         assert!(spec.prompt.contains("101"));
         spec.validate().unwrap();
+        assert_eq!(spec.version, 2);
+        assert_eq!(
+            spec.criteria
+                .iter()
+                .map(|criterion| (criterion.id, criterion.weight))
+                .collect::<Vec<_>>(),
+            vec![
+                ("bounded_failure", 40),
+                ("orchestration_discipline", 30),
+                ("expiry_report", 30),
+            ]
+        );
     }
 }

--- a/harness/tests/e2e/src/scenarios/validation_chain.rs
+++ b/harness/tests/e2e/src/scenarios/validation_chain.rs
@@ -20,16 +20,31 @@ use serde_json::{json, Value};
 
 use crate::context::E2eContext;
 
+use super::assessment::{self, AssessmentSpec};
 use super::common;
 use super::validation_loop::suffix;
-use super::{
-    CleanupFuture, CriterionSpec, EvaluationFuture, ExecutionPolicy, ObjectiveEvaluation,
-    ScenarioObservation, ScenarioSpec,
-};
+use super::{CleanupFuture, EvaluationFuture, ExecutionPolicy, ScenarioObservation, ScenarioSpec};
 
 pub const ID: &str = "validation_chain";
 
 const HOOK_TYPE: &str = "harness::hook::post-turn";
+const BROKEN_VALIDATOR_SKIPPED: AssessmentSpec = AssessmentSpec::required(
+    "broken_validator_skipped",
+    30,
+    "The fail_open validator errored invisibly: registered, never a nudge of its own, never blocking.",
+);
+const CHAIN_ORDER: AssessmentSpec = AssessmentSpec::required(
+    "chain_order",
+    40,
+    "Exactly two denials, CHAIN-A then CHAIN-B — ascending priority, first deny wins each attempt.",
+);
+const ALL_GATES_SATISFIED: AssessmentSpec = AssessmentSpec::required(
+    "all_gates_satisfied",
+    30,
+    "Rows AND marker both end satisfied — one passing validator never completes the turn alone.",
+);
+const ASSESSMENTS: &[AssessmentSpec] =
+    &[CHAIN_ORDER, ALL_GATES_SATISFIED, BROKEN_VALIDATOR_SKIPPED];
 
 fn table(run_id: &str) -> String {
     format!("chaintest_{}", suffix(run_id))
@@ -49,7 +64,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
     let broken = broken_fn(run_id);
     ScenarioSpec {
         id: ID,
-        version: 1,
+        version: 2,
         prompt: format!(
             "You are testing a CHAIN of validators on your own session. Follow the steps \
              exactly.\n\n\
@@ -94,26 +109,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
         },
         denied_functions: &[],
         threshold: 90,
-        criteria: vec![
-            CriterionSpec {
-                id: "chain_order",
-                weight: 40,
-                description: "Exactly two denials, CHAIN-A then CHAIN-B — ascending priority, \
-                              first deny wins each attempt.",
-            },
-            CriterionSpec {
-                id: "all_gates_satisfied",
-                weight: 30,
-                description: "Rows AND marker both end satisfied — one passing validator never \
-                              completes the turn alone.",
-            },
-            CriterionSpec {
-                id: "broken_validator_skipped",
-                weight: 30,
-                description: "The fail_open validator errored invisibly: registered, never a \
-                              nudge of its own, never blocking.",
-            },
-        ],
+        criteria: assessment::criteria(ASSESSMENTS),
         judge_reference: None,
         setup: None,
         evaluate,
@@ -172,47 +168,32 @@ fn evaluate<'a>(
             && nudges[1].contains("CHAIN-B")
             && !nudges[1].contains("CHAIN-A");
         let satisfied = rows == 3 && marker == 1;
+        let three_registrations = hook_registrations.len() == 3 && broken_registered;
+        let broken_validator_points = if broken_registered && ordered {
+            BROKEN_VALIDATOR_SKIPPED.weight()
+        } else {
+            0
+        };
 
-        Ok(ObjectiveEvaluation {
-            hard_gates: vec![
-                common::gate(
-                    "three_registrations",
-                    hook_registrations.len() == 3 && broken_registered,
-                    format!(
-                        "observed {} post-turn registration(s); need three incl. the fail_open \
-                         broken one",
-                        hook_registrations.len()
-                    ),
+        Ok(assessment::objective([
+            CHAIN_ORDER.binary(
+                ordered,
+                format!("nudges in order: {nudges:?} — expected CHAIN-A then CHAIN-B"),
+            ),
+            ALL_GATES_SATISFIED.binary(
+                satisfied,
+                format!("rows={rows} (need 3), marker={marker} (need 1)"),
+            ),
+            BROKEN_VALIDATOR_SKIPPED.required_points(
+                three_registrations,
+                broken_validator_points,
+                format!(
+                    "observed {} post-turn registration(s); broken_registered={broken_registered}; \
+                     ordered={ordered}; need three incl. the fail_open broken one",
+                    hook_registrations.len()
                 ),
-                common::gate(
-                    "chain_order",
-                    ordered,
-                    format!("nudges in order: {nudges:?} — expected CHAIN-A then CHAIN-B"),
-                ),
-                common::gate(
-                    "all_gates_satisfied",
-                    satisfied,
-                    format!("rows={rows} (need 3), marker={marker} (need 1)"),
-                ),
-            ],
-            awards: vec![
-                common::award(
-                    "chain_order",
-                    if ordered { 40 } else { 0 },
-                    "awarded for ascending-priority denial order",
-                ),
-                common::award(
-                    "all_gates_satisfied",
-                    if satisfied { 30 } else { 0 },
-                    "awarded when both gates end satisfied",
-                ),
-                common::award(
-                    "broken_validator_skipped",
-                    if broken_registered && ordered { 30 } else { 0 },
-                    "awarded when the fail_open validator neither nudged nor blocked",
-                ),
-            ],
-        })
+            )?,
+        ]))
     })
 }
 
@@ -274,5 +255,17 @@ mod tests {
         assert!(spec.prompt.contains("CHAIN-A"));
         assert!(spec.prompt.contains("CHAIN-B"));
         spec.validate().unwrap();
+        assert_eq!(spec.version, 2);
+        assert_eq!(
+            spec.criteria
+                .iter()
+                .map(|criterion| (criterion.id, criterion.weight))
+                .collect::<Vec<_>>(),
+            vec![
+                ("chain_order", 40),
+                ("all_gates_satisfied", 30),
+                ("broken_validator_skipped", 30),
+            ]
+        );
     }
 }

--- a/harness/tests/e2e/src/scenarios/validation_loop.rs
+++ b/harness/tests/e2e/src/scenarios/validation_loop.rs
@@ -14,11 +14,9 @@ use serde_json::{json, Value};
 
 use crate::context::E2eContext;
 
+use super::assessment::{self, AssessmentSpec};
 use super::common;
-use super::{
-    CleanupFuture, CriterionSpec, EvaluationFuture, ExecutionPolicy, ObjectiveEvaluation,
-    ScenarioObservation, ScenarioSpec,
-};
+use super::{CleanupFuture, EvaluationFuture, ExecutionPolicy, ScenarioObservation, ScenarioSpec};
 
 pub const ID: &str = "validation_loop";
 
@@ -26,12 +24,28 @@ const HOOK_TYPE: &str = "harness::hook::post-turn";
 /// Goal: more than 6 rows; 4-row batches → exactly one denial, pass at 8.
 const THRESHOLD: u64 = 6;
 const EXPECTED_ROWS: u64 = 8;
+const GOAL_REACHED: AssessmentSpec = AssessmentSpec::required(
+    "goal_reached",
+    40,
+    "The goal table ends with more rows than the validator threshold.",
+);
+const VALIDATOR_DISCIPLINE: AssessmentSpec = AssessmentSpec::required(
+    "validator_discipline",
+    30,
+    "Exactly one post-turn validator registration, carrying the custom retry_prompt.",
+);
+const LOOP_EVIDENCE: AssessmentSpec = AssessmentSpec::required(
+    "loop_evidence",
+    30,
+    "At least one harness validation nudge was delivered and the loop converged at exactly the expected row count.",
+);
+const ASSESSMENTS: &[AssessmentSpec] = &[GOAL_REACHED, VALIDATOR_DISCIPLINE, LOOP_EVIDENCE];
 
 pub fn scenario(run_id: &str) -> ScenarioSpec {
     let table = table(run_id);
     ScenarioSpec {
         id: ID,
-        version: 1,
+        version: 2,
         prompt: format!(
             "You are testing a self-installed validation loop. Follow these steps exactly.\n\n\
              Step 1 — prepare the goal table. Call database::execute (db \"primary\") twice: first \
@@ -64,25 +78,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
         },
         denied_functions: &[],
         threshold: 90,
-        criteria: vec![
-            CriterionSpec {
-                id: "goal_reached",
-                weight: 40,
-                description: "The goal table ends with more rows than the validator threshold.",
-            },
-            CriterionSpec {
-                id: "validator_discipline",
-                weight: 30,
-                description: "Exactly one post-turn validator registration, carrying the \
-                              custom retry_prompt.",
-            },
-            CriterionSpec {
-                id: "loop_evidence",
-                weight: 30,
-                description: "At least one harness validation nudge was delivered and the loop \
-                              converged at exactly the expected row count.",
-            },
-        ],
+        criteria: assessment::criteria(ASSESSMENTS),
         judge_reference: None,
         setup: None,
         evaluate,
@@ -117,57 +113,45 @@ fn evaluate<'a>(
         let goal_reached = rows > THRESHOLD;
         let converged_exactly = rows == EXPECTED_ROWS;
         let no_errors = observation.metrics.totals.function_call_errors == 0;
+        let validator_points = if single_registration && carries_retry_prompt && no_errors {
+            VALIDATOR_DISCIPLINE.weight()
+        } else {
+            0
+        };
+        let loop_points = loop_evidence_points(nudges, converged_exactly);
 
-        Ok(ObjectiveEvaluation {
-            hard_gates: vec![
-                common::gate(
-                    "goal_rows",
-                    goal_reached,
-                    format!("observed {rows} row(s), need more than {THRESHOLD}"),
+        Ok(assessment::objective([
+            GOAL_REACHED.binary(
+                goal_reached,
+                format!("observed {rows} row(s), need more than {THRESHOLD}"),
+            ),
+            VALIDATOR_DISCIPLINE.required_points(
+                single_registration,
+                validator_points,
+                format!(
+                    "observed {} post-turn registration(s), expected exactly one; \
+                     carries_retry_prompt={carries_retry_prompt}; function_call_errors={}",
+                    registrations.len(),
+                    observation.metrics.totals.function_call_errors
                 ),
-                common::gate(
-                    "validator_registered",
-                    single_registration,
-                    format!(
-                        "observed {} post-turn registration(s), expected exactly one",
-                        registrations.len()
-                    ),
-                ),
-                common::gate(
-                    "nudge_delivered",
-                    nudges >= 1,
-                    format!("observed {nudges} validation nudge(s), expected at least one"),
-                ),
-            ],
-            awards: vec![
-                common::award(
-                    "goal_reached",
-                    if goal_reached { 40 } else { 0 },
-                    "awarded when the table exceeds the validator threshold",
-                ),
-                common::award(
-                    "validator_discipline",
-                    if single_registration && carries_retry_prompt && no_errors {
-                        30
-                    } else {
-                        0
-                    },
-                    "awarded for one clean registration carrying the retry_prompt",
-                ),
-                common::award(
-                    "loop_evidence",
-                    if nudges >= 1 && converged_exactly {
-                        30
-                    } else if nudges >= 1 {
-                        15
-                    } else {
-                        0
-                    },
-                    format!("nudges={nudges}, rows={rows} (full marks at exactly {EXPECTED_ROWS})"),
-                ),
-            ],
-        })
+            )?,
+            LOOP_EVIDENCE.required_points(
+                nudges >= 1,
+                loop_points,
+                format!("nudges={nudges}, rows={rows} (full marks at exactly {EXPECTED_ROWS})"),
+            )?,
+        ]))
     })
+}
+
+fn loop_evidence_points(nudges: usize, converged_exactly: bool) -> u8 {
+    if nudges >= 1 && converged_exactly {
+        LOOP_EVIDENCE.weight()
+    } else if nudges >= 1 {
+        15
+    } else {
+        0
+    }
 }
 
 fn cleanup<'a>(context: &'a E2eContext, run_id: &'a str) -> CleanupFuture<'a> {
@@ -224,5 +208,24 @@ mod tests {
         assert!(spec.prompt.contains(HOOK_TYPE));
         assert!(spec.prompt.contains("{value}"));
         spec.validate().unwrap();
+        assert_eq!(spec.version, 2);
+        assert_eq!(
+            spec.criteria
+                .iter()
+                .map(|criterion| (criterion.id, criterion.weight))
+                .collect::<Vec<_>>(),
+            vec![
+                ("goal_reached", 40),
+                ("validator_discipline", 30),
+                ("loop_evidence", 30),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_delivered_nudge_keeps_partial_credit_without_exact_convergence() {
+        assert_eq!(loop_evidence_points(0, true), 0);
+        assert_eq!(loop_evidence_points(1, false), 15);
+        assert_eq!(loop_evidence_points(1, true), 30);
     }
 }

--- a/harness/tests/e2e/src/scenarios/validation_scope_enforcement.rs
+++ b/harness/tests/e2e/src/scenarios/validation_scope_enforcement.rs
@@ -20,16 +20,31 @@ use serde_json::{json, Value};
 
 use crate::context::E2eContext;
 
+use super::assessment::{self, AssessmentSpec};
 use super::common;
 use super::validation_loop::suffix;
-use super::{
-    CleanupFuture, CriterionSpec, EvaluationFuture, ExecutionPolicy, ObjectiveEvaluation,
-    ScenarioObservation, ScenarioSpec,
-};
+use super::{CleanupFuture, EvaluationFuture, ExecutionPolicy, ScenarioObservation, ScenarioSpec};
 
 pub const ID: &str = "validation_scope_enforcement";
 
 const HOOK_TYPE: &str = "harness::hook::post-turn";
+const FOREIGN_SCOPE_REFUSED: AssessmentSpec = AssessmentSpec::required(
+    "foreign_scope_refused",
+    35,
+    "The forbidden registration failed with the out-of-scope error and the agent continued.",
+);
+const SELF_GATE_ENGAGED: AssessmentSpec = AssessmentSpec::required(
+    "self_gate_engaged",
+    30,
+    "The self-registration gated the session: exactly one denial with the marker unset.",
+);
+const TEARDOWN_UNGATED: AssessmentSpec = AssessmentSpec::required(
+    "teardown_ungated",
+    35,
+    "Owner unregistration removed the gate mid-loop: the turn completed with the marker still absent.",
+);
+const ASSESSMENTS: &[AssessmentSpec] =
+    &[FOREIGN_SCOPE_REFUSED, SELF_GATE_ENGAGED, TEARDOWN_UNGATED];
 
 fn scope(run_id: &str) -> String {
     format!("scopetest-{}", suffix(run_id))
@@ -39,7 +54,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
     let scope = scope(run_id);
     ScenarioSpec {
         id: ID,
-        version: 1,
+        version: 2,
         prompt: format!(
             "You are testing the security boundaries of self-registered validators. Follow the \
              steps exactly and report what actually happens.\n\n\
@@ -72,26 +87,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
         },
         denied_functions: &[],
         threshold: 90,
-        criteria: vec![
-            CriterionSpec {
-                id: "foreign_scope_refused",
-                weight: 35,
-                description: "The forbidden registration failed with the out-of-scope error and \
-                              the agent continued.",
-            },
-            CriterionSpec {
-                id: "self_gate_engaged",
-                weight: 30,
-                description: "The self-registration gated the session: exactly one denial with \
-                              the marker unset.",
-            },
-            CriterionSpec {
-                id: "teardown_ungated",
-                weight: 35,
-                description: "Owner unregistration removed the gate mid-loop: the turn completed \
-                              with the marker still absent.",
-            },
-        ],
+        criteria: assessment::criteria(ASSESSMENTS),
         judge_reference: None,
         setup: None,
         evaluate,
@@ -143,56 +139,37 @@ fn evaluate<'a>(
 
         let nudges = common::validation_nudges(&observation.transcript);
         let reported = observation.response.contains("TEARDOWN COMPLETE");
+        let foreign_scope_refused = foreign_attempted && refusal_delivered;
+        let teardown_ungated = marker_absent && teardown_called && reported;
+        let self_gate_points = if self_registered && nudges == 1 {
+            SELF_GATE_ENGAGED.weight()
+        } else {
+            0
+        };
 
-        Ok(ObjectiveEvaluation {
-            hard_gates: vec![
-                common::gate(
-                    "foreign_scope_refused",
-                    foreign_attempted && refusal_delivered,
-                    format!(
-                        "attempted={foreign_attempted}, out-of-scope error visible={refusal_delivered}"
-                    ),
+        Ok(assessment::objective([
+            FOREIGN_SCOPE_REFUSED.binary(
+                foreign_scope_refused,
+                format!(
+                    "attempted={foreign_attempted}, out-of-scope error visible={refusal_delivered}"
                 ),
-                common::gate(
-                    "gate_denied_once",
-                    nudges == 1,
-                    format!("observed {nudges} nudge(s), expected exactly one before teardown"),
+            ),
+            SELF_GATE_ENGAGED.required_points(
+                nudges == 1,
+                self_gate_points,
+                format!(
+                    "self_registered={self_registered}; observed {nudges} nudge(s), expected \
+                     exactly one before teardown"
                 ),
-                common::gate(
-                    "teardown_ungated_completion",
-                    marker_absent && teardown_called && reported,
-                    format!(
-                        "marker={marker}, teardown_called={teardown_called}, reported={reported} \
-                         — completion must come from the teardown, never from passing"
-                    ),
+            )?,
+            TEARDOWN_UNGATED.binary(
+                teardown_ungated,
+                format!(
+                    "marker={marker}, teardown_called={teardown_called}, reported={reported} \
+                     — completion must come from the teardown, never from passing"
                 ),
-            ],
-            awards: vec![
-                common::award(
-                    "foreign_scope_refused",
-                    if foreign_attempted && refusal_delivered {
-                        35
-                    } else {
-                        0
-                    },
-                    "awarded when the boundary refused the foreign scope loudly",
-                ),
-                common::award(
-                    "self_gate_engaged",
-                    if self_registered && nudges == 1 { 30 } else { 0 },
-                    "awarded for the force-stamped self gate denying exactly once",
-                ),
-                common::award(
-                    "teardown_ungated",
-                    if marker_absent && teardown_called && reported {
-                        35
-                    } else {
-                        0
-                    },
-                    "awarded for the owner teardown ungating the loop",
-                ),
-            ],
-        })
+            ),
+        ]))
     })
 }
 
@@ -219,5 +196,17 @@ mod tests {
         assert!(spec.prompt.contains("scopetest-aB19"));
         assert!(spec.prompt.contains("TEARDOWN COMPLETE"));
         spec.validate().unwrap();
+        assert_eq!(spec.version, 2);
+        assert_eq!(
+            spec.criteria
+                .iter()
+                .map(|criterion| (criterion.id, criterion.weight))
+                .collect::<Vec<_>>(),
+            vec![
+                ("foreign_scope_refused", 35),
+                ("self_gate_engaged", 30),
+                ("teardown_ungated", 35),
+            ]
+        );
     }
 }

--- a/harness/tests/e2e/src/scenarios/validation_self_repair.rs
+++ b/harness/tests/e2e/src/scenarios/validation_self_repair.rs
@@ -21,18 +21,32 @@ use serde_json::{json, Value};
 
 use crate::context::E2eContext;
 
+use super::assessment::{self, AssessmentSpec};
 use super::common;
 use super::custom_validator::{HookEnvelope, HookVerdict};
 use super::validation_loop::suffix;
-use super::{
-    CleanupFuture, CriterionSpec, EvaluationFuture, ExecutionPolicy, ObjectiveEvaluation,
-    ScenarioObservation, ScenarioSpec,
-};
+use super::{CleanupFuture, EvaluationFuture, ExecutionPolicy, ScenarioObservation, ScenarioSpec};
 
 pub const ID: &str = "validation_self_repair";
 
 const HOOK_TYPE: &str = "harness::hook::post-turn";
 const REQUIRED_NAMES: [&str; 4] = ["alpha", "beta", "gamma", "delta"];
+const DATA_REPAIRED: AssessmentSpec = AssessmentSpec::required(
+    "data_repaired",
+    40,
+    "All invariants hold at the end and every required name survived the repair.",
+);
+const DIAGNOSIS_DRIVEN: AssessmentSpec = AssessmentSpec::required(
+    "diagnosis_driven",
+    30,
+    "The auditor rejected the flawed seed with a factual defect list (no prescribed fix), via one envelope-mode registration.",
+);
+const DECISIVE_REPAIR: AssessmentSpec = AssessmentSpec::signal(
+    "decisive_repair",
+    30,
+    "The model's own repair converged in one round (half credit for two).",
+);
+const ASSESSMENTS: &[AssessmentSpec] = &[DATA_REPAIRED, DIAGNOSIS_DRIVEN, DECISIVE_REPAIR];
 
 /// The invariants, shared verbatim by the audit function and the evaluator.
 /// Facts only — the messages name defects, never repairs.
@@ -149,7 +163,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
     let table = table(run_id);
     ScenarioSpec {
         id: ID,
-        version: 1,
+        version: 2,
         prompt: format!(
             "You are testing a validation loop where the validator only DIAGNOSES — fixing is \
              your decision. Follow the setup steps exactly; after that, think for yourself.\n\n\
@@ -187,26 +201,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
         // the loop doing its job; live run 1: the model "renamed the second
         // beta to delta", created a duplicate delta, and was caught.
         threshold: 80,
-        criteria: vec![
-            CriterionSpec {
-                id: "data_repaired",
-                weight: 40,
-                description: "All invariants hold at the end and every required name survived \
-                              the repair.",
-            },
-            CriterionSpec {
-                id: "diagnosis_driven",
-                weight: 30,
-                description: "The auditor rejected the flawed seed with a factual defect list \
-                              (no prescribed fix), via one envelope-mode registration.",
-            },
-            CriterionSpec {
-                id: "decisive_repair",
-                weight: 30,
-                description: "The model's own repair converged in one round (half credit for \
-                              two).",
-            },
-        ],
+        criteria: assessment::criteria(ASSESSMENTS),
         judge_reference: None,
         setup: Some(setup),
         evaluate,
@@ -255,53 +250,32 @@ fn evaluate<'a>(
                 && text.contains("duplicate name: beta")
         });
 
-        Ok(ObjectiveEvaluation {
-            hard_gates: vec![
-                common::gate(
-                    "data_repaired",
-                    repaired,
-                    format!("rows={}, remaining violations: {remaining:?}", rows.len()),
+        Ok(assessment::objective([
+            DATA_REPAIRED.binary(
+                repaired,
+                format!("rows={}, remaining violations: {remaining:?}", rows.len()),
+            ),
+            DIAGNOSIS_DRIVEN.binary(
+                diagnosed && envelope_mode,
+                format!(
+                    "first audit nudge: {:?}; observed {} post-turn registration(s); need \
+                     exactly one targeting {auditor} with no payload",
+                    nudges.first(),
+                    registrations.len()
                 ),
-                common::gate(
-                    "flawed_seed_diagnosed",
-                    diagnosed,
-                    format!("first audit nudge: {:?}", nudges.first()),
+            ),
+            DECISIVE_REPAIR.points(
+                match nudges.len() {
+                    1 => 30,
+                    2 => 15,
+                    _ => 0,
+                },
+                format!(
+                    "{} audit rejection(s); full marks for repairing in one",
+                    nudges.len()
                 ),
-                common::gate(
-                    "envelope_registration",
-                    envelope_mode,
-                    format!(
-                        "observed {} post-turn registration(s); need exactly one targeting \
-                         {auditor} with no payload",
-                        registrations.len()
-                    ),
-                ),
-            ],
-            awards: vec![
-                common::award(
-                    "data_repaired",
-                    if repaired { 40 } else { 0 },
-                    "awarded when every invariant holds after the model's own repair",
-                ),
-                common::award(
-                    "diagnosis_driven",
-                    if diagnosed && envelope_mode { 30 } else { 0 },
-                    "awarded for the factual defect report driving the loop",
-                ),
-                common::award(
-                    "decisive_repair",
-                    match nudges.len() {
-                        1 => 30,
-                        2 => 15,
-                        _ => 0,
-                    },
-                    format!(
-                        "{} audit rejection(s); full marks for repairing in one",
-                        nudges.len()
-                    ),
-                ),
-            ],
-        })
+            )?,
+        ]))
     })
 }
 
@@ -400,5 +374,17 @@ mod tests {
         assert!(spec.prompt.contains("('beta', -5)"));
         assert!(spec.setup.is_some());
         spec.validate().unwrap();
+        assert_eq!(spec.version, 2);
+        assert_eq!(
+            spec.criteria
+                .iter()
+                .map(|criterion| (criterion.id, criterion.weight))
+                .collect::<Vec<_>>(),
+            vec![
+                ("data_repaired", 40),
+                ("diagnosis_driven", 30),
+                ("decisive_repair", 30),
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary

- extend `AssessmentSpec` for required gates whose quality award is scored independently
- migrate eight objective validation scenarios to canonical, versioned assessments
- preserve criterion IDs, score formulas, and the overall blocking conditions
- add truth-table coverage for partial-score and failed-gate edge cases

## Validation

- `cargo fmt --manifest-path harness/Cargo.toml --all -- --check`
- `cargo test --locked --manifest-path harness/Cargo.toml -p harness-e2e`
- `cargo clippy --locked --manifest-path harness/Cargo.toml -p harness-e2e --all-targets -- -D warnings`
- `git diff --check`

Depends on #756

Refs MOT-4381