### PR TITLE
(MOT-3250) test(harness): validate first quickstart capability

### DIFF
--- a/harness/tests/quickstart/README.md
+++ b/harness/tests/quickstart/README.md
@@ -21,7 +21,12 @@ It verifies that:
   in the same chat, and complete another message without changing sessions;
 - a user can create a new chat and complete a third message with GPT-5.6 Luna;
 - both successful conversations survive a browser reload and reach durable
-  terminal Harness states; and
+  terminal Harness states;
+- in a separate chat, a user can invoke one real `shell::exec` capability,
+  observe its successful Console card and exact output, and recover the same
+  conversation after a reload;
+- the capability call and its exact output are present in the durable session
+  transcript; and
 - `config.yaml` and `iii.lock` contain the installed workers.
 
 Run it locally with:
@@ -48,10 +53,11 @@ Set `HARNESS_QUICKSTART_TRACE=1` to print only the important external commands
 are omitted.
 
 The CI workflow preserves `result.json`, the generated project files, sanitized
-browser and terminal evidence, raw logs, the command trace, and an MP4 of the
-Console success. It scans every artifact for the literal Anthropic and OpenAI
-credentials before upload. Release-triggered runs replace the released worker
-with its exact candidate version and verify it in `iii.lock`.
+browser, terminal, and first-capability evidence, raw Playwright output, the
+command trace, and the provider-switch MP4. It scans every artifact for the
+literal Anthropic and OpenAI credentials before upload. Release-triggered runs
+replace the released worker with its exact candidate version and verify it in
+`iii.lock`.
 
 After a successful `deploy_harness`, Release Control dispatches this check as a
 child observation. Its result and MP4 are appended to the release Slack thread,

--- a/harness/tests/quickstart/console-first-capability.spec.ts
+++ b/harness/tests/quickstart/console-first-capability.spec.ts
@@ -1,0 +1,124 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { expect, type Page, test } from '@playwright/test'
+
+const MODEL_ID = 'claude-sonnet-5'
+const MODEL_LABEL = /claude[\s-]+sonnet[\s-]+5/i
+const CAPABILITY_FUNCTION = 'shell::exec'
+const CAPABILITY_OUTPUT_MARKER = 'HARNESS_FIRST_CAPABILITY_OUTPUT'
+const RESPONSE_MARKER = 'HARNESS_FIRST_CAPABILITY_OK'
+const PROMPT =
+  `Use ${CAPABILITY_FUNCTION} exactly once to run printf with arguments ` +
+  `["%s", "${CAPABILITY_OUTPUT_MARKER}"]. After the function succeeds, ` +
+  `reply with exactly ${RESPONSE_MARKER} and nothing else.`
+
+function required(name: string): string {
+  const value = process.env[name]
+  if (!value) throw new Error(`${name} is required`)
+  return value
+}
+
+async function selectSonnet(page: Page) {
+  const modelPicker = page.getByRole('button', { name: /^model(?::|\s|$)/i })
+  await expect(modelPicker).toBeEnabled()
+  await modelPicker.click()
+
+  const anthropicGroup = page.getByRole('menuitem', { name: /^anthropic/i })
+  await expect(anthropicGroup).toBeVisible()
+  if ((await anthropicGroup.getAttribute('aria-expanded')) !== 'true') {
+    await anthropicGroup.click()
+  }
+  await expect(anthropicGroup).toHaveAttribute('aria-expanded', 'true')
+
+  const sonnet = page.getByRole('menuitemradio', { name: MODEL_LABEL })
+  await expect(sonnet).toHaveCount(1)
+  await sonnet.click()
+
+  const defaultEffort = page.getByRole('menuitemradio', {
+    name: 'default',
+    exact: true,
+  })
+  if (await defaultEffort.isVisible().catch(() => false)) {
+    await defaultEffort.click()
+  } else {
+    await page.keyboard.press('Escape')
+  }
+  await expect(modelPicker).toHaveAccessibleName(/^model:\s*claude[\s-]+sonnet[\s-]+5,/i)
+}
+
+test('completes and reloads the first real Harness capability', async ({ page }) => {
+  const consoleUrl = required('HARNESS_QUICKSTART_CONSOLE_URL')
+  const artifactsRoot = required('HARNESS_QUICKSTART_ARTIFACTS_DIR')
+
+  await page.goto(consoleUrl)
+
+  const chatTab = page.getByRole('tab', { name: /^chat \+ traces/i })
+  await chatTab.click()
+  await expect(chatTab).toHaveAttribute('aria-selected', 'true')
+
+  await selectSonnet(page)
+
+  const composer = page.getByLabel('message composer')
+  await composer.pressSequentially(PROMPT)
+  await expect(composer).toHaveText(PROMPT)
+  await page.getByRole('button', { name: 'send message' }).click()
+
+  const userMessage = page.locator('[data-message-role="user"]', { hasText: PROMPT })
+  await expect(userMessage).toHaveCount(1)
+  const chat = userMessage.locator('xpath=ancestor::section[@data-chat-session-id][1]')
+  const sessionId = await chat.getAttribute('data-chat-session-id')
+  if (!sessionId) throw new Error('Console did not expose the capability session id')
+  const functionCard = chat.locator(`[data-function-id="${CAPABILITY_FUNCTION}"]`)
+  await expect(functionCard).toHaveCount(1, { timeout: 90_000 })
+  await expect(functionCard).toHaveAttribute('data-function-status', 'done', { timeout: 90_000 })
+
+  const assistant = chat.locator('[data-message-role="assistant"]', {
+    hasText: RESPONSE_MARKER,
+  })
+  await expect(assistant).toHaveCount(1, { timeout: 90_000 })
+  await expect(assistant.locator(':scope > div')).toHaveText(RESPONSE_MARKER)
+  await expect(assistant).toContainText(MODEL_ID)
+  await expect(chat).toHaveAttribute('data-chat-session-hydrated', 'true')
+
+  await page.reload()
+  await page
+    .getByRole('button', { name: /^open use shell::exec exactly once/i })
+    .first()
+    .click()
+  const reloaded = page.locator(`[data-chat-session-id="${sessionId}"]`)
+  await expect(reloaded).toHaveAttribute('data-chat-session-hydrated', 'true')
+  await expect(reloaded.locator('[data-message-role="user"]', { hasText: PROMPT })).toHaveCount(1)
+  const reloadedFunctionCard = reloaded.locator(`[data-function-id="${CAPABILITY_FUNCTION}"]`)
+  await expect(reloadedFunctionCard).toHaveCount(1)
+  await expect(reloadedFunctionCard).toHaveAttribute('data-function-status', 'done')
+  await reloadedFunctionCard.locator('button[aria-expanded]').first().click()
+  await expect(reloadedFunctionCard.locator('[data-function-pane="response"] code, .shui-pre.out code')).toContainText(
+    CAPABILITY_OUTPUT_MARKER,
+  )
+  const reloadedAssistant = reloaded.locator('[data-message-role="assistant"]', { hasText: RESPONSE_MARKER })
+  await expect(reloadedAssistant).toHaveCount(1)
+  await expect(reloadedAssistant.locator(':scope > div')).toHaveText(RESPONSE_MARKER)
+  await expect(reloadedAssistant).toContainText(MODEL_ID)
+
+  await mkdir(artifactsRoot, { recursive: true })
+  await writeFile(
+    path.join(artifactsRoot, 'first-capability-browser-evidence.json'),
+    `${JSON.stringify(
+      {
+        schema_version: 1,
+        provider: 'anthropic',
+        model: MODEL_ID,
+        session_id: sessionId,
+        prompt: PROMPT,
+        response_marker: RESPONSE_MARKER,
+        capability_function: CAPABILITY_FUNCTION,
+        capability_output_marker: CAPABILITY_OUTPUT_MARKER,
+        function_rendered: true,
+        output_rendered_after_reload: true,
+        persisted_after_reload: true,
+      },
+      null,
+      2,
+    )}\n`,
+  )
+})

--- a/harness/tests/quickstart/playwright.config.ts
+++ b/harness/tests/quickstart/playwright.config.ts
@@ -8,7 +8,7 @@ if (!artifactsRoot) {
 
 export default defineConfig({
   testDir: __dirname,
-  testMatch: 'console-first-message.spec.ts',
+  testMatch: ['console-first-message.spec.ts', 'console-first-capability.spec.ts'],
   fullyParallel: false,
   workers: 1,
   retries: 0,

--- a/harness/tests/quickstart/run-ci.sh
+++ b/harness/tests/quickstart/run-ci.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 # Validate the published quickstart in an isolated home and project:
 # install iii, boot an empty engine, add harness + console, and complete the
 # first Console conversation, switch from Anthropic Sonnet 5 to OpenAI Luna,
-# and start a second Luna conversation.
+# start a second Luna conversation, and exercise one real Harness capability.
 
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd -- "$script_dir/../../.." && pwd)
@@ -21,6 +21,8 @@ trace_enabled=${HARNESS_QUICKSTART_TRACE:-0}
 result_provider_id=openai
 result_model_id=gpt-5.6-luna
 result_marker=QUICKSTART_OPENAI_NEW_CHAT_OK
+capability_function=shell::exec
+capability_output_marker=HARNESS_FIRST_CAPABILITY_OUTPUT
 playwright_bin=${HARNESS_QUICKSTART_PLAYWRIGHT_BIN:-"$repo_root/console/web/node_modules/.bin/playwright"}
 
 if [[ -n "${III_CHANNEL:-}" ]]; then
@@ -117,6 +119,8 @@ rm -f \
   "$artifact_dir/model-catalog.json" \
   "$artifact_dir/browser-evidence.json" \
   "$artifact_dir/terminal-status.json" \
+  "$artifact_dir/first-capability-browser-evidence.json" \
+  "$artifact_dir/first-capability-evidence.json" \
   "$artifact_dir/config.yaml" \
   "$artifact_dir/iii.lock" \
   "$artifact_dir/commands.log" \
@@ -163,10 +167,13 @@ die() {
 
 write_result() {
   local status=$1
-  local browser=null terminal=null video=null
+  local browser=null terminal=null first_capability_browser=null first_capability_durable=null
+  local video=null
   local video_path="$artifact_dir/slack-evidence/quickstart-provider-switch.mp4"
   [[ -f "$artifact_dir/browser-evidence.json" ]] && browser=$(jq -c . "$artifact_dir/browser-evidence.json")
   [[ -f "$artifact_dir/terminal-status.json" ]] && terminal=$(jq -c . "$artifact_dir/terminal-status.json")
+  [[ -f "$artifact_dir/first-capability-browser-evidence.json" ]] && first_capability_browser=$(jq -c . "$artifact_dir/first-capability-browser-evidence.json")
+  [[ -f "$artifact_dir/first-capability-evidence.json" ]] && first_capability_durable=$(jq -c . "$artifact_dir/first-capability-evidence.json")
   if [[ -f "$video_path" ]]; then
     video=$(jq -n \
       --arg path "slack-evidence/quickstart-provider-switch.mp4" \
@@ -187,6 +194,8 @@ write_result() {
     --arg marker "$result_marker" \
     --argjson browser "$browser" \
     --argjson terminal "$terminal" \
+    --argjson first_capability_browser "$first_capability_browser" \
+    --argjson first_capability_durable "$first_capability_durable" \
     --argjson slack_evidence "$video" \
     --argjson elapsed_ms "$(((SECONDS - started_at_seconds) * 1000))" \
     --argjson engine_port "$engine_port" \
@@ -204,6 +213,10 @@ write_result() {
       models: ["claude-sonnet-5", "gpt-5.6-luna"],
       browser: $browser,
       terminal: $terminal,
+      first_capability: {
+        browser: $first_capability_browser,
+        durable: $first_capability_durable
+      },
       slack_evidence: $slack_evidence,
       elapsed_ms: $elapsed_ms,
       engine_port: $engine_port
@@ -317,6 +330,7 @@ wait_for_functions() {
     "session::messages",
     "context::assemble",
     "router::models::get",
+    "shell::exec",
     "console::status"
   ]'
 
@@ -379,7 +393,8 @@ record_browser_video() {
   playwright_status=$?
   set -e
 
-  video_source=$(find "$artifact_dir/playwright-output" -type f -name '*.webm' -print -quit 2>/dev/null || true)
+  video_source=$(find "$artifact_dir/playwright-output" \
+    -type f -path '*/console-first-message-*/video.webm' -print -quit 2>/dev/null || true)
   if [[ -n "$video_source" ]]; then
     mkdir -p "$output_dir"
     ffmpeg -hide_banner -loglevel error -y -i "$video_source" \
@@ -387,11 +402,11 @@ record_browser_video() {
       "$output_dir/quickstart-provider-switch.mp4" \
       >"$log_dir/ffmpeg.log" 2>&1 || die "Playwright video conversion failed"
   elif ((playwright_status == 0)); then
-    die "Playwright passed without producing a video"
+    die "provider-switch Playwright test passed without producing a video"
   fi
 
-  ((playwright_status == 0)) || die "Console provider-switch Playwright test failed"
-  ok "Console provider switch completed and Playwright video recorded"
+  ((playwright_status == 0)) || die "Console quickstart Playwright tests failed"
+  ok "Console provider switch and first capability completed with recorded evidence"
 }
 
 wait_for_terminal_turns() {
@@ -433,6 +448,89 @@ wait_for_terminal_turns() {
   done
   jq -n --argjson sessions "$statuses" \
     '{schema_version:2,sessions:$sessions}' >"$artifact_dir/terminal-status.json"
+}
+
+verify_first_capability() {
+  local session_id response attempt completed=0 transcript call_count result_count
+  session_id=$(jq -er '.session_id' "$artifact_dir/first-capability-browser-evidence.json") \
+    || die "first capability browser evidence has no session id"
+
+  log "Verifying the first capability for session $session_id"
+  log_command "iii trigger harness::status --port $engine_port --json '{\"session_id\":\"<capability-session>\"}'"
+  response=''
+  for ((attempt = 0; attempt < wait_seconds; attempt++)); do
+    response=$("$iii_bin" trigger harness::status --port "$engine_port" \
+      --json "{\"session_id\":\"$session_id\"}" \
+      2>>"$log_dir/first-capability-terminal.log" || true)
+    if jq -e '.status == "completed" and (.expects_wake // false) == false' \
+      <<<"$response" >/dev/null 2>&1; then
+      completed=1
+      break
+    fi
+    if jq -e '.status == "failed" or .status == "cancelled"' \
+      <<<"$response" >/dev/null 2>&1; then
+      die "first capability session reached terminal status $(jq -r '.status' <<<"$response")"
+    fi
+    sleep 1
+  done
+  ((completed == 1)) || die "first capability session did not reach durable completion"
+
+  log_command "iii trigger session::messages --port $engine_port --json '{\"session_id\":\"<capability-session>\",\"limit\":500}'"
+  transcript=$("$iii_bin" trigger session::messages --port "$engine_port" \
+    --json "{\"session_id\":\"$session_id\",\"limit\":500}" \
+    2>"$log_dir/first-capability-transcript.log") \
+    || die "could not load the first capability transcript"
+
+  call_count=$(jq -er --arg function "$capability_function" '
+    def normalized_function_id:
+      if .function_id == "agent_trigger"
+      then .arguments.function
+      else .function_id
+      end;
+    [
+      .messages[]?.message?
+      | select(.role == "assistant")
+      | .content[]?
+      | select(.type == "function_call")
+      | select(normalized_function_id == $function)
+    ] | length
+  ' <<<"$transcript") || die "could not inspect the first capability function call"
+  [[ "$call_count" == 1 ]] \
+    || die "expected exactly one durable $capability_function call, found $call_count"
+
+  result_count=$(jq -er \
+    --arg function "$capability_function" \
+    --arg marker "$capability_output_marker" '
+    [
+      .messages[]?.message?
+      | select(.role == "function_result")
+      | select(.function_id == $function)
+      | select((.is_error // false) == false)
+      | select(.details.exit_code == 0)
+      | select(.details.stdout == $marker)
+    ] | length
+  ' <<<"$transcript") || die "could not inspect the first capability result"
+  [[ "$result_count" == 1 ]] \
+    || die "$capability_function did not persist the expected successful output"
+
+  jq -n \
+    --arg session_id "$session_id" \
+    --arg function "$capability_function" \
+    --arg output_marker "$capability_output_marker" \
+    --arg status "$(jq -r '.status' <<<"$response")" \
+    --argjson expects_wake "$(jq -c '.expects_wake // false' <<<"$response")" \
+    --argjson call_count "$call_count" \
+    --argjson successful_result_count "$result_count" \
+    '{
+      schema_version: 1,
+      session_id: $session_id,
+      terminal: {status: $status, expects_wake: $expects_wake},
+      function: $function,
+      output_marker: $output_marker,
+      call_count: $call_count,
+      successful_result_count: $successful_result_count
+    }' >"$artifact_dir/first-capability-evidence.json"
+  ok "$capability_function completed once with the expected durable output"
 }
 
 artifacts_contain_secret() {
@@ -530,9 +628,10 @@ curl -fsS --retry 10 --retry-all-errors --retry-delay 1 \
   "http://127.0.0.1:$console_port/" -o "$artifact_dir/console.html"
 ok "Console answered on port $console_port"
 
-log "Step 8/9: Switch providers and start a new Luna conversation"
+log "Step 8/9: Validate provider switching and the first real capability"
 record_browser_video
 wait_for_terminal_turns
+verify_first_capability
 
 log "Step 9/9: Verify generated project files and secret-safe evidence"
 for output in config.yaml iii.lock; do


### PR DESCRIPTION
## Summary

- add a separate Console quickstart scenario for the first real Harness capability
- invoke `shell::exec` exactly once with a deterministic `printf` command
- verify the completed function card, exact output, final response, and reload persistence
- hard-gate the durable transcript on one successful call with `exit_code: 0` and the expected stdout
- preserve the provider-switch scenario from #796 and run both Playwright specs serially

## Why

The provider-switch quickstart proves model availability and session behavior, but it does not prove that a new user can execute and inspect a real Harness capability. This adds that complementary contract without requiring a second provider in the new scenario.

## Validation

- targeted Anthropic Playwright scenario: 1 passed in 17.5s
- durable status: completed with `expects_wake: false`
- durable transcript: one `shell::exec` call and one matching successful result
- Playwright discovery: 2 tests in 2 files
- Biome check
- `bash -n harness/tests/quickstart/run-ci.sh`
- `git diff --check`

## Playwright evidence

The recording shows the first Harness capability flow in Console, including the successful `shell::exec`, exact output, final response, and reload persistence.

[Watch the Playwright video recording](https://gist.githubusercontent.com/ytallo/d25e6a7ab7ffb53aae7bb6aaea0d90da/raw/8ddc1577bc00b73cd616cea25aa664ed2cea3999/playwright-first-capability.webm)

The video is a WebM generated by Playwright from the passing Anthropic run.

The OpenAI provider-switch scenario was not rerun locally because the configured account has no credit; its implementation is unchanged from #796.

Refs MOT-3250


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added quickstart coverage for executing the first real capability through `shell::exec`.
  - Verifies successful function and assistant responses, expected output, single execution, and state recovery after a console reload.
  - Captures browser and durable transcript evidence, including provider-switch recordings and raw test output.
  - Updated test execution to include both quickstart scenarios.

- **Documentation**
  - Expanded quickstart and CI guidance to explain capability validation and generated evidence artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->