### PR TITLE
chore(ci): fix closed PR cache cleanup

### DIFF
--- a/.github/scripts/tests/test_cache_cleanup_workflow.py
+++ b/.github/scripts/tests/test_cache_cleanup_workflow.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+WORKFLOWS = Path(__file__).parents[2] / "workflows"
+
+
+def test_cache_cleanup_uses_get_and_propagates_list_failures() -> None:
+    workflow = yaml.load(
+        (WORKFLOWS / "cache-cleanup.yml").read_text(),
+        Loader=yaml.BaseLoader,
+    )
+    run = workflow["jobs"]["cleanup"]["steps"][0]["run"]
+
+    assert 'gh api --method GET "repos/$REPOSITORY/actions/caches"' in run
+    assert 'cache_ids="$(' in run
+    assert 'mapfile -t ids <<<"$cache_ids"' in run
+    assert '< <(gh api' not in run

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -24,7 +24,17 @@ jobs:
         run: |
           set -euo pipefail
           ref="refs/pull/$PR_NUMBER/merge"
-          mapfile -t ids < <(gh api "repos/$REPOSITORY/actions/caches" -f ref="$ref" -F per_page=100 --paginate --jq '.actions_caches[].id')
+          cache_ids="$(
+            gh api --method GET "repos/$REPOSITORY/actions/caches" \
+              -f ref="$ref" \
+              -F per_page=100 \
+              --paginate \
+              --jq '.actions_caches[].id'
+          )"
+          ids=()
+          if [[ -n "$cache_ids" ]]; then
+            mapfile -t ids <<<"$cache_ids"
+          fi
           for id in "${ids[@]}"; do
             gh api --method DELETE "repos/$REPOSITORY/actions/caches/$id"
           done


### PR DESCRIPTION
## Summary

- force the cache-list request to use the GitHub Actions cache endpoint with `GET`
- propagate list-request failures before attempting cache deletion
- handle closed pull requests that have no matching caches
- add workflow contract coverage for the request method and failure behavior

## Root cause

Passing `-f` and `-F` fields to `gh api` without an explicit method switched the request to `POST`. The cache-list endpoint rejected that request with `404`. Because the request ran inside process substitution, the failure did not stop `mapfile`, and the error response was later treated as a cache ID.

## Impact

Closed pull request caches can be enumerated and deleted again, reducing stale cache accumulation without attempting malformed deletion URLs.

## Validation

- `python3 -m pytest -q .github/scripts/tests/` - 188 passed, 3 subtests passed
- `actionlint 1.7.12`
- extracted cleanup shell validated with `bash -n`
- `git diff --check`
- live read-only GET against `refs/pull/811/merge` returned 8 matching caches
