### PR TITLE
fix(harness): restore E2E dashboard build after benchmark-site removal

### DIFF
--- a/harness/tests/e2e/assets/dashboard/README.md
+++ b/harness/tests/e2e/assets/dashboard/README.md
@@ -1,0 +1,92 @@
+# Harness E2E benchmark dashboard
+
+This static shell replaces the generic benchmark-action index at
+`dev/harness-e2e/`. The workflow-generated `data.js` remains the source of truth
+for metric trends. `executions.js` indexes workflow attempts, and
+`runs/<execution-id>.json` supplies the retained execution report.
+
+Start the local dashboard from the repository root:
+
+```bash
+cargo build --locked --manifest-path harness/Cargo.toml -p harness-e2e
+harness/target/debug/harness-e2e dashboard
+```
+
+The dashboard can now execute one or more scenarios against the Harness already
+running at `III_URL`. It discovers registered provider/model pairs from that
+stack and scenario ids from the same E2E binary. The primary form only asks for an
+optional label, a subject model, and scenarios; URL, judge override, run count,
+and technical retries remain under **Advanced options** with safe defaults. Use
+**Refresh catalog** after restarting the Harness or changing its URL. The binary
+runs only one experiment at a time, streams its log, indexes the resulting
+`results.json`, and keeps run metadata and logs under
+`target/harness-e2e-local-runs/`.
+
+The dashboard executes itself as an isolated child process, so changing and
+restarting the Harness never recompiles the E2E client. `serve` is an alias for
+`dashboard`; neither command has a Cargo fallback.
+
+`local-runner.js` owns the browser-side execution controls and is loaded only
+when `executions.js` declares `mode: "local"`. The Pages publisher always emits
+`mode: "published"`, so the published dashboard keeps using only its static
+history and never calls the loopback execution APIs.
+
+The execution label is optional and intentionally descriptive only. The local
+dashboard does not inspect or record Harness code changes: restart or modify the
+Harness however you want, run another experiment, then select any two execution
+rows and open **Compare selected**. The comparison always remains available;
+different subjects, run counts, scenario sets, and behavioral contracts are
+shown as warnings instead of blocking the comparison.
+
+The listener is deliberately restricted to loopback. Over SSH, forward it with:
+
+```bash
+ssh -L 4173:127.0.0.1:4173 user@host
+```
+
+Use `--listen 127.0.0.1:PORT` to select another port and `--runs-dir` to select
+another local history. The WebSocket URL is accessed on the host by the runner
+and does not need a browser-side port forward.
+
+To preview the sample fixtures instead, serve `harness/tests/e2e/assets/dashboard` directly:
+
+```bash
+python3 -m http.server 4173 --directory harness/tests/e2e/assets/dashboard
+```
+
+When generated data is absent, the pages load their sample fixtures and label
+the view as preview data. Test both data contracts with:
+
+```bash
+node --test harness/tests/e2e/assets/dashboard/*.test.cjs
+```
+
+Metric names are stable identifiers:
+
+```text
+<quality|efficiency|reliability>::<subject>::<scenario|suite>::<metric>
+```
+
+The execution index retains 100 workflow attempts. The latest 30 also retain the
+complete execution report: per-run prompts, transcripts, criteria, metrics,
+costs, retries, hard gates, traces, and failure evidence. Each publish updates
+the retained report metadata and removes unreferenced run files before deploying
+Pages.
+
+Each full execution summary also carries compact per-scenario averages for
+tokens, wall time, cost, function calls, function-call errors, sessions, and
+turns. Tokens mean input plus output; cache-read tokens are already represented
+in input usage and are not added again. The execution table also exposes exact
+total tokens and function calls for every retained diagnostic report.
+
+Operational health is the primary overview. Efficiency appears after the latest
+status, completeness, first actionable failure, KPIs, and scenario matrix. Its
+cards show current suite totals, while deltas use only successful scenarios with the same subject,
+scenario id, and behavioral contract fingerprint. New and changed scenarios
+collect five comparable executions before receiving a trend verdict. Removed
+scenarios remain visible as historical rows and never count as an efficiency
+gain. Contract changes start a new baseline instead of joining incompatible data.
+Select any scenario in the efficiency table to compare that scenario execution
+by execution. The modal switches between cost, tokens, duration, function calls,
+and function errors, marks contract boundaries, and links each point to its full
+execution details.

--- a/harness/tests/e2e/assets/dashboard/compare.html
+++ b/harness/tests/e2e/assets/dashboard/compare.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Compare two Harness E2E executions.">
+    <meta name="color-scheme" content="dark light">
+    <title>Compare Harness E2E executions</title>
+    <link rel="stylesheet" href="./styles.css">
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to comparison</a>
+    <div class="ambient ambient-one" aria-hidden="true"></div>
+    <div class="ambient ambient-two" aria-hidden="true"></div>
+
+    <header class="topbar">
+      <a class="brand" href="./index.html" aria-label="Harness E2E dashboard">
+        <span class="brand-copy"><strong>iii</strong><span>Harness benchmarks</span></span>
+      </a>
+      <nav class="topbar-actions" aria-label="Comparison actions">
+        <a class="button" href="./index.html">← All executions</a>
+      </nav>
+    </header>
+
+    <main id="main" class="page-shell compare-shell">
+      <section class="page-heading" aria-labelledby="page-title">
+        <div>
+          <div class="eyebrow"><span class="live-dot" aria-hidden="true"></span>Local E2E</div>
+          <h1 id="page-title">Execution comparison</h1>
+          <p>Execution B minus execution A. Different scenarios and contracts remain visible.</p>
+        </div>
+      </section>
+
+      <section id="compare-empty" class="empty-state" hidden>
+        <div class="empty-icon" aria-hidden="true">⌁</div>
+        <h2>Select two existing executions</h2>
+        <p>Return to the execution dashboard and mark any two rows for comparison.</p>
+      </section>
+
+      <div id="compare-content" class="compare-content" hidden>
+        <section class="panel" aria-labelledby="selected-heading">
+          <div class="panel-heading">
+            <div>
+              <div class="section-kicker">Selection</div>
+              <h2 id="selected-heading">A versus B</h2>
+            </div>
+          </div>
+          <div id="compare-selection" class="compare-selection-grid"></div>
+          <ul id="compare-warnings" class="compare-warning-list"></ul>
+        </section>
+
+        <section class="panel executions-panel" aria-labelledby="overall-heading">
+          <div class="panel-heading">
+            <div>
+              <div class="section-kicker">Whole execution</div>
+              <h2 id="overall-heading">Overall delta</h2>
+              <p class="trend-description">Positive and negative deltas always mean B minus A.</p>
+            </div>
+          </div>
+          <div id="compare-metrics" class="compare-metric-grid"></div>
+        </section>
+
+        <section class="panel executions-panel" aria-labelledby="scenario-heading">
+          <div class="panel-heading">
+            <div>
+              <div class="section-kicker">Per scenario</div>
+              <h2 id="scenario-heading">Scenario deltas</h2>
+              <p class="trend-description">Changed contracts are compared but explicitly marked.</p>
+            </div>
+          </div>
+          <div class="table-wrap">
+            <table class="compare-table">
+              <thead>
+                <tr>
+                  <th scope="col">Scenario</th>
+                  <th scope="col">Execution A</th>
+                  <th scope="col">Execution B</th>
+                  <th scope="col">Δ score</th>
+                  <th scope="col">Δ tokens</th>
+                  <th scope="col">Δ cost</th>
+                  <th scope="col">Δ time</th>
+                  <th scope="col">Contract</th>
+                </tr>
+              </thead>
+              <tbody id="compare-scenarios"></tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </main>
+
+    <script>window.HARNESS_EXECUTIONS = window.HARNESS_EXECUTIONS || null;</script>
+    <script src="./execution-data.js"></script>
+    <script src="./executions.js"></script>
+    <script src="./compare.js"></script>
+  </body>
+</html>

--- a/harness/tests/e2e/assets/dashboard/compare.js
+++ b/harness/tests/e2e/assets/dashboard/compare.js
@@ -1,0 +1,198 @@
+(function renderHarnessExecutionComparison() {
+  "use strict";
+
+  const api = window.HarnessExecutionData;
+  const manifest = window.HARNESS_EXECUTIONS || { executions: [] };
+  const history = {
+    executions: (manifest.executions || []).map(api.normalizeExecution),
+  };
+  const parameters = new URLSearchParams(window.location.search);
+  const left = api.findExecution(history, parameters.get("left") || "");
+  const right = api.findExecution(history, parameters.get("right") || "");
+  const elements = {
+    content: document.querySelector("#compare-content"),
+    empty: document.querySelector("#compare-empty"),
+    metrics: document.querySelector("#compare-metrics"),
+    scenarios: document.querySelector("#compare-scenarios"),
+    selection: document.querySelector("#compare-selection"),
+    warnings: document.querySelector("#compare-warnings"),
+  };
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  function number(value, digits = 1) {
+    return typeof value === "number" && Number.isFinite(value)
+      ? new Intl.NumberFormat("en-US", { maximumFractionDigits: digits }).format(value)
+      : "—";
+  }
+
+  function percent(value) {
+    return typeof value === "number" ? `${number(value, 1)}%` : "—";
+  }
+
+  function currency(value) {
+    return typeof value === "number"
+      ? new Intl.NumberFormat("en-US", {
+          style: "currency",
+          currency: "USD",
+          minimumFractionDigits: value < 1 ? 3 : 2,
+          maximumFractionDigits: value < 1 ? 3 : 2,
+        }).format(value)
+      : "—";
+  }
+
+  function duration(value) {
+    if (typeof value !== "number") return "—";
+    if (Math.abs(value) < 60) return `${number(value, 1)}s`;
+    const sign = value < 0 ? "−" : "";
+    const absolute = Math.abs(value);
+    return `${sign}${Math.floor(absolute / 60)}m ${String(Math.round(absolute % 60)).padStart(2, "0")}s`;
+  }
+
+  function date(value) {
+    return value && !Number.isNaN(Date.parse(value))
+      ? new Intl.DateTimeFormat("en-US", {
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+        }).format(new Date(value))
+      : "Unknown date";
+  }
+
+  function status(value) {
+    return {
+      passed: "Passed",
+      hard_gate_failed: "Hard gate failed",
+      technical_failed: "Technical failure",
+      infra_failed: "Infrastructure failure",
+      incomplete: "Incomplete",
+      cancelled: "Cancelled",
+    }[value] || "Unknown";
+  }
+
+  function subjectSummary(execution) {
+    const subjects = (execution.subjects || []).map(
+      (subject) => `${subject.provider || "unknown"}/${subject.model || "unknown"}`,
+    );
+    return subjects.length === 1 ? subjects[0] : `${subjects.length} subjects`;
+  }
+
+  function selectionCard(execution, side) {
+    const label = execution.label || date(execution.completed_at);
+    return `
+      <article class="compare-selection-card">
+        <span>Execution ${side}</span>
+        <h2>${escapeHtml(label)}</h2>
+        <div class="compare-selection-meta">
+          <small>${escapeHtml(date(execution.completed_at))}</small>
+          <small>${escapeHtml(subjectSummary(execution))}</small>
+          <small>${escapeHtml(status(execution.status))}</small>
+          <small>${number(execution.requested_runs, 0)} run${execution.requested_runs === 1 ? "" : "s"}</small>
+        </div>
+        <a class="text-link" href="./execution.html?id=${encodeURIComponent(execution.id)}">Open diagnostic detail →</a>
+      </article>`;
+  }
+
+  function signed(value, formatter) {
+    if (typeof value !== "number") return "—";
+    if (value === 0) return formatter(0);
+    return `${value > 0 ? "+" : ""}${formatter(value)}`;
+  }
+
+  function renderMetric(definition, comparison) {
+    const values = definition.values(comparison);
+    let deltaClass = "";
+    if (typeof values.delta === "number" && values.delta !== 0) {
+      const improved = definition.lowerIsBetter ? values.delta < 0 : values.delta > 0;
+      deltaClass = improved ? "compare-delta-improved" : "compare-delta-regressed";
+    }
+    return `
+      <article class="compare-metric-card">
+        <span>${escapeHtml(definition.label)}</span>
+        <div class="compare-metric-values">
+          <strong>${definition.format(values.left)}</strong>
+          <small>→ ${definition.format(values.right)}</small>
+        </div>
+        <div class="compare-delta ${deltaClass}">${signed(values.delta, definition.format)} B−A</div>
+      </article>`;
+  }
+
+  function blockingFailures(execution) {
+    return ["hard_gate_failures", "technical_failures", "missing_reports"].reduce(
+      (total, field) => total + Number(execution.totals?.[field] || 0),
+      0,
+    );
+  }
+
+  function sideScenario(value) {
+    if (!value) return '<span class="text-incomplete">Not run</span>';
+    const score = typeof value.score === "number" ? ` · score ${number(value.score, 1)}` : "";
+    const passRate =
+      typeof value.passRate === "number" ? ` · ${number(value.passRate * 100, 1)}% pass` : "";
+    return `<span class="table-status status-${value.status === "passed" ? "pass" : "fail"}">${escapeHtml(status(value.status))}</span>${score}${passRate}`;
+  }
+
+  if (!left || !right || left.id === right.id) {
+    elements.empty.hidden = false;
+    return;
+  }
+
+  const comparison = api.compareExecutions(left, right);
+  elements.content.hidden = false;
+  elements.selection.innerHTML =
+    selectionCard(comparison.left, "A") + selectionCard(comparison.right, "B");
+  elements.warnings.innerHTML = comparison.warnings
+    .map((warning) => `<li>${escapeHtml(warning)}</li>`)
+    .join("");
+  elements.warnings.hidden = comparison.warnings.length === 0;
+
+  const metricDefinitions = [
+    { label: "Pass rate", format: percent, lowerIsBetter: false, values: (item) => item.totals.scenario_pass_rate },
+    { label: "Quality score", format: number, lowerIsBetter: false, values: (item) => item.totals.average_score },
+    {
+      label: "Blocking failures",
+      format: (value) => number(value, 0),
+      lowerIsBetter: true,
+      values: (item) => ({
+        left: blockingFailures(item.left),
+        right: blockingFailures(item.right),
+        delta: blockingFailures(item.right) - blockingFailures(item.left),
+      }),
+    },
+    { label: "Tokens", format: (value) => number(value, 0), lowerIsBetter: true, values: (item) => item.totals.total_tokens },
+    { label: "Function calls", format: (value) => number(value, 0), lowerIsBetter: true, values: (item) => item.totals.function_calls },
+    { label: "Cost", format: currency, lowerIsBetter: true, values: (item) => item.totals.total_cost_usd },
+    { label: "Runtime", format: duration, lowerIsBetter: true, values: (item) => item.totals.wall_time_seconds },
+  ];
+  elements.metrics.innerHTML = metricDefinitions
+    .map((definition) => renderMetric(definition, comparison))
+    .join("");
+
+  elements.scenarios.innerHTML = comparison.scenarios
+    .map((row) => `
+      <tr>
+        <th scope="row">
+          <div class="compare-scenario-name">
+            <span>${escapeHtml(row.subjectLabel)}</span>
+            <strong>${escapeHtml(row.scenarioId.replaceAll("_", " "))}</strong>
+          </div>
+        </th>
+        <td>${sideScenario(row.left)}</td>
+        <td>${sideScenario(row.right)}</td>
+        <td>${signed(row.deltas.score, (value) => number(value, 1))}</td>
+        <td>${signed(row.deltas.tokens, (value) => number(value, 0))}</td>
+        <td>${signed(row.deltas.cost_usd, currency)}</td>
+        <td>${signed(row.deltas.duration_seconds, duration)}</td>
+        <td><span class="comparison-contract comparison-contract-${escapeHtml(row.contract)}">${escapeHtml(row.contract)}</span></td>
+      </tr>`)
+    .join("");
+})();

--- a/harness/tests/e2e/assets/dashboard/coverage/index.html
+++ b/harness/tests/e2e/assets/dashboard/coverage/index.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="LLVM line coverage for the harness integration and E2E suites."
+    >
+    <meta name="color-scheme" content="dark light">
+    <title>Harness stack coverage</title>
+    <link rel="stylesheet" href="../styles.css">
+    <style>
+      .coverage-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+        gap: 1.25rem;
+      }
+      .coverage-card {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 1.5rem;
+      }
+      .coverage-card h2 {
+        margin: 0;
+      }
+      .coverage-percent {
+        font-size: 2.5rem;
+        font-weight: 700;
+        font-variant-numeric: tabular-nums;
+      }
+      .coverage-meta {
+        opacity: 0.75;
+        font-size: 0.875rem;
+      }
+      .coverage-links {
+        display: flex;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to coverage reports</a>
+    <div class="ambient ambient-one" aria-hidden="true"></div>
+    <div class="ambient ambient-two" aria-hidden="true"></div>
+
+    <header class="topbar">
+      <a class="brand" href="https://github.com/iii-hq/workers" aria-label="iii workers">
+        <span class="brand-copy">
+          <strong>iii</strong>
+          <span>Harness benchmarks</span>
+        </span>
+      </a>
+      <nav class="topbar-actions" aria-label="Dashboard actions">
+        <a class="button button-secondary" href="../index.html">Executions</a>
+        <a class="button button-secondary" href="../coverage-trend/">Trend</a>
+      </nav>
+    </header>
+
+    <main id="main" class="page-shell overview-shell">
+      <section class="page-heading" aria-labelledby="page-title">
+        <div>
+          <div class="eyebrow">
+            <span class="live-dot" aria-hidden="true"></span>
+            Harness stack
+          </div>
+          <h1 id="page-title">Code coverage</h1>
+          <p>LLVM line coverage of the instrumented stack, refreshed by the daily E2E cycle.</p>
+        </div>
+        <div class="sync-block">
+          <span id="sync-label">Last published</span>
+          <time id="last-update" datetime="">Waiting for data</time>
+        </div>
+      </section>
+
+      <section id="empty-state" class="empty-state" hidden>
+        <div class="empty-icon" aria-hidden="true">⌁</div>
+        <h2>No coverage published yet</h2>
+        <p>The next scheduled Harness E2E Daily workflow will publish the first reports here.</p>
+      </section>
+
+      <section id="coverage-content" class="coverage-grid" hidden>
+        <article class="panel coverage-card" id="card-integration">
+          <h2>Integration suite</h2>
+          <div class="coverage-percent" data-percent>–</div>
+          <div class="coverage-meta" data-meta>Not published yet.</div>
+          <div class="coverage-links">
+            <a class="button button-secondary" href="./integration/index.html" data-report hidden>
+              Browse report
+            </a>
+          </div>
+        </article>
+        <article class="panel coverage-card" id="card-e2e">
+          <h2>E2E suite</h2>
+          <div class="coverage-percent" data-percent>–</div>
+          <div class="coverage-meta" data-meta>Not published yet.</div>
+          <div class="coverage-links">
+            <a class="button button-secondary" href="./e2e/index.html" data-report hidden>
+              Browse report
+            </a>
+          </div>
+        </article>
+      </section>
+    </main>
+
+    <script>
+      window.HARNESS_COVERAGE = null;
+    </script>
+    <script src="./summary.js"></script>
+    <script>
+      (function () {
+        var data = window.HARNESS_COVERAGE;
+        var empty = document.getElementById("empty-state");
+        var content = document.getElementById("coverage-content");
+        var suites = data && data.suites ? data.suites : {};
+        var hasAny = Boolean(suites.e2e || suites.integration);
+        if (!hasAny) {
+          empty.hidden = false;
+          return;
+        }
+        content.hidden = false;
+
+        if (data.updated_at) {
+          var time = document.getElementById("last-update");
+          time.dateTime = data.updated_at;
+          time.textContent = new Date(data.updated_at).toLocaleString();
+        }
+
+        function render(cardId, summary) {
+          var card = document.getElementById(cardId);
+          if (!summary || !summary.totals || !summary.totals.lines) return;
+          var lines = summary.totals.lines;
+          card.querySelector("[data-percent]").textContent =
+            lines.percent.toFixed(1) + "%";
+          card.querySelector("[data-meta]").textContent =
+            (lines.covered != null ? lines.covered.toLocaleString() : "?") +
+            " of " + (lines.count != null ? lines.count.toLocaleString() : "?") +
+            " lines covered · " + (summary.generated_at || "");
+          card.querySelector("[data-report]").hidden = false;
+        }
+        render("card-integration", suites.integration);
+        render("card-e2e", suites.e2e);
+      })();
+    </script>
+  </body>
+</html>

--- a/harness/tests/e2e/assets/dashboard/dashboard-data.js
+++ b/harness/tests/e2e/assets/dashboard/dashboard-data.js
@@ -1,0 +1,374 @@
+(function initHarnessBenchmarkData(root, factory) {
+  const api = factory(root);
+  if (typeof module === "object" && module.exports) {
+    module.exports = api;
+  }
+  root.HarnessBenchmarkData = api;
+})(typeof globalThis !== "undefined" ? globalThis : this, function dashboardDataFactory(root) {
+  "use strict";
+
+  const METRIC_SEPARATOR = "::";
+
+  function parseExtra(extra) {
+    if (!extra || typeof extra !== "string") return {};
+    try {
+      const value = JSON.parse(extra);
+      return value && typeof value === "object" ? value : {};
+    } catch (_error) {
+      return {};
+    }
+  }
+
+  function parseMetricName(name) {
+    if (typeof name !== "string") return null;
+    const parts = name.split(METRIC_SEPARATOR);
+    if (parts.length !== 4 || parts.some((part) => !part)) return null;
+    const [category, subjectId, scenarioId, metricId] = parts;
+    return { category, subjectId, scenarioId, metricId };
+  }
+
+  function pointIdentity(record, extra) {
+    const lane = extra.lane || "unknown";
+    const commitId = record.commit?.id || extra.source?.sha || "unknown";
+    const releaseTag = extra.release?.tag || "";
+    const executionId = extra.execution?.id || "";
+    return `${lane}${METRIC_SEPARATOR}${executionId || releaseTag || commitId}`;
+  }
+
+  function emptyMetricTree() {
+    return {
+      quality: {},
+      reliability: {},
+      efficiency: {},
+    };
+  }
+
+  function ensureScenario(tree, category, scenarioId) {
+    if (!tree[category]) tree[category] = {};
+    if (!tree[category][scenarioId]) tree[category][scenarioId] = {};
+    return tree[category][scenarioId];
+  }
+
+  function normalizeBenchmarkData(raw) {
+    const data = raw && typeof raw === "object" ? raw : {};
+    const snapshots = new Map();
+    const entries = data.entries && typeof data.entries === "object" ? data.entries : {};
+
+    for (const records of Object.values(entries)) {
+      if (!Array.isArray(records)) continue;
+      for (const record of records) {
+        if (!record || !Array.isArray(record.benches)) continue;
+        for (const bench of record.benches) {
+          const parsed = parseMetricName(bench?.name);
+          if (!parsed || typeof bench.value !== "number" || !Number.isFinite(bench.value)) {
+            continue;
+          }
+          const extra = parseExtra(bench.extra);
+          const key = pointIdentity(record, extra);
+          if (!snapshots.has(key)) {
+            snapshots.set(key, {
+              id: key,
+              date: Number(record.date) || 0,
+              lane: extra.lane || "unknown",
+              commit: record.commit || {},
+              release: extra.release || {},
+              source: extra.source || {},
+              execution: extra.execution || {},
+              workflowUrl: extra.workflow_url || "",
+              generatedAt: extra.generated_at || "",
+              subjects: {},
+            });
+          }
+          const snapshot = snapshots.get(key);
+          snapshot.date = Math.max(snapshot.date, Number(record.date) || 0);
+          if (!snapshot.subjects[parsed.subjectId]) {
+            snapshot.subjects[parsed.subjectId] = {
+              id: parsed.subjectId,
+              model: extra.subject?.model || parsed.subjectId,
+              provider: extra.subject?.provider || "",
+              judge: extra.judge || {},
+              engineRevision: extra.engine_revision || "",
+              passed: extra.passed,
+              status: extra.status || "unknown",
+              requestedRuns: extra.requested_runs,
+              metrics: emptyMetricTree(),
+              metadata: extra,
+            };
+          }
+          const subject = snapshot.subjects[parsed.subjectId];
+          subject.metadata = { ...subject.metadata, ...extra };
+          if (parsed.scenarioId === "suite") {
+            subject.passed = extra.passed;
+            subject.status = extra.status || subject.status;
+          }
+          const scenario = ensureScenario(
+            subject.metrics,
+            parsed.category,
+            parsed.scenarioId,
+          );
+          scenario[parsed.metricId] = {
+            value: bench.value,
+            unit: bench.unit || "",
+            range: bench.range || "",
+            passed:
+              typeof extra.passed === "boolean" ? extra.passed : null,
+            status: extra.status || "unknown",
+          };
+        }
+      }
+    }
+
+    const normalizedSnapshots = [...snapshots.values()].sort(
+      (left, right) => left.date - right.date,
+    );
+    return {
+      repoUrl: data.repoUrl || "",
+      lastUpdate: Number(data.lastUpdate) || 0,
+      preview: Boolean(root.HARNESS_BENCHMARK_PREVIEW),
+      snapshots: normalizedSnapshots,
+      lanes: [...new Set(normalizedSnapshots.map((snapshot) => snapshot.lane))],
+      channels: [
+        ...new Set(
+          normalizedSnapshots.map(
+            (snapshot) => snapshot.release?.registry_tag || "manual",
+          ),
+        ),
+      ],
+      subjects: [
+        ...new Set(
+          normalizedSnapshots.flatMap((snapshot) => Object.keys(snapshot.subjects)),
+        ),
+      ],
+    };
+  }
+
+  function getMetric(subject, category, scenarioId, metricId) {
+    return subject?.metrics?.[category]?.[scenarioId]?.[metricId] || null;
+  }
+
+  function metricValue(subject, category, scenarioId, metricId) {
+    return getMetric(subject, category, scenarioId, metricId)?.value ?? null;
+  }
+
+  function listScenarios(subject) {
+    const scenarios = new Set();
+    for (const category of Object.values(subject?.metrics || {})) {
+      for (const scenarioId of Object.keys(category || {})) {
+        if (scenarioId !== "suite") scenarios.add(scenarioId);
+      }
+    }
+    return [...scenarios].sort();
+  }
+
+  function filterSnapshots(data, filters = {}) {
+    let snapshots = [...(data?.snapshots || [])];
+    if (filters.lane && filters.lane !== "all") {
+      snapshots = snapshots.filter((snapshot) => snapshot.lane === filters.lane);
+    }
+    if (filters.channel && filters.channel !== "all") {
+      snapshots = snapshots.filter(
+        (snapshot) =>
+          (snapshot.release?.registry_tag || "manual") === filters.channel,
+      );
+    }
+    if (filters.subjectId) {
+      snapshots = snapshots.filter((snapshot) =>
+        Boolean(snapshot.subjects[filters.subjectId]),
+      );
+    }
+    if (
+      filters.subjectId &&
+      filters.scenarioId &&
+      filters.scenarioId !== "all"
+    ) {
+      snapshots = snapshots.filter((snapshot) =>
+        listScenarios(snapshot.subjects[filters.subjectId]).includes(
+          filters.scenarioId,
+        ),
+      );
+    }
+    const days = Number(filters.days);
+    if (Number.isFinite(days) && days > 0 && snapshots.length > 0) {
+      const millisecondsPerDay = 24 * 60 * 60 * 1000;
+      const latestDay = Math.floor(
+        snapshots.at(-1).date / millisecondsPerDay,
+      );
+      const firstIncludedDay = latestDay - days + 1;
+      snapshots = snapshots.filter(
+        (snapshot) =>
+          Math.floor(snapshot.date / millisecondsPerDay) >= firstIncludedDay,
+      );
+    }
+    const limit = Number(filters.limit);
+    if (Number.isFinite(limit) && limit > 0 && snapshots.length > limit) {
+      snapshots = snapshots.slice(-limit);
+    }
+    return snapshots;
+  }
+
+  function subjectSummary(subject) {
+    if (!subject) return null;
+    const scenarios = listScenarios(subject);
+    const scores = scenarios
+      .map((scenarioId) =>
+        metricValue(subject, "quality", scenarioId, "median_score"),
+      )
+      .filter((value) => value !== null);
+    const averageScore =
+      scores.length > 0
+        ? scores.reduce((total, value) => total + value, 0) / scores.length
+        : null;
+    return {
+      passed: Boolean(subject.passed),
+      status: subject.status,
+      averageScore,
+      scenarioPassRate: metricValue(
+        subject,
+        "quality",
+        "suite",
+        "scenario_pass_rate",
+      ),
+      reportCoverage: metricValue(
+        subject,
+        "quality",
+        "suite",
+        "report_coverage",
+      ),
+      totalCost: metricValue(
+        subject,
+        "efficiency",
+        "suite",
+        "total_cost_usd",
+      ),
+      wallTime: metricValue(
+        subject,
+        "efficiency",
+        "suite",
+        "wall_time_seconds",
+      ),
+      hardGateFailures:
+        metricValue(
+          subject,
+          "reliability",
+          "suite",
+          "hard_gate_failures",
+        ) ?? 0,
+      technicalFailures:
+        metricValue(
+          subject,
+          "reliability",
+          "suite",
+          "technical_failures",
+        ) ?? 0,
+      missingReports:
+        metricValue(subject, "reliability", "suite", "missing_reports") ?? 0,
+      retries:
+        metricValue(subject, "reliability", "suite", "retry_attempts") ?? 0,
+      scenarios,
+    };
+  }
+
+  function scenarioSummary(subject, scenarioId) {
+    if (!subject) return null;
+    const scoreMetric = getMetric(
+      subject,
+      "quality",
+      scenarioId,
+      "median_score",
+    );
+    const passRateMetric = getMetric(
+      subject,
+      "quality",
+      scenarioId,
+      "pass_rate",
+    );
+    return {
+      id: scenarioId,
+      medianScore: scoreMetric?.value ?? null,
+      passed: scoreMetric?.passed ?? passRateMetric?.passed ?? false,
+      status: scoreMetric?.status ?? passRateMetric?.status ?? "unknown",
+      passRate: passRateMetric?.value ?? null,
+      totalCost: metricValue(
+        subject,
+        "efficiency",
+        scenarioId,
+        "total_cost_usd",
+      ),
+      wallTime: metricValue(
+        subject,
+        "efficiency",
+        scenarioId,
+        "wall_time_seconds",
+      ),
+      hardGateFailures:
+        metricValue(
+          subject,
+          "reliability",
+          scenarioId,
+          "hard_gate_failures",
+        ) ?? 0,
+      technicalFailures:
+        metricValue(
+          subject,
+          "reliability",
+          scenarioId,
+          "technical_failures",
+        ) ?? 0,
+      retries:
+        metricValue(
+          subject,
+          "reliability",
+          scenarioId,
+          "retry_attempts",
+        ) ?? 0,
+      missingReports:
+        metricValue(
+          subject,
+          "reliability",
+          scenarioId,
+          "missing_reports",
+        ) ?? 0,
+    };
+  }
+
+  function metricSeries(snapshots, subjectId, category, metricId) {
+    const series = new Map();
+    for (const snapshot of snapshots || []) {
+      const subject = snapshot.subjects?.[subjectId];
+      if (!subject) continue;
+      for (const scenarioId of listScenarios(subject)) {
+        const metric = getMetric(subject, category, scenarioId, metricId);
+        if (!metric) continue;
+        if (!series.has(scenarioId)) series.set(scenarioId, []);
+        series.get(scenarioId).push({
+          snapshotId: snapshot.id,
+          date: snapshot.date,
+          label:
+            snapshot.release?.tag ||
+            snapshot.commit?.id?.slice(0, 7) ||
+            "unknown",
+          value: metric.value,
+          unit: metric.unit,
+          snapshot,
+        });
+      }
+    }
+    return [...series.entries()].map(([scenarioId, points]) => ({
+      scenarioId,
+      points,
+    }));
+  }
+
+  return {
+    filterSnapshots,
+    getMetric,
+    listScenarios,
+    metricSeries,
+    metricValue,
+    normalizeBenchmarkData,
+    parseExtra,
+    parseMetricName,
+    scenarioSummary,
+    subjectSummary,
+  };
+});

--- a/harness/tests/e2e/assets/dashboard/dashboard-data.test.cjs
+++ b/harness/tests/e2e/assets/dashboard/dashboard-data.test.cjs
@@ -1,0 +1,164 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  filterSnapshots,
+  metricSeries,
+  normalizeBenchmarkData,
+  parseMetricName,
+  scenarioSummary,
+  subjectSummary,
+} = require("./dashboard-data.js");
+
+function record(date, value, name, extra = {}) {
+  return {
+    commit: { id: `commit-${date}`, message: "release" },
+    date,
+    benches: [
+      {
+        name,
+        unit: name.endsWith("cost_usd") ? "USD" : "percent",
+        value,
+        extra: JSON.stringify({
+          lane: "release",
+          release: {
+            tag: `harness/v${date}`,
+            worker: "harness",
+            registry_tag: "latest",
+          },
+          subject: { id: "glm", model: "glm-5.2", provider: "zai" },
+          passed: true,
+          ...extra,
+        }),
+      },
+    ],
+  };
+}
+
+test("parses the stable metric id contract", () => {
+  assert.deepEqual(parseMetricName("quality::glm::direct_answer::median_score"), {
+    category: "quality",
+    subjectId: "glm",
+    scenarioId: "direct_answer",
+    metricId: "median_score",
+  });
+  assert.equal(parseMetricName("invalid"), null);
+});
+
+test("merges quality and efficiency records for the same release", () => {
+  const raw = {
+    entries: {
+      "Harness E2E Quality": [
+        record(1, 90, "quality::glm::direct_answer::median_score"),
+        record(1, 100, "quality::glm::suite::scenario_pass_rate"),
+      ],
+      "Harness E2E Efficiency and Reliability": [
+        record(1, 0.42, "efficiency::glm::suite::total_cost_usd"),
+      ],
+    },
+  };
+
+  const data = normalizeBenchmarkData(raw);
+  assert.equal(data.snapshots.length, 1);
+  const subject = data.snapshots[0].subjects.glm;
+  const summary = subjectSummary(subject);
+  assert.equal(summary.averageScore, 90);
+  assert.equal(summary.scenarioPassRate, 100);
+  assert.equal(summary.totalCost, 0.42);
+  const scenario = scenarioSummary(subject, "direct_answer");
+  assert.equal(scenario.passed, true);
+});
+
+test("keeps workflow attempts distinct even when they share a daily release tag", () => {
+  const first = record(1, 90, "quality::glm::direct_answer::median_score", {
+    execution: { id: "123-1", run_id: "123", attempt: 1 },
+    release: { tag: "daily/2026-07-29", registry_tag: "daily" },
+  });
+  const second = record(2, 92, "quality::glm::direct_answer::median_score", {
+    execution: { id: "123-2", run_id: "123", attempt: 2 },
+    release: { tag: "daily/2026-07-29", registry_tag: "daily" },
+  });
+
+  const data = normalizeBenchmarkData({ entries: { quality: [first, second] } });
+
+  assert.equal(data.snapshots.length, 2);
+  assert.deepEqual(
+    data.snapshots.map((snapshot) => snapshot.execution.id),
+    ["123-1", "123-2"],
+  );
+});
+
+test("filters release channels and returns ordered scenario series", () => {
+  const raw = {
+    entries: {
+      quality: [
+        record(1, 80, "quality::glm::direct_answer::median_score"),
+        record(2, 92, "quality::glm::direct_answer::median_score"),
+      ],
+    },
+  };
+  const data = normalizeBenchmarkData(raw);
+  const snapshots = filterSnapshots(data, {
+    channel: "latest",
+    subjectId: "glm",
+    scenarioId: "direct_answer",
+    limit: 1,
+  });
+  const series = metricSeries(
+    snapshots,
+    "glm",
+    "quality",
+    "median_score",
+  );
+
+  assert.equal(snapshots.length, 1);
+  assert.equal(series.length, 1);
+  assert.equal(series[0].scenarioId, "direct_answer");
+  assert.equal(series[0].points[0].value, 92);
+  assert.equal(
+    filterSnapshots(data, {
+      subjectId: "glm",
+      scenarioId: "missing_scenario",
+    }).length,
+    0,
+  );
+});
+
+test("filters snapshots by UTC calendar-day window", () => {
+  const day = 24 * 60 * 60 * 1000;
+  const raw = {
+    entries: {
+      quality: [
+        record(
+          Date.UTC(2026, 6, 1, 6),
+          80,
+          "quality::glm::direct_answer::median_score",
+        ),
+        record(
+          Date.UTC(2026, 6, 15, 6),
+          90,
+          "quality::glm::direct_answer::median_score",
+        ),
+        record(
+          Date.UTC(2026, 6, 30, 6),
+          95,
+          "quality::glm::direct_answer::median_score",
+        ),
+      ],
+    },
+  };
+  const data = normalizeBenchmarkData(raw);
+  const snapshots = filterSnapshots(data, {
+    subjectId: "glm",
+    days: 16,
+  });
+
+  assert.deepEqual(
+    snapshots.map((snapshot) => snapshot.date),
+    [Date.UTC(2026, 6, 15, 6), Date.UTC(2026, 6, 30, 6)],
+  );
+  assert.equal(
+    Math.floor((snapshots[1].date - snapshots[0].date) / day),
+    15,
+  );
+});

--- a/harness/tests/e2e/assets/dashboard/execution-data.js
+++ b/harness/tests/e2e/assets/dashboard/execution-data.js
@@ -1,0 +1,1156 @@
+(function initHarnessExecutionData(root, factory) {
+  const api = factory();
+  if (typeof module === "object" && module.exports) {
+    module.exports = api;
+  }
+  root.HarnessExecutionData = api;
+})(typeof globalThis !== "undefined" ? globalThis : this, function executionDataFactory() {
+  "use strict";
+
+  const SCENARIO_METRIC_IDS = [
+    "tokens",
+    "duration_seconds",
+    "cost_usd",
+    "function_calls",
+    "function_call_errors",
+    "sessions",
+    "turns",
+  ];
+
+  function numberOrNull(value) {
+    return typeof value === "number" && Number.isFinite(value) ? value : null;
+  }
+
+  function mean(values) {
+    const available = values.filter((value) => numberOrNull(value) !== null);
+    return available.length
+      ? available.reduce((total, value) => total + value, 0) / available.length
+      : null;
+  }
+
+  function median(values) {
+    const available = values
+      .filter((value) => numberOrNull(value) !== null)
+      .sort((left, right) => left - right);
+    if (!available.length) return null;
+    const middle = Math.floor(available.length / 2);
+    return available.length % 2
+      ? available[middle]
+      : (available[middle - 1] + available[middle]) / 2;
+  }
+
+  function stableJson(value) {
+    if (Array.isArray(value)) {
+      return `[${value.map(stableJson).join(",")}]`;
+    }
+    if (value && typeof value === "object") {
+      return `{${Object.keys(value)
+        .sort()
+        .map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`)
+        .join(",")}}`;
+    }
+    return JSON.stringify(value);
+  }
+
+  function contractFingerprint(contract) {
+    const text = stableJson(contract);
+    const bytes = typeof TextEncoder === "function"
+      ? new TextEncoder().encode(text)
+      : Uint8Array.from(
+          unescape(encodeURIComponent(text)),
+          (character) => character.charCodeAt(0),
+        );
+    let value = 2_166_136_261;
+    bytes.forEach((byte) => {
+      value ^= byte;
+      value = Math.imul(value, 16_777_619) >>> 0;
+    });
+    return `fnv1a32:${value.toString(16).padStart(8, "0")}`;
+  }
+
+  function scenarioContract(scenario, scenarioId, runs) {
+    return {
+      execution_policy:
+        scenario?.execution_policy && typeof scenario.execution_policy === "object"
+          ? scenario.execution_policy
+          : {},
+      scenario_id: scenarioId,
+      scenario_version: Number(scenario?.scenario_version) || 1,
+    };
+  }
+
+  function normalizeScenarioMetric(item) {
+    const metric = item && typeof item === "object" ? item : {};
+    return {
+      ...metric,
+      subject_id: String(metric.subject_id || ""),
+      scenario_id: String(metric.scenario_id || ""),
+      scenario_version: Number(metric.scenario_version) || 1,
+      contract_fingerprint: String(metric.contract_fingerprint || ""),
+      run_count: Number(metric.run_count) || 0,
+      averages:
+        metric.averages && typeof metric.averages === "object"
+          ? metric.averages
+          : {},
+      samples:
+        metric.samples && typeof metric.samples === "object"
+          ? metric.samples
+          : {},
+    };
+  }
+
+  function metricValue(subject, category, scenarioId, metricId) {
+    return subject?.metrics?.[category]?.[scenarioId]?.[metricId]?.value ?? null;
+  }
+
+  function listLegacyScenarios(subject) {
+    const scenarios = new Set();
+    for (const category of Object.values(subject?.metrics || {})) {
+      for (const scenarioId of Object.keys(category || {})) {
+        if (scenarioId !== "suite") scenarios.add(scenarioId);
+      }
+    }
+    return [...scenarios].sort();
+  }
+
+  function normalizeStatus(value, execution = {}) {
+    const semanticStatuses = [
+      "passed",
+      "hard_gate_failed",
+      "technical_failed",
+      "infra_failed",
+      "incomplete",
+      "cancelled",
+      "running",
+    ];
+    if (semanticStatuses.includes(value)) return value;
+    if (value === "pass" || value === "success") return "passed";
+    if (value === "cancelled") return "cancelled";
+
+    // Schema 2 collapsed every complete non-pass into `failed`. Reconstruct
+    // the semantic outcome from its retained blocking counters.
+    if (value === "fail" || value === "failed" || value === "failure") {
+      const totals = execution?.totals || {};
+      if (Number(totals.missing_reports || 0) > 0) return "incomplete";
+      if (Number(totals.technical_failures || 0) > 0) return "technical_failed";
+      if (Number(totals.hard_gate_failures || 0) > 0) return "hard_gate_failed";
+      return "infra_failed";
+    }
+    return "incomplete";
+  }
+
+  function normalizeScenarioStatus(value) {
+    const scenario = value && typeof value === "object" ? value : {};
+    const status = String(scenario.status || "");
+    if (status === "cancelled") return "cancelled";
+    if (status === "running") return "running";
+    if (status === "missing_report" || status === "incomplete") return "incomplete";
+    if (status === "technical_failed" || Number(scenario.technical_failures || 0) > 0) {
+      return "technical_failed";
+    }
+    if (status === "hard_gate_failed" || Number(scenario.hard_gate_failures || 0) > 0) {
+      return "hard_gate_failed";
+    }
+    if (status === "infra_failed") return "infra_failed";
+    if (scenario.passed || status === "passed" || status === "success") return "passed";
+    return "infra_failed";
+  }
+
+  function normalizeExecution(entry) {
+    const execution = entry && typeof entry === "object" ? entry : {};
+    const subjects = Array.isArray(execution.subjects)
+      ? execution.subjects.filter((subject) => subject && typeof subject === "object")
+      : [];
+    return {
+      ...execution,
+      id: String(execution.id || ""),
+      label: String(execution.label || ""),
+      run_id: String(execution.run_id || ""),
+      attempt: Number(execution.attempt) || 1,
+      status: normalizeStatus(execution.status, execution),
+      conclusion: String(execution.conclusion || ""),
+      event: String(execution.event || ""),
+      actor: String(execution.actor || ""),
+      workflow_url: String(execution.workflow_url || ""),
+      started_at: String(execution.started_at || execution.generated_at || ""),
+      completed_at: String(execution.completed_at || execution.generated_at || ""),
+      availability: ["full", "aggregate", "unavailable"].includes(execution.availability)
+        ? execution.availability
+        : subjects.length
+          ? "aggregate"
+          : "unavailable",
+      detail_path: execution.detail_path || null,
+      source: execution.source && typeof execution.source === "object"
+        ? execution.source
+        : {},
+      release: execution.release && typeof execution.release === "object"
+        ? execution.release
+        : {},
+      subjects,
+      scenario_metrics: Array.isArray(execution.scenario_metrics)
+        ? execution.scenario_metrics
+            .filter((item) => item && typeof item === "object")
+            .map(normalizeScenarioMetric)
+        : [],
+      totals: execution.totals && typeof execution.totals === "object"
+        ? execution.totals
+        : {},
+    };
+  }
+
+  function legacySubject(subject) {
+    const scenarios = listLegacyScenarios(subject).map((scenarioId) => {
+      const score = subject.metrics?.quality?.[scenarioId]?.median_score;
+      const passRate = subject.metrics?.quality?.[scenarioId]?.pass_rate;
+      const scenario = {
+        id: scenarioId,
+        status: score?.status || passRate?.status || "unknown",
+        passed: score?.passed ?? passRate?.passed ?? false,
+        median_score: score?.value ?? null,
+        pass_rate: passRate?.value === null || passRate?.value === undefined
+          ? null
+          : passRate.value / 100,
+        hard_gate_failures:
+          metricValue(subject, "reliability", scenarioId, "hard_gate_failures") ?? 0,
+        technical_failures:
+          metricValue(subject, "reliability", scenarioId, "technical_failures") ?? 0,
+        retries: metricValue(subject, "reliability", scenarioId, "retry_attempts") ?? 0,
+        total_cost_usd:
+          metricValue(subject, "efficiency", scenarioId, "total_cost_usd"),
+        wall_time_seconds:
+          metricValue(subject, "efficiency", scenarioId, "wall_time_seconds"),
+      };
+      return { ...scenario, status: normalizeScenarioStatus(scenario) };
+    });
+    return {
+      id: subject.id,
+      model: subject.model,
+      provider: subject.provider,
+      judge: subject.judge || {},
+      engine_revision: subject.engineRevision || "",
+      passed: Boolean(subject.passed),
+      expected_reports: scenarios.length,
+      received_reports: scenarios.filter((scenario) => scenario.status !== "incomplete")
+        .length,
+      scenario_pass_rate:
+        (metricValue(subject, "quality", "suite", "scenario_pass_rate") ?? 0) / 100,
+      report_coverage:
+        (metricValue(subject, "quality", "suite", "report_coverage") ?? 0) / 100,
+      hard_gate_failures:
+        metricValue(subject, "reliability", "suite", "hard_gate_failures") ?? 0,
+      technical_failures:
+        metricValue(subject, "reliability", "suite", "technical_failures") ?? 0,
+      retry_attempts:
+        metricValue(subject, "reliability", "suite", "retry_attempts") ?? 0,
+      total_cost_usd:
+        metricValue(subject, "efficiency", "suite", "total_cost_usd"),
+      wall_time_seconds:
+        metricValue(subject, "efficiency", "suite", "wall_time_seconds"),
+      scenarios,
+    };
+  }
+
+  function legacyExecution(snapshot) {
+    const subjects = Object.values(snapshot.subjects || {}).map(legacySubject);
+    const scenarios = subjects.flatMap((subject) => subject.scenarios);
+    const scores = scenarios
+      .map((scenario) => numberOrNull(scenario.median_score))
+      .filter((value) => value !== null);
+    const expected = subjects.reduce(
+      (total, subject) => total + Number(subject.expected_reports || 0),
+      0,
+    );
+    const received = subjects.reduce(
+      (total, subject) => total + Number(subject.received_reports || 0),
+      0,
+    );
+    const complete = expected > 0 && expected === received;
+    const passed = complete && subjects.every((subject) => subject.passed);
+    const executionId = snapshot.execution?.id || snapshot.id;
+    const runId = snapshot.execution?.run_id || "";
+    return normalizeExecution({
+      id: executionId,
+      run_id: runId,
+      attempt: snapshot.execution?.attempt || 1,
+      workflow_url: snapshot.workflowUrl,
+      started_at: snapshot.generatedAt || new Date(snapshot.date).toISOString(),
+      completed_at: snapshot.generatedAt || new Date(snapshot.date).toISOString(),
+      event: snapshot.execution?.event || "legacy",
+      actor: snapshot.execution?.actor || "",
+      conclusion: passed ? "success" : "failure",
+      status: complete ? (passed ? "passed" : "failed") : "incomplete",
+      availability: "aggregate",
+      detail_path: null,
+      generated_at: snapshot.generatedAt,
+      lane: snapshot.lane,
+      source: snapshot.source,
+      release: snapshot.release,
+      subjects,
+      totals: {
+        expected_reports: expected,
+        received_reports: received,
+        report_coverage: expected ? (received / expected) * 100 : 0,
+        passed_scenarios: scenarios.filter((scenario) => scenario.passed).length,
+        scenario_pass_rate: expected
+          ? (scenarios.filter((scenario) => scenario.passed).length / expected) * 100
+          : 0,
+        average_score: scores.length
+          ? scores.reduce((total, score) => total + score, 0) / scores.length
+          : null,
+        total_cost_usd: subjects.every(
+          (subject) => numberOrNull(subject.total_cost_usd) !== null,
+        )
+          ? subjects.reduce((total, subject) => total + subject.total_cost_usd, 0)
+          : null,
+        wall_time_seconds: subjects.every(
+          (subject) => numberOrNull(subject.wall_time_seconds) !== null,
+        )
+          ? subjects.reduce((total, subject) => total + subject.wall_time_seconds, 0)
+          : null,
+        hard_gate_failures: subjects.reduce(
+          (total, subject) => total + Number(subject.hard_gate_failures || 0),
+          0,
+        ),
+        technical_failures: subjects.reduce(
+          (total, subject) => total + Number(subject.technical_failures || 0),
+          0,
+        ),
+        missing_reports: Math.max(0, expected - received),
+        retries: subjects.reduce(
+          (total, subject) => total + Number(subject.retry_attempts || 0),
+          0,
+        ),
+      },
+    });
+  }
+
+  function mergeExecutionHistory(manifest, benchmarkData) {
+    const raw = manifest && typeof manifest === "object" ? manifest : {};
+    const byId = new Map(
+      (Array.isArray(raw.executions) ? raw.executions : [])
+        .map(normalizeExecution)
+        .filter((entry) => entry.id)
+        .map((entry) => [entry.id, entry]),
+    );
+    for (const snapshot of benchmarkData?.snapshots || []) {
+      const id = snapshot.execution?.id || snapshot.id;
+      if (!byId.has(id)) byId.set(id, legacyExecution(snapshot));
+    }
+    const executions = [...byId.values()].sort(
+      (left, right) =>
+        Date.parse(right.completed_at || right.started_at || 0) -
+        Date.parse(left.completed_at || left.started_at || 0),
+    );
+    return {
+      schemaVersion: Number(raw.schema_version) || 1,
+      mode: raw.mode === "local" ? "local" : "published",
+      lastUpdate: raw.last_update || benchmarkData?.lastUpdate || "",
+      repoUrl: raw.repo_url || benchmarkData?.repoUrl || "",
+      preview: Boolean(globalThis.HARNESS_BENCHMARK_PREVIEW),
+      retention: raw.retention || { summaries: 100, details: 30 },
+      executions,
+    };
+  }
+
+  function filterExecutions(executions, filters = {}) {
+    const query = String(filters.query || "").trim().toLowerCase();
+    return (executions || []).filter((execution) => {
+      if (filters.status && filters.status !== "all" && execution.status !== filters.status) {
+        return false;
+      }
+      if (filters.event && filters.event !== "all" && execution.event !== filters.event) {
+        return false;
+      }
+      if (!query) return true;
+      const haystack = [
+        execution.label,
+        execution.id,
+        execution.run_id,
+        execution.source?.sha,
+        execution.source?.ref,
+        execution.completed_at,
+        execution.started_at,
+      ]
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(query);
+    });
+  }
+
+  function latestHealthModel(entry) {
+    const execution = normalizeExecution(entry);
+    const release = execution.release || {};
+    const releaseIdentity = [release.worker, release.version]
+      .filter(Boolean)
+      .join("@");
+    const firstFailure =
+      execution.first_failure && typeof execution.first_failure === "object"
+        ? execution.first_failure
+        : null;
+    return {
+      status: execution.status,
+      lane: String(execution.lane || "daily"),
+      identity:
+        releaseIdentity ||
+        String(release.tag || "") ||
+        String(execution.source?.sha || "").slice(0, 12) ||
+        "Unknown",
+      expectedReports: Number(execution.totals?.expected_reports || 0),
+      receivedReports: Number(execution.totals?.received_reports || 0),
+      availability: execution.availability,
+      firstFailure,
+      workflowUrl: execution.workflow_url,
+    };
+  }
+
+  function executionsWithinDays(executions, days, now = Date.now()) {
+    const windowDays = Number(days);
+    if (!Number.isFinite(windowDays) || windowDays <= 0) return [...(executions || [])];
+    const windowEnd = Number(now);
+    const windowStart = windowEnd - windowDays * 24 * 60 * 60 * 1000;
+    return (executions || []).filter((execution) => {
+      const timestamp = Date.parse(
+        execution?.completed_at || execution?.started_at || "",
+      );
+      return Number.isFinite(timestamp) && timestamp >= windowStart && timestamp <= windowEnd;
+    });
+  }
+
+  function matrixRows(executions) {
+    const rows = new Map();
+    for (const execution of executions || []) {
+      for (const subject of execution.subjects || []) {
+        for (const scenario of subject.scenarios || []) {
+          const key = `${subject.id}::${scenario.id}`;
+          if (!rows.has(key)) {
+            rows.set(key, {
+              key,
+              subjectId: subject.id,
+              subjectLabel: `${subject.provider || ""}/${subject.model || subject.id}`.replace(
+                /^\//,
+                "",
+              ),
+              scenarioId: scenario.id,
+            });
+          }
+        }
+      }
+    }
+    return [...rows.values()].sort(
+      (left, right) =>
+        left.subjectLabel.localeCompare(right.subjectLabel) ||
+        left.scenarioId.localeCompare(right.scenarioId),
+    );
+  }
+
+  function matrixCell(execution, row) {
+    const subject = execution?.subjects?.find((item) => item.id === row.subjectId);
+    const scenario = subject?.scenarios?.find((item) => item.id === row.scenarioId);
+    if (!scenario) return null;
+    const status = normalizeScenarioStatus(scenario);
+    return { ...scenario, status };
+  }
+
+  function matrixCellLabel(cell, status) {
+    if (["failed", "hard_gate_failed", "technical_failed", "infra_failed"].includes(status)) {
+      return "×";
+    }
+    if (status === "cancelled") return "○";
+    if (status === "running") return "•";
+    if (status !== "passed") return "–";
+
+    const score = numberOrNull(cell?.median_score);
+    const passRate = numberOrNull(cell?.pass_rate);
+    const percentage = score ?? (passRate === null ? null : passRate * 100);
+    if (percentage === null) return "—";
+
+    const rounded = Math.round(percentage * 10) / 10;
+    return `${rounded.toLocaleString("en-US", {
+      maximumFractionDigits: 1,
+    })}%`;
+  }
+
+  function runMetric(run, metricId) {
+    const totals = run?.metrics?.totals || {};
+    if (metricId === "tokens") {
+      const input = numberOrNull(totals.input_tokens);
+      const output = numberOrNull(totals.output_tokens);
+      return input === null || output === null ? null : input + output;
+    }
+    if (metricId === "duration_seconds") {
+      const wallTime = numberOrNull(run?.wall_time_ms);
+      return wallTime === null ? null : wallTime / 1000;
+    }
+    if (metricId === "cost_usd") {
+      return numberOrNull(run?.cost?.total_usd);
+    }
+    return numberOrNull(totals[metricId]);
+  }
+
+  function executionEfficiencyTotalsFromDetail(detail) {
+    const tokens = [];
+    const functionCalls = [];
+    for (const reportEntry of detail?.reports || []) {
+      if (!reportEntry?.available) continue;
+      for (const scenario of reportEntry?.report?.scenarios || []) {
+        for (const run of scenario?.runs || []) {
+          const tokenValue = runMetric(run, "tokens");
+          const callValue = runMetric(run, "function_calls");
+          if (tokenValue !== null) tokens.push(tokenValue);
+          if (callValue !== null) functionCalls.push(callValue);
+        }
+      }
+    }
+    return {
+      total_tokens: tokens.length
+        ? tokens.reduce((total, value) => total + value, 0)
+        : null,
+      function_calls: functionCalls.length
+        ? functionCalls.reduce((total, value) => total + value, 0)
+        : null,
+    };
+  }
+
+  function scenarioMetricsFromDetail(detail) {
+    const grouped = new Map();
+    for (const reportEntry of detail?.reports || []) {
+      if (!reportEntry?.available) continue;
+      for (const scenario of reportEntry?.report?.scenarios || []) {
+        const scenarioId = String(
+          scenario?.scenario_id || reportEntry?.scenario_id || "",
+        );
+        if (!scenarioId) continue;
+        const runs = Array.isArray(scenario?.runs)
+          ? scenario.runs.filter((run) => run && typeof run === "object")
+          : [];
+        const subjectId = String(reportEntry?.subject_id || "");
+        const key = `${subjectId}::${scenarioId}`;
+        if (!grouped.has(key)) {
+          grouped.set(key, { subjectId, scenarioId, scenario, runs: [] });
+        }
+        grouped.get(key).runs.push(...runs);
+      }
+    }
+    return [...grouped.values()]
+      .sort(
+        (left, right) =>
+          left.subjectId.localeCompare(right.subjectId) ||
+          left.scenarioId.localeCompare(right.scenarioId),
+      )
+      .map(({ subjectId, scenarioId, scenario, runs }) => {
+        const averages = {};
+        const samples = {};
+        SCENARIO_METRIC_IDS.forEach((metricId) => {
+          const values = runs
+            .map((run) => runMetric(run, metricId))
+            .filter((value) => value !== null);
+          averages[metricId] = mean(values);
+          samples[metricId] = values.length;
+        });
+        const contract = scenarioContract(scenario, scenarioId, runs);
+        return {
+          subject_id: subjectId,
+          scenario_id: scenarioId,
+          scenario_version: contract.scenario_version,
+          contract_fingerprint: contractFingerprint(contract),
+          run_count: runs.length,
+          averages,
+          samples,
+        };
+      });
+  }
+
+  function scenarioMetricKey(metric) {
+    return `${metric?.subject_id || ""}::${metric?.scenario_id || ""}`;
+  }
+
+  function scenarioResult(execution, metric) {
+    const subjectId = String(metric?.subject_id || "");
+    const subject = subjectId
+      ? execution?.subjects?.find((item) => String(item.id || "") === subjectId)
+      : execution?.subjects?.find((item) =>
+          (item.scenarios || []).some(
+            (scenario) => scenario.id === metric?.scenario_id,
+          ),
+        );
+    const scenario = subject?.scenarios?.find(
+      (item) => item.id === metric?.scenario_id,
+    );
+    if (!scenario) {
+      return {
+        passed: false,
+        complete: false,
+        hardGateFailures: 0,
+        technicalFailures: 0,
+      };
+    }
+    const hardGateFailures = Number(scenario.hard_gate_failures) || 0;
+    const technicalFailures = Number(scenario.technical_failures) || 0;
+    return {
+      passed: Boolean(scenario.passed),
+      complete: normalizeScenarioStatus(scenario) !== "incomplete",
+      hardGateFailures,
+      technicalFailures,
+      score: numberOrNull(scenario.median_score),
+      passRate: numberOrNull(scenario.pass_rate),
+    };
+  }
+
+  function percentageDelta(current, baseline) {
+    const currentValue = numberOrNull(current);
+    const baselineValue = numberOrNull(baseline);
+    if (currentValue === null || baselineValue === null || baselineValue === 0) {
+      return null;
+    }
+    return ((currentValue - baselineValue) / Math.abs(baselineValue)) * 100;
+  }
+
+  function efficiencyTrend(row) {
+    if (row.lifecycle !== "comparable") return row.lifecycle;
+    if (!row.outcome.passed || !row.outcome.complete) return "non_comparable";
+    if (!row.historyCount) return "collecting";
+    if (!row.established) return "collecting";
+    const primaryMetrics = [
+      "cost_usd",
+      "tokens",
+      "duration_seconds",
+      "function_call_errors",
+    ];
+    let improvements = 0;
+    let regressions = 0;
+    primaryMetrics.forEach((metricId) => {
+      const current = numberOrNull(row.current?.averages?.[metricId]);
+      const baseline = numberOrNull(row.baseline?.[metricId]);
+      if (current === null || baseline === null) return;
+      if (metricId === "function_call_errors" && baseline === 0) {
+        if (current > 0) regressions += 1;
+        return;
+      }
+      const delta = percentageDelta(current, baseline);
+      if (delta !== null && delta <= -10) improvements += 1;
+      if (delta !== null && delta >= 10) regressions += 1;
+    });
+    if (improvements && regressions) return "mixed";
+    if (regressions) return "regressed";
+    if (improvements) return "improving";
+    return "stable";
+  }
+
+  function buildEfficiencyOverview(
+    executions,
+    { baselineWindow = 7, minimumHistory = 5 } = {},
+  ) {
+    const withMetrics = (executions || []).filter(
+      (execution) => (execution.scenario_metrics || []).length,
+    );
+    const latest = withMetrics[0] || null;
+    if (!latest) {
+      return {
+        latest: null,
+        rows: [],
+        metrics: {},
+        counts: {},
+        minimumHistory,
+      };
+    }
+    const history = withMetrics.slice(1);
+    const currentMetrics = new Map(
+      latest.scenario_metrics.map((metric) => [scenarioMetricKey(metric), metric]),
+    );
+    const latestExpected = new Set(
+      (latest.subjects || []).flatMap((subject) =>
+        (subject.scenarios || []).map(
+          (scenario) => `${subject.id || ""}::${scenario.id || ""}`,
+        ),
+      ),
+    );
+    const rows = [];
+
+    currentMetrics.forEach((current, key) => {
+      const sameScenario = history
+        .map((execution) => ({
+          execution,
+          metric: (execution.scenario_metrics || []).find(
+            (candidate) => scenarioMetricKey(candidate) === key,
+          ),
+        }))
+        .filter((entry) => entry.metric);
+      const fingerprint = current.contract_fingerprint;
+      const matchingContract = sameScenario.filter(
+        (entry) =>
+          fingerprint &&
+          entry.metric.contract_fingerprint &&
+          entry.metric.contract_fingerprint === fingerprint,
+      );
+      const sameContract = matchingContract
+        .filter((entry) => scenarioResult(entry.execution, entry.metric).passed)
+        .slice(0, baselineWindow);
+      const lifecycle = !sameScenario.length
+        ? "new"
+        : matchingContract.length
+          ? "comparable"
+          : "changed";
+      const baseline = Object.fromEntries(
+        SCENARIO_METRIC_IDS.map((metricId) => [
+          metricId,
+          median(
+            sameContract.map((entry) =>
+              numberOrNull(entry.metric?.averages?.[metricId]),
+            ),
+          ),
+        ]),
+      );
+      const row = {
+        key,
+        subjectId: current.subject_id,
+        scenarioId: current.scenario_id,
+        scenarioVersion: current.scenario_version,
+        fingerprint,
+        lifecycle,
+        current,
+        baseline,
+        historyCount: sameContract.length,
+        established: sameContract.length >= minimumHistory,
+        outcome: scenarioResult(latest, current),
+      };
+      row.deltas = Object.fromEntries(
+        SCENARIO_METRIC_IDS.map((metricId) => [
+          metricId,
+          percentageDelta(current.averages?.[metricId], baseline[metricId]),
+        ]),
+      );
+      row.trend = efficiencyTrend(row);
+      rows.push(row);
+    });
+
+    const latestHistorical = new Map();
+    history.forEach((execution) => {
+      (execution.scenario_metrics || []).forEach((metric) => {
+        const key = scenarioMetricKey(metric);
+        if (!currentMetrics.has(key) && !latestHistorical.has(key)) {
+          latestHistorical.set(key, { execution, metric });
+        }
+      });
+    });
+    latestHistorical.forEach(({ execution, metric }, key) => {
+      const expected = latestExpected.has(key);
+      rows.push({
+        key,
+        subjectId: metric.subject_id,
+        scenarioId: metric.scenario_id,
+        scenarioVersion: metric.scenario_version,
+        fingerprint: metric.contract_fingerprint,
+        lifecycle: expected ? "non_comparable" : "retired",
+        current: null,
+        baseline: metric.averages || {},
+        deltas: {},
+        historyCount: 0,
+        established: false,
+        outcome: expected
+          ? {
+              passed: false,
+              complete: false,
+              hardGateFailures: 0,
+              technicalFailures: 0,
+            }
+          : scenarioResult(execution, metric),
+        trend: expected ? "non_comparable" : "retired",
+      });
+    });
+
+    rows.sort(
+      (left, right) =>
+        left.scenarioId.localeCompare(right.scenarioId) ||
+        left.subjectId.localeCompare(right.subjectId),
+    );
+    const operationalRows = rows.filter((row) => row.current);
+    const comparableRows = rows.filter(
+      (row) => row.lifecycle === "comparable" && row.outcome.passed,
+    );
+    const metrics = Object.fromEntries(
+      SCENARIO_METRIC_IDS.map((metricId) => {
+        const operational = operationalRows.reduce(
+          (total, row) =>
+            total + (numberOrNull(row.current?.averages?.[metricId]) || 0),
+          0,
+        );
+        const comparableCurrent = comparableRows.reduce(
+          (total, row) =>
+            total + (numberOrNull(row.current?.averages?.[metricId]) || 0),
+          0,
+        );
+        const comparableBaseline = comparableRows.reduce(
+          (total, row) =>
+            total + (numberOrNull(row.baseline?.[metricId]) || 0),
+          0,
+        );
+        return [
+          metricId,
+          {
+            operational,
+            comparableCurrent,
+            comparableBaseline,
+            delta: percentageDelta(comparableCurrent, comparableBaseline),
+          },
+        ];
+      }),
+    );
+    const counts = {
+      active: operationalRows.length,
+      comparable: comparableRows.length,
+      new: rows.filter((row) => row.lifecycle === "new").length,
+      changed: rows.filter((row) => row.lifecycle === "changed").length,
+      retired: rows.filter((row) => row.lifecycle === "retired").length,
+      nonComparable: rows.filter(
+        (row) =>
+          row.lifecycle === "non_comparable" ||
+          (row.current && !row.outcome.passed),
+      ).length,
+      established: rows.filter((row) => row.established).length,
+    };
+    return { latest, rows, metrics, counts, minimumHistory };
+  }
+
+  function scenarioMetricSeries(executions, metricId, scenarioId = "all") {
+    const series = new Map();
+    const orderedExecutions = [...(executions || [])].sort((left, right) => {
+      const leftDate = Date.parse(left?.completed_at || left?.started_at || "") || 0;
+      const rightDate =
+        Date.parse(right?.completed_at || right?.started_at || "") || 0;
+      return leftDate - rightDate;
+    });
+
+    for (const execution of orderedExecutions) {
+      for (const scenario of execution?.scenario_metrics || []) {
+        const currentScenarioId = String(scenario?.scenario_id || "");
+        if (
+          !currentScenarioId ||
+          (scenarioId !== "all" && currentScenarioId !== scenarioId)
+        ) {
+          continue;
+        }
+        const value = numberOrNull(scenario?.averages?.[metricId]);
+        if (value === null) continue;
+        if (!series.has(currentScenarioId)) {
+          series.set(currentScenarioId, {
+            scenarioId: currentScenarioId,
+            points: [],
+          });
+        }
+        series.get(currentScenarioId).points.push({
+          executionId: execution.id,
+          runId: execution.run_id || execution.id,
+          attempt: execution.attempt || 1,
+          timestamp: execution.completed_at || execution.started_at || "",
+          value,
+          subjectId: scenario.subject_id || "",
+          scenarioVersion: scenario.scenario_version || 1,
+          contractFingerprint: scenario.contract_fingerprint || "",
+          runSamples: Number(scenario?.samples?.[metricId]) || 0,
+          execution,
+        });
+      }
+    }
+
+    return [...series.values()].sort((left, right) =>
+      left.scenarioId.localeCompare(right.scenarioId),
+    );
+  }
+
+  function scenarioMetricRows(executions) {
+    const grouped = new Map();
+    for (const execution of executions || []) {
+      for (const scenario of execution?.scenario_metrics || []) {
+        const scenarioId = String(scenario?.scenario_id || "");
+        if (!scenarioId) continue;
+        if (!grouped.has(scenarioId)) {
+          grouped.set(scenarioId, {
+            scenarioId,
+            executionIds: new Set(),
+            runCount: 0,
+            values: Object.fromEntries(
+              SCENARIO_METRIC_IDS.map((metricId) => [metricId, []]),
+            ),
+            runSamples: Object.fromEntries(
+              SCENARIO_METRIC_IDS.map((metricId) => [metricId, 0]),
+            ),
+          });
+        }
+        const row = grouped.get(scenarioId);
+        row.executionIds.add(execution.id);
+        row.runCount += Number(scenario.run_count) || 0;
+        SCENARIO_METRIC_IDS.forEach((metricId) => {
+          const value = numberOrNull(scenario?.averages?.[metricId]);
+          if (value !== null) row.values[metricId].push(value);
+          row.runSamples[metricId] += Number(scenario?.samples?.[metricId]) || 0;
+        });
+      }
+    }
+    return [...grouped.values()]
+      .sort((left, right) => left.scenarioId.localeCompare(right.scenarioId))
+      .map((row) => ({
+        scenarioId: row.scenarioId,
+        executionCount: row.executionIds.size,
+        runCount: row.runCount,
+        averages: Object.fromEntries(
+          SCENARIO_METRIC_IDS.map((metricId) => [
+            metricId,
+            mean(row.values[metricId]),
+          ]),
+        ),
+        executionSamples: Object.fromEntries(
+          SCENARIO_METRIC_IDS.map((metricId) => [
+            metricId,
+            row.values[metricId].length,
+          ]),
+        ),
+        runSamples: row.runSamples,
+      }));
+  }
+
+  function findExecution(history, id) {
+    return history?.executions?.find((execution) => execution.id === id) || null;
+  }
+
+  function comparisonScenarioMap(execution) {
+    const rows = new Map();
+    for (const subject of execution?.subjects || []) {
+      for (const scenario of subject?.scenarios || []) {
+        const key = `${subject.id || ""}::${scenario.id || ""}`;
+        const metric = (execution?.scenario_metrics || []).find(
+          (candidate) =>
+            candidate.subject_id === (subject.id || "") &&
+            candidate.scenario_id === (scenario.id || ""),
+        );
+        rows.set(key, {
+          subjectId: String(subject.id || ""),
+          subjectLabel: `${subject.provider || "unknown"}/${subject.model || "unknown"}`,
+          scenarioId: String(scenario.id || ""),
+          status: normalizeScenarioStatus(scenario),
+          score: numberOrNull(scenario.median_score),
+          passRate: numberOrNull(scenario.pass_rate),
+          fingerprint: String(metric?.contract_fingerprint || ""),
+          averages: Object.fromEntries(
+            SCENARIO_METRIC_IDS.map((metricId) => [
+              metricId,
+              numberOrNull(metric?.averages?.[metricId]),
+            ]),
+          ),
+        });
+      }
+    }
+    return rows;
+  }
+
+  function metricDelta(left, right) {
+    return left === null || right === null ? null : right - left;
+  }
+
+  function compareExecutions(leftValue, rightValue) {
+    const left = normalizeExecution(leftValue);
+    const right = normalizeExecution(rightValue);
+    const leftRows = comparisonScenarioMap(left);
+    const rightRows = comparisonScenarioMap(right);
+    const keys = [...new Set([...leftRows.keys(), ...rightRows.keys()])].sort();
+    const scenarios = keys.map((key) => {
+      const leftScenario = leftRows.get(key) || null;
+      const rightScenario = rightRows.get(key) || null;
+      let contract = "unavailable";
+      if (leftScenario && rightScenario) {
+        if (leftScenario.fingerprint && rightScenario.fingerprint) {
+          contract =
+            leftScenario.fingerprint === rightScenario.fingerprint
+              ? "same"
+              : "changed";
+        }
+      }
+      return {
+        key,
+        subjectId: leftScenario?.subjectId || rightScenario?.subjectId || "",
+        subjectLabel:
+          leftScenario?.subjectLabel || rightScenario?.subjectLabel || "unknown",
+        scenarioId: leftScenario?.scenarioId || rightScenario?.scenarioId || "",
+        left: leftScenario,
+        right: rightScenario,
+        contract,
+        deltas: {
+          score: metricDelta(leftScenario?.score ?? null, rightScenario?.score ?? null),
+          tokens: metricDelta(
+            leftScenario?.averages.tokens ?? null,
+            rightScenario?.averages.tokens ?? null,
+          ),
+          duration_seconds: metricDelta(
+            leftScenario?.averages.duration_seconds ?? null,
+            rightScenario?.averages.duration_seconds ?? null,
+          ),
+          cost_usd: metricDelta(
+            leftScenario?.averages.cost_usd ?? null,
+            rightScenario?.averages.cost_usd ?? null,
+          ),
+          function_calls: metricDelta(
+            leftScenario?.averages.function_calls ?? null,
+            rightScenario?.averages.function_calls ?? null,
+          ),
+        },
+      };
+    });
+
+    const warnings = [];
+    const leftSubjects = [
+      ...new Set(
+        [...leftRows.values()].map(
+          (row) => `${row.subjectId}::${row.subjectLabel}`,
+        ),
+      ),
+    ].sort();
+    const rightSubjects = [
+      ...new Set(
+        [...rightRows.values()].map(
+          (row) => `${row.subjectId}::${row.subjectLabel}`,
+        ),
+      ),
+    ].sort();
+    if (stableJson(leftSubjects) !== stableJson(rightSubjects)) {
+      warnings.push("The executions use different subject sets.");
+    }
+    if (
+      left.requested_runs != null &&
+      right.requested_runs != null &&
+      Number(left.requested_runs) !== Number(right.requested_runs)
+    ) {
+      warnings.push("The executions requested a different number of runs.");
+    }
+    const missingCount = scenarios.filter((row) => !row.left || !row.right).length;
+    if (missingCount) {
+      warnings.push(`${missingCount} scenario${missingCount === 1 ? " is" : "s are"} present in only one execution.`);
+    }
+    const changedCount = scenarios.filter((row) => row.contract === "changed").length;
+    if (changedCount) {
+      warnings.push(`${changedCount} shared scenario contract${changedCount === 1 ? " differs" : "s differ"}.`);
+    }
+
+    const totalFields = [
+      "scenario_pass_rate",
+      "average_score",
+      "hard_gate_failures",
+      "technical_failures",
+      "missing_reports",
+      "total_tokens",
+      "function_calls",
+      "total_cost_usd",
+      "wall_time_seconds",
+    ];
+    const totals = Object.fromEntries(
+      totalFields.map((field) => {
+        const leftValue = numberOrNull(left.totals?.[field]);
+        const rightValue = numberOrNull(right.totals?.[field]);
+        return [field, {
+          left: leftValue,
+          right: rightValue,
+          delta: metricDelta(leftValue, rightValue),
+        }];
+      }),
+    );
+    return { left, right, scenarios, totals, warnings };
+  }
+
+  function groupRunFailures(reports) {
+    const groups = [];
+    (Array.isArray(reports) ? reports : []).forEach((record) => {
+      (record?.report?.scenarios || []).forEach((scenario) => {
+        (scenario.runs || []).forEach((run, runIndex) => {
+          const items = [];
+          (run.failures || []).forEach((failure) => {
+            items.push({
+              kind: "failure",
+              phase: failure.phase || "failure",
+              message: failure.message || "No failure message",
+            });
+          });
+          (run.hard_gates || [])
+            .filter((gate) => gate && gate.passed === false)
+            .forEach((gate) => {
+              items.push({
+                kind: "gate",
+                gateId: gate.id,
+                message: gate.reason || "Hard gate failed",
+              });
+            });
+          if (items.length) {
+            groups.push({
+              subjectId: record.subject_id,
+              scenarioId: scenario.scenario_id,
+              runIndex,
+              items,
+            });
+          }
+        });
+      });
+    });
+    return groups;
+  }
+
+  function cohortMetricSparkline(executions, cohortRows, metricId, limit = 14) {
+    const basket = (cohortRows || [])
+      .filter((row) => row && row.scenarioId)
+      .map((row) => ({
+        key: `${row.subjectId || ""}::${row.scenarioId}`,
+        fingerprint: row.fingerprint || "",
+      }));
+    if (!basket.length) return [];
+    const points = [];
+    for (const execution of executions || []) {
+      if (points.length >= limit) break;
+      const metrics = execution?.scenario_metrics || [];
+      if (!metrics.length) continue;
+      let total = 0;
+      let complete = true;
+      for (const item of basket) {
+        const scenario = metrics.find(
+          (candidate) =>
+            `${candidate?.subject_id || ""}::${candidate?.scenario_id || ""}` ===
+              item.key &&
+            (candidate?.contract_fingerprint || "") === item.fingerprint,
+        );
+        const value = numberOrNull(scenario?.averages?.[metricId]);
+        if (value === null) {
+          complete = false;
+          break;
+        }
+        total += value;
+      }
+      if (!complete) continue;
+      points.push({
+        executionId: execution.id,
+        value: total,
+        timestamp: execution.completed_at || execution.started_at || "",
+      });
+    }
+    return points.reverse();
+  }
+
+  return {
+    buildEfficiencyOverview,
+    cohortMetricSparkline,
+    compareExecutions,
+    contractFingerprint,
+    executionEfficiencyTotalsFromDetail,
+    executionsWithinDays,
+    filterExecutions,
+    findExecution,
+    groupRunFailures,
+    latestHealthModel,
+    legacyExecution,
+    matrixCell,
+    matrixCellLabel,
+    matrixRows,
+    mergeExecutionHistory,
+    normalizeExecution,
+    normalizeScenarioStatus,
+    normalizeStatus,
+    scenarioMetricSeries,
+    scenarioMetricRows,
+    scenarioMetricsFromDetail,
+    scenarioContract,
+  };
+});

--- a/harness/tests/e2e/assets/dashboard/execution-data.test.cjs
+++ b/harness/tests/e2e/assets/dashboard/execution-data.test.cjs
@@ -1,0 +1,770 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  buildEfficiencyOverview,
+  cohortMetricSparkline,
+  compareExecutions,
+  contractFingerprint,
+  executionEfficiencyTotalsFromDetail,
+  executionsWithinDays,
+  filterExecutions,
+  findExecution,
+  groupRunFailures,
+  latestHealthModel,
+  matrixCell,
+  matrixCellLabel,
+  matrixRows,
+  mergeExecutionHistory,
+  normalizeExecution,
+  normalizeScenarioStatus,
+  scenarioMetricSeries,
+  scenarioMetricRows,
+  scenarioMetricsFromDetail,
+  scenarioContract,
+} = require("./execution-data.js");
+
+function execution(overrides = {}) {
+  return {
+    id: "123-1",
+    run_id: "123",
+    attempt: 1,
+    status: "passed",
+    conclusion: "success",
+    event: "schedule",
+    completed_at: "2026-07-29T06:10:00Z",
+    source: { sha: "a".repeat(40), ref: "main" },
+    availability: "full",
+    detail_path: "runs/123-1.json",
+    totals: { average_score: 92, scenario_pass_rate: 100 },
+    subjects: [
+      {
+        id: "glm",
+        model: "glm-5.2",
+        provider: "zai",
+        scenarios: [
+          {
+            id: "direct_answer",
+            passed: true,
+            status: "passed",
+            median_score: 92,
+            pass_rate: 1,
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+test("normalizes execution status and availability", () => {
+  const normalized = normalizeExecution({
+    id: 99,
+    status: "failure",
+    subjects: [],
+  });
+
+  assert.equal(normalized.id, "99");
+  assert.equal(normalized.status, "infra_failed");
+  assert.equal(normalized.availability, "unavailable");
+});
+
+test("compares any two executions and exposes incompatible scenario contracts", () => {
+  const left = execution({
+    id: "left",
+    requested_runs: 1,
+    scenario_metrics: [
+      {
+        subject_id: "glm",
+        scenario_id: "direct_answer",
+        contract_fingerprint: "contract-a",
+        averages: { tokens: 100, duration_seconds: 10, cost_usd: 0.2 },
+      },
+    ],
+    totals: { average_score: 80, scenario_pass_rate: 100, total_tokens: 100 },
+  });
+  const right = execution({
+    id: "right",
+    requested_runs: 2,
+    subjects: [
+      ...execution().subjects,
+      {
+        id: "other",
+        model: "gpt-5",
+        provider: "openai",
+        scenarios: [
+          {
+            id: "persistent_state",
+            passed: false,
+            status: "infra_failed",
+            median_score: 45,
+            pass_rate: 0,
+          },
+        ],
+      },
+    ],
+    scenario_metrics: [
+      {
+        subject_id: "glm",
+        scenario_id: "direct_answer",
+        contract_fingerprint: "contract-b",
+        averages: { tokens: 120, duration_seconds: 8, cost_usd: 0.15 },
+      },
+    ],
+    totals: { average_score: 70, scenario_pass_rate: 50, total_tokens: 120 },
+  });
+
+  const comparison = compareExecutions(left, right);
+
+  assert.equal(comparison.left.id, "left");
+  assert.equal(comparison.right.id, "right");
+  assert.equal(comparison.totals.total_tokens.delta, 20);
+  assert.equal(comparison.scenarios[0].contract, "changed");
+  assert.equal(comparison.scenarios[0].deltas.duration_seconds, -2);
+  assert.equal(comparison.scenarios.length, 2);
+  assert.deepEqual(comparison.warnings, [
+    "The executions use different subject sets.",
+    "The executions requested a different number of runs.",
+    "1 scenario is present in only one execution.",
+    "1 shared scenario contract differs.",
+  ]);
+});
+
+test("normalizes schema 2 failures with blocking precedence", () => {
+  assert.equal(
+    normalizeExecution({
+      status: "failed",
+      conclusion: "failure",
+      totals: {},
+      subjects: [{ passed: false }],
+    }).status,
+    "infra_failed",
+  );
+  assert.equal(
+    normalizeExecution({
+      status: "failed",
+      conclusion: "success",
+      totals: { technical_failures: 1, hard_gate_failures: 1 },
+      subjects: [{ passed: false }],
+    }).status,
+    "technical_failed",
+  );
+  assert.equal(
+    normalizeExecution({
+      status: "failed",
+      conclusion: "failure",
+      totals: { hard_gate_failures: 1 },
+      subjects: [{ passed: false }],
+    }).status,
+    "hard_gate_failed",
+  );
+  assert.equal(
+    normalizeExecution({
+      status: "failed",
+      conclusion: "success",
+      totals: {},
+      subjects: [{ passed: false }],
+    }).status,
+    "infra_failed",
+  );
+});
+
+test("builds the latest health identity, completeness, and compact first failure", () => {
+  const model = latestHealthModel(
+    execution({
+      status: "infra_failed",
+      lane: "daily",
+      release: { worker: "harness", version: "1.7.3" },
+      totals: { expected_reports: 16, received_reports: 0 },
+      first_failure: {
+        kind: "job",
+        job_name: "harness e2e build",
+        step_name: "Validate E2E manifests and lockfiles",
+        message: "provider-deepseek/Cargo.lock needs to be updated",
+      },
+    }),
+  );
+
+  assert.equal(model.status, "infra_failed");
+  assert.equal(model.lane, "daily");
+  assert.equal(model.identity, "harness@1.7.3");
+  assert.equal(model.expectedReports, 16);
+  assert.equal(model.receivedReports, 0);
+  assert.equal(model.firstFailure.step_name, "Validate E2E manifests and lockfiles");
+  assert.equal(model.workflowUrl, "");
+});
+
+test("merges manifest executions and finds a retained detail", () => {
+  const history = mergeExecutionHistory(
+    {
+      schema_version: 2,
+      mode: "local",
+      last_update: "2026-07-29T06:10:00Z",
+      executions: [execution()],
+    },
+    { snapshots: [] },
+  );
+
+  assert.equal(history.executions.length, 1);
+  assert.equal(history.mode, "local");
+  assert.equal(findExecution(history, "123-1").detail_path, "runs/123-1.json");
+});
+
+test("defaults execution history to published mode", () => {
+  assert.equal(
+    mergeExecutionHistory({ executions: [] }, { snapshots: [] }).mode,
+    "published",
+  );
+});
+
+test("keeps workflow attempts distinct and newest first", () => {
+  const history = mergeExecutionHistory(
+    {
+      executions: [
+        execution({ id: "123-1", attempt: 1 }),
+        execution({
+          id: "123-2",
+          attempt: 2,
+          completed_at: "2026-07-29T06:20:00Z",
+        }),
+      ],
+    },
+    { snapshots: [] },
+  );
+
+  assert.deepEqual(
+    history.executions.map((item) => item.id),
+    ["123-2", "123-1"],
+  );
+});
+
+test("filters by status, trigger, run id, commit, and date", () => {
+  const entries = [
+    execution(),
+    execution({
+      id: "456-1",
+      run_id: "456",
+      status: "failed",
+      conclusion: "failure",
+      event: "workflow_dispatch",
+      completed_at: "2026-07-30T07:15:00Z",
+      source: { sha: "b".repeat(40), ref: "main" },
+    }),
+  ];
+
+  assert.deepEqual(
+    filterExecutions(entries, { status: "failed" }).map((item) => item.id),
+    ["456-1"],
+  );
+  assert.deepEqual(
+    filterExecutions(entries, { event: "schedule" }).map((item) => item.id),
+    ["123-1"],
+  );
+  assert.equal(filterExecutions(entries, { query: "456" }).length, 1);
+  assert.equal(filterExecutions(entries, { query: "bbbbbbb" }).length, 1);
+  assert.equal(filterExecutions(entries, { query: "2026-07-29" }).length, 1);
+});
+
+test("filters execution metrics to a rolling day window", () => {
+  const now = Date.parse("2026-07-30T12:00:00Z");
+  const entries = [
+    execution({ id: "recent", completed_at: "2026-07-29T12:00:00Z" }),
+    execution({ id: "edge", completed_at: "2026-06-30T12:00:00Z" }),
+    execution({ id: "old", completed_at: "2026-06-30T11:59:59Z" }),
+  ];
+
+  assert.deepEqual(
+    executionsWithinDays(entries, 30, now).map((item) => item.id),
+    ["recent", "edge"],
+  );
+});
+
+test("builds subject and scenario matrix rows with result cells", () => {
+  const entry = execution();
+  const rows = matrixRows([entry]);
+  const cell = matrixCell(entry, rows[0]);
+
+  assert.deepEqual(rows, [
+    {
+      key: "glm::direct_answer",
+      subjectId: "glm",
+      subjectLabel: "zai/glm-5.2",
+      scenarioId: "direct_answer",
+    },
+  ]);
+  assert.equal(cell.status, "passed");
+  assert.equal(cell.median_score, 92);
+  assert.equal(matrixCellLabel(cell, cell.status), "92%");
+  assert.equal(matrixCellLabel({ passed: false }, "failed"), "×");
+  assert.equal(matrixCellLabel(null, "infra_failed"), "×");
+  assert.equal(matrixCellLabel(null, "running"), "•");
+  assert.equal(matrixCellLabel(null, "incomplete"), "–");
+  assert.equal(matrixCellLabel(null, "cancelled"), "○");
+  assert.equal(
+    matrixCellLabel({ passed: true, median_score: null, pass_rate: 0.875 }, "passed"),
+    "87.5%",
+  );
+});
+
+test("normalizes scenario outcomes with the shared blocking precedence", () => {
+  assert.equal(normalizeScenarioStatus({ status: "missing_report" }), "incomplete");
+  assert.equal(
+    normalizeScenarioStatus({ status: "cancelled", technical_failures: 1 }),
+    "cancelled",
+  );
+  assert.equal(
+    normalizeScenarioStatus({
+      passed: false,
+      hard_gate_failures: 1,
+      technical_failures: 1,
+    }),
+    "technical_failed",
+  );
+  assert.equal(
+    normalizeScenarioStatus({ passed: false, hard_gate_failures: 1 }),
+    "hard_gate_failed",
+  );
+  assert.equal(
+    normalizeScenarioStatus({ passed: false, hard_gate_failures: 0 }),
+    "infra_failed",
+  );
+  assert.equal(
+    normalizeScenarioStatus({ passed: true, hard_gate_failures: 1 }),
+    "hard_gate_failed",
+  );
+  assert.equal(normalizeScenarioStatus({ passed: true }), "passed");
+});
+
+test("derives aggregate legacy entries from benchmark snapshots", () => {
+  const history = mergeExecutionHistory(null, {
+    lastUpdate: 1,
+    snapshots: [
+      {
+        id: "daily::legacy",
+        date: Date.UTC(2026, 6, 28, 6),
+        lane: "daily",
+        execution: {},
+        workflowUrl: "https://github.com/iii-hq/workers/actions/runs/legacy",
+        source: { sha: "c".repeat(40), ref: "main" },
+        subjects: {
+          glm: {
+            id: "glm",
+            model: "glm-5.2",
+            provider: "zai",
+            passed: true,
+            metrics: {
+              quality: {
+                direct_answer: {
+                  median_score: { value: 90, passed: true, status: "passed" },
+                  pass_rate: { value: 100, passed: true, status: "passed" },
+                },
+                suite: {
+                  scenario_pass_rate: { value: 100 },
+                  report_coverage: { value: 100 },
+                },
+              },
+              reliability: { suite: {} },
+              efficiency: { suite: {} },
+            },
+          },
+        },
+      },
+    ],
+  });
+
+  assert.equal(history.executions[0].availability, "aggregate");
+  assert.equal(history.executions[0].totals.average_score, 90);
+  assert.equal(history.executions[0].subjects[0].scenarios[0].id, "direct_answer");
+});
+
+test("derives per-scenario run averages from a full execution detail", () => {
+  const detail = {
+    reports: [
+      {
+        available: true,
+        subject_id: "glm",
+        scenario_id: "direct_answer",
+        report: {
+          scenarios: [
+            {
+              scenario_id: "direct_answer",
+              scenario_version: 1,
+              execution_policy: {
+                max_turns: 2,
+                max_total_tokens: 32768,
+              },
+              runs: [
+                {
+                  run_id: "first",
+                  prompt: "answer for first",
+                  wall_time_ms: 10_000,
+                  cost: { total_usd: 0.2 },
+                  metrics: {
+                    totals: {
+                      input_tokens: 100,
+                      output_tokens: 20,
+                      function_calls: 2,
+                      function_call_errors: 0,
+                      sessions: 1,
+                      turns: 4,
+                    },
+                  },
+                },
+                {
+                  run_id: "second",
+                  prompt: "answer for second",
+                  wall_time_ms: 20_000,
+                  cost: { total_usd: 0.6 },
+                  metrics: {
+                    totals: {
+                      input_tokens: 200,
+                      output_tokens: 40,
+                      function_calls: 4,
+                      function_call_errors: 2,
+                      sessions: 3,
+                      turns: 8,
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  };
+  const metrics = scenarioMetricsFromDetail(detail);
+  const scenario = detail.reports[0].report.scenarios[0];
+
+  assert.deepEqual(executionEfficiencyTotalsFromDetail(detail), {
+    total_tokens: 360,
+    function_calls: 6,
+  });
+
+  assert.deepEqual(metrics, [
+    {
+      subject_id: "glm",
+      scenario_id: "direct_answer",
+      scenario_version: 1,
+      contract_fingerprint: contractFingerprint(
+        scenarioContract(scenario, "direct_answer", scenario.runs),
+      ),
+      run_count: 2,
+      averages: {
+        tokens: 180,
+        duration_seconds: 15,
+        cost_usd: 0.4,
+        function_calls: 3,
+        function_call_errors: 1,
+        sessions: 2,
+        turns: 6,
+      },
+      samples: {
+        tokens: 2,
+        duration_seconds: 2,
+        cost_usd: 2,
+        function_calls: 2,
+        function_call_errors: 2,
+        sessions: 2,
+        turns: 2,
+      },
+    },
+  ]);
+});
+
+test("averages scenario metrics with equal weight per execution", () => {
+  const rows = scenarioMetricRows([
+    execution({
+      id: "first",
+      scenario_metrics: [
+        {
+          scenario_id: "direct_answer",
+          run_count: 3,
+          averages: { tokens: 100, cost_usd: 0.2, turns: 4 },
+          samples: { tokens: 3, cost_usd: 3, turns: 3 },
+        },
+      ],
+    }),
+    execution({
+      id: "second",
+      scenario_metrics: [
+        {
+          scenario_id: "direct_answer",
+          run_count: 2,
+          averages: { tokens: 300, cost_usd: null, turns: 8 },
+          samples: { tokens: 2, cost_usd: 0, turns: 2 },
+        },
+      ],
+    }),
+  ]);
+
+  assert.equal(rows[0].averages.tokens, 200);
+  assert.equal(rows[0].averages.cost_usd, 0.2);
+  assert.equal(rows[0].averages.turns, 6);
+  assert.equal(rows[0].executionCount, 2);
+  assert.equal(rows[0].executionSamples.tokens, 2);
+  assert.equal(rows[0].executionSamples.cost_usd, 1);
+  assert.equal(rows[0].runCount, 5);
+  assert.equal(rows[0].runSamples.tokens, 5);
+});
+
+test("keeps scenario metrics as one point per workflow execution", () => {
+  const series = scenarioMetricSeries(
+    [
+      execution({
+        id: "newer",
+        run_id: "200",
+        completed_at: "2026-07-30T12:00:00Z",
+        scenario_metrics: [
+          {
+            scenario_id: "direct_answer",
+            averages: { tokens: 300 },
+            samples: { tokens: 3 },
+          },
+        ],
+      }),
+      execution({
+        id: "older",
+        run_id: "100",
+        completed_at: "2026-07-29T12:00:00Z",
+        scenario_metrics: [
+          {
+            scenario_id: "direct_answer",
+            averages: { tokens: 100 },
+            samples: { tokens: 2 },
+          },
+          {
+            scenario_id: "persistent_state",
+            averages: { tokens: 200 },
+            samples: { tokens: 2 },
+          },
+        ],
+      }),
+    ],
+    "tokens",
+  );
+
+  assert.deepEqual(
+    series.map((item) => ({
+      scenarioId: item.scenarioId,
+      executionIds: item.points.map((point) => point.executionId),
+      values: item.points.map((point) => point.value),
+    })),
+    [
+      {
+        scenarioId: "direct_answer",
+        executionIds: ["older", "newer"],
+        values: [100, 300],
+      },
+      {
+        scenarioId: "persistent_state",
+        executionIds: ["older"],
+        values: [200],
+      },
+    ],
+  );
+  assert.equal(
+    scenarioMetricSeries(
+      [execution({ scenario_metrics: series.map(() => null) })],
+      "tokens",
+      "missing",
+    ).length,
+    0,
+  );
+});
+
+test("cohort sparkline sums matching contracts and skips partial executions", () => {
+  const cohortRow = {
+    subjectId: "glm",
+    scenarioId: "direct_answer",
+    fingerprint: "fp1",
+    lifecycle: "comparable",
+  };
+  const metric = (fingerprint, tokens) => ({
+    subject_id: "glm",
+    scenario_id: "direct_answer",
+    contract_fingerprint: fingerprint,
+    averages: { tokens },
+  });
+
+  const points = cohortMetricSparkline(
+    [
+      execution({ id: "no-value", scenario_metrics: [metric("fp1", null)] }),
+      execution({ id: "newer", scenario_metrics: [metric("fp1", 300)] }),
+      execution({ id: "changed-contract", scenario_metrics: [metric("fp2", 999)] }),
+      execution({ id: "no-metrics", scenario_metrics: [] }),
+      execution({ id: "older", scenario_metrics: [metric("fp1", 100)] }),
+    ],
+    [cohortRow],
+    "tokens",
+  );
+
+  assert.deepEqual(points, [
+    { executionId: "older", value: 100, timestamp: "2026-07-29T06:10:00Z" },
+    { executionId: "newer", value: 300, timestamp: "2026-07-29T06:10:00Z" },
+  ]);
+  assert.deepEqual(cohortMetricSparkline([execution()], [], "tokens"), []);
+});
+
+test("compares efficiency only within the same scenario contract", () => {
+  const metric = (
+    scenarioId,
+    fingerprint,
+    tokens,
+    cost,
+    duration,
+    errors = 0,
+  ) => ({
+    subject_id: "glm",
+    scenario_id: scenarioId,
+    scenario_version: fingerprint === "v2" ? 2 : 1,
+    contract_fingerprint: fingerprint,
+    run_count: 3,
+    averages: {
+      tokens,
+      cost_usd: cost,
+      duration_seconds: duration,
+      function_calls: 2,
+      function_call_errors: errors,
+      sessions: 1,
+      turns: 2,
+    },
+    samples: {},
+  });
+  const withScenarios = (id, scenarioMetrics, scenarios) =>
+    execution({
+      id,
+      completed_at:
+        id === "latest" ? "2026-07-30T12:00:00Z" : "2026-07-29T12:00:00Z",
+      scenario_metrics: scenarioMetrics,
+      subjects: [
+        {
+          id: "glm",
+          model: "glm-5.2",
+          provider: "zai",
+          scenarios: scenarios.map(([scenarioId, passed]) => ({
+            id: scenarioId,
+            passed,
+            status: passed ? "passed" : "hard_gate_failed",
+            hard_gate_failures: passed ? 0 : 1,
+            technical_failures: 0,
+          })),
+        },
+      ],
+    });
+
+  const overview = buildEfficiencyOverview(
+    [
+      withScenarios(
+      "latest",
+      [
+        metric("stable", "v1", 90, 0.9, 8),
+        metric("changed", "v2", 80, 0.8, 7),
+        metric("new_case", "v1", 20, 0.2, 2),
+        metric("failed", "v1", 30, 0.3, 3, 1),
+      ],
+      [
+        ["stable", true],
+        ["changed", true],
+        ["new_case", true],
+        ["failed", false],
+      ],
+    ),
+      withScenarios(
+      "previous",
+      [
+        metric("stable", "v1", 100, 1, 10),
+        metric("changed", "v1", 70, 0.7, 6),
+        metric("retired", "v1", 40, 0.4, 4),
+        metric("failed", "v1", 40, 0.4, 4),
+      ],
+      [
+        ["stable", true],
+        ["changed", true],
+        ["retired", true],
+        ["failed", true],
+      ],
+      ),
+    ],
+    { minimumHistory: 1 },
+  );
+
+  assert.equal(overview.rows.find((row) => row.scenarioId === "stable").trend, "improving");
+  assert.equal(overview.rows.find((row) => row.scenarioId === "changed").lifecycle, "changed");
+  assert.equal(overview.rows.find((row) => row.scenarioId === "new_case").lifecycle, "new");
+  assert.equal(overview.rows.find((row) => row.scenarioId === "retired").lifecycle, "retired");
+  assert.equal(
+    overview.rows.find((row) => row.scenarioId === "failed").trend,
+    "non_comparable",
+  );
+  assert.equal(overview.counts.comparable, 1);
+  assert.equal(overview.counts.new, 1);
+  assert.equal(overview.counts.changed, 1);
+  assert.equal(overview.counts.retired, 1);
+  assert.equal(overview.counts.nonComparable, 1);
+  assert.equal(overview.metrics.tokens.operational, 220);
+  assert.equal(overview.metrics.tokens.comparableCurrent, 90);
+  assert.equal(overview.metrics.tokens.comparableBaseline, 100);
+  assert.equal(overview.metrics.tokens.delta, -10);
+});
+
+test("groupRunFailures returns empty for missing or empty reports", () => {
+  assert.deepEqual(groupRunFailures(undefined), []);
+  assert.deepEqual(groupRunFailures([]), []);
+  assert.deepEqual(
+    groupRunFailures([
+      {
+        subject_id: "s",
+        report: {
+          scenarios: [
+            {
+              scenario_id: "clean",
+              runs: [{ failures: [], hard_gates: [{ id: "g", passed: true }] }],
+            },
+          ],
+        },
+      },
+    ]),
+    [],
+  );
+});
+
+test("groupRunFailures groups failures and failed gates per run", () => {
+  const groups = groupRunFailures([
+    {
+      subject_id: "anthropic-sonnet",
+      report: {
+        scenarios: [
+          {
+            scenario_id: "persistent_state",
+            runs: [
+              {
+                failures: [{ phase: "execute", message: "boom" }],
+                hard_gates: [
+                  { id: "no_secrets", passed: false, reason: "leaked" },
+                  { id: "compiles", passed: true },
+                ],
+              },
+              { failures: [], hard_gates: [] },
+              { failures: [{ message: "" }] },
+            ],
+          },
+        ],
+      },
+    },
+  ]);
+  assert.equal(groups.length, 2);
+  assert.deepEqual(groups[0], {
+    subjectId: "anthropic-sonnet",
+    scenarioId: "persistent_state",
+    runIndex: 0,
+    items: [
+      { kind: "failure", phase: "execute", message: "boom" },
+      { kind: "gate", gateId: "no_secrets", message: "leaked" },
+    ],
+  });
+  assert.equal(groups[1].runIndex, 2);
+  assert.deepEqual(groups[1].items, [
+    { kind: "failure", phase: "failure", message: "No failure message" },
+  ]);
+});

--- a/harness/tests/e2e/assets/dashboard/execution-transcript.js
+++ b/harness/tests/e2e/assets/dashboard/execution-transcript.js
@@ -1,0 +1,192 @@
+(function exposeHarnessExecutionTranscript(root, factory) {
+  const api = factory();
+  if (typeof module === "object" && module.exports) {
+    module.exports = api;
+  } else {
+    root.HarnessExecutionTranscript = api;
+  }
+})(typeof globalThis === "object" ? globalThis : this, function buildApi() {
+  "use strict";
+
+  function contentBlocks(content) {
+    if (typeof content === "string") {
+      return content.trim() ? [content] : [];
+    }
+    if (!Array.isArray(content)) return [];
+    return content
+      .filter((block) => block?.type === "text" && typeof block.text === "string")
+      .map((block) => block.text)
+      .filter((text) => text.trim());
+  }
+
+  function messageText(content) {
+    return contentBlocks(content).join("\n\n");
+  }
+
+  function eventId(entry, fallback) {
+    return String(entry?.entry_id || fallback).replace(/[^a-zA-Z0-9_-]/g, "-");
+  }
+
+  function displayFunctionId(functionId, argumentsValue) {
+    const wrappedFunction =
+      functionId === "agent_trigger" &&
+      argumentsValue &&
+      typeof argumentsValue === "object" &&
+      typeof argumentsValue.function === "string"
+        ? argumentsValue.function.trim()
+        : "";
+    return wrappedFunction || functionId || "unknown function";
+  }
+
+  function displayFunctionArguments(functionId, argumentsValue) {
+    if (
+      functionId === "agent_trigger" &&
+      argumentsValue &&
+      typeof argumentsValue === "object"
+    ) {
+      return argumentsValue.payload ?? null;
+    }
+    return argumentsValue ?? null;
+  }
+
+  function normalizeTranscript(messages) {
+    const events = [];
+    const calls = new Map();
+
+    (Array.isArray(messages) ? messages : []).forEach((entry, entryIndex) => {
+      const message = entry?.message;
+      const role = message?.role;
+      const baseId = eventId(entry, `entry-${entryIndex + 1}`);
+
+      if (role === "user" || role === "assistant") {
+        const text = messageText(message.content);
+        if (text) {
+          events.push({
+            id: `${baseId}-message`,
+            kind: "message",
+            role,
+            text,
+            timestamp: message.timestamp || null,
+            model: message.model || null,
+            provider: message.provider || null,
+          });
+        }
+
+        if (role === "assistant" && Array.isArray(message.content)) {
+          message.content.forEach((block, blockIndex) => {
+            if (block?.type !== "function_call") return;
+            const callId = String(block.id || `${baseId}-call-${blockIndex + 1}`);
+            const event = {
+              id: eventId(
+                { entry_id: `${baseId}-${callId}` },
+                `${baseId}-call-${blockIndex + 1}`,
+              ),
+              kind: "tool",
+              callId,
+              functionId: displayFunctionId(block.function_id, block.arguments),
+              arguments: displayFunctionArguments(block.function_id, block.arguments),
+              timestamp: message.timestamp || null,
+              result: null,
+              isError: false,
+              status: "pending",
+            };
+            events.push(event);
+            calls.set(callId, event);
+          });
+        }
+        return;
+      }
+
+      if (role === "function_result") {
+        const callId = String(message.function_call_id || "");
+        const result = {
+          text: messageText(message.content),
+          details: message.details ?? null,
+          timestamp: message.timestamp || null,
+        };
+        const isError = message.is_error === true;
+        const existing = callId ? calls.get(callId) : null;
+        if (existing) {
+          existing.result = result;
+          existing.isError = isError;
+          existing.status = isError ? "error" : "completed";
+          if (
+            existing.functionId === "unknown function" &&
+            typeof message.function_id === "string"
+          ) {
+            existing.functionId = message.function_id;
+          }
+          return;
+        }
+
+        events.push({
+          id: `${baseId}-result`,
+          kind: "tool",
+          callId: callId || null,
+          functionId: message.function_id || "unknown function",
+          arguments: null,
+          timestamp: message.timestamp || null,
+          result,
+          isError,
+          status: isError ? "error" : "completed",
+        });
+        return;
+      }
+
+      if (entry?.custom?.type === "function_call") {
+        const status = String(entry.custom.status || "completed").toLowerCase();
+        events.push({
+          id: `${baseId}-custom`,
+          kind: "tool",
+          callId: null,
+          functionId: entry.custom.name || "unknown function",
+          arguments: entry.custom.arguments ?? null,
+          timestamp: entry.custom.timestamp || null,
+          result: entry.custom.result
+            ? { text: "", details: entry.custom.result, timestamp: null }
+            : null,
+          isError: status === "failed" || status === "error",
+          status,
+        });
+      }
+    });
+
+    return events;
+  }
+
+  function summarizeTranscript(events) {
+    const normalized = Array.isArray(events) ? events : [];
+    return normalized.reduce(
+      (summary, event) => {
+        if (event.kind === "message") summary.messages += 1;
+        if (event.kind === "tool") {
+          summary.calls += 1;
+          if (event.isError) summary.errors += 1;
+        }
+        return summary;
+      },
+      { messages: 0, calls: 0, errors: 0 },
+    );
+  }
+
+  function filterTranscript(events, filter) {
+    const normalized = Array.isArray(events) ? events : [];
+    if (filter === "messages") {
+      return normalized.filter((event) => event.kind === "message");
+    }
+    if (filter === "errors") {
+      return normalized.filter((event) => event.kind === "tool" && event.isError);
+    }
+    return normalized;
+  }
+
+  return {
+    contentBlocks,
+    displayFunctionArguments,
+    displayFunctionId,
+    filterTranscript,
+    messageText,
+    normalizeTranscript,
+    summarizeTranscript,
+  };
+});

--- a/harness/tests/e2e/assets/dashboard/execution-transcript.test.cjs
+++ b/harness/tests/e2e/assets/dashboard/execution-transcript.test.cjs
@@ -1,0 +1,135 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  displayFunctionArguments,
+  displayFunctionId,
+  filterTranscript,
+  messageText,
+  normalizeTranscript,
+  summarizeTranscript,
+} = require("./execution-transcript.js");
+
+test("shows the wrapped function name instead of agent_trigger", () => {
+  const wrappedArguments = {
+    function: "database::query",
+    payload: { db: "primary", sql: "SELECT 1" },
+  };
+  assert.equal(
+    displayFunctionId("agent_trigger", wrappedArguments),
+    "database::query",
+  );
+  assert.deepEqual(displayFunctionArguments("agent_trigger", wrappedArguments), {
+    db: "primary",
+    sql: "SELECT 1",
+  });
+  assert.deepEqual(displayFunctionArguments("state::get", { scope: "test" }), {
+    scope: "test",
+  });
+  assert.equal(displayFunctionId("state::get", { scope: "test" }), "state::get");
+  assert.equal(displayFunctionId("agent_trigger", { payload: {} }), "agent_trigger");
+});
+
+test("extracts readable text from current and legacy message content", () => {
+  assert.equal(messageText(" Legacy response. "), " Legacy response. ");
+  assert.equal(
+    messageText([
+      { type: "text", text: "First" },
+      { type: "function_call", function_id: "state::get" },
+      { type: "text", text: "Second" },
+    ]),
+    "First\n\nSecond",
+  );
+});
+
+test("pairs function results with calls and marks recovered errors", () => {
+  const events = normalizeTranscript([
+    {
+      entry_id: "user-1",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "Verify the state." }],
+      },
+    },
+    {
+      entry_id: "assistant-1",
+      message: {
+        role: "assistant",
+        timestamp: "2026-07-30T12:00:00Z",
+        content: [
+          { type: "text", text: "I will inspect it." },
+          {
+            type: "function_call",
+            id: "call-ok",
+            function_id: "agent_trigger",
+            arguments: {
+              function: "state::get",
+              payload: { key: "status" },
+            },
+          },
+          {
+            type: "function_call",
+            id: "call-error",
+            function_id: "shell::exec",
+            arguments: { command: "false" },
+          },
+        ],
+      },
+    },
+    {
+      entry_id: "result-error",
+      message: {
+        role: "function_result",
+        function_call_id: "call-error",
+        function_id: "shell::exec",
+        is_error: true,
+        details: { error: "command failed" },
+        content: [{ type: "text", text: "command failed" }],
+      },
+    },
+    {
+      entry_id: "result-ok",
+      message: {
+        role: "function_result",
+        function_call_id: "call-ok",
+        function_id: "state::get",
+        is_error: false,
+        details: { value: "ready" },
+        content: [{ type: "text", text: "{\"value\":\"ready\"}" }],
+      },
+    },
+  ]);
+
+  assert.deepEqual(
+    events.map((event) => [event.kind, event.functionId || event.role]),
+    [
+      ["message", "user"],
+      ["message", "assistant"],
+      ["tool", "state::get"],
+      ["tool", "shell::exec"],
+    ],
+  );
+  assert.equal(events[2].result.details.value, "ready");
+  assert.deepEqual(events[2].arguments, { key: "status" });
+  assert.equal(events[2].status, "completed");
+  assert.equal(events[3].isError, true);
+  assert.equal(events[3].result.details.error, "command failed");
+});
+
+test("summarizes and filters a conversation for fast error inspection", () => {
+  const events = [
+    { kind: "message", role: "user" },
+    { kind: "message", role: "assistant" },
+    { kind: "tool", isError: false },
+    { kind: "tool", isError: true },
+  ];
+
+  assert.deepEqual(summarizeTranscript(events), {
+    messages: 2,
+    calls: 2,
+    errors: 1,
+  });
+  assert.equal(filterTranscript(events, "messages").length, 2);
+  assert.equal(filterTranscript(events, "errors").length, 1);
+  assert.equal(filterTranscript(events, "all").length, 4);
+});

--- a/harness/tests/e2e/assets/dashboard/execution.html
+++ b/harness/tests/e2e/assets/dashboard/execution.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="Compact Harness E2E workflow health, metrics, and diagnostics."
+    >
+    <meta name="color-scheme" content="dark light">
+    <title>Harness E2E execution detail</title>
+    <link rel="stylesheet" href="./styles.css">
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to execution details</a>
+    <div class="ambient ambient-one" aria-hidden="true"></div>
+    <div class="ambient ambient-two" aria-hidden="true"></div>
+
+    <header class="topbar">
+      <a class="brand" href="https://github.com/iii-hq/workers" aria-label="iii workers">
+        <span class="brand-copy">
+          <strong>iii</strong>
+          <span>Harness benchmarks</span>
+        </span>
+      </a>
+      <nav class="topbar-actions" aria-label="Execution actions">
+        <a id="workflow-link" class="button button-secondary" href="https://github.com/iii-hq/workers/actions">
+          Open workflow <span aria-hidden="true">↗</span>
+        </a>
+      </nav>
+    </header>
+
+    <main id="main" class="page-shell detail-shell">
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        <a href="./index.html">Executions</a>
+        <span aria-hidden="true">/</span>
+        <span id="breadcrumb-run">Run</span>
+      </nav>
+
+      <section id="detail-loading" class="detail-loading" aria-live="polite">
+        Loading execution data…
+      </section>
+
+      <section id="detail-error" class="empty-state" hidden>
+        <div class="empty-icon" aria-hidden="true">!</div>
+        <h1>Execution not found</h1>
+        <p id="detail-error-message">This execution is not present in the retained history.</p>
+        <a class="button" href="./index.html">Back to executions</a>
+      </section>
+
+      <div id="detail-content" hidden>
+        <section class="execution-header" aria-labelledby="execution-title">
+          <div>
+            <div class="eyebrow">Workflow execution</div>
+            <div class="execution-title-row">
+              <h1 id="execution-title">Run</h1>
+              <span id="execution-status" class="status-pill status-incomplete">Loading</span>
+              <span id="availability-badge" class="data-badge">Unknown data</span>
+            </div>
+            <p id="execution-subtitle"></p>
+          </div>
+          <div id="execution-actions" class="execution-actions"></div>
+        </section>
+
+        <section id="detail-failures" class="detail-alert" hidden aria-labelledby="failures-title">
+          <div>
+            <div class="section-kicker">Needs attention</div>
+            <h2 id="failures-title">Execution failures</h2>
+          </div>
+          <div id="failure-summary"></div>
+        </section>
+
+        <section class="kpi-grid detail-kpis" aria-label="Execution metrics">
+          <article class="kpi-card kpi-primary">
+            <div class="kpi-label">Scenario pass rate</div>
+            <div id="detail-pass-rate" class="kpi-value">—</div>
+            <div id="detail-coverage" class="kpi-delta">—</div>
+            <div class="kpi-orbit" aria-hidden="true"></div>
+          </article>
+          <article class="kpi-card">
+            <div class="kpi-label">Quality score</div>
+            <div id="detail-score" class="kpi-value">—</div>
+            <div class="kpi-delta">Mean of scenario medians</div>
+          </article>
+          <article class="kpi-card">
+            <div class="kpi-label">Model cost</div>
+            <div id="detail-cost" class="kpi-value">—</div>
+            <div class="kpi-delta">Subject and judge</div>
+          </article>
+          <article class="kpi-card">
+            <div class="kpi-label">Model runtime</div>
+            <div id="detail-runtime" class="kpi-value">—</div>
+            <div id="workflow-runtime" class="kpi-delta">—</div>
+          </article>
+        </section>
+
+        <div class="detail-layout">
+          <aside class="detail-index" aria-label="Execution detail sections">
+            <span>On this page</span>
+            <a href="#detail-failures">Failures</a>
+            <a href="#overview">Overview</a>
+            <a href="#configuration">Configuration</a>
+            <a href="#scenarios">Scenarios and runs</a>
+            <a href="#raw-data">Raw data</a>
+          </aside>
+
+          <div class="detail-main">
+            <section id="overview" class="detail-section" aria-labelledby="overview-heading">
+              <div class="section-kicker">Execution context</div>
+              <h2 id="overview-heading">Overview</h2>
+              <details class="section-disclosure">
+                <summary>
+                  <span id="overview-digest" class="section-digest">Loading…</span>
+                  <span class="section-chevron" aria-hidden="true">⌄</span>
+                </summary>
+                <div id="metadata-grid" class="metadata-grid"></div>
+              </details>
+            </section>
+
+            <section id="configuration" class="detail-section" aria-labelledby="configuration-heading">
+              <div class="section-kicker">Resolved stack</div>
+              <h2 id="configuration-heading">Configuration</h2>
+              <details class="section-disclosure">
+                <summary>
+                  <span id="configuration-digest" class="section-digest">Loading…</span>
+                  <span class="section-chevron" aria-hidden="true">⌄</span>
+                </summary>
+                <div id="configuration-content"></div>
+              </details>
+            </section>
+
+            <section id="scenarios" class="detail-section" aria-labelledby="scenarios-heading">
+              <div class="section-kicker">Complete result set</div>
+              <h2 id="scenarios-heading">Scenarios and runs</h2>
+              <p id="scenario-intro" class="section-description"></p>
+              <div id="scenario-details" class="scenario-details"></div>
+            </section>
+
+            <section id="raw-data" class="detail-section" aria-labelledby="raw-heading">
+              <div class="section-kicker">Source record</div>
+              <h2 id="raw-heading">Raw data</h2>
+              <p class="section-description">
+                The structured views above preserve the source report. Use the raw record for fields
+                that do not yet have a dedicated visualization.
+              </p>
+              <div id="raw-actions" class="raw-actions"></div>
+              <details id="raw-preview" class="raw-details">
+                <summary>Preview JSON</summary>
+                <pre id="raw-json"></pre>
+              </details>
+            </section>
+          </div>
+        </div>
+      </div>
+
+      <dialog
+        id="session-transcript-dialog"
+        class="session-transcript-dialog"
+        aria-labelledby="session-transcript-title"
+      >
+        <div class="session-transcript-shell">
+          <header class="session-transcript-header">
+            <div>
+              <div class="section-kicker">Session transcript</div>
+              <h2 id="session-transcript-title">Execution conversation</h2>
+              <p id="session-transcript-context"></p>
+            </div>
+            <button
+              id="session-transcript-close"
+              class="session-transcript-close"
+              type="button"
+              aria-label="Close session transcript"
+            >×</button>
+          </header>
+          <div id="session-transcript-body" class="session-transcript-body"></div>
+        </div>
+      </dialog>
+    </main>
+
+    <footer>
+      <span>Harness E2E · public execution report</span>
+      <a href="./index.html">Back to all executions</a>
+    </footer>
+
+    <script>
+      window.BENCHMARK_DATA = window.BENCHMARK_DATA || null;
+      window.HARNESS_EXECUTIONS = window.HARNESS_EXECUTIONS || null;
+    </script>
+    <script src="./data.js"></script>
+    <script>
+      if (!window.BENCHMARK_DATA) {
+        document.write('<script src="./sample-data.js"><\/script>');
+      }
+    </script>
+    <script src="./dashboard-data.js"></script>
+    <script src="./execution-data.js"></script>
+    <script src="./execution-transcript.js"></script>
+    <script src="./executions.js"></script>
+    <script>
+      if (!window.HARNESS_EXECUTIONS) {
+        document.write('<script src="./sample-executions.js"><\/script>');
+      }
+    </script>
+    <script src="./execution.js"></script>
+  </body>
+</html>

--- a/harness/tests/e2e/assets/dashboard/execution.js
+++ b/harness/tests/e2e/assets/dashboard/execution.js
@@ -1,0 +1,1281 @@
+(function renderHarnessExecutionDetail() {
+  "use strict";
+
+  const benchmark = window.HarnessBenchmarkData.normalizeBenchmarkData(
+    window.BENCHMARK_DATA,
+  );
+  const history = window.HarnessExecutionData.mergeExecutionHistory(
+    window.HARNESS_EXECUTIONS,
+    benchmark,
+  );
+  const executionId = new URLSearchParams(window.location.search).get("id") || "";
+  const execution = window.HarnessExecutionData.findExecution(history, executionId);
+  let detail = null;
+
+  const elements = {
+    actions: document.querySelector("#execution-actions"),
+    availability: document.querySelector("#availability-badge"),
+    breadcrumb: document.querySelector("#breadcrumb-run"),
+    configuration: document.querySelector("#configuration-content"),
+    configurationDigest: document.querySelector("#configuration-digest"),
+    content: document.querySelector("#detail-content"),
+    cost: document.querySelector("#detail-cost"),
+    coverage: document.querySelector("#detail-coverage"),
+    error: document.querySelector("#detail-error"),
+    errorMessage: document.querySelector("#detail-error-message"),
+    failureBox: document.querySelector("#detail-failures"),
+    failureSummary: document.querySelector("#failure-summary"),
+    failureTitle: document.querySelector("#failures-title"),
+    loading: document.querySelector("#detail-loading"),
+    metadata: document.querySelector("#metadata-grid"),
+    overviewDigest: document.querySelector("#overview-digest"),
+    passRate: document.querySelector("#detail-pass-rate"),
+    rawActions: document.querySelector("#raw-actions"),
+    rawJson: document.querySelector("#raw-json"),
+    rawPreview: document.querySelector("#raw-preview"),
+    runtime: document.querySelector("#detail-runtime"),
+    scenarioDetails: document.querySelector("#scenario-details"),
+    scenarioIntro: document.querySelector("#scenario-intro"),
+    score: document.querySelector("#detail-score"),
+    status: document.querySelector("#execution-status"),
+    subtitle: document.querySelector("#execution-subtitle"),
+    transcriptBody: document.querySelector("#session-transcript-body"),
+    transcriptClose: document.querySelector("#session-transcript-close"),
+    transcriptContext: document.querySelector("#session-transcript-context"),
+    transcriptDialog: document.querySelector("#session-transcript-dialog"),
+    transcriptTitle: document.querySelector("#session-transcript-title"),
+    title: document.querySelector("#execution-title"),
+    workflowLink: document.querySelector("#workflow-link"),
+    workflowRuntime: document.querySelector("#workflow-runtime"),
+  };
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  function safeUrl(value) {
+    if (!value) return "";
+    try {
+      const url = new URL(value, window.location.href);
+      return ["http:", "https:"].includes(url.protocol) ? url.href : "";
+    } catch (_error) {
+      return "";
+    }
+  }
+
+  function titleCase(value) {
+    return String(value || "")
+      .replaceAll("_", " ")
+      .replaceAll("-", " ")
+      .replace(/\b\w/g, (letter) => letter.toUpperCase());
+  }
+
+  function compactNumber(value, digits = 1) {
+    return typeof value !== "number" || !Number.isFinite(value)
+      ? "—"
+      : new Intl.NumberFormat("en-US", {
+          maximumFractionDigits: digits,
+          minimumFractionDigits: 0,
+        }).format(value);
+  }
+
+  function formatPercent(value) {
+    return typeof value === "number" ? `${compactNumber(value, 1)}%` : "—";
+  }
+
+  function formatCurrency(value) {
+    return typeof value !== "number"
+      ? "—"
+      : new Intl.NumberFormat("en-US", {
+          style: "currency",
+          currency: "USD",
+          minimumFractionDigits: value < 1 ? 3 : 2,
+          maximumFractionDigits: value < 1 ? 3 : 2,
+        }).format(value);
+  }
+
+  function formatDuration(seconds) {
+    if (typeof seconds !== "number") return "—";
+    if (seconds < 60) return `${compactNumber(seconds, 0)}s`;
+    const minutes = Math.floor(seconds / 60);
+    const remainder = Math.round(seconds % 60);
+    return `${minutes}m ${String(remainder).padStart(2, "0")}s`;
+  }
+
+  function formatDate(timestamp) {
+    if (!timestamp || Number.isNaN(Date.parse(timestamp))) return "Unknown date";
+    return new Intl.DateTimeFormat("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    }).format(new Date(timestamp));
+  }
+
+  function statusMeta(status) {
+    const normalized = String(status || "").toLowerCase();
+    if (normalized === "passed" || normalized === "success") {
+      return { label: "Passed", css: "pass" };
+    }
+    if (normalized === "running") return { label: "Running", css: "running" };
+    if (normalized === "cancelled") return { label: "Cancelled", css: "cancelled" };
+    if (
+      normalized === "failed" ||
+      normalized.endsWith("_failed") ||
+      normalized.endsWith("_error") ||
+      normalized === "failure" ||
+      normalized === "resource_limit"
+    ) {
+      return { label: titleCase(normalized), css: "fail" };
+    }
+    return { label: titleCase(normalized || "incomplete"), css: "incomplete" };
+  }
+
+  function availabilityLabel(availability) {
+    return {
+      full: "Full report",
+      aggregate: "Aggregate only",
+      unavailable: "No report",
+    }[availability] || "Unknown data";
+  }
+
+  function scenarioAnchor(subjectId, scenarioId) {
+    return `scenario-${subjectId}-${scenarioId}`.replace(/[^a-zA-Z0-9_-]/g, "-");
+  }
+
+  function runAnchor(subjectId, scenarioId, index) {
+    return `run-${subjectId}-${scenarioId}-${index + 1}`.replace(
+      /[^a-zA-Z0-9_-]/g,
+      "-",
+    );
+  }
+
+  function blockingFailures() {
+    const totals = execution.totals || {};
+    return (
+      Number(totals.hard_gate_failures || 0) +
+      Number(totals.technical_failures || 0) +
+      Number(totals.missing_reports || 0)
+    );
+  }
+
+  function metadataItem(label, value, options = {}) {
+    const content = options.href
+      ? `<a href="${escapeHtml(options.href)}">${escapeHtml(value)} <span aria-hidden="true">↗</span></a>`
+      : `<strong${options.mono ? ' class="mono"' : ""}>${escapeHtml(value)}</strong>`;
+    return `<div class="metadata-item"><span>${escapeHtml(label)}</span>${content}</div>`;
+  }
+
+  function renderHeader() {
+    const meta = statusMeta(execution.status);
+    const runLabel = execution.run_id || execution.id;
+    elements.breadcrumb.textContent = `Run ${runLabel}`;
+    elements.title.textContent = `Run ${runLabel}`;
+    elements.status.className = `status-pill status-${meta.css}`;
+    elements.status.textContent = meta.label;
+    elements.availability.className =
+      `data-badge data-${execution.availability}`;
+    elements.availability.textContent = availabilityLabel(execution.availability);
+    elements.subtitle.textContent =
+      `${formatDate(execution.completed_at || execution.started_at)} · ` +
+      `attempt ${execution.attempt} · ${titleCase(execution.event || "unknown trigger")}`;
+    document.title = `Run ${runLabel} · Harness E2E`;
+
+    const workflowUrl = safeUrl(execution.workflow_url);
+    elements.workflowLink.hidden = !workflowUrl;
+    if (workflowUrl) elements.workflowLink.href = workflowUrl;
+    const commit = execution.source?.sha || "";
+    const repo = history.repoUrl.replace(/\/$/, "");
+    const commitUrl = commit && repo ? safeUrl(`${repo}/commit/${commit}`) : "";
+    elements.actions.innerHTML = `
+      ${commitUrl ? `<a class="button" href="${escapeHtml(commitUrl)}">Commit ${escapeHtml(commit.slice(0, 7))} <span aria-hidden="true">↗</span></a>` : ""}
+      ${workflowUrl ? `<a class="button" href="${escapeHtml(workflowUrl)}">Open in Actions <span aria-hidden="true">↗</span></a>` : ""}
+    `;
+  }
+
+  function renderKpis() {
+    const totals = execution.totals || {};
+    elements.passRate.textContent = formatPercent(totals.scenario_pass_rate);
+    elements.coverage.textContent =
+      `${formatPercent(totals.report_coverage)} report coverage`;
+    elements.score.textContent = compactNumber(totals.average_score, 1);
+    elements.cost.textContent = formatCurrency(totals.total_cost_usd);
+    elements.runtime.textContent = formatDuration(totals.wall_time_seconds);
+    elements.workflowRuntime.textContent =
+      `${formatDuration(execution.workflow_duration_seconds)} workflow elapsed`;
+  }
+
+  function renderMetadata() {
+    const source = execution.source || {};
+    const release = execution.release || {};
+    elements.overviewDigest.textContent = [
+      source.sha ? source.sha.slice(0, 7) : "unknown commit",
+      titleCase(execution.event || "unknown trigger"),
+      execution.actor || "unknown actor",
+    ].join(" · ");
+    elements.metadata.innerHTML = [
+      metadataItem("Workflow run", execution.run_id || "Unknown", { mono: true }),
+      metadataItem("Attempt", execution.attempt),
+      metadataItem("Workflow conclusion", titleCase(execution.conclusion || "unknown")),
+      metadataItem("Benchmark result", titleCase(execution.status)),
+      metadataItem("Trigger", titleCase(execution.event || "unknown")),
+      metadataItem("Actor", execution.actor || "Unknown"),
+      metadataItem("Started", formatDate(execution.started_at)),
+      metadataItem("Completed", formatDate(execution.completed_at)),
+      metadataItem("Commit", source.sha ? source.sha.slice(0, 12) : "Unknown", {
+        mono: true,
+      }),
+      metadataItem("Source ref", source.ref || "Unknown", { mono: true }),
+      metadataItem("Lane", execution.lane || "Unknown"),
+      metadataItem("Release", release.tag || release.version || "Daily"),
+    ].join("");
+  }
+
+  function capability(value) {
+    if (value === true) return "Yes";
+    if (value === false) return "No";
+    return "Unknown";
+  }
+
+  function renderConfiguration() {
+    const reports = (detail?.reports || [])
+      .filter((record) => record?.available && record.report)
+      .map((record) => record.report);
+    const fullSubjects = new Map();
+    const judges = new Map();
+    reports.forEach((report) => {
+      if (report.subject) {
+        fullSubjects.set(
+          `${report.subject.provider}/${report.subject.model}`,
+          report.subject,
+        );
+      }
+      if (report.judge) {
+        judges.set(`${report.judge.provider}/${report.judge.model}`, report.judge);
+      }
+    });
+    const subjectCards = (
+      fullSubjects.size
+        ? [...fullSubjects.values()]
+        : execution.subjects.map((subject) => ({
+            model: subject.model,
+            provider: subject.provider,
+          }))
+    )
+      .map(
+        (subject) => `
+          <article class="config-card">
+            <span>Subject</span>
+            <h3>${escapeHtml(subject.provider)}/${escapeHtml(subject.model)}</h3>
+            <dl>
+              <div><dt>Context</dt><dd>${compactNumber(subject.context_window, 0)}</dd></div>
+              <div><dt>Max output</dt><dd>${compactNumber(subject.max_output_tokens, 0)}</dd></div>
+              <div><dt>Tools</dt><dd>${capability(subject.supports_tools)}</dd></div>
+              <div><dt>Vision</dt><dd>${capability(subject.supports_vision)}</dd></div>
+            </dl>
+          </article>
+        `,
+      )
+      .join("");
+    const judgeCards = [...judges.values()]
+      .map(
+        (judge) => `
+          <article class="config-card">
+            <span>Judge</span>
+            <h3>${escapeHtml(judge.provider)}/${escapeHtml(judge.model)}</h3>
+            <dl>
+              <div><dt>Context</dt><dd>${compactNumber(judge.context_window, 0)}</dd></div>
+              <div><dt>Max output</dt><dd>${compactNumber(judge.max_output_tokens, 0)}</dd></div>
+              <div><dt>Tools</dt><dd>${capability(judge.supports_tools)}</dd></div>
+              <div><dt>Vision</dt><dd>${capability(judge.supports_vision)}</dd></div>
+            </dl>
+          </article>
+        `,
+      )
+      .join("");
+    const revisions = [
+      ...new Set(
+        reports
+          .map((report) => report.engine_revision)
+          .concat(execution.subjects.map((subject) => subject.engine_revision))
+          .filter(Boolean),
+      ),
+    ];
+    const protocols = [
+      ...new Set(reports.map((report) => report.judge_protocol).filter(Boolean)),
+    ];
+    const digestSubject =
+      [...fullSubjects.values()][0] || execution.subjects[0] || null;
+    const digestJudge = [...judges.values()][0] || null;
+    elements.configurationDigest.textContent = [
+      digestSubject
+        ? `${digestSubject.provider}/${digestSubject.model}`
+        : "unknown subject",
+      digestJudge ? `judge ${digestJudge.provider}/${digestJudge.model}` : "",
+      execution.requested_runs != null
+        ? `${execution.requested_runs} runs requested`
+        : "",
+    ]
+      .filter(Boolean)
+      .join(" · ");
+    elements.configuration.innerHTML = `
+      <div class="config-grid">${subjectCards}${judgeCards}</div>
+      <div class="config-facts">
+        ${metadataItem("Engine revision", revisions.join(", ") || "Unknown", { mono: true })}
+        ${metadataItem("Judge protocol", protocols.join(", ") || "Unknown")}
+        ${metadataItem("Requested runs", execution.requested_runs ?? "Unknown")}
+        ${metadataItem("Report availability", availabilityLabel(execution.availability))}
+      </div>
+    `;
+  }
+
+  function scenarioSummaryRow(options) {
+    return `
+      <summary class="scenario-summary-row">
+        <span class="scenario-summary-copy">
+          <strong>${escapeHtml(options.title)}</strong>
+          <small>${escapeHtml(options.subjectLabel)}</small>
+        </span>
+        <span class="scenario-summary-stat">
+          <small>Median</small>
+          <strong>${escapeHtml(options.median)}</strong>
+        </span>
+        <span class="scenario-summary-stat">
+          <small>Pass rate</small>
+          <strong>${escapeHtml(options.passRate)}</strong>
+        </span>
+        <span class="scenario-summary-stat">
+          <small>Cost</small>
+          <strong>${escapeHtml(options.cost)}</strong>
+        </span>
+        <span class="table-status status-${options.statusCss}">${options.statusLabel}</span>
+        <span class="scenario-chevron" aria-hidden="true">⌄</span>
+      </summary>
+    `;
+  }
+
+  function renderAggregateScenario(subject, scenario, options = {}) {
+    const meta = statusMeta(
+      window.HarnessExecutionData.normalizeScenarioStatus(scenario),
+    );
+    const anchor = scenarioAnchor(subject.id, scenario.id);
+    const open = scenario.passed === false || options.soleScenario;
+    return `
+      <details id="${escapeHtml(anchor)}" class="scenario-detail-card" ${open ? "open" : ""}>
+        ${scenarioSummaryRow({
+          title: titleCase(scenario.id),
+          subjectLabel: `${subject.provider}/${subject.model}`,
+          median: compactNumber(scenario.median_score, 1),
+          passRate: formatPercent(
+            typeof scenario.pass_rate === "number" ? scenario.pass_rate * 100 : null,
+          ),
+          cost: formatCurrency(scenario.total_cost_usd),
+          statusCss: meta.css,
+          statusLabel: meta.label,
+        })}
+        <div class="scenario-detail-body">
+          <div class="scenario-detail-metrics">
+            ${metricBlock("Median score", compactNumber(scenario.median_score, 1))}
+            ${metricBlock("Pass rate", formatPercent(typeof scenario.pass_rate === "number" ? scenario.pass_rate * 100 : null))}
+            ${metricBlock("Cost", formatCurrency(scenario.total_cost_usd))}
+            ${metricBlock("Runtime", formatDuration(scenario.wall_time_seconds))}
+            ${metricBlock("Hard gates", compactNumber(scenario.hard_gate_failures, 0))}
+            ${metricBlock("Technical", compactNumber(scenario.technical_failures, 0))}
+            ${metricBlock("Retries", compactNumber(scenario.retries, 0))}
+            ${metricBlock("Runs", compactNumber(scenario.runs, 0))}
+          </div>
+          <div class="aggregate-expired">
+            Per-run chat is available only while the full execution detail is retained.
+          </div>
+        </div>
+      </details>
+    `;
+  }
+
+  function metricBlock(label, value, caption = "") {
+    return `
+      <div class="detail-metric">
+        <span>${escapeHtml(label)}</span>
+        <strong>${escapeHtml(value)}</strong>
+        ${caption ? `<small>${escapeHtml(caption)}</small>` : ""}
+      </div>
+    `;
+  }
+
+  function renderFailureList(failures) {
+    if (!failures?.length) return '<div class="clean-state">No recorded failures.</div>';
+    return `
+      <ul class="diagnostic-list">
+        ${failures
+          .map(
+            (failure) => `
+              <li>
+                <span>${escapeHtml(titleCase(failure.phase || "failure"))}</span>
+                <p>${escapeHtml(failure.message || "No failure message")}</p>
+              </li>
+            `,
+          )
+          .join("")}
+      </ul>
+    `;
+  }
+
+  function renderGateTable(gates) {
+    if (!gates?.length) return '<div class="clean-state">No hard gates recorded.</div>';
+    return `
+      <div class="diagnostic-table-wrap">
+        <table class="diagnostic-table">
+          <thead><tr><th>Gate</th><th>Result</th><th>Reason</th></tr></thead>
+          <tbody>
+            ${gates
+              .map((gate) => {
+                const meta = statusMeta(gate.passed ? "passed" : "failed");
+                return `<tr>
+                  <td class="mono">${escapeHtml(gate.id)}</td>
+                  <td><span class="table-status status-${meta.css}">${meta.label}</span></td>
+                  <td class="wrap-cell">${escapeHtml(gate.reason || "—")}</td>
+                </tr>`;
+              })
+              .join("")}
+          </tbody>
+        </table>
+      </div>
+    `;
+  }
+
+  function renderCriteriaTable(criteria) {
+    if (!criteria?.length) return '<div class="clean-state">No scored criteria recorded.</div>';
+    return `
+      <div class="diagnostic-table-wrap">
+        <table class="diagnostic-table">
+          <thead><tr><th>Criterion</th><th>Points</th><th>Reason</th></tr></thead>
+          <tbody>
+            ${criteria
+              .map(
+                (criterion) => `<tr>
+                  <td class="mono">${escapeHtml(criterion.id)}</td>
+                  <td>${escapeHtml(
+                    `${criterion.awarded ?? "—"} / ${criterion.possible ?? "—"}`,
+                  )}</td>
+                  <td class="wrap-cell">${escapeHtml(criterion.reason || "—")}</td>
+                </tr>`,
+              )
+              .join("")}
+          </tbody>
+        </table>
+      </div>
+    `;
+  }
+
+  function usageBlocks(run) {
+    const totals = run.metrics?.totals || {};
+    const judge = run.judge_usage || {};
+    const cost = run.cost || {};
+    return `
+      <div class="usage-grid">
+        ${metricBlock("Sessions", compactNumber(totals.sessions, 0))}
+        ${metricBlock("Turns", compactNumber(totals.turns, 0))}
+        ${metricBlock("Function calls", compactNumber(totals.function_calls, 0))}
+        ${metricBlock("Function errors", compactNumber(totals.function_call_errors, 0))}
+        ${metricBlock("Input tokens", compactNumber(totals.input_tokens, 0))}
+        ${metricBlock("Output tokens", compactNumber(totals.output_tokens, 0))}
+        ${metricBlock("Cache read", compactNumber(totals.cache_read_tokens, 0))}
+        ${metricBlock("Reasoning", compactNumber(totals.reasoning_tokens, 0))}
+        ${metricBlock("Subject cost", formatCurrency(cost.subject_usd))}
+        ${metricBlock("Judge cost", formatCurrency(cost.judge_usd), `${compactNumber(run.judge_attempts, 0)} attempt(s)`)}
+        ${metricBlock("Total cost", formatCurrency(cost.total_usd))}
+        ${metricBlock("Judge tokens", compactNumber(
+          (judge.input_tokens || 0) + (judge.output_tokens || 0),
+          0,
+        ))}
+      </div>
+    `;
+  }
+
+  function renderRetries(retries) {
+    if (!retries?.length) return '<div class="clean-state">No retry attempts.</div>';
+    return retries
+      .map((retry, index) => {
+        const meta = statusMeta(retry.status);
+        return `
+          <article class="retry-card">
+            <header>
+              <strong>Retry ${index + 1}</strong>
+              <span class="table-status status-${meta.css}">${meta.label}</span>
+            </header>
+            <div class="retry-meta">
+              <span class="mono">${escapeHtml(retry.run_id || "")}</span>
+              <span>${formatDuration((retry.wall_time_ms || 0) / 1000)}</span>
+              <span>${formatCurrency(retry.cost?.total_usd)}</span>
+            </div>
+            ${renderFailureList(retry.failures)}
+          </article>
+        `;
+      })
+      .join("");
+  }
+
+  function formatEventTime(timestamp) {
+    if (!timestamp || Number.isNaN(Date.parse(timestamp))) return "";
+    return new Intl.DateTimeFormat("en-US", {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    }).format(new Date(timestamp));
+  }
+
+  function formatPayload(value) {
+    if (typeof value === "string") return value;
+    if (value === undefined || value === null) return "No payload recorded.";
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch (_error) {
+      return String(value);
+    }
+  }
+
+  function renderConversationText(value) {
+    return escapeHtml(value)
+      .replace(/`([^`\n]+)`/g, "<code>$1</code>")
+      .replace(/\*\*([^*\n]+)\*\*/g, "<strong>$1</strong>")
+      .replaceAll("\n", "<br>");
+  }
+
+  function conversationMessage(event) {
+    const isAssistant = event.role === "assistant";
+    const label = isAssistant ? "assistant" : "you";
+    const context = [event.provider, event.model].filter(Boolean).join("/");
+    const time = formatEventTime(event.timestamp);
+    const metadata = [context, time].filter(Boolean).join(" · ");
+    return `
+      <article
+        id="${escapeHtml(event.id)}"
+        class="conversation-event conversation-message conversation-${escapeHtml(event.role)}"
+        data-kind="message"
+      >
+        <div class="conversation-card">
+          <header>
+            <strong><span aria-hidden="true">${isAssistant ? ">" : "$"}</span> ${label}</strong>
+            <span>${escapeHtml(metadata)}</span>
+          </header>
+          <div class="conversation-copy">${renderConversationText(event.text)}</div>
+        </div>
+      </article>
+    `;
+  }
+
+  function conversationTool(event) {
+    const status = event.isError
+      ? "Error"
+      : event.status === "pending"
+        ? "No result"
+        : "Completed";
+    const resultPayload =
+      event.result?.details !== null && event.result?.details !== undefined
+        ? event.result.details
+        : event.result?.text;
+    const time = formatEventTime(event.timestamp);
+    return `
+      <details
+        id="${escapeHtml(event.id)}"
+        class="conversation-event conversation-tool${event.isError ? " conversation-tool-error" : ""}"
+        data-kind="tool"
+        data-error="${event.isError ? "true" : "false"}"
+        ${event.isError ? "open" : ""}
+      >
+        <summary>
+          <span class="conversation-tool-icon" aria-hidden="true">${event.isError ? "×" : "✓"}</span>
+          <span class="conversation-tool-name">
+            <small>${event.status === "pending" ? "triggering" : "triggered"} <i>ƒ</i></small>
+            <strong class="mono">${escapeHtml(event.functionId)}${time ? ` <em>· ${escapeHtml(time)}</em>` : ""}</strong>
+          </span>
+          <span class="conversation-tool-status">${status}</span>
+          <span class="conversation-chevron" aria-hidden="true">⌄</span>
+        </summary>
+        <div class="conversation-tool-body">
+          ${
+            event.arguments !== null && event.arguments !== undefined
+              ? `<div class="conversation-payload">
+                  <span>Request</span>
+                  <pre>${escapeHtml(formatPayload(event.arguments))}</pre>
+                </div>`
+              : ""
+          }
+          <div class="conversation-payload${event.isError ? " conversation-payload-error" : ""}">
+            <span>${event.isError ? "Error result" : "Result"}</span>
+            <pre>${escapeHtml(formatPayload(resultPayload))}</pre>
+          </div>
+        </div>
+      </details>
+    `;
+  }
+
+  function renderConversation(messages) {
+    const transcript = window.HarnessExecutionTranscript;
+    const events = transcript.normalizeTranscript(messages);
+    if (!events.length) {
+      return '<div class="clean-state">No readable conversation events were recorded.</div>';
+    }
+    const summary = transcript.summarizeTranscript(events);
+    return `
+      <div class="conversation-shell" data-filter="all" data-error-cursor="-1">
+        <div class="conversation-toolbar">
+          <div class="conversation-stats" aria-label="Conversation summary">
+            <span><strong>${summary.messages}</strong> messages</span>
+            <span><strong>${summary.calls}</strong> calls</span>
+            <span class="${summary.errors ? "has-errors" : ""}"><strong>${summary.errors}</strong> errors</span>
+          </div>
+          <div class="conversation-actions">
+            <div class="conversation-filters" aria-label="Filter conversation">
+              <button type="button" class="conversation-filter is-active" data-filter="all" aria-pressed="true">All</button>
+              <button type="button" class="conversation-filter" data-filter="messages" aria-pressed="false">Messages</button>
+              <button type="button" class="conversation-filter" data-filter="errors" aria-pressed="false">Errors only</button>
+            </div>
+            <button
+              type="button"
+              class="conversation-next-error"
+              ${summary.errors ? "" : "disabled"}
+            >
+              Next error
+            </button>
+          </div>
+        </div>
+        <div class="conversation-error-position" aria-live="polite"></div>
+        <div class="conversation-list">
+          ${events
+            .map((event) =>
+              event.kind === "message"
+                ? conversationMessage(event)
+                : conversationTool(event),
+            )
+            .join("")}
+          <div class="conversation-empty-filter">No events match this filter.</div>
+        </div>
+      </div>
+    `;
+  }
+
+  function renderConversationLaunch(messages, run) {
+    const transcript = window.HarnessExecutionTranscript;
+    const events = transcript.normalizeTranscript(messages);
+    const summary = transcript.summarizeTranscript(events);
+    return `
+      <section class="conversation-launch">
+        <div>
+          <span>Session transcript</span>
+          <strong>${summary.messages} messages · ${summary.calls} functions</strong>
+          <small class="${summary.errors ? "has-errors" : ""}">
+            ${summary.errors
+              ? `${summary.errors} error${summary.errors === 1 ? "" : "s"} to inspect`
+              : `${escapeHtml(run.session_id || "No session id")} · read-only`}
+          </small>
+        </div>
+        <button type="button" class="conversation-open">Open chat</button>
+      </section>
+    `;
+  }
+
+  function openConversationDialog(run, context) {
+    const messages = Array.isArray(run.transcript?.messages)
+      ? run.transcript.messages
+      : [];
+    elements.transcriptTitle.textContent =
+      `${titleCase(context.scenarioId)} · run ${context.runIndex + 1}`;
+    elements.transcriptContext.textContent = [
+      context.subjectLabel,
+      run.session_id ? `session ${run.session_id}` : "session unavailable",
+      run.run_id ? `run ${run.run_id}` : "",
+    ]
+      .filter(Boolean)
+      .join(" · ");
+    elements.transcriptBody.innerHTML = renderConversation(messages);
+    attachConversationControls(elements.transcriptBody);
+    if (!elements.transcriptDialog.open) elements.transcriptDialog.showModal();
+  }
+
+  function attachTranscriptDialogControls() {
+    elements.transcriptClose.addEventListener("click", () => {
+      elements.transcriptDialog.close();
+    });
+    elements.transcriptDialog.addEventListener("click", (event) => {
+      if (event.target === elements.transcriptDialog) {
+        elements.transcriptDialog.close();
+      }
+    });
+  }
+
+  function attachConversationControls(container) {
+    container.querySelectorAll(".conversation-shell").forEach((shell) => {
+      const filters = [...shell.querySelectorAll(".conversation-filter")];
+      const position = shell.querySelector(".conversation-error-position");
+      filters.forEach((button) => {
+        button.addEventListener("click", () => {
+          const filter = button.dataset.filter || "all";
+          shell.dataset.filter = filter;
+          filters.forEach((candidate) => {
+            const active = candidate === button;
+            candidate.classList.toggle("is-active", active);
+            candidate.setAttribute("aria-pressed", String(active));
+          });
+          const visibleEvents = [
+            ...shell.querySelectorAll(".conversation-event"),
+          ].filter((event) => {
+            if (filter === "messages") return event.dataset.kind === "message";
+            if (filter === "errors") return event.dataset.error === "true";
+            return true;
+          });
+          shell.classList.toggle(
+            "conversation-filter-empty",
+            visibleEvents.length === 0,
+          );
+          position.textContent = "";
+        });
+      });
+
+      const nextError = shell.querySelector(".conversation-next-error");
+      nextError?.addEventListener("click", () => {
+        const errors = [
+          ...shell.querySelectorAll('.conversation-event[data-error="true"]'),
+        ];
+        if (!errors.length) return;
+        const nextIndex = (Number(shell.dataset.errorCursor || -1) + 1) % errors.length;
+        shell.dataset.errorCursor = String(nextIndex);
+        const error = errors[nextIndex];
+        error.open = true;
+        error.scrollIntoView({ behavior: "smooth", block: "center" });
+        error.classList.add("conversation-focus-error");
+        position.textContent = `Error ${nextIndex + 1} of ${errors.length}`;
+        window.setTimeout(
+          () => error.classList.remove("conversation-focus-error"),
+          1600,
+        );
+      });
+    });
+  }
+
+  function sessionTable(metrics) {
+    const sessions = Array.isArray(metrics?.by_session) ? metrics.by_session : [];
+    const traces = metrics?.traces || {};
+    if (!sessions.length && !Object.keys(traces).length) {
+      return '<div class="clean-state">No session metrics or traces recorded.</div>';
+    }
+    return `
+      ${
+        sessions.length
+          ? `<div class="diagnostic-table-wrap">
+              <table class="diagnostic-table">
+                <thead><tr><th>Session</th><th>Depth</th><th>Turns</th><th>Calls</th><th>Errors</th><th>Tokens</th><th>Cost</th></tr></thead>
+                <tbody>
+                  ${sessions
+                    .map(
+                      (session) => `<tr>
+                        <td class="mono wrap-cell">${escapeHtml(session.session_id)}</td>
+                        <td>${compactNumber(session.depth, 0)}</td>
+                        <td>${compactNumber(session.turns, 0)}</td>
+                        <td>${compactNumber(session.function_calls, 0)}</td>
+                        <td>${compactNumber(session.function_call_errors, 0)}</td>
+                        <td>${compactNumber(
+                          Number(session.input_tokens || 0) +
+                            Number(session.output_tokens || 0),
+                          0,
+                        )}</td>
+                        <td>${formatCurrency(session.cost_usd)}</td>
+                      </tr>`,
+                    )
+                    .join("")}
+                </tbody>
+              </table>
+            </div>`
+          : ""
+      }
+      <details class="nested-raw" data-trace="true">
+        <summary>Trace summary</summary>
+        <pre></pre>
+      </details>
+    `;
+  }
+
+  function runSection(title, content, options = {}) {
+    return `
+      <section class="run-section ${options.wide ? "run-section-wide" : ""}">
+        <h5>${escapeHtml(title)}</h5>
+        ${content}
+      </section>
+    `;
+  }
+
+  const PROMPT_CLAMP_THRESHOLD = 1200;
+
+  function renderEvaluationTab(panel, run) {
+    panel.innerHTML = `
+      ${runSection("Failures", renderFailureList(run.failures))}
+      ${runSection("Hard gates", renderGateTable(run.hard_gates), { wide: true })}
+      ${runSection("Scored criteria", renderCriteriaTable(run.criteria), { wide: true })}
+      ${runSection("Retry attempts", renderRetries(run.retry_attempts), { wide: true })}
+    `;
+  }
+
+  function renderUsageTab(panel, run) {
+    panel.innerHTML = runSection("Usage and cost", usageBlocks(run), { wide: true });
+  }
+
+  function renderPromptTab(panel, run) {
+    const prompt = run.prompt || "No prompt recorded.";
+    const clamp = prompt.length > PROMPT_CLAMP_THRESHOLD;
+    panel.innerHTML = runSection(
+      "Prompt",
+      `
+        <pre class="prompt-block${clamp ? " is-clamped" : ""}">${escapeHtml(prompt)}</pre>
+        ${clamp ? '<button type="button" class="prompt-expand">Show full prompt</button>' : ""}
+      `,
+      { wide: true },
+    );
+    panel.querySelector(".prompt-expand")?.addEventListener("click", (event) => {
+      panel.querySelector(".prompt-block").classList.remove("is-clamped");
+      event.target.remove();
+    });
+  }
+
+  function renderSessionsTab(panel, run) {
+    panel.innerHTML = runSection("Sessions and traces", sessionTable(run.metrics), {
+      wide: true,
+    });
+    const trace = panel.querySelector('details[data-trace="true"]');
+    trace?.addEventListener("toggle", () => {
+      if (!trace.open || trace.dataset.rendered) return;
+      trace.dataset.rendered = "true";
+      trace.querySelector("pre").textContent = JSON.stringify(
+        run.metrics?.traces || {},
+        null,
+        2,
+      );
+    });
+  }
+
+  function renderRawTab(panel, run) {
+    panel.innerHTML = runSection(
+      "Complete run record",
+      '<pre class="prompt-block"></pre>',
+      { wide: true },
+    );
+    panel.querySelector("pre").textContent = JSON.stringify(run, null, 2);
+  }
+
+  const RUN_TABS = [
+    { id: "evaluation", label: "Evaluation", render: renderEvaluationTab },
+    { id: "usage", label: "Usage", render: renderUsageTab },
+    { id: "prompt", label: "Prompt", render: renderPromptTab },
+    { id: "sessions", label: "Sessions", render: renderSessionsTab },
+    { id: "raw", label: "Raw", render: renderRawTab },
+  ];
+
+  function renderRunContent(container, run, context) {
+    const messages = Array.isArray(run.transcript?.messages)
+      ? run.transcript.messages
+      : [];
+    container.innerHTML = `
+      <div class="run-overview">
+        ${metricBlock("Score", compactNumber(run.score, 1))}
+        ${metricBlock("Runtime", formatDuration((run.wall_time_ms || 0) / 1000))}
+        ${metricBlock("Total cost", formatCurrency(run.cost?.total_usd))}
+        ${metricBlock("Judge attempts", compactNumber(run.judge_attempts, 0))}
+        ${metricBlock("Retries", compactNumber(run.retry_attempts?.length || 0, 0))}
+        ${metricBlock("Session", run.session_id || "Unknown")}
+      </div>
+      ${renderConversationLaunch(messages, run)}
+      <div class="run-tabs" role="tablist" aria-label="Run diagnostics">
+        ${RUN_TABS.map(
+          (tab) =>
+            `<button type="button" role="tab" data-tab="${tab.id}" aria-selected="false">${tab.label}</button>`,
+        ).join("")}
+      </div>
+      ${RUN_TABS.map(
+        (tab) =>
+          `<div class="run-sections" role="tabpanel" data-panel="${tab.id}" hidden></div>`,
+      ).join("")}
+    `;
+    container.querySelector(".conversation-open")?.addEventListener("click", () => {
+      openConversationDialog(run, context);
+    });
+    const buttons = [...container.querySelectorAll(".run-tabs button")];
+    const activateRunTab = (tabId) => {
+      RUN_TABS.forEach((tab) => {
+        const panel = container.querySelector(`[data-panel="${tab.id}"]`);
+        const active = tab.id === tabId;
+        if (active && !panel.dataset.rendered) {
+          panel.dataset.rendered = "true";
+          tab.render(panel, run);
+        }
+        panel.hidden = !active;
+      });
+      buttons.forEach((button) => {
+        const active = button.dataset.tab === tabId;
+        button.classList.toggle("active", active);
+        button.setAttribute("aria-selected", String(active));
+      });
+    };
+    buttons.forEach((button) => {
+      button.addEventListener("click", () => activateRunTab(button.dataset.tab));
+    });
+    activateRunTab("evaluation");
+  }
+
+  function renderFullScenario(record, options = {}) {
+    const report = record.report;
+    const scenario = report.scenarios?.find(
+      (item) => item.scenario_id === record.scenario_id,
+    );
+    if (!scenario) return "";
+    const subjectId = record.subject_id;
+    const aggregate = scenario.aggregate || {};
+    const meta = statusMeta(
+      window.HarnessExecutionData.normalizeScenarioStatus({
+        ...scenario,
+        hard_gate_failures: aggregate.hard_gate_failures,
+        technical_failures: aggregate.technical_failures,
+      }),
+    );
+    const policy = scenario.execution_policy || {};
+    const anchor = scenarioAnchor(subjectId, scenario.scenario_id);
+    const failingRun = (scenario.runs || []).some(
+      (run) =>
+        (run.failures || []).length ||
+        (run.hard_gates || []).some((gate) => gate && gate.passed === false),
+    );
+    const open = !scenario.passed || failingRun || options.soleScenario;
+    return `
+      <details id="${escapeHtml(anchor)}" class="scenario-detail-card" ${open ? "open" : ""}>
+        ${scenarioSummaryRow({
+          title: titleCase(scenario.scenario_id),
+          subjectLabel: `${report.subject.provider}/${report.subject.model}`,
+          median: compactNumber(aggregate.median_score, 1),
+          passRate: formatPercent(
+            typeof aggregate.pass_rate === "number" ? aggregate.pass_rate * 100 : null,
+          ),
+          cost: formatCurrency(aggregate.cost?.total_usd),
+          statusCss: meta.css,
+          statusLabel: meta.label,
+        })}
+        <div class="scenario-detail-body">
+        <div class="scenario-detail-metrics">
+          ${metricBlock("Median score", compactNumber(aggregate.median_score, 1))}
+          ${metricBlock("Pass rate", formatPercent(
+            typeof aggregate.pass_rate === "number" ? aggregate.pass_rate * 100 : null,
+          ))}
+          ${metricBlock("Runs passed", `${aggregate.passed_runs ?? "—"} / ${aggregate.runs ?? "—"}`, `${aggregate.required_passes ?? "—"} required`)}
+          ${metricBlock("Cost", formatCurrency(aggregate.cost?.total_usd))}
+          ${metricBlock("Hard gates", compactNumber(aggregate.hard_gate_failures, 0))}
+          ${metricBlock("Technical", compactNumber(aggregate.technical_failures, 0))}
+          ${metricBlock("Max turns", compactNumber(policy.max_turns, 0))}
+          ${metricBlock("Token budget", compactNumber(policy.max_total_tokens, 0))}
+        </div>
+        <div class="run-list">
+          ${(scenario.runs || [])
+            .map((run, index) => {
+              const runMeta = statusMeta(run.status);
+              const runId = runAnchor(subjectId, scenario.scenario_id, index);
+              const functionErrors = Number(
+                run.metrics?.totals?.function_call_errors || 0,
+              );
+              return `
+                <details id="${escapeHtml(runId)}" class="run-detail" data-run-index="${index}">
+                  <summary>
+                    <span class="run-number">${String(index + 1).padStart(2, "0")}</span>
+                    <span class="run-summary-copy">
+                      <strong>Run ${index + 1}</strong>
+                      <small>
+                        <span class="mono">${escapeHtml(run.run_id || "unknown")}</span>
+                        ${
+                          functionErrors
+                            ? `<span class="run-summary-error">${functionErrors} function error${functionErrors === 1 ? "" : "s"}</span>`
+                            : ""
+                        }
+                      </small>
+                    </span>
+                    <span>Score ${compactNumber(run.score, 1)}</span>
+                    <span>${formatDuration((run.wall_time_ms || 0) / 1000)}</span>
+                    <span class="table-status status-${runMeta.css}">${runMeta.label}</span>
+                  </summary>
+                  <div class="run-content" data-pending="true">
+                    <div class="detail-loading-inline">Open run to render diagnostics.</div>
+                  </div>
+                </details>
+              `;
+            })
+            .join("")}
+        </div>
+        </div>
+      </details>
+    `;
+  }
+
+  function attachRunRenderers() {
+    (detail?.reports || []).forEach((record) => {
+      const scenario = record?.report?.scenarios?.find(
+        (item) => item.scenario_id === record.scenario_id,
+      );
+      (scenario?.runs || []).forEach((run, index) => {
+        const id = runAnchor(record.subject_id, record.scenario_id, index);
+        const element = document.getElementById(id);
+        if (!element) return;
+        element.addEventListener("toggle", () => {
+          if (!element.open) return;
+          const container = element.querySelector(".run-content[data-pending='true']");
+          if (!container) return;
+          container.removeAttribute("data-pending");
+          renderRunContent(container, run, {
+            runIndex: index,
+            scenarioId: record.scenario_id,
+            subjectLabel: [
+              record.report?.subject?.provider,
+              record.report?.subject?.model,
+            ]
+              .filter(Boolean)
+              .join("/"),
+          });
+        });
+      });
+    });
+  }
+
+  function renderScenarios() {
+    const availableReports = (detail?.reports || []).filter(
+      (record) => record?.available && record.report,
+    );
+    if (availableReports.length) {
+      const runCount = availableReports.reduce(
+        (total, record) =>
+          total +
+          (record.report.scenarios || []).reduce(
+            (scenarioTotal, scenario) =>
+              scenarioTotal + (scenario.runs?.length || 0),
+            0,
+          ),
+        0,
+      );
+      elements.scenarioIntro.textContent =
+        `${availableReports.length} scenario reports and ${runCount} individual runs. ` +
+        "Select a scenario to expand its runs.";
+      elements.scenarioDetails.innerHTML = availableReports
+        .map((record) =>
+          renderFullScenario(record, { soleScenario: availableReports.length === 1 }),
+        )
+        .join("");
+      attachRunRenderers();
+      return;
+    }
+    elements.scenarioIntro.textContent =
+      execution.availability === "aggregate"
+        ? "The complete report expired after 30 executions. Historical aggregate metrics remain available."
+        : "This workflow did not produce a complete benchmark report.";
+    const aggregateCount = execution.subjects.reduce(
+      (total, subject) => total + (subject.scenarios || []).length,
+      0,
+    );
+    elements.scenarioDetails.innerHTML = execution.subjects
+      .flatMap((subject) =>
+        (subject.scenarios || []).map((scenario) =>
+          renderAggregateScenario(subject, scenario, {
+            soleScenario: aggregateCount === 1,
+          }),
+        ),
+      )
+      .join("");
+    if (!elements.scenarioDetails.children.length) {
+      elements.scenarioDetails.innerHTML =
+        '<div class="clean-state">No scenario data was produced. Open the workflow for build and infrastructure diagnostics.</div>';
+    }
+  }
+
+  const MAX_FAILURE_CHIPS = 5;
+
+  function truncateText(value, limit) {
+    const text = String(value || "");
+    return text.length > limit ? `${text.slice(0, limit - 1)}…` : text;
+  }
+
+  function failureChip(group) {
+    const anchor = runAnchor(group.subjectId, group.scenarioId, group.runIndex);
+    const first = group.items[0];
+    const preview =
+      first.kind === "gate"
+        ? `${first.gateId}: ${first.message}`
+        : `${titleCase(first.phase)}: ${first.message}`;
+    return `
+      <a class="failure-chip" href="#${escapeHtml(anchor)}">
+        <span class="table-status status-fail">${group.items.length} issue${group.items.length === 1 ? "" : "s"}</span>
+        <strong>${escapeHtml(titleCase(group.scenarioId))} · run ${group.runIndex + 1}</strong>
+        <span class="failure-chip-message">${escapeHtml(truncateText(preview, 140))}</span>
+      </a>
+    `;
+  }
+
+  function renderFailures() {
+    const groups = window.HarnessExecutionData.groupRunFailures(detail?.reports);
+    const count = blockingFailures();
+    if (!groups.length && count === 0 && execution.status === "passed") {
+      elements.failureBox.hidden = true;
+      return;
+    }
+    elements.failureBox.hidden = false;
+    elements.failureTitle.textContent = count
+      ? `Execution failures · ${count} blocking event${count === 1 ? "" : "s"}`
+      : "Execution failures";
+    if (groups.length) {
+      const sorted = [...groups].sort((a, b) => b.items.length - a.items.length);
+      const visible = sorted.slice(0, MAX_FAILURE_CHIPS);
+      const overflow = sorted.slice(MAX_FAILURE_CHIPS);
+      elements.failureSummary.innerHTML = `
+        <div class="failure-groups">${visible.map(failureChip).join("")}</div>
+        ${
+          overflow.length
+            ? `<details class="failure-overflow">
+                <summary>Show all ${sorted.length} failing runs</summary>
+                <div class="failure-groups">${overflow.map(failureChip).join("")}</div>
+              </details>`
+            : ""
+        }
+      `;
+      return;
+    }
+    elements.failureSummary.innerHTML = `
+      <p>
+        ${escapeHtml(
+          execution.status === "cancelled"
+            ? "The workflow was cancelled before a complete result was published."
+            : `${count} blocking reliability event${count === 1 ? "" : "s"} recorded in the aggregate result.`,
+        )}
+      </p>
+    `;
+  }
+
+  function renderRawData() {
+    // The detail JSON can be multi-megabyte: serialize only when the preview
+    // is opened or the fallback download is clicked, never at page load.
+    elements.rawPreview.addEventListener("toggle", () => {
+      if (!elements.rawPreview.open || elements.rawPreview.dataset.rendered) return;
+      elements.rawPreview.dataset.rendered = "true";
+      elements.rawJson.textContent = JSON.stringify(detail || execution, null, 2);
+    });
+    elements.rawActions.replaceChildren();
+    if (detail && execution.detail_path && !window.HARNESS_BENCHMARK_PREVIEW) {
+      const link = document.createElement("a");
+      link.className = "button";
+      link.href = execution.detail_path;
+      link.download = `${execution.id}.json`;
+      link.textContent = "Download execution JSON";
+      elements.rawActions.append(link);
+      return;
+    }
+    const link = document.createElement("a");
+    link.className = "button";
+    link.href = "#raw-data";
+    link.download = `${execution.id}.json`;
+    link.textContent = "Download available JSON";
+    link.addEventListener("click", () => {
+      if (link.dataset.blobUrl) return;
+      const blob = new Blob([JSON.stringify(detail || execution, null, 2)], {
+        type: "application/json",
+      });
+      link.dataset.blobUrl = URL.createObjectURL(blob);
+      link.href = link.dataset.blobUrl;
+    });
+    elements.rawActions.append(link);
+  }
+
+  async function loadDetail() {
+    if (execution.availability !== "full" || !execution.detail_path) return null;
+    const preview = window.HARNESS_EXECUTION_DETAILS?.[execution.id];
+    if (preview) return preview;
+    if (
+      typeof execution.detail_path !== "string" ||
+      execution.detail_path.includes("..") ||
+      !execution.detail_path.startsWith("runs/")
+    ) {
+      throw new Error("The retained detail path is invalid.");
+    }
+    const url = new URL(execution.detail_path, window.location.href);
+    const runsRoot = new URL("./runs/", window.location.href);
+    if (url.origin !== runsRoot.origin || !url.pathname.startsWith(runsRoot.pathname)) {
+      throw new Error("The retained detail path is outside the benchmark site.");
+    }
+    const response = await fetch(url, { cache: "no-store" });
+    if (!response.ok) throw new Error(`Execution report returned HTTP ${response.status}.`);
+    const value = await response.json();
+    if (!value || typeof value !== "object") {
+      throw new Error("Execution report is not an object.");
+    }
+    return value;
+  }
+
+  function revealAnchor(anchorId) {
+    if (!anchorId) return;
+    const target = document.getElementById(anchorId);
+    if (!target) return;
+    // Open the target and every collapsed ancestor so deep links land on
+    // rendered content; opening fires toggle, which drives the lazy renderers.
+    let node = target.closest("details");
+    while (node) {
+      node.open = true;
+      node = node.parentElement?.closest("details");
+    }
+    const disclosure = target.querySelector?.("details.section-disclosure");
+    if (disclosure) disclosure.open = true;
+    requestAnimationFrame(() => target.scrollIntoView());
+  }
+
+  function attachAnchorNavigation() {
+    window.addEventListener("hashchange", () => {
+      revealAnchor(window.location.hash.slice(1));
+    });
+    // Same-hash re-clicks do not fire hashchange; handle triage links directly.
+    elements.failureSummary.addEventListener("click", (event) => {
+      const link = event.target.closest('a[href^="#"]');
+      if (link) revealAnchor(link.getAttribute("href").slice(1));
+    });
+  }
+
+  function reveal() {
+    elements.loading.hidden = true;
+    elements.content.hidden = false;
+    requestAnimationFrame(() => revealAnchor(window.location.hash.slice(1)));
+  }
+
+  async function initialize() {
+    attachTranscriptDialogControls();
+    attachAnchorNavigation();
+    if (!execution) {
+      elements.loading.hidden = true;
+      elements.error.hidden = false;
+      elements.errorMessage.textContent = executionId
+        ? `Execution ${executionId} is outside the retained 100-run history.`
+        : "The execution URL does not include a run id.";
+      return;
+    }
+    renderHeader();
+    renderKpis();
+    renderMetadata();
+    try {
+      detail = await loadDetail();
+    } catch (error) {
+      execution.availability = execution.subjects.length ? "aggregate" : "unavailable";
+      elements.availability.className = `data-badge data-${execution.availability}`;
+      elements.availability.textContent = "Aggregate fallback";
+      elements.scenarioIntro.textContent = error.message;
+    }
+    renderConfiguration();
+    renderScenarios();
+    renderFailures();
+    renderRawData();
+    reveal();
+  }
+
+  initialize();
+})();

--- a/harness/tests/e2e/assets/dashboard/index.html
+++ b/harness/tests/e2e/assets/dashboard/index.html
@@ -1,0 +1,453 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="Harness E2E execution health, benchmark results, and workflow history."
+    >
+    <meta name="color-scheme" content="dark light">
+    <title>Harness E2E executions</title>
+    <link rel="stylesheet" href="./styles.css">
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to execution dashboard</a>
+    <div class="ambient ambient-one" aria-hidden="true"></div>
+    <div class="ambient ambient-two" aria-hidden="true"></div>
+
+    <header class="topbar">
+      <a class="brand" href="https://github.com/iii-hq/workers" aria-label="iii workers">
+        <span class="brand-copy">
+          <strong>iii</strong>
+          <span>Harness benchmarks</span>
+        </span>
+      </a>
+      <nav class="topbar-actions" aria-label="Dashboard actions">
+        <span id="preview-badge" class="badge badge-preview" hidden>Preview data</span>
+        <a class="button button-secondary" href="./coverage/">Coverage</a>
+        <a id="actions-link" class="button button-secondary" href="https://github.com/iii-hq/workers/actions">
+          View Actions <span aria-hidden="true">↗</span>
+        </a>
+      </nav>
+    </header>
+
+    <main id="main" class="page-shell overview-shell">
+      <section class="page-heading" aria-labelledby="page-title">
+        <div>
+          <div class="eyebrow">
+            <span class="live-dot" aria-hidden="true"></span>
+            Harness E2E
+          </div>
+          <h1 id="page-title">Execution dashboard</h1>
+          <p>Workflow-level health with scenario results and compact run diagnostics.</p>
+        </div>
+        <div class="sync-block">
+          <span id="sync-label">Last published</span>
+          <time id="last-update" datetime="">Waiting for data</time>
+        </div>
+      </section>
+
+      <section id="local-runner" class="panel local-runner" aria-labelledby="local-runner-title" hidden>
+        <div class="panel-heading local-runner-heading">
+          <div>
+            <div class="section-kicker">Local experiment</div>
+            <h2 id="local-runner-title">Run E2E scenarios</h2>
+            <p class="trend-description">
+              Uses the Harness already running at the selected iii URL. Each run is
+              saved as an independent execution that can be compared with any other.
+            </p>
+          </div>
+          <span id="local-run-status" class="local-run-status">Ready</span>
+        </div>
+        <div class="local-connection" aria-live="polite">
+          <div>
+            <span id="local-catalog-indicator" class="local-connection-dot" aria-hidden="true"></span>
+            <span id="local-catalog-status">Discovering the running Harness…</span>
+            <code id="local-connection-url"></code>
+          </div>
+          <button id="local-catalog-refresh" class="button" type="button">
+            Refresh catalog
+          </button>
+        </div>
+        <form id="local-run-form" class="local-run-form">
+          <label class="local-field">
+            <span>Execution label <small>optional</small></span>
+            <input name="label" maxlength="120" placeholder="Before system prompt change">
+          </label>
+          <label class="local-field">
+            <span>Subject model</span>
+            <select id="local-subject" name="subject" required disabled>
+              <option value="">Loading registered models…</option>
+            </select>
+          </label>
+          <div class="local-field local-field-wide">
+            <span>Scenarios <small>all selected by default</small></span>
+            <details id="local-scenario-picker" class="local-scenario-picker">
+              <summary>
+                <strong id="local-scenario-summary">Loading scenarios…</strong>
+                <span>Choose</span>
+              </summary>
+              <div class="local-scenario-toolbar">
+                <button id="local-scenario-all" type="button">Select all</button>
+                <button id="local-scenario-none" type="button">Clear</button>
+              </div>
+              <div id="local-scenario-options" class="local-scenario-options"></div>
+            </details>
+          </div>
+          <details id="local-advanced" class="local-advanced local-field-wide">
+            <summary>Advanced options</summary>
+            <div class="local-advanced-grid">
+              <label class="local-field local-field-wide">
+                <span>iii WebSocket URL <small>refresh after changing</small></span>
+                <input name="url" required placeholder="ws://127.0.0.1:49134">
+              </label>
+              <label class="local-field local-field-wide">
+                <span>Judge override <small>automatic when blank</small></span>
+                <select id="local-judge" name="judge" disabled>
+                  <option value="">Use subject model when required</option>
+                </select>
+              </label>
+              <label class="local-field">
+                <span>Runs</span>
+                <input name="runs" type="number" min="1" max="20" value="1" required>
+              </label>
+              <label class="local-field">
+                <span>Technical retries</span>
+                <input name="technical_retries" type="number" min="0" max="3" value="1" required>
+              </label>
+            </div>
+          </details>
+          <div class="local-run-actions">
+            <button id="local-run-submit" class="button local-run-submit" type="submit">
+              Run selected E2E
+            </button>
+            <button id="local-run-cancel" class="button" type="button" hidden>Cancel</button>
+          </div>
+        </form>
+        <p id="local-run-error" class="local-run-error" role="alert" hidden></p>
+        <details id="local-run-log-shell" class="local-run-log-shell" hidden>
+          <summary>Live runner output</summary>
+          <pre id="local-run-log" class="local-run-log" aria-live="polite"></pre>
+        </details>
+      </section>
+
+      <section id="empty-state" class="empty-state" hidden>
+        <div class="empty-icon" aria-hidden="true">⌁</div>
+        <h2 id="empty-title">No executions published</h2>
+        <p id="empty-description">The next scheduled Harness E2E workflow will appear here.</p>
+      </section>
+
+      <div id="overview-content">
+        <section
+          class="panel efficiency-overview"
+          aria-labelledby="efficiency-overview-heading"
+        >
+          <div class="panel-heading efficiency-heading">
+            <div>
+              <div class="section-kicker">Primary view</div>
+              <h2 id="efficiency-overview-heading">Efficiency overview</h2>
+              <p class="trend-description">
+                Every figure below — value, delta, and trend — reads the
+                comparable cohort: scenarios whose contract is unchanged and
+                whose latest run passed. New, changed, and missing scenarios
+                are counted in the guardrail and excluded here.
+              </p>
+            </div>
+            <div class="efficiency-heading-meta">
+              <div class="efficiency-result" aria-live="polite">
+                <span>Latest result</span>
+                <strong id="efficiency-status" class="efficiency-result-value text-incomplete">Waiting</strong>
+                <small id="efficiency-status-caption">No execution</small>
+              </div>
+              <div class="efficiency-baseline">
+                <span>Baseline</span>
+                <strong>Median of up to 7 previous runs</strong>
+                <small id="efficiency-run-label">Waiting for data</small>
+              </div>
+            </div>
+          </div>
+
+          <div class="efficiency-card-grid" aria-label="Comparable cohort totals">
+            <article class="efficiency-card" data-efficiency-metric="cost_usd">
+              <div class="efficiency-card-label">Cost</div>
+              <strong id="efficiency-cost">—</strong>
+              <span id="efficiency-cost-delta" class="efficiency-delta">—</span>
+              <small id="efficiency-cost-baseline" class="efficiency-baseline-value"></small>
+              <div id="efficiency-cost-sparkline" class="efficiency-sparkline"></div>
+            </article>
+            <article class="efficiency-card" data-efficiency-metric="tokens">
+              <div class="efficiency-card-label">Tokens</div>
+              <strong id="efficiency-tokens">—</strong>
+              <span id="efficiency-tokens-delta" class="efficiency-delta">—</span>
+              <small id="efficiency-tokens-baseline" class="efficiency-baseline-value"></small>
+              <div id="efficiency-tokens-sparkline" class="efficiency-sparkline"></div>
+            </article>
+            <article class="efficiency-card" data-efficiency-metric="duration_seconds">
+              <div class="efficiency-card-label">Scenario time</div>
+              <strong id="efficiency-duration">—</strong>
+              <span id="efficiency-duration-delta" class="efficiency-delta">—</span>
+              <small id="efficiency-duration-baseline" class="efficiency-baseline-value"></small>
+              <div id="efficiency-duration-sparkline" class="efficiency-sparkline"></div>
+            </article>
+            <article class="efficiency-card" data-efficiency-metric="function_call_errors">
+              <div class="efficiency-card-label">Function errors</div>
+              <strong id="efficiency-errors">—</strong>
+              <span id="efficiency-errors-delta" class="efficiency-delta">—</span>
+              <small id="efficiency-errors-baseline" class="efficiency-baseline-value"></small>
+              <div id="efficiency-errors-sparkline" class="efficiency-sparkline"></div>
+            </article>
+          </div>
+
+          <div id="efficiency-guardrail" class="efficiency-guardrail">
+            <span class="guardrail-status">Waiting for comparable scenarios</span>
+          </div>
+
+          <div class="table-wrap efficiency-table-wrap">
+            <table class="efficiency-table">
+              <thead>
+                <tr>
+                  <th scope="col">Scenario</th>
+                  <th scope="col">Cost</th>
+                  <th scope="col">Tokens</th>
+                  <th scope="col">Duration</th>
+                  <th scope="col">Calls</th>
+                  <th scope="col">Errors</th>
+                  <th scope="col">Trend</th>
+                </tr>
+              </thead>
+              <tbody id="efficiency-body"></tbody>
+            </table>
+          </div>
+        </section>
+
+        <div class="section-divider-heading">
+          <div>
+            <div class="section-kicker">Outcome guardrails</div>
+            <h2>Latest execution health</h2>
+          </div>
+          <p>Efficiency improvements remain advisory when outcomes regress.</p>
+        </div>
+
+        <section class="kpi-grid execution-kpis" aria-label="Latest execution summary">
+          <article class="kpi-card">
+            <div class="kpi-label">Scenario pass rate</div>
+            <div id="kpi-pass-rate" class="kpi-value">—</div>
+            <div id="kpi-coverage" class="kpi-delta">—</div>
+          </article>
+          <article class="kpi-card">
+            <div class="kpi-label">Quality score</div>
+            <div id="kpi-score" class="kpi-value">—</div>
+            <div class="kpi-delta">Mean of scenario medians</div>
+          </article>
+          <article class="kpi-card">
+            <div class="kpi-label">Reliability events</div>
+            <div id="kpi-failures" class="kpi-value">—</div>
+            <div class="kpi-delta">Gates, technical failures, and missing reports</div>
+          </article>
+          <article class="kpi-card">
+            <div class="kpi-label">Model cost</div>
+            <div id="kpi-cost" class="kpi-value">—</div>
+            <div id="kpi-runtime" class="kpi-delta">—</div>
+          </article>
+        </section>
+
+        <section class="panel health-panel" aria-labelledby="health-heading">
+          <div class="panel-heading">
+            <div>
+              <div class="section-kicker">Execution by execution</div>
+              <h2 id="health-heading">Scenario health matrix</h2>
+              <p class="trend-description">
+                Columns are workflow attempts. Select a cell to inspect that execution and scenario.
+              </p>
+            </div>
+            <div class="range-toggle" role="group" aria-label="Matrix execution count">
+              <button class="range-button active" type="button" data-count="14">14 runs</button>
+              <button class="range-button" type="button" data-count="30">30 runs</button>
+            </div>
+          </div>
+          <div class="matrix-legend" aria-label="Result legend">
+            <span><i class="matrix-key matrix-passed matrix-key-score" aria-hidden="true">92%</i> Score reached</span>
+            <span><i class="matrix-key matrix-failed" aria-hidden="true">×</i> Blocking failure</span>
+            <span><i class="matrix-key matrix-incomplete" aria-hidden="true">–</i> Incomplete</span>
+            <span><i class="matrix-key matrix-cancelled" aria-hidden="true">○</i> Cancelled</span>
+          </div>
+          <div id="health-matrix" class="health-matrix-wrap" aria-live="polite"></div>
+        </section>
+
+        <section class="panel executions-panel" aria-labelledby="executions-heading">
+          <div class="panel-heading executions-heading">
+            <div>
+              <div class="section-kicker">Audit trail</div>
+              <h2 id="executions-heading">All executions</h2>
+            </div>
+            <span id="execution-count" class="coverage-note">0 executions</span>
+          </div>
+          <div class="table-filters" aria-label="Execution filters">
+            <label class="search-field">
+              <span class="visually-hidden">Search executions</span>
+              <input id="execution-search" type="search" placeholder="Search run, commit, or date">
+            </label>
+            <label>
+              <span class="visually-hidden">Filter by status</span>
+              <select id="status-filter">
+                <option value="all">All statuses</option>
+                <option value="passed">Passed</option>
+                <option value="hard_gate_failed">Hard gate failed</option>
+                <option value="technical_failed">Technical failure</option>
+                <option value="infra_failed">Infrastructure failure</option>
+                <option value="incomplete">Incomplete</option>
+                <option value="cancelled">Cancelled</option>
+                <option value="running">Running</option>
+              </select>
+            </label>
+            <label>
+              <span class="visually-hidden">Filter by trigger</span>
+              <select id="event-filter">
+                <option value="all">All triggers</option>
+                <option value="schedule">Scheduled</option>
+                <option value="workflow_dispatch">Manual</option>
+                <option value="local">Local</option>
+              </select>
+            </label>
+          </div>
+          <div id="comparison-bar" class="comparison-bar" hidden>
+            <div>
+              <strong id="comparison-count">Select two executions</strong>
+              <span>Comparison is allowed even when subjects, scenarios, or contracts differ.</span>
+            </div>
+            <a id="comparison-link" class="button" href="./compare.html" aria-disabled="true">
+              Compare selected
+            </a>
+          </div>
+          <div class="table-wrap">
+            <table class="execution-table">
+              <thead>
+                <tr>
+                  <th scope="col">Execution</th>
+                  <th scope="col">Result</th>
+                  <th id="execution-commit-heading" scope="col">Commit</th>
+                  <th scope="col">Subjects</th>
+                  <th scope="col">Pass rate</th>
+                  <th scope="col">Score</th>
+                  <th scope="col">Failures</th>
+                  <th scope="col">Total tokens</th>
+                  <th scope="col">Function calls</th>
+                  <th scope="col">Cost</th>
+                  <th scope="col">Runtime</th>
+                  <th scope="col">Data</th>
+                </tr>
+              </thead>
+              <tbody id="execution-body"></tbody>
+            </table>
+          </div>
+          <div class="pagination" aria-label="Execution table pagination">
+            <button id="previous-page" type="button">Previous</button>
+            <span id="page-label" aria-live="polite">Page 1</span>
+            <button id="next-page" type="button">Next</button>
+          </div>
+        </section>
+      </div>
+
+      <dialog id="scenario-history-dialog" class="scenario-history-dialog">
+        <div class="scenario-history-shell">
+          <header class="scenario-history-header">
+            <div>
+              <div class="section-kicker">Scenario history</div>
+              <h2 id="scenario-history-title">Scenario</h2>
+              <p id="scenario-history-context">Execution-by-execution efficiency.</p>
+            </div>
+            <button
+              id="scenario-history-close"
+              class="scenario-history-close"
+              type="button"
+              aria-label="Close scenario history"
+            >×</button>
+          </header>
+
+          <div
+            class="scenario-history-tabs"
+            role="tablist"
+            aria-label="Scenario metric"
+          >
+            <button type="button" role="tab" data-history-metric="cost_usd">
+              Cost
+            </button>
+            <button type="button" role="tab" data-history-metric="tokens">
+              Tokens
+            </button>
+            <button type="button" role="tab" data-history-metric="duration_seconds">
+              Duration
+            </button>
+            <button type="button" role="tab" data-history-metric="function_calls">
+              Function calls
+            </button>
+            <button
+              type="button"
+              role="tab"
+              data-history-metric="function_call_errors"
+            >
+              Function errors
+            </button>
+          </div>
+          <p
+            id="scenario-history-description"
+            class="scenario-history-description"
+          ></p>
+          <div
+            id="scenario-history-chart"
+            class="scenario-history-chart"
+            aria-live="polite"
+          ></div>
+
+          <div class="table-wrap scenario-history-table-wrap">
+            <table class="scenario-history-table">
+              <thead>
+                <tr>
+                  <th scope="col">Execution</th>
+                  <th scope="col">Value</th>
+                  <th scope="col">Delta</th>
+                  <th scope="col">Outcome</th>
+                  <th scope="col">Contract</th>
+                </tr>
+              </thead>
+              <tbody id="scenario-history-body"></tbody>
+            </table>
+          </div>
+        </div>
+      </dialog>
+    </main>
+
+    <footer>
+      <span id="dashboard-footer-summary">Harness E2E · 100 summaries · 30 compact diagnostic reports</span>
+      <a href="https://github.com/iii-hq/workers/tree/main/harness/tests/e2e">
+        Suite documentation <span aria-hidden="true">↗</span>
+      </a>
+    </footer>
+
+    <script>
+      window.BENCHMARK_DATA = window.BENCHMARK_DATA || null;
+      window.HARNESS_EXECUTIONS = window.HARNESS_EXECUTIONS || null;
+    </script>
+    <script src="./data.js"></script>
+    <script>
+      if (!window.BENCHMARK_DATA) {
+        document.write('<script src="./sample-data.js"><\/script>');
+      }
+    </script>
+    <script src="./dashboard-data.js"></script>
+    <script src="./execution-data.js"></script>
+    <script src="./executions.js"></script>
+    <script>
+      if (!window.HARNESS_EXECUTIONS) {
+        document.write('<script src="./sample-executions.js"><\/script>');
+      }
+    </script>
+    <script>
+      if (window.HARNESS_EXECUTIONS?.mode === "local") {
+        document.write('<script src="./local-runner.js"><\/script>');
+      }
+    </script>
+    <script src="./overview.js"></script>
+  </body>
+</html>

--- a/harness/tests/e2e/assets/dashboard/local-runner.js
+++ b/harness/tests/e2e/assets/dashboard/local-runner.js
@@ -1,0 +1,318 @@
+(function defineHarnessLocalRunner(global) {
+  "use strict";
+
+  const elements = {
+    advanced: document.querySelector("#local-advanced"),
+    cancel: document.querySelector("#local-run-cancel"),
+    catalogIndicator: document.querySelector("#local-catalog-indicator"),
+    catalogRefresh: document.querySelector("#local-catalog-refresh"),
+    catalogStatus: document.querySelector("#local-catalog-status"),
+    connectionUrl: document.querySelector("#local-connection-url"),
+    form: document.querySelector("#local-run-form"),
+    judge: document.querySelector("#local-judge"),
+    runError: document.querySelector("#local-run-error"),
+    runLog: document.querySelector("#local-run-log"),
+    runLogShell: document.querySelector("#local-run-log-shell"),
+    runStatus: document.querySelector("#local-run-status"),
+    scenarioAll: document.querySelector("#local-scenario-all"),
+    scenarioNone: document.querySelector("#local-scenario-none"),
+    scenarioOptions: document.querySelector("#local-scenario-options"),
+    scenarioPicker: document.querySelector("#local-scenario-picker"),
+    scenarioSummary: document.querySelector("#local-scenario-summary"),
+    subject: document.querySelector("#local-subject"),
+    submit: document.querySelector("#local-run-submit"),
+  };
+
+  let pollTimer = null;
+  let catalogReady = false;
+  let catalogLoading = false;
+  let jobActive = false;
+  let defaults = {};
+  let initialized = false;
+
+  function formField(name) {
+    return elements.form.elements.namedItem(name);
+  }
+
+  function applyDefaults(nextDefaults) {
+    defaults = { ...defaults, ...(nextDefaults || {}) };
+    Object.entries(nextDefaults || {}).forEach(([name, value]) => {
+      const field = formField(name);
+      if (field && !field.value && value !== null && value !== undefined) {
+        field.value = String(value);
+      }
+    });
+    const url = formField("url")?.value || nextDefaults?.url || "";
+    if (url) elements.connectionUrl.textContent = url;
+  }
+
+  function setControls(active) {
+    jobActive = active;
+    for (const field of elements.form.elements) {
+      if (field !== elements.cancel) field.disabled = active;
+    }
+    elements.subject.disabled = active || !catalogReady;
+    elements.judge.disabled = active || !catalogReady;
+    elements.submit.disabled = active || !catalogReady;
+    elements.catalogRefresh.disabled = active || catalogLoading;
+    elements.scenarioPicker.classList.toggle(
+      "local-picker-disabled",
+      active || !catalogReady,
+    );
+    elements.scenarioPicker.setAttribute(
+      "aria-disabled",
+      String(active || !catalogReady),
+    );
+  }
+
+  function renderJob(response) {
+    applyDefaults(response?.defaults);
+    const job = response?.job;
+    const active = ["running", "cancelling"].includes(job?.status);
+    setControls(active);
+    elements.cancel.hidden = !active;
+    elements.runError.hidden = !job?.error;
+    elements.runError.textContent = job?.error || "";
+    elements.runLogShell.hidden = !job?.log;
+    elements.runLog.textContent = job?.log || "";
+    if (job?.log && active) elements.runLogShell.open = true;
+    elements.runStatus.textContent = !job
+      ? "Ready"
+      : {
+          running: "Running…",
+          cancelling: "Cancelling…",
+          cancelled: "Cancelled",
+          completed: "Results saved",
+          failed: "Runner failed",
+        }[job.status] || job.status;
+    if (active) {
+      clearTimeout(pollTimer);
+      pollTimer = setTimeout(refreshJob, 1_000);
+    } else if (job?.status === "completed" && job.id) {
+      const reloadKey = "harness-e2e-local-last-reload";
+      if (sessionStorage.getItem(reloadKey) !== job.id) {
+        sessionStorage.setItem(reloadKey, job.id);
+        global.location.reload();
+      }
+    }
+  }
+
+  async function api(path, options = {}) {
+    const response = await fetch(path, {
+      cache: "no-store",
+      headers: { "Content-Type": "application/json" },
+      ...options,
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      throw new Error(payload.error || `Request failed (${response.status})`);
+    }
+    return payload;
+  }
+
+  async function refreshJob() {
+    try {
+      const response = await api("./api/local/run");
+      renderJob(response);
+      return response;
+    } catch (error) {
+      elements.runError.hidden = false;
+      elements.runError.textContent = error.message;
+      elements.runStatus.textContent = "Unavailable";
+      return null;
+    }
+  }
+
+  function modelKey(model) {
+    return `${model.provider}\n${model.model}`;
+  }
+
+  function selectedModel(select) {
+    const option = select.selectedOptions[0];
+    return option?.dataset.model && option?.dataset.provider
+      ? { model: option.dataset.model, provider: option.dataset.provider }
+      : null;
+  }
+
+  function fillModelSelect(select, models, { includeAutomatic = false } = {}) {
+    const selected = selectedModel(select);
+    const preferredKey =
+      (selected && modelKey(selected)) ||
+      localStorage.getItem("harness-e2e-local-subject") ||
+      (defaults.model && defaults.provider
+        ? modelKey({ model: defaults.model, provider: defaults.provider })
+        : "");
+    select.replaceChildren();
+    if (includeAutomatic) {
+      const automatic = document.createElement("option");
+      automatic.value = "";
+      automatic.textContent = "Use subject model when required";
+      select.append(automatic);
+    }
+    models.forEach((model, index) => {
+      const option = document.createElement("option");
+      option.value = `model-${index}`;
+      option.dataset.model = model.model;
+      option.dataset.provider = model.provider;
+      option.textContent = `${model.provider} / ${model.model}`;
+      option.selected = !includeAutomatic && modelKey(model) === preferredKey;
+      select.append(option);
+    });
+    if (!includeAutomatic && select.selectedIndex < 0 && select.options.length) {
+      select.selectedIndex = 0;
+    }
+  }
+
+  function scenarioInputs() {
+    return [...elements.scenarioOptions.querySelectorAll("input[type=checkbox]")];
+  }
+
+  function updateScenarioSummary() {
+    const inputs = scenarioInputs();
+    const selected = inputs.filter((input) => input.checked).length;
+    if (!inputs.length) {
+      elements.scenarioSummary.textContent = catalogLoading
+        ? "Loading scenarios…"
+        : "Catalog unavailable";
+      elements.submit.disabled = true;
+      return;
+    }
+    elements.scenarioSummary.textContent =
+      selected === inputs.length
+        ? `All ${inputs.length} scenarios`
+        : `${selected} of ${inputs.length} scenarios`;
+    elements.submit.disabled = jobActive || !catalogReady || selected === 0;
+  }
+
+  function fillScenarios(scenarios) {
+    const previous = new Set(
+      scenarioInputs().filter((input) => input.checked).map((input) => input.value),
+    );
+    const selectAll = previous.size === 0;
+    elements.scenarioOptions.replaceChildren();
+    scenarios.forEach((scenarioId, index) => {
+      const label = document.createElement("label");
+      label.className = "local-scenario-option";
+      const input = document.createElement("input");
+      input.type = "checkbox";
+      input.name = "scenario";
+      input.value = scenarioId;
+      input.id = `local-scenario-${index}`;
+      input.checked = selectAll || previous.has(scenarioId);
+      const text = document.createElement("span");
+      text.textContent = scenarioId.replaceAll("_", " ");
+      text.title = scenarioId;
+      label.append(input, text);
+      elements.scenarioOptions.append(label);
+    });
+    updateScenarioSummary();
+  }
+
+  async function refreshCatalog() {
+    const url = formField("url")?.value || defaults.url || "";
+    elements.connectionUrl.textContent = url;
+    elements.catalogStatus.textContent = "Discovering the running Harness…";
+    elements.catalogIndicator.className = "local-connection-dot";
+    catalogLoading = true;
+    catalogReady = false;
+    setControls(jobActive);
+    try {
+      const query = new URLSearchParams({ url });
+      const catalog = await api(`./api/local/catalog?${query}`);
+      fillModelSelect(elements.subject, catalog.models);
+      fillModelSelect(elements.judge, catalog.models, { includeAutomatic: true });
+      fillScenarios(catalog.scenarios);
+      catalogReady = true;
+      elements.catalogIndicator.className = "local-connection-dot connected";
+      elements.catalogStatus.textContent =
+        `${catalog.models.length} registered model${catalog.models.length === 1 ? "" : "s"} · ${catalog.scenarios.length} scenarios`;
+      elements.runError.hidden = true;
+    } catch (error) {
+      elements.catalogIndicator.className = "local-connection-dot failed";
+      elements.catalogStatus.textContent = "Could not read the Harness catalog";
+      elements.runError.hidden = false;
+      elements.runError.textContent = error.message;
+      elements.scenarioSummary.textContent = "Catalog unavailable";
+      elements.advanced.open = true;
+    } finally {
+      catalogLoading = false;
+      setControls(jobActive);
+      updateScenarioSummary();
+    }
+  }
+
+  function initialize() {
+    if (initialized) return;
+    initialized = true;
+    elements.form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const values = new FormData(elements.form);
+      const subject = selectedModel(elements.subject);
+      const judge = selectedModel(elements.judge);
+      const scenarios = scenarioInputs()
+        .filter((input) => input.checked)
+        .map((input) => input.value);
+      try {
+        if (!subject) throw new Error("Select a registered subject model.");
+        if (!scenarios.length) throw new Error("Select at least one scenario.");
+        localStorage.setItem("harness-e2e-local-subject", modelKey(subject));
+        elements.runError.hidden = true;
+        renderJob(
+          await api("./api/local/run", {
+            method: "POST",
+            body: JSON.stringify({
+              label: values.get("label"),
+              url: values.get("url"),
+              model: subject.model,
+              provider: subject.provider,
+              judge_model: judge?.model || "",
+              judge_provider: judge?.provider || "",
+              scenarios,
+              runs: Number(values.get("runs")),
+              technical_retries: Number(values.get("technical_retries")),
+            }),
+          }),
+        );
+      } catch (error) {
+        elements.runError.hidden = false;
+        elements.runError.textContent = error.message;
+        elements.runStatus.textContent = "Could not start";
+      }
+    });
+    elements.cancel.addEventListener("click", async () => {
+      try {
+        renderJob(
+          await api("./api/local/run/cancel", {
+            method: "POST",
+            body: "{}",
+          }),
+        );
+      } catch (error) {
+        elements.runError.hidden = false;
+        elements.runError.textContent = error.message;
+      }
+    });
+    elements.catalogRefresh.addEventListener("click", refreshCatalog);
+    elements.scenarioAll.addEventListener("click", () => {
+      scenarioInputs().forEach((input) => {
+        input.checked = true;
+      });
+      updateScenarioSummary();
+    });
+    elements.scenarioNone.addEventListener("click", () => {
+      scenarioInputs().forEach((input) => {
+        input.checked = false;
+      });
+      updateScenarioSummary();
+    });
+    elements.scenarioOptions.addEventListener("change", updateScenarioSummary);
+    elements.scenarioPicker.addEventListener("toggle", () => {
+      if (!catalogReady && elements.scenarioPicker.open) {
+        elements.scenarioPicker.open = false;
+      }
+    });
+    refreshJob().then(refreshCatalog);
+  }
+
+  global.HarnessLocalRunner = { initialize };
+})(window);

--- a/harness/tests/e2e/assets/dashboard/overview-structure.test.cjs
+++ b/harness/tests/e2e/assets/dashboard/overview-structure.test.cjs
@@ -1,0 +1,138 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const root = __dirname;
+const index = fs.readFileSync(path.join(root, "index.html"), "utf8");
+const execution = fs.readFileSync(path.join(root, "execution.html"), "utf8");
+const executionScript = fs.readFileSync(path.join(root, "execution.js"), "utf8");
+const sampleExecutions = fs.readFileSync(
+  path.join(root, "sample-executions.js"),
+  "utf8",
+);
+const overview = fs.readFileSync(path.join(root, "overview.js"), "utf8");
+const localRunner = fs.readFileSync(path.join(root, "local-runner.js"), "utf8");
+const styles = fs.readFileSync(path.join(root, "styles.css"), "utf8");
+
+test("places efficiency overview first and removes the operational health panel", () => {
+  const latest = index.indexOf('class="panel latest-health"');
+  const matrix = index.indexOf('class="panel health-panel"');
+  const efficiency = index.indexOf('class="panel efficiency-overview"');
+  const executions = index.indexOf('class="panel executions-panel"');
+
+  assert.equal(latest, -1);
+  assert.ok(efficiency >= 0);
+  assert.ok(efficiency < matrix);
+  assert.ok(efficiency < executions);
+  assert.doesNotMatch(index, /Operational health|latest-daily-execution/i);
+});
+
+test("keeps the latest result inside the efficiency overview", () => {
+  assert.match(index, /class="efficiency-result"/);
+  assert.match(index, /id="efficiency-status"/);
+  assert.doesNotMatch(index, /id="kpi-status"/);
+});
+
+test("keeps hidden preview and diagnostic controls out of layout", () => {
+  assert.match(index, /id="preview-badge"[^>]+hidden/);
+  assert.match(styles, /\[hidden\]\s*\{[^}]*display:\s*none\s*!important;/s);
+});
+
+test("offers every semantic execution status as a filter", () => {
+  for (const status of [
+    "passed",
+    "hard_gate_failed",
+    "technical_failed",
+    "infra_failed",
+    "incomplete",
+    "cancelled",
+    "running",
+  ]) {
+    assert.match(index, new RegExp(`<option value="${status}">`));
+  }
+});
+
+test("restores the per-run chat transcript surface", () => {
+  assert.match(execution, /execution-transcript\.js/);
+  assert.match(execution, /session-transcript-dialog/);
+  assert.match(executionScript, /renderConversationLaunch/);
+  assert.match(executionScript, /conversation-open/);
+  assert.match(executionScript, /openConversationDialog/);
+  assert.match(executionScript, /id: "prompt", label: "Prompt"/);
+  assert.match(executionScript, /id: "sessions", label: "Sessions"/);
+  assert.match(executionScript, /Complete run record/);
+  assert.match(sampleExecutions, /availability: index < 3 \? "full"/);
+  assert.match(sampleExecutions, /transcript:\s*\{/);
+  assert.match(sampleExecutions, /criteria:\s*\[/);
+  assert.match(sampleExecutions, /traces:\s*\{/);
+});
+
+test("uses the delta meaning to color efficiency sparklines", () => {
+  assert.match(overview, /const efficiencyTrendColors =/);
+  assert.match(overview, /efficiencyTrendColors\[meta\.css\]/);
+  assert.doesNotMatch(overview, /const palette =/);
+});
+
+test("discovers local models and scenarios while keeping runner knobs advanced", () => {
+  assert.match(index, /id="local-subject"[^>]+disabled/);
+  assert.match(index, /id="local-scenario-options"/);
+  assert.match(index, /class="local-advanced local-field-wide"/);
+  assert.match(index, /id="local-catalog-refresh"/);
+  assert.doesNotMatch(index, /name="model"|name="provider"/);
+  assert.match(localRunner, /api\/local\/catalog/);
+  assert.match(localRunner, /catalog\.models/);
+  assert.match(localRunner, /catalog\.scenarios/);
+});
+
+test("uses the native local-run contract without import compatibility", () => {
+  assert.match(overview, /Last completed/);
+  assert.match(localRunner, /Results saved/);
+  assert.match(localRunner, /job\?\.status === "completed" && job\.id/);
+  assert.doesNotMatch(
+    overview + localRunner,
+    /execution_id|Results imported|results\.json file/,
+  );
+});
+
+test("loads the local runner only for native local manifests", () => {
+  assert.match(
+    index,
+    /if \(window\.HARNESS_EXECUTIONS\?\.mode === "local"\) \{\s*document\.write\('<script src="\.\/local-runner\.js"/s,
+  );
+  assert.match(overview, /if \(isLocal\) window\.HarnessLocalRunner\.initialize\(\)/);
+  assert.doesNotMatch(overview, /api\/local|local-run-form|local-run-cancel/);
+
+  const loader = index.match(
+    /<script>\s*(if \(window\.HARNESS_EXECUTIONS\?\.mode === "local"\) \{[\s\S]*?local-runner\.js[\s\S]*?\})\s*<\/script>/,
+  )[1];
+  const writesFor = (mode) => {
+    const writes = [];
+    vm.runInNewContext(loader, {
+      document: { write: (value) => writes.push(value) },
+      window: { HARNESS_EXECUTIONS: { mode } },
+    });
+    return writes;
+  };
+  assert.deepEqual(writesFor("published"), []);
+  assert.deepEqual(writesFor("local"), [
+    '<script src="./local-runner.js"></script>',
+  ]);
+});
+
+test("keeps the completed runner log inside a padded local panel", () => {
+  assert.match(index, /id="local-run-log" class="local-run-log"/);
+  assert.match(styles, /\.local-runner\s*\{[^}]*padding:\s*28px 30px;[^}]*overflow:\s*hidden;/s);
+  assert.match(styles, /\.local-run-log-shell\s*\{[^}]*overflow:\s*hidden;/s);
+  assert.match(styles, /\.local-run-log\s*\{[^}]*max-width:\s*100%;[^}]*overflow-wrap:\s*anywhere;/s);
+});
+
+test("keeps comparison content padded with contained long values", () => {
+  assert.match(index, /href="\.\/compare\.html/);
+  const compare = fs.readFileSync(path.join(root, "compare.html"), "utf8");
+  assert.match(compare, /id="compare-content" class="compare-content"/);
+  assert.match(styles, /\.compare-content\s*>\s*\.panel\s*\{[^}]*padding:\s*28px 30px;[^}]*overflow:\s*hidden;/s);
+  assert.match(styles, /\.compare-selection-card h2\s*\{[^}]*overflow-wrap:\s*anywhere;/s);
+  assert.match(styles, /\.compare-metric-card\s*\{[^}]*overflow:\s*hidden;/s);
+});

--- a/harness/tests/e2e/assets/dashboard/overview.js
+++ b/harness/tests/e2e/assets/dashboard/overview.js
@@ -1,0 +1,1310 @@
+(function renderHarnessExecutionOverview() {
+  "use strict";
+
+  const benchmarkApi = window.HarnessBenchmarkData;
+  const executionApi = window.HarnessExecutionData;
+  const benchmarkData = benchmarkApi.normalizeBenchmarkData(window.BENCHMARK_DATA);
+  const history = executionApi.mergeExecutionHistory(
+    window.HARNESS_EXECUTIONS,
+    benchmarkData,
+  );
+  const isLocal = history.mode === "local";
+  const state = {
+    matrixCount: 14,
+    page: 1,
+    pageSize: 25,
+    query: "",
+    status: "all",
+    event: "all",
+    scenarioHistoryRow: null,
+    scenarioHistoryMetric: "cost_usd",
+    comparison: [],
+  };
+  const efficiencyTrendColors = {
+    improved: "var(--success)",
+    regressed: "var(--danger)",
+    neutral: "var(--text-muted)",
+  };
+  const chartAccentColor = "var(--accent)";
+  const scenarioHistoryMetricIds = [
+    "cost_usd",
+    "tokens",
+    "duration_seconds",
+    "function_calls",
+    "function_call_errors",
+  ];
+  const scenarioMetricDefinitions = {
+    tokens: {
+      label: "Tokens",
+      description:
+        "Input plus output tokens. Cache reads remain part of input usage and are not counted twice.",
+      format: (value) => compactNumber(value, value < 100 ? 1 : 0),
+    },
+    duration_seconds: {
+      label: "Time",
+      description: "Wall-clock runtime for one scenario execution.",
+      format: formatDuration,
+    },
+    cost_usd: {
+      label: "Cost",
+      description: "Combined subject and judge cost for one scenario execution.",
+      format: formatCurrency,
+    },
+    function_calls: {
+      label: "Function calls",
+      description: "iii function calls made during one scenario execution.",
+      format: (value) => compactNumber(value, 1),
+    },
+    function_call_errors: {
+      label: "Function errors",
+      description: "iii function results marked as errors during one scenario execution.",
+      format: (value) => compactNumber(value, 1),
+    },
+    sessions: {
+      label: "Sessions",
+      description: "Root and descendant sessions observed during one scenario execution.",
+      format: (value) => compactNumber(value, 1),
+    },
+    turns: {
+      label: "Turns",
+      description: "Agent turns observed during one scenario execution.",
+      format: (value) => compactNumber(value, 1),
+    },
+  };
+
+  const elements = {
+    actionsLink: document.querySelector("#actions-link"),
+    body: document.querySelector("#execution-body"),
+    content: document.querySelector("#overview-content"),
+    count: document.querySelector("#execution-count"),
+    empty: document.querySelector("#empty-state"),
+    emptyDescription: document.querySelector("#empty-description"),
+    emptyTitle: document.querySelector("#empty-title"),
+    efficiencyBody: document.querySelector("#efficiency-body"),
+    efficiencyCost: document.querySelector("#efficiency-cost"),
+    efficiencyCostDelta: document.querySelector("#efficiency-cost-delta"),
+    efficiencyCostBaseline: document.querySelector("#efficiency-cost-baseline"),
+    efficiencyCostSparkline: document.querySelector("#efficiency-cost-sparkline"),
+    efficiencyDuration: document.querySelector("#efficiency-duration"),
+    efficiencyDurationDelta: document.querySelector("#efficiency-duration-delta"),
+    efficiencyDurationBaseline: document.querySelector(
+      "#efficiency-duration-baseline",
+    ),
+    efficiencyDurationSparkline: document.querySelector(
+      "#efficiency-duration-sparkline",
+    ),
+    efficiencyErrors: document.querySelector("#efficiency-errors"),
+    efficiencyErrorsDelta: document.querySelector("#efficiency-errors-delta"),
+    efficiencyErrorsBaseline: document.querySelector(
+      "#efficiency-errors-baseline",
+    ),
+    efficiencyErrorsSparkline: document.querySelector(
+      "#efficiency-errors-sparkline",
+    ),
+    efficiencyGuardrail: document.querySelector("#efficiency-guardrail"),
+    efficiencyRunLabel: document.querySelector("#efficiency-run-label"),
+    efficiencyTokens: document.querySelector("#efficiency-tokens"),
+    efficiencyTokensDelta: document.querySelector("#efficiency-tokens-delta"),
+    efficiencyTokensBaseline: document.querySelector(
+      "#efficiency-tokens-baseline",
+    ),
+    efficiencyTokensSparkline: document.querySelector(
+      "#efficiency-tokens-sparkline",
+    ),
+    event: document.querySelector("#event-filter"),
+    footerSummary: document.querySelector("#dashboard-footer-summary"),
+    commitHeading: document.querySelector("#execution-commit-heading"),
+    kpiCost: document.querySelector("#kpi-cost"),
+    kpiCoverage: document.querySelector("#kpi-coverage"),
+    kpiFailures: document.querySelector("#kpi-failures"),
+    kpiPassRate: document.querySelector("#kpi-pass-rate"),
+    kpiRuntime: document.querySelector("#kpi-runtime"),
+    kpiScore: document.querySelector("#kpi-score"),
+    efficiencyStatus: document.querySelector("#efficiency-status"),
+    efficiencyStatusCaption: document.querySelector("#efficiency-status-caption"),
+    lastUpdate: document.querySelector("#last-update"),
+    localRunner: document.querySelector("#local-runner"),
+    matrix: document.querySelector("#health-matrix"),
+    next: document.querySelector("#next-page"),
+    pageLabel: document.querySelector("#page-label"),
+    preview: document.querySelector("#preview-badge"),
+    previous: document.querySelector("#previous-page"),
+    search: document.querySelector("#execution-search"),
+    scenarioHistoryBody: document.querySelector("#scenario-history-body"),
+    scenarioHistoryChart: document.querySelector("#scenario-history-chart"),
+    scenarioHistoryClose: document.querySelector("#scenario-history-close"),
+    scenarioHistoryContext: document.querySelector("#scenario-history-context"),
+    scenarioHistoryDescription: document.querySelector(
+      "#scenario-history-description",
+    ),
+    scenarioHistoryDialog: document.querySelector("#scenario-history-dialog"),
+    scenarioHistoryTitle: document.querySelector("#scenario-history-title"),
+    syncLabel: document.querySelector("#sync-label"),
+    status: document.querySelector("#status-filter"),
+    comparisonBar: document.querySelector("#comparison-bar"),
+    comparisonCount: document.querySelector("#comparison-count"),
+    comparisonLink: document.querySelector("#comparison-link"),
+  };
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  function safeUrl(value) {
+    if (!value) return "";
+    try {
+      const url = new URL(value, window.location.href);
+      return ["http:", "https:"].includes(url.protocol) ? url.href : "";
+    } catch (_error) {
+      return "";
+    }
+  }
+
+  function detailUrl(execution, row = null) {
+    const query = `./execution.html?id=${encodeURIComponent(execution.id)}`;
+    return row ? `${query}#${scenarioAnchor(row.subjectId, row.scenarioId)}` : query;
+  }
+
+  function scenarioAnchor(subjectId, scenarioId) {
+    return `scenario-${subjectId}-${scenarioId}`.replace(/[^a-zA-Z0-9_-]/g, "-");
+  }
+
+  function titleCase(value) {
+    return String(value || "")
+      .replaceAll("_", " ")
+      .replaceAll("-", " ")
+      .replace(/\b\w/g, (letter) => letter.toUpperCase());
+  }
+
+  function compactNumber(value, digits = 1) {
+    return typeof value !== "number" || !Number.isFinite(value)
+      ? "—"
+      : new Intl.NumberFormat("en-US", {
+          maximumFractionDigits: digits,
+          minimumFractionDigits: 0,
+        }).format(value);
+  }
+
+  function formatPercent(value) {
+    return typeof value === "number" ? `${compactNumber(value, 1)}%` : "—";
+  }
+
+  function formatCurrency(value) {
+    return typeof value !== "number"
+      ? "—"
+      : new Intl.NumberFormat("en-US", {
+          style: "currency",
+          currency: "USD",
+          minimumFractionDigits: value < 1 ? 3 : 2,
+          maximumFractionDigits: value < 1 ? 3 : 2,
+        }).format(value);
+  }
+
+  function formatDuration(seconds) {
+    if (typeof seconds !== "number") return "—";
+    if (seconds < 60) return `${compactNumber(seconds, 0)}s`;
+    const minutes = Math.floor(seconds / 60);
+    const remainder = Math.round(seconds % 60);
+    return `${minutes}m ${String(remainder).padStart(2, "0")}s`;
+  }
+  function formatScenarioHistoryValue(metricId, value) {
+    if (metricId === "cost_usd" && typeof value === "number") {
+      return new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+        minimumFractionDigits: 4,
+        maximumFractionDigits: 4,
+      }).format(value);
+    }
+    if (
+      metricId === "duration_seconds" &&
+      typeof value === "number" &&
+      value < 60
+    ) {
+      return `${compactNumber(value, 1)}s`;
+    }
+    return scenarioMetricDefinitions[metricId].format(value);
+  }
+
+  function formatDate(timestamp, withTime = false) {
+    if (!timestamp || Number.isNaN(Date.parse(timestamp))) return "Unknown date";
+    return new Intl.DateTimeFormat("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: withTime ? "2-digit" : undefined,
+      minute: withTime ? "2-digit" : undefined,
+    }).format(new Date(timestamp));
+  }
+
+  function statusMeta(status) {
+    return {
+      passed: { label: "Passed", short: "", css: "pass" },
+      failed: { label: "Failed", short: "×", css: "fail" },
+      hard_gate_failed: { label: "Hard gate failed", short: "×", css: "fail" },
+      technical_failed: { label: "Technical failure", short: "×", css: "fail" },
+      infra_failed: { label: "Infrastructure failure", short: "×", css: "fail" },
+      incomplete: { label: "Incomplete", short: "–", css: "incomplete" },
+      cancelled: { label: "Cancelled", short: "○", css: "cancelled" },
+      running: { label: "Running", short: "•", css: "running" },
+    }[status] || { label: "Unknown", short: "?", css: "incomplete" };
+  }
+
+  function failureCount(execution) {
+    const totals = execution.totals || {};
+    return (
+      Number(totals.hard_gate_failures || 0) +
+      Number(totals.technical_failures || 0) +
+      Number(totals.missing_reports || 0)
+    );
+  }
+
+  function renderKpis() {
+    const latest = history.executions[0];
+    if (!latest) return;
+    elements.kpiPassRate.textContent = formatPercent(
+      latest.totals?.scenario_pass_rate,
+    );
+    elements.kpiCoverage.textContent =
+      `${formatPercent(latest.totals?.report_coverage)} report coverage`;
+    elements.kpiScore.textContent = compactNumber(latest.totals?.average_score, 1);
+    elements.kpiFailures.textContent = compactNumber(failureCount(latest), 0);
+    elements.kpiCost.textContent = formatCurrency(latest.totals?.total_cost_usd);
+    elements.kpiRuntime.textContent =
+      `${formatDuration(latest.totals?.wall_time_seconds)} model runtime`;
+  }
+
+  function deltaMeta(value) {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      return { label: "Collecting comparable baseline", css: "neutral" };
+    }
+    const absolute = Math.abs(value);
+    if (absolute < 0.05) {
+      return { label: "No change vs baseline median", css: "neutral" };
+    }
+    return {
+      label: `${value < 0 ? "↓" : "↑"} ${compactNumber(absolute, 1)}% vs baseline median`,
+      css: value < 0 ? "improved" : "regressed",
+    };
+  }
+
+  function renderEfficiencySparkline(element, metricId, color, cohortRows, baseline) {
+    const points = executionApi.cohortMetricSparkline(
+      history.executions,
+      cohortRows,
+      metricId,
+      14,
+    );
+    if (!points.length) {
+      element.replaceChildren();
+      return;
+    }
+    const definition = scenarioMetricDefinitions[metricId];
+    const values = points.map((point) => point.value);
+    const baselineValue = typeof baseline === "number" ? baseline : null;
+    const scaleValues =
+      baselineValue === null ? values : [...values, baselineValue];
+    const width = 180;
+    const height = 42;
+    const minimum = Math.min(...scaleValues);
+    const maximum = Math.max(...scaleValues);
+    const range = maximum - minimum || 1;
+    const x = (index) =>
+      values.length === 1 ? width / 2 : (index / (values.length - 1)) * width;
+    const y = (value) => 5 + (1 - (value - minimum) / range) * (height - 10);
+    const svg = svgElement("svg", {
+      viewBox: `0 0 ${width} ${height}`,
+      role: "img",
+      "aria-label": `${definition.label} comparable cohort trend`,
+    });
+    const areaPoints = [
+      `0,${height}`,
+      ...values.map((value, index) => `${x(index)},${y(value)}`),
+      `${width},${height}`,
+    ].join(" ");
+    svg.append(
+      svgElement("polygon", {
+        points: areaPoints,
+        fill: color,
+        class: "efficiency-sparkline-area",
+      }),
+    );
+    if (baselineValue !== null) {
+      const baselineLine = svgElement("line", {
+        x1: 0,
+        x2: width,
+        y1: y(baselineValue),
+        y2: y(baselineValue),
+        class: "efficiency-sparkline-baseline",
+      });
+      const baselineTitle = svgElement("title", {});
+      baselineTitle.textContent =
+        `Baseline ${definition.format(baselineValue)} — median of up to 7 prior comparable runs`;
+      baselineLine.append(baselineTitle);
+      svg.append(baselineLine);
+    }
+    svg.append(
+      svgElement("polyline", {
+        points: values
+          .map((value, index) => `${x(index)},${y(value)}`)
+          .join(" "),
+        stroke: color,
+        class: "efficiency-sparkline-line",
+      }),
+      svgElement("circle", {
+        cx: x(values.length - 1),
+        cy: y(values.at(-1)),
+        r: 3,
+        fill: color,
+      }),
+    );
+    const slot = width / points.length;
+    points.forEach((point, index) => {
+      const hit = svgElement("rect", {
+        x: index * slot,
+        y: 0,
+        width: slot,
+        height,
+        class: "efficiency-sparkline-hit",
+      });
+      const parts = [
+        `Run ${point.executionId}`,
+        formatDate(point.timestamp),
+        definition.format(point.value),
+      ];
+      if (baselineValue !== null && baselineValue !== 0) {
+        const deltaPct = ((point.value - baselineValue) / Math.abs(baselineValue)) * 100;
+        parts.push(
+          `${deltaPct < 0 ? "↓" : "↑"} ${compactNumber(Math.abs(deltaPct), 1)}% vs baseline`,
+        );
+      }
+      const title = svgElement("title", {});
+      title.textContent = parts.join(" · ");
+      hit.append(title);
+      svg.append(hit);
+    });
+    element.replaceChildren(svg);
+  }
+
+  function efficiencyCell(row, metricId, formatter) {
+    const current = row.current?.averages?.[metricId];
+    if (typeof current !== "number") {
+      const previous = row.baseline?.[metricId];
+      return typeof previous === "number"
+        ? `<span class="efficiency-cell-muted">${escapeHtml(
+            formatter(previous),
+          )}<small>last observed</small></span>`
+        : "—";
+    }
+    const delta =
+      row.lifecycle === "comparable" && row.outcome.passed
+        ? row.deltas?.[metricId]
+        : null;
+    const meta = deltaMeta(delta);
+    const deltaLabel =
+      typeof delta === "number"
+        ? `<small class="efficiency-cell-delta delta-${meta.css}">${escapeHtml(
+            `${delta < 0 ? "↓" : delta > 0 ? "↑" : ""}${compactNumber(
+              Math.abs(delta),
+              1,
+            )}%`,
+          )}</small>`
+        : "";
+    return `<span>${escapeHtml(formatter(current))}${deltaLabel}</span>`;
+  }
+
+  function efficiencyTrendMeta(row) {
+    const values = {
+      improving: ["Improving", "improved"],
+      stable: ["Stable", "stable"],
+      regressed: ["Regressed", "regressed"],
+      mixed: ["Mixed", "mixed"],
+      collecting: [
+        `Baseline ${row.historyCount}/${row.established ? row.historyCount : 5}`,
+        "collecting",
+      ],
+      new: ["New", "new"],
+      changed: [`Changed · v${row.scenarioVersion}`, "changed"],
+      retired: ["Removed", "retired"],
+      non_comparable: ["Non-comparable", "non-comparable"],
+    };
+    const [label, css] = values[row.trend] || ["Unknown", "collecting"];
+    return { label, css };
+  }
+
+  function renderEfficiency() {
+    const latest = history.executions[0];
+    if (latest) {
+      const status = statusMeta(latest.status);
+      elements.efficiencyStatus.textContent = status.label;
+      elements.efficiencyStatus.className =
+        `efficiency-result-value text-${status.css}`;
+      elements.efficiencyStatusCaption.textContent =
+        `${formatDate(latest.completed_at, true)} · run ${latest.run_id || latest.id}` +
+        (latest.attempt > 1 ? ` · attempt ${latest.attempt}` : "");
+    }
+    const overview = executionApi.buildEfficiencyOverview(history.executions);
+    if (!overview.latest) {
+      elements.efficiencyBody.innerHTML =
+        '<tr><td colspan="7" class="table-empty">Waiting for complete efficiency reports.</td></tr>';
+      return;
+    }
+    elements.efficiencyRunLabel.textContent =
+      `Run ${overview.latest.run_id || overview.latest.id} · ${formatDate(
+        overview.latest.completed_at,
+        true,
+      )}`;
+    const cards = [
+      {
+        metricId: "cost_usd",
+        value: elements.efficiencyCost,
+        delta: elements.efficiencyCostDelta,
+        baseline: elements.efficiencyCostBaseline,
+        sparkline: elements.efficiencyCostSparkline,
+        format: formatCurrency,
+      },
+      {
+        metricId: "tokens",
+        value: elements.efficiencyTokens,
+        delta: elements.efficiencyTokensDelta,
+        baseline: elements.efficiencyTokensBaseline,
+        sparkline: elements.efficiencyTokensSparkline,
+        format: (value) => compactNumber(value, 0),
+      },
+      {
+        metricId: "duration_seconds",
+        value: elements.efficiencyDuration,
+        delta: elements.efficiencyDurationDelta,
+        baseline: elements.efficiencyDurationBaseline,
+        sparkline: elements.efficiencyDurationSparkline,
+        format: formatDuration,
+      },
+      {
+        metricId: "function_call_errors",
+        value: elements.efficiencyErrors,
+        delta: elements.efficiencyErrorsDelta,
+        baseline: elements.efficiencyErrorsBaseline,
+        sparkline: elements.efficiencyErrorsSparkline,
+        format: (value) => compactNumber(value, 1),
+      },
+    ];
+    const cohortRows = overview.rows.filter(
+      (row) => row.lifecycle === "comparable" && row.outcome.passed,
+    );
+    cards.forEach((card) => {
+      const metric = overview.metrics[card.metricId];
+      // Value, delta, and sparkline must all read the same population; fall
+      // back to the full-suite total only while no cohort exists yet.
+      card.value.textContent = card.format(
+        cohortRows.length ? metric?.comparableCurrent : metric?.operational,
+      );
+      const meta = deltaMeta(metric?.delta);
+      card.delta.textContent = meta.label;
+      card.delta.className = `efficiency-delta delta-${meta.css}`;
+      const baselineValue =
+        cohortRows.length && typeof metric?.comparableBaseline === "number"
+          ? metric.comparableBaseline
+          : null;
+      card.baseline.textContent =
+        baselineValue === null ? "" : `baseline ${card.format(baselineValue)}`;
+      renderEfficiencySparkline(
+        card.sparkline,
+        card.metricId,
+        efficiencyTrendColors[meta.css] || efficiencyTrendColors.neutral,
+        cohortRows,
+        cohortRows.length ? metric?.comparableBaseline : null,
+      );
+    });
+
+    const passed = Number(overview.latest.totals?.passed_scenarios) || 0;
+    const expected = Number(overview.latest.totals?.expected_reports) || 0;
+    const countParts = [
+      `${passed}/${expected} scenarios passed`,
+      `${overview.counts.comparable} comparable`,
+    ];
+    if (overview.counts.new) countParts.push(`${overview.counts.new} new`);
+    if (overview.counts.changed) countParts.push(`${overview.counts.changed} changed`);
+    if (overview.counts.retired) countParts.push(`${overview.counts.retired} removed`);
+    if (overview.counts.nonComparable) {
+      countParts.push(`${overview.counts.nonComparable} non-comparable`);
+    }
+    const guardrailAlert =
+      overview.counts.nonComparable ||
+      overview.counts.changed ||
+      passed < expected;
+    elements.efficiencyGuardrail.className =
+      `efficiency-guardrail${guardrailAlert ? " efficiency-guardrail-alert" : ""}`;
+    elements.efficiencyGuardrail.innerHTML = `
+      <span class="guardrail-status">${
+        guardrailAlert ? "Outcome attention" : "Outcome guardrail passed"
+      }</span>
+      <span>${escapeHtml(countParts.join(" · "))}</span>
+      <small>Lower efficiency totals are positive only for the comparable cohort.</small>
+    `;
+
+    elements.efficiencyBody.replaceChildren();
+    overview.rows.forEach((row) => {
+      const trend = efficiencyTrendMeta(row);
+      const tableRow = document.createElement("tr");
+      tableRow.className = `efficiency-row efficiency-row-${trend.css}`;
+      tableRow.innerHTML = `
+        <th scope="row">
+          <button class="scenario-history-button" type="button">
+            <span>${escapeHtml(titleCase(row.scenarioId))}</span>
+            <small>${escapeHtml(row.subjectId || "default subject")} · v${escapeHtml(
+            row.scenarioVersion,
+          )}</small></button>
+        </th>
+        <td>${efficiencyCell(row, "cost_usd", formatCurrency)}</td>
+        <td>${efficiencyCell(row, "tokens", (value) =>
+          compactNumber(value, 0),
+        )}</td>
+        <td>${efficiencyCell(row, "duration_seconds", formatDuration)}</td>
+        <td>${efficiencyCell(row, "function_calls", (value) =>
+          compactNumber(value, 1),
+        )}</td>
+        <td>${efficiencyCell(row, "function_call_errors", (value) =>
+          compactNumber(value, 1),
+        )}</td>
+        <td><span class="efficiency-trend trend-${trend.css}">${escapeHtml(
+          trend.label,
+        )}</span></td>
+      `;
+      tableRow
+        .querySelector(".scenario-history-button")
+        .addEventListener("click", () => openScenarioHistory(row));
+      elements.efficiencyBody.append(tableRow);
+    });
+  }
+
+  async function hydrateExecutionMetrics() {
+    await Promise.all(
+      history.executions.map(async (execution) => {
+        const hasScenarioMetrics = (execution.scenario_metrics || []).length > 0;
+        const hasEfficiencyTotals =
+          typeof execution.totals?.total_tokens === "number" &&
+          typeof execution.totals?.function_calls === "number";
+        if (
+          (hasScenarioMetrics && hasEfficiencyTotals) ||
+          execution.availability !== "full" ||
+          typeof execution.detail_path !== "string" ||
+          execution.detail_path.includes("..") ||
+          !execution.detail_path.startsWith("runs/")
+        ) {
+          return;
+        }
+        try {
+          const preview = window.HARNESS_EXECUTION_DETAILS?.[execution.id];
+          let detail = preview;
+          if (!detail) {
+            const url = new URL(execution.detail_path, window.location.href);
+            const runsRoot = new URL("./runs/", window.location.href);
+            if (
+              url.origin !== runsRoot.origin ||
+              !url.pathname.startsWith(runsRoot.pathname)
+            ) {
+              return;
+            }
+            const response = await fetch(url, { cache: "no-store" });
+            if (!response.ok) return;
+            detail = await response.json();
+          }
+          if (!hasScenarioMetrics) {
+            execution.scenario_metrics =
+              executionApi.scenarioMetricsFromDetail(detail);
+          }
+          execution.totals = {
+            ...execution.totals,
+            ...executionApi.executionEfficiencyTotalsFromDetail(detail),
+          };
+        } catch (_error) {
+          if (!hasScenarioMetrics) execution.scenario_metrics = [];
+        }
+      }),
+    );
+  }
+
+  function svgElement(name, attributes = {}) {
+    const element = document.createElementNS("http://www.w3.org/2000/svg", name);
+    Object.entries(attributes).forEach(([key, value]) => {
+      element.setAttribute(key, String(value));
+    });
+    return element;
+  }
+
+  function scenarioHistoryEntries(row) {
+    return history.executions
+      .map((execution) => {
+        const metric = (execution.scenario_metrics || []).find(
+          (candidate) =>
+            String(candidate.subject_id || "") === row.subjectId &&
+            candidate.scenario_id === row.scenarioId,
+        );
+        if (!metric) return null;
+        const subject = row.subjectId
+          ? (execution.subjects || []).find(
+              (candidate) => String(candidate.id || "") === row.subjectId,
+            )
+          : (execution.subjects || []).find((candidate) =>
+              (candidate.scenarios || []).some(
+                (scenario) => scenario.id === row.scenarioId,
+              ),
+            );
+        const scenario = (subject?.scenarios || []).find(
+          (candidate) => candidate.id === row.scenarioId,
+        );
+        const status =
+          execution.status === "cancelled"
+            ? "cancelled"
+            : !scenario
+              ? "incomplete"
+              : executionApi.normalizeScenarioStatus(scenario);
+        return { execution, metric, scenario, status };
+      })
+      .filter(Boolean)
+      .reverse();
+  }
+
+  function renderScenarioHistoryTooltip(svg, point, entry, definition, metricId, bounds) {
+    svg.querySelector(".scenario-history-tooltip")?.remove();
+    const width = 212;
+    const height = 70;
+    const x = Math.min(Math.max(point.x - width / 2, 8), bounds.width - width - 8);
+    const y = point.y > 92 ? point.y - height - 15 : point.y + 15;
+    const meta = statusMeta(entry.status);
+    const group = svgElement("g", { class: "scenario-history-tooltip" });
+    group.append(
+      svgElement("rect", {
+        x,
+        y,
+        width,
+        height,
+        rx: 8,
+        class: "chart-tooltip-box",
+      }),
+    );
+    const heading = svgElement("text", {
+      x: x + 12,
+      y: y + 18,
+      class: "chart-tooltip-heading",
+    });
+    heading.textContent = `${formatDate(entry.execution.completed_at, true)} · run ${
+      entry.execution.run_id || entry.execution.id
+    }`;
+    const value = svgElement("text", {
+      x: x + 12,
+      y: y + 40,
+      class: "chart-tooltip-value",
+    });
+    value.textContent = formatScenarioHistoryValue(metricId, point.value);
+    const outcome = svgElement("text", {
+      x: x + 12,
+      y: y + 58,
+      class: `chart-tooltip-status chart-tooltip-status-${meta.css}`,
+    });
+    outcome.textContent = `${meta.label} · v${entry.metric.scenario_version || 1}`;
+    group.append(heading, value, outcome);
+    svg.append(group);
+  }
+
+  function renderScenarioHistoryChart(entries, metricId, row) {
+    const definition = scenarioMetricDefinitions[metricId];
+    const points = entries
+      .map((entry) => ({
+        ...entry,
+        value: entry.metric?.averages?.[metricId],
+      }))
+      .filter(
+        (entry) =>
+          typeof entry.value === "number" && Number.isFinite(entry.value),
+      );
+    if (!points.length) {
+      elements.scenarioHistoryChart.innerHTML =
+        '<div class="chart-empty">No values were collected for this metric.</div>';
+      return;
+    }
+
+    const width = 960;
+    const height = 330;
+    const margin = { top: 28, right: 24, bottom: 48, left: 74 };
+    const plotWidth = width - margin.left - margin.right;
+    const plotHeight = height - margin.top - margin.bottom;
+    const baseline = row.baseline?.[metricId];
+    const domain = points.map((point) => point.value);
+    if (typeof baseline === "number") domain.push(baseline);
+    let minimum = Math.min(...domain);
+    let maximum = Math.max(...domain);
+    const padding =
+      maximum === minimum
+        ? Math.max(Math.abs(maximum) * 0.15, 1)
+        : (maximum - minimum) * 0.15;
+    minimum = Math.max(0, minimum - padding);
+    maximum += padding;
+    if (maximum === minimum) maximum = minimum + 1;
+    const x = (index) =>
+      margin.left +
+      (points.length === 1 ? plotWidth / 2 : (index / (points.length - 1)) * plotWidth);
+    const y = (value) =>
+      margin.top + (1 - (value - minimum) / (maximum - minimum)) * plotHeight;
+    const svg = svgElement("svg", {
+      viewBox: `0 0 ${width} ${height}`,
+      role: "img",
+      "aria-label": `${definition.label} history for ${titleCase(row.scenarioId)}`,
+    });
+
+    for (let index = 0; index <= 4; index += 1) {
+      const value = minimum + ((maximum - minimum) * index) / 4;
+      const pointY = y(value);
+      svg.append(
+        svgElement("line", {
+          x1: margin.left,
+          y1: pointY,
+          x2: width - margin.right,
+          y2: pointY,
+          class: "chart-grid-line",
+        }),
+      );
+      const label = svgElement("text", {
+        x: margin.left - 12,
+        y: pointY + 4,
+        "text-anchor": "end",
+        class: "chart-axis-label",
+      });
+      label.textContent = formatScenarioHistoryValue(metricId, value);
+      svg.append(label);
+    }
+
+    if (typeof baseline === "number") {
+      const baselineY = y(baseline);
+      svg.append(
+        svgElement("line", {
+          x1: margin.left,
+          y1: baselineY,
+          x2: width - margin.right,
+          y2: baselineY,
+          class: "chart-target",
+        }),
+      );
+      const baselineLabel = svgElement("text", {
+        x: width - margin.right,
+        y: baselineY - 7,
+        "text-anchor": "end",
+        class: "chart-target-label",
+      });
+      baselineLabel.textContent = `Comparable baseline ${formatScenarioHistoryValue(
+        metricId,
+        baseline,
+      )}`;
+      svg.append(baselineLabel);
+    }
+
+    let segment = [];
+    const appendSegment = () => {
+      if (segment.length > 1) {
+        svg.append(
+          svgElement("polyline", {
+            points: segment.map((point) => `${point.x},${point.y}`).join(" "),
+            stroke: chartAccentColor,
+            class: "chart-path",
+          }),
+        );
+      }
+      segment = [];
+    };
+    points.forEach((entry, index) => {
+      const point = { x: x(index), y: y(entry.value), value: entry.value };
+      const previous = points[index - 1];
+      if (
+        previous &&
+        previous.metric.contract_fingerprint !== entry.metric.contract_fingerprint
+      ) {
+        appendSegment();
+        const boundaryX = (x(index - 1) + x(index)) / 2;
+        svg.append(
+          svgElement("line", {
+            x1: boundaryX,
+            y1: margin.top,
+            x2: boundaryX,
+            y2: height - margin.bottom,
+            class: "chart-contract-boundary",
+          }),
+        );
+        const label = svgElement("text", {
+          x: boundaryX + 5,
+          y: margin.top + 10,
+          class: "chart-contract-label",
+        });
+        label.textContent = `v${entry.metric.scenario_version || 1}`;
+        svg.append(label);
+      }
+      segment.push(point);
+      if (index === points.length - 1) appendSegment();
+
+      const link = svgElement("a", {
+        href: detailUrl(entry.execution, row),
+        "aria-label": `${definition.label} ${definition.format(entry.value)}, ${
+          statusMeta(entry.status).label
+        }, ${formatDate(entry.execution.completed_at, true)}`,
+      });
+      const circle = svgElement("circle", {
+        cx: point.x,
+        cy: point.y,
+        r: 4.5,
+        fill: chartAccentColor,
+        class: `chart-point chart-point-${statusMeta(entry.status).css}`,
+      });
+      link.append(circle);
+      const showTooltip = () =>
+        renderScenarioHistoryTooltip(
+          svg,
+          point,
+          entry,
+          definition,
+          metricId,
+          { width, height },
+        );
+      link.addEventListener("mouseenter", showTooltip);
+      link.addEventListener("focus", showTooltip);
+      link.addEventListener("mouseleave", () =>
+        svg.querySelector(".scenario-history-tooltip")?.remove(),
+      );
+      link.addEventListener("blur", () =>
+        svg.querySelector(".scenario-history-tooltip")?.remove(),
+      );
+      svg.append(link);
+    });
+
+    const labelIndexes = [
+      ...new Set([0, Math.floor((points.length - 1) / 2), points.length - 1]),
+    ];
+    labelIndexes.forEach((index) => {
+      const label = svgElement("text", {
+        x: x(index),
+        y: height - 16,
+        "text-anchor":
+          index === 0
+            ? "start"
+            : index === points.length - 1
+              ? "end"
+              : "middle",
+        class: "chart-x-label",
+      });
+      label.textContent = formatDate(points[index].execution.completed_at, true);
+      svg.append(label);
+    });
+    elements.scenarioHistoryChart.replaceChildren(svg);
+  }
+
+  function renderScenarioHistoryTable(entries, metricId, row) {
+    const definition = scenarioMetricDefinitions[metricId];
+    let previousComparable = null;
+    const prepared = entries.map((entry, index) => {
+      const value = entry.metric?.averages?.[metricId];
+      const comparable =
+        entry.status === "passed" &&
+        previousComparable &&
+        previousComparable.metric.contract_fingerprint ===
+          entry.metric.contract_fingerprint;
+      const delta = comparable
+        ? ((value - previousComparable.value) / Math.abs(previousComparable.value)) * 100
+        : null;
+      const previous = entries[index - 1];
+      const contractChanged = Boolean(
+        previous &&
+          previous.metric.contract_fingerprint !== entry.metric.contract_fingerprint,
+      );
+      if (entry.status === "passed" && typeof value === "number" && value !== 0) {
+        previousComparable = { metric: entry.metric, value };
+      }
+      return { ...entry, value, delta, contractChanged };
+    });
+    elements.scenarioHistoryBody.replaceChildren();
+    prepared.reverse().forEach((entry) => {
+      const meta = statusMeta(entry.status);
+      const tableRow = document.createElement("tr");
+      const delta =
+        typeof entry.delta === "number" && Number.isFinite(entry.delta)
+          ? `${entry.delta < 0 ? "↓" : entry.delta > 0 ? "↑" : ""}${compactNumber(
+              Math.abs(entry.delta),
+              1,
+            )}%`
+          : "—";
+      tableRow.innerHTML = `
+        <td><div class="release-cell"><a href="${escapeHtml(
+          detailUrl(entry.execution, row),
+        )}">${escapeHtml(formatDate(entry.execution.completed_at, true))}</a><span>run ${escapeHtml(
+          entry.execution.run_id || entry.execution.id,
+        )}</span></div></td>
+        <td>${escapeHtml(definition.format(entry.value))}</td>
+        <td class="${entry.delta < 0 ? "text-pass" : entry.delta > 0 ? "text-fail" : ""}">${escapeHtml(
+          delta,
+        )}</td>
+        <td><span class="table-status status-${meta.css}">${escapeHtml(meta.label)}</span></td>
+        <td><span class="scenario-history-contract">v${escapeHtml(
+          entry.metric.scenario_version || 1,
+        )}${entry.contractChanged ? " · changed" : ""}</span></td>
+      `;
+      elements.scenarioHistoryBody.append(tableRow);
+    });
+  }
+
+  function renderScenarioHistory() {
+    const row = state.scenarioHistoryRow;
+    if (!row) return;
+    const entries = scenarioHistoryEntries(row);
+    const metricId = state.scenarioHistoryMetric;
+    const definition = scenarioMetricDefinitions[metricId];
+    elements.scenarioHistoryTitle.textContent = titleCase(row.scenarioId);
+    elements.scenarioHistoryContext.textContent = `${row.subjectId || "default subject"} · ${
+      entries.length
+    } execution${entries.length === 1 ? "" : "s"} · ${
+      row.lifecycle === "retired"
+        ? "removed from current suite"
+        : `current contract v${row.scenarioVersion}`
+    }`;
+    elements.scenarioHistoryDescription.textContent =
+      `${definition.description} Lines break when the scenario contract changes.`;
+    document.querySelectorAll("[data-history-metric]").forEach((button) => {
+      const active = button.dataset.historyMetric === metricId;
+      button.classList.toggle("active", active);
+      button.setAttribute("aria-selected", String(active));
+      button.tabIndex = active ? 0 : -1;
+    });
+    renderScenarioHistoryChart(entries, metricId, row);
+    renderScenarioHistoryTable(entries, metricId, row);
+  }
+
+  function openScenarioHistory(row) {
+    state.scenarioHistoryRow = row;
+    state.scenarioHistoryMetric = "cost_usd";
+    renderScenarioHistory();
+    if (!elements.scenarioHistoryDialog.open) {
+      elements.scenarioHistoryDialog.showModal();
+    }
+  }
+
+  function matrixTooltip(execution, row, cell) {
+    const status = statusMeta(cell?.status || execution.status);
+    if (!cell) {
+      return `${formatDate(execution.completed_at, true)} · ${status.label} · no scenario report`;
+    }
+    const blocking =
+      Number(cell.hard_gate_failures || 0) +
+      Number(cell.technical_failures || 0);
+    return [
+      `${titleCase(row.scenarioId)} · ${formatDate(execution.completed_at, true)}`,
+      `${status.label} · score ${compactNumber(cell.median_score, 1)} · pass ${formatPercent(
+        typeof cell.pass_rate === "number" ? cell.pass_rate * 100 : null,
+      )}`,
+      `${formatCurrency(cell.total_cost_usd)} · ${formatDuration(
+        cell.wall_time_seconds,
+      )} · ${blocking} blocking event${blocking === 1 ? "" : "s"}`,
+    ].join("\n");
+  }
+
+  function renderMatrix() {
+    const executions = history.executions
+      .slice(0, state.matrixCount)
+      .reverse();
+    const rows = executionApi.matrixRows(executions);
+    if (!executions.length || !rows.length) {
+      elements.matrix.innerHTML =
+        '<div class="matrix-empty">No scenario reports are available for this range.</div>';
+      return;
+    }
+    const table = document.createElement("table");
+    table.className = "health-matrix";
+    const thead = document.createElement("thead");
+    const headerRow = document.createElement("tr");
+    headerRow.innerHTML = '<th scope="col">Subject / scenario</th>';
+    executions.forEach((execution) => {
+      const header = document.createElement("th");
+      header.scope = "col";
+      const status = statusMeta(execution.status);
+      header.innerHTML = `
+        <a href="${escapeHtml(detailUrl(execution))}" aria-label="${escapeHtml(
+          `${formatDate(execution.completed_at, true)}, ${status.label}, run ${execution.run_id}`,
+        )}">
+          <span>${escapeHtml(
+            new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric" }).format(
+              new Date(execution.completed_at || execution.started_at),
+            ),
+          )}</span>
+          <i class="matrix-run-status status-${status.css}" aria-hidden="true"></i>
+        </a>
+      `;
+      headerRow.append(header);
+    });
+    thead.append(headerRow);
+    table.append(thead);
+
+    const tbody = document.createElement("tbody");
+    rows.forEach((row) => {
+      const tableRow = document.createElement("tr");
+      const label = document.createElement("th");
+      label.scope = "row";
+      label.innerHTML = `
+        <span>${escapeHtml(row.subjectLabel)}</span>
+        <strong>${escapeHtml(titleCase(row.scenarioId))}</strong>
+      `;
+      tableRow.append(label);
+      executions.forEach((execution) => {
+        const cell = executionApi.matrixCell(execution, row);
+        const cellStatus =
+          cell?.status ||
+          (["cancelled", "running", "infra_failed"].includes(execution.status)
+            ? execution.status
+            : "incomplete");
+        const meta = statusMeta(cellStatus);
+        const cellLabel = executionApi.matrixCellLabel(cell, cellStatus);
+        const data = document.createElement("td");
+        const tooltip = matrixTooltip(execution, row, cell);
+        data.innerHTML = `
+          <a
+            class="matrix-cell matrix-${escapeHtml(cellStatus)}"
+            href="${escapeHtml(detailUrl(execution, row))}"
+            aria-label="${escapeHtml(tooltip.replaceAll("\n", ". "))}"
+            data-tooltip="${escapeHtml(tooltip)}"
+          >
+            <span aria-hidden="true">${escapeHtml(cellLabel || meta.short)}</span>
+          </a>
+        `;
+        tableRow.append(data);
+      });
+      tbody.append(tableRow);
+    });
+    table.append(tbody);
+    elements.matrix.replaceChildren(table);
+  }
+
+  function dataLabel(availability) {
+    return {
+      full: "Diagnostic detail",
+      aggregate: "Aggregate",
+      unavailable: "No report",
+    }[availability] || "Unknown";
+  }
+
+  function renderComparisonBar() {
+    if (!isLocal) {
+      elements.comparisonBar.hidden = true;
+      return;
+    }
+    elements.comparisonBar.hidden = false;
+    const count = state.comparison.length;
+    elements.comparisonCount.textContent =
+      count === 0
+        ? "Select two executions"
+        : count === 1
+          ? "1 of 2 executions selected"
+          : "2 executions selected";
+    const ready = count === 2;
+    elements.comparisonLink.setAttribute("aria-disabled", String(!ready));
+    elements.comparisonLink.href = ready
+      ? `./compare.html?left=${encodeURIComponent(state.comparison[0])}&right=${encodeURIComponent(state.comparison[1])}`
+      : "./compare.html";
+  }
+
+  function toggleComparison(executionId, checked) {
+    state.comparison = state.comparison.filter((id) => id !== executionId);
+    if (checked) {
+      if (state.comparison.length === 2) state.comparison.shift();
+      state.comparison.push(executionId);
+    }
+    renderTable();
+  }
+
+  function renderTable() {
+    const filtered = executionApi.filterExecutions(history.executions, state);
+    const pageCount = Math.max(1, Math.ceil(filtered.length / state.pageSize));
+    state.page = Math.min(state.page, pageCount);
+    const start = (state.page - 1) * state.pageSize;
+    const page = filtered.slice(start, start + state.pageSize);
+    elements.body.replaceChildren();
+    page.forEach((execution) => {
+      const row = document.createElement("tr");
+      const meta = statusMeta(execution.status);
+      const commit = execution.source?.sha || "";
+      const subjectLabels = (execution.subjects || []).map(
+        (subject) => `${subject.provider}/${subject.model}`,
+      );
+      const failures = failureCount(execution);
+      const trigger =
+        execution.event === "workflow_dispatch" ? "manual" : execution.event || "unknown";
+      const primaryLabel = execution.label || formatDate(execution.completed_at, true);
+      const secondaryLabel = execution.label
+        ? `${formatDate(execution.completed_at, true)} · run ${execution.run_id || execution.id}`
+        : `run ${execution.run_id || execution.id}`;
+      const comparisonControl = isLocal
+        ? `<label class="execution-compare-control">
+            <input type="checkbox" data-compare-id="${escapeHtml(execution.id)}" ${
+              state.comparison.includes(execution.id) ? "checked" : ""
+            }>
+            <span class="visually-hidden">Select ${escapeHtml(primaryLabel)} for comparison</span>
+          </label>`
+        : "";
+      const commitCell = isLocal
+        ? ""
+        : `<td>${
+            commit
+              ? `<a class="commit-link" href="${escapeHtml(
+                  safeUrl(
+                    `${history.repoUrl.replace(/\/$/, "")}/commit/${encodeURIComponent(commit)}`,
+                  ),
+                )}">${escapeHtml(commit.slice(0, 7))}</a>`
+              : "—"
+          }</td>`;
+      row.innerHTML = `
+        <td>
+          <div class="execution-identity-cell">
+            ${comparisonControl}
+            <div class="release-cell">
+            <a href="${escapeHtml(detailUrl(execution))}">${escapeHtml(
+              primaryLabel,
+            )}</a>
+            <span>${escapeHtml(secondaryLabel)} · attempt ${execution.attempt} · ${escapeHtml(trigger)}</span>
+            </div>
+          </div>
+        </td>
+        <td><span class="table-status status-${meta.css}">${meta.label}</span></td>
+        ${commitCell}
+        <td title="${escapeHtml(subjectLabels.join(", "))}">${escapeHtml(
+          subjectLabels.length === 1
+            ? subjectLabels[0]
+            : subjectLabels.length
+              ? `${subjectLabels.length} subjects`
+              : "—",
+        )}</td>
+        <td>${formatPercent(execution.totals?.scenario_pass_rate)}</td>
+        <td>${compactNumber(execution.totals?.average_score, 1)}</td>
+        <td class="${failures ? "text-fail" : ""}">${compactNumber(failures, 0)}</td>
+        <td>${compactNumber(execution.totals?.total_tokens, 0)}</td>
+        <td>${compactNumber(execution.totals?.function_calls, 0)}</td>
+        <td>${formatCurrency(execution.totals?.total_cost_usd)}</td>
+        <td>${formatDuration(execution.totals?.wall_time_seconds)}</td>
+        <td><span class="data-badge data-${escapeHtml(
+          execution.availability,
+        )}">${escapeHtml(dataLabel(execution.availability))}</span></td>
+      `;
+      row.querySelector("[data-compare-id]")?.addEventListener("change", (event) => {
+        toggleComparison(execution.id, event.currentTarget.checked);
+      });
+      elements.body.append(row);
+    });
+    if (!page.length) {
+      const row = document.createElement("tr");
+      row.innerHTML =
+        `<td class="table-empty" colspan="${isLocal ? 11 : 12}">No executions match these filters.</td>`;
+      elements.body.append(row);
+    }
+    elements.count.textContent =
+      `${filtered.length} execution${filtered.length === 1 ? "" : "s"}`;
+    elements.pageLabel.textContent = `Page ${state.page} of ${pageCount}`;
+    elements.previous.disabled = state.page === 1;
+    elements.next.disabled = state.page === pageCount;
+    renderComparisonBar();
+  }
+
+  function render() {
+    const hasData = history.executions.length > 0;
+    elements.empty.hidden = hasData;
+    elements.content.hidden = !hasData;
+    if (!hasData) return;
+    renderKpis();
+    renderEfficiency();
+    renderMatrix();
+    renderTable();
+  }
+
+  async function initialize() {
+    elements.preview.hidden = !(history.preview || isLocal);
+    elements.preview.textContent = isLocal ? "Local data" : "Preview data";
+    if (isLocal) {
+      elements.syncLabel.textContent = "Last completed";
+      elements.emptyTitle.textContent = "No local executions yet";
+      elements.emptyDescription.textContent =
+        "Run an E2E experiment above to create the first local execution.";
+      elements.actionsLink.textContent = "View repository ↗";
+      elements.footerSummary.textContent = "Harness E2E · local execution history";
+      elements.localRunner.hidden = false;
+      elements.commitHeading.hidden = true;
+      elements.search.placeholder = "Search label, run, or date";
+    }
+    const lastUpdate = history.lastUpdate || history.executions[0]?.completed_at;
+    if (lastUpdate) {
+      elements.lastUpdate.dateTime = new Date(lastUpdate).toISOString();
+      elements.lastUpdate.textContent = formatDate(lastUpdate, true);
+    }
+    if (history.repoUrl) {
+      const repo = safeUrl(history.repoUrl);
+      if (repo) {
+        elements.actionsLink.href = isLocal
+          ? repo
+          : `${repo.replace(/\/$/, "")}/actions/workflows/harness-e2e-daily.yml`;
+      }
+    }
+    elements.scenarioHistoryClose.addEventListener("click", () => {
+      elements.scenarioHistoryDialog.close();
+    });
+    elements.scenarioHistoryDialog.addEventListener("click", (event) => {
+      if (event.target === elements.scenarioHistoryDialog) {
+        elements.scenarioHistoryDialog.close();
+      }
+    });
+    elements.scenarioHistoryDialog.addEventListener("close", () => {
+      state.scenarioHistoryRow = null;
+    });
+    document.querySelectorAll("[data-history-metric]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const metricId = button.dataset.historyMetric;
+        if (!scenarioHistoryMetricIds.includes(metricId)) return;
+        state.scenarioHistoryMetric = metricId;
+        renderScenarioHistory();
+      });
+    });
+    document.querySelectorAll(".range-button").forEach((button) => {
+      button.addEventListener("click", () => {
+        state.matrixCount = Number(button.dataset.count);
+        document.querySelectorAll(".range-button").forEach((candidate) => {
+          candidate.classList.toggle("active", candidate === button);
+        });
+        renderMatrix();
+      });
+    });
+    elements.search.addEventListener("input", () => {
+      state.query = elements.search.value;
+      state.page = 1;
+      renderTable();
+    });
+    elements.status.addEventListener("change", () => {
+      state.status = elements.status.value;
+      state.page = 1;
+      renderTable();
+    });
+    elements.event.addEventListener("change", () => {
+      state.event = elements.event.value;
+      state.page = 1;
+      renderTable();
+    });
+    elements.previous.addEventListener("click", () => {
+      state.page = Math.max(1, state.page - 1);
+      renderTable();
+    });
+    elements.next.addEventListener("click", () => {
+      state.page += 1;
+      renderTable();
+    });
+    if (isLocal) window.HarnessLocalRunner.initialize();
+    render();
+    await hydrateExecutionMetrics();
+    renderEfficiency();
+    renderTable();
+  }
+
+  initialize();
+})();

--- a/harness/tests/e2e/assets/dashboard/sample-data.js
+++ b/harness/tests/e2e/assets/dashboard/sample-data.js
@@ -1,0 +1,343 @@
+(function loadHarnessBenchmarkPreview() {
+  "use strict";
+
+  const scenarios = [
+    "direct_answer",
+    "persistent_state",
+    "validation_loop",
+    "reactive_automation",
+  ];
+  const releases = [
+    {
+      tag: "daily/2026-07-22",
+      worker: "main",
+      version: "2026-07-22",
+      channel: "daily",
+      date: Date.UTC(2026, 6, 22, 6),
+      sha: "21b25ebc60deeb6059dc08d195e4f7b2b65df629",
+      scores: [82, 88, 84, 76],
+      passRates: [100, 100, 67, 67],
+      costs: [0.08, 0.12, 0.14, 2.48],
+      durations: [21, 26, 48, 390],
+      hardGates: [0, 0, 0, 1],
+      technical: [0, 0, 0, 0],
+      retries: [0, 0, 1, 0],
+      passed: false,
+    },
+    {
+      tag: "daily/2026-07-23",
+      worker: "main",
+      version: "2026-07-23",
+      channel: "daily",
+      date: Date.UTC(2026, 6, 23, 6),
+      sha: "46b6b917ceec4e1f01d2b54fd2b2bbd9437a8892",
+      scores: [86, 91, 87, 81],
+      passRates: [100, 100, 100, 67],
+      costs: [0.075, 0.11, 0.13, 2.31],
+      durations: [19, 24, 43, 355],
+      hardGates: [0, 0, 0, 0],
+      technical: [0, 0, 0, 0],
+      retries: [0, 0, 0, 1],
+      passed: true,
+    },
+    {
+      tag: "daily/2026-07-24",
+      worker: "main",
+      version: "2026-07-24",
+      channel: "daily",
+      date: Date.UTC(2026, 6, 24, 6),
+      sha: "8867dc0e781bcb5adeb32dc8ef61ca5410a17d21",
+      scores: [89, 94, 90, 84],
+      passRates: [100, 100, 100, 100],
+      costs: [0.072, 0.105, 0.125, 2.18],
+      durations: [18, 23, 41, 328],
+      hardGates: [0, 0, 0, 0],
+      technical: [0, 0, 0, 0],
+      retries: [0, 0, 0, 0],
+      passed: true,
+    },
+    {
+      tag: "daily/2026-07-25",
+      worker: "main",
+      version: "2026-07-25",
+      channel: "daily",
+      date: Date.UTC(2026, 6, 25, 6),
+      sha: "d7737956dcc5e13211b456551b1564b7d0aab11f",
+      scores: [93, 96, 92, 88],
+      passRates: [100, 100, 100, 100],
+      costs: [0.069, 0.099, 0.119, 1.97],
+      durations: [17, 21, 38, 301],
+      hardGates: [0, 0, 0, 0],
+      technical: [0, 0, 0, 0],
+      retries: [0, 0, 0, 0],
+      passed: true,
+    },
+    {
+      tag: "daily/2026-07-26",
+      worker: "main",
+      version: "2026-07-26",
+      channel: "daily",
+      date: Date.UTC(2026, 6, 26, 6),
+      sha: "d4b23bb742deba1acc143fb246e08c77fd99a061",
+      scores: [94, 97, 93, 91],
+      passRates: [100, 100, 100, 100],
+      costs: [0.068, 0.096, 0.116, 1.88],
+      durations: [17, 20, 37, 276],
+      hardGates: [0, 0, 0, 0],
+      technical: [0, 0, 0, 0],
+      retries: [0, 0, 0, 0],
+      passed: true,
+    },
+    {
+      tag: "daily/2026-07-27",
+      worker: "main",
+      version: "2026-07-27",
+      channel: "daily",
+      date: Date.UTC(2026, 6, 27, 6),
+      sha: "ed7f5efffd1541716ef017651e2bd26944171930",
+      scores: [96, 98, 95, 93],
+      passRates: [100, 100, 100, 67],
+      costs: [0.064, 0.092, 0.11, 1.72],
+      durations: [15, 19, 34, 248],
+      hardGates: [0, 0, 0, 1],
+      technical: [0, 0, 0, 0],
+      retries: [0, 0, 0, 0],
+      passed: false,
+    },
+    {
+      tag: "daily/2026-07-28",
+      worker: "main",
+      version: "2026-07-28",
+      channel: "daily",
+      date: Date.UTC(2026, 6, 28, 6),
+      sha: "a88137b350ccb0784e49b7c43682a8fba8a39ad1",
+      scores: [98, 99, 97, 96],
+      passRates: [100, 100, 100, 100],
+      costs: [0.061, 0.088, 0.106, 1.61],
+      durations: [14, 18, 32, 226],
+      hardGates: [0, 0, 0, 0],
+      technical: [0, 0, 0, 0],
+      retries: [0, 0, 0, 0],
+      passed: true,
+    },
+  ];
+
+  function commit(release) {
+    return {
+      author: { name: "iii team", username: "iii-hq" },
+      committer: { name: "iii team", username: "iii-hq" },
+      id: release.sha,
+      message: `release: ${release.tag}`,
+      timestamp: new Date(release.date).toISOString(),
+      url: `https://github.com/iii-hq/workers/commit/${release.sha}`,
+    };
+  }
+
+  function scenarioPassed(release, index) {
+    return (
+      release.passRates[index] >= 67 &&
+      release.hardGates[index] === 0 &&
+      release.technical[index] === 0
+    );
+  }
+
+  function releasePassed(release) {
+    return scenarios.every((_scenario, index) => scenarioPassed(release, index));
+  }
+
+  function extra(release, scenario, passed = null) {
+    const resolvedPassed = passed ?? releasePassed(release);
+    const runId = String(Math.floor(release.date / 1000));
+    return JSON.stringify({
+      schema_version: 2,
+      execution: {
+        id: `${runId}-1`,
+        run_id: runId,
+        attempt: 1,
+        event: "schedule",
+        actor: "github-actions",
+      },
+      lane: "release",
+      generated_at: new Date(release.date + 12 * 60 * 1000).toISOString(),
+      source: {
+        sha: release.sha,
+        ref: release.tag,
+        repository: "iii-hq/workers",
+      },
+      workflow_url: "https://github.com/iii-hq/workers/actions",
+      release: {
+        tag: release.tag,
+        worker: release.worker,
+        version: release.version,
+        url: `https://github.com/iii-hq/workers/releases/tag/${release.tag}`,
+        registry_tag: release.channel,
+      },
+      subject: { id: "glm-5-2", model: "glm-5.2", provider: "zai" },
+      judge: { model: "glm-5.2", provider: "zai" },
+      engine_revision: "c84f918f6f5e92e32ad78e6695d581c9e1995c9b",
+      scenario,
+      requested_runs: 3,
+      passed: resolvedPassed,
+      status: resolvedPassed ? "passed" : "failed",
+    });
+  }
+
+  function metric(name, unit, value, metricExtra) {
+    return { name, unit, value, extra: metricExtra };
+  }
+
+  function qualityRecord(release) {
+    const benches = [];
+    scenarios.forEach((scenario, index) => {
+      benches.push(
+        metric(
+          `quality::glm-5-2::${scenario}::median_score`,
+          "points",
+          release.scores[index],
+          extra(
+            release,
+            scenario,
+            scenarioPassed(release, index),
+          ),
+        ),
+        metric(
+          `quality::glm-5-2::${scenario}::pass_rate`,
+          "percent",
+          release.passRates[index],
+          extra(
+            release,
+            scenario,
+            scenarioPassed(release, index),
+          ),
+        ),
+      );
+    });
+    benches.push(
+      metric(
+        "quality::glm-5-2::suite::scenario_pass_rate",
+        "percent",
+        (scenarios.filter((_scenario, index) => scenarioPassed(release, index))
+          .length /
+          scenarios.length) *
+          100,
+        extra(release, "suite"),
+      ),
+      metric(
+        "quality::glm-5-2::suite::report_coverage",
+        "percent",
+        100,
+        extra(release, "suite"),
+      ),
+    );
+    return {
+      commit: commit(release),
+      date: release.date,
+      tool: "customBiggerIsBetter",
+      benches,
+    };
+  }
+
+  function efficiencyRecord(release) {
+    const benches = [];
+    scenarios.forEach((scenario, index) => {
+      const metricExtra = extra(
+        release,
+        scenario,
+        scenarioPassed(release, index),
+      );
+      benches.push(
+        metric(
+          `efficiency::glm-5-2::${scenario}::total_cost_usd`,
+          "USD",
+          release.costs[index],
+          metricExtra,
+        ),
+        metric(
+          `efficiency::glm-5-2::${scenario}::wall_time_seconds`,
+          "seconds",
+          release.durations[index],
+          metricExtra,
+        ),
+        metric(
+          `reliability::glm-5-2::${scenario}::hard_gate_failures`,
+          "count",
+          release.hardGates[index],
+          metricExtra,
+        ),
+        metric(
+          `reliability::glm-5-2::${scenario}::technical_failures`,
+          "count",
+          release.technical[index],
+          metricExtra,
+        ),
+        metric(
+          `reliability::glm-5-2::${scenario}::retry_attempts`,
+          "count",
+          release.retries[index],
+          metricExtra,
+        ),
+        metric(
+          `reliability::glm-5-2::${scenario}::missing_reports`,
+          "count",
+          0,
+          metricExtra,
+        ),
+      );
+    });
+    const suiteExtra = extra(release, "suite");
+    benches.push(
+      metric(
+        "efficiency::glm-5-2::suite::total_cost_usd",
+        "USD",
+        release.costs.reduce((sum, value) => sum + value, 0),
+        suiteExtra,
+      ),
+      metric(
+        "efficiency::glm-5-2::suite::wall_time_seconds",
+        "seconds",
+        release.durations.reduce((sum, value) => sum + value, 0),
+        suiteExtra,
+      ),
+      metric(
+        "reliability::glm-5-2::suite::hard_gate_failures",
+        "count",
+        release.hardGates.reduce((sum, value) => sum + value, 0),
+        suiteExtra,
+      ),
+      metric(
+        "reliability::glm-5-2::suite::technical_failures",
+        "count",
+        release.technical.reduce((sum, value) => sum + value, 0),
+        suiteExtra,
+      ),
+      metric(
+        "reliability::glm-5-2::suite::retry_attempts",
+        "count",
+        release.retries.reduce((sum, value) => sum + value, 0),
+        suiteExtra,
+      ),
+      metric(
+        "reliability::glm-5-2::suite::missing_reports",
+        "count",
+        0,
+        suiteExtra,
+      ),
+    );
+    return {
+      commit: commit(release),
+      date: release.date,
+      tool: "customSmallerIsBetter",
+      benches,
+    };
+  }
+
+  window.HARNESS_BENCHMARK_PREVIEW = true;
+  window.BENCHMARK_DATA = {
+    lastUpdate: releases.at(-1).date,
+    repoUrl: "https://github.com/iii-hq/workers",
+    entries: {
+      "Harness E2E Quality": releases.map(qualityRecord),
+      "Harness E2E Efficiency and Reliability": releases.map(efficiencyRecord),
+    },
+  };
+})();

--- a/harness/tests/e2e/assets/dashboard/sample-executions.js
+++ b/harness/tests/e2e/assets/dashboard/sample-executions.js
@@ -1,0 +1,285 @@
+(function loadHarnessExecutionPreview() {
+  "use strict";
+
+  const executionApi = window.HarnessExecutionData;
+  const benchmark = window.HarnessBenchmarkData.normalizeBenchmarkData(
+    window.BENCHMARK_DATA,
+  );
+  const derived = executionApi.mergeExecutionHistory(null, benchmark);
+  const executions = derived.executions.map((execution, index) => {
+    const runId = execution.run_id || String(30490000000 - index * 731);
+    const id = execution.id || `${runId}-1`;
+    return {
+      ...execution,
+      id,
+      run_id: runId,
+      attempt: 1,
+      workflow_name: "Harness E2E Daily",
+      workflow_url: `https://github.com/iii-hq/workers/actions/runs/${runId}`,
+      event: index === 3 ? "workflow_dispatch" : "schedule",
+      actor: index === 3 ? "iii-team" : "github-actions",
+      conclusion:
+        execution.status === "passed"
+          ? "success"
+          : execution.status === "cancelled"
+            ? "cancelled"
+            : "failure",
+      availability: index < 3 ? "full" : "aggregate",
+      detail_path: index < 3 ? `runs/${id}.json` : null,
+      workflow_duration_seconds:
+        (execution.totals?.wall_time_seconds || 0) + 104,
+      execution: {
+        id,
+        run_id: runId,
+        attempt: 1,
+        event: index === 3 ? "workflow_dispatch" : "schedule",
+        actor: index === 3 ? "iii-team" : "github-actions",
+      },
+    };
+  });
+
+  function previewRun(execution, subject, scenario, runIndex) {
+    const runId = `${execution.run_id.slice(-4)}-${scenario.id}-${runIndex + 1}`;
+    const sessionId = `e2e_${runId}`;
+    const prompt =
+      `Run the ${scenario.id} E2E scenario against ${subject.provider}/${subject.model}. ` +
+      "Use the registered tools, preserve the requested invariants, and report the evidence.";
+    const recoveredError = scenario.id === "reactive_automation" && runIndex === 1;
+    const status = scenario.passed
+      ? "passed"
+      : scenario.hard_gate_failures
+        ? "hard_gate_failed"
+        : "infrastructure_error";
+    return {
+      run_id: runId,
+      session_id: sessionId,
+      prompt,
+      wall_time_ms: Math.round(
+        ((scenario.wall_time_seconds || 30) * 1000) /
+          Math.max(1, execution.requested_runs || 3),
+      ),
+      score: scenario.median_score,
+      status,
+      hard_gates: [
+        {
+          id: "required_state_present",
+          passed: !scenario.hard_gate_failures,
+          reason: scenario.hard_gate_failures
+            ? "The expected state record was not found."
+            : "All expected state records were present.",
+        },
+      ],
+      criteria: [
+        {
+          id: "task_completion",
+          possible: 60,
+          awarded: Math.min(60, Math.round((scenario.median_score || 0) * 0.6)),
+          reason: "Awarded from the observed task result and persisted evidence.",
+        },
+        {
+          id: "tool_discipline",
+          possible: 40,
+          awarded: Math.min(40, Math.round((scenario.median_score || 0) * 0.4)),
+          reason: "Awarded for bounded tool use and a factual final response.",
+        },
+      ],
+      failures: scenario.passed
+        ? []
+        : [{
+            phase: scenario.hard_gate_failures ? "evaluate" : "collect",
+            message: scenario.hard_gate_failures
+              ? "A required hard gate did not pass."
+              : "The required run pass rate was not met.",
+          }],
+      transcript: {
+        messages: [
+          {
+            entry_id: `${runId}-user`,
+            message: {
+              role: "user",
+              timestamp: "2026-07-30T12:00:00Z",
+              content: [{ type: "text", text: prompt }],
+            },
+          },
+          {
+            entry_id: `${runId}-assistant-1`,
+            message: {
+              role: "assistant",
+              model: subject.model,
+              provider: subject.provider,
+              timestamp: "2026-07-30T12:00:01Z",
+              content: [
+                {
+                  type: "text",
+                  text: "I will inspect the available functions, execute the scenario, and verify the resulting state.",
+                },
+                {
+                  type: "function_call",
+                  id: `${runId}-call-state-read`,
+                  function_id: "state::get",
+                  arguments: { key: `benchmark:${scenario.id}:result` },
+                },
+              ],
+            },
+          },
+          {
+            entry_id: `${runId}-result-1`,
+            message: {
+              role: "function_result",
+              function_call_id: `${runId}-call-state-read`,
+              function_id: "state::get",
+              is_error: recoveredError,
+              timestamp: "2026-07-30T12:00:02Z",
+              details: recoveredError
+                ? { error: "State was not available on the first read." }
+                : { value: { status: "verified", scenario: scenario.id } },
+              content: [
+                {
+                  type: "text",
+                  text: recoveredError
+                    ? "State was not available on the first read."
+                    : `{"value":{"status":"verified","scenario":"${scenario.id}"}}`,
+                },
+              ],
+            },
+          },
+          {
+            entry_id: `${runId}-assistant-2`,
+            message: {
+              role: "assistant",
+              model: subject.model,
+              provider: subject.provider,
+              timestamp: "2026-07-30T12:00:03Z",
+              content: [
+                {
+                  type: "text",
+                  text: recoveredError
+                    ? "The initial read failed, but the final state and required effects were independently verified."
+                    : "The final state and all required effects were verified successfully.",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      metrics: {
+        totals: {
+          sessions: 1,
+          turns: 3,
+          function_calls: 1,
+          function_call_errors: Number(recoveredError),
+          input_tokens: 1200,
+          output_tokens: 180,
+        },
+        by_session: [
+          {
+            session_id: sessionId,
+            depth: 0,
+            turns: 3,
+            function_calls: 1,
+            function_call_errors: Number(recoveredError),
+            input_tokens: 1200,
+            output_tokens: 180,
+            cost_usd:
+              (scenario.total_cost_usd || 0) /
+              Math.max(1, execution.requested_runs || 3),
+          },
+        ],
+        traces: {
+          trace_count: 1,
+          span_count: 8,
+          error_span_count: Number(recoveredError),
+          duration_ms: Math.round((scenario.wall_time_seconds || 30) * 1000),
+        },
+      },
+      judge_usage: { input_tokens: 900, output_tokens: 90, cost_usd: 0.01 },
+      cost: {
+        subject_usd:
+          ((scenario.total_cost_usd || 0) * 0.8) /
+          Math.max(1, execution.requested_runs || 3),
+        judge_usd:
+          ((scenario.total_cost_usd || 0) * 0.2) /
+          Math.max(1, execution.requested_runs || 3),
+        total_usd:
+          (scenario.total_cost_usd || 0) /
+          Math.max(1, execution.requested_runs || 3),
+      },
+      retry_attempts: [],
+      judge_attempts: scenario.passed ? 1 : 2,
+    };
+  }
+
+  function previewDetail(execution) {
+    const reports = [];
+    (execution.subjects || []).forEach((subject) => {
+      (subject.scenarios || []).forEach((scenario) => {
+        const runs = Array.from(
+          { length: execution.requested_runs || 3 },
+          (_, index) => previewRun(execution, subject, scenario, index),
+        );
+        reports.push({
+          subject_id: subject.id,
+          scenario_id: scenario.id,
+          available: true,
+          report: {
+            subject: { model: subject.model, provider: subject.provider },
+            judge: { model: subject.judge?.model, provider: subject.judge?.provider },
+            engine_revision: subject.engine_revision,
+            passed: scenario.passed,
+            scenarios: [
+              {
+                scenario_id: scenario.id,
+                scenario_version: scenario.scenario_version || 1,
+                execution_policy: { max_turns: 16, max_total_tokens: 250000 },
+                aggregate: {
+                  runs: runs.length,
+                  scored_runs: runs.filter((run) => run.score !== null).length,
+                  passed_runs: runs.filter((run) => run.status === "passed").length,
+                  required_passes: 2,
+                  pass_rate: scenario.pass_rate,
+                  median_score: scenario.median_score,
+                  hard_gate_failures: scenario.hard_gate_failures,
+                  technical_failures: scenario.technical_failures,
+                  cost: { total_usd: scenario.total_cost_usd },
+                },
+                passed: scenario.passed,
+                runs,
+              },
+            ],
+          },
+        });
+      });
+    });
+    return {
+      schema_version: 3,
+      execution: execution.execution,
+      generated_at: execution.completed_at,
+      lane: execution.lane,
+      source: execution.source,
+      workflow_url: execution.workflow_url,
+      release: execution.release,
+      requested_runs: execution.requested_runs,
+      subjects: execution.subjects,
+      reports,
+    };
+  }
+
+  const details = Object.fromEntries(
+    executions
+      .filter((execution) => execution.availability === "full")
+      .map((execution) => {
+        const detail = previewDetail(execution);
+        execution.scenario_metrics = executionApi.scenarioMetricsFromDetail(detail);
+        return [execution.id, detail];
+      }),
+  );
+
+  window.HARNESS_EXECUTIONS = {
+    schema_version: 3,
+    last_update: executions[0]?.completed_at,
+    repo_url: "https://github.com/iii-hq/workers",
+    retention: { summaries: 100, details: 30 },
+    executions,
+  };
+  window.HARNESS_EXECUTION_DETAILS = details;
+})();

--- a/harness/tests/e2e/assets/dashboard/styles.css
+++ b/harness/tests/e2e/assets/dashboard/styles.css
@@ -1,0 +1,4295 @@
+:root {
+  --bg: #0a0c0b;
+  --surface: #111412;
+  --surface-raised: #171a18;
+  --surface-soft: #1d211e;
+  --line: rgba(255, 255, 255, 0.09);
+  --line-strong: rgba(255, 255, 255, 0.16);
+  --text: #f5f7f4;
+  --text-soft: #a8b0a9;
+  --text-muted: #707971;
+  --accent: #c7ff4a;
+  --accent-soft: rgba(199, 255, 74, 0.12);
+  --accent-blue: #7bc7ff;
+  --warning: #ffd166;
+  --danger: #ff786f;
+  --success: #9ee66c;
+  --radius-sm: 10px;
+  --radius-md: 16px;
+  --radius-lg: 24px;
+  --shadow: 0 24px 70px rgba(0, 0, 0, 0.24);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  color: var(--text);
+  background: var(--bg);
+  font-synthesis: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+html {
+  background: var(--bg);
+  scroll-behavior: smooth;
+}
+
+body {
+  min-width: 320px;
+  margin: 0;
+  overflow-x: hidden;
+  background:
+    linear-gradient(rgba(255, 255, 255, 0.018) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.018) 1px, transparent 1px),
+    var(--bg);
+  background-size: 56px 56px;
+  color: var(--text);
+}
+
+button,
+select,
+a {
+  font: inherit;
+}
+
+a {
+  color: inherit;
+}
+
+button,
+select {
+  color: var(--text);
+}
+
+.skip-link {
+  position: fixed;
+  z-index: 100;
+  top: 12px;
+  left: 12px;
+  padding: 10px 14px;
+  border-radius: 8px;
+  background: var(--accent);
+  color: #10130c;
+  font-weight: 700;
+  transform: translateY(-150%);
+  transition: transform 160ms ease;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.ambient {
+  position: fixed;
+  z-index: -1;
+  width: 520px;
+  height: 520px;
+  border-radius: 50%;
+  filter: blur(110px);
+  opacity: 0.08;
+  pointer-events: none;
+}
+
+.ambient-one {
+  top: -240px;
+  left: 12%;
+  background: var(--accent);
+}
+
+.ambient-two {
+  top: 380px;
+  right: -280px;
+  background: var(--accent-blue);
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: min(1440px, calc(100% - 48px));
+  min-height: 80px;
+  margin: 0 auto;
+  border-bottom: 1px solid var(--line);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text);
+  text-decoration: none;
+}
+
+.brand-copy {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+}
+
+.brand-copy strong {
+  font-size: 1.18rem;
+  letter-spacing: -0.05em;
+}
+
+.brand-copy span {
+  color: var(--text-soft);
+  font-size: 0.86rem;
+}
+
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.text-link,
+.release-link,
+footer a {
+  color: var(--text-soft);
+  font-size: 0.82rem;
+  text-decoration: none;
+  transition: color 160ms ease;
+}
+
+.text-link:hover,
+.release-link:hover,
+footer a:hover {
+  color: var(--text);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 38px;
+  padding: 0 14px;
+  border: 1px solid var(--line-strong);
+  border-radius: 9px;
+  font-size: 0.8rem;
+  font-weight: 650;
+  text-decoration: none;
+  transition:
+    border-color 160ms ease,
+    background 160ms ease,
+    transform 160ms ease;
+}
+
+.button:hover {
+  border-color: rgba(255, 255, 255, 0.28);
+  background: rgba(255, 255, 255, 0.05);
+  transform: translateY(-1px);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  height: 25px;
+  padding: 0 9px;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 750;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.badge-preview {
+  border: 1px solid rgba(255, 209, 102, 0.35);
+  background: rgba(255, 209, 102, 0.08);
+  color: var(--warning);
+}
+
+.page-shell {
+  width: min(1320px, calc(100% - 48px));
+  margin: 0 auto;
+  padding: 38px 0 84px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  align-items: center;
+  gap: 40px;
+  min-height: 0;
+  padding: 0 0 30px;
+}
+
+.eyebrow,
+.section-kicker {
+  color: var(--text-soft);
+  font-size: 0.68rem;
+  font-weight: 750;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 10px;
+}
+
+.live-dot,
+.data-health-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 5px rgba(199, 255, 74, 0.08);
+}
+
+.hero h1 {
+  max-width: 760px;
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 3.1rem);
+  font-weight: 590;
+  letter-spacing: -0.05em;
+  line-height: 1.02;
+}
+
+.hero p {
+  max-width: 720px;
+  margin: 13px 0 0;
+  color: var(--text-soft);
+  font-size: 0.94rem;
+  line-height: 1.55;
+}
+
+.hero-aside {
+  padding: 18px 20px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+}
+
+.sync-label {
+  margin-bottom: 8px;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero-aside time {
+  display: block;
+  font-size: 1rem;
+  font-weight: 650;
+}
+
+.data-health {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-top: 24px;
+  color: var(--text-soft);
+  font-size: 0.75rem;
+}
+
+.data-health-dot {
+  width: 6px;
+  height: 6px;
+  box-shadow: none;
+}
+
+.control-bar {
+  position: sticky;
+  z-index: 20;
+  top: 12px;
+  display: flex;
+  align-items: end;
+  gap: 12px;
+  margin: 0 0 36px;
+  padding: 13px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(13, 16, 14, 0.86);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.24);
+  backdrop-filter: blur(18px);
+}
+
+.control-bar label {
+  display: grid;
+  gap: 6px;
+}
+
+.control-bar label > span {
+  padding-left: 3px;
+  color: var(--text-muted);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+select {
+  min-width: 150px;
+  height: 39px;
+  padding: 0 34px 0 12px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  outline: none;
+  background: var(--surface-raised);
+  color: var(--text);
+  font-size: 0.78rem;
+}
+
+select:focus-visible,
+button:focus-visible,
+a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.control-context {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-left: auto;
+  padding: 0 12px 10px 0;
+  color: var(--text-soft);
+  font-size: 0.73rem;
+}
+
+.divider {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--text-muted);
+}
+
+.latest-release {
+  margin-bottom: 20px;
+  padding: 28px 30px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(120deg, rgba(199, 255, 74, 0.055), transparent 42%),
+    var(--surface);
+}
+
+.release-heading,
+.panel-heading,
+.section-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.section-kicker {
+  margin-bottom: 10px;
+  color: var(--text-muted);
+}
+
+.release-title-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 14px;
+}
+
+.release-title-row h2,
+.panel-heading h2,
+.section-heading h2 {
+  margin: 0;
+  font-size: 1.42rem;
+  font-weight: 580;
+  letter-spacing: -0.035em;
+}
+
+.status-pill,
+.table-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 27px;
+  padding: 0 10px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 750;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.status-pill::before,
+.table-status::before {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  content: "";
+}
+
+.status-pass {
+  border-color: rgba(158, 230, 108, 0.26);
+  background: rgba(158, 230, 108, 0.08);
+  color: var(--success);
+}
+
+.status-fail {
+  border-color: rgba(255, 120, 111, 0.28);
+  background: rgba(255, 120, 111, 0.08);
+  color: var(--danger);
+}
+
+.status-incomplete {
+  border-color: rgba(255, 209, 102, 0.28);
+  background: rgba(255, 209, 102, 0.08);
+  color: var(--warning);
+}
+
+.meta-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 22px;
+}
+
+.meta-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 29px;
+  padding: 0 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.025);
+  color: var(--text-soft);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.68rem;
+}
+
+.meta-chip strong {
+  color: var(--text-muted);
+  font-family: inherit;
+  font-weight: 500;
+}
+
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.kpi-card {
+  position: relative;
+  min-height: 160px;
+  padding: 22px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+}
+
+.kpi-primary {
+  border-color: rgba(199, 255, 74, 0.19);
+  background:
+    radial-gradient(circle at 88% 14%, rgba(199, 255, 74, 0.13), transparent 36%),
+    var(--surface);
+}
+
+.kpi-label {
+  color: var(--text-muted);
+  font-size: 0.69rem;
+  font-weight: 700;
+  letter-spacing: 0.065em;
+  text-transform: uppercase;
+}
+
+.kpi-value {
+  margin-top: 22px;
+  font-size: clamp(2rem, 3vw, 3rem);
+  font-weight: 540;
+  letter-spacing: -0.06em;
+  line-height: 1;
+}
+
+.kpi-delta {
+  min-height: 18px;
+  margin-top: 12px;
+  color: var(--text-muted);
+  font-size: 0.71rem;
+  line-height: 1.4;
+}
+
+.delta-good {
+  color: var(--success);
+}
+
+.delta-bad {
+  color: var(--danger);
+}
+
+.delta-neutral {
+  color: var(--text-muted);
+}
+
+.kpi-orbit {
+  position: absolute;
+  right: -30px;
+  bottom: -48px;
+  width: 120px;
+  height: 120px;
+  border: 1px solid rgba(199, 255, 74, 0.18);
+  border-radius: 50%;
+}
+
+.kpi-orbit::before,
+.kpi-orbit::after {
+  position: absolute;
+  border: 1px solid rgba(199, 255, 74, 0.1);
+  border-radius: 50%;
+  content: "";
+}
+
+.kpi-orbit::before {
+  inset: 18px;
+}
+
+.kpi-orbit::after {
+  inset: 36px;
+}
+
+.panel {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+}
+
+.trend-panel {
+  padding: 28px 30px 20px;
+}
+
+.trend-panel-primary {
+  margin-bottom: 20px;
+  border-color: rgba(199, 255, 74, 0.16);
+  background:
+    radial-gradient(circle at 100% 0, rgba(123, 199, 255, 0.055), transparent 32%),
+    var(--surface);
+}
+
+.trend-description {
+  max-width: 560px;
+  margin: 10px 0 0;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  line-height: 1.5;
+}
+
+.trend-controls {
+  display: grid;
+  justify-items: end;
+  gap: 10px;
+}
+
+.chart-filter {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.chart-filter > span {
+  color: var(--text-muted);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.chart-filter select {
+  min-width: 190px;
+}
+
+.metric-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--bg);
+}
+
+.metric-tab {
+  min-height: 32px;
+  padding: 0 11px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.72rem;
+  transition:
+    color 160ms ease,
+    background 160ms ease;
+}
+
+.metric-tab:hover {
+  color: var(--text);
+}
+
+.metric-tab.active {
+  background: var(--surface-soft);
+  color: var(--text);
+}
+
+.chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  min-height: 24px;
+  margin-top: 24px;
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-soft);
+  font-size: 0.69rem;
+}
+
+.legend-swatch {
+  width: 16px;
+  height: 3px;
+  border-radius: 999px;
+}
+
+.chart-container {
+  min-height: 340px;
+  margin-top: 8px;
+}
+
+.chart-container svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+.chart-grid-line {
+  stroke: rgba(255, 255, 255, 0.07);
+  stroke-width: 1;
+}
+
+.chart-axis-label,
+.chart-x-label {
+  fill: var(--text-muted);
+  font-size: 11px;
+}
+
+.chart-path {
+  fill: none;
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  pointer-events: none;
+  vector-effect: non-scaling-stroke;
+}
+
+.chart-hit-path {
+  fill: none;
+  stroke: transparent;
+  stroke-width: 18;
+  pointer-events: stroke;
+}
+
+.chart-point {
+  stroke: var(--surface);
+  stroke-width: 2;
+  cursor: pointer;
+  transition: r 120ms ease;
+}
+
+.chart-point:hover {
+  r: 6;
+}
+
+.chart-point:focus-visible {
+  outline: none;
+  stroke: var(--text);
+  stroke-width: 4;
+}
+
+.chart-point-fail {
+  stroke: var(--danger);
+  stroke-width: 4;
+}
+
+.chart-point-incomplete {
+  stroke: var(--warning);
+  stroke-width: 4;
+}
+
+.chart-tooltip {
+  pointer-events: none;
+}
+
+.chart-tooltip-guide {
+  stroke: rgba(255, 255, 255, 0.13);
+  stroke-width: 1;
+  stroke-dasharray: 3 5;
+}
+
+.chart-tooltip-point {
+  stroke: var(--text);
+  stroke-width: 2;
+}
+
+.chart-tooltip-box {
+  fill: #1a1e1b;
+  stroke: rgba(255, 255, 255, 0.16);
+  stroke-width: 1;
+  filter: drop-shadow(0 10px 24px rgba(0, 0, 0, 0.42));
+}
+
+.chart-tooltip-heading {
+  fill: var(--text-soft);
+  font-size: 10px;
+}
+
+.chart-tooltip-value {
+  fill: var(--text);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.chart-tooltip-status {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.chart-tooltip-status-pass {
+  fill: var(--success);
+}
+
+.chart-tooltip-status-fail {
+  fill: var(--danger);
+}
+
+.chart-tooltip-status-incomplete {
+  fill: var(--warning);
+}
+
+.chart-target {
+  stroke: rgba(199, 255, 74, 0.25);
+  stroke-width: 1;
+  stroke-dasharray: 5 6;
+}
+
+.chart-target-label {
+  fill: rgba(199, 255, 74, 0.65);
+  font-size: 10px;
+}
+
+.chart-contract-boundary {
+  stroke: rgba(255, 209, 102, 0.55);
+  stroke-width: 1;
+  stroke-dasharray: 3 5;
+}
+
+.chart-contract-label {
+  fill: var(--warning);
+  font-size: 9px;
+  font-weight: 700;
+}
+
+.chart-empty {
+  display: grid;
+  place-items: center;
+  min-height: 320px;
+  color: var(--text-muted);
+  font-size: 0.84rem;
+}
+
+.scenario-section {
+  padding: 66px 0 20px;
+}
+
+.section-heading {
+  align-items: end;
+  margin-bottom: 24px;
+}
+
+.section-heading p {
+  max-width: 420px;
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  line-height: 1.55;
+  text-align: right;
+}
+
+.scenario-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.scenario-card {
+  padding: 24px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.018), transparent 48%),
+    var(--surface);
+}
+
+.scenario-card-fail {
+  border-color: rgba(255, 120, 111, 0.25);
+  background:
+    linear-gradient(145deg, rgba(255, 120, 111, 0.05), transparent 48%),
+    var(--surface);
+}
+
+.scenario-card-incomplete {
+  border-color: rgba(255, 209, 102, 0.25);
+}
+
+.scenario-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.scenario-name {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.scenario-index {
+  display: grid;
+  place-items: center;
+  width: 25px;
+  height: 25px;
+  flex: 0 0 auto;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  color: var(--text-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.64rem;
+}
+
+.scenario-name h3 {
+  overflow: hidden;
+  margin: 0;
+  font-size: 0.91rem;
+  font-weight: 590;
+  letter-spacing: -0.02em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.scenario-score {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  font-size: 1.8rem;
+  font-weight: 540;
+  letter-spacing: -0.055em;
+}
+
+.scenario-score span {
+  color: var(--text-muted);
+  font-size: 0.68rem;
+  font-weight: 500;
+}
+
+.scenario-stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 26px;
+}
+
+.scenario-stat {
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+}
+
+.scenario-stat span {
+  display: block;
+  color: var(--text-muted);
+  font-size: 0.62rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.scenario-stat strong {
+  display: block;
+  margin-top: 7px;
+  font-size: 0.86rem;
+  font-weight: 560;
+}
+
+.scenario-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: 18px;
+  color: var(--text-muted);
+  font-size: 0.68rem;
+}
+
+.scenario-foot a {
+  color: var(--text);
+  font-weight: 620;
+  text-decoration: none;
+}
+
+.history-panel {
+  margin-top: 46px;
+  padding: 28px 30px 10px;
+}
+
+.coverage-note {
+  color: var(--text-muted);
+  font-size: 0.71rem;
+}
+
+.table-wrap {
+  margin-top: 20px;
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.75rem;
+}
+
+th {
+  padding: 13px 12px;
+  border-bottom: 1px solid var(--line-strong);
+  color: var(--text-muted);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.065em;
+  text-align: left;
+  text-transform: uppercase;
+}
+
+td {
+  padding: 17px 12px;
+  border-bottom: 1px solid var(--line);
+  color: var(--text-soft);
+  white-space: nowrap;
+}
+
+tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+tbody tr {
+  transition: background 120ms ease;
+}
+
+tbody tr:hover {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.release-cell {
+  display: grid;
+  gap: 4px;
+}
+
+.release-cell a {
+  color: var(--text);
+  font-weight: 590;
+  text-decoration: none;
+}
+
+.release-cell span {
+  color: var(--text-muted);
+  font-size: 0.66rem;
+}
+
+.commit-link {
+  color: var(--text-soft);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  text-decoration: none;
+}
+
+.empty-state {
+  min-height: 420px;
+  padding: 80px 24px;
+  border: 1px dashed var(--line-strong);
+  border-radius: var(--radius-lg);
+  text-align: center;
+}
+
+.empty-icon {
+  color: var(--accent);
+  font-size: 3rem;
+}
+
+.empty-state h2 {
+  margin: 18px 0 8px;
+  font-size: 1.4rem;
+}
+
+.empty-state p {
+  max-width: 440px;
+  margin: 0 auto;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: min(1320px, calc(100% - 48px));
+  margin: 0 auto;
+  padding: 28px 0 46px;
+  border-top: 1px solid var(--line);
+  color: var(--text-muted);
+  font-size: 0.72rem;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.page-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 32px;
+  padding: 0 0 34px;
+}
+
+.page-heading h1,
+.execution-header h1 {
+  margin: 0;
+  font-size: clamp(1.9rem, 3vw, 2.8rem);
+  font-weight: 590;
+  letter-spacing: -0.05em;
+}
+
+.page-heading p,
+.execution-header p {
+  margin: 10px 0 0;
+  color: var(--text-soft);
+  font-size: 0.86rem;
+  line-height: 1.55;
+}
+
+.sync-block {
+  display: grid;
+  flex: 0 0 auto;
+  gap: 6px;
+  text-align: right;
+}
+
+.sync-block span {
+  color: var(--text-muted);
+  font-size: 0.63rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.sync-block time {
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.execution-kpis {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-top: 4px;
+}
+
+.efficiency-overview {
+  margin-top: 24px;
+  padding: 30px;
+  overflow: hidden;
+  border-color: rgba(123, 199, 255, 0.22);
+  background:
+    radial-gradient(circle at 100% 0, rgba(123, 199, 255, 0.09), transparent 28%),
+    radial-gradient(circle at 0 100%, rgba(199, 255, 74, 0.045), transparent 34%),
+    var(--surface);
+}
+
+.efficiency-heading {
+  align-items: flex-start;
+}
+
+.efficiency-heading-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: flex-end;
+  gap: 24px;
+}
+
+.efficiency-result {
+  display: grid;
+  justify-items: end;
+  gap: 4px;
+  text-align: right;
+}
+
+.efficiency-result > span {
+  color: var(--text-muted);
+  font-size: 0.58rem;
+  font-weight: 750;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.efficiency-result-value {
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.efficiency-result small {
+  color: var(--text-muted);
+  font-size: 0.64rem;
+}
+
+.efficiency-baseline {
+  display: grid;
+  justify-items: end;
+  gap: 4px;
+  text-align: right;
+}
+
+.efficiency-baseline > span {
+  color: var(--text-muted);
+  font-size: 0.58rem;
+  font-weight: 750;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.efficiency-baseline strong {
+  font-size: 0.72rem;
+  font-weight: 650;
+}
+
+.efficiency-baseline small {
+  color: var(--text-muted);
+  font-size: 0.64rem;
+}
+
+.efficiency-card-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 26px;
+}
+
+.efficiency-card {
+  position: relative;
+  min-width: 0;
+  padding: 18px 18px 12px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: rgba(10, 12, 11, 0.56);
+}
+
+.efficiency-card-label {
+  color: var(--text-muted);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.efficiency-card > strong {
+  display: block;
+  margin-top: 9px;
+  font-size: clamp(1.45rem, 2.2vw, 2rem);
+  font-weight: 590;
+  letter-spacing: -0.045em;
+}
+
+.efficiency-delta {
+  display: block;
+  min-height: 18px;
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: 0.64rem;
+}
+
+.delta-improved {
+  color: var(--success);
+}
+
+.delta-regressed {
+  color: var(--danger);
+}
+
+.delta-neutral {
+  color: var(--text-muted);
+}
+
+.efficiency-sparkline {
+  height: 42px;
+  margin-top: 10px;
+  opacity: 0.88;
+}
+
+.efficiency-sparkline svg {
+  display: block;
+  width: 100%;
+  height: 42px;
+}
+
+.efficiency-sparkline-area {
+  opacity: 0.08;
+}
+
+.efficiency-sparkline-line {
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+}
+
+.efficiency-baseline-value {
+  display: block;
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.efficiency-sparkline-baseline {
+  stroke: var(--text-muted);
+  stroke-width: 1;
+  stroke-dasharray: 3 3;
+  opacity: 0.6;
+  vector-effect: non-scaling-stroke;
+}
+
+.efficiency-sparkline-hit {
+  fill: transparent;
+}
+
+.efficiency-guardrail {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 14px;
+  margin-top: 14px;
+  padding: 12px 14px;
+  border: 1px solid rgba(158, 230, 108, 0.2);
+  border-radius: 10px;
+  background: rgba(158, 230, 108, 0.045);
+  color: var(--text-soft);
+  font-size: 0.68rem;
+}
+
+.efficiency-guardrail-alert {
+  border-color: rgba(255, 209, 102, 0.22);
+  background: rgba(255, 209, 102, 0.045);
+}
+
+.guardrail-status {
+  color: var(--success);
+  font-weight: 750;
+}
+
+.efficiency-guardrail-alert .guardrail-status {
+  color: var(--warning);
+}
+
+.efficiency-guardrail small {
+  margin-left: auto;
+  color: var(--text-muted);
+}
+
+.efficiency-table-wrap {
+  margin-top: 18px;
+}
+
+.efficiency-table {
+  width: 100%;
+  min-width: 880px;
+  border-collapse: collapse;
+}
+
+.efficiency-table th,
+.efficiency-table td {
+  padding: 12px 10px;
+  border-bottom: 1px solid var(--line);
+  font-size: 0.69rem;
+  text-align: right;
+  vertical-align: middle;
+}
+
+.efficiency-table thead th {
+  color: var(--text-muted);
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.efficiency-table th:first-child,
+.efficiency-table td:first-child {
+  padding-left: 0;
+  text-align: left;
+}
+
+.efficiency-table th:last-child,
+.efficiency-table td:last-child {
+  padding-right: 0;
+}
+
+.efficiency-table tbody th > span,
+.efficiency-table tbody th > small,
+.efficiency-table td > span,
+.efficiency-cell-muted {
+  display: block;
+}
+
+.efficiency-table tbody th > span {
+  color: var(--text);
+  font-size: 0.72rem;
+  font-weight: 650;
+}
+
+.scenario-history-button {
+  display: grid;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.scenario-history-button > span {
+  color: var(--text);
+  font-size: 0.72rem;
+  font-weight: 650;
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  text-underline-offset: 3px;
+  transition: text-decoration-color 140ms ease;
+}
+
+.scenario-history-button:hover > span {
+  text-decoration-color: var(--accent-blue);
+}
+
+.scenario-history-button > small {
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 0.57rem;
+  font-weight: 500;
+}
+
+.scenario-history-dialog {
+  width: min(1080px, calc(100% - 32px));
+  max-width: none;
+  max-height: 92vh;
+  margin: auto;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  box-shadow: 0 32px 100px rgba(0, 0, 0, 0.65);
+  color: var(--text);
+}
+
+.scenario-history-dialog::backdrop {
+  background: rgba(2, 4, 3, 0.76);
+  backdrop-filter: blur(5px);
+}
+
+.scenario-history-shell {
+  max-height: 92vh;
+  padding: 28px 30px 32px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.scenario-history-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.scenario-history-header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 610;
+  letter-spacing: -0.035em;
+}
+
+.scenario-history-header p {
+  margin: 7px 0 0;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+}
+
+.scenario-history-close {
+  display: grid;
+  width: 36px;
+  height: 36px;
+  flex: 0 0 auto;
+  place-items: center;
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface-raised);
+  color: var(--text-soft);
+  cursor: pointer;
+  font-size: 1.3rem;
+  line-height: 1;
+}
+
+.scenario-history-tabs,
+.run-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 24px;
+}
+
+.scenario-history-tabs button,
+.run-tabs button {
+  min-height: 32px;
+  padding: 0 11px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.67rem;
+  font-weight: 650;
+}
+
+.scenario-history-tabs button:hover,
+.scenario-history-tabs button.active,
+.run-tabs button:hover,
+.run-tabs button.active {
+  border-color: rgba(199, 255, 74, 0.28);
+  background: var(--accent-soft);
+  color: var(--text);
+}
+
+.scenario-history-description {
+  max-width: 760px;
+  margin: 12px 0 0;
+  color: var(--text-muted);
+  font-size: 0.68rem;
+  line-height: 1.5;
+}
+
+.scenario-history-chart {
+  min-height: 330px;
+  margin-top: 20px;
+  padding: 14px 10px 4px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: rgba(10, 12, 11, 0.55);
+}
+
+.scenario-history-chart svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+.scenario-history-tooltip {
+  pointer-events: none;
+}
+
+.scenario-history-table-wrap {
+  margin-top: 18px;
+}
+
+.scenario-history-table {
+  min-width: 720px;
+}
+
+.scenario-history-table td:nth-child(2),
+.scenario-history-table th:nth-child(2),
+.scenario-history-table td:nth-child(3),
+.scenario-history-table th:nth-child(3) {
+  text-align: right;
+}
+
+.scenario-history-contract {
+  color: var(--text-muted);
+  font-size: 0.65rem;
+}
+
+.efficiency-table tbody th > small,
+.efficiency-cell-muted,
+.efficiency-cell-muted small {
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 0.57rem;
+  font-weight: 500;
+}
+
+.efficiency-cell-delta {
+  display: block;
+  margin-top: 3px;
+  font-size: 0.57rem;
+}
+
+.efficiency-trend {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 8px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.025);
+  color: var(--text-soft);
+  font-size: 0.58rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.trend-improved,
+.trend-stable {
+  border-color: rgba(158, 230, 108, 0.2);
+  color: var(--success);
+}
+
+.trend-regressed,
+.trend-non-comparable {
+  border-color: rgba(255, 120, 111, 0.22);
+  color: var(--danger);
+}
+
+.trend-mixed,
+.trend-changed {
+  border-color: rgba(255, 209, 102, 0.22);
+  color: var(--warning);
+}
+
+.trend-new {
+  border-color: rgba(123, 199, 255, 0.24);
+  color: var(--accent-blue);
+}
+
+.trend-retired,
+.trend-collecting {
+  color: var(--text-muted);
+}
+
+.efficiency-row-retired td,
+.efficiency-row-retired th {
+  opacity: 0.62;
+}
+
+.section-divider-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
+  margin: 28px 0 14px;
+}
+
+.section-divider-heading h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.section-divider-heading p {
+  max-width: 420px;
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.67rem;
+  text-align: right;
+}
+
+.text-pass {
+  color: var(--success);
+}
+
+.text-fail {
+  color: var(--danger);
+}
+
+.text-incomplete {
+  color: var(--warning);
+}
+
+.text-running {
+  color: var(--accent-blue);
+}
+
+.text-cancelled {
+  color: var(--text-soft);
+}
+
+.status-cancelled {
+  border-color: rgba(168, 176, 169, 0.28);
+  background: rgba(168, 176, 169, 0.08);
+  color: var(--text-soft);
+}
+
+.status-running {
+  border-color: rgba(123, 199, 255, 0.28);
+  background: rgba(123, 199, 255, 0.08);
+  color: var(--accent-blue);
+}
+
+.health-panel,
+.executions-panel {
+  margin-top: 20px;
+  padding: 28px 30px;
+}
+
+.range-toggle {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--bg);
+}
+
+.range-button {
+  min-height: 32px;
+  padding: 0 12px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.72rem;
+}
+
+.range-button:hover,
+.range-button.active {
+  background: var(--surface-soft);
+  color: var(--text);
+}
+
+.matrix-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+  margin-top: 22px;
+  color: var(--text-muted);
+  font-size: 0.68rem;
+}
+
+.matrix-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.matrix-key {
+  display: grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
+  font-size: 0.65rem;
+  font-style: normal;
+  font-weight: 800;
+}
+
+.matrix-key-score {
+  width: 30px;
+  font-size: 0.55rem;
+}
+
+.health-matrix-wrap {
+  margin-top: 18px;
+  padding-bottom: 78px;
+  overflow-x: auto;
+  scrollbar-color: var(--line-strong) transparent;
+}
+
+.health-matrix {
+  width: max-content;
+  min-width: 100%;
+  border-collapse: separate;
+  border-spacing: 5px;
+  table-layout: fixed;
+}
+
+.health-matrix th,
+.health-matrix td {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  text-align: center;
+}
+
+.health-matrix thead th {
+  width: 56px;
+  height: 54px;
+  vertical-align: bottom;
+}
+
+.health-matrix thead th:first-child,
+.health-matrix tbody th {
+  position: sticky;
+  z-index: 3;
+  left: 0;
+  width: 210px;
+  min-width: 210px;
+  padding-right: 16px;
+  background: var(--surface);
+  text-align: left;
+}
+
+.health-matrix thead th:first-child {
+  padding-bottom: 9px;
+  color: var(--text-muted);
+  font-size: 0.6rem;
+}
+
+.health-matrix thead a {
+  display: grid;
+  justify-items: center;
+  gap: 6px;
+  color: var(--text-muted);
+  font-size: 0.58rem;
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.matrix-run-status {
+  display: block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.health-matrix tbody th {
+  height: 45px;
+  border-bottom: 1px solid var(--line);
+}
+
+.health-matrix tbody th span,
+.health-matrix tbody th strong {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.health-matrix tbody th span {
+  color: var(--text-muted);
+  font-size: 0.58rem;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.health-matrix tbody th strong {
+  margin-top: 3px;
+  color: var(--text-soft);
+  font-size: 0.68rem;
+  font-weight: 620;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.health-matrix tbody td {
+  width: 50px;
+  height: 44px;
+}
+
+.matrix-cell {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 46px;
+  height: 38px;
+  margin: auto;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  font-size: 0.62rem;
+  font-weight: 850;
+  text-decoration: none;
+  transition:
+    transform 120ms ease,
+    border-color 120ms ease,
+    filter 120ms ease;
+}
+
+.matrix-cell:hover {
+  z-index: 4;
+  filter: brightness(1.15);
+  transform: translateY(-2px);
+}
+
+.matrix-cell::after {
+  position: absolute;
+  z-index: 20;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  width: 238px;
+  padding: 10px 12px;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  background: #1a1e1b;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+  color: var(--text-soft);
+  content: attr(data-tooltip);
+  font-size: 0.65rem;
+  font-weight: 500;
+  line-height: 1.55;
+  opacity: 0;
+  pointer-events: none;
+  text-align: left;
+  transform: translate(-50%, 4px);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
+  white-space: pre-line;
+}
+
+.matrix-cell:hover::after,
+.matrix-cell:focus-visible::after {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.matrix-passed {
+  border-color: rgba(158, 230, 108, 0.26);
+  background: rgba(158, 230, 108, 0.11);
+  color: var(--success);
+}
+
+.matrix-failed,
+.matrix-hard_gate_failed,
+.matrix-technical_failed,
+.matrix-infra_failed {
+  border-color: rgba(255, 120, 111, 0.3);
+  background: rgba(255, 120, 111, 0.13);
+  color: var(--danger);
+}
+
+.matrix-running {
+  border-color: rgba(123, 199, 255, 0.3);
+  background: rgba(123, 199, 255, 0.1);
+  color: var(--accent-blue);
+}
+
+.matrix-incomplete {
+  border-color: rgba(255, 209, 102, 0.3);
+  background: rgba(255, 209, 102, 0.1);
+  color: var(--warning);
+}
+
+.matrix-cancelled {
+  border-color: rgba(168, 176, 169, 0.22);
+  background: rgba(168, 176, 169, 0.07);
+  color: var(--text-soft);
+}
+
+.matrix-empty {
+  padding: 70px 20px 0;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  text-align: center;
+}
+
+.executions-panel {
+  margin-top: 24px;
+}
+
+.local-runner {
+  min-width: 0;
+  margin-bottom: 24px;
+  padding: 28px 30px;
+  overflow: hidden;
+  border-color: rgba(199, 255, 74, 0.2);
+  background:
+    linear-gradient(135deg, rgba(199, 255, 74, 0.055), transparent 45%),
+    var(--surface);
+}
+
+.local-runner > * {
+  min-width: 0;
+}
+
+.local-runner-heading {
+  align-items: flex-start;
+}
+
+.local-run-status {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 0 10px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--text-soft);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.local-connection {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 22px;
+  padding: 11px 12px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.local-connection > div {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  color: var(--text-soft);
+  font-size: 0.76rem;
+}
+
+.local-connection code {
+  color: var(--text-muted);
+  font-size: 0.7rem;
+}
+
+.local-connection-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--warning);
+  box-shadow: 0 0 0 4px rgba(255, 209, 102, 0.08);
+}
+
+.local-connection-dot.connected {
+  background: var(--success);
+  box-shadow: 0 0 0 4px rgba(158, 230, 108, 0.08);
+}
+
+.local-connection-dot.failed {
+  background: var(--danger);
+  box-shadow: 0 0 0 4px rgba(255, 120, 111, 0.08);
+}
+
+.local-run-form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 18px;
+}
+
+.local-field {
+  display: grid;
+  gap: 7px;
+  color: var(--text-soft);
+  font-size: 0.72rem;
+  font-weight: 650;
+}
+
+.local-field > span {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.local-field small {
+  color: var(--text-muted);
+  font-size: 0.65rem;
+  font-weight: 500;
+}
+
+.local-field input,
+.local-field select {
+  width: 100%;
+  height: 42px;
+  padding: 0 12px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  outline: none;
+  background: var(--surface-raised);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.78rem;
+}
+
+.local-field input:focus-visible,
+.local-field select:focus-visible {
+  border-color: var(--accent);
+  outline: 2px solid rgba(199, 255, 74, 0.18);
+}
+
+.local-field input:disabled,
+.local-field select:disabled {
+  opacity: 0.55;
+}
+
+.local-field-wide {
+  grid-column: span 2;
+}
+
+.local-scenario-picker {
+  position: relative;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--surface-raised);
+}
+
+.local-scenario-picker > summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 42px;
+  padding: 0 12px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.local-scenario-picker > summary::-webkit-details-marker {
+  display: none;
+}
+
+.local-scenario-picker > summary strong {
+  color: var(--text);
+  font-size: 0.78rem;
+}
+
+.local-scenario-picker > summary span {
+  color: var(--accent-blue);
+  font-size: 0.7rem;
+}
+
+.local-scenario-picker[open] {
+  border-color: var(--line-strong);
+}
+
+.local-scenario-picker.local-picker-disabled {
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.local-scenario-toolbar {
+  display: flex;
+  gap: 8px;
+  padding: 10px 12px;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.local-scenario-toolbar button {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--accent-blue);
+  cursor: pointer;
+  font-size: 0.68rem;
+}
+
+.local-scenario-options {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 2px;
+  max-height: 250px;
+  padding: 8px;
+  overflow: auto;
+}
+
+.local-scenario-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 8px;
+  border-radius: 7px;
+  color: var(--text-soft);
+  cursor: pointer;
+  font-size: 0.7rem;
+  font-weight: 550;
+}
+
+.local-scenario-option:hover {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+}
+
+.local-scenario-option input {
+  width: 15px;
+  height: 15px;
+  margin: 0;
+  accent-color: var(--accent);
+}
+
+.local-scenario-option span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.local-advanced {
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.018);
+}
+
+.local-advanced > summary {
+  padding: 12px;
+  color: var(--text-soft);
+  cursor: pointer;
+  font-size: 0.72rem;
+  font-weight: 650;
+}
+
+.local-advanced-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  padding: 4px 12px 12px;
+}
+
+.local-run-actions {
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  gap: 8px;
+  grid-column: span 2;
+}
+
+.local-run-submit {
+  border-color: rgba(199, 255, 74, 0.45);
+  background: var(--accent);
+  color: #10130c;
+}
+
+.local-run-submit:hover {
+  border-color: var(--accent);
+  background: #d4ff71;
+}
+
+.local-run-error {
+  margin: 16px 0 0;
+  color: var(--danger);
+  font-size: 0.78rem;
+}
+
+.local-run-log-shell {
+  min-width: 0;
+  margin-top: 18px;
+  overflow: hidden;
+  border-top: 1px solid var(--line);
+  padding-top: 14px;
+}
+
+.local-run-log-shell summary {
+  cursor: pointer;
+  color: var(--text-soft);
+  font-size: 0.76rem;
+  font-weight: 650;
+}
+
+.local-run-log {
+  width: 100%;
+  max-width: 100%;
+  max-height: 360px;
+  margin: 12px 0 0;
+  overflow: auto;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: #080a09;
+  color: #cbd3cc;
+  font-size: 0.7rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.table-filters {
+  display: flex;
+  gap: 8px;
+  margin-top: 22px;
+}
+
+.table-filters input {
+  width: 280px;
+  height: 39px;
+  padding: 0 12px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  outline: none;
+  background: var(--surface-raised);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.78rem;
+}
+
+.table-filters input::placeholder {
+  color: var(--text-muted);
+}
+
+.table-filters input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.comparison-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin-top: 14px;
+  padding: 12px 14px;
+  border: 1px solid rgba(123, 199, 255, 0.2);
+  border-radius: 10px;
+  background: rgba(123, 199, 255, 0.045);
+}
+
+.comparison-bar div {
+  display: grid;
+  gap: 2px;
+}
+
+.comparison-bar strong {
+  font-size: 0.78rem;
+}
+
+.comparison-bar span {
+  color: var(--text-muted);
+  font-size: 0.7rem;
+}
+
+.comparison-bar a[aria-disabled="true"] {
+  opacity: 0.42;
+  pointer-events: none;
+}
+
+.execution-identity-cell {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+}
+
+.execution-compare-control {
+  display: grid;
+  place-items: center;
+}
+
+.execution-compare-control input {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  accent-color: var(--accent);
+}
+
+.compare-shell {
+  min-width: 0;
+  width: min(1440px, calc(100% - 48px));
+}
+
+.compare-content {
+  min-width: 0;
+}
+
+.compare-content > .panel {
+  min-width: 0;
+  padding: 28px 30px;
+  overflow: hidden;
+}
+
+.compare-selection-grid,
+.compare-metric-grid {
+  display: grid;
+  min-width: 0;
+  gap: 14px;
+}
+
+.compare-selection-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 24px;
+}
+
+.compare-selection-card,
+.compare-metric-card {
+  min-width: 0;
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface-raised);
+}
+
+.compare-selection-card {
+  display: grid;
+  gap: 8px;
+}
+
+.compare-selection-card span,
+.compare-selection-card small,
+.compare-metric-card span,
+.compare-metric-card small {
+  color: var(--text-muted);
+  font-size: 0.7rem;
+}
+
+.compare-selection-card h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  overflow-wrap: anywhere;
+}
+
+.compare-selection-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+}
+
+.compare-selection-meta small,
+.compare-selection-card .text-link {
+  overflow-wrap: anywhere;
+}
+
+.compare-warning-list {
+  display: grid;
+  gap: 7px;
+  margin: 18px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.compare-warning-list li {
+  padding: 9px 11px;
+  border-left: 2px solid var(--warning);
+  background: rgba(255, 209, 102, 0.055);
+  color: var(--text-soft);
+  font-size: 0.76rem;
+  overflow-wrap: anywhere;
+}
+
+.compare-metric-grid {
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  margin-top: 18px;
+}
+
+.compare-metric-card {
+  display: grid;
+  gap: 7px;
+  overflow: hidden;
+}
+
+.compare-metric-values {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  min-width: 0;
+  gap: 7px;
+}
+
+.compare-metric-values strong,
+.compare-metric-values small,
+.compare-delta {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+.compare-metric-values strong {
+  font-size: 1rem;
+}
+
+.compare-delta {
+  color: var(--text-soft);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.compare-delta-improved {
+  color: var(--success);
+}
+
+.compare-delta-regressed {
+  color: var(--danger);
+}
+
+.compare-table {
+  min-width: 1220px;
+}
+
+.compare-scenario-name {
+  display: grid;
+  gap: 3px;
+}
+
+.compare-scenario-name span {
+  color: var(--text-muted);
+  font-size: 0.66rem;
+}
+
+.comparison-contract {
+  display: inline-flex;
+  padding: 4px 7px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--text-soft);
+  font-size: 0.65rem;
+}
+
+.comparison-contract-changed {
+  border-color: rgba(255, 209, 102, 0.3);
+  color: var(--warning);
+}
+
+.execution-table {
+  min-width: 1320px;
+}
+
+.data-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 25px;
+  padding: 0 8px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  font-size: 0.64rem;
+  font-weight: 680;
+}
+
+.data-full {
+  border-color: rgba(123, 199, 255, 0.25);
+  background: rgba(123, 199, 255, 0.08);
+  color: var(--accent-blue);
+}
+
+.data-aggregate {
+  color: var(--text-soft);
+}
+
+.data-unavailable {
+  border-color: rgba(255, 209, 102, 0.24);
+  color: var(--warning);
+}
+
+.table-empty {
+  padding: 54px 20px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 18px 0 4px;
+}
+
+.pagination button {
+  min-height: 34px;
+  padding: 0 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-raised);
+  color: var(--text-soft);
+  cursor: pointer;
+  font-size: 0.71rem;
+}
+
+.pagination button:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+
+.pagination span {
+  min-width: 92px;
+  color: var(--text-muted);
+  font-size: 0.68rem;
+  text-align: center;
+}
+
+.breadcrumbs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 28px;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+}
+
+.breadcrumbs a {
+  color: var(--text-soft);
+  text-decoration: none;
+}
+
+.detail-loading {
+  min-height: 420px;
+  padding: 100px 0;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.execution-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 30px;
+  padding-bottom: 30px;
+}
+
+.execution-title-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.execution-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.detail-alert {
+  display: grid;
+  grid-template-columns: 210px minmax(0, 1fr);
+  gap: 26px;
+  margin-bottom: 20px;
+  padding: 22px;
+  border: 1px solid rgba(255, 120, 111, 0.26);
+  border-radius: var(--radius-md);
+  background: rgba(255, 120, 111, 0.055);
+}
+
+.detail-alert h2 {
+  margin: 0;
+  color: var(--danger);
+  font-size: 1rem;
+}
+
+.detail-alert ul {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.detail-alert li {
+  display: grid;
+  gap: 3px;
+}
+
+.detail-alert a {
+  color: var(--text);
+  font-size: 0.72rem;
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.detail-alert span,
+.detail-alert p {
+  margin: 0;
+  color: var(--text-soft);
+  font-size: 0.7rem;
+  line-height: 1.45;
+}
+
+#detail-failures {
+  scroll-margin-top: 24px;
+}
+
+.failure-groups {
+  display: grid;
+  gap: 8px;
+}
+
+.failure-chip {
+  display: grid;
+  grid-template-columns: auto minmax(140px, auto) minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  padding: 9px 12px;
+  border: 1px solid rgba(255, 120, 111, 0.2);
+  border-radius: 9px;
+  background: rgba(255, 120, 111, 0.04);
+  color: var(--text);
+  font-size: 0.7rem;
+  text-decoration: none;
+}
+
+.failure-chip:hover {
+  border-color: rgba(255, 120, 111, 0.45);
+}
+
+.failure-chip strong {
+  font-size: 0.72rem;
+  font-weight: 650;
+}
+
+.failure-chip-message {
+  overflow: hidden;
+  color: var(--text-soft);
+  font-size: 0.66rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.failure-overflow {
+  margin-top: 10px;
+}
+
+.failure-overflow > summary {
+  cursor: pointer;
+  color: var(--text-soft);
+  font-size: 0.68rem;
+  font-weight: 650;
+}
+
+.failure-overflow[open] > summary {
+  margin-bottom: 10px;
+}
+
+.section-disclosure {
+  margin-top: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+}
+
+.section-disclosure > summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 18px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.section-disclosure > summary::-webkit-details-marker {
+  display: none;
+}
+
+.section-digest {
+  color: var(--text-soft);
+  font-size: 0.71rem;
+}
+
+.section-chevron,
+.scenario-chevron {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  transition: transform 0.15s ease;
+}
+
+.section-disclosure[open] .section-chevron,
+.scenario-detail-card[open] .scenario-chevron {
+  transform: rotate(180deg);
+}
+
+.section-disclosure > .metadata-grid,
+.section-disclosure > #configuration-content {
+  padding: 0 18px 18px;
+}
+
+.detail-kpis {
+  margin-bottom: 34px;
+}
+
+.detail-layout {
+  display: grid;
+  grid-template-columns: 180px minmax(0, 1fr);
+  align-items: start;
+  gap: 42px;
+}
+
+.detail-index {
+  position: sticky;
+  top: 24px;
+  display: grid;
+  gap: 4px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
+}
+
+.detail-index > span {
+  padding: 4px 8px 9px;
+  color: var(--text-muted);
+  font-size: 0.61rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.detail-index a {
+  padding: 8px;
+  border-radius: 7px;
+  color: var(--text-soft);
+  font-size: 0.71rem;
+  text-decoration: none;
+}
+
+.detail-index a:hover {
+  background: var(--surface-soft);
+  color: var(--text);
+}
+
+.detail-main {
+  min-width: 0;
+}
+
+.detail-section {
+  scroll-margin-top: 24px;
+  padding: 32px 0 54px;
+  border-top: 1px solid var(--line);
+}
+
+.detail-section:first-child {
+  border-top: 0;
+}
+
+.detail-section > h2 {
+  margin: 0;
+  font-size: 1.55rem;
+  font-weight: 580;
+  letter-spacing: -0.04em;
+}
+
+.section-description {
+  max-width: 720px;
+  margin: 10px 0 0;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  line-height: 1.55;
+}
+
+.metadata-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 22px;
+}
+
+.metadata-item {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+  padding: 15px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface);
+}
+
+.metadata-item > span {
+  color: var(--text-muted);
+  font-size: 0.61rem;
+  font-weight: 680;
+  letter-spacing: 0.055em;
+  text-transform: uppercase;
+}
+
+.metadata-item strong,
+.metadata-item a {
+  overflow: hidden;
+  color: var(--text-soft);
+  font-size: 0.73rem;
+  font-weight: 570;
+  line-height: 1.45;
+  text-decoration: none;
+  text-overflow: ellipsis;
+}
+
+.mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.config-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 22px;
+}
+
+.config-card {
+  padding: 20px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
+}
+
+.config-card > span {
+  color: var(--text-muted);
+  font-size: 0.61rem;
+  font-weight: 720;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.config-card h3 {
+  margin: 8px 0 20px;
+  font-size: 1rem;
+  font-weight: 590;
+}
+
+.config-card dl {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  margin: 0;
+}
+
+.config-card dl div {
+  padding-top: 10px;
+  border-top: 1px solid var(--line);
+}
+
+.config-card dt {
+  color: var(--text-muted);
+  font-size: 0.58rem;
+}
+
+.config-card dd {
+  margin: 5px 0 0;
+  font-size: 0.7rem;
+}
+
+.config-facts {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.scenario-details {
+  display: grid;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.scenario-detail-card {
+  scroll-margin-top: 24px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  content-visibility: auto;
+  contain-intrinsic-size: auto 64px;
+}
+
+.scenario-detail-card[open] {
+  border-color: var(--line-strong);
+}
+
+.scenario-summary-row {
+  display: grid;
+  grid-template-columns: minmax(200px, 1fr) auto auto auto auto auto;
+  align-items: center;
+  gap: 18px;
+  min-height: 64px;
+  padding: 12px 22px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.scenario-summary-row::-webkit-details-marker {
+  display: none;
+}
+
+.scenario-summary-copy {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.scenario-summary-copy strong {
+  font-size: 0.94rem;
+  font-weight: 590;
+}
+
+.scenario-summary-copy small {
+  color: var(--text-muted);
+  font-size: 0.62rem;
+}
+
+.scenario-summary-stat {
+  display: grid;
+  gap: 2px;
+  text-align: right;
+}
+
+.scenario-summary-stat small {
+  color: var(--text-muted);
+  font-size: 0.56rem;
+  font-weight: 680;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.scenario-summary-stat strong {
+  font-size: 0.74rem;
+  font-weight: 600;
+}
+
+.scenario-detail-body {
+  padding: 0 22px 22px;
+  border-top: 1px solid var(--line);
+}
+
+.scenario-detail-card h3 {
+  margin: 4px 0 0;
+  font-size: 1.08rem;
+  font-weight: 590;
+}
+
+.scenario-detail-metrics,
+.run-overview,
+.usage-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 7px;
+  margin-top: 20px;
+}
+
+.detail-metric {
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.018);
+}
+
+.detail-metric > span {
+  display: block;
+  color: var(--text-muted);
+  font-size: 0.58rem;
+  font-weight: 680;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.detail-metric strong {
+  display: block;
+  overflow: hidden;
+  margin-top: 7px;
+  font-size: 0.84rem;
+  font-weight: 580;
+  text-overflow: ellipsis;
+}
+
+.detail-metric small {
+  display: block;
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: 0.57rem;
+}
+
+.aggregate-expired,
+.clean-state {
+  margin-top: 16px;
+  padding: 13px 14px;
+  border: 1px dashed var(--line-strong);
+  border-radius: 9px;
+  color: var(--text-muted);
+  font-size: 0.68rem;
+  line-height: 1.5;
+}
+
+.run-list {
+  display: grid;
+  gap: 7px;
+  margin-top: 18px;
+}
+
+.run-detail {
+  scroll-margin-top: 24px;
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  background: var(--bg);
+  content-visibility: auto;
+  contain-intrinsic-size: auto 64px;
+}
+
+.run-detail[open] {
+  border-color: var(--line-strong);
+}
+
+.run-detail > summary {
+  display: grid;
+  grid-template-columns: 34px minmax(180px, 1fr) auto auto auto;
+  align-items: center;
+  gap: 14px;
+  min-height: 64px;
+  padding: 10px 14px;
+  cursor: pointer;
+  color: var(--text-soft);
+  font-size: 0.7rem;
+  list-style: none;
+}
+
+.run-detail > summary::-webkit-details-marker {
+  display: none;
+}
+
+.run-number {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  color: var(--text-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.62rem;
+}
+
+.run-summary-copy {
+  display: grid;
+  gap: 3px;
+}
+
+.run-summary-copy strong {
+  color: var(--text);
+  font-size: 0.75rem;
+}
+
+.run-summary-copy small {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  color: var(--text-muted);
+  font-size: 0.58rem;
+}
+
+.run-summary-error {
+  color: var(--danger);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  font-weight: 650;
+}
+
+.run-content {
+  padding: 4px 18px 22px;
+  border-top: 1px solid var(--line);
+}
+
+.detail-loading-inline {
+  padding: 24px 0 4px;
+  color: var(--text-muted);
+  font-size: 0.68rem;
+}
+
+.run-overview {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+
+.run-sections {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 9px;
+  margin-top: 14px;
+}
+
+/* The authored display would otherwise override the UA [hidden] rule and
+   show every tab panel at once. */
+.run-sections[hidden] {
+  display: none;
+}
+
+.run-section {
+  min-width: 0;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface);
+}
+
+.run-section-wide {
+  grid-column: 1 / -1;
+}
+
+.run-section h5 {
+  margin: 0 0 13px;
+  color: var(--text-soft);
+  font-size: 0.68rem;
+  font-weight: 720;
+  letter-spacing: 0.045em;
+  text-transform: uppercase;
+}
+
+.diagnostic-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.diagnostic-list li {
+  padding: 10px;
+  border-left: 2px solid var(--danger);
+  background: rgba(255, 120, 111, 0.04);
+}
+
+.diagnostic-list span {
+  color: var(--danger);
+  font-size: 0.58rem;
+  font-weight: 720;
+  text-transform: uppercase;
+}
+
+.diagnostic-list p {
+  margin: 5px 0 0;
+  color: var(--text-soft);
+  font-size: 0.68rem;
+  line-height: 1.5;
+}
+
+.diagnostic-table-wrap {
+  overflow-x: auto;
+}
+
+.diagnostic-table {
+  min-width: 620px;
+  font-size: 0.67rem;
+}
+
+.diagnostic-table th {
+  padding: 9px;
+  font-size: 0.56rem;
+}
+
+.diagnostic-table td {
+  padding: 11px 9px;
+  font-size: 0.65rem;
+  vertical-align: top;
+}
+
+.diagnostic-table .wrap-cell {
+  min-width: 260px;
+  white-space: normal;
+  line-height: 1.5;
+}
+
+.usage-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 0;
+}
+
+.retry-card {
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+}
+
+.retry-card + .retry-card {
+  margin-top: 8px;
+}
+
+.retry-card > header,
+.retry-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.retry-card strong {
+  font-size: 0.7rem;
+}
+
+.retry-meta {
+  justify-content: flex-start;
+  margin-top: 10px;
+  color: var(--text-muted);
+  font-size: 0.62rem;
+}
+
+.prompt-block,
+.conversation-payload pre,
+.nested-raw pre,
+.raw-details pre {
+  max-height: 560px;
+  margin: 0;
+  padding: 14px;
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #090b0a;
+  color: var(--text-soft);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.64rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.prompt-block.is-clamped {
+  max-height: 260px;
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(to bottom, black 72%, transparent);
+  mask-image: linear-gradient(to bottom, black 72%, transparent);
+}
+
+.prompt-expand {
+  min-height: 32px;
+  margin-top: 10px;
+  padding: 0 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--text-soft);
+  cursor: pointer;
+  font-size: 0.67rem;
+  font-weight: 650;
+}
+
+.prompt-expand:hover {
+  border-color: var(--line-strong);
+  color: var(--text);
+}
+
+.conversation-launch {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  margin-top: 14px;
+  padding: 15px 16px;
+  border: 1px solid rgba(123, 199, 255, 0.2);
+  border-radius: 10px;
+  background: rgba(123, 199, 255, 0.035);
+}
+
+.conversation-launch > div {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.conversation-launch span {
+  color: var(--text-muted);
+  font-size: 0.55rem;
+  font-weight: 720;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.conversation-launch strong {
+  color: var(--text);
+  font-size: 0.74rem;
+  font-weight: 620;
+}
+
+.conversation-launch small {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.57rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.conversation-launch small.has-errors {
+  color: var(--danger);
+}
+
+.conversation-open {
+  min-height: 34px;
+  padding: 0 13px;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  background: var(--surface-raised);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 0.65rem;
+  font-weight: 680;
+  white-space: nowrap;
+}
+
+.conversation-open:hover {
+  border-color: rgba(199, 255, 74, 0.35);
+  background: var(--accent-soft);
+}
+
+.session-transcript-dialog {
+  width: min(1040px, calc(100% - 32px));
+  height: min(900px, 92dvh);
+  max-width: none;
+  max-height: none;
+  margin: auto;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-lg);
+  background: var(--bg);
+  box-shadow: 0 32px 100px rgba(0, 0, 0, 0.68);
+  color: var(--text);
+}
+
+.session-transcript-dialog::backdrop {
+  background: rgba(2, 4, 3, 0.78);
+  backdrop-filter: blur(5px);
+}
+
+.session-transcript-shell {
+  display: flex;
+  height: 100%;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.session-transcript-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 22px 24px 18px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+}
+
+.session-transcript-header h2 {
+  margin: 0;
+  font-size: 1.08rem;
+  font-weight: 610;
+  letter-spacing: -0.025em;
+}
+
+.session-transcript-header p {
+  max-width: 760px;
+  margin: 6px 0 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.58rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-transcript-close {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  place-items: center;
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--surface-raised);
+  color: var(--text-soft);
+  cursor: pointer;
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+.session-transcript-body {
+  min-height: 0;
+  flex: 1;
+  overflow: hidden;
+}
+
+.conversation-shell {
+  display: flex;
+  height: 100%;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--bg);
+}
+
+.conversation-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface-raised);
+}
+
+.conversation-stats,
+.conversation-actions,
+.conversation-filters {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.conversation-stats span {
+  padding: 6px 9px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  color: var(--text-muted);
+  font-size: 0.6rem;
+}
+
+.conversation-stats strong {
+  color: var(--text-soft);
+  font-size: 0.68rem;
+}
+
+.conversation-stats .has-errors {
+  border-color: rgba(255, 120, 111, 0.35);
+  color: var(--danger);
+  background: rgba(255, 120, 111, 0.06);
+}
+
+.conversation-stats .has-errors strong {
+  color: var(--danger);
+}
+
+.conversation-filter,
+.conversation-next-error {
+  min-height: 30px;
+  padding: 0 10px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.6rem;
+  font-weight: 650;
+}
+
+.conversation-filter:hover,
+.conversation-next-error:hover:not(:disabled) {
+  border-color: var(--line-strong);
+  color: var(--text);
+}
+
+.conversation-filter.is-active {
+  border-color: rgba(199, 255, 74, 0.28);
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.conversation-next-error {
+  border-color: rgba(255, 120, 111, 0.3);
+  color: var(--danger);
+}
+
+.conversation-next-error:disabled {
+  border-color: var(--line);
+  color: var(--text-muted);
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.conversation-error-position {
+  min-height: 0;
+  padding: 0 16px;
+  color: var(--danger);
+  font-size: 0.58rem;
+  text-align: right;
+}
+
+.conversation-error-position:not(:empty) {
+  padding-top: 8px;
+}
+
+.conversation-list {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 30px;
+  padding: 30px 28px 38px;
+  overflow-y: auto;
+}
+
+.conversation-list::before {
+  display: none;
+}
+
+.conversation-event {
+  position: relative;
+  width: min(760px, 100%);
+  margin-inline: auto;
+  scroll-margin: 90px 0;
+}
+
+.conversation-message {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.conversation-user {
+  align-items: flex-end;
+}
+
+.conversation-card {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.conversation-user .conversation-card {
+  align-items: flex-end;
+}
+
+.conversation-card header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  color: var(--text-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  text-transform: uppercase;
+}
+
+.conversation-card header strong {
+  color: var(--text-muted);
+  font-size: 0.63rem;
+  letter-spacing: 0.06em;
+}
+
+.conversation-card header strong span {
+  color: var(--accent);
+  font-size: 0.72rem;
+}
+
+.conversation-card header span {
+  color: var(--text-muted);
+  font-size: 0.55rem;
+}
+
+.conversation-copy {
+  padding-right: 4px;
+  color: var(--text-soft);
+  font-size: 0.76rem;
+  line-height: 1.68;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.conversation-copy strong {
+  color: var(--text);
+  font-weight: 700;
+}
+
+.conversation-copy code {
+  padding: 1px 4px;
+  border: 1px solid var(--line);
+  background: var(--surface-raised);
+  color: var(--text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.68rem;
+}
+
+.conversation-user .conversation-copy {
+  max-width: 80%;
+  padding: 4px 4px 4px 16px;
+  border-left: 1px solid var(--line-strong);
+}
+
+.conversation-tool {
+  border: 1px solid var(--line);
+  background: var(--surface);
+}
+
+.conversation-tool > summary {
+  display: grid;
+  grid-template-columns: 16px minmax(160px, 1fr) auto 16px;
+  align-items: center;
+  gap: 9px;
+  padding: 10px 12px;
+  cursor: pointer;
+  list-style: none;
+  transition: background 140ms ease;
+}
+
+.conversation-tool > summary:hover {
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.conversation-tool > summary::-webkit-details-marker {
+  display: none;
+}
+
+.conversation-tool-icon {
+  color: var(--success);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.conversation-tool-name {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+  min-width: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.conversation-tool-name small {
+  color: var(--text-muted);
+  font-size: 0.66rem;
+  white-space: nowrap;
+}
+
+.conversation-tool-name small i {
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 750;
+}
+
+.conversation-tool-name strong {
+  overflow: hidden;
+  color: var(--text-soft);
+  font-size: 0.68rem;
+  font-weight: 580;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.conversation-tool-name strong em {
+  color: var(--text-muted);
+  font-size: 0.55rem;
+  font-style: normal;
+  font-weight: 500;
+}
+
+.conversation-tool-status {
+  color: var(--success);
+  font-size: 0.58rem;
+  font-weight: 680;
+}
+
+.conversation-chevron {
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  transition: transform 140ms ease;
+}
+
+.conversation-tool[open] .conversation-chevron {
+  transform: rotate(180deg);
+}
+
+.conversation-tool-body {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  padding: 0 11px 11px 37px;
+  border-top: 1px solid var(--line);
+}
+
+.conversation-payload {
+  min-width: 0;
+  padding-top: 11px;
+}
+
+.conversation-payload > span {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--text-muted);
+  font-size: 0.54rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.conversation-payload pre {
+  max-height: 320px;
+  min-height: 100%;
+  padding: 11px;
+  border-radius: 7px;
+  font-size: 0.61rem;
+}
+
+.conversation-tool-error {
+  border-color: rgba(255, 120, 111, 0.45);
+  background: rgba(255, 120, 111, 0.035);
+  box-shadow: inset 3px 0 0 rgba(255, 120, 111, 0.65);
+}
+
+.conversation-tool-error .conversation-tool-icon {
+  color: var(--danger);
+}
+
+.conversation-tool-error .conversation-tool-status,
+.conversation-payload-error > span {
+  color: var(--danger);
+}
+
+.conversation-payload-error pre {
+  border-color: rgba(255, 120, 111, 0.25);
+  background: rgba(255, 120, 111, 0.045);
+}
+
+.conversation-focus-error {
+  animation: conversation-error-focus 1.6s ease;
+}
+
+@keyframes conversation-error-focus {
+  0%,
+  100% {
+    box-shadow: inset 3px 0 0 rgba(255, 120, 111, 0.65);
+  }
+  45% {
+    box-shadow:
+      inset 3px 0 0 var(--danger),
+      0 0 0 3px rgba(255, 120, 111, 0.2);
+  }
+}
+
+.conversation-shell[data-filter="messages"] .conversation-event[data-kind="tool"],
+.conversation-shell[data-filter="errors"] .conversation-event:not([data-error="true"]) {
+  display: none;
+}
+
+.conversation-empty-filter {
+  display: none;
+  padding: 18px;
+  border: 1px dashed var(--line-strong);
+  border-radius: 8px;
+  color: var(--text-muted);
+  font-size: 0.66rem;
+  text-align: center;
+}
+
+.conversation-filter-empty .conversation-empty-filter {
+  display: block;
+}
+
+.nested-raw {
+  color: var(--text-soft);
+  font-size: 0.67rem;
+}
+
+.nested-raw summary,
+.raw-details summary {
+  padding: 8px 0;
+  cursor: pointer;
+}
+
+.raw-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.raw-details {
+  margin-top: 14px;
+  color: var(--text-soft);
+  font-size: 0.7rem;
+}
+
+.raw-details pre {
+  max-height: 720px;
+}
+
+@media (max-width: 1120px) {
+  .compare-metric-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .local-run-form {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .kpi-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .kpi-primary {
+    grid-column: span 2;
+  }
+
+  .efficiency-card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .metadata-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .run-overview {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 840px) {
+  .local-scenario-options {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .local-connection {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .compare-selection-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .compare-metric-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .comparison-bar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .comparison-bar .button {
+    justify-content: center;
+  }
+  .topbar,
+  .page-shell,
+  footer {
+    width: min(100% - 30px, 1320px);
+  }
+
+  .topbar {
+    min-height: 70px;
+    gap: 12px;
+  }
+
+  .brand-copy span,
+  .topbar .text-link {
+    display: none;
+  }
+
+  .page-shell {
+    padding-top: 42px;
+  }
+
+  .hero {
+    grid-template-columns: 1fr;
+    gap: 36px;
+    padding-bottom: 42px;
+  }
+
+  .hero-aside {
+    max-width: 440px;
+  }
+
+  .control-bar {
+    position: static;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: end;
+  }
+
+  select {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .control-context {
+    grid-column: 1 / -1;
+    margin-left: 0;
+    padding: 4px 4px 2px;
+  }
+
+  .release-heading,
+  .panel-heading,
+  .section-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .kpi-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .kpi-primary {
+    grid-column: 1 / -1;
+  }
+
+  .scenario-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .section-heading p {
+    text-align: left;
+  }
+
+  .trend-controls {
+    width: 100%;
+    justify-items: start;
+  }
+
+  .page-heading,
+  .execution-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .sync-block {
+    text-align: left;
+  }
+
+  .health-panel,
+  .efficiency-overview,
+  .executions-panel {
+    padding: 22px 18px;
+  }
+
+  .efficiency-baseline {
+    justify-items: start;
+    text-align: left;
+  }
+
+  .efficiency-heading-meta {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .efficiency-result {
+    justify-items: start;
+    text-align: left;
+  }
+
+  .section-divider-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .section-divider-heading p {
+    text-align: left;
+  }
+
+  .table-filters {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .search-field,
+  .table-filters input {
+    width: 100%;
+    grid-column: 1 / -1;
+  }
+
+  .detail-alert {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-index {
+    position: static;
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .detail-index > span {
+    width: 100%;
+  }
+
+  .config-grid,
+  .config-facts {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .scenario-detail-metrics,
+  .usage-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .conversation-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .conversation-actions {
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 560px) {
+  .local-runner {
+    padding: 22px 18px;
+  }
+
+  .compare-content > .panel {
+    padding: 22px 18px;
+  }
+
+  .local-run-form,
+  .local-advanced-grid,
+  .compare-metric-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .local-field-wide,
+  .local-run-actions {
+    grid-column: span 1;
+  }
+
+  .local-run-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .local-scenario-options {
+    grid-template-columns: 1fr;
+  }
+  .topbar-actions {
+    gap: 8px;
+  }
+
+  .badge-preview {
+    display: none;
+  }
+
+  .button {
+    padding: 0 10px;
+  }
+
+  .topbar-actions .button {
+    font-size: 0;
+  }
+
+  .topbar-actions .button::before {
+    font-size: 0.72rem;
+    content: "Actions";
+  }
+
+  .hero h1 {
+    font-size: clamp(2rem, 10vw, 2.8rem);
+  }
+
+  .control-bar {
+    grid-template-columns: 1fr;
+  }
+
+  .control-context {
+    grid-column: 1;
+  }
+
+  .latest-release,
+  .trend-panel,
+  .history-panel {
+    padding: 22px 18px;
+  }
+
+  .kpi-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .efficiency-card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .efficiency-guardrail {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .efficiency-guardrail small {
+    margin-left: 0;
+  }
+
+  .scenario-history-dialog {
+    width: 100vw;
+    height: 100dvh;
+    max-height: none;
+    margin: 0;
+    border: 0;
+    border-radius: 0;
+  }
+
+  .scenario-history-shell {
+    max-height: 100dvh;
+    padding: 22px 18px 28px;
+  }
+
+  .scenario-history-chart {
+    min-height: 260px;
+    padding-inline: 0;
+  }
+
+  .session-transcript-dialog {
+    width: 100vw;
+    height: 100dvh;
+    margin: 0;
+    border: 0;
+    border-radius: 0;
+  }
+
+  .session-transcript-header {
+    padding: 18px 16px 15px;
+  }
+
+  .session-transcript-header p {
+    white-space: normal;
+  }
+
+  .conversation-launch {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .conversation-open {
+    width: 100%;
+  }
+
+  .kpi-primary {
+    grid-column: auto;
+  }
+
+  .conversation-toolbar,
+  .conversation-actions {
+    align-items: stretch;
+  }
+
+  .conversation-actions {
+    flex-direction: column;
+  }
+
+  .conversation-filters {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .conversation-filter,
+  .conversation-next-error {
+    width: 100%;
+  }
+
+  .conversation-list {
+    gap: 26px;
+    padding: 22px 16px 30px;
+  }
+
+  .conversation-list::before {
+    top: 14px;
+    bottom: 20px;
+    left: 25px;
+  }
+
+  .conversation-message {
+    gap: 7px;
+  }
+
+  .conversation-user .conversation-copy {
+    max-width: 92%;
+  }
+
+  .conversation-tool {
+    margin-left: 0;
+  }
+
+  .conversation-tool > summary {
+    grid-template-columns: 16px minmax(110px, 1fr) auto 14px;
+    gap: 8px;
+  }
+
+  .conversation-tool-body {
+    grid-template-columns: 1fr;
+    padding-left: 11px;
+  }
+
+  .panel-heading {
+    gap: 18px;
+  }
+
+  .metric-tabs {
+    width: 100%;
+    overflow-x: auto;
+  }
+
+  .chart-filter {
+    align-items: stretch;
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .chart-filter select {
+    width: 100%;
+  }
+
+  .scenario-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .metadata-grid,
+  .config-grid,
+  .config-facts,
+  .scenario-detail-metrics,
+  .run-overview,
+  .usage-grid,
+  .run-sections {
+    grid-template-columns: 1fr;
+  }
+
+  .run-detail > summary {
+    grid-template-columns: 32px minmax(0, 1fr) auto;
+  }
+
+  .run-detail > summary > span:nth-child(3),
+  .run-detail > summary > span:nth-child(4) {
+    display: none;
+  }
+
+  .scenario-summary-row {
+    grid-template-columns: minmax(0, 1fr) auto auto;
+  }
+
+  .scenario-summary-row > .scenario-summary-stat {
+    display: none;
+  }
+
+  .failure-chip {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .failure-chip-message {
+    display: none;
+  }
+
+  .run-section-wide {
+    grid-column: auto;
+  }
+
+  .health-matrix thead th:first-child,
+  .health-matrix tbody th {
+    width: 160px;
+    min-width: 160px;
+  }
+
+  footer {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 10px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/harness/tests/e2e/src/dashboard/assets.rs
+++ b/harness/tests/e2e/src/dashboard/assets.rs
@@ -4,7 +4,7 @@ use axum::response::{IntoResponse, Response};
 use rust_embed::RustEmbed;
 
 #[derive(RustEmbed)]
-#[folder = "../../../.github/benchmark-site/"]
+#[folder = "assets/dashboard/"]
 #[exclude = "*.test.cjs"]
 #[exclude = "README.md"]
 #[exclude = "sample-data.js"]


### PR DESCRIPTION
## Summary

`cargo build -p harness-e2e` fails on a fresh checkout of main: the local E2E dashboard (#749) embeds `.github/benchmark-site/` at compile time via `RustEmbed`, and #765 deleted that folder while removing the release automations. No PR workflow builds the `harness-e2e` package (`_harness-integration.yml` is scoped to `harness-integration`), so the break never surfaced on merge.

This moves the dashboard assets into their consumer at `harness/tests/e2e/assets/dashboard/` and points the `RustEmbed` folder attribute there. The one test assertion that read the deleted `publish_harness_e2e_dashboard.py` script is dropped; asset README paths updated.

Note: ticket pending (Linear connector unavailable) — will retitle with the MOT prefix once created; please don't squash-merge before that.

## Test plan

- [x] `cargo build --locked -p harness-e2e` succeeds from a fresh-checkout-equivalent tree
- [x] `node --test harness/tests/e2e/assets/dashboard/*.test.cjs` — 39/39 pass
- [x] `harness-e2e dashboard` serves `index.html` and `styles.css` (HTTP 200) from the new embed
- [ ] Follow-up: add a `cargo build -p harness-e2e` step to PR CI so compile breaks in this package fail before merge