### PR TITLE
(MOT-4381) refactor(harness): finish objective E2E assessment migrations

### DIFF
--- a/harness/tests/e2e/README.md
+++ b/harness/tests/e2e/README.md
@@ -368,7 +368,9 @@ rules:
   `AssessmentSpec`: use `required` for conditions that must emit a hard gate and
   `binary` when the gate controls a full-or-zero award, `required_points` when
   the gate outcome and quality award are evaluated independently, and `signal`
-  for non-blocking quality awards; existing evaluators can migrate to this
+  for non-blocking quality awards; when an explicit prerequisite gate prevents
+  a check from running, use `unavailable` to retain its zero-point award without
+  emitting a duplicate hard gate; existing evaluators can migrate to this
   pattern incrementally;
 - prompts describe user intent and never prescribe function ids;
 - declare a scenario-sized execution policy;

--- a/harness/tests/e2e/src/scenarios/assessment.rs
+++ b/harness/tests/e2e/src/scenarios/assessment.rs
@@ -50,6 +50,16 @@ impl AssessmentSpec {
         }
     }
 
+    /// Records a check that could not run behind an explicit prerequisite gate.
+    pub(super) fn unavailable(self, reason: impl Into<String>) -> AssessmentResult {
+        AssessmentResult {
+            spec: self,
+            awarded: 0,
+            gate_passed: None,
+            reason: reason.into(),
+        }
+    }
+
     pub(super) fn points(self, awarded: u8, reason: impl Into<String>) -> Result<AssessmentResult> {
         if self.kind == AssessmentKind::Required {
             bail!(
@@ -272,6 +282,29 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             "signal assessment signal cannot produce a required gate"
+        );
+    }
+
+    #[test]
+    fn unavailable_assessments_preserve_order_without_duplicate_gates() {
+        let evaluation = objective([
+            REQUIRED.unavailable("required prerequisite unavailable"),
+            SIGNAL.unavailable("signal prerequisite unavailable"),
+        ]);
+
+        assert!(evaluation.hard_gates.is_empty());
+        assert_eq!(evaluation.awards.len(), 2);
+        assert_eq!(evaluation.awards[0].id, "required");
+        assert_eq!(evaluation.awards[0].awarded, 0);
+        assert_eq!(
+            evaluation.awards[0].reason,
+            "required prerequisite unavailable"
+        );
+        assert_eq!(evaluation.awards[1].id, "signal");
+        assert_eq!(evaluation.awards[1].awarded, 0);
+        assert_eq!(
+            evaluation.awards[1].reason,
+            "signal prerequisite unavailable"
         );
     }
 }

--- a/harness/tests/e2e/src/scenarios/common.rs
+++ b/harness/tests/e2e/src/scenarios/common.rs
@@ -3,7 +3,7 @@ use serde_json::{json, Value};
 use crate::context::E2eContext;
 use crate::report::HardGateReport;
 
-use super::{CriterionAward, EvaluationFuture, ObjectiveEvaluation, ScenarioObservation};
+use super::{EvaluationFuture, ObjectiveEvaluation, ScenarioObservation};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ObservedFunctionCall {
@@ -116,14 +116,6 @@ pub fn gate(id: &str, passed: bool, reason: impl Into<String>) -> HardGateReport
     HardGateReport {
         id: id.to_string(),
         passed,
-        reason: reason.into(),
-    }
-}
-
-pub fn award(id: &'static str, awarded: u8, reason: impl Into<String>) -> CriterionAward {
-    CriterionAward {
-        id: id.to_string(),
-        awarded,
         reason: reason.into(),
     }
 }

--- a/harness/tests/e2e/src/scenarios/reactive_automation/evaluate.rs
+++ b/harness/tests/e2e/src/scenarios/reactive_automation/evaluate.rs
@@ -2,21 +2,25 @@ use std::collections::BTreeSet;
 
 use super::evidence::{Evidence, FinalReport};
 use super::names::ScenarioNames;
-use super::{EXPECTED_ORDERS, EXPECTED_WRITERS, ORDERS_PER_WRITER};
-use crate::scenarios::{common, ObjectiveEvaluation};
+use super::{
+    EXPECTED_ORDERS, EXPECTED_WRITERS, FINALIZATION_CLEANUP, ORDERS_PER_WRITER, PARALLEL_WRITES,
+    REACTIVE_AGGREGATES, TRIGGER_ORCHESTRATION,
+};
+use crate::scenarios::{assessment, common, ObjectiveEvaluation};
 
 pub(super) fn missing_database() -> ObjectiveEvaluation {
     let reason = "database capability is unavailable; the agent was expected to discover and \
                   install the database worker before executing the scenario";
-    ObjectiveEvaluation {
-        hard_gates: vec![common::gate("database_capability_available", false, reason)],
-        awards: vec![
-            common::award("parallel_writes", 0, reason),
-            common::award("reactive_aggregates", 0, reason),
-            common::award("trigger_orchestration", 0, reason),
-            common::award("finalization_cleanup", 0, reason),
-        ],
-    }
+    let mut evaluation = assessment::objective([
+        PARALLEL_WRITES.unavailable(reason),
+        REACTIVE_AGGREGATES.unavailable(reason),
+        TRIGGER_ORCHESTRATION.unavailable(reason),
+        FINALIZATION_CLEANUP.unavailable(reason),
+    ]);
+    evaluation
+        .hard_gates
+        .push(common::gate("database_capability_available", false, reason));
+    evaluation
 }
 
 pub(super) fn score(evidence: &Evidence, names: &ScenarioNames) -> ObjectiveEvaluation {
@@ -129,72 +133,48 @@ pub(super) fn score(evidence: &Evidence, names: &ScenarioNames) -> ObjectiveEval
         && finalizer_completed
         && evidence.active_run_triggers == 0;
 
-    ObjectiveEvaluation {
-        hard_gates: vec![
-            common::gate(
-                "parallel_writers_completed",
-                workload_passed,
-                format!(
-                    "tables={all_tables_exist}, parallel_writers={parallel_writers}, \
-                     orders_complete={orders_complete}, invalid_amounts={invalid_amounts:?}, \
-                     writers_done={writers_done}"
-                ),
+    assessment::objective([
+        PARALLEL_WRITES.binary(
+            workload_passed,
+            format!(
+                "tables={all_tables_exist}, parallel_writers={parallel_writers}, \
+                 orders_complete={orders_complete}, invalid_amounts={invalid_amounts:?}, \
+                 writers_done={writers_done}"
             ),
-            common::gate(
-                "reactive_totals_match",
-                aggregates_passed,
-                format!("totals_match={totals_match}, report_counts_match={report_counts_match}"),
+        ),
+        REACTIVE_AGGREGATES.binary(
+            aggregates_passed,
+            format!("totals_match={totals_match}, report_counts_match={report_counts_match}"),
+        ),
+        TRIGGER_ORCHESTRATION.binary(
+            orchestration_passed,
+            format!(
+                "watch_before_writers={watch_before_writers}, \
+                 watch_documented={watch_documented}, \
+                 aggregate_deliveries={}, completion_wake={}",
+                evidence.aggregate_deliveries, evidence.completion_wake_delivered
             ),
-            common::gate(
-                "trigger_orchestration_proven",
-                orchestration_passed,
-                format!(
-                    "watch_before_writers={watch_before_writers}, \
-                     watch_documented={watch_documented}, \
-                     aggregate_deliveries={}, completion_wake={}",
-                    evidence.aggregate_deliveries, evidence.completion_wake_delivered
-                ),
+        ),
+        FINALIZATION_CLEANUP.binary(
+            finalization_passed,
+            format!(
+                "report_rows={}, report_identity={report_identity_matches}, \
+                 report_checks={report_checks_pass}, completion_wake={}, \
+                 report_watch_before_finalizer={}, report_wake={}, finalizer_spawns={}, \
+                 finalizer_in_tree={}, finalizer_wrote_report={}, root_wrote_report={}, \
+                 active_run_triggers={}",
+                evidence.reports.len(),
+                evidence.completion_wake_delivered,
+                evidence.report_wake_before_finalizer,
+                evidence.report_wake_delivered,
+                evidence.finalizer_spawn_count,
+                evidence.finalizer_in_tree,
+                evidence.finalizer_wrote_report,
+                evidence.root_wrote_report,
+                evidence.active_run_triggers,
             ),
-            common::gate(
-                "finalizer_and_cleanup_completed",
-                finalization_passed,
-                format!(
-                    "report_rows={}, report_identity={report_identity_matches}, \
-                     report_checks={report_checks_pass}, completion_wake={}, \
-                     report_watch_before_finalizer={}, report_wake={}, finalizer_spawns={}, \
-                     finalizer_in_tree={}, finalizer_wrote_report={}, root_wrote_report={}, \
-                     active_run_triggers={}",
-                    evidence.reports.len(), evidence.completion_wake_delivered,
-                    evidence.report_wake_before_finalizer, evidence.report_wake_delivered,
-                    evidence.finalizer_spawn_count, evidence.finalizer_in_tree,
-                    evidence.finalizer_wrote_report, evidence.root_wrote_report,
-                    evidence.active_run_triggers,
-                ),
-            ),
-        ],
-        awards: vec![
-            common::award(
-                "parallel_writes",
-                if workload_passed { 25 } else { 0 },
-                "awarded for three parallel writers and 15 valid rows",
-            ),
-            common::award(
-                "reactive_aggregates",
-                if aggregates_passed { 30 } else { 0 },
-                "awarded when stored totals and event counts cover the source rows exactly",
-            ),
-            common::award(
-                "trigger_orchestration",
-                if orchestration_passed { 25 } else { 0 },
-                "awarded for bounded discovery, a mechanical aggregate reaction, and a barrier wake",
-            ),
-            common::award(
-                "finalization_cleanup",
-                if finalization_passed { 20 } else { 0 },
-                "awarded when the barrier-woken root directly spawns one report-writing finalizer and cleans up",
-            ),
-        ],
-    }
+        ),
+    ])
 }
 
 fn order_summary_complete(summary: Option<&super::evidence::OrderSummary>) -> bool {
@@ -315,6 +295,32 @@ mod tests {
         assert!(evaluation.hard_gates.iter().all(|gate| gate.passed));
         assert_eq!(
             evaluation
+                .hard_gates
+                .iter()
+                .map(|gate| gate.id.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "parallel_writes",
+                "reactive_aggregates",
+                "trigger_orchestration",
+                "finalization_cleanup",
+            ]
+        );
+        assert_eq!(
+            evaluation
+                .awards
+                .iter()
+                .map(|award| award.id.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "parallel_writes",
+                "reactive_aggregates",
+                "trigger_orchestration",
+                "finalization_cleanup",
+            ]
+        );
+        assert_eq!(
+            evaluation
                 .awards
                 .iter()
                 .map(|award| u16::from(award.awarded))
@@ -356,6 +362,19 @@ mod tests {
         assert_eq!(evaluation.hard_gates.len(), 1);
         assert_eq!(evaluation.hard_gates[0].id, "database_capability_available");
         assert!(!evaluation.hard_gates[0].passed);
+        assert_eq!(
+            evaluation
+                .awards
+                .iter()
+                .map(|award| award.id.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "parallel_writes",
+                "reactive_aggregates",
+                "trigger_orchestration",
+                "finalization_cleanup",
+            ]
+        );
         assert_eq!(
             evaluation
                 .awards

--- a/harness/tests/e2e/src/scenarios/reactive_automation/mod.rs
+++ b/harness/tests/e2e/src/scenarios/reactive_automation/mod.rs
@@ -7,7 +7,8 @@ mod queries;
 
 use crate::context::E2eContext;
 
-use super::{CriterionSpec, EvaluationFuture, ExecutionPolicy, ScenarioObservation, ScenarioSpec};
+use super::assessment::{self, AssessmentSpec};
+use super::{EvaluationFuture, ExecutionPolicy, ScenarioObservation, ScenarioSpec};
 use names::ScenarioNames;
 
 pub const ID: &str = "reactive_automation";
@@ -22,11 +23,38 @@ const STUCK_WATCHDOG_SECONDS: u64 = 600;
 // workload without relaxing any behavioral gate.
 const SCENARIO_MAX_TOTAL_TOKENS: u64 = 2_000_000;
 
+const PARALLEL_WRITES: AssessmentSpec = AssessmentSpec::required(
+    "parallel_writes",
+    25,
+    "Three parallel writer sessions produce exactly five valid orders each.",
+);
+const REACTIVE_AGGREGATES: AssessmentSpec = AssessmentSpec::required(
+    "reactive_aggregates",
+    30,
+    "A mechanical trigger call maintains totals that exactly match the source rows.",
+);
+const TRIGGER_ORCHESTRATION: AssessmentSpec = AssessmentSpec::required(
+    "trigger_orchestration",
+    25,
+    "The aggregate call and barrier wake are armed before writers start and proven by delivery records.",
+);
+const FINALIZATION_CLEANUP: AssessmentSpec = AssessmentSpec::required(
+    "finalization_cleanup",
+    20,
+    "The barrier-woken root directly spawns one finalizer, which writes a passing report before cleanup.",
+);
+const ASSESSMENTS: &[AssessmentSpec] = &[
+    PARALLEL_WRITES,
+    REACTIVE_AGGREGATES,
+    TRIGGER_ORCHESTRATION,
+    FINALIZATION_CLEANUP,
+];
+
 pub fn scenario(run_id: &str) -> ScenarioSpec {
     let names = ScenarioNames::new(run_id);
     ScenarioSpec {
         id: ID,
-        version: 1,
+        version: 2,
         prompt: prompt::build(&names, STUCK_WATCHDOG_SECONDS),
         filesystem_root: None,
         execution: ExecutionPolicy {
@@ -37,28 +65,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
         },
         denied_functions: &[],
         threshold: 90,
-        criteria: vec![
-            CriterionSpec {
-                id: "parallel_writes",
-                weight: 25,
-                description: "Three parallel writer sessions produce exactly five valid orders each.",
-            },
-            CriterionSpec {
-                id: "reactive_aggregates",
-                weight: 30,
-                description: "A mechanical trigger call maintains totals that exactly match the source rows.",
-            },
-            CriterionSpec {
-                id: "trigger_orchestration",
-                weight: 25,
-                description: "The aggregate call and barrier wake are armed before writers start and proven by delivery records.",
-            },
-            CriterionSpec {
-                id: "finalization_cleanup",
-                weight: 20,
-                description: "The barrier-woken root directly spawns one finalizer, which writes a passing report before cleanup.",
-            },
-        ],
+        criteria: assessment::criteria(ASSESSMENTS),
         judge_reference: None,
         setup: None,
         evaluate,
@@ -79,4 +86,46 @@ fn evaluate<'a>(
         let evidence = queries::collect(context, observation, &names).await?;
         Ok(evaluate::score(&evidence, &names))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scenario_uses_the_canonical_assessment_contract() {
+        let spec = scenario("run");
+
+        spec.validate().unwrap();
+        assert_eq!(spec.version, 2);
+        assert_eq!(spec.threshold, 90);
+        assert_eq!(
+            spec.criteria
+                .iter()
+                .map(|criterion| (criterion.id, criterion.weight, criterion.description))
+                .collect::<Vec<_>>(),
+            vec![
+                (
+                    "parallel_writes",
+                    25,
+                    "Three parallel writer sessions produce exactly five valid orders each.",
+                ),
+                (
+                    "reactive_aggregates",
+                    30,
+                    "A mechanical trigger call maintains totals that exactly match the source rows.",
+                ),
+                (
+                    "trigger_orchestration",
+                    25,
+                    "The aggregate call and barrier wake are armed before writers start and proven by delivery records.",
+                ),
+                (
+                    "finalization_cleanup",
+                    20,
+                    "The barrier-woken root directly spawns one finalizer, which writes a passing report before cleanup.",
+                ),
+            ]
+        );
+    }
 }

--- a/harness/tests/e2e/src/scenarios/receiving_operation.rs
+++ b/harness/tests/e2e/src/scenarios/receiving_operation.rs
@@ -5,8 +5,9 @@ use serde_json::{json, Value};
 
 use crate::context::E2eContext;
 
+use super::assessment::{self, AssessmentSpec};
 use super::{
-    common, CleanupFuture, CriterionSpec, EvaluationFuture, ExecutionPolicy, ObjectiveEvaluation,
+    common, CleanupFuture, EvaluationFuture, ExecutionPolicy, ObjectiveEvaluation,
     ScenarioObservation, ScenarioSpec,
 };
 
@@ -33,12 +34,38 @@ const COURIER_FUNCTIONS: [&str; 6] = [
     "engine::functions::info",
     "engine::functions::list",
 ];
+const COURIER_WORKLOAD: AssessmentSpec = AssessmentSpec::required(
+    "courier_workload",
+    30,
+    "Three least-privilege couriers produce the exact shipments, corrections, and completion rows.",
+);
+const LIVE_LEDGER: AssessmentSpec = AssessmentSpec::required(
+    "live_ledger",
+    25,
+    "A database-native or mechanical reaction keeps the ledger current without model turns.",
+);
+const DATABASE_FAN_IN: AssessmentSpec = AssessmentSpec::required(
+    "database_fan_in",
+    25,
+    "The root learns completion from one database wake without polling.",
+);
+const VERIFICATION_CLEANUP: AssessmentSpec = AssessmentSpec::required(
+    "verification_cleanup",
+    20,
+    "The root reports verified evidence and removes all standing machinery.",
+);
+const ASSESSMENTS: &[AssessmentSpec] = &[
+    COURIER_WORKLOAD,
+    LIVE_LEDGER,
+    DATABASE_FAN_IN,
+    VERIFICATION_CLEANUP,
+];
 
 pub fn scenario(run_id: &str) -> ScenarioSpec {
     let names = Names::new(run_id);
     ScenarioSpec {
         id: ID,
-        version: 1,
+        version: 2,
         prompt: prompt(&names),
         filesystem_root: None,
         execution: ExecutionPolicy {
@@ -49,28 +76,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
         },
         denied_functions: &["state::*"],
         threshold: 90,
-        criteria: vec![
-            CriterionSpec {
-                id: "courier_workload",
-                weight: 30,
-                description: "Three least-privilege couriers produce the exact shipments, corrections, and completion rows.",
-            },
-            CriterionSpec {
-                id: "live_ledger",
-                weight: 25,
-                description: "A database-native or mechanical reaction keeps the ledger current without model turns.",
-            },
-            CriterionSpec {
-                id: "database_fan_in",
-                weight: 25,
-                description: "The root learns completion from one database wake without polling.",
-            },
-            CriterionSpec {
-                id: "verification_cleanup",
-                weight: 20,
-                description: "The root reports verified evidence and removes all standing machinery.",
-            },
-        ],
+        criteria: assessment::criteria(ASSESSMENTS),
         judge_reference: None,
         setup: None,
         evaluate,
@@ -275,84 +281,48 @@ fn evaluate<'a>(
         let cleanup_passed =
             response_has_evidence && active_bindings == 0 && standing_sql_triggers == 0;
 
-        Ok(ObjectiveEvaluation {
-            hard_gates: vec![
-                common::gate(
-                    "database_only_couriers_completed",
-                    workload_passed,
-                    format!(
-                        "relations={required_relations}, shipments={shipments_match}, \
+        Ok(assessment::objective([
+            COURIER_WORKLOAD.binary(
+                workload_passed,
+                format!(
+                    "relations={required_relations}, shipments={shipments_match}, \
                          couriers_done={couriers_done}, completion_rows={completion_rows}, \
                          minimal_spawns={spawn_policy_ok}, courier_execution={}, \
                          sessions={}, shared_medium={no_shared_medium_violation}",
-                        courier_execution_ok.completed,
-                        observation.metrics.by_session.len(),
-                    ),
+                    courier_execution_ok.completed,
+                    observation.metrics.by_session.len(),
                 ),
-                common::gate(
-                    "live_ledger_matches",
-                    ledger_passed,
-                    format!(
-                        "live_strategy={live_strategy}, no_late_root_repair={no_late_root_repair}, \
-                         expected={ledger_matches_expected}, source={ledger_matches_source}"
-                    ),
+            ),
+            LIVE_LEDGER.binary(
+                ledger_passed,
+                format!(
+                    "live_strategy={live_strategy}, no_late_root_repair={no_late_root_repair}, \
+                        expected={ledger_matches_expected}, source={ledger_matches_source}"
                 ),
-                common::gate(
-                    "single_database_completion_wake",
-                    fan_in_passed,
-                    format!(
-                        "watch_before_spawn={completion_watch_before_spawn}, \
+            ),
+            DATABASE_FAN_IN.binary(
+                fan_in_passed,
+                format!(
+                    "watch_before_spawn={completion_watch_before_spawn}, \
                          wake_records={wake_records}, notifications={}, no_polling={no_polling}, \
                          root_did_not_signal={root_did_not_signal_completion}",
-                        notifications.len(),
-                    ),
+                    notifications.len(),
                 ),
-                common::gate(
-                    "verification_and_cleanup_completed",
-                    cleanup_passed,
-                    format!(
-                        "response_evidence={response_has_evidence}, \
-                         active_bindings={active_bindings}, sql_triggers={standing_sql_triggers}"
-                    ),
+            ),
+            VERIFICATION_CLEANUP.binary(
+                cleanup_passed,
+                format!(
+                    "response_evidence={response_has_evidence}, \
+                        active_bindings={active_bindings}, sql_triggers={standing_sql_triggers}"
                 ),
-            ],
-            awards: vec![
-                common::award(
-                    "courier_workload",
-                    if workload_passed { 30 } else { 0 },
-                    "awarded for the exact corrected workload through three least-privilege couriers",
-                ),
-                common::award(
-                    "live_ledger",
-                    if ledger_passed { 25 } else { 0 },
-                    "awarded for an event-driven ledger matching the shipment rows",
-                ),
-                common::award(
-                    "database_fan_in",
-                    if fan_in_passed { 25 } else { 0 },
-                    "awarded for one database completion wake without polling",
-                ),
-                common::award(
-                    "verification_cleanup",
-                    if cleanup_passed { 20 } else { 0 },
-                    "awarded for a passing evidence report and no standing trigger machinery",
-                ),
-            ],
-        })
+            ),
+        ]))
     })
 }
 
 fn missing_database() -> ObjectiveEvaluation {
     let reason = "database::query is unavailable";
-    ObjectiveEvaluation {
-        hard_gates: vec![common::gate("database_capability_available", false, reason)],
-        awards: vec![
-            common::award("courier_workload", 0, reason),
-            common::award("live_ledger", 0, reason),
-            common::award("database_fan_in", 0, reason),
-            common::award("verification_cleanup", 0, reason),
-        ],
-    }
+    unavailable_with_prerequisite_gate("database_capability_available", reason)
 }
 
 fn missing_primary(databases: &BTreeSet<String>) -> ObjectiveEvaluation {
@@ -360,19 +330,20 @@ fn missing_primary(databases: &BTreeSet<String>) -> ObjectiveEvaluation {
         "database `primary` is unavailable; configured databases: {}",
         databases.iter().cloned().collect::<Vec<_>>().join(", ")
     );
-    ObjectiveEvaluation {
-        hard_gates: vec![common::gate(
-            "primary_database_available",
-            false,
-            reason.clone(),
-        )],
-        awards: vec![
-            common::award("courier_workload", 0, reason.clone()),
-            common::award("live_ledger", 0, reason.clone()),
-            common::award("database_fan_in", 0, reason.clone()),
-            common::award("verification_cleanup", 0, reason),
-        ],
-    }
+    unavailable_with_prerequisite_gate("primary_database_available", &reason)
+}
+
+fn unavailable_with_prerequisite_gate(gate_id: &str, reason: &str) -> ObjectiveEvaluation {
+    let mut evaluation = assessment::objective(
+        ASSESSMENTS
+            .iter()
+            .copied()
+            .map(|spec| spec.unavailable(reason)),
+    );
+    evaluation
+        .hard_gates
+        .push(common::gate(gate_id, false, reason));
+    evaluation
 }
 
 fn cleanup<'a>(context: &'a E2eContext, run_id: &'a str) -> CleanupFuture<'a> {
@@ -1013,8 +984,23 @@ mod tests {
     fn scenario_is_valid_and_removes_state_capability() {
         let scenario = scenario("aB19");
         scenario.validate().unwrap();
+        assert_eq!(scenario.version, 2);
         assert_eq!(scenario.denied_functions, ["state::*"]);
         assert!(!scenario.needs_judge());
+        assert_eq!(scenario.threshold, 90);
+        assert_eq!(
+            scenario
+                .criteria
+                .iter()
+                .map(|criterion| (criterion.id, criterion.weight))
+                .collect::<Vec<_>>(),
+            vec![
+                ("courier_workload", 30),
+                ("live_ledger", 25),
+                ("database_fan_in", 25),
+                ("verification_cleanup", 20),
+            ]
+        );
     }
 
     #[test]
@@ -1080,15 +1066,53 @@ mod tests {
     }
 
     #[test]
-    fn missing_primary_is_a_behavioral_gate_not_an_infrastructure_error() {
-        let evaluation = missing_primary(&BTreeSet::from([
-            "mysql".to_string(),
-            "postgres".to_string(),
-            "sqlite".to_string(),
-        ]));
+    fn missing_database_emits_one_prerequisite_gate_and_ordered_zero_awards() {
+        assert_unavailable_evaluation(
+            missing_database(),
+            "database_capability_available",
+            "database::query is unavailable",
+        );
+    }
 
-        assert_eq!(evaluation.hard_gates[0].id, "primary_database_available");
+    #[test]
+    fn missing_primary_emits_one_prerequisite_gate_and_ordered_zero_awards() {
+        assert_unavailable_evaluation(
+            missing_primary(&BTreeSet::from([
+                "mysql".to_string(),
+                "postgres".to_string(),
+                "sqlite".to_string(),
+            ])),
+            "primary_database_available",
+            "postgres",
+        );
+    }
+
+    fn assert_unavailable_evaluation(
+        evaluation: ObjectiveEvaluation,
+        gate_id: &str,
+        reason_fragment: &str,
+    ) {
+        assert_eq!(evaluation.hard_gates.len(), 1);
+        assert_eq!(evaluation.hard_gates[0].id, gate_id);
         assert!(!evaluation.hard_gates[0].passed);
-        assert!(evaluation.hard_gates[0].reason.contains("postgres"));
+        assert!(evaluation.hard_gates[0].reason.contains(reason_fragment));
+        let prerequisite_reason = &evaluation.hard_gates[0].reason;
+        assert_eq!(
+            evaluation
+                .awards
+                .iter()
+                .map(|award| (award.id.as_str(), award.awarded))
+                .collect::<Vec<_>>(),
+            vec![
+                ("courier_workload", 0),
+                ("live_ledger", 0),
+                ("database_fan_in", 0),
+                ("verification_cleanup", 0),
+            ]
+        );
+        assert!(evaluation
+            .awards
+            .iter()
+            .all(|award| &award.reason == prerequisite_reason));
     }
 }

--- a/harness/tests/e2e/src/scenarios/shell_coder_sandbox.rs
+++ b/harness/tests/e2e/src/scenarios/shell_coder_sandbox.rs
@@ -5,10 +5,9 @@ use serde_json::{json, Value};
 
 use crate::context::E2eContext;
 
-use super::common;
+use super::assessment::{self, AssessmentSpec};
 use super::{
-    CleanupFuture, CriterionSpec, EvaluationFuture, ExecutionPolicy, ObjectiveEvaluation,
-    ScenarioObservation, ScenarioSpec,
+    common, CleanupFuture, EvaluationFuture, ExecutionPolicy, ScenarioObservation, ScenarioSpec,
 };
 
 pub const ID: &str = "shell_coder_sandbox";
@@ -21,12 +20,50 @@ const SANDBOX_STDOUT: &str = "sandbox-check:35";
 const EXPECTED_CORE_OPERATIONS: usize = 12;
 const PASS_THRESHOLD: u8 = 50;
 const EXECUTION_QUALITY_WEIGHT: u8 = 45;
+const WORKER_SETUP: AssessmentSpec = AssessmentSpec::required(
+    "worker_setup",
+    10,
+    "Both registry workers are added and expose their required surfaces.",
+);
+const CODER_WORKFLOW: AssessmentSpec = AssessmentSpec::required(
+    "coder_workflow",
+    20,
+    "Coder inspection, create, update, move, and read operations produce the exact file.",
+);
+const HOST_EXECUTION: AssessmentSpec = AssessmentSpec::required(
+    "host_execution",
+    10,
+    "The final file runs successfully on the host with exact stdout.",
+);
+const SANDBOX_LIFECYCLE: AssessmentSpec = AssessmentSpec::required(
+    "sandbox_lifecycle",
+    10,
+    "A named isolated sandbox is created, executed in, listed, and stopped.",
+);
+const COMPLETION_REPORT: AssessmentSpec = AssessmentSpec::signal(
+    "completion_report",
+    5,
+    "The final response includes both exact observed outputs.",
+);
+const EXECUTION_QUALITY: AssessmentSpec = AssessmentSpec::signal(
+    "execution_quality",
+    EXECUTION_QUALITY_WEIGHT,
+    "The workflow completes without function-call errors; recovered errors lower quality without overriding validated effects.",
+);
+const ASSESSMENTS: &[AssessmentSpec] = &[
+    WORKER_SETUP,
+    CODER_WORKFLOW,
+    HOST_EXECUTION,
+    SANDBOX_LIFECYCLE,
+    COMPLETION_REPORT,
+    EXECUTION_QUALITY,
+];
 
 pub fn scenario(run_id: &str) -> ScenarioSpec {
     let sandbox_name = sandbox_name(run_id);
     ScenarioSpec {
         id: ID,
-        version: 1,
+        version: 2,
         prompt: format!(
             "Perform this verification entirely in the current workspace and in the stated order.\n\n\
              1. Add the `shell` worker from the public registry and wait for that add operation to \
@@ -65,41 +102,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
         },
         denied_functions: &[],
         threshold: PASS_THRESHOLD,
-        criteria: vec![
-            CriterionSpec {
-                id: "worker_setup",
-                weight: 10,
-                description: "Both registry workers are added and expose their required surfaces.",
-            },
-            CriterionSpec {
-                id: "coder_workflow",
-                weight: 20,
-                description:
-                    "Coder inspection, create, update, move, and read operations produce the exact file.",
-            },
-            CriterionSpec {
-                id: "host_execution",
-                weight: 10,
-                description: "The final file runs successfully on the host with exact stdout.",
-            },
-            CriterionSpec {
-                id: "sandbox_lifecycle",
-                weight: 10,
-                description:
-                    "A named isolated sandbox is created, executed in, listed, and stopped.",
-            },
-            CriterionSpec {
-                id: "completion_report",
-                weight: 5,
-                description: "The final response includes both exact observed outputs.",
-            },
-            CriterionSpec {
-                id: "execution_quality",
-                weight: EXECUTION_QUALITY_WEIGHT,
-                description:
-                    "The workflow completes without function-call errors; recovered errors lower quality without overriding validated effects.",
-            },
-        ],
+        criteria: assessment::criteria(ASSESSMENTS),
         judge_reference: None,
         setup: None,
         evaluate,
@@ -224,89 +227,58 @@ fn evaluate<'a>(
         let response_reports_outputs = observation.response.contains(HOST_STDOUT)
             && observation.response.contains(SANDBOX_STDOUT);
 
-        Ok(ObjectiveEvaluation {
-            hard_gates: vec![
-                common::gate(
-                    "workers_added_and_ready",
-                    worker_setup,
-                    format!(
-                        "shell add={installed_shell}, iii-sandbox add={installed_sandbox}, \
-                         shell ready={shell_surface_ready}, coder ready={coder_surface_ready}, \
-                         sandbox ready={sandbox_surface_ready}"
+        let mut evaluation = assessment::objective([
+            WORKER_SETUP.binary(
+                worker_setup,
+                format!(
+                    "shell add={installed_shell}, iii-sandbox add={installed_sandbox}, \
+                     shell ready={shell_surface_ready}, coder ready={coder_surface_ready}, \
+                     sandbox ready={sandbox_surface_ready}"
+                ),
+            ),
+            CODER_WORKFLOW.binary(
+                coder_workflow,
+                match &final_read {
+                    Ok(_) => format!(
+                        "info={coder_info}, create={coder_create}, update={coder_update}, \
+                         move={coder_move}, read={coder_read}, ordered={coder_ordered}, \
+                         successful results={coder_results_succeeded}, exact final \
+                         content={final_matches}, draft removed={draft_removed}"
                     ),
-                ),
-                common::gate(
-                    "ordered_coder_workflow_completed",
-                    coder_workflow,
-                    match &final_read {
-                        Ok(_) => format!(
-                            "info={coder_info}, create={coder_create}, update={coder_update}, \
-                             move={coder_move}, read={coder_read}, ordered={coder_ordered}, \
-                             successful results={coder_results_succeeded}, exact final \
-                             content={final_matches}, draft removed={draft_removed}"
-                        ),
-                        Err(error) => format!(
-                            "coder operations info/create/update/move/read={coder_info}/{coder_create}/\
-                             {coder_update}/{coder_move}/{coder_read}; could not read {}: {error}",
-                            final_path.display()
-                        ),
-                    },
-                ),
-                common::gate(
-                    "host_execution_succeeded",
-                    host_execution,
-                    format!(
-                        "exact host execution call={host_exec}, exact successful stdout={host_output}"
+                    Err(error) => format!(
+                        "coder operations info/create/update/move/read={coder_info}/{coder_create}/\
+                         {coder_update}/{coder_move}/{coder_read}; could not read {}: {error}",
+                        final_path.display()
                     ),
+                },
+            ),
+            HOST_EXECUTION.binary(
+                host_execution,
+                format!(
+                    "exact host execution call={host_exec}, exact successful stdout={host_output}"
                 ),
-                common::gate(
-                    "sandbox_lifecycle_completed",
-                    sandbox_lifecycle,
-                    sandbox.summary(),
+            ),
+            SANDBOX_LIFECYCLE.binary(sandbox_lifecycle, sandbox.summary()),
+            COMPLETION_REPORT.binary(
+                response_reports_outputs,
+                "awarded when the final response includes both exact outputs",
+            ),
+            EXECUTION_QUALITY.points(
+                execution_quality_award(function_call_errors),
+                format!(
+                    "observed {function_call_errors} function-call error(s); recovered errors reduce quality but validated outcomes remain authoritative"
                 ),
-                common::gate(
-                    "operation_volume_reached",
-                    operation_volume,
-                    format!(
-                        "observed {core_operations} of {EXPECTED_CORE_OPERATIONS} required core operations"
-                    ),
-                ),
-            ],
-            awards: vec![
-                common::award(
-                    "worker_setup",
-                    if worker_setup { 10 } else { 0 },
-                    "awarded for adding both registry workers and exposing all three surfaces",
-                ),
-                common::award(
-                    "coder_workflow",
-                    if coder_workflow { 20 } else { 0 },
-                    "awarded for the ordered inspect/create/update/move/read workflow and exact file",
-                ),
-                common::award(
-                    "host_execution",
-                    if host_execution { 10 } else { 0 },
-                    "awarded for exact successful host stdout",
-                ),
-                common::award(
-                    "sandbox_lifecycle",
-                    if sandbox_lifecycle { 10 } else { 0 },
-                    "awarded for creating, executing in, listing, and stopping the isolated sandbox",
-                ),
-                common::award(
-                    "completion_report",
-                    if response_reports_outputs { 5 } else { 0 },
-                    "awarded when the final response includes both exact outputs",
-                ),
-                common::award(
-                    "execution_quality",
-                    execution_quality_award(function_call_errors),
-                    format!(
-                        "observed {function_call_errors} function-call error(s); recovered errors reduce quality but validated outcomes remain authoritative"
-                    ),
-                ),
-            ],
-        })
+            )?,
+        ]);
+        evaluation.hard_gates.push(common::gate(
+            "operation_volume_reached",
+            operation_volume,
+            format!(
+                "observed {core_operations} of {EXPECTED_CORE_OPERATIONS} required core operations"
+            ),
+        ));
+
+        Ok(evaluation)
     })
 }
 
@@ -781,6 +753,96 @@ mod tests {
         assert!(spec
             .prompt
             .contains("Do not create, edit, move, or read this code file with a general shell"));
+    }
+
+    #[test]
+    fn assessment_metadata_and_output_contract_are_canonical() {
+        let spec = scenario("1234567890abcdef");
+        spec.validate().unwrap();
+
+        assert_eq!(spec.version, 2);
+        assert_eq!(
+            spec.criteria
+                .iter()
+                .map(|criterion| (criterion.id, criterion.weight, criterion.description))
+                .collect::<Vec<_>>(),
+            vec![
+                (
+                    "worker_setup",
+                    10,
+                    "Both registry workers are added and expose their required surfaces.",
+                ),
+                (
+                    "coder_workflow",
+                    20,
+                    "Coder inspection, create, update, move, and read operations produce the exact file.",
+                ),
+                (
+                    "host_execution",
+                    10,
+                    "The final file runs successfully on the host with exact stdout.",
+                ),
+                (
+                    "sandbox_lifecycle",
+                    10,
+                    "A named isolated sandbox is created, executed in, listed, and stopped.",
+                ),
+                (
+                    "completion_report",
+                    5,
+                    "The final response includes both exact observed outputs.",
+                ),
+                (
+                    "execution_quality",
+                    45,
+                    "The workflow completes without function-call errors; recovered errors lower quality without overriding validated effects.",
+                ),
+            ]
+        );
+
+        let mut evaluation = assessment::objective([
+            WORKER_SETUP.binary(true, "worker setup"),
+            CODER_WORKFLOW.binary(true, "coder workflow"),
+            HOST_EXECUTION.binary(true, "host execution"),
+            SANDBOX_LIFECYCLE.binary(true, "sandbox lifecycle"),
+            COMPLETION_REPORT.binary(true, "completion report"),
+            EXECUTION_QUALITY
+                .points(EXECUTION_QUALITY_WEIGHT, "execution quality")
+                .unwrap(),
+        ]);
+        evaluation
+            .hard_gates
+            .push(common::gate("operation_volume_reached", true, "volume"));
+
+        assert_eq!(
+            evaluation
+                .hard_gates
+                .iter()
+                .map(|gate| gate.id.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "worker_setup",
+                "coder_workflow",
+                "host_execution",
+                "sandbox_lifecycle",
+                "operation_volume_reached",
+            ]
+        );
+        assert_eq!(
+            evaluation
+                .awards
+                .iter()
+                .map(|award| award.id.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "worker_setup",
+                "coder_workflow",
+                "host_execution",
+                "sandbox_lifecycle",
+                "completion_report",
+                "execution_quality",
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add an `unavailable` assessment result for checks skipped behind an explicit prerequisite gate
- migrate `receiving_operation`, `reactive_automation`, and `shell_coder_sandbox` to canonical assessments
- preserve prerequisite and supplemental gates without duplicating failures
- remove the superseded manual award helper after all objective scenarios migrate

## Validation

- `cargo fmt --manifest-path harness/Cargo.toml --all -- --check`
- `cargo test --locked --manifest-path harness/Cargo.toml -p harness-e2e`
- `cargo clippy --locked --manifest-path harness/Cargo.toml -p harness-e2e --all-targets -- -D warnings`
- `git diff --check`

Depends on #757

Fixes MOT-4381