### PR TITLE
feat(harness-e2e): collect lifecycle evidence

### DIFF
--- a/harness/tests/e2e/src/context.rs
+++ b/harness/tests/e2e/src/context.rs
@@ -1,7 +1,9 @@
+use std::collections::HashMap;
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context, Result};
 use harness::functions::metrics::SessionMetricsResponseV1;
+use harness::functions::session_tree::SessionTreeResponseV1;
 use harness::functions::status::StatusReport;
 use harness::types::turn::TurnStatus;
 use iii_sdk::protocol::TriggerRequest;
@@ -10,6 +12,8 @@ use iii_sdk::{register_worker, IIIClient, InitOptions};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::{json, Value};
+
+use crate::evidence::SessionTranscript;
 
 pub const INVOCATION_TIMEOUT: Duration = Duration::from_secs(120);
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -273,6 +277,51 @@ impl E2eContext {
             }
             tokio::time::sleep(METRICS_POLL_INTERVAL.min(remaining)).await;
         }
+    }
+
+    pub async fn status(&self, session_id: &str) -> Result<Option<StatusReport>> {
+        self.trigger("harness::status", json!({ "session_id": session_id }))
+            .await
+    }
+
+    pub async fn session_tree(&self, root_session_id: &str) -> Result<SessionTreeResponseV1> {
+        self.trigger(
+            "harness::session-tree",
+            json!({ "root_session_id": root_session_id }),
+        )
+        .await
+    }
+
+    pub async fn transcripts_for_tree(
+        &self,
+        tree: &SessionTreeResponseV1,
+    ) -> Result<Vec<SessionTranscript>> {
+        let mut transcripts = Vec::with_capacity(tree.sessions.len());
+        for node in &tree.sessions {
+            transcripts.push(SessionTranscript {
+                session_id: node.session_id.clone(),
+                parent_session_id: node.parent_session_id.clone(),
+                messages: self.transcript(&node.session_id).await?,
+            });
+        }
+        Ok(transcripts)
+    }
+
+    pub async fn statuses_for_tree(
+        &self,
+        tree: &SessionTreeResponseV1,
+    ) -> Result<HashMap<String, StatusReport>> {
+        let mut statuses = HashMap::with_capacity(tree.sessions.len());
+        for node in &tree.sessions {
+            let status = self.status(&node.session_id).await?.ok_or_else(|| {
+                anyhow!(
+                    "harness::status returned no status for tree session {}",
+                    node.session_id
+                )
+            })?;
+            statuses.insert(node.session_id.clone(), status);
+        }
+        Ok(statuses)
     }
 
     pub async fn transcript(&self, session_id: &str) -> Result<Value> {

--- a/harness/tests/e2e/src/evidence.rs
+++ b/harness/tests/e2e/src/evidence.rs
@@ -1,0 +1,538 @@
+use std::collections::{HashMap, HashSet};
+
+use harness::functions::metrics::SessionMetricsResponseV1;
+use harness::functions::session_tree::SessionTreeResponseV1;
+use harness::functions::status::StatusReport;
+use harness::types::turn::TurnStatus;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::report::HardGateReport;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionTranscript {
+    pub session_id: String,
+    pub parent_session_id: Option<String>,
+    pub messages: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HarnessExecutionEvidence {
+    pub root: RootLifecycleEvidence,
+    pub sessions: Vec<SessionLifecycleEvidence>,
+    pub calls: Vec<FunctionCallEvidence>,
+    pub timeline: Vec<TimelineEvent>,
+    pub complete: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RootLifecycleEvidence {
+    pub session_id: String,
+    pub terminal_turn_id: Option<String>,
+    pub terminal_status: String,
+    pub turn_count: u32,
+    pub max_turns: u32,
+    pub validation_retries: u32,
+    pub transient_resumes: u32,
+    pub pending_function_calls: usize,
+    pub queued_messages: usize,
+    pub expects_wake: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionLifecycleEvidence {
+    pub session_id: String,
+    pub parent_session_id: Option<String>,
+    pub depth: u32,
+    pub terminal: bool,
+    pub status: String,
+    pub turn_count: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunctionCallEvidence {
+    pub session_id: String,
+    pub turn_id: Option<String>,
+    pub call_id: Option<String>,
+    pub transport_function_id: String,
+    pub effective_function_id: String,
+    pub arguments: Value,
+    pub result: FunctionResultEvidence,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum FunctionResultEvidence {
+    Succeeded {
+        result_entry_id: Option<String>,
+    },
+    Failed {
+        result_entry_id: Option<String>,
+        error: Option<String>,
+    },
+    Missing,
+    Duplicate {
+        count: usize,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimelineEvent {
+    pub sequence: u64,
+    pub timestamp_ms: Option<u64>,
+    pub session_id: String,
+    pub turn_id: Option<String>,
+    pub entry_id: Option<String>,
+    #[serde(flatten)]
+    pub event: TimelineEventKind,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TimelineEventKind {
+    Message,
+    FunctionCall {
+        call_id: Option<String>,
+        function_id: String,
+    },
+    FunctionResult {
+        call_id: Option<String>,
+        function_id: String,
+        is_error: bool,
+    },
+    ValidationNudge,
+    WakeNotification,
+    TriggerFired,
+}
+
+pub fn build_evidence(
+    root_status: &StatusReport,
+    tree: &SessionTreeResponseV1,
+    transcripts: &[SessionTranscript],
+    statuses: &HashMap<String, StatusReport>,
+) -> HarnessExecutionEvidence {
+    let sessions = tree
+        .sessions
+        .iter()
+        .map(|node| {
+            let status = statuses.get(&node.session_id);
+            SessionLifecycleEvidence {
+                session_id: node.session_id.clone(),
+                parent_session_id: node.parent_session_id.clone(),
+                depth: node.depth,
+                terminal: status.is_some_and(is_terminal),
+                status: status.map(status_name).unwrap_or_else(|| "missing".into()),
+                turn_count: status.map(|status| status.turn_count),
+            }
+        })
+        .collect::<Vec<_>>();
+    let (calls, timeline) = normalize_transcripts(transcripts);
+    let complete = tree.complete && sessions.iter().all(|session| session.terminal);
+    HarnessExecutionEvidence {
+        root: RootLifecycleEvidence {
+            session_id: root_status.session_id.clone(),
+            terminal_turn_id: root_status.turn_id.clone(),
+            terminal_status: status_name(root_status),
+            turn_count: root_status.turn_count,
+            max_turns: root_status.max_turns,
+            validation_retries: root_status.validation_retries,
+            transient_resumes: root_status.transient_resumes,
+            pending_function_calls: root_status.pending_function_calls.len(),
+            queued_messages: root_status.queued.len(),
+            expects_wake: root_status.expects_wake,
+        },
+        sessions,
+        calls,
+        timeline,
+        complete,
+    }
+}
+
+pub fn evaluate_structural_gates(
+    metrics: &SessionMetricsResponseV1,
+    tree: &SessionTreeResponseV1,
+    evidence: &HarnessExecutionEvidence,
+) -> Vec<HardGateReport> {
+    let tree_complete =
+        metrics.complete && tree.complete && evidence.sessions.iter().all(|s| s.terminal);
+    let ownership_error = ownership_error(tree);
+    let integrity_error = call_integrity_error(evidence);
+    vec![
+        gate(
+            "harness.session_tree_complete",
+            tree_complete,
+            format!(
+                "metrics_complete={}; tree_complete={}; terminal_sessions={}/{}",
+                metrics.complete,
+                tree.complete,
+                evidence.sessions.iter().filter(|s| s.terminal).count(),
+                evidence.sessions.len()
+            ),
+        ),
+        gate(
+            "harness.session_ownership",
+            ownership_error.is_none(),
+            ownership_error.unwrap_or_else(|| {
+                format!("validated ownership for {} session(s)", tree.sessions.len())
+            }),
+        ),
+        gate(
+            "harness.call_result_integrity",
+            integrity_error.is_none(),
+            integrity_error
+                .unwrap_or_else(|| format!("validated {} function call(s)", evidence.calls.len())),
+        ),
+    ]
+}
+
+fn gate(id: &str, passed: bool, reason: String) -> HardGateReport {
+    HardGateReport {
+        id: id.into(),
+        passed,
+        reason,
+    }
+}
+
+fn is_terminal(status: &StatusReport) -> bool {
+    matches!(
+        status.status,
+        TurnStatus::Completed | TurnStatus::Failed | TurnStatus::Cancelled
+    ) && !status.expects_wake
+}
+
+fn status_name(status: &StatusReport) -> String {
+    format!("{:?}", status.status).to_ascii_lowercase()
+}
+
+fn ownership_error(tree: &SessionTreeResponseV1) -> Option<String> {
+    if tree.root_session_id.is_empty() {
+        return Some("tree has an empty root session id".into());
+    }
+    let nodes = tree
+        .sessions
+        .iter()
+        .map(|n| (n.session_id.as_str(), n))
+        .collect::<HashMap<_, _>>();
+    let Some(root) = nodes.get(tree.root_session_id.as_str()) else {
+        return Some(format!(
+            "root session {} is absent from tree",
+            tree.root_session_id
+        ));
+    };
+    if root.parent_session_id.is_some() || root.depth != 0 {
+        return Some("root has a parent or non-zero depth".into());
+    }
+    if nodes.len() != tree.sessions.len() {
+        return Some("tree contains duplicate session ids".into());
+    }
+    for node in &tree.sessions {
+        if node.session_id == tree.root_session_id {
+            continue;
+        }
+        let Some(parent_id) = node.parent_session_id.as_deref() else {
+            return Some(format!("session {} has no parent", node.session_id));
+        };
+        let Some(parent) = nodes.get(parent_id) else {
+            return Some(format!(
+                "session {} references missing parent {parent_id}",
+                node.session_id
+            ));
+        };
+        if node.depth != parent.depth + 1 {
+            return Some(format!(
+                "session {} has depth {}, expected {}",
+                node.session_id,
+                node.depth,
+                parent.depth + 1
+            ));
+        }
+        let mut seen = HashSet::new();
+        let mut current = Some(node);
+        while let Some(item) = current {
+            if !seen.insert(item.session_id.as_str()) {
+                return Some(format!("cycle contains session {}", item.session_id));
+            }
+            current = item
+                .parent_session_id
+                .as_deref()
+                .and_then(|id| nodes.get(id).copied());
+        }
+    }
+    None
+}
+
+fn call_integrity_error(evidence: &HarnessExecutionEvidence) -> Option<String> {
+    let bad = evidence
+        .calls
+        .iter()
+        .filter(|call| {
+            !matches!(
+                call.result,
+                FunctionResultEvidence::Succeeded { .. } | FunctionResultEvidence::Failed { .. }
+            )
+        })
+        .count();
+    let calls = evidence
+        .calls
+        .iter()
+        .filter_map(|call| {
+            call.call_id
+                .as_ref()
+                .map(|id| (call.session_id.as_str(), id.as_str()))
+        })
+        .collect::<HashSet<_>>();
+    let orphaned = evidence
+        .timeline
+        .iter()
+        .filter_map(|event| match &event.event {
+            TimelineEventKind::FunctionResult {
+                call_id: Some(id), ..
+            } => Some((event.session_id.as_str(), id.as_str())),
+            _ => None,
+        })
+        .filter(|key| !calls.contains(key))
+        .count();
+    if bad > 0 || orphaned > 0 {
+        Some(format!(
+            "{bad} call(s) have missing or duplicate results; {orphaned} result(s) are orphaned"
+        ))
+    } else {
+        None
+    }
+}
+
+fn normalize_transcripts(
+    transcripts: &[SessionTranscript],
+) -> (Vec<FunctionCallEvidence>, Vec<TimelineEvent>) {
+    let mut calls = Vec::new();
+    let mut timeline = Vec::new();
+    let mut sequence = 0_u64;
+    for transcript in transcripts {
+        let entries = transcript
+            .messages
+            .get("messages")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        let mut results: HashMap<String, Vec<&Value>> = HashMap::new();
+        for entry in &entries {
+            if let Some(message) = entry.get("message") {
+                if message.get("role").and_then(Value::as_str) == Some("function_result") {
+                    if let Some(id) = message.get("function_call_id").and_then(Value::as_str) {
+                        results.entry(id.to_string()).or_default().push(entry);
+                    }
+                }
+            }
+        }
+        for entry in entries {
+            let entry_id = entry
+                .get("entry_id")
+                .and_then(Value::as_str)
+                .map(str::to_owned);
+            let turn_id = entry
+                .get("turn_id")
+                .and_then(Value::as_str)
+                .map(str::to_owned);
+            let timestamp_ms = entry.get("timestamp_ms").and_then(Value::as_u64);
+            let event = classify_entry(entry);
+            timeline.push(TimelineEvent {
+                sequence,
+                timestamp_ms,
+                session_id: transcript.session_id.clone(),
+                turn_id: turn_id.clone(),
+                entry_id: entry_id.clone(),
+                event,
+            });
+            sequence += 1;
+            let Some(message) = entry.get("message") else {
+                continue;
+            };
+            if message.get("role").and_then(Value::as_str) != Some("assistant") {
+                continue;
+            }
+            for block in message
+                .get("content")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+            {
+                if block.get("type").and_then(Value::as_str) != Some("function_call") {
+                    continue;
+                }
+                let Some(transport) = block.get("function_id").and_then(Value::as_str) else {
+                    continue;
+                };
+                let call_id = block.get("id").and_then(Value::as_str).map(str::to_owned);
+                let raw_arguments = block.get("arguments").cloned().unwrap_or_else(|| json!({}));
+                let (effective, arguments) = if transport == "agent_trigger" {
+                    (
+                        raw_arguments
+                            .get("function")
+                            .and_then(Value::as_str)
+                            .unwrap_or(transport)
+                            .to_string(),
+                        raw_arguments
+                            .get("payload")
+                            .cloned()
+                            .unwrap_or_else(|| json!({})),
+                    )
+                } else {
+                    (transport.to_string(), raw_arguments)
+                };
+                let matched = call_id
+                    .as_ref()
+                    .and_then(|id| results.get(id))
+                    .cloned()
+                    .unwrap_or_default();
+                let result = match matched.as_slice() {
+                    [] => FunctionResultEvidence::Missing,
+                    [entry] => {
+                        let result_message = &entry["message"];
+                        let result_entry_id = entry
+                            .get("entry_id")
+                            .and_then(Value::as_str)
+                            .map(str::to_owned);
+                        if result_message
+                            .get("is_error")
+                            .and_then(Value::as_bool)
+                            .unwrap_or(false)
+                        {
+                            FunctionResultEvidence::Failed {
+                                result_entry_id,
+                                error: result_message
+                                    .get("error")
+                                    .and_then(Value::as_str)
+                                    .map(str::to_owned),
+                            }
+                        } else {
+                            FunctionResultEvidence::Succeeded { result_entry_id }
+                        }
+                    }
+                    many => FunctionResultEvidence::Duplicate { count: many.len() },
+                };
+                calls.push(FunctionCallEvidence {
+                    session_id: transcript.session_id.clone(),
+                    turn_id: turn_id.clone(),
+                    call_id,
+                    transport_function_id: transport.into(),
+                    effective_function_id: effective,
+                    arguments,
+                    result,
+                });
+            }
+        }
+    }
+    (calls, timeline)
+}
+
+fn classify_entry(entry: &Value) -> TimelineEventKind {
+    if entry
+        .get("entry_id")
+        .and_then(Value::as_str)
+        .is_some_and(|id| id.contains("_nudge_"))
+        || entry.pointer("/origin/validation").and_then(Value::as_bool) == Some(true)
+    {
+        return TimelineEventKind::ValidationNudge;
+    }
+    if entry.pointer("/custom/custom_type").and_then(Value::as_str) == Some("trigger_fired") {
+        return TimelineEventKind::TriggerFired;
+    }
+    let Some(message) = entry.get("message") else {
+        return TimelineEventKind::Message;
+    };
+    if message.get("role").and_then(Value::as_str) == Some("function_result") {
+        return TimelineEventKind::FunctionResult {
+            call_id: message
+                .get("function_call_id")
+                .and_then(Value::as_str)
+                .map(str::to_owned),
+            function_id: message
+                .get("function_id")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown")
+                .into(),
+            is_error: message
+                .get("is_error")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+        };
+    }
+    if message.get("role").and_then(Value::as_str) == Some("assistant") {
+        if let Some(block) = message
+            .get("content")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .find(|b| b.get("type").and_then(Value::as_str) == Some("function_call"))
+        {
+            return TimelineEventKind::FunctionCall {
+                call_id: block.get("id").and_then(Value::as_str).map(str::to_owned),
+                function_id: block
+                    .get("function_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown")
+                    .into(),
+            };
+        }
+    }
+    TimelineEventKind::Message
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn transcript(messages: Value) -> SessionTranscript {
+        SessionTranscript {
+            session_id: "s".into(),
+            parent_session_id: None,
+            messages,
+        }
+    }
+
+    #[test]
+    fn normalizes_agent_trigger_and_pairs_result() {
+        let input = transcript(json!({"messages":[
+            {"entry_id":"call-entry","message":{"role":"assistant","content":[{"type":"function_call","id":"c1","function_id":"agent_trigger","arguments":{"function":"state::set","payload":{"key":"k"}}}]}},
+            {"entry_id":"result-entry","message":{"role":"function_result","function_call_id":"c1","function_id":"state::set","is_error":false}}
+        ]}));
+        let (calls, _) = normalize_transcripts(&[input]);
+        assert_eq!(calls[0].transport_function_id, "agent_trigger");
+        assert_eq!(calls[0].effective_function_id, "state::set");
+        assert!(matches!(
+            calls[0].result,
+            FunctionResultEvidence::Succeeded { .. }
+        ));
+    }
+
+    #[test]
+    fn detects_missing_and_duplicate_results() {
+        let input = transcript(json!({"messages":[
+            {"message":{"role":"assistant","content":[{"type":"function_call","id":"missing","function_id":"x","arguments":{}},{"type":"function_call","id":"duplicate","function_id":"y","arguments":{}}]}},
+            {"message":{"role":"function_result","function_call_id":"duplicate","function_id":"y","is_error":false}},
+            {"message":{"role":"function_result","function_call_id":"duplicate","function_id":"y","is_error":false}}
+        ]}));
+        let (calls, _) = normalize_transcripts(&[input]);
+        assert!(matches!(calls[0].result, FunctionResultEvidence::Missing));
+        assert!(matches!(
+            calls[1].result,
+            FunctionResultEvidence::Duplicate { count: 2 }
+        ));
+    }
+
+    #[test]
+    fn sequence_is_stable_when_timestamps_match() {
+        let input = transcript(
+            json!({"messages":[{"timestamp_ms":1,"message":{"role":"user"}},{"timestamp_ms":1,"message":{"role":"assistant","content":[]}}]}),
+        );
+        let (_, timeline) = normalize_transcripts(&[input]);
+        assert_eq!(
+            timeline
+                .iter()
+                .map(|event| event.sequence)
+                .collect::<Vec<_>>(),
+            vec![0, 1]
+        );
+    }
+}

--- a/harness/tests/e2e/src/main.rs
+++ b/harness/tests/e2e/src/main.rs
@@ -11,6 +11,7 @@ use crate::suite::{run_suite, SubjectConfig, SuiteRunConfig};
 mod catalog;
 mod context;
 mod dashboard;
+mod evidence;
 mod judge;
 mod report;
 mod scenarios;

--- a/harness/tests/e2e/src/report.rs
+++ b/harness/tests/e2e/src/report.rs
@@ -7,6 +7,7 @@ use harness::types::model::Model;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::evidence::HarnessExecutionEvidence;
 use crate::scenarios::ExecutionPolicy;
 
 mod summary;
@@ -121,6 +122,15 @@ impl From<&E2eRunReport> for RetryAttemptReport {
     }
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CleanupEvidence {
+    pub teardown_attempted: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub teardown_removed: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub teardown_error: Option<String>,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct E2eRunReport {
     pub run_id: String,
@@ -135,6 +145,10 @@ pub struct E2eRunReport {
     pub transcript: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metrics: Option<SessionMetricsResponseV1>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub harness_evidence: Option<HarnessExecutionEvidence>,
+    #[serde(default)]
+    pub cleanup: CleanupEvidence,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub judge_attempts: Option<u8>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -159,6 +173,8 @@ impl E2eRunReport {
             criteria: Vec::new(),
             transcript: None,
             metrics: None,
+            harness_evidence: None,
+            cleanup: CleanupEvidence::default(),
             judge_attempts: None,
             judge_usage: None,
             cost: CostReport::default(),

--- a/harness/tests/e2e/src/scenarios/mod.rs
+++ b/harness/tests/e2e/src/scenarios/mod.rs
@@ -6,10 +6,13 @@ use std::pin::Pin;
 use anyhow::{bail, Result};
 use clap::ValueEnum;
 use harness::functions::metrics::SessionMetricsResponseV1;
+use harness::functions::session_tree::SessionTreeResponseV1;
+use harness::functions::status::StatusReport;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::context::E2eContext;
+use crate::evidence::{HarnessExecutionEvidence, SessionTranscript};
 use crate::report::HardGateReport;
 
 pub mod common;
@@ -153,6 +156,10 @@ impl ScenarioSpec {
 
 pub struct ScenarioObservation {
     pub metrics: SessionMetricsResponseV1,
+    pub root_terminal_status: StatusReport,
+    pub session_tree: SessionTreeResponseV1,
+    pub session_transcripts: Vec<SessionTranscript>,
+    pub execution_evidence: HarnessExecutionEvidence,
     pub transcript: Value,
     pub response: String,
 }

--- a/harness/tests/e2e/src/suite.rs
+++ b/harness/tests/e2e/src/suite.rs
@@ -10,6 +10,7 @@ use serde_json::json;
 use uuid::Uuid;
 
 use crate::context::E2eContext;
+use crate::evidence::{build_evidence, evaluate_structural_gates};
 use crate::judge::{self, JudgeConfig};
 use crate::report::{
     CriterionReport, E2eReport, E2eRunReport, E2eScenarioReport, FailurePhase, ModelArtifact,
@@ -239,12 +240,17 @@ async fn run_once(
         report.push_failure(error.status, error.phase, error.message);
     }
 
-    if let Err(error) = context.teardown(&session_id).await {
-        report.push_failure(
-            RunStatus::InfrastructureError,
-            FailurePhase::Cleanup,
-            format!("harness::teardown: {error}"),
-        );
+    report.cleanup.teardown_attempted = true;
+    match context.teardown(&session_id).await {
+        Ok(removed) => report.cleanup.teardown_removed = Some(removed),
+        Err(error) => {
+            report.cleanup.teardown_error = Some(error.to_string());
+            report.push_failure(
+                RunStatus::InfrastructureError,
+                FailurePhase::Cleanup,
+                format!("harness::teardown: {error}"),
+            );
+        }
     }
     if let Some(cleanup) = spec.cleanup {
         if let Err(error) = cleanup(context, &run_id).await {
@@ -409,7 +415,7 @@ async fn execute(
         ));
     }
 
-    if let Err(error) = context
+    let root_terminal_status = match context
         .wait_for_turn(
             spec.id,
             session_id,
@@ -419,9 +425,12 @@ async fn execute(
         )
         .await
     {
-        capture_partial_observation(context, session_id, report).await;
-        return Err(subject_failure(FailurePhase::Execute, error.to_string()));
-    }
+        Ok(status) => status,
+        Err(error) => {
+            capture_partial_observation(context, session_id, report).await;
+            return Err(subject_failure(FailurePhase::Execute, error.to_string()));
+        }
+    };
     let metrics = match context
         .wait_for_complete_metrics(spec.id, session_id, stuck_timeout, progress_interval)
         .await
@@ -432,22 +441,49 @@ async fn execute(
             return Err(collection_failure(FailurePhase::Collect, error.to_string()));
         }
     };
-    let transcript = context.transcript(session_id).await.map_err(|error| {
-        RunFailure::new(
-            RunStatus::InfrastructureError,
-            FailurePhase::Collect,
-            error.to_string(),
-        )
-    })?;
+    let session_tree = context
+        .session_tree(session_id)
+        .await
+        .map_err(|error| collection_failure(FailurePhase::Collect, error.to_string()))?;
+    let session_transcripts = context
+        .transcripts_for_tree(&session_tree)
+        .await
+        .map_err(|error| collection_failure(FailurePhase::Collect, error.to_string()))?;
+    let statuses = context
+        .statuses_for_tree(&session_tree)
+        .await
+        .map_err(|error| collection_failure(FailurePhase::Collect, error.to_string()))?;
+    let transcript = session_transcripts
+        .iter()
+        .find(|item| item.session_id == session_id)
+        .map(|item| item.messages.clone())
+        .ok_or_else(|| {
+            collection_failure(
+                FailurePhase::Collect,
+                "root transcript is absent from session tree".into(),
+            )
+        })?;
+    let execution_evidence = build_evidence(
+        &root_terminal_status,
+        &session_tree,
+        &session_transcripts,
+        &statuses,
+    );
+    let structural_gates = evaluate_structural_gates(&metrics, &session_tree, &execution_evidence);
     let response = common::final_response(&transcript);
     let observation = ScenarioObservation {
         metrics,
+        root_terminal_status,
+        session_tree,
+        session_transcripts,
+        execution_evidence,
         transcript,
         response,
     };
     report.transcript = Some(observation.transcript.clone());
     report.metrics = Some(observation.metrics.clone());
-    let objective = (spec.evaluate)(context, &observation, run_id)
+    report.harness_evidence = Some(observation.execution_evidence.clone());
+    let mut objective = (spec.evaluate)(context, &observation, run_id)
         .await
         .map_err(|error| {
             RunFailure::new(
@@ -463,6 +499,17 @@ async fn execute(
             error.to_string(),
         )
     })?;
+    let mut gate_ids = HashSet::new();
+    for gate in structural_gates.iter().chain(objective.hard_gates.iter()) {
+        if !gate_ids.insert(gate.id.as_str()) {
+            return Err(RunFailure::new(
+                RunStatus::InfrastructureError,
+                FailurePhase::Evaluate,
+                format!("duplicate hard gate id {}", gate.id),
+            ));
+        }
+    }
+    objective.hard_gates.splice(0..0, structural_gates);
     report.hard_gates = objective.hard_gates;
     let mut awards = objective.awards;
 


### PR DESCRIPTION
## Summary

- preserve the terminal root `StatusReport` and collect the final session tree
- collect status and transcripts for every session owned by the root
- normalize lifecycle, timeline, effective function calls, and call/result integrity into `HarnessExecutionEvidence`
- add common structural gates for tree completeness, session ownership, and call/result integrity
- persist harness evidence and teardown removal details in `results.json`
- keep the existing root transcript and scenario evaluators compatible

## Error semantics

Failures to collect the tree, statuses, or transcripts remain infrastructure errors in the collect phase. Structural gates only fail when evidence was successfully collected and violates the lifecycle contract.

## Validation

- `cargo fmt --all`
- `cargo test -p harness-e2e` — 102 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed execution evidence for end-to-end test runs, including session timelines, function calls, results, and lifecycle events.
  * Reports now include session trees, transcripts, terminal statuses, structural validation results, and cleanup details.
  * Added visibility into teardown attempts, removed resources, and cleanup errors.

* **Bug Fixes**
  * Improved validation for incomplete sessions, missing statuses, and unmatched or duplicate function results.
  * Preserved partial test observations when failures occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->