### PR TITLE
(MOT-4397) fix(console): make harness welcome screen scrollable on short viewports

### DIFF
--- a/console/web/src/components/chat/EmptyState.test.tsx
+++ b/console/web/src/components/chat/EmptyState.test.tsx
@@ -1,0 +1,12 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { EmptyState } from './EmptyState'
+
+describe('EmptyState', () => {
+  it('shrinks and scrolls while keeping short content centered', () => {
+    const html = renderToStaticMarkup(<EmptyState variant="ready" />)
+
+    expect(html).toContain('min-h-0 overflow-y-auto')
+    expect(html).toContain('my-auto')
+  })
+})

--- a/console/web/src/components/chat/EmptyState.tsx
+++ b/console/web/src/components/chat/EmptyState.tsx
@@ -76,8 +76,13 @@ export function EmptyState({
     variant === 'ready' || variant === 'no-provider' ? 'new session' : 'setup'
 
   return (
-    <div className={cn('flex-1 flex items-center justify-center', emptyPad)}>
-      <div className="max-w-[520px] w-full flex flex-col gap-6">
+    <div
+      className={cn(
+        'flex-1 min-h-0 overflow-y-auto flex justify-center',
+        emptyPad,
+      )}
+    >
+      <div className="my-auto max-w-[520px] w-full flex flex-col gap-6">
         <div className="font-mono text-[11px] uppercase tracking-[0.06em] text-ink-faint">
           <Prompt symbol="$">{eyebrow}</Prompt>
         </div>


### PR DESCRIPTION
Fixes [MOT-4397](https://linear.app/motia/issue/MOT-4397/console-harness-welcome-screen-overflows-with-no-scroll-on-short).

The chat `EmptyState` (welcome/setup screen) centered its card with `items-center justify-center` on a `flex-1` container, so on short viewports the top and bottom of the card were clipped with no way to scroll to them.

The container is now `min-h-0 overflow-y-auto`, and the card centers with `my-auto` — short content stays vertically centered, tall content scrolls.

Includes a render test asserting the scroll/centering classes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved empty-state layouts so content remains vertically centered when short and scrollable when it exceeds the available space.
  * Prevented chat content from overflowing while preserving horizontal alignment and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->