### PR TITLE
fix(eval): wrap system prompt strategy in option

### DIFF
--- a/eval/src/runtime.rs
+++ b/eval/src/runtime.rs
@@ -679,9 +679,9 @@ fn send_options(job: &EvalJobRecordV1, variant: &crate::contract::EvalVariantV1)
     SendOptions {
         system_prompt: variant.system_prompt.clone(),
         system_prompt_strategy: if variant.system_prompt.is_none() {
-            harness::prompt::SystemPromptStrategy::Disabled
+            Some(harness::prompt::SystemPromptStrategy::Disabled)
         } else {
-            job.request.model.system_prompt_strategy
+            Some(job.request.model.system_prompt_strategy)
         },
         mode: job.request.model.mode,
         max_turns: Some(job.request.limits.execution.max_turns),


### PR DESCRIPTION
## Summary

Wrap both `system_prompt_strategy` branches in `Some(...)` when constructing Harness `SendOptions`.

## Why

`SendOptions.system_prompt_strategy` is optional, while Eval still supplied `SystemPromptStrategy` directly. This caused Rust error E0308 and prevented Eval from compiling.

## Impact

Eval builds against the current Harness send contract without changing prompt selection behavior.

## Validation

- `cargo check --manifest-path eval/Cargo.toml`
- `cargo fmt --manifest-path eval/Cargo.toml --check`
- `git diff --check`
