### PR TITLE
(MOT-4381) refactor(harness): clarify assessment authoring errors

### DIFF
--- a/harness/tests/e2e/README.md
+++ b/harness/tests/e2e/README.md
@@ -365,13 +365,14 @@ rules:
   criteria, thresholds, execution policy, setup, or evaluation behavior changes,
   while structural refactors that preserve the behavioral contract keep it;
 - for new code-defined objective evaluators, declare each check once as a static
-  `AssessmentSpec`: use `required` for conditions that must emit a hard gate and
-  `binary` when the gate controls a full-or-zero award, `required_points` when
-  the gate outcome and quality award are evaluated independently, and `signal`
-  for non-blocking quality awards; when an explicit prerequisite gate prevents
-  a check from running, use `unavailable` to retain its zero-point award without
-  emitting a duplicate hard gate; existing evaluators can migrate to this
-  pattern incrementally;
+  `AssessmentSpec`: use `hard_gated` for conditions that must emit a hard gate
+  and `full_or_zero` when that condition controls a full-or-zero award,
+  `gate_and_points` when the gate outcome and quality award are evaluated
+  independently, and `score_only` for quality awards that do not emit a hard
+  gate; when an explicit prerequisite gate prevents a check from running, use
+  `assessment::prerequisite_failure(...)` to emit the failed gate and retain
+  each assessment's zero-point award atomically; existing evaluators can migrate
+  to this pattern incrementally;
 - prompts describe user intent and never prescribe function ids;
 - declare a scenario-sized execution policy;
 - objective effects are hard gates, not judge opinions;

--- a/harness/tests/e2e/src/scenarios/assessment.rs
+++ b/harness/tests/e2e/src/scenarios/assessment.rs
@@ -5,9 +5,9 @@ use crate::report::HardGateReport;
 use super::{CriterionAward, CriterionSpec, ObjectiveEvaluation};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum AssessmentKind {
-    Required,
-    Signal,
+enum GatePolicy {
+    HardGated,
+    ScoreOnly,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -15,25 +15,33 @@ pub(super) struct AssessmentSpec {
     id: &'static str,
     weight: u8,
     description: &'static str,
-    kind: AssessmentKind,
+    gate_policy: GatePolicy,
 }
 
 impl AssessmentSpec {
-    pub(super) const fn required(id: &'static str, weight: u8, description: &'static str) -> Self {
+    pub(super) const fn hard_gated(
+        id: &'static str,
+        weight: u8,
+        description: &'static str,
+    ) -> Self {
         Self {
             id,
             weight,
             description,
-            kind: AssessmentKind::Required,
+            gate_policy: GatePolicy::HardGated,
         }
     }
 
-    pub(super) const fn signal(id: &'static str, weight: u8, description: &'static str) -> Self {
+    pub(super) const fn score_only(
+        id: &'static str,
+        weight: u8,
+        description: &'static str,
+    ) -> Self {
         Self {
             id,
             weight,
             description,
-            kind: AssessmentKind::Signal,
+            gate_policy: GatePolicy::ScoreOnly,
         }
     }
 
@@ -41,67 +49,77 @@ impl AssessmentSpec {
         self.weight
     }
 
-    pub(super) fn binary(self, passed: bool, reason: impl Into<String>) -> AssessmentResult {
-        AssessmentResult {
+    pub(super) fn full_or_zero(
+        self,
+        satisfied: bool,
+        details: impl Into<String>,
+    ) -> AssessmentOutcome {
+        AssessmentOutcome {
             spec: self,
-            awarded: if passed { self.weight } else { 0 },
-            gate_passed: matches!(self.kind, AssessmentKind::Required).then_some(passed),
-            reason: reason.into(),
+            awarded: if satisfied { self.weight } else { 0 },
+            gate_passed: matches!(self.gate_policy, GatePolicy::HardGated).then_some(satisfied),
+            details: details.into(),
         }
     }
 
     /// Records a check that could not run behind an explicit prerequisite gate.
-    pub(super) fn unavailable(self, reason: impl Into<String>) -> AssessmentResult {
-        AssessmentResult {
+    /// Prefer [`prerequisite_failure`] when constructing the complete evaluation.
+    fn skipped_due_to_prerequisite(self, details: impl Into<String>) -> AssessmentOutcome {
+        AssessmentOutcome {
             spec: self,
             awarded: 0,
             gate_passed: None,
-            reason: reason.into(),
+            details: details.into(),
         }
     }
 
-    pub(super) fn points(self, awarded: u8, reason: impl Into<String>) -> Result<AssessmentResult> {
-        if self.kind == AssessmentKind::Required {
+    pub(super) fn award(
+        self,
+        awarded: u8,
+        details: impl Into<String>,
+    ) -> Result<AssessmentOutcome> {
+        if self.gate_policy == GatePolicy::HardGated {
             bail!(
-                "required assessment {} cannot use signal-only points; use binary or required_points",
-                self.id
+                "assessment '{}': award(awarded={awarded}) cannot emit a hard gate for a hard-gated assessment; use full_or_zero(...) or gate_and_points(...)",
+                self.id,
             );
         }
-        self.validate_points(awarded)?;
-        Ok(AssessmentResult {
+        self.validate_award("award", awarded)?;
+        Ok(AssessmentOutcome {
             spec: self,
             awarded,
             gate_passed: None,
-            reason: reason.into(),
+            details: details.into(),
         })
     }
 
-    pub(super) fn required_points(
+    pub(super) fn gate_and_points(
         self,
-        passed: bool,
+        gate_passed: bool,
         awarded: u8,
-        reason: impl Into<String>,
-    ) -> Result<AssessmentResult> {
-        if self.kind == AssessmentKind::Signal {
+        details: impl Into<String>,
+    ) -> Result<AssessmentOutcome> {
+        if self.gate_policy == GatePolicy::ScoreOnly {
             bail!(
-                "signal assessment {} cannot produce a required gate",
-                self.id
+                "assessment '{}': gate_and_points(gate_passed={gate_passed}, awarded={awarded}) cannot emit a hard gate for a score-only assessment; use full_or_zero(...) or award(...)",
+                self.id,
             );
         }
-        self.validate_points(awarded)?;
-        Ok(AssessmentResult {
+        self.validate_award("gate_and_points", awarded)?;
+        Ok(AssessmentOutcome {
             spec: self,
             awarded,
-            gate_passed: Some(passed),
-            reason: reason.into(),
+            gate_passed: Some(gate_passed),
+            details: details.into(),
         })
     }
 
-    fn validate_points(self, awarded: u8) -> Result<()> {
+    fn validate_award(self, operation: &str, awarded: u8) -> Result<()> {
         if awarded > self.weight {
             bail!(
-                "assessment {} awarded {awarded} points, exceeding its weight {}",
+                "assessment '{}': {operation}(awarded={awarded}) exceeds max_points={}; expected awarded in 0..={}",
                 self.id,
+                self.weight,
                 self.weight
             );
         }
@@ -118,11 +136,11 @@ impl AssessmentSpec {
 }
 
 #[derive(Debug)]
-pub(super) struct AssessmentResult {
+pub(super) struct AssessmentOutcome {
     spec: AssessmentSpec,
     awarded: u8,
     gate_passed: Option<bool>,
-    reason: String,
+    details: String,
 }
 
 pub(super) fn criteria(specs: &[AssessmentSpec]) -> Vec<CriterionSpec> {
@@ -133,8 +151,8 @@ pub(super) fn criteria(specs: &[AssessmentSpec]) -> Vec<CriterionSpec> {
         .collect()
 }
 
-pub(super) fn objective(
-    results: impl IntoIterator<Item = AssessmentResult>,
+pub(super) fn build_evaluation(
+    results: impl IntoIterator<Item = AssessmentOutcome>,
 ) -> ObjectiveEvaluation {
     let mut hard_gates = Vec::new();
     let mut awards = Vec::new();
@@ -144,30 +162,52 @@ pub(super) fn objective(
             hard_gates.push(HardGateReport {
                 id: result.spec.id.to_string(),
                 passed,
-                reason: result.reason.clone(),
+                reason: result.details.clone(),
             });
         }
         awards.push(CriterionAward {
             id: result.spec.id.to_string(),
             awarded: result.awarded,
-            reason: result.reason,
+            reason: result.details,
         });
     }
 
     ObjectiveEvaluation { hard_gates, awards }
 }
 
+pub(super) fn prerequisite_failure(
+    specs: &[AssessmentSpec],
+    gate_id: impl Into<String>,
+    details: impl Into<String>,
+) -> ObjectiveEvaluation {
+    let gate_id = gate_id.into();
+    let reason = format!("prerequisite gate '{gate_id}' failed: {}", details.into());
+    let mut evaluation = build_evaluation(
+        specs
+            .iter()
+            .copied()
+            .map(|spec| spec.skipped_due_to_prerequisite(reason.clone())),
+    );
+    evaluation.hard_gates.push(HardGateReport {
+        id: gate_id,
+        passed: false,
+        reason,
+    });
+    evaluation
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    const REQUIRED: AssessmentSpec =
-        AssessmentSpec::required("required", 70, "A required outcome.");
-    const SIGNAL: AssessmentSpec = AssessmentSpec::signal("signal", 30, "A quality signal.");
+    const HARD_GATED: AssessmentSpec =
+        AssessmentSpec::hard_gated("required", 70, "A required outcome.");
+    const SCORE_ONLY: AssessmentSpec =
+        AssessmentSpec::score_only("signal", 30, "A quality signal.");
 
     #[test]
     fn criteria_preserve_assessment_definitions() {
-        let criteria = criteria(&[REQUIRED, SIGNAL]);
+        let criteria = criteria(&[HARD_GATED, SCORE_ONLY]);
 
         assert_eq!(criteria.len(), 2);
         assert_eq!(criteria[0].id, "required");
@@ -186,8 +226,8 @@ mod tests {
     }
 
     #[test]
-    fn required_pass_produces_a_passing_gate_and_full_award() {
-        let evaluation = objective([REQUIRED.binary(true, "satisfied")]);
+    fn hard_gated_pass_produces_a_passing_gate_and_full_award() {
+        let evaluation = build_evaluation([HARD_GATED.full_or_zero(true, "satisfied")]);
 
         assert_eq!(evaluation.hard_gates.len(), 1);
         assert_eq!(evaluation.hard_gates[0].id, "required");
@@ -200,17 +240,17 @@ mod tests {
     }
 
     #[test]
-    fn required_failure_produces_a_failed_gate_and_zero_award() {
-        let evaluation = objective([REQUIRED.binary(false, "missing")]);
+    fn hard_gated_failure_produces_a_failed_gate_and_zero_award() {
+        let evaluation = build_evaluation([HARD_GATED.full_or_zero(false, "missing")]);
 
         assert!(!evaluation.hard_gates[0].passed);
         assert_eq!(evaluation.awards[0].awarded, 0);
     }
 
     #[test]
-    fn signal_produces_an_award_without_a_gate() {
-        let passed = objective([SIGNAL.binary(true, "observed")]);
-        let failed = objective([SIGNAL.binary(false, "missing")]);
+    fn score_only_produces_an_award_without_a_gate() {
+        let passed = build_evaluation([SCORE_ONLY.full_or_zero(true, "observed")]);
+        let failed = build_evaluation([SCORE_ONLY.full_or_zero(false, "missing")]);
 
         assert!(passed.hard_gates.is_empty());
         assert_eq!(passed.awards[0].id, "signal");
@@ -220,33 +260,33 @@ mod tests {
     }
 
     #[test]
-    fn signal_accepts_partial_points_within_its_weight() {
-        let evaluation = objective([SIGNAL.points(12, "partial").unwrap()]);
+    fn score_only_accepts_partial_awards_within_its_weight() {
+        let evaluation = build_evaluation([SCORE_ONLY.award(12, "partial").unwrap()]);
 
         assert!(evaluation.hard_gates.is_empty());
         assert_eq!(evaluation.awards[0].awarded, 12);
     }
 
     #[test]
-    fn signal_rejects_points_above_its_weight() {
+    fn score_only_rejects_awards_above_its_weight() {
         assert_eq!(
-            SIGNAL.points(31, "too many").unwrap_err().to_string(),
-            "assessment signal awarded 31 points, exceeding its weight 30"
+            SCORE_ONLY.award(31, "too many").unwrap_err().to_string(),
+            "assessment 'signal': award(awarded=31) exceeds max_points=30; expected awarded in 0..=30"
         );
     }
 
     #[test]
-    fn required_assessments_reject_the_signal_points_api() {
+    fn hard_gated_assessments_reject_the_score_only_award_api() {
         assert_eq!(
-            REQUIRED.points(35, "partial").unwrap_err().to_string(),
-            "required assessment required cannot use signal-only points; use binary or required_points"
+            HARD_GATED.award(35, "partial").unwrap_err().to_string(),
+            "assessment 'required': award(awarded=35) cannot emit a hard gate for a hard-gated assessment; use full_or_zero(...) or gate_and_points(...)"
         );
     }
 
     #[test]
-    fn required_gate_can_award_partial_points_after_passing() {
-        let evaluation = objective([REQUIRED
-            .required_points(true, 35, "passed with partial quality")
+    fn hard_gated_assessment_can_award_partial_points_after_passing() {
+        let evaluation = build_evaluation([HARD_GATED
+            .gate_and_points(true, 35, "passed with partial quality")
             .unwrap()]);
 
         assert!(evaluation.hard_gates[0].passed);
@@ -254,9 +294,9 @@ mod tests {
     }
 
     #[test]
-    fn failed_required_gate_can_retain_independent_quality_points() {
-        let evaluation = objective([REQUIRED
-            .required_points(false, 35, "failed with partial quality")
+    fn failed_hard_gate_can_retain_independent_quality_points() {
+        let evaluation = build_evaluation([HARD_GATED
+            .gate_and_points(false, 35, "failed with partial quality")
             .unwrap()]);
 
         assert!(!evaluation.hard_gates[0].passed);
@@ -264,47 +304,50 @@ mod tests {
     }
 
     #[test]
-    fn required_gate_rejects_points_above_its_weight() {
+    fn hard_gated_assessment_rejects_awards_above_its_weight() {
         assert_eq!(
-            REQUIRED
-                .required_points(true, 71, "too many")
+            HARD_GATED
+                .gate_and_points(true, 71, "too many")
                 .unwrap_err()
                 .to_string(),
-            "assessment required awarded 71 points, exceeding its weight 70"
+            "assessment 'required': gate_and_points(awarded=71) exceeds max_points=70; expected awarded in 0..=70"
         );
     }
 
     #[test]
-    fn signal_rejects_a_required_gate() {
+    fn score_only_rejects_the_hard_gate_api() {
         assert_eq!(
-            SIGNAL
-                .required_points(true, 30, "wrong kind")
+            SCORE_ONLY
+                .gate_and_points(true, 30, "wrong kind")
                 .unwrap_err()
                 .to_string(),
-            "signal assessment signal cannot produce a required gate"
+            "assessment 'signal': gate_and_points(gate_passed=true, awarded=30) cannot emit a hard gate for a score-only assessment; use full_or_zero(...) or award(...)"
         );
     }
 
     #[test]
-    fn unavailable_assessments_preserve_order_without_duplicate_gates() {
-        let evaluation = objective([
-            REQUIRED.unavailable("required prerequisite unavailable"),
-            SIGNAL.unavailable("signal prerequisite unavailable"),
-        ]);
+    fn prerequisite_skips_preserve_order_without_duplicate_gates() {
+        let evaluation = prerequisite_failure(
+            &[HARD_GATED, SCORE_ONLY],
+            "database_available",
+            "database capability is unavailable",
+        );
 
-        assert!(evaluation.hard_gates.is_empty());
+        assert_eq!(evaluation.hard_gates.len(), 1);
+        assert!(!evaluation.hard_gates[0].passed);
+        assert_eq!(evaluation.hard_gates[0].id, "database_available");
         assert_eq!(evaluation.awards.len(), 2);
         assert_eq!(evaluation.awards[0].id, "required");
         assert_eq!(evaluation.awards[0].awarded, 0);
         assert_eq!(
             evaluation.awards[0].reason,
-            "required prerequisite unavailable"
+            "prerequisite gate 'database_available' failed: database capability is unavailable"
         );
         assert_eq!(evaluation.awards[1].id, "signal");
         assert_eq!(evaluation.awards[1].awarded, 0);
         assert_eq!(
             evaluation.awards[1].reason,
-            "signal prerequisite unavailable"
+            "prerequisite gate 'database_available' failed: database capability is unavailable"
         );
     }
 }

--- a/harness/tests/e2e/src/scenarios/custom_validator.rs
+++ b/harness/tests/e2e/src/scenarios/custom_validator.rs
@@ -36,17 +36,17 @@ const HOOK_TYPE: &str = "harness::hook::post-turn";
 /// footgun for anyone writing a validator, so this scenario pins it.
 const HOOK_POINT: &str = "post_turn";
 const TOKENS: [&str; 3] = ["E2E-ACCEPT-1", "E2E-ACCEPT-2", "E2E-ACCEPT-3"];
-const ENVELOPE_REGISTRATION: AssessmentSpec = AssessmentSpec::required(
+const ENVELOPE_REGISTRATION: AssessmentSpec = AssessmentSpec::hard_gated(
     "envelope_registration",
     30,
     "Exactly one post-turn registration targeting the temporary function, envelope mode (no payload template).",
 );
-const CUSTOM_REASONS_DROVE_THE_LOOP: AssessmentSpec = AssessmentSpec::required(
+const CUSTOM_REASONS_DROVE_THE_LOOP: AssessmentSpec = AssessmentSpec::hard_gated(
     "custom_reasons_drove_the_loop",
     30,
     "Both corrective prompts carry the validator's own reasons naming the next rung.",
 );
-const LADDER_CONVERGED: AssessmentSpec = AssessmentSpec::required(
+const LADDER_CONVERGED: AssessmentSpec = AssessmentSpec::hard_gated(
     "ladder_converged",
     40,
     "The final result carries the terminal token — reachable only by following two custom denials.",
@@ -225,12 +225,12 @@ fn evaluate<'a>(
             0
         };
 
-        Ok(assessment::objective([
-            LADDER_CONVERGED.binary(
+        Ok(assessment::build_evaluation([
+            LADDER_CONVERGED.full_or_zero(
                 converged,
                 format!("final response must contain {}", TOKENS[2]),
             ),
-            ENVELOPE_REGISTRATION.required_points(
+            ENVELOPE_REGISTRATION.gate_and_points(
                 envelope_mode,
                 envelope_points,
                 format!(
@@ -240,7 +240,7 @@ fn evaluate<'a>(
                     observation.metrics.totals.function_call_errors
                 ),
             )?,
-            CUSTOM_REASONS_DROVE_THE_LOOP.binary(
+            CUSTOM_REASONS_DROVE_THE_LOOP.full_or_zero(
                 laddered,
                 format!("nudges: {nudge_texts:?} — expected the two ladder reasons in order"),
             ),

--- a/harness/tests/e2e/src/scenarios/mechanical_reaction.rs
+++ b/harness/tests/e2e/src/scenarios/mechanical_reaction.rs
@@ -11,22 +11,22 @@ pub const ID: &str = "mechanical_reaction";
 
 const SOURCE_KEY: &str = "source";
 const MIRROR_KEY: &str = "mirror";
-const REACTIONS_ARMED: AssessmentSpec = AssessmentSpec::required(
+const REACTIONS_ARMED: AssessmentSpec = AssessmentSpec::hard_gated(
     "reactions_armed",
     30,
     "The wake and mechanical call are registered before the source write.",
 );
-const MECHANICAL_MIRROR: AssessmentSpec = AssessmentSpec::required(
+const MECHANICAL_MIRROR: AssessmentSpec = AssessmentSpec::hard_gated(
     "mechanical_mirror",
     35,
     "The call binding mirrors the complete source event without a root write.",
 );
-const PARENT_WOKEN: AssessmentSpec = AssessmentSpec::required(
+const PARENT_WOKEN: AssessmentSpec = AssessmentSpec::hard_gated(
     "parent_woken",
     20,
     "The mirror state event wakes only the original session.",
 );
-const CLEAN_COMPLETION: AssessmentSpec = AssessmentSpec::required(
+const CLEAN_COMPLETION: AssessmentSpec = AssessmentSpec::hard_gated(
     "clean_completion",
     15,
     "The run finishes without children, errors, or surviving bindings.",
@@ -161,8 +161,8 @@ fn evaluate<'a>(
             exact_source_write && mirror_valid && call_delivered && call_payload_recorded;
         let clean_completion = active_bindings == 0 && no_errors && confirmed;
 
-        Ok(assessment::objective([
-            REACTIONS_ARMED.binary(
+        Ok(assessment::build_evaluation([
+            REACTIONS_ARMED.full_or_zero(
                 reactions_armed,
                 format!(
                     "registrations={}, wakes={}, call_bindings={}, writes={}",
@@ -172,14 +172,14 @@ fn evaluate<'a>(
                     writes.len()
                 ),
             ),
-            MECHANICAL_MIRROR.binary(
+            MECHANICAL_MIRROR.full_or_zero(
                 mechanical_mirror,
                 format!(
                     "exact_source_write={exact_source_write}, mirror_valid={mirror_valid}, \
                          call_delivered={call_delivered}, call_payload_recorded={call_payload_recorded}"
                 ),
             ),
-            PARENT_WOKEN.binary(
+            PARENT_WOKEN.full_or_zero(
                 parent_woken,
                 format!(
                     "wake_records={}, sessions={}",
@@ -187,7 +187,7 @@ fn evaluate<'a>(
                     observation.metrics.totals.sessions
                 ),
             ),
-            CLEAN_COMPLETION.binary(
+            CLEAN_COMPLETION.full_or_zero(
                 clean_completion,
                 format!(
                     "active_bindings={active_bindings}, function_errors={}, confirmed={confirmed}",

--- a/harness/tests/e2e/src/scenarios/mod.rs
+++ b/harness/tests/e2e/src/scenarios/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
@@ -68,19 +68,30 @@ pub struct ExecutionPolicy {
 
 impl ExecutionPolicy {
     fn validate(self, scenario_id: &str) -> Result<()> {
-        if self.max_turns == 0
-            || self.max_output_tokens == Some(0)
-            || self.max_total_tokens == 0
-            || self.stuck_timeout_seconds == 0
-        {
-            bail!("scenario {scenario_id} has an invalid execution policy");
+        if self.max_turns == 0 {
+            bail!("scenario '{scenario_id}': execution.max_turns=0; expected at least 1");
+        }
+        if self.max_output_tokens == Some(0) {
+            bail!(
+                "scenario '{scenario_id}': execution.max_output_tokens=0; expected None (provider limit) or at least 1"
+            );
+        }
+        if self.max_total_tokens == 0 {
+            bail!("scenario '{scenario_id}': execution.max_total_tokens=0; expected at least 1");
+        }
+        if self.stuck_timeout_seconds == 0 {
+            bail!(
+                "scenario '{scenario_id}': execution.stuck_timeout_seconds=0; expected at least 1"
+            );
         }
         if self
             .max_output_tokens
             .is_some_and(|max_output_tokens| self.max_total_tokens < max_output_tokens)
         {
+            let max_output_tokens = self.max_output_tokens.expect("checked above");
             bail!(
-                "scenario {scenario_id} total-token budget is smaller than its per-call output budget"
+                "scenario '{scenario_id}': execution.max_total_tokens={} is lower than execution.max_output_tokens={max_output_tokens}; expected max_total_tokens >= max_output_tokens",
+                self.max_total_tokens
             );
         }
         Ok(())
@@ -109,20 +120,49 @@ pub struct ScenarioSpec {
 impl ScenarioSpec {
     pub fn validate(&self) -> Result<()> {
         if self.prompt.trim().is_empty() {
-            bail!("scenario {} has an empty prompt", self.id);
+            bail!(
+                "scenario '{}': prompt is empty after trimming; provide a non-empty task prompt",
+                self.id
+            );
         }
         if self.version == 0 {
-            bail!("scenario {} version must be positive", self.id);
+            bail!("scenario '{}': version=0; expected version >= 1", self.id);
         }
         self.execution.validate(self.id)?;
         if !(1..=100).contains(&self.threshold) {
-            bail!("scenario {} threshold must be between 1 and 100", self.id);
+            bail!(
+                "scenario '{}': threshold={}; expected a value in 1..=100",
+                self.id,
+                self.threshold
+            );
         }
         if self.needs_judge() && self.threshold != JUDGE_BACKED_PASS_THRESHOLD {
             bail!(
-                "judge-backed scenario {} threshold must be {JUDGE_BACKED_PASS_THRESHOLD}",
-                self.id
+                "scenario '{}': judge-backed threshold={}; expected {JUDGE_BACKED_PASS_THRESHOLD}; set this threshold or remove judge_reference",
+                self.id, self.threshold
             );
+        }
+        let mut ids = HashMap::new();
+        for (index, criterion) in self.criteria.iter().enumerate() {
+            if criterion.id.trim().is_empty() {
+                bail!(
+                    "scenario '{}': criteria[{index}].id is empty after trimming; use a stable non-empty identifier",
+                    self.id
+                );
+            }
+            if criterion.weight == 0 {
+                bail!(
+                    "scenario '{}': criterion '{}' has weight=0; expected at least 1",
+                    self.id,
+                    criterion.id
+                );
+            }
+            if let Some(first_index) = ids.insert(criterion.id, index) {
+                bail!(
+                    "scenario '{}': criterion id '{}' is duplicated at indexes {first_index} and {index}; criterion ids must be unique",
+                    self.id, criterion.id
+                );
+            }
         }
         let total: u16 = self
             .criteria
@@ -130,19 +170,16 @@ impl ScenarioSpec {
             .map(|criterion| u16::from(criterion.weight))
             .sum();
         if total != 100 {
+            let declared = self
+                .criteria
+                .iter()
+                .map(|criterion| format!("{}={}", criterion.id, criterion.weight))
+                .collect::<Vec<_>>()
+                .join(", ");
             bail!(
-                "scenario {} criterion weights total {total}, expected 100",
+                "scenario '{}': criterion weights total={total}; expected exactly 100; declared weights=[{declared}]",
                 self.id
             );
-        }
-        let mut ids = HashSet::new();
-        for criterion in &self.criteria {
-            if criterion.id.trim().is_empty() || criterion.weight == 0 {
-                bail!("scenario {} has an invalid criterion", self.id);
-            }
-            if !ids.insert(criterion.id) {
-                bail!("scenario {} repeats criterion {}", self.id, criterion.id);
-            }
         }
         Ok(())
     }
@@ -297,6 +334,8 @@ pub fn selected(requested: &[ScenarioId]) -> Vec<ScenarioId> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
     #[test]
     fn registry_contains_nineteen_unique_valid_scenarios() {
@@ -352,7 +391,7 @@ mod tests {
 
         assert_eq!(
             spec.validate().unwrap_err().to_string(),
-            "judge-backed scenario direct_answer threshold must be 50"
+            "scenario 'direct_answer': judge-backed threshold=51; expected 50; set this threshold or remove judge_reference"
         );
     }
 
@@ -363,7 +402,87 @@ mod tests {
 
         assert_eq!(
             spec.validate().unwrap_err().to_string(),
-            "scenario persistent_state version must be positive"
+            "scenario 'persistent_state': version=0; expected version >= 1"
+        );
+    }
+
+    #[test]
+    fn validation_identifies_the_invalid_execution_field() {
+        type ValidationCase = (&'static str, fn(&mut ExecutionPolicy), &'static str);
+
+        let cases: [ValidationCase; 5] = [
+            (
+                "max_turns",
+                |execution| execution.max_turns = 0,
+                "scenario 'persistent_state': execution.max_turns=0; expected at least 1",
+            ),
+            (
+                "max_output_tokens",
+                |execution| execution.max_output_tokens = Some(0),
+                "scenario 'persistent_state': execution.max_output_tokens=0; expected None (provider limit) or at least 1",
+            ),
+            (
+                "max_total_tokens",
+                |execution| execution.max_total_tokens = 0,
+                "scenario 'persistent_state': execution.max_total_tokens=0; expected at least 1",
+            ),
+            (
+                "stuck_timeout_seconds",
+                |execution| execution.stuck_timeout_seconds = 0,
+                "scenario 'persistent_state': execution.stuck_timeout_seconds=0; expected at least 1",
+            ),
+            (
+                "total_token_order",
+                |execution| execution.max_total_tokens = 1,
+                "scenario 'persistent_state': execution.max_total_tokens=1 is lower than execution.max_output_tokens=8192; expected max_total_tokens >= max_output_tokens",
+            ),
+        ];
+
+        for (field, mutate, expected) in cases {
+            let mut spec = ScenarioId::PersistentState.spec("run");
+            mutate(&mut spec.execution);
+            assert_eq!(
+                spec.validate().unwrap_err().to_string(),
+                expected,
+                "{field}"
+            );
+        }
+    }
+
+    #[test]
+    fn validation_reports_criterion_values_before_weight_total() {
+        let mut spec = ScenarioId::PersistentState.spec("run");
+        spec.criteria = vec![CriterionSpec {
+            id: "durable_result",
+            weight: 0,
+            description: "invalid",
+        }];
+
+        assert_eq!(
+            spec.validate().unwrap_err().to_string(),
+            "scenario 'persistent_state': criterion 'durable_result' has weight=0; expected at least 1"
+        );
+    }
+
+    #[test]
+    fn validation_reports_duplicate_criterion_indexes() {
+        let mut spec = ScenarioId::PersistentState.spec("run");
+        spec.criteria = vec![
+            CriterionSpec {
+                id: "duplicate",
+                weight: 50,
+                description: "first",
+            },
+            CriterionSpec {
+                id: "duplicate",
+                weight: 50,
+                description: "second",
+            },
+        ];
+
+        assert_eq!(
+            spec.validate().unwrap_err().to_string(),
+            "scenario 'persistent_state': criterion id 'duplicate' is duplicated at indexes 0 and 1; criterion ids must be unique"
         );
     }
 }

--- a/harness/tests/e2e/src/scenarios/multi_subagent_validation.rs
+++ b/harness/tests/e2e/src/scenarios/multi_subagent_validation.rs
@@ -25,17 +25,17 @@ const HOOK_TYPE: &str = "harness::hook::post-turn";
 const THRESHOLD: u64 = 6;
 const EXPECTED_ROWS: u64 = 8;
 const WRITERS: [&str; 2] = ["w1", "w2"];
-const CHILDREN_GOAL: AssessmentSpec = AssessmentSpec::required(
+const CHILDREN_GOAL: AssessmentSpec = AssessmentSpec::hard_gated(
     "children_goal",
     35,
     "Both writers exceed the threshold and both verdict keys carry their accepted counts.",
 );
-const ORCHESTRATION_DISCIPLINE: AssessmentSpec = AssessmentSpec::required(
+const ORCHESTRATION_DISCIPLINE: AssessmentSpec = AssessmentSpec::hard_gated(
     "orchestration_discipline",
     35,
     "Two child-scoped validators and two wakes registered before any spawn; both children looped under their own gate.",
 );
-const FAN_IN_REPORT: AssessmentSpec = AssessmentSpec::required(
+const FAN_IN_REPORT: AssessmentSpec = AssessmentSpec::hard_gated(
     "fan_in_report",
     30,
     "The parent tallies both verdicts and finishes with the exact report line.",
@@ -180,8 +180,8 @@ fn evaluate<'a>(
 
         let orchestration_discipline = validator_count == 2 && ordered && both_looped;
 
-        Ok(assessment::objective([
-            CHILDREN_GOAL.required_points(
+        Ok(assessment::build_evaluation([
+            CHILDREN_GOAL.gate_and_points(
                 goal,
                 children_goal_points(goal, &rows),
                 format!(
@@ -189,7 +189,7 @@ fn evaluate<'a>(
                      marks at exactly {EXPECTED_ROWS} rows each"
                 ),
             )?,
-            ORCHESTRATION_DISCIPLINE.binary(
+            ORCHESTRATION_DISCIPLINE.full_or_zero(
                 orchestration_discipline,
                 format!(
                     "observed {validator_count} post-turn registration(s), expected two; \
@@ -198,7 +198,7 @@ fn evaluate<'a>(
                      needs at least one"
                 ),
             ),
-            FAN_IN_REPORT.binary(reported, "expected the exact report line"),
+            FAN_IN_REPORT.full_or_zero(reported, "expected the exact report line"),
         ]))
     })
 }

--- a/harness/tests/e2e/src/scenarios/persistent_state.rs
+++ b/harness/tests/e2e/src/scenarios/persistent_state.rs
@@ -11,17 +11,17 @@ use super::{
 
 pub const ID: &str = "persistent_state";
 const KEY: &str = "persistent_state";
-const DURABLE_RESULT: AssessmentSpec = AssessmentSpec::required(
+const DURABLE_RESULT: AssessmentSpec = AssessmentSpec::hard_gated(
     "durable_result",
     60,
     "The exact requested JSON is present at the requested state key.",
 );
-const FUNCTION_DISCIPLINE: AssessmentSpec = AssessmentSpec::required(
+const FUNCTION_DISCIPLINE: AssessmentSpec = AssessmentSpec::hard_gated(
     "function_discipline",
     30,
     "Exactly one successful write targets the requested scope and key.",
 );
-const CONFIRMATION: AssessmentSpec = AssessmentSpec::signal(
+const CONFIRMATION: AssessmentSpec = AssessmentSpec::score_only(
     "confirmation",
     10,
     "The final response briefly confirms completion.",
@@ -105,18 +105,18 @@ fn assess(
         0
     };
 
-    Ok(assessment::objective([
-        DURABLE_RESULT.binary(
+    Ok(assessment::build_evaluation([
+        DURABLE_RESULT.full_or_zero(
             state_matches,
             format!("expected {expected}, observed {observed}"),
         ),
-        FUNCTION_DISCIPLINE.binary(
+        FUNCTION_DISCIPLINE.full_or_zero(
             function_discipline,
             format!(
                 "exact_write={exact_write}; observed {state_set_calls} state::set call(s); observed {function_call_errors} function-call error(s)"
             ),
         ),
-        CONFIRMATION.points(
+        CONFIRMATION.award(
             confirmation_points,
             format!(
                 "response_present={response_present}; observed {response_chars} character(s); limit 240"

--- a/harness/tests/e2e/src/scenarios/reactive_automation/evaluate.rs
+++ b/harness/tests/e2e/src/scenarios/reactive_automation/evaluate.rs
@@ -2,25 +2,16 @@ use std::collections::BTreeSet;
 
 use super::evidence::{Evidence, FinalReport};
 use super::names::ScenarioNames;
-use super::{
-    EXPECTED_ORDERS, EXPECTED_WRITERS, FINALIZATION_CLEANUP, ORDERS_PER_WRITER, PARALLEL_WRITES,
-    REACTIVE_AGGREGATES, TRIGGER_ORCHESTRATION,
-};
-use crate::scenarios::{assessment, common, ObjectiveEvaluation};
+use super::{ASSESSMENTS, EXPECTED_ORDERS, EXPECTED_WRITERS, ORDERS_PER_WRITER};
+use super::{FINALIZATION_CLEANUP, PARALLEL_WRITES, REACTIVE_AGGREGATES, TRIGGER_ORCHESTRATION};
+use crate::scenarios::{assessment, ObjectiveEvaluation};
 
 pub(super) fn missing_database() -> ObjectiveEvaluation {
-    let reason = "database capability is unavailable; the agent was expected to discover and \
-                  install the database worker before executing the scenario";
-    let mut evaluation = assessment::objective([
-        PARALLEL_WRITES.unavailable(reason),
-        REACTIVE_AGGREGATES.unavailable(reason),
-        TRIGGER_ORCHESTRATION.unavailable(reason),
-        FINALIZATION_CLEANUP.unavailable(reason),
-    ]);
-    evaluation
-        .hard_gates
-        .push(common::gate("database_capability_available", false, reason));
-    evaluation
+    assessment::prerequisite_failure(
+        ASSESSMENTS,
+        "database_capability_available",
+        "database capability is unavailable; the agent was expected to discover and install the database worker before executing the scenario",
+    )
 }
 
 pub(super) fn score(evidence: &Evidence, names: &ScenarioNames) -> ObjectiveEvaluation {
@@ -133,8 +124,8 @@ pub(super) fn score(evidence: &Evidence, names: &ScenarioNames) -> ObjectiveEval
         && finalizer_completed
         && evidence.active_run_triggers == 0;
 
-    assessment::objective([
-        PARALLEL_WRITES.binary(
+    assessment::build_evaluation([
+        PARALLEL_WRITES.full_or_zero(
             workload_passed,
             format!(
                 "tables={all_tables_exist}, parallel_writers={parallel_writers}, \
@@ -142,11 +133,11 @@ pub(super) fn score(evidence: &Evidence, names: &ScenarioNames) -> ObjectiveEval
                  writers_done={writers_done}"
             ),
         ),
-        REACTIVE_AGGREGATES.binary(
+        REACTIVE_AGGREGATES.full_or_zero(
             aggregates_passed,
             format!("totals_match={totals_match}, report_counts_match={report_counts_match}"),
         ),
-        TRIGGER_ORCHESTRATION.binary(
+        TRIGGER_ORCHESTRATION.full_or_zero(
             orchestration_passed,
             format!(
                 "watch_before_writers={watch_before_writers}, \
@@ -155,7 +146,7 @@ pub(super) fn score(evidence: &Evidence, names: &ScenarioNames) -> ObjectiveEval
                 evidence.aggregate_deliveries, evidence.completion_wake_delivered
             ),
         ),
-        FINALIZATION_CLEANUP.binary(
+        FINALIZATION_CLEANUP.full_or_zero(
             finalization_passed,
             format!(
                 "report_rows={}, report_identity={report_identity_matches}, \

--- a/harness/tests/e2e/src/scenarios/reactive_automation/mod.rs
+++ b/harness/tests/e2e/src/scenarios/reactive_automation/mod.rs
@@ -23,22 +23,22 @@ const STUCK_WATCHDOG_SECONDS: u64 = 600;
 // workload without relaxing any behavioral gate.
 const SCENARIO_MAX_TOTAL_TOKENS: u64 = 2_000_000;
 
-const PARALLEL_WRITES: AssessmentSpec = AssessmentSpec::required(
+const PARALLEL_WRITES: AssessmentSpec = AssessmentSpec::hard_gated(
     "parallel_writes",
     25,
     "Three parallel writer sessions produce exactly five valid orders each.",
 );
-const REACTIVE_AGGREGATES: AssessmentSpec = AssessmentSpec::required(
+const REACTIVE_AGGREGATES: AssessmentSpec = AssessmentSpec::hard_gated(
     "reactive_aggregates",
     30,
     "A mechanical trigger call maintains totals that exactly match the source rows.",
 );
-const TRIGGER_ORCHESTRATION: AssessmentSpec = AssessmentSpec::required(
+const TRIGGER_ORCHESTRATION: AssessmentSpec = AssessmentSpec::hard_gated(
     "trigger_orchestration",
     25,
     "The aggregate call and barrier wake are armed before writers start and proven by delivery records.",
 );
-const FINALIZATION_CLEANUP: AssessmentSpec = AssessmentSpec::required(
+const FINALIZATION_CLEANUP: AssessmentSpec = AssessmentSpec::hard_gated(
     "finalization_cleanup",
     20,
     "The barrier-woken root directly spawns one finalizer, which writes a passing report before cleanup.",
@@ -54,7 +54,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
     let names = ScenarioNames::new(run_id);
     ScenarioSpec {
         id: ID,
-        version: 2,
+        version: 3,
         prompt: prompt::build(&names, STUCK_WATCHDOG_SECONDS),
         filesystem_root: None,
         execution: ExecutionPolicy {
@@ -97,7 +97,7 @@ mod tests {
         let spec = scenario("run");
 
         spec.validate().unwrap();
-        assert_eq!(spec.version, 2);
+        assert_eq!(spec.version, 3);
         assert_eq!(spec.threshold, 90);
         assert_eq!(
             spec.criteria

--- a/harness/tests/e2e/src/scenarios/receiving_operation.rs
+++ b/harness/tests/e2e/src/scenarios/receiving_operation.rs
@@ -34,22 +34,22 @@ const COURIER_FUNCTIONS: [&str; 6] = [
     "engine::functions::info",
     "engine::functions::list",
 ];
-const COURIER_WORKLOAD: AssessmentSpec = AssessmentSpec::required(
+const COURIER_WORKLOAD: AssessmentSpec = AssessmentSpec::hard_gated(
     "courier_workload",
     30,
     "Three least-privilege couriers produce the exact shipments, corrections, and completion rows.",
 );
-const LIVE_LEDGER: AssessmentSpec = AssessmentSpec::required(
+const LIVE_LEDGER: AssessmentSpec = AssessmentSpec::hard_gated(
     "live_ledger",
     25,
     "A database-native or mechanical reaction keeps the ledger current without model turns.",
 );
-const DATABASE_FAN_IN: AssessmentSpec = AssessmentSpec::required(
+const DATABASE_FAN_IN: AssessmentSpec = AssessmentSpec::hard_gated(
     "database_fan_in",
     25,
     "The root learns completion from one database wake without polling.",
 );
-const VERIFICATION_CLEANUP: AssessmentSpec = AssessmentSpec::required(
+const VERIFICATION_CLEANUP: AssessmentSpec = AssessmentSpec::hard_gated(
     "verification_cleanup",
     20,
     "The root reports verified evidence and removes all standing machinery.",
@@ -65,7 +65,7 @@ pub fn scenario(run_id: &str) -> ScenarioSpec {
     let names = Names::new(run_id);
     ScenarioSpec {
         id: ID,
-        version: 2,
+        version: 3,
         prompt: prompt(&names),
         filesystem_root: None,
         execution: ExecutionPolicy {
@@ -281,8 +281,8 @@ fn evaluate<'a>(
         let cleanup_passed =
             response_has_evidence && active_bindings == 0 && standing_sql_triggers == 0;
 
-        Ok(assessment::objective([
-            COURIER_WORKLOAD.binary(
+        Ok(assessment::build_evaluation([
+            COURIER_WORKLOAD.full_or_zero(
                 workload_passed,
                 format!(
                     "relations={required_relations}, shipments={shipments_match}, \
@@ -293,14 +293,14 @@ fn evaluate<'a>(
                     observation.metrics.by_session.len(),
                 ),
             ),
-            LIVE_LEDGER.binary(
+            LIVE_LEDGER.full_or_zero(
                 ledger_passed,
                 format!(
                     "live_strategy={live_strategy}, no_late_root_repair={no_late_root_repair}, \
                         expected={ledger_matches_expected}, source={ledger_matches_source}"
                 ),
             ),
-            DATABASE_FAN_IN.binary(
+            DATABASE_FAN_IN.full_or_zero(
                 fan_in_passed,
                 format!(
                     "watch_before_spawn={completion_watch_before_spawn}, \
@@ -309,7 +309,7 @@ fn evaluate<'a>(
                     notifications.len(),
                 ),
             ),
-            VERIFICATION_CLEANUP.binary(
+            VERIFICATION_CLEANUP.full_or_zero(
                 cleanup_passed,
                 format!(
                     "response_evidence={response_has_evidence}, \
@@ -322,7 +322,7 @@ fn evaluate<'a>(
 
 fn missing_database() -> ObjectiveEvaluation {
     let reason = "database::query is unavailable";
-    unavailable_with_prerequisite_gate("database_capability_available", reason)
+    assessment::prerequisite_failure(ASSESSMENTS, "database_capability_available", reason)
 }
 
 fn missing_primary(databases: &BTreeSet<String>) -> ObjectiveEvaluation {
@@ -330,20 +330,7 @@ fn missing_primary(databases: &BTreeSet<String>) -> ObjectiveEvaluation {
         "database `primary` is unavailable; configured databases: {}",
         databases.iter().cloned().collect::<Vec<_>>().join(", ")
     );
-    unavailable_with_prerequisite_gate("primary_database_available", &reason)
-}
-
-fn unavailable_with_prerequisite_gate(gate_id: &str, reason: &str) -> ObjectiveEvaluation {
-    let mut evaluation = assessment::objective(
-        ASSESSMENTS
-            .iter()
-            .copied()
-            .map(|spec| spec.unavailable(reason)),
-    );
-    evaluation
-        .hard_gates
-        .push(common::gate(gate_id, false, reason));
-    evaluation
+    assessment::prerequisite_failure(ASSESSMENTS, "primary_database_available", reason)
 }
 
 fn cleanup<'a>(context: &'a E2eContext, run_id: &'a str) -> CleanupFuture<'a> {
@@ -984,7 +971,7 @@ mod tests {
     fn scenario_is_valid_and_removes_state_capability() {
         let scenario = scenario("aB19");
         scenario.validate().unwrap();
-        assert_eq!(scenario.version, 2);
+        assert_eq!(scenario.version, 3);
         assert_eq!(scenario.denied_functions, ["state::*"]);
         assert!(!scenario.needs_judge());
         assert_eq!(scenario.threshold, 90);
@@ -1067,7 +1054,7 @@ mod tests {
 
     #[test]
     fn missing_database_emits_one_prerequisite_gate_and_ordered_zero_awards() {
-        assert_unavailable_evaluation(
+        assert_prerequisite_failure(
             missing_database(),
             "database_capability_available",
             "database::query is unavailable",
@@ -1076,7 +1063,7 @@ mod tests {
 
     #[test]
     fn missing_primary_emits_one_prerequisite_gate_and_ordered_zero_awards() {
-        assert_unavailable_evaluation(
+        assert_prerequisite_failure(
             missing_primary(&BTreeSet::from([
                 "mysql".to_string(),
                 "postgres".to_string(),
@@ -1087,7 +1074,7 @@ mod tests {
         );
     }
 
-    fn assert_unavailable_evaluation(
+    fn assert_prerequisite_failure(
         evaluation: ObjectiveEvaluation,
         gate_id: &str,
         reason_fragment: &str,

--- a/harness/tests/e2e/src/scenarios/research_pipeline.rs
+++ b/harness/tests/e2e/src/scenarios/research_pipeline.rs
@@ -17,22 +17,22 @@ const SUMMARY_KEY: &str = "summary";
 const FACTS_KEY: &str = "facts";
 const MIN_ARTICLE_CHARS: usize = 5_000;
 const MAX_ARTICLE_CHARS: usize = 6_500;
-const SOURCE_CAPTURE: AssessmentSpec = AssessmentSpec::required(
+const SOURCE_CAPTURE: AssessmentSpec = AssessmentSpec::hard_gated(
     "source_capture",
     25,
     "All wakes are armed before the Wikipedia article is fetched and saved.",
 );
-const PARALLEL_ANALYSIS: AssessmentSpec = AssessmentSpec::required(
+const PARALLEL_ANALYSIS: AssessmentSpec = AssessmentSpec::hard_gated(
     "parallel_analysis",
     30,
     "The article wake causes two analysts to be spawned directly and in parallel.",
 );
-const BARRIER_FAN_IN: AssessmentSpec = AssessmentSpec::required(
+const BARRIER_FAN_IN: AssessmentSpec = AssessmentSpec::hard_gated(
     "barrier_fan_in",
     25,
     "The analysts persist valid outputs and the named barrier retires after both arrive.",
 );
-const RESEARCH_BRIEF: AssessmentSpec = AssessmentSpec::required(
+const RESEARCH_BRIEF: AssessmentSpec = AssessmentSpec::hard_gated(
     "research_brief",
     20,
     "The coordinator returns a merged brief in its barrier-woken turn and leaves no binding armed.",
@@ -285,15 +285,15 @@ fn evaluate<'a>(
             && barrier_woke;
         let report_complete = report_merged && active_bindings == 0 && no_errors;
 
-        Ok(assessment::objective([
-            SOURCE_CAPTURE.binary(
+        Ok(assessment::build_evaluation([
+            SOURCE_CAPTURE.full_or_zero(
                 source_captured,
                 format!(
                     "armed_before_fetch={armed_before_fetch}, source_order={source_order}, \
                      article_valid={article_valid}, exact_write={exact_article_write}"
                 ),
             ),
-            PARALLEL_ANALYSIS.binary(
+            PARALLEL_ANALYSIS.full_or_zero(
                 direct_parallel_analysis,
                 format!(
                     "spawns={}, parallel_calls={parallel_calls}, \
@@ -301,7 +301,7 @@ fn evaluate<'a>(
                     spawns.len()
                 ),
             ),
-            BARRIER_FAN_IN.binary(
+            BARRIER_FAN_IN.full_or_zero(
                 fan_in_complete,
                 format!(
                     "summary_valid={summary_valid}, facts_valid={facts_valid}, \
@@ -309,7 +309,7 @@ fn evaluate<'a>(
                      article_woke={article_woke}, barrier_woke={barrier_woke}"
                 ),
             ),
-            RESEARCH_BRIEF.binary(
+            RESEARCH_BRIEF.full_or_zero(
                 report_complete,
                 format!(
                     "report_merged={report_merged}, active_bindings={active_bindings}, \

--- a/harness/tests/e2e/src/scenarios/shell_coder_sandbox.rs
+++ b/harness/tests/e2e/src/scenarios/shell_coder_sandbox.rs
@@ -20,32 +20,32 @@ const SANDBOX_STDOUT: &str = "sandbox-check:35";
 const EXPECTED_CORE_OPERATIONS: usize = 12;
 const PASS_THRESHOLD: u8 = 50;
 const EXECUTION_QUALITY_WEIGHT: u8 = 45;
-const WORKER_SETUP: AssessmentSpec = AssessmentSpec::required(
+const WORKER_SETUP: AssessmentSpec = AssessmentSpec::hard_gated(
     "worker_setup",
     10,
     "Both registry workers are added and expose their required surfaces.",
 );
-const CODER_WORKFLOW: AssessmentSpec = AssessmentSpec::required(
+const CODER_WORKFLOW: AssessmentSpec = AssessmentSpec::hard_gated(
     "coder_workflow",
     20,
     "Coder inspection, create, update, move, and read operations produce the exact file.",
 );
-const HOST_EXECUTION: AssessmentSpec = AssessmentSpec::required(
+const HOST_EXECUTION: AssessmentSpec = AssessmentSpec::hard_gated(
     "host_execution",
     10,
     "The final file runs successfully on the host with exact stdout.",
 );
-const SANDBOX_LIFECYCLE: AssessmentSpec = AssessmentSpec::required(
+const SANDBOX_LIFECYCLE: AssessmentSpec = AssessmentSpec::hard_gated(
     "sandbox_lifecycle",
     10,
     "A named isolated sandbox is created, executed in, listed, and stopped.",
 );
-const COMPLETION_REPORT: AssessmentSpec = AssessmentSpec::signal(
+const COMPLETION_REPORT: AssessmentSpec = AssessmentSpec::score_only(
     "completion_report",
     5,
     "The final response includes both exact observed outputs.",
 );
-const EXECUTION_QUALITY: AssessmentSpec = AssessmentSpec::signal(
+const EXECUTION_QUALITY: AssessmentSpec = AssessmentSpec::score_only(
     "execution_quality",
     EXECUTION_QUALITY_WEIGHT,
     "The workflow completes without function-call errors; recovered errors lower quality without overriding validated effects.",
@@ -227,8 +227,8 @@ fn evaluate<'a>(
         let response_reports_outputs = observation.response.contains(HOST_STDOUT)
             && observation.response.contains(SANDBOX_STDOUT);
 
-        let mut evaluation = assessment::objective([
-            WORKER_SETUP.binary(
+        let mut evaluation = assessment::build_evaluation([
+            WORKER_SETUP.full_or_zero(
                 worker_setup,
                 format!(
                     "shell add={installed_shell}, iii-sandbox add={installed_sandbox}, \
@@ -236,7 +236,7 @@ fn evaluate<'a>(
                      sandbox ready={sandbox_surface_ready}"
                 ),
             ),
-            CODER_WORKFLOW.binary(
+            CODER_WORKFLOW.full_or_zero(
                 coder_workflow,
                 match &final_read {
                     Ok(_) => format!(
@@ -252,18 +252,18 @@ fn evaluate<'a>(
                     ),
                 },
             ),
-            HOST_EXECUTION.binary(
+            HOST_EXECUTION.full_or_zero(
                 host_execution,
                 format!(
                     "exact host execution call={host_exec}, exact successful stdout={host_output}"
                 ),
             ),
-            SANDBOX_LIFECYCLE.binary(sandbox_lifecycle, sandbox.summary()),
-            COMPLETION_REPORT.binary(
+            SANDBOX_LIFECYCLE.full_or_zero(sandbox_lifecycle, sandbox.summary()),
+            COMPLETION_REPORT.full_or_zero(
                 response_reports_outputs,
                 "awarded when the final response includes both exact outputs",
             ),
-            EXECUTION_QUALITY.points(
+            EXECUTION_QUALITY.award(
                 execution_quality_award(function_call_errors),
                 format!(
                     "observed {function_call_errors} function-call error(s); recovered errors reduce quality but validated outcomes remain authoritative"
@@ -800,14 +800,14 @@ mod tests {
             ]
         );
 
-        let mut evaluation = assessment::objective([
-            WORKER_SETUP.binary(true, "worker setup"),
-            CODER_WORKFLOW.binary(true, "coder workflow"),
-            HOST_EXECUTION.binary(true, "host execution"),
-            SANDBOX_LIFECYCLE.binary(true, "sandbox lifecycle"),
-            COMPLETION_REPORT.binary(true, "completion report"),
+        let mut evaluation = assessment::build_evaluation([
+            WORKER_SETUP.full_or_zero(true, "worker setup"),
+            CODER_WORKFLOW.full_or_zero(true, "coder workflow"),
+            HOST_EXECUTION.full_or_zero(true, "host execution"),
+            SANDBOX_LIFECYCLE.full_or_zero(true, "sandbox lifecycle"),
+            COMPLETION_REPORT.full_or_zero(true, "completion report"),
             EXECUTION_QUALITY
-                .points(EXECUTION_QUALITY_WEIGHT, "execution quality")
+                .award(EXECUTION_QUALITY_WEIGHT, "execution quality")
                 .unwrap(),
         ]);
         evaluation

--- a/harness/tests/e2e/src/scenarios/subagent_validation.rs
+++ b/harness/tests/e2e/src/scenarios/subagent_validation.rs
@@ -26,17 +26,17 @@ pub const ID: &str = "subagent_validation";
 const HOOK_TYPE: &str = "harness::hook::post-turn";
 const THRESHOLD: u64 = 6;
 const EXPECTED_ROWS: u64 = 8;
-const CHILD_GOAL: AssessmentSpec = AssessmentSpec::required(
+const CHILD_GOAL: AssessmentSpec = AssessmentSpec::hard_gated(
     "child_goal",
     35,
     "The child's table work exceeds the validator threshold and the verdict key carries the accepted count.",
 );
-const ORCHESTRATION_DISCIPLINE: AssessmentSpec = AssessmentSpec::required(
+const ORCHESTRATION_DISCIPLINE: AssessmentSpec = AssessmentSpec::hard_gated(
     "orchestration_discipline",
     35,
     "Validator scoped to the child, wake armed before the spawn, and the child spawned with the named session.",
 );
-const WAKE_REPORT: AssessmentSpec = AssessmentSpec::required(
+const WAKE_REPORT: AssessmentSpec = AssessmentSpec::hard_gated(
     "wake_report",
     30,
     "The parent finishes from the verdict wake with the exact report line.",
@@ -170,8 +170,8 @@ fn evaluate<'a>(
         let (orchestration_passed, orchestration_points) =
             orchestration_outcome(ordered, child_nudges);
 
-        Ok(assessment::objective([
-            CHILD_GOAL.required_points(
+        Ok(assessment::build_evaluation([
+            CHILD_GOAL.gate_and_points(
                 goal,
                 child_goal_points(goal, rows),
                 format!(
@@ -179,7 +179,7 @@ fn evaluate<'a>(
                      exactly {EXPECTED_ROWS} rows"
                 ),
             )?,
-            ORCHESTRATION_DISCIPLINE.required_points(
+            ORCHESTRATION_DISCIPLINE.gate_and_points(
                 orchestration_passed,
                 orchestration_points,
                 format!(
@@ -188,7 +188,7 @@ fn evaluate<'a>(
                      in the child transcript"
                 ),
             )?,
-            WAKE_REPORT.binary(reported, "expected the exact report line"),
+            WAKE_REPORT.full_or_zero(reported, "expected the exact report line"),
         ]))
     })
 }

--- a/harness/tests/e2e/src/scenarios/subagent_validation_failure.rs
+++ b/harness/tests/e2e/src/scenarios/subagent_validation_failure.rs
@@ -33,17 +33,17 @@ const EXPECTED_NUDGES: usize = 2;
 /// Wake deadline: comfortably after the child fails (~1 min), well inside
 /// the stuck timeout.
 const EXPIRY_DELAY_MS: u64 = 150_000;
-const BOUNDED_FAILURE: AssessmentSpec = AssessmentSpec::required(
+const BOUNDED_FAILURE: AssessmentSpec = AssessmentSpec::hard_gated(
     "bounded_failure",
     40,
     "The child fails after exactly the budgeted denials; the verdict key is never written.",
 );
-const ORCHESTRATION_DISCIPLINE: AssessmentSpec = AssessmentSpec::signal(
+const ORCHESTRATION_DISCIPLINE: AssessmentSpec = AssessmentSpec::score_only(
     "orchestration_discipline",
     30,
     "Validator scoped to the child and the deadline wake armed before the spawn.",
 );
-const EXPIRY_REPORT: AssessmentSpec = AssessmentSpec::required(
+const EXPIRY_REPORT: AssessmentSpec = AssessmentSpec::hard_gated(
     "expiry_report",
     30,
     "The parent is woken by the expiry notice and reports the give-up with the exact line.",
@@ -176,8 +176,8 @@ fn evaluate<'a>(
         let reported = observation.response.contains("CHILD GAVE UP")
             && observation.response.contains("PARENT DONE");
 
-        Ok(assessment::objective([
-            BOUNDED_FAILURE.binary(
+        Ok(assessment::build_evaluation([
+            BOUNDED_FAILURE.full_or_zero(
                 child_failed && verdict_absent && bounded,
                 format!(
                     "child status `{child_status}`, expected `failed`; verdict key holds \
@@ -185,14 +185,14 @@ fn evaluate<'a>(
                      {EXPECTED_NUDGES} (the child budget)"
                 ),
             ),
-            ORCHESTRATION_DISCIPLINE.binary(
+            ORCHESTRATION_DISCIPLINE.full_or_zero(
                 ordered,
                 format!(
                     "validator@{validator_index:?} wake@{wake_index:?} \
                      spawn@{spawn_index:?} — both must precede the spawn"
                 ),
             ),
-            EXPIRY_REPORT.binary(reported, "expected the exact give-up report line"),
+            EXPIRY_REPORT.full_or_zero(reported, "expected the exact give-up report line"),
         ]))
     })
 }

--- a/harness/tests/e2e/src/scenarios/timer_wake.rs
+++ b/harness/tests/e2e/src/scenarios/timer_wake.rs
@@ -10,22 +10,22 @@ use super::{
 pub const ID: &str = "timer_wake";
 
 const RESULT_KEY: &str = "result";
-const TIMER_ARMED: AssessmentSpec = AssessmentSpec::required(
+const TIMER_ARMED: AssessmentSpec = AssessmentSpec::hard_gated(
     "timer_armed",
     30,
     "One wake-only relative timer is armed before any result write.",
 );
-const PARENT_WOKEN: AssessmentSpec = AssessmentSpec::required(
+const PARENT_WOKEN: AssessmentSpec = AssessmentSpec::hard_gated(
     "parent_woken",
     30,
     "The timer retires after waking the original session exactly once.",
 );
-const WAKE_ACTION: AssessmentSpec = AssessmentSpec::required(
+const WAKE_ACTION: AssessmentSpec = AssessmentSpec::hard_gated(
     "wake_action",
     25,
     "The timer-woken turn persists the requested result.",
 );
-const CLEAN_COMPLETION: AssessmentSpec = AssessmentSpec::required(
+const CLEAN_COMPLETION: AssessmentSpec = AssessmentSpec::hard_gated(
     "clean_completion",
     15,
     "The root completes without children, errors, or surviving bindings.",
@@ -129,8 +129,8 @@ fn evaluate<'a>(
         let wake_action = exact_write && observed == expected;
         let clean_completion = active_bindings == 0 && no_errors && confirmed;
 
-        Ok(assessment::objective([
-            TIMER_ARMED.binary(
+        Ok(assessment::build_evaluation([
+            TIMER_ARMED.full_or_zero(
                 timer_armed,
                 format!(
                     "registrations={}, timers={}, writes={}",
@@ -139,15 +139,15 @@ fn evaluate<'a>(
                     writes.len()
                 ),
             ),
-            PARENT_WOKEN.binary(
+            PARENT_WOKEN.full_or_zero(
                 parent_woken,
                 format!("timer_fired={timer_fired}, root_only={root_only}"),
             ),
-            WAKE_ACTION.binary(
+            WAKE_ACTION.full_or_zero(
                 wake_action,
                 format!("exact_write={exact_write}, observed={observed}"),
             ),
-            CLEAN_COMPLETION.binary(
+            CLEAN_COMPLETION.full_or_zero(
                 clean_completion,
                 format!(
                     "active_bindings={active_bindings}, function_errors={}, confirmed={confirmed}",

--- a/harness/tests/e2e/src/scenarios/validation_chain.rs
+++ b/harness/tests/e2e/src/scenarios/validation_chain.rs
@@ -28,17 +28,17 @@ use super::{CleanupFuture, EvaluationFuture, ExecutionPolicy, ScenarioObservatio
 pub const ID: &str = "validation_chain";
 
 const HOOK_TYPE: &str = "harness::hook::post-turn";
-const BROKEN_VALIDATOR_SKIPPED: AssessmentSpec = AssessmentSpec::required(
+const BROKEN_VALIDATOR_SKIPPED: AssessmentSpec = AssessmentSpec::hard_gated(
     "broken_validator_skipped",
     30,
     "The fail_open validator errored invisibly: registered, never a nudge of its own, never blocking.",
 );
-const CHAIN_ORDER: AssessmentSpec = AssessmentSpec::required(
+const CHAIN_ORDER: AssessmentSpec = AssessmentSpec::hard_gated(
     "chain_order",
     40,
     "Exactly two denials, CHAIN-A then CHAIN-B — ascending priority, first deny wins each attempt.",
 );
-const ALL_GATES_SATISFIED: AssessmentSpec = AssessmentSpec::required(
+const ALL_GATES_SATISFIED: AssessmentSpec = AssessmentSpec::hard_gated(
     "all_gates_satisfied",
     30,
     "Rows AND marker both end satisfied — one passing validator never completes the turn alone.",
@@ -175,16 +175,16 @@ fn evaluate<'a>(
             0
         };
 
-        Ok(assessment::objective([
-            CHAIN_ORDER.binary(
+        Ok(assessment::build_evaluation([
+            CHAIN_ORDER.full_or_zero(
                 ordered,
                 format!("nudges in order: {nudges:?} — expected CHAIN-A then CHAIN-B"),
             ),
-            ALL_GATES_SATISFIED.binary(
+            ALL_GATES_SATISFIED.full_or_zero(
                 satisfied,
                 format!("rows={rows} (need 3), marker={marker} (need 1)"),
             ),
-            BROKEN_VALIDATOR_SKIPPED.required_points(
+            BROKEN_VALIDATOR_SKIPPED.gate_and_points(
                 three_registrations,
                 broken_validator_points,
                 format!(

--- a/harness/tests/e2e/src/scenarios/validation_loop.rs
+++ b/harness/tests/e2e/src/scenarios/validation_loop.rs
@@ -24,17 +24,17 @@ const HOOK_TYPE: &str = "harness::hook::post-turn";
 /// Goal: more than 6 rows; 4-row batches → exactly one denial, pass at 8.
 const THRESHOLD: u64 = 6;
 const EXPECTED_ROWS: u64 = 8;
-const GOAL_REACHED: AssessmentSpec = AssessmentSpec::required(
+const GOAL_REACHED: AssessmentSpec = AssessmentSpec::hard_gated(
     "goal_reached",
     40,
     "The goal table ends with more rows than the validator threshold.",
 );
-const VALIDATOR_DISCIPLINE: AssessmentSpec = AssessmentSpec::required(
+const VALIDATOR_DISCIPLINE: AssessmentSpec = AssessmentSpec::hard_gated(
     "validator_discipline",
     30,
     "Exactly one post-turn validator registration, carrying the custom retry_prompt.",
 );
-const LOOP_EVIDENCE: AssessmentSpec = AssessmentSpec::required(
+const LOOP_EVIDENCE: AssessmentSpec = AssessmentSpec::hard_gated(
     "loop_evidence",
     30,
     "At least one harness validation nudge was delivered and the loop converged at exactly the expected row count.",
@@ -120,12 +120,12 @@ fn evaluate<'a>(
         };
         let loop_points = loop_evidence_points(nudges, converged_exactly);
 
-        Ok(assessment::objective([
-            GOAL_REACHED.binary(
+        Ok(assessment::build_evaluation([
+            GOAL_REACHED.full_or_zero(
                 goal_reached,
                 format!("observed {rows} row(s), need more than {THRESHOLD}"),
             ),
-            VALIDATOR_DISCIPLINE.required_points(
+            VALIDATOR_DISCIPLINE.gate_and_points(
                 single_registration,
                 validator_points,
                 format!(
@@ -135,7 +135,7 @@ fn evaluate<'a>(
                     observation.metrics.totals.function_call_errors
                 ),
             )?,
-            LOOP_EVIDENCE.required_points(
+            LOOP_EVIDENCE.gate_and_points(
                 nudges >= 1,
                 loop_points,
                 format!("nudges={nudges}, rows={rows} (full marks at exactly {EXPECTED_ROWS})"),

--- a/harness/tests/e2e/src/scenarios/validation_scope_enforcement.rs
+++ b/harness/tests/e2e/src/scenarios/validation_scope_enforcement.rs
@@ -28,17 +28,17 @@ use super::{CleanupFuture, EvaluationFuture, ExecutionPolicy, ScenarioObservatio
 pub const ID: &str = "validation_scope_enforcement";
 
 const HOOK_TYPE: &str = "harness::hook::post-turn";
-const FOREIGN_SCOPE_REFUSED: AssessmentSpec = AssessmentSpec::required(
+const FOREIGN_SCOPE_REFUSED: AssessmentSpec = AssessmentSpec::hard_gated(
     "foreign_scope_refused",
     35,
     "The forbidden registration failed with the out-of-scope error and the agent continued.",
 );
-const SELF_GATE_ENGAGED: AssessmentSpec = AssessmentSpec::required(
+const SELF_GATE_ENGAGED: AssessmentSpec = AssessmentSpec::hard_gated(
     "self_gate_engaged",
     30,
     "The self-registration gated the session: exactly one denial with the marker unset.",
 );
-const TEARDOWN_UNGATED: AssessmentSpec = AssessmentSpec::required(
+const TEARDOWN_UNGATED: AssessmentSpec = AssessmentSpec::hard_gated(
     "teardown_ungated",
     35,
     "Owner unregistration removed the gate mid-loop: the turn completed with the marker still absent.",
@@ -147,14 +147,14 @@ fn evaluate<'a>(
             0
         };
 
-        Ok(assessment::objective([
-            FOREIGN_SCOPE_REFUSED.binary(
+        Ok(assessment::build_evaluation([
+            FOREIGN_SCOPE_REFUSED.full_or_zero(
                 foreign_scope_refused,
                 format!(
                     "attempted={foreign_attempted}, out-of-scope error visible={refusal_delivered}"
                 ),
             ),
-            SELF_GATE_ENGAGED.required_points(
+            SELF_GATE_ENGAGED.gate_and_points(
                 nudges == 1,
                 self_gate_points,
                 format!(
@@ -162,7 +162,7 @@ fn evaluate<'a>(
                      exactly one before teardown"
                 ),
             )?,
-            TEARDOWN_UNGATED.binary(
+            TEARDOWN_UNGATED.full_or_zero(
                 teardown_ungated,
                 format!(
                     "marker={marker}, teardown_called={teardown_called}, reported={reported} \

--- a/harness/tests/e2e/src/scenarios/validation_self_repair.rs
+++ b/harness/tests/e2e/src/scenarios/validation_self_repair.rs
@@ -31,17 +31,17 @@ pub const ID: &str = "validation_self_repair";
 
 const HOOK_TYPE: &str = "harness::hook::post-turn";
 const REQUIRED_NAMES: [&str; 4] = ["alpha", "beta", "gamma", "delta"];
-const DATA_REPAIRED: AssessmentSpec = AssessmentSpec::required(
+const DATA_REPAIRED: AssessmentSpec = AssessmentSpec::hard_gated(
     "data_repaired",
     40,
     "All invariants hold at the end and every required name survived the repair.",
 );
-const DIAGNOSIS_DRIVEN: AssessmentSpec = AssessmentSpec::required(
+const DIAGNOSIS_DRIVEN: AssessmentSpec = AssessmentSpec::hard_gated(
     "diagnosis_driven",
     30,
     "The auditor rejected the flawed seed with a factual defect list (no prescribed fix), via one envelope-mode registration.",
 );
-const DECISIVE_REPAIR: AssessmentSpec = AssessmentSpec::signal(
+const DECISIVE_REPAIR: AssessmentSpec = AssessmentSpec::score_only(
     "decisive_repair",
     30,
     "The model's own repair converged in one round (half credit for two).",
@@ -250,12 +250,12 @@ fn evaluate<'a>(
                 && text.contains("duplicate name: beta")
         });
 
-        Ok(assessment::objective([
-            DATA_REPAIRED.binary(
+        Ok(assessment::build_evaluation([
+            DATA_REPAIRED.full_or_zero(
                 repaired,
                 format!("rows={}, remaining violations: {remaining:?}", rows.len()),
             ),
-            DIAGNOSIS_DRIVEN.binary(
+            DIAGNOSIS_DRIVEN.full_or_zero(
                 diagnosed && envelope_mode,
                 format!(
                     "first audit nudge: {:?}; observed {} post-turn registration(s); need \
@@ -264,7 +264,7 @@ fn evaluate<'a>(
                     registrations.len()
                 ),
             ),
-            DECISIVE_REPAIR.points(
+            DECISIVE_REPAIR.award(
                 match nudges.len() {
                     1 => 30,
                     2 => 15,

--- a/harness/tests/e2e/src/suite.rs
+++ b/harness/tests/e2e/src/suite.rs
@@ -16,7 +16,9 @@ use crate::report::{
     RetryAttemptReport, RunStatus,
 };
 use crate::scenarios::common;
-use crate::scenarios::{CriterionAward, ScenarioId, ScenarioObservation, ScenarioSpec};
+use crate::scenarios::{
+    CriterionAward, ObjectiveEvaluation, ScenarioId, ScenarioObservation, ScenarioSpec,
+};
 
 const MAX_RUNS: u32 = 20;
 const MAX_TECHNICAL_RETRIES: u8 = 3;
@@ -243,7 +245,10 @@ async fn run_once(
         report.push_failure(
             RunStatus::InfrastructureError,
             FailurePhase::Cleanup,
-            format!("harness::teardown: {error}"),
+            format!(
+                "scenario '{}': harness::teardown failed: {error:#}",
+                spec.id
+            ),
         );
     }
     if let Some(cleanup) = spec.cleanup {
@@ -251,7 +256,7 @@ async fn run_once(
             report.push_failure(
                 RunStatus::InfrastructureError,
                 FailurePhase::Cleanup,
-                error.to_string(),
+                format!("scenario '{}': scenario cleanup failed: {error:#}", spec.id),
             );
         }
     }
@@ -272,7 +277,10 @@ async fn run_once(
             report.push_failure(
                 RunStatus::InfrastructureError,
                 FailurePhase::Evaluate,
-                "evaluation completed without a score",
+                format!(
+                    "scenario '{}': evaluation completed without a score; expected criterion awards or a judge score",
+                    spec.id
+                ),
             );
         }
     }
@@ -453,10 +461,10 @@ async fn execute(
             RunFailure::new(
                 RunStatus::InfrastructureError,
                 FailurePhase::Evaluate,
-                error.to_string(),
+                format!("scenario '{}' evaluator failed: {error:#}", spec.id),
             )
         })?;
-    validate_objective_awards(spec, &objective.awards).map_err(|error| {
+    validate_objective_evaluation(spec, &objective).map_err(|error| {
         RunFailure::new(
             RunStatus::InfrastructureError,
             FailurePhase::Evaluate,
@@ -484,7 +492,7 @@ async fn execute(
                 return Err(RunFailure::new(
                     RunStatus::JudgeError,
                     FailurePhase::Evaluate,
-                    error.to_string(),
+                    format!("scenario '{}' judge evaluation failed: {error:#}", spec.id),
                 ));
             }
         }
@@ -639,42 +647,115 @@ fn update_score(report: &mut E2eRunReport) {
     });
 }
 
-fn validate_objective_awards(spec: &ScenarioSpec, awards: &[CriterionAward]) -> Result<()> {
+fn validate_objective_evaluation(
+    spec: &ScenarioSpec,
+    evaluation: &ObjectiveEvaluation,
+) -> Result<()> {
+    let mut gate_ids = HashSet::new();
+    for gate in &evaluation.hard_gates {
+        if gate.id.trim().is_empty() {
+            bail!(
+                "scenario '{}': evaluation contract violation: hard gate id is empty; expected a stable non-empty identifier",
+                spec.id
+            );
+        }
+        if gate.reason.trim().is_empty() {
+            bail!(
+                "scenario '{}': evaluation contract violation: hard gate '{}' has an empty reason; include the observed evidence",
+                spec.id, gate.id
+            );
+        }
+        if !gate_ids.insert(gate.id.as_str()) {
+            bail!(
+                "scenario '{}': evaluation contract violation: hard gate '{}' was returned more than once; expected unique gate ids",
+                spec.id, gate.id
+            );
+        }
+    }
+
     if spec.needs_judge() {
-        if awards.is_empty() {
+        if evaluation.awards.is_empty() {
             return Ok(());
         }
         bail!(
-            "scenario {} delegates all criterion scores to the judge",
-            spec.id
+            "scenario '{}': evaluation contract violation: judge-backed evaluator returned awards [{}]; expected no awards because the judge owns criterion scoring",
+            spec.id,
+            evaluation
+                .awards
+                .iter()
+                .map(|award| format!("'{}'", award.id))
+                .collect::<Vec<_>>()
+                .join(", ")
         );
     }
+
     let criteria: HashMap<_, _> = spec
         .criteria
         .iter()
         .map(|criterion| (criterion.id, criterion))
         .collect();
     let mut seen = HashSet::new();
-    for award in awards {
+    for award in &evaluation.awards {
+        if award.id.trim().is_empty() {
+            bail!(
+                "scenario '{}': evaluation contract violation: criterion award id is empty; expected one award per configured criterion",
+                spec.id
+            );
+        }
+        if award.reason.trim().is_empty() {
+            bail!(
+                "scenario '{}': evaluation contract violation: criterion '{}' has an empty reason; include the observed evidence",
+                spec.id, award.id
+            );
+        }
         let criterion = criteria
             .get(award.id.as_str())
-            .with_context(|| format!("unknown objective criterion {}", award.id))?;
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "scenario '{}': evaluation contract violation: unknown criterion '{}'; expected one of [{}]; action: return exactly one award for each configured criterion",
+                    spec.id,
+                    award.id,
+                    spec.criteria
+                        .iter()
+                        .map(|criterion| format!("'{}'", criterion.id))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            })?;
         if award.awarded > criterion.weight {
             bail!(
-                "criterion {} awarded {} of {} points",
-                award.id,
+                "scenario '{}': evaluation contract violation: criterion '{}' awarded {}; expected awarded in 0..={}; action: reduce the award or change the configured weight",
+                spec.id, award.id,
                 award.awarded,
                 criterion.weight
             );
         }
         if !seen.insert(award.id.as_str()) {
-            bail!("objective evaluator repeated criterion {}", criterion.id);
+            bail!(
+                "scenario '{}': evaluation contract violation: criterion '{}' was returned more than once; expected exactly one award per configured criterion",
+                spec.id, criterion.id
+            );
         }
     }
-    for criterion in &spec.criteria {
-        if !seen.contains(criterion.id) {
-            bail!("objective evaluator omitted criterion {}", criterion.id);
-        }
+    let missing = spec
+        .criteria
+        .iter()
+        .filter(|criterion| !seen.contains(criterion.id))
+        .map(|criterion| format!("'{}'", criterion.id))
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        let received = evaluation
+            .awards
+            .iter()
+            .map(|award| format!("'{}'", award.id))
+            .collect::<Vec<_>>()
+            .join(", ");
+        bail!(
+            "scenario '{}': evaluation contract violation: missing awards [{}]; received [{}]; expected exactly one award per configured criterion",
+            spec.id,
+            missing.join(", "),
+            received
+        );
     }
     Ok(())
 }
@@ -761,25 +842,108 @@ mod tests {
     #[test]
     fn objective_awards_must_be_complete_and_bounded() {
         let spec = spec();
-        assert!(validate_objective_awards(
+        assert!(validate_objective_evaluation(
             &spec,
-            &[CriterionAward {
-                id: "objective".into(),
-                awarded: 100,
-                reason: "ok".into(),
-            }]
+            &ObjectiveEvaluation {
+                hard_gates: Vec::new(),
+                awards: vec![CriterionAward {
+                    id: "objective".into(),
+                    awarded: 100,
+                    reason: "ok".into(),
+                }],
+            }
         )
         .is_ok());
-        assert!(validate_objective_awards(&spec, &[]).is_err());
-        assert!(validate_objective_awards(
+        assert!(validate_objective_evaluation(
             &spec,
-            &[CriterionAward {
-                id: "objective".into(),
-                awarded: 101,
-                reason: "too high".into(),
-            }]
+            &ObjectiveEvaluation {
+                hard_gates: Vec::new(),
+                awards: Vec::new(),
+            }
         )
         .is_err());
+        let error = validate_objective_evaluation(
+            &spec,
+            &ObjectiveEvaluation {
+                hard_gates: Vec::new(),
+                awards: vec![CriterionAward {
+                    id: "objective".into(),
+                    awarded: 101,
+                    reason: "too high".into(),
+                }],
+            },
+        )
+        .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "scenario 'case': evaluation contract violation: criterion 'objective' awarded 101; expected awarded in 0..=100; action: reduce the award or change the configured weight"
+        );
+    }
+
+    #[test]
+    fn objective_contract_errors_identify_the_invalid_ids_and_values() {
+        let spec = spec();
+        let unknown = validate_objective_evaluation(
+            &spec,
+            &ObjectiveEvaluation {
+                hard_gates: Vec::new(),
+                awards: vec![CriterionAward {
+                    id: "unknown".into(),
+                    awarded: 1,
+                    reason: "observed".into(),
+                }],
+            },
+        )
+        .unwrap_err();
+        assert_eq!(
+            unknown.to_string(),
+            "scenario 'case': evaluation contract violation: unknown criterion 'unknown'; expected one of ['objective']; action: return exactly one award for each configured criterion"
+        );
+
+        let duplicate = validate_objective_evaluation(
+            &spec,
+            &ObjectiveEvaluation {
+                hard_gates: Vec::new(),
+                awards: vec![
+                    CriterionAward {
+                        id: "objective".into(),
+                        awarded: 1,
+                        reason: "first".into(),
+                    },
+                    CriterionAward {
+                        id: "objective".into(),
+                        awarded: 1,
+                        reason: "second".into(),
+                    },
+                ],
+            },
+        )
+        .unwrap_err();
+        assert_eq!(
+            duplicate.to_string(),
+            "scenario 'case': evaluation contract violation: criterion 'objective' was returned more than once; expected exactly one award per configured criterion"
+        );
+
+        let empty_gate = validate_objective_evaluation(
+            &spec,
+            &ObjectiveEvaluation {
+                hard_gates: vec![HardGateReport {
+                    id: String::new(),
+                    passed: false,
+                    reason: "observed".into(),
+                }],
+                awards: vec![CriterionAward {
+                    id: "objective".into(),
+                    awarded: 1,
+                    reason: "observed".into(),
+                }],
+            },
+        )
+        .unwrap_err();
+        assert_eq!(
+            empty_gate.to_string(),
+            "scenario 'case': evaluation contract violation: hard gate id is empty; expected a stable non-empty identifier"
+        );
     }
 
     #[test]


### PR DESCRIPTION
This PR makes assessment authoring and evaluation failures easier to diagnose while preserving the existing objective scoring behavior. It is stacked on the prerequisite-assessment migration PR.

## Technical details

- Clarifies assessment API names around hard-gated checks, score-only assessments, awards, and evaluation assembly.
- Adds prerequisite-failure construction so skipped assessments retain an explicit cause.
- Improves validation errors with the scenario, assessment, observed values, and expected constraints.
- Adds detailed objective-evaluation contract errors for invalid, duplicate, missing, or excessive gates and awards.
- Updates the authoring documentation and affected scenario versions where the reported output changed.

Validation: `cargo test --locked --manifest-path harness/Cargo.toml -p harness-e2e`, `SKIP_UI_BUILD=1 cargo clippy --locked --manifest-path harness/Cargo.toml -p harness-e2e --all-targets -- -D warnings`, `cargo fmt --manifest-path harness/Cargo.toml --all -- --check`, and `git diff --check`.

Refs MOT-4381
