### PR TITLE
fix(ci): make Registry Harness E2E executable

### DIFF
--- a/.github/workflows/_harness-e2e.yml
+++ b/.github/workflows/_harness-e2e.yml
@@ -317,6 +317,14 @@ jobs:
         if: inputs.stack_mode == 'registry'
         run: cargo build --locked --release --manifest-path harness/Cargo.toml -p harness-e2e
 
+      - name: Checkout workflow scenario validator
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          path: _workflow
+          sparse-checkout: .github/scripts/validate_harness_scenarios.py
+          sparse-checkout-cone-mode: false
+
       - name: Validate exact scenarios against the executable suite
         id: scenarios
         env:
@@ -330,7 +338,7 @@ jobs:
         run: |
           set -euo pipefail
           available=$(harness/target/release/harness-e2e list)
-          resolved=$(python3 .github/scripts/validate_harness_scenarios.py \
+          resolved=$(python3 _workflow/.github/scripts/validate_harness_scenarios.py \
             --available-json "$available" \
             --requested-json "$REQUESTED_SCENARIOS" \
             --required-json "$REQUIRED_SCENARIOS" \

--- a/.github/workflows/harness-e2e-registry.yml
+++ b/.github/workflows/harness-e2e-registry.yml
@@ -84,7 +84,7 @@ jobs:
       source_ref: ${{ inputs.source_sha }}
       stack_mode: registry
       runs: ${{ fromJSON(format('{0}', inputs.runs)) }}
-      max_parallel: 2
+      max_parallel: 1
       validation_lane: ${{ inputs.lane }}
       cli_channel: ${{ inputs.channel }}
       registry_tag: ${{ inputs.channel }}

--- a/.github/workflows/harness-e2e-registry.yml
+++ b/.github/workflows/harness-e2e-registry.yml
@@ -83,7 +83,7 @@ jobs:
     with:
       source_ref: ${{ inputs.source_sha }}
       stack_mode: registry
-      runs: ${{ inputs.runs }}
+      runs: ${{ fromJSON(format('{0}', inputs.runs)) }}
       max_parallel: 2
       validation_lane: ${{ inputs.lane }}
       cli_channel: ${{ inputs.channel }}


### PR DESCRIPTION
## Summary

- coerce the workflow_dispatch runs input to the numeric type required by the reusable workflow
- load the scenario validator from the workflow revision while testing historical release source
- serialize Registry provisioning to avoid parallel bootstrap overload

## Validation

- actionlint v1.7.12
- Registry E2E run 31618785914 compiled the exact Harness release source and materialized the requested scenario matrix
- the run installed the exact harness 1.8.1 Registry stack and then exposed the separate provider registration token mismatch

The E2E product result is intentionally not claimed as green: scored_runs remained 0 because provider registration failed before scenario execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved end-to-end workflow validation by using the validator from the workflow revision.
  * Updated registry end-to-end test execution to use JSON-based run configuration.
  * Limited registry end-to-end tests to a single parallel job for more consistent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->