### PR TITLE
(MOT-4398) feat: stabilize Codex cache affinity, provider discovery, and reasoning output

### DIFF
--- a/harness/src/clients/router.rs
+++ b/harness/src/clients/router.rs
@@ -35,6 +35,7 @@ pub trait StreamSink: Send + Sync {
 /// Inputs for one `router::chat` turn.
 pub struct ChatParams {
     pub request_id: String,
+    pub session_id: String,
     pub model: String,
     pub provider: Option<String>,
     pub system_prompt: Option<String>,
@@ -133,6 +134,7 @@ impl RouterClient {
         let mut payload = json!({
             "writer_ref": channel.writer_ref,
             "request_id": params.request_id,
+            "session_id": params.session_id,
             "model": params.model,
             "messages": params.messages,
             "tools": params.tools,

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -639,6 +639,7 @@ pub async fn run_step(
     };
     let params = ChatParams {
         request_id: format!("{}:{}", record.turn_id, payload.step),
+        session_id: record.session_id.clone(),
         model: record.options.model.clone(),
         provider: record.options.provider.clone(),
         // Cloned into the request so the originals stay available for the

--- a/llm-router/src/chat/chat.rs
+++ b/llm-router/src/chat/chat.rs
@@ -48,6 +48,9 @@ use super::synthesize::{synthesize_aborted, synthesize_error};
 pub struct ChatCall {
     #[serde(default)]
     pub request_id: Option<String>,
+    /// Stable conversation identity, forwarded separately from the per-turn request id.
+    #[serde(default)]
+    pub session_id: Option<String>,
     pub model: String,
     #[serde(default)]
     pub provider: Option<String>,
@@ -538,7 +541,7 @@ fn rand_unit() -> f64 {
 /// null — provider-side schemas reject `null` where a string or array is
 /// expected. `resolution_key` is the request id: stable across retry attempts
 /// within a turn, fresh per turn, so providers can dedupe per-turn credential
-/// resolution.
+/// resolution. `session_id` remains stable across turns for provider affinity.
 fn build_stream_input(
     call: &ChatCall,
     provider: &str,
@@ -555,6 +558,11 @@ fn build_stream_input(
     input.insert(
         "resolution_key".into(),
         Value::String(request_id.to_string()),
+    );
+    insert_present(
+        &mut input,
+        "session_id",
+        call.session_id.clone().map(Value::String),
     );
     insert_present(
         &mut input,
@@ -714,6 +722,7 @@ mod tests {
             "thinking_level",
             "provider_options",
             "model_meta",
+            "session_id",
         ] {
             assert!(
                 !obj.contains_key(absent),
@@ -739,12 +748,14 @@ mod tests {
             "system_prompt": "be brief",
             "tools": [{ "name": "t", "description": "d", "parameters": {} }],
             "thinking_level": "high",
+            "session_id": "s_1",
             "provider_options": { "anthropic": { "beta": true }, "openai": { "x": 1 } },
         }))
         .unwrap();
         let input = build_stream_input(&call, "anthropic", writer_ref, 8192, None, "req-2");
         assert_eq!(input["system_prompt"], json!("be brief"));
         assert_eq!(input["thinking_level"], json!("high"));
+        assert_eq!(input["session_id"], json!("s_1"));
         assert_eq!(input["provider_options"], json!({ "beta": true }));
     }
 }

--- a/llm-router/src/register.rs
+++ b/llm-router/src/register.rs
@@ -11,7 +11,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use iii_sdk::errors::Error;
-use iii_sdk::protocol::{RegisterTriggerInput, TriggerRequest};
+use iii_sdk::protocol::RegisterTriggerInput;
 use iii_sdk::{IIIClient, RegisterFunction};
 use serde_json::{json, Value};
 
@@ -286,27 +286,61 @@ pub async fn register_router(iii: IIIClient) -> Result<RouterRefs, Error> {
     // The ready fan-out only reaches providers whose `router::ready` binding
     // still exists — and the engine drops those bindings when THIS worker
     // (the trigger type's owner) disconnects, so providers that outlived a
-    // router restart never hear it. Nudge every restored provider directly:
+    // router restart never hear it. Nudge every provider directly:
     // `provider::<id>::on_router_ready` is the deterministic per-provider
     // handler (same one the fan-out targets), a live provider re-declares —
     // flipping the boot-reset availability back up — and a dead one is
     // function_not_found, which is exactly the right answer. Detached: boot
     // must not block on provider round-trips.
+    //
+    // The provider set comes from the ENGINE, not `registry.ids()`: the
+    // persisted registry is empty on any stack whose state worker runs
+    // in-memory, and then this repair reached nobody. See
+    // `registry::rediscover`.
     {
         let iii = iii.clone();
-        let ids = registry.ids().await;
         tokio::spawn(async move {
-            for id in ids {
-                let _ = iii
-                    .trigger(TriggerRequest {
-                        function_id: format!("provider::{id}::on_router_ready"),
-                        payload: json!({}),
-                        action: None,
-                        timeout_ms: Some(10_000),
-                    })
-                    .await;
-            }
+            let count = crate::registry::rediscover::nudge_live_providers(&iii).await;
+            tracing::debug!(
+                providers = count,
+                "boot: nudged live providers to re-declare"
+            );
         });
+    }
+
+    // A provider that reconnects to the engine while the router stays up gets
+    // its FUNCTIONS replayed by the SDK, but not its catalog — that is
+    // application state this worker holds, and nothing re-pushes it until the
+    // provider's own periodic timer (three minutes for openai-codex). Watch
+    // the engine's registration stream and re-run the same nudge, so a
+    // returning provider is resolvable in seconds instead of minutes.
+    {
+        let iii_handler = iii.clone();
+        let sweep = crate::registry::rediscover::spawn_debounced_sweep(iii_handler);
+        iii.register_function(
+            surface::ON_FUNCTIONS_CHANGED_ID,
+            RegisterFunction::new_async(move |_event: Value| {
+                let sweep = sweep.clone();
+                async move {
+                    // Coalesce the boot burst: the handler only marks work
+                    // pending, the sweep task fires once it goes quiet.
+                    sweep.request();
+                    Ok::<Value, Error>(json!({ "ok": true }))
+                }
+            })
+            .description(surface::ON_FUNCTIONS_CHANGED_DESC)
+            .metadata(json!({ "internal": true, "trace_hidden": true })),
+        );
+        if let Err(e) = iii.register_trigger(RegisterTriggerInput {
+            trigger_type: "engine::functions-available".into(),
+            function_id: surface::ON_FUNCTIONS_CHANGED_ID.into(),
+            config: json!({}),
+            metadata: None,
+        }) {
+            // Best-effort: without it providers still recover on their own
+            // timer, exactly as before this binding existed.
+            tracing::warn!(error = %e, "binding engine::functions-available failed; provider re-discovery falls back to each provider's periodic refresh");
+        }
     }
 
     Ok(RouterRefs {

--- a/llm-router/src/registry/mod.rs
+++ b/llm-router/src/registry/mod.rs
@@ -1,4 +1,5 @@
 pub mod availability;
+pub mod rediscover;
 pub mod register;
 pub mod resolve;
 pub mod store;

--- a/llm-router/src/registry/rediscover.rs
+++ b/llm-router/src/registry/rediscover.rs
@@ -1,0 +1,209 @@
+//! Provider re-discovery: find live providers from the ENGINE's function
+//! registry rather than from the router's own persisted registry, and nudge
+//! each one to re-declare.
+//!
+//! Why this exists. Providers re-declare (and re-push their catalog) when they
+//! handle `provider::<id>::on_router_ready`. Two things can stop that from
+//! happening, and both leave the router serving an empty catalog while the
+//! providers themselves are healthy and connected:
+//!
+//! 1. The engine drops a trigger binding when the type's owner — this worker —
+//!    disconnects, so a provider that outlived a router restart never hears the
+//!    `router::ready` fan-out. `register.rs` already compensates by nudging
+//!    `registry.ids()` directly, but that list comes from the persisted
+//!    registry: on a stack whose state worker runs in-memory it is EMPTY after
+//!    a restart, so the nudge reaches nobody.
+//! 2. `router::ready` is a one-shot broadcast. A provider that re-binds its
+//!    subscription after the router fired it simply misses it.
+//!
+//! In both cases the provider recovers only on its own periodic catalog timer
+//! (three minutes for openai-codex), and until then every model it serves is
+//! unresolvable — `router::models::budget` returns null, context-manager takes
+//! its conservative 8k fallback, and healthy sessions die with a bewildering
+//! `context/overflow`.
+//!
+//! The engine's function registry is the one source that is always current, so
+//! we derive the provider set from it. `provider::<id>::on_router_ready` is the
+//! deterministic per-provider handler (the same one the fan-out targets), which
+//! makes it both the discovery key and the thing to call.
+
+use iii_sdk::protocol::TriggerRequest;
+use iii_sdk::IIIClient;
+use serde_json::{json, Value};
+use std::collections::HashSet;
+
+/// The handler suffix that identifies a provider and receives the nudge.
+const READY_HANDLER_SUFFIX: &str = "::on_router_ready";
+const PROVIDER_PREFIX: &str = "provider::";
+/// A nudge is a provider round-trip (it re-declares and re-fetches its
+/// catalog); bound it so one slow provider cannot stall the sweep.
+const NUDGE_TIMEOUT_MS: u64 = 10_000;
+
+/// Provider ids with a live `provider::<id>::on_router_ready` registration.
+/// Errors and malformed rows yield an empty list — re-discovery is a repair
+/// path and must never take the router down.
+///
+/// `include_internal` is required, not optional: most providers tag their
+/// ready handler `metadata.internal = true` (it is invoked by id, never
+/// discovered), and the engine's default list hides exactly those. Without
+/// the flag this found only the one provider that happens not to tag it —
+/// verified live, one of four.
+pub async fn live_provider_ids(iii: &IIIClient) -> Vec<String> {
+    let response = iii
+        .trigger(TriggerRequest {
+            function_id: "engine::functions::list".into(),
+            payload: json!({ "prefix": PROVIDER_PREFIX, "include_internal": true }),
+            action: None,
+            timeout_ms: Some(NUDGE_TIMEOUT_MS),
+        })
+        .await;
+    let Ok(value) = response else {
+        return Vec::new();
+    };
+    let mut ids: Vec<String> = value
+        .get("functions")
+        .and_then(Value::as_array)
+        .map(|rows| {
+            rows.iter()
+                .filter_map(|row| row.get("function_id").and_then(Value::as_str))
+                .filter_map(provider_id_of)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    ids.sort();
+    ids.dedup();
+    ids
+}
+
+/// The provider id inside `provider::<id>::on_router_ready`, if that is what
+/// this function id is. Ids are matched whole — a function that merely starts
+/// with the prefix, or one whose id contains the suffix mid-string, is not a
+/// ready handler.
+fn provider_id_of(function_id: &str) -> Option<&str> {
+    let rest = function_id.strip_prefix(PROVIDER_PREFIX)?;
+    let id = rest.strip_suffix(READY_HANDLER_SUFFIX)?;
+    (!id.is_empty() && !id.contains("::")).then_some(id)
+}
+
+fn newly_live_provider_ids(known: &mut HashSet<String>, live: Vec<String>) -> Vec<String> {
+    let added = live
+        .iter()
+        .filter(|id| !known.contains(*id))
+        .cloned()
+        .collect();
+    *known = live.into_iter().collect();
+    added
+}
+
+async fn nudge_provider_ids(iii: &IIIClient, ids: &[String]) {
+    for id in ids {
+        let _ = iii
+            .trigger(TriggerRequest {
+                function_id: format!("{PROVIDER_PREFIX}{id}{READY_HANDLER_SUFFIX}"),
+                payload: json!({}),
+                action: None,
+                timeout_ms: Some(NUDGE_TIMEOUT_MS),
+            })
+            .await;
+    }
+}
+
+/// Nudge every live provider to re-declare. Fire-and-forget per provider: a
+/// dead one answers `function_not_found`, which is exactly the right answer,
+/// and a slow one cannot hold up the rest.
+pub async fn nudge_live_providers(iii: &IIIClient) -> usize {
+    let ids = live_provider_ids(iii).await;
+    nudge_provider_ids(iii, &ids).await;
+    ids.len()
+}
+
+/// Coalescing handle for the re-discovery sweep. `engine::functions-available`
+/// fires for every function registration change, including unrelated console
+/// subscriptions. The sweep tracks provider membership and nudges only newly
+/// live providers after the burst goes quiet.
+#[derive(Clone)]
+pub struct SweepHandle {
+    tx: tokio::sync::mpsc::Sender<()>,
+}
+
+impl SweepHandle {
+    /// Mark a sweep as due. Never blocks and never fails: a full channel
+    /// already means a sweep is pending, which is the same outcome.
+    pub fn request(&self) {
+        let _ = self.tx.try_send(());
+    }
+}
+
+/// Quiet period before a pending sweep runs.
+const SWEEP_DEBOUNCE: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Spawn the sweep task and return its handle.
+pub fn spawn_debounced_sweep(iii: IIIClient) -> SweepHandle {
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<()>(1);
+    tokio::spawn(async move {
+        let mut known = HashSet::new();
+        while rx.recv().await.is_some() {
+            // Drain the rest of the burst, extending the quiet period each
+            // time another request arrives.
+            while tokio::time::timeout(SWEEP_DEBOUNCE, rx.recv())
+                .await
+                .is_ok_and(|received| received.is_some())
+            {}
+            let live = live_provider_ids(&iii).await;
+            let added = newly_live_provider_ids(&mut known, live);
+            let count = added.len();
+            nudge_provider_ids(&iii, &added).await;
+            tracing::debug!(
+                providers = count,
+                "registration change: nudged newly live providers to re-declare"
+            );
+        }
+    });
+    SweepHandle { tx }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_id_is_extracted_only_from_whole_ready_handler_ids() {
+        assert_eq!(
+            provider_id_of("provider::openai-codex::on_router_ready"),
+            Some("openai-codex")
+        );
+        assert_eq!(
+            provider_id_of("provider::anthropic::on_router_ready"),
+            Some("anthropic")
+        );
+        // Other provider functions are not the ready handler.
+        assert_eq!(provider_id_of("provider::anthropic::chat"), None);
+        assert_eq!(provider_id_of("provider::anthropic::models::refresh"), None);
+        // Not a provider function at all.
+        assert_eq!(provider_id_of("router::models::get"), None);
+        assert_eq!(provider_id_of("harness::send"), None);
+        // Degenerate shapes resolve to nothing rather than a bogus id.
+        assert_eq!(provider_id_of("provider::::on_router_ready"), None);
+        assert_eq!(provider_id_of("provider::on_router_ready"), None);
+        // A nested id would make `provider::<id>::on_router_ready` ambiguous.
+        assert_eq!(provider_id_of("provider::a::b::on_router_ready"), None);
+    }
+
+    #[test]
+    fn provider_set_diff_only_returns_new_ids() {
+        let mut known = std::collections::HashSet::from(["anthropic".to_string()]);
+
+        assert!(newly_live_provider_ids(&mut known, vec!["anthropic".into()]).is_empty());
+        assert_eq!(
+            newly_live_provider_ids(&mut known, vec!["anthropic".into(), "openai-codex".into()]),
+            vec!["openai-codex"]
+        );
+
+        assert!(newly_live_provider_ids(&mut known, vec!["openai-codex".into()]).is_empty());
+        assert_eq!(
+            newly_live_provider_ids(&mut known, vec!["anthropic".into(), "openai-codex".into()]),
+            vec!["anthropic"]
+        );
+    }
+}

--- a/llm-router/src/surface.rs
+++ b/llm-router/src/surface.rs
@@ -94,6 +94,12 @@ pub const MODELS_RECONCILE_ID: &str = "router::models::reconcile";
 pub const MODELS_RECONCILE_DESC: &str =
     "Replace a provider's catalog slice — the only catalog write path (token-gated).";
 
+pub const ON_FUNCTIONS_CHANGED_ID: &str = "router::on_functions_changed";
+pub const ON_FUNCTIONS_CHANGED_DESC: &str =
+    "Internal: a worker's function registrations changed — re-discover live \
+     providers and nudge them to re-declare, so a provider that reconnected \
+     is resolvable again without waiting for its own catalog timer.";
+
 pub const ON_CONFIG_CHANGED_ID: &str = "router::on_config_changed";
 pub const ON_CONFIG_CHANGED_DESC: &str =
     "Internal: reactively reload the in-memory configuration snapshot and \

--- a/llm-router/src/types/router.rs
+++ b/llm-router/src/types/router.rs
@@ -25,6 +25,8 @@ pub struct ChatRequest {
     pub writer_ref: StreamChannelRef, // direction "write"; the caller's channel
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_id: Option<String>, // router::abort correlation; generated when omitted
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>, // stable conversation identity for provider affinity
     pub model: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,

--- a/llm-router/tests/golden/schemas/router.chat.json
+++ b/llm-router/tests/golden/schemas/router.chat.json
@@ -69,6 +69,14 @@
       "response_format": {
         "default": null
       },
+      "session_id": {
+        "default": null,
+        "description": "Stable conversation identity, forwarded separately from the per-turn request id.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
       "system_prompt": {
         "default": null,
         "type": [

--- a/llm-router/tests/golden/schemas/router.complete.json
+++ b/llm-router/tests/golden/schemas/router.complete.json
@@ -41,6 +41,14 @@
       "response_format": {
         "default": null
       },
+      "session_id": {
+        "default": null,
+        "description": "Stable conversation identity, forwarded separately from the per-turn request id.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
       "system_prompt": {
         "default": null,
         "type": [

--- a/provider-openai-codex/Cargo.lock
+++ b/provider-openai-codex/Cargo.lock
@@ -1283,6 +1283,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/provider-openai-codex/Cargo.toml
+++ b/provider-openai-codex/Cargo.toml
@@ -33,6 +33,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 # JWT payload (account id / exp) decode — unsigned, no verification.
 base64 = "0.22"
+# Header-safe cache-affinity UUID derived from the stable session id.
+sha2 = "0.10"
 
 [dev-dependencies]
 uuid = { version = "1", features = ["v4"] }

--- a/provider-openai-codex/src/request.rs
+++ b/provider-openai-codex/src/request.rs
@@ -6,6 +6,7 @@ use crate::wire::tools::functions_to_wire;
 use llm_router::types::messages::AgentMessage;
 use llm_router::types::model::AgentFunction;
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 
 /// Codex client version whose Responses contract this worker mirrors.
 ///
@@ -13,14 +14,20 @@ use serde_json::{json, Value};
 /// it makes supported models such as GPT-5.6 Luna fail as "Model not found".
 pub(crate) const CODEX_COMPAT_VERSION: &str = "0.144.1";
 
+const SUMMARY_UNSUPPORTED_MODEL: &str = "gpt-5.3-codex-spark";
+
 pub struct BodyArgs {
     pub model: String, // upstream model id
     pub max_tokens: u64,
     pub system_prompt: String,
     pub messages: Vec<AgentMessage>,
     pub tools: Vec<AgentFunction>,
+    /// Resolved catalog capability, including the model-name fallback.
+    pub supports_thinking: bool,
     /// Pre-resolved reasoning effort; None omits the param.
     pub reasoning_effort: Option<String>,
+    /// Cache-routing key for the Responses backend; None omits the field.
+    pub prompt_cache_key: Option<String>,
 }
 
 /// Responses body: `input` items, `stream`, `store:false` (stateless — the
@@ -40,10 +47,77 @@ pub fn build_body(args: &BodyArgs) -> Value {
     if !wire_tools.is_empty() {
         body["tools"] = Value::Array(wire_tools);
     }
+    let mut reasoning = serde_json::Map::new();
+    if args.supports_thinking && args.model != SUMMARY_UNSUPPORTED_MODEL {
+        reasoning.insert("summary".into(), json!("auto"));
+    }
     if let Some(effort) = &args.reasoning_effort {
-        body["reasoning"] = json!({ "effort": effort });
+        reasoning.insert("effort".into(), json!(effort));
+    }
+    if !reasoning.is_empty() {
+        body["reasoning"] = Value::Object(reasoning);
+    }
+    if let Some(key) = &args.prompt_cache_key {
+        body["prompt_cache_key"] = json!(key);
     }
     body
+}
+
+/// Header-safe UUID derived from a stable conversation identity.
+pub fn derive_affinity_id(conversation_id: &str) -> Option<String> {
+    if conversation_id.trim().is_empty() {
+        return None;
+    }
+    let digest = Sha256::digest(conversation_id.as_bytes());
+    let mut b = [0u8; 16];
+    b.copy_from_slice(&digest[..16]);
+    b[6] = (b[6] & 0x0F) | 0x40;
+    b[8] = (b[8] & 0x3F) | 0x80;
+    Some(format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7], b[8], b[9], b[10], b[11], b[12], b[13],
+        b[14], b[15]
+    ))
+}
+
+/// Resolve header affinity and body cache keys independently. The durable
+/// session id wins; direct router callers fall back to per-request affinity.
+/// A caller's `prompt_cache_key` override affects only the JSON body.
+pub fn resolve_cache_routing(
+    provider_options: Option<&Value>,
+    session_id: Option<&str>,
+    resolution_key: Option<&str>,
+) -> (Vec<(&'static str, String)>, Option<String>) {
+    let affinity_id = session_id
+        .filter(|id| !id.trim().is_empty())
+        .or_else(|| resolution_key.filter(|id| !id.trim().is_empty()))
+        .and_then(derive_affinity_id);
+    let prompt_cache_key = provider_options
+        .and_then(|options| options.get("prompt_cache_key"))
+        .and_then(Value::as_str)
+        .filter(|key| !key.trim().is_empty())
+        .map(str::to_string)
+        .or_else(|| affinity_id.clone());
+    let headers = affinity_id
+        .as_deref()
+        .map(session_affinity_headers)
+        .unwrap_or_default();
+    (headers, prompt_cache_key)
+}
+
+/// Conversation-affinity headers, mirroring upstream Codex CLI's
+/// `ResponsesClient::stream_request` (`session-id`, `thread-id`, and
+/// `x-client-request-id`, all carrying the conversation UUID; our
+/// single-threaded conversations use one value for all three). The ChatGPT
+/// codex backend's cache affinity follows these headers;
+/// the body `prompt_cache_key` alone showed luck-rate hits in live sessions.
+/// Callers pass only derived UUIDs, never arbitrary body cache-key overrides.
+pub fn session_affinity_headers(key: &str) -> Vec<(&'static str, String)> {
+    vec![
+        ("session-id", key.to_string()),
+        ("thread-id", key.to_string()),
+        ("x-client-request-id", key.to_string()),
+    ]
 }
 
 /// Headers shared by every authenticated ChatGPT/Codex backend request.
@@ -91,7 +165,9 @@ mod tests {
                 timestamp: 1,
             })],
             tools: vec![],
+            supports_thinking: true,
             reasoning_effort: None,
+            prompt_cache_key: None,
         }
     }
 
@@ -112,7 +188,8 @@ mod tests {
         assert_eq!(body["input"][0]["role"], "system");
         assert_eq!(body["input"][1]["role"], "user");
         assert!(body.get("tools").is_none());
-        assert!(body.get("reasoning").is_none());
+        assert_eq!(body["reasoning"]["summary"], "auto");
+        assert!(body["reasoning"].get("effort").is_none());
         assert!(body.get("temperature").is_none());
     }
 
@@ -130,6 +207,35 @@ mod tests {
         let body = build_body(&a);
         assert_eq!(body["reasoning"]["effort"], "high");
         assert_eq!(body["tools"][0]["name"], "agent__trigger");
+    }
+
+    #[test]
+    fn spark_omits_the_unsupported_reasoning_summary() {
+        let mut a = args();
+        a.model = "gpt-5.3-codex-spark".into();
+        a.reasoning_effort = Some("high".into());
+        let body = build_body(&a);
+        assert!(body["reasoning"].get("summary").is_none());
+        assert_eq!(body["reasoning"]["effort"], "high");
+    }
+
+    #[test]
+    fn non_prefix_reasoning_model_includes_summary() {
+        let mut a = args();
+        a.model = "catalog-reasoner".into();
+        a.reasoning_effort = Some("high".into());
+        let body = build_body(&a);
+        assert_eq!(body["reasoning"]["summary"], "auto");
+    }
+
+    #[test]
+    fn catalog_capability_false_omits_summary_for_prefix_model() {
+        let mut a = args();
+        a.supports_thinking = false;
+        a.reasoning_effort = Some("high".into());
+        let body = build_body(&a);
+        assert!(body["reasoning"].get("summary").is_none());
+        assert_eq!(body["reasoning"]["effort"], "high");
     }
 
     #[test]
@@ -161,5 +267,122 @@ mod tests {
         assert!(h.contains(&("version", CODEX_COMPAT_VERSION.to_string())));
         assert!(!h.iter().any(|(key, _)| *key == "openai-beta"));
         assert!(!h.iter().any(|(key, _)| *key == "accept"));
+    }
+
+    /// RFC 4122 v4 shape: 36 chars, hyphens at 8/13/18/23, version nibble
+    /// `4`, variant nibble in `[89ab]` — what the backend's UUID parsers
+    /// accept anywhere a session id is expected.
+    fn assert_uuid_format(key: &str) {
+        assert_eq!(key.len(), 36, "not UUID-length: {key}");
+        for idx in [8, 13, 18, 23] {
+            assert_eq!(key.as_bytes()[idx], b'-', "hyphen missing at {idx}: {key}");
+        }
+        assert!(
+            key.chars()
+                .enumerate()
+                .all(|(i, c)| matches!(i, 8 | 13 | 18 | 23) || c.is_ascii_hexdigit()),
+            "non-hex char: {key}"
+        );
+        assert_eq!(key.as_bytes()[14], b'4', "version nibble: {key}");
+        assert!(
+            matches!(key.as_bytes()[19], b'8' | b'9' | b'a' | b'b'),
+            "variant nibble: {key}"
+        );
+    }
+
+    #[test]
+    fn affinity_headers_carry_every_codex_routing_id() {
+        let headers = session_affinity_headers("11112222-3333-4444-8555-666677778888");
+        assert_eq!(
+            headers,
+            vec![
+                (
+                    "session-id",
+                    "11112222-3333-4444-8555-666677778888".to_string()
+                ),
+                (
+                    "thread-id",
+                    "11112222-3333-4444-8555-666677778888".to_string()
+                ),
+                (
+                    "x-client-request-id",
+                    "11112222-3333-4444-8555-666677778888".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn affinity_id_is_stable_for_the_session() {
+        let one = derive_affinity_id("s_conversation").unwrap();
+        let two = derive_affinity_id("s_conversation").unwrap();
+        assert_uuid_format(&one);
+        assert_eq!(one, two);
+        assert_ne!(one, derive_affinity_id("s_other").unwrap());
+    }
+
+    #[test]
+    fn cache_routing_follows_the_session_across_turns() {
+        let before = resolve_cache_routing(None, Some("s_conversation"), Some("turn_1"));
+        let after = resolve_cache_routing(None, Some("s_conversation"), Some("turn_2"));
+        assert_eq!(before, after);
+        assert_eq!(
+            before.0[0].1,
+            before.1.unwrap(),
+            "the default body key matches affinity"
+        );
+    }
+
+    #[test]
+    fn prompt_cache_override_never_becomes_a_session_header() {
+        let provider_options = json!({ "prompt_cache_key": "shared\ncache" });
+        let (headers, prompt_cache_key) = resolve_cache_routing(
+            Some(&provider_options),
+            Some("s_conversation"),
+            Some("turn_1"),
+        );
+        assert_eq!(prompt_cache_key.as_deref(), Some("shared\ncache"));
+        assert_eq!(headers.len(), 3);
+        assert!(headers.iter().all(|(_, value)| !value.contains('\n')));
+    }
+
+    #[test]
+    fn body_carries_prompt_cache_key() {
+        let mut a = args();
+        a.prompt_cache_key = derive_affinity_id("s_conversation");
+        let body = build_body(&a);
+        let key = body["prompt_cache_key"].as_str().unwrap();
+        assert_uuid_format(key);
+    }
+
+    #[test]
+    fn missing_routing_identity_omits_the_default_key() {
+        assert_eq!(resolve_cache_routing(None, None, None), (vec![], None));
+        let mut a = args();
+        a.prompt_cache_key = None;
+        let body = build_body(&a);
+        assert!(body.get("prompt_cache_key").is_none());
+    }
+
+    #[test]
+    fn invalid_override_falls_back_to_affinity_key() {
+        let provider_options = json!({ "prompt_cache_key": 12345 });
+        let (headers, prompt_cache_key) =
+            resolve_cache_routing(Some(&provider_options), Some("s_conversation"), None);
+        assert_eq!(prompt_cache_key.as_deref(), Some(headers[0].1.as_str()));
+    }
+
+    #[test]
+    fn blank_override_falls_back_to_affinity_key() {
+        for blank in ["", "   "] {
+            let provider_options = json!({ "prompt_cache_key": blank });
+            let (headers, prompt_cache_key) =
+                resolve_cache_routing(Some(&provider_options), Some("s_conversation"), None);
+            assert_eq!(
+                prompt_cache_key.as_deref(),
+                Some(headers[0].1.as_str()),
+                "blank override {blank:?}"
+            );
+        }
     }
 }

--- a/provider-openai-codex/src/stream_fn.rs
+++ b/provider-openai-codex/src/stream_fn.rs
@@ -6,7 +6,7 @@
 use crate::config::build_config;
 use crate::errors::classify_bus_error;
 use crate::reasoning::{is_reasoning_model, native_reasoning_effort, reasoning_effort_for};
-use crate::request::{build_body, build_headers, BodyArgs};
+use crate::request::{build_body, build_headers, resolve_cache_routing, BodyArgs};
 use crate::sse::synthetic_error_event;
 use crate::upstream::{spawn_upstream, UpstreamArgs};
 use crate::{auth, router_client, state};
@@ -23,16 +23,26 @@ use llm_router::types::router::{
     CredentialSource, ProviderResolveResponse, ProviderStreamInput, ProviderStreamOutput,
 };
 
+#[derive(Debug, Clone, serde::Deserialize, schemars::JsonSchema)]
+#[schemars(rename = "ProviderStreamInput")]
+pub struct CodexStreamInput {
+    #[serde(flatten)]
+    pub input: ProviderStreamInput,
+    /// Durable conversation identity used only to derive header affinity.
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
 pub fn make_stream(
     iii: IIIClient,
     http: reqwest::Client,
     cache: ScaffoldCache,
     aborts: StreamAborts,
-) -> impl Fn(ProviderStreamInput) -> BoxFuture<'static, Result<ProviderStreamOutput, Error>>
+) -> impl Fn(CodexStreamInput) -> BoxFuture<'static, Result<ProviderStreamOutput, Error>>
        + Send
        + Sync
        + 'static {
-    move |input: ProviderStreamInput| {
+    move |input: CodexStreamInput| {
         let (iii, http, cache, aborts) = (iii.clone(), http.clone(), cache.clone(), aborts.clone());
         Box::pin(async move {
             // Register BEFORE the first await: an abort landing while the sink
@@ -40,10 +50,11 @@ pub fn make_stream(
             // deregisters on every exit — early returns and an executor
             // cancelling this future mid-await alike.
             let abort_reg = input
+                .input
                 .resolution_key
                 .as_ref()
                 .map(|rid| aborts.register(rid));
-            let sink = open_sink(&iii, &input.writer_ref).await?;
+            let sink = open_sink(&iii, &input.input.writer_ref).await?;
             run_stream_call(&iii, http, &cache, abort_reg.as_ref(), input, sink.as_ref()).await;
             sink.close();
             Ok(ProviderStreamOutput { ok: true })
@@ -66,9 +77,10 @@ async fn run_stream_call(
     http: reqwest::Client,
     cache: &ScaffoldCache,
     abort_reg: Option<&AbortGuard>,
-    input: ProviderStreamInput,
+    input: CodexStreamInput,
     sink: &dyn FrameSink,
 ) {
+    let CodexStreamInput { input, session_id } = input;
     let model = input.model.clone(); // router id (e.g. codex/gpt-5.5)
     let mut warnings = Vec::new();
 
@@ -126,12 +138,13 @@ async fn run_stream_call(
                 return;
             }
         };
-    let reasoning_effort = if native_effort.is_some() {
-        native_effort
-    } else if is_reasoning_model(
+    let supports_thinking = is_reasoning_model(
         &cfg.model,
         model_meta.as_ref().and_then(|m| m.supports_thinking),
-    ) {
+    );
+    let reasoning_effort = if native_effort.is_some() {
+        native_effort
+    } else if supports_thinking {
         let effort = reasoning_effort_for(input.thinking_level, &cfg.model);
         if input.thinking_level.is_some() && effort.is_none() {
             warnings.push(format!(
@@ -150,15 +163,29 @@ async fn run_stream_call(
         None
     };
 
+    let system_prompt = input.system_prompt.unwrap_or_default();
+    let (affinity_headers, prompt_cache_key) = resolve_cache_routing(
+        input.provider_options.as_ref(),
+        session_id.as_deref(),
+        input.resolution_key.as_deref(),
+    );
+    tracing::debug!(
+        affinity_configured = !affinity_headers.is_empty(),
+        prompt_cache_key_configured = prompt_cache_key.is_some(),
+        "codex cache affinity key"
+    );
+    let mut headers = build_headers(&cfg);
+    headers.extend(affinity_headers);
     let body = build_body(&BodyArgs {
         model: cfg.model.clone(),
         max_tokens: cfg.max_tokens,
-        system_prompt: input.system_prompt.unwrap_or_default(),
+        system_prompt,
         messages: input.messages,
         tools: input.tools.unwrap_or_default(),
+        supports_thinking,
         reasoning_effort,
+        prompt_cache_key,
     });
-    let headers = build_headers(&cfg);
 
     // Aborted while we were setting up — never start the upstream request.
     if abort_reg.is_some_and(|g| g.is_fired()) {

--- a/provider-openai-codex/src/surface.rs
+++ b/provider-openai-codex/src/surface.rs
@@ -9,8 +9,8 @@
 //! registration emits.
 
 use llm_router::types::router::{
-    ProviderAbortRequest, ProviderAbortResponse, ProviderReadyAck, ProviderStreamInput,
-    ProviderStreamOutput, RefreshModelsRequest, RefreshModelsResponse, RouterReadyEvent,
+    ProviderAbortRequest, ProviderAbortResponse, ProviderReadyAck, ProviderStreamOutput,
+    RefreshModelsRequest, RefreshModelsResponse, RouterReadyEvent,
 };
 
 pub const STREAM_ID: &str = "provider::openai-codex::stream";
@@ -67,7 +67,7 @@ where
 /// `tests/schemas.rs`; keep in lockstep with `register::register_provider`.
 pub fn catalog() -> Vec<FunctionSpec> {
     vec![
-        spec::<ProviderStreamInput, ProviderStreamOutput>(STREAM_ID, STREAM_DESC),
+        spec::<crate::stream_fn::CodexStreamInput, ProviderStreamOutput>(STREAM_ID, STREAM_DESC),
         spec::<ProviderAbortRequest, ProviderAbortResponse>(ABORT_ID, ABORT_DESC),
         spec::<RefreshModelsRequest, RefreshModelsResponse>(REFRESH_MODELS_ID, REFRESH_MODELS_DESC),
         spec::<RouterReadyEvent, ProviderReadyAck>(ON_ROUTER_READY_ID, ON_ROUTER_READY_DESC),

--- a/provider-openai-codex/tests/golden/schemas/provider.openai-codex.stream.json
+++ b/provider-openai-codex/tests/golden/schemas/provider.openai-codex.stream.json
@@ -716,6 +716,14 @@
           }
         ]
       },
+      "session_id": {
+        "default": null,
+        "description": "Durable conversation identity used only to derive header affinity.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
       "system_prompt": {
         "type": [
           "string",


### PR DESCRIPTION
Fixes MOT-4398

Codex prompt-cache hits were luck-rate because nothing stable identified the conversation to the ChatGPT backend, and a provider that reconnected while the router stayed up was unresolvable for up to its 3-minute catalog timer.

## Cache affinity (harness → llm-router → provider-openai-codex)

- The harness forwards the durable `session_id` through `router::chat` into the provider stream input (new optional field end to end; golden schemas updated).
- The provider derives a deterministic UUID from it (SHA-256 of the session id, v4-formatted) and sends the Codex CLI's affinity headers — `session-id`, `thread-id`, `x-client-request-id` — plus body `prompt_cache_key`. The body key alone showed luck-rate hits in live sessions; the backend routes on the headers.
- A `provider_options.prompt_cache_key` override affects only the JSON body, never headers. Direct router callers without a session fall back to per-request (`resolution_key`) affinity.

## Provider rediscovery (llm-router)

- The boot nudge now discovers live providers from the engine instead of the persisted registry, which is empty on any stack whose state worker runs in-memory — the repair previously reached nobody there (new `registry::rediscover`).
- New `engine::functions-available` binding with a debounced sweep re-nudges a reconnecting provider, so it is resolvable in seconds instead of waiting for its own catalog timer (3 minutes for openai-codex). Best-effort: if the binding fails, behavior falls back to the periodic refresh exactly as before.

## Reasoning output (provider-openai-codex)

- Request `reasoning.summary: "auto"` for reasoning models, merged with `effort` into one reasoning object. `gpt-5.3-codex-spark` is excluded — it rejects the field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional session IDs to chat and completion requests for stable conversation identity.
  - Improved provider reconnection handling so live providers are automatically rediscovered.
  - Added OpenAI Codex prompt-cache affinity using session and request information.
  - Added automatic reasoning summaries for supported Codex reasoning models, with model-specific exceptions.

- **Bug Fixes**
  - Preserved provider affinity across streaming requests and reconnections.

- **Tests**
  - Expanded coverage for session propagation, cache affinity, reasoning behavior, and provider discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->