### PR TITLE
(MOT-3250) feat(harness): validate OpenAI model switching in quickstart

### DIFF
--- a/.github/workflows/harness-quickstart.yml
+++ b/.github/workflows/harness-quickstart.yml
@@ -86,6 +86,7 @@ jobs:
       - name: Run quickstart validator
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           HARNESS_QUICKSTART_ARTIFACTS_DIR: ${{ github.workspace }}/target/harness-quickstart
           HARNESS_QUICKSTART_TRACE: '1'
           III_CLI_CHANNEL: ${{ inputs.cli_channel }}

--- a/harness/README.md
+++ b/harness/README.md
@@ -31,6 +31,7 @@ run the engine, initialize a project, and start it:
 ```bash
 curl -fsSL https://install.iii.dev/iii/main/install.sh | sh
 export ANTHROPIC_API_KEY='<your-anthropic-api-key>'
+export OPENAI_API_KEY='<your-openai-api-key>'
 iii project init iii-app && cd iii-app
 iii
 ```
@@ -47,8 +48,11 @@ open http://localhost:3113
 ```
 
 Create a session, select **Anthropic → Claude Sonnet 5**, and send your first
-message. The provider reads `ANTHROPIC_API_KEY` from the engine environment, so
-the credential does not need to be pasted into or stored by the Console.
+message. Then select **OpenAI → GPT-5.6 Luna** in the same chat and send another
+message. Create a new chat and send one more message with GPT-5.6 Luna. The
+providers read `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` from the engine
+environment, so credentials do not need to be pasted into or stored by the
+Console.
 
 `iii worker add harness` installs every worker the loop needs (see the badges
 above); you do not add them one by one. During bootstrap, the harness asks the

--- a/harness/tests/quickstart/README.md
+++ b/harness/tests/quickstart/README.md
@@ -14,18 +14,21 @@ It verifies that:
 - the published installer provides a working `iii` CLI;
 - a clean engine starts;
 - the core harness and Console functions register;
-- `ANTHROPIC_API_KEY` exposes exactly `anthropic/claude-sonnet-5`;
+- `ANTHROPIC_API_KEY` exposes exactly `anthropic/claude-sonnet-5` and
+  `OPENAI_API_KEY` exposes exactly `openai/gpt-5.6-luna`;
 - `console::status` and the Console HTTP root respond;
-- a user can select Claude Sonnet 5 and complete the first message through the
-  Console;
-- the successful conversation survives a browser reload and reaches a durable
-  terminal Harness state; and
+- a user can complete a message with Claude Sonnet 5, switch to GPT-5.6 Luna
+  in the same chat, and complete another message without changing sessions;
+- a user can create a new chat and complete a third message with GPT-5.6 Luna;
+- both successful conversations survive a browser reload and reach durable
+  terminal Harness states; and
 - `config.yaml` and `iii.lock` contain the installed workers.
 
 Run it locally with:
 
 ```bash
 export ANTHROPIC_API_KEY='<your-anthropic-api-key>'
+export OPENAI_API_KEY='<your-openai-api-key>'
 make -C harness quickstart-validate
 ```
 
@@ -46,9 +49,9 @@ are omitted.
 
 The CI workflow preserves `result.json`, the generated project files, sanitized
 browser and terminal evidence, raw logs, the command trace, and an MP4 of the
-Console success. It scans every artifact for the literal Anthropic credential
-before upload. Release-triggered runs replace the released worker with its exact
-candidate version and verify it in `iii.lock`.
+Console success. It scans every artifact for the literal Anthropic and OpenAI
+credentials before upload. Release-triggered runs replace the released worker
+with its exact candidate version and verify it in `iii.lock`.
 
 After a successful `deploy_harness`, Release Control dispatches this check as a
 child observation. Its result and MP4 are appended to the release Slack thread,

--- a/harness/tests/quickstart/console-first-message.spec.ts
+++ b/harness/tests/quickstart/console-first-message.spec.ts
@@ -1,11 +1,21 @@
 import { mkdir, writeFile } from 'node:fs/promises'
 import path from 'node:path'
-import { expect, test } from '@playwright/test'
+import { expect, type Locator, type Page, test } from '@playwright/test'
 
-const MODEL_ID = 'claude-sonnet-5'
-const MODEL_LABEL = /claude[\s-]+sonnet[\s-]+5/i
-const PROMPT = 'Reply with exactly QUICKSTART_OK and nothing else.'
-const MARKER = 'QUICKSTART_OK'
+const ANTHROPIC_MODEL_ID = 'claude-sonnet-5'
+const ANTHROPIC_MODEL_LABEL = /claude[\s-]+sonnet[\s-]+5/i
+const OPENAI_MODEL_ID = 'gpt-5.6-luna'
+const OPENAI_MODEL_LABEL = /gpt[\s-]*5\.6[\s-]*luna/i
+
+const ANTHROPIC_PROMPT =
+  'Reply with exactly QUICKSTART_ANTHROPIC_OK and nothing else.'
+const ANTHROPIC_MARKER = 'QUICKSTART_ANTHROPIC_OK'
+const OPENAI_SWITCH_PROMPT =
+  'Reply with exactly QUICKSTART_OPENAI_SWITCH_OK and nothing else.'
+const OPENAI_SWITCH_MARKER = 'QUICKSTART_OPENAI_SWITCH_OK'
+const OPENAI_NEW_CHAT_PROMPT =
+  'Reply with exactly QUICKSTART_OPENAI_NEW_CHAT_OK and nothing else.'
+const OPENAI_NEW_CHAT_MARKER = 'QUICKSTART_OPENAI_NEW_CHAT_OK'
 
 function required(name: string): string {
   const value = process.env[name]
@@ -13,7 +23,76 @@ function required(name: string): string {
   return value
 }
 
-test('completes and reloads the first Sonnet 5 conversation', async ({
+async function selectModel(
+  page: Page,
+  provider: 'anthropic' | 'openai',
+  modelLabel: RegExp,
+  pickerLabel: RegExp,
+) {
+  const modelPicker = page.getByRole('button', { name: /^model(?::|\s|$)/i })
+  await expect(modelPicker).toBeEnabled()
+  await modelPicker.click()
+
+  const providerGroup = page.getByRole('menuitem', {
+    name: new RegExp(`^${provider}`, 'i'),
+  })
+  await expect(providerGroup).toBeVisible()
+  if ((await providerGroup.getAttribute('aria-expanded')) !== 'true') {
+    await providerGroup.click()
+  }
+  await expect(providerGroup).toHaveAttribute('aria-expanded', 'true')
+
+  const model = page.getByRole('menuitemradio', { name: modelLabel })
+  await expect(model).toHaveCount(1)
+  await model.click()
+
+  const defaultEffort = page.getByRole('menuitemradio', {
+    name: 'default',
+    exact: true,
+  })
+  if (await defaultEffort.isVisible().catch(() => false)) {
+    await defaultEffort.click()
+  } else {
+    await page.keyboard.press('Escape')
+  }
+  await expect(modelPicker).toHaveAccessibleName(pickerLabel)
+}
+
+async function sendExactMessage(
+  page: Page,
+  chat: Locator,
+  prompt: string,
+  marker: string,
+  modelId: string,
+) {
+  const composer = page.getByLabel('message composer')
+  await composer.pressSequentially(prompt)
+  await expect(composer).toHaveText(prompt)
+  await page.getByRole('button', { name: 'send message' }).click()
+
+  await expect(
+    chat.locator('[data-message-role="user"]', { hasText: prompt }),
+  ).toHaveCount(1)
+  const assistant = chat.locator('[data-message-role="assistant"]', {
+    hasText: marker,
+  })
+  await expect(assistant).toHaveCount(1)
+  await expect(assistant.locator(':scope > div')).toHaveText(marker)
+  await expect(assistant).toContainText(modelId)
+}
+
+async function persistedChat(
+  page: Page,
+  titlePrefix: RegExp,
+  sessionId: string,
+) {
+  await page.getByRole('button', { name: titlePrefix }).first().click()
+  const chat = page.locator(`[data-chat-session-id="${sessionId}"]`)
+  await expect(chat).toHaveAttribute('data-chat-session-hydrated', 'true')
+  return chat
+}
+
+test('switches from Sonnet 5 to Luna and starts a new Luna chat', async ({
   page,
 }) => {
   const consoleUrl = required('HARNESS_QUICKSTART_CONSOLE_URL')
@@ -25,85 +104,144 @@ test('completes and reloads the first Sonnet 5 conversation', async ({
   await chatTab.click()
   await expect(chatTab).toHaveAttribute('aria-selected', 'true')
 
-  const modelPicker = page.getByRole('button', { name: /^model(?::|\s|$)/i })
-  await expect(modelPicker).toBeEnabled()
-  await modelPicker.click()
-
-  const anthropicGroup = page.getByRole('menuitem', {
-    name: /^anthropic/i,
-  })
-  await expect(anthropicGroup).toBeVisible()
-  if ((await anthropicGroup.getAttribute('aria-expanded')) !== 'true') {
-    await anthropicGroup.click()
-  }
-  await expect(anthropicGroup).toHaveAttribute('aria-expanded', 'true')
-
-  const sonnet = page.getByRole('menuitemradio', { name: MODEL_LABEL })
-  await expect(sonnet).toHaveCount(1)
-  await sonnet.click()
-
-  const defaultEffort = page.getByRole('menuitemradio', {
-    name: 'default',
-    exact: true,
-  })
-  if (await defaultEffort.isVisible().catch(() => false)) {
-    await defaultEffort.click()
-  } else {
-    await page.keyboard.press('Escape')
-  }
-  await expect(modelPicker).toHaveAccessibleName(
+  await selectModel(
+    page,
+    'anthropic',
+    ANTHROPIC_MODEL_LABEL,
     /^model:\s*claude[\s-]+sonnet[\s-]+5,/i,
   )
 
-  const composer = page.getByLabel('message composer')
-  await composer.pressSequentially(PROMPT)
-  await expect(composer).toHaveText(PROMPT)
-  await page.getByRole('button', { name: 'send message' }).click()
-
-  await expect(
-    page.locator('[data-message-role="user"]', { hasText: PROMPT }),
-  ).toHaveCount(1)
-  const assistant = page.locator('[data-message-role="assistant"]', {
-    hasText: MARKER,
-  })
-  await expect(assistant).toHaveCount(1)
-  await expect(assistant.locator(':scope > div')).toHaveText(MARKER)
-
-  const chat = page.locator('[data-chat-session-id]').first()
-  const sessionId = await chat.getAttribute('data-chat-session-id')
-  if (!sessionId)
+  const firstChat = page.locator('[data-chat-session-id]').first()
+  const firstSessionId = await firstChat.getAttribute('data-chat-session-id')
+  if (!firstSessionId)
     throw new Error('Console did not expose the persisted session id')
-  await expect(chat).toHaveAttribute('data-chat-session-hydrated', 'true')
+  await sendExactMessage(
+    page,
+    firstChat,
+    ANTHROPIC_PROMPT,
+    ANTHROPIC_MARKER,
+    ANTHROPIC_MODEL_ID,
+  )
+  await expect(firstChat).toHaveAttribute('data-chat-session-hydrated', 'true')
+
+  await selectModel(
+    page,
+    'openai',
+    OPENAI_MODEL_LABEL,
+    /^model:\s*gpt[\s-]*5\.6[\s-]*luna,/i,
+  )
+  await sendExactMessage(
+    page,
+    firstChat,
+    OPENAI_SWITCH_PROMPT,
+    OPENAI_SWITCH_MARKER,
+    OPENAI_MODEL_ID,
+  )
+  await expect(firstChat).toHaveAttribute(
+    'data-chat-session-id',
+    firstSessionId,
+  )
+
+  await page.getByRole('button', { name: /^new chat$/i }).click()
+  const secondChat = page.locator('[data-chat-session-id]').first()
+  const secondSessionId = await secondChat.getAttribute('data-chat-session-id')
+  if (!secondSessionId)
+    throw new Error('Console did not expose the new persisted session id')
+  expect(secondSessionId).not.toBe(firstSessionId)
+
+  await selectModel(
+    page,
+    'openai',
+    OPENAI_MODEL_LABEL,
+    /^model:\s*gpt[\s-]*5\.6[\s-]*luna,/i,
+  )
+  await sendExactMessage(
+    page,
+    secondChat,
+    OPENAI_NEW_CHAT_PROMPT,
+    OPENAI_NEW_CHAT_MARKER,
+    OPENAI_MODEL_ID,
+  )
+  await expect(secondChat).toHaveAttribute('data-chat-session-hydrated', 'true')
 
   await page.reload()
-  await page
-    .getByRole('button', {
-      name: /^open reply with exactly quickstart_ok/i,
-    })
-    .first()
-    .click()
-  const reloaded = page.locator(`[data-chat-session-id="${sessionId}"]`)
-  await expect(reloaded).toHaveAttribute('data-chat-session-hydrated', 'true')
-  await expect(
-    reloaded.locator('[data-message-role="user"]', { hasText: PROMPT }),
-  ).toHaveCount(1)
-  const reloadedAssistant = reloaded.locator(
-    '[data-message-role="assistant"]',
-    { hasText: MARKER },
+  const reloadedFirst = await persistedChat(
+    page,
+    /^open reply with exactly quickstart_an/i,
+    firstSessionId,
   )
-  await expect(reloadedAssistant).toHaveCount(1)
-  await expect(reloadedAssistant.locator(':scope > div')).toHaveText(MARKER)
+  await expect(
+    reloadedFirst.locator('[data-message-role="user"]', {
+      hasText: ANTHROPIC_PROMPT,
+    }),
+  ).toHaveCount(1)
+  const reloadedAnthropic = reloadedFirst.locator(
+    '[data-message-role="assistant"]',
+    { hasText: ANTHROPIC_MARKER },
+  )
+  await expect(reloadedAnthropic).toHaveCount(1)
+  await expect(reloadedAnthropic).toContainText(ANTHROPIC_MODEL_ID)
+  const reloadedSwitch = reloadedFirst.locator(
+    '[data-message-role="assistant"]',
+    { hasText: OPENAI_SWITCH_MARKER },
+  )
+  await expect(reloadedSwitch).toHaveCount(1)
+  await expect(reloadedSwitch).toContainText(OPENAI_MODEL_ID)
+
+  const reloadedSecond = await persistedChat(
+    page,
+    /^open reply with exactly quickstart_op/i,
+    secondSessionId,
+  )
+  const reloadedNewChat = reloadedSecond.locator(
+    '[data-message-role="assistant"]',
+    { hasText: OPENAI_NEW_CHAT_MARKER },
+  )
+  await expect(reloadedNewChat).toHaveCount(1)
+  await expect(reloadedNewChat).toContainText(OPENAI_MODEL_ID)
 
   await mkdir(artifactsRoot, { recursive: true })
   await writeFile(
     path.join(artifactsRoot, 'browser-evidence.json'),
     `${JSON.stringify(
       {
-        schema_version: 1,
-        provider: 'anthropic',
-        model: MODEL_ID,
-        session_id: sessionId,
-        marker: MARKER,
+        schema_version: 2,
+        provider: 'openai',
+        model: OPENAI_MODEL_ID,
+        marker: OPENAI_NEW_CHAT_MARKER,
+        providers: ['anthropic', 'openai'],
+        models: [ANTHROPIC_MODEL_ID, OPENAI_MODEL_ID],
+        scenarios: {
+          model_switch_same_chat: true,
+          openai_new_chat: true,
+        },
+        sessions: [
+          {
+            session_id: firstSessionId,
+            turns: [
+              {
+                provider: 'anthropic',
+                model: ANTHROPIC_MODEL_ID,
+                marker: ANTHROPIC_MARKER,
+              },
+              {
+                provider: 'openai',
+                model: OPENAI_MODEL_ID,
+                marker: OPENAI_SWITCH_MARKER,
+              },
+            ],
+          },
+          {
+            session_id: secondSessionId,
+            turns: [
+              {
+                provider: 'openai',
+                model: OPENAI_MODEL_ID,
+                marker: OPENAI_NEW_CHAT_MARKER,
+              },
+            ],
+          },
+        ],
         persisted_after_reload: true,
       },
       null,

--- a/harness/tests/quickstart/console-first-message.spec.ts
+++ b/harness/tests/quickstart/console-first-message.spec.ts
@@ -181,6 +181,11 @@ test('switches from Sonnet 5 to Luna and starts a new Luna chat', async ({
   )
   await expect(reloadedAnthropic).toHaveCount(1)
   await expect(reloadedAnthropic).toContainText(ANTHROPIC_MODEL_ID)
+  await expect(
+    reloadedFirst.locator('[data-message-role="user"]', {
+      hasText: OPENAI_SWITCH_PROMPT,
+    }),
+  ).toHaveCount(1)
   const reloadedSwitch = reloadedFirst.locator(
     '[data-message-role="assistant"]',
     { hasText: OPENAI_SWITCH_MARKER },
@@ -193,6 +198,11 @@ test('switches from Sonnet 5 to Luna and starts a new Luna chat', async ({
     /^open reply with exactly quickstart_op/i,
     secondSessionId,
   )
+  await expect(
+    reloadedSecond.locator('[data-message-role="user"]', {
+      hasText: OPENAI_NEW_CHAT_PROMPT,
+    }),
+  ).toHaveCount(1)
   const reloadedNewChat = reloadedSecond.locator(
     '[data-message-role="assistant"]',
     { hasText: OPENAI_NEW_CHAT_MARKER },

--- a/harness/tests/quickstart/run-ci.sh
+++ b/harness/tests/quickstart/run-ci.sh
@@ -3,7 +3,8 @@ set -Eeuo pipefail
 
 # Validate the published quickstart in an isolated home and project:
 # install iii, boot an empty engine, add harness + console, and complete the
-# first Console conversation with Anthropic Sonnet 5.
+# first Console conversation, switch from Anthropic Sonnet 5 to OpenAI Luna,
+# and start a second Luna conversation.
 
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd -- "$script_dir/../../.." && pwd)
@@ -17,9 +18,9 @@ engine_port=49134
 wait_seconds=${HARNESS_QUICKSTART_WAIT_SECONDS:-180}
 add_timeout_seconds=${HARNESS_QUICKSTART_ADD_TIMEOUT_SECONDS:-600}
 trace_enabled=${HARNESS_QUICKSTART_TRACE:-0}
-provider_id=anthropic
-model_id=claude-sonnet-5
-response_marker=QUICKSTART_OK
+result_provider_id=openai
+result_model_id=gpt-5.6-luna
+result_marker=QUICKSTART_OPENAI_NEW_CHAT_OK
 playwright_bin=${HARNESS_QUICKSTART_PLAYWRIGHT_BIN:-"$repo_root/console/web/node_modules/.bin/playwright"}
 
 if [[ -n "${III_CHANNEL:-}" ]]; then
@@ -60,6 +61,10 @@ fi
 
 [[ -n "${ANTHROPIC_API_KEY:-}" ]] || {
   echo "ANTHROPIC_API_KEY is required" >&2
+  exit 2
+}
+[[ -n "${OPENAI_API_KEY:-}" ]] || {
+  echo "OPENAI_API_KEY is required" >&2
   exit 2
 }
 
@@ -107,6 +112,8 @@ rm -f \
   "$artifact_dir/console-status.json" \
   "$artifact_dir/console.html" \
   "$artifact_dir/model.json" \
+  "$artifact_dir/model-anthropic.json" \
+  "$artifact_dir/model-openai.json" \
   "$artifact_dir/model-catalog.json" \
   "$artifact_dir/browser-evidence.json" \
   "$artifact_dir/terminal-status.json" \
@@ -124,7 +131,7 @@ fi
 export HOME="$quickstart_home"
 export XDG_CONFIG_HOME="$quickstart_home/.config"
 export PATH="$quickstart_home/.local/bin:$quickstart_home/.iii/bin:$PATH"
-unset OPENAI_API_KEY ZAI_API_KEY DEEPSEEK_API_KEY OPENROUTER_API_KEY XAI_API_KEY KIMI_API_KEY
+unset ZAI_API_KEY DEEPSEEK_API_KEY OPENROUTER_API_KEY XAI_API_KEY KIMI_API_KEY
 
 engine_pid=""
 iii_bin=""
@@ -157,12 +164,12 @@ die() {
 write_result() {
   local status=$1
   local browser=null terminal=null video=null
-  local video_path="$artifact_dir/slack-evidence/quickstart-sonnet-5.mp4"
+  local video_path="$artifact_dir/slack-evidence/quickstart-provider-switch.mp4"
   [[ -f "$artifact_dir/browser-evidence.json" ]] && browser=$(jq -c . "$artifact_dir/browser-evidence.json")
   [[ -f "$artifact_dir/terminal-status.json" ]] && terminal=$(jq -c . "$artifact_dir/terminal-status.json")
   if [[ -f "$video_path" ]]; then
     video=$(jq -n \
-      --arg path "slack-evidence/quickstart-sonnet-5.mp4" \
+      --arg path "slack-evidence/quickstart-provider-switch.mp4" \
       --arg media_type "video/mp4" \
       --arg sha256 "$(sha256sum "$video_path" | awk '{print $1}')" \
       --argjson size_bytes "$(stat -c %s "$video_path")" \
@@ -175,9 +182,9 @@ write_result() {
     --arg install_url "$install_url" \
     --arg cli_channel "$cli_channel" \
     --arg worker_tag "$worker_tag" \
-    --arg provider "$provider_id" \
-    --arg model "$model_id" \
-    --arg marker "$response_marker" \
+    --arg provider "$result_provider_id" \
+    --arg model "$result_model_id" \
+    --arg marker "$result_marker" \
     --argjson browser "$browser" \
     --argjson terminal "$terminal" \
     --argjson slack_evidence "$video" \
@@ -193,6 +200,8 @@ write_result() {
       provider: $provider,
       model: $model,
       marker: $marker,
+      providers: ["anthropic", "openai"],
+      models: ["claude-sonnet-5", "gpt-5.6-luna"],
       browser: $browser,
       terminal: $terminal,
       slack_evidence: $slack_evidence,
@@ -255,7 +264,7 @@ cleanup() {
 
   if artifacts_contain_secret; then
     status=1
-    failure_reason="an artifact contains the Anthropic credential"
+    failure_reason="an artifact contains a provider credential"
     # Do not leave a secret-bearing file available to the workflow uploader.
     find "$artifact_dir" -type f -delete
   fi
@@ -334,6 +343,7 @@ wait_for_functions() {
 }
 
 wait_for_model() {
+  local provider_id=$1 model_id=$2 output_path=$3
   local response attempt
   log "Waiting for $provider_id/$model_id in the router catalog (up to ${wait_seconds}s)"
   log_command "iii trigger router::models::get --port $engine_port --json '{\"provider\":\"$provider_id\",\"id\":\"$model_id\"}'"
@@ -343,7 +353,7 @@ wait_for_model() {
       2>>"$log_dir/model-discovery.log" || true)
     if jq -e --arg provider "$provider_id" --arg model "$model_id" \
       '.model.provider == $provider and .model.id == $model' <<<"$response" >/dev/null 2>&1; then
-      printf '%s\n' "$response" >"$artifact_dir/model.json"
+      printf '%s\n' "$response" >"$output_path"
       ok "$provider_id/$model_id available after ${attempt}s"
       return 0
     fi
@@ -374,51 +384,72 @@ record_browser_video() {
     mkdir -p "$output_dir"
     ffmpeg -hide_banner -loglevel error -y -i "$video_source" \
       -map_metadata -1 -c:v libx264 -pix_fmt yuv420p -movflags +faststart \
-      "$output_dir/quickstart-sonnet-5.mp4" \
+      "$output_dir/quickstart-provider-switch.mp4" \
       >"$log_dir/ffmpeg.log" 2>&1 || die "Playwright video conversion failed"
   elif ((playwright_status == 0)); then
     die "Playwright passed without producing a video"
   fi
 
-  ((playwright_status == 0)) || die "Console first-message Playwright test failed"
-  ok "Console conversation completed and Playwright video recorded"
+  ((playwright_status == 0)) || die "Console provider-switch Playwright test failed"
+  ok "Console provider switch completed and Playwright video recorded"
 }
 
-wait_for_terminal_turn() {
-  local session_id response attempt
-  session_id=$(jq -er '.session_id' "$artifact_dir/browser-evidence.json") \
-    || die "browser evidence has no session id"
-  log "Verifying the durable terminal turn for session $session_id"
+wait_for_terminal_turns() {
+  local session_id response attempt completed statuses='[]'
+  local -a session_ids
+  mapfile -t session_ids < <(
+    jq -er '.sessions | map(.session_id) | unique | .[]' \
+      "$artifact_dir/browser-evidence.json"
+  ) || die "browser evidence has no session ids"
+  ((${#session_ids[@]} == 2)) \
+    || die "browser evidence must contain exactly two unique session ids"
+
   log_command "iii trigger harness::status --port $engine_port --json '{\"session_id\":\"<console-session>\"}'"
-  for ((attempt = 0; attempt < wait_seconds; attempt++)); do
-    response=$("$iii_bin" trigger harness::status --port "$engine_port" \
-      --json "{\"session_id\":\"$session_id\"}" 2>>"$log_dir/terminal-status.log" || true)
-    if jq -e '.status == "completed" and (.expects_wake // false) == false' \
-      <<<"$response" >/dev/null 2>&1; then
-      printf '%s\n' "$response" >"$artifact_dir/terminal-status.json"
-      ok "turn completed durably after ${attempt}s"
-      return 0
-    fi
-    if jq -e '.status == "failed" or .status == "cancelled"' \
-      <<<"$response" >/dev/null 2>&1; then
-      printf '%s\n' "$response" >"$artifact_dir/terminal-status.json"
-      die "Console turn reached terminal status $(jq -r '.status' <<<"$response")"
-    fi
-    sleep 1
+  for session_id in "${session_ids[@]}"; do
+    log "Verifying the durable terminal turn for session $session_id"
+    response=''
+    completed=0
+    for ((attempt = 0; attempt < wait_seconds; attempt++)); do
+      response=$("$iii_bin" trigger harness::status --port "$engine_port" \
+        --json "{\"session_id\":\"$session_id\"}" 2>>"$log_dir/terminal-status.log" || true)
+      if jq -e '.status == "completed" and (.expects_wake // false) == false' \
+        <<<"$response" >/dev/null 2>&1; then
+        statuses=$(jq -c \
+          --arg session_id "$session_id" \
+          --argjson status "$response" \
+          '. + [{session_id:$session_id,status:$status}]' <<<"$statuses")
+        ok "session $session_id completed durably after ${attempt}s"
+        completed=1
+        break
+      fi
+      if jq -e '.status == "failed" or .status == "cancelled"' \
+        <<<"$response" >/dev/null 2>&1; then
+        die "Console session $session_id reached terminal status $(jq -r '.status' <<<"$response")"
+      fi
+      sleep 1
+    done
+    ((completed == 1)) \
+      || die "Console session $session_id did not reach durable completion"
   done
-  printf '%s\n' "$response" >"$artifact_dir/terminal-status.json"
-  die "Console turn did not reach durable completion"
+  jq -n --argjson sessions "$statuses" \
+    '{schema_version:2,sessions:$sessions}' >"$artifact_dir/terminal-status.json"
 }
 
 artifacts_contain_secret() {
-  LC_ALL=C grep -R -a -F -l -- "$ANTHROPIC_API_KEY" "$artifact_dir" >/dev/null 2>&1
+  local credential
+  for credential in "$ANTHROPIC_API_KEY" "$OPENAI_API_KEY"; do
+    if LC_ALL=C grep -R -a -F -l -- "$credential" "$artifact_dir" >/dev/null 2>&1; then
+      return 0
+    fi
+  done
+  return 1
 }
 
 assert_secret_safe_artifacts() {
   if artifacts_contain_secret; then
-    die "an artifact contains the Anthropic credential"
+    die "an artifact contains a provider credential"
   fi
-  ok "artifacts do not contain the Anthropic credential"
+  ok "artifacts do not contain provider credentials"
 }
 
 run_worker_add() {
@@ -483,8 +514,9 @@ fi
 log "Step 5/9: Verify registered functions"
 wait_for_functions
 
-log "Step 6/9: Verify Sonnet 5 availability"
-wait_for_model
+log "Step 6/9: Verify Sonnet 5 and Luna availability"
+wait_for_model anthropic claude-sonnet-5 "$artifact_dir/model-anthropic.json"
+wait_for_model openai gpt-5.6-luna "$artifact_dir/model-openai.json"
 
 log "Step 7/9: Verify the Console HTTP surface"
 log_command "iii trigger console::status --port $engine_port --json '{}'"
@@ -498,9 +530,9 @@ curl -fsS --retry 10 --retry-all-errors --retry-delay 1 \
   "http://127.0.0.1:$console_port/" -o "$artifact_dir/console.html"
 ok "Console answered on port $console_port"
 
-log "Step 8/9: Complete the first conversation through the Console"
+log "Step 8/9: Switch providers and start a new Luna conversation"
 record_browser_video
-wait_for_terminal_turn
+wait_for_terminal_turns
 
 log "Step 9/9: Verify generated project files and secret-safe evidence"
 for output in config.yaml iii.lock; do

--- a/provider-openai/Cargo.lock
+++ b/provider-openai/Cargo.lock
@@ -996,7 +996,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llm-router"
-version = "1.4.2"
+version = "1.4.7"
 dependencies = [
  "async-trait",
  "clap",

--- a/provider-openai/src/errors.rs
+++ b/provider-openai/src/errors.rs
@@ -44,13 +44,16 @@ fn classify_openai_value(v: &Value, status: Option<u16>) -> Option<ErrorKind> {
         "context_length_exceeded" => return Some(ErrorKind::ContextOverflow),
         // 429 with insufficient_quota is a billing wall, not a rate limit:
         // the router's retry/backoff cannot fix it.
-        "insufficient_quota" => return Some(ErrorKind::Permanent),
+        "insufficient_quota" | "credit_balance_exhausted" => {
+            return Some(ErrorKind::Permanent);
+        }
         "invalid_api_key" | "account_deactivated" => return Some(ErrorKind::AuthExpired),
         _ => {}
     }
     match err_type {
         "authentication_error" | "permission_error" => Some(ErrorKind::AuthExpired),
         "rate_limit_error" => Some(ErrorKind::RateLimited),
+        "insufficient_quota" => Some(ErrorKind::Permanent),
         "server_error" => Some(ErrorKind::Transient),
         "invalid_request_error" => {
             if status == Some(413) || is_context_overflow_message(msg) {
@@ -122,6 +125,11 @@ mod tests {
 
         let body = r#"{"error":{"message":"You exceeded your current quota.","type":"insufficient_quota","code":"insufficient_quota"}}"#;
         assert_eq!(classify(Some(429), body), ErrorKind::Permanent);
+
+        // Current Responses API billing envelope observed for project keys.
+        let body = r#"{"error":{"message":"You have no credits remaining.","type":"insufficient_quota","code":"credit_balance_exhausted"}}"#;
+        assert_eq!(classify(Some(429), body), ErrorKind::Permanent);
+        assert_eq!(classify(None, body), ErrorKind::Permanent);
 
         let body = r#"{"error":{"message":"Incorrect API key provided.","type":"invalid_request_error","code":"invalid_api_key"}}"#;
         assert_eq!(classify(Some(401), body), ErrorKind::AuthExpired);

--- a/provider-openai/src/sse.rs
+++ b/provider-openai/src/sse.rs
@@ -348,6 +348,19 @@ fn responses_usage(event: &Value, state: &mut PartialState) {
     }
 }
 
+fn responses_error_kind(event: &Value, message: &str) -> ErrorKind {
+    let error = event
+        .get("error")
+        .or_else(|| event.pointer("/response/error"));
+    match error {
+        Some(error) => {
+            let envelope = serde_json::json!({ "error": error });
+            classify(None, &envelope.to_string())
+        }
+        None => classify(None, message),
+    }
+}
+
 fn ensure_function_call(state: &mut PartialState, index: usize) -> &mut PartialFunctionCall {
     while state.function_calls.len() <= index {
         state.function_calls.push(PartialFunctionCall::default());
@@ -527,7 +540,7 @@ fn handle_responses_event(
             state.stop_reason = StopReason::Error;
             state.error_message = Some(message.clone());
             let mut error = build_final(state, model);
-            error.error_kind = Some(classify(None, &message));
+            error.error_kind = Some(responses_error_kind(event, &message));
             events.push(AssistantMessageEvent::Error { error });
         }
         _ => {}
@@ -793,6 +806,44 @@ mod tests {
         assert_eq!(usage.output, Some(2));
         assert_eq!(usage.cache_read, Some(4));
         assert_eq!(usage.reasoning, Some(1));
+    }
+
+    #[test]
+    fn responses_credit_exhaustion_events_are_permanent() {
+        let message = "You have no credits remaining.";
+        let events = [
+            json!({
+                "type": "error",
+                "error": {
+                    "type": "insufficient_quota",
+                    "code": "credit_balance_exhausted",
+                    "message": message,
+                    "param": null
+                }
+            }),
+            json!({
+                "type": "response.failed",
+                "response": {
+                    "status": "failed",
+                    "error": {
+                        "code": "credit_balance_exhausted",
+                        "message": message
+                    }
+                }
+            }),
+        ];
+
+        for event in events {
+            let (_, emitted) = run(&[event]);
+            assert_eq!(emitted.len(), 1);
+            match &emitted[0] {
+                AssistantMessageEvent::Error { error } => {
+                    assert_eq!(error.error_kind, Some(ErrorKind::Permanent));
+                    assert_eq!(error.error_message.as_deref(), Some(message));
+                }
+                other => panic!("want permanent error frame, got {other:?}"),
+            }
+        }
     }
 
     #[test]

--- a/provider-openai/src/upstream.rs
+++ b/provider-openai/src/upstream.rs
@@ -284,6 +284,22 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn http_429_credit_balance_exhausted_is_permanent() {
+        let url = stub(
+            "HTTP/1.1 429 Too Many Requests\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{\"error\":{\"message\":\"You have no credits remaining.\",\"type\":\"insufficient_quota\",\"code\":\"credit_balance_exhausted\"}}",
+        )
+        .await;
+        let events = drain(spawn_upstream(reqwest::Client::new(), args(url))).await;
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AssistantMessageEvent::Error { error } => {
+                assert_eq!(error.error_kind, Some(ErrorKind::Permanent));
+            }
+            other => panic!("want permanent error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn builder_error_surfaces_its_source_not_just_builder_error() {
         // A header value with a newline is an invalid HeaderValue → reqwest
         // raises a builder error before connecting. The frame must name the


### PR DESCRIPTION
## Summary

- require and validate `OPENAI_API_KEY` alongside `ANTHROPIC_API_KEY`
- verify Sonnet 5, switch to `gpt-5.6-luna` in the same Console chat, then validate Luna in a new chat
- persist two-session browser and terminal evidence and record a provider-switch video
- classify OpenAI `credit_balance_exhausted` responses as permanent and preserve the SSE error envelope
- keep the provider lock aligned with `llm-router 1.4.7` for locked release builds
- document the environment-variable flow for both providers

## Root cause

The OpenAI Responses streaming endpoint accepts the request with HTTP 200 and then emits an SSE `error` event followed by `response.failed`. The provider previously kept only the message, discarded `type` and `code`, and classified the failure as transient. The Harness consequently performed three retries for a billing condition that cannot recover without operator action.

The current OpenAI envelope uses `type=insufficient_quota` with `code=credit_balance_exhausted`; both are now classified as permanent for HTTP and SSE responses.

## Validation evidence

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`: 94 tests passed
- regression coverage includes HTTP 429, Responses `error`, and `response.failed` envelopes
- `bash -n` and ShellCheck passed for the quickstart validator
- Actionlint, Biome, and Playwright test discovery passed
- isolated published quickstart resolved both exact models and completed the Sonnet turn
- direct model probe: `GET /v1/models/gpt-5.6-luna` returned HTTP 200
- direct generation probe: `POST /v1/responses` returned HTTP 429 with `type=insufficient_quota` and `code=credit_balance_exhausted`

## Deployment prerequisite

The repository secret is configured, but the associated OpenAI project currently has no credits. Fund that project or replace `OPENAI_API_KEY` before running the quickstart; the code and model access are otherwise validated.

Refs MOT-3250


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quickstart now supports switching between Anthropic Claude Sonnet 5 and OpenAI GPT-5.6 Luna across chats and sessions.
  * OpenAI credentials are supported through the engine environment.

* **Bug Fixes**
  * OpenAI credit-balance exhaustion errors are now recognized as permanent failures, improving error handling for both standard and streaming responses.

* **Tests**
  * Expanded validation covers model switching, chat persistence, reloads, credential protection, and multiple provider scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->