### PR TITLE
chore(provider-opencode-go): set initial version 0.1.0

### DIFF
--- a/provider-opencode-go/Cargo.lock
+++ b/provider-opencode-go/Cargo.lock
@@ -1275,7 +1275,7 @@ dependencies = [
 
 [[package]]
 name = "provider-opencode-go"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "clap",
  "futures",

--- a/provider-opencode-go/Cargo.toml
+++ b/provider-opencode-go/Cargo.toml
@@ -1,11 +1,8 @@
 [workspace]
 
-# 0.3.x: the provider-opencode-go/v0.1.0–v0.2.1 tags belong to a retired
-# bundled Node provider; this lineage starts above them so Create Tag never
-# collides.
 [package]
 name = "provider-opencode-go"
-version = "1.0.0"
+version = "0.1.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0"


### PR DESCRIPTION
## What

Set `provider-opencode-go` to `0.1.0` ahead of its first registry release.

## Why

The worker merged with `version = "1.0.0"`, but a fresh worker with no production use starts at `0.x`. First Release Control cut targets `0.1.0-experimental@next`, so the manifest baseline must sit below it.

The removed Cargo.toml comment claimed `provider-opencode-go/v0.1.0`–`v0.2.1` tags exist from a retired bundled Node provider; no such tags, releases, or registry versions exist, so nothing collides.
