### PR TITLE
(MOT-4407) feat(console): open coder file rows in the shell explorer first

### DIFF
--- a/console/web/src/components/chat/coder/OpenInEditorButton.tsx
+++ b/console/web/src/components/chat/coder/OpenInEditorButton.tsx
@@ -56,8 +56,8 @@ export function OpenInEditorButton({
         <button
           type="button"
           className="inline-flex items-center shrink-0 cursor-pointer text-ink-ghost hover:text-ink transition-colors"
-          aria-label="open in editor"
-          title="open in editor"
+          aria-label="open file"
+          title="open file"
         >
           <SquareArrowOutUpRight size={12} aria-hidden />
         </button>

--- a/console/web/src/components/chat/coder/OpenInEditorButton.tsx
+++ b/console/web/src/components/chat/coder/OpenInEditorButton.tsx
@@ -11,13 +11,14 @@ import { copyTextToClipboard } from '@/lib/clipboard'
 import { EDITORS, type EditorId, editorById } from '@/lib/editor-links'
 
 /**
- * "open in editor" affordance for coder file-change rows: one button that
- * always opens a menu of editors (cursor / vs code / zed) — each entry
- * launches that editor via its URL scheme — plus "copy path", the fallback
- * when the browser isn't on the machine that has the files. No editor is
- * privileged; the menu is shown every time so the choice stays explicit.
- * Renders nothing for non-absolute paths (result resolution failed —
- * `coder` results are jail-resolved absolute on success).
+ * "open in editor" affordance for coder file-change rows: the console's
+ * own shell explorer first (`#/ext/shell/open/<encoded-path>[:line]` —
+ * the shell worker serves both the `coder::*` surface that produced this
+ * row and that page, so the route always resolves), then external
+ * editors (cursor / vs code / zed) via their URL schemes, plus "copy
+ * path" — the fallback when the browser isn't on the machine that has
+ * the files. Renders nothing for non-absolute paths (result resolution
+ * failed — `coder` results are jail-resolved absolute on success).
  */
 export function OpenInEditorButton({
   path,
@@ -28,6 +29,14 @@ export function OpenInEditorButton({
 }) {
   const [copied, setCopied] = useState(false)
   if (!path.startsWith('/')) return null
+
+  const openInShell = () => {
+    const anchor =
+      typeof line === 'number' && Number.isInteger(line) && line > 0
+        ? `:${line}`
+        : ''
+    window.location.hash = `#/ext/shell/open/${encodeURIComponent(path)}${anchor}`
+  }
 
   const openWith = (id: EditorId) => {
     window.location.href = editorById(id).buildUrl(path, line)
@@ -54,6 +63,10 @@ export function OpenInEditorButton({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">
+        <DropdownMenuItem onSelect={openInShell}>
+          open in shell
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
         {EDITORS.map((e) => (
           <DropdownMenuItem key={e.id} onSelect={() => openWith(e.id)}>
             open in {e.label}


### PR DESCRIPTION
The open-in menu on coder file-change chat rows now leads with the console's own surface: **open in shell** sits first, external editors (cursor / vs code / zed) and copy path keep their places below.

Refs MOT-4407.

## How it opens

"open in shell" navigates to `#/ext/shell/open/<encoded-abs-path>[:line]`. The shell explorer page consumes the segment (companion change in #791): it strips the request from the URL, opens the file pinned when it lives under the browsed root, and re-roots the explorer to the file's own folder when it doesn't.

No presence probe needed: the shell worker serves both the `coder::*` functions that produce these rows and the `#/ext/shell` page — when the menu is visible, the route resolves.

## Verification

- `tsc` clean, biome clean, coder component tests green (122), full suite: 1076 tests pass; the 8 collection-failing files (`@pierre/diffs` reading `navigator.userAgent` at import under the node test env) fail identically on clean main — pre-existing, untouched by this change.
- `vite build` clean.
