### PR TITLE
fix(ci): enable KVM for Scrapling candidate smoke

### DIFF
--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -128,6 +128,14 @@ def test_every_dispatch_is_actor_gated_and_emits_factual_evidence() -> None:
         assert ("--mutating" in body) == (name in MUTATING), name
 
 
+def test_candidate_smoke_prepares_kvm_only_for_scrapling() -> None:
+    steps = workflow(WORKFLOWS / "candidate-smoke.yml")["jobs"]["smoke"]["steps"]
+    prepare = next(step for step in steps if step.get("name") == "Prepare KVM for Scrapling sandbox")
+    assert prepare["if"] == "inputs.worker == 'scrapling'"
+    assert "test -c /dev/kvm" in prepare["run"]
+    assert "sudo chmod 0666 /dev/kvm" in prepare["run"]
+
+
 def test_reusable_harness_executor_has_no_implicit_inputs() -> None:
     inputs = workflow(WORKFLOWS / "_harness-e2e.yml")["on"]["workflow_call"]["inputs"]
     assert inputs

--- a/.github/workflows/candidate-smoke.yml
+++ b/.github/workflows/candidate-smoke.yml
@@ -83,6 +83,12 @@ jobs:
           export PATH="$HOME/.local/bin:$HOME/.iii/bin:$PATH"
           iii --version
 
+      - name: Prepare KVM for Scrapling sandbox
+        if: inputs.worker == 'scrapling'
+        run: |
+          test -c /dev/kvm
+          sudo chmod 0666 /dev/kvm
+
       - name: Start empty engine
         run: |
           set -euo pipefail


### PR DESCRIPTION
## What changed

- enable access to `/dev/kvm` before validating the Scrapling candidate
- keep the KVM preparation scoped to Scrapling
- add a structural test for the runner preparation contract

## Why

`scrapling@0.2.7` publishes successfully but cannot complete candidate validation because its sandbox VM cannot access KVM on the hosted runner. The repository already applies the same KVM permission setup for sandbox E2E scenarios.

## Impact

Scrapling candidates can boot their sandbox during validation while candidate checks for other workers remain unchanged.

## Validation

- `175 passed` across `.github/scripts/tests`
- parsed `candidate-smoke.yml` with PyYAML
- `git diff --check`

Classification: `no-ticket` (CI-only release recovery).
