### PR TITLE
fix(release): authenticate iii installer

### DIFF
--- a/.github/scripts/tests/test_release_workflows.py
+++ b/.github/scripts/tests/test_release_workflows.py
@@ -149,3 +149,8 @@ def test_reusable_release_executors_have_no_implicit_inputs() -> None:
         assert inputs, name
         assert all(definition.get("required") == "true" for definition in inputs.values()), name
         assert all("default" not in definition for definition in inputs.values()), name
+
+
+def test_registry_publish_authenticates_iii_installer() -> None:
+    body = (WORKFLOWS / "_publish-registry.yml").read_text()
+    assert "GITHUB_TOKEN: ${{ github.token }}" in body

--- a/.github/workflows/_publish-registry.yml
+++ b/.github/workflows/_publish-registry.yml
@@ -69,6 +69,7 @@ jobs:
       - name: Install iii CLI
         env:
           VERSION: '0.17.0'
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           curl -fsSL https://install.iii.dev/iii/main/install.sh -o /tmp/install-iii.sh


### PR DESCRIPTION
## Summary

- pass the workflow token to the iii installer during Registry publication
- add a release workflow contract test for the authenticated installer configuration

## Why

Release publication could fail before starting the iii engine when the installer exhausted GitHub's unauthenticated API limit. The workflow already has read access to repository contents, so using the ephemeral workflow token raises the API limit without adding a new secret.

This unblocks exact Registry publication and keeps failed mutating releases recoverable through Release Control.

## Validation

- release workflow contract tests
- YAML parse and token wiring assertion
- authenticated iii 0.17.0 installer run
