### PR TITLE
(MOT-4398) fix(llm-router): type provider rediscovery handler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,7 +460,7 @@ jobs:
         run: |
           set -euo pipefail
           python3 .github/scripts/collect_worker_interface.py \
-            --assert-non-empty --assert-file worker-interface.json
+            --assert-non-empty --assert-typed-schemas --assert-file worker-interface.json
 
       - name: Dump logs on failure
         if: failure()

--- a/llm-router/src/register.rs
+++ b/llm-router/src/register.rs
@@ -36,7 +36,7 @@ use crate::registry::store::RegistryStore;
 use crate::surface;
 use crate::triggers::RouterEvents;
 use crate::types::errors::invalid_request_from_serde;
-use crate::types::router::ConfigChangedEvent;
+use crate::types::router::{ConfigChangedEvent, FunctionsChangedEvent, RouterAck};
 
 /// `metadata.internal = true` keeps a registration out of the default
 /// `engine::functions::list`: orchestrator/provider plumbing, invoked by id.
@@ -319,13 +319,13 @@ pub async fn register_router(iii: IIIClient) -> Result<RouterRefs, Error> {
         let sweep = crate::registry::rediscover::spawn_debounced_sweep(iii_handler);
         iii.register_function(
             surface::ON_FUNCTIONS_CHANGED_ID,
-            RegisterFunction::new_async(move |_event: Value| {
+            RegisterFunction::new_async(move |_event: FunctionsChangedEvent| {
                 let sweep = sweep.clone();
                 async move {
                     // Coalesce the boot burst: the handler only marks work
                     // pending, the sweep task fires once it goes quiet.
                     sweep.request();
-                    Ok::<Value, Error>(json!({ "ok": true }))
+                    Ok::<RouterAck, Error>(RouterAck { ok: true })
                 }
             })
             .description(surface::ON_FUNCTIONS_CHANGED_DESC)

--- a/llm-router/src/surface.rs
+++ b/llm-router/src/surface.rs
@@ -13,12 +13,13 @@
 use crate::chat::chat::{ChatCall, ChatFnInput};
 use crate::types::router::{
     AbortRequest, AbortResponse, ChatResponse, CompleteResponse, ConfigChangedEvent,
-    ModelBudgetRequest, ModelBudgetResponse, ModelGetRequest, ModelGetResponse, ModelsListRequest,
-    ModelsListResponse, ModelsReconcileRequest, ModelsReconcileResponse, ModelsSupportsRequest,
-    ModelsSupportsResponse, ProviderListRequest, ProviderListResponse, ProviderRegisterRequest,
-    ProviderRegisterResponse, ProviderResolveRequest, ProviderResolveResponse, RouteRequest,
-    RouteResponse, RouterAck, SystemPromptGetRequest, SystemPromptGetResponse,
-    UpdateCredentialRequest, UpdateCredentialResponse,
+    FunctionsChangedEvent, ModelBudgetRequest, ModelBudgetResponse, ModelGetRequest,
+    ModelGetResponse, ModelsListRequest, ModelsListResponse, ModelsReconcileRequest,
+    ModelsReconcileResponse, ModelsSupportsRequest, ModelsSupportsResponse, ProviderListRequest,
+    ProviderListResponse, ProviderRegisterRequest, ProviderRegisterResponse,
+    ProviderResolveRequest, ProviderResolveResponse, RouteRequest, RouteResponse, RouterAck,
+    SystemPromptGetRequest, SystemPromptGetResponse, UpdateCredentialRequest,
+    UpdateCredentialResponse,
 };
 
 // ── function id + description constants — consumed by both register_router and
@@ -180,5 +181,9 @@ pub fn catalog() -> Vec<FunctionSpec> {
             MODELS_RECONCILE_DESC,
         ),
         spec::<ConfigChangedEvent, RouterAck>(ON_CONFIG_CHANGED_ID, ON_CONFIG_CHANGED_DESC),
+        spec::<FunctionsChangedEvent, RouterAck>(
+            ON_FUNCTIONS_CHANGED_ID,
+            ON_FUNCTIONS_CHANGED_DESC,
+        ),
     ]
 }

--- a/llm-router/src/types/router.rs
+++ b/llm-router/src/types/router.rs
@@ -454,6 +454,19 @@ pub struct ConfigChangedEvent {
     pub id: Option<String>,
 }
 
+/// Advisory function-registry change event delivered to
+/// `router::on_functions_changed`. The handler ignores event values and
+/// re-fetches the authoritative registry before nudging live providers.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct FunctionsChangedEvent {
+    /// Engine event tag (advisory).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event: Option<String>,
+    /// Worker whose registered functions changed (advisory).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worker_id: Option<String>,
+}
+
 /// Generic acknowledgement returned by trigger-bound handlers whose result is
 /// not consumed by callers (kept typed so the response schema is concrete).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]

--- a/llm-router/tests/golden/schemas/router.on_functions_changed.json
+++ b/llm-router/tests/golden/schemas/router.on_functions_changed.json
@@ -1,0 +1,40 @@
+{
+  "description": "Internal: a worker's function registrations changed — re-discover live providers and nudge them to re-declare, so a provider that reconnected is resolvable again without waiting for its own catalog timer.",
+  "function_id": "router::on_functions_changed",
+  "request_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Advisory function-registry change event delivered to `router::on_functions_changed`. The handler ignores event values and re-fetches the authoritative registry before nudging live providers.",
+    "properties": {
+      "event": {
+        "description": "Engine event tag (advisory).",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "worker_id": {
+        "description": "Worker whose registered functions changed (advisory).",
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "title": "FunctionsChangedEvent",
+    "type": "object"
+  },
+  "response_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Generic acknowledgement returned by trigger-bound handlers whose result is not consumed by callers (kept typed so the response schema is concrete).",
+    "properties": {
+      "ok": {
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "ok"
+    ],
+    "title": "RouterAck",
+    "type": "object"
+  }
+}

--- a/llm-router/tests/schemas.rs
+++ b/llm-router/tests/schemas.rs
@@ -32,7 +32,7 @@ fn spec_to_pretty_json(spec: &FunctionSpec) -> String {
     pretty
 }
 
-/// The catalog must cover exactly the 17 registered functions, in registration
+/// The catalog must cover exactly the 18 registered functions, in registration
 /// order (kept in lockstep with `register::register_router`).
 #[test]
 fn catalog_lists_all_functions_in_registration_order() {
@@ -57,6 +57,7 @@ fn catalog_lists_all_functions_in_registration_order() {
             "router::provider::update_credential",
             "router::models::reconcile",
             "router::on_config_changed",
+            "router::on_functions_changed",
         ]
     );
 }


### PR DESCRIPTION
Refs MOT-4398

## What changed

- type the `router::on_functions_changed` request and response instead of registering it as `serde_json::Value`
- add the internal handler to the router surface catalog and commit its schema golden
- run `--assert-typed-schemas` in the llm-router CI boot smoke, matching the release gate

## Root cause

The provider rediscovery handler added in #770 used `Value -> Value`. The SDK therefore emitted `AnyValue` schemas, while the release workflow requires every published function interface to have concrete request and response schemas. The handler was also absent from the static schema catalog, and CI only asserted that the live interface was non-empty.

## Impact

A bad runtime interface will now fail on the pull request before release. The corrected handler publishes a concrete advisory event schema and typed acknowledgement.

## Validation

- `UPDATE_GOLDENS=1 cargo test --manifest-path llm-router/Cargo.toml --test schemas`
- `cargo test --manifest-path llm-router/Cargo.toml` (108 unit + 12 integration passed; one timing-sensitive integration case passed on isolated rerun)
- `cargo test --manifest-path llm-router/Cargo.toml --test integration models_changed_event_reaches_a_trigger_subscriber -- --exact --nocapture`
- `cargo clippy --manifest-path llm-router/Cargo.toml --all-targets --all-features -- -D warnings`
- `git diff --check`
