### PR TITLE
(MOT-4407) feat(shell): explorer hidden-files filter, bounded tree walk, image preview, folder search, resizable sidebar

### DIFF
--- a/shell/src/code/functions/mod.rs
+++ b/shell/src/code/functions/mod.rs
@@ -64,7 +64,10 @@ const READ_FILE_DESC: &str = "Read a file window-first: probe with stat: true (s
      budgeted by max_output_bytes (default 128 KiB; per-call override \
      clamped to max_read_bytes) — an over-budget full read fails with \
      a C218 carrying the file's size, line count, and the window/stat \
-     recovery calls. Batch mode: pass paths[] (XOR path) \
+     recovery calls. encoding: base64 (single-path full reads only) \
+     returns the file's exact bytes base64-encoded — the binary-aware \
+     read for images and other non-text payloads. Batch mode: pass \
+     paths[] (XOR path) \
      to read multiple files in one call — entries are processed in \
      request order against batch_read_budget_bytes, measured in \
      bytes of returned content (after UTF-8 sanitization); per-entry \
@@ -74,7 +77,9 @@ const READ_FILE_DESC: &str = "Read a file window-first: probe with stat: true (s
      shell::fs::*. Non-accessible paths return C211.";
 
 const SEARCH_ID: &str = "coder::search";
-const SEARCH_DESC: &str = "Search file contents and/or paths. Supports literal or regex \
+const SEARCH_DESC: &str = "Search file contents and/or paths. Path search matches files AND \
+     directories (each path_match carries kind: file|dir); content \
+     search reads files only. Supports literal or regex \
      queries with include/exclude globs; non-accessible files are \
      excluded from both content and path results. Only the FIRST match \
      on each line is reported (one content match per matching line). \
@@ -151,7 +156,11 @@ const TREE_DESC: &str = "Recursive directory snapshot bounded by `max_depth` and
      coder::list-folder for pagination. Noise directories matching \
      default_exclude_globs (.git, node_modules, target, … — \
      coder::info lists them) appear as childless `truncated` stubs; \
-     pass use_default_excludes: false to descend into them. Paths are \
+     pass use_default_excludes: false to descend into them. Pass \
+     include_hidden: false to omit dot-prefixed entries (they then \
+     don't count toward per_folder_limit). A total node budget bounds \
+     every snapshot; folders past it are stubs with reason max_nodes \
+     — re-root there or paginate with coder::list-folder. Paths are \
      relative to the primary allowed root or absolute inside any \
      allowed root (coder::info lists them); for host paths outside \
      the jail use shell::fs::*.";

--- a/shell/src/code/functions/read_file.rs
+++ b/shell/src/code/functions/read_file.rs
@@ -39,6 +39,11 @@
 //! never depend on budget state, and deny must precede any metadata
 //! syscall so stat/budget can't become an existence or size oracle.
 //!
+//! **Binary reads**: `encoding: "base64"` (single-path FULL reads only)
+//! returns the file's exact bytes base64-encoded — the binary-aware
+//! read for payloads like images. The encoded length is charged against
+//! `max_output_bytes`; C210 with `stat`/window/`numbered`.
+//!
 //! LINE CONVENTION (shared with `coder::update-file`): a line is a
 //! 0x0A-terminated or EOF-terminated byte segment. An empty file has 0
 //! lines; a trailing newline does NOT create a phantom last line. This
@@ -207,6 +212,16 @@ pub struct ReadFileInput {
     /// is governed by `batch_read_budget_bytes`).
     #[serde(default)]
     pub max_output_bytes: Option<u64>,
+    /// Content encoding for single-path FULL reads. Default `text`
+    /// returns UTF-8 (binary bytes replaced by U+FFFD); `base64` returns
+    /// the file's exact bytes base64-encoded (standard alphabet, padded)
+    /// — for binary payloads like images that a caller needs to
+    /// reconstruct. The ENCODED length is what's charged against
+    /// `max_output_bytes`. C210 combined with `stat`,
+    /// `line_from`/`line_to`, or `numbered` (text-shaping fields);
+    /// ignored when `paths` is set.
+    #[serde(default)]
+    pub encoding: ReadEncoding,
     /// Batch of files (or windowed slices) to read in a single call.
     /// Each entry is either a plain path string (whole-file read) or an
     /// object `{path, line_from?, line_to?}` with per-entry window
@@ -223,6 +238,17 @@ pub struct ReadFileInput {
     #[serde(default)]
     #[schemars(skip)]
     pub fs_scope: Option<crate::fs::FsScope>,
+}
+
+/// Wire encoding for returned `content`.
+#[derive(Debug, Clone, Copy, PartialEq, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ReadEncoding {
+    /// UTF-8 text; invalid bytes replaced by U+FFFD.
+    #[default]
+    Text,
+    /// Exact file bytes, base64-encoded (standard alphabet, padded).
+    Base64,
 }
 
 // examples are wire-contract; goldens pin them.
@@ -304,9 +330,10 @@ pub struct ReadFileOutput {
     /// File content as a UTF-8 string — the whole file, or just the
     /// requested window when `line_from`/`line_to` was given (window
     /// lines keep their newline terminators). Binary content is returned
-    /// with invalid bytes replaced by U+FFFD; use a future binary-aware
-    /// function if exact bytes matter. **Single-path mode only; null when
-    /// the request used `paths[]`.**
+    /// with invalid bytes replaced by U+FFFD; request `encoding:
+    /// "base64"` when exact bytes matter (content is then the file's
+    /// bytes base64-encoded). **Single-path mode only; null when the
+    /// request used `paths[]`.**
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
     /// Whether `content` survived UTF-8 conversion without losing bytes.
@@ -403,6 +430,7 @@ fn inner(
                 stat: req.stat,
                 numbered: req.numbered,
                 max_output_bytes: req.max_output_bytes,
+                encoding: req.encoding,
             };
             single_read(resolver, cfg, single_req).map(|o| ReadFileOutput {
                 path: Some(o.path),
@@ -464,6 +492,7 @@ struct SingleReadReq<'a> {
     stat: bool,
     numbered: bool,
     max_output_bytes: Option<u64>,
+    encoding: ReadEncoding,
 }
 
 /// Internal result for a single-path read before wrapping in
@@ -517,6 +546,26 @@ fn single_read(
                 .into(),
         ));
     }
+    if req.encoding == ReadEncoding::Base64 {
+        if req.stat {
+            return Err(stat_conflict("encoding: base64"));
+        }
+        if window.is_some() {
+            return Err(CoderError::BadInput(
+                "encoding: base64 returns the exact bytes of a FULL read; a \
+                 line_from/line_to window is text-shaped (C210). Drop the \
+                 window to fetch the bytes, or drop encoding to read text."
+                    .into(),
+            ));
+        }
+        if req.numbered {
+            return Err(CoderError::BadInput(
+                "numbered prefixes are text-only and cannot apply to \
+                 encoding: base64 content (C210). Drop one of the two."
+                    .into(),
+            ));
+        }
+    }
     // REDACTION ORDERING: resolve + deny-check (C211) BEFORE any metadata
     // syscall — stat on a denied path must be byte-identical to stat on a
     // missing path, and no budget may reclassify either.
@@ -532,7 +581,15 @@ fn single_read(
         return stat_read(&abs, req.path, cfg, &md);
     }
     match window {
-        None => full_read(&abs, req.path, cfg, &md, req.numbered, req.max_output_bytes),
+        None => full_read(
+            &abs,
+            req.path,
+            cfg,
+            &md,
+            req.numbered,
+            req.max_output_bytes,
+            req.encoding,
+        ),
         Some((from, to)) => windowed_read(&abs, req.path, cfg, &md, from, to, req.numbered),
     }
 }
@@ -581,6 +638,7 @@ fn full_read(
     md: &std::fs::Metadata,
     numbered: bool,
     max_output_override: Option<u64>,
+    encoding: ReadEncoding,
 ) -> Result<SingleReadOut, CoderError> {
     if md.len() > cfg.max_read_bytes {
         return Err(CoderError::TooLarge(format!(
@@ -594,11 +652,24 @@ fn full_read(
     }
     let bytes = std::fs::read(abs).map_err(|e| CoderError::io_for_path(e, wire_path))?;
     let lines = count_lines(&bytes);
-    let (content, is_utf8) = lossy_utf8(bytes);
-    let content = if numbered {
-        number_lines(&content, 1)
-    } else {
-        content
+    let (content, is_utf8) = match encoding {
+        ReadEncoding::Text => {
+            let (content, is_utf8) = lossy_utf8(bytes);
+            let content = if numbered {
+                number_lines(&content, 1)
+            } else {
+                content
+            };
+            (content, is_utf8)
+        }
+        ReadEncoding::Base64 => {
+            use base64::Engine as _;
+            let is_utf8 = std::str::from_utf8(&bytes).is_ok();
+            (
+                base64::engine::general_purpose::STANDARD.encode(&bytes),
+                is_utf8,
+            )
+        }
     };
     // Per-call override clamps SILENTLY to max_read_bytes (documented on
     // the input field); without an override the config value applies.
@@ -1040,6 +1111,73 @@ mod tests {
             paths: Some(paths),
             ..ReadFileInput::default()
         }
+    }
+
+    fn base64_req(path: &str) -> ReadFileInput {
+        ReadFileInput {
+            path: Some(path.into()),
+            encoding: ReadEncoding::Base64,
+            ..ReadFileInput::default()
+        }
+    }
+
+    /// encoding: base64 must round-trip EXACT bytes — the whole point is
+    /// binary payloads (images) that lossy UTF-8 destroys.
+    #[tokio::test]
+    async fn base64_full_read_roundtrips_exact_bytes() {
+        let (tmp, r, c) = setup();
+        let raw: Vec<u8> = vec![0x89, b'P', b'N', b'G', 0x00, 0xFF, 0x0A, 0x1B];
+        std::fs::write(tmp.path().join("img.png"), &raw).unwrap();
+        let out = handle(r, c, base64_req("img.png")).await.unwrap();
+        use base64::Engine as _;
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(out.content.as_deref().unwrap())
+            .unwrap();
+        assert_eq!(decoded, raw);
+        assert_eq!(out.is_utf8, Some(false));
+        assert_eq!(out.size, Some(raw.len() as u64));
+    }
+
+    #[tokio::test]
+    async fn base64_conflicts_with_stat_window_and_numbered() {
+        let (tmp, r, c) = setup();
+        std::fs::write(tmp.path().join("a.bin"), [0u8, 1, 2]).unwrap();
+        for req in [
+            ReadFileInput {
+                stat: true,
+                ..base64_req("a.bin")
+            },
+            ReadFileInput {
+                line_from: Some(1),
+                ..base64_req("a.bin")
+            },
+            ReadFileInput {
+                numbered: true,
+                ..base64_req("a.bin")
+            },
+        ] {
+            let err = handle(r.clone(), c.clone(), req).await.unwrap_err();
+            assert!(err.contains("C210"), "expected C210, got: {err}");
+        }
+    }
+
+    /// The output budget bites on the ENCODED length (4/3 of the raw
+    /// size), never silently on the raw bytes.
+    #[tokio::test]
+    async fn base64_budget_counts_encoded_bytes() {
+        let (tmp, r, _c) = setup();
+        // 90 raw bytes → 120 encoded: inside a 100-byte budget only if
+        // the raw length were (wrongly) the measure.
+        std::fs::write(tmp.path().join("a.bin"), vec![0xFFu8; 90]).unwrap();
+        let cfg = Arc::new(CoderConfig {
+            base_paths: vec![tmp.path().to_path_buf()],
+            max_read_bytes: 1024,
+            max_output_bytes: 100,
+            ..CoderConfig::default()
+        });
+        let err = handle(r, cfg, base64_req("a.bin")).await.unwrap_err();
+        assert!(err.contains("C218"), "expected C218, got: {err}");
+        assert!(err.contains("120"), "names the encoded length: {err}");
     }
 
     fn stat_req(path: &str) -> ReadFileInput {

--- a/shell/src/code/functions/search.rs
+++ b/shell/src/code/functions/search.rs
@@ -147,6 +147,16 @@ pub struct PathMatch {
     /// itself are not resolved. Operations on it re-validate through the
     /// jail.
     pub path: String,
+    /// What matched: `file` or `dir`. Directories match by NAME only —
+    /// content search never reads them.
+    pub kind: PathMatchKind,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum PathMatchKind {
+    File,
+    Dir,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -263,7 +273,11 @@ fn inner(
             && resolver.is_default_excluded_dir(e.path()))
     });
     for entry in entries.filter_map(|e| e.ok()) {
-        if !entry.file_type().is_file() {
+        // Directories participate in PATH matching (a folder is findable
+        // by name); only files go on to content matching. Symlinks and
+        // special files stay out of both lists, as before.
+        let is_dir = entry.file_type().is_dir();
+        if !entry.file_type().is_file() && !is_dir {
             continue;
         }
         let abs = entry.path();
@@ -309,6 +323,11 @@ fn inner(
                 } else if charge(&mut budget_remaining, abs_wire.len()) {
                     path_matches.push(PathMatch {
                         path: abs_wire.clone(),
+                        kind: if is_dir {
+                            PathMatchKind::Dir
+                        } else {
+                            PathMatchKind::File
+                        },
                     });
                 } else {
                     truncated = true;
@@ -318,6 +337,9 @@ fn inner(
         }
         if budget_exhausted {
             break;
+        }
+        if is_dir {
+            continue;
         }
 
         if let Some(matcher) = &content_matcher {
@@ -559,6 +581,56 @@ mod tests {
             std::fs::create_dir_all(parent).unwrap();
         }
         std::fs::write(p, body).unwrap();
+    }
+
+    /// Path search finds FOLDERS by name, not just files — and flags
+    /// each match's kind so a UI can render and act on them differently.
+    /// Content search must never list a directory.
+    #[tokio::test]
+    async fn path_search_matches_directories_with_kind() {
+        let (tmp, r, c) = setup();
+        std::fs::create_dir_all(tmp.path().join("needle-dir/sub")).unwrap();
+        write(&tmp, "needle.txt", "no content hit");
+        let out = handle(
+            r,
+            c,
+            SearchInput {
+                query: "needle".into(),
+                path: ".".into(),
+                regex: false,
+                ignore_case: false,
+                include_globs: vec![],
+                exclude_globs: vec![],
+                max_matches: None,
+                max_line_bytes: None,
+                context_lines_before: None,
+                context_lines_after: None,
+                use_default_excludes: true,
+                search_content: true,
+                search_paths: true,
+                fs_scope: None,
+            },
+        )
+        .await
+        .unwrap();
+        let dir_abs = abs(&tmp, "needle-dir");
+        let file_abs = abs(&tmp, "needle.txt");
+        let dir_match = out
+            .path_matches
+            .iter()
+            .find(|m| m.path == dir_abs)
+            .expect("directory must appear in path matches");
+        assert!(matches!(dir_match.kind, PathMatchKind::Dir));
+        let file_match = out
+            .path_matches
+            .iter()
+            .find(|m| m.path == file_abs)
+            .expect("file must appear in path matches");
+        assert!(matches!(file_match.kind, PathMatchKind::File));
+        assert!(
+            out.content_matches.iter().all(|m| m.path != dir_abs),
+            "a directory must never produce a content match"
+        );
     }
 
     #[tokio::test]

--- a/shell/src/code/functions/tree.rs
+++ b/shell/src/code/functions/tree.rs
@@ -7,9 +7,14 @@
 //! Noise folders matching `default_exclude_globs` (.git, node_modules, …)
 //! surface as childless stub nodes flagged `truncated` with reason
 //! `default_exclude` — never silently hidden; opt out per call with
-//! `use_default_excludes: false`. Nodes carry only `name`; absolute paths
-//! derive from the response's top-level `path` (child = parent + "/" +
-//! name), which cuts thousands of redundant tokens from large snapshots.
+//! `use_default_excludes: false`. `include_hidden: false` omits dot
+//! entries outright, before the per-folder cap is counted, so the cap
+//! serves visible names. A total node budget ([`TREE_NODE_BUDGET`])
+//! bounds every snapshot — folders reached after it is spent are
+//! flagged `truncated` with reason `max_nodes`. Nodes carry only
+//! `name`; absolute paths derive from the response's top-level `path`
+//! (child = parent + "/" + name), which cuts thousands of redundant
+//! tokens from large snapshots.
 
 use std::path::Path;
 use std::sync::Arc;
@@ -46,6 +51,13 @@ pub struct TreeInput {
     /// are omitted. Pass `false` to list everything.
     #[serde(default = "default_true")]
     pub use_default_excludes: bool,
+    /// List hidden (dot-prefixed) entries. Pass `false` to omit them —
+    /// files and folders alike — at every level; omitted entries do not
+    /// count toward `per_folder_limit`, so the cap serves visible names.
+    /// The requested root itself is exempt: explicitly naming a hidden
+    /// folder still lists its contents.
+    #[serde(default = "default_true")]
+    pub include_hidden: bool,
     /// Internal harness filesystem scope; omitted from published schema.
     #[serde(default)]
     #[schemars(skip)]
@@ -94,8 +106,9 @@ pub struct TreeNode {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub children: Option<Vec<TreeNode>>,
     /// Set on directories whose `children` was capped at
-    /// `per_folder_limit`, whose subtree was cut off by `max_depth`, or
-    /// which matched `default_exclude_globs` (reason "default_exclude").
+    /// `per_folder_limit`, whose subtree was cut off by `max_depth`,
+    /// which matched `default_exclude_globs` (reason "default_exclude"),
+    /// or where the snapshot's node budget ran out (reason "max_nodes").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub truncated: Option<TruncationInfo>,
 }
@@ -112,15 +125,16 @@ pub enum NodeKind {
 #[derive(Debug, Serialize, JsonSchema)]
 pub struct TruncationInfo {
     /// Reason this folder was truncated: hit `per_folder_limit`, cut off
-    /// by `max_depth`, or matched `default_exclude_globs`
-    /// (`default_exclude`).
+    /// by `max_depth`, matched `default_exclude_globs`
+    /// (`default_exclude`), or the snapshot's total node budget ran out
+    /// (`max_nodes`).
     pub reason: String,
     /// Number of children actually returned.
     pub shown: u32,
     /// Total number of children eligible for listing in the folder,
-    /// counted after default-exclude filtering (only populated when
-    /// `reason == "per_folder_limit"`; for depth truncation we don't
-    /// peek into the folder).
+    /// counted after hidden and default-exclude filtering (only
+    /// populated when `reason == "per_folder_limit"`; for depth
+    /// truncation we don't peek into the folder).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total: Option<u32>,
     pub hint: String,
@@ -137,6 +151,14 @@ pub async fn handle(
         .await
         .map_err(|e| format!("tree task join failed: {e}"))?
 }
+
+/// Total nodes any snapshot may carry. Without it a wide-and-deep root
+/// (a home directory) walks for tens of seconds and produces a response
+/// large enough to kill the worker's engine socket — the engine stops
+/// the invocation at its own timeout, the worker still tries to flush
+/// the giant frame, and the connection loops on broken pipes. ~20k
+/// nodes is a few MB of JSON and a sub-second walk.
+const TREE_NODE_BUDGET: u32 = 20_000;
 
 fn inner(
     resolver: &PathResolver,
@@ -167,9 +189,10 @@ fn inner(
             .unwrap_or(cfg.tree_per_folder_limit)
             .max(1),
         use_default_excludes,
+        include_hidden: req.include_hidden,
     };
 
-    let root = walk_dir(resolver, &abs, 0, &opts)?;
+    let root = walk(resolver, &abs, &opts, TREE_NODE_BUDGET)?;
     Ok(TreeOutput {
         path: abs.display().to_string(),
         root,
@@ -180,127 +203,239 @@ struct WalkOpts {
     max_depth: u32,
     per_folder_limit: u32,
     use_default_excludes: bool,
+    include_hidden: bool,
 }
 
-fn walk_dir(
-    resolver: &PathResolver,
-    abs: &Path,
+/// A directory waiting for its listing pass, pointing at its arena slot.
+struct PendingDir {
+    slot: usize,
+    abs: std::path::PathBuf,
     depth: u32,
+}
+
+fn max_nodes_truncation(shown: u32, total: Option<u32>) -> TruncationInfo {
+    TruncationInfo {
+        reason: "max_nodes".to_string(),
+        shown,
+        total,
+        hint: "snapshot node budget exhausted; re-call coder::tree rooted at a \
+               subfolder, or use coder::list-folder for paginated access"
+            .into(),
+    }
+}
+
+/// Breadth-first walk under the global node budget. Level order is the
+/// point: when the budget cannot cover the whole tree, it is spent on
+/// the SHALLOW entries first, so every folder the caller can actually
+/// see lists completely and only deep subtrees come back as `max_nodes`
+/// stubs. A depth-first walk under the same budget starves later
+/// siblings — the first big subtree eats the budget and the root
+/// listing itself comes back short.
+///
+/// Nodes live in an arena where parents always precede their children;
+/// a reverse pass at the end attaches fully-built subtrees.
+fn walk(
+    resolver: &PathResolver,
+    root_abs: &Path,
     opts: &WalkOpts,
+    mut budget: u32,
 ) -> Result<TreeNode, CoderError> {
     // Deliberately bare `?` (generic From fallback, no path in the message):
-    // `abs` here can be a DISCOVERED child during the walk — naming it would
-    // violate the REDACTION INVARIANT. Do not "fix" this to io_for_path.
-    let md = std::fs::metadata(abs)?;
-    let name = abs
+    // naming a walked path here would violate the REDACTION INVARIANT.
+    // Do not "fix" this to io_for_path.
+    let md = std::fs::metadata(root_abs)?;
+    let name = root_abs
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_else(|| ".".to_string());
 
-    let mut node = TreeNode {
+    let mut slots: Vec<Option<TreeNode>> = vec![Some(TreeNode {
         name,
         kind: NodeKind::Dir,
         size: md.len(),
         mtime: unix_mtime(&md),
-        non_accessible: resolver.is_non_accessible(abs),
+        non_accessible: resolver.is_non_accessible(root_abs),
         children: None,
         truncated: None,
-    };
+    })];
+    // Children (in listing order) to attach to each slot, and whether
+    // the slot's dir got a listing pass (stubbed dirs and files keep
+    // `children: None`).
+    let mut child_slots: Vec<Vec<usize>> = vec![Vec::new()];
+    let mut listed: Vec<bool> = vec![false];
+    let mut queue = std::collections::VecDeque::new();
+    queue.push_back(PendingDir {
+        slot: 0,
+        abs: root_abs.to_path_buf(),
+        depth: 0,
+    });
 
-    // `abs` is always a directory here (the walk only recurses into
-    // dirs), so the dir-boundary check applies. The excluded node still
-    // appears — never silently hidden. The root can't trip this: inner()
-    // disables the filter when the requested root is itself excluded.
-    if opts.use_default_excludes && resolver.is_default_excluded_dir(abs) {
-        node.truncated = Some(TruncationInfo {
-            reason: "default_exclude".to_string(),
-            shown: 0,
-            total: None,
-            hint: "folder matches default_exclude_globs (coder::info lists them); \
-                   re-call coder::tree with use_default_excludes: false to descend"
-                .into(),
-        });
-        return Ok(node);
-    }
+    while let Some(PendingDir { slot, abs, depth }) = queue.pop_front() {
+        let set_truncated = |slots: &mut Vec<Option<TreeNode>>, info: TruncationInfo| {
+            if let Some(node) = slots[slot].as_mut() {
+                node.truncated = Some(info);
+            }
+        };
 
-    if depth >= opts.max_depth {
-        node.truncated = Some(TruncationInfo {
-            reason: "max_depth".to_string(),
-            shown: 0,
-            total: None,
-            hint: "raise max_depth or call coder::tree with this path as the new root".into(),
-        });
-        return Ok(node);
-    }
-
-    let mut entries: Vec<std::fs::DirEntry> = match std::fs::read_dir(abs) {
-        Ok(it) => it.filter_map(|e| e.ok()).collect(),
-        Err(e) => {
-            // Surface as a node with no children rather than failing the whole tree.
-            node.truncated = Some(TruncationInfo {
-                reason: "io_error".to_string(),
-                shown: 0,
-                total: None,
-                hint: format!("read_dir failed: {e}"),
-            });
-            return Ok(node);
+        // `abs` is always a directory here (only dirs are queued), so
+        // the dir-boundary check applies. The excluded node still
+        // appears — never silently hidden. The root can't trip this:
+        // inner() disables the filter when the requested root is itself
+        // excluded.
+        if opts.use_default_excludes && resolver.is_default_excluded_dir(&abs) {
+            set_truncated(
+                &mut slots,
+                TruncationInfo {
+                    reason: "default_exclude".to_string(),
+                    shown: 0,
+                    total: None,
+                    hint: "folder matches default_exclude_globs (coder::info lists them); \
+                           re-call coder::tree with use_default_excludes: false to descend"
+                        .into(),
+                },
+            );
+            continue;
         }
-    };
-    if opts.use_default_excludes {
-        // Excluded non-directory entries are omitted outright — matched
-        // against the configured globs ONLY (no dir companions), so a
-        // file or symlink merely NAMED like an excluded directory is
-        // kept. Directories stay regardless; excluded ones surface as
-        // childless stubs in the recursive call.
-        entries.retain(|e| {
-            let is_dir = e.file_type().is_ok_and(|t| t.is_dir());
-            is_dir || !resolver.is_default_excluded(&e.path())
-        });
-    }
-    entries.sort_by_key(|a| a.file_name());
 
-    let total = entries.len() as u32;
-    let cap = opts.per_folder_limit as usize;
-    let truncated_here = total as usize > cap;
-    let visible = if truncated_here {
-        &entries[..cap]
-    } else {
-        &entries[..]
-    };
+        if depth >= opts.max_depth {
+            set_truncated(
+                &mut slots,
+                TruncationInfo {
+                    reason: "max_depth".to_string(),
+                    shown: 0,
+                    total: None,
+                    hint: "raise max_depth or call coder::tree with this path as the new root"
+                        .into(),
+                },
+            );
+            continue;
+        }
 
-    let mut children = Vec::with_capacity(visible.len());
-    for e in visible {
-        let child_abs = e.path();
-        let ft = e.file_type().ok();
-        if ft.as_ref().is_some_and(|t| t.is_dir()) {
-            let sub = walk_dir(resolver, &child_abs, depth + 1, opts)?;
-            children.push(sub);
+        // Discovered before the budget ran out, dequeued after: stub it
+        // without reading the directory at all.
+        if budget == 0 {
+            set_truncated(&mut slots, max_nodes_truncation(0, None));
+            continue;
+        }
+
+        let mut entries: Vec<std::fs::DirEntry> = match std::fs::read_dir(&abs) {
+            Ok(it) => it.filter_map(|e| e.ok()).collect(),
+            Err(e) => {
+                // Surface as a node with no children rather than failing the whole tree.
+                set_truncated(
+                    &mut slots,
+                    TruncationInfo {
+                        reason: "io_error".to_string(),
+                        shown: 0,
+                        total: None,
+                        hint: format!("read_dir failed: {e}"),
+                    },
+                );
+                continue;
+            }
+        };
+        if !opts.include_hidden {
+            // Dot entries drop out BEFORE the per-folder cap is counted:
+            // byte order sorts "." names first, so in a home-shaped folder
+            // they would otherwise fill the cap by themselves and every
+            // visible name would land in the truncated remainder.
+            entries.retain(|e| !e.file_name().to_string_lossy().starts_with('.'));
+        }
+        if opts.use_default_excludes {
+            // Excluded non-directory entries are omitted outright — matched
+            // against the configured globs ONLY (no dir companions), so a
+            // file or symlink merely NAMED like an excluded directory is
+            // kept. Directories stay regardless; excluded ones surface as
+            // childless stubs on their own listing pass.
+            entries.retain(|e| {
+                let is_dir = e.file_type().is_ok_and(|t| t.is_dir());
+                is_dir || !resolver.is_default_excluded(&e.path())
+            });
+        }
+        entries.sort_by_key(|a| a.file_name());
+
+        let total = entries.len() as u32;
+        let cap = opts.per_folder_limit as usize;
+        let truncated_here = total as usize > cap;
+        let visible = if truncated_here {
+            &entries[..cap]
         } else {
+            &entries[..]
+        };
+
+        let mut budget_hit = false;
+        for e in visible {
+            if budget == 0 {
+                budget_hit = true;
+                break;
+            }
+            budget -= 1;
+            let child_abs = e.path();
+            // Entries whose metadata vanishes mid-walk (unlink race) are
+            // skipped rather than failing the whole snapshot.
             let cmd = match e.metadata() {
                 Ok(m) => m,
                 Err(_) => continue,
             };
-            children.push(TreeNode {
+            let is_dir = e.file_type().is_ok_and(|t| t.is_dir());
+            slots.push(Some(TreeNode {
                 name: e.file_name().to_string_lossy().into_owned(),
-                kind: classify(&cmd),
+                kind: if is_dir {
+                    NodeKind::Dir
+                } else {
+                    classify(&cmd)
+                },
                 size: cmd.len(),
                 mtime: unix_mtime(&cmd),
                 non_accessible: resolver.is_non_accessible(&child_abs),
                 children: None,
                 truncated: None,
-            });
+            }));
+            child_slots.push(Vec::new());
+            listed.push(false);
+            let child = slots.len() - 1;
+            child_slots[slot].push(child);
+            if is_dir {
+                queue.push_back(PendingDir {
+                    slot: child,
+                    abs: child_abs,
+                    depth: depth + 1,
+                });
+            }
+        }
+        let shown = child_slots[slot].len() as u32;
+        listed[slot] = true;
+        if budget_hit {
+            set_truncated(&mut slots, max_nodes_truncation(shown, Some(total)));
+        } else if truncated_here {
+            set_truncated(
+                &mut slots,
+                TruncationInfo {
+                    reason: "per_folder_limit".to_string(),
+                    shown: cap as u32,
+                    total: Some(total),
+                    hint: "use coder::list-folder for paginated access to all entries".into(),
+                },
+            );
         }
     }
-    node.children = Some(children);
-    if truncated_here {
-        node.truncated = Some(TruncationInfo {
-            reason: "per_folder_limit".to_string(),
-            shown: cap as u32,
-            total: Some(total),
-            hint: "use coder::list-folder for paginated access to all entries".into(),
-        });
+
+    // Assemble bottom-up: children always sit at higher indices than
+    // their parent, so a reverse pass attaches fully-built subtrees.
+    for i in (0..slots.len()).rev() {
+        if !listed[i] {
+            continue;
+        }
+        let ids = std::mem::take(&mut child_slots[i]);
+        let children: Vec<TreeNode> = ids
+            .into_iter()
+            .map(|j| slots[j].take().expect("child slot taken once"))
+            .collect();
+        if let Some(node) = slots[i].as_mut() {
+            node.children = Some(children);
+        }
     }
-    Ok(node)
+    Ok(slots[0].take().expect("root slot"))
 }
 
 fn classify(md: &std::fs::Metadata) -> NodeKind {
@@ -348,6 +483,7 @@ mod tests {
             max_depth: None,
             per_folder_limit: None,
             use_default_excludes: true,
+            include_hidden: true,
             fs_scope: None,
         }
     }
@@ -580,6 +716,180 @@ mod tests {
         assert!(pkg.truncated.is_none());
         assert_eq!(pkg.children.as_ref().unwrap()[0].name, "index.js");
         assert_no_default_exclude_stubs(&out.root);
+    }
+
+    /// The node budget must stop a walk and say so — a snapshot cut
+    /// short by it has to carry `max_nodes` stubs, never pass itself
+    /// off as complete. Exercised through `walk` directly so the test
+    /// doesn't need [`TREE_NODE_BUDGET`]-many real files.
+    #[tokio::test]
+    async fn node_budget_stops_the_walk_and_flags_max_nodes() {
+        let (tmp, r, _c) = setup();
+        for i in 0..6 {
+            std::fs::write(tmp.path().join(format!("f{i}.txt")), "x").unwrap();
+        }
+        let opts = WalkOpts {
+            max_depth: 4,
+            per_folder_limit: 50,
+            use_default_excludes: true,
+            include_hidden: true,
+        };
+        let base = std::fs::canonicalize(tmp.path()).unwrap();
+        let node = walk(&r, &base, &opts, 4).unwrap();
+        assert_eq!(node.children.as_ref().unwrap().len(), 4);
+        let trunc = node.truncated.as_ref().unwrap();
+        assert_eq!(trunc.reason, "max_nodes");
+        assert_eq!(trunc.shown, 4);
+        assert_eq!(trunc.total, Some(6));
+        assert!(trunc.hint.contains("coder::list-folder"));
+    }
+
+    /// The budget is spent breadth-first: every shallow entry lists
+    /// before any deep subtree spends a node, so a big early-alphabet
+    /// folder can't starve its siblings out of the root listing — the
+    /// failure mode that made a depth-first budget return 7 of a home
+    /// directory's 123 visible folders.
+    #[tokio::test]
+    async fn node_budget_spends_breadth_first_so_shallow_entries_win() {
+        let (tmp, r, _c) = setup();
+        std::fs::create_dir(tmp.path().join("aa")).unwrap();
+        for i in 0..3 {
+            std::fs::write(tmp.path().join(format!("aa/f{i}.txt")), "x").unwrap();
+        }
+        std::fs::create_dir(tmp.path().join("zz")).unwrap();
+        std::fs::write(tmp.path().join("zz/late.txt"), "x").unwrap();
+        let opts = WalkOpts {
+            max_depth: 4,
+            per_folder_limit: 50,
+            use_default_excludes: true,
+            include_hidden: true,
+        };
+        // 5 nodes: aa + zz (the whole level), then aa/f0..f2 — zz is
+        // dequeued with the budget spent and must come back a stub.
+        let base = std::fs::canonicalize(tmp.path()).unwrap();
+        let node = walk(&r, &base, &opts, 5).unwrap();
+        assert!(
+            node.truncated.is_none(),
+            "the root listed every direct child"
+        );
+        let kids = node.children.as_ref().unwrap();
+        let names: Vec<_> = kids.iter().map(|k| k.name.as_str()).collect();
+        assert_eq!(names, vec!["aa", "zz"]);
+        let aa = kids.iter().find(|k| k.name == "aa").unwrap();
+        assert_eq!(aa.children.as_ref().unwrap().len(), 3);
+        assert!(aa.truncated.is_none());
+        let zz = kids.iter().find(|k| k.name == "zz").unwrap();
+        let trunc = zz.truncated.as_ref().unwrap();
+        assert_eq!(trunc.reason, "max_nodes");
+        assert_eq!(trunc.shown, 0);
+        assert!(
+            zz.children.is_none(),
+            "a budget stub never got a listing pass"
+        );
+    }
+
+    /// The home-directory shape that motivated the flag: enough dot
+    /// entries to fill the per-folder cap by themselves (byte order
+    /// sorts them first), with the visible names behind them. The filter
+    /// must both omit the dots and stop them consuming the cap.
+    #[tokio::test]
+    async fn include_hidden_false_omits_dot_entries_and_frees_the_cap() {
+        let (tmp, r, _c) = setup();
+        for i in 0..5 {
+            std::fs::create_dir(tmp.path().join(format!(".h{i}"))).unwrap();
+        }
+        std::fs::write(tmp.path().join(".hidden.txt"), "x").unwrap();
+        std::fs::create_dir(tmp.path().join("projects")).unwrap();
+        std::fs::write(tmp.path().join("readme.md"), "x").unwrap();
+        let cfg = Arc::new(CoderConfig {
+            base_paths: vec![tmp.path().to_path_buf()],
+            tree_default_depth: 4,
+            tree_per_folder_limit: 3,
+            ..CoderConfig::default()
+        });
+        let out = handle(
+            r,
+            cfg,
+            TreeInput {
+                include_hidden: false,
+                ..input(".")
+            },
+        )
+        .await
+        .unwrap();
+        let kids = out.root.children.as_ref().unwrap();
+        let names: Vec<_> = kids.iter().map(|k| k.name.as_str()).collect();
+        assert_eq!(names, vec!["projects", "readme.md"]);
+        assert!(
+            out.root.truncated.is_none(),
+            "omitted hidden entries must not count toward per_folder_limit"
+        );
+    }
+
+    /// Hidden entries filter at EVERY level, not just the root's own
+    /// children — and the default (`include_hidden: true`) keeps them.
+    #[tokio::test]
+    async fn hidden_filter_applies_at_depth_and_defaults_to_listing() {
+        let (tmp, r, c) = setup();
+        std::fs::create_dir(tmp.path().join("src")).unwrap();
+        std::fs::write(tmp.path().join("src/.cache"), "x").unwrap();
+        std::fs::write(tmp.path().join("src/lib.rs"), "x").unwrap();
+
+        let filtered = handle(
+            r.clone(),
+            c.clone(),
+            TreeInput {
+                include_hidden: false,
+                ..input(".")
+            },
+        )
+        .await
+        .unwrap();
+        let src = &filtered.root.children.as_ref().unwrap()[0];
+        let names: Vec<_> = src
+            .children
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|k| k.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["lib.rs"]);
+
+        let unfiltered = handle(r, c, input(".")).await.unwrap();
+        let src = &unfiltered.root.children.as_ref().unwrap()[0];
+        assert!(subtree_contains(src, ".cache"), "default must keep dots");
+    }
+
+    /// Explicitly rooting the walk at a hidden folder expresses intent to
+    /// see it — the filter must not blank the listing, only its own
+    /// hidden CHILDREN drop out.
+    #[tokio::test]
+    async fn hidden_root_explicitly_requested_still_lists_contents() {
+        let (tmp, r, c) = setup();
+        std::fs::create_dir(tmp.path().join(".claude")).unwrap();
+        std::fs::write(tmp.path().join(".claude/settings.json"), "x").unwrap();
+        std::fs::write(tmp.path().join(".claude/.credentials"), "x").unwrap();
+
+        let out = handle(
+            r,
+            c,
+            TreeInput {
+                include_hidden: false,
+                ..input(".claude")
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.root.name, ".claude");
+        let names: Vec<_> = out
+            .root
+            .children
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|k| k.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["settings.json"]);
     }
 
     #[tokio::test]

--- a/shell/tests/golden/schemas/coder.read-file.json
+++ b/shell/tests/golden/schemas/coder.read-file.json
@@ -1,9 +1,28 @@
 {
-  "description": "Read a file window-first: probe with stat: true (size/mtime/mode plus total_lines, no content), then fetch just the lines you need with line_from/line_to (1-based, inclusive) — windows keep files larger than max_read_bytes readable window by window, with more_lines/total_lines reporting what remains. numbered: true prefixes each line with its absolute 1-based file line number, matching coder::update-file's line ops exactly. Full reads are budgeted by max_output_bytes (default 128 KiB; per-call override clamped to max_read_bytes) — an over-budget full read fails with a C218 carrying the file's size, line count, and the window/stat recovery calls. Batch mode: pass paths[] (XOR path) to read multiple files in one call — entries are processed in request order against batch_read_budget_bytes, measured in bytes of returned content (after UTF-8 sanitization); per-entry errors (C211/C218) leave other entries unaffected. Paths are relative to the primary allowed root or absolute inside any allowed root (coder::info lists them); for host paths outside the jail use shell::fs::*. Non-accessible paths return C211.",
+  "description": "Read a file window-first: probe with stat: true (size/mtime/mode plus total_lines, no content), then fetch just the lines you need with line_from/line_to (1-based, inclusive) — windows keep files larger than max_read_bytes readable window by window, with more_lines/total_lines reporting what remains. numbered: true prefixes each line with its absolute 1-based file line number, matching coder::update-file's line ops exactly. Full reads are budgeted by max_output_bytes (default 128 KiB; per-call override clamped to max_read_bytes) — an over-budget full read fails with a C218 carrying the file's size, line count, and the window/stat recovery calls. encoding: base64 (single-path full reads only) returns the file's exact bytes base64-encoded — the binary-aware read for images and other non-text payloads. Batch mode: pass paths[] (XOR path) to read multiple files in one call — entries are processed in request order against batch_read_budget_bytes, measured in bytes of returned content (after UTF-8 sanitization); per-entry errors (C211/C218) leave other entries unaffected. Paths are relative to the primary allowed root or absolute inside any allowed root (coder::info lists them); for host paths outside the jail use shell::fs::*. Non-accessible paths return C211.",
   "function_id": "coder::read-file",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
+      "ReadEncoding": {
+        "description": "Wire encoding for returned `content`.",
+        "oneOf": [
+          {
+            "description": "UTF-8 text; invalid bytes replaced by U+FFFD.",
+            "enum": [
+              "text"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Exact file bytes, base64-encoded (standard alphabet, padded).",
+            "enum": [
+              "base64"
+            ],
+            "type": "string"
+          }
+        ]
+      },
       "ReadTarget": {
         "anyOf": [
           {
@@ -75,6 +94,14 @@
       }
     ],
     "properties": {
+      "encoding": {
+        "allOf": [
+          {
+            "$ref": "#/definitions/ReadEncoding"
+          }
+        ],
+        "description": "Content encoding for single-path FULL reads. Default `text` returns UTF-8 (binary bytes replaced by U+FFFD); `base64` returns the file's exact bytes base64-encoded (standard alphabet, padded) — for binary payloads like images that a caller needs to reconstruct. The ENCODED length is what's charged against `max_output_bytes`. C210 combined with `stat`, `line_from`/`line_to`, or `numbered` (text-shaping fields); ignored when `paths` is set."
+      },
       "line_from": {
         "default": null,
         "description": "First line of the window, 1-based inclusive (must be >= 1; 0 is rejected with C210). Setting `line_from` and/or `line_to` switches to windowed mode: the file is streamed and only the requested lines are returned, so files larger than `max_read_bytes` stay readable slice by slice — the byte cap then applies to the returned window, never the file size. Defaults to 1 when only `line_to` is set. A window starting past EOF succeeds with empty content and reports the file's `total_lines`. Only valid in single-path mode (`path`); ignored when `paths` is set. Lines are 0x0A- or EOF-terminated segments; a trailing newline does not create a phantom line (same convention as `coder::update-file`).",
@@ -255,7 +282,7 @@
     },
     "properties": {
       "content": {
-        "description": "File content as a UTF-8 string — the whole file, or just the requested window when `line_from`/`line_to` was given (window lines keep their newline terminators). Binary content is returned with invalid bytes replaced by U+FFFD; use a future binary-aware function if exact bytes matter. **Single-path mode only; null when the request used `paths[]`.**",
+        "description": "File content as a UTF-8 string — the whole file, or just the requested window when `line_from`/`line_to` was given (window lines keep their newline terminators). Binary content is returned with invalid bytes replaced by U+FFFD; request `encoding: \"base64\"` when exact bytes matter (content is then the file's bytes base64-encoded). **Single-path mode only; null when the request used `paths[]`.**",
         "type": [
           "string",
           "null"

--- a/shell/tests/golden/schemas/coder.search.json
+++ b/shell/tests/golden/schemas/coder.search.json
@@ -1,5 +1,5 @@
 {
-  "description": "Search file contents and/or paths. Supports literal or regex queries with include/exclude globs; non-accessible files are excluded from both content and path results. Only the FIRST match on each line is reported (one content match per matching line). Optional context_lines_before/context_lines_after (max 10) attach surrounding lines to each content match so many edits can go straight to coder::update-file with no read in between. Noise paths matching default_exclude_globs (.git, node_modules, target, … — coder::info lists them) are skipped by default; pass use_default_excludes: false to search inside them. Files larger than max_read_bytes are silently skipped during content scanning. Results are capped by max_matches AND a response byte budget (search_response_budget_bytes); when truncated is true, refine the query or add include_globs rather than paginate. Paths are relative to the primary allowed root or absolute inside any allowed root (coder::info lists them); for host paths outside the jail use shell::fs::*.",
+  "description": "Search file contents and/or paths. Path search matches files AND directories (each path_match carries kind: file|dir); content search reads files only. Supports literal or regex queries with include/exclude globs; non-accessible files are excluded from both content and path results. Only the FIRST match on each line is reported (one content match per matching line). Optional context_lines_before/context_lines_after (max 10) attach surrounding lines to each content match so many edits can go straight to coder::update-file with no read in between. Noise paths matching default_exclude_globs (.git, node_modules, target, … — coder::info lists them) are skipped by default; pass use_default_excludes: false to search inside them. Files larger than max_read_bytes are silently skipped during content scanning. Results are capped by max_matches AND a response byte budget (search_response_budget_bytes); when truncated is true, refine the query or add include_globs rather than paginate. Paths are relative to the primary allowed root or absolute inside any allowed root (coder::info lists them); for host paths outside the jail use shell::fs::*.",
   "function_id": "coder::search",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -166,15 +166,31 @@
       },
       "PathMatch": {
         "properties": {
+          "kind": {
+            "allOf": [
+              {
+                "$ref": "#/definitions/PathMatchKind"
+              }
+            ],
+            "description": "What matched: `file` or `dir`. Directories match by NAME only — content search never reads them."
+          },
           "path": {
             "description": "Absolute path under the canonical parent; symlinks at the entry itself are not resolved. Operations on it re-validate through the jail.",
             "type": "string"
           }
         },
         "required": [
+          "kind",
           "path"
         ],
         "type": "object"
+      },
+      "PathMatchKind": {
+        "enum": [
+          "file",
+          "dir"
+        ],
+        "type": "string"
       }
     },
     "properties": {

--- a/shell/tests/golden/schemas/coder.tree.json
+++ b/shell/tests/golden/schemas/coder.tree.json
@@ -1,5 +1,5 @@
 {
-  "description": "Recursive directory snapshot bounded by `max_depth` and a `per_folder_limit`. Slim wire shape: nodes carry only `name` — the root node's path IS the response's top-level `path`; derive any child's path as parent path + '/' + name. Folders that hit the limit are flagged `truncated` and the caller is pointed at coder::list-folder for pagination. Noise directories matching default_exclude_globs (.git, node_modules, target, … — coder::info lists them) appear as childless `truncated` stubs; pass use_default_excludes: false to descend into them. Paths are relative to the primary allowed root or absolute inside any allowed root (coder::info lists them); for host paths outside the jail use shell::fs::*.",
+  "description": "Recursive directory snapshot bounded by `max_depth` and a `per_folder_limit`. Slim wire shape: nodes carry only `name` — the root node's path IS the response's top-level `path`; derive any child's path as parent path + '/' + name. Folders that hit the limit are flagged `truncated` and the caller is pointed at coder::list-folder for pagination. Noise directories matching default_exclude_globs (.git, node_modules, target, … — coder::info lists them) appear as childless `truncated` stubs; pass use_default_excludes: false to descend into them. Pass include_hidden: false to omit dot-prefixed entries (they then don't count toward per_folder_limit). A total node budget bounds every snapshot; folders past it are stubs with reason max_nodes — re-root there or paginate with coder::list-folder. Paths are relative to the primary allowed root or absolute inside any allowed root (coder::info lists them); for host paths outside the jail use shell::fs::*.",
   "function_id": "coder::tree",
   "request_schema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -10,6 +10,11 @@
       }
     ],
     "properties": {
+      "include_hidden": {
+        "default": true,
+        "description": "List hidden (dot-prefixed) entries. Pass `false` to omit them — files and folders alike — at every level; omitted entries do not count toward `per_folder_limit`, so the cap serves visible names. The requested root itself is exempt: explicitly naming a hidden folder still lists its contents.",
+        "type": "boolean"
+      },
       "max_depth": {
         "default": null,
         "description": "Maximum depth to descend; the root node is depth 0.",
@@ -95,7 +100,7 @@
                 "type": "null"
               }
             ],
-            "description": "Set on directories whose `children` was capped at `per_folder_limit`, whose subtree was cut off by `max_depth`, or which matched `default_exclude_globs` (reason \"default_exclude\")."
+            "description": "Set on directories whose `children` was capped at `per_folder_limit`, whose subtree was cut off by `max_depth`, which matched `default_exclude_globs` (reason \"default_exclude\"), or where the snapshot's node budget ran out (reason \"max_nodes\")."
           }
         },
         "required": [
@@ -113,7 +118,7 @@
             "type": "string"
           },
           "reason": {
-            "description": "Reason this folder was truncated: hit `per_folder_limit`, cut off by `max_depth`, or matched `default_exclude_globs` (`default_exclude`).",
+            "description": "Reason this folder was truncated: hit `per_folder_limit`, cut off by `max_depth`, matched `default_exclude_globs` (`default_exclude`), or the snapshot's total node budget ran out (`max_nodes`).",
             "type": "string"
           },
           "shown": {
@@ -123,7 +128,7 @@
             "type": "integer"
           },
           "total": {
-            "description": "Total number of children eligible for listing in the folder, counted after default-exclude filtering (only populated when `reason == \"per_folder_limit\"`; for depth truncation we don't peek into the folder).",
+            "description": "Total number of children eligible for listing in the folder, counted after hidden and default-exclude filtering (only populated when `reason == \"per_folder_limit\"`; for depth truncation we don't peek into the folder).",
             "format": "uint32",
             "minimum": 0.0,
             "type": [

--- a/shell/ui/src/page/EditorPane.tsx
+++ b/shell/ui/src/page/EditorPane.tsx
@@ -10,7 +10,12 @@
 import { CodeEditor, type Host } from '@iii-dev/console-ui'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { errorMessage, formatBytes } from '../lib/format'
-import { coderReadFile, coderWriteFile, joinPath } from './coder'
+import {
+  coderReadFile,
+  coderReadFileBase64,
+  coderWriteFile,
+  joinPath,
+} from './coder'
 
 /** File-extension → Monaco language id (unknown ids render plain). */
 export function monacoLangFromPath(path: string): string {
@@ -70,6 +75,31 @@ export function monacoLangFromPath(path: string): string {
     truncated body would destroy the tail). */
 export type ReadOnlyReason = 'binary' | 'truncated' | null
 
+/** Extension → MIME for the image preview (SVG stays in the text editor
+    — it's editable markup first). */
+export function imageMimeFromPath(path: string): string | null {
+  const ext = path.toLowerCase().match(/\.([a-z0-9]+)$/)?.[1]
+  switch (ext) {
+    case 'png':
+      return 'image/png'
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg'
+    case 'gif':
+      return 'image/gif'
+    case 'webp':
+      return 'image/webp'
+    case 'bmp':
+      return 'image/bmp'
+    case 'ico':
+      return 'image/x-icon'
+    case 'avif':
+      return 'image/avif'
+    default:
+      return null
+  }
+}
+
 export interface EditorCacheEntry {
   /** What the worker last gave (or accepted) for this file. */
   savedContent: string
@@ -78,6 +108,8 @@ export interface EditorCacheEntry {
   readOnly: ReadOnlyReason
   mode: number | null
   size: number | null
+  /** data: URL when the file rendered as an image preview. */
+  image?: string | null
 }
 
 /** Page-owned; survives tab switches, dropped when a tab closes. */
@@ -128,6 +160,30 @@ export function EditorPane({
       return
     }
     setPane({ phase: 'loading' })
+    const mime = imageMimeFromPath(relPath)
+    if (mime) {
+      coderReadFileBase64(host, absPath)
+        .then((out) => {
+          if (seqRef.current !== seq) return
+          const fresh: EditorCacheEntry = {
+            savedContent: '',
+            draft: '',
+            readOnly: 'binary',
+            mode: out.mode ?? null,
+            size: out.size ?? null,
+            image: `data:${mime};base64,${out.content ?? ''}`,
+          }
+          cache.set(relPath, fresh)
+          setDraftState('')
+          setSavedContent('')
+          setPane({ phase: 'ready' })
+        })
+        .catch((err: unknown) => {
+          if (seqRef.current !== seq) return
+          setPane({ phase: 'error', message: errorMessage(err) })
+        })
+      return
+    }
     coderReadFile(host, absPath)
       .then((out) => {
         if (seqRef.current !== seq) return
@@ -219,9 +275,11 @@ export function EditorPane({
         {dirty ? <span className="shui-dirty" title="unsaved changes" /> : null}
         {readOnly ? (
           <span className="shui-ro-note">
-            {readOnly === 'binary'
-              ? 'binary — read-only'
-              : 'truncated read — read-only'}
+            {entry?.image
+              ? 'image'
+              : readOnly === 'binary'
+                ? 'binary — read-only'
+                : 'truncated read — read-only'}
           </span>
         ) : null}
         {entry?.size != null ? (
@@ -245,6 +303,10 @@ export function EditorPane({
           <div className="shui-side-note">loading {relPath}…</div>
         ) : pane.phase === 'error' ? (
           <div className="shui-side-note warn">{pane.message}</div>
+        ) : entry?.image ? (
+          <div className="shui-image-wrap">
+            <img src={entry.image} alt={relPath} />
+          </div>
         ) : (
           <CodeEditor
             value={draft}

--- a/shell/ui/src/page/FilesTab.tsx
+++ b/shell/ui/src/page/FilesTab.tsx
@@ -25,10 +25,17 @@ interface FilesTabProps {
   tree: FlatTree | null
   gitStatus: readonly GitStatusEntry[]
   theme: 'light' | 'dark'
+  /** True while dot entries are filtered out of the listing — an empty
+      tree then reads as filtered, not as an empty folder. */
+  hiddenFiltered: boolean
   /** Slash-less dir paths to expand when (re)setting the tree. */
   expanded: readonly string[]
   /** Debounced snapshot of the currently expanded dirs (slash-less). */
   onExpandedChange: (paths: string[]) => void
+  /** Slash-less dir path to expand + scroll to (a search "folders"
+      result); acknowledged through onRevealed. */
+  reveal: string | null
+  onRevealed: () => void
   /** Single click on a file — open as the preview tab. */
   onPreviewFile: (relPath: string) => void
   /** Double click on a file — open pinned. */
@@ -39,8 +46,11 @@ export function FilesTab({
   tree,
   gitStatus,
   theme,
+  hiddenFiltered,
   expanded,
   onExpandedChange,
+  reveal,
+  onRevealed,
   onPreviewFile,
   onPinFile,
 }: FilesTabProps) {
@@ -134,11 +144,33 @@ export function FilesTab({
     model.setGitStatus(gitStatus.length > 0 ? gitStatus : undefined)
   }, [model, gitStatus])
 
+  // Reveal a folder from a search result: expand every ancestor handle,
+  // scroll it into view, then acknowledge. Expansion only ever OPENS
+  // dirs, so this can't fight the debounced expansion snapshot.
+  useEffect(() => {
+    if (!reveal || !kinds) return
+    const segs = reveal.split('/')
+    for (let i = 1; i <= segs.length; i++) {
+      const p = segs.slice(0, i).join('/')
+      const handle = model.getItem(p) ?? model.getItem(`${p}/`)
+      if (handle?.isDirectory()) {
+        ;(handle as FileTreeDirectoryHandle).expand()
+      }
+    }
+    const target = model.getItem(reveal) ? reveal : `${reveal}/`
+    model.scrollToPath(target, { offset: 'center' })
+    onRevealed()
+  }, [reveal, kinds, model, onRevealed])
+
   if (!tree) {
     return <div className="shui-side-note">loading tree…</div>
   }
   if (tree.paths.length === 0) {
-    return <div className="shui-side-note">· empty folder</div>
+    return (
+      <div className="shui-side-note">
+        {hiddenFiltered ? '· nothing visible — hidden entries are filtered' : '· empty folder'}
+      </div>
+    )
   }
 
   return (

--- a/shell/ui/src/page/SearchTab.tsx
+++ b/shell/ui/src/page/SearchTab.tsx
@@ -15,6 +15,8 @@ interface SearchTabProps {
   onPreviewFile: (relPath: string) => void
   /** Double click — open pinned. */
   onPinFile: (relPath: string) => void
+  /** Click on a FOLDER match — expand + scroll to it in the files tab. */
+  onRevealFolder: (relPath: string) => void
 }
 
 export function SearchTab({
@@ -22,6 +24,7 @@ export function SearchTab({
   root,
   onPreviewFile,
   onPinFile,
+  onRevealFolder,
 }: SearchTabProps) {
   const [query, setQuery] = useState('')
   const [regex, setRegex] = useState(false)
@@ -66,7 +69,7 @@ export function SearchTab({
         <Input
           value={query}
           onChange={setQuery}
-          placeholder="search files…"
+          placeholder="search files & folders…"
           preserveCase
           aria-label="search query"
         />
@@ -104,6 +107,7 @@ export function SearchTab({
           ignoreCase={ignoreCase}
           onPreviewFile={onPreviewFile}
           onPinFile={onPinFile}
+          onRevealFolder={onRevealFolder}
         />
       ) : null}
     </div>
@@ -118,6 +122,7 @@ function SearchResults({
   ignoreCase,
   onPreviewFile,
   onPinFile,
+  onRevealFolder,
 }: {
   result: SearchResponse
   root: string
@@ -126,11 +131,14 @@ function SearchResults({
   ignoreCase: boolean
   onPreviewFile: (relPath: string) => void
   onPinFile: (relPath: string) => void
+  onRevealFolder: (relPath: string) => void
 }) {
   const { content_matches, path_matches, truncated } = result
   if (content_matches.length === 0 && path_matches.length === 0) {
     return <div className="shui-side-note">· no matches</div>
   }
+  const folderMatches = path_matches.filter((m) => m.kind === 'dir')
+  const fileMatches = path_matches.filter((m) => m.kind !== 'dir')
   return (
     <div className="shui-search-results">
       {truncated ? (
@@ -139,10 +147,30 @@ function SearchResults({
         </div>
       ) : null}
 
-      {path_matches.length > 0 ? (
+      {folderMatches.length > 0 ? (
+        <>
+          <div className="shui-side-note head">folders</div>
+          {folderMatches.map((m) => {
+            const rel = relativeTo(root, m.path)
+            return (
+              <button
+                key={m.path}
+                type="button"
+                className="shui-search-row"
+                onClick={() => onRevealFolder(rel)}
+                title={`reveal ${rel} in files`}
+              >
+                <span className="loc">{rel}/</span>
+              </button>
+            )
+          })}
+        </>
+      ) : null}
+
+      {fileMatches.length > 0 ? (
         <>
           <div className="shui-side-note head">files</div>
-          {path_matches.map((m) => {
+          {fileMatches.map((m) => {
             const rel = relativeTo(root, m.path)
             return (
               <button

--- a/shell/ui/src/page/coder.ts
+++ b/shell/ui/src/page/coder.ts
@@ -13,7 +13,7 @@ export interface CoderInfo {
 }
 
 export interface TreeTruncation {
-  /** "per_folder_limit" | "max_depth" | "default_exclude". */
+  /** "per_folder_limit" | "max_depth" | "default_exclude" | "max_nodes". */
   reason: string
   shown: number
   total?: number | null
@@ -66,7 +66,8 @@ export interface ContentMatch {
 
 export interface SearchResponse {
   content_matches: ContentMatch[]
-  path_matches: { path: string }[]
+  /** `kind` distinguishes folder name-matches from file ones. */
+  path_matches: { path: string; kind?: 'file' | 'dir' }[]
   truncated: boolean
 }
 
@@ -74,14 +75,23 @@ export function coderInfo(host: Host): Promise<CoderInfo> {
   return host.iii.trigger<CoderInfo>('coder::info', {})
 }
 
-export function coderTree(host: Host, path: string): Promise<TreeResponse> {
+export function coderTree(
+  host: Host,
+  path: string,
+  includeHidden: boolean,
+): Promise<TreeResponse> {
   return host.iii.trigger<TreeResponse>('coder::tree', {
     path,
     // Deep enough for real repos; the worker's per-folder limit and
     // output budget still bound the response (truncated stubs carry
     // hints the Files tab surfaces).
     max_depth: 25,
+    // The worker default (50) fills with dot entries in home-shaped
+    // folders — byte order sorts them first. 500 matches the editor
+    // worker's browse call.
+    per_folder_limit: 500,
     use_default_excludes: true,
+    include_hidden: includeHidden,
   })
 }
 
@@ -90,6 +100,20 @@ export function coderReadFile(
   path: string,
 ): Promise<ReadFileResponse> {
   return host.iii.trigger<ReadFileResponse>('coder::read-file', { path })
+}
+
+/** Exact bytes, base64-encoded — the image-preview read. The override
+    lifts the 128 KiB text budget; the worker clamps it to its
+    max_read_bytes cap, so oversized files still fail loud (C218). */
+export function coderReadFileBase64(
+  host: Host,
+  path: string,
+): Promise<ReadFileResponse> {
+  return host.iii.trigger<ReadFileResponse>('coder::read-file', {
+    path,
+    encoding: 'base64',
+    max_output_bytes: 100_000_000,
+  })
 }
 
 /** Whole-file save. `mode` (from a prior read) keeps permission bits —

--- a/shell/ui/src/page/index.tsx
+++ b/shell/ui/src/page/index.tsx
@@ -20,7 +20,7 @@ import {
   PageSidebar,
 } from '@iii-dev/console-ui'
 import type { GitStatusEntry } from '@pierre/trees'
-import { FolderTree, GitBranch, Search, SquareTerminal, X } from 'lucide-react'
+import { Eye, EyeOff, FolderTree, GitBranch, Search, SquareTerminal, X } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { errorMessage } from '../lib/format'
 import { type CoderInfo, coderInfo, coderTree, type FlatTree, flattenTree } from './coder'
@@ -46,6 +46,14 @@ import {
 
 type SideTab = 'files' | 'git' | 'search'
 
+const SIDEBAR_DEFAULT_WIDTH = 280
+const SIDEBAR_MIN_WIDTH = 180
+const SIDEBAR_MAX_WIDTH = 560
+
+function clampSidebarWidth(w: number): number {
+  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, Math.round(w)))
+}
+
 const SIDE_TABS: { id: SideTab; label: string; Icon: typeof FolderTree }[] = [
   { id: 'files', label: 'files', Icon: FolderTree },
   { id: 'git', label: 'git', Icon: GitBranch },
@@ -66,10 +74,15 @@ export function ShellExplorerPage({
   const [root, setRoot] = useState<string | null>(null)
   const [sideTab, setSideTab] = useState<SideTab>('files')
   const [collapsed, setCollapsed] = useState(false)
+  const [sideWidth, setSideWidth] = useState(SIDEBAR_DEFAULT_WIDTH)
   const [tree, setTree] = useState<FlatTree | null>(null)
+  // Dot entries are filtered by default (Finder/VS Code convention) —
+  // in home-shaped folders they otherwise crowd out every visible name.
+  const [showHidden, setShowHidden] = useState(false)
   const [git, setGit] = useState<GitState | null>(null)
   const [tabs, setTabs] = useState<TabsState>(EMPTY_TABS)
   const [expanded, setExpanded] = useState<string[]>([])
+  const [reveal, setReveal] = useState<string | null>(null)
   const [dirtyPaths, setDirtyPaths] = useState<ReadonlySet<string>>(new Set())
   const [diff, setDiff] = useState<GitChange | null>(null)
   const cacheRef = useRef<EditorCache>(new Map())
@@ -111,10 +124,14 @@ export function ShellExplorerPage({
     if (persisted) {
       setTabs(restoreTabs(restored?.open, restored?.active))
       setExpanded(restored?.expanded ?? [])
+      setShowHidden(restored?.showHidden ?? false)
+      setSideWidth(clampSidebarWidth(restored?.sideWidth ?? SIDEBAR_DEFAULT_WIDTH))
     } else if (restored && !restored.root && next === info.primary_root) {
       // Legacy/first save without a root: restore against the primary.
       setTabs(restoreTabs(restored.open, restored.active))
       setExpanded(restored.expanded)
+      setShowHidden(restored.showHidden ?? false)
+      setSideWidth(clampSidebarWidth(restored.sideWidth ?? SIDEBAR_DEFAULT_WIDTH))
     }
   }, [info, restored, root, workingDir])
 
@@ -141,7 +158,7 @@ export function ShellExplorerPage({
   const refreshTree = useCallback(() => {
     if (!root) return
     const seq = ++treeSeqRef.current
-    coderTree(host, root)
+    coderTree(host, root, showHidden)
       .then((out) => {
         if (treeSeqRef.current === seq) setTree(flattenTree(out.root))
       })
@@ -150,14 +167,19 @@ export function ShellExplorerPage({
           setTree({ paths: [], kinds: new Map(), truncations: [] })
         }
       })
-  }, [host, root])
+  }, [host, root, showHidden])
 
+  // Separate effects: toggling the hidden filter reloads the TREE only —
+  // the git listing is unaffected and must not flash back to loading.
   useEffect(() => {
     setTree(null)
-    setGit(null)
     refreshTree()
+  }, [refreshTree])
+
+  useEffect(() => {
+    setGit(null)
     refreshGit()
-  }, [refreshTree, refreshGit])
+  }, [refreshGit])
 
   // ── persistence: any state change after boot writes (debounced) ──
   const saver = useMemo(() => createTabUiStateSaver(host, tabId), [host, tabId])
@@ -175,8 +197,10 @@ export function ShellExplorerPage({
       open: tabs.tabs,
       active: tabs.active,
       expanded,
+      showHidden,
+      sideWidth,
     })
-  }, [saver, root, tabs, expanded])
+  }, [saver, root, tabs, expanded, showHidden, sideWidth])
 
   // ── open/close/pin actions ──
   const previewFile = useCallback((relPath: string) => {
@@ -188,6 +212,13 @@ export function ShellExplorerPage({
     setDiff(null)
     setTabs((s) => openPinned(s, relPath))
   }, [])
+
+  const revealFolder = useCallback((relPath: string) => {
+    setSideTab('files')
+    setReveal(relPath)
+  }, [])
+
+  const onRevealed = useCallback(() => setReveal(null), [])
 
   const onDirtyChange = useCallback((relPath: string, dirty: boolean) => {
     setDirtyPaths((prev) => {
@@ -217,6 +248,44 @@ export function ShellExplorerPage({
     },
     [dirtyPaths],
   )
+
+  // ── sidebar resize (drag handle on the boundary toward the main pane) ──
+  const dragRef = useRef<{ startX: number; startWidth: number } | null>(null)
+  const onHandlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      dragRef.current = { startX: e.clientX, startWidth: sideWidth }
+      // Capture is best-effort: some pointer types refuse it, and the
+      // drag still works through the move/up handlers.
+      try {
+        e.currentTarget.setPointerCapture(e.pointerId)
+      } catch {
+        // no capture — moves outside the handle end the drag early
+      }
+    },
+    [sideWidth],
+  )
+  const onHandlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current
+      if (!drag) return
+      const delta = e.clientX - drag.startX
+      // A right-hugging sidebar widens as the handle moves LEFT.
+      setSideWidth(
+        clampSidebarWidth(
+          panelSide === 'right' ? drag.startWidth - delta : drag.startWidth + delta,
+        ),
+      )
+    },
+    [panelSide],
+  )
+  const onHandlePointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    dragRef.current = null
+    try {
+      e.currentTarget.releasePointerCapture(e.pointerId)
+    } catch {
+      // never captured — nothing to release
+    }
+  }, [])
 
   const changeRoot = useCallback((nextRoot: string) => {
     cacheRef.current.clear()
@@ -288,7 +357,22 @@ export function ShellExplorerPage({
     <PageShell>
       {header}
       <PageBody side={panelSide}>
-        <PageSidebar width={collapsed ? 34 : 280} className={`shui-sidebar${collapsed ? ' collapsed' : ''}`}>
+        <PageSidebar
+          width={collapsed ? 34 : sideWidth}
+          className={`shui-sidebar${collapsed ? ' collapsed' : ''}`}
+        >
+          {!collapsed ? (
+            <div
+              className={`shui-resize-handle ${panelSide === 'right' ? 'left' : 'right'}`}
+              onPointerDown={onHandlePointerDown}
+              onPointerMove={onHandlePointerMove}
+              onPointerUp={onHandlePointerUp}
+              role="separator"
+              aria-orientation="vertical"
+              aria-label="resize sidebar"
+              title="drag to resize"
+            />
+          ) : null}
           {collapsed ? (
             <button
               type="button"
@@ -315,6 +399,22 @@ export function ShellExplorerPage({
                   </button>
                 ))}
                 <span className="spacer" />
+                {sideTab === 'files' ? (
+                  <button
+                    type="button"
+                    className={`shui-side-tab${showHidden ? ' active' : ''}`}
+                    onClick={() => setShowHidden((v) => !v)}
+                    aria-pressed={showHidden}
+                    aria-label={showHidden ? 'hide hidden files' : 'show hidden files'}
+                    title={showHidden ? 'hide hidden files' : 'show hidden files'}
+                  >
+                    {showHidden ? (
+                      <Eye aria-hidden className="shui-side-tab-icon" />
+                    ) : (
+                      <EyeOff aria-hidden className="shui-side-tab-icon" />
+                    )}
+                  </button>
+                ) : null}
                 <button
                   type="button"
                   className="shui-collapse-btn"
@@ -352,15 +452,24 @@ export function ShellExplorerPage({
                     tree={tree}
                     gitStatus={treeGitStatus}
                     theme={theme}
+                    hiddenFiltered={!showHidden}
                     expanded={expanded}
                     onExpandedChange={setExpanded}
+                    reveal={reveal}
+                    onRevealed={onRevealed}
                     onPreviewFile={previewFile}
                     onPinFile={pinFile}
                   />
                 ) : sideTab === 'git' ? (
                   <GitTab state={git} theme={theme} onSelect={(change) => setDiff(change)} onRefresh={refreshGit} />
                 ) : (
-                  <SearchTab host={host} root={root} onPreviewFile={previewFile} onPinFile={pinFile} />
+                  <SearchTab
+                    host={host}
+                    root={root}
+                    onPreviewFile={previewFile}
+                    onPinFile={pinFile}
+                    onRevealFolder={revealFolder}
+                  />
                 )}
               </div>
             </>

--- a/shell/ui/src/page/persist.ts
+++ b/shell/ui/src/page/persist.ts
@@ -20,6 +20,10 @@ export interface TabUiState {
   open: OpenTab[]
   active: string | null
   expanded: string[]
+  /** Files-tab dot-entries toggle; absent in legacy saves = hidden. */
+  showHidden?: boolean
+  /** Sidebar width in px from the drag handle; absent = default. */
+  sideWidth?: number
 }
 
 function isUnavailable(err: unknown): boolean {

--- a/shell/ui/styles.css
+++ b/shell/ui/styles.css
@@ -361,6 +361,42 @@
 
 [data-iii-ui="shell"] .shui-sidebar {
   font-family: var(--font-mono, ui-monospace, monospace);
+  position: relative;
+}
+
+/* Resize handle on the sidebar's boundary toward the main pane. */
+[data-iii-ui="shell"] .shui-resize-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 5px;
+  cursor: col-resize;
+  z-index: 2;
+  touch-action: none;
+}
+[data-iii-ui="shell"] .shui-resize-handle.left { left: 0; }
+[data-iii-ui="shell"] .shui-resize-handle.right { right: 0; }
+[data-iii-ui="shell"] .shui-resize-handle:hover,
+[data-iii-ui="shell"] .shui-resize-handle:active {
+  background: var(--color-surface-active);
+}
+
+/* Image preview — centered, contained, own scroll for oversized zooms. */
+[data-iii-ui="shell"] .shui-image-wrap {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+[data-iii-ui="shell"] .shui-image-wrap img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  border: 1px solid var(--color-edge);
+  background: var(--color-surface);
 }
 [data-iii-ui="shell"] .shui-sidebar.collapsed {
   align-items: center;


### PR DESCRIPTION
## Problem

Browsing a home directory in the shell explorer shows only dot folders (Slack report from Mike). Two compounding defects:

- `coder::tree` sorts children in byte order, so dot entries come first, and the per-folder cap (default 50) fills with them. Every visible folder lands in the truncated remainder: "partial listing, 572 folders truncated".
- Raising the cap naively is not safe: an unbounded home-directory walk runs past the engine invocation timeout, and flushing the resulting giant frame kills the worker's engine socket (broken-pipe reconnect loop, worker functions unregistered until restart).

While fixing the tree, three adjacent explorer gaps surfaced in testing: images open as mojibake text, path search never returns folders, and the sidebar width is fixed.

## Changes

**`coder::tree`**
- New `include_hidden` input (default `true`, wire-compatible). When `false`, dot entries are omitted before the per-folder cap is counted, so the cap serves visible names. Explicitly rooting at a hidden folder still lists it.
- The walk is now breadth-first under a total node budget (20k nodes). Level order matters: when the budget cannot cover the whole tree it is spent on shallow entries first, so every folder the user can see lists completely and only deep subtrees come back as stubs (`truncated.reason: "max_nodes"`). A depth-first budget returned 7 of a home directory's 123 visible folders.
- Home-directory snapshot on the live rig: 0.28s, 7 MB bounded response, all 123 root folders listed.

**`coder::read-file`**
- New `encoding: "base64"` (single-path full reads): returns the file's exact bytes base64-encoded, for binary payloads. The encoded length is charged against `max_output_bytes`; C210 with `stat`/window/`numbered`.

**`coder::search`**
- Path matching now includes directories. Each `path_match` carries `kind: "file" | "dir"`; content matching still reads files only.

**Shell explorer UI**
- Files tab: hidden entries filtered by default, eye toggle in the sidebar tab row, persisted per workspace tab. Tree request now passes `per_folder_limit: 500` (matching the editor worker's browse call).
- Editor pane: image files (png/jpg/gif/webp/bmp/ico/avif) render as a preview instead of raw bytes.
- Search tab: separate "folders" section; clicking a folder result switches to the files tab, expands the path, and scrolls to it.
- Sidebar: drag handle on the boundary toward the main pane (180 to 560 px, persisted).

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, full test suite (1352 passed, 15 suites), schema goldens regenerated with `UPDATE_GOLDENS=1`.
- New unit tests: hidden filtering (cap interaction, depth, hidden root), node budget (stop + flag, breadth-first ordering), base64 (exact-byte round trip, C210 conflicts, encoded-length budgeting), directory path matches with kind.
- Shell UI: `tsc --noEmit`, esbuild, vitest 83 passed.
- Live-verified on the rig (engine 0.22.1): wire calls against `/Users/rohitghumare` and `/private/tmp`, plus browser passes of all four features in the console explorer.

Closes MOT-4407.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * View image files directly in a read-only preview.
  * Read individual files as exact Base64 data when needed.
  * Search results now include matching folders as well as files.
  * Reveal matching folders automatically in the file tree.
  * Show or hide hidden files with a persistent setting.
  * Resize the sidebar and retain its width between sessions.
  * Configure tree views to include hidden entries.

* **Improvements**
  * Large trees now prioritize shallow entries and report node-limit truncation.
  * File and folder search results are clearly distinguished.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->