### PR TITLE
(MOT-4407) fix(harness): report context usage truthfully

### DIFF
--- a/harness/src/context_snapshot.rs
+++ b/harness/src/context_snapshot.rs
@@ -16,9 +16,10 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use crate::clients::RouterClient;
+use crate::clients::{LoadedEntry, RouterClient};
 use crate::error::HarnessError;
 use crate::types::event::Usage;
+use crate::types::message::AgentMessage;
 use crate::types::model::AgentFunction;
 
 pub const CONTEXT_SCOPE: &str = "harness_context";
@@ -135,9 +136,8 @@ pub struct ContextSnapshotV1 {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub usage: Option<Usage>,
     /// Running cost of the whole session in USD, accumulated across every
-    /// generation step. `usage.cost_usd` is one step's bill — on providers
-    /// with steep cache discounts the per-step number swings two orders of
-    /// magnitude, so a chip showing it alone reads as a bouncing total.
+    /// generation step. Absent when any completed step did not report a cost:
+    /// a partial sum must not be presented as the whole session's bill.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_cost_usd: Option<f64>,
     pub timestamp: i64,
@@ -178,6 +178,31 @@ pub async fn delete(
     timeout_ms: u64,
 ) -> Result<(), HarnessError> {
     crate::state::state_delete(iii, CONTEXT_SCOPE, session_id, timeout_ms).await
+}
+
+/// Sum every prior assistant generation on the active transcript plus the
+/// current generation. The deterministic current entry is skipped because a
+/// redelivered step may already have appended or updated it. Any missing price
+/// makes the whole value unknown, matching `harness::metrics` completeness.
+pub(crate) fn session_cost_from_entries(
+    entries: &[LoadedEntry],
+    current_assistant_id: &str,
+    step_cost_usd: Option<f64>,
+) -> Option<f64> {
+    let previous = entries.iter().try_fold(0.0, |total, entry| {
+        if entry.entry_id == current_assistant_id {
+            return Some(total);
+        }
+        let Some(AgentMessage::Assistant(assistant)) = &entry.message else {
+            return Some(total);
+        };
+        assistant
+            .usage
+            .as_ref()
+            .and_then(|usage| usage.cost_usd)
+            .map(|cost| total + cost)
+    })?;
+    step_cost_usd.map(|cost| previous + cost)
 }
 
 /// A cached count and the estimator that answered it. Caching the estimator
@@ -250,7 +275,7 @@ impl Part<'_> {
     }
 }
 
-/// One part's provider-exact token count.
+/// One part's tokenizer-derived token count.
 #[derive(Debug, Default)]
 struct Counted {
     tokens: u64,
@@ -275,7 +300,7 @@ async fn probe_base(router: &RouterClient, model: &str, provider: Option<&str>) 
     Some(base)
 }
 
-/// Provider-exact tokens for one part: count(probe + part) - `base`, cached
+/// Tokenizer-derived tokens for one part: count(probe + part) - `base`, cached
 /// by content. `None` means the provider count failed and the caller must
 /// keep its heuristic numbers.
 async fn counted_delta(
@@ -304,10 +329,10 @@ async fn counted_delta(
     })
 }
 
-/// Replace the snapshot's estimated categories with provider-exact numbers
-/// where they exist: the generation's billed usage is the exact total, the
-/// system prompt and tool schemas are counted once via the provider's
-/// tokenizer (cached by content), and the message window is the remainder.
+/// Reconcile the snapshot against provider usage where it exists: the
+/// generation's billed usage supplies the prompt total, the system prompt and
+/// tool schemas are counted once via the configured tokenizer (cached by
+/// content), and the message window is the remainder.
 /// A rig without a provider counter keeps the heuristic snapshot untouched.
 pub async fn exactify(
     snapshot: &mut ContextSnapshotV1,
@@ -432,5 +457,56 @@ mod tests {
         value["from_the_future"] = serde_json::json!(true);
         let parsed: ContextSnapshotV1 = serde_json::from_value(value).unwrap();
         assert_eq!(parsed, snapshot);
+    }
+
+    #[test]
+    fn session_cost_requires_every_assistant_generation_to_be_known() {
+        let mut assistant = crate::types::message::empty_assistant("p", "m");
+        assistant.usage = Some(Usage {
+            cost_usd: Some(1.37),
+            ..Usage::default()
+        });
+        let mut entries = vec![LoadedEntry {
+            entry_id: "assistant_1".into(),
+            message: Some(AgentMessage::Assistant(assistant)),
+            custom: None,
+        }];
+
+        assert_eq!(
+            session_cost_from_entries(&[], "assistant_current", Some(0.42)),
+            Some(0.42)
+        );
+        assert_eq!(
+            session_cost_from_entries(&entries, "assistant_current", Some(0.42)),
+            Some(1.79)
+        );
+        assert_eq!(
+            session_cost_from_entries(&entries, "assistant_current", None),
+            None
+        );
+
+        let mut current = crate::types::message::empty_assistant("p", "m");
+        current.usage = Some(Usage {
+            cost_usd: Some(99.0),
+            ..Usage::default()
+        });
+        entries.push(LoadedEntry {
+            entry_id: "assistant_current".into(),
+            message: Some(AgentMessage::Assistant(current)),
+            custom: None,
+        });
+        assert_eq!(
+            session_cost_from_entries(&entries, "assistant_current", Some(0.42)),
+            Some(1.79)
+        );
+
+        let Some(AgentMessage::Assistant(assistant)) = &mut entries[0].message else {
+            unreachable!()
+        };
+        assistant.usage.as_mut().unwrap().cost_usd = None;
+        assert_eq!(
+            session_cost_from_entries(&entries, "assistant_current", Some(0.42)),
+            None
+        );
     }
 }

--- a/harness/src/turn_loop.rs
+++ b/harness/src/turn_loop.rs
@@ -735,44 +735,17 @@ pub async fn run_step(
     record.watermark_entry_id = watermark;
 
     // Stamp the generation's actual usage into the snapshot, replace the
-    // estimated categories with provider-exact counts where a counter
+    // estimated categories with tokenizer-derived counts where a counter
     // exists, and store the session's latest copy. Best-effort: accounting
     // must never fail a turn that generated successfully.
     if let Some(snapshot) = record.context_snapshot.as_mut() {
         snapshot.usage = outcome.message.usage.clone();
-        // Accumulate the session's running cost on top of the stored
-        // snapshot's total: turns are serialized per session (the harness-turn
-        // queue is fifo grouped by session_id) and steps run sequentially
-        // within a turn, so the loop is the only writer and the read-back is
-        // race-free. Seeding from the store keeps the total honest across
-        // turns and harness restarts. A failed read leaves the total unknown
-        // rather than fabricating one that resets to the current step's cost.
-        let step_cost = outcome
-            .message
-            .usage
-            .as_ref()
-            .and_then(|u| u.cost_usd)
-            .unwrap_or(0.0);
-        snapshot.session_cost_usd = match crate::context_snapshot::get(
-            &deps.iii,
-            &record.session_id,
-            cfg.session_timeout_ms,
-        )
-        .await
-        {
-            Ok(prev) => {
-                let prior_cost = prev.and_then(|p| p.session_cost_usd).unwrap_or(0.0);
-                Some(prior_cost + step_cost)
-            }
-            Err(error) => {
-                tracing::warn!(
-                    session_id = %record.session_id,
-                    %error,
-                    "prior context snapshot read failed; session cost total unknown this step"
-                );
-                None
-            }
-        };
+        // The full active transcript was loaded before this generation. Sum
+        // its assistant usage with the current step, but only when every
+        // generation reported a price; a partial total is not a session bill.
+        let step_cost = outcome.message.usage.as_ref().and_then(|u| u.cost_usd);
+        snapshot.session_cost_usd =
+            crate::context_snapshot::session_cost_from_entries(&entries, &assistant_id, step_cost);
         crate::context_snapshot::exactify(snapshot, &router, gen_system_prompt.as_deref(), &tools)
             .await;
         if let Err(error) =

--- a/harness/tests/golden/schemas/harness.metrics.json
+++ b/harness/tests/golden/schemas/harness.metrics.json
@@ -54,7 +54,7 @@
             ]
           },
           "session_cost_usd": {
-            "description": "Running cost of the whole session in USD, accumulated across every generation step. `usage.cost_usd` is one step's bill — on providers with steep cache discounts the per-step number swings two orders of magnitude, so a chip showing it alone reads as a bouncing total.",
+            "description": "Running cost of the whole session in USD, accumulated across every generation step. Absent when any completed step did not report a cost: a partial sum must not be presented as the whole session's bill.",
             "format": "double",
             "type": [
               "number",

--- a/harness/ui/package.json
+++ b/harness/ui/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && node build.mjs",
+    "test": "vitest run",
     "watch": "node build.mjs --watch"
   },
   "dependencies": {
@@ -13,6 +14,7 @@
   "devDependencies": {
     "@types/react": "^19.2.14",
     "esbuild": "^0.25.0",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "vitest": "^4.1.6"
   }
 }

--- a/harness/ui/src/context-chip/index.tsx
+++ b/harness/ui/src/context-chip/index.tsx
@@ -14,10 +14,14 @@ import type { Host } from '@iii-dev/console-ui'
 import { formatCost, formatTokens } from '../lib/format'
 import {
   type ContextSnapshot,
-  type SnapshotUsage,
   isSnapshot,
 } from '../lib/metrics'
 import { TONE_COLOR, toneFor } from '../lib/tone'
+import {
+  accountingProvenance,
+  outputUsagePresentation,
+  promptUsagePresentation,
+} from './presentation'
 
 /** Per-tab handler id (host.iii.on namespaces it `::<browserId>`). */
 const STATE_FN = 'iii::harness-ui::ctx-state'
@@ -115,28 +119,6 @@ function categories(snapshot: ContextSnapshot): Category[] {
   ]
 }
 
-/**
- * The prompt cache view of the last generation. Providers bill a cache read
- * at a fraction of fresh input and a cache write at a premium, so on a long
- * session the hit rate drives cost more than the window size does. `null`
- * when the provider reported no cache activity at all.
- */
-function cacheSummary(usage: SnapshotUsage | undefined) {
-  const read = usage?.cache_read ?? 0
-  const write = usage?.cache_write ?? 0
-  if (read === 0 && write === 0) return null
-  const prompt = (usage?.input ?? 0) + read + write
-  const hitPct = prompt > 0 ? Math.round((read / prompt) * 100) : 0
-  return {
-    read,
-    write,
-    hitPct,
-    // A cold or broken prefix means the whole prompt is re-billed at the
-    // write premium every turn, which is worth flagging rather than dimming.
-    tone: hitPct >= 70 ? 'ok' : hitPct < 30 ? 'warn' : 'plain',
-  }
-}
-
 interface LegendEntry {
   key: string
   label: string
@@ -229,9 +211,16 @@ function ContextPopover({
     usable > 0 ? Math.round(Math.min(1, snapshot.total / usable) * 100) : 0
   const cats = categories(snapshot)
   const usage = snapshot.usage
-  const hasActuals =
-    usage != null && (usage.input != null || usage.cache_read != null)
-  const cache = cacheSummary(usage)
+  const prompt = promptUsagePresentation(usage)
+  const output = outputUsagePresentation(usage)
+  const cacheTone =
+    prompt?.hitPct == null
+      ? 'plain'
+      : prompt.hitPct >= 70
+        ? 'ok'
+        : prompt.hitPct < 30
+          ? 'warn'
+          : 'plain'
   return (
     <div className="harness-ui-pop" role="dialog" aria-label="context breakdown">
       <div className="harness-ui-pop-head">
@@ -269,44 +258,57 @@ function ContextPopover({
         ))}
       </div>
       <div className="harness-ui-pop-foot">
-        <span>
-          {!snapshot.estimator || snapshot.estimator === 'heuristic'
-            ? `est. ${snapshot.estimator ?? 'unknown'}`
-            : `exact · ${
-                snapshot.estimator === 'provider'
-                  ? 'provider tokenizer'
-                  : snapshot.estimator
-              }`}
-        </span>
-        {hasActuals ? (
+        <span>{accountingProvenance(snapshot)}</span>
+        {prompt ? (
+          <span
+            title={
+              'Fresh tokens missed the prompt cache. Cached tokens were reused. ' +
+              'Cache creation is shown only when the provider reports it.'
+            }
+          >
+            prompt {formatTokens(prompt.total)} total ·{' '}
+            {formatTokens(prompt.fresh)} fresh
+            {prompt.cached != null ? (
+              <> · {formatTokens(prompt.cached)} cached</>
+            ) : null}
+            {prompt.cacheCreation != null ? (
+              <> · {formatTokens(prompt.cacheCreation)} cache creation</>
+            ) : null}
+            {prompt.hitPct != null ? (
+              <>
+                {' · '}
+                <span className="harness-ui-cache-hit" data-tone={cacheTone}>
+                  {prompt.hitPct}% hit
+                </span>
+              </>
+            ) : null}
+          </span>
+        ) : null}
+        {output ? (
           <span>
-            last step {formatTokens(usage?.input ?? 0)} in · output{' '}
-            {formatTokens(usage?.output ?? 0)}
-            {usage?.cost_usd != null ? <> · {formatCost(usage.cost_usd)}</> : null}
+            output {formatTokens(output.output)}
+            {output.reasoning != null ? (
+              <>
+                {' · '}reasoning {formatTokens(output.reasoning)} (included in
+                output)
+              </>
+            ) : null}
+            {usage?.cost_usd != null ? (
+              <> · {formatCost(usage.cost_usd)}</>
+            ) : null}
           </span>
         ) : null}
-        {cache ? (
+        {usage ? (
           <span
             title={
-              'cache read is billed at a fraction of fresh input; cache write ' +
-              'carries a premium. Hit rate is the cached share of the prompt.'
+              snapshot.session_cost_usd != null
+                ? 'Every generation step of this session summed.'
+                : 'At least one generation did not report a USD cost, so a partial total is not shown.'
             }
           >
-            cache {formatTokens(cache.read)} read ·{' '}
-            {formatTokens(cache.write)} write ·{' '}
-            <span className="harness-ui-cache-hit" data-tone={cache.tone}>
-              {cache.hitPct}% hit
-            </span>
-          </span>
-        ) : null}
-        {snapshot.session_cost_usd != null ? (
-          <span
-            title={
-              'every generation step of this session summed. The per-step ' +
-              'cost on the line above swings with cache hits; this one only grows.'
-            }
-          >
-            session total {formatCost(snapshot.session_cost_usd)}
+            {snapshot.session_cost_usd != null
+              ? `session total ${formatCost(snapshot.session_cost_usd)}`
+              : 'session cost unavailable'}
           </span>
         ) : null}
       </div>

--- a/harness/ui/src/context-chip/presentation.test.ts
+++ b/harness/ui/src/context-chip/presentation.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import type { ContextSnapshot } from '../lib/metrics'
+import {
+  accountingProvenance,
+  outputUsagePresentation,
+  promptUsagePresentation,
+} from './presentation'
+
+const snapshot = (overrides: Partial<ContextSnapshot> = {}): ContextSnapshot => ({
+  session_id: 's_1',
+  turn_id: 't_1',
+  step: 31,
+  model: 'glm-5.3',
+  provider: 'zai',
+  estimator: 'tokenizer',
+  usable: 948_000,
+  effective_max_output_tokens: 32_000,
+  total: 86_280,
+  free: 861_720,
+  categories: {
+    system_prompt: 7_005,
+    tools: 75,
+    messages: {
+      user: 79_200,
+      assistant: 0,
+      function_result: 0,
+      custom: 0,
+    },
+    overhead: 0,
+  },
+  compacted: false,
+  timestamp: 1,
+  usage: {
+    input: 1_544,
+    output: 1_141,
+    cache_read: 84_736,
+    reasoning: 41,
+  },
+  ...overrides,
+})
+
+describe('accountingProvenance', () => {
+  it('separates the provider prompt total from the local tokenizer breakdown', () => {
+    expect(accountingProvenance(snapshot())).toBe(
+      'prompt total: provider usage · breakdown: local tokenizer',
+    )
+  })
+
+  it('separates provider totals from heuristic and pre-response breakdowns', () => {
+    expect(
+      accountingProvenance(snapshot({ estimator: 'heuristic' })),
+    ).toBe('prompt total: provider usage · breakdown: chars/4')
+    expect(
+      accountingProvenance(
+        snapshot({ estimator: 'heuristic', usage: undefined }),
+      ),
+    ).toBe('prompt total: estimated · breakdown: chars/4')
+    expect(
+      accountingProvenance(snapshot({ estimator: 'provider' })),
+    ).toBe('prompt total: provider usage · breakdown: provider tokenizer')
+  })
+})
+
+describe('promptUsagePresentation', () => {
+  it('reconciles the live GLM-5.3 fresh and cached prompt usage', () => {
+    expect(promptUsagePresentation(snapshot().usage)).toEqual({
+      fresh: 1_544,
+      cached: 84_736,
+      cacheCreation: undefined,
+      hitPct: 98,
+      total: 86_280,
+    })
+  })
+
+  it('keeps an absent cache-write metric distinct from a reported zero', () => {
+    expect(promptUsagePresentation({ input: 10, cache_read: 5 })).toEqual({
+      fresh: 10,
+      cached: 5,
+      cacheCreation: undefined,
+      hitPct: 33,
+      total: 15,
+    })
+    expect(
+      promptUsagePresentation({ input: 10, cache_read: 5, cache_write: 0 }),
+    ).toEqual({
+      fresh: 10,
+      cached: 5,
+      cacheCreation: 0,
+      hitPct: 33,
+      total: 15,
+    })
+  })
+
+  it('does not invent a cache-hit percentage when cache reads were not reported', () => {
+    expect(promptUsagePresentation({ input: 10, cache_write: 5 })).toEqual({
+      fresh: 10,
+      cached: undefined,
+      cacheCreation: 5,
+      hitPct: undefined,
+      total: 15,
+    })
+  })
+
+  it('does not invent prompt usage when the provider reported none', () => {
+    expect(promptUsagePresentation(undefined)).toBeNull()
+    expect(promptUsagePresentation({ output: 12 })).toBeNull()
+  })
+})
+
+describe('outputUsagePresentation', () => {
+  it('keeps reasoning as a reported subset of output', () => {
+    expect(outputUsagePresentation(snapshot().usage)).toEqual({
+      output: 1_141,
+      reasoning: 41,
+    })
+  })
+
+  it('omits absent and zero reasoning without inventing output', () => {
+    expect(outputUsagePresentation({ output: 12 })).toEqual({
+      output: 12,
+      reasoning: undefined,
+    })
+    expect(outputUsagePresentation({ output: 12, reasoning: 0 })).toEqual({
+      output: 12,
+      reasoning: undefined,
+    })
+    expect(outputUsagePresentation({ reasoning: 4 })).toBeNull()
+  })
+})

--- a/harness/ui/src/context-chip/presentation.ts
+++ b/harness/ui/src/context-chip/presentation.ts
@@ -1,0 +1,78 @@
+import type {
+  ContextSnapshot,
+  SnapshotUsage,
+} from '../lib/metrics'
+
+export interface PromptUsagePresentation {
+  fresh: number
+  cached?: number
+  cacheCreation?: number
+  hitPct?: number
+  total: number
+}
+
+export interface OutputUsagePresentation {
+  output: number
+  /** A subset of output, not an additional token charge. */
+  reasoning?: number
+}
+
+function hasProviderPromptUsage(usage: SnapshotUsage | undefined) {
+  return (
+    usage?.input != null ||
+    usage?.cache_read != null ||
+    usage?.cache_write != null
+  )
+}
+
+export function promptUsagePresentation(
+  usage: SnapshotUsage | undefined,
+): PromptUsagePresentation | null {
+  if (!hasProviderPromptUsage(usage)) return null
+
+  const fresh = usage?.input ?? 0
+  const cached = usage?.cache_read
+  const cacheCreation = usage?.cache_write
+  const total = fresh + (cached ?? 0) + (cacheCreation ?? 0)
+
+  return {
+    fresh,
+    cached,
+    cacheCreation,
+    hitPct:
+      cached != null && total > 0
+        ? Math.round((cached / total) * 100)
+        : undefined,
+    total,
+  }
+}
+
+function breakdownSource(estimator: string | undefined) {
+  if (!estimator || estimator === 'heuristic') return 'chars/4'
+  if (estimator === 'provider') return 'provider tokenizer'
+  if (estimator === 'tokenizer' || estimator === 'tiktoken') {
+    return 'local tokenizer'
+  }
+  return estimator
+}
+
+export function accountingProvenance(snapshot: ContextSnapshot) {
+  const prompt = promptUsagePresentation(snapshot.usage)
+
+  return `prompt total: ${
+    prompt != null ? 'provider usage' : 'estimated'
+  } · breakdown: ${breakdownSource(snapshot.estimator)}`
+}
+
+export function outputUsagePresentation(
+  usage: SnapshotUsage | undefined,
+): OutputUsagePresentation | null {
+  if (usage?.output == null) return null
+  return {
+    output: usage.output,
+    reasoning:
+      usage.reasoning != null && usage.reasoning > 0
+        ? usage.reasoning
+        : undefined,
+  }
+}

--- a/harness/ui/src/lib/metrics.ts
+++ b/harness/ui/src/lib/metrics.ts
@@ -46,7 +46,7 @@ export interface ContextSnapshot {
   compacted: boolean
   summarized_head_tokens?: number
   usage?: SnapshotUsage
-  /** Running cost of the whole session, summed across generation steps. */
+  /** Running cost of the whole session when every generation reported one. */
   session_cost_usd?: number | null
   timestamp: number
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,6 +363,9 @@ importers:
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0))
 
   iii-directory/ui:
     dependencies:


### PR DESCRIPTION
Refs MOT-4407

## What

- make the Harness context chip provider-agnostic and explicit about where each number comes from
- separate provider-reported prompt totals from provider-tokenizer, local-tokenizer, or chars-per-four breakdowns
- show cache creation, cache hits, and reasoning only when the provider reports them
- derive session cost from the complete assistant transcript and report it as unavailable when any generation lacks pricing
- exclude the deterministic current assistant entry during redelivery so a retried step cannot be double-counted
- add focused presentation tests and update the metrics schema

## Why

The context popover previously described mixed accounting as `exact · tokenizer`, rendered absent cache fields as zero, and could present a partial or missing price as a complete session total. GLM-5.3 made the mismatch visible, but the issue was in the shared Harness layer.

This applies to every current and future provider through the common `Usage` contract. Provider adapters remain responsible only for accurately parsing the usage fields their API returns.

## Verification

- `cargo fmt --manifest-path harness/Cargo.toml --all -- --check`
- `SKIP_UI_BUILD=1 cargo clippy --manifest-path harness/Cargo.toml -p harness --all-targets --all-features -- -D warnings`
- `SKIP_UI_BUILD=1 cargo test --manifest-path harness/Cargo.toml -p harness --all-features` (329 tests)
- `pnpm --dir harness/ui test` (8 tests)
- `pnpm --dir harness/ui build`
- isolated Harness integration playground UI-001 scenario passed in Chromium; the popover showed provider usage, local breakdown, truthful cache/cost state, and no console warnings or errors
- `git diff --check`
