### PR TITLE
(MOT-4412) fix(llm-router): show providers on fresh installs

### DIFF
--- a/llm-router/ui/package.json
+++ b/llm-router/ui/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && node build.mjs",
-    "watch": "node build.mjs --watch"
+    "watch": "node build.mjs --watch",
+    "test": "vitest run"
   },
   "dependencies": {
     "@iii-dev/console-ui": "workspace:*"
@@ -13,6 +14,7 @@
   "devDependencies": {
     "@types/react": "^19.2.14",
     "esbuild": "^0.25.0",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "vitest": "^4.1.6"
   }
 }

--- a/llm-router/ui/src/configuration/index.tsx
+++ b/llm-router/ui/src/configuration/index.tsx
@@ -24,6 +24,7 @@ import {
   Select,
   type SelectOption,
 } from '@iii-dev/console-ui'
+import { providerCardIds } from './provider-cards'
 
 type JsonObject = { [key: string]: JsonValue }
 
@@ -136,7 +137,7 @@ const SETTINGS_FIELDS = [
 export function LlmRouterConfigForm(props: ConfigFormProps) {
   const value = asObject(props.value)
   const providers = asObject(value.providers)
-  const providerIds = Object.keys(providers)
+  const providerIds = providerCardIds(props.schema, props.value)
   const settings = asObject(value.settings)
   const heuristics = Array.isArray(value.routing_heuristics)
     ? (value.routing_heuristics as JsonValue[])

--- a/llm-router/ui/src/configuration/provider-cards.test.ts
+++ b/llm-router/ui/src/configuration/provider-cards.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { providerCardIds } from './provider-cards'
+
+const schema = {
+  properties: {
+    providers: {
+      properties: {
+        anthropic: {},
+        openai: {},
+      },
+    },
+  },
+}
+
+describe('providerCardIds', () => {
+  it('shows providers from the schema when fresh-install config is null', () => {
+    expect(providerCardIds(schema, null)).toEqual(['anthropic', 'openai'])
+  })
+
+  it('keeps configured providers that are no longer in the schema', () => {
+    expect(
+      providerCardIds(schema, {
+        providers: { openai: { api_key: 'configured' }, custom: {} },
+      }),
+    ).toEqual(['anthropic', 'openai', 'custom'])
+  })
+
+  it('returns no cards only when neither source contains providers', () => {
+    expect(providerCardIds(null, null)).toEqual([])
+    expect(providerCardIds({ properties: {} }, {})).toEqual([])
+  })
+})

--- a/llm-router/ui/src/configuration/provider-cards.ts
+++ b/llm-router/ui/src/configuration/provider-cards.ts
@@ -1,0 +1,34 @@
+/**
+ * Build the provider card list from both the registered schema and the saved
+ * configuration. A fresh installation has a null configuration value, while
+ * its schema already contains the providers that operators can configure.
+ */
+
+type JsonObject = Record<string, unknown>
+
+function asObject(value: unknown): JsonObject {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as JsonObject)
+    : {}
+}
+
+function schemaProviderIds(
+  schema: Record<string, unknown> | null,
+): string[] {
+  const properties = asObject(schema?.properties)
+  const providers = asObject(properties.providers)
+  return Object.keys(asObject(providers.properties))
+}
+
+export function providerCardIds(
+  schema: Record<string, unknown> | null,
+  value: unknown,
+): string[] {
+  const configuredProviders = asObject(asObject(value).providers)
+  return [
+    ...new Set([
+      ...schemaProviderIds(schema),
+      ...Object.keys(configuredProviders),
+    ]),
+  ]
+}

--- a/llm-router/ui/vitest.config.ts
+++ b/llm-router/ui/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -361,6 +361,9 @@ importers:
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0))
 
   memory/ui:
     dependencies:


### PR DESCRIPTION
## Summary

- render llm-router provider cards from the registered configuration schema before a configuration value exists
- retain configured-only providers so stale or custom entries remain editable
- add focused regression coverage for fresh, stale, and empty provider lists

## Root cause

Fresh installations return `null` for the `llm-router` configuration value. The custom form built its cards only from `value.providers`, so it rendered an empty provider section even though the registered schema already contained Anthropic and OpenAI.

## Impact

Users can configure provider credentials immediately after installing Harness and Console, without first creating an llm-router configuration entry through another path.

## Testing

- `pnpm --filter @iii-workers/llm-router-ui test`
- `pnpm --filter @iii-workers/llm-router-ui build`
- `cargo build --manifest-path llm-router/Cargo.toml`
- live bundle verification against Console on `127.0.0.1:3113` with a null llm-router configuration

Refs MOT-4412


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider configuration cards now include both available providers and previously saved providers, even when they are no longer in the current schema.
  * Duplicate or invalid provider entries are handled safely.

* **Tests**
  * Added automated coverage for provider discovery, saved-provider retention, empty configurations, and invalid data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->