### PR TITLE
chore(providers): align state dependency ranges

### DIFF
--- a/.github/scripts/tests/test_worker_dependency_compatibility.py
+++ b/.github/scripts/tests/test_worker_dependency_compatibility.py
@@ -29,6 +29,10 @@ def test_approval_gate_uses_shared_runtime_dependency_ranges() -> None:
 
 def test_harness_llm_stack_uses_shared_state_range() -> None:
     expected = dependencies("harness")["state"]
+    providers = sorted(
+        manifest.parent.name
+        for manifest in REPO_ROOT.glob("provider-*/iii.worker.yaml")
+    )
 
-    for worker in ("llm-router", "provider-anthropic", "provider-openai"):
+    for worker in ("llm-router", *providers):
         assert dependencies(worker)["state"] == expected

--- a/provider-claude-code/iii.worker.yaml
+++ b/provider-claude-code/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, anthropic, claude, claude-code, subscription, provider]
 description: Claude Code (Pro/Max subscription) Messages API provider worker; implements provider::claude-code::stream and provider::claude-code::refresh_models behind llm-router, using OAuth credentials from the auth-credentials vault or ~/.claude/.credentials.json.
 
 dependencies:
-  state: "^0.21.2"
+  state: "^0.22.0"
   llm-router: "^1.0.0"

--- a/provider-deepseek/iii.worker.yaml
+++ b/provider-deepseek/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, deepseek, chat-completions, provider]
 description: DeepSeek Chat Completions provider worker; implements provider::deepseek::stream and provider::deepseek::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.21.2"
+  state: "^0.22.0"
   llm-router: "^1.0.0"

--- a/provider-github-copilot/iii.worker.yaml
+++ b/provider-github-copilot/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, github, copilot, subscription, chat-completions, provider]
 description: GitHub Copilot subscription provider worker; sign in with GitHub once and the models the plan grants appear in the picker. Implements provider::github-copilot::stream, refresh_models, and a device-flow login surface behind llm-router.
 
 dependencies:
-  state: "^0.21.6"
+  state: "^0.22.0"
   llm-router: "^1.0.0"

--- a/provider-kimi/iii.worker.yaml
+++ b/provider-kimi/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, kimi, moonshot, chat-completions, provider]
 description: Moonshot (Kimi) Chat Completions provider worker; implements provider::kimi::stream and provider::kimi::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.21.6"
+  state: "^0.22.0"
   llm-router: "^1.0.0"

--- a/provider-llamacpp/iii.worker.yaml
+++ b/provider-llamacpp/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, llama.cpp, local, open-source, provider]
 description: llama.cpp server (llama-server) Chat Completions provider worker; implements provider::llamacpp::stream and provider::llamacpp::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.21.2"
+  state: "^0.22.0"
   llm-router: "^1.0.0"

--- a/provider-openai-codex/iii.worker.yaml
+++ b/provider-openai-codex/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, openai, codex, chatgpt, subscription, provider]
 description: OpenAI Codex (ChatGPT subscription) provider; implements provider::openai-codex::stream and provider::openai-codex::refresh_models behind llm-router, sourcing credentials from the auth-credentials vault.
 
 dependencies:
-  state: "^0.21.2"
+  state: "^0.22.0"
   llm-router: "^1.0.0"

--- a/provider-openrouter/iii.worker.yaml
+++ b/provider-openrouter/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, openrouter, aggregator, chat-completions, provider]
 description: OpenRouter Chat Completions provider worker; one API key in front of every major vendor. Implements provider::openrouter::stream and provider::openrouter::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.21.6"
+  state: "^0.22.0"
   llm-router: "^1.0.0"

--- a/provider-xai/iii.worker.yaml
+++ b/provider-xai/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, xai, grok, chat-completions, provider]
 description: xAI Chat Completions provider worker; implements provider::xai::stream and provider::xai::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.21.2"
+  state: "^0.22.0"
   llm-router: "^1.0.0"

--- a/provider-zai/iii.worker.yaml
+++ b/provider-zai/iii.worker.yaml
@@ -9,5 +9,5 @@ tags: [llm, zai, glm, chat-completions, provider]
 description: Z.AI Chat Completions provider worker; implements provider::zai::stream and provider::zai::refresh_models behind llm-router.
 
 dependencies:
-  state: "^0.21.2"
+  state: "^0.22.0"
   llm-router: "^1.0.0"


### PR DESCRIPTION
## Summary

- update every remaining LLM provider to depend on `state ^0.22.0`
- extend the dependency compatibility regression to discover all `provider-*` manifests automatically

## Why

Provider manifests still required `state ^0.21.x`, which cannot be resolved in the same worker graph as Harness's `state ^0.22.0` requirement. This caused the same version conflict whenever an additional provider was included in a Harness deployment.

## Impact

After publishing new provider versions, every provider can participate in the Harness worker graph with the shared State 0.22 dependency range.

## Validation

- dependency compatibility tests passed
- `git diff --check` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated AI provider integrations to support the latest shared state dependency version.
  * Improved compatibility coverage across all available provider integrations and the routing service.

* **Tests**
  * Compatibility checks now automatically discover provider integrations, helping ensure newly added providers are included in validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->