### PR TITLE
(MOT-3250) fix(harness): share Playwright browser cache

### DIFF
--- a/.github/workflows/harness-quickstart.yml
+++ b/.github/workflows/harness-quickstart.yml
@@ -48,6 +48,8 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
## Summary

- give the quickstart job one explicit Playwright browser cache outside its isolated HOME
- make the browser installation step and Console validator resolve the same Chromium executable

## Root cause

The workflow installed Chromium under the runner's default HOME, then the quickstart validator replaced HOME with a temporary secret-safe directory. Playwright consequently searched the isolated cache and failed before launching the Console browser.

Failure evidence: https://github.com/iii-hq/workers/actions/runs/31763504042/job/94654571775

## Impact

The Console first-message quickstart can launch Chromium while preserving the isolated quickstart HOME.

## Validation

- actionlint 1.7.12
- ShellCheck 0.10.0
- installed Chromium in an explicit cache, changed HOME, and launched the browser successfully
- Playwright collected the focused quickstart test
- `git diff --check`

Refs MOT-3250
