### PR TITLE
fix(provider-zai): add GLM 5.3 to Coding Plan catalog

### DIFF
--- a/provider-zai/README.md
+++ b/provider-zai/README.md
@@ -10,8 +10,10 @@ Implements the provider protocol from
 Default upstream: `https://api.z.ai/api/coding/paas/v4/chat/completions` —
 the GLM Coding Plan endpoint (subscription keys, the common case). The
 catalog follows the resolved endpoint: the coding endpoint reconciles only
-the plan's models (`glm-5.2`, `glm-5.1`, `glm-5`, `glm-5-turbo`, `glm-4.7`,
-`glm-4.5-air`); override `api_url`
+the plan's models (`glm-5.3`, `glm-5.2`, `glm-5.1`, `glm-5`, `glm-5-turbo`,
+`glm-4.7`, `glm-4.5-air`). GLM-5.3 is Coding Plan-only until Z.AI launches
+it on the general API; its catalog record intentionally has no USD pricing.
+Override `api_url`
 to `https://api.z.ai/api/paas/v4/chat/completions` (pay-as-you-go) for the
 full GLM lineup.
 

--- a/provider-zai/src/curated.rs
+++ b/provider-zai/src/curated.rs
@@ -1,8 +1,8 @@
 //! The hand-maintained Z.AI catalog. Z.AI's OpenAI-compatible API exposes no
 //! models-listing endpoint (`GET /models` is absent from docs.z.ai's OpenAPI
 //! spec), so this table IS the catalog: ids, limits, capabilities, and
-//! pricing, all from docs.z.ai (guides/overview/pricing, guides/llm/*,
-//! guides/vlm/*), snapshot 2026-07. A stale row degrades cost display and
+//! available pricing, all from docs.z.ai (guides/overview/pricing, guides/llm/*,
+//! guides/vlm/*), snapshot 2026-08. A stale row degrades cost display and
 //! limits, never routing correctness.
 use crate::PROVIDER_ID;
 use llm_router::types::model::{Model, Pricing};
@@ -153,12 +153,12 @@ const ROWS: &[Row] = &[
     },
 ];
 
-/// Models the GLM Coding Plan endpoint serves: the featured tier models
-/// (docs.z.ai devpack/overview: GLM-5.2, GLM-5-Turbo, GLM-4.7) plus the
+/// Models from the priced general catalog that the GLM Coding Plan endpoint
+/// also serves: the featured tier models (docs.z.ai devpack/overview:
+/// GLM-5.2, GLM-5-Turbo, GLM-4.7) plus the
 /// additional codes the coding-tools guide documents for that endpoint
 /// (docs.z.ai scenario-example/develop-tools/others: GLM-5.1, GLM-5,
-/// GLM-4.5-air). The catalog shrinks to these when the resolved endpoint
-/// is the coding one.
+/// GLM-4.5-air). The coding-only GLM-5.3 record is added separately below.
 const CODING_PLAN_IDS: [&str; 6] = [
     "glm-5.2",
     "glm-5.1",
@@ -175,10 +175,37 @@ pub fn models() -> Vec<Model> {
 
 /// The Coding Plan subset of the catalog.
 pub fn coding_models() -> Vec<Model> {
-    ROWS.iter()
-        .filter(|r| CODING_PLAN_IDS.contains(&r.id))
-        .map(to_model)
+    std::iter::once(glm_53_coding_model())
+        .chain(
+            ROWS.iter()
+                .filter(|r| CODING_PLAN_IDS.contains(&r.id))
+                .map(to_model),
+        )
         .collect()
+}
+
+/// GLM-5.3 is currently exclusive to the Coding Plan endpoint. Z.AI has not
+/// launched it on the general API or published USD-per-token pricing, so keep
+/// it separate from `ROWS` and leave pricing absent rather than claiming the
+/// plan's credit multipliers are pay-as-you-go prices.
+fn glm_53_coding_model() -> Model {
+    Model {
+        id: "glm-5.3".into(),
+        provider: PROVIDER_ID.into(),
+        display_name: Some("GLM 5.3".into()),
+        context_window: 1_000_000,
+        max_output_tokens: 128_000,
+        input_limit: None,
+        supports_thinking: Some(true),
+        supports_xhigh: Some(true),
+        reasoning_efforts: None,
+        supports_tools: Some(true),
+        supports_vision: Some(false),
+        supports_cache: Some(true),
+        supports_structured_output: Some(false),
+        thinking_budgets: None,
+        pricing: None,
+    }
 }
 
 fn to_model(r: &Row) -> Model {
@@ -219,11 +246,12 @@ mod tests {
 
     #[test]
     fn catalog_ids_are_unique_and_owned_by_zai() {
-        let models = models();
-        assert!(!models.is_empty());
-        let ids: HashSet<&str> = models.iter().map(|m| m.id.as_str()).collect();
-        assert_eq!(ids.len(), models.len(), "duplicate ids in ROWS");
-        assert!(models.iter().all(|m| m.provider == "zai"));
+        for catalog in [models(), coding_models()] {
+            assert!(!catalog.is_empty());
+            let ids: HashSet<&str> = catalog.iter().map(|m| m.id.as_str()).collect();
+            assert_eq!(ids.len(), catalog.len(), "duplicate ids in catalog");
+            assert!(catalog.iter().all(|m| m.provider == "zai"));
+        }
     }
 
     #[test]
@@ -238,6 +266,24 @@ mod tests {
         assert_eq!(p.input, Some(1.40));
         assert_eq!(p.cache_read, Some(0.26));
         assert_eq!(p.output, Some(4.40));
+    }
+
+    #[test]
+    fn glm_53_is_coding_only_and_has_no_invented_usd_pricing() {
+        assert!(models().iter().all(|m| m.id != "glm-5.3"));
+
+        let coding = coding_models();
+        let m = coding.iter().find(|m| m.id == "glm-5.3").unwrap();
+        assert_eq!(coding.first().map(|m| m.id.as_str()), Some("glm-5.3"));
+        assert_eq!(m.display_name.as_deref(), Some("GLM 5.3"));
+        assert_eq!(m.context_window, 1_000_000);
+        assert_eq!(m.max_output_tokens, 128_000);
+        assert_eq!(m.supports_thinking, Some(true));
+        assert_eq!(m.supports_xhigh, Some(true));
+        assert_eq!(m.supports_tools, Some(true));
+        assert_eq!(m.supports_vision, Some(false));
+        assert_eq!(m.supports_cache, Some(true));
+        assert_eq!(m.pricing, None);
     }
 
     #[test]

--- a/provider-zai/src/discovery.rs
+++ b/provider-zai/src/discovery.rs
@@ -76,6 +76,7 @@ mod tests {
         assert_eq!(
             coding,
             [
+                "glm-5.3",
                 "glm-5.2",
                 "glm-5.1",
                 "glm-5",


### PR DESCRIPTION
## Summary

- add GLM-5.3 to the Z.AI Coding Plan catalog
- keep it out of the general pay-as-you-go catalog until that API launches
- omit USD pricing because Z.AI currently publishes only Coding Plan credit multipliers
- update catalog documentation and endpoint-specific tests

## Why

`provider-zai` uses a curated model catalog because Z.AI does not expose a models-listing endpoint. Z.AI now offers GLM-5.3 to Coding Plan users, but the worker still advertised the previous six-model catalog. That kept GLM-5.3 out of the Console picker and automatic provider routing.

Reference: https://docs.z.ai/guides/llm/glm-5.3

## Impact

The Coding Plan catalog now exposes GLM-5.3 with a 1,000,000-token context window, 128,000-token maximum output, thinking, tools, caching, and xhigh effort. General and custom endpoint catalogs remain unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo build --release --bin provider-zai`
- schema golden tests
- patch version resolves to `0.5.2` and passes release-history validation
- live `provider::zai::refresh_models` returned 7 models
- live `router::route model=glm-5.3` selected `zai`
- Console model picker showed GLM-5.3 with no browser console errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GLM-5.3 to the Z.AI Coding Plan model catalog.
  * Identified GLM-5.3 as Coding Plan-only and without USD pricing.
  * Updated the catalog snapshot and model capability coverage.

* **Documentation**
  * Clarified catalog descriptions and guidance for overriding the API URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->