### PR TITLE
(MOT-3250) feat(harness): test first Console message in quickstart

### DIFF
--- a/.github/workflows/harness-quickstart.yml
+++ b/.github/workflows/harness-quickstart.yml
@@ -61,8 +61,29 @@ jobs:
           --operation-id '${{ inputs.operation_id }}'
           --step-id '${{ inputs.step_id }}'
 
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 11.13.1
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          package-manager-cache: false
+
+      - name: Install Console Playwright dependencies
+        working-directory: console/web
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Chromium and video tooling
+        working-directory: console/web
+        run: |
+          pnpm exec playwright install --with-deps chromium
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+
       - name: Run quickstart validator
         env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           HARNESS_QUICKSTART_ARTIFACTS_DIR: ${{ github.workspace }}/target/harness-quickstart
           HARNESS_QUICKSTART_TRACE: '1'
           III_CLI_CHANNEL: ${{ inputs.cli_channel }}
@@ -113,7 +134,8 @@ jobs:
           checks=$(jq -cn --arg status "$JOB_STATUS" '[{name:"quickstart",status:$status}]')
           outputs=$(jq -cn --arg cli '${{ inputs.cli_channel }}' --arg registry '${{ inputs.registry_tag }}' \
             --arg release_run_id '${{ inputs.release_run_id }}' --arg release_run_attempt '${{ inputs.release_run_attempt }}' \
-            '{cli_channel:$cli,registry_tag:$registry,release_run:{id:($release_run_id|tonumber),attempt:($release_run_attempt|tonumber)}}')
+            --slurpfile quickstart target/harness-quickstart/result.json \
+            '{cli_channel:$cli,registry_tag:$registry,release_run:{id:($release_run_id|tonumber),attempt:($release_run_attempt|tonumber)},quickstart:($quickstart[0] // null),slack_evidence:(($quickstart[0].slack_evidence // null) | if . == null then null else .path = ("target/harness-quickstart/" + .path) end)}')
           python3 .github/scripts/release_control_contract.py write-result \
             --kind test --repository '${{ github.repository }}' \
             --operation-id '${{ inputs.operation_id }}' --step-id '${{ inputs.step_id }}' \
@@ -125,6 +147,8 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: execution-result-${{ inputs.operation_id }}-${{ inputs.step_id }}
-          path: execution-result.json
+          path: |
+            execution-result.json
+            target/harness-quickstart/slack-evidence/
           retention-days: 30
           if-no-files-found: error

--- a/harness/README.md
+++ b/harness/README.md
@@ -25,11 +25,12 @@ alongside it for the full loop.
 
 ## Quickstart
 
-Install the engine, init a project, start it, then add harness and the
-console from a second terminal in the same folder:
+Install the engine, export the Anthropic credential in the terminal that will
+run the engine, initialize a project, and start it:
 
 ```bash
 curl -fsSL https://install.iii.dev/iii/main/install.sh | sh
+export ANTHROPIC_API_KEY='<your-anthropic-api-key>'
 iii project init iii-app && cd iii-app
 iii
 ```
@@ -45,14 +46,9 @@ iii worker add harness console
 open http://localhost:3113
 ```
 
-Add a model key from the console: open the model picker and use **configure
-Anthropic** / **configure OpenAI** to paste a key. It is stored in the
-`llm-router` worker config and the model catalog populates within seconds.
-Until a provider is configured the picker is empty and chat will not generate.
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/iii-hq/workers/main/harness/docs/images/configure-a-provider.webp" alt="Configure a provider key in the iii console" width="100%">
-</p>
+Create a session, select **Anthropic → Claude Sonnet 5**, and send your first
+message. The provider reads `ANTHROPIC_API_KEY` from the engine environment, so
+the credential does not need to be pasted into or stored by the Console.
 
 `iii worker add harness` installs every worker the loop needs (see the badges
 above); you do not add them one by one. During bootstrap, the harness asks the

--- a/harness/tests/quickstart/README.md
+++ b/harness/tests/quickstart/README.md
@@ -14,32 +14,44 @@ It verifies that:
 - the published installer provides a working `iii` CLI;
 - a clean engine starts;
 - the core harness and Console functions register;
-- `console::status` and the Console HTTP root respond; and
+- `ANTHROPIC_API_KEY` exposes exactly `anthropic/claude-sonnet-5`;
+- `console::status` and the Console HTTP root respond;
+- a user can select Claude Sonnet 5 and complete the first message through the
+  Console;
+- the successful conversation survives a browser reload and reaches a durable
+  terminal Harness state; and
 - `config.yaml` and `iii.lock` contain the installed workers.
 
 Run it locally with:
 
 ```bash
+export ANTHROPIC_API_KEY='<your-anthropic-api-key>'
 make -C harness quickstart-validate
 ```
 
-The machine needs `curl` and `jq`. The default engine and Console ports (`49134`
-and `3113`) must be available. The CLI installer and Registry worker selectors
-are independent: `III_CLI_CHANNEL` chooses `latest` or `next` for `iii`, while
-`III_WORKER_TAG` chooses the Registry tag used by `harness` and `console`.
-The old combined `III_CHANNEL` variable is rejected to prevent a silent test
-against the wrong side of the split.
+The machine needs `curl`, `jq`, `ffmpeg`, the `console/web` dependencies, and
+Chromium for Playwright. The validator invokes the repository's local
+Playwright binary directly, so Corepack cannot silently select a different
+pnpm version while the quickstart is running.
+The default engine and Console ports (`49134` and `3113`) must be available.
+The CLI installer and Registry worker selectors are independent:
+`III_CLI_CHANNEL` chooses `latest` or `next` for `iii`, while `III_WORKER_TAG`
+chooses the Registry tag used by `harness` and `console`. The old combined
+`III_CHANNEL` variable is rejected to prevent a silent test against the wrong
+side of the split.
 Set `HARNESS_QUICKSTART_TRACE=1` to print only the important external commands
 (`iii worker add`, `iii trigger`, installer, and engine) and save the list as
 `commands.log`. Polling attempts, assignments, cleanup, and other shell internals
 are omitted.
 
-The nightly/manual CI workflow preserves `result.json`, the generated project
-files, Console responses, raw logs, and the command trace. Release-triggered
-runs replace the released worker with its exact candidate version and verify it
-in `iii.lock`. The Release workflow calls quickstart and deployed E2E
-synchronously; manual quickstart runs may still request the E2E cascade.
+The CI workflow preserves `result.json`, the generated project files, sanitized
+browser and terminal evidence, raw logs, the command trace, and an MP4 of the
+Console success. It scans every artifact for the literal Anthropic credential
+before upload. Release-triggered runs replace the released worker with its exact
+candidate version and verify it in `iii.lock`.
 
-The nightly schedule runs paired `latest/latest` and `next/next` CLI/worker lanes.
-Manual runs select both values explicitly. Behavioral quality remains covered
-by the Harness E2E workflows.
+After a successful `deploy_harness`, Release Control dispatches this check as a
+child observation. Its result and MP4 are appended to the release Slack thread,
+but cannot change the already successful deployment result. A manually created
+quickstart operation gets its own Slack root. Slack delivery retries through the
+notification outbox and does not fail the test operation.

--- a/harness/tests/quickstart/console-first-message.spec.ts
+++ b/harness/tests/quickstart/console-first-message.spec.ts
@@ -1,0 +1,113 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { expect, test } from '@playwright/test'
+
+const MODEL_ID = 'claude-sonnet-5'
+const MODEL_LABEL = /claude[\s-]+sonnet[\s-]+5/i
+const PROMPT = 'Reply with exactly QUICKSTART_OK and nothing else.'
+const MARKER = 'QUICKSTART_OK'
+
+function required(name: string): string {
+  const value = process.env[name]
+  if (!value) throw new Error(`${name} is required`)
+  return value
+}
+
+test('completes and reloads the first Sonnet 5 conversation', async ({
+  page,
+}) => {
+  const consoleUrl = required('HARNESS_QUICKSTART_CONSOLE_URL')
+  const artifactsRoot = required('HARNESS_QUICKSTART_ARTIFACTS_DIR')
+
+  await page.goto(consoleUrl)
+
+  const chatTab = page.getByRole('tab', { name: /^chat \+ traces/i })
+  await chatTab.click()
+  await expect(chatTab).toHaveAttribute('aria-selected', 'true')
+
+  const modelPicker = page.getByRole('button', { name: /^model(?::|\s|$)/i })
+  await expect(modelPicker).toBeEnabled()
+  await modelPicker.click()
+
+  const anthropicGroup = page.getByRole('menuitem', {
+    name: /^anthropic/i,
+  })
+  await expect(anthropicGroup).toBeVisible()
+  if ((await anthropicGroup.getAttribute('aria-expanded')) !== 'true') {
+    await anthropicGroup.click()
+  }
+  await expect(anthropicGroup).toHaveAttribute('aria-expanded', 'true')
+
+  const sonnet = page.getByRole('menuitemradio', { name: MODEL_LABEL })
+  await expect(sonnet).toHaveCount(1)
+  await sonnet.click()
+
+  const defaultEffort = page.getByRole('menuitemradio', {
+    name: 'default',
+    exact: true,
+  })
+  if (await defaultEffort.isVisible().catch(() => false)) {
+    await defaultEffort.click()
+  } else {
+    await page.keyboard.press('Escape')
+  }
+  await expect(modelPicker).toHaveAccessibleName(
+    /^model:\s*claude[\s-]+sonnet[\s-]+5,/i,
+  )
+
+  const composer = page.getByLabel('message composer')
+  await composer.pressSequentially(PROMPT)
+  await expect(composer).toHaveText(PROMPT)
+  await page.getByRole('button', { name: 'send message' }).click()
+
+  await expect(
+    page.locator('[data-message-role="user"]', { hasText: PROMPT }),
+  ).toHaveCount(1)
+  const assistant = page.locator('[data-message-role="assistant"]', {
+    hasText: MARKER,
+  })
+  await expect(assistant).toHaveCount(1)
+  await expect(assistant.locator(':scope > div')).toHaveText(MARKER)
+
+  const chat = page.locator('[data-chat-session-id]').first()
+  const sessionId = await chat.getAttribute('data-chat-session-id')
+  if (!sessionId)
+    throw new Error('Console did not expose the persisted session id')
+  await expect(chat).toHaveAttribute('data-chat-session-hydrated', 'true')
+
+  await page.reload()
+  await page
+    .getByRole('button', {
+      name: /^open reply with exactly quickstart_ok/i,
+    })
+    .first()
+    .click()
+  const reloaded = page.locator(`[data-chat-session-id="${sessionId}"]`)
+  await expect(reloaded).toHaveAttribute('data-chat-session-hydrated', 'true')
+  await expect(
+    reloaded.locator('[data-message-role="user"]', { hasText: PROMPT }),
+  ).toHaveCount(1)
+  const reloadedAssistant = reloaded.locator(
+    '[data-message-role="assistant"]',
+    { hasText: MARKER },
+  )
+  await expect(reloadedAssistant).toHaveCount(1)
+  await expect(reloadedAssistant.locator(':scope > div')).toHaveText(MARKER)
+
+  await mkdir(artifactsRoot, { recursive: true })
+  await writeFile(
+    path.join(artifactsRoot, 'browser-evidence.json'),
+    `${JSON.stringify(
+      {
+        schema_version: 1,
+        provider: 'anthropic',
+        model: MODEL_ID,
+        session_id: sessionId,
+        marker: MARKER,
+        persisted_after_reload: true,
+      },
+      null,
+      2,
+    )}\n`,
+  )
+})

--- a/harness/tests/quickstart/playwright.config.ts
+++ b/harness/tests/quickstart/playwright.config.ts
@@ -1,0 +1,25 @@
+import path from 'node:path'
+import { defineConfig } from '@playwright/test'
+
+const artifactsRoot = process.env.HARNESS_QUICKSTART_ARTIFACTS_DIR
+if (!artifactsRoot) {
+  throw new Error('HARNESS_QUICKSTART_ARTIFACTS_DIR is required')
+}
+
+export default defineConfig({
+  testDir: __dirname,
+  testMatch: 'console-first-message.spec.ts',
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  timeout: 180_000,
+  expect: { timeout: 30_000 },
+  reporter: [['list']],
+  outputDir: path.join(artifactsRoot, 'playwright-output'),
+  use: {
+    browserName: 'chromium',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'on',
+  },
+})

--- a/harness/tests/quickstart/run-ci.sh
+++ b/harness/tests/quickstart/run-ci.sh
@@ -2,8 +2,8 @@
 set -Eeuo pipefail
 
 # Validate the published quickstart in an isolated home and project:
-# install iii, boot an empty engine, add harness + console, and probe the
-# resulting function and HTTP surfaces.
+# install iii, boot an empty engine, add harness + console, and complete the
+# first Console conversation with Anthropic Sonnet 5.
 
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd -- "$script_dir/../../.." && pwd)
@@ -17,6 +17,10 @@ engine_port=49134
 wait_seconds=${HARNESS_QUICKSTART_WAIT_SECONDS:-180}
 add_timeout_seconds=${HARNESS_QUICKSTART_ADD_TIMEOUT_SECONDS:-600}
 trace_enabled=${HARNESS_QUICKSTART_TRACE:-0}
+provider_id=anthropic
+model_id=claude-sonnet-5
+response_marker=QUICKSTART_OK
+playwright_bin=${HARNESS_QUICKSTART_PLAYWRIGHT_BIN:-"$repo_root/console/web/node_modules/.bin/playwright"}
 
 if [[ -n "${III_CHANNEL:-}" ]]; then
   echo "III_CHANNEL was split into III_CLI_CHANNEL and III_WORKER_TAG" >&2
@@ -54,12 +58,22 @@ if [[ -n "$release_worker" || -n "$release_version" ]]; then
   }
 fi
 
-for command_name in curl jq; do
+[[ -n "${ANTHROPIC_API_KEY:-}" ]] || {
+  echo "ANTHROPIC_API_KEY is required" >&2
+  exit 2
+}
+
+for command_name in curl jq ffmpeg; do
   command -v "$command_name" >/dev/null 2>&1 || {
     echo "$command_name is required" >&2
     exit 2
   }
 done
+
+[[ -x "$playwright_bin" ]] || {
+  echo "Playwright is required at $playwright_bin" >&2
+  exit 2
+}
 
 [[ "$wait_seconds" =~ ^[0-9]+$ ]] || {
   echo "HARNESS_QUICKSTART_WAIT_SECONDS must be a positive integer" >&2
@@ -92,10 +106,15 @@ rm -f \
   "$artifact_dir/cli-version.txt" \
   "$artifact_dir/console-status.json" \
   "$artifact_dir/console.html" \
+  "$artifact_dir/model.json" \
+  "$artifact_dir/model-catalog.json" \
+  "$artifact_dir/browser-evidence.json" \
+  "$artifact_dir/terminal-status.json" \
   "$artifact_dir/config.yaml" \
   "$artifact_dir/iii.lock" \
   "$artifact_dir/commands.log" \
   "$log_dir"/*.log
+rm -rf "$artifact_dir/playwright-output" "$artifact_dir/slack-evidence"
 
 trace_log="$artifact_dir/commands.log"
 if [[ "$trace_enabled" == 1 ]]; then
@@ -105,7 +124,7 @@ fi
 export HOME="$quickstart_home"
 export XDG_CONFIG_HOME="$quickstart_home/.config"
 export PATH="$quickstart_home/.local/bin:$quickstart_home/.iii/bin:$PATH"
-unset ANTHROPIC_API_KEY OPENAI_API_KEY ZAI_API_KEY
+unset OPENAI_API_KEY ZAI_API_KEY DEEPSEEK_API_KEY OPENROUTER_API_KEY XAI_API_KEY KIMI_API_KEY
 
 engine_pid=""
 iii_bin=""
@@ -137,6 +156,18 @@ die() {
 
 write_result() {
   local status=$1
+  local browser=null terminal=null video=null
+  local video_path="$artifact_dir/slack-evidence/quickstart-sonnet-5.mp4"
+  [[ -f "$artifact_dir/browser-evidence.json" ]] && browser=$(jq -c . "$artifact_dir/browser-evidence.json")
+  [[ -f "$artifact_dir/terminal-status.json" ]] && terminal=$(jq -c . "$artifact_dir/terminal-status.json")
+  if [[ -f "$video_path" ]]; then
+    video=$(jq -n \
+      --arg path "slack-evidence/quickstart-sonnet-5.mp4" \
+      --arg media_type "video/mp4" \
+      --arg sha256 "$(sha256sum "$video_path" | awk '{print $1}')" \
+      --argjson size_bytes "$(stat -c %s "$video_path")" \
+      '{path:$path,media_type:$media_type,sha256:$sha256,size_bytes:$size_bytes}')
+  fi
   jq -n \
     --arg status "$status" \
     --arg reason "$failure_reason" \
@@ -144,6 +175,12 @@ write_result() {
     --arg install_url "$install_url" \
     --arg cli_channel "$cli_channel" \
     --arg worker_tag "$worker_tag" \
+    --arg provider "$provider_id" \
+    --arg model "$model_id" \
+    --arg marker "$response_marker" \
+    --argjson browser "$browser" \
+    --argjson terminal "$terminal" \
+    --argjson slack_evidence "$video" \
     --argjson elapsed_ms "$(((SECONDS - started_at_seconds) * 1000))" \
     --argjson engine_port "$engine_port" \
     '{
@@ -153,6 +190,12 @@ write_result() {
       install_url: $install_url,
       cli_channel: $cli_channel,
       worker_tag: $worker_tag,
+      provider: $provider,
+      model: $model,
+      marker: $marker,
+      browser: $browser,
+      terminal: $terminal,
+      slack_evidence: $slack_evidence,
       elapsed_ms: $elapsed_ms,
       engine_port: $engine_port
     }' >"$artifact_dir/result.json"
@@ -209,6 +252,13 @@ cleanup() {
   stop_managed_workers
   stop_engine
   stop_owned_orphans
+
+  if artifacts_contain_secret; then
+    status=1
+    failure_reason="an artifact contains the Anthropic credential"
+    # Do not leave a secret-bearing file available to the workflow uploader.
+    find "$artifact_dir" -type f -delete
+  fi
 
   if ((status == 0)); then
     write_result passed
@@ -283,6 +333,94 @@ wait_for_functions() {
   die "required functions did not register: $missing"
 }
 
+wait_for_model() {
+  local response attempt
+  log "Waiting for $provider_id/$model_id in the router catalog (up to ${wait_seconds}s)"
+  log_command "iii trigger router::models::get --port $engine_port --json '{\"provider\":\"$provider_id\",\"id\":\"$model_id\"}'"
+  for ((attempt = 0; attempt < wait_seconds; attempt++)); do
+    response=$("$iii_bin" trigger router::models::get --port "$engine_port" \
+      --json "{\"provider\":\"$provider_id\",\"id\":\"$model_id\"}" \
+      2>>"$log_dir/model-discovery.log" || true)
+    if jq -e --arg provider "$provider_id" --arg model "$model_id" \
+      '.model.provider == $provider and .model.id == $model' <<<"$response" >/dev/null 2>&1; then
+      printf '%s\n' "$response" >"$artifact_dir/model.json"
+      ok "$provider_id/$model_id available after ${attempt}s"
+      return 0
+    fi
+    if ((attempt > 0 && attempt % 15 == 0)); then
+      log "Still waiting for $provider_id/$model_id"
+    fi
+    sleep 1
+  done
+  "$iii_bin" trigger router::models::list --port "$engine_port" --json '{}' \
+    >"$artifact_dir/model-catalog.json" 2>>"$log_dir/model-discovery.log" || true
+  die "$provider_id/$model_id did not appear in the router catalog"
+}
+
+record_browser_video() {
+  local playwright_status video_source
+  local output_dir="$artifact_dir/slack-evidence"
+  export HARNESS_QUICKSTART_CONSOLE_URL="http://127.0.0.1:$console_port/"
+  export NODE_PATH="$repo_root/console/web/node_modules${NODE_PATH:+:$NODE_PATH}"
+  set +e
+  "$playwright_bin" test \
+    --config "$script_dir/playwright.config.ts" \
+    >"$log_dir/playwright.log" 2>&1
+  playwright_status=$?
+  set -e
+
+  video_source=$(find "$artifact_dir/playwright-output" -type f -name '*.webm' -print -quit 2>/dev/null || true)
+  if [[ -n "$video_source" ]]; then
+    mkdir -p "$output_dir"
+    ffmpeg -hide_banner -loglevel error -y -i "$video_source" \
+      -map_metadata -1 -c:v libx264 -pix_fmt yuv420p -movflags +faststart \
+      "$output_dir/quickstart-sonnet-5.mp4" \
+      >"$log_dir/ffmpeg.log" 2>&1 || die "Playwright video conversion failed"
+  elif ((playwright_status == 0)); then
+    die "Playwright passed without producing a video"
+  fi
+
+  ((playwright_status == 0)) || die "Console first-message Playwright test failed"
+  ok "Console conversation completed and Playwright video recorded"
+}
+
+wait_for_terminal_turn() {
+  local session_id response attempt
+  session_id=$(jq -er '.session_id' "$artifact_dir/browser-evidence.json") \
+    || die "browser evidence has no session id"
+  log "Verifying the durable terminal turn for session $session_id"
+  log_command "iii trigger harness::status --port $engine_port --json '{\"session_id\":\"<console-session>\"}'"
+  for ((attempt = 0; attempt < wait_seconds; attempt++)); do
+    response=$("$iii_bin" trigger harness::status --port "$engine_port" \
+      --json "{\"session_id\":\"$session_id\"}" 2>>"$log_dir/terminal-status.log" || true)
+    if jq -e '.status == "completed" and (.expects_wake // false) == false' \
+      <<<"$response" >/dev/null 2>&1; then
+      printf '%s\n' "$response" >"$artifact_dir/terminal-status.json"
+      ok "turn completed durably after ${attempt}s"
+      return 0
+    fi
+    if jq -e '.status == "failed" or .status == "cancelled"' \
+      <<<"$response" >/dev/null 2>&1; then
+      printf '%s\n' "$response" >"$artifact_dir/terminal-status.json"
+      die "Console turn reached terminal status $(jq -r '.status' <<<"$response")"
+    fi
+    sleep 1
+  done
+  printf '%s\n' "$response" >"$artifact_dir/terminal-status.json"
+  die "Console turn did not reach durable completion"
+}
+
+artifacts_contain_secret() {
+  LC_ALL=C grep -R -a -F -l -- "$ANTHROPIC_API_KEY" "$artifact_dir" >/dev/null 2>&1
+}
+
+assert_secret_safe_artifacts() {
+  if artifacts_contain_secret; then
+    die "an artifact contains the Anthropic credential"
+  fi
+  ok "artifacts do not contain the Anthropic credential"
+}
+
 run_worker_add() {
   log_command "iii worker add $*"
   if command -v timeout >/dev/null 2>&1; then
@@ -306,7 +444,7 @@ start_engine() {
 
 cd "$project_dir"
 
-log "Step 1/7: Install iii from $install_url (channel=$cli_channel)"
+log "Step 1/9: Install iii from $install_url (channel=$cli_channel)"
 log_command "curl -fsSL $install_url -o install.sh"
 curl -fsSL --retry 3 --retry-connrefused --retry-delay 5 \
   "$install_url" -o "$run_root/install.sh"
@@ -324,16 +462,16 @@ cli_version=$("$iii_bin" --version 2>&1)
 printf '%s\n' "$cli_version" >"$artifact_dir/cli-version.txt"
 ok "installed $cli_version"
 
-log "Step 2/7: Start an empty engine"
+log "Step 2/9: Start an empty engine"
 printf 'workers: []\n' >config.yaml
 start_engine
 wait_for_engine
 
-log "Step 3/7: Add harness and Console from worker tag $worker_tag"
+log "Step 3/9: Add harness and Console from worker tag $worker_tag"
 run_worker_add "harness@$worker_tag" "console@$worker_tag" 2>&1 | tee "$log_dir/worker-add.log"
 ok "iii worker add harness console exited successfully"
 
-log "Step 4/7: Apply exact release candidate override"
+log "Step 4/9: Apply exact release candidate override"
 if [[ -n "$release_worker" ]]; then
   run_worker_add "${release_worker}@${release_version}" --force \
     2>&1 | tee "$log_dir/candidate-override.log"
@@ -342,10 +480,13 @@ else
   ok "no release candidate override requested"
 fi
 
-log "Step 5/7: Verify registered functions"
+log "Step 5/9: Verify registered functions"
 wait_for_functions
 
-log "Step 6/7: Verify the Console HTTP surface"
+log "Step 6/9: Verify Sonnet 5 availability"
+wait_for_model
+
+log "Step 7/9: Verify the Console HTTP surface"
 log_command "iii trigger console::status --port $engine_port --json '{}'"
 console_status=$("$iii_bin" trigger console::status --port "$engine_port" \
   --json '{}' 2>"$log_dir/console-status.log")
@@ -357,12 +498,18 @@ curl -fsS --retry 10 --retry-all-errors --retry-delay 1 \
   "http://127.0.0.1:$console_port/" -o "$artifact_dir/console.html"
 ok "Console answered on port $console_port"
 
-log "Step 7/7: Verify generated project files"
+log "Step 8/9: Complete the first conversation through the Console"
+record_browser_video
+wait_for_terminal_turn
+
+log "Step 9/9: Verify generated project files and secret-safe evidence"
 for output in config.yaml iii.lock; do
   [[ -s "$output" ]] || die "worker add did not write $output"
   grep -Eiq 'harness' "$output" || die "$output does not contain harness"
   grep -Eiq 'console' "$output" || die "$output does not contain console"
 done
 ok "config.yaml and iii.lock reference harness + console"
+snapshot_project
+assert_secret_safe_artifacts
 
 log "ALL QUICKSTART ASSERTIONS PASSED ($cli_version, cli=$cli_channel, workers=$worker_tag)"


### PR DESCRIPTION
## Summary

- document `ANTHROPIC_API_KEY` as the quickstart credential source and guide users to Claude Sonnet 5
- drive the published Console with Playwright, send the first message, reload the conversation, and verify durable Harness completion
- record structured browser/terminal evidence and a secret-safe MP4 for release reporting
- install the required Console, Chromium, and video dependencies in the quickstart GitHub Actions job

## Why

The quickstart previously proved installation, worker registration, and Console availability, but it could pass without proving that a new user could complete the first model-backed interaction. This extends the check through the first successful Console conversation while keeping credentials out of persisted configuration and uploaded artifacts.

## Impact

A passing quickstart now demonstrates the documented environment-variable setup, exact Sonnet 5 selection, an exact `QUICKSTART_OK` response, persistence after reload, and a durable completed Harness turn.

## Paired delivery

Slack thread updates and verified MP4 upload are implemented in iii-hq/release-control#18. Release Control must be deployed before end-to-end Slack reporting becomes active.

## Validation

- clean Docker reproduction against `latest/latest`: iii `0.22.1`, Harness `1.8.1`, Console `1.9.3`
- Playwright completed the Sonnet 5 conversation and reload successfully
- terminal status reached `completed` with `expects_wake=false`
- artifact credential scan passed
- ShellCheck passed
- actionlint passed
- Playwright test collection passed
- `git diff --check` passed

Fixes MOT-3250


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quickstart now supports selecting Claude Sonnet 5 in the Console, sending a message, and verifying conversation persistence after reload.
  * Automated checks capture browser, terminal, video, and Slack-compatible evidence.
* **Documentation**
  * Updated setup instructions to use an Anthropic API key through the engine environment.
  * Added guidance for Playwright, FFmpeg, ports, release channels, and validation requirements.
* **Bug Fixes**
  * Improved validation, cleanup, artifact handling, and credential-safety checks for quickstart runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->