### PR TITLE
(MOT-4414) fix(console): prevent configuration form flash

### DIFF
--- a/console/web/src/lib/ui-loader.test.tsx
+++ b/console/web/src/lib/ui-loader.test.tsx
@@ -1,0 +1,187 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type {
+  ConfigFormProps,
+  ConsoleApi,
+  SetupFn,
+  UiAssetsPush,
+} from '../types/injectable-ui'
+import type { IiiClient } from './iii-client'
+import { startUiLoader, UI_ASSETS_FN } from './ui-loader'
+import {
+  getExtConfigForm,
+  getUiAssetsStatus,
+  setUiAssetsStatus,
+} from './ui-slots'
+
+type UiModule = { default?: SetupFn }
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, reject, resolve }
+}
+
+function setupForm(label: string): UiModule {
+  return {
+    default(host) {
+      host.configForms.register('llm-router', () => <p>{label}</p>)
+    },
+  }
+}
+
+function createHarness({
+  importModule = vi.fn(async () => setupForm('default')),
+  manifest = Promise.resolve({ disabled: false }),
+}: {
+  importModule?: (url: string) => Promise<UiModule>
+  manifest?: Promise<{ disabled: boolean }>
+} = {}) {
+  let handler: ((payload: UiAssetsPush) => void | Promise<void>) | undefined
+  const offHandler = vi.fn()
+  const offTrigger = vi.fn()
+  const client = {
+    browserId: 'test-browser',
+    trigger: vi.fn(() => manifest),
+    on: vi.fn((functionId, nextHandler) => {
+      expect(functionId).toBe(UI_ASSETS_FN)
+      handler = nextHandler
+      return offHandler
+    }),
+    registerTrigger: vi.fn(() => offTrigger),
+  } as unknown as IiiClient
+  const api = {
+    iii: client,
+    components: {},
+    tokens: [],
+    useTheme: () => 'light',
+  } as ConsoleApi
+  const stop = startUiLoader(client, api, {
+    baseUrl: new URL('http://console.test/base/'),
+    importModule,
+  })
+  return {
+    emit(payload: UiAssetsPush) {
+      if (!handler) throw new Error('asset handler was not registered')
+      return handler(payload)
+    },
+    offHandler,
+    offTrigger,
+    stop,
+  }
+}
+
+function renderCurrentForm(): string {
+  const registration = getExtConfigForm('llm-router')
+  if (!registration) return ''
+  const props: ConfigFormProps = {
+    id: 'llm-router',
+    schema: null,
+    value: {},
+    onChange: vi.fn(),
+  }
+  return renderToStaticMarkup(<registration.component {...props} />)
+}
+
+afterEach(() => {
+  setUiAssetsStatus('unavailable')
+  vi.restoreAllMocks()
+})
+
+describe('injectable UI loader readiness', () => {
+  it('stays loading until the initial sync is fully applied', async () => {
+    const candidate = deferred<UiModule>()
+    const harness = createHarness({ importModule: () => candidate.promise })
+
+    expect(getUiAssetsStatus()).toBe('loading')
+    harness.emit({
+      event: 'sync',
+      assets: [{ path: 'llm-router/page.js', kind: 'script', hash: 'one' }],
+    })
+    await vi.waitFor(() => expect(renderCurrentForm()).toBe(''))
+    expect(getUiAssetsStatus()).toBe('loading')
+
+    candidate.resolve(setupForm('custom form'))
+    await vi.waitFor(() => {
+      expect(getUiAssetsStatus()).toBe('ready')
+      expect(renderCurrentForm()).toContain('custom form')
+    })
+
+    harness.stop()
+    expect(renderCurrentForm()).toBe('')
+  })
+
+  it('falls back when injectable UI is disabled', async () => {
+    const harness = createHarness({
+      manifest: Promise.resolve({ disabled: true }),
+    })
+
+    expect(getUiAssetsStatus()).toBe('loading')
+    await vi.waitFor(() => expect(getUiAssetsStatus()).toBe('unavailable'))
+
+    harness.stop()
+  })
+})
+
+describe('injectable UI script updates', () => {
+  it('keeps the last good form until its replacement finishes setup', async () => {
+    const candidate = deferred<UiModule>()
+    const importModule = vi
+      .fn<(url: string) => Promise<UiModule>>()
+      .mockResolvedValueOnce(setupForm('old form'))
+      .mockImplementationOnce(() => candidate.promise)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const harness = createHarness({ importModule })
+
+    harness.emit({
+      event: 'sync',
+      assets: [{ path: 'llm-router/page.js', kind: 'script', hash: 'old' }],
+    })
+    await vi.waitFor(() => expect(renderCurrentForm()).toContain('old form'))
+
+    harness.emit({
+      event: 'set',
+      path: 'llm-router/page.js',
+      kind: 'script',
+      hash: 'new',
+    })
+    await vi.waitFor(() => expect(importModule).toHaveBeenCalledTimes(2))
+    expect(renderCurrentForm()).toContain('old form')
+
+    candidate.resolve(setupForm('new form'))
+    await vi.waitFor(() => expect(renderCurrentForm()).toContain('new form'))
+    expect(warn).not.toHaveBeenCalled()
+
+    harness.stop()
+  })
+
+  it('retains the last good form when a replacement fails', async () => {
+    const importModule = vi
+      .fn<(url: string) => Promise<UiModule>>()
+      .mockResolvedValueOnce(setupForm('old form'))
+      .mockRejectedValueOnce(new Error('broken module'))
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const harness = createHarness({ importModule })
+
+    harness.emit({
+      event: 'sync',
+      assets: [{ path: 'llm-router/page.js', kind: 'script', hash: 'old' }],
+    })
+    await vi.waitFor(() => expect(renderCurrentForm()).toContain('old form'))
+
+    harness.emit({
+      event: 'set',
+      path: 'llm-router/page.js',
+      kind: 'script',
+      hash: 'broken',
+    })
+    await vi.waitFor(() => expect(error).toHaveBeenCalledTimes(1))
+    expect(renderCurrentForm()).toContain('old form')
+
+    harness.stop()
+  })
+})

--- a/console/web/src/lib/ui-loader.tsx
+++ b/console/web/src/lib/ui-loader.tsx
@@ -6,7 +6,7 @@
  * is this tab's own handler. The console worker answers with a `sync` push
  * (the subscription IS the seed) and follows with incremental `set`/`delete`
  * pushes. The loader diffs every event against loaded state — new/changed
- * hash ⇒ dispose + cache-busted re-import + `setup(host)`; missing path ⇒
+ * hash ⇒ cache-busted import + `setup(host)` + atomic swap; missing path ⇒
  * dispose. Styles are `<link>` swaps; scripts are ES modules.
  */
 
@@ -17,6 +17,7 @@ import {
   registerExtPage,
   registerExtRenderer,
   registerExtSessionChip,
+  setUiAssetsStatus,
 } from '@/lib/ui-slots'
 import type {
   ConfigFormProps,
@@ -49,6 +50,13 @@ interface LoadedStyle {
 }
 
 type Loaded = LoadedScript | LoadedStyle
+
+interface UiLoaderOptions {
+  /** Test seam; production resolves assets against the document base. */
+  baseUrl?: URL
+  /** Test seam; production uses a cache-busted dynamic import. */
+  importModule?: (url: string) => Promise<{ default?: SetupFn }>
+}
 
 /**
  * The scope wrapper every injected render mounts inside: `data-iii-ui`
@@ -167,17 +175,27 @@ function makeHost(
  * unsubscribes and disposes every loaded asset (tests; the real tab never
  * calls it).
  */
-export function startUiLoader(client: IiiClient, api: ConsoleApi): () => void {
+export function startUiLoader(
+  client: IiiClient,
+  api: ConsoleApi,
+  options: UiLoaderOptions = {},
+): () => void {
   const loaded = new Map<string, Loaded>()
+  let active = true
+  let receivedInitialSync = false
+  setUiAssetsStatus('loading')
   // Asset URLs resolve against the DOCUMENT base (the console supports
   // arbitrary subpath mounting); the loader itself lives in a Vite chunk
   // under assets/, so module-relative resolution would be wrong.
-  const base = new URL('.', document.baseURI)
+  const base = options.baseUrl ?? new URL('.', document.baseURI)
+  const importModule =
+    options.importModule ??
+    ((url: string) =>
+      import(/* @vite-ignore */ url) as Promise<{
+        default?: SetupFn
+      }>)
 
-  function dispose(path: string) {
-    const entry = loaded.get(path)
-    if (!entry) return
-    loaded.delete(path)
+  function disposeEntry(entry: Loaded) {
     if (entry.kind === 'style') {
       entry.link.remove()
       return
@@ -186,9 +204,16 @@ export function startUiLoader(client: IiiClient, api: ConsoleApi): () => void {
       try {
         cleanup()
       } catch (err) {
-        console.error(`[iii-ui] cleanup for ${path} threw`, err)
+        console.error(`[iii-ui] cleanup for ${entry.path} threw`, err)
       }
     }
+  }
+
+  function dispose(path: string) {
+    const entry = loaded.get(path)
+    if (!entry) return
+    loaded.delete(path)
+    disposeEntry(entry)
   }
 
   function assetUrl(path: string, hash: string): string {
@@ -196,12 +221,10 @@ export function startUiLoader(client: IiiClient, api: ConsoleApi): () => void {
   }
 
   async function applyScript(path: string, hash: string) {
-    dispose(path)
+    const previous = loaded.get(path)
     const cleanups: Array<() => void> = []
     try {
-      const mod = (await import(/* @vite-ignore */ assetUrl(path, hash))) as {
-        default?: SetupFn
-      }
+      const mod = await importModule(assetUrl(path, hash))
       if (typeof mod.default !== 'function') {
         throw new Error('no default setup() export')
       }
@@ -209,9 +232,10 @@ export function startUiLoader(client: IiiClient, api: ConsoleApi): () => void {
       const teardown = await mod.default(host)
       if (typeof teardown === 'function') cleanups.push(teardown)
       loaded.set(path, { kind: 'script', path, hash, cleanups })
+      if (previous) disposeEntry(previous)
     } catch (err) {
-      // Non-fatal: the previous version was already disposed, so this
-      // script's contributions simply drop out until the next good version.
+      // Non-fatal and atomic: discard only the failed candidate. The last
+      // good version stays registered until a replacement finishes setup.
       for (const cleanup of [...cleanups].reverse()) {
         try {
           cleanup()
@@ -283,7 +307,12 @@ export function startUiLoader(client: IiiClient, api: ConsoleApi): () => void {
       if (!payload || typeof payload !== 'object') return
       switch (payload.event) {
         case 'sync':
-          return applySync(Array.isArray(payload.assets) ? payload.assets : [])
+          return applySync(
+            Array.isArray(payload.assets) ? payload.assets : [],
+          ).then(() => {
+            receivedInitialSync = true
+            if (active) setUiAssetsStatus('ready')
+          })
         case 'set':
           return applySet(payload.path, payload.kind, payload.hash)
         case 'delete':
@@ -300,9 +329,32 @@ export function startUiLoader(client: IiiClient, api: ConsoleApi): () => void {
     config: {},
   })
 
+  // With injectable UI disabled, the console intentionally does not own the
+  // `console:assets` trigger type, so no initial sync will arrive. The
+  // manifest remains registered specifically to expose that kill switch and
+  // lets built-in forms fall back instead of waiting forever.
+  void client
+    .trigger<{ disabled?: boolean }>(
+      'console::ui-manifest',
+      {},
+      { timeoutMs: 5_000 },
+    )
+    .then((manifest) => {
+      if (active && !receivedInitialSync && manifest.disabled) {
+        setUiAssetsStatus('unavailable')
+      }
+    })
+    .catch((err) => {
+      if (!active || receivedInitialSync) return
+      setUiAssetsStatus('unavailable')
+      console.warn('[iii-ui] availability check failed', err)
+    })
+
   return () => {
+    active = false
     offTrigger()
     offHandler()
     for (const path of [...loaded.keys()]) dispose(path)
+    setUiAssetsStatus('unavailable')
   }
 }

--- a/console/web/src/lib/ui-slots.test.ts
+++ b/console/web/src/lib/ui-slots.test.ts
@@ -5,8 +5,12 @@
  */
 
 import { describe, expect, it } from 'vitest'
-import type { RegisteredSessionChip } from './ui-slots'
-import { getExtSessionChips, registerExtSessionChip } from './ui-slots'
+import type { RegisteredConfigForm, RegisteredSessionChip } from './ui-slots'
+import {
+  getExtSessionChips,
+  isExtConfigFormPending,
+  registerExtSessionChip,
+} from './ui-slots'
 
 function chip(id: string, path: string): RegisteredSessionChip {
   return { id, path, scope: path.split('/')[0], render: () => null }
@@ -38,5 +42,16 @@ describe('session chip slot', () => {
     offA()
     offA()
     expect(getExtSessionChips()).toEqual([])
+  })
+})
+
+describe('config form slot readiness', () => {
+  const form = {} as RegisteredConfigForm
+
+  it('waits only while the initial assets are loading without an override', () => {
+    expect(isExtConfigFormPending('loading', undefined)).toBe(true)
+    expect(isExtConfigFormPending('loading', form)).toBe(false)
+    expect(isExtConfigFormPending('ready', undefined)).toBe(false)
+    expect(isExtConfigFormPending('unavailable', undefined)).toBe(false)
   })
 })

--- a/console/web/src/lib/ui-slots.ts
+++ b/console/web/src/lib/ui-slots.ts
@@ -48,6 +48,12 @@ interface Store<T> {
   add(entry: T): () => void
 }
 
+interface ValueStore<T> {
+  subscribe(listener: () => void): () => void
+  get(): T
+  set(value: T): void
+}
+
 function createStore<T>(): Store<T> {
   let snapshot: readonly T[] = []
   const listeners = new Set<() => void>()
@@ -76,10 +82,32 @@ function createStore<T>(): Store<T> {
   }
 }
 
+function createValueStore<T>(initialValue: T): ValueStore<T> {
+  let value = initialValue
+  const listeners = new Set<() => void>()
+  return {
+    subscribe(listener) {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    get() {
+      return value
+    },
+    set(nextValue) {
+      if (nextValue === value) return
+      value = nextValue
+      for (const listener of [...listeners]) listener()
+    },
+  }
+}
+
+export type UiAssetsStatus = 'loading' | 'ready' | 'unavailable'
+
 const pagesStore = createStore<RegisteredPage>()
 const renderersStore = createStore<RegisteredRenderer>()
 const configFormsStore = createStore<RegisteredConfigForm>()
 const sessionChipsStore = createStore<RegisteredSessionChip>()
+const uiAssetsStatusStore = createValueStore<UiAssetsStatus>('unavailable')
 
 /**
  * Register an extension page. Duplicate `id`: last registration wins in
@@ -88,7 +116,7 @@ const sessionChipsStore = createStore<RegisteredSessionChip>()
  */
 export function registerExtPage(entry: RegisteredPage): () => void {
   const duplicate = pagesStore.get().find((p) => p.id === entry.id)
-  if (duplicate) {
+  if (duplicate && duplicate.path !== entry.path) {
     console.warn(
       `[iii-ui] duplicate extension page id '${entry.id}' — ` +
         `'${entry.path}' overrides '${duplicate.path}'`,
@@ -106,7 +134,7 @@ export function registerExtConfigForm(entry: RegisteredConfigForm): () => void {
   const duplicate = configFormsStore
     .get()
     .find((f) => f.configurationId === entry.configurationId)
-  if (duplicate) {
+  if (duplicate && duplicate.path !== entry.path) {
     console.warn(
       `[iii-ui] duplicate config-form override for '${entry.configurationId}' — ` +
         `'${entry.path}' overrides '${duplicate.path}'`,
@@ -120,7 +148,7 @@ export function registerExtSessionChip(
   entry: RegisteredSessionChip,
 ): () => void {
   const duplicate = sessionChipsStore.get().find((c) => c.id === entry.id)
-  if (duplicate) {
+  if (duplicate && duplicate.path !== entry.path) {
     console.warn(
       `[iii-ui] duplicate session chip id '${entry.id}' — ` +
         `'${entry.path}' overrides '${duplicate.path}'`,
@@ -140,6 +168,32 @@ export function getExtPage(id: string): RegisteredPage | undefined {
     if (pages[i].id === id) return pages[i]
   }
   return undefined
+}
+
+/** The injected form override for one configuration id (last wins). */
+export function getExtConfigForm(
+  configurationId: string,
+): RegisteredConfigForm | undefined {
+  const forms = configFormsStore.get()
+  for (let i = forms.length - 1; i >= 0; i--) {
+    if (forms[i].configurationId === configurationId) return forms[i]
+  }
+  return undefined
+}
+
+export function getUiAssetsStatus(): UiAssetsStatus {
+  return uiAssetsStatusStore.get()
+}
+
+export function setUiAssetsStatus(status: UiAssetsStatus): void {
+  uiAssetsStatusStore.set(status)
+}
+
+export function isExtConfigFormPending(
+  status: UiAssetsStatus,
+  form: RegisteredConfigForm | undefined,
+): boolean {
+  return status === 'loading' && form === undefined
 }
 
 const EMPTY: readonly never[] = []
@@ -197,4 +251,16 @@ export function useExtConfigForm(
     if (forms[i].configurationId === configurationId) return forms[i]
   }
   return undefined
+}
+
+/**
+ * Initial injected assets must settle before a consumer can distinguish
+ * "there is no override" from "the override has not loaded yet".
+ */
+export function useUiAssetsStatus(): UiAssetsStatus {
+  return useSyncExternalStore(
+    uiAssetsStatusStore.subscribe,
+    uiAssetsStatusStore.get,
+    () => 'unavailable',
+  )
 }

--- a/console/web/src/main.test.ts
+++ b/console/web/src/main.test.ts
@@ -25,3 +25,20 @@ describe('main.tsx polyfill wiring', () => {
     expect(src).toContain('installRandomUUIDPolyfill()')
   })
 })
+
+describe('main.tsx injectable UI readiness wiring', () => {
+  const src = readFileSync(new URL('./main.tsx', import.meta.url), 'utf8')
+
+  it('marks assets as loading before asynchronous client bootstrap', () => {
+    const loadingAt = src.indexOf("setUiAssetsStatus('loading')")
+    const clientBootstrapAt = src.indexOf('\ngetIiiClient()')
+
+    expect(loadingAt).toBeGreaterThan(-1)
+    expect(clientBootstrapAt).toBeGreaterThan(-1)
+    expect(loadingAt).toBeLessThan(clientBootstrapAt)
+  })
+
+  it('allows built-in forms to recover when client bootstrap fails', () => {
+    expect(src).toContain("setUiAssetsStatus('unavailable')")
+  })
+})

--- a/console/web/src/main.tsx
+++ b/console/web/src/main.tsx
@@ -10,6 +10,7 @@ import { buildConsoleApi } from '@/lib/console-api'
 import { installRandomUUIDPolyfill } from '@/lib/crypto-polyfill'
 import { getIiiClient } from '@/lib/iii-client'
 import { startUiLoader } from '@/lib/ui-loader'
+import { setUiAssetsStatus } from '@/lib/ui-slots'
 import { App } from './App'
 import faviconUrl from './icons/favicon.svg?url'
 import './index.css'
@@ -39,6 +40,10 @@ const bootGlobal: NonNullable<Window['__III_CONSOLE__']> = {
 }
 window.__III_CONSOLE__ = bootGlobal
 
+// The app renders before the asynchronous engine bootstrap settles. Mark the
+// injected-UI slots as loading synchronously so configuration editors do not
+// mistake a not-yet-registered override for a genuinely absent one.
+setUiAssetsStatus('loading')
 getIiiClient()
   .then((client) => {
     bootGlobal.api = buildConsoleApi(client)
@@ -46,6 +51,7 @@ getIiiClient()
     startUiLoader(client, bootGlobal.api)
   })
   .catch((err) => {
+    setUiAssetsStatus('unavailable')
     console.error('[iii-ui] loader not started — engine client failed', err)
   })
 

--- a/console/web/src/pages/Configuration/tabs/WorkersTab/WorkerEditor.tsx
+++ b/console/web/src/pages/Configuration/tabs/WorkersTab/WorkerEditor.tsx
@@ -1,7 +1,11 @@
 import { ArrowLeft } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Skeleton } from '@/components/ui/Skeleton'
-import { useExtConfigForm } from '@/lib/ui-slots'
+import {
+  isExtConfigFormPending,
+  useExtConfigForm,
+  useUiAssetsStatus,
+} from '@/lib/ui-slots'
 import { cn } from '@/lib/utils'
 import type { ConfigurationSchemaView, JsonValue } from './api'
 import { isDirty } from './dirty'
@@ -56,6 +60,11 @@ export function WorkerEditor({
   // Injectable-UI configForms slot: a worker-registered form replaces the
   // FORM REGION only — the save lifecycle below stays host-owned either way.
   const formOverride = useExtConfigForm(entry.id)
+  const uiAssetsStatus = useUiAssetsStatus()
+  const isFormOverrideLoading = isExtConfigFormPending(
+    uiAssetsStatus,
+    formOverride,
+  )
 
   const [draft, setDraft] = useState<JsonValue | undefined>(undefined)
   const [status, setStatus] = useState<SaveStatus>({ kind: 'idle' })
@@ -197,7 +206,9 @@ export function WorkerEditor({
           />
         ) : null}
         {!valueQuery.isLoading && !valueQuery.isError && draft !== undefined ? (
-          formOverride ? (
+          isFormOverrideLoading ? (
+            <EditorLoading />
+          ) : formOverride ? (
             <>
               <div className="mx-auto max-w-3xl w-full px-6 py-8">
                 <formOverride.component


### PR DESCRIPTION
## Summary

- keep the worker configuration editor in its loading state until the initial injectable UI sync finishes
- fall back to the schema form when injectable UI is unavailable or no override is registered
- swap injected scripts atomically so hot updates retain the last good form until the replacement is ready

## Root cause

The config-form slot used `undefined` for both “the initial UI sync is still loading” and “this worker has no override.” If configuration data resolved first, the editor rendered the schema form and replaced it when `llm-router/page.js` finished loading. Script updates also disposed the active registration before the replacement module completed setup.

## Verification

- `pnpm --dir console/web test` (1,200 tests)
- `pnpm --dir console/web build`
- `pnpm --dir console/web exec biome check src/lib/ui-slots.ts src/lib/ui-slots.test.ts src/lib/ui-loader.tsx src/lib/ui-loader.test.tsx src/main.tsx src/main.test.ts src/pages/Configuration/tabs/WorkersTab/WorkerEditor.tsx`

Refs MOT-4414


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear loading, ready, and unavailable states for injectable UI assets.
  * Worker configuration forms now show a loading state while external forms are being fetched.
* **Bug Fixes**
  * Existing forms remain visible until replacement forms load successfully.
  * Failed form updates no longer replace working forms with incomplete content.
  * The console now correctly indicates when injectable UI is disabled or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->