### PR TITLE
fix(registry): allow roll-forward from unresolved latest

### DIFF
--- a/.github/scripts/registry_release.py
+++ b/.github/scripts/registry_release.py
@@ -20,11 +20,11 @@ class RegistryError(RuntimeError):
 def request_json(
     method: str,
     url: str,
-    payload: dict[str, Any],
+    payload: dict[str, Any] | None,
     *,
     api_key: str | None = None,
 ) -> tuple[int, dict[str, Any]]:
-    body = json.dumps(payload).encode()
+    body = json.dumps(payload).encode() if payload is not None else None
     headers = {"Content-Type": "application/json"}
     if api_key:
         headers["X-API-Key"] = api_key
@@ -63,6 +63,36 @@ def resolve_version(api_url: str, worker: str, selector: str, *, allow_missing: 
     raise RegistryError(f"resolve {worker}@{selector} failed with HTTP {status}: {json.dumps(response)}")
 
 
+def release_tag_version(api_url: str, worker: str, tag: str, *, allow_missing: bool = False) -> str | None:
+    encoded_worker = urllib.parse.quote(worker, safe="")
+    status, response = request_json(
+        "GET",
+        f"{api_url.rstrip('/')}/w/{encoded_worker}/versions",
+        None,
+    )
+    if status == 200:
+        versions = response.get("versions")
+        if not isinstance(versions, list):
+            raise RegistryError(f"versions response for {worker} has no versions list")
+        matches = [
+            entry.get("version")
+            for entry in versions
+            if isinstance(entry, dict) and tag in (entry.get("tags") or [])
+        ]
+        if len(matches) == 1 and isinstance(matches[0], str) and matches[0]:
+            return matches[0]
+        if not matches and allow_missing:
+            return None
+        if not matches:
+            raise RegistryError(f"release tag {worker}@{tag} was not found")
+        raise RegistryError(f"release tag {worker}@{tag} points to multiple versions")
+    error = response.get("error")
+    code = error.get("code") if isinstance(error, dict) else None
+    if allow_missing and status == 404 and code in {"version_not_found", "worker_not_found"}:
+        return None
+    raise RegistryError(f"list versions for {worker} failed with HTTP {status}: {json.dumps(response)}")
+
+
 def promotion_payload(version: str, current_latest: str | None) -> dict[str, str]:
     payload = {"version": version, "expected_tag": "next"}
     if current_latest is not None:
@@ -78,13 +108,19 @@ def promote(
     expected_next: str,
     expected_latest: str | None,
 ) -> dict[str, Any]:
-    current_latest = resolve_version(api_url, worker, "latest", allow_missing=True)
-    current_next = resolve_version(api_url, worker, "next", allow_missing=True)
+    # Read the raw release-tag pointers for CAS. Resolving the current latest
+    # graph may fail precisely when a dependency was promoted first; that must
+    # not prevent a compatible next candidate from rolling the graph forward.
+    current_latest = release_tag_version(api_url, worker, "latest", allow_missing=True)
+    current_next = release_tag_version(api_url, worker, "next", allow_missing=True)
     if current_next != expected_next:
         raise RegistryError(f"next points to {current_next}, expected {expected_next}")
     if expected_next != version:
         raise RegistryError(f"promotion target {version} does not match expected next {expected_next}")
     if current_latest == version:
+        resolved_latest = resolve_version(api_url, worker, "latest")
+        if resolved_latest != version:
+            raise RegistryError(f"promotion verification resolved {resolved_latest}, expected {version}")
         return {
             "worker": worker,
             "version": version,
@@ -106,6 +142,9 @@ def promote(
     if status != 200:
         raise RegistryError(f"promotion failed with HTTP {status}: {json.dumps(response)}")
 
+    promoted_tag = release_tag_version(api_url, worker, "latest")
+    if promoted_tag != version:
+        raise RegistryError(f"latest tag points to {promoted_tag}, expected {version}")
     promoted = resolve_version(api_url, worker, "latest")
     if promoted != version:
         raise RegistryError(f"promotion verification resolved {promoted}, expected {version}")

--- a/.github/scripts/tests/test_registry_release.py
+++ b/.github/scripts/tests/test_registry_release.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 import registry_release
-from registry_release import RegistryError, promotion_payload, resolved_root_version
+from registry_release import RegistryError, promotion_payload, release_tag_version, resolved_root_version
 
 
 def test_promotion_payload_uses_source_and_destination_preconditions():
@@ -30,17 +30,43 @@ def test_resolved_root_version_rejects_malformed_response():
         resolved_root_version({"graph": []})
 
 
-def test_exact_cas_promotes_observed_channels(monkeypatch):
-    latest_calls = 0
+def test_release_tag_version_reads_raw_pointer_without_resolving_dependencies(monkeypatch):
+    monkeypatch.setattr(
+        registry_release,
+        "request_json",
+        lambda *_args, **_kwargs: (
+            200,
+            {
+                "versions": [
+                    {"version": "1.2.3", "tags": ["next"]},
+                    {"version": "1.2.2", "tags": ["latest"]},
+                ]
+            },
+        ),
+    )
+    assert release_tag_version("https://registry.test", "pdf", "latest") == "1.2.2"
 
-    def resolve(_api_url, _worker, selector, *, allow_missing=False):
-        nonlocal latest_calls
+
+def test_release_tag_version_allows_missing_pointer(monkeypatch):
+    monkeypatch.setattr(
+        registry_release,
+        "request_json",
+        lambda *_args, **_kwargs: (200, {"versions": [{"version": "1.2.3", "tags": ["next"]}]}),
+    )
+    assert release_tag_version("https://registry.test", "pdf", "latest", allow_missing=True) is None
+
+
+def test_exact_cas_promotes_observed_channels(monkeypatch):
+    tag_calls = {"latest": 0}
+
+    def tag(_api_url, _worker, selector, *, allow_missing=False):
         if selector == "next":
             return "1.2.3"
-        latest_calls += 1
-        return "1.2.2" if latest_calls == 1 else "1.2.3"
+        tag_calls["latest"] += 1
+        return "1.2.2" if tag_calls["latest"] == 1 else "1.2.3"
 
-    monkeypatch.setattr(registry_release, "resolve_version", resolve)
+    monkeypatch.setattr(registry_release, "release_tag_version", tag)
+    monkeypatch.setattr(registry_release, "resolve_version", lambda *_args, **_kwargs: "1.2.3")
     monkeypatch.setattr(
         registry_release,
         "request_json",
@@ -55,11 +81,11 @@ def test_exact_cas_promotes_observed_channels(monkeypatch):
 
 
 def test_stale_candidate_is_rejected_before_tag_update(monkeypatch):
-    def resolve(_api_url, _worker, selector, *, allow_missing=False):
+    def tag(_api_url, _worker, selector, *, allow_missing=False):
         assert allow_missing is True
         return "1.2.2" if selector == "latest" else "1.2.4"
 
-    monkeypatch.setattr(registry_release, "resolve_version", resolve)
+    monkeypatch.setattr(registry_release, "release_tag_version", tag)
     called = False
 
     def request(*_args, **_kwargs):
@@ -76,10 +102,11 @@ def test_stale_candidate_is_rejected_before_tag_update(monkeypatch):
 
 
 def test_completed_promotion_is_idempotent_for_recovery(monkeypatch):
-    def resolve(_api_url, _worker, selector, *, allow_missing=False):
+    def tag(_api_url, _worker, selector, *, allow_missing=False):
         return "1.2.3"
 
-    monkeypatch.setattr(registry_release, "resolve_version", resolve)
+    monkeypatch.setattr(registry_release, "release_tag_version", tag)
+    monkeypatch.setattr(registry_release, "resolve_version", lambda *_args, **_kwargs: "1.2.3")
 
     def request(*_args, **_kwargs):
         raise AssertionError("an already-promoted target must not be written again")
@@ -100,10 +127,10 @@ def test_completed_promotion_is_idempotent_for_recovery(monkeypatch):
 
 
 def test_stale_latest_is_rejected_before_tag_update(monkeypatch):
-    def resolve(_api_url, _worker, selector, *, allow_missing=False):
+    def tag(_api_url, _worker, selector, *, allow_missing=False):
         return "1.2.3" if selector == "next" else "1.2.1"
 
-    monkeypatch.setattr(registry_release, "resolve_version", resolve)
+    monkeypatch.setattr(registry_release, "release_tag_version", tag)
 
     def request(*_args, **_kwargs):
         raise AssertionError("a stale destination must not be updated")


### PR DESCRIPTION
## What changed

- read raw `latest` and `next` Registry tag pointers for promotion preconditions
- keep the exact compare-and-swap update and full dependency resolution as post-promotion verification
- cover raw tag lookup, stale candidates, stale destinations, and idempotent recovery in tests

## Why

A provider promotion could not roll forward because resolving the old `latest` dependency graph failed after a shared dependency had already advanced. The Registry still had valid raw tag pointers and a compatible `next` candidate, but preflight stopped before the guarded tag update.

## Impact

The exact-version promotion executor can recover this ordering failure without weakening its expected-current-tag or expected-candidate checks. A successful promotion still has to resolve the resulting `latest` graph to the requested version.

## Validation

- `10 passed` in `test_registry_release.py`
- `174 passed` across `.github/scripts/tests`
- `python3 -m compileall -q .github/scripts/registry_release.py`
- `git diff --check`

Classification: `no-ticket` (CI/release recovery).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release promotion checks to accurately validate raw version tags.
  * Added safer handling for missing release tags during registry operations.
  * Improved post-promotion verification to confirm the correct release tag before resolving its version.

* **Tests**
  * Expanded coverage for raw tag lookup, missing tags, and promotion validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->