### PR TITLE
(MOT-4388) feat(shell): sandbox target picker on the page

### DIFF
--- a/shell/ui/src/page/EditorPane.tsx
+++ b/shell/ui/src/page/EditorPane.tsx
@@ -2,6 +2,12 @@
    CodeEditor over `coder::read-file` / `coder::create-file(overwrite)`.
    Never bundles an editor: Monaco ships once, inside the console.
 
+   With a sandbox target selected the pane goes read-only: reads ride
+   `shell::exec` stdout (guestReadFile — the coder surface is host-only
+   and the page cannot consume `shell::fs::read`'s stream channel), and
+   writes have no guest path at all (`shell::fs::write` demands the
+   streamed ContentRef form on sandbox targets).
+
    File content + unsaved drafts live in a page-owned cache keyed by
    path, so switching editor tabs never discards edits: the pane is
    remounted per file (key=path) and rehydrates from the cache instead
@@ -11,6 +17,7 @@ import { CodeEditor, type Host } from '@iii-dev/console-ui'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { errorMessage, formatBytes } from '../lib/format'
 import { coderReadFile, coderWriteFile, joinPath } from './coder'
+import { guestReadFile } from './sandbox'
 
 /** File-extension → Monaco language id (unknown ids render plain). */
 export function monacoLangFromPath(path: string): string {
@@ -66,9 +73,10 @@ export function monacoLangFromPath(path: string): string {
   }
 }
 
-/** Read-only reasons: binary content, or a byte-capped read (saving a
-    truncated body would destroy the tail). */
-export type ReadOnlyReason = 'binary' | 'truncated' | null
+/** Read-only reasons: binary content, a byte-capped read (saving a
+    truncated body would destroy the tail), or a sandbox target (no
+    guest write path — see the header comment). */
+export type ReadOnlyReason = 'binary' | 'truncated' | 'sandbox' | null
 
 export interface EditorCacheEntry {
   /** What the worker last gave (or accepted) for this file. */
@@ -92,6 +100,8 @@ interface EditorPaneProps {
   host: Host
   root: string
   relPath: string
+  /** Sandbox target of the browsed tree; null = host. */
+  sandboxId: string | null
   cache: EditorCache
   /** Fired after a successful save (the git tab refreshes on it). */
   onSaved: () => void
@@ -103,6 +113,7 @@ export function EditorPane({
   host,
   root,
   relPath,
+  sandboxId,
   cache,
   onSaved,
   onDirtyChange,
@@ -128,25 +139,40 @@ export function EditorPane({
       return
     }
     setPane({ phase: 'loading' })
-    coderReadFile(host, absPath)
-      .then((out) => {
-        if (seqRef.current !== seq) return
-        const content = out.content ?? ''
-        const fresh: EditorCacheEntry = {
-          savedContent: content,
-          draft: content,
-          readOnly:
-            out.is_utf8 === false
+    const read: Promise<EditorCacheEntry> =
+      sandboxId !== null
+        ? guestReadFile(host, sandboxId, absPath).then((out) => ({
+            savedContent: out.content,
+            draft: out.content,
+            readOnly: out.binary
               ? 'binary'
-              : out.more_lines
+              : out.truncated
                 ? 'truncated'
-                : null,
-          mode: out.mode ?? null,
-          size: out.size ?? null,
-        }
+                : 'sandbox',
+            mode: null,
+            size: out.size,
+          }))
+        : coderReadFile(host, absPath).then((out) => {
+            const content = out.content ?? ''
+            return {
+              savedContent: content,
+              draft: content,
+              readOnly:
+                out.is_utf8 === false
+                  ? 'binary'
+                  : out.more_lines
+                    ? 'truncated'
+                    : null,
+              mode: out.mode ?? null,
+              size: out.size ?? null,
+            }
+          })
+    read
+      .then((fresh) => {
+        if (seqRef.current !== seq) return
         cache.set(relPath, fresh)
-        setDraftState(content)
-        setSavedContent(content)
+        setDraftState(fresh.draft)
+        setSavedContent(fresh.savedContent)
         setPane({ phase: 'ready' })
       })
       .catch((err: unknown) => {
@@ -156,7 +182,7 @@ export function EditorPane({
           message: errorMessage(err),
         })
       })
-  }, [host, absPath, relPath, cache])
+  }, [host, absPath, relPath, sandboxId, cache])
 
   const dirty = pane.phase === 'ready' && draft !== savedContent
   const readOnly = entry?.readOnly ?? null
@@ -218,10 +244,19 @@ export function EditorPane({
         </span>
         {dirty ? <span className="shui-dirty" title="unsaved changes" /> : null}
         {readOnly ? (
-          <span className="shui-ro-note">
+          <span
+            className="shui-ro-note"
+            title={
+              readOnly === 'sandbox'
+                ? 'sandbox writes need the streamed channel form — the page edits host files only'
+                : undefined
+            }
+          >
             {readOnly === 'binary'
               ? 'binary — read-only'
-              : 'truncated read — read-only'}
+              : readOnly === 'truncated'
+                ? 'truncated read — read-only'
+                : 'sandbox target — read-only'}
           </span>
         ) : null}
         {entry?.size != null ? (
@@ -229,15 +264,17 @@ export function EditorPane({
         ) : null}
         <span className="spacer" />
         {saveError ? <span className="shui-ro-note warn">{saveError}</span> : null}
-        <button
-          type="button"
-          className="shui-save-btn"
-          disabled={!canSave}
-          onClick={save}
-          title="save (⌘S)"
-        >
-          {saving ? 'saving…' : 'save'}
-        </button>
+        {sandboxId === null ? (
+          <button
+            type="button"
+            className="shui-save-btn"
+            disabled={!canSave}
+            onClick={save}
+            title="save (⌘S)"
+          >
+            {saving ? 'saving…' : 'save'}
+          </button>
+        ) : null}
       </div>
 
       <div className="shui-editor-body">

--- a/shell/ui/src/page/SearchTab.tsx
+++ b/shell/ui/src/page/SearchTab.tsx
@@ -1,5 +1,7 @@
 /* The search tab — content + path search over the browsed root via the
-   worker's `coder::search`. Rows open the file in the editor pane. */
+   worker's `coder::search`; with a sandbox target selected, content-only
+   search via `shell::fs::grep` (the coder surface is host-only). Rows
+   open the file in the editor pane. */
 
 import { Input } from '@iii-dev/console-ui'
 import { useCallback, useRef, useState } from 'react'
@@ -7,10 +9,13 @@ import type { Host } from '@iii-dev/console-ui'
 import { errorMessage } from '../lib/format'
 import { renderWithHighlight } from '../lib/highlight'
 import { coderSearch, relativeTo, type SearchResponse } from './coder'
+import { guestGrep } from './sandbox'
 
 interface SearchTabProps {
   host: Host
   root: string
+  /** Sandbox target of the browsed tree; null = host. */
+  sandboxId: string | null
   /** Single click — open as the preview tab. */
   onPreviewFile: (relPath: string) => void
   /** Double click — open pinned. */
@@ -20,6 +25,7 @@ interface SearchTabProps {
 export function SearchTab({
   host,
   root,
+  sandboxId,
   onPreviewFile,
   onPinFile,
 }: SearchTabProps) {
@@ -39,7 +45,12 @@ export function SearchTab({
     const seq = ++seqRef.current
     setSearching(true)
     setError(null)
-    coderSearch(host, { query: q, regex, ignoreCase, path: root })
+    const params = { query: q, regex, ignoreCase, path: root }
+    const search =
+      sandboxId !== null
+        ? guestGrep(host, sandboxId, params)
+        : coderSearch(host, params)
+    search
       .then((out) => {
         if (seqRef.current !== seq) return
         setResult(out)
@@ -52,7 +63,7 @@ export function SearchTab({
       .finally(() => {
         if (seqRef.current === seq) setSearching(false)
       })
-  }, [host, query, regex, ignoreCase, root])
+  }, [host, query, regex, ignoreCase, root, sandboxId])
 
   return (
     <div className="shui-search">

--- a/shell/ui/src/page/__tests__/sandbox.test.ts
+++ b/shell/ui/src/page/__tests__/sandbox.test.ts
@@ -1,14 +1,18 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildGuestTree,
-  catPayload,
+  createFleetSequencer,
   escapeRegex,
+  type ExecResponse,
   type FsEntry,
+  GUEST_READ_MAX_BYTES,
   grepPayload,
+  guestReadResult,
   isFunctionNotFound,
   lsPayload,
   parseFleetEvent,
   parseSandboxList,
+  readPayload,
   sandboxGone,
   sandboxTarget,
   statPayload,
@@ -31,7 +35,7 @@ describe('payload builders', () => {
       lsPayload('/x', null),
       statPayload('/x', null),
       grepPayload({ path: '/x', pattern: 'p', ignoreCase: false }, null),
-      catPayload('/x', null),
+      readPayload('/x', null),
     ]) {
       expect('target' in payload).toBe(false)
     }
@@ -42,7 +46,7 @@ describe('payload builders', () => {
       lsPayload('/x', target),
       statPayload('/x', target),
       grepPayload({ path: '/x', pattern: 'p', ignoreCase: true }, target),
-      catPayload('/x', target),
+      readPayload('/x', target),
     ]) {
       expect(payload.target).toEqual({
         kind: 'sandbox',
@@ -51,13 +55,70 @@ describe('payload builders', () => {
     }
   })
 
-  it('cat rides argv form with no cwd/env/stdin (host-only fields, S210 on sandbox)', () => {
-    const payload = catPayload('/etc/os release', target)
-    expect(payload.command).toBe('cat')
-    expect(payload.args).toEqual(['/etc/os release'])
+  it('read rides capped head -c argv with no cwd/env/stdin (host-only fields, S210 on sandbox)', () => {
+    const payload = readPayload('/etc/os release', target)
+    expect(payload.command).toBe('head')
+    // `-c <cap>` — shell::exec never loads an entire guest file.
+    expect(payload.args).toEqual(['-c', String(GUEST_READ_MAX_BYTES), '/etc/os release'])
     for (const key of ['cwd', 'env', 'stdin']) {
       expect(key in payload).toBe(false)
     }
+  })
+})
+
+describe('guestReadResult', () => {
+  const exec = (stdout: string, stdout_truncated?: boolean): ExecResponse => ({
+    exit_code: 0,
+    stdout,
+    stderr: '',
+    ...(stdout_truncated === undefined ? {} : { stdout_truncated }),
+  })
+
+  it('a capped read shorter than the stat size is truncated', () => {
+    expect(guestReadResult(exec('abc'), 10).truncated).toBe(true)
+  })
+
+  it('a whole read matching the stat size is not', () => {
+    expect(guestReadResult(exec('abc'), 3).truncated).toBe(false)
+  })
+
+  it('without a stat size, filling the cap flags truncation', () => {
+    expect(guestReadResult(exec('x'.repeat(GUEST_READ_MAX_BYTES)), null).truncated).toBe(true)
+    expect(guestReadResult(exec('small'), null).truncated).toBe(false)
+  })
+
+  it('honors the exec-side truncation flag and detects NUL binaries', () => {
+    expect(guestReadResult(exec('abc', true), 3).truncated).toBe(true)
+    expect(guestReadResult(exec(`a${String.fromCharCode(0)}b`), 3).binary).toBe(true)
+    expect(guestReadResult(exec('ab'), 2).binary).toBe(false)
+  })
+
+  it('compares in bytes, not UTF-16 units', () => {
+    // é is one UTF-16 unit but two bytes — a 2-byte stat size means whole.
+    expect(guestReadResult(exec('é'), 2).truncated).toBe(false)
+  })
+})
+
+describe('createFleetSequencer', () => {
+  it('only the latest refresh may apply', () => {
+    const seq = createFleetSequencer()
+    const first = seq.begin()
+    const second = seq.begin()
+    expect(seq.isCurrent(first)).toBe(false)
+    expect(seq.isCurrent(second)).toBe(true)
+  })
+
+  it('a pushed snapshot invalidates every in-flight read', () => {
+    const seq = createFleetSequencer()
+    const inFlight = seq.begin()
+    seq.invalidate()
+    expect(seq.isCurrent(inFlight)).toBe(false)
+  })
+
+  it('a refresh begun after a push is current again', () => {
+    const seq = createFleetSequencer()
+    seq.invalidate()
+    expect(seq.isCurrent(seq.begin())).toBe(true)
   })
 })
 

--- a/shell/ui/src/page/__tests__/sandbox.test.ts
+++ b/shell/ui/src/page/__tests__/sandbox.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildGuestTree,
+  catPayload,
+  escapeRegex,
+  type FsEntry,
+  grepPayload,
+  isFunctionNotFound,
+  lsPayload,
+  parseFleetEvent,
+  parseSandboxList,
+  sandboxGone,
+  sandboxTarget,
+  statPayload,
+} from '../sandbox'
+
+const entry = (name: string, kind: 'file' | 'dir' | 'symlink' = 'file'): FsEntry => ({
+  name,
+  is_dir: kind === 'dir',
+  is_symlink: kind === 'symlink',
+  size: 0,
+})
+
+describe('payload builders', () => {
+  const target = sandboxTarget('3f2a4c1d-0000-0000-0000-000000000000')
+
+  it('omit the target key entirely for host (the wire default)', () => {
+    // An explicit `{kind:"host"}` would be fine, but `target: null` is a
+    // server-side deserialize error — omission is the one safe spelling.
+    for (const payload of [
+      lsPayload('/x', null),
+      statPayload('/x', null),
+      grepPayload({ path: '/x', pattern: 'p', ignoreCase: false }, null),
+      catPayload('/x', null),
+    ]) {
+      expect('target' in payload).toBe(false)
+    }
+  })
+
+  it('carry the sandbox target verbatim when selected', () => {
+    for (const payload of [
+      lsPayload('/x', target),
+      statPayload('/x', target),
+      grepPayload({ path: '/x', pattern: 'p', ignoreCase: true }, target),
+      catPayload('/x', target),
+    ]) {
+      expect(payload.target).toEqual({
+        kind: 'sandbox',
+        sandbox_id: '3f2a4c1d-0000-0000-0000-000000000000',
+      })
+    }
+  })
+
+  it('cat rides argv form with no cwd/env/stdin (host-only fields, S210 on sandbox)', () => {
+    const payload = catPayload('/etc/os release', target)
+    expect(payload.command).toBe('cat')
+    expect(payload.args).toEqual(['/etc/os release'])
+    for (const key of ['cwd', 'env', 'stdin']) {
+      expect(key in payload).toBe(false)
+    }
+  })
+})
+
+describe('parseSandboxList', () => {
+  it('tolerates junk: non-object input, rows without sandbox_id', () => {
+    expect(parseSandboxList(null)).toEqual([])
+    expect(parseSandboxList('nope')).toEqual([])
+    expect(parseSandboxList({ sandboxes: 'nope' })).toEqual([])
+    expect(
+      parseSandboxList({ sandboxes: [{ name: 'x' }, null, 42, { sandbox_id: '' }] }),
+    ).toEqual([])
+  })
+
+  it('defaults every missing field and keeps stopped honest', () => {
+    const out = parseSandboxList({
+      sandboxes: [
+        { sandbox_id: 'a' },
+        { sandbox_id: 'b', name: 'runner', image: 'img', stopped: true },
+      ],
+    })
+    expect(out).toEqual([
+      { sandbox_id: 'a', name: null, image: '', stopped: false },
+      { sandbox_id: 'b', name: 'runner', image: 'img', stopped: true },
+    ])
+  })
+})
+
+describe('parseFleetEvent', () => {
+  it('applies only { kind: "fleet" } snapshots', () => {
+    expect(parseFleetEvent(null)).toBeNull()
+    expect(parseFleetEvent({ kind: 'exec', sandboxes: [] })).toBeNull()
+    expect(parseFleetEvent({ sandboxes: [{ sandbox_id: 'a' }] })).toBeNull()
+  })
+
+  it('carries the parsed fleet and the daemon-absent flag', () => {
+    const snapshot = parseFleetEvent({
+      kind: 'fleet',
+      sandboxes: [{ sandbox_id: 'a' }],
+      daemon_absent: true,
+    })
+    expect(snapshot?.sandboxes.map((s) => s.sandbox_id)).toEqual(['a'])
+    expect(snapshot?.daemonAbsent).toBe(true)
+    expect(parseFleetEvent({ kind: 'fleet', sandboxes: [] })?.daemonAbsent).toBe(false)
+  })
+})
+
+describe('isFunctionNotFound', () => {
+  it('matches the bus-level absence phrasings', () => {
+    expect(isFunctionNotFound('Function sandbox::list not found')).toBe(true)
+    expect(isFunctionNotFound('function_not_found')).toBe(true)
+    expect(isFunctionNotFound('unknown function sandbox::list')).toBe(true)
+    expect(isFunctionNotFound('no such function')).toBe(true)
+  })
+
+  it('ignores prose that merely contains "not found" (a missing path must not hide the picker)', () => {
+    expect(isFunctionNotFound('path /tmp/x not found')).toBe(false)
+    expect(isFunctionNotFound('S211: no such file or directory')).toBe(false)
+  })
+})
+
+describe('sandboxGone', () => {
+  const fleet = (
+    status: 'loading' | 'ready' | 'absent' | 'error',
+    ids: string[] = [],
+  ) => ({
+    status,
+    sandboxes: ids.map((sandbox_id) => ({
+      sandbox_id,
+      name: null,
+      image: '',
+      stopped: false,
+    })),
+  })
+
+  it('host mode never degrades', () => {
+    expect(sandboxGone(null, fleet('ready'))).toBe(false)
+    expect(sandboxGone(null, fleet('absent'))).toBe(false)
+  })
+
+  it('a selected sandbox missing from a ready fleet is gone', () => {
+    expect(sandboxGone('a', fleet('ready', ['a', 'b']))).toBe(false)
+    expect(sandboxGone('a', fleet('ready', ['b']))).toBe(true)
+  })
+
+  it('a vanished daemon takes every sandbox with it', () => {
+    expect(sandboxGone('a', fleet('absent', ['a']))).toBe(true)
+  })
+
+  it('transient states never evict an open view', () => {
+    expect(sandboxGone('a', fleet('loading'))).toBe(false)
+    expect(sandboxGone('a', fleet('error'))).toBe(false)
+  })
+})
+
+describe('buildGuestTree', () => {
+  it('marks directories with the trailing slash and keys kinds slash-less', () => {
+    const loaded = new Map<string, FsEntry[]>([
+      ['', [entry('usr', 'dir'), entry('init'), entry('lib64', 'symlink')]],
+      ['usr', [entry('bin', 'dir')]],
+    ])
+    const tree = buildGuestTree(loaded)
+    expect(tree.paths).toEqual(['init', 'lib64', 'usr/', 'usr/bin/'])
+    expect(tree.kinds.get('usr')).toBe('dir')
+    expect(tree.kinds.get('usr/bin')).toBe('dir')
+    expect(tree.kinds.get('init')).toBe('file')
+    expect(tree.kinds.get('lib64')).toBe('symlink')
+    expect(tree.truncations).toEqual([])
+  })
+
+  it('renders an unlisted directory as expandable via its parent entry', () => {
+    const tree = buildGuestTree(new Map([['', [entry('etc', 'dir')]]]))
+    expect(tree.paths).toEqual(['etc/'])
+    expect(tree.kinds.get('etc')).toBe('dir')
+  })
+
+  it('returns the empty tree before the root listing lands', () => {
+    const tree = buildGuestTree(new Map())
+    expect(tree.paths).toEqual([])
+  })
+})
+
+describe('escapeRegex', () => {
+  it('neutralizes every metacharacter for literal grep queries', () => {
+    const literal = 'a.b*c?(d)[e]{f}|g^h$i\\j+k'
+    const re = new RegExp(escapeRegex(literal))
+    expect(re.test(literal)).toBe(true)
+    expect(re.test('aXb*c?(d)[e]{f}|g^h$i\\j+k')).toBe(false)
+  })
+})

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -5,12 +5,20 @@
  * (single click previews, double click pins) and a FileDiff pane for
  * git selections.
  *
+ * A target picker beside the root affordance retargets the same surface
+ * at a live sandbox microVM: fs calls then carry
+ * `target: { kind: "sandbox", sandbox_id }` (host mode omits the field —
+ * the wire default), the tree roots at `/`, and the host-coupled
+ * affordances (git tab, workspace roots, editor writes) drop out.
+ *
  * The sidebar hugs the pane's OUTER edge (`panelSide`), and the whole
  * UI state — browsed root, open tabs, expanded folders — persists per
- * workspace tab (`tabId`) in the `shell-ui` configuration entry.
+ * workspace tab (`tabId`) in the `shell-ui` configuration entry (host
+ * mode only; guest state is per-VM and ephemeral).
  */
 
 import {
+  EmptyState,
   type Host,
   PageBody,
   PageHeader,
@@ -18,11 +26,20 @@ import {
   type PageRenderProps,
   PageShell,
   PageSidebar,
+  StatusDot,
 } from '@iii-dev/console-ui'
 import type { GitStatusEntry } from '@pierre/trees'
-import { FolderTree, GitBranch, Search, SquareTerminal, X } from 'lucide-react'
+import {
+  Copy,
+  FolderTree,
+  GitBranch,
+  RefreshCw,
+  Search,
+  SquareTerminal,
+  X,
+} from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { errorMessage } from '../lib/format'
+import { errorMessage, truncateMiddle } from '../lib/format'
 import { type CoderInfo, coderInfo, coderTree, type FlatTree, flattenTree } from './coder'
 import { DiffPane } from './DiffPane'
 import { type EditorCache, EditorPane } from './EditorPane'
@@ -30,6 +47,7 @@ import { FilesTab } from './FilesTab'
 import { GitTab } from './GitTab'
 import { type GitChange, type GitState, gitChanges } from './git'
 import { createTabUiStateSaver, loadTabUiState, type TabUiState } from './persist'
+import { GUEST_ROOT, sandboxGone } from './sandbox'
 import { SearchTab } from './SearchTab'
 import {
   activateTab,
@@ -43,6 +61,8 @@ import {
   restoreTabs,
   type TabsState,
 } from './tabs'
+import { useGuestTree } from './useGuestTree'
+import { useSandboxFleet } from './useSandboxFleet'
 
 type SideTab = 'files' | 'git' | 'search'
 
@@ -64,6 +84,7 @@ export function ShellExplorerPage({
   const [infoError, setInfoError] = useState<string | null>(null)
   const [restored, setRestored] = useState<TabUiState | null | 'loading'>('loading')
   const [root, setRoot] = useState<string | null>(null)
+  const [sandboxId, setSandboxId] = useState<string | null>(null)
   const [sideTab, setSideTab] = useState<SideTab>('files')
   const [collapsed, setCollapsed] = useState(false)
   const [tree, setTree] = useState<FlatTree | null>(null)
@@ -73,6 +94,10 @@ export function ShellExplorerPage({
   const [dirtyPaths, setDirtyPaths] = useState<ReadonlySet<string>>(new Set())
   const [diff, setDiff] = useState<GitChange | null>(null)
   const cacheRef = useRef<EditorCache>(new Map())
+
+  const { fleet, refreshFleet } = useSandboxFleet(host)
+  const guestTree = useGuestTree(host, sandboxId, expanded)
+  const gone = sandboxGone(sandboxId, fleet)
 
   // ── boot: worker info + this workspace tab's persisted state ──
   useEffect(() => {
@@ -118,10 +143,11 @@ export function ShellExplorerPage({
     }
   }, [info, restored, root, workingDir])
 
-  // ── data loads (gated on the resolved root) ──
+  // ── data loads (gated on the resolved root; host mode only — the
+  // guest tree loads through useGuestTree) ──
   const gitSeqRef = useRef(0)
   const refreshGit = useCallback(() => {
-    if (!root) return
+    if (!root || sandboxId !== null) return
     const seq = ++gitSeqRef.current
     gitChanges(host, root)
       .then((state) => {
@@ -135,11 +161,11 @@ export function ShellExplorerPage({
           })
         }
       })
-  }, [host, root])
+  }, [host, root, sandboxId])
 
   const treeSeqRef = useRef(0)
   const refreshTree = useCallback(() => {
-    if (!root) return
+    if (!root || sandboxId !== null) return
     const seq = ++treeSeqRef.current
     coderTree(host, root)
       .then((out) => {
@@ -150,7 +176,7 @@ export function ShellExplorerPage({
           setTree({ paths: [], kinds: new Map(), truncations: [] })
         }
       })
-  }, [host, root])
+  }, [host, root, sandboxId])
 
   useEffect(() => {
     setTree(null)
@@ -170,13 +196,15 @@ export function ShellExplorerPage({
       bootedRef.current = true
       return
     }
+    // Guest state is per-VM and ephemeral — only host state persists.
+    if (sandboxId !== null) return
     saver.save({
       root,
       open: tabs.tabs,
       active: tabs.active,
       expanded,
     })
-  }, [saver, root, tabs, expanded])
+  }, [saver, root, tabs, expanded, sandboxId])
 
   // ── open/close/pin actions ──
   const previewFile = useCallback((relPath: string) => {
@@ -227,6 +255,17 @@ export function ShellExplorerPage({
     setRoot(nextRoot)
   }, [])
 
+  const changeTarget = useCallback((next: string | null) => {
+    cacheRef.current.clear()
+    setDirtyPaths(new Set())
+    setTabs(EMPTY_TABS)
+    setExpanded([])
+    setDiff(null)
+    // The git tab is host-only chrome — land on files when entering a VM.
+    if (next !== null) setSideTab((t) => (t === 'git' ? 'files' : t))
+    setSandboxId(next)
+  }, [])
+
   // ── follow the chat's working directory ──
   // Picking another folder in chat re-roots the explorer (the split-screen
   // sync). Only CHANGES sync: the boot-resolved root wins on mount, and a
@@ -236,8 +275,15 @@ export function ShellExplorerPage({
     const next = workingDir ?? null
     if (next === lastWorkingDirRef.current) return
     lastWorkingDirRef.current = next
-    if (next !== null && root !== null && next !== root) changeRoot(next)
-  }, [workingDir, root, changeRoot])
+    if (next === null || root === null || next === root) return
+    if (sandboxId !== null) {
+      // The chat's folder is a host concept — remember it for the return
+      // to host without evicting the sandbox view.
+      setRoot(next)
+      return
+    }
+    changeRoot(next)
+  }, [workingDir, root, sandboxId, changeRoot])
 
   const onSaved = useCallback(() => {
     refreshGit()
@@ -256,11 +302,63 @@ export function ShellExplorerPage({
     return info.base_paths.includes(root) ? info.base_paths : [root, ...info.base_paths]
   }, [info, root])
 
+  // Same rule for the target select: a selected sandbox that left the
+  // fleet stays present as a labeled option until the user moves off it.
+  const targetOptions = useMemo(() => {
+    const options = fleet.sandboxes.map((s) => ({
+      value: s.sandbox_id,
+      label: `${s.name ?? truncateMiddle(s.sandbox_id, 16)}${s.stopped ? ' · stopped' : ''}`,
+      title: s.sandbox_id,
+    }))
+    if (sandboxId !== null && !fleet.sandboxes.some((s) => s.sandbox_id === sandboxId)) {
+      options.push({
+        value: sandboxId,
+        label: `${truncateMiddle(sandboxId, 16)} · gone`,
+        title: sandboxId,
+      })
+    }
+    return options
+  }, [fleet.sandboxes, sandboxId])
+
+  // Function-not-found on sandbox::list = no sandbox daemon on this
+  // engine — the picker hides entirely and the page stays pure host.
+  const showTargetPicker = fleet.status === 'ready' || fleet.status === 'error'
+  const selected =
+    sandboxId !== null
+      ? fleet.sandboxes.find((s) => s.sandbox_id === sandboxId)
+      : undefined
+  const effectiveRoot = sandboxId !== null ? GUEST_ROOT : root
+
+  const copySandboxId = useCallback(() => {
+    if (sandboxId !== null) void navigator.clipboard?.writeText(sandboxId)
+  }, [sandboxId])
+
+  const sideTabs =
+    sandboxId === null ? SIDE_TABS : SIDE_TABS.filter((t) => t.id !== 'git')
+
   const header = (
     <PageHeader
       icon={<SquareTerminal />}
       title="shell"
-      description={root ? <span title={root}>{root}</span> : undefined}
+      description={
+        sandboxId !== null ? (
+          <span className="shui-target-desc" title={sandboxId}>
+            <StatusDot tone={gone ? 'warn' : selected?.stopped ? 'ink' : 'accent'} />
+            <span className="id">{truncateMiddle(sandboxId, 24)}</span>
+            <button
+              type="button"
+              className="shui-copy-btn"
+              onClick={copySandboxId}
+              aria-label="copy sandbox id"
+              title="copy sandbox id"
+            >
+              <Copy aria-hidden className="shui-copy-icon" />
+            </button>
+          </span>
+        ) : root ? (
+          <span title={root}>{root}</span>
+        ) : undefined
+      }
       onClose={onRequestClose}
     />
   )
@@ -275,7 +373,7 @@ export function ShellExplorerPage({
       </PageShell>
     )
   }
-  if (!info || !root) {
+  if (!info || !root || !effectiveRoot) {
     return (
       <PageShell>
         {header}
@@ -302,7 +400,7 @@ export function ShellExplorerPage({
           ) : (
             <>
               <div className="shui-side-tabs">
-                {SIDE_TABS.map(({ id, label, Icon }) => (
+                {sideTabs.map(({ id, label, Icon }) => (
                   <button
                     key={id}
                     type="button"
@@ -326,30 +424,69 @@ export function ShellExplorerPage({
                 </button>
               </div>
 
-              {rootOptions.length > 1 ? (
-                <select
-                  className="shui-root-select"
-                  value={root}
-                  onChange={(e) => changeRoot(e.target.value)}
-                  aria-label="browsed root"
-                  title={root}
-                >
-                  {rootOptions.map((p) => (
-                    <option key={p} value={p}>
-                      {lastSegments(p)}
-                    </option>
-                  ))}
-                </select>
-              ) : (
-                <div className="shui-root-label" title={root}>
-                  {lastSegments(root)}
+              {showTargetPicker ? (
+                <div className="shui-target-row">
+                  <select
+                    className="shui-target-select"
+                    value={sandboxId ?? 'host'}
+                    onChange={(e) => {
+                      const value = e.target.value
+                      changeTarget(value === 'host' ? null : value)
+                    }}
+                    aria-label="target"
+                    title={sandboxId ?? 'host'}
+                  >
+                    <option value="host">host</option>
+                    {targetOptions.map((o) => (
+                      <option key={o.value} value={o.value} title={o.title}>
+                        {o.label}
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    className="shui-target-refresh"
+                    onClick={refreshFleet}
+                    aria-label="refresh sandbox list"
+                    title="refresh sandbox list"
+                  >
+                    <RefreshCw aria-hidden className="shui-refresh-icon" />
+                  </button>
                 </div>
-              )}
+              ) : null}
+
+              {sandboxId === null ? (
+                rootOptions.length > 1 ? (
+                  <select
+                    className="shui-root-select"
+                    value={root}
+                    onChange={(e) => changeRoot(e.target.value)}
+                    aria-label="browsed root"
+                    title={root}
+                  >
+                    {rootOptions.map((p) => (
+                      <option key={p} value={p}>
+                        {lastSegments(p)}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <div className="shui-root-label" title={root}>
+                    {lastSegments(root)}
+                  </div>
+                )
+              ) : null}
 
               <div className="shui-side-body">
-                {sideTab === 'files' ? (
+                {gone ? (
+                  <EmptyState
+                    title="sandbox gone"
+                    description="reaped or stopped — the microVM left the fleet"
+                    action={{ label: 'back to host', onClick: () => changeTarget(null) }}
+                  />
+                ) : sideTab === 'files' ? (
                   <FilesTab
-                    tree={tree}
+                    tree={sandboxId !== null ? guestTree : tree}
                     gitStatus={treeGitStatus}
                     theme={theme}
                     expanded={expanded}
@@ -360,7 +497,13 @@ export function ShellExplorerPage({
                 ) : sideTab === 'git' ? (
                   <GitTab state={git} theme={theme} onSelect={(change) => setDiff(change)} onRefresh={refreshGit} />
                 ) : (
-                  <SearchTab host={host} root={root} onPreviewFile={previewFile} onPinFile={pinFile} />
+                  <SearchTab
+                    host={host}
+                    root={effectiveRoot}
+                    sandboxId={sandboxId}
+                    onPreviewFile={previewFile}
+                    onPinFile={pinFile}
+                  />
                 )}
               </div>
             </>
@@ -410,15 +553,20 @@ export function ShellExplorerPage({
             <EditorPane
               key={tabs.active}
               host={host}
-              root={root}
+              root={effectiveRoot}
               relPath={tabs.active}
+              sandboxId={sandboxId}
               cache={cacheRef.current}
               onSaved={onSaved}
               onDirtyChange={onDirtyChange}
             />
           ) : (
             <div className="shui-main-empty">
-              <span className="t-ghost">select a file to edit — or a git change to diff</span>
+              <span className="t-ghost">
+                {sandboxId !== null
+                  ? 'select a file to view — sandbox target is read-only'
+                  : 'select a file to edit — or a git change to diff'}
+              </span>
             </div>
           )}
         </PageMain>

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -30,6 +30,8 @@ import {
 } from '@iii-dev/console-ui'
 import type { GitStatusEntry } from '@pierre/trees'
 import {
+  Check,
+  CircleAlert,
   Copy,
   FolderTree,
   GitBranch,
@@ -255,16 +257,33 @@ export function ShellExplorerPage({
     setRoot(nextRoot)
   }, [])
 
-  const changeTarget = useCallback((next: string | null) => {
-    cacheRef.current.clear()
-    setDirtyPaths(new Set())
-    setTabs(EMPTY_TABS)
-    setExpanded([])
-    setDiff(null)
-    // The git tab is host-only chrome — land on files when entering a VM.
-    if (next !== null) setSideTab((t) => (t === 'git' ? 'files' : t))
-    setSandboxId(next)
-  }, [])
+  // Host tabs/expanded survive a round-trip through a sandbox: snapshot
+  // on the way in, restore on the way out — in the same commit, so the
+  // persistence effect never sees (and saves) cleared guest state over
+  // the host state it stored.
+  const hostUiRef = useRef<{ tabs: TabsState; expanded: string[] } | null>(null)
+
+  const changeTarget = useCallback(
+    (next: string | null) => {
+      cacheRef.current.clear()
+      setDirtyPaths(new Set())
+      setDiff(null)
+      if (next !== null) {
+        if (sandboxId === null) hostUiRef.current = { tabs, expanded }
+        setTabs(EMPTY_TABS)
+        setExpanded([])
+        // The git tab is host-only chrome — land on files when entering a VM.
+        setSideTab((t) => (t === 'git' ? 'files' : t))
+      } else {
+        const snap = hostUiRef.current
+        hostUiRef.current = null
+        setTabs(snap?.tabs ?? EMPTY_TABS)
+        setExpanded(snap?.expanded ?? [])
+      }
+      setSandboxId(next)
+    },
+    [sandboxId, tabs, expanded],
+  )
 
   // ── follow the chat's working directory ──
   // Picking another folder in chat re-roots the explorer (the split-screen
@@ -278,7 +297,9 @@ export function ShellExplorerPage({
     if (next === null || root === null || next === root) return
     if (sandboxId !== null) {
       // The chat's folder is a host concept — remember it for the return
-      // to host without evicting the sandbox view.
+      // to host without evicting the sandbox view. The snapshotted tabs
+      // belong to the old root, so the return starts clean instead.
+      hostUiRef.current = null
       setRoot(next)
       return
     }
@@ -329,8 +350,35 @@ export function ShellExplorerPage({
       : undefined
   const effectiveRoot = sandboxId !== null ? GUEST_ROOT : root
 
+  // Click-to-copy with a copied/failed flash — the clipboard write can
+  // reject (denied permission) or be missing entirely (insecure context),
+  // and a silent no-op reads as a working copy.
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle')
+  const copyTimerRef = useRef<number | null>(null)
+  useEffect(
+    () => () => {
+      if (copyTimerRef.current !== null) window.clearTimeout(copyTimerRef.current)
+    },
+    [],
+  )
   const copySandboxId = useCallback(() => {
-    if (sandboxId !== null) void navigator.clipboard?.writeText(sandboxId)
+    if (sandboxId === null) return
+    const flash = (state: 'copied' | 'failed') => {
+      setCopyState(state)
+      if (copyTimerRef.current !== null) window.clearTimeout(copyTimerRef.current)
+      copyTimerRef.current = window.setTimeout(() => {
+        copyTimerRef.current = null
+        setCopyState('idle')
+      }, 1400)
+    }
+    if (!navigator.clipboard?.writeText) {
+      flash('failed')
+      return
+    }
+    navigator.clipboard.writeText(sandboxId).then(
+      () => flash('copied'),
+      () => flash('failed'),
+    )
   }, [sandboxId])
 
   const sideTabs =
@@ -347,12 +395,24 @@ export function ShellExplorerPage({
             <span className="id">{truncateMiddle(sandboxId, 24)}</span>
             <button
               type="button"
-              className="shui-copy-btn"
+              className={`shui-copy-btn${copyState === 'idle' ? '' : ` ${copyState}`}`}
               onClick={copySandboxId}
               aria-label="copy sandbox id"
-              title="copy sandbox id"
+              title={
+                copyState === 'copied'
+                  ? 'copied'
+                  : copyState === 'failed'
+                    ? 'copy failed'
+                    : 'copy sandbox id'
+              }
             >
-              <Copy aria-hidden className="shui-copy-icon" />
+              {copyState === 'copied' ? (
+                <Check aria-hidden className="shui-copy-icon" />
+              ) : copyState === 'failed' ? (
+                <CircleAlert aria-hidden className="shui-copy-icon" />
+              ) : (
+                <Copy aria-hidden className="shui-copy-icon" />
+              )}
             </button>
           </span>
         ) : root ? (

--- a/shell/ui/src/page/sandbox.ts
+++ b/shell/ui/src/page/sandbox.ts
@@ -66,14 +66,25 @@ export function grepPayload(
   )
 }
 
-export function catPayload(
+/** Byte cap on a guest read — the same 1 MiB the host editor path lives
+    under (`coder::read-file`'s per-entry cap and exec's default output
+    budget), so a giant guest file never rides `shell::exec` whole. */
+export const GUEST_READ_MAX_BYTES = 1_048_576
+
+export function readPayload(
   path: string,
   target: WireTarget | null,
 ): Record<string, unknown> {
-  // argv form — the path is never shell-tokenized. cwd/env/stdin stay
-  // omitted: all three are host-only (S210 on a sandbox target).
+  // argv form — the path is never shell-tokenized. `head -c` caps the
+  // read guest-side (plain `cat` would load the entire file). cwd/env/
+  // stdin stay omitted: all three are host-only (S210 on a sandbox
+  // target).
   return withTarget(
-    { command: 'cat', args: [path], timeout_ms: 15_000 },
+    {
+      command: 'head',
+      args: ['-c', String(GUEST_READ_MAX_BYTES), path],
+      timeout_ms: 15_000,
+    },
     target,
   )
 }
@@ -100,7 +111,7 @@ export async function guestLs(
   return out.entries ?? []
 }
 
-interface ExecResponse {
+export interface ExecResponse {
   exit_code: number | null
   stdout: string
   stderr: string
@@ -114,13 +125,34 @@ export interface GuestReadResult {
   truncated: boolean
 }
 
+/** Shape a capped exec read into the editor's result: truncated whenever
+    the bytes that came back fall short of the stat-reported size (the
+    `head -c` cap bit), or — when stat gave no size to compare — whenever
+    the output filled the cap exactly. Exported for tests. */
+export function guestReadResult(
+  out: ExecResponse,
+  size: number | null,
+): GuestReadResult {
+  const bytes = new TextEncoder().encode(out.stdout).length
+  return {
+    content: out.stdout,
+    size,
+    binary: out.stdout.includes('\u0000'),
+    truncated:
+      out.stdout_truncated === true ||
+      (size !== null && bytes < size) ||
+      (size === null && bytes >= GUEST_READ_MAX_BYTES),
+  }
+}
+
 /** Guest file read. `shell::fs::read` hands back a stream-channel ref the
     console extension client cannot consume (`host.iii` has no channel
     API), and `coder::read-file` is host-only — so guest reads ride
-    `shell::exec` stdout, the same way the git tab already consumes file
-    bodies (`git show`). Truncation is caught by comparing byte counts
-    against `shell::fs::stat`, since the sandbox exec path does not
-    report host-side truncation. */
+    `shell::exec` stdout (capped by `head -c`, see GUEST_READ_MAX_BYTES),
+    the same way the git tab already consumes file bodies (`git show`).
+    Truncation is caught by comparing byte counts against
+    `shell::fs::stat`, since the sandbox exec path does not report
+    host-side truncation. */
 export async function guestReadFile(
   host: Host,
   sandboxId: string,
@@ -133,22 +165,14 @@ export async function guestReadFile(
   )
   const out = await host.iii.trigger<ExecResponse>(
     'shell::exec',
-    catPayload(path, target),
+    readPayload(path, target),
   )
   if (out.exit_code !== 0) {
     throw new Error(
-      out.stderr.trim() || `cat exited ${out.exit_code ?? 'without a code'}`,
+      out.stderr.trim() || `read exited ${out.exit_code ?? 'without a code'}`,
     )
   }
-  const size = typeof stat.size === 'number' ? stat.size : null
-  return {
-    content: out.stdout,
-    size,
-    binary: out.stdout.includes('\u0000'),
-    truncated:
-      out.stdout_truncated === true ||
-      (size !== null && new TextEncoder().encode(out.stdout).length < size),
-  }
+  return guestReadResult(out, typeof stat.size === 'number' ? stat.size : null)
 }
 
 /** `shell::fs::grep` patterns are always regexes — literal queries get
@@ -288,6 +312,28 @@ export function isFunctionNotFound(message: string): boolean {
   return /\bfunction(\s+\S+)?[\s_-]not[ _-]?(found|registered)\b|\bunknown function\b|\bno such function\b/i.test(
     message,
   )
+}
+
+/** Ordering guard for fleet reads vs pushed snapshots: `begin()` stamps
+    a `sandbox::list` request, `isCurrent` gates its response (a later
+    refresh supersedes it), and `invalidate()` — run on every pushed
+    `{ kind: "fleet" }` snapshot — drops ALL in-flight reads, since the
+    push is fresher than any list response still on the wire. */
+export interface FleetSequencer {
+  begin(): number
+  invalidate(): void
+  isCurrent(seq: number): boolean
+}
+
+export function createFleetSequencer(): FleetSequencer {
+  let latest = 0
+  return {
+    begin: () => ++latest,
+    invalidate: () => {
+      latest += 1
+    },
+    isCurrent: (seq) => seq === latest,
+  }
 }
 
 export type FleetStatus = 'loading' | 'ready' | 'absent' | 'error'

--- a/shell/ui/src/page/sandbox.ts
+++ b/shell/ui/src/page/sandbox.ts
@@ -1,0 +1,311 @@
+/* Guest-target plumbing for the explorer — the `shell::fs::*` /
+   `shell::exec` twins of coder.ts, threading the per-call
+   `target: { kind: "sandbox", sandbox_id }` selector every shell
+   function already accepts (host omits the field — the wire default),
+   plus tolerant parsing for the `sandbox::list` fleet read and its
+   pushed `{ kind: "fleet" }` snapshots. `coder::*` is host-only by
+   contract, so guest mode swaps surfaces instead of adding a field to
+   the host payloads. */
+
+import type { Host } from '@iii-dev/console-ui'
+import type { FlatTree, SearchParams, SearchResponse, TreeNode } from './coder'
+
+/** Tree root for guests — a microVM has no workspace roots to pick. */
+export const GUEST_ROOT = '/'
+
+export interface WireTarget {
+  kind: 'sandbox'
+  sandbox_id: string
+}
+
+export function sandboxTarget(sandboxId: string): WireTarget {
+  return { kind: 'sandbox', sandbox_id: sandboxId }
+}
+
+/* ── payload builders ───────────────────────────────────────────────────
+   `target: null` = host: the key is OMITTED, not sent as `{kind:"host"}` —
+   an explicit `null` would be a server-side deserialize error (the field
+   is `#[serde(default)]` on a non-Option type). */
+
+function withTarget(
+  payload: Record<string, unknown>,
+  target: WireTarget | null,
+): Record<string, unknown> {
+  return target === null ? payload : { ...payload, target }
+}
+
+export function lsPayload(
+  path: string,
+  target: WireTarget | null,
+): Record<string, unknown> {
+  return withTarget({ path }, target)
+}
+
+export function statPayload(
+  path: string,
+  target: WireTarget | null,
+): Record<string, unknown> {
+  return withTarget({ path }, target)
+}
+
+/** Keep the sidebar's match list bounded. */
+export const GUEST_GREP_MAX_MATCHES = 500
+
+export function grepPayload(
+  args: { path: string; pattern: string; ignoreCase: boolean },
+  target: WireTarget | null,
+): Record<string, unknown> {
+  return withTarget(
+    {
+      path: args.path,
+      pattern: args.pattern,
+      ignore_case: args.ignoreCase,
+      max_matches: GUEST_GREP_MAX_MATCHES,
+    },
+    target,
+  )
+}
+
+export function catPayload(
+  path: string,
+  target: WireTarget | null,
+): Record<string, unknown> {
+  // argv form — the path is never shell-tokenized. cwd/env/stdin stay
+  // omitted: all three are host-only (S210 on a sandbox target).
+  return withTarget(
+    { command: 'cat', args: [path], timeout_ms: 15_000 },
+    target,
+  )
+}
+
+/* ── guest calls ──────────────────────────────────────────────────────── */
+
+/** `iii-shell-proto::FsEntry` — only the fields the page reads. */
+export interface FsEntry {
+  name: string
+  is_dir: boolean
+  is_symlink: boolean
+  size: number
+}
+
+export async function guestLs(
+  host: Host,
+  sandboxId: string,
+  path: string,
+): Promise<FsEntry[]> {
+  const out = await host.iii.trigger<{ entries?: FsEntry[] }>(
+    'shell::fs::ls',
+    lsPayload(path, sandboxTarget(sandboxId)),
+  )
+  return out.entries ?? []
+}
+
+interface ExecResponse {
+  exit_code: number | null
+  stdout: string
+  stderr: string
+  stdout_truncated?: boolean
+}
+
+export interface GuestReadResult {
+  content: string
+  size: number | null
+  binary: boolean
+  truncated: boolean
+}
+
+/** Guest file read. `shell::fs::read` hands back a stream-channel ref the
+    console extension client cannot consume (`host.iii` has no channel
+    API), and `coder::read-file` is host-only — so guest reads ride
+    `shell::exec` stdout, the same way the git tab already consumes file
+    bodies (`git show`). Truncation is caught by comparing byte counts
+    against `shell::fs::stat`, since the sandbox exec path does not
+    report host-side truncation. */
+export async function guestReadFile(
+  host: Host,
+  sandboxId: string,
+  path: string,
+): Promise<GuestReadResult> {
+  const target = sandboxTarget(sandboxId)
+  const stat = await host.iii.trigger<{ size?: number | null }>(
+    'shell::fs::stat',
+    statPayload(path, target),
+  )
+  const out = await host.iii.trigger<ExecResponse>(
+    'shell::exec',
+    catPayload(path, target),
+  )
+  if (out.exit_code !== 0) {
+    throw new Error(
+      out.stderr.trim() || `cat exited ${out.exit_code ?? 'without a code'}`,
+    )
+  }
+  const size = typeof stat.size === 'number' ? stat.size : null
+  return {
+    content: out.stdout,
+    size,
+    binary: out.stdout.includes('\u0000'),
+    truncated:
+      out.stdout_truncated === true ||
+      (size !== null && new TextEncoder().encode(out.stdout).length < size),
+  }
+}
+
+/** `shell::fs::grep` patterns are always regexes — literal queries get
+    their metacharacters escaped. */
+export function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+interface GrepResponse {
+  matches: { path: string; line: number; content: string }[]
+  truncated: boolean
+}
+
+/** Guest search — `shell::fs::grep` mapped onto the SearchTab's
+    `coder::search` response shape (grep has no path matches and no
+    column, so those degrade to empty/0). */
+export async function guestGrep(
+  host: Host,
+  sandboxId: string,
+  { query, regex, ignoreCase, path }: SearchParams,
+): Promise<SearchResponse> {
+  const out = await host.iii.trigger<GrepResponse>(
+    'shell::fs::grep',
+    grepPayload(
+      {
+        path,
+        pattern: regex ? query : escapeRegex(query),
+        ignoreCase,
+      },
+      sandboxTarget(sandboxId),
+    ),
+  )
+  return {
+    content_matches: (out.matches ?? []).map((m) => ({
+      path: m.path,
+      line: m.line,
+      column: 0,
+      text: m.content,
+    })),
+    path_matches: [],
+    truncated: out.truncated === true,
+  }
+}
+
+/* ── guest tree ───────────────────────────────────────────────────────── */
+
+/** Flatten per-directory `shell::fs::ls` listings (keyed by root-relative
+    dir path, '' = the guest root) into the FilesTab's FlatTree. There is
+    no recursive tree function on the `shell::fs::*` surface, so the tree
+    fills in lazily — an unlisted directory still renders (expandable)
+    via its parent's entry; its children appear once its own listing
+    lands. Directories carry the trailing-slash marker for the same
+    collision reason as flattenTree. */
+export function buildGuestTree(
+  loaded: ReadonlyMap<string, FsEntry[]>,
+): FlatTree {
+  const paths: string[] = []
+  const kinds = new Map<string, TreeNode['kind']>()
+
+  const walk = (prefix: string) => {
+    const entries = loaded.get(prefix)
+    if (!entries) return
+    const sorted = [...entries].sort((a, b) =>
+      a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
+    )
+    for (const entry of sorted) {
+      const childPath = prefix === '' ? entry.name : `${prefix}/${entry.name}`
+      const kind = entry.is_dir ? 'dir' : entry.is_symlink ? 'symlink' : 'file'
+      paths.push(kind === 'dir' ? `${childPath}/` : childPath)
+      kinds.set(childPath, kind)
+      if (kind === 'dir') walk(childPath)
+    }
+  }
+  walk('')
+
+  return { paths, kinds, truncations: [] }
+}
+
+/* ── fleet parsing ────────────────────────────────────────────────────── */
+
+const asRecord = (v: unknown): Record<string, unknown> | null =>
+  v !== null && typeof v === 'object' && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : null
+
+const asString = (v: unknown): string | null =>
+  typeof v === 'string' && v.length > 0 ? v : null
+
+export interface SandboxSummary {
+  sandbox_id: string
+  name: string | null
+  image: string
+  stopped: boolean
+}
+
+/** `{ sandboxes: [...] }` → summaries. Rows missing `sandbox_id` are
+    dropped; every other field degrades to a sane default. */
+export function parseSandboxList(value: unknown): SandboxSummary[] {
+  const list = asRecord(value)?.sandboxes
+  if (!Array.isArray(list)) return []
+  const out: SandboxSummary[] = []
+  for (const item of list) {
+    const rec = asRecord(item)
+    const id = rec && asString(rec.sandbox_id)
+    if (!rec || !id) continue
+    out.push({
+      sandbox_id: id,
+      name: asString(rec.name),
+      image: asString(rec.image) ?? '',
+      stopped: rec.stopped === true,
+    })
+  }
+  return out
+}
+
+export interface FleetSnapshot {
+  sandboxes: SandboxSummary[]
+  daemonAbsent: boolean
+}
+
+/** A pushed `{ kind: "fleet" }` snapshot; every other event kind returns
+    null (exec/runtime events don't change fleet membership). */
+export function parseFleetEvent(payload: unknown): FleetSnapshot | null {
+  const rec = asRecord(payload)
+  if (!rec || rec.kind !== 'fleet') return null
+  return {
+    sandboxes: parseSandboxList(rec),
+    daemonAbsent: rec.daemon_absent === true,
+  }
+}
+
+/** Does this error read as "the function does not exist on the bus"?
+    "function" must sit next to the not-found phrase (spaced or the
+    engine's `function_not_found` spelling) so prose that merely contains
+    "not found" (a missing path, say) does not hide the picker. */
+export function isFunctionNotFound(message: string): boolean {
+  return /\bfunction(\s+\S+)?[\s_-]not[ _-]?(found|registered)\b|\bunknown function\b|\bno such function\b/i.test(
+    message,
+  )
+}
+
+export type FleetStatus = 'loading' | 'ready' | 'absent' | 'error'
+
+export interface FleetState {
+  status: FleetStatus
+  sandboxes: SandboxSummary[]
+}
+
+/** The degrade gate: a selected sandbox that left the fleet (or the whole
+    daemon left). `loading`/`error` never degrade — a transient read
+    failure must not evict an open view. */
+export function sandboxGone(
+  sandboxId: string | null,
+  fleet: FleetState,
+): boolean {
+  if (sandboxId === null) return false
+  if (fleet.status === 'absent') return true
+  if (fleet.status !== 'ready') return false
+  return !fleet.sandboxes.some((s) => s.sandbox_id === sandboxId)
+}

--- a/shell/ui/src/page/useGuestTree.ts
+++ b/shell/ui/src/page/useGuestTree.ts
@@ -1,0 +1,57 @@
+/* The guest-target file tree: `shell::fs::ls` has no recursive form, so
+   directory listings load lazily — the guest root on selection, then one
+   `ls` per directory the FilesTab reports expanded (its debounced
+   expansion snapshot is the only expansion signal the tree model
+   exposes). Listings cache per target; a failed `ls` caches an empty
+   listing (matching the host tree's silent degrade). */
+
+import type { Host } from '@iii-dev/console-ui'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { type FlatTree, joinPath } from './coder'
+import { buildGuestTree, type FsEntry, GUEST_ROOT, guestLs } from './sandbox'
+
+export function useGuestTree(
+  host: Host,
+  sandboxId: string | null,
+  expanded: readonly string[],
+): FlatTree | null {
+  const cacheRef = useRef<Map<string, FsEntry[]>>(new Map())
+  const seqRef = useRef(0)
+  const [tree, setTree] = useState<FlatTree | null>(null)
+
+  const load = useCallback(
+    async (sid: string, dirs: string[]) => {
+      const seq = seqRef.current
+      await Promise.all(
+        dirs.map(async (dir) => {
+          let entries: FsEntry[] = []
+          try {
+            entries = await guestLs(host, sid, joinPath(GUEST_ROOT, dir))
+          } catch {
+            // Cache the empty listing so the miss is not refetched on
+            // every expansion snapshot.
+          }
+          if (seqRef.current === seq) cacheRef.current.set(dir, entries)
+        }),
+      )
+      if (seqRef.current === seq) setTree(buildGuestTree(cacheRef.current))
+    },
+    [host],
+  )
+
+  useEffect(() => {
+    seqRef.current++
+    cacheRef.current = new Map()
+    setTree(null)
+    if (sandboxId === null) return
+    void load(sandboxId, [''])
+  }, [sandboxId, load])
+
+  useEffect(() => {
+    if (sandboxId === null) return
+    const missing = expanded.filter((dir) => !cacheRef.current.has(dir))
+    if (missing.length > 0) void load(sandboxId, missing)
+  }, [sandboxId, expanded, load])
+
+  return tree
+}

--- a/shell/ui/src/page/useSandboxFleet.ts
+++ b/shell/ui/src/page/useSandboxFleet.ts
@@ -1,0 +1,90 @@
+/* Live fleet for the target picker: one `sandbox::list` read on mount,
+   then pushed `{ kind: "fleet" }` snapshots over a tab-scoped
+   `sandbox-code-runner::event` trigger (the `iii::` handler-id prefix
+   keeps per-event invocations span-suppressed; `host.iii.on` namespaces
+   the handler `::<browserId>`, which the trigger's function_id repeats
+   to address it). The code-runner worker may be absent — the mount read
+   plus the manual refresh affordance stand alone then. A `sandbox::list`
+   that reads as function-not-found means no sandbox daemon at all:
+   status `absent`, and the picker hides entirely. */
+
+import type { Host } from '@iii-dev/console-ui'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { errorMessage } from '../lib/format'
+import {
+  type FleetState,
+  isFunctionNotFound,
+  parseFleetEvent,
+  parseSandboxList,
+} from './sandbox'
+
+const FLEET_HANDLER_FN = 'iii::shell-ui::fleet'
+const FLEET_EVENT_TRIGGER = 'sandbox-code-runner::event'
+
+export function useSandboxFleet(host: Host): {
+  fleet: FleetState
+  refreshFleet: () => void
+} {
+  const [fleet, setFleet] = useState<FleetState>({
+    status: 'loading',
+    sandboxes: [],
+  })
+  const aliveRef = useRef(true)
+  useEffect(() => {
+    aliveRef.current = true
+    return () => {
+      aliveRef.current = false
+    }
+  }, [])
+
+  const refreshFleet = useCallback(() => {
+    host.iii
+      .trigger('sandbox::list', {})
+      .then((out) => {
+        if (!aliveRef.current) return
+        setFleet({ status: 'ready', sandboxes: parseSandboxList(out) })
+      })
+      .catch((err: unknown) => {
+        if (!aliveRef.current) return
+        setFleet((prev) => ({
+          status: isFunctionNotFound(errorMessage(err)) ? 'absent' : 'error',
+          // A transient failure keeps the last-known fleet — the picker
+          // must not dump a live selection over one bad read.
+          sandboxes: prev.sandboxes,
+        }))
+      })
+  }, [host])
+
+  useEffect(() => {
+    refreshFleet()
+  }, [refreshFleet])
+
+  useEffect(() => {
+    let offHandler: (() => void) | null = null
+    let offTrigger: (() => void) | null = null
+    try {
+      offHandler = host.iii.on(FLEET_HANDLER_FN, (payload: unknown) => {
+        const snapshot = parseFleetEvent(payload)
+        if (!snapshot || !aliveRef.current) return
+        setFleet({
+          status: snapshot.daemonAbsent ? 'absent' : 'ready',
+          sandboxes: snapshot.sandboxes,
+        })
+      })
+      offTrigger = host.iii.registerTrigger({
+        type: FLEET_EVENT_TRIGGER,
+        function_id: `${FLEET_HANDLER_FN}::${host.iii.browserId}`,
+        config: {},
+      })
+    } catch {
+      // Code-runner absent or the trigger type unregistered — the mount
+      // read and the refresh affordance remain.
+    }
+    return () => {
+      offTrigger?.()
+      offHandler?.()
+    }
+  }, [host])
+
+  return { fleet, refreshFleet }
+}

--- a/shell/ui/src/page/useSandboxFleet.ts
+++ b/shell/ui/src/page/useSandboxFleet.ts
@@ -12,6 +12,7 @@ import type { Host } from '@iii-dev/console-ui'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { errorMessage } from '../lib/format'
 import {
+  createFleetSequencer,
   type FleetState,
   isFunctionNotFound,
   parseFleetEvent,
@@ -37,15 +38,20 @@ export function useSandboxFleet(host: Host): {
     }
   }, [])
 
+  // Overlapping reads resolve in any order — only the latest request may
+  // apply, and a pushed snapshot outranks every read still in flight.
+  const seqRef = useRef(createFleetSequencer())
+
   const refreshFleet = useCallback(() => {
+    const seq = seqRef.current.begin()
     host.iii
       .trigger('sandbox::list', {})
       .then((out) => {
-        if (!aliveRef.current) return
+        if (!aliveRef.current || !seqRef.current.isCurrent(seq)) return
         setFleet({ status: 'ready', sandboxes: parseSandboxList(out) })
       })
       .catch((err: unknown) => {
-        if (!aliveRef.current) return
+        if (!aliveRef.current || !seqRef.current.isCurrent(seq)) return
         setFleet((prev) => ({
           status: isFunctionNotFound(errorMessage(err)) ? 'absent' : 'error',
           // A transient failure keeps the last-known fleet — the picker
@@ -66,6 +72,8 @@ export function useSandboxFleet(host: Host): {
       offHandler = host.iii.on(FLEET_HANDLER_FN, (payload: unknown) => {
         const snapshot = parseFleetEvent(payload)
         if (!snapshot || !aliveRef.current) return
+        // The snapshot is fresher than any older list read in flight.
+        seqRef.current.invalidate()
         setFleet({
           status: snapshot.daemonAbsent ? 'absent' : 'ready',
           sandboxes: snapshot.sandboxes,

--- a/shell/ui/styles.css
+++ b/shell/ui/styles.css
@@ -476,6 +476,10 @@
   color: var(--color-ink);
   background: var(--color-surface-hover);
 }
+[data-iii-ui="shell"] .shui-target-refresh:focus-visible {
+  outline: 1px solid var(--color-rule-focus);
+  outline-offset: 1px;
+}
 [data-iii-ui="shell"] .shui-refresh-icon {
   width: 12px;
   height: 12px;
@@ -511,6 +515,13 @@
   color: var(--color-ink);
   background: var(--color-surface-hover);
 }
+[data-iii-ui="shell"] .shui-copy-btn:focus-visible {
+  outline: 1px solid var(--color-rule-focus);
+  outline-offset: 1px;
+}
+/* copied/failed flash — the icon swaps (check / alert) and takes the tone */
+[data-iii-ui="shell"] .shui-copy-btn.copied { color: var(--color-ok); }
+[data-iii-ui="shell"] .shui-copy-btn.failed { color: var(--color-alert); }
 [data-iii-ui="shell"] .shui-copy-icon {
   width: 12px;
   height: 12px;

--- a/shell/ui/styles.css
+++ b/shell/ui/styles.css
@@ -437,6 +437,85 @@
 }
 [data-iii-ui="shell"] .shui-root-select { width: calc(100% - 12px); }
 
+/* target picker — host vs live microVMs, above the root affordance */
+[data-iii-ui="shell"] .shui-target-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin: 6px 6px 0;
+}
+[data-iii-ui="shell"] .shui-target-select {
+  flex: 1;
+  min-width: 0;
+  padding: 3px 6px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  color: var(--color-ink-faint);
+  border: 1px solid var(--color-edge);
+  background: var(--color-surface);
+  border-radius: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+[data-iii-ui="shell"] .shui-target-refresh {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-ink-faint);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+[data-iii-ui="shell"] .shui-target-refresh:hover {
+  color: var(--color-ink);
+  background: var(--color-surface-hover);
+}
+[data-iii-ui="shell"] .shui-refresh-icon {
+  width: 12px;
+  height: 12px;
+}
+
+/* header chip for a sandbox target: dot + truncated id + copy */
+[data-iii-ui="shell"] .shui-target-desc {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+[data-iii-ui="shell"] .shui-target-desc .id {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+[data-iii-ui="shell"] .shui-copy-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 0;
+  border-radius: 2px;
+  background: transparent;
+  color: var(--color-ink-ghost);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+[data-iii-ui="shell"] .shui-copy-btn:hover {
+  color: var(--color-ink);
+  background: var(--color-surface-hover);
+}
+[data-iii-ui="shell"] .shui-copy-icon {
+  width: 12px;
+  height: 12px;
+}
+
 [data-iii-ui="shell"] .shui-side-body {
   flex: 1;
   min-height: 0;


### PR DESCRIPTION
## What

Every shell function already takes `target: { kind: "sandbox", sandbox_id }` — host and sandbox share one wire shape on `exec`, `exec_bg`, and all `fs::*`. The page never exposed it. This adds a **target picker** to shell's injected page so the same file browser serves the host workspace and every live microVM.

- **Picker**: `host` (default — byte-identical behavior, still on the `coder::*` twin surface) + one entry per live sandbox. Fleet source: one `sandbox::list` read on mount, plus `{kind:'fleet'}` snapshots over the `sandbox-code-runner::event` trigger when that worker is present (handler `iii::shell-ui::fleet::<browserId>`); `sandbox::list` function-not-found hides the picker entirely.
- **Guest mode**: the tree/search swap to the target-carrying `shell::fs::*` twins (`ls` lazily per expand from `/`, search via `fs::grep` with regex-escaped literals). Host-only affordances (git tab, workspace roots) hide; the header shows the sandbox id (truncated, copyable) and a running dot; a sandbox that leaves the fleet degrades to "sandbox gone — reaped or stopped" with a one-click return to host.
- **Guest reads**: `shell::exec` `cat` — the page cannot consume `shell::fs::read`'s ContentRef channel (the console extension client has no channel API), and the README's `read_inline` wrapper does not exist in-repo. Truncation is detected by byte-count against `fs::stat`; binaries by NUL probe; both flip the viewer read-only with the existing notes.
- **Guest writes**: none exist for this surface (inline `content` is S210 on sandbox targets; the mandatory ContentRef form is unproducible from the page) — the editor is explicitly read-only for guests with a visible note, rather than a save that breaks.

## Verification

- shell/ui: tsc clean, vitest 100 passed (32 new: tolerant fleet parsing, host-omits/sandbox-carries payload threading, gone-degrade, guest tree, regex escape), biome clean, build green (bundle unchanged aside from the new module).
- shell: cargo fmt/clippy `-D warnings` clean, 1334 tests passed.
- Live-verified on a running engine: picker listed a live python microVM, its real rootfs browsed from the shell page, read-only note shown, host mode unchanged.

Fixes MOT-4388
