### PR TITLE
(MOT-4385) fix(release): make rerun recovery attempt-aware

### DIFF
--- a/.github/scripts/registry_publish.py
+++ b/.github/scripts/registry_publish.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Publish a worker and reconcile ambiguous Registry responses."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import urllib.error
+from pathlib import Path
+from typing import Any
+
+from registry_release import RegistryError, request_json, resolve_version
+
+
+def reconcile_publish(
+    api_url: str,
+    worker: str,
+    version: str,
+    registry_tag: str,
+    reason: str,
+) -> dict[str, Any]:
+    try:
+        resolved = resolve_version(api_url, worker, registry_tag, allow_missing=True)
+    except (RegistryError, TimeoutError, OSError, urllib.error.URLError) as error:
+        raise RegistryError(
+            f"{reason}; Registry reconciliation also failed: {error}; publication state is unknown"
+        ) from error
+    if resolved != version:
+        raise RegistryError(
+            f"{reason}; {worker}@{registry_tag} resolves {resolved or 'nothing'}, "
+            f"expected {version}; publication state is unknown"
+        )
+    return {
+        "worker": worker,
+        "version": version,
+        "registry_tag": registry_tag,
+        "resolved_version": resolved,
+        "reconciled": True,
+        "reason": reason,
+    }
+
+
+def publish(
+    api_url: str,
+    api_key: str,
+    payload: dict[str, Any],
+    worker: str,
+    version: str,
+    registry_tag: str,
+) -> dict[str, Any]:
+    try:
+        status, response = request_json(
+            "POST",
+            f"{api_url.rstrip('/')}/publish",
+            payload,
+            api_key=api_key,
+        )
+    except (json.JSONDecodeError, UnicodeDecodeError, TimeoutError, OSError, urllib.error.URLError) as error:
+        return reconcile_publish(
+            api_url,
+            worker,
+            version,
+            registry_tag,
+            f"publish transport failed: {error}",
+        )
+
+    if status == 200:
+        return {
+            "worker": worker,
+            "version": version,
+            "registry_tag": registry_tag,
+            "reconciled": False,
+            "registry_response": response,
+        }
+    if status == 409:
+        return reconcile_publish(
+            api_url,
+            worker,
+            version,
+            registry_tag,
+            "Registry reported a duplicate publish",
+        )
+    raise RegistryError(f"publish failed with HTTP {status}: {json.dumps(response, sort_keys=True)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--api-url", required=True)
+    parser.add_argument("--worker", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--registry-tag", choices=("next", "latest"), required=True)
+    parser.add_argument("--payload", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    api_key = os.environ.get("WORKERS_REGISTRY_API_KEY", "")
+    if not api_key:
+        raise SystemExit("WORKERS_REGISTRY_API_KEY is required")
+    try:
+        result = publish(
+            args.api_url,
+            api_key,
+            json.loads(args.payload.read_text()),
+            args.worker,
+            args.version,
+            args.registry_tag,
+        )
+    except RegistryError as error:
+        print(f"::error::{error}")
+        raise SystemExit(1) from error
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/tests/test_registry_publish.py
+++ b/.github/scripts/tests/test_registry_publish.py
@@ -1,0 +1,63 @@
+import urllib.error
+import unittest
+from unittest.mock import patch
+
+import registry_publish
+from registry_release import RegistryError
+
+
+PAYLOAD = {"worker": "iii-directory", "version": "1.2.0"}
+
+
+class RegistryPublishTests(unittest.TestCase):
+    def test_publish_accepts_a_normal_success(self):
+        with patch.object(registry_publish, "request_json", return_value=(200, {"ok": True})):
+            result = registry_publish.publish(
+                "https://registry", "secret", PAYLOAD, "iii-directory", "1.2.0", "next"
+            )
+
+        self.assertFalse(result["reconciled"])
+        self.assertEqual(result["registry_response"], {"ok": True})
+
+    def test_publish_reconciles_duplicate_or_ambiguous_transport_failure(self):
+        failures = [
+            (409, {"error": "already exists"}),
+            urllib.error.URLError("timed out"),
+        ]
+        for failure in failures:
+            with self.subTest(failure=failure):
+                if isinstance(failure, Exception):
+                    request = patch.object(registry_publish, "request_json", side_effect=failure)
+                else:
+                    request = patch.object(registry_publish, "request_json", return_value=failure)
+                with request, patch.object(registry_publish, "resolve_version", return_value="1.2.0"):
+                    result = registry_publish.publish(
+                        "https://registry", "secret", PAYLOAD, "iii-directory", "1.2.0", "next"
+                    )
+
+                self.assertTrue(result["reconciled"])
+                self.assertEqual(result["resolved_version"], "1.2.0")
+
+    def test_publish_reports_unknown_state_when_transport_fails_and_channel_does_not_match(self):
+        with (
+            patch.object(registry_publish, "request_json", side_effect=urllib.error.URLError("timed out")),
+            patch.object(registry_publish, "resolve_version", return_value="1.1.2"),
+            self.assertRaisesRegex(RegistryError, "publication state is unknown"),
+        ):
+            registry_publish.publish(
+                "https://registry", "secret", PAYLOAD, "iii-directory", "1.2.0", "next"
+            )
+
+    def test_publish_reports_unknown_state_when_reconciliation_also_times_out(self):
+        with (
+            patch.object(registry_publish, "request_json", side_effect=urllib.error.URLError("publish timed out")),
+            patch.object(registry_publish, "resolve_version", side_effect=urllib.error.URLError("resolve timed out")),
+            self.assertRaisesRegex(RegistryError, "reconciliation also failed"),
+        ):
+            registry_publish.publish(
+                "https://registry", "secret", PAYLOAD, "iii-directory", "1.2.0", "next"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -352,41 +352,24 @@ jobs:
       - name: POST /publish
         env:
           API_URL: ${{ inputs.api_url }}
-          API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}
+          WORKERS_REGISTRY_API_KEY: ${{ secrets.WORKERS_REGISTRY_API_KEY }}
           WORKER: ${{ inputs.worker }}
           VERSION: ${{ inputs.version }}
           REGISTRY_TAG: ${{ inputs.registry_tag }}
         run: |
           set -euo pipefail
-          if [[ -z "$API_KEY" ]]; then
+          if [[ -z "$WORKERS_REGISTRY_API_KEY" ]]; then
             echo "::error::WORKERS_REGISTRY_API_KEY secret is not set"
             exit 1
           fi
-          http=$(curl -sS -o response.json -w '%{http_code}' \
-            -H "X-API-Key: $API_KEY" \
-            -H "Content-Type: application/json" \
-            -X POST "$API_URL/publish" \
-            --data-binary @payload.json)
-          echo "HTTP $http"
+          python3 .github/scripts/registry_publish.py \
+            --api-url "$API_URL" \
+            --worker "$WORKER" \
+            --version "$VERSION" \
+            --registry-tag "$REGISTRY_TAG" \
+            --payload payload.json \
+            --output response.json
           cat response.json
-          if [[ "$http" == "409" ]]; then
-            resolve_http=$(curl -sS -o resolve-response.json -w '%{http_code}' \
-              -H "Content-Type: application/json" \
-              -X POST "$API_URL/resolve" \
-              --data "$(jq -cn --arg worker "$WORKER" --arg version "$REGISTRY_TAG" \
-                '{worker: $worker, version: $version}')")
-            resolved=$(jq -r '.root.version // empty' resolve-response.json)
-            if [[ "$resolve_http" == "200" && "$resolved" == "$VERSION" ]]; then
-              echo "::notice::$WORKER@$VERSION already exists and $REGISTRY_TAG still points to it; continuing idempotently"
-            else
-              echo "::error::duplicate publish is not a safe retry: $WORKER@$REGISTRY_TAG resolved ${resolved:-nothing} (HTTP $resolve_http), expected $VERSION"
-              cat resolve-response.json
-              exit 1
-            fi
-          elif [[ "$http" != "200" ]]; then
-            echo "::error::publish failed with HTTP $http"
-            exit 1
-          fi
 
       - name: Build skills payload
         id: skills_payload

--- a/.github/workflows/promote-worker.yml
+++ b/.github/workflows/promote-worker.yml
@@ -18,13 +18,28 @@ on:
         required: false
         type: string
         default: ''
+      release_run_attempt:
+        description: 'Expected Release run attempt (empty = current attempt)'
+        required: false
+        type: string
+        default: ''
       candidate_evidence_run_id:
         description: 'Run containing candidate evidence; empty uses the Release run'
         required: false
         type: string
         default: ''
+      candidate_evidence_run_attempt:
+        description: 'Expected candidate-evidence run attempt (empty = current attempt)'
+        required: false
+        type: string
+        default: ''
       e2e_run_id:
         description: 'Promotion-ready deployed E2E run; required for Harness and auto-located when empty'
+        required: false
+        type: string
+        default: ''
+      e2e_run_attempt:
+        description: 'Expected deployed E2E run attempt (empty = current attempt)'
         required: false
         type: string
         default: ''
@@ -91,8 +106,11 @@ jobs:
         env:
           VERSION_INPUT: ${{ inputs.version }}
           RUN_ID_INPUT: ${{ inputs.release_run_id }}
+          RUN_ATTEMPT_INPUT: ${{ inputs.release_run_attempt }}
           EVIDENCE_RUN_ID_INPUT: ${{ inputs.candidate_evidence_run_id }}
+          EVIDENCE_RUN_ATTEMPT_INPUT: ${{ inputs.candidate_evidence_run_attempt }}
           E2E_RUN_ID_INPUT: ${{ inputs.e2e_run_id }}
+          E2E_RUN_ATTEMPT_INPUT: ${{ inputs.e2e_run_attempt }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -125,7 +143,16 @@ jobs:
           if [[ -z "$run_id" ]]; then
             tag="${WORKER}/v${version}"
             run_id=$(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/release.yml/runs" \
-              -f head_branch="$tag" --jq '.workflow_runs[0].id // empty')
+              -f branch="$tag" -f status=completed -f per_page=100 | \
+              jq -r --arg tag "$tag" '
+                [.workflow_runs[] | select(
+                  .path == ".github/workflows/release.yml" and
+                  .head_branch == $tag and
+                  .event == "push" and
+                  .status == "completed" and
+                  .conclusion == "success"
+                )][0].id // empty
+              ')
             [[ -n "$run_id" ]] || {
               echo "::error::No Release run found for tag ${tag}; pass release_run_id explicitly"
               exit 2
@@ -136,14 +163,28 @@ jobs:
             echo "::error::release_run_id must be numeric"
             exit 2
           }
+          release_attempt="$RUN_ATTEMPT_INPUT"
+          if [[ -n "$release_attempt" && ! "$release_attempt" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::release_run_attempt must be a positive integer"
+            exit 2
+          fi
 
           evidence_run_id="${EVIDENCE_RUN_ID_INPUT:-$run_id}"
           [[ "$evidence_run_id" =~ ^[0-9]+$ ]] || {
             echo "::error::candidate_evidence_run_id must be numeric"
             exit 2
           }
+          evidence_attempt="$EVIDENCE_RUN_ATTEMPT_INPUT"
+          if [[ -z "$evidence_attempt" && "$evidence_run_id" == "$run_id" ]]; then
+            evidence_attempt="$release_attempt"
+          fi
+          if [[ -n "$evidence_attempt" && ! "$evidence_attempt" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::candidate_evidence_run_attempt must be a positive integer"
+            exit 2
+          fi
 
           e2e_run_id="$E2E_RUN_ID_INPUT"
+          e2e_attempt="$E2E_RUN_ATTEMPT_INPUT"
           if [[ "$WORKER" == harness && -z "$e2e_run_id" ]]; then
             title="Harness E2E · ${WORKER}@${version} ·"
             mapfile -t e2e_candidates < <(gh api -X GET \
@@ -180,12 +221,19 @@ jobs:
             echo "::error::e2e_run_id must be numeric"
             exit 2
           fi
+          if [[ -n "$e2e_attempt" && ! "$e2e_attempt" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::e2e_run_attempt must be a positive integer"
+            exit 2
+          fi
 
           {
             echo "VERSION=${version}"
             echo "RELEASE_RUN_ID=${run_id}"
+            echo "EXPECTED_RELEASE_RUN_ATTEMPT=${release_attempt}"
             echo "EVIDENCE_RUN_ID=${evidence_run_id}"
+            echo "EXPECTED_EVIDENCE_RUN_ATTEMPT=${evidence_attempt}"
             echo "E2E_RUN_ID=${e2e_run_id}"
+            echo "EXPECTED_E2E_RUN_ATTEMPT=${e2e_attempt}"
             echo "PROMOTION_OPERATION_ID=${{ inputs.operation_id || format('github:{0}', github.run_id) }}"
             echo "PROMOTION_STEP_ID=${{ inputs.step_id || 'promote' }}"
           } >>"$GITHUB_ENV"
@@ -204,6 +252,11 @@ jobs:
             echo "::error::run $RELEASE_RUN_ID did not execute release.yml"
             exit 1
           }
+          release_attempt=$(jq -r .run_attempt release-run.json)
+          if [[ -n "$EXPECTED_RELEASE_RUN_ATTEMPT" && "$release_attempt" != "$EXPECTED_RELEASE_RUN_ATTEMPT" ]]; then
+            echo "::error::Release run attempt is $release_attempt, expected $EXPECTED_RELEASE_RUN_ATTEMPT"
+            exit 1
+          fi
           event=$(jq -r .event release-run.json)
           [[ "$event" == push || "$event" == workflow_dispatch ]] || {
             echo "::error::Release run event '$event' is not promotable"
@@ -226,6 +279,11 @@ jobs:
               echo "::error::run $EVIDENCE_RUN_ID cannot produce candidate evidence"
               exit 1
             }
+          fi
+          evidence_attempt=$(jq -r .run_attempt evidence-run.json)
+          if [[ -n "$EXPECTED_EVIDENCE_RUN_ATTEMPT" && "$evidence_attempt" != "$EXPECTED_EVIDENCE_RUN_ATTEMPT" ]]; then
+            echo "::error::Evidence run attempt is $evidence_attempt, expected $EXPECTED_EVIDENCE_RUN_ATTEMPT"
+            exit 1
           fi
 
       - name: Download candidate evidence
@@ -306,6 +364,10 @@ jobs:
             --version "$VERSION" \
             --output validated-harness-e2e.json
           run_attempt=$(jq -r .run_attempt e2e-run.json)
+          if [[ -n "$EXPECTED_E2E_RUN_ATTEMPT" && "$run_attempt" != "$EXPECTED_E2E_RUN_ATTEMPT" ]]; then
+            echo "::error::E2E run attempt is $run_attempt, expected $EXPECTED_E2E_RUN_ATTEMPT"
+            exit 1
+          fi
           evidence_attempt=$(jq -r .run_attempt validated-harness-e2e.json)
           [[ "$run_attempt" == "$evidence_attempt" ]] || {
             echo "::error::E2E run attempt is $run_attempt, evidence records $evidence_attempt"

--- a/.github/workflows/repair-worker-release.yml
+++ b/.github/workflows/repair-worker-release.yml
@@ -16,6 +16,11 @@ on:
         description: Original Release workflow run
         required: true
         type: string
+      release_run_attempt:
+        description: 'Expected Release run attempt (empty = current attempt)'
+        required: false
+        type: string
+        default: ''
       action:
         description: Repair action
         required: true
@@ -97,6 +102,10 @@ jobs:
             echo "::error::release_run_id must be numeric"
             exit 2
           }
+          if [[ -n "${{ inputs.release_run_attempt }}" && ! "${{ inputs.release_run_attempt }}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::release_run_attempt must be a positive integer"
+            exit 2
+          fi
           {
             echo "operation_id=${OPERATION_ID_INPUT:-github:${GITHUB_RUN_ID}}"
             echo "step_id=${STEP_ID_INPUT:-repair}"
@@ -123,6 +132,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_RUN_ID: ${{ inputs.release_run_id }}
+          EXPECTED_RELEASE_ATTEMPT: ${{ inputs.release_run_attempt }}
           WORKER: ${{ inputs.worker }}
           VERSION: ${{ inputs.version }}
           TAG: ${{ steps.meta.outputs.tag }}
@@ -131,18 +141,28 @@ jobs:
           set -euo pipefail
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RELEASE_RUN_ID" >release-run.json
           jq -e '
-            .name == "Release" and
-            (.path | startswith(".github/workflows/release.yml@")) and
-            (.event == "push" or .event == "workflow_dispatch")
+            .path == ".github/workflows/release.yml" and
+            (.event == "push" or .event == "workflow_dispatch") and
+            .status == "completed"
           ' release-run.json >/dev/null || {
             echo "::error::run $RELEASE_RUN_ID is not a standard Release run"
             exit 1
           }
+          run_attempt=$(jq -r .run_attempt release-run.json)
+          if [[ -n "$EXPECTED_RELEASE_ATTEMPT" && "$run_attempt" != "$EXPECTED_RELEASE_ATTEMPT" ]]; then
+            echo "::error::Release run attempt is $run_attempt, expected $EXPECTED_RELEASE_ATTEMPT"
+            exit 1
+          fi
           event=$(jq -r .event release-run.json)
           if [[ "$event" == push ]]; then
             jq -e --arg tag "$TAG" --arg sha "$EXPECTED_TAG_SHA" \
               '.head_branch == $tag and .head_sha == $sha' release-run.json >/dev/null || {
               echo "::error::push run $RELEASE_RUN_ID does not match $TAG at $EXPECTED_TAG_SHA"
+              exit 1
+            }
+          else
+            jq -e --arg title "Release · $TAG" '.display_title == $title' release-run.json >/dev/null || {
+              echo "::error::workflow_dispatch run $RELEASE_RUN_ID is not for $TAG"
               exit 1
             }
           fi
@@ -151,6 +171,21 @@ jobs:
             --name "release-candidate-${WORKER}-${VERSION}" --dir source 2>/dev/null || true
           gh run download "$RELEASE_RUN_ID" --repo "$GITHUB_REPOSITORY" \
             --name "release-result-${RELEASE_RUN_ID}" --dir source 2>/dev/null || true
+
+          evidence_found=false
+          for evidence_file in source/release-candidate.json source/release-result.json; do
+            [[ -s "$evidence_file" ]] || continue
+            evidence_found=true
+            evidence_attempt=$(jq -r '.run_attempt // empty' "$evidence_file")
+            [[ "$evidence_attempt" == "$run_attempt" ]] || {
+              echo "::error::$evidence_file records attempt ${evidence_attempt:-missing}, current Release attempt is $run_attempt"
+              exit 1
+            }
+          done
+          [[ "$evidence_found" == true ]] || {
+            echo "::error::run $RELEASE_RUN_ID attempt $run_attempt has no attempt-scoped release evidence"
+            exit 1
+          }
 
           evidence_sha=$(jq -r '.tag_sha // empty' source/release-candidate.json 2>/dev/null || true)
           if [[ -z "$evidence_sha" ]]; then


### PR DESCRIPTION
## Summary

- validate repair and promotion against the exact GitHub run attempt
- locate manual promotion runs with the supported `branch` filter and defensive release identity checks
- reconcile Registry publish timeouts and duplicate responses before classifying publication as failed
- emit an actionable `publication state is unknown` error when neither publish nor reconciliation can establish the result

## Root cause

GitHub reruns reuse the same run ID while producing new attempt-scoped artifacts. The repair workflow matched unstable API fields, manual promotion used an ignored `head_branch` parameter, and a transport timeout from `/publish` exited before checking whether the Registry had committed the version.

## Impact

A successful rerun can be verified without accidentally consuming evidence from another attempt. Transient publish failures become idempotent success when the requested channel already resolves to the exact version, while unresolved effects fail closed with a precise message.

## Validation

- 4 focused Registry publish reconciliation tests
- Python compile check
- workflow YAML parse check
- actionlint 1.7.12
- `git diff --check`

Refs MOT-4385

Paired Release Control PR: iii-hq/release-control#12.

Merge this PR first so the new attempt inputs exist before Release Control dispatches them.
