### PR TITLE
(MOT-4401) feat(harness,console): push trigger-binding change events, drop the console trigger poll

### DIFF
--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -26,6 +26,7 @@ import { useWorktreeEvents } from '@/hooks/use-worktree-events'
 import type { ChatBackend } from '@/lib/backend'
 import { approvalBelongsToConversationTree } from '@/lib/backend/approval-events-live'
 import { predictedUserEntryId } from '@/lib/backend/harness-send'
+import { serialRefresh } from '@/lib/backend/serial-refresh'
 import {
   mergeFiredTriggers,
   type SessionTriggerInfo,
@@ -324,37 +325,47 @@ export function ChatView({
   // binding fires and retires, the refetch drops it — this cache lets the
   // fired ghost keep its full config/conditions after retirement.
   const seenTriggersRef = useRef<Map<string, SessionTriggerInfo>>(new Map())
+  // The current conversation's serialized list loader. Doorbells arrive
+  // at-least-once and burst on rapid fires; serialRefresh coalesces them
+  // behind one in-flight read so snapshots never apply out of order.
+  const triggersLoaderRef = useRef<{ refresh: () => void } | null>(null)
   const refreshTriggers = useCallback(() => {
+    triggersLoaderRef.current?.refresh()
+  }, [])
+  useEffect(() => {
     const listTriggers = backend.listTriggers
     if (!listTriggers) return
-    listTriggers(conversation.id)
-      .then((rows) => {
-        for (const row of rows) seenTriggersRef.current.set(row.id, row)
-        setSessionTriggers(rows)
-      })
-      .catch(() => {})
-  }, [backend.listTriggers, conversation.id])
-  useEffect(() => {
-    if (!backend.listTriggers) return
     seenTriggersRef.current = new Map()
     setSessionTriggers([])
-    refreshTriggers()
-    const off = backend.onTriggersChanged?.(conversation.id, refreshTriggers)
-    // Catch-up for doorbells missed while hidden (throttled tab, socket blip).
+    const loader = serialRefresh(
+      () => listTriggers(conversation.id),
+      (rows) => {
+        for (const row of rows) seenTriggersRef.current.set(row.id, row)
+        setSessionTriggers(rows)
+      },
+    )
+    triggersLoaderRef.current = loader
+    // Subscribe BEFORE the first snapshot so a mutation in the setup gap
+    // rings instead of being missed (both ride the same client bootstrap, so
+    // the registration frames are queued ahead of the list read).
+    const off = backend.onTriggersChanged?.(conversation.id, loader.refresh)
+    loader.refresh()
+    // Catch-up for doorbells missed while hidden (throttled tab). Missed
+    // doorbells across a socket outage are reseeded by the backend's
+    // reconnect listener.
     const onVisible = () => {
-      if (document.visibilityState === 'visible') refreshTriggers()
+      if (document.visibilityState === 'visible') loader.refresh()
     }
     document.addEventListener('visibilitychange', onVisible)
     return () => {
       off?.()
       document.removeEventListener('visibilitychange', onVisible)
+      // Discard any in-flight snapshot so the old conversation's rows can't
+      // land in the next conversation's state.
+      loader.reset()
+      if (triggersLoaderRef.current === loader) triggersLoaderRef.current = null
     }
-  }, [
-    refreshTriggers,
-    backend.listTriggers,
-    backend.onTriggersChanged,
-    conversation.id,
-  ])
+  }, [backend.listTriggers, backend.onTriggersChanged, conversation.id])
 
   const handleUnregisterTrigger = useCallback(
     async (subscriptionId: string) => {

--- a/console/web/src/components/chat/ChatView.tsx
+++ b/console/web/src/components/chat/ChatView.tsx
@@ -315,13 +315,14 @@ export function ChatView({
 
   // Registered trigger subscriptions (the harness's durable binding rows,
   // owned by this session): shown above the composer, unregisterable, detail
-  // on click. Polled — bindings come and go as the agent registers them.
+  // on click. Pushed — `harness::triggers-changed` rings on every binding
+  // mutation (any tab, fires, expiry, GC) and the handler refetches the list.
   const [sessionTriggers, setSessionTriggers] = useState<SessionTriggerInfo[]>(
     [],
   )
-  // Every full row this tab has EVER polled, by subscription id. When a once
-  // binding fires and retires, the poll drops it — this cache lets the fired
-  // ghost keep its full config/conditions after retirement.
+  // Every full row this tab has EVER fetched, by subscription id. When a once
+  // binding fires and retires, the refetch drops it — this cache lets the
+  // fired ghost keep its full config/conditions after retirement.
   const seenTriggersRef = useRef<Map<string, SessionTriggerInfo>>(new Map())
   const refreshTriggers = useCallback(() => {
     const listTriggers = backend.listTriggers
@@ -338,9 +339,22 @@ export function ChatView({
     seenTriggersRef.current = new Map()
     setSessionTriggers([])
     refreshTriggers()
-    const timer = window.setInterval(refreshTriggers, 5000)
-    return () => window.clearInterval(timer)
-  }, [refreshTriggers, backend.listTriggers])
+    const off = backend.onTriggersChanged?.(conversation.id, refreshTriggers)
+    // Catch-up for doorbells missed while hidden (throttled tab, socket blip).
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') refreshTriggers()
+    }
+    document.addEventListener('visibilitychange', onVisible)
+    return () => {
+      off?.()
+      document.removeEventListener('visibilitychange', onVisible)
+    }
+  }, [
+    refreshTriggers,
+    backend.listTriggers,
+    backend.onTriggersChanged,
+    conversation.id,
+  ])
 
   const handleUnregisterTrigger = useCallback(
     async (subscriptionId: string) => {
@@ -396,7 +410,7 @@ export function ChatView({
 
   // Fired-trigger history: durable `trigger_fired` transcript entries (mapped to
   // system messages). Drives the panel's fired/unregistered ghost rows so a
-  // once-trigger stays visible after the engine drops it from the poll.
+  // once-trigger stays visible after the engine drops it from the list.
   const firedTriggers = useMemo<TriggerFiredData[]>(() => {
     const out: TriggerFiredData[] = []
     for (const m of conversation.messages) {

--- a/console/web/src/lib/backend/real.ts
+++ b/console/web/src/lib/backend/real.ts
@@ -520,7 +520,10 @@ function realOnQueuedMessage(
 /**
  * `harness::triggers-changed` subscription: the doorbell to refetch
  * `listTriggers`. Same sync-return-over-async-bootstrap shape as
- * `realOnQueuedMessage`.
+ * `realOnQueuedMessage`, plus a reconnect reseed: the SDK replays trigger
+ * registrations on reconnect, but doorbells rung during the outage are gone,
+ * so every `connected` transition fires one catch-up event (the same repair
+ * TracesV2 uses).
  */
 function realOnTriggersChanged(
   sessionId: string,
@@ -528,15 +531,20 @@ function realOnTriggersChanged(
 ): () => void {
   let disposed = false
   let off: (() => void) | null = null
+  let offConn: (() => void) | null = null
   getIiiClient()
     .then((client) => {
       if (disposed) return
       off = startTriggersChangedSubscription(client, sessionId, () => onEvent())
+      offConn = client.addConnectionStateListener((state) => {
+        if (state === 'connected') onEvent()
+      })
     })
     .catch(() => {})
   return () => {
     disposed = true
     off?.()
+    offConn?.()
   }
 }
 

--- a/console/web/src/lib/backend/real.ts
+++ b/console/web/src/lib/backend/real.ts
@@ -49,6 +49,7 @@ import {
 } from './triggers'
 import {
   startQueuedEventsSubscription,
+  startTriggersChangedSubscription,
   startTurnEventsSubscription,
 } from './turn-events-live'
 import type {
@@ -516,6 +517,29 @@ function realOnQueuedMessage(
   }
 }
 
+/**
+ * `harness::triggers-changed` subscription: the doorbell to refetch
+ * `listTriggers`. Same sync-return-over-async-bootstrap shape as
+ * `realOnQueuedMessage`.
+ */
+function realOnTriggersChanged(
+  sessionId: string,
+  onEvent: () => void,
+): () => void {
+  let disposed = false
+  let off: (() => void) | null = null
+  getIiiClient()
+    .then((client) => {
+      if (disposed) return
+      off = startTriggersChangedSubscription(client, sessionId, () => onEvent())
+    })
+    .catch(() => {})
+  return () => {
+    disposed = true
+    off?.()
+  }
+}
+
 async function realListTriggers(
   sessionId: string,
 ): Promise<SessionTriggerInfo[]> {
@@ -697,6 +721,7 @@ export const realBackend: ChatBackend = {
   editQueued: realEditQueued,
   onQueuedMessage: realOnQueuedMessage,
   listTriggers: realListTriggers,
+  onTriggersChanged: realOnTriggersChanged,
   unregisterTrigger: realUnregisterTrigger,
   stateKeyExists: realStateKeyExists,
   watchApprovals: realWatchApprovals,

--- a/console/web/src/lib/backend/serial-refresh.test.ts
+++ b/console/web/src/lib/backend/serial-refresh.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest'
+import { serialRefresh } from './serial-refresh'
+
+function deferred<T>() {
+  let resolve!: (v: T) => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0))
+
+describe('serialRefresh', () => {
+  it('coalesces refreshes during a flight into one trailing rerun', async () => {
+    const gates: Array<ReturnType<typeof deferred<number>>> = []
+    const load = vi.fn(() => {
+      const gate = deferred<number>()
+      gates.push(gate)
+      return gate.promise
+    })
+    const apply = vi.fn()
+    const { refresh } = serialRefresh(load, apply)
+
+    refresh()
+    refresh()
+    refresh()
+    refresh()
+    expect(load).toHaveBeenCalledTimes(1)
+
+    gates[0].resolve(1)
+    await flush()
+    // The three extra signals collapsed into exactly one trailing rerun.
+    expect(load).toHaveBeenCalledTimes(2)
+    gates[1].resolve(2)
+    await flush()
+    expect(apply.mock.calls).toEqual([[1], [2]])
+    expect(load).toHaveBeenCalledTimes(2)
+  })
+
+  it('never overlaps requests, so responses apply in order', async () => {
+    const gates: Array<ReturnType<typeof deferred<string>>> = []
+    const { refresh } = serialRefresh(
+      () => {
+        const gate = deferred<string>()
+        gates.push(gate)
+        return gate.promise
+      },
+      (v) => applied.push(v),
+    )
+    const applied: string[] = []
+
+    refresh()
+    refresh() // queued behind the first — not a concurrent request
+    expect(gates).toHaveLength(1)
+    gates[0].resolve('old')
+    await flush()
+    gates[1].resolve('new')
+    await flush()
+    expect(applied).toEqual(['old', 'new'])
+  })
+
+  it('reset discards the in-flight response and its queued rerun', async () => {
+    const gate = deferred<string>()
+    const load = vi.fn(() => gate.promise)
+    const apply = vi.fn()
+    const { refresh, reset } = serialRefresh(load, apply)
+
+    refresh()
+    refresh() // pending rerun
+    reset()
+    gate.resolve('stale')
+    await flush()
+    expect(apply).not.toHaveBeenCalled()
+    expect(load).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps working after a load failure', async () => {
+    let fail = true
+    const apply = vi.fn()
+    const { refresh } = serialRefresh(
+      () => (fail ? Promise.reject(new Error('nope')) : Promise.resolve('ok')),
+      apply,
+    )
+    refresh()
+    await flush()
+    fail = false
+    refresh()
+    await flush()
+    expect(apply.mock.calls).toEqual([['ok']])
+  })
+})

--- a/console/web/src/lib/backend/serial-refresh.ts
+++ b/console/web/src/lib/backend/serial-refresh.ts
@@ -1,0 +1,48 @@
+/**
+ * Serialize an async reload behind one in-flight request. Doorbell events
+ * arrive at-least-once and can burst (every claim/retire of a rapidly firing
+ * binding rings), so `refresh()` calls during a flight coalesce into exactly
+ * one trailing rerun — never overlapping requests, so an older response can
+ * never land after (and overwrite) a newer one.
+ *
+ * `reset()` bumps the generation: an in-flight response is discarded instead
+ * of applied, and its coalesced rerun is dropped. Callers use it when the
+ * target changes (conversation switch) or on unmount.
+ */
+export function serialRefresh<T>(
+  load: () => Promise<T>,
+  apply: (value: T) => void,
+): { refresh: () => void; reset: () => void } {
+  let inFlight = false
+  let pending = false
+  let generation = 0
+  const refresh = () => {
+    if (inFlight) {
+      pending = true
+      return
+    }
+    inFlight = true
+    const started = generation
+    load()
+      .then((value) => {
+        if (generation === started) apply(value)
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (generation !== started) return
+        inFlight = false
+        if (pending) {
+          pending = false
+          refresh()
+        }
+      })
+  }
+  return {
+    refresh,
+    reset: () => {
+      generation += 1
+      inFlight = false
+      pending = false
+    },
+  }
+}

--- a/console/web/src/lib/backend/triggers.ts
+++ b/console/web/src/lib/backend/triggers.ts
@@ -35,8 +35,8 @@ export interface SessionTriggerInfo {
   /**
    * This subscription already fired and was retired (per a durable
    * `trigger_fired` transcript entry — see `mergeFiredTriggers`). Either a
-   * still-polled row annotated ahead of the next poll, or a synthesized
-   * "ghost" row reconstructed after the poll dropped it. Nothing left to
+   * still-listed row annotated ahead of the next refetch, or a synthesized
+   * "ghost" row reconstructed after the refetch dropped it. Nothing left to
    * unregister — the ✕ dismisses locally instead.
    */
   fired?: boolean
@@ -133,23 +133,23 @@ function firedGhostRow(t: TriggerFiredData): SessionTriggerInfo {
 }
 
 /**
- * Merge the live poll with fired-subscription history, correlated on the
+ * Merge the live list with fired-subscription history, correlated on the
  * subscription id (present on both sides). A *retired* fire means the binding
- * is gone: if the (≤5s stale) poll still lists it, annotate that row as fired
- * in place; once the poll drops it, append a greyed "ghost" row. Non-retired
- * fires leave their live row untouched; repeat fires collapse to one record
- * (newest wins).
+ * is gone: if a not-yet-refetched list still carries it, annotate that row as
+ * fired in place; once the refetch drops it, append a greyed "ghost" row.
+ * Non-retired fires leave their live row untouched; repeat fires collapse to
+ * one record (newest wins).
  *
- * Ghost fidelity is two-tier: prefer the FULL last-seen polled row (from
+ * Ghost fidelity is two-tier: prefer the FULL last-seen listed row (from
  * `seenRows`) — the fired record alone carries no config or conditions. The
  * thin record-only ghost remains the post-reload fallback.
  */
 export function mergeFiredTriggers(
-  polled: SessionTriggerInfo[],
+  listed: SessionTriggerInfo[],
   fired: TriggerFiredData[],
   seenRows?: ReadonlyMap<string, SessionTriggerInfo>,
 ): SessionTriggerInfo[] {
-  const liveIds = new Set(polled.map((t) => t.id))
+  const liveIds = new Set(listed.map((t) => t.id))
   const retiredLive = new Map<string, TriggerFiredData>()
   const ghosts: SessionTriggerInfo[] = []
   const seen = new Set<string>()
@@ -160,7 +160,7 @@ export function mergeFiredTriggers(
     if (seen.has(key)) continue
     seen.add(key)
     if (liveIds.has(key)) {
-      retiredLive.set(key, t) // stale poll row — mark, don't ghost
+      retiredLive.set(key, t) // not-yet-refetched row — mark, don't ghost
     } else {
       const remembered = seenRows?.get(key)
       ghosts.push(
@@ -170,8 +170,8 @@ export function mergeFiredTriggers(
       )
     }
   }
-  if (retiredLive.size === 0 && ghosts.length === 0) return polled
-  const rows = polled.map((row) => {
+  if (retiredLive.size === 0 && ghosts.length === 0) return listed
+  const rows = listed.map((row) => {
     const t = retiredLive.get(row.id)
     return t ? { ...row, fired: true, firedAt: t.fired_at } : row
   })

--- a/console/web/src/lib/backend/turn-events-live.test.ts
+++ b/console/web/src/lib/backend/turn-events-live.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it, vi } from 'vitest'
 import type { IiiClient } from '@/lib/iii-client'
 import type {
   MessageQueuedEvent,
+  TriggersChangedEvent,
   TurnCompletedEvent,
   TurnStartedEvent,
 } from '@/types/iii-agent-event'
 import {
   startQueuedEventsSubscription,
+  startTriggersChangedSubscription,
   startTurnEventsSubscription,
 } from './turn-events-live'
 
@@ -147,6 +149,45 @@ describe('startQueuedEventsSubscription', () => {
   it('unregisters handler and trigger on cleanup', () => {
     const { client, offHandler, triggerUnregister } = fakeClient()
     const stop = startQueuedEventsSubscription(client, 'sess-1', () => {})
+    stop()
+    expect(offHandler).toHaveBeenCalledTimes(1)
+    expect(triggerUnregister).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('startTriggersChangedSubscription', () => {
+  it('binds harness::triggers-changed scoped to the session and delivers', () => {
+    const { client, triggers, fire } = fakeClient()
+    const onChanged = vi.fn()
+    startTriggersChangedSubscription(client, 'sess-1', onChanged)
+
+    expect(triggers).toEqual([
+      {
+        type: 'harness::triggers-changed',
+        function_id: 'iii::console::triggers_changed::console-test',
+        config: { session_id: 'sess-1' },
+      },
+    ])
+    const event: TriggersChangedEvent = { session_id: 'sess-1', timestamp: 1 }
+    fire('iii::console::triggers_changed', event)
+    expect(onChanged).toHaveBeenCalledWith(event)
+  })
+
+  it("drops another session's doorbell (shared handler id)", () => {
+    const { client, fire } = fakeClient()
+    const onChanged = vi.fn()
+    startTriggersChangedSubscription(client, 'sess-1', onChanged)
+
+    fire('iii::console::triggers_changed', {
+      session_id: 'sess-2',
+      timestamp: 1,
+    })
+    expect(onChanged).not.toHaveBeenCalled()
+  })
+
+  it('unregisters handler and trigger on cleanup', () => {
+    const { client, offHandler, triggerUnregister } = fakeClient()
+    const stop = startTriggersChangedSubscription(client, 'sess-1', () => {})
     stop()
     expect(offHandler).toHaveBeenCalledTimes(1)
     expect(triggerUnregister).toHaveBeenCalledTimes(1)

--- a/console/web/src/lib/backend/turn-events-live.ts
+++ b/console/web/src/lib/backend/turn-events-live.ts
@@ -15,6 +15,7 @@
 import type { IiiClient } from '@/lib/iii-client'
 import type {
   MessageQueuedEvent,
+  TriggersChangedEvent,
   TurnCompletedEvent,
   TurnStartedEvent,
 } from '@/types/iii-agent-event'
@@ -22,9 +23,11 @@ import type {
 const TURN_COMPLETED_FN = 'iii::console::turn_completed'
 const TURN_STARTED_FN = 'iii::console::turn_started'
 const MESSAGE_QUEUED_FN = 'iii::console::message_queued'
+const TRIGGERS_CHANGED_FN = 'iii::console::triggers_changed'
 const TURN_COMPLETED_TRIGGER = 'harness::turn-completed'
 const TURN_STARTED_TRIGGER = 'harness::turn-started'
 const MESSAGE_QUEUED_TRIGGER = 'harness::message-queued'
+const TRIGGERS_CHANGED_TRIGGER = 'harness::triggers-changed'
 
 type ClientSubset = Pick<IiiClient, 'browserId' | 'on' | 'registerTrigger'>
 
@@ -119,5 +122,26 @@ export function startQueuedEventsSubscription(
     MESSAGE_QUEUED_TRIGGER,
     sessionId,
     onQueued,
+  )
+}
+
+/**
+ * Bind `harness::triggers-changed` for one session: fires when the session's
+ * trigger-binding set or a fire count changes (registration, unregistration
+ * from any tab, a fire, expiry, GC). A doorbell — consumers refetch
+ * `harness::triggers::list`, which stays idempotent under the trigger's
+ * at-least-once delivery. Returns a cleanup.
+ */
+export function startTriggersChangedSubscription(
+  client: ClientSubset,
+  sessionId: string,
+  onChanged: (event: TriggersChangedEvent) => void,
+): () => void {
+  return bind<TriggersChangedEvent>(
+    client,
+    TRIGGERS_CHANGED_FN,
+    TRIGGERS_CHANGED_TRIGGER,
+    sessionId,
+    onChanged,
   )
 }

--- a/console/web/src/lib/backend/types.ts
+++ b/console/web/src/lib/backend/types.ts
@@ -315,6 +315,13 @@ export interface ChatBackend {
    */
   listTriggers?(sessionId: string): Promise<SessionTriggerInfo[]>
   /**
+   * Subscribe to `harness::triggers-changed` for a session: fires when the
+   * binding set or a fire count changes (registration, unregistration from
+   * any tab, a fire, expiry, GC) — the signal to refetch `listTriggers`.
+   * Returns an unsubscribe.
+   */
+  onTriggersChanged?(sessionId: string, onEvent: () => void): () => void
+  /**
    * Tear one subscription down via `harness::triggers::unregister` (engine
    * trigger AND durable record; a raw engine unregister would orphan the
    * record and strand the owner's armed wake).

--- a/console/web/src/types/iii-agent-event.ts
+++ b/console/web/src/types/iii-agent-event.ts
@@ -71,6 +71,15 @@ export interface MessageQueuedEvent {
   timestamp: number
 }
 
+/**
+ * `harness::triggers-changed` — the session's trigger-binding set or a fire
+ * count changed. A doorbell, not the data: refetch `harness::triggers::list`.
+ */
+export interface TriggersChangedEvent {
+  session_id: string
+  timestamp: number
+}
+
 /** Outcome of a resolved approval (approval-gate `ResolvedOutcome`). */
 export type ResolvedOutcome = 'allow' | 'deny' | 'timeout' | 'aborted'
 

--- a/harness/src/bindings/store.rs
+++ b/harness/src/bindings/store.rs
@@ -49,11 +49,20 @@ pub enum ReserveOutcome {
 pub struct BindingStore {
     iii: std::sync::Arc<IIIClient>,
     timeout_ms: u64,
+    events: crate::events::TurnEvents,
 }
 
 impl BindingStore {
-    pub fn new(iii: std::sync::Arc<IIIClient>, timeout_ms: u64) -> Self {
-        Self { iii, timeout_ms }
+    pub fn new(
+        iii: std::sync::Arc<IIIClient>,
+        timeout_ms: u64,
+        events: crate::events::TurnEvents,
+    ) -> Self {
+        Self {
+            iii,
+            timeout_ms,
+            events,
+        }
     }
 
     pub async fn get(&self, id: &str) -> Result<Option<Binding>, HarnessError> {
@@ -123,7 +132,12 @@ impl BindingStore {
         }
 
         match self.reserve_owner_slot(binding).await {
-            Ok(ReserveOutcome::Reserved) => Ok(ReserveOutcome::Reserved),
+            Ok(ReserveOutcome::Reserved) => {
+                self.events
+                    .emit_triggers_changed(&binding.owner.session_id)
+                    .await;
+                Ok(ReserveOutcome::Reserved)
+            }
             Ok(outcome) => {
                 let _ = self.delete_if_unchanged(binding).await;
                 Ok(outcome)
@@ -156,7 +170,12 @@ impl BindingStore {
             let mut next = expected.clone();
             next.trigger_id = Some(trigger_id.to_string());
             match state::cas_binding(&self.iii, Some(&expected), &next, self.timeout_ms).await? {
-                None => return Ok(AttachOutcome::Attached(Box::new(next))),
+                None => {
+                    self.events
+                        .emit_triggers_changed(&binding.owner.session_id)
+                        .await;
+                    return Ok(AttachOutcome::Attached(Box::new(next)));
+                }
                 Some(current) if current.is_null() => return Ok(AttachOutcome::Gone),
                 Some(current) => {
                     expected = serde_json::from_value(current).map_err(|e| {
@@ -179,6 +198,9 @@ impl BindingStore {
     pub async fn delete_if_unchanged(&self, binding: &Binding) -> Result<bool, HarnessError> {
         let deleted = state::cas_delete_binding(&self.iii, binding, self.timeout_ms).await?;
         if deleted {
+            self.events
+                .emit_triggers_changed(&binding.owner.session_id)
+                .await;
             if let Err(error) = self
                 .release_owner_slot(&binding.owner.session_id, &binding.id)
                 .await
@@ -219,7 +241,12 @@ impl BindingStore {
             next.fires = expected.fires + 1;
 
             match state::cas_binding(&self.iii, Some(&expected), &next, self.timeout_ms).await? {
-                None => return Ok(ClaimOutcome::Claimed(Box::new(next))),
+                None => {
+                    self.events
+                        .emit_triggers_changed(&binding.owner.session_id)
+                        .await;
+                    return Ok(ClaimOutcome::Claimed(Box::new(next)));
+                }
                 Some(current) => {
                     // Someone moved it. A record that is gone means the binding
                     // retired between the read and here — not an error, just

--- a/harness/src/deps.rs
+++ b/harness/src/deps.rs
@@ -85,6 +85,10 @@ impl Deps {
     /// clients so a hot-reloaded timeout applies to the next read.
     pub async fn bindings(&self) -> BindingStore {
         let cfg = self.cfg().await;
-        BindingStore::new(self.iii.clone(), cfg.session_timeout_ms)
+        BindingStore::new(
+            self.iii.clone(),
+            cfg.session_timeout_ms,
+            self.events.clone(),
+        )
     }
 }

--- a/harness/src/events.rs
+++ b/harness/src/events.rs
@@ -1,8 +1,10 @@
 //! The async orchestration trigger types the harness emits —
 //! `harness::ready` after boot, `harness::turn-started` /
-//! `harness::turn-completed` at turn boundaries, and `harness::message-queued`
-//! when a message parks in the mid-turn queue (harness.md § Trigger types
-//! emitted). Consumers and siblings bind these to react without polling.
+//! `harness::turn-completed` at turn boundaries, `harness::message-queued`
+//! when a message parks in the mid-turn queue, and
+//! `harness::triggers-changed` when a session's binding set or fire count
+//! changes (harness.md § Trigger types emitted). Consumers and siblings bind
+//! these to react without polling.
 //!
 //! Delivery is fire-and-forget (`TriggerAction::Void`), at-least-once, and
 //! unordered. Per-binding `config` filters (`session_id`, `parent_session_id`)
@@ -27,6 +29,7 @@ use crate::types::turn::ParentLink;
 pub const TURN_STARTED: &str = "harness::turn-started";
 pub const TURN_COMPLETED: &str = "harness::turn-completed";
 pub const MESSAGE_QUEUED: &str = "harness::message-queued";
+pub const TRIGGERS_CHANGED: &str = "harness::triggers-changed";
 pub const READY: &str = "harness::ready";
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -216,6 +219,7 @@ pub struct TurnEvents {
     started: SubscriberSet,
     completed: SubscriberSet,
     queued: SubscriberSet,
+    triggers_changed: SubscriberSet,
 }
 
 impl TurnEvents {
@@ -227,6 +231,7 @@ impl TurnEvents {
         let started = SubscriberSet::default();
         let completed = SubscriberSet::default();
         let queued = SubscriberSet::default();
+        let triggers_changed = SubscriberSet::default();
 
         let _ = iii.register_trigger_type(
             RegisterTriggerType::new(
@@ -273,8 +278,19 @@ impl TurnEvents {
             )
             .trigger_request_format::<TurnEventBindingConfig>(),
         );
+        let _ = iii.register_trigger_type(
+            RegisterTriggerType::new(
+                TRIGGERS_CHANGED,
+                "A session's trigger-binding set or fire count changed — refetch harness::triggers::list.",
+                TurnEventTriggerHandler {
+                    type_id: TRIGGERS_CHANGED,
+                    set: triggers_changed.clone(),
+                },
+            )
+            .trigger_request_format::<TurnEventBindingConfig>(),
+        );
         tracing::info!(
-            "registered harness::ready / harness::turn-started / harness::turn-completed / harness::message-queued trigger types"
+            "registered harness::ready / harness::turn-started / harness::turn-completed / harness::message-queued / harness::triggers-changed trigger types"
         );
 
         Self {
@@ -284,6 +300,7 @@ impl TurnEvents {
             started,
             completed,
             queued,
+            triggers_changed,
         }
     }
 
@@ -311,6 +328,25 @@ impl TurnEvents {
         self.fan_out(
             &self.queued,
             MESSAGE_QUEUED,
+            session_id,
+            None,
+            None,
+            payload,
+        )
+        .await;
+    }
+
+    /// Doorbell only — a session's binding set or fires count changed;
+    /// consumers refetch `harness::triggers::list`. No per-event logging:
+    /// a single fire rings twice (claim + retirement).
+    pub async fn emit_triggers_changed(&self, session_id: &str) {
+        let payload = serde_json::json!({
+            "session_id": session_id,
+            "timestamp": now_ms(),
+        });
+        self.fan_out(
+            &self.triggers_changed,
+            TRIGGERS_CHANGED,
             session_id,
             None,
             None,

--- a/harness/src/subscriptions/fired.rs
+++ b/harness/src/subscriptions/fired.rs
@@ -7,8 +7,8 @@
 //! model context), so this is a pure UI signal with two uses on the console:
 //!   * render a turn-less "trigger fired" notice in the timeline, and
 //!   * keep a fired `once` trigger visible in the panel after the engine
-//!     unregisters it (the 5s poll can no longer see it, but this durable
-//!     record can).
+//!     unregisters it (the console's list refetch can no longer see it, but
+//!     this durable record can).
 //!
 //! Best-effort: a failed append logs and returns; it never blocks the fire's
 //! real work (the notification wake or the dispatched call).


### PR DESCRIPTION
## Why

Live-engine traces showed every open console chat tab polling `harness::triggers::list` on a 5s interval (`setInterval` in ChatView, added in #452, pointed at the harness in #687) — 3,704 stored spans on the dev stack, almost all returning `{"subscriptions":[]}`. Each poll costs two invocations: the handler does a **full-scope** `harness::state::list` on the state worker and filters client-side.

Fires/expiry were already push-visible (durable `trigger_fired` transcript entries), but binding-set mutations had no event — and several happen out-of-turn (expiry sweep, GC, unregister from another tab, `harness::function::trigger`, deferred approval release), so the poll couldn't be replaced by inference from existing events.

## What

Same pattern #452 used to kill the status poll with `harness::message-queued`:

**harness**
- New `harness::triggers-changed` event trigger type (5th), registered alongside the existing four.
- Doorbell payload `{session_id, timestamp}` — consumers refetch `harness::triggers::list`.
- Emitted from the four `BindingStore` CAS primitives (`reserve`, `attach_trigger_id`, `claim_fire`, `delete_if_unchanged`), so every mutation path — registration, agent/console unregister, fires, once/max_fires retirement, expiry sweep, GC, teardown, rollbacks — rings from one layer. `delete` loops through `delete_if_unchanged`, so it's covered.

**console/web**
- `onTriggersChanged` backend hook (same shape as `onQueuedMessage`), `startTriggersChangedSubscription` reusing the generic `bind()` in turn-events-live.
- ChatView: the 5s interval is gone — initial fetch + doorbell subscription + `visibilitychange` catch-up (missed doorbells while hidden/throttled). Always-on for the selected conversation, unlike the streaming-gated queued subscription, because bindings mutate outside turns.
- Ghost/fired-row behavior (`seenTriggersRef`, `mergeFiredTriggers`) unchanged; post-unregister refetches kept.

## Version skew

- New console + old harness: the engine parks the unknown trigger-type registration; the strip degrades to mount/visibility/post-unregister refetches. No error.
- Old console + new harness: the old UI keeps polling; the new type just has no subscribers.
- No fallback poll, matching #452.

## Verification

- `cargo fmt --check`, `clippy --all-features -D warnings`, `cargo test --all-features` (harness) ✓
- `pnpm test` (1149 incl. 3 new doorbell subscription tests), `pnpm typecheck`, biome scoped to touched files ✓ (ChatView has two pre-existing biome errors on main, untouched)
- **Live on the dev stack**: swapped the harness binary in, bound a `harness::triggers-changed` subscription for a test session, then registered a binding through the harness interceptor and unregistered it via `harness::triggers::unregister`. Traces show exactly three doorbell deliveries (reserve, attach, delete) with the session filter applied, and no periodic `triggers::list` traffic from the subscriber. Test session, subscription, and engine trigger cleaned up afterwards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trigger updates now refresh automatically when changes occur or when the page becomes visible again.
  * Added session-specific notifications for trigger changes.

* **Bug Fixes**
  * Reduced delays and unnecessary background activity caused by periodic trigger polling.
  * Ensured trigger updates from unrelated sessions are ignored.

* **Tests**
  * Added coverage for trigger-change notifications, session filtering, and subscription cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->