### PR TITLE
chore(workers): align state dependency ranges

### DIFF
--- a/.github/scripts/tests/test_worker_dependency_compatibility.py
+++ b/.github/scripts/tests/test_worker_dependency_compatibility.py
@@ -25,3 +25,10 @@ def test_approval_gate_uses_shared_runtime_dependency_ranges() -> None:
 
     for dependency, expected in expected_ranges.items():
         assert approval_gate[dependency] == expected
+
+
+def test_harness_llm_stack_uses_shared_state_range() -> None:
+    expected = dependencies("harness")["state"]
+
+    for worker in ("llm-router", "provider-anthropic", "provider-openai"):
+        assert dependencies(worker)["state"] == expected

--- a/llm-router/iii.worker.yaml
+++ b/llm-router/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, router, models, providers]
 description: One front door + provider protocol in front of every LLM provider.
 
 dependencies:
-  state: "^0.21.2"
+  state: "^0.22.0"
   configuration: "^0.21.6"

--- a/provider-anthropic/iii.worker.yaml
+++ b/provider-anthropic/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, anthropic, claude, messages, provider]
 description: Anthropic Messages API provider worker; implements provider::anthropic::stream and provider::anthropic::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.21.2"
+  state: "^0.22.0"
   llm-router: "^1.0.0"

--- a/provider-openai/iii.worker.yaml
+++ b/provider-openai/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, openai, responses, chat-completions, provider]
 description: OpenAI Responses provider worker with Chat Completions compatibility; implements provider::openai::stream and provider::openai::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.21.2"
+  state: "^0.22.0"
   llm-router: "^1.0.0"


### PR DESCRIPTION
## Summary

- update `llm-router` to require `state ^0.22.0`
- update `provider-anthropic` and `provider-openai` to require the same state range
- add a compatibility regression that keeps the Harness LLM stack aligned on one state range

## Why

Harness requires `state ^0.22.0`, but the LLM router and providers still required `^0.21.2`. Since caret ranges below 1.0 do not cross minor versions, the Registry could not select one state version for the graph and returned `version_conflict`.

## Impact

Once new versions are published in dependency order (`llm-router`, providers, then Harness), the Registry can resolve the Harness graph with `state 0.22.x`.

## Validation

- `python3 -m py_compile .github/scripts/tests/test_worker_dependency_compatibility.py`
- executed both dependency compatibility regression functions with PyYAML
- `git diff --check`
